### PR TITLE
Fix ordering of categories in Product Categories widget

### DIFF
--- a/widgets/widget-product_categories.php
+++ b/widgets/widget-product_categories.php
@@ -177,8 +177,8 @@ class WooCommerce_Widget_Product_Categories extends WP_Widget {
 		
 		<p><label for="<?php echo $this->get_field_id('orderby'); ?>"><?php _e('Order by:', 'woocommerce') ?></label>
 		<select id="<?php echo esc_attr( $this->get_field_id('orderby') ); ?>" name="<?php echo esc_attr( $this->get_field_name('orderby') ); ?>">
-			<option value="and" <?php selected($orderby, 'order'); ?>><?php _e('Category Order', 'woocommerce'); ?></option>
-			<option value="or" <?php selected($orderby, 'name'); ?>><?php _e('Name', 'woocommerce'); ?></option>
+			<option value="order" <?php selected($orderby, 'order'); ?>><?php _e('Category Order', 'woocommerce'); ?></option>
+			<option value="name" <?php selected($orderby, 'name'); ?>><?php _e('Name', 'woocommerce'); ?></option>
 		</select></p>
 
 		<p><input type="checkbox" class="checkbox" id="<?php echo esc_attr( $this->get_field_id('dropdown') ); ?>" name="<?php echo esc_attr( $this->get_field_name('dropdown') ); ?>"<?php checked( $dropdown ); ?> />


### PR DESCRIPTION
The options in the admin form for the Product Categories widget uses `and` and `or` for ordering values - it should be `order` and `name`.
