### PR TITLE
My approach to fix #914

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_downloads.php
+++ b/admin/post-types/writepanels/writepanel-order_downloads.php
@@ -259,16 +259,28 @@ function woocommerce_order_downloads_save( $post_id, $post ) {
 		$customer_user = (int) get_post_meta($post->ID, '_customer_user', true);
 
 		for ($i=0; $i<sizeof($download_ids); $i++) :
-			
-			$wpdb->update( $wpdb->prefix . "woocommerce_downloadable_product_permissions", array( 
+
+            $data = array(
 				'user_id'				=> $customer_user,
 				'user_email' 			=> $customer_email,
 				'downloads_remaining'	=> $downloads_remaining[$i],
-				'access_expires'		=> ($access_expires[$i]) ? date('Y-m-d', strtotime($access_expires[$i])) : ''
-			), array( 
+            );
+
+            $format = array( '%d', '%s', '%s');
+
+            $expiry  = array_key_exists($i, $access_expires) ? date('Y-m-d', strtotime($access_expires[$i])) : null;
+
+            if ( ! is_null($expiry)) {
+                $data['access_expires'] = $expiry;
+                $format[] = '%s';
+            }
+
+            $wpdb->update( $wpdb->prefix . "woocommerce_downloadable_product_permissions",
+			    $data,
+                array( 
 				'order_id' 		=> $post_id,
 				'product_id' 	=> $download_ids[$i] 
-			), array( '%d', '%s', '%s', '%s' ), array( '%d', '%d' ) );
+			), $format, array( '%d', '%d' ) );
 			
 		endfor;
 		

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -591,33 +591,45 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 				$limit = trim(get_post_meta($download_id, '_download_limit', true));
 				$expiry = trim(get_post_meta($download_id, '_download_expiry', true));
 				
-				$limit = (empty($limit)) ? '' : (int) $limit;
-				$expiry = (empty($expiry)) ? '' : (int) $expiry;
+                $limit = (empty($limit)) ? '' : (int) $limit;
+
+                // Default value is NULL in the table schema
+				$expiry = (empty($expiry)) ? null : (int) $expiry;
 				
 				if ($expiry) $expiry = date("Y-m-d", strtotime('NOW + ' . $expiry . ' DAY'));
-				
-				// Downloadable product - give access to the customer
-				$wpdb->insert( $wpdb->prefix . 'woocommerce_downloadable_product_permissions', array( 
-					'product_id' 			=> $download_id, 
+
+                $data = array(
+					'product_id' 			=> $download_id,
 					'user_id' 				=> $order->user_id,
 					'user_email' 			=> $user_email,
 					'order_id' 				=> $order->id,
 					'order_key' 			=> $order->order_key,
 					'downloads_remaining' 	=> $limit,
 					'access_granted'		=> current_time('mysql'),
-					'access_expires'		=> $expiry,
 					'download_count'		=> 0
-				), array( 
+                );
+
+                $format = array(
 					'%s', 
 					'%s', 
 					'%s', 
 					'%s', 
-					'%s',
 					'%s',
 					'%s',
 					'%s',
 					'%d'
-				) );	
+                );
+
+                if ( ! is_null($expiry)) {
+                    $data['access_expires'] = $expiry;
+                    $format[] = '%s';
+                }
+
+				// Downloadable product - give access to the customer
+                $wpdb->insert( $wpdb->prefix . 'woocommerce_downloadable_product_permissions', 
+                    $data,
+                    $format
+                );	
 				
 			endif;
 			


### PR DESCRIPTION
This is only to show the approach I used to fix https://github.com/woothemes/woocommerce/issues/914

If access_expires is null, I remove that piece of data form the call to $wpdb->insert() and $wpdb->update().  I grepped the code with ack to find the instances where these calls are made, and tested on my environment.

HTH
