### PR TITLE
Multiple Downloads per Product

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -392,7 +392,7 @@ function woocommerce_order_items_meta_box($post) {
 							</table>
 						</td>
 
-						<?php do_action('woocommerce_admin_order_item_values', $_product, $item); ?>
+						<?php do_action( 'woocommerce_admin_order_item_values', $_product, $item, $loop ); ?>
 
 						<td class="tax_class" width="1%">
 							<select class="tax_class" name="item_tax_class[<?php echo $loop; ?>]" title="<?php _e('Tax class', 'woocommerce'); ?>">
@@ -846,7 +846,7 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 					'line_subtotal_tax' => rtrim(rtrim(number_format(woocommerce_clean($line_subtotal_tax[$i]), 4, '.', ''), '0'), '.'),
 					'item_meta'			=> $item_meta->meta,
 					'tax_class'			=> woocommerce_clean($item_tax_class[$i])
-				));
+				), $i);
 
 			 endfor;
 		endif;

--- a/admin/post-types/writepanels/writepanels-init.php
+++ b/admin/post-types/writepanels/writepanels-init.php
@@ -213,6 +213,46 @@ function woocommerce_order_data( $data ) {
 add_filter('wp_insert_post_data', 'woocommerce_order_data');
 
 
+
+/**
+ * Grant downloadable file access to any newly added files on any existing 
+ * orders for this product that have previously been granted downloadable file access
+ * 
+ * @access public
+ * @param int $product_id product identifier
+ * @param int $variation_id optional product variation identifier
+ * @param array $file_paths newly set file paths
+ */
+function woocommerce_process_product_file_download_paths( $product_id, $variation_id, $file_paths ) {
+	global $wpdb;
+
+	if ( $variation_id ) $product_id = $variation_id;
+
+	// determine whether any new files have been added
+	$existing_file_paths = apply_filters( 'woocommerce_file_download_paths', get_post_meta( $product_id, '_file_paths', true ), $product_id, null, null );
+	if ( ! $existing_file_paths ) $existing_file_paths = array();
+	$new_download_ids = array_diff( array_keys( $file_paths ), array_keys( $existing_file_paths ) );
+
+	if ( $new_download_ids ) {
+		// determine whether downloadable file access has been granted (either via the typical order completion, or via the admin ajax method)
+		$existing_permissions = $wpdb->get_results( $wpdb->prepare( "SELECT * from {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE product_id = %d GROUP BY order_id", $product_id ) );
+		foreach ( $existing_permissions as $existing_permission ) {
+			$order = new WC_Order( $existing_permission->order_id );
+
+			if ( $order->id ) { 
+				foreach ( $new_download_ids as $new_download_id ) {
+					// grant permission if it doesn't already exist
+					if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT true FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE order_id = %d AND product_id = %d AND download_id = %s", $order->id, $product_id, $new_download_id ) ) ) { 
+						woocommerce_downloadable_file_permission( $new_download_id, $product_id, $order );
+					}
+				}
+			}
+		}
+	}
+}
+
+add_action( 'woocommerce_process_product_file_download_paths', 'woocommerce_process_product_file_download_paths', 10, 3 );
+
 /**
  * Stores error messages in a variable so they can be displayed on the edit post screen after saving.
  *

--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -853,7 +853,7 @@ jQuery( function($){
 
 	jQuery('.upload_file_button').live('click', function(){
 
-		file_path_field = jQuery(this).parent().find('.file_path');
+		file_path_field = jQuery(this).parent().find('.file_paths');
 
 		formfield = jQuery(file_path_field).attr('name');
 
@@ -867,7 +867,7 @@ jQuery( function($){
 
 		file_url = jQuery(html).attr('href');
 		if (file_url) {
-			jQuery(file_path_field).val(file_url);
+			jQuery(file_path_field).val(jQuery(file_path_field).val() ? jQuery(file_path_field).val() + "\n" + file_url : file_url);
 		}
 		tb_remove();
 		window.send_to_editor = window.send_to_editor_default;

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -718,7 +718,7 @@ class WC_Cart {
 			if ( $quantity < 1 ) return false;
 
 			// Load cart item data - may be added by other plugins
-			$cart_item_data = (array) apply_filters( 'woocommerce_add_cart_item_data', $cart_item_data, $product_id );
+			$cart_item_data = (array) apply_filters( 'woocommerce_add_cart_item_data', $cart_item_data, $product_id, $variation_id );
 
 			// Generate a ID based on product ID, variation ID, variation data, and other cart item data
 			$cart_id = $this->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -378,18 +378,26 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
-	 * Check if downloadable product has a file attached.
-	 *
-	 * @return bool Whether downloadable product has a file attached.
+	 * Get file download path identified by $download_id
+	 * 
+	 * @access public
+	 * @param string $download_id file identifier
+	 * @return array
 	 */
