### PR TITLE
Fix metabox toggle

### DIFF
--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -570,7 +570,7 @@ jQuery( function($){
 		// Open/close
 		jQuery('.wc-metaboxes-wrapper').on('click', '.wc-metabox h3', function(event){
 			// If the user clicks on some form input inside the h3, like a select list (for variations), the box should not be toggled
-			if ($(event.target).is(':input')) return;
+			if ($(event.target).filter(':input, option').length) return;
 
 			jQuery(this).next('.wc-metabox-content').toggle();
 		});


### PR DESCRIPTION
Follow-up to 47f57504bdfb43d0672e811f91a6412ce77cbb29 #814

Turns out clicking an `option` element does not get matched by jQuery's `:input` selector, `select` does. So, the old fix was only working partially. I'm on Firefox mac.
