### PR TITLE
Assign a specific class to root level UL element for css targeting

### DIFF
--- a/widgets/widget-product_categories.php
+++ b/widgets/widget-product_categories.php
@@ -111,7 +111,7 @@ class WooCommerce_Widget_Product_Categories extends WP_Widget {
 			$cat_args['current_category']	= ( $this->current_cat ) ? $this->current_cat->term_id : '';
 			$cat_args['current_category_ancestors']	= $this->cat_ancestors;
 			
-			echo '<ul>';
+			echo '<ul class="product-categories">';
 			
 			wp_list_categories( apply_filters( 'woocommerce_product_categories_widget_args', $cat_args ) );
 			


### PR DESCRIPTION
Assign a specific class to root level UL element for css targeting (without select all sub UL elements). A better solution would be to apply a filter or give the user an option, but this is considerably better than just having a plain UL element.
