### PR TITLE
Fix Downloadable Product Variation Linking in WC 1.6.2

### DIFF
--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -310,6 +310,21 @@ class WC_Product_Variation extends WC_Product {
 		}
 		return (int) $this->variation_shipping_class_id;
 	}
+	
+	/**
+	 * Check if downloadable product has a file attached.
+	 *
+	 * @return bool Whether downloadable product has a file attached.
+	 */
+	function has_file() {
+		if ( ! $this->is_downloadable() )
+			return false;
+		
+		if ( apply_filters( 'woocommerce_file_download_path', get_post_meta( $this->variation_id, '_file_path', true ), $this->variation_id ) )
+			return true;
+
+		return false;
+	}
 
 }
 


### PR DESCRIPTION
Fix the downloadable product variation linking, which seems to have been broken in WC 1.6.2 due to the introduction of the has_file() method at the WC_Product class, with an implementation that does not function properly for the child WC_Product_Variation class.

Tried creating a downloadable product variation in a fresh install with WC 1.6.2, the Download File link on the email order items and order details templates failed to display, because get_file() defined at WC_Product checks for a _file_path using the parent product id.  My fix is to override the get_file() method in the WC_Product_Variation class with a check using variation_id instead.
