### PR TITLE
Use WC_Order's method to display order number.

### DIFF
--- a/admin/post-types/shop_order.php
+++ b/admin/post-types/shop_order.php
@@ -77,7 +77,7 @@ function woocommerce_custom_order_columns($column) {
            		$user = __('Guest', 'woocommerce');
            	endif;
            	
-           	echo '<a href="'.admin_url('post.php?post='.$post->ID.'&action=edit').'"><strong>'.sprintf( __('Order #%s', 'woocommerce'), $post->ID ).'</strong></a> ' . __('made by', 'woocommerce') . ' ' . $user;
+           	echo '<a href="'.admin_url('post.php?post='.$post->ID.'&action=edit').'"><strong>'.sprintf( __('Order #%s', 'woocommerce'), $order->get_order_number() ).'</strong></a> ' . __('made by', 'woocommerce') . ' ' . $user;
            	
            	if ($order->billing_email) :
         		echo '<small class="meta">'.__('Email:', 'woocommerce') . ' ' . '<a href="' . esc_url( 'mailto:'.$order->billing_email ).'">'.esc_html( $order->billing_email ).'</a></small>';


### PR DESCRIPTION
In `woocommerce_custom_order_columns()`, should use the `get_order_number()` method from `WC_Order` class to display order number because it contains the `woocommerce_order_number` filter.

I am working on a sequential order number plugin and this would be very helpful.
