### PR TITLE
Only slide payment box up-and-down if > 1 method

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -104,12 +104,14 @@ jQuery(document).ready(function($) {
 	
 	}
 	
-	$('.payment_methods input.input-radio').live('click', function(){
-		$('div.payment_box').filter(':visible').slideUp(250);
-		if ($(this).is(':checked')) {
-			$('div.payment_box.' + $(this).attr('ID')).slideDown(250);
-		}
-	});
+	if($('.payment_methods input.input-radio').length > 1) {
+		$('.payment_methods input.input-radio').live('click', function(){
+			$('div.payment_box').filter(':visible').slideUp(250);
+			if ($(this).is(':checked')) {
+				$('div.payment_box.' + $(this).attr('ID')).slideDown(250);
+			}
+		});
+	}
 	
 	$('#order_review input[name=payment_method]:checked').click();
 	


### PR DESCRIPTION
The payment fields box on the checkout page currently slides up-and-down even when there is only one option for payment. This patch changes that to only display the animation if there is > one payment method.
