### PR TITLE
Don't delete _regular_price (et al) for custom post types

### DIFF
--- a/admin/post-types/writepanels/writepanel-product_data.php
+++ b/admin/post-types/writepanels/writepanel-product_data.php
@@ -752,7 +752,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 	set_transient( 'wc_product_type_' . $post_id, $product_type );
 
 	// Sales and prices
-	if ($product_type=='simple' || $product_type=='external') :
+	if ( in_array( $product_type, apply_filters( 'woocommerce_product_types_with_price', array('simple', 'external') ) ) ):
 
 		$date_from = (isset($_POST['_sale_price_dates_from'])) ? $_POST['_sale_price_dates_from'] : '';
 		$date_to = (isset($_POST['_sale_price_dates_to'])) ? $_POST['_sale_price_dates_to'] : '';


### PR DESCRIPTION
Perhaps I should be using a simple product type, but I think I need to create a custom one so that I can integrate WC with [EZ Prints](http://www.ezpservices.com/)' product customization and fulfillment.  Anyway, I found that the price meta is reset (set to a null string) if the product type is neither simple nor external and I found myself having to re-produce this code to get the data to save.  

Instead, I added this filter which will let the existing code run for my custom post type.  
