### PR TITLE
Small fix for price filter widget.

### DIFF
--- a/widgets/widget-price_filter.php
+++ b/widgets/widget-price_filter.php
@@ -40,7 +40,10 @@ function woocommerce_price_filter( $filtered_posts ) {
 		$matched_products = array();
 		
 		$matched_products_query = get_posts(array(
-			'post_type' => 'product',
+			'post_type' => array(
+				'product_variation',
+				'product'
+			),
 			'post_status' => 'publish',
 			'posts_per_page' => -1,
 			'meta_query' => array(
@@ -55,8 +58,9 @@ function woocommerce_price_filter( $filtered_posts ) {
 
 		if ($matched_products_query) :
 			foreach ($matched_products_query as $product) :
-				$matched_products[] = $product->ID;
-				if ($product->post_parent>0) $matched_products[] = $product->post_parent;
+				if ($product->post_type == 'product') $matched_products[] = $product->ID;
+				if ($product->post_parent>0 && !in_array($product->post_parent, $matched_products))
+					$matched_products[] = $product->post_parent;
 			endforeach;
 		endif;
 		


### PR DESCRIPTION
Try this:
1. Make a product with a variation at $100, a variation at $200 and a variation at $300.
2. View the product on a page with the price filter widget. Notice the price filter widget shows $0 - $300 (or more if you have higher priced products).
3. Change the filter to products between $110 and $300. Your product disappears. It should still be displayed here because it has a price (actually, 2) in between the filter values.

This commit fixes that bug.
