### PR TITLE
Fixes issue with coupon field box styling

### DIFF
--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -17,7 +17,7 @@ $info_message = apply_filters('woocommerce_checkout_coupon_message', __('Have a 
 <form class="checkout_coupon" method="post">
 
 	<p class="form-row form-row-first">
-		<input name="coupon_code" class="input-text" placeholder="<?php _e('Coupon code', 'woocommerce'); ?>" id="coupon_code" value="" />
+		<input type="text" name="coupon_code" class="input-text" placeholder="<?php _e('Coupon code', 'woocommerce'); ?>" id="coupon_code" value="" />
 	</p>
 
 	<p class="form-row form-row-last">


### PR DESCRIPTION
The coupon box doesn't have the correct input type so theme designers can't apply there custom style to the box field.

It doesn't have input type="text" so this commit fixes the issue.

See screen shot of issue: http://o7.no/NfKtDe
