### PR TITLE
Changing the load order of the translation files

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -305,10 +305,11 @@ class Woocommerce {
 	 * Localisation
 	 **/
 	function load_plugin_textdomain() {
-		$variable_lang = (get_option('woocommerce_informal_localisation_type')=='yes') ? 'informal' : 'formal';
-		load_plugin_textdomain('woocommerce', false, dirname( plugin_basename( __FILE__ ) ) . '/languages');
-		load_plugin_textdomain('woocommerce', false, dirname( plugin_basename( __FILE__ ) ) . '/../../languages/woocommerce');
-		load_plugin_textdomain('woocommerce', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' . $variable_lang );
+		// Note: the first-loaded translation file overrides any following ones if the same translation is present
+		$variable_lang = ( get_option( 'woocommerce_informal_localisation_type' ) == 'yes' ) ? 'informal' : 'formal';
+		load_plugin_textdomain( 'woocommerce', false, dirname( plugin_basename( __FILE__ ) ).'/../../languages/woocommerce');
+		load_plugin_textdomain( 'woocommerce', false, dirname( plugin_basename( __FILE__ ) ).'/languages/'.$variable_lang );
+		load_plugin_textdomain( 'woocommerce', false, dirname( plugin_basename( __FILE__ ) ).'/languages');
 	}
 	
 	/**


### PR DESCRIPTION
If you call `load_plugin_textdomain` multiple times for the same domain, the translations will be merged. If both sets have the same string, the translation from the original value will be taken. 

http://codex.wordpress.org/Function_Reference/load_plugin_textdomain

Knowing this, doesn't it make sense to change the load order for WooCommerce translation? By loading the user file (if any) from `wp-content/languages/woocommerce/` first, this file is actually useful since we can now override existing translations with our own. That is also why the (in)formal translation file should be loaded before the default WooCommerce translation file.
