### PR TITLE
Adding Support Check Function to WC_Payment_Gateway

### DIFF
--- a/classes/gateways/class-wc-payment-gateway.php
+++ b/classes/gateways/class-wc-payment-gateway.php
@@ -111,6 +111,32 @@ class WC_Payment_Gateway extends WC_Settings_API {
         if ($this->description) echo wpautop(wptexturize($this->description));
     }
     
+	/**
+	 * Check if a gateway supports a given feature.
+	 * 
+	 * Gateways should override this to declare support (or lack of support) for a feature. 
+	 * For backward compatibility, gateways support 'products' by default, but nothing else. 
+	 * 
+	 * @param $feature string The name of a feature to test support for.
+	 * @return bool True if the gateway supports the feature, false otherwise. 
+	 * @since 1.5.7
+	 */
+	function is_supported( $feature ) {
+		switch ( $feature ) {
+			case 'products' :
+				$is_supported = true;
+				break;
+			case 'subscriptions' :
+				$is_supported = false;
+				break;
+			default :
+				$is_supported = false;
+				break;
+		}
+
+		return apply_filters( 'woocommerce_payment_gateway_support', $is_supported, $feature, $this );
+	}
+
 }
 
 /** Depreciated */


### PR DESCRIPTION
In response to discussion with Mike I've added a first version of `WC_Payment_Gateway::is_supported()` function. This makes it possible for gateways to register support for certain features that other extensions may require.

For backward compatibility, gateways support 'products' by default, but nothing else. The only other feature I've tested for in core is `'subscriptions'`. Gateways extending the `WC_Payment_Gateway` can add other features as required.

An example of the of this function extended for a gateway that supports more advanced subscription features (like cancellation) but doesn't support 'products':

``` php
<?php
/**
 * Extending the WC_Payment_Gateway::is_supported() function to register support for
 * advanced subscription features and remove support for products.
 * 
 * This could be code used for a gateway like "Chargify" or "Recurly".
 */
function is_supported( $feature ) {
    switch ( $feature ) {
        case 'subscriptions' :
            $is_supported = true;
            break;
        case 'subscription_cancellation' :
            $is_supported = true;
            break;
        case 'subscription_modification' :
            $is_supported = true;
            break;
        case 'products' :
            $is_supported = false;
            break;
        default :
            $is_supported = parent::is_supported( $feature );
            break;
    }

    return $is_supported;
}
?>
```
