### PR TITLE
Add add_to_cart_url filter in loop/add-to-cart.php template.

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -658,10 +658,63 @@ class WC_Cart {
 			// Force quantity to 1 if sold individually
 			if ( $product_data->is_sold_individually() )
 				$quantity = 1;
-
-			// Check if this product can be added to the cart
-			if ( !add_to_cart_check( $product_data, $product_id, $quantity, $variation_id, $cart_item_key, $cart_item_data ) ) 
+			
+			// Type/Exists check
+			if ( $product_data->is_type('external') || ! $product_data->exists() ) {
+				$woocommerce->add_error( __('This product cannot be purchased.', 'woocommerce') );
+				return false; 
+			}
+			
+			// Price set check
+			if( $product_data->get_price() === '' ) {
+				$woocommerce->add_error( __('This product cannot be purchased - the price is not yet set.', 'woocommerce') );
+				return false; 
+			}
+	
+			// Stock check - only check if we're managing stock and backorders are not allowed
+			if ( ! $product_data->has_enough_stock( $quantity ) ) {
+				$woocommerce->add_error( sprintf(__('You cannot add that amount to the cart since there is not enough stock. We have %s in stock.', 'woocommerce'), $product_data->get_stock_quantity() ));
+				return false; 
+			} elseif ( ! $product_data->is_in_stock() ) {
+				$woocommerce->add_error( __('You cannot add that product to the cart since the product is out of stock.', 'woocommerce') );
 				return false;
+			}
+
+			// Downloadable/virtual qty check
+			if ( $product_data->is_sold_individually() ) {
+				$in_cart_quantity = ( $cart_item_key ) ? $this->cart_contents[$cart_item_key]['quantity'] + $quantity : $quantity;
+				
+				// If its greater than 1, its already in the cart
+				if ( $in_cart_quantity > 1 ) {
+					$woocommerce->add_error( sprintf('<a href="%s" class="button">%s</a> %s', get_permalink(woocommerce_get_page_id('cart')), __('View Cart &rarr;', 'woocommerce'), __('You already have this item in your cart.', 'woocommerce') ) );
+					return false;
+				}
+			}
+			
+			// Stock check - this time accounting for whats already in-cart
+			$product_qty_in_cart = $this->get_cart_item_quantities();
+			
+			if ( $product_data->managing_stock() ) {
+				
+				// Variations
+				if ( $variation_id && $product_data->variation_has_stock ) {
+						
+					if ( isset( $product_qty_in_cart[ $variation_id ] ) && ! $product_data->has_enough_stock( $product_qty_in_cart[ $variation_id ] + $quantity ) ) {
+						$woocommerce->add_error( sprintf(__('<a href="%s" class="button">%s</a> You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce'), get_permalink(woocommerce_get_page_id('cart')), __('View Cart &rarr;', 'woocommerce'), $product_data->get_stock_quantity(), $product_qty_in_cart[ $variation_id ] ));
+						return false;
+					}
+				
+				// Products
+				} else {
+					
+					if ( isset( $product_qty_in_cart[ $product_id ] ) && ! $product_data->has_enough_stock( $product_qty_in_cart[ $product_id ] + $quantity ) ) {
+						$woocommerce->add_error( sprintf(__('<a href="%s" class="button">%s</a> You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce'), get_permalink(woocommerce_get_page_id('cart')), __('View Cart &rarr;', 'woocommerce'), $product_data->get_stock_quantity(), $product_qty_in_cart[ $product_id ] ));
+						return false;
+					}
+					
+				}
+				
+			}			
 			
 			// If cart_item_key is set, the item is already in the cart
 			if ( $cart_item_key ) {
@@ -692,80 +745,6 @@ class WC_Cart {
 			$this->set_session();
 			
 			return true;
-		}
-
-
-		/**
-		 * Check if a product can be added to the cart
-		 *
-		 * @param string $product_id contains the id of the product to check
-		 * @param string $quantity contains the quantity of the item to add
-		 * @param int $variation_id
-		 * @param array $variation attribute values
-		 * @param array $cart_item_data extra cart item data passed into the item
-		 * @return bool
-		 */
-		function add_to_cart_check( $product_data, $product_id, $quantity, $variation_id, $cart_item_key, $cart_item_data ) {
-			global $woocommerce;
-
-			// Type/Exists check
-			if ( $product_data->is_type('external') || ! $product_data->exists() ) {
-				$woocommerce->add_error( apply_filters( 'woocommerce_add_to_cart_error_message', __('This product cannot be purchased.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ) );
-				return false; 
-			}
-			
-			// Price set check
-			if( $product_data->get_price() === '' && apply_filters( 'woocommerce_add_to_cart_empty_price_halt', true, $product_data, $cart_item_key, $cart_item_data ) ) {
-				$woocommerce->add_error( apply_filters( 'woocommerce_add_to_cart_error_message', __('This product cannot be purchased - the price is not yet set.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ) );
-				return false; 
-			}
-
-			// Downloadable/virtual qty check
-			if ( $product_data->is_sold_individually() ) {
-				$in_cart_quantity = ( $cart_item_key ) ? $this->cart_contents[$cart_item_key]['quantity'] + $quantity : $quantity;
-				
-				// If its greater than 1, its already in the cart
-				if ( $in_cart_quantity > 1 && apply_filters( 'woocommerce_add_to_cart_individual_halt', true, $product_data, $cart_item_key, $cart_item_data ) ) {
-					$woocommerce->add_error( sprintf('<a href="%s" class="button">%s</a> %s', get_permalink(woocommerce_get_page_id('cart')), __('View Cart &rarr;', 'woocommerce'), apply_filters( 'woocommerce_add_to_cart_error_message', __('You already have this item in your cart.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ) ) );
-					return false;
-				}
-			}
-
-			// Stock check - only check if we're managing stock and backorders are not allowed
-			if ( ! $product_data->has_enough_stock( $quantity ) ) {
-				$woocommerce->add_error( sprintf( apply_filters( 'woocommerce_add_to_cart_error_message', __('You cannot add that amount to the cart since there is not enough stock. We have %s in stock.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ), $product_data->get_stock_quantity() ) );
-				return false; 
-			} elseif ( ! $product_data->is_in_stock() ) {
-				$woocommerce->add_error( apply_filters( 'woocommerce_add_to_cart_error_message', __('You cannot add that product to the cart since the product is out of stock.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ) );
-				return false;
-			}
-			
-			// Stock check - this time accounting for whats already in-cart
-			$product_qty_in_cart = $this->get_cart_item_quantities();
-			
-			if ( $product_data->managing_stock() ) {
-				
-				// Variations
-				if ( $variation_id && $product_data->variation_has_stock ) {
-						
-					if ( isset( $product_qty_in_cart[ $variation_id ] ) && ! $product_data->has_enough_stock( $product_qty_in_cart[ $variation_id ] + $quantity ) ) {
-						$woocommerce->add_error( sprintf( '<a href="%s" class="button">%s</a> ' . apply_filters( 'woocommerce_add_to_cart_error_message', __( 'You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ), get_permalink(woocommerce_get_page_id('cart')), __('View Cart &rarr;', 'woocommerce'), $product_data->get_stock_quantity(), $product_qty_in_cart[ $variation_id ] ));
-						return false;
-					}
-				
-				// Products
-				} else {
-					
-					if ( isset( $product_qty_in_cart[ $product_id ] ) && ! $product_data->has_enough_stock( $product_qty_in_cart[ $product_id ] + $quantity ) ) {
-						$woocommerce->add_error( sprintf( '<a href="%s" class="button">%s</a> ' . apply_filters( 'woocommerce_add_to_cart_error_message', __( 'You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce'), $product_data, $cart_item_key, $cart_item_data ), get_permalink(woocommerce_get_page_id('cart')), __('View Cart &rarr;', 'woocommerce'), $product_data->get_stock_quantity(), $product_qty_in_cart[ $product_id ] ));
-						return false;
-					}
-					
-				}
-				
-			}		
-
-			return true;		
 		}
 
 		/**

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -10,7 +10,7 @@ if( $product->get_price() === '' && $product->product_type != 'external' ) retur
 
 <?php if ( ! $product->is_in_stock() ) : ?>
 		
-	<a href="<?php echo get_permalink($product->id); ?>" class="button"><?php echo apply_filters('out_of_stock_add_to_cart_text', __('Read More', 'woocommerce')); ?></a>
+	<a href="<?php echo get_permalink( $product->id ); ?>" class="button"><?php echo apply_filters( 'out_of_stock_add_to_cart_text', __('Read More', 'woocommerce') ); ?></a>
 
 <?php else : ?>
 	
@@ -18,20 +18,20 @@ if( $product->get_price() === '' && $product->product_type != 'external' ) retur
 	
 		switch ( $product->product_type ) {
 			case "variable" :
-				$link 	= get_permalink($product->id);
-				$label 	= apply_filters('variable_add_to_cart_text', __('Select options', 'woocommerce'));
+				$link 	= get_permalink( $product->id );
+				$label 	= apply_filters( 'variable_add_to_cart_text', __('Select options', 'woocommerce') );
 			break;
 			case "grouped" :
 				$link 	= get_permalink($product->id);
-				$label 	= apply_filters('grouped_add_to_cart_text', __('View options', 'woocommerce'));
+				$label 	= apply_filters( 'grouped_add_to_cart_text', __('View options', 'woocommerce') );
 			break;
 			case "external" :
 				$link 	= get_permalink($product->id);
-				$label 	= apply_filters('external_add_to_cart_text', __('Read More', 'woocommerce'));
+				$label 	= apply_filters( 'external_add_to_cart_text', __('Read More', 'woocommerce') );
 			break;
 			default :
-				$link 	= esc_url( $product->add_to_cart_url() );
-				$label 	= apply_filters('add_to_cart_text', __('Add to cart', 'woocommerce'));
+				$link 	= apply_filters( 'add_to_cart_url', esc_url( $product->add_to_cart_url() ), $product );
+				$label 	= apply_filters( 'add_to_cart_text', __('Add to cart', 'woocommerce'), $product );
 			break;
 		}
 	

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -10,7 +10,7 @@ if( $product->get_price() === '' && $product->product_type != 'external' ) retur
 
 <?php if ( ! $product->is_in_stock() ) : ?>
 		
-	<a href="<?php echo get_permalink( $product->id ); ?>" class="button"><?php echo apply_filters( 'out_of_stock_add_to_cart_text', __('Read More', 'woocommerce') ); ?></a>
+	<a href="<?php echo get_permalink($product->id); ?>" class="button"><?php echo apply_filters('out_of_stock_add_to_cart_text', __('Read More', 'woocommerce')); ?></a>
 
 <?php else : ?>
 	
@@ -18,20 +18,20 @@ if( $product->get_price() === '' && $product->product_type != 'external' ) retur
 	
 		switch ( $product->product_type ) {
 			case "variable" :
-				$link 	= get_permalink( $product->id );
-				$label 	= apply_filters( 'variable_add_to_cart_text', __('Select options', 'woocommerce') );
+				$link 	= get_permalink($product->id);
+				$label 	= apply_filters('variable_add_to_cart_text', __('Select options', 'woocommerce'));
 			break;
 			case "grouped" :
 				$link 	= get_permalink($product->id);
-				$label 	= apply_filters( 'grouped_add_to_cart_text', __('View options', 'woocommerce') );
+				$label 	= apply_filters('grouped_add_to_cart_text', __('View options', 'woocommerce'));
 			break;
 			case "external" :
 				$link 	= get_permalink($product->id);
-				$label 	= apply_filters( 'external_add_to_cart_text', __('Read More', 'woocommerce') );
+				$label 	= apply_filters('external_add_to_cart_text', __('Read More', 'woocommerce'));
 			break;
 			default :
-				$link 	= apply_filters( 'add_to_cart_url', esc_url( $product->add_to_cart_url() ), $product );
-				$label 	= apply_filters( 'add_to_cart_text', __('Add to cart', 'woocommerce'), $product );
+				$link 	= esc_url( $product->add_to_cart_url() );
+				$label 	= apply_filters('add_to_cart_text', __('Add to cart', 'woocommerce'));
 			break;
 		}
 	


### PR DESCRIPTION
This helps get rid of the last template file override in the 'Bundles' extension.

Non-standard product types can all hook here.

Sorry for the commit mess, just look at the diff.

The $product parameter passed to the filters is 

[absolutely needed, at least by Product Bundles: the properties of the product need to be accessible, otherwise the filter would be useless. For consistency, you may want to add the parameter to all filters in the template, but it's the 'default' case that certainly needs the extra flexibility.] 

probably not needed ;).
