### PR TITLE
Better shipping class lookup for products

### DIFF
--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -47,6 +47,7 @@ class WC_Product {
 	var $max_variation_sale_price;
 	var $featured;
 	var $shipping_class;
+	var $shipping_classes;
 	var $dimensions;
 	
 	/**
@@ -768,12 +769,34 @@ class WC_Product {
 	}
 	
 	/** Returns the product shipping class */
+	/** Deprecated: use get_shipping_classes instead */
 	function get_shipping_class() {
 		if (!$this->shipping_class) :
 			$classes = get_the_terms( $this->id, 'product_shipping_class' );
 			if ($classes && !is_wp_error($classes)) $this->shipping_class = current($classes)->slug; else $this->shipping_class = '';
 		endif;
 		return $this->shipping_class;
+	}
+	
+	/**
+	 * Returns all the shipping classes for the product.
+	 *
+	 * @return array of product_shipping_class term objects
+	 */
+	function get_shipping_classes() {
+		// Return from cache if possible
+		if ( $this->shipping_classes !== NULL )
+			return $this->shipping_classes;
+
+		// Load all shipping classes
+		$this->shipping_classes = get_the_terms( $this->id, 'product_shipping_class' );
+
+		// Always return an array, also if no shipping classes were found
+		if ( ! $this->shipping_classes ) {
+			$this->shipping_classes = array();
+		}
+
+		return $this->shipping_classes;
 	}
 	
 	/** Get and return related products */


### PR DESCRIPTION
The current `get_shipping_class()` method doesn't cut it.
1. It only returns a single shipping class (the first one), while you can set multiple shipping classes in the admin.
2. It only returns the slug. What if I need the term ID? Looking up the term by slug again is wasteful.

I created a new `get_shipping_classes()` method which solves both issues. It returns an array containing _all_ shipping classes as term _objects_.
