### PR TITLE
Add filter to needs_payment() and display formatted taxes if set

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1436,7 +1436,8 @@ class WC_Cart {
 		 * @return bool
 		 */
 		function needs_payment() {
-			if ( $this->total > 0 ) return true; else return false;
+			$needs_payment = ( $this->total > 0 ) ? true : false;
+			return apply_filters( 'woocommerce_cart_needs_payment', $needs_payment, $this );
 		}
 
     /*-----------------------------------------------------------------------------------*/

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -121,9 +121,9 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 			<?php endif; ?>
 
 			<?php
-				if ($woocommerce->cart->get_cart_tax()) :
+				$taxes = $woocommerce->cart->get_formatted_taxes();
 
-					$taxes = $woocommerce->cart->get_formatted_taxes();
+				if ( $woocommerce->cart->get_cart_tax() || ! empty( $taxes ) ) :
 
 					if (sizeof($taxes)>0) :
 


### PR DESCRIPTION
Subscriptions will eventually use order totals as a true record of payments.

As of version 1.2, they will be correct in all cases except when an order has a free trial and no sign-up fee, and therefore, order taxes/totals are 0. This is because it's not possible to sign-up for a subscription when order totals are 0.

These commits make it possible:

SHA: f2150e7c7c4ddf408eebe56e030cd59284800115 makes it possible for a plugin to display payment fields on order review even if cart total is 0.

SHA: 137b01c74c280e2768a9b05c4214f86a403c0a25 makes it possible for a plugin to have taxes display on the order review page, even when the order's taxes are 0.

Instead of checkout displaying this: http://cl.ly/image/220K0f3t290h

It will display this: http://cl.ly/image/022m2f3U0T3X
