### PR TITLE
Convert show_messages to a template function

### DIFF
--- a/woocommerce-hooks.php
+++ b/woocommerce-hooks.php
@@ -28,7 +28,7 @@ add_action( 'get_sidebar', 'woocommerce_prevent_sidebar_cache' );
 add_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10);
 
 /* Products Loop */
-add_action( 'woocommerce_before_shop_loop', array(&$woocommerce, 'show_messages'), 10 );
+add_action( 'woocommerce_before_shop_loop', 'woocommerce_show_messages', 10 );
 add_action( 'woocommerce_before_shop_loop_products', 'woocommerce_product_subcategories' );
 add_action( 'woocommerce_after_shop_loop_item', 'woocommerce_template_loop_add_to_cart', 10);
 add_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail', 10);
@@ -38,7 +38,7 @@ add_action( 'woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop
 add_action( 'woocommerce_before_subcategory_title', 'woocommerce_subcategory_thumbnail', 10);
 
 /* Before Single Products */
-add_action( 'woocommerce_before_single_product', array(&$woocommerce, 'show_messages'), 10 );
+add_action( 'woocommerce_before_single_product', 'woocommerce_show_messages', 10 );
 
 /* Before Single Products Summary Div */
 add_action( 'woocommerce_before_single_product_summary', 'woocommerce_show_product_images', 20);

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -148,6 +148,37 @@ if (!function_exists('woocommerce_demo_store')) {
 	}
 }
 
+/**
+ * Show Messages
+ *
+ * Displays WooCommerce errors and messages
+ **/
+if (!function_exists('woocommerce_show_messages')) {
+  function woocommerce_show_messages() {
+    global $woocommerce;
+
+		// Show multiple errors in a list format
+		if (isset($woocommerce->errors) && sizeof($woocommerce->errors)>0) {
+			echo '<ul class="woocommerce_error">';
+			foreach ($woocommerce->errors as $error) {
+				echo '<li>' . $error . '</li>';
+			}
+			echo '</ul>';
+			$woocommerce->clear_messages();
+			return true;
+
+		// Show a single message in a div
+		} elseif (isset($woocommerce->messages) && sizeof($woocommerce->messages)>0) {
+			echo '<div class="woocommerce_message">'.$woocommerce->messages[0].'</div>';
+			$woocommerce->clear_messages();
+			return true;
+
+		} else {
+			return false;
+		}
+  }
+}
+
 /** Loop ******************************************************************/
 
 /**


### PR DESCRIPTION
Currrently when the hooks are setup the woocommerce global variable
is null so the _wp_filter_build_unique_id fails to create a unique id.
This prevents the hook begin removed in a theme so that the message
output can be repositioned.

To fix this the code for generating the message HTML has being moved
to a template function and the hooks changed to a simple function name.
This has the added benefit that the message HTML can be changed within
a theme by overriding the woocommerce_show_messages function.
