### PR TITLE
Product searchform template

### DIFF
--- a/templates/widgets/product-searchform.php
+++ b/templates/widgets/product-searchform.php
@@ -1,0 +1,8 @@
+<form role="search" method="get" id="searchform" action="<?php echo esc_url( home_url() ); ?>">
+	<div>
+		<label class="screen-reader-text" for="s"><?php _e('Search for:', 'woocommerce'); ?></label>
+		<input type="text" value="<?php the_search_query(); ?>" name="s" id="s" placeholder="<?php esc_attr_e('Search for products', 'woocommerce'); ?>" />
+		<input type="submit" id="searchsubmit" value="<?php esc_attr_e('Search', 'woocommerce'); ?>" />
+		<input type="hidden" name="post_type" value="product" />
+	</div>
+</form>

--- a/widgets/widget-product_search.php
+++ b/widgets/widget-product_search.php
@@ -46,8 +46,8 @@ class WooCommerce_Widget_Product_Search extends WP_Widget {
 		<form role="search" method="get" id="searchform" action="<?php echo esc_url( home_url() ); ?>">
 			<div>
 				<label class="screen-reader-text" for="s"><?php _e('Search for:', 'woocommerce'); ?></label>
-				<input type="text" value="<?php the_search_query(); ?>" name="s" id="s" placeholder="<?php _e('Search for products', 'woocommerce'); ?>" />
-				<input type="submit" id="searchsubmit" value="<?php _e('Search', 'woocommerce'); ?>" />
+				<input type="text" value="<?php the_search_query(); ?>" name="s" id="s" placeholder="<?php esc_attr_e('Search for products', 'woocommerce'); ?>" />
+				<input type="submit" id="searchsubmit" value="<?php esc_attr_e('Search', 'woocommerce'); ?>" />
 				<input type="hidden" name="post_type" value="product" />
 			</div>
 		</form>

--- a/widgets/widget-product_search.php
+++ b/widgets/widget-product_search.php
@@ -41,17 +41,7 @@ class WooCommerce_Widget_Product_Search extends WP_Widget {
 		echo $before_widget;
 		
 		if ($title) echo $before_title . $title . $after_title;
-		
-		?>
-		<form role="search" method="get" id="searchform" action="<?php echo esc_url( home_url() ); ?>">
-			<div>
-				<label class="screen-reader-text" for="s"><?php _e('Search for:', 'woocommerce'); ?></label>
-				<input type="text" value="<?php the_search_query(); ?>" name="s" id="s" placeholder="<?php esc_attr_e('Search for products', 'woocommerce'); ?>" />
-				<input type="submit" id="searchsubmit" value="<?php esc_attr_e('Search', 'woocommerce'); ?>" />
-				<input type="hidden" name="post_type" value="product" />
-			</div>
-		</form>
-		<?php
+		woocommerce_get_template( 'widgets/product-searchform.php' );
 		
 		echo $after_widget;
 	}


### PR DESCRIPTION
The markup can be overridden now by a theme file, just like [`get_search_form`](http://codex.wordpress.org/Function_Reference/get_search_form).
