### PR TITLE
Fix for issue #1218

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -604,7 +604,7 @@ function woocommerce_exclude_order_comments( $clauses ) {
 	
 	if (is_admin() && $typenow=='shop_order') return $clauses; // Don't hide when viewing orders in admin
 	
-	$clauses['join'] = "LEFT JOIN $wpdb->posts ON $wpdb->comments.comment_post_ID = $wpdb->posts.ID";
+	if ($clauses['join']) $clauses['join'] .= "LEFT JOIN $wpdb->posts ON $wpdb->comments.comment_post_ID = $wpdb->posts.ID";
 	
 	if ($clauses['where']) $clauses['where'] .= ' AND ';
 	


### PR DESCRIPTION
If there is something in clauses['join'] append the join from
woocommerce instead of overwriting it, just as for the clauses['where']
section bellow.

This happens if you use comments translaton with wpml, the clauses['join'] part filled in by wpml is overwritten by woocommerce.

Please review or comment how we can improve the fix.
