### PR TITLE
Settings page title.

### DIFF
--- a/admin/admin-init.php
+++ b/admin/admin-init.php
@@ -35,7 +35,7 @@ function woocommerce_admin_menu() {
 	if ( current_user_can( 'manage_woocommerce' ) ) $menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' );
 	
     add_menu_page(__('WooCommerce', 'woothemes'), __('WooCommerce', 'woothemes'), 'manage_woocommerce', 'woocommerce' , 'woocommerce_settings', $woocommerce->plugin_url() . '/assets/images/icons/menu_icon_wc.png', 55);
-    add_submenu_page('woocommerce', __('General Settings', 'woothemes'),  __('Settings', 'woothemes') , 'manage_woocommerce', 'woocommerce', 'woocommerce_settings');
+    add_submenu_page('woocommerce', __('WooCommerce Settings', 'woothemes'),  __('Settings', 'woothemes') , 'manage_woocommerce', 'woocommerce', 'woocommerce_settings');
     add_submenu_page('woocommerce', __('Reports', 'woothemes'),  __('Reports', 'woothemes') , 'manage_woocommerce', 'woocommerce_reports', 'woocommerce_reports');
     add_submenu_page('edit.php?post_type=product', __('Attributes', 'woothemes'), __('Attributes', 'woothemes'), 'manage_categories', 'woocommerce_attributes', 'woocommerce_attributes');
     


### PR DESCRIPTION
Currently the settings page of WooCommerce has the title 'General Settings'. This is misleading because the settings page has a general tab. Suppose you were under the 'Pages' or 'Catalog' tab, you would expect the title to become 'Pages Settings' or 'Catalog Settings'.

Quick fix for this is changing the settings page title to 'WooCommerce Settings'. Alternatively you could just use Settings, but I would opt for 'WooCommerce Settings' to differentiate it from other settings pages.
