### PR TITLE
added add to cart google analytics event tracking

### DIFF
--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -35,7 +35,7 @@ if( $product->get_price() === '' && $product->product_type != 'external' ) retur
 			break;
 		}
 	
-		printf('<a href="%s" rel="nofollow" data-product_id="%s" class="button add_to_cart_button product_type_%s">%s</a>', $link, $product->id, $product->product_type, $label);
+		printf('<a href="%s" rel="nofollow" data-product_id="%s" class="button add_to_cart_button product_type_%s" onClick="%s">%s</a>', $link, $product->id, $product->product_type, apply_filters( 'woocommerce_onclick_javascript', '', 'add_to_cart', $product->id ), $label );
 
 	?>
 

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -5,6 +5,6 @@
 ?>
 <?php do_action('woocommerce_before_add_to_cart_button'); ?>
 
-<p class="cart"><a href="<?php echo $product_url; ?>" rel="nofollow" class="button alt"><?php echo apply_filters('single_add_to_cart_text', $button_text, 'external'); ?></a></p>
+<p class="cart"><a href="<?php echo $product_url; ?>" rel="nofollow" class="button alt" onClick="<?php echo apply_filters( 'woocommerce_onclick_javascript', '', 'add_to_cart', $product->id ); ?>"><?php echo apply_filters('single_add_to_cart_text', $button_text, 'external'); ?></a></p>
 
 <?php do_action('woocommerce_after_add_to_cart_button'); ?>

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -40,7 +40,7 @@ foreach ( $product->get_children() as $child_id ) {
 						
 						<?php elseif ( ! $quantites_required ) : ?>
 						
-							<button type="submit" name="quantity[<?php echo $child_product['product']->id; ?>]" value="1" class="button alt"><?php _e('Add to cart', 'woocommerce'); ?></button>
+							<button type="submit" name="quantity[<?php echo $child_product['product']->id; ?>]" value="1" class="button alt" onClick="<?php echo apply_filters( 'woocommerce_onclick_javascript', '', 'add_to_cart', $product->id ); ?>"><?php _e('Add to cart', 'woocommerce'); ?></button>
 						
 						<?php else : ?>
 						
@@ -70,7 +70,7 @@ foreach ( $product->get_children() as $child_id ) {
 	
 		<?php do_action('woocommerce_before_add_to_cart_button'); ?>
 	
-		<button type="submit" class="button alt"><?php echo apply_filters('single_add_to_cart_text', __('Add to cart', 'woocommerce'), $product->product_type); ?></button>
+		<button type="submit" class="button alt" onClick="<?php echo apply_filters( 'woocommerce_onclick_javascript', '', 'add_to_cart', $product->id ); ?>"><?php echo apply_filters('single_add_to_cart_text', __('Add to cart', 'woocommerce'), $product->product_type); ?></button>
 	
 		<?php do_action('woocommerce_after_add_to_cart_button'); ?>
 	

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -29,8 +29,8 @@ if( $product->get_price() === '') return;
 	 		if ( ! $product->is_sold_individually() ) 
 	 			woocommerce_quantity_input( array( 'min_value' => 1, 'max_value' => $product->backorders_allowed() ? '' : $product->get_stock_quantity() ) ); 
 	 	?>
-
-	 	<button type="submit" class="button alt"><?php echo apply_filters('single_add_to_cart_text', __('Add to cart', 'woocommerce'), $product->product_type); ?></button>
+	 	
+	 	<button type="submit" class="button alt" onClick="<?php echo apply_filters( 'woocommerce_onclick_javascript', '', 'add_to_cart', $product->id ); ?>"><?php echo apply_filters('single_add_to_cart_text', __('Add to cart', 'woocommerce'), $product->product_type); ?></button>
 
 	 	<?php do_action('woocommerce_after_add_to_cart_button'); ?>
 

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -58,7 +58,7 @@ global $woocommerce, $product, $post;
 		<div class="variations_button">
 			<input type="hidden" name="variation_id" value="" />
 			<?php woocommerce_quantity_input(); ?>
-			<button type="submit" class="button alt"><?php echo apply_filters('single_add_to_cart_text', __('Add to cart', 'woocommerce'), $product->product_type); ?></button>
+			<button type="submit" class="button alt" onClick="<?php echo apply_filters( 'woocommerce_onclick_javascript', '', 'add_to_cart', $product->id ); ?>"><?php echo apply_filters('single_add_to_cart_text', __('Add to cart', 'woocommerce'), $product->product_type); ?></button>
 		</div>
 	</div>
 	<div><input type="hidden" name="product_id" value="<?php echo esc_attr( $post->ID ); ?>" /></div>


### PR DESCRIPTION
Initial implementation of GA event tracking. There was no way to hook into the add to cart links / buttons as-is, so I added the onClick attribute to each type. It's built to allow additional event types to be added easily. I've tested it, but it could use some additional auditing.

two new filters: 

woocommerce_onclick_javascript - allows GA integration
(and other plugins / themes) to hook into onClick attribute javascript
for add to cart buttons / links. This filter could be added to other links / buttons to allow tracking of additional events.

woocommerce_ga_event_tracking_parameters - allows change of category,
action, or label parameters included in the _trackEvent js code within
onClick.

Closes #1256
