### PR TITLE
Add product revisions and fix the background color in Product Short Description

### DIFF
--- a/admin/post-types/writepanels/writepanels-init.php
+++ b/admin/post-types/writepanels/writepanels-init.php
@@ -108,7 +108,7 @@ function woocommerce_product_short_description_meta_box( $post ) {
 		'textarea_name'	=> 'excerpt',
 		'quicktags' 	=> true,
 		'tinymce' 		=> true,
-		'editor_css'	=> '<style>#wp-excerpt-editor-container .wp-editor-area{height:175px; width:100%;}</style>'
+		'editor_css'	=> '<style>#wp-excerpt-editor-container .wp-editor-area{height:175px; width:100%;}.wp_themeSkin iframe {background-color: #fff;}</style>'
 		);
 		
 	wp_editor( htmlspecialchars_decode( $post->post_excerpt ), 'excerpt', $settings );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -772,7 +772,7 @@ class Woocommerce {
 				'hierarchical' 			=> false, // Hierarcal causes memory issues - WP loads all records!
 				'rewrite' 				=> array( 'slug' => $product_base, 'with_front' => false, 'feeds' => $base_slug ),
 				'query_var' 			=> true,			
-				'supports' 				=> array( 'title', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes' ),
+				'supports' 				=> array( 'title', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions' ),
 				'has_archive' 			=> $base_slug,
 				'show_in_nav_menus' 	=> true
 			)


### PR DESCRIPTION
After doing some client training today we realised that it's pretty important to have Product revisions enabled by default.

I also did a "quick" CSS tweak to make the background color of the wp_editor white in the Visual tab of the  Product Short Description as it was grey.
