### PR TITLE
Made first year retrieval more robust

### DIFF
--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -678,7 +678,7 @@ function woocommerce_monthly_sales() {
 	
 	global $start_date, $end_date, $woocommerce, $wpdb;
 	
-	$first_year = $wpdb->get_var("SELECT post_date FROM $wpdb->posts ORDER BY post_date ASC LIMIT 1;");
+	$first_year = $wpdb->get_var("SELECT post_date FROM $wpdb->posts WHERE post_date != 0 ORDER BY post_date ASC LIMIT 1;");
 	if ($first_year) $first_year = date('Y', strtotime($first_year)); else $first_year = date('Y');
 	
 	$current_year = (isset($_POST['show_year'])) ? $_POST['show_year'] : date('Y', current_time('timestamp'));


### PR DESCRIPTION
The first year is used as a starting point for the year dropdown in the sales by month report screen. The problem was it ranged from 0 to 2012 on my installation. Turns out my wp_posts table contains some product variations with a "0000-00-00 00:00:00" value in the post_date field. Don't know how they got there.
