### PR TITLE
Filtering Available Gateways

### DIFF
--- a/classes/gateways/class-wc-payment-gateways.php
+++ b/classes/gateways/class-wc-payment-gateways.php
@@ -68,7 +68,7 @@ class WC_Payment_Gateways {
 			
 		endforeach;
 
-		return $_available_gateways;
+		return apply_filters( 'woocommerce_available_gateways', $_available_gateways );
 	}
 	
 	function process_admin_options() {


### PR DESCRIPTION
Adding a filter to result of `WC_Payment_Gateways::get_available_payment_gateways()` so that functions can override which gateways are available for a given transaction. 

My use case for this is with my subscriptions extension. I need to make sure only gateways which support subscriptions are available at checkout, even if other gateways are enabled for product purchases.
