### PR TITLE
add_to_cart signature change

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -531,13 +531,13 @@ class WC_Cart {
 		 * @param   int     variation_id
 		 * @param   array   variation attribute values
 		 */
-		function add_to_cart( $product_id, $quantity = 1, $variation_id = '', $variation = '' ) {
+		function add_to_cart( $product_id, $quantity = 1, $variation_id = '', $variation = '', $cart_item_data = array() ) {
 			global $woocommerce;
 			
 			if ($quantity < 1) return false;
 			
 			// Load cart item data - may be added by other plugins
-			$cart_item_data = (array) apply_filters('woocommerce_add_cart_item_data', array(), $product_id);
+			$cart_item_data = (array) apply_filters('woocommerce_add_cart_item_data', $cart_item_data, $product_id);
 			
 			// Generate a ID based on product ID, variation ID, variation data, and other cart item data
 			$cart_id = $this->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );


### PR DESCRIPTION
Allows code to manually call $woocommerce->cart->add_to_cart  and pass in additional cart item data that has already been set by the calling code.  Provides for a more straight forward to create additional cart item data when authoring custom add-to-cart handlers. 
