### PR TITLE
Deprecated PHP in a few lines.

### DIFF
--- a/classes/gateways/gateway-cod.php
+++ b/classes/gateways/gateway-cod.php
@@ -77,7 +77,7 @@ class woocommerce_cod extends woocommerce_payment_gateway {
     // Process the payment
 	function process_payment ($order_id) {
 		global $woocommerce;
-		$order = &new woocommerce_order ($order_id);
+		$order = new woocommerce_order ($order_id);
 		$order->update_status('on-hold', __('Payment to be made upon delivery.', 'woocommerce'));
 		$woocommerce->cart->empty_cart(); // Dump the cart
 		unset($_SESSION['order_awaiting_payment']); // Lose our session	

--- a/classes/shipping/shipping-local-delivery.php
+++ b/classes/shipping/shipping-local-delivery.php
@@ -34,7 +34,7 @@ class local_delivery extends woocommerce_shipping_method {
 
 	 function calculate_shipping() {
 		global $woocommerce;
-		$_tax = &new woocommerce_tax();
+		$_tax = new woocommerce_tax();
 		if ($this->type=='free') 		$shipping_total 	= 0;
 		if ($this->type=='fixed') 		$shipping_total 	= $this->fee;
 		if ($this->type=='percent') 	$shipping_total 	= $woocommerce->cart->cart_contents_total * ($this->fee/100);

--- a/classes/shipping/shipping-local-pickup.php
+++ b/classes/shipping/shipping-local-pickup.php
@@ -32,7 +32,7 @@ class local_pickup extends woocommerce_shipping_method {
 
 	 function calculate_shipping() {
 		global $woocommerce;
-		$_tax = &new woocommerce_tax();
+		$_tax = new woocommerce_tax();
 		
 		$rate = array(
 			'id' 		=> $this->id,


### PR DESCRIPTION
Deprecated: Assigning the return value of new by reference is deprecated in woocommerce/classes/shipping/shipping-local-delivery.php on line 38 

Deprecated: Assigning the return value of new by reference is deprecated in woocommerce/classes/shipping/shipping-local-pickup.php on line 35 

Deprecated: Assigning the return value of new by reference is deprecated in woocommerce/classes/gateways/gateway-cod.php on line 95
