### PR TITLE
add a trailing space (display on Paypal checkout)

### DIFF
--- a/classes/gateways/paypal/class-wc-paypal.php
+++ b/classes/gateways/paypal/class-wc-paypal.php
@@ -286,7 +286,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 			// $paypal_args['shipping_1']		= number_format( $order->get_shipping() + $order->get_shipping_tax() , 2, '.', '' );
 			
 			if ( ( $order->get_shipping() + $order->get_shipping_tax() ) > 0 ) :
-				$paypal_args['item_name_2'] = __( 'Shipping via', 'woocommerce' ) . ' ' . ucwords( $order->shipping_method_title );
+				$paypal_args['item_name_2'] = __( 'Shipping via ', 'woocommerce' ) . ' ' . ucwords( $order->shipping_method_title );
 				$paypal_args['quantity_2'] 	= '1';
 				$paypal_args['amount_2'] 	= number_format( $order->get_shipping() + $order->get_shipping_tax() , 2, '.', '' );
 			endif;
@@ -323,7 +323,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 			// Shipping Cost item - paypal only allows shipping per item, we want to send shipping for the order
 			if ($order->get_shipping()>0) :
 				$item_loop++;
-				$paypal_args['item_name_'.$item_loop] = __('Shipping via', 'woocommerce') . ucwords($order->shipping_method_title);
+				$paypal_args['item_name_'.$item_loop] = __('Shipping via ', 'woocommerce') . ucwords($order->shipping_method_title);
 				$paypal_args['quantity_'.$item_loop] = '1';
 				$paypal_args['amount_'.$item_loop] = number_format($order->get_shipping(), 2, '.', '');
 			endif;


### PR DESCRIPTION
On the Paypal.com checkout page, there is missing a space.

Before:
Shipping viaInternational Delivery

After:
Shipping via International Delivery
