### PR TITLE
add description to coupons

### DIFF
--- a/admin/post-types/shop_coupon.php
+++ b/admin/post-types/shop_coupon.php
@@ -5,7 +5,7 @@
  * @author 		WooThemes
  * @category 	Admin
  * @package 	WooCommerce/Admin/Coupons
- * @version     1.6.4
+ * @version     1.7
  */
 
 /**
@@ -22,6 +22,7 @@ function woocommerce_edit_coupon_columns($columns){
 	$columns["cb"] 			= "<input type=\"checkbox\" />";
 	$columns["title"] 		= __("Code", 'woocommerce');
 	$columns["type"] 		= __("Coupon type", 'woocommerce');
+	$columns["description"]	= __("Description", 'woocommerce');
 	$columns["amount"] 		= __("Coupon amount", 'woocommerce');
 	$columns["products"]	= __("Product IDs", 'woocommerce');
 	$columns["usage_limit"] = __("Usage limit", 'woocommerce');
@@ -44,6 +45,7 @@ add_filter('manage_edit-shop_coupon_columns', 'woocommerce_edit_coupon_columns')
 function woocommerce_custom_coupon_columns($column) {
 	global $post, $woocommerce;
 
+	$description	= get_post_meta($post->ID, 'description', true);
 	$type 			= get_post_meta($post->ID, 'discount_type', true);
 	$amount 		= get_post_meta($post->ID, 'coupon_amount', true);
 	$individual_use = get_post_meta($post->ID, 'individual_use', true);
@@ -53,6 +55,9 @@ function woocommerce_custom_coupon_columns($column) {
 	$expiry_date 	= get_post_meta($post->ID, 'expiry_date', true);
 
 	switch ($column) {
+		case "description" :
+			echo $description;
+		break;
 		case "type" :
 			echo $woocommerce->get_coupon_discount_type($type);
 		break;

--- a/admin/post-types/writepanels/writepanel-coupon_data.php
+++ b/admin/post-types/writepanels/writepanel-coupon_data.php
@@ -7,7 +7,7 @@
  * @author 		WooThemes
  * @category 	Admin
  * @package 	WooCommerce/Admin/WritePanels
- * @version     1.6.4
+ * @version     1.7
  */
 
 
@@ -31,7 +31,10 @@ function woocommerce_coupon_data_meta_box($post) {
 		<?php
 
 			echo '<div class="options_group">';
-
+			
+			// Description
+			woocommerce_wp_text_input( array( 'id' => 'coupon_description', 'label' => __('Coupon Description', 'woocommerce'), 'description' => __('Enter a description for this coupon', 'woocommerce') ) );
+			
 			// Type
     		woocommerce_wp_select( array( 'id' => 'discount_type', 'label' => __('Discount type', 'woocommerce'), 'options' => $woocommerce->get_coupon_discount_types() ) );
 
@@ -183,6 +186,7 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 		$woocommerce_errors[] = __( 'Coupon code already exists.', 'woocommerce' );
 
 	// Add/Replace data to array
+		$description	= strip_tags(stripslashes( $_POST['coupon_description'] ));
 		$type 			= strip_tags(stripslashes( $_POST['discount_type'] ));
 		$amount 		= strip_tags(stripslashes( $_POST['coupon_amount'] ));
 		$usage_limit 	= (isset($_POST['usage_limit']) && $_POST['usage_limit']>0) ? (int) $_POST['usage_limit'] : '';
@@ -211,6 +215,7 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 		$exclude_product_categories = (isset($_POST['exclude_product_categories'])) ? array_map('intval', $_POST['exclude_product_categories']) : array();
 
 	// Save
+		update_post_meta( $post_id, 'description', $description );
 		update_post_meta( $post_id, 'discount_type', $type );
 		update_post_meta( $post_id, 'coupon_amount', $amount );
 		update_post_meta( $post_id, 'individual_use', $individual_use );


### PR DESCRIPTION
I think this is useful for larger shops with lots of coupon codes, where it's easy to forget what marketing program 'FREESHIP4123' was for. This commit doesn't add the descriptions to the front-end, but I can add if necessary.
