### PR TITLE
woocommerce_create_term returns Notice

### DIFF
--- a/admin/woocommerce-admin-functions.php
+++ b/admin/woocommerce-admin-functions.php
@@ -316,17 +316,22 @@ function woocommerce_create_term( $term_id, $tt_id, $taxonomy ) {
 
 	$term = get_term($term_id, $taxonomy);
 
-	// gets the sibling terms
-	$siblings = get_terms($taxonomy, "parent={$term->parent}&menu_order=ASC&hide_empty=0");
-
-	foreach ($siblings as $sibling) {
-		if( $sibling->term_id == $term_id ) continue;
-		$next_id =  $sibling->term_id; // first sibling term of the hierarchy level
-		break;
+	if ( $term != null ){
+	
+		// gets the sibling terms
+		$siblings = get_terms($taxonomy, "parent={$term->parent}&menu_order=ASC&hide_empty=0");
+	
+		foreach ($siblings as $sibling) {
+			if( $sibling->term_id == $term_id ) continue;
+			$next_id =  $sibling->term_id; // first sibling term of the hierarchy level
+			break;
+		}
+	
+		// reorder
+		woocommerce_order_terms( $term, $next_id, $taxonomy );		
+	
 	}
 
-	// reorder
-	woocommerce_order_terms( $term, $next_id, $taxonomy );
 }
 
 


### PR DESCRIPTION
fixed bug where woocommerce_create_term would return notice Trying to get property of non-object if $term was null. Pretty rare circumstances, but present.
