### PR TITLE
Added missing classes for the 3 last <li> tags in ul.product_data_tabs

### DIFF
--- a/admin/writepanels/writepanel-product_data.php
+++ b/admin/writepanels/writepanel-product_data.php
@@ -29,9 +29,9 @@ function woocommerce_product_data_box() {
 			<li class="active"><a href="#general_product_data"><?php _e('General', 'woothemes'); ?></a></li>
 			<li class="tax_tab"><a href="#tax_product_data"><?php _e('Tax', 'woothemes'); ?></a></li>
 			<?php if (get_option('woocommerce_manage_stock')=='yes') : ?><li class="inventory_tab"><a href="#inventory_product_data"><?php _e('Inventory', 'woothemes'); ?></a></li><?php endif; ?>
-			<li><a href="#woocommerce_attributes"><?php _e('Attributes', 'woothemes'); ?></a></li>
-			<li><a href="#upsell_product_data" title="<?php _e('Up-sells are products which you recommend instead of the currently viewed product, for example, products that are more profitable or better quality or more expensive.', 'woothemes'); ?>"><?php _e('Up-sells', 'woothemes'); ?></a></li>
-			<li><a href="#crosssell_product_data" title="<?php _e('Cross-sells are products which you promote in the cart, based on the current product.', 'woothemes'); ?>"><?php _e('Cross-sells', 'woothemes'); ?></a></li>
+			<li class="attributes_tab"><a href="#woocommerce_attributes"><?php _e('Attributes', 'woothemes'); ?></a></li>
+			<li class="upsell_tab"><a href="#upsell_product_data" title="<?php _e('Up-sells are products which you recommend instead of the currently viewed product, for example, products that are more profitable or better quality or more expensive.', 'woothemes'); ?>"><?php _e('Up-sells', 'woothemes'); ?></a></li>
+			<li class="crosssell_tab"><a href="#crosssell_product_data" title="<?php _e('Cross-sells are products which you promote in the cart, based on the current product.', 'woothemes'); ?>"><?php _e('Cross-sells', 'woothemes'); ?></a></li>
 			<?php do_action('woocommerce_product_write_panel_tabs'); ?>
 
 		</ul>


### PR DESCRIPTION
It didn't make sense that the first 3 <li> tags had classes but the last 3 <li> tags did not. So I added the 3 last missing classes for the <li> tags in ul.product_data_tabs

Furthermore, our site needed to style these 3 tabs differently from the others, but there was no class that we could select for CSS [we were still able to do it via ul.product_data_tabs li:nth-child(3) ].
