### PR TITLE
added lost password shortcode / email notification

### DIFF
--- a/admin/settings/settings-init.php
+++ b/admin/settings/settings-init.php
@@ -523,6 +523,17 @@ $woocommerce_settings['pages'] = apply_filters('woocommerce_page_settings', arra
 		'desc_tip'	=>  true,
 	),
 
+	array(
+		'name' => __( 'Lost Password Page', 'woocommerce' ),
+		'desc' 		=> __( 'Page contents: [woocommerce_lost_password]', 'woocommerce' ),
+		'id' 		=> 'woocommerce_lost_password_page_id',
+		'type' 		=> 'single_select_page',
+		'std' 		=> '',
+		'class'		=> 'chosen_select_nostd',
+		'css' 		=> 'min-width:300px;',
+		'desc_tip'	=>  true,
+	),
+
 	array( 'type' => 'sectionend', 'id' => 'page_options'),
 
 )); // End pages settings

--- a/admin/woocommerce-admin-install.php
+++ b/admin/woocommerce-admin-install.php
@@ -207,6 +207,8 @@ function woocommerce_create_pages() {
     // Thanks page
     woocommerce_create_page( esc_sql( _x( 'order-received', 'page_slug', 'woocommerce' ) ), 'woocommerce_thanks_page_id', __( 'Order Received', 'woocommerce' ), '[woocommerce_thankyou]', woocommerce_get_page_id( 'checkout' ) );
 
+	// Lost password page
+	woocommerce_create_page( esc_sql( _x( 'lost-password', 'page_slug', 'woocommerce' ) ), 'woocommerce_lost_password_page_id', __( 'Lost Password', 'woocommerce' ), '[woocommerce_lost_password]' );
 }
 
 

--- a/classes/emails/class-wc-email-customer-reset-password.php
+++ b/classes/emails/class-wc-email-customer-reset-password.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Customer Reset Password
+ *
+ * An email sent to the customer when they reset their password.
+ *
+ * @class 		WC_Email_Customer_Reset_Password
+ * @version		1.7.0
+ * @package		WooCommerce/Classes/Emails
+ * @author 		WooThemes
+ * @extends 	WC_Email
+ */
+class WC_Email_Customer_Reset_Password extends WC_Email {
+
+	/** @var string */
+	var $user_login;
+
+	/** @var string */
+	var $user_email;
+
+	/** @var string */
+	var $reset_key;
+
+	/**
+	 * Constructor
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function __construct() {
+
+		$this->id 				= 'customer_reset_password';
+		$this->title 			= __( 'Reset password', 'woocommerce' );
+		$this->description		= __( 'Customer reset password emails are sent when a customer resets their password.', 'woocommerce' );
+
+		$this->template_html 	= 'emails/customer-reset-password.php';
+		$this->template_plain 	= 'emails/plain/customer-reset-password.php';
+
+		$this->subject 			= __( 'Password Reset for {blogname}', 'woocommerce');
+		$this->heading      	= __( 'Password Reset Instructions for {blogname}', 'woocommerce');
+
+		// Trigger
+		add_action( 'woocommerce_reset_password_notification', array( $this, 'trigger' ), 10, 2 );
+
+		// Call parent constuctor
+		parent::__construct();
+	}
+
+	/**
+	 * trigger function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function trigger( $user_login = '', $reset_key = '' ) {
+		global $woocommerce;
+		if ( $user_login && $reset_key ) {
+			$this->object 		= get_user_by( 'login', $user_login );
+
+			$this->user_login 	= $user_login;
+			$this->reset_key		= $reset_key;
+			$this->user_email 	= stripslashes( $this->object->user_email );
+			$this->recipient	= $this->user_email;
+		}
+
+		if ( ! $this->is_enabled() || ! $this->get_recipient() )
+			return;
+
+		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+
+	}
+
+	/**
+	 * get_content_html function.
+	 *
+	 * @access public
+	 * @return string
+	 */
+	function get_content_html() {
+		ob_start();
+		woocommerce_get_template( $this->template_html, array(
+			'email_heading' => $this->get_heading(),
+			'user_login' 	=> $this->user_login,
+			'reset_key'		=> $this->reset_key,
+			'blogname'		=> $this->get_blogname()
+		) );
+		return ob_get_clean();
+	}
+
+	/**
+	 * get_content_plain function.
+	 *
+	 * @access public
+	 * @return string
+	 */
+	function get_content_plain() {
+		ob_start();
+		woocommerce_get_template( $this->template_plain, array(
+			'email_heading' => $this->get_heading(),
+			'user_login' 	=> $this->user_login,
+			'reset_key'		=> $this->reset_key,
+			'blogname'		=> $this->get_blogname()
+		) );
+		return ob_get_clean();
+	}
+}

