### PR TITLE
Update templates/shop/breadcrumb.php

### DIFF
--- a/templates/shop/breadcrumb.php
+++ b/templates/shop/breadcrumb.php
@@ -15,7 +15,6 @@ $home_link = home_url();
 
 $prepend = '';
 
-if ( get_option('woocommerce_prepend_shop_page_to_urls')=="yes" && woocommerce_get_page_id('shop') && get_option('page_on_front') !== woocommerce_get_page_id('shop') )
 	$prepend =  $before . '<a href="' . get_permalink( woocommerce_get_page_id('shop') ) . '">' . get_the_title( woocommerce_get_page_id('shop') ) . '</a> ' . $after . $delimiter;
 
 if ( (!is_home() && !is_front_page() && !(is_post_type_archive() && get_option('page_on_front')==woocommerce_get_page_id('shop'))) || is_paged() ) :


### PR DESCRIPTION
<code>if ( get_option('woocommerce_prepend_shop_page_to_urls')=="yes" && woocommerce_get_page_id('shop') && get_option('page_on_front') !== woocommerce_get_page_id('shop') )</code>
The deleted line makes the Shop trail not to show on single product pages.
Now, deleted, the breadcrumb trail for product is Home > Shop > Catergory > Title
The breadcrumb does not show up on front page, even if Shop page is set to Home page and this is ok.
