### PR TITLE
Apply the current-cat-parent class to the top level category

### DIFF
--- a/widgets/widget-product_categories.php
+++ b/widgets/widget-product_categories.php
@@ -104,7 +104,9 @@ class WooCommerce_Widget_Product_Categories extends WP_Widget {
 				echo '<li class="cat-item cat-item-'.$cat->term_id;
 				
 				if (is_tax('product_cat', $cat->slug)) echo ' current-cat';
-				if ($current_cat_parent->term_id==$cat->term_id) echo ' current-cat-parent';
+				if ($current_cat && $current_cat_parent
+						&& $current_cat_parent->term_id == $cat->term_id 
+						&& $current_cat_parent->term_id != $current_cat->term_id) echo ' current-cat-parent';
 				
 				echo '"><a href="'.get_term_link( $cat->slug, 'product_cat' ).'">'.$cat->name.'</a>';
 				

--- a/widgets/widget-product_categories.php
+++ b/widgets/widget-product_categories.php
@@ -104,6 +104,7 @@ class WooCommerce_Widget_Product_Categories extends WP_Widget {
 				echo '<li class="cat-item cat-item-'.$cat->term_id;
 				
 				if (is_tax('product_cat', $cat->slug)) echo ' current-cat';
+				if ($current_cat_parent->term_id==$cat->term_id) echo ' current-cat-parent';
 				
 				echo '"><a href="'.get_term_link( $cat->slug, 'product_cat' ).'">'.$cat->name.'</a>';
 				


### PR DESCRIPTION
The category widget does not add a class to the topmost category to
indicate that it is the parent of the current category. This commit
fixes this by applying the standard 'current-cat-parent' class.
