### PR TITLE
Added a few filters for WPML compatibility

### DIFF
--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -239,11 +239,14 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						?>
 						<li>
 						<input type="radio" id="payment_method_<?php echo $gateway->id; ?>" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php if ($gateway->chosen) echo 'checked="checked"'; ?> />
-						<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo $gateway->title; ?> <?php echo apply_filters('woocommerce_gateway_icon', $gateway->icon(), $gateway->id); ?></label> 
+						<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo apply_filters('woocommerce_gateway_title', $gateway->title); ?> <?php echo apply_filters('woocommerce_gateway_icon', $gateway->icon(), $gateway->id); ?></label> 
 							<?php
 								if ($gateway->has_fields || $gateway->description) : 
 									echo '<div class="payment_box payment_method_'.$gateway->id.'" style="display:none;">';
-									$gateway->payment_fields();
+									
+									//$gateway->payment_fields();
+									echo apply_filters('woocommerce_gateway_raw_description', wpautop(wptexturize($gateway->description)), $gateway->description);
+									
 									echo '</div>';
 								endif;
 							?>

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -14,37 +14,34 @@ global $woocommerce, $product, $post;
 <form action="<?php echo esc_url( $product->add_to_cart_url() ); ?>" class="variations_form cart" method="post" enctype='multipart/form-data'>
 	<table class="variations" cellspacing="0">
 		<tbody>
-			<?php $loop = 0; foreach ( $attributes as $name => $options ) : $loop++; ?>
+			<?php $loop = 0; foreach ($attributes as $name => $options) : $loop++; ?>
 				<tr>
 					<td><label for="<?php echo sanitize_title($name); ?>"><?php echo $woocommerce->attribute_label($name); ?></label></td>
 					<td><select id="<?php echo esc_attr( sanitize_title($name) ); ?>" name="attribute_<?php echo sanitize_title($name); ?>">
 						<option value=""><?php echo __('Choose an option', 'woocommerce') ?>&hellip;</option>
-						<?php 
-							if ( is_array( $options ) ) {
-							
-								if ( empty( $_POST ) )
-									$selected_value = ( isset( $selected_attributes[ sanitize_title( $name ) ] ) ) ? $selected_attributes[ sanitize_title( $name ) ] : '';
-								else
-									$selected_value = isset( $_POST[ 'attribute_' . sanitize_title( $name ) ] ) ? $_POST[ 'attribute_' . sanitize_title( $name ) ] : '';
-
+						<?php if(is_array($options)) : ?>
+							<?php
+								$selected_value = (isset($selected_attributes[sanitize_title($name)])) ? $selected_attributes[sanitize_title($name)] : '';
 								// Get terms if this is a taxonomy - ordered
-								if ( taxonomy_exists( sanitize_title( $name ) ) ) {
-
-									$terms = get_terms( sanitize_title($name), array('menu_order' => 'ASC') );
+								if (taxonomy_exists(sanitize_title($name))) :
+									$args = array('menu_order' => 'ASC');
+									$terms = get_terms( sanitize_title($name), $args );
 	
-									foreach ( $terms as $term ) {
-										if ( ! in_array( $term->slug, $options ) ) continue;
-										echo '<option value="' . $term->slug . '" ' . selected( $selected_value, $term->slug ) . '>' . $term->name . '</option>';
-									}
-								} else {
-									foreach ($options as $option)
-										echo '<option value="' . $option . '" ' . selected( $selected_value, $option ) . '>' . $option . '</option>';
-								}
-							}
-						?>
+									foreach ($terms as $term) :
+										if (!in_array($term->slug, $options)) continue;
+										echo '<option value="'.$term->slug.'" '.selected($selected_value, $term->slug).'>'. apply_filters('woocommerce_variation_term_name', $term->name) .'</option>';
+									endforeach;
+								else :
+									foreach ($options as $option) :
+										echo '<option value="'.$option.'" '.selected($selected_value, $option).'>'. apply_filters('woocommerce_variation_term_name', $option) .'</option>';
+									endforeach;
+								endif;
+							?>
+						<?php endif;?>
 					</select> <?php
-						if ( sizeof($attributes) == $loop )
+						if ( sizeof($attributes) == $loop ) {
 							echo '<a class="reset_variations" href="#reset">'.__('Clear selection', 'woocommerce').'</a>';
+						}
 					?></td>
 				</tr>
 	        <?php endforeach;?>


### PR DESCRIPTION
Filename: variable.php

apply_filters('woocommerce_variation_term_name', $term->name);
apply_filters('woocommerce_variation_term_name', $option)

In order to filter custom attributes used in variations (needed to make them translatable)
# 

Filename: review-order.php

apply_filters('woocommerce_gateway_title', $gateway->title);

echo apply_filters('woocommerce_gateway_raw_description', wpautop(wptexturize($gateway->description)), $gateway->description);

also changed instead of:
$gateway->payment_fields();

because I couldn't filter this. These needed for payment gateways translations.

:) Thanks guys
