### PR TITLE
Added two hooks in the admin order data panel

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -84,7 +84,9 @@ function woocommerce_order_data_meta_box($post) {
 				
 				<p class="form-field form-field-wide"><label for="excerpt"><?php _e('Customer Note:', 'woocommerce') ?></label>
 				<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php _e('Customer\'s notes about the order', 'woocommerce'); ?>"><?php echo $post->post_excerpt; ?></textarea></p>
-			
+
+				<?php do_action('woocommerce_admin_order_data_after_order_details'); ?>
+
 			</div>
 			<div class="order_data_right">
 				<div class="order_data">
@@ -165,6 +167,8 @@ function woocommerce_order_data_meta_box($post) {
 						endforeach;
 						
 						echo '</div>';
+
+						do_action('woocommerce_admin_order_data_after_billing_address');
 					?>
 				</div>
 				<div class="order_data order_data_alt">

--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -85,7 +85,7 @@ function woocommerce_order_data_meta_box($post) {
 				<p class="form-field form-field-wide"><label for="excerpt"><?php _e('Customer Note:', 'woocommerce') ?></label>
 				<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php _e('Customer\'s notes about the order', 'woocommerce'); ?>"><?php echo $post->post_excerpt; ?></textarea></p>
 
-				<?php do_action('woocommerce_admin_order_data_after_order_details', $order->id); ?>
+				<?php do_action( 'woocommerce_admin_order_data_after_order_details', $order->id ); ?>
 
 			</div>
 			<div class="order_data_right">
@@ -168,7 +168,7 @@ function woocommerce_order_data_meta_box($post) {
 						
 						echo '</div>';
 
-						do_action('woocommerce_admin_order_data_after_billing_address', $order->id);
+						do_action( 'woocommerce_admin_order_data_after_billing_address', $order->id );
 					?>
 				</div>
 				<div class="order_data order_data_alt">
@@ -245,7 +245,7 @@ function woocommerce_order_data_meta_box($post) {
 						
 						echo '</div>';
 						
-						do_action('woocommerce_admin_order_data_after_shipping_address', $order->id);
+						do_action( 'woocommerce_admin_order_data_after_shipping_address', $order->id );
 					?>
 				</div>
 			</div>

--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -85,7 +85,7 @@ function woocommerce_order_data_meta_box($post) {
 				<p class="form-field form-field-wide"><label for="excerpt"><?php _e('Customer Note:', 'woocommerce') ?></label>
 				<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php _e('Customer\'s notes about the order', 'woocommerce'); ?>"><?php echo $post->post_excerpt; ?></textarea></p>
 
-				<?php do_action( 'woocommerce_admin_order_data_after_order_details', $order->id ); ?>
+				<?php do_action( 'woocommerce_admin_order_data_after_order_details', $order ); ?>
 
 			</div>
 			<div class="order_data_right">
@@ -168,7 +168,7 @@ function woocommerce_order_data_meta_box($post) {
 						
 						echo '</div>';
 
-						do_action( 'woocommerce_admin_order_data_after_billing_address', $order->id );
+						do_action( 'woocommerce_admin_order_data_after_billing_address', $order );
 					?>
 				</div>
 				<div class="order_data order_data_alt">
@@ -245,7 +245,7 @@ function woocommerce_order_data_meta_box($post) {
 						
 						echo '</div>';
 						
-						do_action( 'woocommerce_admin_order_data_after_shipping_address', $order->id );
+						do_action( 'woocommerce_admin_order_data_after_shipping_address', $order );
 					?>
 				</div>
 			</div>

--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -85,7 +85,7 @@ function woocommerce_order_data_meta_box($post) {
 				<p class="form-field form-field-wide"><label for="excerpt"><?php _e('Customer Note:', 'woocommerce') ?></label>
 				<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php _e('Customer\'s notes about the order', 'woocommerce'); ?>"><?php echo $post->post_excerpt; ?></textarea></p>
 
-				<?php do_action('woocommerce_admin_order_data_after_order_details'); ?>
+				<?php do_action('woocommerce_admin_order_data_after_order_details', $order->id); ?>
 
 			</div>
 			<div class="order_data_right">
@@ -168,7 +168,7 @@ function woocommerce_order_data_meta_box($post) {
 						
 						echo '</div>';
 
-						do_action('woocommerce_admin_order_data_after_billing_address');
+						do_action('woocommerce_admin_order_data_after_billing_address', $order->id);
 					?>
 				</div>
 				<div class="order_data order_data_alt">
@@ -245,7 +245,7 @@ function woocommerce_order_data_meta_box($post) {
 						
 						echo '</div>';
 						
-						do_action('woocommerce_admin_order_data_after_shipping_address');
+						do_action('woocommerce_admin_order_data_after_shipping_address', $order->id);
 					?>
 				</div>
 			</div>


### PR DESCRIPTION
A `woocommerce_admin_order_data_after_shipping_address` action hook already existed, but this only applies to the last of the three columns in the order details meta box.
