### PR TITLE
Putting the title in the summary section puts it inside the "offers" mic...

### DIFF
--- a/woocommerce-hooks.php
+++ b/woocommerce-hooks.php
@@ -45,13 +45,13 @@ if ( !is_admin() || defined('DOING_AJAX') ) {
 	/* Before Single Products Summary Div */
 	add_action( 'woocommerce_before_single_product_summary', 'woocommerce_show_product_images', 20);
 	add_action( 'woocommerce_product_thumbnails', 'woocommerce_show_product_thumbnails', 20 );
-	
+	add_action( 'woocommerce_before_single_product_summary', 'woocommerce_template_single_title', 5);
 	/* After Single Products Summary Div */
 	add_action( 'woocommerce_after_single_product_summary', 'woocommerce_output_product_data_tabs', 10);
 	add_action( 'woocommerce_after_single_product_summary', 'woocommerce_output_related_products', 20);
 	
 	/* Product Summary Box */
-	add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_title', 5);
+
 	add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_price', 10);
 	add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_excerpt', 20);
 	add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_meta', 40);


### PR DESCRIPTION
...rodata instead of the product microdata. As such, the appropriate micro data (pricing and availability) will never be displayed in a google snippet. Moving the title to be just before the summary section corrects this and has no impact on the layout.
