### PR TITLE
Passing along the order object to the woocommerce_order_items_table hook

### DIFF
--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -58,7 +58,7 @@ $order = new WC_Order( $order_id );
 			endforeach;
 		endif;
 
-		do_action( 'woocommerce_order_items_table' );
+		do_action( 'woocommerce_order_items_table', $order );
 		?>
 	</tbody>
 </table>


### PR DESCRIPTION
This actually makes this action useful, otherwise you don't know which order is being displayed since the order-details template is called for any past order too.
