### PR TITLE
Filtered nav widget

### DIFF
--- a/classes/class-wc-query.php
+++ b/classes/class-wc-query.php
@@ -25,19 +25,15 @@ class WC_Query {
 	/**
 	 * Hook into pre_get_posts to do the main product query
 	 */
-	function pre_get_posts( $q ) {
+	function pre_get_posts( $q ) { 
 		
-		// Only apply to product categories, the product post archive, the shop page, and product tags
+		// Apply to the product post archive, the shop page, and any taxonomy (ie attributes) associated with the product post type
 	    if 	( 
-	    		( !$q->is_main_query() ) || (
-	    			!$q->is_tax( 'product_cat' ) 
-	    			&& !$q->is_tax( 'product_tag' ) 
-	    			&& !$q->is_post_type_archive( 'product' ) 
-	    		)
+	    		!$q->is_main_query()  && !$q->is_post_type_archive( 'product' ) && !$q->is_tax && !in_array( $q->queried_object->taxonomy,  get_object_taxonomies('product') ) 
 	    	) 
 	    return;
-	    
-	    $this->product_query( $q );
+
+	    $this->product_query( $q ); 
 	    
 	    // We're on a shop page so queue the woocommerce_get_products_in_view function
 	    add_action('wp', array( &$this, 'get_products_in_view' ), 2);
@@ -60,7 +56,7 @@ class WC_Query {
 		$ordering = $this->get_catalog_ordering_args();
 		
 		// Get a list of post id's which match the current filters set (in the layered nav and price filter)
-		$post__in = array_unique(apply_filters('loop_shop_post_in', array()));
+		$post__in = array_unique(apply_filters('loop_shop_post_in', array()));  
 		
 		// Ordering query vars
 		$q->set( 'orderby', $ordering['orderby'] );
@@ -88,7 +84,7 @@ class WC_Query {
 	/**
 	 * Get an unpaginated list all product ID's (both filtered and unfiltered). Makes use of transients.
 	 */
-	function get_products_in_view() {
+	function get_products_in_view() {  
 		global $wp_query;
 		
 		$unfiltered_product_ids = array();
@@ -101,7 +97,7 @@ class WC_Query {
 		$transient_name = 'woocommerce_unfiltered_product_ids_' . sanitize_key( http_build_query($current_wp_query) );
 		$transient_name = (is_search()) ? $transient_name . '_search' : $transient_name;
 		
-		if ( false === ( $unfiltered_product_ids = get_transient( $transient_name ) ) ) {
+		//if ( false === ( $unfiltered_product_ids = get_transient( $transient_name ) ) ) {
 
 			// Get all visible posts, regardless of filters
 		    $unfiltered_product_ids = get_posts(
@@ -118,11 +114,11 @@ class WC_Query {
 				)
 			);
 		
-			set_transient( $transient_name, $unfiltered_product_ids );
-		}
+			//set_transient( $transient_name, $unfiltered_product_ids );
+		//}
 		
 		// Store the variable
-		$this->unfiltered_product_ids = $unfiltered_product_ids;
+		$this->unfiltered_product_ids = $unfiltered_product_ids; 
 		
 		// Also store filtered posts ids...
 		if (sizeof($this->post__in)>0) :

--- a/classes/class-wc-query.php
+++ b/classes/class-wc-query.php
@@ -25,15 +25,23 @@ class WC_Query {
 	/**
 	 * Hook into pre_get_posts to do the main product query
 	 */
-	function pre_get_posts( $q ) { 
-		
-		// Apply to the product post archive, the shop page, and any taxonomy (ie attributes) associated with the product post type
+	function pre_get_posts( $q ) {
+
+		global $_attributes_array;
+
+		// Only apply to product categories, the product post archive, the shop page, product tags, and product attribute taxonomies
 	    if 	( 
-	    		!$q->is_main_query()  && !$q->is_post_type_archive( 'product' ) && !$q->is_tax && !in_array( $q->queried_object->taxonomy,  get_object_taxonomies('product') ) 
+	    		( !$q->is_main_query() ) || (
+	    			!$q->is_post_type_archive( 'product' ) 
+					&& !$q->is_tax( 'product_cat' ) 
+	    			&& !$q->is_tax( 'product_tag' ) 
+					&& !$q->is_tax($_attributes_array)
+	    		) 
 	    	) 
 	    return;
 
-	    $this->product_query( $q ); 
+	    
+	    $this->product_query( $q );
 	    
 	    // We're on a shop page so queue the woocommerce_get_products_in_view function
 	    add_action('wp', array( &$this, 'get_products_in_view' ), 2);
@@ -56,7 +64,7 @@ class WC_Query {
 		$ordering = $this->get_catalog_ordering_args();
 		
 		// Get a list of post id's which match the current filters set (in the layered nav and price filter)
-		$post__in = array_unique(apply_filters('loop_shop_post_in', array()));  
+		$post__in = array_unique(apply_filters('loop_shop_post_in', array()));
 		
 		// Ordering query vars
 		$q->set( 'orderby', $ordering['orderby'] );
@@ -84,7 +92,7 @@ class WC_Query {
 	/**
 	 * Get an unpaginated list all product ID's (both filtered and unfiltered). Makes use of transients.
 	 */
-	function get_products_in_view() {  
+	function get_products_in_view() {
 		global $wp_query;
 		
 		$unfiltered_product_ids = array();
@@ -97,7 +105,7 @@ class WC_Query {
 		$transient_name = 'woocommerce_unfiltered_product_ids_' . sanitize_key( http_build_query($current_wp_query) );
 		$transient_name = (is_search()) ? $transient_name . '_search' : $transient_name;
 		
-		//if ( false === ( $unfiltered_product_ids = get_transient( $transient_name ) ) ) {
+		if ( false === ( $unfiltered_product_ids = get_transient( $transient_name ) ) ) {
 
 			// Get all visible posts, regardless of filters
 		    $unfiltered_product_ids = get_posts(
@@ -114,11 +122,12 @@ class WC_Query {
 				)
 			);
 		
-			//set_transient( $transient_name, $unfiltered_product_ids );
-		//}
+			set_transient( $transient_name, $unfiltered_product_ids );
+
+		}
 		
 		// Store the variable
-		$this->unfiltered_product_ids = $unfiltered_product_ids; 
+		$this->unfiltered_product_ids = $unfiltered_product_ids;
 		
 		// Also store filtered posts ids...
 		if (sizeof($this->post__in)>0) :

--- a/widgets/widget-layered_nav.php
+++ b/widgets/widget-layered_nav.php
@@ -7,48 +7,59 @@
  * @author		WooThemes
  */
  
-if (is_active_widget( false, false, 'layered_nav', 'true' ) && !is_admin()) :
-	add_action('init', 'woocommerce_layered_nav_init', 1);
+ 
+if (is_active_widget( false, false, 'woocommerce_layered_nav', 'true' ) && !is_admin()) :
+	add_action('parse_query', 'woocommerce_layered_nav_init', 1);
 	add_filter('loop_shop_post_in', 'woocommerce_layered_nav_query');
+	
 endif;
+
 
 /**
  * Layered Nav Init
  */
-function woocommerce_layered_nav_init() {
-	global $_chosen_attributes, $woocommerce;
+function woocommerce_layered_nav_init( ) {
+	global $_chosen_attributes, $woocommerce, $_attributes_array;   
 	
 	$_chosen_attributes = array();
+	$_attributes_array = array();
 	
-	$attribute_taxonomies = $woocommerce->attribute_taxonomies;
-	if ( $attribute_taxonomies ) :
+	$attribute_taxonomies = $woocommerce->attribute_taxonomies;   
+	if ( $attribute_taxonomies ) : 
 		foreach ($attribute_taxonomies as $tax) :
 	    	
 	    	$attribute = strtolower(sanitize_title($tax->attribute_name));
-	    	$taxonomy = $woocommerce->attribute_taxonomy_name($attribute);
+	    	$taxonomy = $woocommerce->attribute_taxonomy_name($attribute);  
+			
+			/* KIA */
+			// create an array of product attribute taxonomies
+			$_attributes_array[] = $taxonomy;
+			/* end KIA */
 	    	$name = 'filter_' . $attribute;
 	    	$query_type_name = 'query_type_' . $attribute;
 	    	
-	    	if (isset($_GET[$name]) && $_GET[$name] && taxonomy_exists($taxonomy)) :
+	    	if (isset($_GET[$name]) && taxonomy_exists($taxonomy)) : 
 	    		$_chosen_attributes[$taxonomy]['terms'] = explode(',', $_GET[$name] );
 	    		if (isset($_GET[$query_type_name]) && $_GET[$query_type_name]=='or') :
 	    			$_chosen_attributes[$taxonomy]['query_type'] = 'or';
 	    		else :
 	    			$_chosen_attributes[$taxonomy]['query_type'] = 'and';
 	    		endif;
-	    	endif;
-	    		
+			/* KIA */
+			elseif ( $taxonomy == get_queried_object()->taxonomy ) :
+				$_chosen_attributes[$taxonomy]['terms'] = array( get_queried_object()->term_id );
+			/* end KIA */
+			endif;
 	    endforeach;    	
-    endif;
-
+    endif;  	
 }
 
 /**
  * Layered Nav post filter
  */
-function woocommerce_layered_nav_query( $filtered_posts ) {
-	global $_chosen_attributes, $woocommerce;
-	
+function woocommerce_layered_nav_query( $filtered_posts ) {  
+	global $_chosen_attributes, $woocommerce, $wp_query; 
+
 	if (sizeof($_chosen_attributes)>0) :
 		
 		$matched_products = array();
@@ -59,7 +70,7 @@ function woocommerce_layered_nav_query( $filtered_posts ) {
 			$matched_products_from_attribute = array();
 			$filtered = false;
 			
-			if (sizeof($data['terms'])>0) :
+			if (sizeof($data['terms'])>0) :  
 				foreach ($data['terms'] as $value) :
 					
 					$posts = get_objects_in_term( $value, $attribute );
@@ -112,8 +123,7 @@ function woocommerce_layered_nav_query( $filtered_posts ) {
 			endif;
 			
 		endif;
-	
-	endif;
+	endif;   
 
 	return (array) $filtered_posts;
 }
@@ -136,88 +146,73 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 		$this->woo_widget_cssclass = 'widget_layered_nav';
 		$this->woo_widget_description = __( 'Shows a custom attribute in a widget which lets you narrow down the list of products when viewing product categories.', 'woocommerce' );
 		$this->woo_widget_idbase = 'woocommerce_layered_nav';
-		$this->woo_widget_name = __('WooCommerce Layered Nav', 'woocommerce' );
+		$this->woo_widget_name = __('WooCommerce Layered Nav', 'marcovaldo' );
 		
 		/* Widget settings. */
 		$widget_ops = array( 'classname' => $this->woo_widget_cssclass, 'description' => $this->woo_widget_description );
 		
 		/* Create the widget. */
-		$this->WP_Widget('layered_nav', $this->woo_widget_name, $widget_ops);
+		$this->WP_Widget('woocommerce_layered_nav', $this->woo_widget_name, $widget_ops);
 	}
 
 	/** @see WP_Widget */
 	function widget( $args, $instance ) {
 		extract($args);
-		
-		if (!is_tax( 'product_cat' ) && !is_post_type_archive('product') && !is_tax( 'product_tag' )) return;
-		
-		global $_chosen_attributes, $woocommerce, $wp_query;
 				
+		global $_chosen_attributes, $woocommerce;
+
+		/* KIA */
+		global $_attributes_array;
+		if ( !is_tax( 'product_cat' ) && !is_post_type_archive('product') && !is_tax( 'product_tag' ) && !in_array(get_query_var('taxonomy'), $_attributes_array ) ) return;
+		
+		$current_term = (is_tax($_attributes_array)) ? get_queried_object()->term_id : NULL;
+		$current_tax = (is_tax($_attributes_array)) ? get_queried_object()->taxonomy: NULL;
+		/* end KIA*/
+					
 		$title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base);
 		$taxonomy 	= $woocommerce->attribute_taxonomy_name($instance['attribute']);
 		$query_type = (isset($instance['query_type'])) ? $instance['query_type'] : 'and';
 		$display_type = (isset($instance['display_type'])) ? $instance['display_type'] : 'list';
 		
-		if (!taxonomy_exists($taxonomy)) return;
+		if (!taxonomy_exists($taxonomy)) return;  
 
 		$args = array(
 			'hide_empty' => '1'
 		);
-		$terms = get_terms( $taxonomy, $args );
+		$terms = get_terms( $taxonomy, $args );  
+
+		/* KIA */
+		//fix get_terms() that aren't sorting properly 
+		usort($terms, array($this, 'kia_term_sort_function'));
+		/* end KIA */
+		
 		$count = count($terms);
 		
-		if($count > 0){
+		if($count > 0){   
 
 			$found = false;
 			ob_start();
 
 			echo $before_widget . $before_title . $title . $after_title;
 			
-			// Force found when option is selected
-			if (is_array($_chosen_attributes) && array_key_exists($taxonomy, $_chosen_attributes)) $found = true;
-				
-			if ($display_type=='dropdown') {
+			if ($display_type=='dropdown') { 
 			
 				$taxonomy_filter = str_replace('pa_', '', $taxonomy);
+				
+				$found = true;
 				
 				echo '<select id="dropdown_layered_nav_'.$taxonomy_filter.'">';
 				
 				echo '<option value="">'. sprintf( __('Any %s', 'woocommerce'), $woocommerce->attribute_label( $taxonomy ) ) .'</option>';
 				
 				foreach ($terms as $term) {
-				
-					// Get count based on current view - uses transients
-					$transient_name = 'woocommerce_layered_nav_count_' . sanitize_key($taxonomy) . sanitize_key( $term->term_id );
 					
-					if ( false === ( $_products_in_term = get_transient( $transient_name ) ) ) {
-			
-						$_products_in_term = get_objects_in_term( $term->term_id, $taxonomy );
+					/* KIA */
+					//if on a term page, skip that term in widget list
+					if( $term->term_id == get_queried_object()->term_id ) continue;
+					/* end KIA */
 					
-						set_transient( $transient_name, $_products_in_term );
-					}
-					
-					$option_is_set = (isset($_chosen_attributes[$taxonomy]) && in_array($term->term_id, $_chosen_attributes[$taxonomy]['terms']));
-					
-					// If this is an AND query, only show options with count > 0
-					if ($query_type=='and') {
-						
-						$count = sizeof(array_intersect($_products_in_term, $woocommerce->query->unfiltered_product_ids));
-	
-						if ($count>0) $found = true;
-					
-						if ($count==0 && !$option_is_set) continue;
-					
-					// If this is an OR query, show all options so search can be expanded
-					} else {
-						
-						$count = sizeof(array_intersect($_products_in_term, $woocommerce->query->unfiltered_product_ids));
-						
-						if ($count>0) $found = true;
-	
-					}
-										
 					echo '<option value="'.$term->term_id.'" '.selected( (isset($_GET['filter_'.$taxonomy_filter])) ? $_GET['filter_'.$taxonomy_filter] : '' , $term->term_id, false).'>'.$term->name.'</option>';
-					
 				}
 					
 				echo '</select>';
@@ -233,11 +228,20 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 				");
 			
 			} else {
-				
+
 				// List display
 				echo "<ul>";
+				
+				// Force found when option is selected
+				if (is_array($_chosen_attributes) && array_key_exists($taxonomy, $_chosen_attributes)) $found = true;  
+//print_r($_chosen_attributes);
 
-				foreach ($terms as $term) {
+				foreach ($terms as $term) { 
+		
+					/* KIA */
+					//if on a term page, skip that term in widget list
+					if( $term->term_id == get_queried_object()->term_id ) continue;
+					/* end KIA */
 					
 					// Get count based on current view - uses transients
 					$transient_name = 'woocommerce_layered_nav_count_' . sanitize_key($taxonomy) . sanitize_key( $term->term_id );
@@ -249,8 +253,16 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 						set_transient( $transient_name, $_products_in_term );
 					}
 					
-					$option_is_set = (isset($_chosen_attributes[$taxonomy]) && in_array($term->term_id, $_chosen_attributes[$taxonomy]['terms']));
+					/* KIA */					
+					//this is adding an additional chosen attribute on tax pages			
+					//change: if there are no terms in array then don't add $taxonomy to array		
+					if (is_array($_chosen_attributes[$taxonomy]['terms'])) { 
+						$_chosen_attributes[$taxonomy]['terms'] = $_chosen_attributes[$taxonomy]['terms'];
+					}
+					/* end KIA */	
 					
+					$option_is_set = (isset($_chosen_attributes[$taxonomy]) && in_array($term->term_id, $_chosen_attributes[$taxonomy]['terms'])); 
+		
 					// If this is an AND query, only show options with count > 0
 					if ($query_type=='and') {
 						
@@ -261,7 +273,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 						if ($count==0 && !$option_is_set) continue;
 					
 					// If this is an OR query, show all options so search can be expanded
-					} else {
+					} else { 
 						
 						$count = sizeof(array_intersect($_products_in_term, $woocommerce->query->unfiltered_product_ids));
 						
@@ -286,15 +298,30 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 						$link = get_post_type_archive_link('product');
 					else :					
 						$link = get_term_link( get_query_var('term'), get_query_var('taxonomy') );
-					endif;
-					
+					endif;   
+			
 					// All current filters
-					if ($_chosen_attributes) foreach ($_chosen_attributes as $name => $data) :
-						if ($name!==$taxonomy) :
-							$link = add_query_arg( strtolower(sanitize_title(str_replace('pa_', 'filter_', $name))), implode(',', $data['terms']), $link );
-							if ($data['query_type']=='or') $link = add_query_arg( strtolower(sanitize_title(str_replace('pa_', 'query_type_', $name))), 'or', $link );
-						endif;
-					endforeach;
+
+					if ($_chosen_attributes) : 	
+					foreach ($_chosen_attributes as $name => $data) : 
+						if ($name!==$taxonomy  ) :  
+							
+							/* KIA */
+							//exclude query arg for current term archive term						
+							while(in_array($current_term, $data['terms'])) {
+								$key = array_search($current_term, $data);
+								unset($data['terms'][$key]);
+							}
+
+							if(!empty($data['terms'])){
+								$link = add_query_arg( strtolower(sanitize_title(str_replace('pa_', 'filter_', $name))), implode(',', $data['terms']), $link );  
+							}
+							/* end KIA */
+							
+							if ($data['query_type']=='or') $link = add_query_arg( strtolower(sanitize_title(str_replace('pa_', 'query_type_', $name))), 'or', $link ); 
+						endif; 
+						endforeach;
+					endif;
 					
 					// Min/Max
 					if (isset($_GET['min_price'])) :
@@ -309,7 +336,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 						$class = 'class="chosen"';
 						
 						// Remove this term is $current_filter has more than 1 term filtered
-						if (sizeof($current_filter)>1) :
+						if (sizeof($current_filter)>1) :  
 							$current_filter_without_this = array_diff($current_filter, array($term->term_id));
 							$link = add_query_arg( $arg, implode(',', $current_filter_without_this), $link );
 						endif;
@@ -352,15 +379,22 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 			echo $after_widget;
 			
 			if (!$found) :
-				ob_clean();
+				ob_clean(); 
 				return;
 			else :
-				$widget = ob_get_clean();
-				echo $widget;
+				$widget = ob_get_clean(); 
+				echo $widget; 
 			endif;
 			
 		}
 	}
+	
+	/** @see WP_Widget->kia_term_sort 
+		used by usort() to fix get_terms() that aren't sorting properly */
+	function kia_term_sort_function($a, $b) {
+		return strcmp($a->name, $b->name);
+	}
+
 	
 	/** @see WP_Widget->update */
 	function update( $new_instance, $old_instance ) {

--- a/widgets/widget-layered_nav.php
+++ b/widgets/widget-layered_nav.php
@@ -163,7 +163,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 
 		/* KIA */
 		global $_attributes_array;
-		if ( !is_tax( 'product_cat' ) && !is_post_type_archive('product') && !is_tax( 'product_tag' ) && !in_array(get_query_var('taxonomy'), $_attributes_array ) ) return;
+		if ( !is_tax( 'product_cat' ) && !is_post_type_archive('product') && !is_tax( 'product_tag' ) && !is_tax($_attributes_array ) ) return;
 		
 		$current_term = (is_tax($_attributes_array)) ? get_queried_object()->term_id : NULL;
 		$current_tax = (is_tax($_attributes_array)) ? get_queried_object()->taxonomy: NULL;

--- a/widgets/widget-layered_nav.php
+++ b/widgets/widget-layered_nav.php
@@ -232,15 +232,16 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 				// List display
 				echo "<ul>";
 				
-				// Force found when option is selected
-				if (is_array($_chosen_attributes) && array_key_exists($taxonomy, $_chosen_attributes)) $found = true;  
-//print_r($_chosen_attributes);
-
+				/* KIA */
+				// Force found when option is selected - do not force found on taxonomy attributes
+				if (!is_tax($_attributes_array) && is_array($_chosen_attributes) && array_key_exists($taxonomy, $_chosen_attributes) && $current_term !== $term->term_id) $found = true;  
+				/* end KIA */
+				
 				foreach ($terms as $term) { 
 		
 					/* KIA */
 					//if on a term page, skip that term in widget list
-					if( $term->term_id == get_queried_object()->term_id ) continue;
+					//if( $term->term_id == get_queried_object()->term_id ) continue;
 					/* end KIA */
 					
 					// Get count based on current view - uses transients
@@ -261,14 +262,19 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 					}
 					/* end KIA */	
 					
-					$option_is_set = (isset($_chosen_attributes[$taxonomy]) && in_array($term->term_id, $_chosen_attributes[$taxonomy]['terms'])); 
-		
+					$option_is_set = (isset($_chosen_attributes[$taxonomy]) && in_array($term->term_id, $_chosen_attributes[$taxonomy]['terms'])) ; 
+	
 					// If this is an AND query, only show options with count > 0
 					if ($query_type=='and') {
 						
 						$count = sizeof(array_intersect($_products_in_term, $woocommerce->query->filtered_product_ids));
-	
-						if ($count>0) $found = true;
+
+						/* KIA */
+						// skip the term for the current archive
+						if ( $current_term == $term->term_id ) continue ; 
+						/* end  KIA */
+						
+						if ($count>0 && $current_term !== $term->term_id ) $found = true;
 					
 						if ($count==0 && !$option_is_set) continue;
 					


### PR DESCRIPTION
i never really know how to do pull requests this properly, so hopefully this is correct procedure.

have been tweaking the filtered nav widget so that it will appear on attribute taxonomy pages.  i'm not 100% sure of the dropdown (or the "or" query for that matter)... but "and" queries and "lists" seem to work.  

see it in action here:
http://www.marcovaldousa.com/material/vinyl/

and here:
http://www.marcovaldousa.com/style/contemporary/

if you're on the vinyl page i've excluded the term vinyl from the list... and for that particular taxonomy, since there are no other terms.... that widget doesn't show.

similarly, on contemporary... contemporary isn't shown under Styles (since we're already there)
