### PR TITLE
Adding a password form field to the woocommerce_form_field() function

### DIFF
--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -619,6 +619,14 @@ if (!function_exists('woocommerce_form_field')) {
 				</p>'.$after;
 				
 			break;
+			case "password" :
+		
+				$field = '<p class="form-row '.implode(' ', $args['class']).'" id="'.$key.'_field">
+					<label for="'.$key.'" class="'.implode(' ', $args['label_class']).'">'.$args['label'].'</label>
+					<input type="password" class="input-text" name="'.$key.'" id="'.$key.'" placeholder="'.$args['placeholder'].'" value="'. $value.'" />
+				</p>'.$after;
+
+			break;
 			default :
 			
 				$field = '<p class="form-row '.implode(' ', $args['class']).'" id="'.$key.'_field">


### PR DESCRIPTION
When choosing to create a new account on checkout, the _Account Password_ fields are currently output as text fields. This patch adds a password field to the `woocommerce_form_field()` function to fix this.