--- a/classes/emails/class-wc-emails.php
+++ b/classes/emails/class-wc-emails.php
@@ -49,6 +49,7 @@ class WC_Emails {
 		include_once( 'class-wc-email-customer-invoice.php' );
 		include_once( 'class-wc-email-customer-new-account.php' );
 		include_once( 'class-wc-email-customer-note.php' );
+		include_once( 'class-wc-email-customer-reset-password.php' );
 		include_once( 'class-wc-email-customer-processing-order.php' );
 		include_once( 'class-wc-email-new-order.php' );
 		
@@ -57,6 +58,7 @@ class WC_Emails {
 		$this->emails['WC_Email_Customer_Completed_Order'] = new WC_Email_Customer_Completed_Order();
 		$this->emails['WC_Email_Customer_Invoice'] = new WC_Email_Customer_Invoice();
 		$this->emails['WC_Email_Customer_Note'] = new WC_Email_Customer_Note();
+		$this->emails['WC_Email_Customer_Reset_Password'] = new WC_Email_Customer_Reset_Password();
 		$this->emails['WC_Email_Customer_New_Account'] = new WC_Email_Customer_New_Account();
 		
 		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );

--- a/shortcodes/shortcode-init.php
+++ b/shortcodes/shortcode-init.php
@@ -7,7 +7,7 @@
  * @author 		WooThemes
  * @category 	Shortcodes
  * @package 	WooCommerce/Shortcodes
- * @version     1.6.4
+ * @version     1.7.0
  */
 
 /** Cart shortcode */
@@ -21,6 +21,9 @@ include_once('shortcode-my_account.php');
 
 /** Order tracking shortcode */
 include_once('shortcode-order_tracking.php');
+
+/** Lost password shortcode */
+include_once( 'shortcode-lost_password.php' );
 
 /** Pay shortcode */
 include_once('shortcode-pay.php');
@@ -857,6 +860,7 @@ add_shortcode('woocommerce_order_tracking', 'get_woocommerce_order_tracking');
 add_shortcode('woocommerce_my_account', 'get_woocommerce_my_account');
 add_shortcode('woocommerce_edit_address', 'get_woocommerce_edit_address');
 add_shortcode('woocommerce_change_password', 'get_woocommerce_change_password');
+add_shortcode('woocommerce_lost_password', 'get_woocommerce_lost_password');
 add_shortcode('woocommerce_view_order', 'get_woocommerce_view_order');
 add_shortcode('woocommerce_pay', 'get_woocommerce_pay');
 add_shortcode('woocommerce_thankyou', 'get_woocommerce_thankyou');

--- a/shortcodes/shortcode-lost_password.php
+++ b/shortcodes/shortcode-lost_password.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Lost Password Shortcode
+ *
+ * Displays the lost password / reset password forms
+ *
+ * @author 		WooThemes
+ * @category 	Shortcodes
+ * @package 	WooCommerce/Shortcodes/Lost Password
+ * @version     1.7.0
+ */
+
+/**
+ * Get the lost password shortcode content.
+ *
+ * @access public
+ * @return string
+ */
+function get_woocommerce_lost_password() {
+	global $woocommerce;
+	return $woocommerce->shortcode_wrapper( 'woocommerce_lost_password' );
+}
+
+/**
+ * Output the lost password shortcode.
+ *
+ * @access public
+ * @return void
+ */
+function woocommerce_lost_password() {
+	global $woocommerce;
+
+	$woocommerce->nocache();
+
+	global $post;
+
+	// arguments to pass to template
+	$args = array( 'form' => 'lost_password' );
+
+	// process lost password form
+	if( isset( $_POST['user_login'] ) ) {
+
+		$woocommerce->verify_nonce( 'lost_password' );
+
+		woocommerce_retrieve_password();
+	}
+
+	// process reset key / login from email confirmation link
+	if( isset( $_GET['key'] ) && isset( $_GET['login'] ) ) {
+
+		$user = woocommerce_check_password_reset_key( $_GET['key'], $_GET['login'] );
+
+		// reset key / login is correct, display reset password form with hidden key / login values
+		if( is_object( $user ) ) {
+			$args['form'] = 'reset_password';
+			$args['key'] = esc_attr( $_GET['key'] );
+			$args['login'] = esc_attr( $_GET['login'] );
+		}
+	}
+
+	// process reset password form
+	if( isset( $_POST['password_1'] ) && isset( $_POST['password_2'] ) && isset( $_POST['reset_key'] ) && isset( $_POST['reset_login'] ) ) :
+
+		// verify reset key again
+		$user = woocommerce_check_password_reset_key( $_POST['reset_key'], $_POST['reset_login'] );
+
+		if( is_object( $user ) ) {
+
+			// save these values into the form again in case of errors
+			$args['key'] = esc_attr( $_POST['reset_key'] );
+			$args['login'] = esc_attr( $_POST['reset_login'] );
+
+			$woocommerce->verify_nonce( 'reset_password' );
+
+			if( empty( $_POST['password_1'] ) || empty( $_POST['password_2'] ) ) {
+				$woocommerce->add_error( __( 'Please enter your password.', 'woocommerce' ) );
+				$args['form'] = 'reset_password';
+			}
+
+			if( $_POST[ 'password_1' ] !== $_POST[ 'password_2' ] ) {
+				$woocommerce->add_error( __('Passwords do not match.', 'woocommerce') );
+				$args['form'] = 'reset_password';
+			}
+
+			if( 0 == $woocommerce->error_count() && ( $_POST['password_1'] == $_POST['password_2'] ) ) {
+
+				woocommerce_reset_password( $user, esc_attr( $_POST['password_1'] ) );
+
+				do_action( 'woocommerce_customer_reset_password', $user );
+
+				$woocommerce->add_message( __( 'Your password has been reset.', 'woocommerce' ) . ' <a href="' . get_permalink( woocommerce_get_page_id( 'myaccount' ) ) . '">' . __( 'Log in', 'woocommerce' ) . '</a>' );
+			}
+		}
+
+	endif;
+
+	woocommerce_get_template( 'myaccount/form-lost-password.php', $args );
+}
+
+/**
+ * Handles sending password retrieval email to customer.
+ *
+ * @access public
+ * @uses $wpdb WordPress Database object
+ * @return bool True: when finish. False: on error
+ */
+function woocommerce_retrieve_password() {
+	global $woocommerce,$wpdb;
+
+	if ( empty( $_POST['user_login'] ) ) {
+
+		$woocommerce->add_error( __( 'Enter a username or e-mail address.', 'woocommerce' ) );
+
+	} elseif ( strpos( $_POST['user_login'], '@' ) ) {
+
+		$user_data = get_user_by( 'email', trim( $_POST['user_login'] ) );
+
+		if ( empty( $user_data ) )
+			$woocommerce->add_error( __( 'There is no user registered with that email address.', 'woocommerce' ) );
+
+	} else {
+
+		$login = trim( $_POST['user_login'] );
+
+		$user_data = get_user_by('login', $login );
+	}
+
+	do_action('lostpassword_post');
+
+	if( $woocommerce->error_count() > 0 )
+		return false;
+
+	if ( ! $user_data ) {
+		$woocommerce->add_error( __( 'Invalid username or e-mail.', 'woocommerce' ) );
+		return false;
+	}
+
+	// redefining user_login ensures we return the right case in the email
+	$user_login = $user_data->user_login;
+	$user_email = $user_data->user_email;
+
+	do_action('retrieve_password', $user_login);
+
+	$allow = apply_filters('allow_password_reset', true, $user_data->ID);
+
+	if ( ! $allow ) {
+
+		$woocommerce->add_error( __( 'Password reset is not allowed for this user') );
+
+		return false;
+
+	} elseif ( is_wp_error( $allow ) ) {
+
+		$woocommerce->add_error( $allow->get_error_message );
+
+		return false;
+	}
+
+	$key = $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM $wpdb->users WHERE user_login = %s", $user_login ) );
+
+	if ( empty( $key ) ) {
+
+		// Generate something random for a key...
+		$key = wp_generate_password( 20, false );
+
+		do_action('retrieve_password_key', $user_login, $key);
+
+		// Now insert the new md5 key into the db
+		$wpdb->update( $wpdb->users, array( 'user_activation_key' => $key ), array( 'user_login' => $user_login ) );
+	}
+
+	// Send email notification
+	$mailer = $woocommerce->mailer();
+	do_action( 'woocommerce_reset_password_notification', $user_login, $key );
+
+	$woocommerce->add_message( __( 'Check your e-mail for the confirmation link.' ) );
+	return true;
+}
+
+/**
+ * Retrieves a user row based on password reset key and login
+ *
+ * @uses $wpdb WordPress Database object
+ *
+ * @access public
+ * @param string $key Hash to validate sending user's password
+ * @param string $login The user login
+ * @return object|bool User's database row on success, false for invalid keys
+ */
+function woocommerce_check_password_reset_key( $key, $login ) {
+	global $woocommerce,$wpdb;
+
+	$key = preg_replace( '/[^a-z0-9]/i', '', $key );
+
+	if ( empty( $key ) || ! is_string( $key ) ) {
+		$woocommerce->add_error( __( 'Invalid key', 'woocommerce' ) );
+		return false;
+	}
+
+	if ( empty( $login ) || ! is_string( $login ) ) {
+		$woocommerce->add_error( __( 'Invalid key', 'woocommerce' ) );
+		return false;
+	}
+
+	$user = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->users WHERE user_activation_key = %s AND user_login = %s", $key, $login ) );
+
+	if ( empty( $user ) ) {
+		$woocommerce->add_error( __( 'Invalid key', 'woocommerce' ) );
+		return false;
+	}
+
+	return $user;
+}
+
+/**
+ * Handles resetting the user's password.
+ *
+ * @access public
+ * @param object $user The user
+ * @param string $new_pass New password for the user in plaintext
+ * @return void
+ */
+function woocommerce_reset_password( $user, $new_pass ) {
+	do_action( 'password_reset', $user, $new_pass );
+
+	wp_set_password( $new_pass, $user->ID );
+
+	wp_password_change_notification( $user );
+}

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Customer Reset Password email
+ *
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates/Emails
+ * @version     1.7.0
+ */
+
+if (!defined('ABSPATH')) exit; ?>
+<?php do_action('woocommerce_email_header', $email_heading); ?>
+
+<p><?php _e( 'Someone requested that the password be reset for the following account:', 'woocommerce' ); ?></p>
+<p><?php printf( __( 'Username: %s', 'woocommerce' ), $user_login ); ?></p>
+<p><?php _e( 'If this was a mistake, just ignore this email and nothing will happen.', 'woocommerce' ); ?></p>
+<p><?php _e( 'To reset your password, visit the following address:', 'woocommerce' ); ?></p>
+<p>
+    <a href="<?php echo esc_url( get_permalink( woocommerce_get_page_id( 'lost_password' ) ) . sprintf( '?key=%s&login=%s', $reset_key, $user_login ) ); ?>">
+			<?php _e( 'Click here to reset your password', 'woocommerce' ); ?></a>
+</p>
+<p></p>
+
+<?php do_action('woocommerce_email_footer'); ?>

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Customer Reset Password email
+ *
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates/Emails/Plain
+ * @version     1.7.0
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+echo $email_heading . "\n\n";
+
+echo __( 'Someone requested that the password be reset for the following account:', 'woocommerce' ) . "\r\n\r\n";
+echo network_home_url( '/' ) . "\r\n\r\n";
+echo sprintf(__( 'Username: %s', 'woocommerce' ), $user_login) . "\r\n\r\n";
+echo __( 'If this was a mistake, just ignore this email and nothing will happen.', 'woocommerce' ) . "\r\n\r\n";
+echo __( 'To reset your password, visit the following address:', 'woocommerce' ) . "\r\n\r\n";
+
+echo get_permalink( woocommerce_get_page_id( 'lost_password' ) ) . sprintf( '?key=%s&login=%s', $reset_key, $user_login ) . "\r\n";
+
+echo "\n****************************************************\n\n";
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Lost password form
+ *
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates
+ * @version     1.7.0
+ */
+
+global $woocommerce, $post;
+
+?>
+
+<?php $woocommerce->show_messages(); ?>
+
+<form action="<?php echo esc_url( get_permalink($post->ID) ); ?>" method="post" class="lost_reset_password">
+
+	<?php	if( 'lost_password' == $args['form'] ) : ?>
+
+    <p><?php echo apply_filters( 'woocommerce_lost_password_message', __( 'Lost your password? Please enter your username or email address. You will receive a link to create a new password via email.', 'woocommerce' ) ); ?></p>
+
+    <p class="form-row form-row-first"><label for="user_login"><?php _e( 'Username or email', 'woocommerce' ); ?></label> <input class="input-text" type="text" name="user_login" id="user_login" /></p>
+
+	<?php else : ?>
+
+    <p><?php echo apply_filters( 'woocommerce_reset_password_message', __( 'Enter a new password below.', 'woocommerce') ); ?></p>
+
+    <p class="form-row form-row-first">
+        <label for="password_1"><?php _e( 'New password', 'woocommerce' ); ?> <span class="required">*</span></label>
+        <input type="password" class="input-text" name="password_1" id="password_1" />
+    </p>
+    <p class="form-row form-row-last">
+        <label for="password_2"><?php _e( 'Re-enter new password', 'woocommerce' ); ?> <span class="required">*</span></label>
+        <input type="password" class="input-text" name="password_2" id="password_2" />
+    </p>
+
+    <input type="hidden" name="reset_key" value="<?php echo isset( $args['key'] ) ? $args['key'] : ''; ?>" />
+    <input type="hidden" name="reset_login" value="<?php echo isset( $args['login'] ) ? $args['login'] : ''; ?>" />
+	<?php endif; ?>
+
+    <div class="clear"></div>
+
+    <p class="form-row"><input type="submit" class="button" name="reset" value="<?php echo 'lost_password' == $args['form'] ? __( 'Reset Password', 'woocommerce' ) : __( 'Save', 'woocommerce' ); ?>" /></p>
+	<?php $woocommerce->nonce_field( $args['form'] ); ?>
+
+</form>


### PR DESCRIPTION
I think the current process for a customer to reset their password is jarring, especially if the shop hasn't styled the wordpress login form to match their branding. This adds a new shortcode, page, and template to match the similar process for changing passwords within my account. The form processing is mainly copied from the reset password section in wp-login.php and fires the same actions to maintain compatibility.

Arguably the email notification section could be removed for simplicity, but since wordpress doesn't provide an easy way to style password reset emails, it seems like most shop owners would want to keep the styling of all customer email notifications consistent.
