### PR TITLE
Fix for undefined index notice on General Settings page

### DIFF
--- a/admin/admin-settings.php
+++ b/admin/admin-settings.php
@@ -95,7 +95,8 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'desc' 		=> sprintf( __( 'Enter your %1$sShareThis publisher ID%2$s to show ShareThis on product pages.', 'woothemes' ), '<a href="http://sharethis.com/account/">', '</a>' ),
 		'id' 		=> 'woocommerce_sharethis',
 		'type' 		=> 'text',
-		'std' 		=> ''
+		'std' 		=> '',
+        'css'       => ''
 	),
 	
 	array(  
@@ -103,6 +104,7 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'desc' 		=> __('Log into your google analytics account to find your ID. e.g. <code>UA-XXXXX-X</code>', 'woothemes'),
 		'id' 		=> 'woocommerce_ga_id',
 		'type' 		=> 'text',
+        'css'       => ''
 	),
 	
 	array(  


### PR DESCRIPTION
Modified the $woocommerce_settings variable in admin-settings.php to remove undefined index notices on the General Settings page. The undefined index notices occur on line 144 of admin-settings-forms.php. This script attempts to use the "css" and "std" indices and they are not in the array. I added these values as empty values to the array to avoid the notice. It looks like these arrays are supposed to be set to something. Either these values should be set, or the attempt to use them on line 144 should be removed.
