### PR TITLE
Added two hooks to insert content inside the cart form but outside the table

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -9,6 +9,7 @@ global $woocommerce;
 <?php $woocommerce->show_messages(); ?>
 
 <form action="<?php echo esc_url( $woocommerce->cart->get_cart_url() ); ?>" method="post">
+<?php do_action( 'woocommerce_before_cart_table' ); ?>
 <table class="shop_table cart" cellspacing="0">
 	<thead>
 		<tr>
@@ -102,6 +103,7 @@ global $woocommerce;
 		<?php do_action( 'woocommerce_after_cart_contents' ); ?>
 	</tbody>
 </table>
+<?php do_action( 'woocommerce_after_cart_table' ); ?>
 </form>
 <div class="cart-collaterals">
 	


### PR DESCRIPTION
This allows for extra flexibility when you need to add custom input fields to the cart that don't belong in the cart contents table.
