### PR TITLE
My Account Force SSL

### DIFF
--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -117,7 +117,7 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 	),
 	
 	array(  
-		'desc' 		=> __( 'Un-force <abbr title="Secure Sockets Layer, a computing protocol that ensures the security of data sent via the Internet by using encryption">SSL</abbr>/HTTPS when leaving the checkout', 'woocommerce' ),
+		'desc' 		=> __( 'Un-force <abbr title="Secure Sockets Layer, a computing protocol that ensures the security of data sent via the Internet by using encryption">SSL</abbr>/HTTPS when leaving the checkout/my account', 'woocommerce' ),
 		'id' 		=> 'woocommerce_unforce_ssl_checkout',
 		'std' 		=> 'no',
 		'type' 		=> 'checkbox',

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -363,8 +363,11 @@ class Woocommerce {
 		if (!is_ssl() && get_option('woocommerce_force_ssl_checkout')=='yes' && is_checkout()) :
 			wp_safe_redirect( str_replace('http:', 'https:', get_permalink(woocommerce_get_page_id('checkout'))), 301 );
 			exit;
-		// Break out of SSL if we leave the checkout (anywhere but thanks page)
-		elseif (is_ssl() && get_option('woocommerce_force_ssl_checkout')=='yes' && get_option('woocommerce_unforce_ssl_checkout')=='yes' && $_SERVER['REQUEST_URI'] && !is_checkout() && !is_page(woocommerce_get_page_id('thanks')) && !is_ajax()) :
+		elseif (!is_ssl() && get_option('woocommerce_force_ssl_checkout')=='yes' && is_account_page()) :
+			wp_safe_redirect( 'https://'.$_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], 301 );
+			exit;
+		// Break out of SSL if we leave the checkout/my accounts (anywhere but thanks)
+		elseif (is_ssl() && get_option('woocommerce_force_ssl_checkout')=='yes' && get_option('woocommerce_unforce_ssl_checkout')=='yes' && $_SERVER['REQUEST_URI'] && !is_checkout() && !is_page(woocommerce_get_page_id('thanks')) && !is_ajax() && !is_account_page()) :
 			
 			if ( 0 === strpos($_SERVER['REQUEST_URI'], 'http') ) {
 				wp_redirect(preg_replace('|^https://|', 'http://', $_SERVER['REQUEST_URI']));


### PR DESCRIPTION
With this minor change the force SSL option forces the My Account pages to be served over HTTPS (so as to secure customer's login), and the unforce SSL option is also modified to allow the My Account pages to be protected.

The only thing is, I left the woocommerce_force_ssl_checkout/woocommerce_unforce_ssl_checkout option names the same even though they are slightly incorrect in my code, as I wasn't sure whether you would want to deal with an upgrade function.
