### PR TITLE
Use a non-breaking space between currency symbol and price

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -215,10 +215,10 @@ function woocommerce_price( $price, $args = array() ) {
 			$return = '<span class="amount">'. $price . $currency_symbol . '</span>';
 		break;
 		case 'left_space' :
-			$return = '<span class="amount">'. $currency_symbol . ' ' . $price . '</span>';
+			$return = '<span class="amount">'. $currency_symbol . '&nbsp;' . $price . '</span>';
 		break;
 		case 'right_space' :
-			$return = '<span class="amount">'. $price . ' ' . $currency_symbol . '</span>';
+			$return = '<span class="amount">'. $price . '&nbsp;' . $currency_symbol . '</span>';
 		break;
 	endswitch;
 


### PR DESCRIPTION
Keeps the currency symbol together with the price.
