### PR TITLE
Default function admin_options() with settings fields

### DIFF
--- a/classes/woocommerce_settings_api.class.php
+++ b/classes/woocommerce_settings_api.class.php
@@ -23,7 +23,12 @@ class woocommerce_settings_api {
 	 *
 	 * @since 1.0.0
 	 */
-	function admin_options() {}
+	function admin_options() { ?>
+		<h3><?php echo (isset($this->method_title)) ? $this->method_title : __('Settings','woocommerce') ; ?></h3>
+		<table class="form-table">
+			<?php $this->generate_settings_html(); ?>
+		</table><?php
+	}
 	
 	/**
 	 * Initialise Settings Form Fields


### PR DESCRIPTION
Default the admin_options() function with the basics, makes standard gateways have one less function.

```
    function admin_options() { ?>
        <h3><?php echo (isset($this->method_title)) ? $this->method_title : __('Settings','woocommerce') ; ?></h3>
        <table class="form-table">
            <?php $this->generate_settings_html(); ?>
        </table><?php
    }
```

init_form_fields could probably use a more specific returned line when it is not created by the gateway developer, like...

```
    function init_form_fields () { return __( 'The init_form_fields() function needs to be overridden by your payment gateway class.', 'woocommerce' ); }
```
