### PR TITLE
Use WP_LANG_DIR constant for path to languages folder

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -307,7 +307,7 @@ class Woocommerce {
 	function load_plugin_textdomain() {
 		// Note: the first-loaded translation file overrides any following ones if the same translation is present
 		$variable_lang = ( get_option( 'woocommerce_informal_localisation_type' ) == 'yes' ) ? 'informal' : 'formal';
-		load_plugin_textdomain( 'woocommerce', false, dirname( plugin_basename( __FILE__ ) ).'/../../languages/woocommerce');
+		load_plugin_textdomain( 'woocommerce', false, WP_LANG_DIR.'/woocommerce');
 		load_plugin_textdomain( 'woocommerce', false, dirname( plugin_basename( __FILE__ ) ).'/languages/'.$variable_lang );
 		load_plugin_textdomain( 'woocommerce', false, dirname( plugin_basename( __FILE__ ) ).'/languages');
 	}


### PR DESCRIPTION
Beats using a relative path.
