### PR TITLE
Smarter toggling of the metabox for variations

### DIFF
--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -568,7 +568,10 @@ jQuery( function($){
 		});
 		
 		// Open/close
-		jQuery('.wc-metaboxes-wrapper').on('click', '.wc-metabox h3', function(){
+		jQuery('.wc-metaboxes-wrapper').on('click', '.wc-metabox h3', function(event){
+			// If the user clicks on some form input inside the h3, like a select list (for variations), the box should not be toggled
+			if ($(event.target).is(':input')) return;
+
 			jQuery(this).next('.wc-metabox-content').toggle();
 		});
 		


### PR DESCRIPTION
The metabox h3 rows for variations contain select lists. When you click a select list, the event bubbles up to the h3 meaning that both the select list will expand as well as the box. You are basically triggering two things while you only wanted to interact with the select list.
