### PR TITLE
add hook (woocommerce_after_get_tax_rates) to get_tax_rates

### DIFF
--- a/classes/class-wc-tax.php
+++ b/classes/class-wc-tax.php
@@ -96,6 +96,9 @@ class WC_Tax {
 			
 			$this->rates = $flat_rates;
 			$this->parsed_rates = $parsed_rates;
+			
+			do_action('woocommerce_after_get_tax_rates',$this);
+			
 		endif;
 	}
 	


### PR DESCRIPTION
I would like to propose adding a hook at the end of get_tax_rates as the first step towards tax lookup service integration.
