### PR TITLE
Checkout Payment Box JS Tweak

### DIFF
--- a/assets/js/woocommerce.js
+++ b/assets/js/woocommerce.js
@@ -626,7 +626,7 @@ jQuery(document).ready(function($) {
 		}
 		
 		$('.payment_methods input.input-radio').live('click', function(){
-			$('div.payment_box').hide();
+			$('div.payment_box').filter(':visible').slideUp();
 			if ($(this).is(':checked')) {
 				$('div.payment_box.' + $(this).attr('ID')).slideDown();
 			}


### PR DESCRIPTION
Currently when selecting a new payment method on the checkout page, the payment description box of the existing payment method is instantly hidden. This patch slides the displayed payment box up and slides down the new box in its place. 

A very minor aesthetic patch, merge or delete at your discretion. :)
