### PR TITLE
Update Variation Image Title/Alt

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -93,6 +93,7 @@ jQuery(document).ready(function($) {
 
         var variation_image = variation.image_src;
         var variation_link = variation.image_link;
+		var variation_title = variation.image_title;
 		
 		$('.variations_button').show();
         $('.single_variation').html( variation.price_html + variation.availability_html );
@@ -108,6 +109,8 @@ jQuery(document).ready(function($) {
         if (variation_image && variation_image.length > 1) {	
             $(img).attr('src', variation_image);
             $(link).attr('href', variation_link);
+			$(img).attr('alt', variation_title);
+			$(img).attr('title', variation_title);
         } else {
             $(img).attr('src', o_src);
             $(link).attr('href', o_href);

--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -1077,8 +1077,10 @@ class WC_Product {
 					
 					$attachment = wp_get_attachment_image_src( $attachment_id, 'full'  );
 					$image_link = $attachment ? current( $attachment ) : '';
+					
+					$image_title = get_the_title( $attachment_id );
 				} else {
-					$image = $image_link = '';
+					$image = $image_link = $image_title = '';
 				}
 
 				$available_variations[] = apply_filters( 'woocommerce_available_variation', array(
@@ -1086,6 +1088,7 @@ class WC_Product {
 					'attributes' 			=> $variation_attributes,
 					'image_src' 			=> $image,
 					'image_link' 			=> $image_link,
+					'image_title'			=> $image_title,
 					'price_html' 			=> $this->min_variation_price != $this->max_variation_price ? '<span class="price">' . $variation->get_price_html() . '</span>' : '',
 					'availability_html' 	=> $availability_html,
 					'sku' 					=> __( 'SKU:', 'woocommerce' ) . ' ' . $variation->get_sku(),


### PR DESCRIPTION
We should update the image title/alt when the product image changes for different variations.

Pre-patch:
http://cl.ly/image/1B0u3a0D0R1j
http://cl.ly/image/2Y3H1k3Y3H1e

Post-patch:
http://cl.ly/image/1E0l2P1b2R2P
http://cl.ly/image/0G1412211W41

May need to clean up Javascript. Let me know.
