### PR TITLE
Force the tax row to show up even if no taxes are applicable

### DIFF
--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -824,6 +824,14 @@ $woocommerce_settings['tax'] = apply_filters('woocommerce_tax_settings', array(
 		'checkboxgroup'		=> ''
 	),
 
+	array(
+		'desc'          => __( 'Also display tax row if no taxes are applicable', 'woocommerce' ),
+		'id'            => 'woocommerce_display_cart_taxes_if_zero',
+		'std'           => 'no',
+		'type'          => 'checkbox',
+		'checkboxgroup' => '',
+	),
+
 	array(  
 		'desc' 		=> __( 'Round tax at subtotal level, instead of per line', 'woocommerce' ),
 		'id' 		=> 'woocommerce_tax_round_at_subtotal',

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -504,7 +504,9 @@ class WC_Order {
 				$total_rows[ $woocommerce->countries->tax_or_vat() ] = woocommerce_price($this->get_total_tax());
 			
 			endif;
-			
+
+		else:
+			$total_rows[ $woocommerce->countries->tax_or_vat() ] = _x( 'NA', 'Relating to tax', 'woocommerce' );
 		endif;
 		
 		if ($this->get_order_discount() > 0)

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -505,7 +505,7 @@ class WC_Order {
 			
 			endif;
 
-		else:
+		elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) :
 			$total_rows[ $woocommerce->countries->tax_or_vat() ] = _x( 'NA', 'Relating to tax', 'woocommerce' );
 		endif;
 		

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -143,12 +143,21 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 					
 						?>
 						<tr class="tax">
-							<th colspan="2"><?php _e('Tax', 'woocommerce'); ?></th>
+							<th colspan="2"><?php echo $woocommerce->countries->tax_or_vat(); ?></th>
 							<td><?php echo $woocommerce->cart->get_cart_tax(); ?></td>
 						</tr>
 						<?php
 					
 					endif;	
+				else :
+				?>
+
+					<tr class="tax">
+						<th colspan="2"><?php echo $woocommerce->countries->tax_or_vat(); ?></th>
+						<td><?php _ex( 'NA', 'Relating to tax', 'woocommerce' ); ?></td>
+					</tr>
+
+				<?php
 				endif;
 			?>
 

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -149,7 +149,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						<?php
 					
 					endif;	
-				else :
+				elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) :
 				?>
 
 					<tr class="tax">


### PR DESCRIPTION
Currently, if no taxes apply, the tax/vat row is hidden. On invoices it is required to display taxes (even if zero), at least in Belgium. I added an option to still display the tax row, even if no taxes apply.
