### PR TITLE
Added class for available on backorder.

### DIFF
--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -422,6 +422,7 @@ class WC_Product {
 					if ($this->backorders_allowed()) :
 						if ($this->backorders_require_notification()) :
 							$availability = __('Available on backorder', 'woocommerce');
+							$class = 'available-on-backorder';
 						else :
 							$availability = __('In stock', 'woocommerce');
 						endif;
@@ -434,6 +435,7 @@ class WC_Product {
 			else :
 				if ($this->backorders_allowed()) :
 					$availability = __('Available on backorder', 'woocommerce');
+					$class = 'available-on-backorder';
 				else :
 					$availability = __('Out of stock', 'woocommerce');
 					$class = 'out-of-stock';


### PR DESCRIPTION
This will help in cases where the user wants to hide the # of items in stock, but still wants to show when an item is out of stock, or on backorder.

Currently there is no way of differentiating in CSS between an in-stock item, and an item that is out of stock but available on backorder, since no additional classes are added for a backordered item.
