### PR TITLE
added woocommerce_rate_label filter

### DIFF
--- a/classes/class-wc-tax.php
+++ b/classes/class-wc-tax.php
@@ -509,8 +509,8 @@ class WC_Tax {
 	 * @return  string		
 	 */
 	function get_rate_label( $key ) {
-		if (isset($this->rates[$key]) && $this->rates[$key]['label']) return $this->rates[$key]['label'];
-		return '';
+        $label = ( isset( $this->rates[ $key ] ) && $this->rates[ $key ]['label'] ) ? $this->rates[ $key ]['label'] : '';
+        return apply_filters( 'woocommerce_rate_label' , $label, $this, $key );
 	}
 	
 	/**


### PR DESCRIPTION
added the filter 'woocommerce_rate_label' to better integrate 3rd party tax/address lookup to replace the rate with synced values instead of adding to the $rates array as the state may change and it is not reasonable to request a full array, by address and ZIP+4 for all nexus.  This allows a single call to the remote API.
