### PR TITLE
wp_debug notice fix

### DIFF
--- a/classes/class-wc-tax.php
+++ b/classes/class-wc-tax.php
@@ -19,8 +19,8 @@ class WC_Tax {
 		if (!is_array($this->parsed_rates)) :
 			global $woocommerce;
 			
-			$tax_rates 			= (array) get_option('woocommerce_tax_rates');
-			$local_tax_rates 	= (array) get_option('woocommerce_local_tax_rates');
+			$tax_rates 			= get_option('woocommerce_tax_rates');
+			$local_tax_rates 	= get_option('woocommerce_local_tax_rates');
 			
 			$parsed_rates 		= array();
 			$flat_rates			= array();


### PR DESCRIPTION
Fix for a whole heap of Notices that are displayed (and break admin-ajax) when wp-debug is on and the woocommerce_tax_rates option hasn't been saved. By typecasting $tax_rates and $local_tax_rates as arrays, it makes "if ($tax_rates)" and "if ($local_tax_rates)" to return true instead of false.
