### PR TITLE
add before order review checkout template hook

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -30,6 +30,8 @@ $get_checkout_url = apply_filters( 'woocommerce_get_checkout_url', $woocommerce-
 		</div>
 	</div>
 	
+	<?php do_action( 'woocommerce_checkout_before_order_review'); ?>
+	
 	<h3 id="order_review_heading"><?php _e('Your order', 'woocommerce'); ?></h3>
 	
 	<?php endif; ?>


### PR DESCRIPTION
This hook is helpful if you need to add a lot of fields to the checkout page and need them to be full width and after the billing / shipping fields. All other hooks exist in either the first or second column, which makes them unsuitable.
