### PR TITLE
Fix metabox collapsing

### DIFF
--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -580,12 +580,12 @@ jQuery( function($){
 	// META BOXES
 	
 		jQuery('.expand_all').click(function(){
-			jQuery(this).closest('.wc-metaboxes-wrapper').find('.wc-metabox table').show();
+			jQuery(this).closest('.wc-metaboxes-wrapper').find('.wc-metabox > table').show();
 			return false;
 		});
 		
 		jQuery('.close_all').click(function(){
-			jQuery(this).closest('.wc-metaboxes-wrapper').find('.wc-metabox table').hide();
+			jQuery(this).closest('.wc-metaboxes-wrapper').find('.wc-metabox > table').hide();
 			return false;
 		});
 		


### PR DESCRIPTION
How to reproduce the bug:
- Edit a variable product, select the Variations tab.
- Click "close all" at the top right.
- Toggle an individual box by clicking on its title.

Only the left side is shown, this is because the other (nested) table got hidden also by "close all".

Todo: minify.
