### PR TITLE
Fixed localisation init

### DIFF
--- a/classes/class-wc-countries.php
+++ b/classes/class-wc-countries.php
@@ -509,7 +509,7 @@ class WC_Countries {
 			else :
     			echo '<option';
     			if ($selected_country==$key && $selected_state=='*') echo ' selected="selected"';
-    			echo ' value="'.$key.'">'. ($escape ? esc_js( __($value, 'woocommerce') ) : __($value, 'woocommerce') ) .'</option>';
+    			echo ' value="'.$key.'">'. ($escape ? esc_js( $value ) : $value) .'</option>';
 			endif;
 		endforeach;
 	}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -81,7 +81,10 @@ class Woocommerce {
 		
 		// Define version constant
 		define( 'WOOCOMMERCE_VERSION', $this->version );
-		
+
+		// Set up localisation
+		$this->load_plugin_textdomain();
+
 		// Include required files
 		$this->includes();
 		
@@ -265,10 +268,6 @@ class Woocommerce {
 	 * Init WooCommerce when WordPress Initialises
 	 **/
 	function init() {
-		
-		// Set up localisation
-		$this->load_plugin_textdomain();
-
 		// Register globals for WC environment
 		$this->register_globals();
 


### PR DESCRIPTION
Bug introduced by fdc122214e797d77cacc3a4e32a7fa7c6c0372ee.

The problem is that by moving localisation setup to the "init" action, localisation gets initialized too late. The payment, shipping and countries classes are setup before the "init" action. This causes the translations not to be loaded. The constructor of WC_Countries, for example, immediately needs the translations of all countries and states.
