### PR TITLE
Allow date for sales by day statistics to be changed

### DIFF
--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -567,7 +567,7 @@ function woocommerce_daily_sales() {
 	
 	?>
 	<form method="post" action="">
-		<p><label for="from"><?php _e('From:', 'woocommerce'); ?></label> <input type="text" name="start_date" id="from" readonly="readonly" value="<?php echo esc_attr( date('Y-m-d', $start_date) ); ?>" /> <label for="to"><?php _e('To:', 'woocommerce'); ?></label> <input type="text" name="end_date" id="to" readonly="readonly" value="<?php echo esc_attr( date('Y-m-d', $end_date) ); ?>" /> <input type="submit" class="button" value="<?php _e('Show', 'woocommerce'); ?>" /></p>
+		<p><label for="from"><?php _e('From:', 'woocommerce'); ?></label> <input type="text" name="start_date" id="from" value="<?php echo esc_attr( date('Y-m-d', $start_date) ); ?>" /> <label for="to"><?php _e('To:', 'woocommerce'); ?></label> <input type="text" name="end_date" id="to" value="<?php echo esc_attr( date('Y-m-d', $end_date) ); ?>" /> <input type="submit" class="button" value="<?php _e('Show', 'woocommerce'); ?>" /></p>
 	</form>
 	
 	<div id="poststuff" class="woocommerce-reports-wrap">


### PR DESCRIPTION
I have no idea why those fields were set to readonly.

(By the way, the graphs on the same pages are not loaded. JavaScript error: jQuery.plot is not a function. Haven't investigated further.)
