### PR TITLE
Woo Sessions - Cookie expires customization

### DIFF
--- a/classes/abstracts/abstract-wc-session.php
+++ b/classes/abstracts/abstract-wc-session.php
@@ -18,7 +18,23 @@ abstract class WC_Session {
      * @return void
      */
     abstract public function save_data();
-
+	
+	/**
+     * Abstract function to set cookie expiration time in seconds.
+     * 
+     * @access public
+     * @return void
+     */
+	abstract public function set_cookie_expires($seconds);
+	
+	/**
+     * Abstract function to get cookie expiration time in seconds.
+     * 
+     * @access public
+     * @return string
+     */
+	abstract public function get_cookie_expires();
+	
 	/**
 	 * Constructor for the session classes. Hooks in methods.
 	 *

--- a/classes/class-wc-session-transients.php
+++ b/classes/class-wc-session-transients.php
@@ -19,6 +19,9 @@ class WC_Session_Transients extends WC_Session {
 	/** cookie name */
 	private $_cookie;
 	
+	/** cookie expiration time in seconds */
+	private $_cookie_expires;
+	
 	/**
 	 * Constructor for the session class.
 	 *
@@ -27,12 +30,16 @@ class WC_Session_Transients extends WC_Session {
 	 */
 	public function __construct() {
 		parent::__construct();
+		$this->_cookie			= 'wc_session_cookie_' . COOKIEHASH;
+		$this->_cookie_expires	= get_transient( 'wc_cookie_expires' );
 		
-		$this->_cookie		= 'wc_session_cookie_' . COOKIEHASH;
-		$this->_customer_id = $this->get_customer_id();
-		$this->_data 		= maybe_unserialize( get_transient( 'wc_session_' . $this->_customer_id ) );
+		if ( false === $this->_cookie_expires )
+    		$this->_cookie_expires = 172800;
+		
+		$this->_customer_id 	= $this->get_customer_id();
+		$this->_data 			= maybe_unserialize( get_transient( 'wc_session_' . $this->_customer_id ) );
     	
-    	if ( false === $this->_data )
+		if ( false === $this->_data )
     		$this->_data = array();
     }
 	
@@ -82,13 +89,13 @@ class WC_Session_Transients extends WC_Session {
 	 */
 	private function create_customer_id() {
 		$customer_id 	= wp_generate_password( 32 ); // Ensure this and the transient is < 45 chars. wc_session_ leaves 34.
-		$expires 		= time() + 172800;
+		$expires 		= time() + $this->_cookie_expires;
 		$data 			= $customer_id . $expires;
 		$hash 			= hash_hmac( 'md5', $data, wp_hash( $data ) );
 		$value 			= $customer_id . '|' . $expires . '|' . $hash;
-
+		
 		setcookie( $this->_cookie, $value, $expires, COOKIEPATH, COOKIE_DOMAIN, false, true );
-
+		
 		return $customer_id;
 	}
     
@@ -100,6 +107,53 @@ class WC_Session_Transients extends WC_Session {
      */
     public function save_data() {
 	    // Set cart data for 48 hours
-	    set_transient( 'wc_session_' . $this->_customer_id, $this->_data, 172800 );
+		set_transient( 'wc_session_' . $this->_customer_id, $this->_data, $this->_cookie_expires );
     }
+	
+	/**
+     * Sets cookie expiration time in seconds.
+     * 
+     * @access public
+     * @return void
+     */
+	public function set_cookie_expires( $seconds = 0, $auto_extend = false ) {
+		$seconds = absint($seconds);
+		if ( ( $seconds > 0 ) && ( $this->_cookie_expires != $seconds ) ) {
+			$this->_cookie_expires = $seconds;
+			set_transient( 'wc_cookie_expires', $this->_cookie_expires );
+			$this->regenerate_cookie();
+		} else if ( $auto_extend ) {
+			$this->regenerate_cookie();
+		}
+	}
+	
+	/**
+     * Returns cookie expiration time in seconds.
+     * 
+     * @access public
+     * @return string
+     */
+	public function get_cookie_expires() {
+		return $this->_cookie_expires;
+	}
+	
+	/**
+	 * Regenerate cookie to store new expiration date
+	 * 
+	 * @access private
+	 * @return void
+	 */
+	private function regenerate_cookie() {
+		$customer_id 	= $this->get_session_cookie();
+		
+		if ( false === $customer_id )
+			$customer_id = wp_generate_password( 32 );
+		
+		$expires 		= time() + $this->_cookie_expires;
+		$data 			= $customer_id . $expires;
+		$hash 			= hash_hmac( 'md5', $data, wp_hash( $data ) );
+		$value 			= $customer_id . '|' . $expires . '|' . $hash;
+		
+		setcookie( $this->_cookie, $value, $expires, COOKIEPATH, COOKIE_DOMAIN, false, true );
+	}
 }


### PR DESCRIPTION
Hi!

In some cases developers migth want to have control over woo session cookies expiration time. For example, I want to be able to track guest-visitors (not logged in) to see whether it's their first visit this month, or if they previously have visited this particular category/page, etc. Currently cooke lifetime is hard coded as 48 hours.

By applying this update one can change cookie expiration time with the following code:

``` php
$woocommerce->session->set_cookie_expires(60*60*24*7);
```

Also you can regenerate cookie every visit by adding "true" as a second parameter (could be useful as guests can visit your shop from search once in a while and you don't want to lose "history"):

``` php
$woocommerce->session->set_cookie_expires(60*60*24*7,true);
```
