### PR TITLE
Added spacing around first / last css class names for 1 column shop page...

### DIFF
--- a/templates/loop-shop.php
+++ b/templates/loop-shop.php
@@ -26,7 +26,7 @@ if (!isset($woocommerce_loop['columns']) || !$woocommerce_loop['columns']) $wooc
 		$woocommerce_loop['loop']++;
 		
 		?>
-		<li class="product <?php if ($woocommerce_loop['loop']%$woocommerce_loop['columns']==0) echo 'last'; if (($woocommerce_loop['loop']-1)%$woocommerce_loop['columns']==0) echo 'first'; ?>">
+		<li class="product <?php if ($woocommerce_loop['loop']%$woocommerce_loop['columns']==0) echo ' last'; if (($woocommerce_loop['loop']-1)%$woocommerce_loop['columns']==0) echo ' first'; ?>">
 			
 			<?php do_action('woocommerce_before_shop_loop_item'); ?>
 			


### PR DESCRIPTION
Seems like there's a small bug in the handling of 1 column shop pages.  Added spaces before the css class names to resolve this issue
