### PR TITLE
fix woocommerce_disable_admin_bar

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -167,12 +167,12 @@ if ( ! function_exists( 'woocommerce_empty_cart' ) ) {
  *
  **/
 if ( ! function_exists( 'woocommerce_disable_admin_bar' ) ) {
-	function woocommerce_disable_admin_bar() {
-		if ( get_option('woocommerce_lock_down_admin')=='yes' && !current_user_can('edit_posts') ) {
-			add_filter( 'show_admin_bar', '__return_false' );
-			wp_deregister_style( 'admin-bar' );
-			remove_action('wp_head', '_admin_bar_bump_cb');
+	function woocommerce_disable_admin_bar( $show_admin_bar ) {
+		if ( get_option('woocommerce_lock_down_admin')=='yes' && ! current_user_can('edit_posts') ) {
+			$show_admin_bar = false;
 		}
+		
+		return $show_admin_bar;
 	}
 }
 

--- a/woocommerce-hooks.php
+++ b/woocommerce-hooks.php
@@ -112,7 +112,7 @@ if (get_option('woocommerce_clear_cart_on_logout')=='yes') add_action( 'wp_logou
 add_action( 'get_header', 'woocommerce_clear_cart_after_payment' );
 
 /* Disable admin bar */
-add_action( 'init', 'woocommerce_disable_admin_bar' );
+add_filter( 'show_admin_bar', 'woocommerce_disable_admin_bar', 10, 1 );
 
 /* Catalog sorting/ordering */
 add_action( 'init', 'woocommerce_update_catalog_ordering' );


### PR DESCRIPTION
current version of woocomerce_disable_admin_bar leaves admin-bar.js in footer, resulting in an unnecessary HTTP request. This version neatly and completely removes the admin bar when the customer is logged in.