-	function has_file() {
-		if ( ! $this->is_downloadable() )
-			return false;
+	function get_file_download_path( $download_id ) {
+		
+		$file_path = '';
+		$file_paths = apply_filters( 'woocommerce_file_download_paths', get_post_meta( $this->variation_id, '_file_paths', true ), $this->variation_id, null, null );
 
-		if ( apply_filters( 'woocommerce_file_download_path', get_post_meta( $this->variation_id, '_file_path', true ), $this->variation_id ) )
-			return true;
+		if ( ! $download_id && count( $file_paths ) == 1 ) {
+			// backwards compatibility for old-style download URLs and template files
+			$file_path = array_shift( $file_paths );
+		} elseif ( isset( $file_paths[ $download_id ] ) ) {
+			$file_path = $file_paths[ $download_id ];
+		}
 
-		return false;
+		// allow overriding based on the particular file being requested
+		return apply_filters( 'woocommerce_file_download_path', $file_path, $this->variation_id, $download_id );
 	}
 }
 

--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -371,16 +371,42 @@ class WC_Product {
 	 *
 	 * @since 1.6.2
 	 *
+	 * @access public
+	 * @param string $download_id file identifier
 	 * @return bool Whether downloadable product has a file attached.
 	 */
-	function has_file() {
+	function has_file( $download_id = '' ) {
 		if ( ! $this->is_downloadable() )
 			return false;
 
-		if ( apply_filters( 'woocommerce_file_download_path', get_post_meta( $this->id, '_file_path', true ), $this->id ) )
+		if ( $this->get_file_download_path( $download_id ) )
 			return true;
 
 		return false;
+	}
+	
+	
+	/**
+	 * Get file download path identified by $download_id
+	 * 
+	 * @access public
+	 * @param string $download_id file identifier
+	 * @return array
+	 */
+	function get_file_download_path( $download_id ) {
+		
+		$file_path = '';
+		$file_paths = apply_filters( 'woocommerce_file_download_paths', get_post_meta( $this->id, '_file_paths', true ), $this->id, null, null );
+
+		if ( ! $download_id && count( $file_paths ) == 1 ) {
+			// backwards compatibility for old-style download URLs and template files
+			$file_path = array_shift( $file_paths );
+		} elseif ( isset( $file_paths[ $download_id ] ) ) {
+			$file_path = $file_paths[ $download_id ];
+		}
+
+		// allow overriding based on the particular file being requested
+		return apply_filters( 'woocommerce_file_download_path', $file_path, $this->id, $download_id );
 	}
 
 

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -33,13 +33,13 @@ if (!defined('ABSPATH')) exit; ?>
 		<?php
 			switch ( $order->status ) {
 				case "completed" :
-					echo $order->email_order_items_table( true, false, true );
+					echo $order->email_order_items_table( $order->is_download_permitted(), false, true );
 				break;
 				case "processing" :
-					echo $order->email_order_items_table( get_option('woocommerce_downloads_grant_access_after_payment')=='yes' ? true : false, true, true );
+					echo $order->email_order_items_table( $order->is_download_permitted(), true, true );
 				break;
 				default :
-					echo $order->email_order_items_table( false, true, false );
+					echo $order->email_order_items_table( $order->is_download_permitted(), true, false );
 				break;
 			}
 		?>

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -30,7 +30,7 @@ if (!defined('ABSPATH')) exit; ?>
 		</tr>
 	</thead>
 	<tbody>
-		<?php if ($order->status=='completed') echo $order->email_order_items_table( true, true ); else echo $order->email_order_items_table( false, true ); ?>
+		<?php echo $order->email_order_items_table( $order->is_download_permitted(), true ); ?>
 	</tbody>
 	<tfoot>
 		<?php

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -26,7 +26,7 @@ if (!defined('ABSPATH')) exit; ?>
 		</tr>
 	</thead>
 	<tbody>
-		<?php echo $order->email_order_items_table( (get_option('woocommerce_downloads_grant_access_after_payment')=='yes' && $order->status=='processing') ? true : false, true, ($order->status=='processing') ? true : false ); ?>
+		<?php echo $order->email_order_items_table( $order->is_download_permitted(), true, ($order->status=='processing') ? true : false ); ?>
 	</tbody>
 	<tfoot>
 		<?php

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -31,8 +31,19 @@ foreach ($items as $item) :
 			// SKU
 			echo 	($show_sku && $_product->get_sku()) ? ' (#' . $_product->get_sku() . ')' : '';
 
-			// File URL
-			echo 	( $show_download_links && $_product->exists() && $_product->is_downloadable() && $_product->has_file() ) ? '<br/><small>' . __( 'Download:', 'woocommerce' ) . ' <a href="' . $order->get_downloadable_file_url( $item['id'], $item['variation_id'] ) . '" target="_blank">' . $order->get_downloadable_file_url( $item['id'], $item['variation_id'] ) . '</a></small>' : '';
+			// File URLs
+			if ( $show_download_links && $_product->exists() && $_product->is_downloadable() ) :
+				$download_file_urls = $order->get_downloadable_file_urls( $item['id'], $item['variation_id'], $item );
+				foreach ( $download_file_urls as $i => $download_file_url ) :
+					echo '<br/><small>';
+					if ( $i == 0 ) echo __( 'Download:', 'woocommerce' );
+					if ( count( $download_file_urls ) > 1 ) :
+						if ( $i == 0 ) echo '</small><br/><small>';
+						echo sprintf( __('File %d:', 'woocommerce' ), $i + 1 );
+					endif;
+					echo ' <a href="' . $download_file_url . '" target="_blank">' . $download_file_url . '</a></small>';
+				endforeach;
+			endif;
 
 			// Variation
 			echo 	($item_meta->meta) ? '<br/><small>' . nl2br( $item_meta->display( true, true ) ) . '</small>' : '';

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -53,9 +53,12 @@ $order = new WC_Order( $order_id );
 				$item_meta = new WC_Order_Item_Meta( $item['item_meta'] );
 				$item_meta->display();
 
-				if ( $_product->exists() && $_product->is_downloadable() && $_product->has_file() && ( $order->status=='completed' || ( get_option( 'woocommerce_downloads_grant_access_after_payment' ) == 'yes' && $order->status == 'processing' ) ) ) :
+				if ( $_product->exists() && $_product->is_downloadable() && $order->is_download_permitted() ) :
 
-					echo '<br/><small><a href="' . $order->get_downloadable_file_url( $item['id'], $item['variation_id'] ) . '">' . __('Download file &rarr;', 'woocommerce') . '</a></small>';
+				$download_file_urls = $order->get_downloadable_file_urls( $item['id'], $item['variation_id'], $item );
+				foreach ( $download_file_urls as $i => $download_file_url ) :
+					echo '<br/><small><a href="' . $download_file_url . '">' . sprintf( __('Download file %s &rarr;', 'woocommerce'), ( count( $download_file_urls ) > 1 ? $i + 1 : '' ) ) . '</a></small>';
+				endforeach;
 
 				endif;
 


### PR DESCRIPTION
Support for multiple downloadable files per product: both simple and variable.  This includes all admin, frontend, and database modification code required for allowing multiple files, while maintaining backwards compatibility for existing single-file download URLs and templates.
