### PR TITLE
Don't show a select list if there's only a single shipping method to choose from.

### DIFF
--- a/templates/cart/totals.php
+++ b/templates/cart/totals.php
@@ -64,7 +64,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							if ( 1 === count( $available_methods ) ) {
 
 								echo esc_html( $method->full_label );
-								echo '<input type="hidden" name="shipping_method" value="'.esc_attr( $method->id ).'">';
+								echo '<input type="hidden" name="shipping_method" id="shipping_method" value="'.esc_attr( $method->id ).'">';
 
 							// Show multiple shipping methods in a select list
 							} else {

--- a/templates/cart/totals.php
+++ b/templates/cart/totals.php
@@ -35,51 +35,60 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 					<th><?php _e('Shipping', 'woocommerce'); ?></th>
 					<td>
 					<?php
-						if (sizeof($available_methods)>0) :
-							
-							echo '<select name="shipping_method" id="shipping_method">';
-							
-							foreach ($available_methods as $method ) :
-								
-								echo '<option value="'.esc_attr($method->id).'" '.selected($method->id, $_SESSION['_chosen_shipping_method'], false).'>'.$method->label;								
-								if ($method->cost>0) :
-								
-									echo ' &mdash; ';
-									
-									if ($woocommerce->cart->display_totals_ex_tax || !$woocommerce->cart->prices_include_tax) :
-	
-										echo woocommerce_price($method->cost);
-										if ( $method->get_shipping_tax()>0 && $woocommerce->cart->prices_include_tax ) :
-											echo ' ' . $woocommerce->countries->ex_tax_or_vat();
-										endif;
-	
-									else :
-	
-										echo woocommerce_price($method->cost + $method->get_shipping_tax());
-										if ( $method->get_shipping_tax()>0 && !$woocommerce->cart->prices_include_tax ) :
-											echo ' ' . $woocommerce->countries->inc_tax_or_vat();
-										endif;
-	
-									endif;
-									
-								endif;
-								
-								echo '</option>';
-	
-							endforeach;
-							
-							echo '</select>';
-							
-						else :
-							
-							if ( !$woocommerce->customer->get_shipping_country() || !$woocommerce->customer->get_shipping_state() || !$woocommerce->customer->get_shipping_postcode() ) : 
+						// If at least one shipping method is available
+						if ( $available_methods ) {
+
+							// Prepare text labels with price for each shipping method
+							foreach ( $available_methods as $method ) {
+								$method->full_label = $method->label;
+
+								if ( $method->cost > 0 ) {
+									$method->full_label .= ' &mdash; ';
+
+									// Append price to label using the correct tax settings
+									if ( $woocommerce->cart->display_totals_ex_tax || ! $woocommerce->cart->prices_include_tax ) {
+										$method->full_label .= woocommerce_price( $method->cost );
+										if ( $method->get_shipping_tax() > 0 && $woocommerce->cart->prices_include_tax ) {
+											$method->full_label .= ' '.$woocommerce->countries->ex_tax_or_vat();
+										}
+									} else {
+										$method->full_label .= woocommerce_price( $method->cost + $method->get_shipping_tax() );
+										if ( $method->get_shipping_tax() > 0 && ! $woocommerce->cart->prices_include_tax ) {
+											$method->full_label .= ' '.$woocommerce->countries->inc_tax_or_vat();
+										}
+									}
+								}
+							}
+
+							// Print a single available shipping method as plain text
+							if ( 1 === count( $available_methods ) ) {
+
+								echo esc_html( $method->full_label );
+								echo '<input type="hidden" name="shipping_method" value="'.esc_attr( $method->id ).'">';
+
+							// Show multiple shipping methods in a select list
+							} else {
+
+								echo '<select name="shipping_method" id="shipping_method">';
+								foreach ( $available_methods as $method ) {
+									echo '<option value="'.esc_attr( $method->id ).'" '.selected( $method->id, $_SESSION['_chosen_shipping_method'], false).'>';
+									echo esc_html( $method->full_label );
+									echo '</option>';
+								}
+								echo '</select>';
+
+							}
+
+						// No shipping methods are available
+						} else {
+
+							if ( ! $woocommerce->customer->get_shipping_country() || ! $woocommerce->customer->get_shipping_state() || ! $woocommerce->customer->get_shipping_postcode() ) {
 								echo '<p>'.__('Please fill in your details above to see available shipping methods.', 'woocommerce').'</p>';
-							else :
+							} else {
 								echo '<p>'.__('Sorry, it seems that there are no available shipping methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce').'</p>';
-							endif;
-							
-						endif;
-				
+							}
+
+						}
 					?></td>
 					
 				</tr>

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -1,4 +1,12 @@
-<?php global $woocommerce; ?>
+<?php
+/**
+ * Review Order
+ */
+ 
+global $woocommerce;
+
+$available_methods = $woocommerce->shipping->get_available_shipping_methods();
+?>
 <div id="order_review">
 	
 	<table class="shop_table">
@@ -31,59 +39,60 @@
 				<th colspan="2"><?php _e('Shipping', 'woocommerce'); ?></th>
 				<td>
 				<?php
-					
-					$available_methods = $woocommerce->shipping->get_available_shipping_methods();
-					
-					if (sizeof($available_methods)>0) :
-						
-						echo '<select name="shipping_method" id="shipping_method">';
-						
-						foreach ($available_methods as $method ) :
-							
-							echo '<option value="'.esc_attr($method->id).'" ';
-							
-							if ($method->id==$_SESSION['_chosen_shipping_method']) echo 'selected="selected"';
-							
-							echo '>'.esc_html($method->label);
-							
-							if ($method->cost>0) :
-							
-								echo ' &mdash; ';
-							
-								if ($woocommerce->cart->display_totals_ex_tax || !$woocommerce->cart->prices_include_tax) :
+					// If at least one shipping method is available
+					if ( $available_methods ) {
 
-									echo woocommerce_price($method->cost);
-									if ( $method->get_shipping_tax()>0 && $woocommerce->cart->prices_include_tax ) :
-										echo ' ' . $woocommerce->countries->ex_tax_or_vat();
-									endif;
+						// Prepare text labels with price for each shipping method
+						foreach ( $available_methods as $method ) {
+							$method->full_label = $method->label;
 
-								else :
+							if ( $method->cost > 0 ) {
+								$method->full_label .= ' &mdash; ';
 
-									echo woocommerce_price($method->cost + $method->get_shipping_tax());
-									if ( $method->get_shipping_tax()>0 && !$woocommerce->cart->prices_include_tax ) :
-										echo ' ' . $woocommerce->countries->inc_tax_or_vat();
-									endif;
+								// Append price to label using the correct tax settings
+								if ( $woocommerce->cart->display_totals_ex_tax || ! $woocommerce->cart->prices_include_tax ) {
+									$method->full_label .= woocommerce_price( $method->cost );
+									if ( $method->get_shipping_tax() > 0 && $woocommerce->cart->prices_include_tax ) {
+										$method->full_label .= ' '.$woocommerce->countries->ex_tax_or_vat();
+									}
+								} else {
+									$method->full_label .= woocommerce_price( $method->cost + $method->get_shipping_tax() );
+									if ( $method->get_shipping_tax() > 0 && ! $woocommerce->cart->prices_include_tax ) {
+										$method->full_label .= ' '.$woocommerce->countries->inc_tax_or_vat();
+									}
+								}
+							}
+						}
 
-								endif;
-								
-							endif;
-							
-							echo '</option>';
+						// Print a single available shipping method as plain text
+						if ( 1 === count( $available_methods ) ) {
 
-						endforeach;
-						
-						echo '</select>';
-						
-					else :
-						
-						if ( !$woocommerce->customer->get_shipping_country() || !$woocommerce->customer->get_shipping_state() || !$woocommerce->customer->get_shipping_postcode() ) : 
+							echo esc_html( $method->full_label );
+							echo '<input type="hidden" name="shipping_method" value="'.esc_attr( $method->id ).'">';
+
+						// Show multiple shipping methods in a select list
+						} else {
+
+							echo '<select name="shipping_method" id="shipping_method">';
+							foreach ( $available_methods as $method ) {
+								echo '<option value="'.esc_attr( $method->id ).'" '.selected( $method->id, $_SESSION['_chosen_shipping_method'], false).'>';
+								echo esc_html( $method->full_label );
+								echo '</option>';
+							}
+							echo '</select>';
+
+						}
+
+					// No shipping methods are available
+					} else {
+
+						if ( ! $woocommerce->customer->get_shipping_country() || ! $woocommerce->customer->get_shipping_state() || ! $woocommerce->customer->get_shipping_postcode() ) {
 							echo '<p>'.__('Please fill in your details above to see available shipping methods.', 'woocommerce').'</p>';
-						else :
+						} else {
 							echo '<p>'.__('Sorry, it seems that there are no available shipping methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce').'</p>';
-						endif;
-						
-					endif;
-			
+						}
+
+					}
 				?></td>
 				
 			</tr>

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -68,7 +68,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						if ( 1 === count( $available_methods ) ) {
 
 							echo esc_html( $method->full_label );
-							echo '<input type="hidden" name="shipping_method" value="'.esc_attr( $method->id ).'">';
+							echo '<input type="hidden" name="shipping_method" id="shipping_method" value="'.esc_attr( $method->id ).'">';
 
 						// Show multiple shipping methods in a select list
 						} else {


### PR DESCRIPTION
Closes issue #605.

First I generated full labels (label name + price) for each shipping method. Then these labels are used in a loop to build a select list if multiple options are available. In case of a single option, the label is printed as plain text with a hidden input for the value.

All code uses WP coding standards.
