### PR TITLE
Fixing "Automatically add pages" bug

### DIFF
--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -980,7 +980,7 @@ function woocommerce_settings() {
     
     // Add pages button
     if (isset($_GET['install_woocommerce_pages']) && $_GET['install_woocommerce_pages']) :
-	    	
+		require_once( 'woocommerce-admin-install.php' );
     	woocommerce_create_pages();
     	update_option('skip_install_woocommerce_pages', 1);
     	$install_complete = true;


### PR DESCRIPTION
When visiting `/wp-admin/admin.php?page=woocommerce` after a clean install of the development version, and clicking the _Automatically add pages_ button, WooCommerce throws:

`PHP Fatal error:  Call to undefined function woocommerce_create_pages() in /Applications/MAMP/htdocs/wp34/wp-content/plugins/woocommerce/admin/woocommerce-admin-settings.php on line 984`

This bug appears to spawn from the removal of `include_once( admin-install.php );` call in the top of the file formerly known as `admin-init.php` in commit SHA: 34032965a8ba43db9ecf081fd9755f9930b7cc8e

Not sure if this is the elegant place to reinstate the inclusion of the `woocommerce-admin-install.php` file, but it's memory efficient and works. 

PS - you guys do an awesome job of merging pull requests :D
