### PR TITLE
WooCommerce 1.5.7 full fr translation.

### DIFF
--- a/languages/woocommerce-fr_FR.po
+++ b/languages/woocommerce-fr_FR.po
@@ -1,11 +1,11 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce 1.3.2.1\n"
+"Project-Id-Version: WooCommerce v1.5.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-05-03 10:25+0100\n"
-"PO-Revision-Date: \n"
-"Last-Translator: Antoine Nicolas <antoine.nicolas@mediana.fr>\n"
-"Language-Team: ABSOLUTE Web et prédécesseurs <woocommerce@absoluteweb.net>\n"
+"POT-Creation-Date: 2012-06-12 14:30+0100\n"
+"PO-Revision-Date: 2012-06-14 08:30:59+0000\n"
+"Last-Translator: Arnaud CHEMINAND <nodar44@gmail.com>\n"
+"Language-Team: AVTALIA <contact@avtalia.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,10142 +13,11101 @@ msgstr ""
 "X-Poedit-Language: French\n"
 "X-Poedit-Country: FRANCE\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Poedit-KeywordsList: __;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;_n_noop:1,2;_c,_nc:4c,1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2\n"
+"X-Poedit-KeywordsList: __;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;_n_noop:1,2;_c,_nc:4c,1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;\n"
 "X-Poedit-Basepath: .\n"
-"X-Textdomain-Support: yes\n"
+"X-Poedit-Bookmarks: \n"
 "X-Poedit-SearchPath-0: ..\n"
+"X-Textdomain-Support: yes"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:108
+#: woocommerce-ajax.php:67
+#@ woocommerce
+msgid "Please enter your username and password to login."
+msgstr "Veuillez entrer votre identifiant et votre mot de passe pour vous connecter."
+
+#: shortcodes/shortcode-cart.php:30
+#: woocommerce-ajax.php:92
+#@ woocommerce
+msgid "Please enter a coupon code."
+msgstr "Veuillez entrer un code promo."
+
+#: woocommerce-ajax.php:136
+#@ woocommerce
 msgid "Sorry, your session has expired."
-msgstr "Désolé, votre session a expiré"
+msgstr "D&eacute;sol&eacute;, votre session a expir&eacute;."
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:108
+#: woocommerce-ajax.php:136
+#@ woocommerce
 msgid "Return to homepage &rarr;"
-msgstr "Retour à l'accueil &rarr;"
+msgstr "Retour &agrave; l&rsquo;accueil &rarr;"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:190
-#: ../woocommerce-ajax.php:220
-#: ../woocommerce-ajax.php:239
+#: woocommerce-ajax.php:218
+#: woocommerce-ajax.php:248
+#: woocommerce-ajax.php:267
+#@ woocommerce
 msgid "You do not have sufficient permissions to access this page."
-msgstr "Vous n'avez pas les droits suffisants pour accéder à cette page."
+msgstr "Vous n&rsquo;avez pas les droits suffisants pour acc&eacute;der &agrave; cette page."
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:192
-#: ../woocommerce-ajax.php:221
-#: ../woocommerce-ajax.php:240
+#: woocommerce-ajax.php:220
+#: woocommerce-ajax.php:249
+#: woocommerce-ajax.php:268
+#@ woocommerce
 msgid "You have taken too long. Please go back and retry."
-msgstr "Vous avez mis trop de temps. Revenez en arrière et essayez encore, svp."
+msgstr "Vous avez mis trop longtemps. Veuillez revenir en arri&egrave;re et essayer &agrave; nouveau."
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:688
+#: admin/post-types/writepanels/writepanel-order_data.php:305
+#: woocommerce-ajax.php:707
+#@ woocommerce
 msgid "Product ID:"
-msgstr "ID Produit :"
+msgstr "ID Produit&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:689
+#: admin/post-types/writepanels/writepanel-order_data.php:306
+#: woocommerce-ajax.php:708
+#@ woocommerce
 msgid "Variation ID:"
-msgstr "ID Variation :"
+msgstr "ID Variation&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:690
+#: admin/post-types/writepanels/writepanel-order_data.php:307
+#: woocommerce-ajax.php:709
+#@ woocommerce
 msgid "Product SKU:"
-msgstr "UGS du produit :"
+msgstr "UGS Produit&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:702
+#: admin/post-types/writepanels/writepanel-order_data.php:319
+#: woocommerce-ajax.php:721
+#@ woocommerce
 msgid "Delete item"
-msgstr "Supprimer l'article"
+msgstr "Supprimer l&rsquo;article"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:703
+#: admin/post-types/writepanels/writepanel-order_data.php:320
+#: woocommerce-ajax.php:722
+#@ woocommerce
 msgid "View product"
-msgstr "Voir Produit"
+msgstr "Voir le produit"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:711
+#: admin/post-types/writepanels/writepanel-order_data.php:330
+#: woocommerce-ajax.php:730
+#@ woocommerce
 msgid "Add&nbsp;meta"
-msgstr "Ajouter&nbsp;meta"
+msgstr "Ajouter&nbsp;m&eacute;ta"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:725
+#: admin/post-types/writepanels/writepanel-order_data.php:363
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:48
+#: admin/post-types/writepanels/writepanel-product_data.php:199
+#: woocommerce-ajax.php:744
+#@ woocommerce
 msgid "Standard"
 msgstr "Standard"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:739
-#: ../woocommerce-ajax.php:745
+#: admin/post-types/writepanels/writepanel-order_data.php:377
+#: admin/post-types/writepanels/writepanel-order_data.php:383
+#: classes/shipping/class-wc-flat-rate.php:360
+#: woocommerce-ajax.php:758
+#: woocommerce-ajax.php:764
+#@ woocommerce
 msgid "Cost"
-msgstr "Coût"
+msgstr "Tarif"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:741
-#: ../woocommerce-ajax.php:747
-#: ../admin/woocommerce-admin-content.php:42
+#: admin/post-types/writepanels/writepanel-order_data.php:379
+#: admin/post-types/writepanels/writepanel-order_data.php:385
+#: admin/post-types/writepanels/writepanel-product_data.php:31
+#: admin/woocommerce-admin-content.php:42
+#: admin/woocommerce-admin-settings.php:187
+#: classes/class-wc-countries.php:473
+#: templates/cart/totals.php:172
+#: templates/cart/totals.php:182
+#: woocommerce-ajax.php:760
+#: woocommerce-ajax.php:766
+#@ woocommerce
 msgid "Tax"
 msgstr "Taxe"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:834
+#: admin/post-types/writepanels/writepanel-order_notes.php:37
+#: woocommerce-ajax.php:853
+#@ woocommerce
 msgid "Delete note"
-msgstr "Supprimer la note"
+msgstr "Supprimer le commentaire"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:990
+#: woocommerce-ajax.php:1009
+#@ woocommerce
 msgid "Cross-sell"
-msgstr "Ventes croisées"
+msgstr "Ventes crois&eacute;es"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:990
+#: woocommerce-ajax.php:1009
+#@ woocommerce
 msgid "Up-sell"
-msgstr "Ventes à la Une"
+msgstr "Mont&eacute;e en gamme"
 
-# @ woocommerce
-#: ../woocommerce-ajax.php:995
+#: woocommerce-ajax.php:1014
+#@ woocommerce
 msgid "No products found"
-msgstr "Aucun produit trouvé"
+msgstr "Aucun produit trouv&eacute;"
 
-# @ woocommerce
-#: ../woocommerce-core-functions.php:620
-#: ../woocommerce-core-functions.php:684
+#: woocommerce-core-functions.php:635
+#: woocommerce-core-functions.php:699
+#@ woocommerce
 msgid "Download Permissions Granted"
-msgstr ""
+msgstr "Permission de t&eacute;l&eacute;charger accord&eacute;e"
 
-# @ woocommerce
-#: ../woocommerce-core-functions.php:718
-#: ../woocommerce.php:543
+#: woocommerce-core-functions.php:733
+#: woocommerce.php:547
+#@ woocommerce
 msgctxt "slug"
 msgid "product"
 msgstr "produit"
 
-# @ woocommerce
-#: ../woocommerce-core-functions.php:811
+#: woocommerce-core-functions.php:867
+#@ woocommerce
 msgid "Select a category"
-msgstr "Sélectionnez une catégorie"
+msgstr "Choisissez une cat&eacute;gorie"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:171
+#: woocommerce-core-functions.php:869
+#@ woocommerce
+msgid "Uncategorized"
+msgstr "Non cat&eacute;goris&eacute;"
+
+#: widgets/widget-login.php:58
+#: woocommerce-functions.php:171
+#@ woocommerce
 msgid "Logout"
-msgstr "Déconnexion"
+msgstr "D&eacute;connexion"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:206
-#: ../woocommerce-functions.php:247
+#: woocommerce-functions.php:206
+#: woocommerce-functions.php:247
+#@ woocommerce
 msgid "Cart updated."
-msgstr "Panier mis à jour"
+msgstr "Panier mis &agrave; jour."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:235
+#: woocommerce-functions.php:235
 #, php-format
+#@ woocommerce
 msgid "You can only have 1 %s in your cart."
-msgstr ""
+msgstr "Vous pouvez seulement avoir 1 %s dans votre panier."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:275
-#: ../woocommerce-functions.php:315
+#: woocommerce-functions.php:276
+#: woocommerce-functions.php:316
+#@ woocommerce
 msgid "Please choose product options&hellip;"
-msgstr "Choisissez les options produit svp &hellip;"
+msgstr "Veuillez choisir les options du produit..."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:346
+#: woocommerce-functions.php:347
+#@ woocommerce
 msgid "Please choose a quantity&hellip;"
-msgstr "Choisissez une quantité, svp &hellip;"
+msgstr "Veuillez choisir une quantit&eacute;..."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:354
+#: woocommerce-functions.php:355
+#@ woocommerce
 msgid "Please choose a product&hellip;"
-msgstr "Choisissez un produit svp &hellip;"
+msgstr "Veuillez choisir un produit..."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:419
+#: woocommerce-functions.php:420
+#@ woocommerce
 msgid "Continue Shopping &rarr;"
-msgstr "Poursuivre vos achats &rarr;"
+msgstr "Continuer mes achats &rarr;"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:419
-#: ../woocommerce-functions.php:423
+#: woocommerce-functions.php:420
+#: woocommerce-functions.php:424
+#@ woocommerce
 msgid "Product successfully added to your cart."
-msgstr "Produit ajouté avec succès à votre panier."
+msgstr "Produit ajout&eacute; &agrave; votre panier avec succ&egrave;s."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:423
+#: classes/class-wc-cart.php:664
+#: classes/class-wc-cart.php:678
+#: classes/class-wc-cart.php:686
+#: widgets/widget-cart.php:89
+#: woocommerce-functions.php:424
+#@ woocommerce
 msgid "View Cart &rarr;"
-msgstr "Voir panier &rarr;"
+msgstr "Voir le panier &rarr;"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:556
+#: woocommerce-functions.php:557
+#@ woocommerce
 msgid "Username is required."
-msgstr "Nom d'utilisateur requis"
+msgstr "Nom d&rsquo;utilisateur requis."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:557
-#: ../woocommerce-functions.php:653
+#: woocommerce-functions.php:558
+#: woocommerce-functions.php:632
+#@ woocommerce
 msgid "Password is required."
-msgstr "Mot de passe requis"
+msgstr "Mot de passe requis."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:634
-#: ../woocommerce-functions.php:636
-#: ../woocommerce-functions.php:639
-#: ../woocommerce-functions.php:644
-#: ../woocommerce-functions.php:646
-#: ../woocommerce-functions.php:649
-#: ../woocommerce-functions.php:672
+#: classes/class-wc-checkout.php:287
+#: widgets/widget-login.php:232
+#: widgets/widget-login.php:235
+#: woocommerce-functions.php:613
+#: woocommerce-functions.php:615
+#: woocommerce-functions.php:618
+#: woocommerce-functions.php:623
+#: woocommerce-functions.php:625
+#: woocommerce-functions.php:628
+#: woocommerce-functions.php:651
+#@ woocommerce
 msgid "ERROR"
-msgstr "ERREUR"
+msgstr "ERROR"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:634
+#: widgets/widget-login.php:232
+#: woocommerce-functions.php:613
+#@ woocommerce
 msgid "Please enter a username."
-msgstr "Veuillez entrer un nom d'utilisateur."
+msgstr "Veuillez entrer un nom d&rsquo;utilisateur."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:636
+#: woocommerce-functions.php:615
+#@ woocommerce
 msgid "This username is invalid because it uses illegal characters. Please enter a valid username."
-msgstr "Ce nom est invalide car il contient des caractères non autorisés. Veuillez saisir un nom valide."
+msgstr "Ce nom d&rsquo;utilisateur est invalide car il contient des caract&egrave;res non autoris&eacute;s. Veuillez entrer un nom valide."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:639
+#: woocommerce-functions.php:618
+#@ woocommerce
 msgid "This username is already registered, please choose another one."
-msgstr "Ce nom est déjà enregistré, veuillez en choisir un autre."
+msgstr "Ce nom d&rsquo;utilisateur est d&eacute;j&agrave; enregistr&eacute;, veuillez en choisir un autre."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:644
+#: woocommerce-functions.php:623
+#@ woocommerce
 msgid "Please type your e-mail address."
-msgstr "Veuillez saisir votre adresse email."
+msgstr "Veuillez saisir votre adresse e-mail."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:646
+#: woocommerce-functions.php:625
+#@ woocommerce
 msgid "The email address isn&#8217;t correct."
-msgstr "L'adresse email n'est pas correcte."
+msgstr "L&rsquo;adresse e-mail n&rsquo;est pas correcte."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:649
+#: woocommerce-functions.php:628
+#@ woocommerce
 msgid "This email is already registered, please choose another one."
-msgstr "Cet email est déjà enregistré, veuillez en choisir un autre."
+msgstr "Cet e-mail est d&eacute;j&agrave; enregistr&eacute;, veuillez en choisir un autre."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:654
+#: woocommerce-functions.php:633
+#@ woocommerce
 msgid "Re-enter your password."
-msgstr "Entrez à nouveau votre mot de passe."
+msgstr "Entrez &agrave; nouveau votre mot de passe."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:655
+#: classes/class-wc-checkout.php:222
+#: shortcodes/shortcode-my_account.php:224
+#: woocommerce-functions.php:634
+#@ woocommerce
 msgid "Passwords do not match."
-msgstr "Mots de passe non correspondants"
+msgstr "Les mots de passe ne correspondent pas."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:658
+#: woocommerce-functions.php:637
+#@ woocommerce
 msgid "Anti-spam field was filled in."
-msgstr "Le champ Anti-spam a été rempli."
+msgstr "Le champ anti-spam a &eacute;t&eacute; rempli."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:672
-msgid "Couldn&#8217;t register you... please contact us if you continue to have problems."
-msgstr "Impossible de vous inscrire... veuillez nous contacter if vous continuez d'avoir des problèmes."
+#: classes/class-wc-checkout.php:287
+#: woocommerce-functions.php:651
+#@ woocommerce
+msgid "Couldn&#8217;t register you&hellip; please contact us if you continue to have problems."
+msgstr "Impossible de vous inscrire&hellip; Veuillez nous contacter si vous continuez d&rsquo;avoir des probl&egrave;mes."
 
-#: ../woocommerce-functions.php:746
+#: woocommerce-functions.php:725
+#@ woocommerce
 msgid "The cart has been filled with the items from your previous order."
-msgstr ""
+msgstr "Le panier a &eacute;t&eacute; rempli avec les articles de votre pr&eacute;c&eacute;dente commande."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:768
+#: woocommerce-functions.php:747
+#@ woocommerce
 msgid "Order cancelled by customer."
-msgstr "Commande annulée par le client"
+msgstr "Commande annul&eacute;e par le client."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:771
+#: woocommerce-functions.php:750
+#@ woocommerce
 msgid "Your order was cancelled."
-msgstr "Votre commande a été annulée"
+msgstr "Votre commande a &eacute;t&eacute; annul&eacute;e."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:775
+#: woocommerce-functions.php:754
+#@ woocommerce
 msgid "Your order is no longer pending and could not be cancelled. Please contact us if you need assistance."
-msgstr "Votre commande n'est plus en attente et ne peut être annulée. Contactez nous si vous avez besoin d'assistance."
+msgstr "Votre commande n&rsquo;est plus en attente et ne peut &ecirc;tre annul&eacute;e. Veuillez nous contacter si vous avez besoin d&rsquo;assistance."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:779
-#: ../woocommerce-functions.php:841
+#: shortcodes/shortcode-my_account.php:261
+#: shortcodes/shortcode-pay.php:53
+#: shortcodes/shortcode-pay.php:108
+#: woocommerce-functions.php:758
+#: woocommerce-functions.php:820
+#@ woocommerce
 msgid "Invalid order."
-msgstr "Commande non valide"
+msgstr "Commande invalide."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:803
+#: woocommerce-functions.php:782
+#@ woocommerce
 msgid "Invalid email address."
-msgstr "Adresse email invalide."
+msgstr "Adresse e-mail invalide."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:803
-#: ../woocommerce-functions.php:815
-#: ../woocommerce-functions.php:841
-#: ../woocommerce-functions.php:848
-#: ../woocommerce-functions.php:855
-#: ../woocommerce-functions.php:1027
+#: woocommerce-functions.php:782
+#: woocommerce-functions.php:794
+#: woocommerce-functions.php:820
+#: woocommerce-functions.php:827
+#: woocommerce-functions.php:834
+#: woocommerce-functions.php:1006
+#@ woocommerce
 msgid "Go to homepage &rarr;"
-msgstr "Retour à l'accueil &rarr;"
+msgstr "Retourner &agrave; l&rsquo;accueil &rarr;"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:815
+#: woocommerce-functions.php:794
+#@ woocommerce
 msgid "Invalid download."
-msgstr "Téléchargement invalide."
+msgstr "T&eacute;l&eacute;chargement invalide."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:827
+#: woocommerce-functions.php:806
+#@ woocommerce
 msgid "You must be logged in to download files."
-msgstr ""
+msgstr "Vous devez &ecirc;tre connect&eacute;(e) pour t&eacute;l&eacute;charger des fichiers."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:827
+#: widgets/widget-login.php:97
+#: woocommerce-functions.php:806
+#@ woocommerce
 msgid "Login &rarr;"
-msgstr "Login &rarr;"
+msgstr "Connexion &rarr;"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:832
+#: woocommerce-functions.php:811
+#@ woocommerce
 msgid "This is not your download link."
-msgstr ""
+msgstr "Ce n&rsquo;est pas votre lien de t&eacute;l&eacute;chargement."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:848
+#: woocommerce-functions.php:827
+#@ woocommerce
 msgid "Sorry, you have reached your download limit for this file"
-msgstr "Désolé, vous avez atteint le nombre limite de téléchargements pour ce fichier"
+msgstr "D&eacute;sol&eacute;, vous avez atteint la limite de t&eacute;l&eacute;chargements pour ce fichier"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:855
+#: woocommerce-functions.php:834
+#@ woocommerce
 msgid "Sorry, this download has expired"
-msgstr ""
+msgstr "D&eacute;sol&eacute;, ce t&eacute;l&eacute;chargement a expir&eacute;"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:1027
+#: woocommerce-functions.php:1006
+#@ woocommerce
 msgid "File not found"
-msgstr "Fichier non trouvé"
+msgstr "Fichier non trouv&eacute;"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:1090
+#: woocommerce-functions.php:1071
+#@ woocommerce
 msgid "New products"
 msgstr "Nouveaux produits"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:1098
+#: woocommerce-functions.php:1079
 #, php-format
+#@ woocommerce
 msgid "New products added to %s"
-msgstr "Nouveaux produits ajoutés a %s"
+msgstr "Nouveaux produits ajout&eacute;s a %s"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:1106
+#: woocommerce-functions.php:1087
 #, php-format
+#@ woocommerce
 msgid "New products tagged %s"
-msgstr "Nouveaux produits taggés avec %s"
+msgstr "Nouveaux produits avec le mot-clef %s"
 
-# @ woocommerce
-#: ../woocommerce-functions.php:1128
+#: woocommerce-functions.php:1109
+#@ woocommerce
 msgid "You have taken too long. Please go back and refresh the page."
-msgstr "Vous avez été trop long. Revenez en arrière et rafraîchissez la page, svp."
+msgstr "Vous avez mis trop longtemps. Veuillez revenir en arri&egrave;re et rafra&icirc;chir la page."
 
-# @ woocommerce
-#: ../woocommerce-functions.php:1131
+#: woocommerce-functions.php:1112
+#@ woocommerce
 msgid "Please rate the product."
-msgstr "Donnez une note au produit svp."
+msgstr "Veuillez noter le produit."
 
-# @ woocommerce
-#: ../woocommerce-template.php:35
+#: woocommerce-template.php:35
+#@ woocommerce
 msgid "Search Results:"
-msgstr "Résultats de recherche :"
+msgstr "R&eacute;sultats de recherche&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce-template.php:36
+#: templates/shop/breadcrumb.php:183
+#: woocommerce-template.php:36
+#@ woocommerce
 msgid "Page"
 msgstr "Page"
 
-# @ woocommerce
-#: ../woocommerce-template.php:173
+#: woocommerce-template.php:173
+#@ woocommerce
 msgid "This is a demo store for testing purposes &mdash; no orders shall be fulfilled."
-msgstr "Ceci est une boutique de démonstration pour test &mdash; aucune commande ne sera honorée."
+msgstr "Boutique de d&eacute;monstration &agrave; usage de test uniquement &mdash; Aucune commande ne sera trait&eacute;e."
 
-# @ woocommerce
-#: ../woocommerce-template.php:352
-msgid "SKU:"
-msgstr "UGS :"
-
-# @ woocommerce
-#: ../woocommerce-template.php:378
+#: woocommerce-template.php:332
+#@ woocommerce
 msgid "Buy product"
-msgstr "Achater le produit"
+msgstr "Acheter le produit"
 
-# @ woocommerce
-#: ../woocommerce-template.php:692
+#: admin/post-types/writepanels/writepanel-order_data.php:126
+#: templates/cart/shipping-calculator.php:18
+#: woocommerce-template.php:646
+#@ woocommerce
 msgid "Select a country&hellip;"
-msgstr "Choix de Pays&hellip;"
+msgstr "Choisissez un pays..."
 
-# @ woocommerce
-#: ../woocommerce-template.php:721
+#: templates/cart/shipping-calculator.php:38
+#: woocommerce-template.php:675
+#@ woocommerce
 msgid "Select a state&hellip;"
-msgstr "Choix de région&hellip;"
+msgstr "Choisissez un &eacute;tat..."
 
-# @ woocommerce
-#: ../woocommerce-template.php:807
+#: woocommerce-template.php:761
+#@ woocommerce
 msgid "Search for:"
-msgstr "Recherche pour :"
+msgstr "Rechercher&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce-template.php:808
+#: woocommerce-template.php:762
+#@ woocommerce
 msgid "Search for products"
-msgstr "Recherche des produits"
+msgstr "Rechercher des produits"
 
-# @ woocommerce
-#: ../woocommerce.php:471
+#: woocommerce.php:475
+#@ woocommerce
 msgid "Customer"
 msgstr "Client"
 
-# @ woocommerce
-#: ../woocommerce.php:478
+#: woocommerce.php:482
+#@ woocommerce
 msgid "Shop Manager"
-msgstr "Gestionnaire Boutique"
+msgstr "Gestionnaire de boutique"
 
-# @ woocommerce
-#: ../woocommerce.php:539
+#: woocommerce.php:543
+#@ woocommerce
 msgctxt "slug"
 msgid "product-category"
-msgstr "catégorie-produit"
+msgstr "categorie-produit"
 
-# @ woocommerce
-#: ../woocommerce.php:541
+#: woocommerce.php:545
+#@ woocommerce
 msgctxt "slug"
 msgid "product-tag"
-msgstr "mot clé-produit"
+msgstr "mot-clef-produit"
 
-# @ woocommerce
-#: ../woocommerce.php:571
-#: ../woocommerce.php:573
+#: admin/post-types/writepanels/writepanel-coupon_data.php:103
+#: widgets/widget-product_categories.php:40
+#: woocommerce.php:576
+#: woocommerce.php:578
+#@ woocommerce
 msgid "Product Categories"
-msgstr "Catégories"
+msgstr "Cat&eacute;gories de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:574
-#: ../admin/woocommerce-admin-dashboard.php:55
+#. gettext fix: identical singular and plural forms found, that may be ambiguous! Please check the code!
+#: admin/woocommerce-admin-dashboard.php:54
+#: woocommerce.php:579
+#@ woocommerce
 msgid "Product Category"
 msgid_plural "Product Categories"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Cat&eacute;gorie de produits"
+msgstr[1] "Cat&eacute;gories de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:575
+#: woocommerce.php:580
+#@ woocommerce
+msgctxt "Admin menu name"
+msgid "Product Categories"
+msgstr "Cat&eacute;gories de produits"
+
+#: woocommerce.php:581
+#@ woocommerce
 msgid "Search Product Categories"
-msgstr "Recherche catégories"
+msgstr "Rechercher des cat&eacute;gories de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:576
+#: woocommerce.php:582
+#@ woocommerce
 msgid "All Product Categories"
-msgstr "Toutes les catégories"
+msgstr "Toutes les cat&eacute;gories de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:577
+#: woocommerce.php:583
+#@ woocommerce
 msgid "Parent Product Category"
-msgstr "Catégorie Produit Parente"
+msgstr "Cat&eacute;gorie de produits parente"
 
-# @ woocommerce
-#: ../woocommerce.php:578
+#: woocommerce.php:584
+#@ woocommerce
 msgid "Parent Product Category:"
-msgstr "Catégorie Produit Parente :"
+msgstr "Cat&eacute;gorie de produits parente&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce.php:579
+#: woocommerce.php:585
+#@ woocommerce
 msgid "Edit Product Category"
-msgstr "Modifier Produit Parente"
+msgstr "Modifier la cat&eacute;gorie de produits parente"
 
-# @ woocommerce
-#: ../woocommerce.php:580
+#: woocommerce.php:586
+#@ woocommerce
 msgid "Update Product Category"
-msgstr "Mise à Jour Catégorie Produit"
+msgstr "Mettre &agrave; jour la cat&eacute;gorie de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:581
+#: woocommerce.php:587
+#@ woocommerce
 msgid "Add New Product Category"
-msgstr "Ajouter une nouvelle catégorie de produit"
+msgstr "Ajouter une nouvelle cat&eacute;gorie de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:582
+#: woocommerce.php:588
+#@ woocommerce
 msgid "New Product Category Name"
-msgstr "Nouveau Nom Catégorie Produit"
+msgstr "Nom de la nouvelle cat&eacute;gorie de produits"
 
-# @ woocommerce
-#: ../woocommerce.php:601
+#: widgets/widget-product_tag_cloud.php:42
+#: woocommerce.php:607
+#@ woocommerce
 msgid "Product Tags"
-msgstr "Mots-Clés"
+msgstr "mots-clefs de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:603
+#: admin/post-types/product.php:78
+#: woocommerce.php:609
+#@ woocommerce
 msgid "Tags"
-msgstr "Mots-Clés"
+msgstr "mots-clefs"
 
-# @ woocommerce
-#: ../woocommerce.php:604
-#: ../admin/woocommerce-admin-dashboard.php:69
+#. gettext fix: identical singular and plural forms found, that may be ambiguous! Please check the code!
+#: admin/woocommerce-admin-dashboard.php:68
+#: woocommerce.php:610
+#@ woocommerce
 msgid "Product Tag"
 msgid_plural "Product Tags"
-msgstr[0] "Tag Produit"
-msgstr[1] "Tags Produits"
+msgstr[0] "mot-clef de produit"
+msgstr[1] "mots-clefs de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:605
+#: woocommerce.php:611
+#@ woocommerce
+msgctxt "Admin menu name"
+msgid "Tags"
+msgstr "mots-clefs"
+
+#: woocommerce.php:612
+#@ woocommerce
 msgid "Search Product Tags"
-msgstr "Recherche mots clés"
+msgstr "Rechercher des mots-clefs de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:606
+#: woocommerce.php:613
+#@ woocommerce
 msgid "All Product Tags"
-msgstr "Tous les Mots-Clés Produit"
+msgstr "Tous les mots-clefs de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:607
+#: woocommerce.php:614
+#@ woocommerce
 msgid "Parent Product Tag"
-msgstr "Mot-Clé Produit Parent"
+msgstr "Mot-clef de produit parent"
 
-# @ woocommerce
-#: ../woocommerce.php:608
+#: woocommerce.php:615
+#@ woocommerce
 msgid "Parent Product Tag:"
-msgstr "Mot-Clé Produit Parent :"
+msgstr "Mot-clef de produit parent&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce.php:609
+#: woocommerce.php:616
+#@ woocommerce
 msgid "Edit Product Tag"
-msgstr "Modifier Mot-Clé Produit"
+msgstr "Modifier le mot-clef de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:610
+#: woocommerce.php:617
+#@ woocommerce
 msgid "Update Product Tag"
-msgstr "Mise à Jour Mot-Clé Produit"
+msgstr "Mettre &agrave; jour le mot-clef de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:611
+#: woocommerce.php:618
+#@ woocommerce
 msgid "Add New Product Tag"
-msgstr "Ajouter un nouveau mot clé produit"
+msgstr "Ajouter un nouveau mot-clef de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:612
+#: woocommerce.php:619
+#@ woocommerce
 msgid "New Product Tag Name"
-msgstr "Nouveau Nom Mot-Clé Produit"
+msgstr "Nom du nouveau mot-clef de produit"
 
-# @ woocommerce
-#: ../woocommerce.php:631
-#: ../woocommerce.php:633
+#: woocommerce.php:638
+#: woocommerce.php:640
+#@ woocommerce
 msgid "Shipping Classes"
 msgstr "Classes de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:634
+#: classes/shipping/class-wc-flat-rate.php:359
+#: woocommerce.php:641
+#@ woocommerce
 msgid "Shipping Class"
 msgstr "Classe de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:635
-msgid "Search Shipping Classes"
-msgstr "Recherche des classes de livraison"
+#: woocommerce.php:642
+#@ woocommerce
+msgctxt "Admin menu name"
+msgid "Shipping Classes"
+msgstr "Classes de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:636
+#: woocommerce.php:643
+#@ woocommerce
+msgid "Search Shipping Classes"
+msgstr "Rechercher des classes de livraison"
+
+#: woocommerce.php:644
+#@ woocommerce
 msgid "All Shipping Classes"
 msgstr "Toutes les classes de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:637
+#: woocommerce.php:645
+#@ woocommerce
 msgid "Parent Shipping Class"
 msgstr "Classe de livraison parente"
 
-# @ woocommerce
-#: ../woocommerce.php:638
+#: woocommerce.php:646
+#@ woocommerce
 msgid "Parent Shipping Class:"
-msgstr "Classe de livraison parente :"
+msgstr "Classe de livraison parente&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce.php:639
+#: woocommerce.php:647
+#@ woocommerce
 msgid "Edit Shipping Class"
-msgstr "Editer la classe de livraison"
+msgstr "Modifier la classe de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:640
+#: woocommerce.php:648
+#@ woocommerce
 msgid "Update Shipping Class"
-msgstr "Actualiser la classe de livraison"
+msgstr "Mettre &agrave; jour la classe de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:641
+#: woocommerce.php:649
+#@ woocommerce
 msgid "Add New Shipping Class"
 msgstr "Ajouter une nouvelle classe de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:642
+#: woocommerce.php:650
+#@ woocommerce
 msgid "New Shipping Class Name"
-msgstr "Nouveau nom de classe de livraison"
+msgstr "Nom de la nouvelle classe de livraison"
 
-# @ woocommerce
-#: ../woocommerce.php:663
+#: woocommerce.php:671
+#@ woocommerce
 msgid "Order statuses"
-msgstr "États de commande"
+msgstr "&Eacute;tats de commande"
 
-# @ woocommerce
-#: ../woocommerce.php:664
+#: woocommerce.php:672
+#@ woocommerce
 msgid "Order status"
-msgstr "États de commande"
+msgstr "&Eacute;tat de la commande"
 
-# @ woocommerce
-#: ../woocommerce.php:665
+#: woocommerce.php:673
+#@ woocommerce
 msgid "Search Order statuses"
-msgstr "Recherche des états de commande"
+msgstr "Rechercher des &eacute;tats de commande"
 
-# @ woocommerce
-#: ../woocommerce.php:666
-msgid "All  Order statuses"
-msgstr "Tous les états de commande"
+#: woocommerce.php:674
+#@ woocommerce
+msgid "All Order statuses"
+msgstr "Tous les &eacute;tats de commande"
 
-# @ woocommerce
-#: ../woocommerce.php:667
+#: woocommerce.php:675
+#@ woocommerce
 msgid "Parent Order status"
-msgstr "État de la commande parente"
+msgstr "&Eacute;tat de la commande parente"
 
-# @ woocommerce
-#: ../woocommerce.php:668
+#: woocommerce.php:676
+#@ woocommerce
 msgid "Parent Order status:"
-msgstr "État de la commande parente :"
+msgstr "&Eacute;tat de la commande parente&nbsp;:"
 
-# @ woocommerce
-#: ../woocommerce.php:669
+#: woocommerce.php:677
+#@ woocommerce
 msgid "Edit Order status"
-msgstr "Modifier l'état de la commande"
+msgstr "Modifier l&rsquo;&eacute;tat de la commande"
 
-# @ woocommerce
-#: ../woocommerce.php:670
+#: woocommerce.php:678
+#@ woocommerce
 msgid "Update Order status"
-msgstr "Mise à jour de l'état de la commande"
+msgstr "Mettre &agrave; jour l&rsquo;&eacute;tat de la commande"
 
-# @ woocommerce
-#: ../woocommerce.php:671
+#: woocommerce.php:679
+#@ woocommerce
 msgid "Add New Order status"
-msgstr "Ajouter un nouvel état de commande"
+msgstr "Ajouter un nouvel &eacute;tat de commande"
 
-# @ woocommerce
-#: ../woocommerce.php:672
+#: woocommerce.php:680
+#@ woocommerce
 msgid "New Order status Name"
-msgstr "Nom du nouvel état de commande"
+msgstr "Nom du nouvel &eacute;tat de commande"
 
-# @ woocommerce
-#: ../woocommerce.php:700
+#: admin/post-types/product.php:546
+#: admin/post-types/product.php:788
+#: admin/post-types/writepanels/writepanel-product_data.php:146
+#: woocommerce-template.php:763
+#: woocommerce.php:709
+#@ woocommerce
+#@ default
 msgid "Search"
 msgstr "Recherche"
 
-# @ woocommerce
-#: ../woocommerce.php:701
+#: admin/settings/settings-tax-rates.php:56
+#: admin/settings/settings-tax-rates.php:216
+#: admin/woocommerce-admin-settings-forms.php:436
+#: admin/woocommerce-admin-settings-forms.php:599
+#: woocommerce.php:710
+#@ woocommerce
 msgid "All"
 msgstr "Tous"
 
-# @ woocommerce
-#: ../woocommerce.php:702
-#: ../woocommerce.php:703
+#: woocommerce.php:711
+#: woocommerce.php:712
+#@ woocommerce
 msgid "Parent"
 msgstr "Parent"
 
-# @ woocommerce
-#: ../woocommerce.php:704
-#: ../woocommerce.php:730
-#: ../woocommerce.php:773
-#: ../woocommerce.php:814
-#: ../woocommerce.php:858
-#: ../admin/woocommerce-admin-attributes.php:179
+#: admin/post-types/writepanels/writepanel-order_data.php:91
+#: admin/post-types/writepanels/writepanel-order_data.php:172
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:81
+#: admin/settings/settings-tax-rates.php:51
+#: admin/settings/settings-tax-rates.php:163
+#: admin/settings/settings-tax-rates.php:170
+#: admin/settings/settings-tax-rates.php:211
+#: admin/woocommerce-admin-attributes.php:179
+#: admin/woocommerce-admin-settings-forms.php:431
+#: admin/woocommerce-admin-settings-forms.php:546
+#: admin/woocommerce-admin-settings-forms.php:553
+#: admin/woocommerce-admin-settings-forms.php:594
+#: templates/myaccount/my-address.php:21
+#: templates/myaccount/my-address.php:52
+#: woocommerce.php:713
+#: woocommerce.php:740
+#: woocommerce.php:783
+#: woocommerce.php:844
+#: woocommerce.php:890
+#@ woocommerce
 msgid "Edit"
 msgstr "Modifier"
 
-# @ woocommerce
-#: ../woocommerce.php:705
-#: ../admin/woocommerce-admin-attributes.php:138
+#: admin/woocommerce-admin-attributes.php:138
+#: woocommerce.php:714
+#@ woocommerce
 msgid "Update"
-msgstr "Mettre à jour"
+msgstr "Mettre &agrave; jour"
 
-# @ woocommerce
-#: ../woocommerce.php:706
+#: woocommerce.php:715
+#@ woocommerce
 msgid "Add New"
-msgstr "Ajouter"
+msgstr "Ajouter nouveau"
 
-# @ woocommerce
-#: ../woocommerce.php:707
+#: woocommerce.php:716
+#@ woocommerce
 msgid "New"
 msgstr "Nouveau"
 
-# @ woocommerce
-#: ../woocommerce.php:726
+#: admin/post-types/writepanels/writepanel-coupon_data.php:55
+#: woocommerce.php:735
+#@ woocommerce
 msgid "Products"
 msgstr "Produits"
 
-# @ woocommerce
-#: ../woocommerce.php:727
-#: ../admin/woocommerce-admin-dashboard.php:41
+#. gettext fix: identical singular and plural forms found, that may be ambiguous! Please check the code!
+#: admin/woocommerce-admin-dashboard.php:40
+#: admin/woocommerce-admin-reports.php:921
+#: admin/woocommerce-admin-reports.php:1018
+#: templates/checkout/form-pay.php:12
+#: templates/checkout/review-order.php:15
+#: templates/emails/admin-new-order.php:14
+#: templates/emails/customer-completed-order.php:14
+#: templates/emails/customer-invoice.php:18
+#: templates/emails/customer-note.php:18
+#: templates/emails/customer-processing-order.php:14
+#: templates/order/order-details.php:14
+#: woocommerce.php:736
+#@ woocommerce
 msgid "Product"
 msgid_plural "Products"
 msgstr[0] "Produit"
 msgstr[1] "Produits"
 
-# @ woocommerce
-#: ../woocommerce.php:728
-msgid "Add Product"
-msgstr "Ajouter"
+#: woocommerce.php:737
+#@ woocommerce
+msgctxt "Admin menu name"
+msgid "Products"
+msgstr "Produits"
 
-# @ woocommerce
-#: ../woocommerce.php:729
+#: woocommerce.php:738
+#@ woocommerce
+msgid "Add Product"
+msgstr "Ajouter un produit"
+
+#: woocommerce.php:739
+#@ woocommerce
 msgid "Add New Product"
 msgstr "Ajouter un nouveau produit"
 
-# @ woocommerce
-#: ../woocommerce.php:731
+#: woocommerce.php:741
+#@ woocommerce
 msgid "Edit Product"
-msgstr "Modifier Produit"
+msgstr "Modifier un produit"
 
-# @ woocommerce
-#: ../woocommerce.php:732
+#: woocommerce.php:742
+#@ woocommerce
 msgid "New Product"
-msgstr "Nouveau Produit"
+msgstr "Nouveau produit"
 
-# @ woocommerce
-#: ../woocommerce.php:733
-#: ../woocommerce.php:734
+#: woocommerce.php:743
+#: woocommerce.php:744
+#@ woocommerce
 msgid "View Product"
-msgstr "Voir Produit"
+msgstr "Voir le produit"
 
-# @ woocommerce
-#: ../woocommerce.php:735
+#: woocommerce.php:745
+#@ woocommerce
 msgid "Search Products"
-msgstr "Recherche produits"
+msgstr "Rechercher un produit"
 
-# @ woocommerce
-#: ../woocommerce.php:736
+#: woocommerce.php:746
+#@ woocommerce
 msgid "No Products found"
-msgstr "Aucun produit trouvé"
+msgstr "Aucun produit trouv&eacute;"
 
-# @ woocommerce
-#: ../woocommerce.php:737
+#: woocommerce.php:747
+#@ woocommerce
 msgid "No Products found in trash"
-msgstr "Aucun produit trouvé dans la corbeille"
+msgstr "Aucun produit trouv&eacute; dans la Corbeille"
 
-# @ woocommerce
-#: ../woocommerce.php:738
+#: woocommerce.php:748
+#@ woocommerce
 msgid "Parent Product"
 msgstr "Produit parent"
 
-# @ woocommerce
-#: ../woocommerce.php:740
+#: woocommerce.php:750
+#@ woocommerce
 msgid "This is where you can add new products to your store."
-msgstr "Ceci est l'endroit où vous pouvez ajouter des nouveaux produits dans votre boutique."
+msgstr "C&rsquo;est ici que vous pouvez ajouter des nouveaux produits dans votre boutique."
 
-# @ woocommerce
-#: ../woocommerce.php:769
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:19
+#: woocommerce.php:779
+#@ woocommerce
 msgid "Variations"
 msgstr "Variations"
 
-# @ woocommerce
-#: ../woocommerce.php:770
+#: woocommerce.php:780
+#@ woocommerce
 msgid "Variation"
 msgstr "Variation"
 
-# @ woocommerce
-#: ../woocommerce.php:771
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:255
+#: woocommerce.php:781
+#@ woocommerce
 msgid "Add Variation"
 msgstr "Ajouter une variation"
 
-# @ woocommerce
-#: ../woocommerce.php:772
+#: woocommerce.php:782
+#@ woocommerce
 msgid "Add New Variation"
 msgstr "Ajouter une nouvelle variation"
 
-# @ woocommerce
-#: ../woocommerce.php:774
+#: woocommerce.php:784
+#@ woocommerce
 msgid "Edit Variation"
-msgstr "Modifier Variation"
+msgstr "Modifier la variation"
 
-# @ woocommerce
-#: ../woocommerce.php:775
+#: woocommerce.php:785
+#@ woocommerce
 msgid "New Variation"
-msgstr "Nouvelle Variation"
+msgstr "Nouvelle variation"
 
-# @ woocommerce
-#: ../woocommerce.php:776
-#: ../woocommerce.php:777
+#: woocommerce.php:786
+#: woocommerce.php:787
+#@ woocommerce
 msgid "View Variation"
-msgstr "Voir Variation"
+msgstr "Voir la variation"
 
-# @ woocommerce
-#: ../woocommerce.php:778
+#: woocommerce.php:788
+#@ woocommerce
 msgid "Search Variations"
-msgstr "Recherche variations"
+msgstr "Rechercher des variations"
 
-# @ woocommerce
-#: ../woocommerce.php:779
+#: woocommerce.php:789
+#@ woocommerce
 msgid "No Variations found"
-msgstr "Aucune variation trouvée"
+msgstr "Aucune variation trouv&eacute;e"
 
-# @ woocommerce
-#: ../woocommerce.php:780
+#: woocommerce.php:790
+#@ woocommerce
 msgid "No Variations found in trash"
-msgstr "Pas de variations trouvées dans la corbeille"
+msgstr "Aucune variation trouv&eacute;e dans la Corbeille"
 
-# @ woocommerce
-#: ../woocommerce.php:781
+#: woocommerce.php:791
+#@ woocommerce
 msgid "Parent Variation"
-msgstr "Variation Parente"
+msgstr "Variation parente"
 
-# @ woocommerce
-#: ../woocommerce.php:810
-#: ../admin/woocommerce-admin-content.php:61
-#: ../admin/woocommerce-admin-dashboard.php:99
+#: woocommerce.php:832
+#@ woocommerce
+msgctxt "Admin menu name"
 msgid "Orders"
 msgstr "Commandes"
 
-# @ woocommerce
-#: ../woocommerce.php:811
+#: admin/woocommerce-admin-content.php:61
+#: admin/woocommerce-admin-dashboard.php:98
+#: admin/woocommerce-admin-users.php:21
+#: woocommerce.php:840
+#@ woocommerce
+msgid "Orders"
+msgstr "Commandes"
+
+#: admin/post-types/shop_order.php:35
+#: templates/myaccount/my-orders.php:27
+#: woocommerce.php:841
+#@ woocommerce
 msgid "Order"
 msgstr "Commande"
 
-# @ woocommerce
-#: ../woocommerce.php:812
+#: woocommerce.php:842
+#@ woocommerce
 msgid "Add Order"
-msgstr "Ajouter commande"
+msgstr "Ajouter une commande"
 
-# @ woocommerce
-#: ../woocommerce.php:813
+#: woocommerce.php:843
+#@ woocommerce
 msgid "Add New Order"
-msgstr "Nouvelle commande"
+msgstr "Ajouter une nouvelle commande"
 
-# @ woocommerce
-#: ../woocommerce.php:815
+#: woocommerce.php:845
+#@ woocommerce
 msgid "Edit Order"
-msgstr "Modifier commande"
+msgstr "Modifier la commande"
 
-# @ woocommerce
-#: ../woocommerce.php:816
+#: woocommerce.php:846
+#@ woocommerce
 msgid "New Order"
 msgstr "Nouvelle commande"
 
-# @ woocommerce
-#: ../woocommerce.php:817
-#: ../woocommerce.php:818
+#: admin/woocommerce-admin-install.php:179
+#: woocommerce.php:847
+#: woocommerce.php:848
+#@ woocommerce
 msgid "View Order"
 msgstr "Voir la commande"
 
-# @ woocommerce
-#: ../woocommerce.php:819
+#: woocommerce.php:849
+#@ woocommerce
 msgid "Search Orders"
-msgstr "Recherche commandes"
+msgstr "Rechercher des commandes"
 
-# @ woocommerce
-#: ../woocommerce.php:820
+#: woocommerce.php:850
+#@ woocommerce
 msgid "No Orders found"
-msgstr "Aucune commande trouvée"
+msgstr "Aucune commande trouv&eacute;e"
 
-# @ woocommerce
-#: ../woocommerce.php:821
+#: woocommerce.php:851
+#@ woocommerce
 msgid "No Orders found in trash"
-msgstr "Aucune commande trouvée dans la corbeille"
+msgstr "Aucune commande trouv&eacute;e dans la Corbeille"
 
-# @ woocommerce
-#: ../woocommerce.php:822
+#: woocommerce.php:852
+#@ woocommerce
 msgid "Parent Orders"
-msgstr "Commandes Parentes"
+msgstr "Commandes parentes"
 
-# @ woocommerce
-#: ../woocommerce.php:824
+#: woocommerce.php:855
+#@ woocommerce
 msgid "This is where store orders are stored."
-msgstr "Voici où les produits sont stockés"
+msgstr "C&rsquo;est ici que sont stock&eacute;es les commandes de la boutique."
 
-# @ woocommerce
-#: ../woocommerce.php:854
-#: ../admin/woocommerce-admin-content.php:69
+#: admin/settings/settings-init.php:142
+#: admin/woocommerce-admin-content.php:69
+#: woocommerce.php:885
+#@ woocommerce
 msgid "Coupons"
-msgstr "Codes Promo"
+msgstr "Codes promo"
 
-# @ woocommerce
-#: ../woocommerce.php:855
+#: classes/shipping/class-wc-free-shipping.php:65
+#: templates/cart/cart.php:108
+#: woocommerce.php:886
+#@ woocommerce
 msgid "Coupon"
-msgstr "Code Promo"
+msgstr "Code promo"
 
-# @ woocommerce
-#: ../woocommerce.php:856
+#: woocommerce.php:887
+#@ woocommerce
+msgctxt "Admin menu name"
+msgid "Coupons"
+msgstr "Codes promo"
+
+#: woocommerce.php:888
+#@ woocommerce
 msgid "Add Coupon"
-msgstr "Ajouter Code Promo"
+msgstr "Ajouter un code promo"
 
-# @ woocommerce
-#: ../woocommerce.php:857
+#: woocommerce.php:889
+#@ woocommerce
 msgid "Add New Coupon"
-msgstr "Ajouter un nouveau Code Promo"
+msgstr "Ajouter un nouveau code promo"
 
-# @ woocommerce
-#: ../woocommerce.php:859
+#: woocommerce.php:891
+#@ woocommerce
 msgid "Edit Coupon"
-msgstr "Modifier Code Promo"
+msgstr "Modifier le code promo"
 
-# @ woocommerce
-#: ../woocommerce.php:860
+#: woocommerce.php:892
+#@ woocommerce
 msgid "New Coupon"
-msgstr "Nouveau Code Promo"
+msgstr "Nouveau code promo"
 
-# @ woocommerce
-#: ../woocommerce.php:861
+#: woocommerce.php:893
+#@ woocommerce
 msgid "View Coupons"
-msgstr "Voir Codes Promo"
+msgstr "Voir les codes promo"
 
-# @ woocommerce
-#: ../woocommerce.php:862
+#: woocommerce.php:894
+#@ woocommerce
 msgid "View Coupon"
-msgstr "Voir Code Promo"
+msgstr "Voir le code promo"
 
-# @ woocommerce
-#: ../woocommerce.php:863
+#: woocommerce.php:895
+#@ woocommerce
 msgid "Search Coupons"
-msgstr "Recherche Codes Promo"
+msgstr "Rechercher des codes promo"
 
-# @ woocommerce
-#: ../woocommerce.php:864
+#: woocommerce.php:896
+#@ woocommerce
 msgid "No Coupons found"
-msgstr "Aucun Code Promo trouvé"
+msgstr "Aucun code promo trouv&eacute;"
 
-# @ woocommerce
-#: ../woocommerce.php:865
+#: woocommerce.php:897
+#@ woocommerce
 msgid "No Coupons found in trash"
-msgstr "Aucun Code Promo trouvé dans la corbeille"
+msgstr "Aucun code promo trouv&eacute; dans la Corbeille"
 
-# @ woocommerce
-#: ../woocommerce.php:866
+#: woocommerce.php:898
+#@ woocommerce
 msgid "Parent Coupon"
-msgstr "Code Promo parent"
+msgstr "Code promo parent"
 
-# @ woocommerce
-#: ../woocommerce.php:868
+#: woocommerce.php:900
+#@ woocommerce
 msgid "This is where you can add new coupons that customers can use in your store."
-msgstr "Voici où vous pouvez ajouter de nouveaux codes promo que vos clients peuvent utiliser dans votre boutique."
+msgstr "C&rsquo;est ici que vous pouvez ajouter les nouveaux codes promo que les clients peuvent utiliser dans votre boutique."
 
-# @ woocommerce
-#: ../woocommerce.php:974
+#: woocommerce.php:1006
+#@ woocommerce
 msgid "Select an option&hellip;"
-msgstr "Sélectionnez une option&hellip;"
+msgstr "Choisissez une option..."
 
-# @ woocommerce
-#: ../woocommerce.php:1244
+#: templates/cart/totals.php:28
+#: templates/checkout/review-order.php:30
+#: woocommerce.php:1276
+#@ woocommerce
 msgid "Cart Discount"
-msgstr "Remise panier"
+msgstr "Remise sur panier"
 
-# @ woocommerce
-#: ../woocommerce.php:1245
+#: woocommerce.php:1277
+#@ woocommerce
 msgid "Cart % Discount"
-msgstr "Remise en % du panier"
+msgstr "Remise sur panier en %"
 
-# @ woocommerce
-#: ../woocommerce.php:1246
+#: woocommerce.php:1278
+#@ woocommerce
 msgid "Product Discount"
-msgstr "Remise produit"
+msgstr "Remise sur produit(s)"
 
-# @ woocommerce
-#: ../woocommerce.php:1247
+#: woocommerce.php:1279
+#@ woocommerce
 msgid "Product % Discount"
-msgstr "Remise en % du produit"
+msgstr "Remise sur produit(s) en %"
 
-# @ woocommerce
-#: ../woocommerce.php:1289
+#: admin/woocommerce-admin-settings.php:34
+#: woocommerce.php:1321
+#@ woocommerce
 msgid "Action failed. Please refresh the page and retry."
-msgstr "L'action a échoué. Rafraîchissez la page et essayez à nouveau, svp."
+msgstr "L&rsquo;action a &eacute;chou&eacute;e. Veuillez rafraichir la page et essayer &agrave; nouveau."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:111
+#: admin/woocommerce-admin-attributes.php:111
+#@ woocommerce
 msgid "Edit Attribute"
-msgstr "Modifier l'attribut"
+msgstr "Modifier l&rsquo;attribut"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:117
-#: ../admin/woocommerce-admin-attributes.php:164
-#: ../admin/woocommerce-admin-attributes.php:217
-#: ../admin/woocommerce-admin-init.php:258
+#: admin/post-types/product.php:67
+#: admin/post-types/writepanels/writepanel-order_data.php:271
+#: admin/post-types/writepanels/writepanel-product_data.php:303
+#: admin/post-types/writepanels/writepanel-product_data.php:383
+#: admin/woocommerce-admin-attributes.php:117
+#: admin/woocommerce-admin-attributes.php:164
+#: admin/woocommerce-admin-attributes.php:217
+#: admin/woocommerce-admin-init.php:262
+#: templates/single-product-reviews.php:79
+#: widgets/widget-product_categories.php:155
+#@ woocommerce
 msgid "Name"
 msgstr "Nom"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:121
-#: ../admin/woocommerce-admin-attributes.php:219
+#: admin/woocommerce-admin-attributes.php:121
+#: admin/woocommerce-admin-attributes.php:219
+#@ woocommerce
 msgid "Name for the attribute (shown on the front-end)."
-msgstr "Nom pour l'attribut (affiché dans la partie publique)."
+msgstr "Nom de l&rsquo;attribut (affich&eacute; sur le site)."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:126
-#: ../admin/woocommerce-admin-attributes.php:166
-#: ../admin/woocommerce-admin-attributes.php:229
+#: admin/post-types/product.php:80
+#: admin/woocommerce-admin-attributes.php:126
+#: admin/woocommerce-admin-attributes.php:166
+#: admin/woocommerce-admin-attributes.php:229
+#@ woocommerce
 msgid "Type"
 msgstr "Type"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:130
-#: ../admin/woocommerce-admin-attributes.php:231
+#: admin/woocommerce-admin-attributes.php:130
+#: admin/woocommerce-admin-attributes.php:231
+#@ woocommerce
 msgid "Select"
-msgstr "Select"
+msgstr "Choix"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:131
-#: ../admin/woocommerce-admin-attributes.php:232
+#: admin/woocommerce-admin-attributes.php:131
+#: admin/woocommerce-admin-attributes.php:232
+#@ woocommerce
 msgid "Text"
 msgstr "Texte"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:133
-#: ../admin/woocommerce-admin-attributes.php:234
+#: admin/woocommerce-admin-attributes.php:133
+#: admin/woocommerce-admin-attributes.php:234
+#@ woocommerce
 msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
-msgstr "Détermine comment vous sélectionnez les attributs des produits. <strong>Texte</strong> permet une saisie manuelle via la page produit, alors que <strong>Choix</strong> permet de choisir les attributs à partir de cette section. Si vous planifiez d'utiliser un attribut pour des variations utilisez <strong>Choix</strong>."
+msgstr "D&eacute;termine le mode de s&eacute;lection des attributs de produits. <strong>Texte</strong> autorise la saisie sur la page produit, tandis que <strong>Choix</strong> permet de choisir des attributs dans une liste. Si vous envisager d&rsquo;utiliser un attribut dans les variations, utilisez <strong>Choix</strong>."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:156
-#: ../admin/woocommerce-admin-init.php:31
+#: admin/post-types/writepanels/writepanel-product_data.php:37
+#: admin/woocommerce-admin-attributes.php:156
+#: admin/woocommerce-admin-init.php:32
+#@ woocommerce
 msgid "Attributes"
 msgstr "Attributs"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:165
-#: ../admin/woocommerce-admin-attributes.php:223
+#: admin/woocommerce-admin-attributes.php:165
+#: admin/woocommerce-admin-attributes.php:223
+#@ woocommerce
 msgid "Slug"
-msgstr "Slug"
+msgstr "Identifiant"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:167
+#: admin/woocommerce-admin-attributes.php:167
+#@ woocommerce
 msgid "Terms"
 msgstr "Termes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:179
+#: admin/woocommerce-admin-attributes.php:179
+#@ woocommerce
 msgid "Delete"
 msgstr "Supprimer"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:199
+#: admin/woocommerce-admin-attributes.php:199
+#@ woocommerce
 msgid "Configure&nbsp;terms"
-msgstr "Configurer&nbsp;les&nbsp;termes"
+msgstr "Configurer les termes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:203
+#: admin/woocommerce-admin-attributes.php:203
+#@ woocommerce
 msgid "No attributes currently exist."
 msgstr "Aucun attribut pour le moment."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:213
+#: admin/woocommerce-admin-attributes.php:213
+#@ woocommerce
 msgid "Add New Attribute"
 msgstr "Ajouter un nouvel attribut"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:214
+#: admin/woocommerce-admin-attributes.php:214
+#@ woocommerce
 msgid "Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the \"layered nav\" widgets. Please note: you cannot rename an attribute later on."
-msgstr "Les attributs vous laisse définir des données supplémentaires pour les produits, tels que la taille ou la couleur. Vous pouvez utiliser ces attributs dans la barre latérale de la boutique en utilisant les widgets \"layered nav\". Veuillez noter : vous ne pouvez pas renommer un attribut ultérieurement."
+msgstr "Les attributs permettent d&rsquo;ajouter des options aux produits, comme la taille ou la couleur. Vous pouvez utiliser ces attributs dans le menu de la boutique &agrave; l&rsquo;aide des widgets \"layered nav\". Veuillez noter&nbsp;: vous ne pouvez pas renommer un attribut ult&eacute;rieurement."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:225
+#: admin/woocommerce-admin-attributes.php:225
+#@ woocommerce
 msgid "Unique slug/reference for the attribute; must be shorter than 28 characters."
-msgstr "Slug/Référence unique pour l'attribut, doit avoir moins de 28 caractères."
+msgstr "Identifiant/R&eacute;f&eacute;rence unique de l&rsquo;attribut, doit avoir moins de 28 caract&egrave;res."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:237
+#: admin/woocommerce-admin-attributes.php:237
+#@ woocommerce
 msgid "Add Attribute"
 msgstr "Ajouter un attribut"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-attributes.php:248
+#: admin/woocommerce-admin-attributes.php:248
+#@ woocommerce
 msgid "Are you sure you want to delete this attribute?"
-msgstr "Êtes vous sur de vouloir supprimer cet attribut?"
+msgstr "&Ecirc;tes-vous s&ucirc;r(e) de vouloir supprimer cet attribut&nbsp;?"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:20
+#: admin/woocommerce-admin-content.php:20
+#: admin/woocommerce-admin-reports.php:18
+#: admin/woocommerce-admin-reports.php:51
+#: admin/woocommerce-admin-reports.php:59
+#@ woocommerce
 msgid "Overview"
-msgstr "Aperçu"
+msgstr "Aper&ccedil;u"
 
-#: ../admin/woocommerce-admin-content.php:23
+#: admin/woocommerce-admin-content.php:23
 #, php-format
+#@ woocommerce
 msgid "Thank you for using WooCommerce :) Should you need help using or extending WooCommerce please <a href=\"%s\">read the documentation</a>. For further assistance you can use the <a href=\"%s\">community forum</a> or if you have access, <a href=\"%s\">the members forum</a>."
-msgstr ""
+msgstr "Merci d&rsquo;utiliser WooCommerce&nbsp;:) Si vous avez besoin d&rsquo;aide pour utiliser ou d&eacute;velopper WooCommerce, veuillez <a href=\"%s\">lire la documentation</a>. Pour une assistance suppl&eacute;mentaire, vous pouvez utiliser le <a href=\"%s\">forum communautaire</a> ou si vous y avez acc&egrave;s, le <a href=\"%s\">forum des membres</a>."
 
-#: ../admin/woocommerce-admin-content.php:25
-msgid "If you are having problems, or to assist us with support, please check the debugging page to identify any problems with your configuration:"
-msgstr ""
+#: admin/woocommerce-admin-content.php:25
+#@ woocommerce
+msgid "If you are having problems, or to assist us with support, please check the status page to identify any problems with your configuration:"
+msgstr "Si vous rencontrez des probl&egrave;mes, ou pour nous aider a les identifier, veuillez consulter la page d&rsquo;&eacute;tats pour identifier d&rsquo;&eacute;ventuels probl&egrave;mes avec votre configuration&nbsp;:"
 
-#: ../admin/woocommerce-admin-content.php:27
-msgid "Debugging Info &amp; Tools"
-msgstr ""
+#: admin/woocommerce-admin-content.php:27
+#: admin/woocommerce-admin-init.php:45
+#: admin/woocommerce-admin-status.php:29
+#@ woocommerce
+msgid "System Status"
+msgstr "&Eacute;tats du syst&egrave;me"
 
-#: ../admin/woocommerce-admin-content.php:29
+#: admin/woocommerce-admin-content.php:29
 #, php-format
+#@ woocommerce
 msgid "If you come across a bug, or wish to contribute to the project you can also <a href=\"%s\">get involved on GitHub</a>."
-msgstr ""
+msgstr "Si vous rencontrez un bug, ou si vous souhaitez contribuer au projet, vous pouvez &eacute;galement <a href=\"%s\">participer sur GitHub</a>."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:35
-#: ../admin/woocommerce-admin-debug.php:95
-#: ../admin/woocommerce-admin-init.php:27
-#: ../admin/woocommerce-admin-init.php:92
+#: admin/woocommerce-admin-content.php:35
+#: admin/woocommerce-admin-debug.php:123
+#: admin/woocommerce-admin-init.php:28
+#: admin/woocommerce-admin-init.php:97
+#: admin/woocommerce-admin-status.php:123
+#: classes/class-wc-settings-api.php:27
+#: classes/integrations/class-wc-integration.php:24
+#@ woocommerce
 msgid "Settings"
-msgstr "Paramètres"
+msgstr "Param&egrave;tres"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:37
+#: admin/woocommerce-admin-content.php:37
+#@ woocommerce
 msgid "Here you can set up your store and customise it to fit your needs. The sections available from the settings page include:"
-msgstr ""
+msgstr "Ici vous pouvez configurer votre magasin et le personnaliser pour r&eacute;pondre &agrave; vos besoins. Les sections disponibles &agrave; partir de la page des param&egrave;tres comprennent&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:38
+#: admin/post-types/writepanels/writepanel-product_data.php:29
+#: admin/woocommerce-admin-content.php:38
+#: admin/woocommerce-admin-settings.php:183
+#@ woocommerce
 msgid "General"
-msgstr "Général"
+msgstr "G&eacute;n&eacute;ral"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:38
+#: admin/woocommerce-admin-content.php:38
+#@ woocommerce
 msgid "General settings such as your shop base, currency, and script/styling options which affect features used in your store."
-msgstr "Paramètres généraux tels que la racine de votre boutique, la monnaie, et les options de scripts et de styles qui affectent les caractéristiques utilisées dans votre magasin."
+msgstr "Param&egrave;tres g&eacute;n&eacute;raux, comme la base de votre boutique, la monnaie et les options de script/d&rsquo;apparence qui affectent les fonctionnalit&eacute;s de votre magasin."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:39
+#: admin/woocommerce-admin-content.php:39
+#: admin/woocommerce-admin-settings.php:185
+#@ woocommerce
 msgid "Pages"
 msgstr "Pages"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:39
+#: admin/woocommerce-admin-content.php:39
+#@ woocommerce
 msgid "This is where important store page are defined. You can also set up other pages (such as a Terms page) here."
-msgstr "C'est la section où les pages importantes du magasin sont définies. Vous pouvez également mettre en place d'autres pages (telle que les CGV) ici."
+msgstr "C&rsquo;est ici que les pages importantes de la boutique sont d&eacute;finies. Vous pouvez &eacute;galement configurer d&rsquo;autres pages (comme vos CGV)."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:40
+#: admin/post-types/product.php:545
+#: admin/post-types/product.php:787
+#: admin/post-types/writepanels/writepanel-product_data.php:145
+#: admin/woocommerce-admin-content.php:40
+#: admin/woocommerce-admin-settings.php:184
+#@ woocommerce
 msgid "Catalog"
 msgstr "Catalogue"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:40
+#: admin/woocommerce-admin-content.php:40
+#@ woocommerce
 msgid "Options for how things like price, images and weights appear in your product catalog."
-msgstr "Options pour la manière dont les choses comme le prix, les images et le poids apparaissent dans votre catalogue de produits."
+msgstr "Options d&eacute;finissant la mani&egrave;re dont les choses comme le prix, les images et le poids apparaissent dans votre catalogue de produits."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:41
+#: admin/post-types/writepanels/writepanel-product_data.php:33
+#: admin/woocommerce-admin-content.php:41
+#: admin/woocommerce-admin-settings.php:186
+#@ woocommerce
 msgid "Inventory"
 msgstr "Inventaire"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:41
+#: admin/woocommerce-admin-content.php:41
+#@ woocommerce
 msgid "Options concerning stock and stock notices."
 msgstr "Options concernant le stock et les alertes de stock."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:42
+#: admin/woocommerce-admin-content.php:42
+#@ woocommerce
 msgid "Options concerning tax, including international and local tax rates."
-msgstr "Options concernant les taxes, incluant les taux de taxes internationnales et locales."
+msgstr "Options concernant les taxes, y compris les taux de taxes internationnales et locales."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:43
+#: admin/post-types/shop_order.php:37
+#: admin/post-types/writepanels/writepanel-order_data.php:473
+#: admin/settings/settings-tax-rates.php:33
+#: admin/settings/settings-tax-rates.php:102
+#: admin/woocommerce-admin-content.php:43
+#: admin/woocommerce-admin-settings-forms.php:413
+#: admin/woocommerce-admin-settings-forms.php:485
+#: admin/woocommerce-admin-settings.php:188
+#: templates/cart/totals.php:37
+#: templates/checkout/review-order.php:41
+#@ woocommerce
 msgid "Shipping"
 msgstr "Livraison"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:43
+#: admin/woocommerce-admin-content.php:43
+#@ woocommerce
 msgid "This is where shipping options are defined, and shipping methods are set up."
-msgstr "C'est la section où les options de livraison sont définies, et que les méthodes de livraison sont définies."
+msgstr "C&rsquo;est ici que les options de livraison sont d&eacute;finies et que les modes de livraison sont configur&eacute;s."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:44
+#: admin/woocommerce-admin-content.php:44
+#@ woocommerce
 msgid "Payment Methods"
-msgstr "Méthodes de Paiement"
+msgstr "Modes de paiement"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:44
+#: admin/woocommerce-admin-content.php:44
+#@ woocommerce
 msgid "This is where payment gateway options are defined, and individual payment gateways are set up."
-msgstr "C'est la section où les passerelles de paiement sont définies, et que chaque passerelle est paramétrée."
+msgstr "C&rsquo;est ici que les options des passerelles de paiement sont d&eacute;finies, et que chaque passerelle de paiement est configur&eacute;e."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:45
+#: admin/woocommerce-admin-content.php:45
+#: admin/woocommerce-admin-settings.php:190
+#@ woocommerce
 msgid "Emails"
-msgstr "Emails"
+msgstr "E-mails"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:45
+#: admin/woocommerce-admin-content.php:45
+#@ woocommerce
 msgid "Here you can customise the way WooCommerce emails appear."
-msgstr "Ici vous pouvez personnaliser la manière dont les emails WooCommerce apparaissent."
+msgstr "Ici vous pouvez personnaliser la mani&egrave;re dont les e-mails WooCommerce apparaissent."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:46
+#: admin/woocommerce-admin-content.php:46
+#: admin/woocommerce-admin-settings.php:191
+#@ woocommerce
 msgid "Integration"
-msgstr "Intégration"
+msgstr "Int&eacute;gration"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:46
+#: admin/woocommerce-admin-content.php:46
+#@ woocommerce
 msgid "The integration section contains options for third party services which integrate with WooCommerce."
-msgstr "La section d'intégration contient les options pour les services tierces qui sont intégrés avec WooCommerce."
+msgstr "La section int&eacute;gration contient les options pour les services tiers qui sont int&eacute;gr&eacute;s avec WooCommerce."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:51
-#: ../admin/woocommerce-admin-init.php:29
+#: admin/woocommerce-admin-content.php:51
+#: admin/woocommerce-admin-init.php:30
+#@ woocommerce
 msgid "Reports"
 msgstr "Rapports"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:53
+#: admin/woocommerce-admin-content.php:53
+#@ woocommerce
 msgid "The reports section can be accessed from the left-hand navigation menu. Here you can generate reports for sales and customers."
-msgstr "La section rapports est accessible depuis le menu de navigation de gauche. Là vous pouvez générer des rapports de ventes et de clients."
+msgstr "La section rapports est accessible depuis le menu de navigation gauche. Ici vous pouvez g&eacute;n&eacute;rer des rapports de vente et sur les clients."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:54
+#: admin/woocommerce-admin-content.php:54
+#: admin/woocommerce-admin-reports.php:922
+#: admin/woocommerce-admin-reports.php:1019
+#: admin/woocommerce-admin-reports.php:1129
+#@ woocommerce
 msgid "Sales"
 msgstr "Ventes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:54
+#: admin/woocommerce-admin-content.php:54
+#@ woocommerce
 msgid "Reports for sales based on date, top sellers and top earners."
-msgstr "Rapports des ventes basés sur la date, les meilleures ventes et les meilleurs gains."
+msgstr "Rapports de vente en fontion de la date, des meilleures ventes et des meilleurs gains."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:55
+#: admin/woocommerce-admin-content.php:55
+#@ woocommerce
 msgid "Customers"
 msgstr "Clients"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:55
+#: admin/woocommerce-admin-content.php:55
+#@ woocommerce
 msgid "Customer reports, such as signups per day."
-msgstr "Rapports sur les clients, tels que les inscriptions par jour."
+msgstr "Rapports sur les clients, comme les inscriptions par jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:56
+#: admin/post-types/product.php:73
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:73
+#: admin/woocommerce-admin-content.php:56
+#@ woocommerce
 msgid "Stock"
 msgstr "Stock"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:56
-msgid "Stock reports for low sotck and out of stock items."
-msgstr "Rapports de stock pour les bas niveaux de stock et les articles épuisés."
+#: admin/woocommerce-admin-content.php:56
+#@ woocommerce
+msgid "Stock reports for low stock and out of stock items."
+msgstr "Rapports de stock pour les articles en \"stock faible\" et en \"rupture de stock\"."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:63
+#: admin/woocommerce-admin-content.php:63
+#@ woocommerce
 msgid "The orders section can be accessed from the left-hand navigation menu. Here you can view and manage customer orders."
-msgstr "La section des commandes est accessible depuis le menu de gauche. Là vous pouvez voir et gérer les commandes client."
+msgstr "La section commandes est accessible depuis le menu de navigation gauche. Ici vous pouvez voir et g&eacute;rer les commandes client."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:64
+#: admin/woocommerce-admin-content.php:64
+#@ woocommerce
 msgid "Orders can also be added from this section if you want to set them up for a customer manually."
-msgstr "Les commandes peuvent également être ajoutées depuis cette section si vous voulez les mettre en place manuellement pour un client."
+msgstr "Des commandes peuvent &eacute;galement &ecirc;tre ajout&eacute;es depuis cette section si vous voulez les configurer manuellement pour un client."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-content.php:71
+#: admin/woocommerce-admin-content.php:71
+#@ woocommerce
 msgid "Coupons can be managed from this section. Once added, customers will be able to enter coupon codes on the cart/checkout page. If a customer uses a coupon code they will be viewable when viewing orders."
-msgstr "Les codes promo peuvent être gérés depuis cette section. Une fois ajoutés, les clients seront en mesure de saisir les codes promo sur la page panier/commande. Si un client utilise un code promo il sera visible lors de la visualisation des commandes."
+msgstr "Les codes promo peuvent &ecirc;tre g&eacute;r&eacute;s depuis cette section. Une fois ajout&eacute;s, les clients pouront les saisir sur la page panier/commande. Si un client utilise un code promo il sera affich&eacute; lors de la visualisation des commandes."
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:75
+#: admin/woocommerce-admin-content.php:75
+#@ woocommerce
 msgid "For more information:"
-msgstr "Pour plus d'information :"
+msgstr "Pour plus d&rsquo;informations&nbsp;:"
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:76
+#: admin/woocommerce-admin-content.php:76
+#@ woocommerce
 msgid "<a href=\"http://www.woothemes.com/woocommerce/\" target=\"_blank\">WooCommerce</a>"
 msgstr "<a href=\"http://www.woothemes.com/woocommerce/\" target=\"_blank\">WooCommerce</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:77
+#: admin/woocommerce-admin-content.php:77
+#@ woocommerce
 msgid "<a href=\"http://wordpress.org/extend/plugins/woocommerce/\" target=\"_blank\">Project on WordPress.org</a>"
 msgstr "<a href=\"http://wordpress.org/extend/plugins/woocommerce/\" target=\"_blank\">Projet sur WordPress.org</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:78
+#: admin/woocommerce-admin-content.php:78
+#@ woocommerce
 msgid "<a href=\"https://github.com/woothemes/woocommerce\" target=\"_blank\">Project on Github</a>"
 msgstr "<a href=\"https://github.com/woothemes/woocommerce\" target=\"_blank\">Projet sur Github</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:79
+#: admin/woocommerce-admin-content.php:79
+#@ woocommerce
 msgid "<a href=\"http://www.woothemes.com/woocommerce-docs/\" target=\"_blank\">WooCommerce Docs</a>"
 msgstr "<a href=\"http://www.woothemes.com/woocommerce-docs/\" target=\"_blank\">Documentation WooCommerce</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:80
+#: admin/woocommerce-admin-content.php:80
+#@ woocommerce
 msgid "<a href=\"http://www.woothemes.com/extensions/woocommerce-extensions/\" target=\"_blank\">Official Extensions</a>"
 msgstr "<a href=\"http://www.woothemes.com/extensions/woocommerce-extensions/\" target=\"_blank\">Extensions officielles</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-content.php:81
-msgid "<a href=\"http://www.woothemes.com/themes/woocommerce-themes/\" target=\"_blank\">Offical Themes</a>"
-msgstr "<a href=\"http://www.woothemes.com/themes/woocommerce-themes/\" target=\"_blank\">Themes officiels</a>"
+#: admin/woocommerce-admin-content.php:81
+#@ woocommerce
+msgid "<a href=\"http://www.woothemes.com/themes/woocommerce-themes/\" target=\"_blank\">Official Themes</a>"
+msgstr "<a href=\"http://www.woothemes.com/themes/woocommerce-themes/\" target=\"_blank\">Th&egrave;mes officiels</a>"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:35
+#: admin/woocommerce-admin-dashboard.php:34
+#@ woocommerce
 msgid "Shop Content"
 msgstr "Contenu de la boutique"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:83
+#: admin/woocommerce-admin-dashboard.php:82
+#@ woocommerce
 msgid "Attribute"
 msgid_plural "Attributes"
 msgstr[0] "Attribut"
 msgstr[1] "Attributs"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:105
+#: admin/woocommerce-admin-dashboard.php:104
+#@ woocommerce
 msgid "Pending"
-msgstr "Attente"
+msgstr "En suspens"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:119
+#: admin/woocommerce-admin-dashboard.php:118
+#@ woocommerce
 msgid "On-Hold"
 msgstr "En attente"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:133
+#: admin/post-types/shop_order.php:140
+#: admin/woocommerce-admin-dashboard.php:132
+#@ woocommerce
 msgid "Processing"
 msgstr "En cours"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:147
+#: admin/woocommerce-admin-dashboard.php:146
+#@ woocommerce
 msgid "Completed"
-msgstr "Expédiée"
+msgstr "Termin&eacute;e"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:164
+#: admin/woocommerce-admin-dashboard.php:163
 #, php-format
+#@ woocommerce
 msgid "You are using <strong>WooCommerce %s</strong>."
-msgstr ""
+msgstr "Vous utilisez <strong>WooCommerce %s</strong>."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:190
+#: admin/woocommerce-admin-dashboard.php:189
+#@ woocommerce
 msgid "Monthly Sales"
-msgstr "Ventes du mois"
+msgstr "Ventes par mois"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:193
+#: admin/woocommerce-admin-dashboard.php:192
+#@ woocommerce
 msgid "WooCommerce Right Now"
-msgstr ""
+msgstr "WooCommerce - En ce moment"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:194
+#: admin/woocommerce-admin-dashboard.php:193
+#@ woocommerce
 msgid "WooCommerce Recent Orders"
-msgstr ""
+msgstr "WooCommerce - Commandes r&eacute;centes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:195
+#: admin/woocommerce-admin-dashboard.php:194
+#: widgets/widget-recent_reviews.php:25
+#@ woocommerce
 msgid "WooCommerce Recent Reviews"
-msgstr "WooCommerce Avis Récents"
+msgstr "WooCommerce - Avis r&eacute;cents"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:224
+#: admin/woocommerce-admin-dashboard.php:223
+#@ woocommerce
 msgid "l jS \\of F Y h:i:s A"
 msgstr "l j F Y h:i:s"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:225
+#: admin/woocommerce-admin-dashboard.php:224
+#@ woocommerce
 msgid "item"
 msgid_plural "items"
-msgstr[0] "élément"
-msgstr[1] "éléments"
+msgstr[0] "article"
+msgstr[1] "articles"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:225
+#: admin/woocommerce-admin-dashboard.php:224
+#: shortcodes/shortcode-pay.php:81
+#: templates/checkout/thankyou.php:44
+#@ woocommerce
 msgid "Total:"
-msgstr "Total :"
+msgstr "Total&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:231
+#: admin/woocommerce-admin-dashboard.php:230
+#@ woocommerce
 msgid "There are no product orders yet."
-msgstr ""
+msgstr "Il n&rsquo;y a pas encore de commandes."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:261
+#: admin/woocommerce-admin-dashboard.php:260
+#: classes/class-wc-product.php:748
+#: templates/single-product/review.php:18
+#: templates/single-product-reviews.php:29
+#: widgets/widget-recent_reviews.php:74
+#@ woocommerce
 msgid "out of 5"
 msgstr "sur 5"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:269
+#: admin/woocommerce-admin-dashboard.php:268
+#@ woocommerce
 msgid "There are no product reviews yet."
-msgstr "Il n'y a pas encore d'avis de produits"
+msgstr "Il n&rsquo;y a pas encore d&rsquo;avis de produits."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:393
+#: admin/woocommerce-admin-dashboard.php:394
+#: admin/woocommerce-admin-reports.php:158
+#: admin/woocommerce-admin-reports.php:447
+#: admin/woocommerce-admin-reports.php:638
+#: admin/woocommerce-admin-reports.php:825
+#@ woocommerce
 msgid "Number of sales"
 msgstr "Nombre de ventes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-dashboard.php:394
+#: admin/woocommerce-admin-dashboard.php:395
+#: admin/woocommerce-admin-reports.php:153
+#: admin/woocommerce-admin-reports.php:447
+#: admin/woocommerce-admin-reports.php:638
+#: admin/woocommerce-admin-reports.php:825
+#@ woocommerce
 msgid "Sales amount"
-msgstr "Montant des Ventes"
+msgstr "Montant des ventes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:16
+#: admin/woocommerce-admin-debug.php:15
+#: admin/woocommerce-admin-status.php:15
+#@ woocommerce
+msgid "Transients"
+msgstr "Donn&eacute;es temporaires"
+
+#: admin/woocommerce-admin-debug.php:16
+#: admin/woocommerce-admin-status.php:16
+#@ woocommerce
+msgid "Clear Transients"
+msgstr "Effacer les donn&eacute;es temporaires"
+
+#: admin/woocommerce-admin-debug.php:17
+#: admin/woocommerce-admin-status.php:17
+#@ woocommerce
+msgid "This tool will clear the product/shop transients cache."
+msgstr "Cet outil vide le cache des donn&eacute;es temporaires produits/boutique."
+
+#: admin/woocommerce-admin-debug.php:20
+#: admin/woocommerce-admin-status.php:20
+#@ woocommerce
+msgid "Capabilities"
+msgstr "Capacit&eacute;s"
+
+#: admin/woocommerce-admin-debug.php:21
+#: admin/woocommerce-admin-status.php:21
+#@ woocommerce
+msgid "Reset Capabilities"
+msgstr "R&eacute;initialiser les capacit&eacute;s"
+
+#: admin/woocommerce-admin-debug.php:22
+#: admin/woocommerce-admin-status.php:22
+#@ woocommerce
+msgid "This tool will reset the admin, customer and shop_manager roles to default. Use this if your users cannot access all of the WooCommerce admin pages."
+msgstr "Cet outil permet de remettre les r&ocirc;les d&rsquo;administrateur, de client et de g&eacute;rant de la boutique par d&eacute;faut. Utilisez cette option si vos utilisateurs ne peuvent pas acc&eacute;der &agrave; toutes les pages d&rsquo;administration de WooCommerce."
+
+#: admin/woocommerce-admin-debug.php:29
+#@ woocommerce
 msgid "Debugging Information"
-msgstr "Information de Débuggage"
+msgstr "Information de d&eacute;bogage"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:16
+#: admin/woocommerce-admin-debug.php:29
+#: admin/woocommerce-admin-status.php:29
+#@ woocommerce
 msgid "Generate report"
-msgstr "Générer un rapport"
+msgstr "G&eacute;n&eacute;rer un rapport"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:24
+#: admin/woocommerce-admin-debug.php:38
+#: admin/woocommerce-admin-status.php:38
+#@ woocommerce
 msgid "Product Transients Cleared"
-msgstr ""
+msgstr "Donn&eacute;es temporaires du produit effac&eacute;es"
 
-#: ../admin/woocommerce-admin-debug.php:38
+#: admin/woocommerce-admin-debug.php:52
+#: admin/woocommerce-admin-status.php:52
+#@ woocommerce
 msgid "Roles successfully reset"
-msgstr ""
+msgstr "R&ocirc;les initialis&eacute;s avec succ&egrave;s"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:49
+#: admin/woocommerce-admin-debug.php:61
+#: admin/woocommerce-admin-status.php:61
+#, php-format
+#@ woocommerce
+msgid "There was an error calling %s::%s"
+msgstr "Il y a eu une erreur en appelant %s::%s"
+
+#: admin/woocommerce-admin-debug.php:64
+#: admin/woocommerce-admin-status.php:64
+#, php-format
+#@ woocommerce
+msgid "There was an error calling %s"
+msgstr "Il y a eu une erreur en appelant %s"
+
+#: admin/woocommerce-admin-debug.php:77
+#: admin/woocommerce-admin-status.php:77
+#@ woocommerce
 msgid "Versions"
 msgstr "Versions"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:55
+#: admin/woocommerce-admin-debug.php:83
+#: admin/woocommerce-admin-status.php:83
+#@ woocommerce
 msgid "WooCommerce version"
-msgstr "WooCommerce version"
+msgstr "Version de WooCommerce"
 
-#: ../admin/woocommerce-admin-debug.php:59
+#: admin/woocommerce-admin-debug.php:87
+#: admin/woocommerce-admin-status.php:87
+#@ woocommerce
 msgid "WordPress version"
-msgstr "Version WordPress"
+msgstr "Version de WordPress"
 
-#: ../admin/woocommerce-admin-debug.php:63
+#: admin/woocommerce-admin-debug.php:91
+#: admin/woocommerce-admin-status.php:91
+#@ woocommerce
 msgid "Installed plugins"
-msgstr "Plugins installés"
+msgstr "Plugins install&eacute;s"
 
-#: ../admin/woocommerce-admin-debug.php:81
+#: admin/woocommerce-admin-debug.php:109
+#: admin/woocommerce-admin-status.php:109
+#@ woocommerce
 msgid "by"
 msgstr "par"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:81
+#: admin/woocommerce-admin-debug.php:109
+#: admin/woocommerce-admin-status.php:109
+#@ woocommerce
 msgid "version"
 msgstr "version"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:101
+#: admin/woocommerce-admin-debug.php:129
+#: admin/woocommerce-admin-status.php:129
+#@ woocommerce
 msgid "Home URL"
-msgstr "URL Accueil"
+msgstr "URL de l&rsquo;accueil"
 
-#: ../admin/woocommerce-admin-debug.php:105
+#: admin/woocommerce-admin-debug.php:133
+#: admin/woocommerce-admin-status.php:133
+#@ woocommerce
 msgid "Site URL"
-msgstr "URL Site"
+msgstr "URL du site"
 
-#: ../admin/woocommerce-admin-debug.php:109
+#: admin/woocommerce-admin-debug.php:137
+#: admin/woocommerce-admin-status.php:137
+#@ woocommerce
 msgid "Force SSL"
-msgstr "Forcer SSL"
+msgstr "Forcer le SSL"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:116
+#: admin/settings/settings-init.php:426
+#: admin/woocommerce-admin-debug.php:144
+#: admin/woocommerce-admin-status.php:144
+#@ woocommerce
 msgid "Shop Pages"
-msgstr "Pages boutique"
+msgstr "Pages de la boutique"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:123
+#: admin/woocommerce-admin-debug.php:151
+#: admin/woocommerce-admin-status.php:151
+#@ woocommerce
 msgid "Shop base page"
 msgstr "Page de base de la boutique"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:127
+#: admin/settings/settings-init.php:429
+#: admin/woocommerce-admin-debug.php:155
+#: admin/woocommerce-admin-status.php:155
+#@ woocommerce
 msgid "Cart Page"
-msgstr "Page panier"
+msgstr "Page du panier"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:131
+#: admin/settings/settings-init.php:440
+#: admin/woocommerce-admin-debug.php:159
+#: admin/woocommerce-admin-status.php:159
+#@ woocommerce
 msgid "Checkout Page"
-msgstr "Page commande"
+msgstr "Page de commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:135
+#: admin/settings/settings-init.php:451
+#: admin/woocommerce-admin-debug.php:163
+#: admin/woocommerce-admin-status.php:163
+#@ woocommerce
 msgid "Pay Page"
-msgstr "Page paiement"
+msgstr "Page de paiement"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:139
+#: admin/settings/settings-init.php:462
+#: admin/woocommerce-admin-debug.php:167
+#: admin/woocommerce-admin-status.php:167
+#@ woocommerce
 msgid "Thanks Page"
 msgstr "Page de remerciements"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:143
+#: admin/settings/settings-init.php:473
+#: admin/woocommerce-admin-debug.php:171
+#: admin/woocommerce-admin-status.php:171
+#@ woocommerce
 msgid "My Account Page"
 msgstr "Page mon compte"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:147
+#: admin/settings/settings-init.php:484
+#: admin/woocommerce-admin-debug.php:175
+#: admin/woocommerce-admin-status.php:175
+#@ woocommerce
 msgid "Edit Address Page"
-msgstr "Page modification adresse"
+msgstr "Page de modification d&rsquo;adresse"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:151
+#: admin/settings/settings-init.php:495
+#: admin/woocommerce-admin-debug.php:179
+#: admin/woocommerce-admin-status.php:179
+#@ woocommerce
 msgid "View Order Page"
-msgstr "Page voir commande"
+msgstr "Page de visualistion de commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:155
+#: admin/settings/settings-init.php:506
+#: admin/woocommerce-admin-debug.php:183
+#: admin/woocommerce-admin-status.php:183
+#@ woocommerce
 msgid "Change Password Page"
-msgstr "Page changement mot de passe"
+msgstr "Page de modification de mot de passe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:175
+#: admin/woocommerce-admin-debug.php:203
+#: admin/woocommerce-admin-status.php:203
+#@ woocommerce
 msgid "Page not set"
-msgstr ""
+msgstr "Page non d&eacute;finie"
 
-#: ../admin/woocommerce-admin-debug.php:185
+#: admin/woocommerce-admin-debug.php:213
+#: admin/woocommerce-admin-status.php:213
 #, php-format
+#@ woocommerce
 msgid "Page does not contain the shortcode: %s"
-msgstr ""
+msgstr "La page ne contient pas le shortcode&nbsp;: %s"
 
-#: ../admin/woocommerce-admin-debug.php:204
+#: admin/woocommerce-admin-debug.php:232
+#: admin/woocommerce-admin-status.php:232
+#@ woocommerce
 msgid "Server Environment"
-msgstr "Environnement Serveur "
+msgstr "Environnement du serveur "
 
-#: ../admin/woocommerce-admin-debug.php:210
+#: admin/woocommerce-admin-debug.php:238
+#: admin/woocommerce-admin-status.php:238
+#@ woocommerce
 msgid "PHP Version"
-msgstr "Version PHP"
+msgstr "Version de PHP"
 
-#: ../admin/woocommerce-admin-debug.php:216
+#: admin/woocommerce-admin-debug.php:244
+#: admin/woocommerce-admin-status.php:244
+#@ woocommerce
 msgid "Server Software"
-msgstr ""
+msgstr "Logiciel du serveur"
 
-#: ../admin/woocommerce-admin-debug.php:222
+#: admin/woocommerce-admin-debug.php:250
+#: admin/woocommerce-admin-status.php:250
+#@ woocommerce
 msgid "WP Max Upload Size"
-msgstr ""
+msgstr "WP taille max. d&rsquo;upload"
 
-#: ../admin/woocommerce-admin-debug.php:228
+#: admin/woocommerce-admin-debug.php:256
+#: admin/woocommerce-admin-status.php:256
+#@ woocommerce
 msgid "Server upload_max_filesize"
-msgstr "Server upload_max_filesize"
+msgstr "Serveur upload_max_filesize"
 
-#: ../admin/woocommerce-admin-debug.php:235
+#: admin/woocommerce-admin-debug.php:263
+#: admin/woocommerce-admin-status.php:263
+#@ woocommerce
 msgid "Server post_max_size"
-msgstr "Server post_max_size"
+msgstr "Serveur post_max_size"
 
-#: ../admin/woocommerce-admin-debug.php:242
+#: admin/woocommerce-admin-debug.php:270
+#: admin/woocommerce-admin-status.php:270
+#@ woocommerce
 msgid "WP Memory Limit"
-msgstr "WP Memory Limit"
+msgstr "Limite m&eacute;moire de WP"
 
-#: ../admin/woocommerce-admin-debug.php:248
+#: admin/woocommerce-admin-debug.php:276
+#: admin/woocommerce-admin-status.php:282
+#@ woocommerce
 msgid "WP Debug Mode"
-msgstr "WP Debug Mode"
+msgstr "Mode de d&eacute;bogage de WP"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:249
+#: admin/post-types/product.php:805
+#: admin/post-types/product.php:841
+#: admin/post-types/shop_order.php:149
+#: admin/woocommerce-admin-debug.php:277
+#: admin/woocommerce-admin-status.php:138
+#: admin/woocommerce-admin-status.php:283
+#@ woocommerce
 msgid "Yes"
 msgstr "Oui"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:249
+#: admin/post-types/product.php:806
+#: admin/post-types/product.php:842
+#: admin/post-types/shop_order.php:151
+#: admin/woocommerce-admin-debug.php:277
+#: admin/woocommerce-admin-status.php:138
+#: admin/woocommerce-admin-status.php:283
+#@ woocommerce
 msgid "No"
 msgstr "Non"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:252
+#: admin/woocommerce-admin-debug.php:280
+#: admin/woocommerce-admin-status.php:286
+#@ woocommerce
 msgid "WC Logging"
-msgstr "WC Logging"
+msgstr "Connexion &agrave; WC"
 
-#: ../admin/woocommerce-admin-debug.php:255
+#: admin/woocommerce-admin-debug.php:283
+#: admin/woocommerce-admin-status.php:289
+#@ woocommerce
 msgid "Log directory is writable."
-msgstr ""
+msgstr "Le r&eacute;pertoire de connexion est autoris&eacute; en &eacute;criture."
 
-#: ../admin/woocommerce-admin-debug.php:257
+#: admin/woocommerce-admin-debug.php:285
+#: admin/woocommerce-admin-status.php:291
+#@ woocommerce
 msgid "Log directory (<code>woocommerce/logs/</code>) is not writable. Logging will not be possible."
-msgstr ""
+msgstr "Le r&eacute;pertoire de connexion (<code>woocommerce/logs/</code>) n&rsquo;est pas autoris&eacute; en &eacute;criture. La connexion ne sera pas possible."
 
-#: ../admin/woocommerce-admin-debug.php:264
+#: admin/woocommerce-admin-debug.php:292
+#: admin/woocommerce-admin-status.php:298
+#@ woocommerce
 msgid "PHP Sessions"
-msgstr "Sessions PHP"
+msgstr "Sessions de PHP"
 
-#: ../admin/woocommerce-admin-debug.php:270
+#: admin/woocommerce-admin-debug.php:298
+#: admin/woocommerce-admin-status.php:304
+#@ woocommerce
 msgid "Session save path"
-msgstr ""
+msgstr "Chemin de sauvegarde de session"
 
-#: ../admin/woocommerce-admin-debug.php:275
+#: admin/woocommerce-admin-debug.php:303
+#: admin/woocommerce-admin-status.php:309
 #, php-format
+#@ woocommerce
 msgid "<code>%s</code> does not exist - contact your host to resolve the problem."
-msgstr ""
+msgstr "<code>%s</code> n&rsquo;existe pas - Contactez votre h&eacute;bergeur pour r&eacute;soudre le probl&egrave;me."
 
-#: ../admin/woocommerce-admin-debug.php:277
+#: admin/woocommerce-admin-debug.php:305
+#: admin/woocommerce-admin-status.php:311
 #, php-format
+#@ woocommerce
 msgid "<code>%s</code> is not writable - contact your host to resolve the problem."
-msgstr ""
+msgstr "<code>%s</code> n&rsquo;est pas autoris&eacute; en &eacute;criture - Contactez votre h&eacute;bergeur pour r&eacute;soudre le probl&egrave;me."
 
-#: ../admin/woocommerce-admin-debug.php:279
+#: admin/woocommerce-admin-debug.php:307
+#: admin/woocommerce-admin-status.php:313
 #, php-format
+#@ woocommerce
 msgid "<code>%s</code> is writable."
-msgstr ""
+msgstr "<code>%s</code> est autoris&eacute; en &eacute;criture."
 
-#: ../admin/woocommerce-admin-debug.php:287
+#: admin/woocommerce-admin-debug.php:315
+#: admin/woocommerce-admin-status.php:321
+#@ woocommerce
 msgid "Remote Posting/IPN"
-msgstr ""
+msgstr "Remote Posting/IPN"
 
-#: ../admin/woocommerce-admin-debug.php:293
+#: admin/woocommerce-admin-debug.php:323
+#@ woocommerce
 msgid "fsockopen/Curl"
-msgstr ""
+msgstr "fsockopen/Curl"
 
-#: ../admin/woocommerce-admin-debug.php:296
+#: admin/woocommerce-admin-debug.php:325
+#@ woocommerce
 msgid "Your server has fsockopen or Curl enabled."
-msgstr ""
+msgstr "fsockopen ou Curl est activ&eacute; sur votre serveur."
 
-#: ../admin/woocommerce-admin-debug.php:298
+#: admin/woocommerce-admin-debug.php:328
+#@ woocommerce
 msgid "Your server does not have fsockopen or Curl enabled - PayPal IPN and other scripts which communicate with other servers will not work. Contact your hosting provider."
-msgstr ""
+msgstr "fsockopen ou Curl n&rsquo;est pas activ&eacute; sur votre serveur - PayPal IPN et les autres scripts communiquant avec d&rsquo;autres serveurs ne fonctionneront pas. Contactez votre h&eacute;bergeur pour r&eacute;soudre le probl&egrave;me."
 
-#: ../admin/woocommerce-admin-debug.php:301
+#: admin/woocommerce-admin-debug.php:333
+#: admin/woocommerce-admin-status.php:345
+#@ woocommerce
 msgid "WP Remote Post Check"
-msgstr ""
+msgstr "V&eacute;rifier WP Remote Post"
 
-#: ../admin/woocommerce-admin-debug.php:311
+#: admin/woocommerce-admin-debug.php:341
+#: admin/woocommerce-admin-status.php:353
+#@ woocommerce
 msgid "wp_remote_post() was successful - PayPal IPN is working."
-msgstr ""
+msgstr "wp_remote_post() a r&eacute;ussi - PayPal IPN fonctionne."
 
-#: ../admin/woocommerce-admin-debug.php:313
+#: admin/woocommerce-admin-debug.php:344
+#@ woocommerce
 msgid "wp_remote_post() failed. PayPal IPN won't work with your server. Contact your hosting provider. Error: "
-msgstr ""
+msgstr "wp_remote_post() a &eacute;chou&eacute;. PayPal IPN ne fonctionne pas sur votre serveur. Contactez votre h&eacute;bergeur pour r&eacute;soudre le probl&egrave;me. Erreur&nbsp;: "
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:320
+#: admin/woocommerce-admin-debug.php:366
+#: admin/woocommerce-admin-status.php:378
+#@ woocommerce
 msgid "Tools"
 msgstr "Outils"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-debug.php:326
-msgid "Transients"
-msgstr ""
-
-#: ../admin/woocommerce-admin-debug.php:329
-msgid "Clear Transients"
-msgstr ""
-
-#: ../admin/woocommerce-admin-debug.php:330
-msgid "This tool will clear the product/shop transients cache."
-msgstr ""
-
-#: ../admin/woocommerce-admin-debug.php:335
-msgid "Capabilities"
-msgstr ""
-
-#: ../admin/woocommerce-admin-debug.php:338
-msgid "Reset Capabilities"
-msgstr ""
-
-#: ../admin/woocommerce-admin-debug.php:339
-msgid "This tool will reset the admin, customer and shop_manager roles to default. Use this if your users cannot access all of the WooCommerce admin pages."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-functions.php:106
+#: admin/woocommerce-admin-functions.php:106
+#@ woocommerce
 msgid "Email preview"
-msgstr "Prévisualisation de l'email"
+msgstr "Pr&eacute;visualisation de l&rsquo;e-mail"
 
-#: ../admin/woocommerce-admin-functions.php:279
-msgid "Could not compile woocommerce.less: "
-msgstr ""
+#: admin/woocommerce-admin-functions.php:281
+#@ woocommerce
+msgid "Could not compile woocommerce.less:"
+msgstr "Impossible de compiler woocommerce.less&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:25
+#. translators: plugin header field 'Name'
+#: admin/woocommerce-admin-init.php:26
+#: woocommerce.php:0
+#@ woocommerce
 msgid "WooCommerce"
 msgstr "WooCommerce"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:27
+#: admin/woocommerce-admin-init.php:28
+#@ woocommerce
 msgid "WooCommerce Settings"
-msgstr "Paramètres WooCommerce"
+msgstr "WooCommerce - Param&egrave;tres"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:33
-msgid "WooCommerce Debug"
-msgstr "WooCommerce Debug"
+#: admin/woocommerce-admin-init.php:45
+#@ woocommerce
+msgid "WooCommerce Status"
+msgstr "WooCommerce &Eacute;tats"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:33
-msgid "WC Debug"
-msgstr "Débuguer"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:80
+#: admin/woocommerce-admin-init.php:85
+#@ woocommerce
 msgid "<strong>Welcome to WooCommerce</strong> &#8211; You're almost ready to start selling :)"
-msgstr ""
+msgstr "<strong>Bienvenue sur WooCommerce</strong> &#8211; Vous &ecirc;tes presque pr&ecirc;t &agrave; commencer &agrave; vendre&nbsp;:)"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:81
+#: admin/woocommerce-admin-init.php:86
+#@ woocommerce
 msgid "Install WooCommerce Pages"
-msgstr ""
+msgstr "Installer les pages WooCommerce"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:81
+#: admin/woocommerce-admin-init.php:86
+#@ woocommerce
 msgid "Skip setup"
 msgstr "Ignorer la configuration"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:90
+#: admin/woocommerce-admin-init.php:95
+#@ woocommerce
 msgid "<strong>WooCommerce has been installed</strong> &#8211; You're ready to start selling :)"
-msgstr ""
+msgstr "<strong>WooCommerce a &eacute;t&eacute; install&eacute;</strong> &#8211; Vous &ecirc;tes pr&ecirc;t &agrave; commencer &agrave; vendre&nbsp;:)"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:92
+#: admin/woocommerce-admin-init.php:97
+#@ woocommerce
 msgid "Documentation"
 msgstr "Documentation"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:256
+#: admin/woocommerce-admin-init.php:260
+#@ woocommerce
 msgid "Remove this item? If you have previously reduced this item's stock, or this order was submitted by a customer, will need to manually restore the item's stock."
-msgstr "Enlever cet élément? Si vous avez précédemment réduit le stock de cet élément, ou bien si cette commande à été envoyée par un client, vous devrez manuellement restaurer le stock de cet élément."
+msgstr "Supprimer cet article&nbsp;? Si vous avez r&eacute;duit le stock de cet article auparavant, ou bien si cette commande a &eacute;t&eacute; envoy&eacute;e par un client, vous devrez restaurer le stock de cet article manuellement."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:257
+#: admin/woocommerce-admin-init.php:261
+#@ woocommerce
 msgid "Remove this attribute?"
-msgstr "Suppr. cet attribut ?"
+msgstr "Supprimer cet attribut&nbsp;?"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:259
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:117
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:335
+#: admin/post-types/writepanels/writepanel-product_data.php:295
+#: admin/post-types/writepanels/writepanel-product_data.php:375
+#: admin/woocommerce-admin-init.php:263
+#@ woocommerce
 msgid "Remove"
-msgstr "Enlever"
+msgstr "Supprimer"
 
-# @ default
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:260
+#: admin/post-types/writepanels/writepanel-order_downloads.php:39
+#: admin/post-types/writepanels/writepanel-order_downloads.php:155
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:118
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:336
+#: admin/post-types/writepanels/writepanel-product_data.php:296
+#: admin/post-types/writepanels/writepanel-product_data.php:376
+#: admin/woocommerce-admin-init.php:264
+#@ woocommerce
 msgid "Click to toggle"
-msgstr ""
+msgstr "Cliquez ici pour basculer"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:261
+#: admin/post-types/writepanels/writepanel-product_data.php:311
+#: admin/post-types/writepanels/writepanel-product_data.php:389
+#: admin/woocommerce-admin-init.php:265
+#@ woocommerce
 msgid "Value(s)"
-msgstr "Valeurs"
+msgstr "Valeur(s)"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:262
+#: admin/post-types/writepanels/writepanel-product_data.php:390
+#: admin/woocommerce-admin-init.php:266
+#@ woocommerce
 msgid "Enter some text, or some attributes by pipe (|) separating values."
-msgstr ""
+msgstr "Entrez du texte, ou des attributs en les s&eacute;parant par un pipe (|)."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:263
+#: admin/post-types/writepanels/writepanel-product_data.php:347
+#: admin/post-types/writepanels/writepanel-product_data.php:395
+#: admin/woocommerce-admin-init.php:267
+#@ woocommerce
 msgid "Visible on the product page"
-msgstr ""
+msgstr "Visible sur la page produit"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:264
+#: admin/post-types/writepanels/writepanel-product_data.php:353
+#: admin/post-types/writepanels/writepanel-product_data.php:401
+#: admin/woocommerce-admin-init.php:268
+#@ woocommerce
 msgid "Used for variations"
-msgstr ""
+msgstr "Utilis&eacute; pour les variations"
 
-#: ../admin/woocommerce-admin-init.php:265
+#: admin/woocommerce-admin-init.php:269
+#@ woocommerce
 msgid "Enter a name for the new attribute term:"
-msgstr ""
+msgstr "Donnez un nom au nouvel attribut&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:266
+#: admin/woocommerce-admin-init.php:270
+#@ woocommerce
 msgid "Calculate totals based on order items, discount amount, and shipping? Note, you will need to (optionally) calculate tax rows and cart discounts manually."
-msgstr "Calcul des totaux basés sur les articles de la commande, le montant de remise et la livraison ? Notez que vous devrez (optionnellement) calculer les lignes de taxe et les remises du panier manuellement."
+msgstr "Calculez le total en fonction des articles de la commande, du montant de la remise et de la livraison&nbsp;? Veuillez noter que vous devrez (optionnellement) calculer les lignes de taxe et les remises sur panier manuellement."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:267
+#: admin/woocommerce-admin-init.php:271
+#@ woocommerce
 msgid "Calculate line taxes? This will calculate taxes based on the customers country. If no billing/shipping is set it will use the store base country."
-msgstr "Calculer les taxes en ligne? Cela calculera les taxes basées sur le pays des clients. Si aucune facture/livraison n'est paramétrée cela prendra le pays de base de la boutique."
+msgstr "Calculer les lignes de taxe&nbsp;? Ceci calculera les taxes en fonction du pays des clients. Si aucune adresse de facturation/livraison n&rsquo;est renseign&eacute;e, le pays de base de la boutique sera utilis&eacute; par d&eacute;faut."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:268
+#: admin/woocommerce-admin-init.php:272
+#@ woocommerce
 msgid "Copy billing information to shipping information? This will remove any currently entered shipping information."
-msgstr "Copier les informations de facturation vers les informations d'expédition? Ceci enlèvera tout ce qui a été entré dans les informations d'expédition."
+msgstr "Copier les coordonn&eacute;es de facturation vers les coordonn&eacute;es de livraison&nbsp;? Cela supprimera les coordonn&eacute;es de livraison actuellement saisies."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:269
+#: admin/woocommerce-admin-init.php:273
+#@ woocommerce
 msgid "Load the customer's billing information? This will remove any currently entered billing information."
-msgstr "Charger les informations de facturation du client ? Ceci supprimera toutes les informations de facturation actuellement saisies."
+msgstr "Charger les coordonn&eacute;es de facturation du client&nbsp;? Cela supprimera les coordonn&eacute;es de facturation actuellement saisies."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:270
+#: admin/woocommerce-admin-init.php:274
+#@ woocommerce
 msgid "Load the customer's shipping information? This will remove any currently entered shipping information."
-msgstr "Charger les informations de livraison du client ? Ceci supprimera toutes les informations de livraison actuellement saisies."
+msgstr "Charger les coordonn&eacute;es de livraison du client&nbsp;? Cela supprimera les coordonn&eacute;es de livraison actuellement saisies."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:274
+#: admin/woocommerce-admin-init.php:278
+#@ woocommerce
 msgid "Meta Name"
-msgstr "Nom Meta"
+msgstr "M&eacute;ta-nom"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:275
+#: admin/woocommerce-admin-init.php:279
+#@ woocommerce
 msgid "Meta Value"
-msgstr "Valeur Meta"
+msgstr "M&eacute;ta-valeur"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:276
+#: admin/woocommerce-admin-init.php:280
+#@ woocommerce
 msgid "No customer selected"
-msgstr "Aucun client sélectionné"
+msgstr "Aucun client s&eacute;lectionn&eacute;"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:277
+#: admin/post-types/writepanels/writepanel-order_data.php:504
+#: admin/woocommerce-admin-init.php:281
+#@ woocommerce
 msgid "Tax Label:"
-msgstr "Légende de taxe :"
+msgstr "Titre de la taxe&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:278
+#: admin/post-types/writepanels/writepanel-order_data.php:508
+#: admin/woocommerce-admin-init.php:282
+#@ woocommerce
 msgid "Compound:"
-msgstr "Cumulable :"
+msgstr "Cumulable&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:279
+#: admin/post-types/writepanels/writepanel-order_data.php:512
+#: admin/post-types/writepanels/writepanel-order_data.php:536
+#: admin/woocommerce-admin-init.php:283
+#@ woocommerce
 msgid "Cart Tax:"
-msgstr "Taxe panier :"
+msgstr "Taxe du panier&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:280
+#: admin/post-types/writepanels/writepanel-order_data.php:516
+#: admin/post-types/writepanels/writepanel-order_data.php:543
+#: admin/woocommerce-admin-init.php:284
+#@ woocommerce
 msgid "Shipping Tax:"
-msgstr "Taxe livraison :"
+msgstr "Taxe de livraison&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:436
+#: admin/woocommerce-admin-init.php:447
+#@ woocommerce
 msgid "Exclude image"
-msgstr "Exclure l'image"
+msgstr "Exclure l&rsquo;image"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:445
+#: admin/woocommerce-admin-init.php:456
+#@ woocommerce
 msgid "Enabling this option will hide it from the product page image gallery."
-msgstr "Cette option cachera l'image de la galerie dans une page de produit."
+msgstr "Cette option cachera l&rsquo;image de la galerie sur la page produit."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:489
+#: admin/woocommerce-admin-init.php:500
 #, php-format
+#@ woocommerce
 msgid "Product updated. <a href=\"%s\">View Product</a>"
-msgstr ""
+msgstr "Produit mis &agrave; jour. <a href=\"%s\">Voir le produit</a>"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:490
-#: ../admin/woocommerce-admin-init.php:505
-#: ../admin/woocommerce-admin-init.php:520
+#: admin/woocommerce-admin-init.php:501
+#: admin/woocommerce-admin-init.php:516
+#: admin/woocommerce-admin-init.php:531
+#@ woocommerce
 msgid "Custom field updated."
-msgstr ""
+msgstr "Champ personnalis&eacute; mis &agrave; jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:491
-#: ../admin/woocommerce-admin-init.php:506
-#: ../admin/woocommerce-admin-init.php:521
+#: admin/woocommerce-admin-init.php:502
+#: admin/woocommerce-admin-init.php:517
+#: admin/woocommerce-admin-init.php:532
+#@ woocommerce
 msgid "Custom field deleted."
-msgstr ""
+msgstr "Champ personnalis&eacute; supprim&eacute;."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:492
+#: admin/woocommerce-admin-init.php:503
+#@ woocommerce
 msgid "Product updated."
-msgstr "Produit mis à jour."
+msgstr "Produit mis &agrave; jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:493
+#: admin/woocommerce-admin-init.php:504
 #, php-format
+#@ woocommerce
 msgid "Product restored to revision from %s"
-msgstr ""
+msgstr "Produit restaur&eacute; &agrave; la version du %s"
 
-#: ../admin/woocommerce-admin-init.php:494
+#: admin/woocommerce-admin-init.php:505
 #, php-format
+#@ woocommerce
 msgid "Product published. <a href=\"%s\">View Product</a>"
-msgstr ""
+msgstr "Produit publi&eacute;. <a href=\"%s\">Voir le produit</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-init.php:495
+#: admin/woocommerce-admin-init.php:506
+#@ woocommerce
 msgid "Product saved."
-msgstr "Produit sauvegardé."
+msgstr "Produit enregistr&eacute;."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:496
+#: admin/woocommerce-admin-init.php:507
 #, php-format
+#@ woocommerce
 msgid "Product submitted. <a target=\"_blank\" href=\"%s\">Preview Product</a>"
-msgstr ""
+msgstr "Produit envoy&eacute;. <a target=\"_blank\" href=\"%s\">Pr&eacute;visualiser le produit</a>"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:497
+#: admin/woocommerce-admin-init.php:508
 #, php-format
+#@ woocommerce
 msgid "Product scheduled for: <strong>%1$s</strong>. <a target=\"_blank\" href=\"%2$s\">Preview Product</a>"
-msgstr ""
+msgstr "Produit planifi&eacute; pour&nbsp;: <strong>%1$s</strong>. <a target=\"_blank\" href=\"%2$s\">Pr&eacute;visualiser le produit</a>"
 
-# @ default
-#: ../admin/woocommerce-admin-init.php:498
-#: ../admin/woocommerce-admin-init.php:513
-#: ../admin/woocommerce-admin-init.php:528
+#: admin/woocommerce-admin-init.php:509
+#: admin/woocommerce-admin-init.php:524
+#: admin/woocommerce-admin-init.php:539
+#@ woocommerce
 msgid "M j, Y @ G:i"
-msgstr ""
+msgstr "j M Y @ G:i"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:499
+#: admin/woocommerce-admin-init.php:510
 #, php-format
+#@ woocommerce
 msgid "Product draft updated. <a target=\"_blank\" href=\"%s\">Preview Product</a>"
-msgstr ""
+msgstr "Brouillon de produit mis &agrave; jour. <a target=\"_blank\" href=\"%s\">Pr&eacute;visualiser le produit</a>"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:504
-#: ../admin/woocommerce-admin-init.php:507
-#: ../admin/woocommerce-admin-init.php:509
+#: admin/woocommerce-admin-init.php:515
+#: admin/woocommerce-admin-init.php:518
+#: admin/woocommerce-admin-init.php:520
+#@ woocommerce
 msgid "Order updated."
-msgstr "Commande mise à jour."
+msgstr "Commande mise &agrave; jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:508
+#: admin/woocommerce-admin-init.php:519
 #, php-format
+#@ woocommerce
 msgid "Order restored to revision from %s"
-msgstr ""
+msgstr "Commande restaur&eacute;e &agrave; la version du %s"
 
-# @ default
-#: ../admin/woocommerce-admin-init.php:510
+#: admin/woocommerce-admin-init.php:521
+#@ woocommerce
 msgid "Order saved."
-msgstr "Commande sauvegardée."
+msgstr "Commande enregistr&eacute;e."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:511
+#: admin/woocommerce-admin-init.php:522
+#@ woocommerce
 msgid "Order submitted."
-msgstr "Commande soumise."
+msgstr "Commande envoy&eacute;e."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:512
+#: admin/woocommerce-admin-init.php:523
 #, php-format
+#@ woocommerce
 msgid "Order scheduled for: <strong>%1$s</strong>."
-msgstr ""
+msgstr "Commande planifi&eacute;e pour&nbsp;: <strong>%1$s</strong>."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:514
+#: admin/woocommerce-admin-init.php:525
+#@ woocommerce
 msgid "Order draft updated."
-msgstr ""
+msgstr "Brouillon de commande mis &agrave; jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:519
-#: ../admin/woocommerce-admin-init.php:522
-#: ../admin/woocommerce-admin-init.php:524
+#: admin/woocommerce-admin-init.php:530
+#: admin/woocommerce-admin-init.php:533
+#: admin/woocommerce-admin-init.php:535
+#@ woocommerce
 msgid "Coupon updated."
-msgstr "Coupon mis à jour."
+msgstr "Code promo mis &agrave; jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:523
+#: admin/woocommerce-admin-init.php:534
 #, php-format
+#@ woocommerce
 msgid "Coupon restored to revision from %s"
-msgstr ""
+msgstr "Code promo restaur&eacute; &agrave; la version du %s"
 
-# @ default
-#: ../admin/woocommerce-admin-init.php:525
+#: admin/woocommerce-admin-init.php:536
+#@ woocommerce
 msgid "Coupon saved."
-msgstr "Coupon sauvegardé."
+msgstr "Code promo enregistr&eacute;."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:526
+#: admin/woocommerce-admin-init.php:537
+#@ woocommerce
 msgid "Coupon submitted."
-msgstr "Coupon soumis."
+msgstr "Code promo envoy&eacute;."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:527
+#: admin/woocommerce-admin-init.php:538
 #, php-format
+#@ woocommerce
 msgid "Coupon scheduled for: <strong>%1$s</strong>."
-msgstr ""
+msgstr "Code promo planifi&eacute; pour&nbsp;: <strong>%1$s</strong>."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-init.php:529
+#: admin/woocommerce-admin-init.php:540
+#@ woocommerce
 msgid "Coupon draft updated."
-msgstr ""
+msgstr "Brouillon de code promo mis &agrave; jour."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:182
+#: admin/woocommerce-admin-install.php:161
+#@ woocommerce
 msgctxt "page_slug"
 msgid "shop"
 msgstr "boutique"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:182
+#: admin/woocommerce-admin-install.php:161
+#@ woocommerce
 msgid "Shop"
 msgstr "Boutique"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:185
+#: admin/woocommerce-admin-install.php:164
+#@ woocommerce
 msgctxt "page_slug"
 msgid "cart"
 msgstr "panier"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:185
+#: admin/woocommerce-admin-install.php:164
+#: widgets/widget-cart.php:42
+#@ woocommerce
 msgid "Cart"
 msgstr "Panier"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:188
+#: admin/woocommerce-admin-install.php:167
+#@ woocommerce
 msgctxt "page_slug"
 msgid "checkout"
 msgstr "commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:188
-#: ../admin/woocommerce-admin-settings.php:111
+#: admin/settings/settings-init.php:105
+#: admin/woocommerce-admin-install.php:167
+#@ woocommerce
 msgid "Checkout"
 msgstr "Commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:191
+#: admin/woocommerce-admin-install.php:170
+#@ woocommerce
 msgctxt "page_slug"
 msgid "order-tracking"
-msgstr "suivi de commande"
+msgstr "suivi-commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:191
+#: admin/woocommerce-admin-install.php:170
+#@ woocommerce
 msgid "Track your order"
-msgstr "Suivre votre commande"
+msgstr "Suivez votre commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:194
+#: admin/woocommerce-admin-install.php:173
+#@ woocommerce
 msgctxt "page_slug"
 msgid "my-account"
-msgstr "mon compte"
+msgstr "mon-compte"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:194
+#: admin/woocommerce-admin-install.php:173
+#: templates/checkout/thankyou.php:26
+#@ woocommerce
 msgid "My Account"
-msgstr "Mon Compte"
+msgstr "Mon compte"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:197
+#: admin/woocommerce-admin-install.php:176
+#@ woocommerce
 msgctxt "page_slug"
 msgid "edit-address"
-msgstr "modification adresse"
+msgstr "modififier-adresse"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:197
+#: admin/woocommerce-admin-install.php:176
+#@ woocommerce
 msgid "Edit My Address"
 msgstr "Modifier mon adresse"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:200
+#: admin/woocommerce-admin-install.php:179
+#@ woocommerce
 msgctxt "page_slug"
 msgid "view-order"
-msgstr "voir commande"
+msgstr "voir-commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:203
+#: admin/woocommerce-admin-install.php:182
+#@ woocommerce
 msgctxt "page_slug"
 msgid "change-password"
-msgstr "changer mot de passe"
+msgstr "changer-mot-de-passe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:203
+#: admin/woocommerce-admin-install.php:182
+#@ woocommerce
 msgid "Change Password"
 msgstr "Changer de mot de passe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:206
+#: admin/woocommerce-admin-install.php:185
+#@ woocommerce
 msgctxt "page_slug"
 msgid "pay"
-msgstr "Payer"
+msgstr "payer"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:206
+#: admin/woocommerce-admin-install.php:185
+#@ woocommerce
 msgid "Checkout &rarr; Pay"
 msgstr "Commande &rarr; Paiement"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:209
+#: admin/woocommerce-admin-install.php:188
+#@ woocommerce
 msgctxt "page_slug"
 msgid "order-received"
-msgstr "commande recue"
+msgstr "commande-recue"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-install.php:209
+#: admin/woocommerce-admin-install.php:188
+#: classes/class-wc-email.php:155
+#@ woocommerce
 msgid "Order Received"
-msgstr "Commande reçue"
+msgstr "Commande re&ccedil;ue"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:24
+#: admin/woocommerce-admin-reports.php:24
+#@ woocommerce
 msgid "Sales by day"
 msgstr "Ventes par jour"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:29
+#: admin/woocommerce-admin-reports.php:29
+#@ woocommerce
 msgid "Sales by month"
 msgstr "Ventes par mois"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:34
+#: admin/woocommerce-admin-reports.php:34
+#@ woocommerce
 msgid "Product Sales"
-msgstr "Ventes produits"
+msgstr "Ventes par produit"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:39
+#: admin/woocommerce-admin-reports.php:39
+#@ woocommerce
 msgid "Top sellers"
-msgstr "Top ventes"
+msgstr "Meilleures ventes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:44
+#: admin/woocommerce-admin-reports.php:44
+#@ woocommerce
 msgid "Top earners"
-msgstr "Top gains"
+msgstr "Meilleurs gains"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:310
+#: admin/woocommerce-admin-reports.php:310
+#@ woocommerce
 msgid "Total sales"
 msgstr "Total des ventes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:312
-#: ../admin/woocommerce-admin-reports.php:318
-#: ../admin/woocommerce-admin-reports.php:324
-#: ../admin/woocommerce-admin-reports.php:330
-#: ../admin/woocommerce-admin-reports.php:336
-#: ../admin/woocommerce-admin-reports.php:342
-#: ../admin/woocommerce-admin-reports.php:578
-#: ../admin/woocommerce-admin-reports.php:584
-#: ../admin/woocommerce-admin-reports.php:590
-#: ../admin/woocommerce-admin-reports.php:596
-#: ../admin/woocommerce-admin-reports.php:778
-#: ../admin/woocommerce-admin-reports.php:784
-#: ../admin/woocommerce-admin-reports.php:790
-#: ../admin/woocommerce-admin-reports.php:796
-#: ../admin/woocommerce-admin-reports.php:1259
-#: ../admin/woocommerce-admin-reports.php:1265
-#: ../admin/woocommerce-admin-reports.php:1271
-#: ../admin/woocommerce-admin-reports.php:1277
-#: ../admin/woocommerce-admin-reports.php:1283
-#: ../admin/woocommerce-admin-reports.php:1289
+#: admin/woocommerce-admin-reports.php:312
+#: admin/woocommerce-admin-reports.php:318
+#: admin/woocommerce-admin-reports.php:324
+#: admin/woocommerce-admin-reports.php:330
+#: admin/woocommerce-admin-reports.php:336
+#: admin/woocommerce-admin-reports.php:342
+#: admin/woocommerce-admin-reports.php:579
+#: admin/woocommerce-admin-reports.php:585
+#: admin/woocommerce-admin-reports.php:591
+#: admin/woocommerce-admin-reports.php:597
+#: admin/woocommerce-admin-reports.php:769
+#: admin/woocommerce-admin-reports.php:775
+#: admin/woocommerce-admin-reports.php:781
+#: admin/woocommerce-admin-reports.php:787
+#: admin/woocommerce-admin-reports.php:1257
+#: admin/woocommerce-admin-reports.php:1263
+#: admin/woocommerce-admin-reports.php:1269
+#: admin/woocommerce-admin-reports.php:1275
+#: admin/woocommerce-admin-reports.php:1281
+#: admin/woocommerce-admin-reports.php:1287
+#@ woocommerce
 msgid "n/a"
 msgstr "n/a"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:316
+#: admin/woocommerce-admin-reports.php:316
+#@ woocommerce
 msgid "Total orders"
-msgstr "Total commandes"
+msgstr "Total des commandes"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:318
-#: ../admin/woocommerce-admin-reports.php:584
-#: ../admin/woocommerce-admin-reports.php:784
-msgid " items"
-msgstr " éléments"
+#: admin/woocommerce-admin-reports.php:318
+#: admin/woocommerce-admin-reports.php:585
+#: admin/woocommerce-admin-reports.php:775
+#@ woocommerce
+msgid "items"
+msgstr "articles"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:322
+#: admin/woocommerce-admin-reports.php:322
+#@ woocommerce
 msgid "Average order total"
-msgstr "Montant moyen des commandes"
+msgstr "Montant moyen d&rsquo;une commande"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:328
+#: admin/woocommerce-admin-reports.php:328
+#@ woocommerce
 msgid "Average order items"
-msgstr "Moyenne des éléments commandés"
+msgstr "Montant moyen d&rsquo;un article"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:334
+#: admin/woocommerce-admin-reports.php:334
+#@ woocommerce
 msgid "Discounts used"
-msgstr "Remises utilisées"
+msgstr "Remises utilis&eacute;es"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:340
+#: admin/woocommerce-admin-reports.php:340
+#@ woocommerce
 msgid "Total shipping costs"
-msgstr "Total coût d'expédition"
+msgstr "Total des frais de livraison"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:348
+#: admin/woocommerce-admin-reports.php:348
+#@ woocommerce
 msgid "This months sales"
-msgstr "Ventes de ce mois"
+msgstr "Ventes du mois"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:570
-#: ../admin/woocommerce-admin-reports.php:924
-#: ../admin/woocommerce-admin-reports.php:1021
+#: admin/woocommerce-admin-reports.php:571
+#: admin/woocommerce-admin-reports.php:916
+#: admin/woocommerce-admin-reports.php:1013
+#@ woocommerce
 msgid "From:"
-msgstr "A partir de :"
+msgstr "Du&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:570
-#: ../admin/woocommerce-admin-reports.php:924
-#: ../admin/woocommerce-admin-reports.php:1021
+#: admin/woocommerce-admin-reports.php:571
+#: admin/woocommerce-admin-reports.php:916
+#: admin/woocommerce-admin-reports.php:1013
+#@ woocommerce
 msgid "To:"
-msgstr "Au :"
+msgstr "Au&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:570
-#: ../admin/woocommerce-admin-reports.php:771
-#: ../admin/woocommerce-admin-reports.php:924
-#: ../admin/woocommerce-admin-reports.php:1021
-#: ../admin/woocommerce-admin-reports.php:1155
+#: admin/woocommerce-admin-reports.php:571
+#: admin/woocommerce-admin-reports.php:762
+#: admin/woocommerce-admin-reports.php:916
+#: admin/woocommerce-admin-reports.php:1013
+#: admin/woocommerce-admin-reports.php:1155
+#@ woocommerce
 msgid "Show"
 msgstr "Afficher"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:576
+#: admin/woocommerce-admin-reports.php:577
+#@ woocommerce
 msgid "Total sales in range"
-msgstr "Les ventes totales de la gamme"
+msgstr "Total des ventes sur la p&eacute;riode"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:582
+#: admin/woocommerce-admin-reports.php:583
+#@ woocommerce
 msgid "Total orders in range"
-msgstr "Les commandes totales de la gamme"
+msgstr "Total des commandes sur la p&eacute;riode"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:588
+#: admin/woocommerce-admin-reports.php:589
+#@ woocommerce
 msgid "Average order total in range"
-msgstr "Total de la commande moyenne dans la gamme"
+msgstr "Montant moyen d&rsquo;une commande sur la p&eacute;riode"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:594
+#: admin/woocommerce-admin-reports.php:595
+#@ woocommerce
 msgid "Average order items in range"
-msgstr "Moyenne des éléments commandés dans la gamme"
+msgstr "Montant moyen d&rsquo;un article sur la p&eacute;riode"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:602
+#: admin/woocommerce-admin-reports.php:603
+#@ woocommerce
 msgid "Sales in range"
-msgstr "Les ventes de la gamme"
+msgstr "Ventes sur la p&eacute;riode"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:766
+#: admin/woocommerce-admin-reports.php:757
+#@ woocommerce
 msgid "Year:"
-msgstr "Année :"
+msgstr "Ann&eacute;e&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:776
+#: admin/woocommerce-admin-reports.php:767
+#@ woocommerce
 msgid "Total sales for year"
-msgstr "Ventes totales pour l'année"
+msgstr "Total des ventes sur l&rsquo;ann&eacute;e"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:782
+#: admin/woocommerce-admin-reports.php:773
+#@ woocommerce
 msgid "Total orders for year"
-msgstr "Commandes totales pour l'année"
+msgstr "Total des commandes sur l&rsquo;ann&eacute;e"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:788
+#: admin/woocommerce-admin-reports.php:779
+#@ woocommerce
 msgid "Average order total for year"
-msgstr "Montant moyen des commandes pour l'année"
+msgstr "Montant moyen d&rsquo;une commande sur l&rsquo;ann&eacute;e"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:794
+#: admin/woocommerce-admin-reports.php:785
+#@ woocommerce
 msgid "Average order items for year"
-msgstr "Moyenne d'éléments commandés pour l'année"
+msgstr "Montant moyen d&rsquo;un article sur l&rsquo;ann&eacute;e"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:802
+#: admin/woocommerce-admin-reports.php:793
+#@ woocommerce
 msgid "Monthly sales for year"
-msgstr "Ventes Mensuelles pour l'année"
+msgstr "Ventes par mois sur l&rsquo;ann&eacute;e"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:944
+#: admin/woocommerce-admin-reports.php:936
+#@ woocommerce
 msgid "Product does not exist"
-msgstr "Produit Inexistant"
+msgstr "Le produit n&rsquo;existe pas"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1041
+#: admin/woocommerce-admin-reports.php:1033
+#@ woocommerce
 msgid "Product no longer exists"
-msgstr "Produit inexistant"
+msgstr "Le produit n&rsquo;existe plus"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1130
-msgid "Product:"
-msgstr "Produit :"
+#: admin/woocommerce-admin-reports.php:1124
+#, php-format
+#@ woocommerce
+msgid "Sales for %s:"
+msgstr "Ventes pour %s&nbsp;:"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1133
-msgid "Choose an product&hellip;"
-msgstr "Choisir un produit&hellip;"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1161
+#: admin/woocommerce-admin-reports.php:1128
+#@ woocommerce
 msgid "Month"
 msgstr "Mois"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1179
+#: admin/woocommerce-admin-reports.php:1146
+#@ woocommerce
 msgid "No sales :("
-msgstr "Pas de Ventes :("
+msgstr "Aucune vente&nbsp;:("
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1257
+#: admin/post-types/writepanels/writepanel-coupon_data.php:56
+#: admin/post-types/writepanels/writepanel-order_data.php:395
+#: admin/post-types/writepanels/writepanel-product_data.php:434
+#: admin/post-types/writepanels/writepanel-product_data.php:453
+#: admin/woocommerce-admin-reports.php:1155
+#@ woocommerce
+msgid "Search for a product&hellip;"
+msgstr "Rechercher un produit..."
+
+#: admin/woocommerce-admin-reports.php:1255
+#@ woocommerce
 msgid "Total customers"
 msgstr "Total des clients"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1263
+#: admin/woocommerce-admin-reports.php:1261
+#@ woocommerce
 msgid "Total customer sales"
-msgstr "Total ventes clients"
+msgstr "Total des ventes clients"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1269
+#: admin/woocommerce-admin-reports.php:1267
+#@ woocommerce
 msgid "Total guest sales"
-msgstr "Total ventes invités"
+msgstr "Total des ventes invit&eacute;s"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1275
+#: admin/woocommerce-admin-reports.php:1273
+#@ woocommerce
 msgid "Total customer orders"
-msgstr "Total commandes clients"
+msgstr "Total des commandes clients"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1281
+#: admin/woocommerce-admin-reports.php:1279
+#@ woocommerce
 msgid "Total guest orders"
-msgstr "Total commandes invités"
+msgstr "Total des commandes invit&eacute;s"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1287
+#: admin/woocommerce-admin-reports.php:1285
+#@ woocommerce
 msgid "Average orders per customer"
-msgstr "Moyenne de commandes par client"
+msgstr "Montant moyen d&rsquo;une commande par client"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1295
+#: admin/woocommerce-admin-reports.php:1293
+#@ woocommerce
 msgid "Signups per day"
 msgstr "Inscriptions par jour"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1490
+#: admin/woocommerce-admin-reports.php:1487
+#@ woocommerce
 msgid "Low stock"
 msgstr "Stock faible"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1505
-#: ../admin/woocommerce-admin-reports.php:1540
-#: ../admin/post-types/product.php:70
-#: ../admin/post-types/product.php:464
-#: ../admin/post-types/writepanels/writepanel-order_data.php:270
+#: admin/post-types/product.php:70
+#: admin/post-types/product.php:483
+#: admin/post-types/writepanels/writepanel-order_data.php:270
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:157
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:367
+#: admin/post-types/writepanels/writepanel-product_data.php:50
+#: admin/woocommerce-admin-reports.php:1502
+#: admin/woocommerce-admin-reports.php:1537
+#@ woocommerce
 msgid "SKU"
 msgstr "UGS"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1512
-#: ../admin/woocommerce-admin-reports.php:1547
+#: admin/woocommerce-admin-reports.php:1509
+#: admin/woocommerce-admin-reports.php:1544
 #, php-format
+#@ woocommerce
 msgid "%d in stock"
 msgid_plural "%d in stock"
 msgstr[0] " %d en stock"
 msgstr[1] "%d en stock"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1517
+#: admin/woocommerce-admin-reports.php:1514
+#@ woocommerce
 msgid "No products are low in stock."
 msgstr "Aucun produit en stock faible."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1525
-#: ../admin/post-types/product.php:231
-#: ../admin/post-types/product.php:549
-#: ../admin/post-types/product.php:804
+#: admin/post-types/product.php:232
+#: admin/post-types/product.php:568
+#: admin/post-types/product.php:824
+#: admin/post-types/writepanels/writepanel-product_data.php:235
+#: admin/woocommerce-admin-reports.php:1522
+#: classes/class-wc-product.php:437
+#: classes/class-wc-product.php:476
+#: classes/class-wc-product.php:486
+#@ woocommerce
 msgid "Out of stock"
-msgstr "Produit épuisé"
+msgstr "Rupture de stock"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-reports.php:1552
+#: admin/woocommerce-admin-reports.php:1549
+#@ woocommerce
 msgid "No products are out in stock."
-msgstr "Aucun produit épuisé."
+msgstr "Aucun produit en rupture de stock."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:246
-#: ../admin/post-types/product.php:509
-#: ../admin/post-types/product.php:753
+#: admin/post-types/product.php:528
+#: admin/post-types/product.php:773
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:76
+#: admin/post-types/writepanels/writepanel-product_data.php:112
+#: admin/woocommerce-admin-settings-forms.php:247
+#: admin/woocommerce-admin-settings.php:492
+#@ woocommerce
 msgid "Width"
 msgstr "Largeur"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:248
-#: ../admin/post-types/product.php:510
-#: ../admin/post-types/product.php:754
+#: admin/post-types/product.php:529
+#: admin/post-types/product.php:774
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:77
+#: admin/post-types/writepanels/writepanel-product_data.php:113
+#: admin/woocommerce-admin-settings-forms.php:249
+#: admin/woocommerce-admin-settings.php:494
+#@ woocommerce
 msgid "Height"
 msgstr "Hauteur"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:250
+#: admin/woocommerce-admin-settings-forms.php:251
+#: admin/woocommerce-admin-settings.php:496
+#@ woocommerce
 msgid "Hard Crop"
-msgstr "Recadrage forcé"
+msgstr "Recadrage forc&eacute;"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:349
+#: admin/woocommerce-admin-settings-forms.php:350
+#@ woocommerce
 msgid "Select a page..."
 msgstr "Choisissez une page..."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:367
+#: admin/woocommerce-admin-settings-forms.php:368
+#: admin/woocommerce-admin-settings.php:613
+#@ woocommerce
 msgid "Choose a country&hellip;"
-msgstr "Choisissez un pays&hellip;"
+msgstr "Choisissez un pays..."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:382
+#: admin/woocommerce-admin-settings-forms.php:383
+#: admin/woocommerce-admin-settings.php:628
+#@ woocommerce
 msgid "Choose countries&hellip;"
-msgstr "Choisissez des pays&hellip;"
+msgstr "Choisissez des pays..."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:398
+#: admin/settings/settings-tax-rates.php:19
+#: admin/woocommerce-admin-settings-forms.php:399
+#@ woocommerce
 msgid "Tax Rates"
 msgstr "Taux de taxe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:400
-#: ../admin/woocommerce-admin-settings-forms.php:472
+#: admin/settings/settings-tax-rates.php:21
+#: admin/woocommerce-admin-settings-forms.php:401
+#: admin/woocommerce-admin-settings-forms.php:473
+#@ woocommerce
 msgid "Export rates"
-msgstr "Taux d'exportation"
+msgstr "Exporter les taux"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:401
-#: ../admin/woocommerce-admin-settings-forms.php:473
+#: admin/settings/settings-tax-rates.php:22
+#: admin/woocommerce-admin-settings-forms.php:402
+#: admin/woocommerce-admin-settings-forms.php:474
+#@ woocommerce
 msgid "Import rates"
-msgstr "Importer taux"
+msgstr "Importer les taux"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:402
+#: admin/settings/settings-tax-rates.php:23
+#: admin/woocommerce-admin-settings-forms.php:403
 #, php-format
+#@ woocommerce
 msgid "Define tax rates for countries and states below, or alternatively upload a CSV file containing your rates to <code>wp-content/woocommerce_tax_rates.csv</code> instead. <a href=\"%s\">Download sample csv.</a>"
-msgstr "Definir les taux de taxe pour les pays et les régions ci-dessous, ou alternativement transférez un fichier CSV contenant vos taux sur <code>wp-content/woocommerce_tax_rates.csv</code>. <a href=\"%s\">Télécharger un csv modèle.</a>"
+msgstr "D&eacute;finissez des taux de taxe pour les pays/&eacute;tats ci-dessous, ou alternativement envoyez un fichier CSV contenant vos taux sur <code>wp-content/woocommerce_tax_rates.csv</code>. <a href=\"%s\">T&eacute;l&eacute;charger un csv mod&egrave;le.</a>"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:407
+#: admin/settings/settings-tax-rates.php:28
+#: admin/woocommerce-admin-settings-forms.php:408
+#@ woocommerce
 msgid "Countries/states"
-msgstr "Pays/États"
+msgstr "Pays/&Eacute;tats"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:408
-#: ../admin/woocommerce-admin-settings-forms.php:480
-#: ../admin/post-types/writepanels/writepanel-order_data.php:274
+#: admin/post-types/writepanels/writepanel-order_data.php:274
+#: admin/post-types/writepanels/writepanel-product_data.php:204
+#: admin/settings/settings-tax-rates.php:29
+#: admin/settings/settings-tax-rates.php:98
+#: admin/woocommerce-admin-settings-forms.php:409
+#: admin/woocommerce-admin-settings-forms.php:481
+#@ woocommerce
 msgid "Tax Class"
-msgstr "Classe taxe"
+msgstr "Classe de taxe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:409
-#: ../admin/woocommerce-admin-settings-forms.php:451
-#: ../admin/woocommerce-admin-settings-forms.php:481
-#: ../admin/woocommerce-admin-settings-forms.php:521
-#: ../admin/woocommerce-admin-settings-forms.php:612
-#: ../admin/woocommerce-admin-settings-forms.php:655
+#: admin/settings/settings-tax-rates.php:30
+#: admin/settings/settings-tax-rates.php:72
+#: admin/settings/settings-tax-rates.php:99
+#: admin/settings/settings-tax-rates.php:139
+#: admin/settings/settings-tax-rates.php:230
+#: admin/settings/settings-tax-rates.php:273
+#: admin/woocommerce-admin-settings-forms.php:410
+#: admin/woocommerce-admin-settings-forms.php:452
+#: admin/woocommerce-admin-settings-forms.php:482
+#: admin/woocommerce-admin-settings-forms.php:522
+#: admin/woocommerce-admin-settings-forms.php:613
+#: admin/woocommerce-admin-settings-forms.php:656
+#@ woocommerce
 msgid "Label"
 msgstr "Titre"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:409
-#: ../admin/woocommerce-admin-settings-forms.php:481
+#: admin/settings/settings-tax-rates.php:30
+#: admin/settings/settings-tax-rates.php:99
+#: admin/woocommerce-admin-settings-forms.php:410
+#: admin/woocommerce-admin-settings-forms.php:482
+#@ woocommerce
 msgid "Optionally, enter a label for this rate - this will appear in the totals table"
-msgstr "Optionnellement, entrez une légende pour ce taux - cela apparaitra dans le tableau des totaux"
+msgstr "Donnez &eacute;ventuellement un titre &agrave; ce taux - Cela apparaitra dans le tableau du total"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:410
-#: ../admin/woocommerce-admin-settings-forms.php:454
-#: ../admin/woocommerce-admin-settings-forms.php:482
-#: ../admin/woocommerce-admin-settings-forms.php:524
-#: ../admin/woocommerce-admin-settings-forms.php:615
-#: ../admin/woocommerce-admin-settings-forms.php:658
+#: admin/settings/settings-tax-rates.php:31
+#: admin/settings/settings-tax-rates.php:75
+#: admin/settings/settings-tax-rates.php:100
+#: admin/settings/settings-tax-rates.php:142
+#: admin/settings/settings-tax-rates.php:233
+#: admin/settings/settings-tax-rates.php:276
+#: admin/woocommerce-admin-settings-forms.php:411
+#: admin/woocommerce-admin-settings-forms.php:455
+#: admin/woocommerce-admin-settings-forms.php:483
+#: admin/woocommerce-admin-settings-forms.php:525
+#: admin/woocommerce-admin-settings-forms.php:616
+#: admin/woocommerce-admin-settings-forms.php:659
+#@ woocommerce
 msgid "Rate"
 msgstr "Taux"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:410
-#: ../admin/woocommerce-admin-settings-forms.php:482
+#: admin/settings/settings-tax-rates.php:31
+#: admin/settings/settings-tax-rates.php:100
+#: admin/woocommerce-admin-settings-forms.php:411
+#: admin/woocommerce-admin-settings-forms.php:483
+#@ woocommerce
 msgid "Enter a tax rate (percentage) to 4 decimal places."
-msgstr "Entrez un taux de taxe (en pourcentage) à 4 décimales."
+msgstr "Entrez un taux de taxe (en pourcentage) &agrave; 4 d&eacute;cimales."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:411
-#: ../admin/woocommerce-admin-settings-forms.php:483
+#: admin/settings/settings-tax-rates.php:32
+#: admin/settings/settings-tax-rates.php:101
+#: admin/woocommerce-admin-settings-forms.php:412
+#: admin/woocommerce-admin-settings-forms.php:484
+#@ woocommerce
 msgid "Compound"
 msgstr "Cumulable"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:411
-#: ../admin/woocommerce-admin-settings-forms.php:483
+#: admin/settings/settings-tax-rates.php:32
+#: admin/settings/settings-tax-rates.php:101
+#: admin/woocommerce-admin-settings-forms.php:412
+#: admin/woocommerce-admin-settings-forms.php:484
+#@ woocommerce
 msgid "Choose whether or not this is a compound rate. Compound tax rates are applied on top of other tax rates."
-msgstr "Choisissez si oui ou non il s'agit d'un taux cumulable. Les taux cumulables sont appliqués sur les autres taux de taxe."
+msgstr "Choisissez si oui ou non il s&rsquo;agit d&rsquo;un taux cumulable. Les taux cumulables sont appliqu&eacute;s par dessus les autres taux de taxe."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:412
-#: ../admin/woocommerce-admin-settings-forms.php:484
+#: admin/settings/settings-tax-rates.php:33
+#: admin/settings/settings-tax-rates.php:102
+#: admin/woocommerce-admin-settings-forms.php:413
+#: admin/woocommerce-admin-settings-forms.php:485
+#@ woocommerce
 msgid "Choose whether or not this tax rate also gets applied to shipping."
-msgstr "Indiquer si cette taxe s'applique ou non aux frais de port."
+msgstr "Choisissez si oui ou non cette taxe s&rsquo;applique aux frais de livraison."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:417
-#: ../admin/woocommerce-admin-settings-forms.php:489
+#: admin/settings/settings-tax-rates.php:38
+#: admin/settings/settings-tax-rates.php:107
+#: admin/woocommerce-admin-settings-forms.php:418
+#: admin/woocommerce-admin-settings-forms.php:490
+#@ woocommerce
 msgid "+ Add Tax Rate"
-msgstr "+ Ajouter taux de taxe"
+msgstr "&plus; Ajouter un taux de taxe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:419
-#: ../admin/woocommerce-admin-settings-forms.php:491
+#: admin/settings/settings-tax-rates.php:40
+#: admin/settings/settings-tax-rates.php:109
+#: admin/woocommerce-admin-settings-forms.php:420
+#: admin/woocommerce-admin-settings-forms.php:492
+#@ woocommerce
 msgid "All matching rates will be applied, and non-compound rates will be summed."
-msgstr "Tous les taux correspondants seront appliqués, et les taux non cumulables seront aditionnés."
+msgstr "Tous les taux correspondants seront appliqu&eacute;s, et les taux non cumulables seront additionn&eacute;s."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:420
-#: ../admin/woocommerce-admin-settings-forms.php:492
+#: admin/settings/settings-tax-rates.php:41
+#: admin/settings/settings-tax-rates.php:110
+#: admin/woocommerce-admin-settings-forms.php:421
+#: admin/woocommerce-admin-settings-forms.php:493
+#@ woocommerce
 msgid "Duplicate selected rows"
-msgstr "Dupliquer les lignes sélectionnées"
+msgstr "Dupliquer les lignes s&eacute;lectionn&eacute;es"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:420
-#: ../admin/woocommerce-admin-settings-forms.php:492
+#: admin/settings/settings-tax-rates.php:41
+#: admin/settings/settings-tax-rates.php:110
+#: admin/woocommerce-admin-settings-forms.php:421
+#: admin/woocommerce-admin-settings-forms.php:493
+#@ woocommerce
 msgid "Delete selected rows"
-msgstr "Supprimer les lignes sélectionnées"
+msgstr "Supprimer les lignes s&eacute;lectionn&eacute;es"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:432
-#: ../admin/woocommerce-admin-settings-forms.php:595
+#: admin/settings/settings-tax-rates.php:53
+#: admin/settings/settings-tax-rates.php:213
+#: admin/woocommerce-admin-settings-forms.php:433
+#: admin/woocommerce-admin-settings-forms.php:596
+#@ woocommerce
 msgid "Select countries/states&hellip;"
-msgstr "Sélectionnez des pays/états"
+msgstr "Choisissez des pays/&eacute;tats..."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:435
-#: ../admin/woocommerce-admin-settings-forms.php:598
+#: admin/post-types/writepanels/writepanel-product_data.php:194
+#: admin/settings/settings-tax-rates.php:56
+#: admin/settings/settings-tax-rates.php:216
+#: admin/woocommerce-admin-settings-forms.php:436
+#: admin/woocommerce-admin-settings-forms.php:599
+#: classes/shipping/class-wc-flat-rate.php:115
+#: classes/shipping/class-wc-international-delivery.php:86
+#@ woocommerce
 msgid "None"
 msgstr "Aucun"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:435
-#: ../admin/woocommerce-admin-settings-forms.php:598
+#: admin/settings/settings-tax-rates.php:56
+#: admin/settings/settings-tax-rates.php:216
+#: admin/woocommerce-admin-settings-forms.php:436
+#: admin/woocommerce-admin-settings-forms.php:599
+#@ woocommerce
 msgid "US States"
-msgstr "États-Unis"
+msgstr "&Eacute;tats-Unis"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:435
-#: ../admin/woocommerce-admin-settings-forms.php:598
+#: admin/settings/settings-tax-rates.php:56
+#: admin/settings/settings-tax-rates.php:216
+#: admin/woocommerce-admin-settings-forms.php:436
+#: admin/woocommerce-admin-settings-forms.php:599
+#@ woocommerce
 msgid "EU States"
 msgstr "Europe"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:440
-#: ../admin/woocommerce-admin-settings-forms.php:510
-#: ../admin/woocommerce-admin-settings-forms.php:603
-#: ../admin/woocommerce-admin-settings-forms.php:646
+#: admin/settings/settings-tax-rates.php:61
+#: admin/settings/settings-tax-rates.php:128
+#: admin/settings/settings-tax-rates.php:221
+#: admin/settings/settings-tax-rates.php:264
+#: admin/woocommerce-admin-settings-forms.php:441
+#: admin/woocommerce-admin-settings-forms.php:511
+#: admin/woocommerce-admin-settings-forms.php:604
+#: admin/woocommerce-admin-settings-forms.php:647
+#@ woocommerce
 msgid "Standard Rate"
-msgstr "Taux standard"
+msgstr "Taux standards"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:470
+#: admin/settings/settings-tax-rates.php:91
+#: admin/woocommerce-admin-settings-forms.php:471
+#@ woocommerce
 msgid "Local Tax Rates"
-msgstr "Taux de taxe local"
+msgstr "Taux locaux"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:474
+#: admin/woocommerce-admin-settings-forms.php:475
 #, php-format
+#@ woocommerce
 msgid "Define local tax rates below, or alternatively upload a CSV file containing your rates to <code>wp-content/woocommerce_local_tax_rates.csv</code> instead. <a href=\"%s\">Download sample csv.</a>"
-msgstr "Definir les taux de taxe locale ci-dessous, ou alternativement transférez un fichier CSV contenant vos taux sur <code>wp-content/woocommerce_local_tax_rates.csv</code>. <a href=\"%s\">Télécharger un csv modèle.</a>"
+msgstr "Definissez des taux locaux de taxe ci-dessous, ou alternativement envoyez un fichier CSV contenant vos taux sur <code>wp-content/woocommerce_local_tax_rates.csv</code>. <a href=\"%s\">T&eacute;l&eacute;charger un csv mod&egrave;le.</a>"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:479
-#: ../admin/woocommerce-admin-settings-forms.php:506
-#: ../admin/woocommerce-admin-settings-forms.php:642
+#: admin/settings/settings-tax-rates.php:97
+#: admin/settings/settings-tax-rates.php:124
+#: admin/settings/settings-tax-rates.php:260
+#: admin/woocommerce-admin-settings-forms.php:480
+#: admin/woocommerce-admin-settings-forms.php:507
+#: admin/woocommerce-admin-settings-forms.php:643
+#@ woocommerce
 msgid "Post/zip codes"
-msgstr "Codes Postaux"
+msgstr "Codes postaux/ZIP"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:479
+#: admin/settings/settings-tax-rates.php:97
+#: admin/woocommerce-admin-settings-forms.php:480
+#@ woocommerce
 msgid "List postcodes/zips this rate applies to separated by semi-colons. You may also enter ranges for numeric zip codes. e.g. 12345-12349;23456;"
-msgstr "Liste des codes postaux qui s'appliquent à ce taux, séparés par un point-virgule. Vous pouvez également saisir une plage de codes postaux. Ex.: 77000-77999;75001"
+msgstr "Liste des codes postaux/ZIP auxquels s&rsquo;appliquent ce taux, s&eacute;par&eacute;s par un point-virgule. Vous pouvez &eacute;galement saisir une plage de codes postaux (ex.: 77000-77999;75001)."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:503
-#: ../admin/woocommerce-admin-settings-forms.php:639
+#: admin/settings/settings-tax-rates.php:121
+#: admin/settings/settings-tax-rates.php:257
+#: admin/woocommerce-admin-settings-forms.php:504
+#: admin/woocommerce-admin-settings-forms.php:640
+#@ woocommerce
 msgid "Select a country/state&hellip;"
-msgstr "Sélectionnez un Pays/une Région&hellip;"
+msgstr "Choisissez un pays/&eacute;tat..."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:549
+#: admin/settings/settings-tax-rates.php:167
+#: admin/woocommerce-admin-settings-forms.php:550
+#@ woocommerce
 msgid "Done"
-msgstr "Fait"
+msgstr "Termin&eacute;"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:577
+#: admin/woocommerce-admin-settings-forms.php:578
+#@ woocommerce
 msgid " countries/states selected"
-msgstr "pays/états sélectionnés"
+msgstr " pays/&eacute;tats s&eacute;lectionn&eacute;s"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:593
-#: ../admin/woocommerce-admin-settings-forms.php:828
+#: admin/settings/settings-tax-rates.php:211
+#: admin/settings/settings-tax-rates.php:375
+#: admin/woocommerce-admin-settings-forms.php:594
+#: admin/woocommerce-admin-settings-forms.php:827
+#@ woocommerce
 msgid "No countries selected"
-msgstr "Aucun pays sélectionné"
+msgstr "Aucun pays s&eacute;lectionn&eacute;"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:675
+#: admin/settings/settings-tax-rates.php:293
+#: admin/woocommerce-admin-settings-forms.php:676
+#: classes/shipping/class-wc-flat-rate.php:434
+#@ woocommerce
 msgid "Delete the selected rates?"
-msgstr "Supprimer les taux sélectionnés"
+msgstr "Supprimer les taux s&eacute;lectionn&eacute;s"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:689
+#: admin/settings/settings-tax-rates.php:307
+#: admin/woocommerce-admin-settings-forms.php:690
+#@ woocommerce
 msgid "Duplicate the selected rates?"
-msgstr "Dupliquer les taux sélectionnés ?"
+msgstr "Dupliquer les taux s&eacute;lectionn&eacute;s&nbsp;?"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:747
+#: admin/settings/settings-frontend-styles.php:35
+#: admin/woocommerce-admin-settings-forms.php:749
+#@ woocommerce
 msgid "Primary"
 msgstr "Primaire"
 
-#: ../admin/woocommerce-admin-settings-forms.php:747
+#: admin/settings/settings-frontend-styles.php:35
+#: admin/woocommerce-admin-settings-forms.php:749
+#@ woocommerce
 msgid "Call to action buttons/price slider/layered nav UI"
-msgstr ""
+msgstr "Appelle les actions boutons/slider de prix/layered dans l&rsquo;interface."
 
-#: ../admin/woocommerce-admin-settings-forms.php:748
+#: admin/settings/settings-frontend-styles.php:36
+#: admin/woocommerce-admin-settings-forms.php:750
+#@ woocommerce
 msgid "Secondary"
 msgstr "Secondaire"
 
-#: ../admin/woocommerce-admin-settings-forms.php:748
+#: admin/settings/settings-frontend-styles.php:36
+#: admin/woocommerce-admin-settings-forms.php:750
+#@ woocommerce
 msgid "Buttons and tabs"
-msgstr ""
+msgstr "Boutons et onglets"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:749
+#: admin/settings/settings-frontend-styles.php:37
+#: admin/woocommerce-admin-settings-forms.php:751
+#@ woocommerce
 msgid "Highlight"
-msgstr ""
+msgstr "Mettre en surbrillance"
 
-#: ../admin/woocommerce-admin-settings-forms.php:749
+#: admin/settings/settings-frontend-styles.php:37
+#: admin/woocommerce-admin-settings-forms.php:751
+#@ woocommerce
 msgid "Price labels and Sale Flashes"
-msgstr ""
+msgstr "&Eacute;tiquettes de prix et ventes flash"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:753
-msgid "Content BG"
-msgstr "Contenu BG"
+#: admin/settings/settings-frontend-styles.php:38
+#: admin/woocommerce-admin-settings-forms.php:752
+#@ woocommerce
+msgid "Content"
+msgstr "Contenu"
 
-#: ../admin/woocommerce-admin-settings-forms.php:753
+#: admin/settings/settings-frontend-styles.php:38
+#: admin/woocommerce-admin-settings-forms.php:752
+#@ woocommerce
 msgid "Your themes page background - used for tab active states"
-msgstr ""
+msgstr "Le fond de vos pages de th&egrave;me - Utilis&eacute; dans les onglets actifs."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:754
+#: admin/settings/settings-frontend-styles.php:39
+#: admin/woocommerce-admin-settings-forms.php:753
+#@ woocommerce
 msgid "Subtext"
-msgstr "Sous texte"
+msgstr "Sous-texte"
 
-#: ../admin/woocommerce-admin-settings-forms.php:754
+#: admin/settings/settings-frontend-styles.php:39
+#: admin/woocommerce-admin-settings-forms.php:753
+#@ woocommerce
 msgid "Used for certain text and asides - breadcrumbs, small text etc."
-msgstr ""
+msgstr "Utilis&eacute; dans certains textes et apart&eacute;s - Fils d&rsquo;Ariane, petits textes, etc."
 
-#: ../admin/woocommerce-admin-settings-forms.php:758
+#: admin/settings/settings-frontend-styles.php:43
+#: admin/woocommerce-admin-settings-forms.php:757
+#@ woocommerce
 msgid "To edit colours <code>woocommerce/assets/css/woocommerce-base.less</code> and <code>woocommerce.css</code> need to be writable. See <a href=\"http://codex.wordpress.org/Changing_File_Permissions\">the Codex</a> for more information."
-msgstr ""
+msgstr "Pour modifier les couleurs, <code>woocommerce/assets/css/woocommerce-base.less</code> et <code>woocommerce.css</code> doivent &ecirc;tre autoris&eacute;s en &eacute;criture. Voir <a href=\"http://codex.wordpress.org/Changing_File_Permissions\">le Codex</a> pour plus d&rsquo;informations."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:832
+#: admin/settings/settings-tax-rates.php:379
+#: admin/woocommerce-admin-settings-forms.php:831
 #, php-format
+#@ woocommerce
 msgid "(1 state)"
 msgid_plural "(%s states)"
-msgstr[0] "(1 état)"
-msgstr[1] "(%s états)"
+msgstr[0] "(1 &eacute;tat)"
+msgstr[1] "(%s &eacute;tats)"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:838
+#: admin/settings/settings-tax-rates.php:385
+#: admin/woocommerce-admin-settings-forms.php:837
 #, php-format
+#@ woocommerce
 msgid "and 1 state"
 msgid_plural "and %s states"
-msgstr[0] "et 1 état"
-msgstr[1] "et %s états"
+msgstr[0] "et 1 &eacute;tat"
+msgstr[1] "et %s &eacute;tats"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings-forms.php:840
+#: admin/settings/settings-tax-rates.php:387
+#: admin/woocommerce-admin-settings-forms.php:839
 #, php-format
+#@ woocommerce
 msgid "1 country"
 msgid_plural "%1$s countries"
 msgstr[0] "1 pays"
 msgstr[1] "%1$s pays"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:19
-msgid "Localisation"
-msgstr "Localisation"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:20
-msgid "Use informal localisation file if it exists"
-msgstr "Utiliser le fichier de traduction informel si disponible"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:28
-msgid "General Options"
-msgstr "Options générales"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:31
-msgid "Base Country/Region"
-msgstr "Pays/Région de base"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:32
-msgid "This is the base country for your business. Tax rates will be based on this country."
-msgstr "Ceci est le pays de base de votre boutique. Les taux de taxes seront appliqués pour ce pays."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:41
-msgid "Currency"
-msgstr "Monnaie"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:42
-msgid "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in."
-msgstr "Ceci contrôle quelle monnaie est listée dans le catalogue et quelle monnaie de passerelle sera utilisée pour le paiement."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:50
-msgid "US Dollars (&#36;)"
-msgstr "Dollars US (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:51
-msgid "Euros (&euro;)"
-msgstr "Euros (&euro;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:52
-msgid "Pounds Sterling (&pound;)"
-msgstr "Livres Sterling (&pound;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:53
-msgid "Australian Dollars (&#36;)"
-msgstr "Dollars Australiens (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:54
-msgid "Brazilian Real (&#36;)"
-msgstr "Real Brésilien (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:55
-msgid "Canadian Dollars (&#36;)"
-msgstr "Dollars Canadiens (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:56
-msgid "Czech Koruna (&#75;&#269;)"
-msgstr "Couronne tchèque (&#75;&#269;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:57
-msgid "Danish Krone"
-msgstr "Couronne danoise"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:58
-msgid "Hong Kong Dollar (&#36;)"
-msgstr "Dollar Hong Kong (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:59
-msgid "Hungarian Forint"
-msgstr "Forint hongrois"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:60
-msgid "Israeli Shekel"
-msgstr "Shekel israélien"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:61
-msgid "Chinese Yuan (&yen;)"
-msgstr "Yuan Chinois (&yen;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:62
-msgid "Japanese Yen (&yen;)"
-msgstr "Yen Japonais (&yen;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:63
-msgid "Malaysian Ringgits (RM)"
-msgstr "Ringgits Malaisien (RM)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:64
-msgid "Mexican Peso (&#36;)"
-msgstr "Peso Mexicain (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:65
-msgid "New Zealand Dollar (&#36;)"
-msgstr "Dollar Nouvelle Zélande (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:66
-msgid "Norwegian Krone"
-msgstr "Couronne Norvégienne"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:67
-msgid "Philippine Pesos"
-msgstr "Peso Philippin"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:68
-msgid "Polish Zloty"
-msgstr "Zloty polonais"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:69
-msgid "Singapore Dollar (&#36;)"
-msgstr "Dollar de Singapour (&#36;)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:70
-msgid "Swedish Krona"
-msgstr "Couronne Suédoise"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:71
-msgid "Swiss Franc"
-msgstr "Franc Suisse"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:72
-msgid "Taiwan New Dollars"
-msgstr "Nouveaux Dollars de Taiwan"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:73
-msgid "Thai Baht"
-msgstr "Baht Thai"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:74
-msgid "Turkish Lira (TL)"
-msgstr "Turkish Lira (TL)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:75
-msgid "South African rand (R)"
-msgstr "South African rand (R)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:81
-msgid "Allowed Countries"
-msgstr "Pays autorisés"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:82
-msgid "These are countries that you are willing to ship to."
-msgstr "Voici les pays où vous voulez vendre."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:90
-msgid "All Countries"
-msgstr "Tous les pays"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:91
-#: ../admin/woocommerce-admin-settings.php:96
-msgid "Specific Countries"
-msgstr "Pays spécifiques"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:108
-msgid "Checkout and Accounts"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:108
-msgid "The following options control the behaviour of the checkout process and customer accounts."
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:112
-msgid "Enable guest checkout (no account required)"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:120
-msgid "Show order comments section"
-msgstr "Afficher la section commentaires de commande"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:128
-msgid "Security"
-msgstr "Sécurité"
-
-#: ../admin/woocommerce-admin-settings.php:129
-msgid "Force secure checkout"
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:135
-msgid "Force SSL (HTTPS) on the checkout pages (an SSL Certificate is required)"
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:139
-msgid "Un-force HTTPS when leaving the checkout"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:149
-msgid "Enable coupons"
-msgstr "Activer Coupons"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:158
-msgid "Enable coupon form on checkout"
-msgstr "Activer le formulaire de codes promo sur la commande"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:167
-msgid "Registration"
-msgstr "S'enregistrer"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:168
-msgid "Allow unregistered users to register from the Checkout"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:176
-msgid "Allow unregistered users to register from \"My Account\""
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:184
-msgid "Customer Accounts"
-msgstr "Compte client"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:185
-msgid "Prevent customers from accessing WordPress admin"
-msgstr "Empêcher les clients d'accéder à l'administration WordPress"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:193
-msgid "Clear cart when logging out"
-msgstr "Vider le panier lors de la déconnexion"
-
-#: ../admin/woocommerce-admin-settings.php:201
-msgid "Allow customers to repurchase past orders"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:210
-msgid "Styles and Scripts"
-msgstr "Styles et Scripts"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:210
-msgid "The following options affect the styling of your store, as well as how certain features behave."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:213
-msgid "Styling"
-msgstr "Mise en forme"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:214
-msgid "Enable the \"Demo Store\" notice on your site"
-msgstr "Activer la notice \"Boutique de Démonstration\" sur votre site"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:222
-msgid "Enable WooCommerce CSS styles"
-msgstr "Activer les styles CSS WooCommerce"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:230
-msgid "Colours"
-msgstr "Coloris"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:236
-msgid "Scripts"
-msgstr "Scripts"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:237
-msgid "Enable AJAX add to cart buttons on product archives"
-msgstr "Activer les boutons AJAX d'ajout au panier sur les produits archive"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:245
-msgid "Enable WooCommerce lightbox on the product page"
-msgstr "Activer la lightbox WooCommerce sur la page produit"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:253
-#, fuzzy
-msgid "Enable enhanced country select boxes"
-msgstr "Activer \"choisie\" (entrée sélectionnée améliorée) pour les entrées de sélection de pays"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:261
-msgid "Enable jQuery UI (used by the price slider widget)"
-msgstr "Activer JQuery UI (utilisé par le widget prix slider)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:269
-msgid "Output WooCommerce JavaScript in the footer"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:278
-msgid "Digital Downloads"
-msgstr "Téléchargements numériques"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:278
-msgid "The following options are specific to downloadable products."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:281
-msgid "File download method"
-msgstr "Méthode de téléchargement de fichiers"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:282
-msgid "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect</code>/ <code>X-Sendfile</code> can be used to serve downloads instead (server requires <code>mod_xsendfile</code>)."
-msgstr "Le Forçage des téléchargements laissera les URL cachés, mais certains serveurs peuvent proposer de gros fichiers de façon non fiable. Si supportés, <code>X-Accel-Redirect</code>/ <code>X-Sendfile</code> peuvent être utilisés pour distribuer les téléchargements en remplacement (nécessite <code>mod_xsendfile</code> sur le serveur)."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:290
-msgid "Force Downloads"
-msgstr "Forcer le téléchargement"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:291
-msgid "X-Accel-Redirect/X-Sendfile"
-msgstr "X-Accel-Redirect/X-Sendfile"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:292
-msgid "Redirect only"
-msgstr "Redirection seulement"
-
-#: ../admin/woocommerce-admin-settings.php:297
-msgid "Access Restrictions"
-msgstr "Restrictions d'accès"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:298
-#, fuzzy
-msgid "Must be logged in to download files"
-msgstr "Vous devez être identifié pour commander."
-
-#: ../admin/woocommerce-admin-settings.php:302
-msgid "This setting does not apply to guest downloads."
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:307
-msgid "Grant access to downloadable products after payment"
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:311
-msgid "Turn this option off to only grant access when an order is \"complete\", rather than \"processing\""
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:316
-msgid "Limit quantity"
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:317
-msgid "Limit the purchasable quantity of downloadable-virtual items to 1"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:335
-msgid "Note: The shop page has children - child pages will not work if you enable this option."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:339
-msgid "Page Setup"
-msgstr "Paramètres des pages"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:342
-msgid "Shop Base Page"
-msgstr "Page de base de la boutique"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:343
-msgid "This sets the base page of your shop - this is where your product archive will be."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:353
-msgid "Base Page Title"
-msgstr "Titre de la page de base"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:354
-msgid "This title to show on the shop base page. Leave blank to use the page title."
-msgstr "Le titre à afficher sur la page de départ de la boutique. Laisser vide pour utiliser le titre de la page."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:363
-msgid "Terms page ID"
-msgstr "Page CGV"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:364
-msgid "If you define a \"Terms\" page the customer will be asked if they accept them when checking out."
-msgstr "Si vous définissez une page \"Conditions Générales de Vente\" il sera demandé au client d'accepter ces CGV lors de la commande."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:375
-msgid "Logout link"
-msgstr "Lien de déconnexion"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:376
-msgid "Append a logout link to menus containing \"My Account\""
-msgstr "Ajoute un lien de déconnexion aux menus contenant \"Mon compte\""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:384
-msgid "Permalinks"
-msgstr "Permaliens"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:387
-msgid "Taxonomy base page"
-msgstr "Page de base de la taxinomie"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:388
-#, php-format
-msgid "Prepend shop categories/tags with shop base page (<code>%s</code>)"
-msgstr "Préfixer les catégories et mots clés avec la page de base de la boutique (<code>%s</code>)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:395
-msgid "Product category slug"
-msgstr "Slug catégorie produit"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:396
-msgid "Shows in the product category URLs. Leave blank to use the default slug."
-msgstr "Affiché dans les URL de catégorie produit. Laisser vide pour utiliser le slug par défaut."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:405
-msgid "Product tag slug"
-msgstr "Slug mots-clés produit"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:406
-msgid "Shows in the product tag URLs. Leave blank to use the default slug."
-msgstr "Affiché dans les URL des mots-clés produit. Laisser vide pour utiliser le slug par défaut."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:415
-msgid "Product base page"
-msgstr "Page de base produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:416
-#, php-format
-msgid "Prepend product permalinks with shop base page (<code>%s</code>)"
-msgstr "Préfixer les permaliens produit avec la page de base de la boutique (<code>%s</code>)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:424
-msgid "Product base category"
-msgstr "Catégorie catalogue produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:425
-msgid "Prepend product permalinks with product category"
-msgstr "Préfixer les permaliens produit avec leur catégorie (<code>categorie/produit</code>)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:434
-msgid "The following pages need selecting so that WooCommerce knows where they are. These pages should have been created upon installation of the plugin, if not you will need to create them."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:438
-msgid "Page contents: [woocommerce_cart]"
-msgstr "Contenu page : [woocommerce_cart]"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:449
-msgid "Page contents: [woocommerce_checkout]"
-msgstr "Contenu page : [woocommerce_checkout]"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:460
-msgid "Page contents: [woocommerce_pay] Parent: \"Checkout\""
-msgstr "Contenu page : [woocommerce_pay] Parent : \"Commande\""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:471
-msgid "Page contents: [woocommerce_thankyou] Parent: \"Checkout\""
-msgstr "Contenu page :  [woocommerce_thankyou] Parent : \"Commande\""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:482
-msgid "Page contents: [woocommerce_my_account]"
-msgstr "Contenu page : [woocommerce_my_account]"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:493
-msgid "Page contents: [woocommerce_edit_address] Parent: \"My Account\""
-msgstr "Contenu page : [woocommerce_edit_address] Parent : \"Mon Compte\""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:504
-msgid "Page contents: [woocommerce_view_order] Parent: \"My Account\""
-msgstr "Contenu page : [woocommerce_view_order] Parent: \"Mon Compte\""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:515
-msgid "Page contents: [woocommerce_change_password] Parent: \"My Account\""
-msgstr "Contenu page : [woocommerce_change_password] Parent: \"Mon Compte\""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:531
-msgid "Catalog Options"
-msgstr "Options du catalogue"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:534
-#, fuzzy
-msgid "Default product sorting"
-msgstr "Coût par défaut"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:535
-#, fuzzy
-msgid "This controls the default sort order of the catalog."
-msgstr "Cela détermine la position du symbole de monnaie."
-
-#: ../admin/woocommerce-admin-settings.php:541
-msgid "Sort by title"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:542
-msgid "Sort by date"
-msgstr "Trier par date"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:543
-msgid "Sort by price"
-msgstr "Trier par prix"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:549
-#, fuzzy
-msgid "Show subcategories"
-msgstr "Sous catégories"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:550
-msgid "Show subcategories on category pages"
-msgstr "Montrer les sous catégories dans les pages catégorie"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:558
-msgid "Show subcategories on the shop page"
-msgstr "Montrer les sous catégories dans la page boutique"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:566
-msgid "When showing subcategories, hide products"
-msgstr "Quand les sous catégories sont affichées, cacher les produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:574
-msgid "Redirects"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:575
-msgid "Redirect to cart after adding a product to the cart (on single product pages)"
-msgstr "Rediriger vers le panier après l'ajout d'un produit au panier (ou sur les pages de produits simples)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:583
-msgid "Redirect to the product page on a single matching search result"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:592
-#: ../admin/post-types/product.php:459
-#: ../admin/post-types/product.php:663
-msgid "Product Data"
-msgstr "Données Produit"
-
-#: ../admin/woocommerce-admin-settings.php:592
-msgid "The following options affect the fields available on the edit product page."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:595
-msgid "Product fields"
-msgstr "Champs des produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:596
-msgid "Enable the SKU field for products"
-msgstr "Activer le champ UGS (Unité de Gestion des Stocks) pour les produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:604
-msgid "Enable the weight field for products"
-msgstr "Activer le champ poids pour les produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:612
-msgid "Enable the dimension fields for products"
-msgstr "Activer les champs dimensions pour les produits"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:620
-msgid "Show weight and dimension fields in product attributes tab"
-msgstr "Afficher le poids et les dimentions dans l'onglet d'attributs du produit"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:628
-msgid "Weight Unit"
-msgstr "Unité de poids"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:629
-msgid "This controls what unit you will define weights in."
-msgstr "Cela détermine dans quelle unité vous définirez les poids."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:635
-msgid "kg"
-msgstr "Kilos"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:636
-msgid "g"
-msgstr "g"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:637
-msgid "lbs"
-msgstr "Livres"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:643
-msgid "Dimensions Unit"
-msgstr "Unité des dimensions"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:644
-msgid "This controls what unit you will define lengths in."
-msgstr "Cela détermine dans quelle unité vous définirez les longueurs."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:650
-#: ../admin/post-types/writepanels/writepanel-order_data.php:70
-msgid "m"
-msgstr "m"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:651
-msgid "cm"
-msgstr "cm"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:652
-msgid "mm"
-msgstr "mm"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:653
-msgid "in"
-msgstr "pouce"
-
-#: ../admin/woocommerce-admin-settings.php:654
-msgid "yd"
-msgstr "yd"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:660
-#, fuzzy
-msgid "Product Ratings"
-msgstr "Mots-Clés"
-
-#: ../admin/woocommerce-admin-settings.php:661
-msgid "Enable the star rating field on the review form"
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:670
-msgid "Ratings are required to leave a review"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:680
-msgid "Pricing Options"
-msgstr "Options de prix"
-
-#: ../admin/woocommerce-admin-settings.php:680
-msgid "The following options affect how prices are displayed on the frontend."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:683
-msgid "Currency Position"
-msgstr "Position monnaie"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:684
-msgid "This controls the position of the currency symbol."
-msgstr "Cela détermine la position du symbole de monnaie."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:691
-msgid "Left"
-msgstr "Gauche"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:692
-msgid "Right"
-msgstr "Droite"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:693
-msgid "Left (with space)"
-msgstr "Gauche (avec espace)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:694
-msgid "Right (with space)"
-msgstr "Droite (avec espace)"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:700
-msgid "Thousand separator"
-msgstr "Séparateur de milliers"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:701
-msgid "This sets the thousand separator of displayed prices."
-msgstr "Cela détermine le séparateur de milliers pour les prix affichés."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:711
-msgid "Decimal separator"
-msgstr "Séparateur décimal"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:712
-msgid "This sets the decimal separator of displayed prices."
-msgstr "Cela détermine le séparateur de décimales pour les prix affichés."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:722
-msgid "Number of decimals"
-msgstr "Nombre de décimales"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:723
-msgid "This sets the number of decimal points shown in displayed prices."
-msgstr "Cela détermine le nombre de décimales pour les prix affichés."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:733
-#, fuzzy
-msgid "Trailing zeros"
-msgstr "Supprimer les zéros"
-
-#: ../admin/woocommerce-admin-settings.php:734
-msgid "Remove zeros after the decimal point. e.g. <code>$10.00</code> becomes <code>$10</code>"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:742
-msgid "Image Options"
-msgstr "Options images"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:742
-#, php-format
-msgid "These settings affect the actual dimensions of images in your catalog - the display on the front-end will still be affected by CSS styles. After changing these settings you may need to <a href=\"%s\">regenerate your thumbnails</a>."
-msgstr "Ces paramètres affectent les dimensions actuelles des images dans votre catalogue - l'affichage sur le site sera encore affecté par les styles CSS. Après avoir changé ces paramètres vous pourrez avoir besoin de <a href=\"%s\">régénérer vos vignettes</a>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:745
-msgid "Catalog Images"
-msgstr "Catalogue d'images"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:746
-msgid "This size is usually used in product listings"
-msgstr "Cette taille est habituellement utilisée dans les listes de produits."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:755
-msgid "Single Product Image"
-msgstr "Image produit détail"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:756
-msgid "This is the size used by the main image on the product page."
-msgstr "C'est la taille utilisée pour l'image principale sur la page produit."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:765
-msgid "Product Thumbnails"
-msgstr "Vignettes produit"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:766
-msgid "This size is usually used for the gallery of images on the product page."
-msgstr "Cette taille est habituellement utilisée pour la galerie d'image sur la page des produits."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:781
-msgid "Inventory Options"
-msgstr "Options inventaire"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:784
-msgid "Manage stock"
-msgstr "Gestion du stock"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:785
-msgid "Enable stock management"
-msgstr "Activer la gestion du stock"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:792
-msgid "Notifications"
-msgstr "Notifications"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:793
-msgid "Enable low stock notifications"
-msgstr "Activer les notifications de stock faible"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:801
-msgid "Enable out of stock notifications"
-msgstr "Activer les notifications de stock épuisé"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:809
-msgid "Low stock threshold"
-msgstr "Seuil de stock faible"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:819
-msgid "Out of stock threshold"
-msgstr "Seuil de stock épuisé"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:829
-msgid "Out of stock visibility"
-msgstr "Visibilité des stocks épuisés"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:830
-msgid "Hide out of stock items from the catalog"
-msgstr "Cacher les produits en stock épuisé du catalogue"
-
-#: ../admin/woocommerce-admin-settings.php:837
-msgid "Stock display format"
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:838
-msgid "This controls how stock is displayed on the frontend."
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:844
-msgid "Always show stock e.g. \"12 in stock\""
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:845
-msgid "Only show stock when low e.g. \"Only 2 left in stock\" vs. \"In Stock\""
-msgstr ""
-
-#: ../admin/woocommerce-admin-settings.php:846
-msgid "Never show stock amount"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:858
-#: ../admin/woocommerce-admin-settings.php:1310
-msgid "Shipping Options"
-msgstr "Options des frais"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:858
-msgid "Shipping can be enabled and disabled from this section."
-msgstr "La livraison peut être activée et désactivée depuis cette section."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:861
-#: ../admin/woocommerce-admin-settings.php:870
-#: ../admin/woocommerce-admin-settings.php:879
-msgid "Shipping calculations"
-msgstr "Calcul de frais de port"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:862
-msgid "Enable shipping"
-msgstr "Activer la livraison"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:871
-msgid "Enable the shipping calculator on the cart page"
-msgstr "Activer le calculateur de frais dans la page panier"
-
-#: ../admin/woocommerce-admin-settings.php:880
-msgid "Hide shipping costs until an address is entered"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:888
-msgid "Shipping destination"
-msgstr "Destination de la livraison"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:889
-msgid "Only ship to the users billing address"
-msgstr "Livrer uniquement à l'adresse de facturation"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:897
-msgid "Ship to billing address by default"
-msgstr "Livrer à l'adresse de facturation par défault"
-
-#: ../admin/woocommerce-admin-settings.php:905
-msgid "Collect shipping address even when not required"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:919
-msgid "Tax Options"
-msgstr "Options des taxes"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:922
-msgid "Tax calculations"
-msgstr "Calcul des taxes"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:923
-msgid "Enable taxes and tax calculations"
-msgstr "Activer les taxes et le calcul de taxes"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:931
-msgid "Display taxes on cart page"
-msgstr "Afficher les taxes sur la page du panier"
-
-#: ../admin/woocommerce-admin-settings.php:939
-msgid "Display taxes even when the amount is zero"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:947
-msgid "Round tax at subtotal level, instead of per line"
-msgstr "Arrondir les taxes au niveau du sous-total, plutôt que pour chaque ligne"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:955
-msgid "Catalog Prices"
-msgstr "Prix catalogue"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:956
-msgid "Catalog prices defined including tax"
-msgstr "Les prix catalogues définis incluent les taxes"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:965
-msgid "Display cart contents excluding tax"
-msgstr "Afficher les contenus du panier en H.T."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:974
-msgid "Display cart totals excluding tax"
-msgstr "Afficher les totaux du panier en H.T."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:983
-msgid "Additional Tax classes"
-msgstr "Classes additionnelles des taxes"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:984
-msgid "List 1 per line. This is in addition to the default <em>Standard Rate</em>."
-msgstr "Une par ligne. Ceci est un ajout aux <em>Taxes Standards</em>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:985
-msgid "List product and shipping tax classes here, e.g. Zero Tax, Reduced Rate."
-msgstr "Liste produit et classes de taxes de livraison ici. Ex : Exonération de Taxe, Taux Réduit."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:989
-#, php-format
-msgid "Reduced Rate%sZero Rate"
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:993
-msgid "Tax rates"
-msgstr "Taux de taxes"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:994
-msgid "All fields are required."
-msgstr "Tous les champs sont requis."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:995
-msgid "To avoid rounding errors, insert tax rates with 4 decimal places."
-msgstr "Afin d'éviter les erreurs d'arrondi, insérez les taux d'imposition avec 4 décimales."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1008
-msgid "Email Recipient Options"
-msgstr "Options d'email du destinataire"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1011
-msgid "New order notifications"
-msgstr "Notification de nouvelle commande"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1012
-msgid "The recipient of new order emails. Defaults to the admin email."
-msgstr "Le destinataire des emails de nouvelle commande. Par défaut l'email de l'administrateur."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1020
-msgid "Inventory notifications"
-msgstr "Notifications d'inventaire"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1021
-msgid "The recipient of stock emails. Defaults to the admin email."
-msgstr "Le destinataire des emails d'inventaire. Par défaut l'email de l'administrateur."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1030
-msgid "Email Sender Options"
-msgstr "Options d'email de l'expéditeur"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1030
-msgid "The following options affect the sender (email address and name) used in WooCommerce emails."
-msgstr ""
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1033
-msgid "\"From\" name"
-msgstr "\"From\" nom"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1042
-msgid "\"From\" email address"
-msgstr "\"From\" adresse email"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1052
-msgid "Email template"
-msgstr "Modèle d'email"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1052
-#, php-format
-msgid "This section lets you customise the WooCommerce emails. <a href=\"%s\" target=\"_blank\">Click here to preview your email template</a>. For more advanced control copy <code>woocommerce/templates/emails/</code> to <code>yourtheme/woocommerce/emails/</code>."
-msgstr "Cette section vous laisse la possibilité de personnaliser les emails WooCommerce. <a href=\"%s\" target=\"_blank\">Cliquer ici pour prévisualiser votre modèle d'email</a>. Pour davantage de contrôles copiez <code>woocommerce/templates/emails/</code> dans <code>votretheme/woocommerce/emails/</code>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1055
-msgid "Header image"
-msgstr "Image d'entête"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1056
-#, php-format
-msgid "Enter a URL to an image you want to show in the email's header. Upload your image using the <a href=\"%s\">media uploader</a>."
-msgstr "Entrer l'URL d'une image que vous souhaitez afficher dans l'entête de l'email. Transférez votre image en utilisant le <a href=\"%s\">transfert de médias</a>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1064
-msgid "Email footer text"
-msgstr "Texte de pied de page de l'email"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1065
-msgid "The text to appear in the footer of WooCommerce emails."
-msgstr "Le texte à afficher dans le pied de page des emails WooCommerce."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1069
-msgid "Powered by WooCommerce"
-msgstr "Propulsé par WooCommerce"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1073
-msgid "Base colour"
-msgstr "Couleur de base"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1074
-msgid "The base colour for WooCommerce email templates. Default <code>#557da1</code>."
-msgstr "La couleur de base pour les modèles d'emails WooCommerce. Par défaut <code>#557da1</code>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1082
-msgid "Background colour"
-msgstr "Couleur du fond"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1083
-msgid "The background colour for WooCommerce email templates. Default <code>#eeeeee</code>."
-msgstr "La couleur de fond pour les modèles d'emails WooCommerce. Par défaut <code>#eeeeee</code>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1091
-msgid "Email body background colour"
-msgstr "Couleur de fond du corps de l'email"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1092
-msgid "The main body background colour. Default <code>#fdfdfd</code>."
-msgstr "La couleur principale du fond du corps. Par défaut <code>#fdfdfd</code>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1100
-msgid "Email body text colour"
-msgstr "Couleur du texte du corps de l'email"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1101
-msgid "The main body text colour. Default <code>#505050</code>."
-msgstr "La couleur principale du texte du corps. Par défaut <code>#505050</code>."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1212
+#: admin/woocommerce-admin-settings.php:127
+#@ woocommerce
 msgid "Your settings have been saved."
-msgstr "Vos paramètres ont été enregistrés."
+msgstr "Vos param&egrave;tres ont &eacute;t&eacute; enregistr&eacute;s."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1249
+#: admin/woocommerce-admin-settings.php:164
+#@ woocommerce
 msgid "<strong>Congratulations!</strong> &#8211; WooCommerce has been installed and setup. Enjoy :)"
-msgstr ""
+msgstr "<strong>F&eacute;licitations&nbsp;!</strong> &#8211; WooCommerce a &eacute;t&eacute; install&eacute; et param&eacute;tr&eacute;. Amusez-vous bien&nbsp;:)"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1274
-#: ../admin/woocommerce-admin-settings.php:1381
-#: ../admin/woocommerce-admin-settings.php:1394
+#: admin/settings/settings-init.php:928
+#: admin/woocommerce-admin-settings.php:189
+#: admin/woocommerce-admin-settings.php:268
+#@ woocommerce
 msgid "Payment Gateways"
-msgstr "Passerelles de Paiement"
+msgstr "Paiement"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1293
+#: admin/woocommerce-admin-settings.php:208
 #, php-format
+#@ woocommerce
 msgid "More functionality and gateway options available via <a href=\"%s\" target=\"_blank\">WC official extensions</a>."
-msgstr "Plus de fonctionnalités et d'options de passerelle disponibles sur <a href=\"%s\" target=\"_blank\">Extensions WC officielles</a>."
+msgstr "Plus de fonctionnalit&eacute;s et de passerelles disponibles sur <a href=\"%s\" target=\"_blank\">Extensions WC officielles</a>."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1326
-msgid "Shipping Methods"
-msgstr "Expédition"
+#: admin/settings/settings-init.php:851
+#: admin/woocommerce-admin-settings.php:233
+#: classes/shipping/class-wc-flat-rate.php:137
+#@ woocommerce
+msgid "Shipping Options"
+msgstr "Options de livraison"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1327
-msgid "Your activated shipping methods are listed below. Drag and drop rows to re-order them for display on the frontend."
-msgstr "Vos méthodes de livraison actives sont listées ci-dessous. Cliquez/Deplacez les lignes pour les réordonner pour l'affichage sur le site."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1331
-#: ../admin/woocommerce-admin-settings.php:1399
-msgid "Default"
-msgstr "Valeur par défaut"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1332
-msgid "Shipping Method"
-msgstr "Méthode de livraison"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1333
-#: ../admin/woocommerce-admin-settings.php:1401
-#: ../admin/post-types/shop_order.php:34
-msgid "Status"
-msgstr "État"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1348
-msgid "Method ID"
-msgstr "ID de la méthode"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1395
-msgid "Your activated payment gateways are listed below. Drag and drop rows to re-order them for display on the checkout."
-msgstr "Vos passerelles de paiement actives sont listées ci-dessous. Cliquez/Deplacez les lignes pour les réordonner pour l'affichage sur la commande."
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1400
-msgid "Gateway"
-msgstr "Passerelle"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1417
-msgid "Gateway ID"
-msgstr "ID Passerelle"
-
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1472
+#: admin/woocommerce-admin-settings.php:320
+#@ woocommerce
 msgid "Save changes"
 msgstr "Enregistrer les changements"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-settings.php:1527
+#: admin/woocommerce-admin-settings.php:386
+#@ woocommerce
 msgid "The changes you made will be lost if you navigate away from this page."
-msgstr "Les changements effectués seront perdus si vous quittez cette page."
+msgstr "Les changements effectu&eacute;s seront perdus si vous quittez cette page."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:22
-#: ../admin/woocommerce-admin-taxonomies.php:85
+#: admin/woocommerce-admin-settings.php:595
+#@ woocommerce
+msgid "Select a page&hellip;"
+msgstr "Choisissez une page&hellip;"
+
+#: admin/woocommerce-admin-status.php:275
+#, php-format
+#@ woocommerce
+msgid "%s - We recommend setting memory to at least 64MB. See: <a href=\"%s\">Increasing memory allocated to PHP</a>"
+msgstr "%s - Nous recommandons un r&eacute;glage m&eacute;moire d&rsquo;au moins 64MB. Voir&nbsp;: <a href=\"%s\">Augmenter la m&eacute;moire allou&eacute;e &agrave; PHP</a>"
+
+#: admin/woocommerce-admin-status.php:329
+#@ woocommerce
+msgid "fsockopen/cURL"
+msgstr "fsockopen/cURL"
+
+#: admin/woocommerce-admin-status.php:332
+#@ woocommerce
+msgid "Your server has fsockopen and cURL enabled."
+msgstr "fsockopen et Curl sont activ&eacute;s sur votre serveur."
+
+#: admin/woocommerce-admin-status.php:334
+#@ woocommerce
+msgid "Your server has fsockopen enabled, cURL is disabled."
+msgstr "fsockopen est activ&eacute; sur votre serveur, cURL est d&eacute;sactiv&eacute;."
+
+#: admin/woocommerce-admin-status.php:336
+#@ woocommerce
+msgid "Your server has cURL enabled, fsockopen is disabled."
+msgstr "cURL est activ&eacute; sur votre serveur, fsockopen est d&eacute;sactiv&eacute;."
+
+#: admin/woocommerce-admin-status.php:340
+#@ woocommerce
+msgid "Your server does not have fsockopen or cURL enabled - PayPal IPN and other scripts which communicate with other servers will not work. Contact your hosting provider."
+msgstr "fsockopen ou cURL n&rsquo;est pas activ&eacute; sur votre serveur - PayPal IPN et les autres scripts communiquant avec d&rsquo;autres serveurs ne fonctionneront pas. Contactez votre h&eacute;bergeur pour r&eacute;soudre le probl&egrave;me."
+
+#: admin/woocommerce-admin-status.php:356
+#@ woocommerce
+msgid "wp_remote_post() failed. PayPal IPN won't work with your server. Contact your hosting provider. Error:"
+msgstr "wp_remote_post() a &eacute;chou&eacute;. PayPal IPN ne fonctionne pas sur votre serveur. Contactez votre h&eacute;bergeur pour r&eacute;soudre le probl&egrave;me. Erreur&nbsp;:"
+
+#: admin/woocommerce-admin-taxonomies.php:22
+#: admin/woocommerce-admin-taxonomies.php:85
+#@ woocommerce
 msgid "Thumbnail"
 msgstr "Vignette"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:26
-#: ../admin/woocommerce-admin-taxonomies.php:90
+#: admin/woocommerce-admin-taxonomies.php:26
+#: admin/woocommerce-admin-taxonomies.php:90
+#@ woocommerce
 msgid "Upload/Add image"
-msgstr "Transférer/Ajouter image"
+msgstr "Envoyer/Ajouter une image"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:27
-#: ../admin/woocommerce-admin-taxonomies.php:91
+#: admin/woocommerce-admin-taxonomies.php:27
+#: admin/woocommerce-admin-taxonomies.php:91
+#@ woocommerce
 msgid "Remove image"
-msgstr "Supprimer image"
+msgstr "Supprimer l&rsquo;image"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:150
+#: admin/woocommerce-admin-taxonomies.php:150
+#@ woocommerce
 msgid "Product categories for your store can be managed here. To change the order of categories on the front-end you can drag and drop to sort them. To see more categories listed click the \"screen options\" link at the top of the page."
-msgstr "Les catégories de produit pour votre boutique peuvent être gérées ici. Pour changer l'ordre des catégories sur le site vous pouvez les cliquer/déplacer pour les ordonner. Pour voir plus de catégories listées cliquer le lien \"Options de l'écran\" en haut de la page."
+msgstr "Les cat&eacute;gories de produit de votre boutique peuvent &ecirc;tre g&eacute;r&eacute;es ici. Cliquer/D&eacute;placer les lignes pour les r&eacute;ordonner sur le site. Pour voir plus de cat&eacute;gories list&eacute;es, cliquer sur le lien \"Options de l&rsquo;&eacute;cran\" en haut de la page."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:161
+#: admin/woocommerce-admin-taxonomies.php:161
+#@ woocommerce
 msgid "Shipping classes can be used to group products of similar type. These groups can then be used by certain shipping methods to provide different rates to different products."
-msgstr "Les classes de livraison peuvent être utilisées pour grouper des produits similaires. Ces groupes peuvent alors être utilisés par certaines méthodes de livraison pour fournir différents taux à différents produits."
+msgstr "Les classes de livraison peuvent &ecirc;tre utilis&eacute;es pour regrouper des produits similaires. Ces groupes peuvent alors &ecirc;tre utilis&eacute;s par certains modes de livraison pour fournir diff&eacute;rents taux &agrave; diff&eacute;rents produits."
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:208
-#: ../admin/post-types/product.php:65
+#: admin/post-types/product.php:65
+#: admin/woocommerce-admin-taxonomies.php:208
+#@ woocommerce
 msgid "Image"
 msgstr "Image"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-taxonomies.php:245
+#: admin/woocommerce-admin-taxonomies.php:245
+#@ woocommerce
 msgid "Configure shipping class"
 msgstr "Configurer la classe de livraison"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:18
+#: admin/woocommerce-admin-users.php:18
+#: templates/checkout/form-billing.php:14
+#: templates/myaccount/form-edit-address.php:21
+#: templates/myaccount/my-address.php:20
+#: templates/order/order-details.php:100
+#@ woocommerce
 msgid "Billing Address"
-msgstr "Adresse de Facturation"
+msgstr "Adresse de facturation"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:19
+#: admin/woocommerce-admin-users.php:19
+#: templates/checkout/form-shipping.php:28
+#: templates/myaccount/form-edit-address.php:21
+#: templates/myaccount/my-address.php:51
+#: templates/order/order-details.php:115
+#@ woocommerce
 msgid "Shipping Address"
-msgstr "Adresse de Livraison"
+msgstr "Adresse de livraison"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:20
+#: admin/woocommerce-admin-users.php:20
+#@ woocommerce
 msgid "Paying Customer?"
-msgstr "Payer au Client ?"
+msgstr "Paiement client&nbsp;?"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:61
-#: ../admin/woocommerce-admin-users.php:80
+#: admin/woocommerce-admin-users.php:61
+#: admin/woocommerce-admin-users.php:80
+#: templates/order/order-details.php:104
+#: templates/order/order-details.php:119
+#@ woocommerce
 msgid "N/A"
 msgstr "N/A"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:102
+#: admin/woocommerce-admin-users.php:102
+#@ woocommerce
 msgid "Customer Billing Address"
 msgstr "Adresse de facturation du client"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:105
-#: ../admin/woocommerce-admin-users.php:154
+#: admin/woocommerce-admin-users.php:105
+#: admin/woocommerce-admin-users.php:154
+#@ woocommerce
 msgid "First name"
-msgstr "Prénom"
+msgstr "Pr&eacute;nom"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:109
-#: ../admin/woocommerce-admin-users.php:158
+#: admin/woocommerce-admin-users.php:109
+#: admin/woocommerce-admin-users.php:158
+#@ woocommerce
 msgid "Last name"
 msgstr "Nom"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:113
-#: ../admin/woocommerce-admin-users.php:162
-#: ../admin/post-types/writepanels/writepanel-order_data.php:103
-#: ../admin/post-types/writepanels/writepanel-order_data.php:184
+#: admin/post-types/writepanels/writepanel-order_data.php:103
+#: admin/post-types/writepanels/writepanel-order_data.php:184
+#: admin/woocommerce-admin-users.php:113
+#: admin/woocommerce-admin-users.php:162
+#@ woocommerce
 msgid "Company"
 msgstr "Entreprise"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:117
-#: ../admin/woocommerce-admin-users.php:166
-#: ../admin/post-types/writepanels/writepanel-order_data.php:107
-#: ../admin/post-types/writepanels/writepanel-order_data.php:188
+#: admin/post-types/writepanels/writepanel-order_data.php:107
+#: admin/post-types/writepanels/writepanel-order_data.php:188
+#: admin/woocommerce-admin-users.php:117
+#: admin/woocommerce-admin-users.php:166
+#@ woocommerce
 msgid "Address 1"
-msgstr "Adresse 1"
+msgstr "Adresse"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:121
-#: ../admin/woocommerce-admin-users.php:170
-#: ../admin/post-types/writepanels/writepanel-order_data.php:111
-#: ../admin/post-types/writepanels/writepanel-order_data.php:192
+#: admin/post-types/writepanels/writepanel-order_data.php:111
+#: admin/post-types/writepanels/writepanel-order_data.php:192
+#: admin/woocommerce-admin-users.php:121
+#: admin/woocommerce-admin-users.php:170
+#: classes/class-wc-countries.php:912
+#@ woocommerce
 msgid "Address 2"
 msgstr "Adresse 2"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:125
-#: ../admin/woocommerce-admin-users.php:174
-#: ../admin/post-types/writepanels/writepanel-order_data.php:115
-#: ../admin/post-types/writepanels/writepanel-order_data.php:196
+#: admin/post-types/writepanels/writepanel-order_data.php:115
+#: admin/post-types/writepanels/writepanel-order_data.php:196
+#: admin/woocommerce-admin-users.php:125
+#: admin/woocommerce-admin-users.php:174
+#@ woocommerce
 msgid "City"
 msgstr "Ville"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:129
-#: ../admin/woocommerce-admin-users.php:178
-#: ../admin/post-types/writepanels/writepanel-order_data.php:119
-#: ../admin/post-types/writepanels/writepanel-order_data.php:200
+#: admin/post-types/writepanels/writepanel-order_data.php:119
+#: admin/post-types/writepanels/writepanel-order_data.php:200
+#: admin/woocommerce-admin-users.php:129
+#: admin/woocommerce-admin-users.php:178
+#: classes/class-wc-countries.php:823
+#: classes/class-wc-countries.php:824
+#: templates/cart/shipping-calculator.php:57
+#@ woocommerce
 msgid "Postcode"
-msgstr "Code Postal"
+msgstr "Code postal/ZIP"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:133
-#: ../admin/woocommerce-admin-users.php:182
-#: ../admin/post-types/writepanels/writepanel-order_data.php:129
-#: ../admin/post-types/writepanels/writepanel-order_data.php:210
+#: admin/post-types/writepanels/writepanel-order_data.php:129
+#: admin/post-types/writepanels/writepanel-order_data.php:210
+#: admin/woocommerce-admin-users.php:133
+#: admin/woocommerce-admin-users.php:182
+#: classes/class-wc-countries.php:864
+#: classes/class-wc-countries.php:865
+#: classes/class-wc-countries.php:940
+#@ woocommerce
 msgid "State/County"
-msgstr "Etat/Pays"
+msgstr "&Eacute;tat/R&eacute;gion"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:137
-#: ../admin/woocommerce-admin-users.php:186
-#: ../admin/post-types/writepanels/writepanel-order_data.php:123
-#: ../admin/post-types/writepanels/writepanel-order_data.php:204
+#: admin/post-types/writepanels/writepanel-order_data.php:123
+#: admin/post-types/writepanels/writepanel-order_data.php:204
+#: admin/woocommerce-admin-users.php:137
+#: admin/woocommerce-admin-users.php:186
+#: classes/class-wc-countries.php:933
+#@ woocommerce
 msgid "Country"
 msgstr "Pays"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:141
+#: admin/woocommerce-admin-users.php:141
+#@ woocommerce
 msgid "Telephone"
-msgstr "Téléphone"
+msgstr "T&eacute;l&eacute;phone"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:145
-#: ../admin/post-types/writepanels/writepanel-order_data.php:133
+#: admin/post-types/writepanels/writepanel-order_data.php:133
+#: admin/woocommerce-admin-users.php:145
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:199
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:222
+#: templates/myaccount/form-login.php:48
+#: templates/single-product-reviews.php:81
+#@ woocommerce
 msgid "Email"
-msgstr "Email"
+msgstr "E-mail"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:151
+#: admin/woocommerce-admin-users.php:151
+#@ woocommerce
 msgid "Customer Shipping Address"
 msgstr "Adresse de livraison du client"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:183
+#: admin/woocommerce-admin-users.php:183
+#@ woocommerce
 msgid "State/County or state code"
-msgstr "Région/Pays ou code de la région"
+msgstr "&Eacute;tat/R&eacute;gion ou code de l&rsquo;&eacute;tat"
 
-# @ woocommerce
-#: ../admin/woocommerce-admin-users.php:187
+#: admin/woocommerce-admin-users.php:187
+#@ woocommerce
 msgid "2 letter Country code"
-msgstr "2 lettres du code pays"
+msgstr "Code du pays &agrave; 2 lettres"
 
-# @ woocommerce
-#: ../admin/includes/duplicate_product.php:14
+#: admin/includes/duplicate_product.php:14
+#@ woocommerce
 msgid "No product to duplicate has been supplied!"
-msgstr "Aucun produit à dupliquer n'a été fourni !"
+msgstr "Aucun produit &agrave; dupliquer n&rsquo;a &eacute;t&eacute; fourni&nbsp;!"
 
-# @ woocommerce
-#: ../admin/includes/duplicate_product.php:34
+#: admin/includes/duplicate_product.php:34
+#@ woocommerce
 msgid "Product creation failed, could not find original product:"
-msgstr "Échec de création du produit, impossible de trouver le produit original :"
+msgstr "La cr&eacute;ation du produit &agrave; &eacute;chou&eacute;e, impossible de trouver le produit original&nbsp;:"
 
-# @ woocommerce
-#: ../admin/includes/duplicate_product.php:68
-msgid " (Copy)"
+#: admin/includes/duplicate_product.php:68
+#@ woocommerce
+msgid "(Copy)"
 msgstr "(Copier)"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:24
+#: admin/post-types/product.php:24
+#@ woocommerce
 msgid "Make a duplicate from this product"
 msgstr "Duplique ce produit"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:25
+#: admin/post-types/product.php:25
+#@ woocommerce
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:49
+#: admin/post-types/product.php:49
+#@ woocommerce
 msgid "Copy to a new draft"
 msgstr "Copier vers un nouveau brouillon"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:75
-#: ../admin/post-types/product.php:475
-#: ../admin/post-types/product.php:667
+#: admin/post-types/product.php:75
+#: admin/post-types/product.php:494
+#: admin/post-types/product.php:687
+#: templates/cart/cart.php:21
+#: templates/emails/admin-new-order.php:16
+#: templates/emails/customer-completed-order.php:16
+#: templates/emails/customer-invoice.php:20
+#: templates/emails/customer-note.php:20
+#: templates/emails/customer-processing-order.php:16
+#@ woocommerce
 msgid "Price"
 msgstr "Prix"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:77
+#: admin/post-types/product.php:77
+#@ woocommerce
 msgid "Categories"
-msgstr "Catégories"
+msgstr "Cat&eacute;gories"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:79
-#: ../admin/post-types/product.php:539
-#: ../admin/post-types/product.php:779
+#: admin/post-types/product.php:79
+#: admin/post-types/product.php:558
+#: admin/post-types/product.php:799
+#: admin/post-types/writepanels/writepanel-product_data.php:151
+#@ woocommerce
 msgid "Featured"
-msgstr "Mis en avant"
+msgstr "&Agrave; la une"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:81
-#: ../admin/post-types/shop_order.php:41
+#: admin/post-types/product.php:81
+#: admin/post-types/shop_order.php:41
+#@ woocommerce
 msgid "Date"
 msgstr "Date"
 
-# @ default
-#: ../admin/post-types/product.php:124
+#: admin/post-types/product.php:124
+#@ woocommerce
 msgid "Edit this item inline"
-msgstr "Editer cet article en ligne"
+msgstr "Modifier cet article en ligne"
 
-# @ default
-#: ../admin/post-types/product.php:124
+#: admin/post-types/product.php:124
+#@ woocommerce
 msgid "Quick&nbsp;Edit"
-msgstr "Edition&nbsp;rapide"
+msgstr "Modification&nbsp;rapide"
 
-# @ default
-#: ../admin/post-types/product.php:128
+#: admin/post-types/product.php:128
+#@ woocommerce
 msgid "Restore this item from the Trash"
-msgstr "Récupérer cet élément de la Corbeille"
+msgstr "Restaurer cet article de la Corbeille"
 
-# @ default
-#: ../admin/post-types/product.php:128
+#: admin/post-types/product.php:128
+#@ woocommerce
 msgid "Restore"
 msgstr "Restaurer"
 
-# @ default
-#: ../admin/post-types/product.php:130
+#: admin/post-types/product.php:130
+#@ woocommerce
 msgid "Move this item to the Trash"
-msgstr "Mettre cet article à la corbeille"
+msgstr "D&eacute;placer cet article dans la Corbeille"
 
-# @ default
-#: ../admin/post-types/product.php:130
+#: admin/post-types/product.php:130
+#@ woocommerce
 msgid "Trash"
 msgstr "Corbeille"
 
-# @ default
-#: ../admin/post-types/product.php:132
+#: admin/post-types/product.php:132
+#@ woocommerce
 msgid "Delete this item permanently"
-msgstr "Supprimer cet article définitivement"
+msgstr "Supprimer cet article d&eacute;finitivement"
 
-# @ default
-# @ woocommerce
-#: ../admin/post-types/product.php:132
-#: ../admin/post-types/writepanels/writepanel-order_data.php:430
+#: admin/post-types/product.php:132
+#: admin/post-types/writepanels/writepanel-order_data.php:430
+#@ woocommerce
 msgid "Delete Permanently"
-msgstr "Supprimer Définitivement"
+msgstr "Supprimer d&eacute;finitivement"
 
-# @ default
-#: ../admin/post-types/product.php:137
+#: admin/post-types/product.php:137
 #, php-format
+#@ woocommerce
 msgid "Preview &#8220;%s&#8221;"
-msgstr "Prévisualiser &#8220;%s&#8221;"
+msgstr "Pr&eacute;visualiser &#8220;%s&#8221;"
 
-# @ default
-#: ../admin/post-types/product.php:137
+#: admin/post-types/product.php:137
+#@ woocommerce
 msgid "Preview"
-msgstr "Aperçu"
+msgstr "Aper&ccedil;u"
 
-# @ default
-#: ../admin/post-types/product.php:139
+#: admin/post-types/product.php:139
 #, php-format
+#@ woocommerce
 msgid "View &#8220;%s&#8221;"
 msgstr "Voir &#8220;%s&#8221;"
 
-# @ default
-# @ woocommerce
-#: ../admin/post-types/product.php:139
-#: ../admin/post-types/shop_order.php:142
+#: admin/post-types/product.php:139
+#: admin/post-types/shop_order.php:142
+#: templates/myaccount/my-orders.php:60
+#@ woocommerce
 msgid "View"
 msgstr "Voir"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:184
+#: admin/post-types/product.php:185
+#@ woocommerce
 msgid "Grouped"
-msgstr "Groupé"
+msgstr "Group&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:186
+#: admin/post-types/product.php:187
+#@ woocommerce
 msgid "External/Affiliate"
-msgstr "Externe/Affiliation"
+msgstr "Externe/Affili&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:190
-#: ../admin/post-types/product.php:357
+#: admin/post-types/product.php:191
+#: admin/post-types/product.php:358
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:82
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:243
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:442
+#: admin/post-types/writepanels/writepanel-product_data.php:882
+#@ woocommerce
 msgid "Virtual"
 msgstr "Virtuel"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:192
-#: ../admin/post-types/product.php:353
+#: admin/post-types/product.php:193
+#: admin/post-types/product.php:354
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:82
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:241
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:440
+#: admin/post-types/writepanels/writepanel-product_data.php:884
+#@ woocommerce
 msgid "Downloadable"
-msgstr "Téléchargeable"
+msgstr "T&eacute;l&eacute;chargeable"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:194
+#: admin/post-types/product.php:195
+#@ woocommerce
 msgid "Simple"
 msgstr "Simple"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:198
-#: ../admin/post-types/product.php:337
+#: admin/post-types/product.php:199
+#: admin/post-types/product.php:338
+#@ woocommerce
 msgid "Variable"
 msgstr "Variable"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:221
+#: admin/post-types/product.php:222
+#@ woocommerce
 msgid "Change"
-msgstr "Change"
+msgstr "Changer"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:229
-#: ../admin/post-types/product.php:548
-#: ../admin/post-types/product.php:803
+#: admin/post-types/product.php:230
+#: admin/post-types/product.php:567
+#: admin/post-types/product.php:823
+#: admin/post-types/writepanels/writepanel-product_data.php:234
+#: classes/class-wc-product.php:448
+#: classes/class-wc-product.php:453
+#: classes/class-wc-product.php:473
+#@ woocommerce
 msgid "In stock"
-msgstr "En Stock"
+msgstr "En stock"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:323
+#: admin/post-types/product.php:324
+#@ woocommerce
 msgid "Show all product types"
 msgstr "Afficher tous les types de produits"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:331
+#: admin/post-types/product.php:332
+#: admin/post-types/writepanels/writepanel-product_data.php:878
+#@ woocommerce
 msgid "Grouped product"
-msgstr "Produits groupés"
+msgstr "Produit group&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:333
+#: admin/post-types/product.php:334
+#: admin/post-types/writepanels/writepanel-product_data.php:879
+#@ woocommerce
 msgid "External/Affiliate product"
-msgstr "Produit externe/affiliation"
+msgstr "Produit externe/affili&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:335
+#: admin/post-types/product.php:336
+#: admin/post-types/writepanels/writepanel-product_data.php:877
+#@ woocommerce
 msgid "Simple product"
 msgstr "Produit simple"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:349
+#: admin/post-types/product.php:350
+#@ woocommerce
 msgid "Show all sub-types"
-msgstr "Afficher tous les sous types"
+msgstr "Afficher tous les sous-types"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:434
+#: admin/post-types/product.php:453
 #, php-format
+#@ woocommerce
 msgid "[%s with SKU of %s]"
 msgstr "[%s avec UGS sur %s]"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:440
+#: admin/post-types/product.php:459
 #, php-format
+#@ woocommerce
 msgid "[%s with ID of %d]"
 msgstr "[%s avec ID sur %d]"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:477
-#: ../admin/post-types/product.php:683
+#: admin/post-types/product.php:478
+#: admin/post-types/product.php:683
+#: admin/post-types/writepanels/writepanels-init.php:30
+#: admin/settings/settings-init.php:585
+#@ woocommerce
+msgid "Product Data"
+msgstr "Informations du produit"
+
+#: admin/post-types/product.php:496
+#: admin/post-types/product.php:703
+#@ woocommerce
 msgid "Regular price"
-msgstr "Prix régulier"
+msgstr "Prix r&eacute;gulier"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:482
-#: ../admin/post-types/product.php:689
+#: admin/post-types/product.php:501
+#: admin/post-types/product.php:709
+#@ woocommerce
 msgid "Sale"
-msgstr "Promotion"
+msgstr "Solde"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:484
-#: ../admin/post-types/product.php:705
+#: admin/post-types/product.php:503
+#: admin/post-types/product.php:725
+#@ woocommerce
 msgid "Sale price"
-msgstr "Prix promotionnel"
+msgstr "Prix sold&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:495
-#: ../admin/post-types/product.php:712
+#: admin/post-types/product.php:514
+#: admin/post-types/product.php:732
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:74
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:178
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:386
+#: admin/post-types/writepanels/writepanel-product_data.php:102
+#: templates/single-product/product-attributes.php:22
+#@ woocommerce
 msgid "Weight"
 msgstr "Poids"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:506
-#: ../admin/post-types/product.php:736
+#: admin/post-types/product.php:525
+#: admin/post-types/product.php:756
+#@ woocommerce
 msgid "L/W/H"
 msgstr "L/l/H"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:508
-#: ../admin/post-types/product.php:752
+#: admin/post-types/product.php:527
+#: admin/post-types/product.php:772
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:75
+#: admin/post-types/writepanels/writepanel-product_data.php:111
+#@ woocommerce
 msgid "Length"
 msgstr "Longueur"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:520
-#: ../admin/post-types/product.php:760
+#: admin/post-types/product.php:539
+#: admin/post-types/product.php:780
+#: admin/post-types/writepanels/writepanel-product_data.php:143
+#@ woocommerce
 msgid "Visibility"
-msgstr "Visibilité"
+msgstr "Visibilit&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:525
-#: ../admin/post-types/product.php:766
+#: admin/post-types/product.php:544
+#: admin/post-types/product.php:786
+#: admin/post-types/writepanels/writepanel-product_data.php:144
+#@ woocommerce
 msgid "Catalog &amp; search"
-msgstr "Catalogue &amp; recherche"
+msgstr "Catalogue et recherche"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:528
-#: ../admin/post-types/product.php:769
+#: admin/post-types/product.php:547
+#: admin/post-types/product.php:789
+#: admin/post-types/writepanels/writepanel-product_data.php:147
+#@ woocommerce
 msgid "Hidden"
-msgstr "Caché"
+msgstr "Cach&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:543
-#: ../admin/post-types/product.php:797
+#: admin/post-types/product.php:562
+#: admin/post-types/product.php:817
+#@ woocommerce
 msgid "In stock?"
-msgstr "En stock ?"
+msgstr "En stock&nbsp;?"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:564
-#: ../admin/post-types/product.php:815
+#: admin/post-types/product.php:583
+#: admin/post-types/product.php:835
+#: admin/post-types/writepanels/writepanel-product_data.php:217
+#@ woocommerce
 msgid "Manage stock?"
-msgstr "Gérer les stocks?"
+msgstr "G&eacute;rer le stock&nbsp;?"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:568
-#: ../admin/post-types/product.php:834
-#: ../admin/post-types/product.php:850
+#: admin/post-types/product.php:587
+#: admin/post-types/product.php:854
+#: admin/post-types/product.php:870
+#: admin/post-types/writepanels/writepanel-product_data.php:224
+#@ woocommerce
 msgid "Stock Qty"
-msgstr "Qté Stock"
+msgstr "Qt&eacute; en stock"
 
-# @ default
-#: ../admin/post-types/product.php:672
-#: ../admin/post-types/product.php:694
-#: ../admin/post-types/product.php:717
-#: ../admin/post-types/product.php:741
-#: ../admin/post-types/product.php:765
-#: ../admin/post-types/product.php:784
-#: ../admin/post-types/product.php:802
-#: ../admin/post-types/product.php:820
-#: ../admin/post-types/product.php:839
+#: admin/post-types/product.php:692
+#: admin/post-types/product.php:714
+#: admin/post-types/product.php:737
+#: admin/post-types/product.php:761
+#: admin/post-types/product.php:785
+#: admin/post-types/product.php:804
+#: admin/post-types/product.php:822
+#: admin/post-types/product.php:840
+#: admin/post-types/product.php:859
+#@ woocommerce
 msgid "— No Change —"
-msgstr "— Pas de changement —"
+msgstr "&mdash; Aucun changement &mdash;"
 
-# @ woocommerce
-#: ../admin/post-types/product.php:673
-#: ../admin/post-types/product.php:695
-#: ../admin/post-types/product.php:718
-#: ../admin/post-types/product.php:742
-#: ../admin/post-types/product.php:840
+#: admin/post-types/product.php:693
+#: admin/post-types/product.php:715
+#: admin/post-types/product.php:738
+#: admin/post-types/product.php:762
+#: admin/post-types/product.php:860
+#@ woocommerce
 msgid "Change to:"
-msgstr "Changer pour :"
+msgstr "Changer pour&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:20
+#: admin/post-types/product.php:983
+#@ woocommerce
+msgid "Sort Products"
+msgstr "Trier les produits"
+
+#: admin/post-types/shop_coupon.php:20
+#@ woocommerce
 msgid "Code"
 msgstr "Code"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:21
+#: admin/post-types/shop_coupon.php:21
+#@ woocommerce
 msgid "Coupon type"
-msgstr "Type de Code Promo"
+msgstr "Type de code promo"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:22
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:35
+#: admin/post-types/shop_coupon.php:22
+#: admin/post-types/writepanels/writepanel-coupon_data.php:35
+#@ woocommerce
 msgid "Coupon amount"
-msgstr "Montant du Code Promo"
+msgstr "Montant du code promo"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:23
+#: admin/post-types/shop_coupon.php:23
+#@ woocommerce
 msgid "Product IDs"
-msgstr "ID Produits"
+msgstr "IDs Produits"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:24
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:143
+#: admin/post-types/shop_coupon.php:24
+#: admin/post-types/writepanels/writepanel-coupon_data.php:143
+#@ woocommerce
 msgid "Usage limit"
-msgstr "Limite d'utilisation"
+msgstr "Limite d&rsquo;utilisation"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:25
+#: admin/post-types/shop_coupon.php:25
+#@ woocommerce
 msgid "Usage count"
-msgstr "Compteur d'utilisations"
+msgstr "Compteur d&rsquo;utilisations"
 
-# @ woocommerce
-#: ../admin/post-types/shop_coupon.php:26
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:146
+#: admin/post-types/shop_coupon.php:26
+#: admin/post-types/writepanels/writepanel-coupon_data.php:146
+#@ woocommerce
 msgid "Expiry date"
-msgstr "Date d'expiration"
+msgstr "Date d&rsquo;expiration"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:36
+#: admin/post-types/shop_order.php:34
+#: admin/settings/settings-payment-gateways.php:21
+#: admin/settings/settings-shipping-methods.php:23
+#: templates/myaccount/my-orders.php:30
+#@ woocommerce
+msgid "Status"
+msgstr "&Eacute;tat"
+
+#: admin/post-types/shop_order.php:36
+#@ woocommerce
 msgid "Billing"
 msgstr "Facturation"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:38
+#: admin/post-types/shop_order.php:38
+#: templates/cart/totals.php:200
+#: templates/checkout/review-order.php:193
+#@ woocommerce
 msgid "Order Total"
 msgstr "Montant"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:40
+#: admin/post-types/shop_order.php:40
+#@ woocommerce
 msgid "Customer Notes"
-msgstr "Notes Client"
+msgstr "Commentaires client"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:42
+#: admin/post-types/shop_order.php:42
+#@ woocommerce
 msgid "Actions"
 msgstr "Actions"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:77
-#: ../admin/post-types/writepanels/writepanel-order_data.php:75
+#: admin/post-types/shop_order.php:77
+#: admin/post-types/writepanels/writepanel-order_data.php:75
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:86
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:135
+#@ woocommerce
 msgid "Guest"
-msgstr "Invité"
+msgstr "Invit&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:80
+#: admin/post-types/shop_order.php:80
+#: classes/gateways/class-wc-paypal.php:275
+#: classes/gateways/paypal/class-wc-paypal.php:275
 #, php-format
-msgid "Order #%s"
+#@ woocommerce
+msgid "Order %s"
 msgstr "Commande n&deg;%s"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:80
+#: admin/post-types/shop_order.php:80
+#@ woocommerce
 msgid "made by"
-msgstr "propulsé par"
+msgstr "effectu&eacute; par"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:83
+#: admin/post-types/shop_order.php:83
+#: templates/emails/admin-new-order.php:43
+#: templates/emails/customer-completed-order.php:43
+#: templates/emails/customer-note.php:47
+#: templates/emails/customer-processing-order.php:43
+#: templates/order/order-details.php:86
+#@ woocommerce
 msgid "Email:"
-msgstr "Email :"
+msgstr "E-mail&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:86
+#: admin/post-types/shop_order.php:86
+#: templates/emails/admin-new-order.php:46
+#: templates/emails/customer-completed-order.php:46
+#: templates/emails/customer-note.php:50
+#: templates/emails/customer-processing-order.php:46
+#@ woocommerce
 msgid "Tel:"
-msgstr "Tél.:"
+msgstr "T&eacute;l.:"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:99
-#: ../admin/post-types/shop_order.php:112
+#: admin/post-types/shop_order.php:99
+#: admin/post-types/shop_order.php:112
+#@ woocommerce
 msgid "Via"
 msgstr "Par"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:121
+#: admin/post-types/shop_order.php:121
+#@ woocommerce
 msgid "Unpublished"
-msgstr "Non publié"
+msgstr "Non publi&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:123
+#: admin/post-types/shop_order.php:123
+#@ woocommerce
 msgid "Y/m/d g:i:s A"
 msgstr "d/m/Y G:i:s"
 
-#  il y a" déplacé dans la chaine parente car en anglais "ago" est placé après la durée.
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:129
+#: admin/post-types/shop_order.php:129
 #, php-format
+#@ woocommerce
 msgid "%s ago"
 msgstr "%s"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:131
+#: admin/post-types/shop_order.php:131
+#@ woocommerce
 msgid "Y/m/d"
 msgstr "d/m/Y"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:141
+#: admin/post-types/shop_order.php:141
+#@ woocommerce
 msgid "Complete"
-msgstr "Expédier"
+msgstr "Termin&eacute;e"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:220
+#: admin/post-types/shop_order.php:220
+#@ woocommerce
 msgid "Show all statuses"
-msgstr "Afficher tous les états"
+msgstr "Afficher tous les &eacute;tats"
 
-# @ woocommerce
-#: ../admin/post-types/shop_order.php:249
+#: admin/post-types/shop_order.php:249
+#@ woocommerce
 msgid "Show all customers"
 msgstr "Afficher tous les clients"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:32
+#: admin/post-types/writepanels/writepanel-coupon_data.php:32
+#@ woocommerce
 msgid "Discount type"
 msgstr "Type de remise"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:35
+#: admin/post-types/writepanels/writepanel-coupon_data.php:35
+#@ woocommerce
 msgid "Enter an amount e.g. 2.99"
-msgstr "Entrez un montant ex.: 2.99"
+msgstr "Entrez un montant (ex.: 2.99)"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:38
+#: admin/post-types/writepanels/writepanel-coupon_data.php:38
+#@ woocommerce
 msgid "Individual use"
-msgstr "Utilisation individuelle"
+msgstr "Non cumulable"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:38
+#: admin/post-types/writepanels/writepanel-coupon_data.php:38
+#@ woocommerce
 msgid "Check this box if the coupon cannot be used in conjunction with other coupons"
-msgstr "Cochez cette case si le code promo ne peut être utilisé conjointement avec d'autres codes promo"
+msgstr "Cochez cette case si le code promo n&rsquo;est pas cumulable avec d&rsquo;autres codes promo"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:41
+#: admin/post-types/writepanels/writepanel-coupon_data.php:41
+#@ woocommerce
 msgid "Apply before tax"
 msgstr "Appliquer avant la taxe"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:41
+#: admin/post-types/writepanels/writepanel-coupon_data.php:41
+#@ woocommerce
 msgid "Check this box if the coupon should be applied before calculating cart tax"
-msgstr "Cochez cette case si le code promo doit être appliqué avant le calcul de taxe du panier"
+msgstr "Cochez cette case si le code promo doit s&rsquo;appliquer avant le calcul de la taxe dans le panier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:44
+#: admin/post-types/writepanels/writepanel-coupon_data.php:44
+#@ woocommerce
 msgid "Enable free shipping"
 msgstr "Activer la livraison gratuite"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:44
+#: admin/post-types/writepanels/writepanel-coupon_data.php:44
 #, php-format
+#@ woocommerce
 msgid "Check this box if the coupon enables free shipping (see <a href=\"%s\">Free Shipping</a>)"
-msgstr "Cocher cette case si le code promo active la gratuité de livraison (voir <a href=\"%s\">Livraison Gratuite</a>)"
+msgstr "Cochez cette case si le code promo active la livraison gratuite (voir <a href=\"%s\">Livraison gratuite</a>)"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:49
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:49
+#@ woocommerce
 msgid "Minimum amount"
-msgstr "Montant minimum de commande"
+msgstr "Montant minimum"
 
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:49
+#: admin/post-types/writepanels/writepanel-coupon_data.php:49
+#@ woocommerce
 msgid "No minimum"
 msgstr "Pas de minimum"
 
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:49
+#: admin/post-types/writepanels/writepanel-coupon_data.php:49
+#@ woocommerce
 msgid "This field allows you to set the minimum subtotal needed to use the coupon."
-msgstr ""
+msgstr "Ce champ vous permet de d&eacute;finir le sous-total minimum n&eacute;cessaire pour utiliser le code promo."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:56
-#, fuzzy
-msgid "Search for a product..."
-msgstr "Recherche pour produit"
-
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:73
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:73
+#@ woocommerce
 msgid "Products which need to be in the cart to use this coupon or, for \"Product Discounts\", which products are discounted."
-msgstr "(optionnel) ID séparés par une virgule qui doivent être dans le panier pour utiliser ce code promo ou, pour les \"Produits Remisés\", les produits qui sont remisés."
+msgstr "Produits qui doivent &ecirc;tre dans le panier pour utiliser ce code promo ou, pour les \"Remise sur produit(s)\", les produits qui sont remis&eacute;s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:78
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:78
+#@ woocommerce
 msgid "Exclude Products"
-msgstr "Exclure les ID produit"
+msgstr "Exclure les produits"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:79
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:79
+#@ woocommerce
 msgid "Search for a product…"
-msgstr "Recherche pour produit"
+msgstr "Rechercher un produit&hellip;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:96
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:96
+#@ woocommerce
 msgid "Products which must not be in the cart to use this coupon or, for \"Product Discounts\", which products are not discounted."
-msgstr "(optionnel) ID séparés par une virgule qui ne doivent pas être dans le panier pour utiliser ce code promo ou, pour les \"Produits Remisés\", les produits qui ne sont pas remisés."
+msgstr "Produits qui doivent ne pas &ecirc;tre dans le panier pour utiliser ce code promo ou, pour les \"Remise sur produit(s)\", les produits qui ne sont pas remis&eacute;s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:104
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:104
+#@ woocommerce
 msgid "Any category"
-msgstr "Catégories :"
+msgstr "Toute cat&eacute;gorie"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:115
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:115
+#@ woocommerce
 msgid "A product must be in this category for the coupon to remain valid or, for \"Product Discounts\", products in these categories will be discounted."
-msgstr "(optionnel) ID séparés par une virgule qui ne doivent pas être dans le panier pour utiliser ce code promo ou, pour les \"Produits Remisés\", les produits qui ne sont pas remisés."
+msgstr "Un produit doit &ecirc;tre dans cette cat&eacute;gorie pour que le code promo soit valide ou, pour les \"Remise sur produit(s)\", les produits dans cette cat&eacute;gorie seront remis&eacute;s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:120
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:120
+#@ woocommerce
 msgid "Exclude Categories"
-msgstr "Catégories"
+msgstr "Exclure les cat&eacute;gories"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:121
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:121
+#@ woocommerce
 msgid "No categories"
-msgstr "Catégories"
+msgstr "Aucune cat&eacute;gorie"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:132
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:132
+#@ woocommerce
 msgid "Product must not be in this category for the coupon to remain valid or, for \"Product Discounts\", products in these categories will not be discounted."
-msgstr "(optionnel) ID séparés par une virgule qui ne doivent pas être dans le panier pour utiliser ce code promo ou, pour les \"Produits Remisés\", les produits qui ne sont pas remisés."
+msgstr "Un produit doit ne pas &ecirc;tre dans cette cat&eacute;gorie pour que le code promo soit valide ou, pour les \"Remise sur produit(s)\", les produits dans cette cat&eacute;gorie ne seront pas remis&eacute;s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:138
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:138
+#@ woocommerce
 msgid "Customer Emails"
-msgstr "Détails Client"
+msgstr "E-mails client"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:138
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:138
+#@ woocommerce
 msgid "Any customer"
-msgstr "clients"
+msgstr "Tout client"
 
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:138
+#: admin/post-types/writepanels/writepanel-coupon_data.php:138
+#@ woocommerce
 msgid "Comma separate email addresses to restrict this coupon to specific billing and user emails."
-msgstr ""
+msgstr "Adresses e-mail s&eacute;par&eacute;es par une virgule pour restreindre ce code promo aux e-mails sp&eacute;cifiques de facturation et d&rsquo;utilisateurs."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:143
+#: admin/post-types/writepanels/writepanel-coupon_data.php:143
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Unlimited usage"
-msgstr "Utilisation illimitée"
+msgstr "Utilisation illimit&eacute;e"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:143
+#: admin/post-types/writepanels/writepanel-coupon_data.php:143
+#@ woocommerce
 msgid "How many times this coupon can be used before it is void"
-msgstr "(optionnel) Combien de fois ce code promo peut il être utilisé avant de ne plus être valide ?"
+msgstr "Nombre de fois ou ce code promo peut &ecirc;tre utilis&eacute; avant de ne plus &ecirc;tre valide"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:146
+#: admin/post-types/writepanels/writepanel-coupon_data.php:146
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Never expire"
-msgstr "N'expire jamais"
+msgstr "N&rsquo;expire jamais"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-coupon_data.php:146
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-coupon_data.php:146
+#@ woocommerce
 msgid "The date this coupon will expire, <code>YYYY-MM-DD</code>"
-msgstr "(optionnel) La date d'expiration du code promo <code>AAAA-MM-JJ</code>"
+msgstr "La date d&rsquo;expiration du code promo, <code>AAAA-MM-JJ</code>"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:55
+#: admin/post-types/writepanels/writepanel-order_data.php:55
+#: templates/order/order-details.php:10
+#@ woocommerce
 msgid "Order Details"
-msgstr "Détails Commande"
+msgstr "D&eacute;tails de la commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:57
+#: admin/post-types/writepanels/writepanel-order_data.php:57
+#@ woocommerce
 msgid "Order status:"
-msgstr "État de la commande :"
+msgstr "&Eacute;tat de la commande&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:69
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-order_data.php:69
+#@ woocommerce
 msgid "Order Date:"
-msgstr "Données de la commande"
+msgstr "Date de la commande&nbsp;:"
 
-#: ../admin/post-types/writepanels/writepanel-order_data.php:70
+#: admin/post-types/writepanels/writepanel-order_data.php:70
+#@ woocommerce
 msgid "h"
-msgstr ""
+msgstr "h"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:73
+#: admin/post-types/writepanels/writepanel-order_data.php:70
+#: admin/settings/settings-init.php:643
+#@ woocommerce
+msgid "m"
+msgstr "m"
+
+#: admin/post-types/writepanels/writepanel-order_data.php:73
+#@ woocommerce
 msgid "Customer:"
-msgstr "Client :"
+msgstr "Client&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:85
+#: admin/post-types/writepanels/writepanel-order_data.php:85
+#@ woocommerce
 msgid "Customer Note:"
-msgstr "Note client :"
+msgstr "Commentaire client&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:86
+#: admin/post-types/writepanels/writepanel-order_data.php:86
+#@ woocommerce
 msgid "Customer's notes about the order"
-msgstr "Notes du client à propos de la commande"
+msgstr "Commentaires du client &agrave; propos de la commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:91
+#: admin/post-types/writepanels/writepanel-order_data.php:91
+#@ woocommerce
 msgid "Billing Details"
-msgstr "Détails de la facturation"
+msgstr "Coordonn&eacute;es de facturation"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:95
-#: ../admin/post-types/writepanels/writepanel-order_data.php:176
+#: admin/post-types/writepanels/writepanel-order_data.php:95
+#: admin/post-types/writepanels/writepanel-order_data.php:176
+#: classes/class-wc-countries.php:888
+#@ woocommerce
 msgid "First Name"
-msgstr "Prénom"
+msgstr "Pr&eacute;nom"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:99
-#: ../admin/post-types/writepanels/writepanel-order_data.php:180
+#: admin/post-types/writepanels/writepanel-order_data.php:99
+#: admin/post-types/writepanels/writepanel-order_data.php:180
+#: classes/class-wc-countries.php:894
+#@ woocommerce
 msgid "Last Name"
 msgstr "Nom"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:136
+#: admin/post-types/writepanels/writepanel-order_data.php:136
+#: classes/class-wc-countries.php:976
+#@ woocommerce
 msgid "Phone"
-msgstr "Tel"
+msgstr "T&eacute;l&eacute;phone"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:143
-#: ../admin/post-types/writepanels/writepanel-order_data.php:218
+#: admin/post-types/writepanels/writepanel-order_data.php:143
+#: admin/post-types/writepanels/writepanel-order_data.php:218
+#: classes/class-wc-countries.php:906
+#@ woocommerce
 msgid "Address"
 msgstr "Adresse"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:143
+#: admin/post-types/writepanels/writepanel-order_data.php:143
+#@ woocommerce
 msgid "No billing address set."
 msgstr "Aucune adresse de facturation."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:153
+#: admin/post-types/writepanels/writepanel-order_data.php:153
+#@ woocommerce
 msgid "Load customer billing address"
-msgstr "Charger l'adresse de facturation du client"
+msgstr "Charger l&rsquo;adresse de facturation du client"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:172
+#: admin/post-types/writepanels/writepanel-order_data.php:172
+#@ woocommerce
 msgid "Shipping Details"
-msgstr "Détails de la livraison"
+msgstr "Coordon&eacute;es de livraison"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:218
+#: admin/post-types/writepanels/writepanel-order_data.php:218
+#@ woocommerce
 msgid "No shipping address set."
 msgstr "Aucune adresse de livraison."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:228
+#: admin/post-types/writepanels/writepanel-order_data.php:228
+#@ woocommerce
 msgid "Load customer shipping address"
-msgstr "Charger l'adresse de livraison du client"
+msgstr "Charger l&rsquo;adresse de livraison du client"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:269
+#: admin/post-types/writepanels/writepanel-order_data.php:269
+#@ woocommerce
 msgid "Item"
 msgstr "Article"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:274
+#: admin/post-types/writepanels/writepanel-order_data.php:274
+#@ woocommerce
 msgid "Tax class for the line item"
-msgstr "Classe de taxe pour la ligne de l'élément"
+msgstr "Classe de taxe pour la ligne d&rsquo;article"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:276
+#: admin/post-types/writepanels/writepanel-order_data.php:276
+#: templates/checkout/form-pay.php:13
+#: templates/checkout/review-order.php:16
+#: templates/order/order-details.php:15
+#@ woocommerce
 msgid "Qty"
-msgstr "Qté"
+msgstr "Qt&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:278
+#: admin/post-types/writepanels/writepanel-order_data.php:278
+#@ woocommerce
 msgid "Line&nbsp;Subtotal"
-msgstr "Ligne&nbsp;Sous-total"
+msgstr "Ligne du sous-total"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:278
+#: admin/post-types/writepanels/writepanel-order_data.php:278
+#@ woocommerce
 msgid "Line cost and line tax before pre-tax discounts"
-msgstr "Ligne de coûts et ligne de taxe avant les remises de pré-taxes"
+msgstr "Ligne du tarif et ligne de taxe avant les remises pr&eacute;-taxes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:280
+#: admin/post-types/writepanels/writepanel-order_data.php:280
+#@ woocommerce
 msgid "Line&nbsp;Total"
-msgstr "Ligne&nbsp;Total"
+msgstr "Ligne du total"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:280
+#: admin/post-types/writepanels/writepanel-order_data.php:280
+#@ woocommerce
 msgid "Line cost and line tax after pre-tax discounts"
-msgstr "Ligne tarif et ligne taxe après les remises pré-taxes"
+msgstr "Ligne du tarif et ligne de taxe apr&egrave;s les remises pr&eacute;-taxes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:358
+#: admin/post-types/writepanels/writepanel-order_data.php:358
+#@ woocommerce
 msgid "Tax class"
-msgstr "Classe taxe"
+msgstr "Classe de taxe"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:395
-#, fuzzy
-msgid "Search for a product&hellip;"
-msgstr "Recherche pour produit"
-
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:397
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-order_data.php:397
+#@ woocommerce
 msgid "Add item(s)"
-msgstr "Ajouter élément"
+msgstr "Ajouter article(s)"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:400
+#: admin/post-types/writepanels/writepanel-order_data.php:400
+#@ woocommerce
 msgid "Calc line tax &uarr;"
 msgstr "Calculer la ligne de taxe &uarr;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:401
+#: admin/post-types/writepanels/writepanel-order_data.php:401
+#@ woocommerce
 msgid "Calc totals &rarr;"
-msgstr "Calcul totaux &rarr;"
+msgstr "Calcul du total &rarr;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:416
+#: admin/post-types/writepanels/writepanel-order_data.php:416
+#@ woocommerce
 msgid "Save Order"
-msgstr "Enregistrer la cde"
+msgstr "Enregistrer la commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:416
+#: admin/post-types/writepanels/writepanel-order_data.php:416
+#@ woocommerce
 msgid "Save/update the order"
 msgstr "Enregistrer/Actualiser la commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:418
+#: admin/post-types/writepanels/writepanel-order_data.php:418
+#@ woocommerce
 msgid "Reduce stock"
-msgstr "Réduire stock"
+msgstr "R&eacute;duire le stock"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:418
+#: admin/post-types/writepanels/writepanel-order_data.php:418
+#@ woocommerce
 msgid "Reduces stock for each item in the order; useful after manually creating an order or manually marking an order as paid."
-msgstr "Réduire le stock de chaque élément dans la commande; utile en cas de création manuelle d'une commande ou le passage manuel d'une commande comme payée."
+msgstr "R&eacute;duire le stock de chaque article de la commande&nbsp;; utile en cas de cr&eacute;ation manuelle d&rsquo;une commande ou de passage manuel d&rsquo;une commande comme pay&eacute;e."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:420
+#: admin/post-types/writepanels/writepanel-order_data.php:420
+#@ woocommerce
 msgid "Restore stock"
-msgstr "Restaurer stock"
+msgstr "Restaurer le stock"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:420
+#: admin/post-types/writepanels/writepanel-order_data.php:420
+#@ woocommerce
 msgid "Restores stock for each item in the order; useful after refunding or canceling the entire order."
-msgstr "Restaurer le stock de chaque élément de la commande; utile en cas de remboursement ou d'annulation de la commande complète."
+msgstr "Restaurer le stock de chaque article de la commande&nbsp;; utile en cas de remboursement ou d&rsquo;annulation d&rsquo;une commande compl&egrave;te."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:422
+#: admin/post-types/writepanels/writepanel-order_data.php:422
+#@ woocommerce
 msgid "Email invoice"
-msgstr "Email facture"
+msgstr "Facture e-mail"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:422
+#: admin/post-types/writepanels/writepanel-order_data.php:422
+#@ woocommerce
 msgid "Email the order to the customer. Unpaid orders will include a payment link."
-msgstr "Envoyer la commande au client. Les commande impayées incluront un lien vers le paiement."
+msgstr "Envoyer la commande au client par e-mail. Les commandes impay&eacute;es incluront un lien de paiement."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:432
+#: admin/post-types/writepanels/writepanel-order_data.php:432
+#@ woocommerce
 msgid "Move to Trash"
-msgstr "Mettre à la corbeille"
+msgstr "Mettre &agrave; la Corbeille"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:452
+#: admin/post-types/writepanels/writepanel-order_data.php:452
+#@ woocommerce
 msgid "Discounts"
 msgstr "Remises"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:456
+#: admin/post-types/writepanels/writepanel-order_data.php:456
+#: classes/class-wc-order.php:523
+#@ woocommerce
 msgid "Cart Discount:"
-msgstr "Panier remisé :"
+msgstr "Remise sur panier&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:463
+#: admin/post-types/writepanels/writepanel-order_data.php:463
+#: classes/class-wc-order.php:570
+#@ woocommerce
 msgid "Order Discount:"
-msgstr "Remise commande :"
+msgstr "Remise sur commande&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:477
+#: admin/post-types/writepanels/writepanel-order_data.php:477
+#@ woocommerce
 msgid "Cost ex. tax:"
-msgstr "Tarif H.T. :"
+msgstr "Tarif H.T.&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:478
+#: admin/post-types/writepanels/writepanel-order_data.php:478
+#: classes/class-wc-countries.php:485
+#@ woocommerce
 msgid "(ex. tax)"
 msgstr "(ex. taxe)"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:483
+#: admin/post-types/writepanels/writepanel-order_data.php:483
+#@ woocommerce
 msgid "Method:"
-msgstr "Méthode:"
+msgstr "Mode&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:486
-msgid "Shipping method..."
-msgstr "Méthode d'expédition..."
+#: admin/post-types/writepanels/writepanel-order_data.php:486
+#@ woocommerce
+msgid "Shipping method&hellip;"
+msgstr "Modes de livraison&hellip;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:494
+#: admin/post-types/writepanels/writepanel-order_data.php:494
+#@ woocommerce
 msgid "Tax Rows"
-msgstr "Rangées de taxes"
+msgstr "Lignes de taxes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:494
+#: admin/post-types/writepanels/writepanel-order_data.php:494
+#@ woocommerce
 msgid "These rows contain taxes for this order. This allows you to display multiple or compound taxes rather than a single total."
-msgstr "Ces lignes contiennent des taxes pour cette commande. Cela vous permet d'afficher des taxes multiples ou cumulables plutôt qu'un total simple."
+msgstr "Ces lignes contiennent les taxes de cette commande. Cela vous permet d&rsquo;afficher des taxes multiples ou cumulables plut&ocirc;t qu&rsquo;un total simple."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:528
+#: admin/post-types/writepanels/writepanel-order_data.php:528
+#@ woocommerce
 msgid "+ Add tax row"
-msgstr "+ Ajouter ligne taxe"
+msgstr "&plus; Ajouter une ligne taxe"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:532
+#: admin/post-types/writepanels/writepanel-order_data.php:532
+#@ woocommerce
 msgid "Tax Totals"
-msgstr "Total taxes"
+msgstr "Total des taxes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:553
+#: admin/post-types/writepanels/writepanel-order_data.php:553
+#: templates/myaccount/my-orders.php:29
+#@ woocommerce
 msgid "Total"
 msgstr "Total"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:557
+#: admin/post-types/writepanels/writepanel-order_data.php:557
+#: classes/class-wc-order.php:572
+#@ woocommerce
 msgid "Order Total:"
-msgstr "Total commande :"
+msgstr "Montant&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:564
+#: admin/post-types/writepanels/writepanel-order_data.php:564
+#@ woocommerce
 msgid "Payment Method:"
-msgstr "Méthode de Paiement :"
+msgstr "Mode de paiement&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:567
-msgid "Payment method..."
-msgstr "Méthode de paiement..."
+#: admin/post-types/writepanels/writepanel-order_data.php:567
+#@ woocommerce
+msgid "Payment method&hellip;"
+msgstr "Mode de paiement&nbsp;&hellip;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:750
+#: admin/post-types/writepanels/writepanel-order_data.php:748
+#@ woocommerce
 msgid "Manually reducing stock."
-msgstr "Réduction des stock manuelle."
+msgstr "R&eacute;duire manuellement le stock."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:764
+#: admin/post-types/writepanels/writepanel-order_data.php:762
+#: classes/class-wc-order.php:814
 #, php-format
+#@ woocommerce
 msgid "Item #%s stock reduced from %s to %s."
-msgstr "L'élément n&deg;%s est en stock réduit de %s jusqu'à %s"
+msgstr "Stock de l&rsquo;article n&deg;%s r&eacute;duit de %s &agrave; %s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:772
-#: ../admin/post-types/writepanels/writepanel-order_data.php:802
+#: admin/post-types/writepanels/writepanel-order_data.php:770
+#: admin/post-types/writepanels/writepanel-order_data.php:800
 #, php-format
+#@ woocommerce
 msgid "Item %s %s not found, skipping."
-msgstr "L'élément %s %s est introuvable, passage au suivant"
+msgstr "Article %s %s introuvable, passage au suivant."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:778
+#: admin/post-types/writepanels/writepanel-order_data.php:776
+#@ woocommerce
 msgid "Manual stock reduction complete."
-msgstr "Réduction de stock manuelle complète"
+msgstr "R&eacute;duction manuelle du stock termin&eacute;e."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:782
+#: admin/post-types/writepanels/writepanel-order_data.php:780
+#@ woocommerce
 msgid "Manually restoring stock."
-msgstr "Restauration manuelle du stock"
+msgstr "Restaurer manuellement le stock."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:796
+#: admin/post-types/writepanels/writepanel-order_data.php:794
 #, php-format
+#@ woocommerce
 msgid "Item #%s stock increased from %s to %s."
-msgstr "Stock de l'élément n&deg;%s augmenté de %s à %s"
+msgstr "Stock de l&rsquo;article n&deg;%s augment&eacute; de %s &agrave; %s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_data.php:810
+#: admin/post-types/writepanels/writepanel-order_data.php:808
+#@ woocommerce
 msgid "Manual stock restore complete."
-msgstr "Restauration de stock manuelle complète."
+msgstr "Restauration manuelle du stock termin&eacute;e."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:38
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:154
+#: admin/post-types/writepanels/writepanel-order_downloads.php:38
+#: admin/post-types/writepanels/writepanel-order_downloads.php:154
+#@ woocommerce
 msgid "Revoke Access"
-msgstr ""
+msgstr "Retirer l&rsquo;acc&egrave;s"
 
-# @ default
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:40
+#: admin/post-types/writepanels/writepanel-order_downloads.php:40
 #, php-format
+#@ woocommerce
 msgid "Downloaded %s time"
 msgid_plural "Downloaded %s times"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "T&eacute;l&eacute;charg&eacute; %s fois"
+msgstr[1] "T&eacute;l&eacute;charg&eacute; %s fois"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:46
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:162
+#: admin/post-types/writepanels/writepanel-order_downloads.php:46
+#: admin/post-types/writepanels/writepanel-order_downloads.php:162
+#@ woocommerce
 msgid "Downloads Remaining"
-msgstr ""
+msgstr "T&eacute;l&eacute;chargements restant"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:48
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:164
+#: admin/post-types/writepanels/writepanel-order_downloads.php:48
+#: admin/post-types/writepanels/writepanel-order_downloads.php:164
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:223
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:427
+#: admin/post-types/writepanels/writepanel-product_data.php:173
+#@ woocommerce
 msgid "Unlimited"
-msgstr "Illimitée"
+msgstr "Illimit&eacute;e"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:51
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:167
+#: admin/post-types/writepanels/writepanel-order_downloads.php:51
+#: admin/post-types/writepanels/writepanel-order_downloads.php:167
+#@ woocommerce
 msgid "Access Expires"
-msgstr ""
+msgstr "L&rsquo;acc&egrave;s expire"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:52
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:168
+#: admin/post-types/writepanels/writepanel-order_downloads.php:52
+#: admin/post-types/writepanels/writepanel-order_downloads.php:168
+#: admin/post-types/writepanels/writepanel-product_data.php:176
+#@ woocommerce
 msgid "Never"
 msgstr "Jamais"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:65
+#: admin/post-types/writepanels/writepanel-order_downloads.php:65
+#@ woocommerce
 msgid "Choose a downloadable product&hellip;"
-msgstr ""
+msgstr "Choisissez un produit t&eacute;l&eacute;chargeable..."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:115
+#: admin/post-types/writepanels/writepanel-order_downloads.php:115
+#@ woocommerce
 msgid "Grant Access"
-msgstr ""
+msgstr "Autoriser l&rsquo;acc&egrave;s"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:176
+#: admin/post-types/writepanels/writepanel-order_downloads.php:176
+#@ woocommerce
 msgid "Could not grant access - the user may already have permission for this file."
-msgstr ""
+msgstr "Impossible d&rsquo;autoris&eacute; l&rsquo;acc&egrave;s - L&rsquo;utilisateur peut avoir d&eacute;j&agrave; la permission pour ce fichier."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_downloads.php:198
+#: admin/post-types/writepanels/writepanel-order_downloads.php:198
+#@ woocommerce
 msgid "Are you sure you want to revoke access to this download?"
-msgstr ""
+msgstr "&Ecirc;tes-vous s&ucirc;r(e) de vouloir retirer l&rsquo;acc&egrave;s &agrave; ce t&eacute;l&eacute;chargement&nbsp;?"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:37
+#: admin/post-types/writepanels/writepanel-order_notes.php:37
 #, php-format
+#@ woocommerce
 msgid "added %s ago"
-msgstr "ajouté il y a %s"
+msgstr "ajout&eacute; il y a %s"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:41
+#: admin/post-types/writepanels/writepanel-order_notes.php:41
+#@ woocommerce
 msgid "There are no notes for this order yet."
-msgstr "Il n'y a pas encore de notes pour cette commande."
+msgstr "Il n&rsquo;y a pas encore de commentaire sur cette commande."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:47
+#: admin/post-types/writepanels/writepanel-order_notes.php:47
+#@ woocommerce
 msgid "Add note"
-msgstr "Ajouter une note"
+msgstr "Ajouter un commentaire"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:48
+#: admin/post-types/writepanels/writepanel-order_notes.php:48
+#@ woocommerce
 msgid "Add a note for your reference, or add a customer note (the user will be notified)."
-msgstr "Ajouter une note pour vous y référer, ou ajouter une note client (l'utilisateur sera notifié)."
+msgstr "Ajoutez un commentaire pour votre information, ou ajoutez un commentaire client (l&rsquo;utilisateur en sera notifi&eacute;)."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:51
+#: admin/post-types/writepanels/writepanel-order_notes.php:51
+#@ woocommerce
 msgid "Customer note"
-msgstr "Note client"
+msgstr "Commentaire client"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:52
+#: admin/post-types/writepanels/writepanel-order_notes.php:52
+#@ woocommerce
 msgid "Private note"
-msgstr "Note privée"
+msgstr "Commentaire priv&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-order_notes.php:54
+#: admin/post-types/writepanels/writepanel-order_notes.php:54
+#: admin/post-types/writepanels/writepanel-product_data.php:414
+#@ woocommerce
 msgid "Add"
 msgstr "Ajouter"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:19
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:19
+#@ woocommerce
 msgid "Variations for variable products are defined here."
-msgstr "Les variations pour les produits variables sont définies ici."
+msgstr "Les variations pour les produits variables sont d&eacute;finies ici."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:47
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:200
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:407
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:47
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:200
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:407
+#@ woocommerce
 msgid "Same as parent"
-msgstr ""
+msgstr "Identique au parent"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:59
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:59
+#@ woocommerce
 msgid "Before adding variations, add and save some attributes on the <strong>Attributes</strong> tab."
-msgstr "Avant que vous ne puissiez commencer à ajouter des variations vous devez paramétrer et sauvegarder quelques attributs de variable à partir de l'onglet <strong>Attributs</strong>"
+msgstr "Avant d&rsquo;ajouter des variations, cr&eacute;ez et sauvegardez quelques attributs dans l&rsquo;onglet <strong>Attributs</strong>."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:61
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:61
+#@ woocommerce
 msgid "Learn more"
-msgstr "Lire Plus"
+msgstr "En savoir plus"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:68
-#: ../admin/post-types/writepanels/writepanel-product_data.php:245
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:68
+#: admin/post-types/writepanels/writepanel-product_data.php:260
+#@ woocommerce
 msgid "Close all"
-msgstr "Fermer tous"
+msgstr "Tout fermer"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:68
-#: ../admin/post-types/writepanels/writepanel-product_data.php:245
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:68
+#: admin/post-types/writepanels/writepanel-product_data.php:260
+#@ woocommerce
 msgid "Expand all"
-msgstr "Déplier tous"
+msgstr "Tout d&eacute;plier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:69
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:69
+#@ woocommerce
 msgid "Bulk edit:"
-msgstr "Modification groupée :"
+msgstr "Modifications group&eacute;es&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:71
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:71
+#@ woocommerce
 msgid "Prices"
 msgstr "Prix"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:72
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:72
+#@ woocommerce
 msgid "Sale prices"
-msgstr "Prix promotionnels"
+msgstr "Prix sold&eacute;s"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:78
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:78
+#@ woocommerce
 msgid "File Path"
-msgstr "Chemin fichier"
+msgstr "Chemin du fichier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:79
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:79
+#@ woocommerce
 msgid "Download limit"
-msgstr "Limite de téléchargement"
+msgstr "Limite de t&eacute;l&eacute;chargement"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:82
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:239
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:438
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:82
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:239
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:438
+#@ woocommerce
 msgid "Enabled"
-msgstr "Activé"
+msgstr "Activ&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:82
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:82
+#@ woocommerce
 msgid "Delete all"
-msgstr "Suppr. tous"
+msgstr "Tout supprimer"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:130
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:343
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:130
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:343
+#@ woocommerce
 msgid "Any"
 msgstr "Toute"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:157
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:367
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:157
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:367
+#@ woocommerce
 msgid "Enter a SKU for this variation or leave blank to use the parent product SKU."
-msgstr "Entrez une référence pour cette variation ou laissez vide pour utiliser la référence du produit parent."
+msgstr "Entrez un UGS pour cette variation ou laissez vide pour utiliser l&rsquo;UGS du produit parent."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:167
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:376
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:167
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:376
+#@ woocommerce
 msgid "Stock Qty:"
-msgstr "Qté Stock :"
+msgstr "Qt&eacute; en stock&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:167
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:376
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:167
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:376
+#@ woocommerce
 msgid "Enter a quantity to enable stock management for this variation, or leave blank to use the variable product stock options."
-msgstr "Entrez une quantité pour gérer les stocks pour cette variation, ou laissez vide pour utiliser les options de variable de stock du produit."
+msgstr "Entrez une quantit&eacute; pour activer la gestion de stock sur cette variation, ou laissez vide pour utiliser les options de stock des produits variables."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:171
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:380
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:171
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:380
+#: widgets/widget-price_filter.php:170
+#@ woocommerce
 msgid "Price:"
-msgstr "Prix :"
+msgstr "Prix&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:173
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:381
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:173
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:381
+#@ woocommerce
 msgid "Sale Price:"
-msgstr "Prix promotionnel :"
+msgstr "Prix sold&eacute;&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:178
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:386
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:178
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:386
+#@ woocommerce
 msgid "Enter a weight for this variation or leave blank to use the parent product weight."
-msgstr "Saisissez un poids pour cette variation ou laissez vide pour utiliser le poids de produit parent."
+msgstr "Entrez un poids pour cette variation ou laissez vide pour utiliser le poids du produit parent."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:184
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:392
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:184
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:392
+#@ woocommerce
 msgid "Dimensions (L&times;W&times;H)"
-msgstr "Dimensions (L&times;Larg.&times;H)"
+msgstr "Dimensions (L&times;l&times;H)"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:196
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:403
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:196
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:403
+#@ woocommerce
 msgid "Shipping class:"
-msgstr ""
+msgstr "Classe de livraison&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:207
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:414
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:207
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:414
+#@ woocommerce
 msgid "Tax class:"
-msgstr "Classe taxe"
+msgstr "Classe de taxe&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:218
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:218
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#@ woocommerce
 msgid "File path:"
-msgstr "Chemin fichier :"
+msgstr "Chemin de fichier&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:218
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:218
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#@ woocommerce
 msgid "Enter a File Path to make this variation a downloadable product, or leave blank."
-msgstr "Saisissez le chemin du fichier pour faire de cette variation un produit téléchargeable, ou laissé vide."
+msgstr "Entrez un chemin de fichier pour faire de cette variation un produit t&eacute;l&eacute;chargeable, ou laissez vide."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:218
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:424
-#: ../admin/post-types/writepanels/writepanel-product_data.php:153
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:218
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#: admin/post-types/writepanels/writepanel-product_data.php:168
+#@ woocommerce
 msgid "File path/URL"
-msgstr "URL fichier"
+msgstr "URL du fichier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:218
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:218
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#@ woocommerce
 msgid "&uarr;"
 msgstr "&uarr;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:218
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:218
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:424
+#@ woocommerce
 msgid "Upload"
-msgstr "Envoyer un fichier"
+msgstr "Envoyer"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:223
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:427
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:223
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:427
+#@ woocommerce
 msgid "Download Limit:"
-msgstr "Limite téléchargement :"
+msgstr "Limite t&eacute;l&eacute;chargement&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:223
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:427
-#: ../admin/post-types/writepanels/writepanel-product_data.php:158
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:223
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:427
+#: admin/post-types/writepanels/writepanel-product_data.php:173
+#@ woocommerce
 msgid "Leave blank for unlimited re-downloads."
-msgstr "Laissez vide pour les téléchargements illimités."
+msgstr "Laissez vide pour les t&eacute;l&eacute;chargements illimit&eacute;s."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:241
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:440
-msgid "Enable this option if access is given to a downloadable file upon purchase of a product."
-msgstr "Activer cette option si un accès est donné à un fichier téléchargeable à un produit acheté."
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:241
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:440
+#: admin/post-types/writepanels/writepanel-product_data.php:884
+#@ woocommerce
+msgid "Enable this option if access is given to a downloadable file upon purchase of a product"
+msgstr "Activer cette option si l&rsquo;acc&egrave;s est donn&eacute; &agrave; un fichier t&eacute;l&eacute;chargeable lors de l&rsquo;achat du produit."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:243
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:442
-msgid "Enable this option if a product is not shipped or there is no shipping cost."
-msgstr "Activer cette option pour un produit non expédié ou sans de frais de port."
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:243
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:442
+#: admin/post-types/writepanels/writepanel-product_data.php:882
+#@ woocommerce
+msgid "Enable this option if a product is not shipped or there is no shipping cost"
+msgstr "Activez cette option si le produit n&rsquo;est pas exp&eacute;di&eacute; ou ne g&eacute;n&egrave;re aucun frais de livraison."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:257
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:257
+#@ woocommerce
 msgid "Link all variations"
 msgstr "Lier toutes les variations"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:259
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:259
+#@ woocommerce
 msgid "Default selections:"
-msgstr ""
+msgstr "S&eacute;lections par d&eacute;faut&nbsp;:"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:271
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:271
+#@ woocommerce
 msgid "No default"
-msgstr "Pas de valeur par défaut"
+msgstr "Aucune valeur par d&eacute;faut"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:308
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:308
+#@ woocommerce
 msgid "You must add some attributes via the \"Product Data\" panel and save before adding a new variation."
-msgstr "Vous devez ajouter des attributs via le panneau \"Données Produits\" et enregistrer avant d'ajouter une autre variation."
+msgstr "Vous devez ajouter quelques attributs par le panneau \"Informations de produit\" et les enregistrer avant d&rsquo;ajouter une nouvelle variation."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:468
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:468
+#@ woocommerce
 msgid "Are you sure you want to link all variations? This will create a new variation for each and every possible combination of variation attributes (max 50 per run)."
-msgstr "Êtes-vous sur de vouloir lier toutes les variations ? Ceci créera une nouvelle variation pour chaque combinaison possible des attributs de variations (max. 50 par lancement)."
+msgstr "&Ecirc;tes-vous s&ucirc;r(e) de vouloir lier toutes les variations&nbsp;? Cela cr&eacute;era une nouvelle variation pour chaque combinaison possible d&rsquo;attributs de variation (50 max. par lancement)."
 
-# @ default
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:489
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:489
+#@ woocommerce
 msgid "variation added"
-msgstr "variation ajoutée"
+msgstr "variation ajout&eacute;e"
 
-# @ default
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:491
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:491
+#@ woocommerce
 msgid "variations added"
-msgstr "variations ajoutées"
+msgstr "variations ajout&eacute;es"
 
-# @ default
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:493
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:493
+#@ woocommerce
 msgid "No variations added"
-msgstr ""
+msgstr "Aucune variation ajout&eacute;e"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:505
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:505
+#@ woocommerce
 msgid "Are you sure you want to remove this variation?"
-msgstr "Êtes vous sur de vouloir supprimer cette variation?"
+msgstr "&Ecirc;tes-vous s&ucirc;r(e) de vouloir supprimer cette variation&nbsp;?"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:540
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:540
+#@ woocommerce
 msgid "Are you sure you want to delete all variations? This cannot be undone."
-msgstr "Êtes-vous sur de vouloir supprimer toutes les attributs ? Cela ne pourra pas être annulé."
+msgstr "&Ecirc;tes-vous s&ucirc;r(e) de vouloir supprimer tous les attributs&nbsp;? Cela ne peut pas &ecirc;tre annul&eacute;."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:543
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:543
+#@ woocommerce
 msgid "Last warning, are you sure?"
-msgstr "Dernier avertissement, vous êtes certain ?"
+msgstr "Dernier avertissement, vous &ecirc;tes s&ucirc;r(e)&nbsp;?"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:579
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:579
+#@ woocommerce
 msgid "Enter a value"
-msgstr "Entrez un prix"
+msgstr "Entrez une valeur"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:715
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:715
+#@ woocommerce
 msgid "Variable product"
 msgstr "Produit variable"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product-type-variable.php:776
-#: ../classes/class-wc-email.php:324
-#: ../classes/class-wc-email.php:352
-#: ../classes/class-wc-email.php:393
-#, fuzzy, php-format
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:773
+#: classes/class-wc-email.php:324
+#: classes/class-wc-email.php:352
+#: classes/class-wc-email.php:393
+#, php-format
+#@ woocommerce
 msgid "Variation #%s of %s"
-msgstr "Variations"
+msgstr "Variation n&deg;%s sur %s"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:35
+#: admin/post-types/writepanels/writepanel-product_data.php:35
+#: templates/single-product/related.php:12
+#@ woocommerce
 msgid "Related Products"
-msgstr "Produits en Rapport"
+msgstr "Produits connexes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:39
-#: ../admin/post-types/writepanels/writepanel-product_data.php:489
+#: admin/post-types/writepanels/writepanel-product_data.php:39
+#: admin/post-types/writepanels/writepanel-product_data.php:504
+#@ woocommerce
 msgid "Grouping"
 msgstr "Grouper"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:50
+#: admin/post-types/writepanels/writepanel-product_data.php:50
+#@ woocommerce
 msgid "Stock Keeping Unit"
-msgstr ""
+msgstr "Unit&eacute; de Gestion de Stock"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:62
+#: admin/post-types/writepanels/writepanel-product_data.php:62
+#@ woocommerce
 msgid "Product URL"
 msgstr "URL du produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:62
+#: admin/post-types/writepanels/writepanel-product_data.php:62
+#@ woocommerce
 msgid "Enter the external URL to the product."
-msgstr "Saisissez l'URL externe au produit."
+msgstr "Entrez l&rsquo;URL externe du produit."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:65
+#: admin/post-types/writepanels/writepanel-product_data.php:65
+#@ woocommerce
 msgid "Button text"
-msgstr ""
+msgstr "Bouton texte"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:65
+#: admin/post-types/writepanels/writepanel-product_data.php:65
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Buy product"
-msgstr ""
+msgstr "Acheter le produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:65
+#: admin/post-types/writepanels/writepanel-product_data.php:65
+#@ woocommerce
 msgid "This text will be shown on the button linking to the external product."
-msgstr ""
+msgstr "Ce texte sera visible sur le bouton renvoyant vers le produit externe."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:72
+#: admin/post-types/writepanels/writepanel-product_data.php:72
+#@ woocommerce
 msgid "Regular Price"
-msgstr "Prix régulier"
+msgstr "Prix r&eacute;gulier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:75
+#: admin/post-types/writepanels/writepanel-product_data.php:75
+#@ woocommerce
 msgid "Sale Price"
-msgstr "Prix promotionnel"
+msgstr "Prix sold&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:75
+#: admin/post-types/writepanels/writepanel-product_data.php:75
+#@ woocommerce
 msgid "Schedule"
-msgstr "Planifié"
+msgstr "Planifi&eacute;"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:78
+#: admin/post-types/writepanels/writepanel-product_data.php:78
+#@ woocommerce
 msgid "Sale Price Dates"
-msgstr "Dates de Promotion"
+msgstr "Dates des soldes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:87
+#: admin/post-types/writepanels/writepanel-product_data.php:87
+#@ woocommerce
 msgctxt "placeholder"
 msgid "From&hellip;"
-msgstr ""
+msgstr "Du..."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:90
+#: admin/post-types/writepanels/writepanel-product_data.php:90
+#@ woocommerce
 msgctxt "placeholder"
 msgid "To&hellip;"
-msgstr ""
+msgstr "Au..."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:91
+#: admin/post-types/writepanels/writepanel-product_data.php:91
+#: templates/myaccount/my-orders.php:51
+#@ woocommerce
 msgid "Cancel"
 msgstr "Annuler"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:110
+#: admin/post-types/writepanels/writepanel-product_data.php:110
+#: templates/single-product/product-attributes.php:31
+#@ woocommerce
 msgid "Dimensions"
 msgstr "Dimensions"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:133
+#: admin/post-types/writepanels/writepanel-product_data.php:128
+#@ woocommerce
+msgid "No shipping class"
+msgstr "Pas de classe de livraison"
+
+#: admin/post-types/writepanels/writepanel-product_data.php:134
+#@ woocommerce
+msgid "Shipping class"
+msgstr "Classe de livraison"
+
+#: admin/post-types/writepanels/writepanel-product_data.php:134
+#@ woocommerce
+msgid "Shipping classes are used by certain shipping methods to group similar products."
+msgstr "Les classes de livraison sont utilis&eacute;es par certains modes de livraison pour regrouper des produits similaires."
+
+#: admin/post-types/writepanels/writepanel-product_data.php:148
+#@ woocommerce
 msgid "Define the loops this product should be visible in. It will still be accessible directly."
-msgstr "Définir les boucles dans lequelles ce produit doit être visible. Il sera toujours accessible directement."
+msgstr "D&eacute;finir les boucles dans lequelles ce produit doit &ecirc;tre visible. Il sera toujours accessible directement."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:136
+#: admin/post-types/writepanels/writepanel-product_data.php:151
+#@ woocommerce
 msgid "Enable this option to feature this product"
-msgstr "Activer cette option pour mettre en avant ce produit"
+msgstr "Activer cette option pour mettre ce produit &agrave; la une"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:143
+#: admin/post-types/writepanels/writepanel-product_data.php:158
+#@ woocommerce
 msgid "Purchase Note"
-msgstr ""
+msgstr "Commentaire d&rsquo;achat"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:143
+#: admin/post-types/writepanels/writepanel-product_data.php:158
+#@ woocommerce
 msgid "Enter an optional note to send the customer after purchase."
-msgstr ""
+msgstr "Saisissez un commentaire optionnel &agrave; envoyer au client apr&egrave;s l&rsquo;achat."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:151
+#: admin/post-types/writepanels/writepanel-product_data.php:166
+#@ woocommerce
 msgid "File path"
-msgstr "Chemin fichier"
+msgstr "Chemin de fichier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:154
+#: admin/post-types/writepanels/writepanel-product_data.php:169
+#@ woocommerce
 msgid "Upload a file"
 msgstr "Envoyer un fichier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:158
+#: admin/post-types/writepanels/writepanel-product_data.php:173
+#@ woocommerce
 msgid "Download Limit"
-msgstr "Limite de téléchargement"
+msgstr "Limite de t&eacute;l&eacute;chargement"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:161
+#: admin/post-types/writepanels/writepanel-product_data.php:176
+#@ woocommerce
 msgid "Download Expiry"
-msgstr ""
+msgstr "Expiration du t&eacute;l&eacute;chargement"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:161
+#: admin/post-types/writepanels/writepanel-product_data.php:176
+#@ woocommerce
 msgid "Enter the number of days before a download link expires, or leave blank."
-msgstr ""
+msgstr "Saisissez le nombre de jours avant qu&rsquo;un lien de t&eacute;l&eacute;chargement n&rsquo;expire, ou laissez vide."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:176
+#: admin/post-types/writepanels/writepanel-product_data.php:191
+#: classes/shipping/class-wc-flat-rate.php:109
+#: classes/shipping/class-wc-international-delivery.php:80
+#@ woocommerce
 msgid "Tax Status"
-msgstr "État de la taxe"
+msgstr "&Eacute;tat de la taxe"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:177
+#: admin/post-types/writepanels/writepanel-product_data.php:192
+#: classes/shipping/class-wc-flat-rate.php:114
+#: classes/shipping/class-wc-international-delivery.php:85
+#@ woocommerce
 msgid "Taxable"
 msgstr "Taxable"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:178
+#: admin/post-types/writepanels/writepanel-product_data.php:193
+#@ woocommerce
 msgid "Shipping only"
-msgstr "Expédition seulement"
+msgstr "Livraison seulement"
 
-#: ../admin/post-types/writepanels/writepanel-product_data.php:209
+#: admin/post-types/writepanels/writepanel-product_data.php:224
+#@ woocommerce
 msgid "Stock quantity. If this is a variable product this value will be used to control stock for all variations, unless you define stock at variation level."
-msgstr ""
+msgstr "Quantit&eacute; en stock. S&rsquo;il s&rsquo;agit d&rsquo;un produit variable, cette valeur sera utilis&eacute;e pour contr&ocirc;ler le stock de toutes les variations, sauf si vous d&eacute;finissez un niveau de stock par variation."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:218
+#: admin/post-types/writepanels/writepanel-product_data.php:233
+#@ woocommerce
 msgid "Stock status"
-msgstr "État du stock"
+msgstr "&Eacute;tat du stock"
 
-#: ../admin/post-types/writepanels/writepanel-product_data.php:221
+#: admin/post-types/writepanels/writepanel-product_data.php:236
+#@ woocommerce
 msgid "Controls whether or not the product is listed as \"in stock\" or \"out of stock\" on the frontend."
-msgstr ""
+msgstr "Contr&ocirc;le si oui ou non le produit est inscrit comme \"En stock\" ou en \"Rupture de stock\" sur le site."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:228
+#: admin/post-types/writepanels/writepanel-product_data.php:243
+#@ woocommerce
 msgid "Allow Backorders?"
-msgstr "Autoriser les commandes en retard ?"
+msgstr "Autoriser les reliquats&nbsp;?"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:229
+#: admin/post-types/writepanels/writepanel-product_data.php:244
+#@ woocommerce
 msgid "Do not allow"
 msgstr "Ne pas autoriser"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:230
+#: admin/post-types/writepanels/writepanel-product_data.php:245
+#@ woocommerce
 msgid "Allow, but notify customer"
-msgstr "Autoriser, mais avec notification client"
+msgstr "Autoriser, mais en notifiant le client"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:231
+#: admin/post-types/writepanels/writepanel-product_data.php:246
+#@ woocommerce
 msgid "Allow"
 msgstr "Autoriser"
 
-#: ../admin/post-types/writepanels/writepanel-product_data.php:232
+#: admin/post-types/writepanels/writepanel-product_data.php:247
+#@ woocommerce
 msgid "If managing stock, this controls whether or not backorders are allowed for this product and variations. If enabled, stock quantity can go below 0."
-msgstr ""
+msgstr "Si la gestion de stock est activ&eacute;e, cela contr&ocirc;le si oui ou non les reliquats sont autoris&eacute;s pour ce produit et ses variations. Si elle est activ&eacute;e, la quantit&eacute; de stock peut descendre en dessous 0."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:298
+#: admin/post-types/writepanels/writepanel-product_data.php:313
+#@ woocommerce
 msgid "Select terms"
-msgstr "Choix des termes"
+msgstr "Choisissez des termes"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:310
+#: admin/post-types/writepanels/writepanel-product_data.php:325
+#@ woocommerce
 msgid "Select all"
-msgstr ""
+msgstr "Tout s&eacute;lectionner"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:310
+#: admin/post-types/writepanels/writepanel-product_data.php:325
+#@ woocommerce
 msgid "Select none"
-msgstr ""
+msgstr "Ne rien s&eacute;lectionner"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:312
-#, fuzzy
+#: admin/post-types/writepanels/writepanel-product_data.php:327
+#@ woocommerce
 msgid "Add new"
-msgstr "Ajouter"
+msgstr "Ajouter nouveau"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:326
+#: admin/post-types/writepanels/writepanel-product_data.php:341
+#@ woocommerce
 msgid "Pipe separate terms"
-msgstr "Séparation des termes par Pipe (|)"
+msgstr "Termes s&eacute;par&eacute;s par un pipe (|)"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:401
+#: admin/post-types/writepanels/writepanel-product_data.php:416
+#@ woocommerce
 msgid "Custom product attribute"
-msgstr "Attribut personnalisé du produit"
+msgstr "Attribut personnalis&eacute; du produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:418
+#: admin/post-types/writepanels/writepanel-product_data.php:433
+#@ woocommerce
 msgid "Up-Sells"
-msgstr "A la Une"
+msgstr "Mont&eacute;es en gamme"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:435
+#: admin/post-types/writepanels/writepanel-product_data.php:450
+#@ woocommerce
 msgid "Up-sells are products which you recommend instead of the currently viewed product, for example, products that are more profitable or better quality or more expensive."
-msgstr "Les produits A la Une sont des produits que vous recommandez à la place de ceux actuellement vus, par exemple, les produits qui sont plus profitables ou de meilleure qualité ou plus chers."
+msgstr "Les mont&eacute;es en gamme sont des produits recommand&eacute;s &agrave; la place de ceux actuellement vus, par exemple, les produits qui sont plus profitables ou de meilleure qualit&eacute; ou plus chers."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:437
+#: admin/post-types/writepanels/writepanel-product_data.php:452
+#@ woocommerce
 msgid "Cross-Sells"
-msgstr "Ventes Croisées"
+msgstr "Ventes crois&eacute;es"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:454
+#: admin/post-types/writepanels/writepanel-product_data.php:469
+#@ woocommerce
 msgid "Cross-sells are products which you promote in the cart, based on the current product."
-msgstr "Les Ventes Croisées sont des produits que vous mettez en avant dans la panier, basés sur le produit actuel."
+msgstr "Les ventes crois&eacute;es sont des produits que vous mettez en avant dans la panier, en fonction du produit actuel."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:465
+#: admin/post-types/writepanels/writepanel-product_data.php:480
+#@ woocommerce
 msgid "Choose a grouped product&hellip;"
-msgstr "Choix d'un produit groupé&hellip;"
+msgstr "Choisissez un produit group&eacute;..."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:492
-msgctxt "ordering"
-msgid "Sort Order"
-msgstr "Tri Commande"
-
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:567
+#: admin/post-types/writepanels/writepanel-product_data.php:581
+#@ woocommerce
 msgid "Product SKU must be unique."
-msgstr "L'UGS du produit doit être unique"
+msgstr "L&rsquo;UGS du produit doit &ecirc;tre unique."
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:854
-#: ../admin/post-types/writepanels/writepanels-init.php:29
+#: admin/post-types/writepanels/writepanel-product_data.php:876
+#: admin/post-types/writepanels/writepanels-init.php:29
+#@ woocommerce
 msgid "Product Type"
 msgstr "Type de produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:860
-msgid "Enable this option if a product is not shipped or there is no shipping cost"
-msgstr "Activer cette option si un produit n'est pas expédié ou s'il n'y a pas de frais de port"
-
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:862
-msgid "Enable this option if access is given to a downloadable file upon purchase of a product"
-msgstr "Activer cette option si l'accès est donné à un fichier téléchargeable à l'achat d'un produit"
-
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanel-product_data.php:878
+#: admin/post-types/writepanels/writepanel-product_data.php:902
+#@ woocommerce
 msgid "Use this file"
-msgstr ""
+msgstr "Utiliser ce fichier"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:35
-#, fuzzy
+#: admin/post-types/writepanels/writepanels-init.php:36
+#@ woocommerce
 msgid "Product Short Description"
-msgstr "Description Produit"
+msgstr "Description courte du produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:40
-#, fuzzy
+#: admin/post-types/writepanels/writepanels-init.php:41
+#@ woocommerce
 msgid "Product Reviews"
-msgstr "Champs des produits"
+msgstr "Avis du produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:44
+#: admin/post-types/writepanels/writepanels-init.php:45
+#: templates/single-product/tabs/tab-reviews.php:2
+#: templates/single-product-reviews.php:37
+#@ woocommerce
 msgid "Reviews"
 msgstr "Avis"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:48
+#: admin/post-types/writepanels/writepanels-init.php:49
+#@ woocommerce
 msgid "Order Data"
-msgstr "Données de la commande"
+msgstr "Informations de commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:49
+#: admin/post-types/writepanels/writepanels-init.php:50
+#@ woocommerce
 msgid "Order Items <small>&ndash; Note: if you edit quantities or remove items from the order you will need to manually change the item's stock levels.</small>"
-msgstr "Eléments commande <small>&ndash; Note : si vous modifiez les quantités ou enlevez les éléments de la commande vous devrez manuellement changer le niveau de stock de l'élément.</small>"
+msgstr "Articles command&eacute;s <small>&ndash; Veuillez noter&nbsp;: si vous modifiez les quantit&eacute;s ou supprimer des articles de la commande vous devrez restaurer le stock des articles manuellement.</small>"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:50
+#: admin/post-types/writepanels/writepanels-init.php:51
+#@ woocommerce
 msgid "Order Totals"
-msgstr "Total de la commande"
+msgstr "Montants"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:51
-#: ../classes/class-wc-checkout.php:57
+#: admin/post-types/shop_order.php:39
+#: admin/post-types/writepanels/writepanels-init.php:52
+#: classes/class-wc-checkout.php:57
+#@ woocommerce
 msgid "Order Notes"
-msgstr "Notes de la commande"
+msgstr "Commentaires de commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:52
+#: admin/post-types/writepanels/writepanels-init.php:53
+#@ woocommerce
 msgid "Downloadable Product Permissions <small>&ndash; Note: Permissions for order items will automatically be granted when the order status changes to processing/completed.</small>"
-msgstr ""
+msgstr "Permissions sur les produits t&eacute;l&eacute;chargeables <small>&ndash; Veuillez noter&nbsp;: les permissions pour les articles command&eacute;s seront automatiquement accord&eacute;es quand l&rsquo;&eacute;tat de la commande passera de \"en cours\" &agrave; \"finalis&eacute;e\".</small>"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:53
+#: admin/post-types/writepanels/writepanels-init.php:54
+#@ woocommerce
 msgid "Order Actions"
 msgstr "Actions sur la commande"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:61
+#: admin/post-types/writepanels/writepanels-init.php:62
+#@ woocommerce
 msgid "Coupon Data"
-msgstr "Données Code Promo"
+msgstr "Informations du code promo"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:74
+#: admin/post-types/writepanels/writepanels-init.php:75
+#: templates/checkout/form-coupon.php:15
+#@ woocommerce
 msgid "Coupon code"
-msgstr "Code Promo"
+msgstr "Code promo"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:75
+#: admin/post-types/writepanels/writepanels-init.php:76
+#@ woocommerce
 msgid "Product name"
 msgstr "Nom du produit"
 
-# @ woocommerce
-#: ../admin/post-types/writepanels/writepanels-init.php:126
-#, fuzzy
+#: admin/post-types/writepanels/writepanels-init.php:129
+#@ woocommerce
 msgid "Allow reviews."
-msgstr "Pays autorisés"
+msgstr "Autoriser les avis."
 
-#: ../admin/post-types/writepanels/writepanels-init.php:127
+#: admin/post-types/writepanels/writepanels-init.php:130
 #, php-format
+#@ default
 msgid "Allow <a href=\"%s\" target=\"_blank\">trackbacks and pingbacks</a> on this page."
-msgstr ""
+msgstr "Autoriser les <a href=\"%s\" target=\"_blank\">trackbacks et pingbacks</a> sur cette page."
 
-#: ../admin/post-types/writepanels/writepanels-init.php:127
+#: admin/post-types/writepanels/writepanels-init.php:130
+#@ default
 msgid "http://codex.wordpress.org/Introduction_to_Blogging#Managing_Comments"
-msgstr ""
+msgstr "http://codex.wordpress.org/Introduction_to_Blogging#Managing_Comments"
 
-#: ../classes/class-wc-cart.php:297
+#: admin/settings/settings-frontend-styles.php:15
+#@ woocommerce
+msgid "Styles"
+msgstr "Styles"
+
+#: admin/settings/settings-init.php:13
+#@ woocommerce
+msgid "Localisation"
+msgstr "Traduction"
+
+#: admin/settings/settings-init.php:14
+#@ woocommerce
+msgid "Use informal localisation file if it exists"
+msgstr "Utiliser le fichier de traduction informel si disponible."
+
+#: admin/settings/settings-init.php:22
+#@ woocommerce
+msgid "General Options"
+msgstr "Options g&eacute;n&eacute;rales"
+
+#: admin/settings/settings-init.php:25
+#@ woocommerce
+msgid "Base Country/Region"
+msgstr "Pays/R&eacute;gion de base"
+
+#: admin/settings/settings-init.php:26
+#@ woocommerce
+msgid "This is the base country for your business. Tax rates will be based on this country."
+msgstr "C&rsquo;est le pays de base de votre boutique. Les taux de taxes seront fonction de ce pays."
+
+#: admin/settings/settings-init.php:35
+#@ woocommerce
+msgid "Currency"
+msgstr "Monnaie"
+
+#: admin/settings/settings-init.php:36
+#@ woocommerce
+msgid "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in."
+msgstr "Cela contr&ocirc;le quelle monnaie est list&eacute;e dans le catalogue et quelle monnaie sera utilis&eacute;e par les passerelles de paiement."
+
+#: admin/settings/settings-init.php:44
+#@ woocommerce
+msgid "US Dollars (&#36;)"
+msgstr "Dollar am&eacute;ricain (&#36;)"
+
+#: admin/settings/settings-init.php:45
+#@ woocommerce
+msgid "Euros (&euro;)"
+msgstr "Euro (&euro;)"
+
+#: admin/settings/settings-init.php:46
+#@ woocommerce
+msgid "Pounds Sterling (&pound;)"
+msgstr "Livre sterling (&pound;)"
+
+#: admin/settings/settings-init.php:47
+#@ woocommerce
+msgid "Australian Dollars (&#36;)"
+msgstr "Dollar australien (&#36;)"
+
+#: admin/settings/settings-init.php:48
+#@ woocommerce
+msgid "Brazilian Real (&#36;)"
+msgstr "R&eacute;al br&eacute;silien (R&#36;)"
+
+#: admin/settings/settings-init.php:49
+#@ woocommerce
+msgid "Canadian Dollars (&#36;)"
+msgstr "Dollar canadien (&#36;)"
+
+#: admin/settings/settings-init.php:50
+#@ woocommerce
+msgid "Czech Koruna (&#75;&#269;)"
+msgstr "Couronne tch&egrave;que (&#75;&#269;)"
+
+#: admin/settings/settings-init.php:51
+#@ woocommerce
+msgid "Danish Krone"
+msgstr "Couronne danoise (&#107;&#114;)"
+
+#: admin/settings/settings-init.php:52
+#@ woocommerce
+msgid "Hong Kong Dollar (&#36;)"
+msgstr "Dollar de Hong Kong (&#36;)"
+
+#: admin/settings/settings-init.php:53
+#@ woocommerce
+msgid "Hungarian Forint"
+msgstr "Forint hongrois (&#70;&#116;)"
+
+#: admin/settings/settings-init.php:54
+#@ woocommerce
+msgid "Israeli Shekel"
+msgstr "Shekel isra&eacute;lien (&#8362;)"
+
+#: admin/settings/settings-init.php:55
+#@ woocommerce
+msgid "Chinese Yuan (&yen;)"
+msgstr "Yuan chinois (&yen;)"
+
+#: admin/settings/settings-init.php:56
+#@ woocommerce
+msgid "Japanese Yen (&yen;)"
+msgstr "Yen japonais (&yen;)"
+
+#: admin/settings/settings-init.php:57
+#@ woocommerce
+msgid "Malaysian Ringgits (RM)"
+msgstr "Ringgit malaisien (&#82;&#77;)"
+
+#: admin/settings/settings-init.php:58
+#@ woocommerce
+msgid "Mexican Peso (&#36;)"
+msgstr "Peso mexicain (&#36;)"
+
+#: admin/settings/settings-init.php:59
+#@ woocommerce
+msgid "New Zealand Dollar (&#36;)"
+msgstr "Dollar n&eacute;o-z&eacute;landais (&#36;)"
+
+#: admin/settings/settings-init.php:60
+#@ woocommerce
+msgid "Norwegian Krone"
+msgstr "Couronne norv&eacute;gienne (&#107;&#114;)"
+
+#: admin/settings/settings-init.php:61
+#@ woocommerce
+msgid "Philippine Pesos"
+msgstr "Peso philippin (&#8369;)"
+
+#: admin/settings/settings-init.php:62
+#@ woocommerce
+msgid "Polish Zloty"
+msgstr "Zloty polonais (&#322;&#122;)"
+
+#: admin/settings/settings-init.php:63
+#@ woocommerce
+msgid "Singapore Dollar (&#36;)"
+msgstr "Dollar de Singapour (&#83;&#36;)"
+
+#: admin/settings/settings-init.php:64
+#@ woocommerce
+msgid "Swedish Krona"
+msgstr "Couronne su&eacute;doise (&#107;&#114;)"
+
+#: admin/settings/settings-init.php:65
+#@ woocommerce
+msgid "Swiss Franc"
+msgstr "Franc suisse (&#70;&#114;)"
+
+#: admin/settings/settings-init.php:66
+#@ woocommerce
+msgid "Taiwan New Dollars"
+msgstr "Nouveau dollar de Taiwan (&#78;&#84;&#36;)"
+
+#: admin/settings/settings-init.php:67
+#@ woocommerce
+msgid "Thai Baht"
+msgstr "Baht thailandais (&#3647;)"
+
+#: admin/settings/settings-init.php:68
+#@ woocommerce
+msgid "Turkish Lira (TL)"
+msgstr "Livre turque (&#84;&#76;)"
+
+#: admin/settings/settings-init.php:69
+#@ woocommerce
+msgid "South African rand (R)"
+msgstr "Rand sud-africain (&#82;)"
+
+#: admin/settings/settings-init.php:75
+#@ woocommerce
+msgid "Allowed Countries"
+msgstr "Pays autoris&eacute;s"
+
+#: admin/settings/settings-init.php:76
+#@ woocommerce
+msgid "These are countries that you are willing to ship to."
+msgstr "Se sont les pays o&ugrave; vous &ecirc;tes pr&ecirc;t &agrave; livrer."
+
+#: admin/settings/settings-init.php:84
+#@ woocommerce
+msgid "All Countries"
+msgstr "Tous les pays"
+
+#: admin/settings/settings-init.php:85
+#: admin/settings/settings-init.php:90
+#: classes/shipping/class-wc-flat-rate.php:86
+#: classes/shipping/class-wc-flat-rate.php:90
+#: classes/shipping/class-wc-free-shipping.php:78
+#: classes/shipping/class-wc-free-shipping.php:82
+#: classes/shipping/class-wc-local-delivery.php:114
+#: classes/shipping/class-wc-local-delivery.php:118
+#: classes/shipping/class-wc-local-pickup.php:67
+#: classes/shipping/class-wc-local-pickup.php:71
+#@ woocommerce
+msgid "Specific Countries"
+msgstr "Pays sp&eacute;cifiques"
+
+#: admin/settings/settings-init.php:102
+#@ woocommerce
+msgid "Checkout and Accounts"
+msgstr "Commande et comptes"
+
+#: admin/settings/settings-init.php:102
+#@ woocommerce
+msgid "The following options control the behaviour of the checkout process and customer accounts."
+msgstr "Les options suivantes contr&ocirc;lent le comportement du processus de commande et des comptes clients."
+
+#: admin/settings/settings-init.php:106
+#@ woocommerce
+msgid "Enable guest checkout (no account required)"
+msgstr "Activer la commande invit&eacute; (aucun compte requis)"
+
+#: admin/settings/settings-init.php:114
+#@ woocommerce
+msgid "Show order comments section"
+msgstr "Afficher la section commentaires de commande"
+
+#: admin/settings/settings-init.php:122
+#@ woocommerce
+msgid "Security"
+msgstr "S&eacute;curit&eacute;"
+
+#: admin/settings/settings-init.php:123
+#@ woocommerce
+msgid "Force secure checkout"
+msgstr "Forcer le HTTPS lors de la commande"
+
+#: admin/settings/settings-init.php:129
+#@ woocommerce
+msgid "Force SSL (HTTPS) on the checkout pages (an SSL Certificate is required)"
+msgstr "Force l&rsquo;utilisation du SSL (HTTPS) lors de la commande (un certificat SSL est requis)."
+
+#: admin/settings/settings-init.php:133
+#@ woocommerce
+msgid "Un-force HTTPS when leaving the checkout"
+msgstr "Abandonner le HTTPS lorsque l&rsquo;on quitte la commande"
+
+#: admin/settings/settings-init.php:143
+#@ woocommerce
+msgid "Enable coupons"
+msgstr "Activer les codes promo"
+
+#: admin/settings/settings-init.php:152
+#@ woocommerce
+msgid "Enable coupon form on checkout"
+msgstr "Activer le formulaire de code promo sur la commande"
+
+#: admin/settings/settings-init.php:161
+#@ woocommerce
+msgid "Registration"
+msgstr "Enregistrement"
+
+#: admin/settings/settings-init.php:162
+#@ woocommerce
+msgid "Allow unregistered users to register from the Checkout"
+msgstr "Autoriser les invit&eacute;s &agrave; s&rsquo;enregistrer lors de la commande"
+
+#: admin/settings/settings-init.php:170
+#@ woocommerce
+msgid "Allow unregistered users to register from \"My Account\""
+msgstr "Autoriser les invit&eacute;s &agrave; s&rsquo;enregistrer depuis \"Mon Compte\""
+
+#: admin/settings/settings-init.php:178
+#@ woocommerce
+msgid "Customer Accounts"
+msgstr "Comptes client"
+
+#: admin/settings/settings-init.php:179
+#@ woocommerce
+msgid "Prevent customers from accessing WordPress admin"
+msgstr "Emp&ecirc;cher les clients d&rsquo;acc&eacute;der &agrave; l&rsquo;administration de WordPress"
+
+#: admin/settings/settings-init.php:187
+#@ woocommerce
+msgid "Clear cart when logging out"
+msgstr "Vider le panier lors de la d&eacute;connexion"
+
+#: admin/settings/settings-init.php:195
+#@ woocommerce
+msgid "Allow customers to repurchase past orders"
+msgstr "Autoriser les clients &agrave; repasser d&rsquo;anciennes commandes"
+
+#: admin/settings/settings-init.php:204
+#@ woocommerce
+msgid "Styles and Scripts"
+msgstr "Styles et scripts"
+
+#: admin/settings/settings-init.php:204
+#@ woocommerce
+msgid "The following options affect the styling of your store, as well as how certain features behave."
+msgstr "Les options suivantes affectent l&rsquo;apparence de votre boutique, ainsi que le comportement de certaines fonctionnalit&eacute;s."
+
+#: admin/settings/settings-init.php:207
+#@ woocommerce
+msgid "Styling"
+msgstr "Apparence"
+
+#: admin/settings/settings-init.php:208
+#@ woocommerce
+msgid "Enable the \"Demo Store\" notice on your site"
+msgstr "Activer la notice \"Boutique de D&eacute;monstration\" sur votre site"
+
+#: admin/settings/settings-init.php:216
+#@ woocommerce
+msgid "Enable WooCommerce CSS styles"
+msgstr "Activer les styles CSS de WooCommerce"
+
+#: admin/settings/settings-init.php:228
+#@ woocommerce
+msgid "Scripts"
+msgstr "Scripts"
+
+#: admin/settings/settings-init.php:229
+#@ woocommerce
+msgid "Enable AJAX add to cart buttons on product archives"
+msgstr "Activer les boutons AJAX d&rsquo;ajout au panier sur les produits"
+
+#: admin/settings/settings-init.php:237
+#@ woocommerce
+msgid "Enable WooCommerce lightbox on the product page"
+msgstr "Activer la lightbox de WooCommerce sur la page produit"
+
+#: admin/settings/settings-init.php:245
+#@ woocommerce
+msgid "Enable enhanced country select boxes"
+msgstr "Activer les boites de s&eacute;lection am&eacute;lior&eacute;es de pays"
+
+#: admin/settings/settings-init.php:253
+#@ woocommerce
+msgid "Enable jQuery UI (used by the price slider widget)"
+msgstr "Activer JQuery UI (utilis&eacute; par le widget slider de prix)"
+
+#: admin/settings/settings-init.php:261
+#@ woocommerce
+msgid "Output WooCommerce JavaScript in the footer"
+msgstr "Positionner le JavaScript de WooCommerce en pied de page"
+
+#: admin/settings/settings-init.php:270
+#@ woocommerce
+msgid "Digital Downloads"
+msgstr "T&eacute;l&eacute;chargements digitaux"
+
+#: admin/settings/settings-init.php:270
+#@ woocommerce
+msgid "The following options are specific to downloadable products."
+msgstr "Les options suivantes sont sp&eacute;cifiques aux produits t&eacute;l&eacute;chargeables."
+
+#: admin/settings/settings-init.php:273
+#@ woocommerce
+msgid "File download method"
+msgstr "Mode de t&eacute;l&eacute;chargement de fichiers"
+
+#: admin/settings/settings-init.php:274
+#@ woocommerce
+msgid "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect</code>/ <code>X-Sendfile</code> can be used to serve downloads instead (server requires <code>mod_xsendfile</code>)."
+msgstr "For&ccedil;er les t&eacute;l&eacute;chargements laissera les URL cach&eacute;es, mais certains serveurs peuvent proposer de gros fichiers de fa&ccedil;on peu fiable. Si support&eacute;s, <code>X-Accel-Redirect</code>/ et <code>X-Sendfile</code> peuvent &ecirc;tre utilis&eacute;s &agrave; la place pour proposer les t&eacute;l&eacute;chargements (n&eacute;cessite <code>mod_xsendfile</code> sur le serveur)."
+
+#: admin/settings/settings-init.php:282
+#@ woocommerce
+msgid "Force Downloads"
+msgstr "Forcer le t&eacute;l&eacute;chargement"
+
+#: admin/settings/settings-init.php:283
+#@ woocommerce
+msgid "X-Accel-Redirect/X-Sendfile"
+msgstr "X-Accel-Redirect/X-Sendfile"
+
+#: admin/settings/settings-init.php:284
+#@ woocommerce
+msgid "Redirect only"
+msgstr "Rediriger seulement"
+
+#: admin/settings/settings-init.php:289
+#@ woocommerce
+msgid "Access Restrictions"
+msgstr "Restrictions d&rsquo;acc&egrave;s"
+
+#: admin/settings/settings-init.php:290
+#@ woocommerce
+msgid "Must be logged in to download files"
+msgstr "Vous devez &ecirc;tre connect&eacute;(e) pour t&eacute;l&eacute;charger des fichiers"
+
+#: admin/settings/settings-init.php:294
+#@ woocommerce
+msgid "This setting does not apply to guest downloads."
+msgstr "Ce param&egrave;tre ne s&rsquo;applique pas aux t&eacute;l&eacute;chargements invit&eacute;."
+
+#: admin/settings/settings-init.php:299
+#@ woocommerce
+msgid "Grant access to downloadable products after payment"
+msgstr "Autoriser l&rsquo;acc&egrave;s aux produits t&eacute;l&eacute;chargeables apr&egrave;s paiement."
+
+#: admin/settings/settings-init.php:303
+#@ woocommerce
+msgid "Turn this option off to only grant access when an order is \"complete\", rather than \"processing\""
+msgstr "D&eacute;sactiver cette option pour autoriser l&rsquo;acc&egrave;s au t&eacute;l&eacute;chargement seulement lorsque la commande est \"termin&eacute;e\" et pas \"en cours\"."
+
+#: admin/settings/settings-init.php:308
+#@ woocommerce
+msgid "Limit quantity"
+msgstr "Limite de quantit&eacute;"
+
+#: admin/settings/settings-init.php:309
+#@ woocommerce
+msgid "Limit the purchasable quantity of downloadable-virtual items to 1"
+msgstr "Limiter la quantit&eacute; d&rsquo;achat des produits t&eacute;l&eacute;chargeables-virtuels &agrave; 1."
+
+#: admin/settings/settings-init.php:327
+#@ woocommerce
+msgid "Note: The shop page has children - child pages will not work if you enable this option."
+msgstr "Veuillez noter&nbsp;: la page boutique a des enfants - Les pages enfant ne fonctionneront pas si vous activez cette option."
+
+#: admin/settings/settings-init.php:331
+#@ woocommerce
+msgid "Page Setup"
+msgstr "Param&egrave;tres des pages"
+
+#: admin/settings/settings-init.php:334
+#@ woocommerce
+msgid "Shop Base Page"
+msgstr "Page de base de la boutique"
+
+#: admin/settings/settings-init.php:335
+#@ woocommerce
+msgid "This sets the base page of your shop - this is where your product archive will be."
+msgstr "Cela d&eacute;termine la page de base de votre boutique - C&rsquo;est ici que se trouvera votre archive de produits."
+
+#: admin/settings/settings-init.php:345
+#@ woocommerce
+msgid "Base Page Title"
+msgstr "Titre de la page de base"
+
+#: admin/settings/settings-init.php:346
+#@ woocommerce
+msgid "This title to show on the shop base page. Leave blank to use the page title."
+msgstr "Le titre &agrave; afficher sur la page de base de la boutique. Laissez vide pour utiliser le titre de la page."
+
+#: admin/settings/settings-init.php:355
+#@ woocommerce
+msgid "Terms page ID"
+msgstr "CGV"
+
+#: admin/settings/settings-init.php:356
+#@ woocommerce
+msgid "If you define a \"Terms\" page the customer will be asked if they accept them when checking out."
+msgstr "Si vous d&eacute;finissez une page \"Conditions G&eacute;n&eacute;rales de Vente\", il sera demand&eacute; au client d&rsquo;accepter vos CGV lors de la commande."
+
+#: admin/settings/settings-init.php:367
+#@ woocommerce
+msgid "Logout link"
+msgstr "Lien de d&eacute;connexion"
+
+#: admin/settings/settings-init.php:368
+#@ woocommerce
+msgid "Append a logout link to menus containing \"My Account\""
+msgstr "Ajouter un lien de d&eacute;connexion aux menus contenant \"Mon compte\""
+
+#: admin/settings/settings-init.php:376
+#@ woocommerce
+msgid "Permalinks"
+msgstr "Permaliens"
+
+#: admin/settings/settings-init.php:379
+#@ woocommerce
+msgid "Taxonomy base page"
+msgstr "Page de base de la taxinomie"
+
+#: admin/settings/settings-init.php:380
 #, php-format
+#@ woocommerce
+msgid "Prepend shop categories/tags with shop base page (<code>%s</code>)"
+msgstr "Pr&eacute;fixer les cat&eacute;gories et mots-clefs avec la page de base de la boutique (<code>%s</code>)"
+
+#: admin/settings/settings-init.php:387
+#@ woocommerce
+msgid "Product category slug"
+msgstr "Identifiant de cat&eacute;gorie de produit"
+
+#: admin/settings/settings-init.php:388
+#@ woocommerce
+msgid "Shows in the product category URLs. Leave blank to use the default slug."
+msgstr "Affich&eacute; dans les URL de cat&eacute;gorie de produit. Laissez vide pour utiliser l&rsquo;identifiant par d&eacute;faut."
+
+#: admin/settings/settings-init.php:397
+#@ woocommerce
+msgid "Product tag slug"
+msgstr "Identifiant de mots-clefs de produit"
+
+#: admin/settings/settings-init.php:398
+#@ woocommerce
+msgid "Shows in the product tag URLs. Leave blank to use the default slug."
+msgstr "Affich&eacute; dans les URL de mots-clefs de produit. Laissez vide pour utiliser l&rsquo;identifiant par d&eacute;faut."
+
+#: admin/settings/settings-init.php:407
+#@ woocommerce
+msgid "Product base page"
+msgstr "Page de base de produit"
+
+#: admin/settings/settings-init.php:408
+#, php-format
+#@ woocommerce
+msgid "Prepend product permalinks with shop base page (<code>%s</code>)"
+msgstr "Pr&eacute;fixer les permaliens de produit avec la page de base de la boutique (<code>%s</code>)"
+
+#: admin/settings/settings-init.php:416
+#@ woocommerce
+msgid "Product base category"
+msgstr "Cat&eacute;gorie de base de produit"
+
+#: admin/settings/settings-init.php:417
+#@ woocommerce
+msgid "Prepend product permalinks with product category"
+msgstr "Pr&eacute;fixer les permaliens de produit avec leur cat&eacute;gorie (<code>categorie/produit</code>)"
+
+#: admin/settings/settings-init.php:426
+#@ woocommerce
+msgid "The following pages need selecting so that WooCommerce knows where they are. These pages should have been created upon installation of the plugin, if not you will need to create them."
+msgstr "Les pages suivantes doivent &ecirc;tre indiqu&eacute;es afin que WooCommerce sache o&ugrave; elles sont. Ces pages doivent avoir &eacute;t&eacute; cr&eacute;&eacute;es lors de l&rsquo;installation de l&rsquo;extension, dans le cas contraire vous devrez les cr&eacute;er."
+
+#: admin/settings/settings-init.php:430
+#@ woocommerce
+msgid "Page contents: [woocommerce_cart]"
+msgstr "Contenu de la page&nbsp;: [woocommerce_cart]"
+
+#: admin/settings/settings-init.php:441
+#@ woocommerce
+msgid "Page contents: [woocommerce_checkout]"
+msgstr "Contenu de la page&nbsp;: [woocommerce_checkout]"
+
+#: admin/settings/settings-init.php:452
+#@ woocommerce
+msgid "Page contents: [woocommerce_pay] Parent: \"Checkout\""
+msgstr "Contenu de la page&nbsp;: [woocommerce_pay] Parent&nbsp;: \"Commande\""
+
+#: admin/settings/settings-init.php:463
+#@ woocommerce
+msgid "Page contents: [woocommerce_thankyou] Parent: \"Checkout\""
+msgstr "Contenu de la page&nbsp;: [woocommerce_thankyou] Parent&nbsp;: \"Commande\""
+
+#: admin/settings/settings-init.php:474
+#@ woocommerce
+msgid "Page contents: [woocommerce_my_account]"
+msgstr "Contenu de la page&nbsp;: [woocommerce_my_account]"
+
+#: admin/settings/settings-init.php:485
+#@ woocommerce
+msgid "Page contents: [woocommerce_edit_address] Parent: \"My Account\""
+msgstr "Contenu de la page&nbsp;: [woocommerce_edit_address] Parent&nbsp;: \"Mon compte\""
+
+#: admin/settings/settings-init.php:496
+#@ woocommerce
+msgid "Page contents: [woocommerce_view_order] Parent: \"My Account\""
+msgstr "Contenu de la page&nbsp;: [woocommerce_view_order] Parent&nbsp;: \"Mon compte\""
+
+#: admin/settings/settings-init.php:507
+#@ woocommerce
+msgid "Page contents: [woocommerce_change_password] Parent: \"My Account\""
+msgstr "Contenu de la page&nbsp;: [woocommerce_change_password] Parent&nbsp;: \"Mon compte\""
+
+#: admin/settings/settings-init.php:523
+#@ woocommerce
+msgid "Catalog Options"
+msgstr "Options du catalogue"
+
+#: admin/settings/settings-init.php:526
+#@ woocommerce
+msgid "Default product sorting"
+msgstr "Mode de tri par d&eacute;faut"
+
+#: admin/settings/settings-init.php:527
+#@ woocommerce
+msgid "This controls the default sort order of the catalog."
+msgstr "Cela contr&ocirc;le l&rsquo;ordre de tri par d&eacute;faut du catalogue."
+
+#: admin/settings/settings-init.php:533
+#: templates/loop/sorting.php:10
+#@ woocommerce
+msgid "Default sorting"
+msgstr "Tri par d&eacute;faut"
+
+#: admin/settings/settings-init.php:534
+#: templates/loop/sorting.php:11
+#@ woocommerce
+msgid "Sort alphabetically"
+msgstr "Ordre alphab&eacute;tique"
+
+#: admin/settings/settings-init.php:535
+#: templates/loop/sorting.php:12
+#@ woocommerce
+msgid "Sort by most recent"
+msgstr "Le plus r&eacute;cent d&rsquo;abord"
+
+#: admin/settings/settings-init.php:536
+#: templates/loop/sorting.php:13
+#@ woocommerce
+msgid "Sort by price"
+msgstr "Trier par prix"
+
+#: admin/settings/settings-init.php:542
+#@ woocommerce
+msgid "Show subcategories"
+msgstr "Afficher les sous-cat&eacute;gories"
+
+#: admin/settings/settings-init.php:543
+#@ woocommerce
+msgid "Show subcategories on category pages"
+msgstr "Afficher les sous-cat&eacute;gories sur les pages cat&eacute;gorie"
+
+#: admin/settings/settings-init.php:551
+#@ woocommerce
+msgid "Show subcategories on the shop page"
+msgstr "Afficher les sous-cat&eacute;gories sur la page boutique"
+
+#: admin/settings/settings-init.php:559
+#@ woocommerce
+msgid "When showing subcategories, hide products"
+msgstr "Quand les sous-cat&eacute;gories sont affich&eacute;es, cacher les produits"
+
+#: admin/settings/settings-init.php:567
+#@ woocommerce
+msgid "Redirects"
+msgstr "Redirections"
+
+#: admin/settings/settings-init.php:568
+#@ woocommerce
+msgid "Redirect to cart after adding a product to the cart (on single product pages)"
+msgstr "Rediriger vers le panier apr&egrave;s l&rsquo;ajout d&rsquo;un produit au panier (sur les pages produit simple)"
+
+#: admin/settings/settings-init.php:576
+#@ woocommerce
+msgid "Redirect to the product page on a single matching search result"
+msgstr "Rediriger directement sur la page produit lorsqu&rsquo;une recherche renvoie un r&eacute;sultat unique."
+
+#: admin/settings/settings-init.php:585
+#@ woocommerce
+msgid "The following options affect the fields available on the edit product page."
+msgstr "Les options suivantes affectent les champs disponibles sur la page de modification du produit."
+
+#: admin/settings/settings-init.php:588
+#@ woocommerce
+msgid "Product fields"
+msgstr "Champs des produits"
+
+#: admin/settings/settings-init.php:589
+#@ woocommerce
+msgid "Enable the SKU field for products"
+msgstr "Activer le champ UGS pour les produits"
+
+#: admin/settings/settings-init.php:597
+#@ woocommerce
+msgid "Enable the weight field for products"
+msgstr "Activer le champ poids pour les produits"
+
+#: admin/settings/settings-init.php:605
+#@ woocommerce
+msgid "Enable the dimension fields for products"
+msgstr "Activer les champs dimensions pour les produits"
+
+#: admin/settings/settings-init.php:613
+#@ woocommerce
+msgid "Show weight and dimension fields in product attributes tab"
+msgstr "Afficher le poids et les dimensions dans l&rsquo;onglet attributs du produit"
+
+#: admin/settings/settings-init.php:621
+#@ woocommerce
+msgid "Weight Unit"
+msgstr "Unit&eacute; de poids"
+
+#: admin/settings/settings-init.php:622
+#@ woocommerce
+msgid "This controls what unit you will define weights in."
+msgstr "Cela contr&ocirc;le en quelle unit&eacute; est d&eacute;finie le poids."
+
+#: admin/settings/settings-init.php:628
+#@ woocommerce
+msgid "kg"
+msgstr "kg"
+
+#: admin/settings/settings-init.php:629
+#@ woocommerce
+msgid "g"
+msgstr "g"
+
+#: admin/settings/settings-init.php:630
+#@ woocommerce
+msgid "lbs"
+msgstr "lb"
+
+#: admin/settings/settings-init.php:636
+#@ woocommerce
+msgid "Dimensions Unit"
+msgstr "Unit&eacute; de dimension"
+
+#: admin/settings/settings-init.php:637
+#@ woocommerce
+msgid "This controls what unit you will define lengths in."
+msgstr "Cela contr&ocirc;le en quelle unit&eacute; sont d&eacute;finies les longueurs."
+
+#: admin/settings/settings-init.php:644
+#@ woocommerce
+msgid "cm"
+msgstr "cm"
+
+#: admin/settings/settings-init.php:645
+#@ woocommerce
+msgid "mm"
+msgstr "mm"
+
+#: admin/settings/settings-init.php:646
+#@ woocommerce
+msgid "in"
+msgstr "po"
+
+#: admin/settings/settings-init.php:647
+#@ woocommerce
+msgid "yd"
+msgstr "vg"
+
+#: admin/settings/settings-init.php:653
+#@ woocommerce
+msgid "Product Ratings"
+msgstr "Notes des produits"
+
+#: admin/settings/settings-init.php:654
+#@ woocommerce
+msgid "Enable the star rating field on the review form"
+msgstr "Activer le champ &eacute;toile dans le formulaire d&rsquo;avis"
+
+#: admin/settings/settings-init.php:663
+#@ woocommerce
+msgid "Ratings are required to leave a review"
+msgstr "Une note est requise pour laisser un avis"
+
+#: admin/settings/settings-init.php:673
+#@ woocommerce
+msgid "Pricing Options"
+msgstr "Options de prix"
+
+#: admin/settings/settings-init.php:673
+#@ woocommerce
+msgid "The following options affect how prices are displayed on the frontend."
+msgstr "Les options suivantes affectent la fa&ccedil;on dont les prix sont affich&eacute;s sur le site."
+
+#: admin/settings/settings-init.php:676
+#@ woocommerce
+msgid "Currency Position"
+msgstr "Position de la monnaie"
+
+#: admin/settings/settings-init.php:677
+#@ woocommerce
+msgid "This controls the position of the currency symbol."
+msgstr "Cela contr&ocirc;le la position du symbole mon&eacute;taire."
+
+#: admin/settings/settings-init.php:684
+#@ woocommerce
+msgid "Left"
+msgstr "Gauche"
+
+#: admin/settings/settings-init.php:685
+#@ woocommerce
+msgid "Right"
+msgstr "Droite"
+
+#: admin/settings/settings-init.php:686
+#@ woocommerce
+msgid "Left (with space)"
+msgstr "Gauche (avec espace)"
+
+#: admin/settings/settings-init.php:687
+#@ woocommerce
+msgid "Right (with space)"
+msgstr "Droite (avec espace)"
+
+#: admin/settings/settings-init.php:693
+#@ woocommerce
+msgid "Thousand separator"
+msgstr "S&eacute;parateur de milliers"
+
+#: admin/settings/settings-init.php:694
+#@ woocommerce
+msgid "This sets the thousand separator of displayed prices."
+msgstr "Cela d&eacute;termine le s&eacute;parateur de milliers dans les prix affich&eacute;s."
+
+#: admin/settings/settings-init.php:704
+#@ woocommerce
+msgid "Decimal separator"
+msgstr "S&eacute;parateur d&eacute;cimal"
+
+#: admin/settings/settings-init.php:705
+#@ woocommerce
+msgid "This sets the decimal separator of displayed prices."
+msgstr "Cela d&eacute;termine le s&eacute;parateur de d&eacute;cimales dans les prix affich&eacute;s."
+
+#: admin/settings/settings-init.php:715
+#@ woocommerce
+msgid "Number of decimals"
+msgstr "Nombre de d&eacute;cimales"
+
+#: admin/settings/settings-init.php:716
+#@ woocommerce
+msgid "This sets the number of decimal points shown in displayed prices."
+msgstr "Cela d&eacute;termine le nombre de d&eacute;cimales dans les prix affich&eacute;s."
+
+#: admin/settings/settings-init.php:726
+#@ woocommerce
+msgid "Trailing zeros"
+msgstr "Suppression des z&eacute;ros"
+
+#: admin/settings/settings-init.php:727
+#@ woocommerce
+msgid "Remove zeros after the decimal point. e.g. <code>$10.00</code> becomes <code>$10</code>"
+msgstr "Supprimer les z&eacute;ros apr&egrave;s le s&eacute;parateur de d&eacute;cimales (ex.: <code>$10.00</code> devient <code>$10</code>)."
+
+#: admin/settings/settings-init.php:735
+#@ woocommerce
+msgid "Image Options"
+msgstr "Options d&rsquo;image"
+
+#: admin/settings/settings-init.php:735
+#, php-format
+#@ woocommerce
+msgid "These settings affect the actual dimensions of images in your catalog - the display on the front-end will still be affected by CSS styles. After changing these settings you may need to <a href=\"%s\">regenerate your thumbnails</a>."
+msgstr "Ces param&egrave;tres affectent les dimensions actuelles des images dans votre catalogue - L&rsquo;affichage sur le site sera &eacute;galement affect&eacute; par les styles CSS. Apr&egrave;s avoir chang&eacute; ces param&egrave;tres vous pourrez avoir besoin de <a href=\"%s\">r&eacute;g&eacute;n&eacute;rer vos vignettes</a>."
+
+#: admin/settings/settings-init.php:738
+#@ woocommerce
+msgid "Catalog Images"
+msgstr "Images du catalogue"
+
+#: admin/settings/settings-init.php:739
+#@ woocommerce
+msgid "This size is usually used in product listings"
+msgstr "Cette taille est habituellement utilis&eacute;e dans les listes de produits."
+
+#: admin/settings/settings-init.php:748
+#@ woocommerce
+msgid "Single Product Image"
+msgstr "Image de produit simple"
+
+#: admin/settings/settings-init.php:749
+#@ woocommerce
+msgid "This is the size used by the main image on the product page."
+msgstr "Cette taille est utilis&eacute;e pour l&rsquo;image principale sur la page produit."
+
+#: admin/settings/settings-init.php:758
+#@ woocommerce
+msgid "Product Thumbnails"
+msgstr "Vignettes de produit"
+
+#: admin/settings/settings-init.php:759
+#@ woocommerce
+msgid "This size is usually used for the gallery of images on the product page."
+msgstr "Cette taille est habituellement utilis&eacute;e pour la galerie d&rsquo;image de la page produit."
+
+#: admin/settings/settings-init.php:774
+#@ woocommerce
+msgid "Inventory Options"
+msgstr "Options d&rsquo;inventaire"
+
+#: admin/settings/settings-init.php:777
+#@ woocommerce
+msgid "Manage stock"
+msgstr "G&eacute;rer le stock"
+
+#: admin/settings/settings-init.php:778
+#@ woocommerce
+msgid "Enable stock management"
+msgstr "Activer la gestion du stock"
+
+#: admin/settings/settings-init.php:785
+#@ woocommerce
+msgid "Notifications"
+msgstr "Notifications"
+
+#: admin/settings/settings-init.php:786
+#@ woocommerce
+msgid "Enable low stock notifications"
+msgstr "Activer les notifications de stock faible"
+
+#: admin/settings/settings-init.php:794
+#@ woocommerce
+msgid "Enable out of stock notifications"
+msgstr "Activer les notifications de rupture de stock"
+
+#: admin/settings/settings-init.php:802
+#@ woocommerce
+msgid "Low stock threshold"
+msgstr "Seuil de stock faible"
+
+#: admin/settings/settings-init.php:812
+#@ woocommerce
+msgid "Out of stock threshold"
+msgstr "Seuil de rupture de stock"
+
+#: admin/settings/settings-init.php:822
+#@ woocommerce
+msgid "Out of stock visibility"
+msgstr "Visibilit&eacute; des ruptures de stock"
+
+#: admin/settings/settings-init.php:823
+#@ woocommerce
+msgid "Hide out of stock items from the catalog"
+msgstr "Cacher les articles en rupture de stock du catalogue"
+
+#: admin/settings/settings-init.php:830
+#@ woocommerce
+msgid "Stock display format"
+msgstr "Format d&rsquo;affichage du stock"
+
+#: admin/settings/settings-init.php:831
+#@ woocommerce
+msgid "This controls how stock is displayed on the frontend."
+msgstr "Cela contr&ocirc;le la fa&ccedil;on dont le stock est affich&eacute; sur le site."
+
+#: admin/settings/settings-init.php:837
+#@ woocommerce
+msgid "Always show stock e.g. \"12 in stock\""
+msgstr "Toujours afficher le stock (ex.: \"12 en stock\")"
+
+#: admin/settings/settings-init.php:838
+#@ woocommerce
+msgid "Only show stock when low e.g. \"Only 2 left in stock\" vs. \"In Stock\""
+msgstr "Afficher le stock seulement lorsqu&rsquo;il est faible (ex.:\"Plus que 2 en stock\" contre \"En stock\")"
+
+#: admin/settings/settings-init.php:839
+#@ woocommerce
+msgid "Never show stock amount"
+msgstr "Ne jamais afficher le niveau du stock"
+
+#: admin/settings/settings-init.php:854
+#@ woocommerce
+msgid "Shipping calculations"
+msgstr "Calcul des frais de livraison"
+
+#: admin/settings/settings-init.php:855
+#@ woocommerce
+msgid "Enable shipping"
+msgstr "Activer la livraison"
+
+#: admin/settings/settings-init.php:863
+#@ woocommerce
+msgid "Enable the shipping calculator on the cart page"
+msgstr "Activer le calculateur de livraison sur la page panier"
+
+#: admin/settings/settings-init.php:871
+#@ woocommerce
+msgid "Hide shipping costs until an address is entered"
+msgstr "Cacher les frais de livraison jusqu&rsquo;&agrave; ce qu&rsquo;une adresse soit entr&eacute;e"
+
+#: admin/settings/settings-init.php:879
+#@ woocommerce
+msgid "Shipping method display"
+msgstr "Affichage des modes de livraison"
+
+#: admin/settings/settings-init.php:880
+#@ woocommerce
+msgid "This controls how multiple shipping methods are displayed on the frontend."
+msgstr "Cela contr&ocirc;le comment les multiples modes de livraison sont affich&eacute;s sur le site."
+
+#: admin/settings/settings-init.php:886
+#@ woocommerce
+msgid "Radio buttons"
+msgstr "Boutons radio"
+
+#: admin/settings/settings-init.php:887
+#@ woocommerce
+msgid "Select box"
+msgstr "Bo&icirc;tes de s&eacute;lection"
+
+#: admin/settings/settings-init.php:893
+#@ woocommerce
+msgid "Shipping Destination"
+msgstr "Destination de livraison"
+
+#: admin/settings/settings-init.php:894
+#@ woocommerce
+msgid "Only ship to the users billing address"
+msgstr "Livrer uniquement &agrave; l&rsquo;adresse de facturation"
+
+#: admin/settings/settings-init.php:902
+#@ woocommerce
+msgid "Ship to billing address by default"
+msgstr "Livrer &agrave; l&rsquo;adresse de facturation par d&eacute;fault"
+
+#: admin/settings/settings-init.php:910
+#@ woocommerce
+msgid "Collect shipping address even when not required"
+msgstr "Collecter l&rsquo;adresse de livraison m&ecirc;me lorsque ce n&rsquo;est pas n&eacute;cessaire."
+
+#: admin/settings/settings-init.php:928
+#@ woocommerce
+msgid "Installed payment gateways are displayed below. Drag and drop payment gateways to control their display order on the checkout."
+msgstr "Les passerelles de paiement install&eacute;es sont list&eacute;es ci-dessous. Cliquez/D&eacute;placez les passerelles de paiement pour modifier leur ordre d&rsquo;affichage sur la page de commande."
+
+#: admin/settings/settings-init.php:941
+#@ woocommerce
+msgid "Tax Options"
+msgstr "Options de taxe"
+
+#: admin/settings/settings-init.php:944
+#@ woocommerce
+msgid "Tax calculations"
+msgstr "Calcul des taxes"
+
+#: admin/settings/settings-init.php:945
+#@ woocommerce
+msgid "Enable taxes and tax calculations"
+msgstr "Activer les taxes et le calcul des taxes"
+
+#: admin/settings/settings-init.php:953
+#@ woocommerce
+msgid "Display taxes on cart page"
+msgstr "Afficher les taxes sur la page panier"
+
+#: admin/settings/settings-init.php:961
+#@ woocommerce
+msgid "Display taxes even when the amount is zero"
+msgstr "Afficher les taxes, m&ecirc;me lorsque le montant est &eacute;gal &agrave; z&eacute;ro"
+
+#: admin/settings/settings-init.php:969
+#@ woocommerce
+msgid "Round tax at subtotal level, instead of per line"
+msgstr "Arrondir les taxes au niveau du sous-total, plut&ocirc;t que pour chaque ligne"
+
+#: admin/settings/settings-init.php:977
+#@ woocommerce
+msgid "Catalog Prices"
+msgstr "Prix au catalogue"
+
+#: admin/settings/settings-init.php:978
+#@ woocommerce
+msgid "Catalog prices defined including tax"
+msgstr "Les prix d&eacute;finis dans le catalogue comprennent les taxes"
+
+#: admin/settings/settings-init.php:987
+#@ woocommerce
+msgid "Display cart contents excluding tax"
+msgstr "Afficher le contenu du panier hors taxes"
+
+#: admin/settings/settings-init.php:996
+#@ woocommerce
+msgid "Display cart totals excluding tax"
+msgstr "Afficher le total du panier hors taxes"
+
+#: admin/settings/settings-init.php:1005
+#@ woocommerce
+msgid "Additional Tax classes"
+msgstr "Classes additionnelles de taxes"
+
+#: admin/settings/settings-init.php:1006
+#@ woocommerce
+msgid "List 1 per line. This is in addition to the default <em>Standard Rate</em>."
+msgstr "1 par ligne. Cela s&rsquo;ajoute aux <em>Taux standards</em>."
+
+#: admin/settings/settings-init.php:1007
+#@ woocommerce
+msgid "List product and shipping tax classes here, e.g. Zero Tax, Reduced Rate."
+msgstr "Listez les classe de taxe de produits et de livraison ici (ex.: Exon&eacute;ration de taxe, Taux r&eacute;duit)."
+
+#: admin/settings/settings-init.php:1011
+#, php-format
+#@ woocommerce
+msgid "Reduced Rate%sZero Rate"
+msgstr "Taux r&eacute;duit%sTaux z&eacute;ro"
+
+#: admin/settings/settings-init.php:1015
+#@ woocommerce
+msgid "Tax rates"
+msgstr "Taux de taxes"
+
+#: admin/settings/settings-init.php:1016
+#@ woocommerce
+msgid "All fields are required."
+msgstr "Tous les champs sont requis."
+
+#: admin/settings/settings-init.php:1017
+#@ woocommerce
+msgid "To avoid rounding errors, insert tax rates with 4 decimal places."
+msgstr "Afin d&rsquo;&eacute;viter les erreurs d&rsquo;arrondi, veuillez saisir des taux de taxe &agrave; 4 d&eacute;cimales."
+
+#: admin/settings/settings-init.php:1030
+#@ woocommerce
+msgid "Email Recipient Options"
+msgstr "Options d&rsquo;e-mail du destinataire"
+
+#: admin/settings/settings-init.php:1033
+#@ woocommerce
+msgid "New order notifications"
+msgstr "Notification de nouvelle commande"
+
+#: admin/settings/settings-init.php:1034
+#@ woocommerce
+msgid "The recipient of new order emails. Defaults to the admin email."
+msgstr "Le destinataire des e-mails de nouvelle commande. Par d&eacute;faut l&rsquo;e-mail de l&rsquo;administrateur."
+
+#: admin/settings/settings-init.php:1042
+#@ woocommerce
+msgid "Inventory notifications"
+msgstr "Notifications d&rsquo;inventaire"
+
+#: admin/settings/settings-init.php:1043
+#@ woocommerce
+msgid "The recipient of stock emails. Defaults to the admin email."
+msgstr "Le destinataire des e-mails de stock. Par d&eacute;faut l&rsquo;e-mail de l&rsquo;administrateur."
+
+#: admin/settings/settings-init.php:1052
+#@ woocommerce
+msgid "Email Sender Options"
+msgstr "Options d&rsquo;e-mail de l&rsquo;exp&eacute;diteur"
+
+#: admin/settings/settings-init.php:1052
+#@ woocommerce
+msgid "The following options affect the sender (email address and name) used in WooCommerce emails."
+msgstr "Les options suivantes affectent l&rsquo;exp&eacute;diteur (adresse e-mail et nom) utilis&eacute; dans les e-mails WooCommerce."
+
+#: admin/settings/settings-init.php:1055
+#@ woocommerce
+msgid "\"From\" name"
+msgstr "\"De\" nom"
+
+#: admin/settings/settings-init.php:1064
+#@ woocommerce
+msgid "\"From\" email address"
+msgstr "\"De\" adresse e-mail"
+
+#: admin/settings/settings-init.php:1074
+#@ woocommerce
+msgid "Email template"
+msgstr "Mod&egrave;le d&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1074
+#, php-format
+#@ woocommerce
+msgid "This section lets you customise the WooCommerce emails. <a href=\"%s\" target=\"_blank\">Click here to preview your email template</a>. For more advanced control copy <code>woocommerce/templates/emails/</code> to <code>yourtheme/woocommerce/emails/</code>."
+msgstr "Cette section vous permet de personnaliser les e-mails WooCommerce. <a href=\"%s\" target=\"_blank\">Cliquer ici pour pr&eacute;visualiser votre mod&egrave;le d&rsquo;e-mail</a>. Pour un contr&ocirc;le plus avanc&eacute;, copiez <code>woocommerce/templates/emails/</code> dans <code>votretheme/woocommerce/emails/</code>."
+
+#: admin/settings/settings-init.php:1077
+#@ woocommerce
+msgid "Header image"
+msgstr "Image d&rsquo;ent&ecirc;te de l&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1078
+#, php-format
+#@ woocommerce
+msgid "Enter a URL to an image you want to show in the email's header. Upload your image using the <a href=\"%s\">media uploader</a>."
+msgstr "Entrez l&rsquo;URL d&rsquo;une image que vous souhaitez afficher dans l&rsquo;ent&ecirc;te de l&rsquo;e-mail. Envoyez votre image en utilisant le <a href=\"%s\">media uploader</a>."
+
+#: admin/settings/settings-init.php:1086
+#@ woocommerce
+msgid "Email footer text"
+msgstr "Texte de pied de page de l&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1087
+#@ woocommerce
+msgid "The text to appear in the footer of WooCommerce emails."
+msgstr "Le texte &agrave; afficher dans le pied de page des e-mails WooCommerce."
+
+#: admin/settings/settings-init.php:1091
+#@ woocommerce
+msgid "Powered by WooCommerce"
+msgstr "Propuls&eacute; par WooCommerce"
+
+#: admin/settings/settings-init.php:1095
+#@ woocommerce
+msgid "Base colour"
+msgstr "Couleur de base de l&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1096
+#@ woocommerce
+msgid "The base colour for WooCommerce email templates. Default <code>#557da1</code>."
+msgstr "La couleur de base des mod&egrave;les d&rsquo;e-mail WooCommerce. Par d&eacute;faut <code>#557da1</code>."
+
+#: admin/settings/settings-init.php:1104
+#@ woocommerce
+msgid "Background colour"
+msgstr "Couleur de fond de l&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1105
+#@ woocommerce
+msgid "The background colour for WooCommerce email templates. Default <code>#eeeeee</code>."
+msgstr "La couleur de fond des mod&egrave;les d&rsquo;e-mail WooCommerce. Par d&eacute;faut <code>#eeeeee</code>."
+
+#: admin/settings/settings-init.php:1113
+#@ woocommerce
+msgid "Email body background colour"
+msgstr "Couleur de fond du corps de l&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1114
+#@ woocommerce
+msgid "The main body background colour. Default <code>#fdfdfd</code>."
+msgstr "La couleur principale de fond du corps de l&rsquo;e-mail. Par d&eacute;faut <code>#fdfdfd</code>."
+
+#: admin/settings/settings-init.php:1122
+#@ woocommerce
+msgid "Email body text colour"
+msgstr "Couleur de texte du corps de l&rsquo;e-mail"
+
+#: admin/settings/settings-init.php:1123
+#@ woocommerce
+msgid "The main body text colour. Default <code>#505050</code>."
+msgstr "La couleur principale de texte du corps de l&rsquo;e-mail. Par d&eacute;faut <code>#505050</code>."
+
+#: admin/settings/settings-payment-gateways.php:19
+#: admin/settings/settings-shipping-methods.php:21
+#@ woocommerce
+msgid "Default"
+msgstr "Valeur par d&eacute;faut"
+
+#: admin/settings/settings-payment-gateways.php:20
+#@ woocommerce
+msgid "Gateway"
+msgstr "Passerelle"
+
+#: admin/settings/settings-payment-gateways.php:37
+#@ woocommerce
+msgid "Gateway ID"
+msgstr "ID Passerelle"
+
+#: admin/settings/settings-shipping-methods.php:15
+#@ woocommerce
+msgid "Shipping Methods"
+msgstr "Modes de livraison"
+
+#: admin/settings/settings-shipping-methods.php:17
+#@ woocommerce
+msgid "Drag and drop methods to control their display order."
+msgstr "Cliquez/D&eacute;placez les modes pour modifier leur ordre d&rsquo;affichage."
+
+#: admin/settings/settings-shipping-methods.php:22
+#@ woocommerce
+msgid "Shipping Method"
+msgstr "Mode de livraison"
+
+#: admin/settings/settings-shipping-methods.php:38
+#@ woocommerce
+msgid "Method ID"
+msgstr "ID Mode"
+
+#: admin/settings/settings-tax-rates.php:195
+#@ woocommerce
+msgid "countries/states selected"
+msgstr "pays/&eacute;tats s&eacute;lectionn&eacute;s"
+
+#: classes/class-wc-cart.php:297
+#, php-format
+#@ woocommerce
 msgid "Sorry, it seems the coupon \"%s\" is not yours - it has now been removed from your order."
-msgstr ""
+msgstr "D&eacute;sol&eacute;, il semble que le code promo \"%s\" n&rsquo;est pas le v&ocirc;tre - Il vient d&rsquo;&ecirc;tre supprim&eacute; de votre commande."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:333
-#: ../classes/class-wc-cart.php:343
-#: ../classes/class-wc-cart.php:350
+#: classes/class-wc-cart.php:333
+#: classes/class-wc-cart.php:343
+#: classes/class-wc-cart.php:350
 #, php-format
+#@ woocommerce
 msgid "Sorry, we do not have enough \"%s\" in stock to fulfill your order (%s in stock). Please edit your cart and try again. We apologise for any inconvenience caused."
-msgstr "Désolé, nous n'avons pas assez de  \"%s\" en stock pour honorer votre commande (%s en stock). Modifier votre panier svp et essayez encore. Nous sommes désolés pour ce désagrément."
+msgstr "D&eacute;sol&eacute;, nous n&rsquo;avons pas assez de \"%s\" en stock pour traiter votre commande (%s en stock). Veuillez modifier votre panier et essayer &agrave; nouveau. Nous nous excusons pour le d&eacute;sagr&eacute;ment occasionn&eacute;."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:361
+#: classes/class-wc-cart.php:361
 #, php-format
+#@ woocommerce
 msgid "Sorry, we do not have enough \"%s\" in stock to fulfill your order. Please edit your cart and try again. We apologise for any inconvenience caused."
-msgstr "Désolé, nous n'avons pas assez de \"%s\" en stock  pour honorer votre commande. Modifiez votre panier svp et essayez à nouveau. Nous nous excusons pour ce désagrément."
+msgstr "D&eacute;sol&eacute;, nous n&rsquo;avons pas assez de \"%s\" en stock pour traiter votre commande. Veuillez modifier votre panier et essayer &agrave; nouveau. Nous nous excusons pour le d&eacute;sagr&eacute;ment occasionn&eacute;."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:620
+#: classes/class-wc-cart.php:639
+#@ woocommerce
 msgid "This product cannot be purchased."
-msgstr "Ce produit ne peut pas être commandé."
+msgstr "Ce produit ne peut pas &ecirc;tre achet&eacute;."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:626
+#: classes/class-wc-cart.php:645
+#@ woocommerce
 msgid "This product cannot be purchased - the price is not yet set."
-msgstr "Ce produit ne peut pas être commandé - le prix n'est pas encore renseigné."
+msgstr "Ce produit ne peut pas &ecirc;tre achet&eacute; - Le prix n&rsquo;est pas encore renseign&eacute;."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:632
+#: classes/class-wc-cart.php:651
 #, php-format
+#@ woocommerce
 msgid "You cannot add that amount to the cart since there is not enough stock. We have %s in stock."
-msgstr "Vous ne pouvez pas ajouter ce montant au panier car il n'y a pas assez de stock. Nous avons %s en stock"
+msgstr "Vous ne pouvez pas ajouter cette quantit&eacute; au panier car le stock est trop faible. Nous en avons %s en stock."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:635
+#: classes/class-wc-cart.php:654
+#@ woocommerce
 msgid "You cannot add that product to the cart since the product is out of stock."
-msgstr "Vous ne pouvez ajouter ce produit au panier car nous n'en avons plus en stock."
+msgstr "Vous ne pouvez ajouter ce produit au panier car il est en rupture de stock."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:643
+#: classes/class-wc-cart.php:664
+#@ woocommerce
 msgid "You already have this item in your cart."
-msgstr ""
+msgstr "Vous avez d&eacute;j&agrave; cet article dans votre panier."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:657
-#: ../classes/class-wc-cart.php:665
-#, fuzzy, php-format
+#: classes/class-wc-cart.php:678
+#: classes/class-wc-cart.php:686
+#, php-format
+#@ woocommerce
 msgid "<a href=\"%s\" class=\"button\">%s</a> You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart."
-msgstr "Vous ne pouvez ajouter ce montant au panier car il n'y a pas assez de stock. Nous avons %s en stock et vous en avez déjà %s dans votre panier."
+msgstr "<a href=\"%s\" class=\"button\">%s</a> Vous ne pouvez pas ajouter cette quantit&eacute; au panier &mdash; Nous en avons %s en stock et vous en avez d&eacute;j&agrave; %s dans votre panier."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:1470
-#: ../classes/class-wc-order.php:476
-#: ../classes/class-wc-product.php:640
-#: ../classes/class-wc-product.php:649
-#: ../classes/class-wc-product.php:680
-#: ../classes/class-wc-product.php:686
+#: classes/class-wc-cart.php:1492
+#: classes/class-wc-order.php:484
+#: classes/class-wc-product.php:644
+#: classes/class-wc-product.php:653
+#: classes/class-wc-product.php:684
+#: classes/class-wc-product.php:690
+#@ woocommerce
 msgid "Free!"
-msgstr "Gratuit!"
+msgstr "Gratuit&nbsp;!"
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:1482
+#: classes/class-wc-cart.php:1504
+#@ woocommerce
 msgid "via"
 msgstr "par"
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:1519
+#: classes/class-wc-cart.php:1542
+#@ woocommerce
 msgid "Invalid coupon."
-msgstr "Code Promo non valide"
+msgstr "Code promo invalide."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:1525
+#: classes/class-wc-cart.php:1548
+#@ woocommerce
 msgid "Discount code already applied!"
-msgstr "Code Promo déjà utilisé!"
+msgstr "Code promo d&eacute;j&agrave; utilis&eacute;&nbsp;!"
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:1545
+#: classes/class-wc-cart.php:1568
+#@ woocommerce
 msgid "Discount code applied successfully."
-msgstr "Code Promo appliqué avec succès."
+msgstr "Code promo appliqu&eacute; avec succ&egrave;s."
 
-# @ woocommerce
-#: ../classes/class-wc-cart.php:1549
+#: classes/class-wc-cart.php:1572
+#@ woocommerce
 msgid "Coupon does not exist!"
-msgstr "Code Promo inexistant !"
+msgstr "Ce code promo n&rsquo;existe pas&nbsp;!"
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:36
+#: classes/class-wc-checkout.php:36
+#@ woocommerce
 msgid "Account username"
-msgstr "Nom d'Utilisateur du Compte"
+msgstr "Nom d&rsquo;utilisateur du compte"
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:37
-#, fuzzy
+#: classes/class-wc-checkout.php:37
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Username"
-msgstr "Nom d'Utilisateur"
+msgstr "Nom d&rsquo;utilisateur"
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:41
-#: ../classes/class-wc-checkout.php:47
+#: classes/class-wc-checkout.php:41
+#: classes/class-wc-checkout.php:47
+#@ woocommerce
 msgid "Account password"
-msgstr "Mot de Passe Compte"
+msgstr "Mot de passe du compte"
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:42
-#: ../classes/class-wc-checkout.php:48
-#, fuzzy
+#: classes/class-wc-checkout.php:42
+#: classes/class-wc-checkout.php:48
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Password"
-msgstr "Mot de Passe"
+msgstr "Mot de passe"
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:58
-#, fuzzy
+#: classes/class-wc-checkout.php:58
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Notes about your order, e.g. special notes for delivery."
-msgstr "Notes concernant votre commande. Ex : Détails de livraison"
+msgstr "Commentaires sur votre commande (ex.: pr&eacute;cisions de livraison)."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:93
+#: classes/class-wc-checkout.php:93
 #, php-format
+#@ woocommerce
 msgid "Sorry, your session has expired. <a href=\"%s\">Return to homepage &rarr;</a>"
-msgstr "Désolé, votre session a expiré. <a href=\"%s\">Retour à l'accueil &rarr;</a>"
+msgstr "D&eacute;sol&eacute;, votre session a expir&eacute;. <a href=\"%s\">Retour &agrave; l&rsquo;accueil &rarr;</a>"
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:148
+#: classes/class-wc-checkout.php:147
+#: shortcodes/shortcode-my_account.php:140
+#@ woocommerce
 msgid "is a required field."
 msgstr "est un champ requis."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:157
-msgid "(billing) is not a valid postcode/ZIP."
-msgstr "(facturation) n'est pas un code postal valide."
+#: classes/class-wc-checkout.php:157
+#, php-format
+#@ woocommerce
+msgid "(%s) is not a valid postcode/ZIP."
+msgstr "(%s) n&rsquo;est pas un code postal/ZIP valide."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:163
+#: classes/class-wc-checkout.php:165
+#@ woocommerce
 msgid "is not a valid number."
-msgstr "n'est pas un nombre valide."
+msgstr "n&rsquo;est pas un nombre valide."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:167
+#: classes/class-wc-checkout.php:169
+#@ woocommerce
 msgid "is not a valid email address."
-msgstr "n'est pas une adresse email valide."
+msgstr "n&rsquo;est pas une adresse e-mail valide."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:218
+#: classes/class-wc-checkout.php:220
+#@ woocommerce
 msgid "Please enter an account username."
-msgstr "Entrez un nom d'utilisateur."
+msgstr "Veuillez entrer un nom d&rsquo;utilisateur."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:219
+#: classes/class-wc-checkout.php:221
+#@ woocommerce
 msgid "Please enter an account password."
-msgstr "Entre un mot de passe, svp."
+msgstr "Veuillez entrer un mot de passe."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:224
+#: classes/class-wc-checkout.php:226
+#@ woocommerce
 msgid "Invalid email/username."
-msgstr "Email/nom d'utilisateur non valide."
+msgstr "E-mail/Nom d&rsquo;utilisateur invalide."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:226
+#: classes/class-wc-checkout.php:228
+#@ woocommerce
 msgid "An account is already registered with that username. Please choose another."
-msgstr "Un compte est déjà enregistré avec ce nom d'utilisateur. Choisissez en un autre, svp."
+msgstr "Un compte est d&eacute;j&agrave; enregistr&eacute; avec ce nom d&rsquo;utilisateur. Veuillez en choisir un autre."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:231
+#: classes/class-wc-checkout.php:233
+#@ woocommerce
 msgid "An account is already registered with your email address. Please login."
-msgstr "Un compte est déjà enregistré avec cette adresse email. Connectez vous, svp."
+msgstr "Un compte est d&eacute;j&agrave; enregistr&eacute; avec cette adresse e-mail. Veuillez vous identifier."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:237
+#: classes/class-wc-checkout.php:239
+#@ woocommerce
 msgid "You must accept our Terms &amp; Conditions."
-msgstr "Vous devez accepter nos Termes &amp; Conditions."
+msgstr "Vous devez accepter nos Condition G&eacute;n&eacute;rales de Vente."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:245
+#: classes/class-wc-checkout.php:247
+#@ woocommerce
 msgid "Invalid shipping method."
-msgstr "Méthode de livraison non valide."
+msgstr "Mode de livraison invalide."
 
-# @ woocommerce
-#: ../classes/class-wc-checkout.php:254
+#: classes/class-wc-checkout.php:256
+#@ woocommerce
 msgid "Invalid payment method."
-msgstr "Méthode de paiement non valide."
+msgstr "Mode de paiement invalide."
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:25
+#: classes/class-wc-countries.php:25
+#@ woocommerce
 msgid "Afghanistan"
 msgstr "Afghanistan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:26
-msgid "Aland Islands"
-msgstr "Aland Islands"
+#: classes/class-wc-countries.php:26
+#@ woocommerce
+msgid "&#197;land Islands"
+msgstr "&Icirc;les &Aring;land"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:27
+#: classes/class-wc-countries.php:27
+#@ woocommerce
 msgid "Albania"
-msgstr "Albania"
+msgstr "Albanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:28
+#: classes/class-wc-countries.php:28
+#@ woocommerce
 msgid "Algeria"
-msgstr "Algeria"
+msgstr "Alg&eacute;rie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:29
+#: classes/class-wc-countries.php:29
+#@ woocommerce
 msgid "American Samoa"
-msgstr "American Samoa"
+msgstr "Samoa am&eacute;ricaines"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:30
+#: classes/class-wc-countries.php:30
+#@ woocommerce
 msgid "Andorra"
-msgstr "Andorra"
+msgstr "Andorre"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:31
+#: classes/class-wc-countries.php:31
+#@ woocommerce
 msgid "Angola"
 msgstr "Angola"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:32
+#: classes/class-wc-countries.php:32
+#@ woocommerce
 msgid "Anguilla"
 msgstr "Anguilla"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:33
+#: classes/class-wc-countries.php:33
+#@ woocommerce
 msgid "Antarctica"
-msgstr "Antarctica"
+msgstr "Antarctique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:34
+#: classes/class-wc-countries.php:34
+#@ woocommerce
 msgid "Antigua and Barbuda"
-msgstr "Antigua and Barbuda"
+msgstr "Antigua-et-Barbuda"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:35
+#: classes/class-wc-countries.php:35
+#@ woocommerce
 msgid "Argentina"
-msgstr "Argentina"
+msgstr "Argentine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:36
+#: classes/class-wc-countries.php:36
+#@ woocommerce
 msgid "Armenia"
-msgstr "Armenia"
+msgstr "Arm&eacute;nie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:37
+#: classes/class-wc-countries.php:37
+#@ woocommerce
 msgid "Aruba"
 msgstr "Aruba"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:38
+#: classes/class-wc-countries.php:38
+#@ woocommerce
 msgid "Australia"
-msgstr "Australia"
+msgstr "Australie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:39
+#: classes/class-wc-countries.php:39
+#@ woocommerce
 msgid "Austria"
-msgstr "Austria"
+msgstr "Autriche"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:40
+#: classes/class-wc-countries.php:40
+#@ woocommerce
 msgid "Azerbaijan"
-msgstr "Azerbaijan"
+msgstr "Azerba&iuml;djan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:41
+#: classes/class-wc-countries.php:41
+#@ woocommerce
 msgid "Bahamas"
 msgstr "Bahamas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:42
+#: classes/class-wc-countries.php:42
+#@ woocommerce
 msgid "Bahrain"
-msgstr "Bahrain"
+msgstr "Bahre&iuml;n"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:43
+#: classes/class-wc-countries.php:43
+#@ woocommerce
 msgid "Bangladesh"
 msgstr "Bangladesh"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:44
+#: classes/class-wc-countries.php:44
+#@ woocommerce
 msgid "Barbados"
-msgstr "Barbados"
+msgstr "Barbade"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:45
+#: classes/class-wc-countries.php:45
+#@ woocommerce
 msgid "Belarus"
-msgstr "Belarus"
-
-# @ woocommerce
-#: ../classes/class-wc-countries.php:46
-msgid "Belgium"
 msgstr "Belgique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:47
+#: classes/class-wc-countries.php:46
+#@ woocommerce
+msgid "Belgium"
+msgstr "Belize"
+
+#: classes/class-wc-countries.php:47
+#@ woocommerce
 msgid "Belize"
 msgstr "Belize"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:48
+#: classes/class-wc-countries.php:48
+#@ woocommerce
 msgid "Benin"
-msgstr "Benin"
+msgstr "B&eacute;nin"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:49
+#: classes/class-wc-countries.php:49
+#@ woocommerce
 msgid "Bermuda"
-msgstr "Bermuda"
+msgstr "Bermudes"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:50
+#: classes/class-wc-countries.php:50
+#@ woocommerce
 msgid "Bhutan"
-msgstr "Bhutan"
+msgstr "Bhoutan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:51
+#: classes/class-wc-countries.php:51
+#@ woocommerce
 msgid "Bolivia"
-msgstr "Bolivia"
+msgstr "Bolivie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:52
+#: classes/class-wc-countries.php:52
+#@ woocommerce
 msgid "Bosnia and Herzegovina"
-msgstr "Bosnia and Herzegovina"
+msgstr "Bosnie-Herz&eacute;govine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:53
+#: classes/class-wc-countries.php:53
+#@ woocommerce
 msgid "Botswana"
 msgstr "Botswana"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:54
+#: classes/class-wc-countries.php:54
+#@ woocommerce
 msgid "Brazil"
-msgstr "Brazil"
+msgstr "Br&eacute;sil"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:55
+#: classes/class-wc-countries.php:55
+#@ woocommerce
 msgid "British Indian Ocean Territory"
-msgstr "British Indian Ocean Territory"
+msgstr "Territoire britannique de l&rsquo;oc&eacute;an Indien"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:56
+#: classes/class-wc-countries.php:56
+#@ woocommerce
 msgid "British Virgin Islands"
-msgstr "British Virgin Islands"
+msgstr "&Icirc;les Vierges britanniques"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:57
+#: classes/class-wc-countries.php:57
+#@ woocommerce
 msgid "Brunei"
 msgstr "Brunei"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:58
+#: classes/class-wc-countries.php:58
+#@ woocommerce
 msgid "Bulgaria"
-msgstr "Bulgaria"
+msgstr "Bulgarie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:59
+#: classes/class-wc-countries.php:59
+#@ woocommerce
 msgid "Burkina Faso"
 msgstr "Burkina Faso"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:60
+#: classes/class-wc-countries.php:60
+#@ woocommerce
 msgid "Burundi"
 msgstr "Burundi"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:61
+#: classes/class-wc-countries.php:61
+#@ woocommerce
 msgid "Cambodia"
-msgstr "Cambodia"
+msgstr "Cambodge"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:62
+#: classes/class-wc-countries.php:62
+#@ woocommerce
 msgid "Cameroon"
-msgstr "Cameroon"
+msgstr "Cameroun"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:63
+#: classes/class-wc-countries.php:63
+#@ woocommerce
 msgid "Canada"
 msgstr "Canada"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:64
+#: classes/class-wc-countries.php:64
+#@ woocommerce
 msgid "Cape Verde"
-msgstr "Cape Verde"
+msgstr "Cap-Vert"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:65
+#: classes/class-wc-countries.php:65
+#@ woocommerce
 msgid "Cayman Islands"
-msgstr "Cayman Islands"
+msgstr "&Icirc;les Ca&iuml;mans"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:66
+#: classes/class-wc-countries.php:66
+#@ woocommerce
 msgid "Central African Republic"
-msgstr "Central African Republic"
+msgstr "R&eacute;publique centrafricaine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:67
+#: classes/class-wc-countries.php:67
+#@ woocommerce
 msgid "Chad"
-msgstr "Chad"
+msgstr "Tchad"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:68
+#: classes/class-wc-countries.php:68
+#@ woocommerce
 msgid "Chile"
-msgstr "Chile"
+msgstr "Chili"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:69
+#: classes/class-wc-countries.php:69
+#@ woocommerce
 msgid "China"
-msgstr "China"
+msgstr "Chine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:70
+#: classes/class-wc-countries.php:70
+#@ woocommerce
 msgid "Christmas Island"
-msgstr "Christmas Island"
+msgstr "&Icirc;le Christmas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:71
+#: classes/class-wc-countries.php:71
+#@ woocommerce
 msgid "Cocos (Keeling) Islands"
-msgstr "Cocos (Keeling) Islands"
+msgstr "&Icirc;les Cocos"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:72
+#: classes/class-wc-countries.php:72
+#@ woocommerce
 msgid "Colombia"
-msgstr "Colombia"
+msgstr "Colombie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:73
+#: classes/class-wc-countries.php:73
+#@ woocommerce
 msgid "Comoros"
-msgstr "Comoros"
+msgstr "Comores"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:74
+#: classes/class-wc-countries.php:74
+#@ woocommerce
 msgid "Congo (Brazzaville)"
-msgstr "Congo (Brazzaville)"
+msgstr "R&eacute;publique du Congo"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:75
+#: classes/class-wc-countries.php:75
+#@ woocommerce
 msgid "Congo (Kinshasa)"
-msgstr "Congo (Kinshasa)"
+msgstr "R&eacute;publique d&eacute;mocratique du Congo"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:76
+#: classes/class-wc-countries.php:76
+#@ woocommerce
 msgid "Cook Islands"
-msgstr "Cook Islands"
+msgstr "&Icirc;les Cook"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:77
+#: classes/class-wc-countries.php:77
+#@ woocommerce
 msgid "Costa Rica"
 msgstr "Costa Rica"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:78
+#: classes/class-wc-countries.php:78
+#@ woocommerce
 msgid "Croatia"
-msgstr "Croatia"
+msgstr "Croatie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:79
+#: classes/class-wc-countries.php:79
+#@ woocommerce
 msgid "Cuba"
 msgstr "Cuba"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:80
+#: classes/class-wc-countries.php:80
+#@ woocommerce
 msgid "Cyprus"
-msgstr "Cyprus"
+msgstr "Chypre"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:81
+#: classes/class-wc-countries.php:81
+#@ woocommerce
 msgid "Czech Republic"
-msgstr "Czech Republic"
+msgstr "R&eacute;publique tch&egrave;que"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:82
+#: classes/class-wc-countries.php:82
+#@ woocommerce
 msgid "Denmark"
-msgstr "Denmark"
+msgstr "Danemark"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:83
+#: classes/class-wc-countries.php:83
+#@ woocommerce
 msgid "Djibouti"
 msgstr "Djibouti"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:84
+#: classes/class-wc-countries.php:84
+#@ woocommerce
 msgid "Dominica"
-msgstr "Dominica"
+msgstr "Dominique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:85
+#: classes/class-wc-countries.php:85
+#@ woocommerce
 msgid "Dominican Republic"
-msgstr "Dominican Republic"
+msgstr "R&eacute;publique dominicaine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:86
+#: classes/class-wc-countries.php:86
+#@ woocommerce
 msgid "Ecuador"
-msgstr "Ecuador"
+msgstr "&Eacute;quateur"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:87
+#: classes/class-wc-countries.php:87
+#@ woocommerce
 msgid "Egypt"
-msgstr "Egypt"
+msgstr "&Eacute;gypte"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:88
+#: classes/class-wc-countries.php:88
+#@ woocommerce
 msgid "El Salvador"
-msgstr "El Salvador"
+msgstr "Salvador"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:89
+#: classes/class-wc-countries.php:89
+#@ woocommerce
 msgid "Equatorial Guinea"
-msgstr "Equatorial Guinea"
+msgstr "Guin&eacute;e &eacute;quatoriale"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:90
+#: classes/class-wc-countries.php:90
+#@ woocommerce
 msgid "Eritrea"
-msgstr "Eritrea"
+msgstr "&Eacute;rythr&eacute;e"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:91
+#: classes/class-wc-countries.php:91
+#@ woocommerce
 msgid "Estonia"
-msgstr "Estonia"
+msgstr "Estonie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:92
+#: classes/class-wc-countries.php:92
+#@ woocommerce
 msgid "Ethiopia"
-msgstr "Ethiopia"
+msgstr "&Eacute;thiopie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:93
+#: classes/class-wc-countries.php:93
+#@ woocommerce
 msgid "Falkland Islands"
-msgstr "Falkland Islands"
+msgstr "&Icirc;les Malouines"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:94
+#: classes/class-wc-countries.php:94
+#@ woocommerce
 msgid "Faroe Islands"
-msgstr "Faroe Islands"
+msgstr "&Icirc;les F&eacute;ro&eacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:95
+#: classes/class-wc-countries.php:95
+#@ woocommerce
 msgid "Fiji"
-msgstr "Fiji"
+msgstr "Fidji"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:96
+#: classes/class-wc-countries.php:96
+#@ woocommerce
 msgid "Finland"
-msgstr "Finland"
+msgstr "Finlande"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:97
+#: classes/class-wc-countries.php:97
+#@ woocommerce
 msgid "France"
 msgstr "France"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:98
+#: classes/class-wc-countries.php:98
+#@ woocommerce
 msgid "French Guiana"
-msgstr "French Guiana"
+msgstr "Guyane"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:99
+#: classes/class-wc-countries.php:99
+#@ woocommerce
 msgid "French Polynesia"
-msgstr "French Polynesia"
+msgstr "Polyn&eacute;sie fran&ccedil;aise"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:100
+#: classes/class-wc-countries.php:100
+#@ woocommerce
 msgid "French Southern Territories"
-msgstr "French Southern Territories"
+msgstr "Terres australes et antarctiques fran&ccedil;aises"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:101
+#: classes/class-wc-countries.php:101
+#@ woocommerce
 msgid "Gabon"
 msgstr "Gabon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:102
+#: classes/class-wc-countries.php:102
+#@ woocommerce
 msgid "Gambia"
-msgstr "Gambia"
+msgstr "Gambie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:103
-#: ../classes/class-wc-countries.php:363
+#: classes/class-wc-countries.php:103
+#: classes/class-wc-countries.php:363
+#@ woocommerce
 msgid "Georgia"
-msgstr "Georgia"
+msgstr "G&eacute;orgie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:104
+#: classes/class-wc-countries.php:104
+#@ woocommerce
 msgid "Germany"
-msgstr "Germany"
+msgstr "Allemagne"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:105
+#: classes/class-wc-countries.php:105
+#@ woocommerce
 msgid "Ghana"
 msgstr "Ghana"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:106
+#: classes/class-wc-countries.php:106
+#@ woocommerce
 msgid "Gibraltar"
 msgstr "Gibraltar"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:107
+#: classes/class-wc-countries.php:107
+#@ woocommerce
 msgid "Greece"
-msgstr "Greece"
+msgstr "Gr&egrave;ce"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:108
+#: classes/class-wc-countries.php:108
+#@ woocommerce
 msgid "Greenland"
-msgstr "Greenland"
+msgstr "Groenland"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:109
+#: classes/class-wc-countries.php:109
+#@ woocommerce
 msgid "Grenada"
-msgstr "Grenada"
+msgstr "Grenade"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:110
+#: classes/class-wc-countries.php:110
+#@ woocommerce
 msgid "Guadeloupe"
 msgstr "Guadeloupe"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:111
+#: classes/class-wc-countries.php:111
+#@ woocommerce
 msgid "Guam"
-msgstr "Guam"
+msgstr "GUAM"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:112
+#: classes/class-wc-countries.php:112
+#@ woocommerce
 msgid "Guatemala"
 msgstr "Guatemala"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:113
+#: classes/class-wc-countries.php:113
+#@ woocommerce
 msgid "Guernsey"
-msgstr "Guernsey"
+msgstr "Guernesey"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:114
+#: classes/class-wc-countries.php:114
+#@ woocommerce
 msgid "Guinea"
-msgstr "Guinea"
+msgstr "Guin&eacute;e"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:115
+#: classes/class-wc-countries.php:115
+#@ woocommerce
 msgid "Guinea-Bissau"
-msgstr "Guinea-Bissau"
+msgstr "Guin&eacute;e-Bissau"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:116
+#: classes/class-wc-countries.php:116
+#@ woocommerce
 msgid "Guyana"
 msgstr "Guyana"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:117
+#: classes/class-wc-countries.php:117
+#@ woocommerce
 msgid "Haiti"
-msgstr "Haiti"
+msgstr "Ha&iuml;ti"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:118
+#: classes/class-wc-countries.php:118
+#@ woocommerce
 msgid "Honduras"
 msgstr "Honduras"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:119
+#: classes/class-wc-countries.php:119
+#@ woocommerce
 msgid "Hong Kong"
 msgstr "Hong Kong"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:120
+#: classes/class-wc-countries.php:120
+#@ woocommerce
 msgid "Hungary"
-msgstr "Hungary"
+msgstr "Hongrie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:121
+#: classes/class-wc-countries.php:121
+#@ woocommerce
 msgid "Iceland"
-msgstr "Iceland"
+msgstr "Islande"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:122
+#: classes/class-wc-countries.php:122
+#@ woocommerce
 msgid "India"
-msgstr "India"
+msgstr "Inde"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:123
+#: classes/class-wc-countries.php:123
+#@ woocommerce
 msgid "Indonesia"
-msgstr "Indonesia"
+msgstr "Indon&eacute;sie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:124
+#: classes/class-wc-countries.php:124
+#@ woocommerce
 msgid "Iran"
 msgstr "Iran"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:125
+#: classes/class-wc-countries.php:125
+#@ woocommerce
 msgid "Iraq"
 msgstr "Iraq"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:126
+#: classes/class-wc-countries.php:126
+#@ woocommerce
 msgid "Ireland"
-msgstr "Ireland"
+msgstr "Irlande"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:127
+#: classes/class-wc-countries.php:127
+#@ woocommerce
 msgid "Isle of Man"
-msgstr "Isle of Man"
+msgstr "&Icirc;le de Man"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:128
+#: classes/class-wc-countries.php:128
+#@ woocommerce
 msgid "Israel"
-msgstr "Israel"
+msgstr "Isra&euml;l"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:129
+#: classes/class-wc-countries.php:129
+#@ woocommerce
 msgid "Italy"
-msgstr "Italy"
+msgstr "Italie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:130
+#: classes/class-wc-countries.php:130
+#@ woocommerce
 msgid "Ivory Coast"
-msgstr "Ivory Coast"
+msgstr "C&ocirc;te d&rsquo;Ivoire"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:131
+#: classes/class-wc-countries.php:131
+#@ woocommerce
 msgid "Jamaica"
-msgstr "Jamaica"
+msgstr "Jama&iuml;que"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:132
+#: classes/class-wc-countries.php:132
+#@ woocommerce
 msgid "Japan"
-msgstr "Japan"
+msgstr "Japon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:133
+#: classes/class-wc-countries.php:133
+#@ woocommerce
 msgid "Jersey"
 msgstr "Jersey"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:134
+#: classes/class-wc-countries.php:134
+#@ woocommerce
 msgid "Jordan"
-msgstr "Jordan"
+msgstr "Jordanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:135
+#: classes/class-wc-countries.php:135
+#@ woocommerce
 msgid "Kazakhstan"
 msgstr "Kazakhstan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:136
+#: classes/class-wc-countries.php:136
+#@ woocommerce
 msgid "Kenya"
 msgstr "Kenya"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:137
+#: classes/class-wc-countries.php:137
+#@ woocommerce
 msgid "Kiribati"
 msgstr "Kiribati"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:138
+#: classes/class-wc-countries.php:138
+#@ woocommerce
 msgid "Kuwait"
-msgstr "Kuwait"
+msgstr "Kowe&iuml;t"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:139
+#: classes/class-wc-countries.php:139
+#@ woocommerce
 msgid "Kyrgyzstan"
-msgstr "Kyrgyzstan"
+msgstr "Kirghizistan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:140
+#: classes/class-wc-countries.php:140
+#@ woocommerce
 msgid "Laos"
 msgstr "Laos"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:141
+#: classes/class-wc-countries.php:141
+#@ woocommerce
 msgid "Latvia"
-msgstr "Latvia"
+msgstr "Lettonie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:142
+#: classes/class-wc-countries.php:142
+#@ woocommerce
 msgid "Lebanon"
-msgstr "Lebanon"
+msgstr "Liban"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:143
+#: classes/class-wc-countries.php:143
+#@ woocommerce
 msgid "Lesotho"
 msgstr "Lesotho"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:144
+#: classes/class-wc-countries.php:144
+#@ woocommerce
 msgid "Liberia"
 msgstr "Liberia"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:145
+#: classes/class-wc-countries.php:145
+#@ woocommerce
 msgid "Libya"
-msgstr "Libya"
+msgstr "Libye"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:146
+#: classes/class-wc-countries.php:146
+#@ woocommerce
 msgid "Liechtenstein"
 msgstr "Liechtenstein"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:147
+#: classes/class-wc-countries.php:147
+#@ woocommerce
 msgid "Lithuania"
-msgstr "Lithuania"
+msgstr "Lituanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:148
+#: classes/class-wc-countries.php:148
+#@ woocommerce
 msgid "Luxembourg"
 msgstr "Luxembourg"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:149
+#: classes/class-wc-countries.php:149
+#@ woocommerce
 msgid "Macao S.A.R., China"
-msgstr "Macao S.A.R., China"
+msgstr "Macao"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:150
+#: classes/class-wc-countries.php:150
+#@ woocommerce
 msgid "Macedonia"
-msgstr "Macedonia"
+msgstr "Mac&eacute;doine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:151
+#: classes/class-wc-countries.php:151
+#@ woocommerce
 msgid "Madagascar"
 msgstr "Madagascar"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:152
+#: classes/class-wc-countries.php:152
+#@ woocommerce
 msgid "Malawi"
 msgstr "Malawi"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:153
+#: classes/class-wc-countries.php:153
+#@ woocommerce
 msgid "Malaysia"
-msgstr "Malaysia"
+msgstr "Malaisie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:154
+#: classes/class-wc-countries.php:154
+#@ woocommerce
 msgid "Maldives"
 msgstr "Maldives"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:155
+#: classes/class-wc-countries.php:155
+#@ woocommerce
 msgid "Mali"
 msgstr "Mali"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:156
+#: classes/class-wc-countries.php:156
+#@ woocommerce
 msgid "Malta"
-msgstr "Malta"
+msgstr "Malte"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:157
+#: classes/class-wc-countries.php:157
+#@ woocommerce
 msgid "Marshall Islands"
-msgstr "Marshall Islands"
+msgstr "&Icirc;les Marshall"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:158
+#: classes/class-wc-countries.php:158
+#@ woocommerce
 msgid "Martinique"
 msgstr "Martinique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:159
+#: classes/class-wc-countries.php:159
+#@ woocommerce
 msgid "Mauritania"
-msgstr "Mauritania"
+msgstr "Mauritanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:160
+#: classes/class-wc-countries.php:160
+#@ woocommerce
 msgid "Mauritius"
-msgstr "Mauritius"
+msgstr "Maurice"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:161
+#: classes/class-wc-countries.php:161
+#@ woocommerce
 msgid "Mayotte"
 msgstr "Mayotte"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:162
+#: classes/class-wc-countries.php:162
+#@ woocommerce
 msgid "Mexico"
-msgstr "Mexico"
+msgstr "Mexique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:163
+#: classes/class-wc-countries.php:163
+#@ woocommerce
 msgid "Micronesia"
-msgstr "Micronesia"
+msgstr "Micron&eacute;sie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:164
+#: classes/class-wc-countries.php:164
+#@ woocommerce
 msgid "Moldova"
-msgstr "Moldova"
+msgstr "Moldavie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:165
+#: classes/class-wc-countries.php:165
+#@ woocommerce
 msgid "Monaco"
 msgstr "Monaco"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:166
+#: classes/class-wc-countries.php:166
+#@ woocommerce
 msgid "Mongolia"
-msgstr "Mongolia"
+msgstr "Mongolie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:167
+#: classes/class-wc-countries.php:167
+#@ woocommerce
 msgid "Montenegro"
-msgstr "Montenegro"
+msgstr "Mont&eacute;n&eacute;gro"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:168
+#: classes/class-wc-countries.php:168
+#@ woocommerce
 msgid "Montserrat"
 msgstr "Montserrat"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:169
+#: classes/class-wc-countries.php:169
+#@ woocommerce
 msgid "Morocco"
-msgstr "Morocco"
+msgstr "Maroc"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:170
+#: classes/class-wc-countries.php:170
+#@ woocommerce
 msgid "Mozambique"
 msgstr "Mozambique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:171
+#: classes/class-wc-countries.php:171
+#@ woocommerce
 msgid "Myanmar"
-msgstr "Myanmar"
+msgstr "Birmanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:172
+#: classes/class-wc-countries.php:172
+#@ woocommerce
 msgid "Namibia"
-msgstr "Namibia"
+msgstr "Namibie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:173
+#: classes/class-wc-countries.php:173
+#@ woocommerce
 msgid "Nauru"
 msgstr "Nauru"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:174
+#: classes/class-wc-countries.php:174
+#@ woocommerce
 msgid "Nepal"
-msgstr "Nepal"
+msgstr "N&eacute;pal"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:175
+#: classes/class-wc-countries.php:175
+#@ woocommerce
 msgid "Netherlands"
-msgstr "Netherlands"
+msgstr "Pays-Bas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:176
+#: classes/class-wc-countries.php:176
+#@ woocommerce
 msgid "Netherlands Antilles"
-msgstr "Netherlands Antilles"
+msgstr "Antilles n&eacute;erlandaises"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:177
+#: classes/class-wc-countries.php:177
+#@ woocommerce
 msgid "New Caledonia"
-msgstr "New Caledonia"
+msgstr "Nouvelle-Cal&eacute;donie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:178
+#: classes/class-wc-countries.php:178
+#@ woocommerce
 msgid "New Zealand"
-msgstr "New Zealand"
+msgstr "Nouvelle-Z&eacute;lande"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:179
+#: classes/class-wc-countries.php:179
+#@ woocommerce
 msgid "Nicaragua"
 msgstr "Nicaragua"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:180
+#: classes/class-wc-countries.php:180
+#@ woocommerce
 msgid "Niger"
 msgstr "Niger"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:181
+#: classes/class-wc-countries.php:181
+#@ woocommerce
 msgid "Nigeria"
 msgstr "Nigeria"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:182
+#: classes/class-wc-countries.php:182
+#@ woocommerce
 msgid "Niue"
 msgstr "Niue"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:183
+#: classes/class-wc-countries.php:183
+#@ woocommerce
 msgid "Norfolk Island"
-msgstr "Norfolk Island"
+msgstr "&Icirc;le Norfolk"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:184
+#: classes/class-wc-countries.php:184
+#@ woocommerce
 msgid "North Korea"
-msgstr "North Korea"
+msgstr "Cor&eacute;e du Nord"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:185
+#: classes/class-wc-countries.php:185
+#@ woocommerce
 msgid "Northern Mariana Islands"
-msgstr "Northern Mariana Islands"
+msgstr "&Icirc;les Mariannes du Nord"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:186
+#: classes/class-wc-countries.php:186
+#@ woocommerce
 msgid "Norway"
-msgstr "Norway"
+msgstr "Norv&egrave;ge"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:187
+#: classes/class-wc-countries.php:187
+#@ woocommerce
 msgid "Oman"
 msgstr "Oman"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:188
+#: classes/class-wc-countries.php:188
+#@ woocommerce
 msgid "Pakistan"
 msgstr "Pakistan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:189
+#: classes/class-wc-countries.php:189
+#@ woocommerce
 msgid "Palau"
-msgstr "Palau"
+msgstr "Palaos"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:190
+#: classes/class-wc-countries.php:190
+#@ woocommerce
 msgid "Palestinian Territory"
-msgstr "Palestinian Territory"
+msgstr "Palestine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:191
+#: classes/class-wc-countries.php:191
+#@ woocommerce
 msgid "Panama"
 msgstr "Panama"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:192
+#: classes/class-wc-countries.php:192
+#@ woocommerce
 msgid "Papua New Guinea"
 msgstr "Papua New Guinea"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:193
+#: classes/class-wc-countries.php:193
+#@ woocommerce
 msgid "Paraguay"
 msgstr "Paraguay"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:194
+#: classes/class-wc-countries.php:194
+#@ woocommerce
 msgid "Peru"
-msgstr "Peru"
+msgstr "P&eacute;rou"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:195
+#: classes/class-wc-countries.php:195
+#@ woocommerce
 msgid "Philippines"
 msgstr "Philippines"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:196
+#: classes/class-wc-countries.php:196
+#@ woocommerce
 msgid "Pitcairn"
-msgstr "Pitcairn"
+msgstr "&Icirc;les Pitcairn"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:197
+#: classes/class-wc-countries.php:197
+#@ woocommerce
 msgid "Poland"
-msgstr "Poland"
+msgstr "Pologne"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:198
+#: classes/class-wc-countries.php:198
+#@ woocommerce
 msgid "Portugal"
 msgstr "Portugal"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:199
+#: classes/class-wc-countries.php:199
+#@ woocommerce
 msgid "Puerto Rico"
-msgstr "Puerto Rico"
+msgstr "Porto Rico"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:200
+#: classes/class-wc-countries.php:200
+#@ woocommerce
 msgid "Qatar"
 msgstr "Qatar"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:201
+#: classes/class-wc-countries.php:201
+#@ woocommerce
 msgid "Reunion"
-msgstr "Reunion"
+msgstr "R&eacute;union"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:202
+#: classes/class-wc-countries.php:202
+#@ woocommerce
 msgid "Romania"
-msgstr "Romania"
+msgstr "Roumanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:203
+#: classes/class-wc-countries.php:203
+#@ woocommerce
 msgid "Russia"
-msgstr "Russia"
+msgstr "Russie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:204
+#: classes/class-wc-countries.php:204
+#@ woocommerce
 msgid "Rwanda"
 msgstr "Rwanda"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:205
-msgid "Saint Barthélemy"
-msgstr "Saint Barthélemy"
+#: classes/class-wc-countries.php:205
+#@ woocommerce
+msgid "Saint Barth&eacute;lemy"
+msgstr "Saint-Barth&eacute;lemy"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:206
+#: classes/class-wc-countries.php:206
+#@ woocommerce
 msgid "Saint Helena"
-msgstr "Saint Helena"
+msgstr "Sainte-H&eacute;l&egrave;ne"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:207
+#: classes/class-wc-countries.php:207
+#@ woocommerce
 msgid "Saint Kitts and Nevis"
-msgstr "Saint Kitts and Nevis"
+msgstr "Saint-Christophe-et-Ni&eacute;v&egrave;s"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:208
+#: classes/class-wc-countries.php:208
+#@ woocommerce
 msgid "Saint Lucia"
-msgstr "Saint Lucia"
+msgstr "Sainte-Lucie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:209
+#: classes/class-wc-countries.php:209
+#@ woocommerce
 msgid "Saint Martin (French part)"
-msgstr "Saint Martin (French part)"
+msgstr "Saint-Martin (Antilles fran&ccedil;aises)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:210
+#: classes/class-wc-countries.php:210
+#@ woocommerce
 msgid "Saint Pierre and Miquelon"
-msgstr "Saint Pierre and Miquelon"
+msgstr "Saint-Pierre-et-Miquelon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:211
+#: classes/class-wc-countries.php:211
+#@ woocommerce
 msgid "Saint Vincent and the Grenadines"
-msgstr "Saint Vincent and the Grenadines"
+msgstr "Saint-Vincent-et-les-Grenadines"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:212
+#: classes/class-wc-countries.php:212
+#@ woocommerce
 msgid "Samoa"
 msgstr "Samoa"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:213
+#: classes/class-wc-countries.php:213
+#@ woocommerce
 msgid "San Marino"
-msgstr "San Marino"
+msgstr "Saint-Marin"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:214
-msgid "Sao Tome and Principe"
-msgstr "Sao Tome and Principe"
+#: classes/class-wc-countries.php:214
+#@ woocommerce
+msgid "S&atilde;o Tom&eacute; and Pr&iacute;ncipe"
+msgstr "Sao Tom&eacute;-et-Principe"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:215
+#: classes/class-wc-countries.php:215
+#@ woocommerce
 msgid "Saudi Arabia"
-msgstr "Saudi Arabia"
+msgstr "Arabie saoudite"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:216
+#: classes/class-wc-countries.php:216
+#@ woocommerce
 msgid "Senegal"
-msgstr "Senegal"
+msgstr "S&eacute;n&eacute;gal"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:217
+#: classes/class-wc-countries.php:217
+#@ woocommerce
 msgid "Serbia"
-msgstr "Serbia"
+msgstr "Serbie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:218
+#: classes/class-wc-countries.php:218
+#@ woocommerce
 msgid "Seychelles"
 msgstr "Seychelles"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:219
+#: classes/class-wc-countries.php:219
+#@ woocommerce
 msgid "Sierra Leone"
 msgstr "Sierra Leone"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:220
+#: classes/class-wc-countries.php:220
+#@ woocommerce
 msgid "Singapore"
-msgstr "Singapore"
+msgstr "Singapour"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:221
+#: classes/class-wc-countries.php:221
+#@ woocommerce
 msgid "Slovakia"
-msgstr "Slovakia"
+msgstr "Slovaquie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:222
+#: classes/class-wc-countries.php:222
+#@ woocommerce
 msgid "Slovenia"
-msgstr "Slovenia"
+msgstr "Slov&eacute;nie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:223
+#: classes/class-wc-countries.php:223
+#@ woocommerce
 msgid "Solomon Islands"
-msgstr "Solomon Islands"
+msgstr "&Icirc;les Salomon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:224
+#: classes/class-wc-countries.php:224
+#@ woocommerce
 msgid "Somalia"
-msgstr "Somalia"
+msgstr "Somalie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:225
+#: classes/class-wc-countries.php:225
+#@ woocommerce
 msgid "South Africa"
-msgstr "South Africa"
+msgstr "Afrique du Sud"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:226
+#: classes/class-wc-countries.php:226
+#@ woocommerce
 msgid "South Georgia/Sandwich Islands"
-msgstr "South Georgia/Sandwich Islands"
+msgstr "G&eacute;orgie du Sud-et-les &Icirc;les Sandwich du Sud"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:227
+#: classes/class-wc-countries.php:227
+#@ woocommerce
 msgid "South Korea"
-msgstr "South Korea"
+msgstr "Cor&eacute;e du Sud"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:228
+#: classes/class-wc-countries.php:228
+#@ woocommerce
 msgid "Spain"
-msgstr "Spain"
+msgstr "Espagne"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:229
+#: classes/class-wc-countries.php:229
+#@ woocommerce
 msgid "Sri Lanka"
 msgstr "Sri Lanka"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:230
+#: classes/class-wc-countries.php:230
+#@ woocommerce
 msgid "Sudan"
-msgstr "Sudan"
+msgstr "Soudan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:231
+#: classes/class-wc-countries.php:231
+#@ woocommerce
 msgid "Suriname"
 msgstr "Suriname"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:232
+#: classes/class-wc-countries.php:232
+#@ woocommerce
 msgid "Svalbard and Jan Mayen"
-msgstr "Svalbard and Jan Mayen"
+msgstr "Svalbard et Jan Mayen"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:233
+#: classes/class-wc-countries.php:233
+#@ woocommerce
 msgid "Swaziland"
 msgstr "Swaziland"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:234
+#: classes/class-wc-countries.php:234
+#@ woocommerce
 msgid "Sweden"
-msgstr "Sweden"
+msgstr "Su&egrave;de"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:235
+#: classes/class-wc-countries.php:235
+#@ woocommerce
 msgid "Switzerland"
 msgstr "Suisse"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:236
+#: classes/class-wc-countries.php:236
+#@ woocommerce
 msgid "Syria"
-msgstr "Syria"
+msgstr "Syrie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:237
+#: classes/class-wc-countries.php:237
+#@ woocommerce
 msgid "Taiwan"
-msgstr "Taiwan"
+msgstr "Ta&iuml;wan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:238
+#: classes/class-wc-countries.php:238
+#@ woocommerce
 msgid "Tajikistan"
-msgstr "Tajikistan"
+msgstr "Tadjikistan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:239
+#: classes/class-wc-countries.php:239
+#@ woocommerce
 msgid "Tanzania"
-msgstr "Tanzania"
+msgstr "Tanzanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:240
+#: classes/class-wc-countries.php:240
+#@ woocommerce
 msgid "Thailand"
-msgstr "Thailand"
+msgstr "Tha&iuml;lande"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:241
+#: classes/class-wc-countries.php:241
+#@ woocommerce
 msgid "Timor-Leste"
-msgstr "Timor-Leste"
+msgstr "Timor oriental"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:242
+#: classes/class-wc-countries.php:242
+#@ woocommerce
 msgid "Togo"
 msgstr "Togo"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:243
+#: classes/class-wc-countries.php:243
+#@ woocommerce
 msgid "Tokelau"
 msgstr "Tokelau"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:244
+#: classes/class-wc-countries.php:244
+#@ woocommerce
 msgid "Tonga"
 msgstr "Tonga"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:245
+#: classes/class-wc-countries.php:245
+#@ woocommerce
 msgid "Trinidad and Tobago"
-msgstr "Trinidad and Tobago"
+msgstr "Trinit&eacute;-et-Tobago"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:246
+#: classes/class-wc-countries.php:246
+#@ woocommerce
 msgid "Tunisia"
-msgstr "Tunisia"
+msgstr "Tunisie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:247
+#: classes/class-wc-countries.php:247
+#@ woocommerce
 msgid "Turkey"
-msgstr "Turkey"
+msgstr "Turquie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:248
+#: classes/class-wc-countries.php:248
+#@ woocommerce
 msgid "Turkmenistan"
-msgstr "Turkmenistan"
+msgstr "Turkm&eacute;nistan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:249
+#: classes/class-wc-countries.php:249
+#@ woocommerce
 msgid "Turks and Caicos Islands"
-msgstr "Turks and Caicos Islands"
+msgstr "&Icirc;les Turques-et-Ca&iuml;ques"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:250
+#: classes/class-wc-countries.php:250
+#@ woocommerce
 msgid "Tuvalu"
 msgstr "Tuvalu"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:251
+#: classes/class-wc-countries.php:251
+#@ woocommerce
 msgid "U.S. Virgin Islands"
-msgstr "U.S. Virgin Islands"
+msgstr "&Icirc;les Vierges des &Eacute;tats-Unis"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:252
+#: classes/class-wc-countries.php:252
+#@ woocommerce
 msgid "US Armed Forces"
-msgstr "Forces armées américaines"
+msgstr "Forces arm&eacute;es des &Eacute;tats-Unis"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:253
+#: classes/class-wc-countries.php:253
+#@ woocommerce
 msgid "US Minor Outlying Islands"
-msgstr "US Minor Outlying Islands"
+msgstr "&Icirc;les mineures &eacute;loign&eacute;es des &Eacute;tats-Unis"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:254
+#: classes/class-wc-countries.php:254
+#@ woocommerce
 msgid "Uganda"
-msgstr "Uganda"
+msgstr "Ouganda"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:255
+#: classes/class-wc-countries.php:255
+#@ woocommerce
 msgid "Ukraine"
 msgstr "Ukraine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:256
+#: classes/class-wc-countries.php:256
+#@ woocommerce
 msgid "United Arab Emirates"
-msgstr "Émirats Arabes Unis"
+msgstr "&Eacute;mirats arabes unis"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:257
+#: classes/class-wc-countries.php:257
+#@ woocommerce
 msgid "United Kingdom"
-msgstr "Royaume Uni"
+msgstr "Royaume-Uni"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:258
+#: classes/class-wc-countries.php:258
+#@ woocommerce
 msgid "United States"
-msgstr "États-Unis"
+msgstr ""
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:259
+#: classes/class-wc-countries.php:259
+#@ woocommerce
 msgid "Uruguay"
 msgstr "Uruguay"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:260
+#: classes/class-wc-countries.php:260
+#@ woocommerce
 msgid "Uzbekistan"
-msgstr "Uzbekistan"
+msgstr "Ouzb&eacute;kistan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:261
+#: classes/class-wc-countries.php:261
+#@ woocommerce
 msgid "Vanuatu"
 msgstr "Vanuatu"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:262
+#: classes/class-wc-countries.php:262
+#@ woocommerce
 msgid "Vatican"
 msgstr "Vatican"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:263
+#: classes/class-wc-countries.php:263
+#@ woocommerce
 msgid "Venezuela"
-msgstr "Venezuela"
+msgstr "V&eacute;n&eacute;zuela"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:264
+#: classes/class-wc-countries.php:264
+#@ woocommerce
 msgid "Vietnam"
-msgstr "Vietnam"
+msgstr "Vi&ecirc;t Nam"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:265
+#: classes/class-wc-countries.php:265
+#@ woocommerce
 msgid "Wallis and Futuna"
-msgstr "Wallis and Futuna"
+msgstr "Wallis-et-Futuna"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:266
+#: classes/class-wc-countries.php:266
+#@ woocommerce
 msgid "Western Sahara"
-msgstr "Western Sahara"
+msgstr "Sahara occidental"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:267
+#: classes/class-wc-countries.php:267
+#@ woocommerce
 msgid "Yemen"
-msgstr "Yemen"
+msgstr "Y&eacute;men"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:268
+#: classes/class-wc-countries.php:268
+#@ woocommerce
 msgid "Zambia"
-msgstr "Zambia"
+msgstr "Zambie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:269
+#: classes/class-wc-countries.php:269
+#@ woocommerce
 msgid "Zimbabwe"
 msgstr "Zimbabwe"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:274
+#: classes/class-wc-countries.php:274
+#@ woocommerce
 msgid "Australian Capital Territory"
-msgstr "Australian Capital Territory"
+msgstr "Territoire de la capitale australienne"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:275
+#: classes/class-wc-countries.php:275
+#@ woocommerce
 msgid "New South Wales"
-msgstr "New South Wales"
+msgstr "Nouvelle-Galles du Sud"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:276
+#: classes/class-wc-countries.php:276
+#@ woocommerce
 msgid "Northern Territory"
-msgstr "Northern Territory"
+msgstr "Territoire du Nord"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:277
+#: classes/class-wc-countries.php:277
+#@ woocommerce
 msgid "Queensland"
 msgstr "Queensland"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:278
+#: classes/class-wc-countries.php:278
+#@ woocommerce
 msgid "South Australia"
-msgstr "South Australia"
+msgstr "Australie-M&eacute;ridional"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:279
+#: classes/class-wc-countries.php:279
+#@ woocommerce
 msgid "Tasmania"
-msgstr "Tasmania"
+msgstr "Tasmanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:280
+#: classes/class-wc-countries.php:280
+#@ woocommerce
 msgid "Victoria"
 msgstr "Victoria"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:281
+#: classes/class-wc-countries.php:281
+#@ woocommerce
 msgid "Western Australia"
-msgstr "Western Australia"
+msgstr "Australie-Occidentale"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:286
+#: classes/class-wc-countries.php:286
+#@ woocommerce
 msgid "Amazonas"
 msgstr "Amazonas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:287
+#: classes/class-wc-countries.php:287
+#@ woocommerce
 msgid "Acre"
 msgstr "Acre"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:288
+#: classes/class-wc-countries.php:288
+#@ woocommerce
 msgid "Alagoas"
 msgstr "Alagoas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:289
+#: classes/class-wc-countries.php:289
+#@ woocommerce
 msgid "Amap&aacute;"
 msgstr "Amap&aacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:290
+#: classes/class-wc-countries.php:290
+#@ woocommerce
 msgid "Cear&aacute;"
 msgstr "Cear&aacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:291
+#: classes/class-wc-countries.php:291
+#@ woocommerce
 msgid "Distrito federal"
-msgstr "Distrito federal"
+msgstr "District f&eacute;d&eacute;ral"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:292
-msgid "Espirito santo"
-msgstr "Espirito santo"
+#: classes/class-wc-countries.php:292
+#@ woocommerce
+msgid "Esp&iacute;rito Santo"
+msgstr "Esp&iacute;rito Santo"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:293
+#: classes/class-wc-countries.php:293
+#@ woocommerce
 msgid "Maranh&atilde;o"
 msgstr "Maranh&atilde;o"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:294
+#: classes/class-wc-countries.php:294
+#@ woocommerce
 msgid "Paran&aacute;"
 msgstr "Paran&aacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:295
+#: classes/class-wc-countries.php:295
+#@ woocommerce
 msgid "Pernambuco"
-msgstr "Pernambuco"
+msgstr "Pernambouc"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:296
+#: classes/class-wc-countries.php:296
+#@ woocommerce
 msgid "Piau&iacute;"
 msgstr "Piau&iacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:297
+#: classes/class-wc-countries.php:297
+#@ woocommerce
 msgid "Rio grande do norte"
-msgstr "Rio grande do norte"
+msgstr "Rio Grande do Norte"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:298
-#: ../classes/class-wc-countries.php:311
+#: classes/class-wc-countries.php:298
+#: classes/class-wc-countries.php:311
+#@ woocommerce
 msgid "Rio grande do sul"
-msgstr "Rio grande do sul"
+msgstr "Rio Grande do Sul"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:299
+#: classes/class-wc-countries.php:299
+#@ woocommerce
 msgid "Rond&ocirc;nia"
 msgstr "Rond&ocirc;nia"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:300
+#: classes/class-wc-countries.php:300
+#@ woocommerce
 msgid "Roraima"
 msgstr "Roraima"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:301
+#: classes/class-wc-countries.php:301
+#@ woocommerce
 msgid "Santa catarina"
-msgstr "Santa catarina"
+msgstr "Santa Catarina"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:302
+#: classes/class-wc-countries.php:302
+#@ woocommerce
 msgid "Sergipe"
 msgstr "Sergipe"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:303
+#: classes/class-wc-countries.php:303
+#@ woocommerce
 msgid "Tocantins"
 msgstr "Tocantins"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:304
+#: classes/class-wc-countries.php:304
+#@ woocommerce
 msgid "Par&aacute;"
 msgstr "Par&aacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:305
+#: classes/class-wc-countries.php:305
+#@ woocommerce
 msgid "Bahia"
 msgstr "Bahia"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:306
+#: classes/class-wc-countries.php:306
+#@ woocommerce
 msgid "Goi&aacute;s"
 msgstr "Goi&aacute;s"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:307
+#: classes/class-wc-countries.php:307
+#@ woocommerce
 msgid "Mato grosso"
-msgstr "Mato grosso"
+msgstr "Mato Grosso"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:308
+#: classes/class-wc-countries.php:308
+#@ woocommerce
 msgid "Mato grosso do sul"
-msgstr "Mato grosso do sul"
+msgstr "Mato Grosso do Sul"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:309
+#: classes/class-wc-countries.php:309
+#@ woocommerce
 msgid "Rio de janeiro"
-msgstr "Rio de janeiro"
+msgstr "Rio de Janeiro"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:310
+#: classes/class-wc-countries.php:310
+#@ woocommerce
 msgid "S&atilde;o paulo"
-msgstr "S&atilde;o paulo"
+msgstr "S&atilde;o Paulo"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:312
+#: classes/class-wc-countries.php:312
+#@ woocommerce
 msgid "Minas gerais"
-msgstr "Minas gerais"
+msgstr "Minas Gerais"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:313
-msgid "Paraiba"
-msgstr "Paraiba"
+#: classes/class-wc-countries.php:313
+#@ woocommerce
+msgid "Para&iacute;ba"
+msgstr "Para&iacute;ba"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:316
+#: classes/class-wc-countries.php:316
+#@ woocommerce
 msgid "Alberta"
 msgstr "Alberta"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:317
+#: classes/class-wc-countries.php:317
+#@ woocommerce
 msgid "British Columbia"
 msgstr "Colombie-Britannique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:318
+#: classes/class-wc-countries.php:318
+#@ woocommerce
 msgid "Manitoba"
 msgstr "Manitoba"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:319
+#: classes/class-wc-countries.php:319
+#@ woocommerce
 msgid "New Brunswick"
 msgstr "Nouveau-Brunswick"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:320
+#: classes/class-wc-countries.php:320
+#@ woocommerce
 msgid "Newfoundland"
 msgstr "Terre-Neuve"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:321
+#: classes/class-wc-countries.php:321
+#@ woocommerce
 msgid "Northwest Territories"
 msgstr "Territoires du Nord-Ouest"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:322
+#: classes/class-wc-countries.php:322
+#@ woocommerce
 msgid "Nova Scotia"
-msgstr "Nouvelle-Écosse"
+msgstr "Nouvelle-&Eacute;cosse"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:323
+#: classes/class-wc-countries.php:323
+#@ woocommerce
 msgid "Nunavut"
 msgstr "Nunavut"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:324
+#: classes/class-wc-countries.php:324
+#@ woocommerce
 msgid "Ontario"
 msgstr "Ontario"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:325
+#: classes/class-wc-countries.php:325
+#@ woocommerce
 msgid "Prince Edward Island"
-msgstr "Île du Prince-Édouard"
+msgstr "&Icirc;le-du-Prince-&Eacute;douard"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:326
+#: classes/class-wc-countries.php:326
+#@ woocommerce
 msgid "Quebec"
-msgstr "Québec"
+msgstr "Qu&eacute;bec"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:327
+#: classes/class-wc-countries.php:327
+#@ woocommerce
 msgid "Saskatchewan"
 msgstr "Saskatchewan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:328
+#: classes/class-wc-countries.php:328
+#@ woocommerce
 msgid "Yukon Territory"
 msgstr "Yukon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:336
+#: classes/class-wc-countries.php:336
+#@ woocommerce
 msgid "Hong Kong Island"
-msgstr "Hong Kong Island"
+msgstr "&Icirc;le de Hong Kong"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:337
-msgid "Kowloong"
-msgstr "Kowloong"
+#: classes/class-wc-countries.php:337
+#@ woocommerce
+msgid "Kowloon"
+msgstr "Kowloon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:338
+#: classes/class-wc-countries.php:338
+#@ woocommerce
 msgid "New Territories"
 msgstr "Nouveaux Territoires"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:353
+#: classes/class-wc-countries.php:353
+#@ woocommerce
 msgid "Alabama"
 msgstr "Alabama"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:354
+#: classes/class-wc-countries.php:354
+#@ woocommerce
 msgid "Alaska"
 msgstr "Alaska"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:355
+#: classes/class-wc-countries.php:355
+#@ woocommerce
 msgid "Arizona"
 msgstr "Arizona"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:356
+#: classes/class-wc-countries.php:356
+#@ woocommerce
 msgid "Arkansas"
 msgstr "Arkansas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:357
+#: classes/class-wc-countries.php:357
+#@ woocommerce
 msgid "California"
-msgstr "California"
+msgstr "Californie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:358
+#: classes/class-wc-countries.php:358
+#@ woocommerce
 msgid "Colorado"
 msgstr "Colorado"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:359
+#: classes/class-wc-countries.php:359
+#@ woocommerce
 msgid "Connecticut"
 msgstr "Connecticut"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:360
+#: classes/class-wc-countries.php:360
+#@ woocommerce
 msgid "Delaware"
 msgstr "Delaware"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:361
+#: classes/class-wc-countries.php:361
+#@ woocommerce
 msgid "District Of Columbia"
-msgstr "District Of Columbia"
+msgstr "Washington (district de Columbia)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:362
+#: classes/class-wc-countries.php:362
+#@ woocommerce
 msgid "Florida"
-msgstr "Florida"
+msgstr "Floride"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:364
+#: classes/class-wc-countries.php:364
+#@ woocommerce
 msgid "Hawaii"
-msgstr "Hawaii"
+msgstr "Hawa&iuml;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:365
+#: classes/class-wc-countries.php:365
+#@ woocommerce
 msgid "Idaho"
 msgstr "Idaho"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:366
+#: classes/class-wc-countries.php:366
+#@ woocommerce
 msgid "Illinois"
 msgstr "Illinois"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:367
+#: classes/class-wc-countries.php:367
+#@ woocommerce
 msgid "Indiana"
 msgstr "Indiana"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:368
+#: classes/class-wc-countries.php:368
+#@ woocommerce
 msgid "Iowa"
 msgstr "Iowa"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:369
+#: classes/class-wc-countries.php:369
+#@ woocommerce
 msgid "Kansas"
 msgstr "Kansas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:370
+#: classes/class-wc-countries.php:370
+#@ woocommerce
 msgid "Kentucky"
 msgstr "Kentucky"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:371
+#: classes/class-wc-countries.php:371
+#@ woocommerce
 msgid "Louisiana"
-msgstr "Louisiana"
+msgstr "Louisiane"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:372
+#: classes/class-wc-countries.php:372
+#@ woocommerce
 msgid "Maine"
 msgstr "Maine"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:373
+#: classes/class-wc-countries.php:373
+#@ woocommerce
 msgid "Maryland"
 msgstr "Maryland"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:374
+#: classes/class-wc-countries.php:374
+#@ woocommerce
 msgid "Massachusetts"
 msgstr "Massachusetts"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:375
+#: classes/class-wc-countries.php:375
+#@ woocommerce
 msgid "Michigan"
 msgstr "Michigan"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:376
+#: classes/class-wc-countries.php:376
+#@ woocommerce
 msgid "Minnesota"
 msgstr "Minnesota"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:377
+#: classes/class-wc-countries.php:377
+#@ woocommerce
 msgid "Mississippi"
 msgstr "Mississippi"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:378
+#: classes/class-wc-countries.php:378
+#@ woocommerce
 msgid "Missouri"
 msgstr "Missouri"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:379
+#: classes/class-wc-countries.php:379
+#@ woocommerce
 msgid "Montana"
 msgstr "Montana"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:380
+#: classes/class-wc-countries.php:380
+#@ woocommerce
 msgid "Nebraska"
 msgstr "Nebraska"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:381
+#: classes/class-wc-countries.php:381
+#@ woocommerce
 msgid "Nevada"
 msgstr "Nevada"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:382
+#: classes/class-wc-countries.php:382
+#@ woocommerce
 msgid "New Hampshire"
 msgstr "New Hampshire"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:383
+#: classes/class-wc-countries.php:383
+#@ woocommerce
 msgid "New Jersey"
 msgstr "New Jersey"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:384
+#: classes/class-wc-countries.php:384
+#@ woocommerce
 msgid "New Mexico"
-msgstr "New Mexico"
+msgstr "Nouveau-Mexique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:385
+#: classes/class-wc-countries.php:385
+#@ woocommerce
 msgid "New York"
 msgstr "New York"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:386
+#: classes/class-wc-countries.php:386
+#@ woocommerce
 msgid "North Carolina"
-msgstr "North Carolina"
+msgstr "Caroline du Nord"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:387
+#: classes/class-wc-countries.php:387
+#@ woocommerce
 msgid "North Dakota"
-msgstr "North Dakota"
+msgstr "Dakota du Nord"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:388
+#: classes/class-wc-countries.php:388
+#@ woocommerce
 msgid "Ohio"
 msgstr "Ohio"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:389
+#: classes/class-wc-countries.php:389
+#@ woocommerce
 msgid "Oklahoma"
 msgstr "Oklahoma"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:390
+#: classes/class-wc-countries.php:390
+#@ woocommerce
 msgid "Oregon"
 msgstr "Oregon"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:391
+#: classes/class-wc-countries.php:391
+#@ woocommerce
 msgid "Pennsylvania"
-msgstr "Pennsylvania"
+msgstr "Pennsylvanie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:392
+#: classes/class-wc-countries.php:392
+#@ woocommerce
 msgid "Rhode Island"
 msgstr "Rhode Island"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:393
+#: classes/class-wc-countries.php:393
+#@ woocommerce
 msgid "South Carolina"
-msgstr "South Carolina"
+msgstr "Caroline du Sud"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:394
+#: classes/class-wc-countries.php:394
+#@ woocommerce
 msgid "South Dakota"
-msgstr "South Dakota"
+msgstr "Dakota du Sud"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:395
+#: classes/class-wc-countries.php:395
+#@ woocommerce
 msgid "Tennessee"
 msgstr "Tennessee"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:396
+#: classes/class-wc-countries.php:396
+#@ woocommerce
 msgid "Texas"
 msgstr "Texas"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:397
+#: classes/class-wc-countries.php:397
+#@ woocommerce
 msgid "Utah"
 msgstr "Utah"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:398
+#: classes/class-wc-countries.php:398
+#@ woocommerce
 msgid "Vermont"
 msgstr "Vermont"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:399
+#: classes/class-wc-countries.php:399
+#@ woocommerce
 msgid "Virginia"
-msgstr "Virginia"
+msgstr "Virginie"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:400
+#: classes/class-wc-countries.php:400
+#@ woocommerce
 msgid "Washington"
 msgstr "Washington"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:401
+#: classes/class-wc-countries.php:401
+#@ woocommerce
 msgid "West Virginia"
-msgstr "West Virginia"
+msgstr "Virginie-Occidentale"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:402
+#: classes/class-wc-countries.php:402
+#@ woocommerce
 msgid "Wisconsin"
 msgstr "Wisconsin"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:403
+#: classes/class-wc-countries.php:403
+#@ woocommerce
 msgid "Wyoming"
 msgstr "Wyoming"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:406
+#: classes/class-wc-countries.php:406
+#@ woocommerce
 msgid "Americas"
-msgstr "Americas"
+msgstr "Am&eacute;rique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:407
+#: classes/class-wc-countries.php:407
+#@ woocommerce
 msgid "Europe"
 msgstr "Europe"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:408
+#: classes/class-wc-countries.php:408
+#@ woocommerce
 msgid "Pacific"
-msgstr "Pacific"
+msgstr "Pacifique"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:459
+#: classes/class-wc-countries.php:459
+#@ woocommerce
 msgid "to the"
 msgstr "pour le"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:460
+#: classes/class-wc-countries.php:460
+#@ woocommerce
 msgid "to"
 msgstr "pour"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:467
+#: classes/class-wc-countries.php:467
+#@ woocommerce
 msgid "the"
 msgstr "le"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:473
+#: classes/class-wc-countries.php:473
+#@ woocommerce
 msgid "VAT"
 msgstr "TVA"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:479
+#: classes/class-wc-countries.php:479
+#@ woocommerce
 msgid "(incl. VAT)"
 msgstr "(avec TVA)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:479
+#: classes/class-wc-countries.php:479
+#@ woocommerce
 msgid "(incl. tax)"
-msgstr "(incluant la taxe)"
+msgstr "(avec taxe)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:485
+#: classes/class-wc-countries.php:485
+#@ woocommerce
 msgid "(ex. VAT)"
-msgstr "(hors TVA)"
+msgstr "(sans TVA)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:665
-#: ../classes/class-wc-countries.php:666
-#: ../classes/class-wc-countries.php:680
-#: ../classes/class-wc-countries.php:681
-#: ../classes/class-wc-countries.php:791
-#: ../classes/class-wc-countries.php:792
-#: ../classes/class-wc-countries.php:809
-#: ../classes/class-wc-countries.php:810
+#: classes/class-wc-countries.php:663
+#: classes/class-wc-countries.php:664
+#: classes/class-wc-countries.php:678
+#: classes/class-wc-countries.php:679
+#: classes/class-wc-countries.php:789
+#: classes/class-wc-countries.php:790
+#: classes/class-wc-countries.php:807
+#: classes/class-wc-countries.php:808
+#@ woocommerce
 msgid "Province"
 msgstr "Province"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:674
-#: ../classes/class-wc-countries.php:675
+#: classes/class-wc-countries.php:672
+#: classes/class-wc-countries.php:673
+#@ woocommerce
 msgid "Municipality"
-msgstr "Municipalité"
+msgstr "Municipalit&eacute;"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:718
-#: ../classes/class-wc-countries.php:719
+#: classes/class-wc-countries.php:716
+#: classes/class-wc-countries.php:717
+#@ woocommerce
 msgid "Town/District"
-msgstr "Ville / Quartier"
+msgstr "Ville/Quartier"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:722
-#: ../classes/class-wc-countries.php:723
+#: classes/class-wc-countries.php:720
+#: classes/class-wc-countries.php:721
+#@ woocommerce
 msgid "Region"
-msgstr "Région"
+msgstr "R&eacute;gion"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:815
-#: ../classes/class-wc-countries.php:816
+#: classes/class-wc-countries.php:813
+#: classes/class-wc-countries.php:814
+#@ woocommerce
 msgid "Zip"
-msgstr "Code postal"
+msgstr "ZIP"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:819
-#: ../classes/class-wc-countries.php:820
+#: classes/class-wc-countries.php:817
+#: classes/class-wc-countries.php:818
+#: templates/cart/shipping-calculator.php:50
+#@ woocommerce
 msgid "State"
-msgstr "Etat"
+msgstr "&Eacute;tat"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:829
-#: ../classes/class-wc-countries.php:830
+#: classes/class-wc-countries.php:827
+#: classes/class-wc-countries.php:828
+#@ woocommerce
 msgid "County"
-msgstr "Comté"
+msgstr "R&eacute;gion"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:856
-#: ../classes/class-wc-countries.php:857
-#: ../classes/class-wc-countries.php:927
+#: classes/class-wc-countries.php:854
+#: classes/class-wc-countries.php:855
+#: classes/class-wc-countries.php:925
+#: templates/cart/shipping-calculator.php:57
+#@ woocommerce
 msgid "Postcode/Zip"
-msgstr "Code Postal / Zip"
+msgstr "Code postal/ZIP"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:861
-#: ../classes/class-wc-countries.php:862
-#: ../classes/class-wc-countries.php:921
+#: classes/class-wc-countries.php:859
+#: classes/class-wc-countries.php:860
+#: classes/class-wc-countries.php:919
+#@ woocommerce
 msgid "Town/City"
 msgstr "Ville"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:891
+#: classes/class-wc-countries.php:889
+#@ woocommerce
 msgctxt "placeholder"
 msgid "First Name"
-msgstr "Prénom"
+msgstr "Pr&eacute;nom"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:897
+#: classes/class-wc-countries.php:895
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Last Name"
 msgstr "Nom"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:903
+#: classes/class-wc-countries.php:901
+#@ woocommerce
 msgid "Company Name"
-msgstr "Nom de l'entreprise"
+msgstr "Nom de l&rsquo;entreprise"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:904
+#: classes/class-wc-countries.php:902
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Company (optional)"
-msgstr "Société (optionnel)"
+msgstr "Soci&eacute;t&eacute; (optionnel)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:909
+#: classes/class-wc-countries.php:907
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Address"
 msgstr "Adresse"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:915
+#: classes/class-wc-countries.php:913
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Address 2 (optional)"
 msgstr "Adresse 2 (optionnel)"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:922
+#: classes/class-wc-countries.php:920
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Town/City"
 msgstr "Ville"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:928
+#: classes/class-wc-countries.php:926
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Postcode/Zip"
-msgstr "Code Postal"
+msgstr "Code postal/ZIP"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:936
+#: classes/class-wc-countries.php:934
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Country"
 msgstr "Pays"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:943
+#: classes/class-wc-countries.php:941
+#@ woocommerce
 msgctxt "placeholder"
 msgid "State/County"
-msgstr "Etat/Conté"
+msgstr "&Eacute;tat/R&eacute;gion"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:972
+#: classes/class-wc-countries.php:970
+#@ woocommerce
 msgid "Email Address"
-msgstr "Adresse email"
+msgstr "Adresse E-mail"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:973
+#: classes/class-wc-countries.php:971
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Email Address"
-msgstr "Adresse e-mail"
+msgstr "Adresse E-mail"
 
-# @ woocommerce
-#: ../classes/class-wc-countries.php:979
+#: classes/class-wc-countries.php:977
+#@ woocommerce
 msgctxt "placeholder"
 msgid "Phone"
-msgstr "Téléphone"
+msgstr "T&eacute;l&eacute;phone"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:120
+#: classes/class-wc-coupon.php:143
+#@ woocommerce
+msgid "Coupon usage limit has been reached."
+msgstr "La limite d&rsquo;utilisation du coupon a &eacute;t&eacute; atteinte."
+
+#: classes/class-wc-coupon.php:151
+#@ woocommerce
+msgid "This coupon has expired."
+msgstr "Ce code promo est expir&eacute;"
+
+#: classes/class-wc-coupon.php:159
+#, php-format
+#@ woocommerce
+msgid "The minimum spend for this coupon is %s."
+msgstr "Le minimum de commande pour utiliser ce code promo est de %s."
+
+#: classes/class-wc-email.php:120
+#@ woocommerce
 msgid "New Customer Order"
 msgstr "Nouvelle commande client"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:124
+#: classes/class-wc-email.php:124
 #, php-format
-msgid "[%s] New Customer Order (# %s)"
-msgstr "[%s] Nouvelle commande client (n&deg;%s)"
+#@ woocommerce
+msgid "[%s] New Customer Order (%s)"
+msgstr "[%s] Nouvelle commande client (%s)"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:159
+#: classes/class-wc-email.php:159
 #, php-format
+#@ woocommerce
 msgid "[%s] Order Received"
-msgstr "[%s] Commande reçue"
+msgstr "[%s] Commande re&ccedil;ue"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:191
+#: classes/class-wc-email.php:191
 #, php-format
+#@ woocommerce
 msgid "[%s] Order Complete/Download Links"
-msgstr "[%s] Commandefinalisée/Liens de téléchargement"
+msgstr "[%s] Commande termin&eacute;e/Liens de t&eacute;l&eacute;chargement"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:192
+#: classes/class-wc-email.php:192
+#@ woocommerce
 msgid "Order Complete/Download Links"
-msgstr "Commande finalisée/Liens de téléchargement"
+msgstr "Commande termin&eacute;e/Liens de t&eacute;l&eacute;chargement"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:194
+#: classes/class-wc-email.php:194
 #, php-format
+#@ woocommerce
 msgid "[%s] Order Complete"
-msgstr "[%s] Commande expédiée"
+msgstr "[%s] Commande termin&eacute;e"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:195
+#: classes/class-wc-email.php:195
+#@ woocommerce
 msgid "Order Complete"
-msgstr "Commande expédiée"
+msgstr "Commande termin&eacute;e"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:236
-#, fuzzy, php-format
+#: classes/class-wc-email.php:236
+#, php-format
+#@ woocommerce
 msgid "Your order on %s"
-msgstr "Votre commande"
+msgstr "Votre commande sur %s"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:237
-#, fuzzy, php-format
+#: classes/class-wc-email.php:237
+#, php-format
+#@ woocommerce
 msgid "[%s] Your order"
-msgstr "Votre commande"
+msgstr "[%s] Votre commande"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:239
-#, fuzzy, php-format
+#: classes/class-wc-email.php:239
+#, php-format
+#@ woocommerce
 msgid "Invoice for Order %s"
 msgstr "Facture de la commande n&deg;%s"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:240
+#: classes/class-wc-email.php:240
 #, php-format
+#@ woocommerce
 msgid "[%s] Pay for Order"
 msgstr "[%s] Payer la commande"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:283
+#: classes/class-wc-email.php:283
+#@ woocommerce
 msgid "A note has been added to your order"
-msgstr "Une note a été ajoutée à votre commande"
+msgstr "Un commentaire a &eacute;t&eacute; ajout&eacute; &agrave; votre commande"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:287
+#: classes/class-wc-email.php:287
 #, php-format
+#@ woocommerce
 msgid "[%s] A note has been added to your order"
-msgstr "[%s]  Une note a été ajoutée à votre commande"
+msgstr "[%s] Un commentaire a &eacute;t&eacute; ajout&eacute; &agrave; votre commande"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:319
+#: classes/class-wc-email.php:319
+#@ woocommerce
 msgid "Product low in stock"
-msgstr "Produit avec stock faible"
+msgstr "Produit en stock faible"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:326
-#: ../classes/class-wc-email.php:354
-#: ../classes/class-wc-email.php:395
+#: classes/class-wc-email.php:326
+#: classes/class-wc-email.php:354
+#: classes/class-wc-email.php:395
 #, php-format
+#@ woocommerce
 msgid "Product #%s - %s"
-msgstr "Produits #%s - %s"
+msgstr "Produits n&deg;%s - %s"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:328
+#: classes/class-wc-email.php:328
+#@ woocommerce
 msgid "is low in stock."
 msgstr "est en stock faible."
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:347
+#: classes/class-wc-email.php:347
+#@ woocommerce
 msgid "Product out of stock"
-msgstr "Produit non disponible"
+msgstr "Produit en rupture de stock"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:356
+#: classes/class-wc-email.php:356
+#@ woocommerce
 msgid "is out of stock."
-msgstr "n'est plus en stock"
+msgstr "est en rupture de stock."
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:388
+#: classes/class-wc-email.php:388
+#@ woocommerce
 msgid "Product Backorder"
-msgstr "Product Backorder"
+msgstr "Produits en reliquat"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:397
-#, fuzzy, php-format
-msgid "%s units of %s have been backordered in order #%s."
-msgstr "%s unités de n&deg;%s %s (%s) ont été restockés dans la commande n&deg;%s."
-
-# @ woocommerce
-#: ../classes/class-wc-email.php:418
-msgid "Note"
-msgstr "Note"
-
-# @ woocommerce
-#: ../classes/class-wc-email.php:429
-msgid "Order information"
-msgstr "Informations sur la commande"
-
-# @ woocommerce
-#: ../classes/class-wc-email.php:451
+#: classes/class-wc-email.php:397
 #, php-format
+#@ woocommerce
+msgid "%s units of %s have been backordered in order #%s."
+msgstr "%s unit&eacute;s de %s sont en reliquat sur la commande n&deg;%s."
+
+#: classes/class-wc-email.php:418
+#@ woocommerce
+msgid "Note"
+msgstr "Commentaire"
+
+#: classes/class-wc-email.php:429
+#@ woocommerce
+msgid "Order information"
+msgstr "Information sur la commande"
+
+#: classes/class-wc-email.php:451
+#, php-format
+#@ woocommerce
 msgid "Your account on %s"
 msgstr "Votre compte sur %s"
 
-# @ woocommerce
-#: ../classes/class-wc-email.php:452
+#: classes/class-wc-email.php:452
 #, php-format
+#@ woocommerce
 msgid "Welcome to %s"
-msgstr "Bienvenue à %s"
+msgstr "Bienvenue sur %s"
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:473
+#: classes/class-wc-order.php:481
 #, php-format
-msgid " <small>%svia %s</small>"
-msgstr " <small>%svia %s</small>"
+#@ woocommerce
+msgid "&nbsp;<small>%svia %s</small>"
+msgstr "&nbsp;<small>%s par %s</small>"
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:502
+#: classes/class-wc-order.php:520
+#@ woocommerce
 msgid "Cart Subtotal:"
-msgstr "Sous-Total du panier :"
+msgstr "Sous-total du panier&nbsp;:"
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:508
+#: classes/class-wc-order.php:526
+#@ woocommerce
 msgid "Shipping:"
-msgstr "Expédition :"
+msgstr "Livraison&nbsp;:"
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:530
+#: classes/class-wc-order.php:548
+#@ woocommerce
 msgid "Subtotal:"
-msgstr "Sous-Total :"
+msgstr "Sous-total&nbsp;:"
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:548
-#, fuzzy
+#: classes/class-wc-order.php:566
+#: templates/cart/totals.php:183
+#: templates/checkout/review-order.php:174
+#@ woocommerce
 msgctxt "Relating to tax"
 msgid "N/A"
 msgstr "N/A"
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:674
+#: classes/class-wc-order.php:692
 #, php-format
+#@ woocommerce
 msgid "Order status changed from %s to %s."
-msgstr "État de la commande modifié de %s à %s"
+msgstr "L&rsquo;&eacute;tat de la commande est pass&eacute; de %s &agrave; %s."
 
-# @ woocommerce
-#: ../classes/class-wc-order.php:802
+#: classes/class-wc-order.php:826
+#@ woocommerce
 msgid "Order item stock reduced successfully."
-msgstr "Stock d'éléments de la commande diminué avec succès"
+msgstr "Stock d&rsquo;article de la commande diminu&eacute; avec succ&egrave;s."
 
-# @ woocommerce
-#: ../classes/class-wc-product.php:449
-#, fuzzy, php-format
-msgid "Only %s left in stock"
-msgstr "est en stock faible."
-
-# @ woocommerce
-#: ../classes/class-wc-product.php:452
+#: classes/class-wc-product.php:453
 #, php-format
+#@ woocommerce
+msgid "Only %s left in stock"
+msgstr "Plus que %s en stock"
+
+#: classes/class-wc-product.php:456
+#, php-format
+#@ woocommerce
 msgid "%s in stock"
-msgstr ""
+msgstr "%s en stock"
 
-# @ woocommerce
-#: ../classes/class-wc-product.php:459
+#: classes/class-wc-product.php:463
+#@ woocommerce
 msgid "(backorders allowed)"
-msgstr ""
+msgstr "(reliquats autoris&eacute;s)"
 
-# @ woocommerce
-#: ../classes/class-wc-product.php:466
-#: ../classes/class-wc-product.php:479
+#: classes/class-wc-product.php:470
+#: classes/class-wc-product.php:483
+#: templates/cart/cart.php:58
+#@ woocommerce
 msgid "Available on backorder"
-msgstr "Disponible en backorder"
+msgstr "Disponible sur commande"
 
-# @ woocommerce
-#: ../classes/class-wc-product.php:700
+#: classes/class-wc-product.php:704
+#@ woocommerce
 msgctxt "min_price"
 msgid "From:"
-msgstr "A partir de :"
+msgstr "Du&nbsp;:"
 
-# @ woocommerce
-#: ../classes/class-wc-product.php:744
+#: classes/class-wc-product.php:748
+#: templates/single-product-reviews.php:29
 #, php-format
+#@ woocommerce
 msgid "Rated %s out of 5"
-msgstr "Note %s sur 5"
+msgstr "Not&eacute; %s sur 5"
 
-# @ woocommerce
-#: ../classes/class-wc-settings-api.php:42
+#: classes/class-wc-product.php:1076
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:165
+#: templates/single-product/meta.php:11
+#@ woocommerce
+msgid "SKU:"
+msgstr "UGS&nbsp;:"
+
+#: classes/class-wc-settings-api.php:44
+#@ woocommerce
 msgid "This function needs to be overridden by your payment gateway class."
-msgstr "Cette fonction doit être remplacée par votre classe de passerelle de paiement."
+msgstr "Cette fonction doit &ecirc;tre remplac&eacute;e par votre classe de passerelle de paiement."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:18
+#: classes/gateways/bacs/class-wc-bacs.php:18
+#: classes/gateways/class-wc-bacs.php:18
+#@ woocommerce
 msgid "Bacs"
-msgstr ""
+msgstr "Virement bancaire"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:50
-#: ../classes/gateways/class-wc-cheque.php:45
-#: ../classes/gateways/class-wc-paypal.php:100
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:299
+#: classes/gateways/bacs/class-wc-bacs.php:50
+#: classes/gateways/cheque/class-wc-cheque.php:45
+#: classes/gateways/class-wc-bacs.php:50
+#: classes/gateways/class-wc-cheque.php:45
+#: classes/gateways/class-wc-paypal.php:100
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:152
+#: classes/gateways/paypal/class-wc-paypal.php:100
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:299
+#: classes/shipping/class-wc-flat-rate.php:62
+#: classes/shipping/class-wc-free-shipping.php:47
+#: classes/shipping/class-wc-international-delivery.php:39
+#@ woocommerce
 msgid "Enable/Disable"
-msgstr "Activer/Désactiver"
+msgstr "Activer/D&eacute;sactiver"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:52
+#: classes/gateways/bacs/class-wc-bacs.php:52
+#: classes/gateways/class-wc-bacs.php:52
+#@ woocommerce
 msgid "Enable Bank Transfer"
-msgstr "Activer Virement Bancaire"
+msgstr "Activer le virement bancaire"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:56
-#: ../classes/gateways/class-wc-cheque.php:51
-#: ../classes/gateways/class-wc-cod.php:53
-#: ../classes/gateways/class-wc-paypal.php:106
+#: classes/gateways/bacs/class-wc-bacs.php:56
+#: classes/gateways/cheque/class-wc-cheque.php:51
+#: classes/gateways/class-wc-bacs.php:56
+#: classes/gateways/class-wc-cheque.php:51
+#: classes/gateways/class-wc-cod.php:53
+#: classes/gateways/class-wc-paypal.php:106
+#: classes/gateways/cod/class-wc-cod.php:53
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:164
+#: classes/gateways/paypal/class-wc-paypal.php:106
+#: classes/shipping/class-wc-local-delivery.php:79
+#: classes/shipping/class-wc-local-pickup.php:55
+#@ woocommerce
 msgid "Title"
 msgstr "Titre"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:58
-#: ../classes/gateways/class-wc-cheque.php:53
-#: ../classes/gateways/class-wc-paypal.php:108
+#: classes/gateways/bacs/class-wc-bacs.php:58
+#: classes/gateways/cheque/class-wc-cheque.php:53
+#: classes/gateways/class-wc-bacs.php:58
+#: classes/gateways/class-wc-cheque.php:53
+#: classes/gateways/class-wc-paypal.php:108
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:166
+#: classes/gateways/paypal/class-wc-paypal.php:108
+#: classes/shipping/class-wc-flat-rate.php:70
+#: classes/shipping/class-wc-free-shipping.php:55
+#: classes/shipping/class-wc-international-delivery.php:47
+#: classes/shipping/class-wc-local-delivery.php:81
+#: classes/shipping/class-wc-local-pickup.php:57
+#@ woocommerce
 msgid "This controls the title which the user sees during checkout."
-msgstr "Cela détermine le titre que les utilisateurs verront durant la commande."
+msgstr "Cela contr&ocirc;le le titre que les utilisateurs verront lors de la commande."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:59
+#: classes/gateways/bacs/class-wc-bacs.php:59
+#: classes/gateways/class-wc-bacs.php:59
+#@ woocommerce
 msgid "Direct Bank Transfer"
-msgstr "Virement Bancaire Direct"
+msgstr "Virement bancaire"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:62
-#: ../classes/gateways/class-wc-cheque.php:57
+#: classes/gateways/bacs/class-wc-bacs.php:62
+#: classes/gateways/cheque/class-wc-cheque.php:57
+#: classes/gateways/class-wc-bacs.php:62
+#: classes/gateways/class-wc-cheque.php:57
+#@ woocommerce
 msgid "Customer Message"
-msgstr "Message Client"
+msgstr "Message au client"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:64
+#: classes/gateways/bacs/class-wc-bacs.php:64
+#: classes/gateways/class-wc-bacs.php:64
+#@ woocommerce
 msgid "Give the customer instructions for paying via BACS, and let them know that their order won't be shipping until the money is received."
-msgstr "Donne au client les instructions pour régler via BACS, et l'informer que sa commande ne sera pas envoyée avant que le règlement ne soit reçu."
+msgstr "Donne au client les instructions pour payer par virement bancaire, et l&rsquo;informe que sa commande ne sera pas livr&eacute;e tant que l&rsquo;argent ne sera pas re&ccedil;u."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:65
+#: classes/gateways/bacs/class-wc-bacs.php:65
+#: classes/gateways/class-wc-bacs.php:65
+#@ woocommerce
 msgid "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order wont be shipped until the funds have cleared in our account."
-msgstr "Effectuez votre paiement directement avec votre compte bancaire. Utilisez votre ID de commande comme référence de paiement. Votre commande ne sera pas livrée avant le règlement de la commande."
+msgstr "Effectuez votre paiement directement depuis votre compte bancaire. Veuillez utiliser votre n&deg; de commande comme r&eacute;f&eacute;rence de paiement. Votre commande ne sera livr&eacute;e qu&rsquo;&agrave; r&eacute;ception des fonds sur notre compte."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:68
-#: ../classes/gateways/class-wc-bacs.php:141
-#: ../classes/gateways/class-wc-bacs.php:174
+#: classes/gateways/bacs/class-wc-bacs.php:68
+#: classes/gateways/bacs/class-wc-bacs.php:141
+#: classes/gateways/bacs/class-wc-bacs.php:174
+#: classes/gateways/class-wc-bacs.php:68
+#: classes/gateways/class-wc-bacs.php:141
+#: classes/gateways/class-wc-bacs.php:174
+#@ woocommerce
 msgid "Account Name"
-msgstr "Nom Compte"
+msgstr "Titulaire du compte"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:74
-#: ../classes/gateways/class-wc-bacs.php:142
-#: ../classes/gateways/class-wc-bacs.php:175
+#: classes/gateways/bacs/class-wc-bacs.php:74
+#: classes/gateways/bacs/class-wc-bacs.php:142
+#: classes/gateways/bacs/class-wc-bacs.php:175
+#: classes/gateways/class-wc-bacs.php:74
+#: classes/gateways/class-wc-bacs.php:142
+#: classes/gateways/class-wc-bacs.php:175
+#@ woocommerce
 msgid "Account Number"
-msgstr "Numéro Compte"
+msgstr "Num&eacute;ro du compte"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:80
-#: ../classes/gateways/class-wc-bacs.php:143
-#: ../classes/gateways/class-wc-bacs.php:176
+#: classes/gateways/bacs/class-wc-bacs.php:80
+#: classes/gateways/bacs/class-wc-bacs.php:143
+#: classes/gateways/bacs/class-wc-bacs.php:176
+#: classes/gateways/class-wc-bacs.php:80
+#: classes/gateways/class-wc-bacs.php:143
+#: classes/gateways/class-wc-bacs.php:176
+#@ woocommerce
 msgid "Sort Code"
-msgstr "Sort Code"
+msgstr "Code Banque/Guichet"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:86
-#: ../classes/gateways/class-wc-bacs.php:144
-#: ../classes/gateways/class-wc-bacs.php:177
+#: classes/gateways/bacs/class-wc-bacs.php:86
+#: classes/gateways/bacs/class-wc-bacs.php:144
+#: classes/gateways/bacs/class-wc-bacs.php:177
+#: classes/gateways/class-wc-bacs.php:86
+#: classes/gateways/class-wc-bacs.php:144
+#: classes/gateways/class-wc-bacs.php:177
+#@ woocommerce
 msgid "Bank Name"
-msgstr "Nom Banque"
+msgstr "Nom de la banque"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:92
-#: ../classes/gateways/class-wc-bacs.php:145
-#: ../classes/gateways/class-wc-bacs.php:178
+#: classes/gateways/bacs/class-wc-bacs.php:92
+#: classes/gateways/bacs/class-wc-bacs.php:145
+#: classes/gateways/bacs/class-wc-bacs.php:178
+#: classes/gateways/class-wc-bacs.php:92
+#: classes/gateways/class-wc-bacs.php:145
+#: classes/gateways/class-wc-bacs.php:178
+#@ woocommerce
 msgid "IBAN"
 msgstr "IBAN"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:94
-#: ../classes/gateways/class-wc-bacs.php:100
+#: classes/gateways/bacs/class-wc-bacs.php:94
+#: classes/gateways/bacs/class-wc-bacs.php:100
+#: classes/gateways/class-wc-bacs.php:94
+#: classes/gateways/class-wc-bacs.php:100
+#@ woocommerce
 msgid "Your bank may require this for international payments"
-msgstr "Votre banque peut demander ceci pour les règlements internationaux"
+msgstr "Votre banque peut le demander pour les r&egrave;glements internationaux"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:98
+#: classes/gateways/bacs/class-wc-bacs.php:98
+#: classes/gateways/class-wc-bacs.php:98
+#@ woocommerce
 msgid "BIC (formerly Swift)"
 msgstr "BIC (anciennement Swift)"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:116
+#: classes/gateways/bacs/class-wc-bacs.php:116
+#: classes/gateways/class-wc-bacs.php:116
+#@ woocommerce
 msgid "BACS Payment"
-msgstr "Paiement BACS"
+msgstr "Paiement par virement bancaire"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:117
+#: classes/gateways/bacs/class-wc-bacs.php:117
+#: classes/gateways/class-wc-bacs.php:117
+#@ woocommerce
 msgid "Allows payments by BACS (Bank Account Clearing System), more commonly known as direct bank/wire transfer."
-msgstr "Autorise les paiement par BACS (Bank Account Clearing System), plus communément connu comme  banque/virement bancaire"
+msgstr "Autorise les paiements par virement bancaire, aussi appel&eacute;s BACS (Bank Account Clearing System)."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:138
-#: ../classes/gateways/class-wc-bacs.php:171
+#: classes/gateways/bacs/class-wc-bacs.php:138
+#: classes/gateways/bacs/class-wc-bacs.php:171
+#: classes/gateways/class-wc-bacs.php:138
+#: classes/gateways/class-wc-bacs.php:171
+#@ woocommerce
 msgid "Our Details"
-msgstr "Nos Détails"
+msgstr "Nos coordonn&eacute;es"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:146
-#: ../classes/gateways/class-wc-bacs.php:179
+#: classes/gateways/bacs/class-wc-bacs.php:146
+#: classes/gateways/bacs/class-wc-bacs.php:179
+#: classes/gateways/class-wc-bacs.php:146
+#: classes/gateways/class-wc-bacs.php:179
+#@ woocommerce
 msgid "BIC"
 msgstr "BIC"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-bacs.php:200
+#: classes/gateways/bacs/class-wc-bacs.php:200
+#: classes/gateways/class-wc-bacs.php:200
+#@ woocommerce
 msgid "Awaiting BACS payment"
-msgstr "En attente de paiement BACS"
+msgstr "En attente du virement bancaire"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:18
+#: classes/gateways/cheque/class-wc-cheque.php:18
+#: classes/gateways/class-wc-cheque.php:18
+#@ woocommerce
 msgid "Cheque"
-msgstr "Chèque"
+msgstr "Ch&egrave;que"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:47
+#: classes/gateways/cheque/class-wc-cheque.php:47
+#: classes/gateways/class-wc-cheque.php:47
+#@ woocommerce
 msgid "Enable Cheque Payment"
-msgstr "Activer Paiement Chèque"
+msgstr "Activer le paiement par ch&egrave;que"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:54
-#: ../classes/gateways/class-wc-cheque.php:75
+#: classes/gateways/cheque/class-wc-cheque.php:54
+#: classes/gateways/cheque/class-wc-cheque.php:75
+#: classes/gateways/class-wc-cheque.php:54
+#: classes/gateways/class-wc-cheque.php:75
+#@ woocommerce
 msgid "Cheque Payment"
-msgstr "Paiement Chèque"
+msgstr "Ch&egrave;que"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:59
+#: classes/gateways/cheque/class-wc-cheque.php:59
+#: classes/gateways/class-wc-cheque.php:59
+#@ woocommerce
 msgid "Let the customer know the payee and where they should be sending the cheque to and that their order won't be shipping until you receive it."
-msgstr "Faire savoir au client bénéficiaire et où ils devra envoyer le chèque à l'ordre et que leur port ne sera pas jusqu'à ce que vous recevez."
+msgstr "Donne au client les instructions pour payer par ch&egrave;que, et l&rsquo;informe que sa commande ne sera pas livr&eacute;e tant que le ch&egrave;que ne sera pas re&ccedil;u."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:60
+#: classes/gateways/cheque/class-wc-cheque.php:60
+#: classes/gateways/class-wc-cheque.php:60
+#@ woocommerce
 msgid "Please send your cheque to Store Name, Store Street, Store Town, Store State / County, Store Postcode."
-msgstr ""
+msgstr "Veuillez envoyer votre ch&egrave;que &agrave; Nom Boutique, Rue Boutique, Code Postal Boutique, Ville Boutique, Pays Boutique."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:76
+#: classes/gateways/cheque/class-wc-cheque.php:76
+#: classes/gateways/class-wc-cheque.php:76
+#@ woocommerce
 msgid "Allows cheque payments. Why would you take cheques in this day and age? Well you probably wouldn't but it does allow you to make test purchases for testing order emails and the 'success' pages etc."
-msgstr "Autorise les paiements par chèque.  Pourquoi voudriez-vous prendre des chèques? Et bien, vous ne l'utiliserez probablement pas, mais cela vous permet de faire des achats de test pour tester des emails ordre et le «succès» des pages etc"
+msgstr "Autoriser les paiements par ch&egrave;que. Pourquoi accepter les ch&egrave;ques &agrave; notre &eacute;poque&nbsp;? Peut-&ecirc;tre que vous ne l&rsquo;utiliserez pas, mais cela vous permet de passer des commandes test pour v&eacute;rifier les e-mails de commande, le bon fonctionnement des pages, etc."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cheque.php:116
+#: classes/gateways/cheque/class-wc-cheque.php:116
+#: classes/gateways/class-wc-cheque.php:116
+#@ woocommerce
 msgid "Awaiting cheque payment"
-msgstr "En attente règlement par chèque"
+msgstr "En attente du ch&egrave;que"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:16
-#: ../classes/gateways/class-wc-cod.php:36
-#: ../classes/gateways/class-wc-cod.php:56
+#: classes/gateways/class-wc-cod.php:16
+#: classes/gateways/class-wc-cod.php:36
+#: classes/gateways/class-wc-cod.php:56
+#: classes/gateways/cod/class-wc-cod.php:16
+#: classes/gateways/cod/class-wc-cod.php:36
+#: classes/gateways/cod/class-wc-cod.php:56
+#@ woocommerce
 msgid "Cash on Delivery"
-msgstr "Paiement à la livraison"
+msgstr "Paiement &agrave; la livraison"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:37
+#: classes/gateways/class-wc-cod.php:37
+#: classes/gateways/cod/class-wc-cod.php:37
+#@ woocommerce
 msgid "Have your customers pay with cash (or by other means) upon delivery."
-msgstr "Demandez à vos clients de payer en espèces (ou par tout autre moyen) à la livraison."
+msgstr "Permettre &agrave; vos clients de payer en esp&egrave;ces (ou par tout autre moyen) lors de la livraison."
 
-#  COD : Cash On Delivery
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:46
+#: classes/gateways/class-wc-cod.php:46
+#: classes/gateways/cod/class-wc-cod.php:46
+#@ woocommerce
 msgid "Enable COD"
-msgstr "Activer le Paiement à la Livraison"
+msgstr "Activer le paiement &agrave; la livraison"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:47
-#, fuzzy
+#: classes/gateways/class-wc-cod.php:47
+#: classes/gateways/cod/class-wc-cod.php:47
+#@ woocommerce
 msgid "Enable Cash on Delivery"
-msgstr "Paiement à la livraison"
+msgstr "Activer le paiement &agrave; la livraison"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:55
+#: classes/gateways/class-wc-cod.php:55
+#: classes/gateways/cod/class-wc-cod.php:55
+#@ woocommerce
 msgid "Payment method title that the customer will see on your website."
-msgstr "Titre de la méthode de paiement que le client verra sur votre site web."
+msgstr "Titre du mode de paiement que le client verra sur votre site web."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:59
-#: ../classes/gateways/class-wc-paypal.php:112
+#: classes/gateways/class-wc-cod.php:59
+#: classes/gateways/class-wc-paypal.php:112
+#: classes/gateways/cod/class-wc-cod.php:59
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:170
+#: classes/gateways/paypal/class-wc-paypal.php:112
+#: templates/single-product/tabs/tab-description.php:4
+#@ woocommerce
 msgid "Description"
 msgstr "Description"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:61
+#: classes/gateways/class-wc-cod.php:61
+#: classes/gateways/cod/class-wc-cod.php:61
+#@ woocommerce
 msgid "Payment method description that the customer will see on your website."
-msgstr "Description de la méthode de paiement que le client verra sur votre site web."
+msgstr "Description du mode de paiement que le client verra sur votre site web."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:65
+#: classes/gateways/class-wc-cod.php:65
+#: classes/gateways/cod/class-wc-cod.php:65
+#@ woocommerce
 msgid "Instructions"
 msgstr "Instructions"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:67
+#: classes/gateways/class-wc-cod.php:67
+#: classes/gateways/cod/class-wc-cod.php:67
+#@ woocommerce
 msgid "Instructions that will be added to the thank you page."
-msgstr "Instructions qui seront ajoutées à la page de remerciements."
+msgstr "Donne au client les instructions pour payer &agrave; la livraison."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-cod.php:84
+#: classes/gateways/class-wc-cod.php:84
+#: classes/gateways/cod/class-wc-cod.php:84
+#@ woocommerce
 msgid "Payment to be made upon delivery."
-msgstr "Paiement à effectuer à la livraison."
+msgstr "Paiement &agrave; effectuer lors de la livraison."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:22
+#: classes/gateways/class-wc-paypal.php:22
+#@ woocommerce
 msgid "Paypal"
-msgstr "Paypal"
+msgstr "PayPal"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:72
+#: classes/gateways/class-wc-paypal.php:72
+#: classes/gateways/paypal/class-wc-paypal.php:72
+#@ woocommerce
 msgid "PayPal standard"
 msgstr "PayPal standard"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:73
+#: classes/gateways/class-wc-paypal.php:73
+#: classes/gateways/paypal/class-wc-paypal.php:73
+#@ woocommerce
 msgid "PayPal standard works by sending the user to PayPal to enter their payment information."
-msgstr "PayPal standard fonctionne en envoyant l'utilisateur vers PayPal pour entrer ces informations de règlement."
+msgstr "PayPal standard fonctionne en envoyant l&rsquo;utilisateur sur PayPal pour saisir ses informations de paiement."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:84
+#: classes/gateways/class-wc-paypal.php:84
+#: classes/gateways/paypal/class-wc-paypal.php:84
+#@ woocommerce
 msgid "Gateway Disabled"
-msgstr "Passerelle désactivée"
+msgstr "Passerelle d&eacute;sactiv&eacute;e"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:84
+#: classes/gateways/class-wc-paypal.php:84
+#: classes/gateways/paypal/class-wc-paypal.php:84
+#@ woocommerce
 msgid "PayPal does not support your store currency."
-msgstr "PayPal ne gère pas la monnaie de votre boutique."
+msgstr "PayPal ne g&egrave;re pas la monnaie de votre boutique."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:102
+#: classes/gateways/class-wc-paypal.php:102
+#: classes/gateways/paypal/class-wc-paypal.php:102
+#@ woocommerce
 msgid "Enable PayPal standard"
 msgstr "Activer PayPal standard"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:109
+#: classes/gateways/class-wc-paypal.php:109
+#: classes/gateways/paypal/class-wc-paypal.php:22
+#: classes/gateways/paypal/class-wc-paypal.php:109
+#@ woocommerce
 msgid "PayPal"
 msgstr "PayPal"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:114
+#: classes/gateways/class-wc-paypal.php:114
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:173
+#: classes/gateways/paypal/class-wc-paypal.php:114
+#@ woocommerce
 msgid "This controls the description which the user sees during checkout."
-msgstr "Ceci contrôle la description que les utilisateurs verront durant le réglement."
+msgstr "Cela contr&ocirc;le la description que les utilisateurs verront lors de la commande."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:115
+#: classes/gateways/class-wc-paypal.php:115
+#: classes/gateways/paypal/class-wc-paypal.php:115
+#@ woocommerce
 msgid "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account"
-msgstr "Régler via PayPal, vous pouvez régler avec votre carte bancaire même si vous ne possédez pas de compte PayPal"
+msgstr "Payer par PayPal, vous pouvez payer avec votre carte bancaire m&ecirc;me si vous ne poss&eacute;dez pas de compte PayPal."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:118
+#: classes/gateways/class-wc-paypal.php:118
+#: classes/gateways/paypal/class-wc-paypal.php:118
+#@ woocommerce
 msgid "PayPal Email"
-msgstr "Email PayPal"
+msgstr "E-mail PayPal"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:120
+#: classes/gateways/class-wc-paypal.php:120
+#: classes/gateways/paypal/class-wc-paypal.php:120
+#@ woocommerce
 msgid "Please enter your PayPal email address; this is needed in order to take payment."
-msgstr "Entrez votre adresse email PayPal, svp, ceci est nécessaire dans la commande pour prendre le paiement."
+msgstr "Veuillez entrer votre adresse e-mail PayPal, c&rsquo;est n&eacute;cessaire pour recevoir le paiement."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:124
+#: classes/gateways/class-wc-paypal.php:124
+#: classes/gateways/paypal/class-wc-paypal.php:124
+#@ woocommerce
 msgid "Shipping details"
-msgstr "Détails Expédition"
+msgstr "Coordonn&eacute;es de livraison"
 
-#: ../classes/gateways/class-wc-paypal.php:126
+#: classes/gateways/class-wc-paypal.php:126
+#: classes/gateways/paypal/class-wc-paypal.php:126
+#@ woocommerce
 msgid "Send shipping details to PayPal instead of billing."
-msgstr ""
+msgstr "Envoyer les coordonn&eacute;es de livraison plut&ocirc;t que de facturation &agrave; PayPal."
 
-#: ../classes/gateways/class-wc-paypal.php:128
+#: classes/gateways/class-wc-paypal.php:128
+#: classes/gateways/paypal/class-wc-paypal.php:128
+#@ woocommerce
 msgid "PayPal allows us to send 1 address. If you are using PayPal for shipping labels you may prefer to send the shipping address rather than billing."
-msgstr ""
+msgstr "PayPal ne permet d&rsquo;envoyer qu&rsquo;une seule adresse. Si vous utilisez PayPal pour les &eacute;tiquettes de livraison, vous pr&eacute;f&eacute;rerez peut-&ecirc;tre envoyer l&rsquo;adresse de livraison plut&ocirc;t que de facturation."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:132
-#, fuzzy
+#: classes/gateways/class-wc-paypal.php:132
+#: classes/gateways/paypal/class-wc-paypal.php:132
+#@ woocommerce
 msgid "Address override"
-msgstr "Adresse 1"
+msgstr "Address override"
 
-#: ../classes/gateways/class-wc-paypal.php:134
+#: classes/gateways/class-wc-paypal.php:134
+#: classes/gateways/paypal/class-wc-paypal.php:134
+#@ woocommerce
 msgid "Enable \"address_override\" to prevent address information from being changed."
-msgstr ""
+msgstr "Activer \"address_override\" pour &eacute;viter que les informations d&rsquo;adresse ne soit modifi&eacute;es."
 
-#: ../classes/gateways/class-wc-paypal.php:135
+#: classes/gateways/class-wc-paypal.php:135
+#: classes/gateways/paypal/class-wc-paypal.php:135
+#@ woocommerce
 msgid "PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled)."
-msgstr ""
+msgstr "PayPal v&eacute;rifie les adresses donc ce param&egrave;tre peut causer des erreurs (nous recommandons de le laisser d&eacute;sactiv&eacute;)."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:139
-#, fuzzy
+#: classes/gateways/class-wc-paypal.php:139
+#: classes/gateways/paypal/class-wc-paypal.php:139
+#@ woocommerce
 msgid "Submission method"
-msgstr "Méthode d'expédition..."
+msgstr "Mode de transmission"
 
-#: ../classes/gateways/class-wc-paypal.php:141
+#: classes/gateways/class-wc-paypal.php:141
+#: classes/gateways/paypal/class-wc-paypal.php:141
+#@ woocommerce
 msgid "Use form submission method."
-msgstr ""
+msgstr "Utilisez la m&eacute;thode de transmission par formulaire."
 
-#: ../classes/gateways/class-wc-paypal.php:142
+#: classes/gateways/class-wc-paypal.php:142
+#: classes/gateways/paypal/class-wc-paypal.php:142
+#@ woocommerce
 msgid "Enable this to post order data to PayPal via a form instead of using a redirect/querystring."
-msgstr ""
+msgstr "Activer cette option pour transmettre les informations de commande &agrave; PayPal par un formulaire plut&ocirc;t que par une redirection/querystring."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:146
-#, fuzzy
+#: classes/gateways/class-wc-paypal.php:146
+#: classes/gateways/paypal/class-wc-paypal.php:146
+#@ woocommerce
 msgid "Page Style"
-msgstr "Paramètres des pages"
+msgstr "Style de page"
 
-#: ../classes/gateways/class-wc-paypal.php:148
+#: classes/gateways/class-wc-paypal.php:148
+#: classes/gateways/paypal/class-wc-paypal.php:148
+#@ woocommerce
 msgid "Optionally enter the name of the page style you wish to use. These are defined within your PayPal account."
-msgstr ""
+msgstr "Entrez &eacute;ventuellement le nom du style de page que vous souhaitez utiliser. Ceux-ci sont d&eacute;finis dans votre compte PayPal."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:152
+#: classes/gateways/class-wc-paypal.php:152
+#: classes/gateways/paypal/class-wc-paypal.php:152
+#@ woocommerce
 msgid "PayPal sandbox"
 msgstr "PayPal sandbox"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:154
+#: classes/gateways/class-wc-paypal.php:154
+#: classes/gateways/paypal/class-wc-paypal.php:154
+#@ woocommerce
 msgid "Enable PayPal sandbox"
 msgstr "Activer PayPal sandbox"
 
-#: ../classes/gateways/class-wc-paypal.php:156
+#: classes/gateways/class-wc-paypal.php:156
+#: classes/gateways/paypal/class-wc-paypal.php:156
 #, php-format
+#@ woocommerce
 msgid "PayPal sandbox can be used to test payments. Sign up for a developer account <a href=\"%s\">here</a>."
-msgstr ""
+msgstr "PayPal sandbox peut &ecirc;tre utilis&eacute; pour tester les paiements. Inscrivez-vous <a href=\"%s\">ici</a> pour ouvrir un compte d&eacute;veloppeur."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:159
+#: classes/gateways/class-wc-paypal.php:159
+#: classes/gateways/paypal/class-wc-paypal.php:159
+#@ woocommerce
 msgid "Debug Log"
-msgstr "Log Débug"
+msgstr "Consigne de d&eacute;bogage"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:161
+#: classes/gateways/class-wc-paypal.php:161
+#: classes/gateways/paypal/class-wc-paypal.php:161
+#@ woocommerce
 msgid "Enable logging"
-msgstr "Activer le log"
+msgstr "Activer la consigne"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:163
-#, fuzzy
+#: classes/gateways/class-wc-paypal.php:163
+#: classes/gateways/paypal/class-wc-paypal.php:163
+#@ default
 msgid "Log PayPal events, such as IPN requests, inside <code>woocommerce/logs/paypal.txt</code>"
-msgstr "Activer les logs (<code>woocommerce/logs/paypal.txt</code>)"
+msgstr "Consigner les &eacute;venements PayPal, comme les requ&ecirc;tes IPN, dans <code>woocommerce/logs/paypal.txt</code>"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:275
-#, php-format
-msgid "Order %s"
-msgstr "Commande %s"
-
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:320
+#: classes/gateways/class-wc-paypal.php:320
+#: classes/gateways/paypal/class-wc-paypal.php:320
+#@ woocommerce
 msgid "Shipping via"
 msgstr "Livraison par"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:356
+#: classes/gateways/class-wc-paypal.php:356
+#: classes/gateways/paypal/class-wc-paypal.php:356
+#@ woocommerce
 msgid "Thank you for your order. We are now redirecting you to PayPal to make payment."
-msgstr "Merci de votre commande. Nous allons maintenant vous rediriger vers PayPal pour effectuer votre paiement."
+msgstr "Merci pour votre commande. Nous allons maintenant vous rediriger vers PayPal pour effectuer le paiement."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:377
+#: classes/gateways/class-wc-paypal.php:377
+#: classes/gateways/paypal/class-wc-paypal.php:377
+#@ woocommerce
 msgid "Pay via PayPal"
-msgstr "Régler via PayPal"
+msgstr "Payer par PayPal"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:377
+#: classes/gateways/class-wc-paypal.php:377
+#: classes/gateways/paypal/class-wc-paypal.php:377
+#@ woocommerce
 msgid "Cancel order &amp; restore cart"
 msgstr "Annuler la commande et restaurer le panier"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:422
+#: classes/gateways/class-wc-paypal.php:422
+#: classes/gateways/paypal/class-wc-paypal.php:422
+#@ woocommerce
 msgid "Thank you for your order, please click the button below to pay with PayPal."
-msgstr "Merci de votre commande, cliquez sur le bouton ci-dessous pour régler via PayPal, svp."
+msgstr "Merci pour votre commande, veuillez cliquer sur le bouton ci-dessous pour payer par PayPal."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:553
+#: classes/gateways/class-wc-paypal.php:558
+#: classes/gateways/paypal/class-wc-paypal.php:558
+#@ woocommerce
 msgid "IPN payment completed"
-msgstr "Paiement IPN complété"
+msgstr "Paiement IPN termin&eacute;"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:564
-#: ../classes/gateways/class-wc-paypal.php:572
-#: ../classes/gateways/class-wc-paypal.php:589
+#: classes/gateways/class-wc-paypal.php:569
+#: classes/gateways/class-wc-paypal.php:577
+#: classes/gateways/class-wc-paypal.php:594
+#: classes/gateways/paypal/class-wc-paypal.php:569
+#: classes/gateways/paypal/class-wc-paypal.php:577
+#: classes/gateways/paypal/class-wc-paypal.php:594
 #, php-format
+#@ woocommerce
 msgid "Payment %s via IPN."
-msgstr "Paiement %s via IPN"
+msgstr "Paiement %s par IPN."
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:575
-#: ../classes/gateways/class-wc-paypal.php:592
+#: classes/gateways/class-wc-paypal.php:580
+#: classes/gateways/class-wc-paypal.php:597
+#: classes/gateways/paypal/class-wc-paypal.php:580
+#: classes/gateways/paypal/class-wc-paypal.php:597
+#@ woocommerce
 msgid "Order refunded/reversed"
-msgstr "Commande recréditée/remboursée"
+msgstr "Commande recr&eacute;dit&eacute;e/rembours&eacute;e"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:576
-#: ../classes/gateways/class-wc-paypal.php:593
-#, fuzzy, php-format
+#: classes/gateways/class-wc-paypal.php:581
+#: classes/gateways/class-wc-paypal.php:598
+#: classes/gateways/paypal/class-wc-paypal.php:581
+#: classes/gateways/paypal/class-wc-paypal.php:598
+#, php-format
+#@ woocommerce
 msgid "Order %s has been marked as refunded - PayPal reason code: %s"
-msgstr "La commande n&deg;%s a été indiquée comme recrédité - Code explicatif PayPal : %s"
+msgstr "La commande n&deg;%s a &eacute;t&eacute; marqu&eacute;e comme recr&eacute;dit&eacute;e - Code explicatif PayPal&nbsp;: %s"
 
-# @ woocommerce
-#: ../classes/gateways/class-wc-paypal.php:580
-#: ../classes/gateways/class-wc-paypal.php:597
-#, fuzzy, php-format
+#: classes/gateways/class-wc-paypal.php:585
+#: classes/gateways/class-wc-paypal.php:602
+#: classes/gateways/paypal/class-wc-paypal.php:585
+#: classes/gateways/paypal/class-wc-paypal.php:602
+#, php-format
+#@ woocommerce
 msgid "Payment for order %s refunded/reversed"
-msgstr "Paiement pour la commande n&deg;%s recréditée/remboursée"
+msgstr "Paiement de la commande n&deg;%s recr&eacute;dit&eacute;/rembours&eacute;"
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:16
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:26
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:180
+#@ woocommerce
+msgid "Mijireh Checkout"
+msgstr "Mijireh Checkout"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:138
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:291
+#@ woocommerce
+msgid "Mijireh error:"
+msgstr "Erreur Mijireh&nbsp;:"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:154
+#@ woocommerce
+msgid "Enable Mijireh Checkout"
+msgstr "Activer Mijireh Checkout"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:158
+#@ woocommerce
+msgid "Access Key"
+msgstr "Clef d&rsquo;acc&egrave;s"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:160
+#@ woocommerce
+msgid "The Mijireh access key for your store."
+msgstr "La clef d&rsquo;acc&egrave;s Mijireh de votre boutique."
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:167
+#@ woocommerce
+msgid "Credit Card"
+msgstr "Carte bancaire"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:172
+#@ woocommerce
+msgid "Pay securely with you credit card."
+msgstr "Payer avec votre carte bancaire en toute s&eacute;curit&eacute;."
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:184
+#@ woocommerce
+msgid "Get started with Mijireh Checkout"
+msgstr "Commencer avec Mijireh Checkout"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:185
+#@ woocommerce
+msgid "provides a fully PCI Compliant, secure way to collect and transmit credit card data to your payment gateway while keeping you in control of the design of your site. Mijireh supports a wide variety of payment gateways: Stripe, Authorize.net, PayPal, eWay, SagePay, Braintree, PayLeap, and more."
+msgstr "est enti&egrave;rement conforme avec les normes PCI et offre un moyen s&eacute;curis&eacute;e pour collecter et transmettre les informations sensibles des cartes bancaires &agrave; vos passerelles de paiement tout en restant dans le design de votre site. Mijireh supporte une large gamme de passerelles de paiement&nbsp;: Stripe, Authorize.net, PayPal, eWay, SagePay, Braintree, PayLeap, etc."
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:187
+#@ woocommerce
+msgid "Join for free"
+msgstr "Inscrivez-vous gratuitement"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:187
+#@ woocommerce
+msgid "Learn more about WooCommerce and Mijireh"
+msgstr "En savoir plus sur WooCommerce et Mijireh"
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:191
+#@ woocommerce
+msgid "provides a fully PCI Compliant, secure way to collect and transmit credit card data to your payment gateway while keeping you in control of the design of your site."
+msgstr "est enti&egrave;rement conforme avec les normes PCI et offre un moyen s&eacute;curis&eacute;e pour collecter et transmettre les informations sensibles des cartes bancaires &agrave; vos passerelles de paiement tout en restant dans le design de votre site."
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:16
+#@ woocommerce
 msgid "Google Analytics"
 msgstr "Google Analytics"
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:17
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:17
+#@ woocommerce
 msgid "Google Analytics is a free service offered by Google that generates detailed statistics about the visitors to a website."
-msgstr "Google Analytics est un service gratuit offert par Google qui génère des statistiques détaillées sur les visiteurs d'un site."
+msgstr "Google Analytics est un service gratuit offert par Google qui g&eacute;n&egrave;re des statistiques d&eacute;taill&eacute;es sur les visiteurs d&rsquo;un site."
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:45
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:45
+#@ woocommerce
 msgid "Google Analytics ID"
-msgstr "Google Analytics ID"
+msgstr "ID Google Analytics"
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:46
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:46
+#@ woocommerce
 msgid "Log into your google analytics account to find your ID. e.g. <code>UA-XXXXX-X</code>"
-msgstr "Connectez vous à votre compte Google analytics pour trouver votre ID. Ex :  <code>UA-XXXXX-X</code>"
+msgstr "Connectez-vous &agrave; votre compte Google Analytics pour trouver votre ID <code>UA-XXXXX-X</code>"
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:51
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:51
+#@ woocommerce
 msgid "Tracking code"
 msgstr "Code de suivi"
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:52
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:52
+#@ woocommerce
 msgid "Add tracking code to your site's footer. You don't need to enable this if using a 3rd party analytics plugin."
-msgstr "Ajouter le code de suivi dans le pied de page du site. Vous n'avez pas besoin de l'activer si vous vous servez d'un outil tierce de statistiques."
+msgstr "Ajouter le code de suivi dans le pied de page de votre site. Vous n&rsquo;avez pas besoin de l&rsquo;activer si vous utilisez une extention de statistiques tierce."
 
-# @ woocommerce
-#: ../classes/integrations/google-analytics/class-wc-google-analytics.php:58
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:58
+#@ woocommerce
 msgid "Add eCommerce tracking code to the thankyou page"
-msgstr "Ajouter le code de suivi eCommerce à votre page de remerciements."
+msgstr "Ajouter le code de suivi eCommerce &agrave; votre page de remerciements."
 
-# @ woocommerce
-#: ../classes/integrations/sharedaddy/class-wc-sharedaddy.php:16
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:16
+#@ woocommerce
 msgid "ShareDaddy"
 msgstr "ShareDaddy"
 
-# @ woocommerce
-#: ../classes/integrations/sharedaddy/class-wc-sharedaddy.php:17
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:17
+#@ woocommerce
 msgid "ShareDaddy is a sharing plugin bundled with JetPack."
-msgstr ""
+msgstr "ShareDaddy est une extension de partage livr&eacute;e avec JetPack."
 
-# @ woocommerce
-#: ../classes/integrations/sharedaddy/class-wc-sharedaddy.php:42
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:42
+#@ woocommerce
 msgid "Output ShareDaddy button?"
-msgstr ""
+msgstr "Bouton ShareDaddy&nbsp;?"
 
-# @ woocommerce
-#: ../classes/integrations/sharedaddy/class-wc-sharedaddy.php:43
-#, fuzzy
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:43
+#@ woocommerce
 msgid "Enable this option to show the ShareDaddy button on the product page."
-msgstr "Activer cette option pour mettre en avant ce produit"
+msgstr "Activer cette option pour afficher le bouton ShareDaddy sur la page produit."
 
-# @ woocommerce
-#: ../classes/integrations/sharethis/class-wc-sharethis.php:18
+#: classes/integrations/sharethis/class-wc-sharethis.php:18
+#@ woocommerce
 msgid "ShareThis"
 msgstr "ShareThis"
 
-# @ woocommerce
-#: ../classes/integrations/sharethis/class-wc-sharethis.php:19
+#: classes/integrations/sharethis/class-wc-sharethis.php:19
+#@ woocommerce
 msgid "ShareThis offers a sharing widget which will allow customers to share links to products with their friends."
-msgstr "ShareThis propose un widget de partage qui permet aux clients de partager les liens des produits avec leurs amis."
+msgstr "ShareThis propose un widget de partage qui permet aux clients de partager des liens vers les produits avec leurs amis."
 
-# @ woocommerce
-#: ../classes/integrations/sharethis/class-wc-sharethis.php:52
+#: classes/integrations/sharethis/class-wc-sharethis.php:52
+#@ woocommerce
 msgid "ShareThis Publisher ID"
-msgstr "ID Editeur ShareThis"
+msgstr "ID ShareThis"
 
-# @ woocommerce
-#: ../classes/integrations/sharethis/class-wc-sharethis.php:53
+#: classes/integrations/sharethis/class-wc-sharethis.php:53
 #, php-format
+#@ woocommerce
 msgid "Enter your %1$sShareThis publisher ID%2$s to show social sharing buttons on product pages."
-msgstr "Entrez votre %1$sID Editeur ShareThis%2$s pour afficher les boutons de partage social sur les pages produit."
+msgstr "Entrez votre %1$sID ShareThis%2$s pour afficher les boutons de partage social sur les pages produit."
 
-# @ woocommerce
-#: ../classes/integrations/sharethis/class-wc-sharethis.php:58
+#: classes/integrations/sharethis/class-wc-sharethis.php:58
+#@ woocommerce
 msgid "ShareThis Code"
 msgstr "Code ShareThis"
 
-#: ../classes/integrations/sharethis/class-wc-sharethis.php:59
+#: classes/integrations/sharethis/class-wc-sharethis.php:59
+#@ woocommerce
 msgid "You can tweak the ShareThis code by editing this option."
-msgstr ""
+msgstr "Vous pouvez personnaliser le code de ShareThis en modifiant cette option."
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:19
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:19
+#@ woocommerce
 msgid "ShareYourCart"
 msgstr "ShareYourCart"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:20
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:20
 #, php-format
+#@ woocommerce
 msgid "Increase your social media exposure by 10 percent! ShareYourCart helps you get more customers by motivating satisfied customers to talk with their friends about your products. For help with ShareYourCart view the <a href=\"%s\">documentation</a>."
-msgstr ""
+msgstr "Augmentez votre exposition aux m&eacute;dias sociaux de 10 pour cent&nbsp;! ShareYourCart vous aide &agrave; obtenir plus de clients en motivant les clients satisfaits &agrave; parler de vos produit &agrave; leurs amis. Pour obtenir de l&rsquo;aide sur ShareYourCart, consultez la <a href=\"%s\">documentation</a>."
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:113
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:152
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:113
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:152
+#@ woocommerce
 msgid "Please complete all fields."
-msgstr ""
+msgstr "Veuillez remplir tous les champs."
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:192
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:192
+#@ woocommerce
 msgid "Create a ShareYourCart account"
-msgstr "Créer un Compte?"
+msgstr "Cr&eacute;er un compte ShareYourCart"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:195
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:218
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:195
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:218
+#@ woocommerce
 msgid "Domain"
-msgstr "Dominica"
+msgstr "Domaine"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:204
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:204
 #, php-format
+#@ woocommerce
 msgid "I agree to the <a href=\"%s\">ShareYourCart terms and conditions</a>"
-msgstr ""
+msgstr "J&rsquo;accepte les <a href=\"%s\">conditions d&rsquo;utilisation de ShareYourCart</a>"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:207
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:207
+#@ woocommerce
 msgid "Create Account"
-msgstr "Créer un Compte?"
+msgstr "Cr&eacute;er un compte"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:215
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:215
+#@ woocommerce
 msgid "Recover your ShareYourCart account"
-msgstr ""
+msgstr "R&eacute;cup&eacute;rer votre compte ShareYourCart"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:226
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:226
+#@ woocommerce
 msgid "Email me my details"
-msgstr "Options d'email de l'expéditeur"
+msgstr "Envoyez-moi mes coordonn&eacute;es par e-mail"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:234
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:234
+#@ woocommerce
 msgid "Setup your ShareYourCart account"
-msgstr ""
+msgstr "Configurer votre compte ShareYourCart"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:236
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:236
+#@ woocommerce
 msgid "Create an account"
-msgstr "Créer un compte"
+msgstr "Cr&eacute;er un compte"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:236
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:236
+#@ woocommerce
 msgid "Can't access your account?"
-msgstr "Créer un Compte?"
+msgstr "Impossible d&rsquo;acc&eacute;der &agrave; votre compte&nbsp;?"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:251
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:251
+#@ woocommerce
 msgid "Configure ShareYourCart"
 msgstr "Configurer ShareYourCart"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:253
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:253
+#@ woocommerce
 msgid "You can choose how much of a discount to give (in fixed amount, percentage, or free shipping) and to which social media channels it should it be applied. You can also define what the advertisement should say, so that it fully benefits your sales."
-msgstr ""
+msgstr "Vous pouvez fixer le montant de la r&eacute;duction &agrave; donner (montant fixe, pourcentage, ou livraison gratuite) et sur quel r&eacute;seaux sociaux l&rsquo;appliquer. Vous pouvez &eacute;galement choisir le contenu de la publicit&eacute;, une fa&ccedil;on d&rsquo;augmenter encore vos ventes."
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:254
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:254
+#@ woocommerce
 msgid "Configure"
-msgstr "Configurer&nbsp;les&nbsp;termes"
+msgstr "Configurer"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:300
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:300
+#@ woocommerce
 msgid "Enable ShareYourCart integration"
-msgstr ""
+msgstr "Int&eacute;grer ShareYourCart"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:305
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:305
+#@ woocommerce
 msgid "Client ID"
 msgstr "ID Client"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:306
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:306
+#@ woocommerce
 msgid "Get your client ID by creating a ShareYourCart account."
-msgstr ""
+msgstr "Obtenez votre ID client en cr&eacute;ant un compte ShareYourCart."
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:312
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:312
+#@ woocommerce
 msgid "App Key"
-msgstr "App Key"
+msgstr "Cl&eacute;"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:313
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:313
+#@ woocommerce
 msgid "Get your app key by creating a ShareYourCart account."
-msgstr ""
+msgstr "Obtenez votre cl&eacute; en cr&eacute;ant un compte ShareYourCart."
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:319
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:319
+#@ woocommerce
 msgid "Email address"
-msgstr "Adresse email"
+msgstr "Adresse e-mail"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:320
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:320
+#@ woocommerce
 msgid "The email address you used to sign up for ShareYourCart."
-msgstr ""
+msgstr "L&rsquo;adresse e-mail que vous avez utilis&eacute; pour vous inscrire sur ShareYourCart."
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:326
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:326
+#@ woocommerce
 msgid "Show button by default on:"
-msgstr ""
+msgstr "Afficher le bouton par d&eacute;faut sur&nbsp;:"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:327
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:327
+#@ woocommerce
 msgid "Product page"
-msgstr "Mots-Clés"
+msgstr "Page produit"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:332
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:332
+#@ woocommerce
 msgid "Cart page"
-msgstr "Page Panier"
+msgstr "Page panier"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:337
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:337
+#@ woocommerce
 msgid "Button style"
-msgstr "Type de Code Promo"
+msgstr "Style de bouton"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:338
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:338
+#@ woocommerce
 msgid "Select a style for your share buttons"
-msgstr ""
+msgstr "Choisissez un style pour votre bouton de partage"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:342
-#, fuzzy
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:342
+#@ woocommerce
 msgid "Standard Button"
-msgstr "Taux standard"
+msgstr "Bouton standard"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:343
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:343
+#@ woocommerce
 msgid "Custom HTML"
-msgstr "HTML personnalisé"
+msgstr "Bouton HTML"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:347
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:347
+#@ woocommerce
 msgid "Button skin"
-msgstr ""
+msgstr "Mod&egrave;le de bouton"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:348
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:348
+#@ woocommerce
 msgid "Select a skin for your share buttons"
-msgstr ""
+msgstr "Choisissez un mod&egrave;le pour votre bouton de partage"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:352
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:352
+#@ woocommerce
 msgid "Orange"
 msgstr "Orange"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:353
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:353
+#@ woocommerce
 msgid "Blue"
 msgstr "Bleu"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:354
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:354
+#@ woocommerce
 msgid "Light"
-msgstr "Light"
+msgstr "Clair"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:355
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:355
+#@ woocommerce
 msgid "Dark"
-msgstr "Dark"
+msgstr "Fonc&eacute;"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:360
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:360
+#@ woocommerce
 msgid "Button position"
 msgstr "Position du bouton"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:361
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:361
+#@ woocommerce
 msgid "Where should the button be positioned?"
-msgstr ""
+msgstr "Ou doit-&ecirc;tre positionn&eacute; le bouton&nbsp;?"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:365
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:365
+#@ woocommerce
 msgid "Normal"
 msgstr "Normal"
 
-# @ woocommerce
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:366
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:366
+#@ woocommerce
 msgid "Floating"
-msgstr ""
+msgstr "Flotant"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:371
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:371
+#@ woocommerce
 msgid "HTML for the button"
-msgstr ""
+msgstr "Code HTML du bouton"
 
-#: ../classes/integrations/shareyourcart/class-wc-shareyourcart.php:372
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:372
+#@ woocommerce
 msgid "Enter the HTML code for your custom button."
-msgstr ""
+msgstr "Entrez le code HTML de votre bouton personnalis&eacute;."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:16
+#: classes/shipping/class-wc-flat-rate.php:15
+#@ woocommerce
 msgid "Flat rate"
-msgstr "Taux Fixe"
+msgstr "Taux fixe"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:19
-#: ../classes/shipping/class-wc-flat-rate.php:360
+#: classes/shipping/class-wc-flat-rate.php:18
+#: classes/shipping/class-wc-flat-rate.php:353
+#@ woocommerce
 msgid "Flat Rates"
-msgstr "Taux Fixes"
+msgstr "Taux fixes"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:20
+#: classes/shipping/class-wc-flat-rate.php:19
+#@ woocommerce
 msgid "Flat rates let you define a standard rate per item, or per order."
-msgstr "Les taux fixes vous laissent définir un taux standard par élément, ou par commande."
+msgstr "Les taux fixes permettent de d&eacute;finir un taux standard par article, ou par commande."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:65
+#: classes/shipping/class-wc-flat-rate.php:64
+#: classes/shipping/class-wc-international-delivery.php:41
+#@ woocommerce
 msgid "Enable this shipping method"
-msgstr "Activer la méthode de livraison"
+msgstr "Activer le mode de livraison"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:69
+#: classes/shipping/class-wc-flat-rate.php:68
+#: classes/shipping/class-wc-free-shipping.php:53
+#: classes/shipping/class-wc-international-delivery.php:45
+#@ woocommerce
 msgid "Method Title"
-msgstr "Titre de la méthode"
+msgstr "Titre du mode"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:72
+#: classes/shipping/class-wc-flat-rate.php:71
+#@ woocommerce
 msgid "Flat Rate"
-msgstr "Taux Fixe"
+msgstr "Taux fixe"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:75
+#: classes/shipping/class-wc-flat-rate.php:74
+#@ woocommerce
+msgid "Cost per order"
+msgstr "Tarif par commande"
+
+#: classes/shipping/class-wc-flat-rate.php:76
+#@ woocommerce
+msgid "Enter a cost per order, e.g. 5.00. Leave blank to disable."
+msgstr "Entrez un tarif par commande (ex.: 5.00). Laissez vide pour d&eacute;sactiver."
+
+#: classes/shipping/class-wc-flat-rate.php:80
+#: classes/shipping/class-wc-free-shipping.php:72
+#: classes/shipping/class-wc-local-delivery.php:108
+#: classes/shipping/class-wc-local-pickup.php:61
+#@ woocommerce
 msgid "Method availability"
-msgstr "Méthode de disponibilité"
+msgstr "Disponibilit&eacute; du mode"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:80
+#: classes/shipping/class-wc-flat-rate.php:85
+#: classes/shipping/class-wc-free-shipping.php:77
+#: classes/shipping/class-wc-local-delivery.php:113
+#: classes/shipping/class-wc-local-pickup.php:66
+#@ woocommerce
 msgid "All allowed countries"
-msgstr "Tous les pays autorisés"
+msgstr "Tous les pays autoris&eacute;s"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:93
+#: classes/shipping/class-wc-flat-rate.php:98
+#: classes/shipping/class-wc-international-delivery.php:69
+#@ woocommerce
 msgid "Calculation Type"
 msgstr "Type de calcul"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:98
+#: classes/shipping/class-wc-flat-rate.php:103
+#: classes/shipping/class-wc-international-delivery.php:74
+#@ woocommerce
 msgid "Per Order - charge shipping for the entire order as a whole"
-msgstr "Par commande - frais d'envoi pour toute la commande dans son ensemble"
+msgstr "Par commande - Frais de livraison pour la commande dans son ensemble"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:99
+#: classes/shipping/class-wc-flat-rate.php:104
+#: classes/shipping/class-wc-international-delivery.php:75
+#@ woocommerce
 msgid "Per Item - charge shipping for each item individually"
-msgstr "Par Article - frais d'envoi pour chaque article individuellement"
+msgstr "Par article - Frais de livraison pour chaque article individuellement"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:100
+#: classes/shipping/class-wc-flat-rate.php:105
+#: classes/shipping/class-wc-international-delivery.php:76
+#@ woocommerce
 msgid "Per Class - charge shipping for each shipping class in an order"
-msgstr "Par Classe - frais d'envoi pour chaque classe de livraison dans une commande"
+msgstr "Par classe - Frais de livraison pour chaque classe de livraison d&rsquo;une commande"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:114
+#: classes/shipping/class-wc-flat-rate.php:119
+#: classes/shipping/class-wc-international-delivery.php:90
+#@ woocommerce
 msgid "Default Cost"
-msgstr "Coût par défaut"
+msgstr "Tarif par d&eacute;faut"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:116
+#: classes/shipping/class-wc-flat-rate.php:121
+#: classes/shipping/class-wc-international-delivery.php:92
+#@ woocommerce
 msgid "Cost excluding tax. Enter an amount, e.g. 2.50."
-msgstr "Coût sans les taxes. Entrez un montant. Ex : 2.50."
+msgstr "Tarif hors taxes. Entrez un montant (ex.: 2.50)."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:120
+#: classes/shipping/class-wc-flat-rate.php:125
+#: classes/shipping/class-wc-international-delivery.php:96
+#@ woocommerce
 msgid "Default Handling Fee"
-msgstr "Frais de gestion par défaut"
+msgstr "Frais de manutention par d&eacute;faut"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:122
+#: classes/shipping/class-wc-flat-rate.php:127
+#: classes/shipping/class-wc-international-delivery.php:98
+#@ woocommerce
 msgid "Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%. Leave blank to disable."
-msgstr "Les frais sans les taxes. Entrez un montant (Ex : 2.50) ou un pourcentage (Ex : 5%). Laissez vide pour désactiver."
+msgstr "Frais hors taxes. Entrez un montant (ex.: 2.50) ou un pourcentage (ex.: 5%). Laissez vide pour d&eacute;sactiver."
 
-#: ../classes/shipping/class-wc-flat-rate.php:126
+#: classes/shipping/class-wc-flat-rate.php:131
+#@ woocommerce
 msgid "Minimum Fee"
-msgstr ""
+msgstr "Frais minimum"
 
-#: ../classes/shipping/class-wc-flat-rate.php:128
+#: classes/shipping/class-wc-flat-rate.php:133
+#@ woocommerce
 msgid "Enter a minimum fee amount. Fee's less than this will be increased. Leave blank to disable."
-msgstr ""
+msgstr "Entrez un montant de frais minimum. Si les frais sont inf&eacute;rieurs, alors le montant sera augment&eacute;. Laissez vide pour d&eacute;sactiver."
 
-#: ../classes/shipping/class-wc-flat-rate.php:134
+#: classes/shipping/class-wc-flat-rate.php:139
+#@ woocommerce
 msgid "Optional extra shipping options with additional costs (one per line). Example: <code>Option Name|Cost|Per-order (yes or no)</code>. Example: <code>Priority Mail|6.95|yes</code>. If per-order is set to no, it will use the \"Calculation Type\" setting."
-msgstr ""
+msgstr "Options de livraison avec tarifs additionnels (un par ligne). Exemple&nbsp;: <code>Nom de l&rsquo;option|Tarif|Par commande (yes ou no)</code>. Exemple&nbsp;: <code>Exp&eacute;dition prioritaire|6.95|yes</code>. Si \"Par commande\" est d&eacute;fini sur \"no\", le param&egrave;tre \"Type de calcul\" sera utilis&eacute;."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:367
+#: classes/shipping/class-wc-flat-rate.php:360
+#@ woocommerce
 msgid "Cost, excluding tax."
-msgstr "Coût, H.T.."
+msgstr "Tarif, hors taxes."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:368
+#: classes/shipping/class-wc-flat-rate.php:361
+#@ woocommerce
 msgid "Handling Fee"
-msgstr "Frais de gestion"
+msgstr "Frais de Manutention"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:368
+#: classes/shipping/class-wc-flat-rate.php:361
+#@ woocommerce
 msgid "Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%."
-msgstr "Frais H.T.. Entrez un montant, ex.: 2.50, ou un pourcentage, ex.: 5%."
+msgstr "Frais hors taxes. Entrez un montant (ex.: 2.50), ou un pourcentage (ex.: 5%)."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:373
+#: classes/shipping/class-wc-flat-rate.php:366
+#@ woocommerce
 msgid "+ Add Flat Rate"
-msgstr "+ Ajout Taux Fixe"
+msgstr "&plus; Ajouter un taux fixe"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:374
+#: classes/shipping/class-wc-flat-rate.php:367
+#@ woocommerce
 msgid "Add rates for shipping classes here &mdash; they will override the default costs defined above."
-msgstr "Ajoutez des taux pour les classes d'expédition ici &mdash; ils vont écraser les coûts par défaut défini ci-dessus."
+msgstr "Ajoutez des taux pour les classes de livraison ici &mdash; Ils vont &eacute;craser les tarifs par d&eacute;faut d&eacute;finis ci-dessus."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:374
+#: classes/shipping/class-wc-flat-rate.php:367
+#@ woocommerce
 msgid "Delete selected rates"
-msgstr "Supprimer les taux sélectionnés"
+msgstr "Supprimer les taux s&eacute;lectionn&eacute;s"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:391
-#: ../classes/shipping/class-wc-flat-rate.php:423
+#: classes/shipping/class-wc-flat-rate.php:387
+#: classes/shipping/class-wc-flat-rate.php:420
+#@ woocommerce
 msgid "Select a class&hellip;"
-msgstr "Sélectionnez une classe&hellip;"
+msgstr "Choisissez une classe..."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-flat-rate.php:396
-#: ../classes/shipping/class-wc-flat-rate.php:397
+#: classes/shipping/class-wc-flat-rate.php:392
+#: classes/shipping/class-wc-flat-rate.php:393
+#@ woocommerce
 msgid "0.00"
 msgstr "0.00"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:16
-msgid "Free shipping"
+#: classes/shipping/class-wc-free-shipping.php:16
+#: classes/shipping/class-wc-free-shipping.php:56
+#: classes/shipping/class-wc-free-shipping.php:103
+#@ woocommerce
+msgid "Free Shipping"
 msgstr "Livraison gratuite"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:49
+#: classes/shipping/class-wc-free-shipping.php:49
+#@ woocommerce
 msgid "Enable Free Shipping"
 msgstr "Activer la livraison gratuite"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:56
-#: ../classes/shipping/class-wc-free-shipping.php:103
-msgid "Free Shipping"
-msgstr "Livraison Gratuite"
-
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:59
+#: classes/shipping/class-wc-free-shipping.php:59
+#@ woocommerce
 msgid "Minimum Order Amount"
 msgstr "Montant minimum de commande"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:61
+#: classes/shipping/class-wc-free-shipping.php:61
+#@ woocommerce
 msgid "Users will need to spend this amount to get free shipping. Leave blank to disable."
-msgstr "Les utilisateurs auront besoin de dépenser cette somme pour obtenir la livraison gratuite. Laissez vide pour désactiver."
+msgstr "Les utilisateurs devront atteindre ce montant pour obtenir la livraison gratuite. Laissez vide pour d&eacute;sactiver."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:67
+#: classes/shipping/class-wc-free-shipping.php:67
+#@ woocommerce
 msgid "Free shipping requires a free shipping coupon"
-msgstr "La livraison gratuite nécessite un code promo de livraison gratuite"
+msgstr "La livraison gratuite n&eacute;cessite un code promo de livraison gratuite"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:68
+#: classes/shipping/class-wc-free-shipping.php:68
+#@ woocommerce
 msgid "Users will need to enter a valid free shipping coupon code to use this method. If a coupon is used, the minimum order amount will be ignored."
-msgstr "Les utilisateurs devront saisir un code promo valide de frais de port gratuits pour utiliser cette méthode. Si un code promo est utilisé, le montant minimum de commande sera ignoré."
+msgstr "Les utilisateurs devront saisir un code promo valide de livraison gratuite pour utiliser ce mode. Si un code promo est utilis&eacute;, le montant minimum de commande sera ignor&eacute;."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-free-shipping.php:104
+#: classes/shipping/class-wc-free-shipping.php:104
+#@ woocommerce
 msgid "Free Shipping - does what it says on the tin."
-msgstr " "
+msgstr "Livraison gratuite - Fait ce qui est promis."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-international-delivery.php:19
-#: ../classes/shipping/class-wc-international-delivery.php:22
-#: ../classes/shipping/class-wc-international-delivery.php:48
+#: classes/shipping/class-wc-international-delivery.php:19
+#: classes/shipping/class-wc-international-delivery.php:22
+#: classes/shipping/class-wc-international-delivery.php:48
+#@ woocommerce
 msgid "International Delivery"
 msgstr "Livraison internationale"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-international-delivery.php:23
+#: classes/shipping/class-wc-international-delivery.php:23
+#@ woocommerce
 msgid "International delivery based on flat rate shipping."
-msgstr "Livraison internationale basée sur l'expédition forfaitaire."
+msgstr "Livraison internationale bas&eacute;e sur un taux fixe de livraison."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-international-delivery.php:51
+#: classes/shipping/class-wc-international-delivery.php:51
+#@ woocommerce
 msgid "Availability"
-msgstr "Disponibilité"
+msgstr "Disponibilit&eacute;"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-international-delivery.php:56
+#: classes/shipping/class-wc-international-delivery.php:56
+#@ woocommerce
 msgid "Selected countries"
-msgstr "Pays sélectionnés"
+msgstr "Pays s&eacute;lectionn&eacute;s"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-international-delivery.php:57
+#: classes/shipping/class-wc-international-delivery.php:57
+#@ woocommerce
 msgid "Excluding selected countries"
-msgstr "Exclure les pays sélectionnés"
+msgstr "Exclure les pays s&eacute;lectionn&eacute;s"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-international-delivery.php:61
+#: classes/shipping/class-wc-international-delivery.php:61
+#@ woocommerce
 msgid "Countries"
 msgstr "Pays"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:17
-#: ../classes/shipping/class-wc-local-delivery.php:82
+#: classes/shipping/class-wc-local-delivery.php:17
+#: classes/shipping/class-wc-local-delivery.php:82
+#@ woocommerce
 msgid "Local Delivery"
 msgstr "Livraison locale"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:73
-#: ../classes/shipping/class-wc-local-pickup.php:49
+#: classes/shipping/class-wc-local-delivery.php:73
+#: classes/shipping/class-wc-local-pickup.php:49
+#@ woocommerce
 msgid "Enable"
 msgstr "Activer"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:75
+#: classes/shipping/class-wc-local-delivery.php:75
+#@ woocommerce
 msgid "Enable local delivery"
 msgstr "Activer la livraison locale"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:85
+#: classes/shipping/class-wc-local-delivery.php:85
+#@ woocommerce
 msgid "Fee Type"
-msgstr "Type de Frais"
+msgstr "Type de frais"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:87
+#: classes/shipping/class-wc-local-delivery.php:87
+#@ woocommerce
 msgid "How to calculate delivery charges"
 msgstr "Comment calculer les frais de livraison"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:90
+#: classes/shipping/class-wc-local-delivery.php:90
+#@ woocommerce
 msgid "Fixed amount"
 msgstr "Montant fixe"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:91
+#: classes/shipping/class-wc-local-delivery.php:91
+#@ woocommerce
 msgid "Percentage of cart total"
-msgstr "Pourcentage du Total Panier"
+msgstr "Pourcentage sur le total du panier"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:92
-#, fuzzy
+#: classes/shipping/class-wc-local-delivery.php:92
+#@ woocommerce
 msgid "Fixed amount per product"
-msgstr "Produit simple"
+msgstr "Montant fixe par produit"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:96
+#: classes/shipping/class-wc-local-delivery.php:96
+#@ woocommerce
 msgid "Delivery Fee"
 msgstr "Frais de livraison"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:98
-#, fuzzy
+#: classes/shipping/class-wc-local-delivery.php:98
+#@ woocommerce
 msgid "What fee do you want to charge for local delivery, disregarded if you choose free. Leave blank to disable."
-msgstr "Quels frais voulez-vous facturer pour la livraison locale ? Ignorez si vous choisissez la livraison gratuite."
+msgstr "Combien voulez-vous facturer la livraison locale&nbsp;? Ignor&eacute; si vous choisissez la livraison gratuite. Laissez vide pour d&eacute;sactiver."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:102
+#: classes/shipping/class-wc-local-delivery.php:102
+#@ woocommerce
 msgid "Zip/Post Codes"
-msgstr "Codes Postaux"
+msgstr "Codes postaux/ZIP"
 
-#: ../classes/shipping/class-wc-local-delivery.php:104
+#: classes/shipping/class-wc-local-delivery.php:104
+#@ woocommerce
 msgid "What zip/post codes would you like to offer delivery to? Separate codes with a comma."
-msgstr ""
+msgstr "Pour quels codes postaux/ZIP souhaitez-vous offrir la livraison&nbsp;? S&eacute;parez les codes par une virgule."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-delivery.php:131
+#: classes/shipping/class-wc-local-delivery.php:131
+#@ woocommerce
 msgid "Local delivery is a simple shipping method for delivering orders locally."
-msgstr "La livraison locale est une méthode simple de livraison pour expédier des commandes localement."
+msgstr "La livraison locale est un mode de livraison simple pour exp&eacute;dier des commandes localement."
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-pickup.php:17
-#: ../classes/shipping/class-wc-local-pickup.php:58
+#: classes/shipping/class-wc-local-pickup.php:17
+#: classes/shipping/class-wc-local-pickup.php:58
+#@ woocommerce
 msgid "Local Pickup"
-msgstr "Point de vente"
+msgstr "Point retrait"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-pickup.php:51
+#: classes/shipping/class-wc-local-pickup.php:51
+#@ woocommerce
 msgid "Enable local pickup"
-msgstr "Activer le Point de vente"
+msgstr "Activer le point retrait"
 
-# @ woocommerce
-#: ../classes/shipping/class-wc-local-pickup.php:84
+#: classes/shipping/class-wc-local-pickup.php:84
+#@ woocommerce
 msgid "Local pickup is a simple method which allows the customer to pick up their order themselves."
-msgstr "Point de vente est une méthode simple qui permet au client de récupérer leur commande eux-mêmes."
+msgstr "Le point retrait est un mode le livraison simple qui permet aux clients de r&eacute;cup&eacute;rer leur commande par eux-m&ecirc;mes."
 
-# @ woocommerce
-#: ../languages/strings.php:13
+#: languages/strings.php:13
+#@ woocommerce
 msgid "pending"
-msgstr "attente"
-
-# @ woocommerce
-#: ../languages/strings.php:14
-msgid "failed"
-msgstr "échouée"
-
-# @ woocommerce
-#: ../languages/strings.php:15
-msgid "on-hold"
 msgstr "en attente"
 
-# @ woocommerce
-#: ../languages/strings.php:16
+#: languages/strings.php:14
+#@ woocommerce
+msgid "failed"
+msgstr "&eacute;chou&eacute;e"
+
+#: languages/strings.php:15
+#@ woocommerce
+msgid "on-hold"
+msgstr "suspendue"
+
+#: languages/strings.php:16
+#@ woocommerce
 msgid "processing"
 msgstr "en cours"
 
-# @ woocommerce
-#: ../languages/strings.php:17
+#: languages/strings.php:17
+#@ woocommerce
 msgid "completed"
-msgstr "terminée"
+msgstr "termin&eacute;e"
 
-# @ woocommerce
-#: ../languages/strings.php:18
+#: languages/strings.php:18
+#@ woocommerce
 msgid "refunded"
-msgstr "remboursée"
+msgstr "rembours&eacute;e"
 
-# @ woocommerce
-#: ../languages/strings.php:19
+#: languages/strings.php:19
+#@ woocommerce
 msgid "cancelled"
-msgstr "annulée"
+msgstr "annul&eacute;e"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-cart.php:41
-#: ../shortcodes/shortcode-my_account.php:145
+#: shortcodes/shortcode-cart.php:50
+#: shortcodes/shortcode-my_account.php:145
+#@ woocommerce
 msgid "Please enter a valid postcode/ZIP."
-msgstr "Entrez un code postal/ZIP valide, svp."
+msgstr "Veuillez entrer un code postal/ZIP valide."
 
-# @ woocommerce
-#: ../shortcodes/shortcode-cart.php:52
-#: ../shortcodes/shortcode-cart.php:58
+#: shortcodes/shortcode-cart.php:61
+#: shortcodes/shortcode-cart.php:67
+#@ woocommerce
 msgid "Shipping costs updated."
-msgstr "Coûts d'expédition mis à jour."
+msgstr "Frais de livraison mis &agrave; jour."
 
-# @ woocommerce
-#: ../shortcodes/shortcode-checkout.php:43
+#: shortcodes/shortcode-checkout.php:43
+#@ woocommerce
 msgid "The order totals have been updated. Please confirm your order by pressing the Place Order button at the bottom of the page."
-msgstr "Le total de la commande à été mis à jour. Confirmez votre commande svp en cliquant sur le bouton en bas de la page."
+msgstr "Le montant de la commande &agrave; &eacute;t&eacute; mis &agrave; jour. Veuillez confirmer votre commande en cliquant sur le bouton \"Passer commande\" en bas de la page."
 
-# @ woocommerce
-#: ../shortcodes/shortcode-init.php:304
+#: shortcodes/shortcode-init.php:304
+#: templates/loop/add-to-cart.php:34
+#: templates/single-product/add-to-cart/grouped.php:43
+#: templates/single-product/add-to-cart/grouped.php:73
+#: templates/single-product/add-to-cart/simple.php:37
+#: templates/single-product/add-to-cart/variable.php:61
+#@ woocommerce
 msgid "Add to cart"
 msgstr "Ajouter au panier"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-my_account.php:221
+#: shortcodes/shortcode-my_account.php:221
+#: widgets/widget-login.php:235
+#@ woocommerce
 msgid "Please enter your password."
-msgstr "Entrez votre mot de passe, svp."
+msgstr "Veuillez entrer votre mot de passe."
 
-# @ woocommerce
-#: ../shortcodes/shortcode-my_account.php:261
+#: shortcodes/shortcode-my_account.php:261
+#@ woocommerce
 msgid "My Account &rarr;"
 msgstr "Mon compte &rarr;"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-my_account.php:268
-#, fuzzy, php-format
+#: shortcodes/shortcode-my_account.php:268
+#, php-format
+#@ woocommerce
 msgid "Order <mark>%s</mark> made on <mark>%s</mark>"
-msgstr "Commande <mark>n&deg;%s</mark> effectuée le <mark>%s</mark>"
+msgstr "Commande n&deg;<mark>%s</mark> effectu&eacute;e le <mark>%s</mark>"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-my_account.php:269
+#: shortcodes/shortcode-my_account.php:269
 #, php-format
+#@ woocommerce
 msgid ". Order status: <mark>%s</mark>"
-msgstr ". État de la commande : <mark>%s</mark>"
+msgstr ". &Eacute;tat de la commande&nbsp;: <mark>%s</mark>"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-my_account.php:275
+#: shortcodes/shortcode-my_account.php:275
+#: templates/order/tracking.php:25
+#@ woocommerce
 msgid "Order Updates"
-msgstr "Mises à jour de la commande"
+msgstr "Mises &agrave; jour de la commande"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-order_tracking.php:49
-#, php-format
-msgid "Sorry, we could not find that order id in our database. <a href=\"%s\">Want to retry?</a>"
-msgstr "Désolé, nous ne pouvons pas trouver cette commande dans notre base de données. <a href=\"%s\">Voulez-vous recommencer ?</a>"
+#: shortcodes/shortcode-order_tracking.php:35
+#@ woocommerce
+msgid "Please enter a valid order ID"
+msgstr "Veuillez entrer un n&deg; de commande valide"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-pay.php:48
-#: ../shortcodes/shortcode-pay.php:101
+#: shortcodes/shortcode-order_tracking.php:39
+#@ woocommerce
+msgid "Please enter a valid order email"
+msgstr "Veuillez entrer une adresse e-mail de commande valide"
+
+#: shortcodes/shortcode-order_tracking.php:58
+#@ woocommerce
+msgid "Sorry, we could not find that order id in our database."
+msgstr "D&eacute;sol&eacute;, nous ne trouvons pas ce n&deg; de commande dans notre base de donn&eacute;es."
+
+#: shortcodes/shortcode-pay.php:48
+#: shortcodes/shortcode-pay.php:101
+#@ woocommerce
 msgid "Your order has already been paid for. Please contact us if you need assistance."
-msgstr "Votre commande a déjà été réglée. Contactez nous, svp si vous avez besoin d'assistance."
+msgstr "Votre commande a d&eacute;j&agrave; &eacute;t&eacute; pay&eacute;e. Veuillez nous contacter si vous avez besoin d&rsquo;assistance."
 
-# @ woocommerce
-#: ../shortcodes/shortcode-pay.php:73
+#: shortcodes/shortcode-pay.php:73
+#: templates/checkout/thankyou.php:36
+#: templates/emails/admin-new-order.php:9
+#: templates/emails/customer-completed-order.php:9
+#: templates/emails/customer-invoice.php:13
+#: templates/emails/customer-note.php:13
+#: templates/emails/customer-processing-order.php:9
+#@ woocommerce
 msgid "Order:"
-msgstr "Commande :"
+msgstr "Commande&nbsp;:"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-pay.php:77
+#: shortcodes/shortcode-pay.php:77
+#: templates/checkout/thankyou.php:40
+#@ woocommerce
 msgid "Date:"
-msgstr "Date :"
+msgstr "Date&nbsp;:"
 
-# @ woocommerce
-#: ../shortcodes/shortcode-pay.php:86
+#: shortcodes/shortcode-pay.php:86
+#: templates/checkout/thankyou.php:49
+#@ woocommerce
 msgid "Payment method:"
-msgstr "Méthode de Paiement :"
+msgstr "Mode de paiement&nbsp;:"
 
-# @ woocommerce
-#: ../templates/loop-shop.php:49
+#: templates/loop-shop.php:49
+#@ woocommerce
 msgid "No products found which match your selection."
-msgstr "Aucun produit trouvé correspondant à votre sélection."
+msgstr "Aucun produit correspondant &agrave; votre s&eacute;lection n&rsquo;a &eacute;t&eacute; trouv&eacute;."
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:31
+#: templates/single-product-reviews.php:31
 #, php-format
+#@ woocommerce
 msgid "%s review for %s"
 msgid_plural "%s reviews for %s"
 msgstr[0] "%s avis pour %s"
 msgstr[1] "%s avis pour %s"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:53
+#: templates/loop/pagination.php:13
+#: templates/single-product-reviews.php:53
+#@ woocommerce
 msgid "<span class=\"meta-nav\">&larr;</span> Previous"
-msgstr "<span class=\"meta-nav\">&larr;</span> Précédent"
+msgstr "<span class=\"meta-nav\">&larr;</span> Pr&eacute;c&eacute;dent"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:54
+#: templates/loop/pagination.php:12
+#: templates/single-product-reviews.php:54
+#@ woocommerce
 msgid "Next <span class=\"meta-nav\">&rarr;</span>"
 msgstr "Suivant <span class=\"meta-nav\">&rarr;</span>"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:58
+#: templates/single-product-reviews.php:58
+#@ woocommerce
 msgid "Add Review"
-msgstr "Ajouter Avis"
+msgstr "Ajouter un avis"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:60
+#: templates/single-product-reviews.php:60
+#@ woocommerce
 msgid "Add a review"
-msgstr "Ajouter un Avis"
+msgstr "Ajouter un avis"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:64
+#: templates/single-product-reviews.php:64
+#@ woocommerce
 msgid "Be the first to review"
-msgstr "Soyez le premier à donner votre avis"
+msgstr "Soyez le premier &agrave; donner votre avis"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:66
+#: templates/single-product-reviews.php:66
+#@ woocommerce
 msgid "There are no reviews yet, would you like to <a href=\"#review_form\" class=\"inline show_review_form\">submit yours</a>?"
-msgstr "Il n'y a pas encore d'avis, voulez-vous <a href=\"#review_form\" class=\"inline show_review_form\">donner le votre</a> ?"
+msgstr "Il n&rsquo;y a pas encore d&rsquo;avis, voulez-vous <a href=\"#review_form\" class=\"inline show_review_form\">donner le votre</a>&nbsp;?"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:84
+#: templates/single-product-reviews.php:84
+#@ woocommerce
 msgid "Submit Review"
-msgstr "Envoyer l'avis"
+msgstr "Envoyer l&rsquo;avis"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:91
+#: templates/single-product-reviews.php:91
+#@ woocommerce
 msgid "Rating"
 msgstr "Noter"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:92
-msgid "Rate..."
-msgstr "Note..."
+#: templates/single-product-reviews.php:92
+#@ woocommerce
+msgid "Rate&hellip;"
+msgstr "Note&hellip;"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:93
+#: templates/single-product-reviews.php:93
+#@ woocommerce
 msgid "Perfect"
 msgstr "Parfait"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:94
+#: templates/single-product-reviews.php:94
+#@ woocommerce
 msgid "Good"
 msgstr "Bon"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:95
+#: templates/single-product-reviews.php:95
+#@ woocommerce
 msgid "Average"
 msgstr "Moyen"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:96
+#: templates/single-product-reviews.php:96
+#@ woocommerce
 msgid "Not that bad"
-msgstr "Pas Mal"
+msgstr "Pas mal"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:97
+#: templates/single-product-reviews.php:97
+#@ woocommerce
 msgid "Very Poor"
-msgstr "Très Mauvais"
+msgstr "Mauvais"
 
-# @ woocommerce
-#: ../templates/single-product-reviews.php:102
+#: templates/single-product-reviews.php:102
+#@ woocommerce
 msgid "Your Review"
-msgstr "Votre Avis"
+msgstr "Votre avis"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:18
+#: templates/cart/cart.php:18
+#@ woocommerce
 msgid "Product Name"
-msgstr "Nom Produit"
+msgstr "Nom du produit"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:19
-msgid "Unit Price"
-msgstr "Prix à l'Unité"
+#: templates/cart/cart.php:19
+#@ woocommerce
+msgid "Unit"
+msgstr "Unit&eacute;"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:20
+#: templates/cart/cart.php:20
+#: templates/emails/admin-new-order.php:15
+#: templates/emails/customer-completed-order.php:15
+#: templates/emails/customer-invoice.php:19
+#: templates/emails/customer-note.php:19
+#: templates/emails/customer-processing-order.php:15
+#@ woocommerce
 msgid "Quantity"
-msgstr "Quantité"
+msgstr "Quantit&eacute;"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:37
+#: templates/cart/cart.php:37
+#@ woocommerce
 msgid "Remove this item"
-msgstr "Enlever cet élément"
+msgstr "Supprimer cet article"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:58
-msgid "Available on backorder."
-msgstr "Disponible sur commande."
-
-# @ woocommerce
-#: ../templates/cart/cart.php:108
-#: ../templates/checkout/form-coupon.php:19
+#: templates/cart/cart.php:108
+#: templates/checkout/form-coupon.php:19
+#@ woocommerce
 msgid "Apply Coupon"
-msgstr "Valider Code Promo"
+msgstr "Appliquer le code promo"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:116
+#: templates/cart/cart.php:115
+#@ woocommerce
 msgid "Update Cart"
-msgstr "Mettre à jour le panier"
+msgstr "Mettre &agrave; jour le panier"
 
-# @ woocommerce
-#: ../templates/cart/cart.php:116
+#: templates/cart/cart.php:115
+#@ woocommerce
 msgid "Proceed to Checkout &rarr;"
-msgstr "Procéder à la commande &rarr;"
+msgstr "Valider la commande &rarr;"
 
-# @ woocommerce
-#: ../templates/cart/cross-sells.php:12
+#: templates/cart/cross-sells.php:12
+#@ woocommerce
 msgid "You may be interested in&hellip;"
-msgstr "Vous serez peut-être intéressé par&hellip;"
+msgstr "Vous pourriez &ecirc;tre int&eacute;ress&eacute; par..."
 
-# @ woocommerce
-#: ../templates/cart/empty.php:7
+#: templates/cart/empty.php:7
+#@ woocommerce
 msgid "Your cart is currently empty."
 msgstr "Votre panier est actuellement vide."
 
-# @ woocommerce
-#: ../templates/cart/empty.php:11
+#: templates/cart/empty.php:11
+#@ woocommerce
 msgid "&larr; Return To Shop"
-msgstr "&larr; Retour à la Boutique"
+msgstr "&larr; Retour &agrave; la boutique"
 
-# @ woocommerce
-#: ../templates/cart/shipping-calculator.php:14
+#: templates/cart/shipping-calculator.php:14
+#@ woocommerce
 msgid "Calculate Shipping"
-msgstr "Calculer frais d'expédition"
+msgstr "Calculer la livraison"
 
-# @ woocommerce
-#: ../templates/cart/shipping-calculator.php:60
+#: templates/cart/shipping-calculator.php:60
+#@ woocommerce
 msgid "Update Totals"
-msgstr "Mise à jour totaux"
+msgstr "Mettre &agrave; jour le total"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:16
+#: templates/cart/totals.php:16
+#@ woocommerce
 msgid "Cart Totals"
-msgstr "Total panier"
+msgstr "Total du panier"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:21
+#: templates/cart/totals.php:21
+#: templates/checkout/review-order.php:23
+#@ woocommerce
 msgid "Cart Subtotal"
 msgstr "Sous-total du panier"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:28
-#: ../templates/cart/totals.php:167
+#: templates/cart/totals.php:28
+#: templates/cart/totals.php:193
+#@ woocommerce
 msgid "[Remove]"
-msgstr "[Enlever]"
+msgstr "[Supprimer]"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:88
+#: templates/cart/totals.php:100
+#@ woocommerce
 msgid "Please fill in your details to see available shipping methods."
-msgstr ""
+msgstr "Veuillez saisir vos coordonn&eacute;es pour afficher les modes de livraison disponibles."
 
-# @ woocommerce
-#: ../templates/cart/totals.php:90
+#: templates/cart/totals.php:102
+#: templates/checkout/review-order.php:107
+#@ woocommerce
 msgid "Sorry, it seems that there are no available shipping methods for your state. Please contact us if you require assistance or wish to make alternate arrangements."
-msgstr "Désolé, il semble qu'il n'y ai pas de méthodes de livraison disponibles pour votre région. Svp, contactez nous si vous avez besoin d'assistance ou si vous voulez effectuer un autre arrangement."
+msgstr "D&eacute;sol&eacute;, il semble qu&rsquo;il n&rsquo;y ai pas de modes de livraison disponibles pour cet &eacute;tat. Veuillez nous contacter si vous avez besoin d&rsquo;assistance ou si vous souhaitez prendre d&rsquo;autres dispositions."
 
-# @ woocommerce
-#: ../templates/cart/totals.php:114
-#: ../templates/cart/totals.php:135
+#: templates/cart/totals.php:129
+#: templates/cart/totals.php:157
+#: templates/checkout/review-order.php:132
+#: templates/checkout/review-order.php:152
+#@ woocommerce
 msgid "incl."
 msgstr "incl."
 
-# @ woocommerce
-#: ../templates/cart/totals.php:124
+#: templates/cart/totals.php:143
+#: widgets/widget-cart.php:85
+#@ woocommerce
 msgid "Subtotal"
 msgstr "Sous-total"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:167
+#: templates/cart/totals.php:193
+#: templates/checkout/review-order.php:184
+#@ woocommerce
 msgid "Order Discount"
-msgstr "Commande remisée"
+msgstr "Remise sur commande"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:191
+#: templates/cart/totals.php:218
 #, php-format
+#@ woocommerce
 msgid "(taxes estimated for %s)"
-msgstr "(taxes estimées à %s)"
+msgstr "(taxes estim&eacute;es &agrave; %s)"
 
-# @ woocommerce
-#: ../templates/cart/totals.php:199
+#: templates/cart/totals.php:220
 #, php-format
+#@ woocommerce
 msgid "Note: Shipping and taxes are estimated%s and will be updated during checkout based on your billing and shipping information."
-msgstr "Note : La livraison et les taxes sont estimés%s et seront mis à jour au cours de la commande selon vos informations de livraison et de facturation."
+msgstr "Veuillez noter&nbsp;: La livraison et les taxes sont estim&eacute;s%s et seront mises &agrave; jour lors de la commande en fonction de vos informations de livraison et de facturation."
 
-# @ woocommerce
-#: ../templates/cart/totals.php:207
+#: templates/cart/totals.php:230
+#@ woocommerce
 msgid "No shipping methods were found; please recalculate your shipping and enter your state/county and zip/postcode to ensure their are no other available methods for your location."
-msgstr "Aucune méthode d'expédition n'a été trouvée. Veuillez entrer à nouveau votre adresse de livraison, recalculer la livraison et vous assurer qu'il n'y a pas d'autre méthode d'expédition pour votre région."
+msgstr "Aucun mode de livraison n&rsquo;a &eacute;t&eacute; trouv&eacute;e. Veuillez saisir &agrave; nouveau votre &eacute;tat/r&eacute;gion et code postal/ZIP, recalculer la livraison et vous assurer qu&rsquo;il n&rsquo;y a pas d&rsquo;autre mode de livraison pour cet endroit."
 
-# @ woocommerce
-#: ../templates/cart/totals.php:214
+#: templates/cart/totals.php:237
 #, php-format
+#@ woocommerce
 msgid "Sorry, it seems that there are no available shipping methods for your location (%s)."
-msgstr "Désolé, il semble qu'aucune méthode d'expédition ne soit disponible pour votre région (%s)."
+msgstr "D&eacute;sol&eacute;, il semble qu&rsquo;aucun mode de livraison ne soit disponible pour cet endroit (%s)."
 
-# @ woocommerce
-#: ../templates/cart/totals.php:216
+#: templates/cart/totals.php:239
+#@ woocommerce
 msgid "If you require assistance or wish to make alternate arrangements please contact us."
-msgstr "Si vous désirez de l'assistance ou encore planifier d'autres types d'arrangements, veuillez nous contacter."
+msgstr "Si vous avez besoin d&rsquo;assistance ou si vous souhaitez prendre d&rsquo;autres dispositions, veuillez nous contacter."
 
-# @ woocommerce
-#: ../templates/checkout/cart-errors.php:9
+#: templates/checkout/cart-errors.php:9
+#@ woocommerce
 msgid "There are some issues with the items in your cart (shown above). Please go back to the cart page and resolve these issues before checking out."
-msgstr ""
+msgstr "Il y a quelques probl&egrave;mes avec les articles pr&eacute;sents dans votre panier (voir ci-dessous). Veuillez retourner sur la page du panier pour les r&eacute;soudre avant de commander."
 
-# @ woocommerce
-#: ../templates/checkout/cart-errors.php:13
+#: templates/checkout/cart-errors.php:13
+#@ woocommerce
 msgid "&larr; Return To Cart"
-msgstr ""
+msgstr "&larr; Retour au panier"
 
-# @ woocommerce
-#: ../templates/checkout/form-billing.php:10
-#, fuzzy
+#: templates/checkout/form-billing.php:10
+#@ woocommerce
 msgid "Billing &amp; Shipping"
-msgstr "Facturation &amp Expédition"
+msgstr "Facturation et livraison"
 
-# @ woocommerce
-#: ../templates/checkout/form-billing.php:33
+#: templates/checkout/form-billing.php:33
+#@ woocommerce
 msgid "Create an account?"
-msgstr "Créer un Compte?"
+msgstr "Cr&eacute;er un compte&nbsp;?"
 
-# @ woocommerce
-#: ../templates/checkout/form-billing.php:42
+#: templates/checkout/form-billing.php:42
+#@ woocommerce
 msgid "Create an account by entering the information below. If you are a returning customer please login with your username at the top of the page."
-msgstr "Créez un compte en entrant les informations ci-dessous. Si vous en possédez déjà un, connectez vous avec votre nom d'utilisateur en haut de la page."
+msgstr "Cr&eacute;ez un compte en entrant les informations ci-dessous. Si vous &ecirc;tes d&eacute;j&agrave; client, veuillez vous identifier avec votre nom d&rsquo;utilisateur en haut de la page."
 
-# @ woocommerce
-#: ../templates/checkout/form-checkout.php:9
+#: templates/checkout/form-checkout.php:9
+#@ woocommerce
 msgid "You must be logged in to checkout."
-msgstr "Vous devez être identifié pour commander."
+msgstr "Vous devez &ecirc;tre connect&eacute;(e) pour valider la commande."
 
-# @ woocommerce
-#: ../templates/checkout/form-checkout.php:33
+#: templates/checkout/form-checkout.php:33
+#@ woocommerce
 msgid "Your order"
 msgstr "Votre commande"
 
-# @ woocommerce
-#: ../templates/checkout/form-coupon.php:7
+#: templates/checkout/form-coupon.php:7
+#@ woocommerce
 msgid "Have a coupon?"
-msgstr "Avez-vous un code promo ?"
+msgstr "Un code promo&nbsp;?"
 
-# @ woocommerce
-#: ../templates/checkout/form-coupon.php:10
+#: templates/checkout/form-coupon.php:10
+#@ woocommerce
 msgid "Click here to enter your code"
 msgstr "Cliquez ici pour entrer votre code"
 
-# @ woocommerce
-#: ../templates/checkout/form-login.php:8
+#: templates/checkout/form-login.php:8
+#@ woocommerce
 msgid "Already registered?"
-msgstr "Déjà Inscrit?"
+msgstr "D&eacute;j&agrave; inscrit&nbsp;?"
 
-# @ woocommerce
-#: ../templates/checkout/form-login.php:11
+#: templates/checkout/form-login.php:11
+#@ woocommerce
 msgid "Click here to login"
-msgstr "Cliquez ici pour vous connecter"
+msgstr "Cliquez ici pour vous identifier"
 
-# @ woocommerce
-#: ../templates/checkout/form-login.php:13
+#: templates/checkout/form-login.php:13
+#@ woocommerce
 msgid "If you have shopped with us before, please enter your username and password in the boxes below. If you are a new customer please proceed to the Billing &amp; Shipping section."
-msgstr "Si vous avez déjà acheté chez nous, entre votre nom d'utilisateur et votre mot de passe dans les boîtes ci-dessous. Si vous êtes un nouveau client, rendez-vous à la section Facturation &amp; Livraison"
+msgstr "Si vous avez d&eacute;j&agrave; command&eacute; chez nous, veuillez entrer votre nom d&rsquo;utilisateur et votre mot de passe ci-dessous. Si vous &ecirc;tes un nouveau client, veuillez vous rendre dans la section \"Facturation et livraison\"."
 
-# @ woocommerce
-#: ../templates/checkout/form-pay.php:14
-#: ../templates/checkout/review-order.php:17
+#: templates/checkout/form-pay.php:14
+#: templates/checkout/review-order.php:17
+#: templates/order/order-details.php:16
+#@ woocommerce
 msgid "Totals"
-msgstr "Totaux"
+msgstr "Total"
 
-# @ woocommerce
-#: ../templates/checkout/form-pay.php:70
+#: templates/checkout/form-pay.php:70
+#@ woocommerce
 msgid "Sorry, it seems that there are no available payment methods for your location. Please contact us if you require assistance or wish to make alternate arrangements."
-msgstr "Désolé, il semble qu'il n'y ai pas de méthodes de paiement disponibles pour votre localisation. Contactez nous, svp si vous avez besoin d'assistance ou si vous désirez effectuer un autre arrangement."
+msgstr "D&eacute;sol&eacute;, il semble qu&rsquo;il n&rsquo;y ai pas de modes de paiement disponibles pour cet endroit. Veuillez nous contacter si vous avez besoin d&rsquo;assistance ou si vous souhaitez prendre d&rsquo;autres dispositions."
 
-# @ woocommerce
-#: ../templates/checkout/form-pay.php:79
+#: templates/checkout/form-pay.php:79
+#@ woocommerce
 msgid "Pay for order"
-msgstr "Règlement pour la commande"
+msgstr "Payer la commande"
 
-# @ woocommerce
-#: ../templates/checkout/form-shipping.php:25
-#, fuzzy
+#: templates/checkout/form-shipping.php:25
+#@ woocommerce
 msgid "Ship to billing address?"
-msgstr "Livrer à l'adresse de facturation par défault"
+msgstr "Livrer &agrave; l&rsquo;adresse de facturation&nbsp;?"
 
-# @ woocommerce
-#: ../templates/checkout/form-shipping.php:52
+#: templates/checkout/form-shipping.php:52
+#: templates/single-product/tabs/attributes.php:14
+#: templates/single-product/tabs/tab-attributes.php:7
+#@ woocommerce
 msgid "Additional Information"
-msgstr "Information Complémentaire"
+msgstr "Information compl&eacute;mentaire"
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:92
+#: templates/checkout/review-order.php:105
+#@ woocommerce
 msgid "Please fill in your details above to see available shipping methods."
-msgstr "Veuillez entrer une adresse de livraison ci-haut pour voir les modes d'expédition disponibles."
+msgstr "Veuillez saisir vos coordonn&eacute;es ci-dessus pour afficher les modes de livraison disponibles."
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:129
+#: templates/checkout/review-order.php:142
+#@ woocommerce
 msgid "Order Subtotal"
 msgstr "Sous-total de la commande"
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:243
+#: templates/checkout/review-order.php:256
+#@ woocommerce
 msgid "Please fill in your details above to see available payment methods."
-msgstr "Veuillez entrer une adresse de livraison ci-haut pour voir les modes de paiement disponibles."
+msgstr "Veuillez saisir vos coordonn&eacute;es ci-dessus pour afficher les modes de paiement disponibles."
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:245
+#: templates/checkout/review-order.php:258
+#@ woocommerce
 msgid "Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements."
-msgstr "Désolé, il semble qu'il n'y ai pas de méthode de règlement disponible pour votre région. Svp, contactez nous si vous avez besoin d'aide ou si vous désirez effectuer un autre arrangement."
+msgstr "D&eacute;sol&eacute;, il semble qu&rsquo;il n&rsquo;y ai pas de mode de paiement disponible pour cet &eacute;tat. Veuillez nous contacter si vous avez besoin d&rsquo;assistance ou si vous souhaitez prendre d&rsquo;autres dispositions."
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:255
+#: templates/checkout/review-order.php:268
+#@ woocommerce
 msgid "Since your browser does not support JavaScript, or it is disabled, please ensure you click the <em>Update Totals</em> button before placing your order. You may be charged more than the amount stated above if you fail to do so."
-msgstr "Votre navigateur ne supporte pas JavaScript ou bien il est désactivé, assurez vous de cliquer sur le bouton <em>Mise à Jour Totaux</em> avant de passer votre commande. Vous pouvez être facturé plus que le montant indiqué ci-dessus si vous omettez de le faire."
+msgstr "Votre navigateur ne supporte pas JavaScript ou bien il est d&eacute;sactiv&eacute;, veuillez vous assurer de cliquer sur le bouton <em>Mettre &agrave; jour le total</em> avant de passer votre commande. Vous pouvez &ecirc;tre factur&eacute; plus que le montant indiqu&eacute; ci-dessus si vous omettez de le faire."
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:255
+#: templates/checkout/review-order.php:268
+#@ woocommerce
 msgid "Update totals"
-msgstr "Mise à Jour Totaux"
+msgstr "Mettre &agrave; jour le total"
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:261
+#: templates/checkout/review-order.php:274
+#@ woocommerce
 msgid "Place order"
-msgstr "Payer"
+msgstr "Passer commande"
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:265
+#: templates/checkout/review-order.php:278
+#@ woocommerce
 msgid "I accept the"
-msgstr "J'accepte les"
+msgstr "J&rsquo;accepte les"
 
-# @ woocommerce
-#: ../templates/checkout/review-order.php:265
+#: templates/checkout/review-order.php:278
+#@ woocommerce
 msgid "terms &amp; conditions"
-msgstr "termes &amp; conditions"
+msgstr "Conditions G&eacute;r&eacute;rales de Vente"
 
-# @ woocommerce
-#: ../templates/checkout/thankyou.php:13
+#: templates/checkout/thankyou.php:13
+#@ woocommerce
 msgid "Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction."
-msgstr "Malheureusement votre commande ne peut être effectuée car la banque a décliné votre transaction."
+msgstr "Malheureusement votre commande ne peut pas &ecirc;tre trait&eacute;e car la banque/le marchant a refus&eacute; votre transaction."
 
-# @ woocommerce
-#: ../templates/checkout/thankyou.php:17
+#: templates/checkout/thankyou.php:17
+#@ woocommerce
 msgid "Please attempt your purchase again or go to your account page."
-msgstr "S'il vous plaît essayez à nouveau votre achat ou allez sur la page de votre compte."
+msgstr "Veuillez essayer de valider votre achat &agrave; nouveau ou retournez sur la page de votre compte."
 
-# @ woocommerce
-#: ../templates/checkout/thankyou.php:19
+#: templates/checkout/thankyou.php:19
+#@ woocommerce
 msgid "Please attempt your purchase again."
-msgstr "S'il vous plaît essayez à nouveau votre achat."
+msgstr "Veuillez essayer de valider votre achat &agrave; nouveau."
 
-# @ woocommerce
-#: ../templates/checkout/thankyou.php:24
+#: templates/checkout/thankyou.php:24
+#: templates/myaccount/my-orders.php:57
+#@ woocommerce
 msgid "Pay"
 msgstr "Payer"
 
-# @ woocommerce
-#: ../templates/checkout/thankyou.php:32
-#: ../templates/checkout/thankyou.php:65
+#: templates/checkout/thankyou.php:32
+#: templates/checkout/thankyou.php:65
+#@ woocommerce
 msgid "Thank you. Your order has been received."
-msgstr "Merci. Votre commande a été reçue."
+msgstr "Merci. Votre commande a &eacute;t&eacute; re&ccedil;ue."
 
-# @ woocommerce
-#: ../templates/emails/admin-new-order.php:5
+#: templates/emails/admin-new-order.php:5
+#@ woocommerce
 msgid "You have received an order from"
-msgstr "Vous avez reçu une commande de"
+msgstr "Vous avez re&ccedil;u une commande de"
 
-# @ woocommerce
-#: ../templates/emails/admin-new-order.php:5
+#: templates/emails/admin-new-order.php:5
+#@ woocommerce
 msgid ". Their order is as follows:"
-msgstr ". La commande est la suivante :"
+msgstr ". La commande est la suivante&nbsp;:"
 
-# @ woocommerce
-#: ../templates/emails/admin-new-order.php:40
-#: ../templates/emails/customer-completed-order.php:40
-#: ../templates/emails/customer-note.php:44
-#: ../templates/emails/customer-processing-order.php:40
+#: templates/emails/admin-new-order.php:40
+#: templates/emails/customer-completed-order.php:40
+#: templates/emails/customer-note.php:44
+#: templates/emails/customer-processing-order.php:40
+#: templates/order/order-details.php:82
+#@ woocommerce
 msgid "Customer details"
-msgstr "Détails Client"
+msgstr "Coordonn&eacute;es du client"
 
-# @ woocommerce
-#: ../templates/emails/customer-completed-order.php:5
+#: templates/emails/customer-completed-order.php:5
+#@ woocommerce
 msgid "Your order is complete. Your order's details are below:"
-msgstr "Votre commande est expédiée. En voici les détails :"
+msgstr "Votre commande est termin&eacute;e. En voici les d&eacute;tails&nbsp;:"
 
-# @ woocommerce
-#: ../templates/emails/customer-invoice.php:7
+#: templates/emails/customer-invoice.php:7
 #, php-format
+#@ woocommerce
 msgid "An order has been created for you on &ldquo;%s&rdquo;. To pay for this order please use the following link: <a href=\"%s\">Pay</a>"
-msgstr "Une commande a été crée pour vous sur &ldquo;%s&rdquo;. Pour régler cette commande, veuillez utiliser le lien suivant : <a href=\"%s\">Règlement</a>"
+msgstr "Une commande a &eacute;t&eacute; cr&eacute;e pour vous sur &ldquo;%s&rdquo;. Pour payer cette commande, veuillez utiliser le lien suivant&nbsp;: <a href=\"%s\">Payer</a>"
 
-#: ../templates/emails/customer-new-account.php:5
+#: templates/emails/customer-new-account.php:5
 #, php-format
+#@ woocommerce
 msgid "Thanks for creating an account on %s. Your username is <strong>%s</strong>."
-msgstr ""
+msgstr "Merci d&rsquo;avoir cr&eacute;&eacute; un compte sur %s. Votre nom d&rsquo;utilisateur est <strong>%s</strong>."
 
-# @ woocommerce
-#: ../templates/emails/customer-new-account.php:7
-#, fuzzy, php-format
+#: templates/emails/customer-new-account.php:7
+#, php-format
+#@ woocommerce
 msgid "You can access your account area here: %s."
-msgstr "Vous pouvez accéder à votre compte ici : %s."
+msgstr "Vous pouvez acc&eacute;der &agrave; votre compte ici&nbsp;: %s."
 
-# @ woocommerce
-#: ../templates/emails/customer-note.php:5
+#: templates/emails/customer-note.php:5
+#@ woocommerce
 msgid "Hello, a note has just been added to your order:"
-msgstr "Bonjour, une note vient juste d'être ajoutée à votre commande :"
+msgstr "Bonjour, un commentaire vient juste d&rsquo;&ecirc;tre ajout&eacute; &agrave; votre commande&nbsp;:"
 
-# @ woocommerce
-#: ../templates/emails/customer-note.php:9
+#: templates/emails/customer-note.php:9
+#@ woocommerce
 msgid "For your reference, your order details are shown below."
-msgstr "Pour votre information, les détails de votre commande sont affichés ci-dessous."
+msgstr "Pour votre information, les d&eacute;tails de votre commande sont affich&eacute;s ci-dessous."
 
-# @ woocommerce
-#: ../templates/emails/customer-processing-order.php:5
+#: templates/emails/customer-processing-order.php:5
+#@ woocommerce
 msgid "Thank you, we are now processing your order. Your order's details are below."
-msgstr "Merci, nous traitons votre commande. Les détails de la commande sont ci-dessous."
+msgstr "Merci, nous traitons votre commande. Les d&eacute;tails de la commande sont ci-dessous."
 
-# @ woocommerce
-#: ../templates/emails/email-addresses.php:7
+#: templates/emails/email-addresses.php:7
+#@ woocommerce
 msgid "Billing address"
-msgstr "Adresse de Facturation"
+msgstr "Adresse de facturation"
 
-# @ woocommerce
-#: ../templates/emails/email-addresses.php:17
+#: templates/emails/email-addresses.php:17
+#@ woocommerce
 msgid "Shipping address"
-msgstr "Adresse de Livraison"
+msgstr "Adresse de livraison"
 
-# @ woocommerce
-#: ../templates/emails/email-order-items.php:31
+#: templates/emails/email-order-items.php:31
+#@ woocommerce
 msgid "Download:"
-msgstr "Téléchargement :"
+msgstr "T&eacute;l&eacute;chargement&nbsp;:"
 
-# @ woocommerce
-#: ../templates/loop/add-to-cart.php:13
-#: ../templates/loop/add-to-cart.php:29
+#: templates/loop/add-to-cart.php:13
+#: templates/loop/add-to-cart.php:30
+#@ woocommerce
 msgid "Read More"
-msgstr "Lire Plus"
+msgstr "Lire plus"
 
-# @ woocommerce
-#: ../templates/loop/add-to-cart.php:21
+#: templates/loop/add-to-cart.php:22
+#@ woocommerce
 msgid "Select options"
-msgstr "Choix options"
+msgstr "Choisissez des options"
 
-# @ woocommerce
-#: ../templates/loop/add-to-cart.php:25
+#: templates/loop/add-to-cart.php:26
+#@ woocommerce
 msgid "View options"
 msgstr "Voir les options"
 
-# @ woocommerce
-#: ../templates/loop/sale-flash.php:10
+#: templates/loop/sale-flash.php:10
+#: templates/single-product/sale-flash.php:10
+#@ woocommerce
 msgid "Sale!"
-msgstr "Vente !"
+msgstr "En solde&nbsp;!"
 
-# @ woocommerce
-#: ../templates/loop/sorting.php:10
-msgid "Alphabetically"
-msgstr "Alphabétique"
-
-# @ woocommerce
-#: ../templates/loop/sorting.php:11
-msgid "Most Recent"
-msgstr "Plus Récents"
-
-# @ woocommerce
-#: ../templates/myaccount/form-change-password.php:14
+#: templates/myaccount/form-change-password.php:14
+#@ woocommerce
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
-# @ woocommerce
-#: ../templates/myaccount/form-change-password.php:18
+#: templates/myaccount/form-change-password.php:18
+#@ woocommerce
 msgid "Re-enter new password"
-msgstr "Entrez le nouveau mot de passe à nouveau"
+msgstr "Entrez le nouveau mot de passe &agrave; nouveau"
 
-# @ woocommerce
-#: ../templates/myaccount/form-change-password.php:23
+#: templates/myaccount/form-change-password.php:23
+#@ woocommerce
 msgid "Save"
-msgstr "Sauver"
+msgstr "Enregistrer"
 
-# @ woocommerce
-#: ../templates/myaccount/form-edit-address.php:36
+#: templates/myaccount/form-edit-address.php:36
+#@ woocommerce
 msgid "Save Address"
-msgstr "Sauver Adresse"
+msgstr "Enregistrer l&rsquo;adresse"
 
-# @ woocommerce
-#: ../templates/myaccount/form-login.php:15
-#: ../templates/myaccount/form-login.php:29
-#: ../templates/shop/form-login.php:25
+#: templates/myaccount/form-login.php:15
+#: templates/myaccount/form-login.php:29
+#: templates/shop/form-login.php:25
+#@ woocommerce
 msgid "Login"
 msgstr "Connexion"
 
-# @ woocommerce
-#: ../templates/myaccount/form-login.php:18
-#: ../templates/myaccount/form-login.php:44
-#: ../templates/shop/form-login.php:14
+#: templates/myaccount/form-login.php:18
+#: templates/myaccount/form-login.php:44
+#: templates/shop/form-login.php:14
+#: widgets/widget-login.php:93
+#@ woocommerce
 msgid "Username"
-msgstr "Nom d'Utilisateur"
+msgstr "Nom d&rsquo;utilisateur"
 
-# @ woocommerce
-#: ../templates/myaccount/form-login.php:22
-#: ../templates/myaccount/form-login.php:54
-#: ../templates/shop/form-login.php:18
+#: templates/myaccount/form-login.php:22
+#: templates/myaccount/form-login.php:54
+#: templates/shop/form-login.php:18
+#: widgets/widget-login.php:95
+#@ woocommerce
 msgid "Password"
-msgstr "Mot de Passe"
+msgstr "Mot de passe"
 
-# @ woocommerce
-#: ../templates/myaccount/form-login.php:30
-#: ../templates/shop/form-login.php:27
+#: templates/myaccount/form-login.php:30
+#: templates/shop/form-login.php:27
+#@ woocommerce
 msgid "Lost Password?"
-msgstr "Mot de Passe perdu?"
+msgstr "Mot de passe perdu&nbsp;?"
 
-# @ woocommerce
-#: ../templates/myaccount/form-login.php:40
-#: ../templates/myaccount/form-login.php:68
+#: templates/myaccount/form-login.php:40
+#: templates/myaccount/form-login.php:70
+#@ woocommerce
 msgid "Register"
-msgstr "S'enregistrer"
+msgstr "S&rsquo;enregistrer"
 
-# @ woocommerce
-#: ../templates/myaccount/form-login.php:58
+#: templates/myaccount/form-login.php:58
+#@ woocommerce
 msgid "Re-enter password"
-msgstr "Entrez à nouveau le mot de passe"
+msgstr "Entrez &agrave; nouveau le mot de passe"
 
-# @ woocommerce
-#: ../templates/myaccount/my-account.php:11
+#: templates/myaccount/my-account.php:11
 #, php-format
+#@ woocommerce
 msgid "Hello, <strong>%s</strong>. From your account dashboard you can view your recent orders, manage your shipping and billing addresses and <a href=\"%s\">change your password</a>."
-msgstr "Hello, <strong>%s</strong>. Vous pouvez voir vos commandes récentes, gérer vos adresses de livraison et de facturation et <a href=\"%s\">changer votre mot de passe</a> à partir du tableau de bord de votre compte"
+msgstr "Bonjour, <strong>%s</strong>. Vous pouvez voir vos commandes r&eacute;centes, g&eacute;rer vos adresses de livraison et de facturation et <a href=\"%s\">changer votre mot de passe</a> &agrave; partir du tableau de bord de votre compte."
 
-# @ woocommerce
-#: ../templates/myaccount/my-account.php:16
+#: templates/myaccount/my-account.php:16
+#@ woocommerce
 msgid "Available downloads"
-msgstr "Téléchargements Disponibles"
+msgstr "T&eacute;l&eacute;chargements disponibles"
 
-# @ woocommerce
-#: ../templates/myaccount/my-account.php:19
-msgid " download Remaining"
-msgid_plural " downloads remaining"
-msgstr[0] " téléchargement restant"
-msgstr[1] " téléchargements restants"
+#: templates/myaccount/my-account.php:19
+#@ woocommerce
+msgid "&nbsp;download remaining"
+msgid_plural "&nbsp;downloads remaining"
+msgstr[0] "&nbsc;t&eacute;l&eacute;chargement restant"
+msgstr[1] "&nbsc;t&eacute;l&eacute;chargements restants"
 
-# @ woocommerce
-#: ../templates/myaccount/my-account.php:24
+#: templates/myaccount/my-account.php:24
+#@ woocommerce
 msgid "Recent Orders"
-msgstr "Commandes récentes"
+msgstr "Commandes r&eacute;centes"
 
-# @ woocommerce
-#: ../templates/myaccount/my-account.php:27
+#: templates/myaccount/my-account.php:27
+#@ woocommerce
 msgid "My Address"
-msgstr "Mon Adresse"
+msgstr "Mon adresse"
 
-# @ woocommerce
-#: ../templates/myaccount/my-account.php:28
+#: templates/myaccount/my-account.php:28
+#@ woocommerce
 msgid "The following addresses will be used on the checkout page by default."
-msgstr "Les adresse suivantes seront utilisées par défaut sur la page de commande."
+msgstr "Les adresse suivantes seront utilis&eacute;es par d&eacute;faut sur les pages commande."
 
-# @ woocommerce
-#: ../templates/myaccount/my-address.php:39
+#: templates/myaccount/my-address.php:39
+#@ woocommerce
 msgid "You have not set up a billing address yet."
-msgstr "Vous n'avez pas défini d'adresse de facturation."
+msgstr "Vous n&rsquo;avez pas encore renseign&eacute; d&rsquo;adresse de facturation."
 
-# @ woocommerce
-#: ../templates/myaccount/my-address.php:70
+#: templates/myaccount/my-address.php:70
+#@ woocommerce
 msgid "You have not set up a shipping address yet."
-msgstr "Vous n'avez pas encore défini d'adresse de livraison."
+msgstr "Vous n&rsquo;avez pas encore renseign&eacute; d&rsquo;adresse de livraison."
 
-# @ woocommerce
-#: ../templates/myaccount/my-orders.php:28
+#: templates/myaccount/my-orders.php:28
+#@ woocommerce
 msgid "Ship to"
-msgstr "Expédié à"
+msgstr "Exp&eacute;di&eacute; &agrave;"
 
-#: ../templates/myaccount/my-orders.php:51
+#: templates/myaccount/my-orders.php:51
+#@ woocommerce
 msgid "Click to cancel this order"
-msgstr ""
+msgstr "Cliquer pour supprimer cette commande"
 
-# @ woocommerce
-#: ../templates/myaccount/my-orders.php:72
+#: templates/myaccount/my-orders.php:72
+#@ woocommerce
 msgid "You have no recent orders."
-msgstr "Vous n'avez pas de commande récente."
+msgstr "Vous n&rsquo;avez pas de commande r&eacute;cente."
 
-# @ woocommerce
-#: ../templates/order/form-tracking.php:11
+#: templates/order/form-tracking.php:11
+#@ woocommerce
 msgid "To track your order please enter your Order ID in the box below and press return. This was given to you on your receipt and in the confirmation email you should have received."
-msgstr "Pour suivre votre commande saisissez votre n&deg; et votre email de commande dans les champs ci-dessous et cliquez sur le bouton \"Suivi\". Le n&deg; de commande vous a été indiqué dans votre reçu et dans l'email de confirmation qui vous a été envoyé."
+msgstr "Pour suivre votre commande, veuillez saisir votre n&deg; de commande ci-dessous et appuyer sur entr&eacute;e. Le n&deg; de commande vous a &eacute;t&eacute; indiqu&eacute; dans votre re&ccedil;u et dans l&rsquo;e-mail de confirmation qui vous a &eacute;t&eacute; envoy&eacute;."
 
-# @ woocommerce
-#: ../templates/order/form-tracking.php:13
+#: templates/order/form-tracking.php:13
+#@ woocommerce
 msgid "Order ID"
 msgstr "N&deg; de commande"
 
-# @ woocommerce
-#: ../templates/order/form-tracking.php:13
+#: templates/order/form-tracking.php:13
+#@ woocommerce
 msgid "Found in your order confirmation email."
-msgstr "Présent dans l'email de confirmation"
+msgstr "Pr&eacute;sent dans l&rsquo;e-mail de confirmation."
 
-# @ woocommerce
-#: ../templates/order/form-tracking.php:14
+#: templates/order/form-tracking.php:14
+#@ woocommerce
 msgid "Billing Email"
-msgstr "Email de facturation"
+msgstr "E-mail de facturation"
 
-# @ woocommerce
-#: ../templates/order/form-tracking.php:14
+#: templates/order/form-tracking.php:14
+#@ woocommerce
 msgid "Email you used during checkout."
-msgstr "Email utilisé pour la commande"
+msgstr "E-mail utilis&eacute; lors de la commande."
 
-# @ woocommerce
-#: ../templates/order/form-tracking.php:17
+#: templates/order/form-tracking.php:17
+#@ woocommerce
 msgid "Track\""
 msgstr "Suivi\""
 
-# @ woocommerce
-#: ../templates/order/order-details.php:54
+#: templates/order/order-details.php:54
+#@ woocommerce
 msgid "Download file &rarr;"
-msgstr "Télécharger le fichier &rarr;"
+msgstr "T&eacute;l&eacute;charger le fichier &rarr;"
 
-# @ woocommerce
-#: ../templates/order/order-details.php:77
+#: templates/order/order-details.php:77
+#@ woocommerce
 msgid "Order Again"
-msgstr "Commander une nouvelle fois"
+msgstr "Commander encore"
 
-# @ woocommerce
-#: ../templates/order/order-details.php:87
+#: templates/order/order-details.php:87
+#@ woocommerce
 msgid "Telephone:"
-msgstr "Téléphone :"
+msgstr "T&eacute;l&eacute;phone&nbsp;:"
 
-#  il y a" est ajouté dans cette chaine car en anglais le "ago" est placé après la durée.
-# @ woocommerce
-#: ../templates/order/tracking.php:12
-#, fuzzy, php-format
+#: templates/order/tracking.php:12
+#, php-format
+#@ woocommerce
 msgid "Order %s which was made %s has the status &ldquo;%s&rdquo;"
-msgstr "Commande n&deg;%s qui a été effectuée il y a %s avec l'état &ldquo;%s&rdquo;"
+msgstr "La commande n&deg;%s qui a &eacute;t&eacute; pass&eacute;e il y a %s est &ldquo;%s&rdquo;"
 
-#  il y a" déplacé dans la chaine parente car "ago" est placé après la durée en anglais.
-# @ woocommerce
-#: ../templates/order/tracking.php:12
-#: ../templates/order/tracking.php:14
+#: templates/order/tracking.php:12
+#@ woocommerce
+msgid "ago"
+msgstr "&nbsp;"
+
+#: templates/order/tracking.php:14
+#@ woocommerce
+msgid "and was completed"
+msgstr "et a &eacute;t&eacute; termin&eacute;e il y a "
+
+#: templates/order/tracking.php:14
+#@ woocommerce
 msgid " ago"
 msgstr " "
 
-# @ woocommerce
-#: ../templates/order/tracking.php:14
-msgid "and was completed"
-msgstr "et a été expédiée il y a "
-
-# @ woocommerce
-#: ../templates/shop/breadcrumb.php:8
+#: templates/shop/breadcrumb.php:8
+#@ woocommerce
 msgctxt "breadcrumb"
 msgid "Home"
 msgstr "Accueil"
 
-# @ woocommerce
-#: ../templates/shop/breadcrumb.php:61
+#: templates/shop/breadcrumb.php:61
+#@ woocommerce
 msgid "Products tagged &ldquo;"
-msgstr "Produits avec le mot-clé &ldquo;"
+msgstr "Produits avec le mot-clef &ldquo;"
 
-# @ woocommerce
-#: ../templates/shop/breadcrumb.php:84
-#: ../templates/shop/breadcrumb.php:168
+#: templates/shop/breadcrumb.php:84
+#: templates/shop/breadcrumb.php:168
+#@ woocommerce
 msgid "Search results for &ldquo;"
-msgstr "Résultats de recherche pour &ldquo;"
+msgstr "R&eacute;sultats de recherche pour &ldquo;"
 
-# @ woocommerce
-#: ../templates/shop/breadcrumb.php:132
+#: templates/shop/breadcrumb.php:132
+#@ woocommerce
 msgid "Error 404"
 msgstr "Erreur 404"
 
-# @ woocommerce
-#: ../templates/shop/breadcrumb.php:172
+#: templates/shop/breadcrumb.php:172
+#@ woocommerce
 msgid "Posts tagged &ldquo;"
-msgstr "Articles avec le mot-clé &ldquo;"
+msgstr "Articles avec le mot-clef &ldquo;"
 
-# @ woocommerce
-#: ../templates/shop/breadcrumb.php:177
+#: templates/shop/breadcrumb.php:177
+#@ woocommerce
 msgid "Author:"
-msgstr "Auteur :"
+msgstr "Auteur&nbsp;:"
 
-# @ woocommerce
-#: ../templates/single-product/meta.php:14
+#: templates/single-product/meta.php:14
+#@ woocommerce
 msgid "Category:"
-msgstr "Catégories :"
+msgstr "Cat&eacute;gories&nbsp;:"
 
-# @ woocommerce
-#: ../templates/single-product/meta.php:16
+#: templates/single-product/meta.php:16
+#@ woocommerce
 msgid "Tags:"
-msgstr "Mots-Clés :"
+msgstr "Mots-clefs&nbsp;:"
 
-# @ woocommerce
-#: ../templates/single-product/review.php:22
+#: templates/single-product/review.php:22
+#@ woocommerce
 msgid "Your comment is awaiting approval"
 msgstr "Votre commentaire est en attente de validation"
 
-# @ woocommerce
-#: ../templates/single-product/review.php:25
+#: templates/single-product/review.php:25
+#@ woocommerce
 msgid "Rating by"
-msgstr "Noté par"
+msgstr "Not&eacute; par"
 
-# @ woocommerce
-#: ../templates/single-product/review.php:25
+#: templates/single-product/review.php:25
+#@ woocommerce
 msgid "on"
 msgstr "le"
 
-# @ woocommerce
-#: ../templates/single-product/review.php:25
+#: templates/single-product/review.php:25
+#@ woocommerce
 msgid "M jS Y"
-msgstr ""
+msgstr "j M Y"
 
-# @ woocommerce
-#: ../templates/single-product/up-sells.php:11
+#: templates/single-product/up-sells.php:11
+#@ woocommerce
 msgid "You may also like&hellip;"
-msgstr "Vous aimerez peut-être aussi&hellip;"
+msgstr "Vous pourriez aussi aimer..."
 
-# @ woocommerce
-#: ../templates/single-product/add-to-cart/variable.php:21
+#: templates/single-product/add-to-cart/variable.php:21
+#@ woocommerce
 msgid "Choose an option"
 msgstr "Choisir une option"
 
-# @ woocommerce
-#: ../templates/single-product/add-to-cart/variable.php:43
-msgid "Reset selection"
-msgstr "Effacer la sélection"
+#: templates/single-product/add-to-cart/variable.php:47
+#@ woocommerce
+msgid "Clear selection"
+msgstr "Effacer le s&eacute;lection"
 
-# @ woocommerce
-#: ../templates/single-product/tabs/description.php:11
+#: templates/single-product/tabs/description.php:11
+#@ woocommerce
 msgid "Product Description"
-msgstr "Description Produit"
+msgstr "Description du produit"
 
-# @ woocommerce
-#: ../widgets/widget-best_sellers.php:22
+#: widgets/widget-best_sellers.php:22
+#@ woocommerce
 msgid "Display a list of your best selling products on your site."
 msgstr "Affiche une liste des produits se vendant le mieux sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-best_sellers.php:24
+#: widgets/widget-best_sellers.php:24
+#@ woocommerce
 msgid "WooCommerce Best Sellers"
-msgstr "Meilleures ventes WooCommerce"
+msgstr "WooCommerce - Meilleures ventes"
 
-# @ woocommerce
-#: ../widgets/widget-best_sellers.php:53
+#: widgets/widget-best_sellers.php:53
+#@ woocommerce
 msgid "Best Sellers"
 msgstr "Meilleures ventes"
 
-# @ woocommerce
-#: ../widgets/widget-best_sellers.php:116
-#: ../widgets/widget-cart.php:104
-#: ../widgets/widget-featured_products.php:113
+#: widgets/widget-best_sellers.php:136
+#: widgets/widget-cart.php:118
+#: widgets/widget-featured_products.php:119
+#: widgets/widget-layered_nav.php:436
+#: widgets/widget-onsale.php:154
+#: widgets/widget-price_filter.php:192
+#: widgets/widget-product_categories.php:149
+#: widgets/widget-product_search.php:60
+#: widgets/widget-product_tag_cloud.php:70
+#: widgets/widget-random_products.php:103
+#: widgets/widget-recent_products.php:134
+#: widgets/widget-recent_reviews.php:125
+#: widgets/widget-recently_viewed.php:121
+#: widgets/widget-top_rated_products.php:139
+#@ woocommerce
 msgid "Title:"
-msgstr "Titre :"
+msgstr "Titre&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-best_sellers.php:119
-#: ../widgets/widget-featured_products.php:116
+#: widgets/widget-best_sellers.php:139
+#: widgets/widget-featured_products.php:122
+#: widgets/widget-onsale.php:157
+#: widgets/widget-random_products.php:108
+#: widgets/widget-recent_products.php:137
+#: widgets/widget-recent_reviews.php:128
+#: widgets/widget-recently_viewed.php:124
+#: widgets/widget-top_rated_products.php:142
+#@ woocommerce
 msgid "Number of products to show:"
-msgstr "Nombre de produits à afficher :"
+msgstr "Nombre de produits &agrave; afficher&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-cart.php:24
+#: widgets/widget-best_sellers.php:143
+#@ woocommerce
+msgid "Hide free products"
+msgstr "Cacher les produits gratuits"
+
+#: widgets/widget-cart.php:24
+#@ woocommerce
 msgid "Display the user's Shopping Cart in the sidebar."
-msgstr "Affiche le Panier du visiteur dans la barre latérale."
+msgstr "Affiche le panier du visiteur dans le menu."
 
-# @ woocommerce
-#: ../widgets/widget-cart.php:26
+#: widgets/widget-cart.php:26
+#@ woocommerce
 msgid "WooCommerce Shopping Cart"
-msgstr "Panier WooCommerce"
+msgstr "WooCommerce - Panier"
 
-# @ woocommerce
-#: ../widgets/widget-cart.php:68
+#: widgets/widget-cart.php:79
+#@ woocommerce
 msgid "No products in the cart."
 msgstr "Votre panier est vide."
 
-# @ woocommerce
-#: ../widgets/widget-cart.php:77
+#: widgets/widget-cart.php:89
+#@ woocommerce
 msgid "Checkout &rarr;"
 msgstr "Commander &rarr;"
 
-# @ woocommerce
-#: ../widgets/widget-cart.php:108
+#: widgets/widget-cart.php:122
+#@ woocommerce
 msgid "Hide if cart is empty"
 msgstr "Masquer si le panier est vide"
 
-# @ woocommerce
-#: ../widgets/widget-featured_products.php:24
+#: widgets/widget-featured_products.php:24
+#@ woocommerce
 msgid "Display a list of featured products on your site."
-msgstr "Affiche une liste de vos produits mis en avant dans votre site."
+msgstr "Affiche une liste des produits &agrave; la une sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-featured_products.php:26
+#: widgets/widget-featured_products.php:26
+#@ woocommerce
 msgid "WooCommerce Featured Products"
-msgstr "WooCommerce Produits mis en avant"
+msgstr "WooCommerce - Produits &agrave; la une"
 
-# @ woocommerce
-#: ../widgets/widget-featured_products.php:55
+#: widgets/widget-featured_products.php:55
+#@ woocommerce
 msgid "Featured Products"
-msgstr "Produits Mis en Avant"
+msgstr "Produits &agrave; la une"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:139
+#: widgets/widget-layered_nav.php:154
+#@ woocommerce
 msgid "Shows a custom attribute in a widget which lets you narrow down the list of products when viewing product categories."
-msgstr "Affiche un attribut personnalisé dans un widget qui vous permet d'affiner la liste des produits lors de la visualisation des catégories de produits."
+msgstr "Affiche un attribut personnalis&eacute; dans un widget qui vous permet d&rsquo;affiner la liste des produits lors de la visualisation des cat&eacute;gories de produits."
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:141
+#: widgets/widget-layered_nav.php:156
+#@ woocommerce
 msgid "WooCommerce Layered Nav"
-msgstr "WooCommerce Layered Nav"
+msgstr "WooCommerce - Layered Nav"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:201
+#: widgets/widget-layered_nav.php:216
 #, php-format
+#@ woocommerce
 msgid "Any %s"
-msgstr ""
+msgstr "Toute %s"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:424
+#: widgets/widget-layered_nav.php:439
+#@ woocommerce
 msgid "Attribute:"
-msgstr "Attribut :"
+msgstr "Attribut&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:444
+#: widgets/widget-layered_nav.php:459
+#@ woocommerce
 msgid "Display Type:"
-msgstr ""
+msgstr "Type d&rsquo;affichage&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:446
+#: widgets/widget-layered_nav.php:461
+#@ woocommerce
 msgid "List"
 msgstr "Liste"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:447
+#: widgets/widget-layered_nav.php:462
+#@ woocommerce
 msgid "Dropdown"
-msgstr "Dropdown"
+msgstr "Menu d&eacute;roulant"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:450
+#: widgets/widget-layered_nav.php:465
+#@ woocommerce
 msgid "Query Type:"
-msgstr "Type de requête :"
+msgstr "Type de requ&ecirc;te&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:452
+#: widgets/widget-layered_nav.php:467
+#@ woocommerce
 msgid "AND"
 msgstr "AND"
 
-# @ woocommerce
-#: ../widgets/widget-layered_nav.php:453
+#: widgets/widget-layered_nav.php:468
+#@ woocommerce
 msgid "OR"
 msgstr "OR"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:22
+#: widgets/widget-login.php:22
+#@ woocommerce
 msgid "Display a login area and \"My Account\" links in the sidebar."
-msgstr "Affiche une zone d'identification et un lien vers \"Mon Compte\" dans la barre latérale."
+msgstr "Affiche une zone d&rsquo;identification et un lien vers \"Mon Compte\" dans le menu."
 
-# @ woocommerce
-#: ../widgets/widget-login.php:24
+#: widgets/widget-login.php:24
+#@ woocommerce
 msgid "WooCommerce Login"
-msgstr "WooCommerce Identification"
+msgstr "WooCommerce - Identification"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:42
-#: ../widgets/widget-login.php:180
+#: widgets/widget-login.php:42
+#: widgets/widget-login.php:185
+#@ woocommerce
 msgid "Customer Login"
-msgstr "Identification client"
+msgstr "Identification du client"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:43
-#: ../widgets/widget-login.php:183
+#: widgets/widget-login.php:43
+#: widgets/widget-login.php:188
 #, php-format
+#@ woocommerce
 msgid "Welcome %s"
 msgstr "Bienvenue %s"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:56
+#: widgets/widget-login.php:56
+#@ woocommerce
 msgid "My account"
-msgstr "Mon Compte"
+msgstr "Mon compte"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:57
+#: widgets/widget-login.php:57
+#@ woocommerce
 msgid "Change my password"
 msgstr "Changer mon mot de passe"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:97
-msgid "Login &raquo;"
-msgstr "Connexion &raquo;"
-
-# @ woocommerce
-#: ../widgets/widget-login.php:97
+#: widgets/widget-login.php:97
+#@ woocommerce
 msgid "Lost password?"
-msgstr "Mot de Passe perdu ?"
+msgstr "Mot de passe perdu&nbsp;?"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:179
+#: widgets/widget-login.php:184
+#@ woocommerce
 msgid "Logged out title:"
-msgstr "Titre Déconnecté :"
+msgstr "Titre D&eacute;connect&eacute;(e)&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-login.php:182
+#: widgets/widget-login.php:187
+#@ woocommerce
 msgid "Logged in title:"
-msgstr "Titre Connecté :"
+msgstr "Titre connect&eacute;(e)&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-onsale.php:23
+#: widgets/widget-onsale.php:23
+#@ woocommerce
 msgid "Display a list of your on-sale products on your site."
-msgstr "Affiche une liste de vos produits en vente sur votre site."
+msgstr "Affiche une liste des produits sold&eacute;s sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-onsale.php:25
+#: widgets/widget-onsale.php:25
+#@ woocommerce
 msgid "WooCommerce On-sale"
-msgstr "WooCommerce En vente"
+msgstr "WooCommerce - En solde"
 
-# @ woocommerce
-#: ../widgets/widget-onsale.php:54
+#: widgets/widget-onsale.php:54
+#@ woocommerce
 msgid "On Sale"
-msgstr "En vente"
+msgstr "En solde"
 
-# @ woocommerce
-#: ../widgets/widget-price_filter.php:91
+#: widgets/widget-price_filter.php:91
+#@ woocommerce
 msgid "Shows a price filter slider in a widget which lets you narrow down the list of shown products when viewing product categories."
-msgstr "Affiche un widget de filtre de prix glissant qui permet d'afficher la liste des produits en visualisant une catégorie de produits."
+msgstr "Affiche un widget slider de prix qui permet d&rsquo;afficher la liste des produits en visualisant une cat&eacute;gorie de produits."
 
-# @ woocommerce
-#: ../widgets/widget-price_filter.php:93
+#: widgets/widget-price_filter.php:93
+#@ woocommerce
 msgid "WooCommerce Price Filter"
-msgstr "WooCommerce Filtre de Prix"
+msgstr "WooCommerce - Filtre de prix"
 
-# @ woocommerce
-#: ../widgets/widget-price_filter.php:166
+#: widgets/widget-price_filter.php:166
+#@ woocommerce
 msgid "Min price"
-msgstr "Prix min"
+msgstr "Prix min."
 
-# @ woocommerce
-#: ../widgets/widget-price_filter.php:167
+#: widgets/widget-price_filter.php:167
+#@ woocommerce
 msgid "Max price"
-msgstr "Prix max"
+msgstr "Prix max."
 
-# @ woocommerce
-#: ../widgets/widget-price_filter.php:168
+#: widgets/widget-price_filter.php:168
+#@ woocommerce
 msgid "Filter"
-msgstr "Filtre"
+msgstr "Filtrer"
 
-# @ woocommerce
-#: ../widgets/widget-price_filter.php:183
+#: widgets/widget-price_filter.php:183
+#@ woocommerce
 msgid "Filter by price"
 msgstr "Filtrer par prix"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:25
+#: widgets/widget-product_categories.php:25
+#@ woocommerce
 msgid "A list or dropdown of product categories."
-msgstr "Une liste ou un menu déroulant des catégories de produits"
+msgstr "Une liste ou un menu d&eacute;roulant des cat&eacute;gories de produits."
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:27
+#: widgets/widget-product_categories.php:27
+#@ woocommerce
 msgid "WooCommerce Product Categories"
-msgstr "WooCommerce Catégories Produits"
+msgstr "WooCommerce - Cat&eacute;gories de produits"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:110
-#, fuzzy
+#: widgets/widget-product_categories.php:110
+#@ woocommerce
 msgid "No product categories exist."
-msgstr "Catégories"
+msgstr "Aucune cat&eacute;gorie de produit."
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:152
+#: widgets/widget-product_categories.php:152
+#@ woocommerce
 msgid "Order by:"
-msgstr "Trié par :"
+msgstr "Tri&eacute; par&nbsp;:"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:154
+#: widgets/widget-product_categories.php:154
+#@ woocommerce
 msgid "Category Order"
-msgstr "Ordre categorie"
+msgstr "Ordre des categories"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:159
+#: widgets/widget-product_categories.php:159
+#@ woocommerce
 msgid "Show as dropdown"
-msgstr "Afficher menu déroulant"
+msgstr "Afficher un menu d&eacute;roulant"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:162
+#: widgets/widget-product_categories.php:162
+#@ woocommerce
 msgid "Show post counts"
-msgstr "Afficher compteur articles"
+msgstr "Afficher un compteur d&rsquo;articles"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:165
+#: widgets/widget-product_categories.php:165
+#@ woocommerce
 msgid "Show hierarchy"
-msgstr "Afficher Hiérarchie"
+msgstr "Afficher une hi&eacute;rarchie"
 
-# @ woocommerce
-#: ../widgets/widget-product_categories.php:168
-#, fuzzy
+#: widgets/widget-product_categories.php:168
+#@ woocommerce
 msgid "Show children of current category only"
-msgstr "Montrer uniquement les enfants de la catégorie courante"
+msgstr "Afficher uniquement les enfants de la cat&eacute;gorie actuelle"
 
-# @ woocommerce
-#: ../widgets/widget-product_search.php:23
+#: widgets/widget-product_search.php:23
+#@ woocommerce
 msgid "A Search box for products only."
-msgstr "Une boîte de recherche uniquement pour les produits"
+msgstr "Une bo&icirc;te de recherche uniquement pour les produits."
 
-# @ woocommerce
-#: ../widgets/widget-product_search.php:25
+#: widgets/widget-product_search.php:25
+#@ woocommerce
 msgid "WooCommerce Product Search"
-msgstr "WooCommerce Recherche Produits"
+msgstr "WooCommerce - Recherche de produits"
 
-# @ woocommerce
-#: ../widgets/widget-product_tag_cloud.php:23
+#: widgets/widget-product_tag_cloud.php:23
+#@ woocommerce
 msgid "Your most used product tags in cloud format."
-msgstr "Vos mots-clés de produits les plus utilisés dans un format nuage"
+msgstr "Vos mots-clefs de produits les plus utilis&eacute;s dans un format nuage."
 
-# @ woocommerce
-#: ../widgets/widget-product_tag_cloud.php:25
+#: widgets/widget-product_tag_cloud.php:25
+#@ woocommerce
 msgid "WooCommerce Product Tags"
-msgstr "WooCommerce Mots-Clés Produits"
+msgstr "WooCommerce - Mots-clefs de produits"
 
-# @ woocommerce
-#: ../widgets/widget-random_products.php:15
+#: widgets/widget-random_products.php:15
+#@ woocommerce
 msgid "WooCommerce Random Products"
-msgstr "WooCommerce Produits Aléatoires"
+msgstr "WooCommerce - Produits al&eacute;atoires"
 
-# @ woocommerce
-#: ../widgets/widget-random_products.php:18
+#: widgets/widget-random_products.php:18
+#@ woocommerce
 msgid "Display a list of random products on your site."
-msgstr "Afficher une liste aléatoire des produits sur votre site."
+msgstr "Affiche une liste al&eacute;atoire de produits sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-random_products.php:29
+#: widgets/widget-random_products.php:29
+#@ woocommerce
 msgid "Random Products"
-msgstr "Produits aléatoires"
+msgstr "Produits al&eacute;atoires"
 
-# @ woocommerce
-#: ../widgets/widget-random_products.php:114
-#: ../widgets/widget-recent_products.php:136
+#: widgets/widget-random_products.php:114
+#: widgets/widget-recent_products.php:141
+#@ woocommerce
 msgid "Show hidden product variations"
-msgstr "Afficher les variations de produits cachées"
+msgstr "Affiche les variations de produits cach&eacute;es"
 
-# @ woocommerce
-#: ../widgets/widget-recently_viewed.php:23
+#: widgets/widget-recently_viewed.php:23
+#@ woocommerce
 msgid "Display a list of recently viewed products."
-msgstr "Affiche une liste des produits récemment vus"
+msgstr "Affiche une liste des produits r&eacute;cemment vus."
 
-# @ woocommerce
-#: ../widgets/widget-recently_viewed.php:25
+#: widgets/widget-recently_viewed.php:25
+#@ woocommerce
 msgid "WooCommerce Recently Viewed Products"
-msgstr "WooCommerce Produits Vus Récemment"
+msgstr "WooCommerce - Produits r&eacute;cemment vus"
 
-# @ woocommerce
-#: ../widgets/widget-recently_viewed.php:56
+#: widgets/widget-recently_viewed.php:56
+#@ woocommerce
 msgid "Recently viewed"
-msgstr "Récemment vus"
+msgstr "R&eacute;cemment vus"
 
-# @ woocommerce
-#: ../widgets/widget-recent_products.php:23
+#: widgets/widget-recent_products.php:23
+#@ woocommerce
 msgid "Display a list of your most recent products on your site."
-msgstr "Affiche une liste de vos produits récents sur votre site;"
+msgstr "Affiche une liste des produits les plus r&eacute;cents sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-recent_products.php:25
+#: widgets/widget-recent_products.php:25
+#@ woocommerce
 msgid "WooCommerce Recent Products"
-msgstr "WooCommerce Produits Récents"
+msgstr "WooCommerce - Produits r&eacute;cents"
 
-# @ woocommerce
-#: ../widgets/widget-recent_products.php:54
+#: widgets/widget-recent_products.php:54
+#@ woocommerce
 msgid "New Products"
-msgstr "Nouveaux Produits"
+msgstr "Nouveaux produits"
 
-# @ woocommerce
-#: ../widgets/widget-recent_reviews.php:23
+#: widgets/widget-recent_reviews.php:23
+#@ woocommerce
 msgid "Display a list of your most recent reviews on your site."
-msgstr "Affiche une liste des avis les plus récents sur votre site"
+msgstr "Affiche une liste des avis les plus r&eacute;cents sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-recent_reviews.php:55
+#: widgets/widget-recent_reviews.php:55
+#@ woocommerce
 msgid "Recent Reviews"
-msgstr "Avis Récents"
+msgstr "Avis r&eacute;cents"
 
-# @ default
-#: ../widgets/widget-recent_reviews.php:85
+#: widgets/widget-recent_reviews.php:85
 #, php-format
+#@ woocommerce
 msgctxt "by comment author"
 msgid "by %1$s"
 msgstr "par %1$s"
 
-# @ woocommerce
-#: ../widgets/widget-top_rated_products.php:24
+#: widgets/widget-top_rated_products.php:24
+#@ woocommerce
 msgid "Display a list of top rated products on your site."
-msgstr "Affiche une liste de vos produits les mieux notés sur votre site."
+msgstr "Affiche une liste des produits les mieux not&eacute;s sur votre site."
 
-# @ woocommerce
-#: ../widgets/widget-top_rated_products.php:26
+#: widgets/widget-top_rated_products.php:26
+#@ woocommerce
 msgid "WooCommerce Top Rated Products"
-msgstr "WooCommerce Produits les mieux notés"
+msgstr "WooCommerce - Produits les mieux not&eacute;s"
 
-# @ woocommerce
-#: ../widgets/widget-top_rated_products.php:55
+#: widgets/widget-top_rated_products.php:55
+#@ woocommerce
 msgid "Top Rated Products"
-msgstr "Produits les mieux notés"
+msgstr "Produits les mieux not&eacute;s"
+
+#: woocommerce-template.php:638
+#: woocommerce.php:1007
+#@ woocommerce
+msgid "required"
+msgstr "requis"
+
+#. translators: plugin header field 'PluginURI'
+#: woocommerce.php:0
+#@ woocommerce
+msgid "http://www.woothemes.com/woocommerce/"
+msgstr "http://www.woothemes.com/woocommerce/"
+
+#. translators: plugin header field 'Description'
+#: woocommerce.php:0
+#@ woocommerce
+msgid "An e-commerce toolkit that helps you sell anything. Beautifully."
+msgstr "Une formidable extension e-commerce qui vous aidera &agrave; vendre n&rsquo;importe quoi."
+
+#. translators: plugin header field 'Author'
+#: woocommerce.php:0
+#@ woocommerce
+msgid "WooThemes"
+msgstr "WooThemes"
+
+#. translators: plugin header field 'AuthorURI'
+#: woocommerce.php:0
+#@ woocommerce
+msgid "http://woothemes.com"
+msgstr "http://woothemes.com"
+
+#. translators: plugin header field 'Version'
+#: woocommerce.php:0
+#@ woocommerce
+msgid "1.5.7"
+msgstr "1.5.7"
+
+#: woocommerce.php:1008
+#@ woocommerce
+msgid "Please select a rating"
+msgstr "Veuillez donner une note"
 


### PR DESCRIPTION
WooCommerce 1.5.7 full fr translation (UTF8 everywhere).
Beta version, maybe few display bugs to fix, waiting for review.
Works fine for me on wampsever/localhost.

Need also to generate the new mo file.
