### PR TITLE
Made legend on the reports graphs translatable

### DIFF
--- a/admin/woocommerce-admin-dashboard.php
+++ b/admin/woocommerce-admin-dashboard.php
@@ -306,7 +306,7 @@ function woocommerce_dashboard_sales() {
  */
 function woocommerce_dashboard_sales_js() {
 	
-	global $woocommerce;
+	global $woocommerce, $wp_locale;
 	
 	$screen = get_current_screen();
 	
@@ -393,6 +393,7 @@ function woocommerce_dashboard_sales_js() {
 		'currency_symbol' => get_woocommerce_currency_symbol(),
 		'number_of_sales' => __( 'Number of sales', 'woocommerce' ),
 		'sales_amount'    => __( 'Sales amount', 'woocommerce' ),
+		'month_names'     => array_values( $wp_locale->month_abbrev ),
 	);
 	
 	$order_counts_array = array();

--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -150,12 +150,12 @@ function woocommerce_tooltip_js() {
                 
                 jQuery("#tooltip").remove();
                 
-                if (item.series.label=="Sales amount") {
+                if (item.series.label=="<?php echo esc_js( __( 'Sales amount', 'woocommerce' ) ) ?>") {
                 	
                 	var y = item.datapoint[1].toFixed(2);
                 	showTooltip(item.pageX, item.pageY, item.series.label + " - " + "<?php echo get_woocommerce_currency_symbol(); ?>" + y);
                 	
-                } else if (item.series.label=="Number of sales") {
+                } else if (item.series.label=="<?php echo esc_js( __( 'Number of sales', 'woocommerce' ) ) ?>") {
                 	
                 	var y = item.datapoint[1];
                 	showTooltip(item.pageX, item.pageY, item.series.label + " - " + y);
@@ -444,7 +444,7 @@ function woocommerce_sales_overview() {
 			
 			var placeholder = jQuery("#placeholder");
 			 
-			var plot = jQuery.plot(placeholder, [ { label: "Number of sales", data: d }, { label: "Sales amount", data: d2, yaxis: 2 } ], {
+			var plot = jQuery.plot(placeholder, [ { label: "<?php echo esc_js( __( 'Number of sales', 'woocommerce' ) ) ?>", data: d }, { label: "<?php echo esc_js( __( 'Sales amount', 'woocommerce' ) ) ?>", data: d2, yaxis: 2 } ], {
 				series: {
 					lines: { show: true },
 					points: { show: true }
@@ -634,7 +634,7 @@ function woocommerce_daily_sales() {
 			
 			var placeholder = jQuery("#placeholder");
 			 
-			var plot = jQuery.plot(placeholder, [ { label: "Number of sales", data: d }, { label: "Sales amount", data: d2, yaxis: 2 } ], {
+			var plot = jQuery.plot(placeholder, [ { label: "<?php echo esc_js( __( 'Number of sales', 'woocommerce' ) ) ?>", data: d }, { label: "<?php echo esc_js( __( 'Sales amount', 'woocommerce' ) ) ?>", data: d2, yaxis: 2 } ], {
 				series: {
 					lines: { show: true },
 					points: { show: true }
@@ -820,7 +820,7 @@ function woocommerce_monthly_sales() {
 			
 			var placeholder = jQuery("#placeholder");
 			 
-			var plot = jQuery.plot(placeholder, [ { label: "Number of sales", data: d }, { label: "Sales amount", data: d2, yaxis: 2 } ], {
+			var plot = jQuery.plot(placeholder, [ { label: "<?php echo esc_js( __( 'Number of sales', 'woocommerce' ) ) ?>", data: d }, { label: "<?php echo esc_js( __( 'Sales amount', 'woocommerce' ) ) ?>", data: d2, yaxis: 2 } ], {
 				series: {
 					lines: { show: true },
 					points: { show: true, align: "left" }

--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -227,7 +227,7 @@ function orders_within_range( $where = '' ) {
  */
 function woocommerce_sales_overview() {
 
-	global $start_date, $end_date, $woocommerce, $wpdb;
+	global $start_date, $end_date, $woocommerce, $wpdb, $wp_locale;
 	
 	$total_sales = 0;
 	$total_orders = 0;
@@ -463,6 +463,7 @@ function woocommerce_sales_overview() {
 				xaxis: { 
 					mode: "time",
 					timeformat: "%d %b", 
+					monthNames: <?php echo json_encode( array_values( $wp_locale->month_abbrev ) ) ?>,
 					tickLength: 1,
 					minTickSize: [1, "day"]
 				},
@@ -484,7 +485,7 @@ function woocommerce_sales_overview() {
  */
 function woocommerce_daily_sales() {
 	
-	global $start_date, $end_date, $woocommerce, $wpdb;
+	global $start_date, $end_date, $woocommerce, $wpdb, $wp_locale;
 	
 	$start_date = (isset($_POST['start_date'])) ? $_POST['start_date'] : '';
 	$end_date	= (isset($_POST['end_date'])) ? $_POST['end_date'] : '';
@@ -653,6 +654,7 @@ function woocommerce_daily_sales() {
 				xaxis: { 
 					mode: "time",
 					timeformat: "%d %b", 
+					monthNames: <?php echo json_encode( array_values( $wp_locale->month_abbrev ) ) ?>,
 					tickLength: 1,
 					minTickSize: [1, "day"]
 				},
@@ -676,7 +678,7 @@ function woocommerce_daily_sales() {
  */
 function woocommerce_monthly_sales() {
 	
-	global $start_date, $end_date, $woocommerce, $wpdb;
+	global $start_date, $end_date, $woocommerce, $wpdb, $wp_locale;
 	
 	$first_year = $wpdb->get_var("SELECT post_date FROM $wpdb->posts ORDER BY post_date ASC LIMIT 1;");
 	if ($first_year) $first_year = date('Y', strtotime($first_year)); else $first_year = date('Y');
@@ -838,6 +840,7 @@ function woocommerce_monthly_sales() {
 				xaxis: { 
 					mode: "time",
 					timeformat: "%b %y", 
+					monthNames: <?php echo json_encode( array_values( $wp_locale->month_abbrev ) ) ?>,
 					tickLength: 1,
 					minTickSize: [1, "month"]
 				},
@@ -1185,7 +1188,7 @@ function woocommerce_product_sales() {
  */
 function woocommerce_customer_overview() {
 
-	global $start_date, $end_date, $woocommerce, $wpdb;
+	global $start_date, $end_date, $woocommerce, $wpdb, $wp_locale;
 	
 	$total_customers = 0;
 	$total_customer_sales = 0;
@@ -1362,6 +1365,7 @@ function woocommerce_customer_overview() {
 				xaxis: { 
 					mode: "time",
 					timeformat: "%d %b", 
+					monthNames: <?php echo json_encode( array_values( $wp_locale->month_abbrev ) ) ?>,
 					tickLength: 1,
 					minTickSize: [1, "day"]
 				},

--- a/assets/js/admin/dashboard_sales.js
+++ b/assets/js/admin/dashboard_sales.js
@@ -48,6 +48,7 @@ jQuery(function(){
 		xaxis: { 
 			mode: "time",
 			timeformat: "%d %b", 
+			monthNames: params.month_names,
 			tickLength: 1,
 			minTickSize: [1, "day"]
 		},


### PR DESCRIPTION
Just like the dashboard widget, except without the use of `wp_localize_script()` because these javascripts are inline.

Update: also made the month labels translatable in the report graphs using the month names from `WP_Locale`:
http://codex.wordpress.org/Translating_WordPress#Month_names
