### PR TITLE
more granular rights on dashboard widgets by role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 logs/
+/nbproject/private/
+project.xml
+project.properties

--- a/admin/woocommerce-admin-dashboard.php
+++ b/admin/woocommerce-admin-dashboard.php
@@ -8,7 +8,7 @@
  */
 
 // Only hook in admin parts if the user has admin access
-if (current_user_can('manage_woocommerce')) :
+if (current_user_can('view_woocommerce_reports') || current_user_can('manage_woocommerce_orders')|| current_user_can('manage_woocommerce')) :
 	add_action('wp_dashboard_setup', 'woocommerce_init_dashboard_widgets' );
 	add_action('admin_footer', 'woocommerce_dashboard_sales_js');
 endif;
@@ -189,10 +189,15 @@ function woocommerce_init_dashboard_widgets() {
 	
 	$sales_heading .= '<a href="index.php?month='.($current_month_offset-1).'" class="previous">&larr; '.date('F', strtotime('01-'.($the_month_num-1).'-2011')).'</a><span>'.__('Monthly Sales', 'woocommerce').'</span>';
 
-	wp_add_dashboard_widget( 'woocommerce_dashboard_right_now', __( 'WooCommerce Right Now', 'woocommerce' ), 'woocommerce_dashboard_widget_right_now' );
-	wp_add_dashboard_widget('woocommerce_dashboard_sales', $sales_heading, 'woocommerce_dashboard_sales');
-	wp_add_dashboard_widget('woocommerce_dashboard_recent_orders', __('WooCommerce Recent Orders', 'woocommerce'), 'woocommerce_dashboard_recent_orders');
-	wp_add_dashboard_widget('woocommerce_dashboard_recent_reviews', __('WooCommerce Recent Reviews', 'woocommerce'), 'woocommerce_dashboard_recent_reviews');
+	if(current_user_can('manage_woocommerce_orders')){
+            wp_add_dashboard_widget( 'woocommerce_dashboard_right_now', __( 'WooCommerce Right Now', 'woocommerce' ), 'woocommerce_dashboard_widget_right_now' );
+            wp_add_dashboard_widget('woocommerce_dashboard_recent_orders', __('WooCommerce Recent Orders', 'woocommerce'), 'woocommerce_dashboard_recent_orders');
+            wp_add_dashboard_widget('woocommerce_dashboard_recent_reviews', __('WooCommerce Recent Reviews', 'woocommerce'), 'woocommerce_dashboard_recent_reviews');
+        }
+	if(current_user_can('view_woocommerce_reports') || current_user_can('manage_woocommerce_orders')){
+            wp_add_dashboard_widget('woocommerce_dashboard_sales', $sales_heading, 'woocommerce_dashboard_sales');
+        }
+        
 } 
 				     		
 /**


### PR DESCRIPTION
When a user is not a woocommerce admin but has access to reports or manage products, they should see the dashboard widgets that support their workflow.
