### PR TITLE
Fix color modifications on shorthand hex colors

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -495,7 +495,9 @@ function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
 if (!function_exists('woocommerce_hex_darker')) {
 	function woocommerce_hex_darker( $color, $factor = 30 ) {
 		$color = str_replace('#', '', $color);
-		
+		// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
+		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
+
 		$base['R'] = hexdec($color{0}.$color{1});
 		$base['G'] = hexdec($color{2}.$color{3});
 		$base['B'] = hexdec($color{4}.$color{5});
@@ -520,7 +522,9 @@ if (!function_exists('woocommerce_hex_darker')) {
 if (!function_exists('woocommerce_hex_lighter')) {
 	function woocommerce_hex_lighter( $color, $factor = 30 ) {
 		$color = str_replace('#', '', $color);
-		
+		// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
+		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
+
 		$base['R'] = hexdec($color{0}.$color{1});
 		$base['G'] = hexdec($color{2}.$color{3});
 		$base['B'] = hexdec($color{4}.$color{5});

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -492,18 +492,22 @@ function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
 /**
  * Hex darker/lighter/contrast functions for colours
  **/
+function woocommerce_rgb_from_hex( $color ) {
+	$color = str_replace( '#', '', $color );
+	// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
+	$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
+
+	$rgb['R'] = hexdec( $color{0}.$color{1} );
+	$rgb['G'] = hexdec( $color{2}.$color{3} );
+	$rgb['B'] = hexdec( $color{4}.$color{5} );
+	return $rgb;
+}
+
 if (!function_exists('woocommerce_hex_darker')) {
 	function woocommerce_hex_darker( $color, $factor = 30 ) {
-		$color = str_replace('#', '', $color);
-		// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
-		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
-
-		$base['R'] = hexdec($color{0}.$color{1});
-		$base['G'] = hexdec($color{2}.$color{3});
-		$base['B'] = hexdec($color{4}.$color{5});
-		
+		$base = woocommerce_rgb_from_hex( $color );
 		$color = '#';
-		
+
 		foreach ($base as $k => $v) :
 	        $amount = $v / 100;
 	        $amount = round($amount * $factor);
@@ -521,16 +525,9 @@ if (!function_exists('woocommerce_hex_darker')) {
 }
 if (!function_exists('woocommerce_hex_lighter')) {
 	function woocommerce_hex_lighter( $color, $factor = 30 ) {
-		$color = str_replace('#', '', $color);
-		// Convert shorthand colors to full format, e.g. "FFF" -> "FFFFFF"
-		$color = preg_replace( '~^(.)(.)(.)$~', '$1$1$2$2$3$3', $color );
-
-		$base['R'] = hexdec($color{0}.$color{1});
-		$base['G'] = hexdec($color{2}.$color{3});
-		$base['B'] = hexdec($color{4}.$color{5});
-		
+		$base = woocommerce_rgb_from_hex( $color );
 		$color = '#';
-	     
+
 	    foreach ($base as $k => $v) :
 	        $amount = 255 - $v; 
 	        $amount = $amount / 100; 


### PR DESCRIPTION
The `woocommerce_hex_darker` and `woocommerce_hex_lighter` functions didn't work correctly with shorthand hex colors like `#333`. These shorthand notations can be entered by the admin though.

For example: `#333` would become a bit pinkish `#856866` instead of the lighter gray `#858585`.
