### PR TITLE
WC_Flat_Rate no have a method get_title()

### DIFF
--- a/admin/settings/settings-shipping-methods.php
+++ b/admin/settings/settings-shipping-methods.php
@@ -34,7 +34,7 @@ function woocommerce_shipping_methods_setting() {
 				    			<input type="radio" name="default_shipping_method" value="' . $method->id . '" ' . checked( $default_shipping_method, $method->id, false ) . ' />
 				    			<input type="hidden" name="method_order[]" value="' . $method->id . '" />
 				    			<td>
-				    				<p><strong>' . $method->get_title() . '</strong><br/>
+				    				<p><strong>' . $method->title . '</strong><br/>
 				    				<small>' . __('Method ID', 'woocommerce') . ': ' . $method->id . '</small></p>
 				    			</td>
 				    			<td>';


### PR DESCRIPTION
"Fatal error: Call to undefined method WC_Flat_Rate::get_title() in C:\xampp\htdocs\woocommerce\wp-content\plugins\woocommerce\admin\settings\settings-shipping-methods.php on line 37"
