### PR TITLE
Add previous price to on-sale variable product

### DIFF
--- a/admin/post-types/writepanels/writepanel-product-type-variable.php
+++ b/admin/post-types/writepanels/writepanel-product-type-variable.php
@@ -731,33 +731,37 @@ function process_product_meta_variable( $post_id ) {
 		'fields' 		=> 'ids'
 	));
 	$lowest_price = '';
+	$lowest_regular_price = '';
+	$lowest_sale_price = '';
 	$highest_price = '';
+	$highest_regular_price = '';
+	$highest_sale_price = '';
 	if ($children) :
 		foreach ($children as $child) :
 			$child_price = get_post_meta($child, '_price', true);
 			$child_sale_price = get_post_meta($child, '_sale_price', true);
 			
 			// Low price
-			if (!is_numeric($lowest_price) || $child_price<$lowest_price) $lowest_price = $child_price;
-			if (!empty($child_sale_price) && $child_sale_price<$lowest_price) $lowest_price = $child_sale_price;
+			if (!is_numeric($lowest_regular_price) || $child_price < $lowest_regular_price) $lowest_regular_price = $child_price;
+			if (!empty($child_sale_price) && (!is_numeric($lowest_sale_price) || $child_sale_price < $lowest_sale_price)) $lowest_sale_price = $child_sale_price;
 			
 			// High price
-			if (!empty($child_sale_price)) :
-				if ($child_sale_price>$highest_price) :
-					$highest_price = $child_sale_price;
-				endif;	
-			else :
-				if ($child_price>$highest_price) :
-					$highest_price = $child_price;
-				endif;
-			endif;
+			if (!is_numeric($highest_regular_price) || @child_price > $highest_regular_price) $highest_regular_price = $child_price;
+			if (!empty($child_sale_price) && (!is_numeric($highest_sale_price) || $child_sale_price > $highest_sale_price)) $highest_sale_price = $child_sale_price;
 			
 		endforeach;
+
+    $lowest_price = empty($lowest_sale_price) ? $lowest_regular_price : $lowest_sale_price;
+    $highest_price = empty($highest_sale_price) ? $highest_regular_price : $highest_sale_price;
 	endif;
 	
 	update_post_meta( $post_parent, '_price', $lowest_price );
 	update_post_meta( $post_parent, '_min_variation_price', $lowest_price );
 	update_post_meta( $post_parent, '_max_variation_price', $highest_price );
+	update_post_meta( $post_parent, '_min_variation_regular_price', $lowest_regular_price );
+	update_post_meta( $post_parent, '_max_variation_regular_price', $highest_regular_price );
+	update_post_meta( $post_parent, '_min_variation_sale_price', $lowest_sale_price );
+	update_post_meta( $post_parent, '_max_variation_sale_price', $highest_sale_price );
 	
 	// Update default attribute options setting
 	$default_attributes = array();

--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -42,6 +42,10 @@ class WC_Product {
 	var $sale_price_dates_to;
 	var $min_variation_price;
 	var $max_variation_price;
+	var $min_variation_regular_price;
+	var $max_variation_regular_price;
+	var $min_variation_sale_price;
+	var $max_variation_sale_price;
 	var $featured;
 	var $shipping_class;
 	var $dimensions;
@@ -84,6 +88,10 @@ class WC_Product {
 			'sale_price_dates_to' 	=> '',
 			'min_variation_price'	=> '',
 			'max_variation_price'	=> '',
+			'min_variation_regular_price'	=> '',
+			'max_variation_regular_price'	=> '',
+			'min_variation_sale_price'	=> '',
+			'max_variation_sale_price'	=> '',
 			'featured'		=> 'no'
 		);
 		
@@ -536,13 +544,45 @@ class WC_Product {
 			$price = apply_filters('woocommerce_grouped_price_html', $price, $this);
 				
 		elseif ($this->is_type('variable')) :
-			
-			if ( !$this->min_variation_price || $this->min_variation_price !== $this->max_variation_price ) $price .= '<span class="from">' . _x('From:', 'min_price', 'woocommerce') . ' </span>';
-			
-			$price .= woocommerce_price($this->get_price());
-			
-			$price = apply_filters('woocommerce_variable_price_html', $price, $this);
-			
+			if ($this->price > 0) :
+				if ($this->is_on_sale() && isset($this->min_variation_price)) :
+
+					if ( !$this->min_variation_price || $this->min_variation_price !== $this->max_variation_price ) $price .= '<span class="from">' . _x('From:', 'min_price', 'woocommerce') . ' </span>';
+					$price .= '<del>'.woocommerce_price( $this->min_variation_regular_price ).'</del> <ins>'.woocommerce_price($this->get_price()).'</ins>';
+
+					$price = apply_filters('woocommerce_variable_sale_price_html', $price, $this);
+
+				else :
+
+					if ( !$this->min_variation_price || $this->min_variation_price !== $this->max_variation_price ) $price .= '<span class="from">' . _x('From:', 'min_price', 'woocommerce') . ' </span>';
+					$price .= woocommerce_price($this->get_price());
+
+					$price = apply_filters('woocommerce_variable_price_html', $price, $this);
+
+				endif;
+			elseif ($this->price === '' ) :
+
+				$price = apply_filters('woocommerce_variable_empty_price_html', '', $this);
+
+			elseif ($this->price == 0 ) :
+
+				if ($this->is_on_sale() && isset($this->min_variation_regular_price)) :
+
+					if ( !$this->min_variation_price || $this->min_variation_price !== $this->max_variation_price ) $price .= '<span class="from">' . _x('From:', 'min_price', 'woocommerce') . ' </span>';
+					$price .= '<del>'.woocommerce_price( $this->min_variation_regular_price ).'</del> <ins>'.__('Free!', 'woocommerce').'</ins>';
+
+					$price = apply_filters('woocommerce_variable_free_sale_price_html', $price, $this);
+
+				else :
+
+					if ( !$this->min_variation_price || $this->min_variation_price !== $this->max_variation_price ) $price .= '<span class="from">' . _x('From:', 'min_price', 'woocommerce') . ' </span>';
+					$price = __('Free!', 'woocommerce');
+
+					$price = apply_filters('woocommerce_variable_free_price_html', $price, $this);
+
+				endif;
+
+			endif;
 		else :
 			if ($this->price > 0) :
 				if ($this->is_on_sale() && isset($this->regular_price)) :


### PR DESCRIPTION
As discussed in #647.

One thing I haven't addressed is whether you want to add an upgrade hook to add the new meta data to existing products - is that something you'd want? Also the previous variable price filter only gets called for prices that match the old format - do you want it called for all variable prices? There's an argument either way for backwards compatibility - existing sites may be expecting it to be a certain format or to be called for all variable prices (or both!).
