### PR TITLE
Fixed fancy box close icon

### DIFF
--- a/assets/css/fancybox.css
+++ b/assets/css/fancybox.css
@@ -97,8 +97,8 @@
 	position: absolute;
 	top: -15px;
 	right: -15px;
-	width: 30px;
-	height: 30px;
+	width: 25px;
+	height: 25px;
 	background: transparent url('../images/fancybox/fancybox.png') -40px 0px;
 	cursor: pointer;
 	z-index: 1103;


### PR DESCRIPTION
Fancy box close icon was showing other images beside/above because the width and height we set too large. This sets the width properly so we don't get the extra images showing.
