### PR TITLE
Fixed 'unterminated string literal' in write-panels.js which broke the product data tabs

### DIFF
--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -579,7 +579,7 @@ jQuery( function($){
 									</td>\
 									<td rowspan="3">\
 										<label>' + woocommerce_writepanel_params.values_label + ':</label>\
-										<textarea name="attribute_values[' + size + ']" cols="5" rows="5" placeholder="' + woocommerce_writepanel_params.text_attribute_tip + '"></textarea>\								
+										<textarea name="attribute_values[' + size + ']" cols="5" rows="5" placeholder="' + woocommerce_writepanel_params.text_attribute_tip + '"></textarea>\
 									</td>\
 								</tr>\
 								<tr>\


### PR DESCRIPTION
There's a lot of trailing space in many files, which is against coding standards. A script like this would be cool:

http://stackoverflow.com/questions/149057/how-to-removing-trailing-whitespace-of-all-files-recursively
