### PR TITLE
Use a token when escaping the add_order_item query. props Jon Cave.

### DIFF
--- a/woocommerce_actions.php
+++ b/woocommerce_actions.php
@@ -186,9 +186,9 @@ function woocommerce_add_order_item() {
 			WHERE $wpdb->postmeta.meta_key = 'sku'
 			AND $wpdb->posts.post_status = 'publish'
 			AND $wpdb->posts.post_type = 'shop_product'
-			AND $wpdb->postmeta.meta_value = '".$item_to_add."'
+			AND $wpdb->postmeta.meta_value = %s
 			LIMIT 1
-		"));
+		"), $item_to_add );
 		$post = get_post( $post_id );
 	endif;
 	


### PR DESCRIPTION
It's not enough to just use `$wpdb->prepare()` — you need to actually use the `%s` tokens!
