### PR TITLE
added hooks to support analytics plugins

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1593,6 +1593,9 @@ class WC_Cart {
 				$this->set_session();
 				
 				$woocommerce->add_message( __('Discount code applied successfully.', 'woocommerce') );
+				
+				do_action( 'woocommerce_applied_coupon ', $coupon_code );
+				
 				return true;
 			
 			} else {

--- a/shortcodes/shortcode-cart.php
+++ b/shortcodes/shortcode-cart.php
@@ -67,6 +67,8 @@ function woocommerce_cart( $atts ) {
 			$woocommerce->add_message(  __('Shipping costs updated.', 'woocommerce') );
 			
 		endif;
+		
+		do_action( 'woocommerce_calculated_shipping' );
 
 	}
 	

--- a/shortcodes/shortcode-order_tracking.php
+++ b/shortcodes/shortcode-order_tracking.php
@@ -45,7 +45,7 @@ function woocommerce_order_tracking( $atts ) {
 			if ( $order->id && $order_email ) {
 	
 				if ( strtolower( $order->billing_email ) == strtolower( $order_email ) ) {
-				
+					do_action( 'woocommerce_track_order', $order->id );
 					woocommerce_get_template( 'order/tracking.php', array(
 						'order' => $order
 					) );

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -174,6 +174,7 @@ function woocommerce_ajax_add_to_cart() {
 	if ($passed_validation && $woocommerce->cart->add_to_cart($product_id, 1)) :
 		// Return html fragments
 		$data = apply_filters('add_to_cart_fragments', array());
+		do_action( 'woocommerce_ajax_added_to_cart', $product_id);
 	else :
 		// If there was an error adding to the cart, redirect to the product page to show any errors
 		$data = array(

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -658,6 +658,8 @@ function woocommerce_order_again() {
 
 		$woocommerce->cart->add_to_cart( $product_id, $quantity, $variation_id, $variations );
 	}
+	
+	do_action( 'woocommerce_ordered_again', $order->id );
 
 	// Redirect to cart
 	$woocommerce->add_message( __('The cart has been filled with the items from your previous order.', 'woocommerce' ) );
@@ -686,6 +688,8 @@ function woocommerce_cancel_order() {
 			
 			// Message
 			$woocommerce->add_message( __('Your order was cancelled.', 'woocommerce') );
+			
+			do_action( 'woocommerce_cancelled_order', $order->id );
 		
 		elseif ($order->status!='pending') :
 			


### PR DESCRIPTION
Added 5 hooks to support tracking of events without needing to access _GET or _POST variables for KISS Metrics plugin and upcoming Mixpanel plugin.

EDIT: extended commit message below is missing one hook that was added, cancelled order : woocommerce_cancelled_order, $order->id
