### PR TITLE
Redirect when there is a single search result

### DIFF
--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -534,12 +534,21 @@ $woocommerce_settings['catalog'] = apply_filters('woocommerce_catalog_settings',
 		),
 	),
 
-	array(  
-		'name' => __( 'Cart redirect', 'woocommerce' ),
+	array(
+		'name' => __( 'Redirects', 'woocommerce' ),
 		'desc' 		=> __( 'Redirect to cart after adding a product to the cart (on single product pages)', 'woocommerce' ),
 		'id' 		=> 'woocommerce_cart_redirect_after_add',
 		'std' 		=> 'no',
-		'type' 		=> 'checkbox'
+		'type' 		=> 'checkbox',
+		'checkboxgroup'		=> 'start'
+	),
+
+	array(
+		'desc' 		=> __( 'Redirect to the product page on a single matching search result', 'woocommerce' ),
+		'id' 		=> 'woocommerce_redirect_on_single_search_result',
+		'std' 		=> 'no',
+		'type' 		=> 'checkbox',
+		'checkboxgroup'		=> 'end'
 	),
 	
 	array( 'type' => 'sectionend', 'id' => 'catalog_options' ),

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -39,6 +39,14 @@ function woocommerce_redirects() {
 		exit;
 	endif;
 
+	// Redirect to the product page if we have a single product
+	if (is_search() && is_post_type_archive('product') && get_option('woocommerce_redirect_on_single_search_result')=='yes') {
+		if ($wp_query->post_count==1) {
+			$product = new WC_Product($wp_query->post->ID);
+			if ($product->is_visible()) wp_safe_redirect( get_permalink($product->id), 302 );
+			exit;
+		}
+	}
 }
 
 /**

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -13,7 +13,7 @@
  * Handle redirects before content is output - hooked into template_redirect so is_page works
  **/
 function woocommerce_redirects() {
-	global $woocommerce;
+	global $woocommerce, $wp_query;
 	
 	// When default permalinks are enabled, redirect shop page to post type archive url
 	if ( isset($_GET['page_id']) && $_GET['page_id'] > 0 && get_option( 'permalink_structure' )=="" && $_GET['page_id'] == woocommerce_get_page_id('shop') ) :


### PR DESCRIPTION
Adds an option to redirect to a product page when there is a single visible product. Only affects custom post type archive searches and not the general search. Defaults to off for backwards compatibility.
