### PR TITLE
Added action 'woocommerce_cart_contents_review' to the order review page

### DIFF
--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -557,7 +557,9 @@ class WC_Order {
 			</tr>';
 			
 		endforeach;	
-		
+
+		$return = apply_filters( 'woocommerce_email_order_items_table', $return );
+
 		return $return;	
 		
 	}

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -187,7 +187,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 					endforeach; 
 				endif;
 
-				do_action( 'woocommerce_cart_contents_review' );
+				do_action( 'woocommerce_cart_contents_review_order' );
 			?>
 		</tbody>
 	</table>

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -186,6 +186,8 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						endif;
 					endforeach; 
 				endif;
+
+				do_action( 'woocommerce_cart_contents_review' );
 			?>
 		</tbody>
 	</table>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -57,6 +57,8 @@ $order = new WC_Order( $order_id );
 				
 			endforeach;
 		endif;
+
+		do_action( 'woocommerce_cart_contents_review' );
 		?>
 	</tbody>
 </table>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -58,7 +58,7 @@ $order = new WC_Order( $order_id );
 			endforeach;
 		endif;
 
-		do_action( 'woocommerce_cart_contents_review' );
+		do_action( 'woocommerce_cart_contents_order_details' );
 		?>
 	</tbody>
 </table>


### PR DESCRIPTION
The `cart/cart.php` template has an action for adding extra rows to the body of the cart table, which is handy. The action is called "woocommerce_cart_contents".

However, the `checkout/review-order.php` template, where the same cart contents is repeated, does not have such a hook. Added now.
