### PR TITLE
Fix install

### DIFF
--- a/admin/woocommerce-admin-hooks.php
+++ b/admin/woocommerce-admin-hooks.php
@@ -15,7 +15,6 @@ global $woocommerce;
 add_action('delete_post', 'woocommerce_delete_product_sync', 10);
 add_action('admin_init', 'woocommerce_preview_emails');
 add_action('admin_init', 'woocommerce_prevent_admin_access');
-add_action('admin_init', 'install_woocommerce_redirect');
 add_action('woocommerce_settings_saved', 'woocomerce_check_download_folder_protection');
 
 /** Filters ***************************************************************/


### PR DESCRIPTION
Warning: call_user_func_array() expects parameter 1 to be a valid callback, function 'install_woocommerce_redirect' not found or invalid function name
