### PR TITLE
Added 'woocommerce_order_status_changed' hook

### DIFF
--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -1133,7 +1133,8 @@ class WC_Order {
 				// Status was changed
 				do_action( 'woocommerce_order_status_' . $new_status->slug , $this->id );
 				do_action( 'woocommerce_order_status_' . $this->status . '_to_' . $new_status->slug, $this->id );
-
+				do_action( 'woocommerce_order_status_changed' , $this->id , $this->status , $new_status->slug );
+				
 				$this->add_order_note( $note . sprintf( __('Order status changed from %s to %s.', 'woocommerce'), __( $old_status->name, 'woocommerce' ), __( $new_status->name, 'woocommerce' ) ) );
 
 				// Record the completed date of the order


### PR DESCRIPTION
Something that I've found would be useful is the ability to access the before and after statuses when an order status is changed. I can't see another way of accessing this information without hooking onto  `'woocommerce_order_status_' . $this->status . '_to_' . $new_status->slug` with all possible permeatations.

Unless I'm missing it somewhere and you can point me in the right direction?
