### PR TITLE
Better CPT Update messages. Fix for assorted PHP Strict notices. 

### DIFF
--- a/admin/admin-settings-forms.php
+++ b/admin/admin-settings-forms.php
@@ -136,6 +136,7 @@ function woocommerce_admin_fields($options) {
 	global $woocommerce;
 
     foreach ($options as $value) :
+    	if (!isset( $value['name'] ) ) $value['name'] = '';
     	if (!isset( $value['class'] )) $value['class'] = '';
     	if (!isset( $value['css'] )) $value['css'] = '';
     	if (!isset( $value['std'] )) $value['std'] = '';

--- a/woocommerce_taxonomy.php
+++ b/woocommerce_taxonomy.php
@@ -334,6 +334,41 @@ function woocommerce_post_type() {
 
 } 
 
+/**
+ * Replaces "Post" in the update messages for custom post types on the "Edit" post screen.
+ *
+ * For example "Post updated. View Post." becomes "Product updated. View Product".
+ *
+ * @since 1.1
+ *
+ * @param array $messages The default WordPress messages.
+ */
+function woocommerce_custom_update_messages( $messages ) {
+	global $post, $post_ID;
+
+	$post_types = get_post_types( array( 'show_ui' => true, '_builtin' => false ), 'objects' );
+
+	foreach( $post_types as $post_type => $post_object ) {
+
+		$messages[$post_type] = array(
+			0 => '', // Unused. Messages start at index 1.
+			1 => sprintf( __( '%s updated. <a href="%s">View %s</a>' ), $post_object->labels->singular_name, esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
+			2 => __( 'Custom field updated.' ),
+			3 => __( 'Custom field deleted.' ),
+			4 => sprintf( __( '%s updated.' ), $post_object->labels->singular_name ),
+			5 => isset( $_GET['revision']) ? sprintf( __( '%s restored to revision from %s' ), $post_object->labels->singular_name, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			6 => sprintf( __( '%s published. <a href="%s">View %s</a>' ), $post_object->labels->singular_name, esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
+			7 => sprintf( __( '%s saved.' ), $post_object->labels->singular_name ),
+			8 => sprintf( __( '%s submitted. <a target="_blank" href="%s">Preview %s</a>'), $post_object->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $post_object->labels->singular_name ),
+			9 => sprintf( __( '%s scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview %s</a>'), $post_object->labels->singular_name, date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
+			10 => sprintf( __( '%s draft updated. <a target="_blank" href="%s">Preview %s</a>'), $post_object->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $post_object->labels->singular_name ),
+			);
+	}
+
+	return $messages;
+}
+add_filter( 'post_updated_messages', 'woocommerce_custom_update_messages' );
+
 
 /**
  * Filter to allow product_cat in the permalinks for products.

--- a/woocommerce_taxonomy.php
+++ b/woocommerce_taxonomy.php
@@ -352,16 +352,16 @@ function woocommerce_custom_update_messages( $messages ) {
 
 		$messages[$post_type] = array(
 			0 => '', // Unused. Messages start at index 1.
-			1 => sprintf( __( '%s updated. <a href="%s">View %s</a>' ), $post_object->labels->singular_name, esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
-			2 => __( 'Custom field updated.' ),
-			3 => __( 'Custom field deleted.' ),
-			4 => sprintf( __( '%s updated.' ), $post_object->labels->singular_name ),
-			5 => isset( $_GET['revision']) ? sprintf( __( '%s restored to revision from %s' ), $post_object->labels->singular_name, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			1 => sprintf( __( '%s updated. <a href="%s">View %s</a>', 'woothemes' ), $post_object->labels->singular_name, esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
+			2 => __( 'Custom field updated.', 'woothemes' ),
+			3 => __( 'Custom field deleted.', 'woothemes' ),
+			4 => sprintf( __( '%s updated.', 'woothemes' ), $post_object->labels->singular_name ),
+			5 => isset( $_GET['revision'] ) ? sprintf( __( '%s restored to revision from %s', 'woothemes' ), $post_object->labels->singular_name, wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 			6 => sprintf( __( '%s published. <a href="%s">View %s</a>' ), $post_object->labels->singular_name, esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
-			7 => sprintf( __( '%s saved.' ), $post_object->labels->singular_name ),
-			8 => sprintf( __( '%s submitted. <a target="_blank" href="%s">Preview %s</a>'), $post_object->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $post_object->labels->singular_name ),
-			9 => sprintf( __( '%s scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview %s</a>'), $post_object->labels->singular_name, date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
-			10 => sprintf( __( '%s draft updated. <a target="_blank" href="%s">Preview %s</a>'), $post_object->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $post_object->labels->singular_name ),
+			7 => sprintf( __( '%s saved.', 'woothemes' ), $post_object->labels->singular_name ),
+			8 => sprintf( __( '%s submitted. <a target="_blank" href="%s">Preview %s</a>', 'woothemes' ), $post_object->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $post_object->labels->singular_name ),
+			9 => sprintf( __( '%s scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview %s</a>', 'woothemes' ), $post_object->labels->singular_name, date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ), $post_object->labels->singular_name ),
+			10 => sprintf( __( '%s draft updated. <a target="_blank" href="%s">Preview %s</a>', 'woothemes' ), $post_object->labels->singular_name, esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ), $post_object->labels->singular_name ),
 			);
 	}
 


### PR DESCRIPTION
Adding woocommerce_custom_update_messages() function to change "Post updated" messages for CPTs to be more appropriate - eg. "Product updated". Fixing a bunch of "PHP Notice:  Undefined index" warnings on admin settings form with "$value["name"]" is not set.
