### PR TITLE
Piwik ecommerce tracking

### DIFF
--- a/woocommerce_actions.php
+++ b/woocommerce_actions.php
@@ -772,6 +772,11 @@ add_action('woocommerce_thankyou', 'woocommerce_ecommerce_tracking');
 function woocommerce_ecommerce_tracking( $order_id ) {
 	global $woocommerce;
 	
+	// Call the Piwik ecommerce function if WP-Piwik is configured to add
+	// tracking codes to the page
+	$wp_piwik_global_settings = get_option('wp-piwik_global-settings');
+	if($wp_piwik_global_settings['add_tracking_code']) woocommerce_ecommerce_tracking_piwik( $order_id );
+	
 	if (!get_option('woocommerce_ga_ecommerce_tracking_enabled')) return;
 	if (is_admin()) return; // Don't track admin
 	
@@ -836,6 +841,56 @@ function woocommerce_ecommerce_tracking( $order_id ) {
 			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
 			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 		})();
+	</script>
+	<?php
+} 
+
+/**
+ * ecommerce tracking with piwik
+ */
+function woocommerce_ecommerce_tracking_piwik( $order_id ) {
+	global $woocommerce;
+	
+	// Remove WP-Piwik from wp_footer and run it here instead, to get Piwik 
+	// loaded *before* we do our ecommerce tracking calls
+	remove_action('wp_footer', array($GLOBALS['wp_piwik'],'footer'));
+	$GLOBALS['wp_piwik']->footer();
+	
+	if (is_admin()) return; // Don't track admin
+	
+	// Get the order and output tracking code
+	$order = &new woocommerce_order($order_id);
+	
+	$loggedin 	= (is_user_logged_in()) ? 'yes' : 'no';
+	if (is_user_logged_in()) :
+		$user_id 		= get_current_user_id();
+		$current_user 	= get_user_by('id', $user_id);
+		$username 		= $current_user->user_login;
+	else :
+		$user_id 		= '';
+		$username 		= __('Guest', 'woothemes');
+	endif;
+	?>
+	<script type="text/javascript">
+	// Add order items
+	<?php if ($order->items) foreach($order->items as $item) : $_product = $order->get_product_from_item( $item ); ?>
+		piwikTracker.addEcommerceItem(
+			"<?php echo $_product->sku; ?>",	// (required) SKU: Product unique identifier
+			"<?php echo $item['name']; ?>",		// (optional) Product name
+			"<?php if (isset($_product->variation_data)) echo woocommerce_get_formatted_variation( $_product->variation_data, true ); ?>",	// (optional) Product category. You can also specify an array of up to 5 categories eg. ["Books", "New releases", "Biography"]
+			<?php echo $item['cost']; ?>,		// (recommended) Product price
+			<?php echo $item['qty']; ?> 		// (optional, default to 1) Product quantity
+		);
+	<?php endforeach; ?>
+	// Track order
+	piwikTracker.trackEcommerceOrder(
+		"<?php echo $order_id; ?>",		// (required) Unique Order ID
+		<?php echo $order->order_total; ?>,	// (required) Order Revenue grand total (includes tax, shipping, and subtracted discount)
+		false,					// (optional) Order sub total (excludes shipping)
+		<?php echo $order->order_tax; ?>,	// (optional) Tax amount
+		<?php echo $order->order_shipping; ?>,	// (optional) Shipping amount
+		false 					// (optional) Discount offered (set to false for unspecified parameter)
+	);
 	</script>
 	<?php
 } 

