### PR TITLE
Added option to globally enable/disable the use of coupons

### DIFF
--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -133,7 +133,15 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'type' 		=> 'checkbox',
 		'checkboxgroup'	=> 'start'
 	),
-	
+
+	array(
+		'desc'          => __( 'Enable coupons', 'woocommerce' ),
+		'id'            => 'woocommerce_enable_coupons',
+		'std'           => 'yes',
+		'type'          => 'checkbox',
+		'checkboxgroup' => '',
+	),
+
 	array(  
 		'desc' 		=> __( 'Enable coupon form on checkout', 'woocommerce' ),
 		'id' 		=> 'woocommerce_enable_coupon_form_on_checkout',

--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -135,7 +135,7 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 	),
 
 	array(
-		'desc'          => __( 'Enable coupons', 'woocommerce' ),
+		'desc'          => __( 'Enable the use of coupons', 'woocommerce' ),
 		'id'            => 'woocommerce_enable_coupons',
 		'std'           => 'yes',
 		'type'          => 'checkbox',

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -154,5 +154,14 @@ jQuery(function(){
 		}
 		
 	}).change();
-    
+
+	// Enable/disable the coupon form on checkout checkbox
+	var $woocommerce_enable_coupons = jQuery('#woocommerce_enable_coupons'),
+		$woocommerce_enable_coupon_form_on_checkout = jQuery('#woocommerce_enable_coupon_form_on_checkout'),
+		toggle_woocommerce_enable_coupon_form_on_checkout = function () {
+			$woocommerce_enable_coupon_form_on_checkout.closest('fieldset').attr('disabled', ! $woocommerce_enable_coupons.is(':checked'));
+		};
+	toggle_woocommerce_enable_coupon_form_on_checkout();
+	$woocommerce_enable_coupons.change(toggle_woocommerce_enable_coupon_form_on_checkout);
+
 });

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -68,7 +68,9 @@ class WC_Cart {
 			global $woocommerce;
 			
 			// Load the coupons
-			$this->applied_coupons = (isset($_SESSION['coupons'])) ? array_unique(array_filter((array) $_SESSION['coupons'])) : array();
+			if ( get_option( 'woocommerce_enable_coupons' ) == 'yes' ) {
+				$this->applied_coupons = (isset($_SESSION['coupons'])) ? array_unique(array_filter((array) $_SESSION['coupons'])) : array();
+			}
 			
 			// Load the cart
 			if ( isset($_SESSION['cart']) && is_array($_SESSION['cart']) ) :

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1224,7 +1224,10 @@ class WC_Cart {
 		 */
 		function add_discount( $coupon_code ) {
 			global $woocommerce;
-			
+
+			// Coupons are globally disabled
+			if ( get_option( 'woocommerce_enable_coupons' ) == 'no' ) return false;
+
 			$the_coupon = new WC_Coupon($coupon_code);
 			
 			if ($the_coupon->id) :

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -86,9 +86,13 @@ global $woocommerce;
 		?>
 		<tr>
 			<td colspan="6" class="actions">
-				<div class="coupon">
-					<label for="coupon_code"><?php _e('Coupon', 'woocommerce'); ?>:</label> <input name="coupon_code" class="input-text" id="coupon_code" value="" /> <input type="submit" class="button" name="apply_coupon" value="<?php _e('Apply Coupon', 'woocommerce'); ?>" />
-				</div>
+
+				<?php if ( get_option( 'woocommerce_enable_coupons' ) == 'yes' ) { ?>
+					<div class="coupon">
+						<label for="coupon_code"><?php _e('Coupon', 'woocommerce'); ?>:</label> <input name="coupon_code" class="input-text" id="coupon_code" value="" /> <input type="submit" class="button" name="apply_coupon" value="<?php _e('Apply Coupon', 'woocommerce'); ?>" />
+					</div>
+				<?php } ?>
+
 				<?php $woocommerce->nonce_field('cart') ?>
 				<input type="submit" class="button" name="update_cart" value="<?php _e('Update Cart', 'woocommerce'); ?>" /> <a href="<?php echo esc_url( $woocommerce->cart->get_checkout_url() ); ?>" class="checkout-button button alt"><?php _e('Proceed to Checkout &rarr;', 'woocommerce'); ?></a>
 				<?php do_action('woocommerce_proceed_to_checkout'); ?>

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -2,7 +2,7 @@
 /**
  * Checkout Coupon Form
  */
-if (get_option('woocommerce_enable_coupon_form_on_checkout')=="no") return;
+if ( get_option( 'woocommerce_enable_coupons' ) == 'no' || get_option( 'woocommerce_enable_coupon_form_on_checkout' ) == 'no' ) return;
 
 $info_message = apply_filters('woocommerce_checkout_coupon_message', __('Have a coupon?', 'woocommerce'));
 ?>

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -590,7 +590,10 @@ function woocommerce_process_login() {
  **/
 function woocommerce_process_coupon_form() {
 	global $woocommerce;
-	
+
+	// Do nothing if coupons are globally disabled
+	if ( get_option( 'woocommerce_enable_coupons' ) == 'no' ) return;
+
 	if (isset($_POST['coupon_code']) && $_POST['coupon_code']) :
 	
 		$coupon_code = stripslashes(trim($_POST['coupon_code']));


### PR DESCRIPTION
One checkbox added in the admin. By disabling coupons globally, the coupon form(s) get hidden and no coupon discounts will be calculated in the cart.

Needed to implement this for a client. I think this is a useful feature.
