### PR TITLE
A few filters needed by the 'Product Bundles' extension.

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -30,7 +30,7 @@ global $woocommerce;
 				$_product = $values['data'];
 				if ( $_product->exists() && $values['quantity'] > 0 ) {
 					?>
-					<tr>
+					<tr class = "<?php echo esc_attr( apply_filters('woocommerce_cart_table_item_class', 'cart_table_item', $values, $cart_item_key ) ); ?>">
 						<!-- Remove from cart link -->
 						<td class="product-remove">
 							<?php 

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -88,7 +88,7 @@ global $woocommerce;
 						<!-- Product subtotal -->
 						<td class="product-subtotal">
 							<?php 
-								echo $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ); 
+								echo apply_filters( 'woocommerce_cart_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ), $values, $cart_item_key ); 
 							?>
 						</td>
 					</tr>

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -207,7 +207,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 								<tr>
 									<td class="product-name">'.$_product->get_title().$woocommerce->cart->get_item_data( $values ).'</td>
 									<td class="product-quantity">'.$values['quantity'].'</td>
-									<td class="product-total">' . $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ) . '</td>
+									<td class="product-total">' . apply_filters( 'woocommerce_checkout_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ), $values, $cart_item_key ) . '</td>
 								</tr>';
 						endif;
 					endforeach; 

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -204,10 +204,10 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						$_product = $values['data'];
 						if ($_product->exists() && $values['quantity']>0) :
 							echo '
-								<tr>
+								<tr class = "' . esc_attr( apply_filters('woocommerce_checkout_table_item_class', 'checkout_table_item', $values, $item_id ) ) . '">
 									<td class="product-name">'.$_product->get_title().$woocommerce->cart->get_item_data( $values ).'</td>
 									<td class="product-quantity">'.$values['quantity'].'</td>
-									<td class="product-total">' . apply_filters( 'woocommerce_checkout_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ), $values, $cart_item_key ) . '</td>
+									<td class="product-total">' . apply_filters( 'woocommerce_checkout_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ), $values, $item_id ) . '</td>
 								</tr>';
 						endif;
 					endforeach; 

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -41,7 +41,7 @@ $order = new WC_Order( $order_id );
 				endif;
 
 				echo '
-					<tr>
+					<tr class = "' . esc_attr( apply_filters('woocommerce_order_table_item_class', 'order_table_item', $item, $order ) ) . '">
 						<td class="product-name">';
 						
 				echo '<a href="'.get_permalink( $item['id'] ).'">' . $item['name'] . '</a>';


### PR DESCRIPTION
Following Mike's advice, I am sending a few lines of additions useful to theme & extension developers in general (tr formatting commit), myself included.

The filtering of the get_product_subtotal output is used by the 'Product Bundles' extension to "hide" the 0$ subtotals of bundled items (when the bundle price is fixed), or the 0$ subtotal of the "bundle" itself (when doing per-product pricing).

The reason a "bundle" entry gets added to the cart apart from all bundled items is multi-fold:

1) It controls all quantities of the bundled items in the cart, just like "forced sells".

2) Is has "real" shipping properties, which are used when doing "bundle shipping". In this case, all bundled items are marked as virtual and do not contribute to any shipping cost.

3) It has its own price, when selling a bundle at a fixed price, regardless of its contents. In this case, all bundled items' prices are set to zero (that's the zeroes I'm hiding, since they are irrelevant - and the opposite, in the case of per-product pricing).

4) It is used to group the bundled items under a single logical "umbrella" in the above template files.

Since these items are grouped together in all template tables (bundle + bundled items below), it is a good idea to allow changing the style of these "item groups" by looking at the class attribute of each item.

For example, bundled items could get a smaller font, or have no tr borders. That's up to theme developers to decide.
