### PR TITLE
Replacing deprecated get_current_theme()

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -424,8 +424,9 @@ class Woocommerce {
 	 * Add body classes
 	 **/
 	function wp_head() {
-		$this->add_body_class('theme-' . strtolower( get_current_theme() ));
-	
+		$theme_name = ( function_exists( 'wp_get_theme' ) ) ? wp_get_theme() : get_current_theme();
+		$this->add_body_class( 'theme-' . strtolower( $theme_name ) );
+
 		if ( is_woocommerce() ) $this->add_body_class('woocommerce');
 		
 		if ( is_checkout() ) $this->add_body_class('woocommerce-checkout');


### PR DESCRIPTION
The get_current_theme() is being deprecated in WP 3.4, this patch uses the newer wp_get_theme() when it exists (with fallback to get_current_theme() for backward compatability).
