### PR TITLE
Fixing "Billing & Shipping" & "no shipping methods" Bugs

### DIFF
--- a/templates/cart/totals.php
+++ b/templates/cart/totals.php
@@ -199,7 +199,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 			printf(__('Note: Shipping and taxes are estimated%s and will be updated during checkout based on your billing and shipping information.', 'woocommerce'), $estimated_text ); 
 		?></small></p>
 	
-	<?php else : ?>
+	<?php elseif( $woocommerce->cart->needs_shipping() ) : ?>
 		
 		<?php if ( ! $woocommerce->customer->get_shipping_state() || ! $woocommerce->customer->get_shipping_postcode() ) : ?>
 		

--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -5,7 +5,7 @@
 global $woocommerce;
 ?>
 
-<?php if ($woocommerce->cart->ship_to_billing_address_only()) : ?>
+<?php if ( $woocommerce->cart->ship_to_billing_address_only() && $woocommerce->cart->needs_shipping() ) : ?>
 	
 	<h3><?php _e('Billing &amp; Shipping', 'woocommerce'); ?></h3>
 	

--- a/widgets/widget-product_categories.php
+++ b/widgets/widget-product_categories.php
@@ -105,7 +105,7 @@ class WooCommerce_Widget_Product_Categories extends WP_Widget {
 			
 			$cat_args['walker'] 			= new WC_Product_Cat_List_Walker;
 			$cat_args['title_li'] 			= '';
-			$cat_args['show_children_only']	= ( $instance['show_children_only'] ) ? 1 : 0;
+			$cat_args['show_children_only']	= ( isset( $instance['show_children_only'] ) && $instance['show_children_only'] ) ? 1 : 0;
 			$cat_args['pad_counts'] 		= 1;
 			$cat_args['show_option_none'] 	= __('No product categories exist.', 'woocommerce');
 			$cat_args['current_category']	= ( $this->current_cat ) ? $this->current_cat->term_id : '';


### PR DESCRIPTION
If the _"Only ship to the users billing address"_ admin option is set to true, the checkout form displays "Billing & Shipping". Even when a cart contains only virtual goods and does not require shipping. 

Also, when on the cart page, even if the cart doesn't need shipping, the _"no available shipping methods"_ warnings are displayed. 

This pull request fixes these (and a PHP notice for undefined index). :)
