### PR TITLE
a proposed addition to allow the user to choose to load the js in the footer via the general settings page

### DIFF
--- a/admin/admin-settings.php
+++ b/admin/admin-settings.php
@@ -188,6 +188,14 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'type' 		=> 'checkbox',
 		'checkboxgroup'		=> 'end'
 	),
+  
+  array(  
+		'name' => __( 'Javascript', 'woothemes' ),
+		'desc' 		=> __( 'Enable Output of JavaScript in the footer?', 'woothemes' ),
+		'id' 		=> 'woocommerce_scripts_position',
+		'std' 		=> 'yes',
+		'type' 		=> 'checkbox'
+	),
 	
 	array(  
 		'name' => __( 'Demo store notice', 'woothemes' ),

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -234,10 +234,11 @@ function woocommerce_frontend_scripts() {
 	global $woocommerce;
 	
 	$suffix = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '' : '.min';
-	
-	wp_register_script( 'woocommerce', $woocommerce->plugin_url() . '/assets/js/woocommerce'.$suffix.'.js', 'jquery', '1.0' );
-	wp_register_script( 'woocommerce_plugins', $woocommerce->plugin_url() . '/assets/js/woocommerce_plugins'.$suffix.'.js', 'jquery', '1.0' );
-	wp_register_script( 'fancybox', $woocommerce->plugin_url() . '/assets/js/fancybox'.$suffix.'.js', 'jquery', '1.0' );
+  $scripts_position = (get_option('woocommerce_scripts_position') == 'yes') ? true : false;
+  
+	wp_register_script( 'woocommerce', $woocommerce->plugin_url() . '/assets/js/woocommerce'.$suffix.'.js', 'jquery', '1.0', $scripts_position );
+	wp_register_script( 'woocommerce_plugins', $woocommerce->plugin_url() . '/assets/js/woocommerce_plugins'.$suffix.'.js', 'jquery', '1.0', $scripts_position );
+	wp_register_script( 'fancybox', $woocommerce->plugin_url() . '/assets/js/fancybox'.$suffix.'.js', 'jquery', '1.0', $scripts_position );
 	
 	wp_enqueue_script('jquery');
 	wp_enqueue_script('woocommerce_plugins');


### PR DESCRIPTION
relates to this issue: https://github.com/woothemes/woocommerce/issues/214

I found myself wanting to load the js in the footer, because the three js files loaded by woocommerce have 'jquery' in their dependencies they also stop users from being able to load jquery in the footer too.
