### PR TITLE
fix fatal error on users page

### DIFF
--- a/admin/woocommerce-admin-users.php
+++ b/admin/woocommerce-admin-users.php
@@ -150,11 +150,11 @@ function woocommerce_get_customer_meta_fields() {
 					),
 				'billing_state' => array(
 						'label' => __('State/County', 'woocommerce'),
-						'description' => '__('Country or state code', 'woocommerce'),
+						'description' => __('Country or state code', 'woocommerce'),
 					),
 				'billing_country' => array(
 						'label' => __('Country', 'woocommerce'),
-						'description' => '__('2 letter Country code', 'woocommerce')'
+						'description' => __('2 letter Country code', 'woocommerce')
 					),
 				'billing_phone' => array(
 						'label' => __('Telephone', 'woocommerce'),


### PR DESCRIPTION
localization addition had typo that caused a fatal error when viewing the users page.
