### PR TITLE
fixed a typo

### DIFF
--- a/languages/woocommerce-it_IT.po
+++ b/languages/woocommerce-it_IT.po
@@ -2428,7 +2428,7 @@ msgstr "rintraccia-ordine"
 #: admin/woocommerce-admin-install.php:159
 #@ woocommerce
 msgid "Track your order"
-msgstr "Rintraccia il uo ordine"
+msgstr "Rintraccia il tuo ordine"
 
 #: admin/woocommerce-admin-install.php:162
 #@ woocommerce


### PR DESCRIPTION
i fixed a very visible typo in the main menu: "rintraccia il tuo ordine" rather than "rintraccia il uo ordine"
