### PR TITLE
Issue #214: A slightly different take on adding javascript to the footer

### DIFF
--- a/admin/admin-settings.php
+++ b/admin/admin-settings.php
@@ -189,6 +189,14 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'checkboxgroup'		=> 'end'
 	),
 	
+  array(  
+    'name' => __( 'Javascript', 'woothemes' ),
+    'desc'     => __( 'Enable Output of JavaScript in the footer?', 'woothemes' ),
+    'id'     => 'woocommerce_scripts_position',
+    'std'     => 'yes',
+    'type'     => 'checkbox'
+  ),
+	
 	array(  
 		'name' => __( 'Demo store notice', 'woothemes' ),
 		'desc' 		=> __( 'Enable the "Demo Store" notice on your site', 'woothemes' ),

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -133,7 +133,7 @@ function woocommerce_init() {
 }
 
 /**
- * Init WooCommerce Tempalte Functions
+ * Init WooCommerce Template Functions
  *
  * This makes them pluggable by plugins and themes
  **/
@@ -234,15 +234,17 @@ function woocommerce_frontend_scripts() {
 	global $woocommerce;
 	
 	$suffix = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '' : '.min';
-	
-	wp_register_script( 'woocommerce', $woocommerce->plugin_url() . '/assets/js/woocommerce'.$suffix.'.js', 'jquery', '1.0' );
-	wp_register_script( 'woocommerce_plugins', $woocommerce->plugin_url() . '/assets/js/woocommerce_plugins'.$suffix.'.js', 'jquery', '1.0' );
-	wp_register_script( 'fancybox', $woocommerce->plugin_url() . '/assets/js/fancybox'.$suffix.'.js', 'jquery', '1.0' );
-	
+	$lightbox_en = (get_option('woocommerce_enable_lightbox')=='yes') ? 0 : 1;
+	$scripts_position = (get_option('woocommerce_scripts_position') == 'yes') ? true : false;
+
+	wp_register_script( 'woocommerce', $woocommerce->plugin_url() . '/assets/js/woocommerce'.$suffix.'.js', 'jquery', '1.0', $scripts_position );
+	wp_register_script( 'woocommerce_plugins', $woocommerce->plugin_url() . '/assets/js/woocommerce_plugins'.$suffix.'.js', 'jquery', '1.0', $scripts_position );
+	if $lightbox_en wp_register_script( 'fancybox', $woocommerce->plugin_url() . '/assets/js/fancybox'.$suffix.'.js', 'jquery', '1.0', $scripts_position );
+
 	wp_enqueue_script('jquery');
 	wp_enqueue_script('woocommerce_plugins');
 	wp_enqueue_script('woocommerce');
-	if (get_option('woocommerce_enable_lightbox')=='yes') wp_enqueue_script('fancybox');
+	if $lightbox_en wp_enqueue_script('fancybox');
     	
 	/* Script variables */
 	$states = json_encode( $woocommerce->countries->states );


### PR DESCRIPTION
- Added option to insert javascript in footer using wordpress standard wp_register footer attribute (requires dependencies in theme also be registered). 
  credit: https://github.com/ralcus/woocommerce/commit/d35312fba83a8839033b71a45fedf7768269f351
- Set lightbox enabled to $lightbox_en to only have to perform one check
- Set re-register fancybox to conditional.  
- Set enque fancybox conditional to check variable rather than request the same check
- Also fixed a minor typo in unrelated comment
