### PR TITLE
coupons tweaks

### DIFF
--- a/admin/settings/settings-init.php
+++ b/admin/settings/settings-init.php
@@ -147,7 +147,16 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'checkboxgroup' => 'start',
 		'show_if_checked' => 'option'
 	),
-
+	
+	array(  
+		'desc' 		=> __( 'Enable coupon form on cart', 'woocommerce' ),
+		'id' 		=> 'woocommerce_enable_coupon_form_on_cart',
+		'std' 		=> 'yes',
+		'type' 		=> 'checkbox',
+		'checkboxgroup'	=> '',
+		'show_if_checked' => 'yes'
+	),
+	
 	array(  
 		'desc' 		=> __( 'Enable coupon form on checkout', 'woocommerce' ),
 		'id' 		=> 'woocommerce_enable_coupon_form_on_checkout',

--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -535,7 +535,13 @@ class WC_Checkout {
 				wp_set_object_terms( $order_id, 'pending', 'shop_order_status' );
 					
 				// Discount code meta
-				if ($applied_coupons = $woocommerce->cart->get_applied_coupons()) update_post_meta($order_id, 'coupons', implode(', ', $applied_coupons));
+				if ( $applied_coupons = $woocommerce->cart->get_applied_coupons() ) {
+				
+					update_post_meta( $order_id, 'coupons', implode(', ', $applied_coupons) );
+					
+					$order = new WC_Order( $order_id );
+					$order->add_order_note( sprintf( __( 'Coupon Code Used: %s', 'woocommerce' ), implode(', ', $applied_coupons ) ) );
+				}
 				
 				// Order is saved
 				do_action('woocommerce_checkout_order_processed', $order_id, $this->posted);

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -106,7 +106,7 @@ global $woocommerce;
 		<tr>
 			<td colspan="6" class="actions">
 
-				<?php if ( get_option( 'woocommerce_enable_coupons' ) == 'yes' ) { ?>
+				<?php if ( get_option( 'woocommerce_enable_coupons' ) == 'yes' && get_option( 'woocommerce_enable_coupon_form_on_cart' ) == 'yes') { ?>
 					<div class="coupon">
 					
 						<label for="coupon_code"><?php _e('Coupon', 'woocommerce'); ?>:</label> <input name="coupon_code" class="input-text" id="coupon_code" value="" /> <input type="submit" class="button" name="apply_coupon" value="<?php _e('Apply Coupon', 'woocommerce'); ?>" />


### PR DESCRIPTION
I think for some users, removing the coupon form on the cart page is the only reason to edit the cart template, so it makes sense to make it available as an option.

Also, the only way to view a coupon used with an order is with the custom fields area, which isn't very intuitive, especially if this is hidden. I added the coupon(s) used as a single order note when the post meta is updated. Seems like the best spot, but could possibly be added as a text field elsewhere if there's a use case for an admin to change the coupon code used for an order.
