### PR TITLE
Small usability tweak for adding product attributes

### DIFF
--- a/admin/woocommerce-admin-settings-forms.php
+++ b/admin/woocommerce-admin-settings-forms.php
@@ -299,7 +299,7 @@ function woocommerce_admin_fields($options) {
             	?><tr valign="top">
 					<th scope="row" class="titledesc"><?php echo $value['name'] ?></th>
                     <td class="forminp">
-                        <textarea <?php if ( isset($value['args']) ) echo $value['args'] . ' '; ?>name="<?php echo esc_attr( $value['id'] ); ?>" id="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>"><?php if (get_option($value['id'])) echo esc_textarea(stripslashes(get_option($value['id']))); else echo esc_textarea( $value['std'] ); ?></textarea> <span class="description"><?php echo $value['desc'] ?></span>
+                        <textarea <?php if ( isset($value['args']) ) echo $value['args'] . ' '; ?>name="<?php echo esc_attr( $value['id'] ); ?>" id="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>"><?php if (false !== get_option($value['id'])) echo esc_textarea(stripslashes(get_option($value['id']))); else echo esc_textarea( $value['std'] ); ?></textarea> <span class="description"><?php echo $value['desc'] ?></span>
                     </td>
                 </tr><?php
             break;

--- a/admin/woocommerce-admin-settings-forms.php
+++ b/admin/woocommerce-admin-settings-forms.php
@@ -299,7 +299,7 @@ function woocommerce_admin_fields($options) {
             	?><tr valign="top">
 					<th scope="row" class="titledesc"><?php echo $value['name'] ?></th>
                     <td class="forminp">
-                        <textarea <?php if ( isset($value['args']) ) echo $value['args'] . ' '; ?>name="<?php echo esc_attr( $value['id'] ); ?>" id="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>"><?php if (false !== get_option($value['id'])) echo esc_textarea(stripslashes(get_option($value['id']))); else echo esc_textarea( $value['std'] ); ?></textarea> <span class="description"><?php echo $value['desc'] ?></span>
+                        <textarea <?php if ( isset($value['args']) ) echo $value['args'] . ' '; ?>name="<?php echo esc_attr( $value['id'] ); ?>" id="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>"><?php if (get_option($value['id'])) echo esc_textarea(stripslashes(get_option($value['id']))); else echo esc_textarea( $value['std'] ); ?></textarea> <span class="description"><?php echo $value['desc'] ?></span>
                     </td>
                 </tr><?php
             break;

--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -570,7 +570,8 @@ jQuery( function($){
 				$('table.woocommerce_attributes tbody').append( $(thisrow) );
 				$(thisrow).show();
 				row_indexes();
-				
+				// Reset selected attribute in the list
+				$('select.attribute_taxonomy').val('');
 			}
 	
 			show_attribute_table();


### PR DESCRIPTION
When you add a specific product attribute, you first select the attribute name from a dropdown list, then you click "Add". Previously the select list remained the same with the same attribute selected. This makes no sense because you can't add the same attribute again.

With this small tweak, the select list gets reset to the "Custom product attribute" option, which always can be added.
