### PR TITLE
Fixed the default selected reports tab

### DIFF
--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -9,7 +9,7 @@
 
 function woocommerce_reports() {
 
-	$current_tab = (isset($_GET['tab'])) ? $_GET['tab'] : 'sales';
+	$current_tab = (isset($_GET['tab'])) ? $_GET['tab'] : __('sales', 'woocommerce');
 	$current_chart = (isset($_GET['chart'])) ? $_GET['chart'] : 0;
 	
 	$charts = apply_filters('woocommerce_reports_charts', array(


### PR DESCRIPTION
The hardcoded string "sales" didn't exist as key in the `$charts` array if using a translation.

This fix works but using translated strings for array keys feels quite dirty to me. Translated strings can contain anything. The `ucfirst()` on the key on line 73 makes it only worse. A separate array, or a subarray, with translations should be a lot cleaner.
