### PR TITLE
Updating cart widget to use more appropriate WC_Product::get_price_html() function

### DIFF
--- a/widgets/widget-cart.php
+++ b/widgets/widget-cart.php
@@ -61,7 +61,7 @@ class WooCommerce_Widget_Cart extends WP_Widget {
 
 	   				echo $woocommerce->cart->get_item_data( $cart_item );
 
-					echo '<span class="quantity">' .$cart_item['quantity'].' &times; '.woocommerce_price($_product->get_price()).'</span></li>';
+					echo '<span class="quantity">' .$cart_item['quantity'].' &times; '. $_product->get_price_html() .'</span></li>';
 				endif;
 			endforeach;
 		else:


### PR DESCRIPTION
The `WC_Product::get_price_html()` function seems more appropriate for displaying the product price in the cart widget.
