### PR TITLE
Added classes to the table cells for order review

### DIFF
--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -180,8 +180,8 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							echo '
 								<tr>
 									<td class="product-name">'.$_product->get_title().$woocommerce->cart->get_item_data( $values ).'</td>
-									<td>'.$values['quantity'].'</td>
-									<td>' . $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ) . '</td>
+									<td class="product-quantity">'.$values['quantity'].'</td>
+									<td class="product-subtotal">' . $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ) . '</td>
 								</tr>';
 						endif;
 					endforeach; 

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -12,9 +12,9 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 	<table class="shop_table">
 		<thead>
 			<tr>
-				<th><?php _e('Product', 'woocommerce'); ?></th>
-				<th><?php _e('Qty', 'woocommerce'); ?></th>
-				<th><?php _e('Totals', 'woocommerce'); ?></th>
+				<th class="product-name"><?php _e('Product', 'woocommerce'); ?></th>
+				<th class="product-quantity"><?php _e('Qty', 'woocommerce'); ?></th>
+				<th class="product-subtotal"><?php _e('Totals', 'woocommerce'); ?></th>
 			</tr>
 		</thead>
 		<tfoot>


### PR DESCRIPTION
These are the same table cell classes as applied in the cart template.

Too bad the order details table uses `product-total` instead of `product-subtotal`. Would be handy if those were consistent.
