### PR TITLE
Elements in select lists should not have ucfirst applied

### DIFF
--- a/admin/woocommerce-admin-settings-forms.php
+++ b/admin/woocommerce-admin-settings-forms.php
@@ -241,7 +241,7 @@ function woocommerce_admin_fields($options) {
                         <?php
                         foreach ($value['options'] as $key => $val) {
                         ?>
-                            <option value="<?php echo esc_attr( $key ); ?>" <?php if (get_option($value['id']) == $key) { ?> selected="selected" <?php } ?>><?php echo ucfirst($val) ?></option>
+                            <option value="<?php echo esc_attr( $key ); ?>" <?php if (get_option($value['id']) == $key) { ?> selected="selected" <?php } ?>><?php echo $val ?></option>
                         <?php
                         }
                         ?>


### PR DESCRIPTION
Applying `ucfirst()` to all select list options in the admin area like this is quite a thoughtless move. The strings themselves should be formatted correctly. For example, I don't like dimension units like "cm" to be turned into "Cm" for no reason.

(Moreover, `ucfirst()` is not UTF-8 compatible.)
