### PR TITLE
is_sold_individually into the simple product template

### DIFF
--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -30,7 +30,7 @@ if( $product->get_price() === '') return;
 	 	<?php do_action('woocommerce_before_add_to_cart_button'); ?>
 
 	 	<?php 
-	 		if ( ! ( get_option('woocommerce_limit_downloadable_product_qty')=='yes' && $product->is_downloadable() && $product->is_virtual() ) ) 
+	 		if ( !$product->is_sold_individually() ) 
 	 			woocommerce_quantity_input( array( 'min_value' => 1, 'max_value' => ($product->backorders_allowed()) ? '' : $product->get_stock_quantity() ) ); 
 	 	?>
 


### PR DESCRIPTION
With the is_sold_individually the other way of checking was deprecated.
Using this method to check allows for the use of the
'woocommerce_is_sold_individually' filter.
