### PR TITLE
Correction of the currency symbol

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Yes you can! Join in on our GitHub repository :) https://github.com/woothemes/wo
 == Changelog ==
 
 = 1.4 =
+* Displaying correct currency symbol (Real of Brazil)
 * Support for multiple and stacked (compound) taxes
 * Locale options for country address formatting and checkout fields
 * Multiple taxes shown in order total tables

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -114,7 +114,7 @@ function get_woocommerce_currency_symbol( $currency = '' ) {
 	$currency_symbol = '';
 	switch ($currency) :
 		case 'AUD' :
-		case 'BRL' :
+		case 'BRL' : $currency_symbol = 'R&#36;'; break; // in Brazil the correct is R$ 0.00,00
 		case 'CAD' :
 		case 'MXN' :
 		case 'NZD' :


### PR DESCRIPTION
Correction of the currency symbol, in Brazil the currency is displayed like R$ 
