### PR TITLE
Make product category URLs heirarchical

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -503,7 +503,7 @@ class Woocommerce {
 	            	'delete_terms' 		=> 'manage_woocommerce_products',
 	            	'assign_terms' 		=> 'manage_woocommerce_products',
 	            ),
-	            'rewrite' 				=> array( 'slug' => $category_base . $category_slug, 'with_front' => false ),
+	            'rewrite' 				=> array( 'slug' => $category_base . $category_slug, 'with_front' => false, 'heirarchical' => true ),
 	        )
 	    );
 	    


### PR DESCRIPTION
Heirarchical URLs for custom taxonomies is an opt-in feature added
in WordPress 3.1. This commit enables that support by adding the
appropriate flag to the rewrite setting for the product_cat taxonomy.

It may be preferred to make this a setting for backwards compatibility,
if so just say where you want it added.
