### PR TITLE
Applied woocommerce filter to all return values of the is_available method

### DIFF
--- a/classes/shipping/class-wc-local-pickup.php
+++ b/classes/shipping/class-wc-local-pickup.php
@@ -87,28 +87,29 @@ class WC_Local_Pickup extends WC_Shipping_Method {
     	</table> <?php
 	}
 
-    function is_available( $package ) {
-    	global $woocommerce;
-    	
-    	if ($this->enabled=="no") return false;
+	function is_available( $package ) {
+		global $woocommerce;
+		$is_available = true;
 
-		$ship_to_countries = '';
-		
-		if ($this->availability == 'specific') :
-			$ship_to_countries = $this->countries;
-		else :
-			if (get_option('woocommerce_allowed_countries')=='specific') :
-				$ship_to_countries = get_option('woocommerce_specific_allowed_countries');
-			endif;
-		endif; 
-		
-		if (is_array($ship_to_countries))
-			if ( ! in_array( $package['destination']['country'], $ship_to_countries ) )
-				return false;
-		
-		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', true );
-    } 
-    
+		if ( $this->enabled == 'no' ) {
+			$is_available = false;
+		} else {
+			$ship_to_countries = '';
+
+			if ( $this->availability == 'specific' ) {
+				$ship_to_countries = $this->countries;
+			} elseif ( get_option( 'woocommerce_allowed_countries' ) == 'specific' ) {
+				$ship_to_countries = get_option( 'woocommerce_specific_allowed_countries' );
+			}
+
+			if ( is_array( $ship_to_countries ) && ! in_array( $package['destination']['country'], $ship_to_countries ) ) {
+				$is_available = false;
+			}
+		}
+
+		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available );
+	}
+
 }
 
 function add_local_pickup_method($methods) { $methods[] = 'WC_Local_Pickup'; return $methods; }

--- a/classes/shipping/class-wc-local-pickup.php
+++ b/classes/shipping/class-wc-local-pickup.php
@@ -107,7 +107,7 @@ class WC_Local_Pickup extends WC_Shipping_Method {
 			}
 		}
 
-		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available );
+		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available, $package );
 	}
 
 }


### PR DESCRIPTION
The `woocommerce_shipping_{id}_is_available` filter was not being applied to all return values. In two cases the `is_available()` method returned `false` without this filter being applied.

Also updated coding style.

Edit: similar changes are needed for other shipping methods.