--- a/woocommerce_actions.php
+++ b/woocommerce_actions.php
@@ -872,25 +872,27 @@ function woocommerce_ecommerce_tracking_piwik( $order_id ) {
 	endif;
 	?>
 	<script type="text/javascript">
-	// Add order items
-	<?php if ($order->items) foreach($order->items as $item) : $_product = $order->get_product_from_item( $item ); ?>
-		piwikTracker.addEcommerceItem(
-			"<?php echo $_product->sku; ?>",	// (required) SKU: Product unique identifier
-			"<?php echo $item['name']; ?>",		// (optional) Product name
-			"<?php if (isset($_product->variation_data)) echo woocommerce_get_formatted_variation( $_product->variation_data, true ); ?>",	// (optional) Product category. You can also specify an array of up to 5 categories eg. ["Books", "New releases", "Biography"]
-			<?php echo $item['cost']; ?>,		// (recommended) Product price
-			<?php echo $item['qty']; ?> 		// (optional, default to 1) Product quantity
+	try {
+		// Add order items
+		<?php if ($order->items) foreach($order->items as $item) : $_product = $order->get_product_from_item( $item ); ?>
+			piwikTracker.addEcommerceItem(
+				"<?php echo $_product->sku; ?>",	// (required) SKU: Product unique identifier
+				"<?php echo $item['name']; ?>",		// (optional) Product name
+				"<?php if (isset($_product->variation_data)) echo woocommerce_get_formatted_variation( $_product->variation_data, true ); ?>",	// (optional) Product category. You can also specify an array of up to 5 categories eg. ["Books", "New releases", "Biography"]
+				<?php echo $item['cost']; ?>,		// (recommended) Product price
+				<?php echo $item['qty']; ?> 		// (optional, default to 1) Product quantity
+			);
+		<?php endforeach; ?>
+		// Track order
+		piwikTracker.trackEcommerceOrder(
+			"<?php echo $order_id; ?>",		// (required) Unique Order ID
+			<?php echo $order->order_total; ?>,	// (required) Order Revenue grand total (includes tax, shipping, and subtracted discount)
+			false,					// (optional) Order sub total (excludes shipping)
+			<?php echo $order->order_tax; ?>,	// (optional) Tax amount
+			<?php echo $order->order_shipping; ?>,	// (optional) Shipping amount
+			false 					// (optional) Discount offered (set to false for unspecified parameter)
 		);
-	<?php endforeach; ?>
-	// Track order
-	piwikTracker.trackEcommerceOrder(
-		"<?php echo $order_id; ?>",		// (required) Unique Order ID
-		<?php echo $order->order_total; ?>,	// (required) Order Revenue grand total (includes tax, shipping, and subtracted discount)
-		false,					// (optional) Order sub total (excludes shipping)
-		<?php echo $order->order_tax; ?>,	// (optional) Tax amount
-		<?php echo $order->order_shipping; ?>,	// (optional) Shipping amount
-		false 					// (optional) Discount offered (set to false for unspecified parameter)
-	);
+	} catch( err ) {}
 	</script>
 	<?php
 } 

--- a/woocommerce_actions.php
+++ b/woocommerce_actions.php
@@ -860,16 +860,6 @@ function woocommerce_ecommerce_tracking_piwik( $order_id ) {
 	
 	// Get the order and output tracking code
 	$order = &new woocommerce_order($order_id);
-	
-	$loggedin 	= (is_user_logged_in()) ? 'yes' : 'no';
-	if (is_user_logged_in()) :
-		$user_id 		= get_current_user_id();
-		$current_user 	= get_user_by('id', $user_id);
-		$username 		= $current_user->user_login;
-	else :
-		$user_id 		= '';
-		$username 		= __('Guest', 'woothemes');
-	endif;
 	?>
 	<script type="text/javascript">
 	try {


### PR DESCRIPTION
Added ecommerce tracking calls for the open source analytics [Piwik](http://piwik.org/) after checkout.

This does not add any new admin options but instead works with the [WP-Piwik plugin](http://wordpress.org/extend/plugins/wp-piwik/) to find out whether to insert the javascript or not. If WP-Piwik is installed and set to insert page tracking code into every page, we insert the ecommerce code at the thankyou hook, too.

Tracking cart updates and product views is still a todo. See http://piwik.org/docs/ecommerce-analytics/ for possibilities.
