### PR TITLE
WooCommerce <body> classes should be sanitised

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -424,7 +424,7 @@ class Woocommerce {
 	 * Add body classes
 	 **/
 	function wp_head() {
-		$this->add_body_class('theme-' . strtolower( get_current_theme() ));
+		$this->add_body_class('theme-' . get_current_theme() );
 	
 		if ( is_woocommerce() ) $this->add_body_class('woocommerce');
 		
@@ -1354,7 +1354,7 @@ class Woocommerce {
 	/** Body Classes **********************************************************/
 	
 	function add_body_class( $class ) {
-		$this->_body_classes[] = $class;
+		$this->_body_classes[] = sanitize_html_class( strtolower($class) );
 	}
 	
 	function output_body_class( $classes ) {


### PR DESCRIPTION
Currently, WP theme names that contain spaces and other strange characters cause problem with the `<body>` classes that are added.

For example, Twenty Eleven currently outputs these classes (note the space between "theme-twenty" and "eleven"):

`<body class="home blog logged-in single-author two-column right-sidebar theme-twenty eleven">`

After this change is applied, we get:

`<body class="home blog logged-in single-author two-column right-sidebar theme-twentyeleven">`

This change also ensures that any other WooCommerce body classes are correct sanitised/filtered before being output.
