### PR TITLE
Add WooCommerce Products to Appearance->Menus

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -774,7 +774,7 @@ class Woocommerce {
 				'query_var' 			=> true,			
 				'supports' 				=> array( 'title', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes' ),
 				'has_archive' 			=> $base_slug,
-				'show_in_nav_menus' 	=> false
+				'show_in_nav_menus' 	=> true
 			)
 		);
 		


### PR DESCRIPTION
After making my second WooCommerce site I realised that it's not easy to add WooCommerce products to WordPress menus. We had to use Custom Links in the Menus as an alternative. As Products are a custom post type this can be easily resolved with this patch.

Obviously the user will also need to click on Screen Options and tick Products for them to show on the Appearance Menus screen
