### PR TITLE
Redirect to cart after cart update to prevent reload warnings in browser

### DIFF
--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -221,7 +221,10 @@ function woocommerce_update_cart_action() {
 		endif;
 		
 		$woocommerce->add_message( __('Cart updated.', 'woocommerce') );
-		
+
+		wp_safe_redirect( $woocommerce->cart->get_cart_url() );
+		exit;
+
 	endif;
 }
 


### PR DESCRIPTION
On line 206 a redirect is performed after having deleted a cart item. No redirect is done after updating the cart, though.

http://shiflett.org/articles/how-to-avoid-page-has-expired-warnings

(I could live with a cart_updated hook too. What do you think?)
