### PR TITLE
add option to enable / disable generator meta tag

### DIFF
--- a/admin/settings/settings-init.php
+++ b/admin/settings/settings-init.php
@@ -267,6 +267,14 @@ $woocommerce_settings['general'] = apply_filters('woocommerce_general_settings',
 		'type' 		=> 'checkbox',
 		'checkboxgroup'		=> ''
 	),
+	
+	array(
+		'desc'		=> __( 'Enable generator meta tag output in the HEAD section' ),
+		'id'		=> 'woocommerce_enable_generator_meta_tag',
+		'std'		=> 'yes',
+		'type'		=> 'checkbox',
+		'checkboxgroup'		=> ''
+	),
 
 	array(
 		'desc' 		=> __( 'Enable enhanced country select boxes', 'woocommerce' ),

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -578,7 +578,8 @@ class Woocommerce {
 	 * @return void
 	 */
 	function generator() {
-		echo "\n\n" . '<!-- WooCommerce Version -->' . "\n" . '<meta name="generator" content="WooCommerce ' . $this->version . '" />' . "\n\n";
+		if( 'yes' == get_option( 'woocommerce_enable_generator_meta_tag' ) )
+			echo "\n\n" . '<!-- WooCommerce Version -->' . "\n" . '<meta name="generator" content="WooCommerce ' . $this->version . '" />' . "\n\n";
 	}
 
 


### PR DESCRIPTION
The WooFramework provides this option for themes, so it made sense to me to add it for woocommerce, especially for those of us that like to keep our HEAD clean :)
