### PR TITLE
add trailing space to 'Shipping via'

### DIFF
--- a/classes/gateways/paypal/class-wc-paypal.php
+++ b/classes/gateways/paypal/class-wc-paypal.php
@@ -323,7 +323,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 			// Shipping Cost item - paypal only allows shipping per item, we want to send shipping for the order
 			if ($order->get_shipping()>0) :
 				$item_loop++;
-				$paypal_args['item_name_'.$item_loop] = __('Shipping via', 'woocommerce') . ucwords($order->shipping_method_title);
+				$paypal_args['item_name_'.$item_loop] = __('Shipping via', 'woocommerce') . ' ' . ucwords($order->shipping_method_title);
 				$paypal_args['quantity_'.$item_loop] = '1';
 				$paypal_args['amount_'.$item_loop] = number_format($order->get_shipping(), 2, '.', '');
 			endif;


### PR DESCRIPTION
On the Paypal.com checkout page, there is missing a trailing space on the text "Shipping via".

Before patch:
Shipping viaInternational Delivery

After patch:
Shipping via International Delivery
