### PR TITLE
Check cross-sells before displaying related products in single product template

### DIFF
--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -9,8 +9,9 @@
 
 global $product, $woocommerce_loop;
 
-$related = $product->get_related();
-
+$related = $product->get_cross_sells(); 
+if ( sizeof( $related ) == 0 )
+	$related = $product->get_related();
 if ( sizeof( $related ) == 0 ) return;
 
 $args = apply_filters('woocommerce_related_products_args', array(


### PR DESCRIPTION
Related products are similar to cross-sells.

If the user defines cross-sells, they should replace default related products.

If you disagree (and find "related products" and "cross-sells" fundamentally different, and think both need to be displayed), then I suggest adding a 'cross-sells.php' template, in similar fashion as 'up-sells.php'
