### PR TITLE
Added a custom event for when the variation select lists are updated.

### DIFF
--- a/assets/js/woocommerce.js
+++ b/assets/js/woocommerce.js
@@ -366,6 +366,9 @@ jQuery(document).ready(function($) {
 	        }
         	
         });
+
+		// Custom event for when variations have been updated
+		$(document).trigger('woocommerce_update_variation_values');
         
     }
     


### PR DESCRIPTION
This seems like the cleanest way of letting other scripts know when the variation selects are updated. I need this because I've customized some select list via javascript (with image popup and stuff). The problem is that the disabled state of some options changes depending on the chosen attributes. Simply binding my script to 'focus' or 'change' events of the select list doesn't work since variation check by woocommerce.js still happens a tad later.
