### PR TITLE
New WC_Order Class Formatting Filters & Function

### DIFF
--- a/admin/post-types/shop_order.php
+++ b/admin/post-types/shop_order.php
@@ -113,7 +113,7 @@ function woocommerce_custom_order_columns($column) {
         	endif;
 		break;
 		case "total_cost" :
-			echo woocommerce_price($order->order_total);
+			echo $order->get_formatted_order_total();
 		break;
 		case "order_date" :
 		

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -551,7 +551,7 @@ class WC_Order {
 		if ( $this->get_order_discount() > 0 )
 			$total_rows[ __( 'Order Discount:', 'woocommerce' ) ] = '-' . woocommerce_price( $this->get_order_discount() );
 		
-		$total_rows[ __( 'Order Total:', 'woocommerce' ) ] = woocommerce_price( $this->get_order_total() );
+		$total_rows[ __( 'Order Total:', 'woocommerce' ) ] = $this->get_formatted_order_total();
 		
 		return apply_filters( 'woocommerce_get_order_item_totals', $total_rows, $this );
 	}

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -377,7 +377,16 @@ class WC_Order {
 		else :
 			$subtotal = woocommerce_price( $this->get_line_subtotal( $item, true ) );
 		endif;
-		return $subtotal;
+
+		return apply_filters( 'woocommerce_order_formatted_line_subtotal', $subtotal, $item, $this );
+	}
+	
+	/** Gets order total - formatted for display */
+	function get_formatted_order_total() {
+
+		$fomatted_total = woocommerce_price( $this->order_total );
+
+		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this );
 	}
 	
 	/** Gets subtotal - subtotal is shown before discounts, but with localised taxes */

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -384,7 +384,7 @@ class WC_Order {
 	/** Gets order total - formatted for display */
 	function get_formatted_order_total() {
 
-		$fomatted_total = woocommerce_price( $this->order_total );
+		$formatted_total = woocommerce_price( $this->order_total );
 
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this );
 	}

--- a/shortcodes/shortcode-pay.php
+++ b/shortcodes/shortcode-pay.php
@@ -79,7 +79,7 @@ function woocommerce_pay() {
 					</li>
 					<li class="total">
 						<?php _e('Total:', 'woocommerce'); ?>
-						<strong><?php echo woocommerce_price($order->order_total); ?></strong>
+						<strong><?php echo $order->get_formatted_order_total(); ?></strong>
 					</li>
 					<?php if ($order->payment_method_title) : ?>
 					<li class="method">

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -42,7 +42,7 @@ global $woocommerce;
 			</li>
 			<li class="total">
 				<?php _e('Total:', 'woocommerce'); ?>
-				<strong><?php echo woocommerce_price($order->order_total); ?></strong>
+				<strong><?php echo $order->get_formatted_order_total(); ?></strong>
 			</li>
 			<?php if ($order->payment_method_title) : ?>
 			<li class="method">

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -35,18 +35,7 @@ foreach ($items as $item) :
 					
 		?></td>
 		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $item['qty'] ;?></td>
-		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php
-					
-			// Tax
-			if ( $order->display_cart_ex_tax || !$order->prices_include_tax ) :	
-				$ex_tax_label = ( $order->prices_include_tax ) ? 1 : 0;
-				echo woocommerce_price( $order->get_line_subtotal( $item ), array('ex_tax_label' => $ex_tax_label ));
-			else :
-				echo woocommerce_price( $order->get_line_subtotal( $item, true ) );
-			endif;
-					
-		?></td>
-	
+		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
 	</tr>
 	
 	<?php if ($show_purchase_note && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true)) : ?>

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -44,7 +44,7 @@ if ($customer_orders) :
 						<a href="<?php echo esc_url( add_query_arg('order', $order->id, get_permalink(woocommerce_get_page_id('view_order'))) ); ?>"><?php echo $order->get_order_number(); ?></a> &ndash; <time title="<?php echo esc_attr( strtotime($order->order_date) ); ?>"><?php echo date_i18n(get_option('date_format'), strtotime($order->order_date)); ?></time>
 					</td>
 					<td class="order-shipto"><address><?php if ($order->get_formatted_shipping_address()) echo $order->get_formatted_shipping_address(); else echo '&ndash;'; ?></address></td>
-					<td class="order-total" width="1%"><?php echo woocommerce_price($order->order_total); ?></td>
+					<td class="order-total" width="1%"><?php echo $order->get_formatted_order_total(); ?></td>
 					<td class="order-status" style="text-align:left; white-space:nowrap;">
 						<?php echo ucfirst( __( $status->name, 'woocommerce' ) ); ?>
 						<?php if (in_array($order->status, array('pending', 'failed'))) : ?>


### PR DESCRIPTION
- Adding `"woocommerce_order_formatted_line_subtotal"` filter to `get_formatted_line_subtotal()` function. 
- Adding new `WC_Order::get_formatted_order_total()` function to centralise order total formatting and provide a central filter for order total. 
- Replacing all instances of `woocommerce_price($order->order_total)` with new `WC_Order::get_formatted_order_total()` function.
