### PR TITLE
Translation / formatting of custom variation attributes & disable cart.php thumbnail link when product is hidden.

### DIFF
--- a/admin/post-types/writepanels/writepanel-product-type-variable.php
+++ b/admin/post-types/writepanels/writepanel-product-type-variable.php
@@ -213,7 +213,7 @@ function variable_product_type_options() {
 						} else {
 							$options = explode( '|', $attribute['value'] );
 							foreach ( $options as $option )
-								echo '<option ' . selected( $variation_selected_value, $option, false ) . ' value="' . esc_attr( $option ) . '">' . ucfirst( esc_html( $option ) ) . '</option>';
+								echo '<option ' . selected( $variation_selected_value, $option, false ) . ' value="' . esc_attr( $option ) . '">' . ucfirst( apply_filters( 'woocommerce_variation_option_name', ( esc_html( $option ) ) ) ) . '</option>';
 						}
 
 						echo '</select>';

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -502,7 +502,7 @@ class WC_Cart {
 		            	if ( ! is_wp_error( $term ) && $term->name )
 		            		$value = $term->name;
 		            } else {
-		            	$value = ucfirst( $value );
+		            	$value = ucfirst( apply_filters( 'woocommerce_variation_option_name', $value ) );
 					}
 
 					if ( $flat )

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -1598,7 +1598,7 @@ class WC_Order_Item_Meta {
 	            	if ( ! is_wp_error( $term ) && $term->name )
 	            		$meta_value = $term->name;
 	            } else {
-	            	$meta_value = ucfirst( $meta_value );
+	            	$meta_value = ucfirst( apply_filters( 'woocommerce_variation_option_name', $meta_value ) );
 	            }
 
 				if ( $flat )

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -48,7 +48,12 @@ global $woocommerce;
 						<td class="product-thumbnail">
 							<?php
 								$thumbnail = apply_filters( 'woocommerce_in_cart_product_thumbnail', $_product->get_image(), $values, $cart_item_key );
-								printf('<a href="%s">%s</a>', esc_url( get_permalink( apply_filters('woocommerce_in_cart_product_id', $values['product_id'] ) ) ), $thumbnail );
+								$thumbnail_link = esc_url( get_permalink( apply_filters('woocommerce_in_cart_product_id', $values['product_id'] ) ) );
+
+								if ( ! $_product->is_visible() || ( $_product instanceof WC_Product_Variation && ! $_product->parent_is_visible() ) )
+									$thumbnail_link = '#';
+								
+								printf('<a href="%s">%s</a>', $thumbnail_link, $thumbnail );
 							?>
 						</td>
 

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -48,12 +48,14 @@ global $woocommerce;
 						<td class="product-thumbnail">
 							<?php
 								$thumbnail = apply_filters( 'woocommerce_in_cart_product_thumbnail', $_product->get_image(), $values, $cart_item_key );
-								$thumbnail_link = esc_url( get_permalink( apply_filters('woocommerce_in_cart_product_id', $values['product_id'] ) ) );
 
-								if ( ! $_product->is_visible() || ( $_product instanceof WC_Product_Variation && ! $_product->parent_is_visible() ) )
-									$thumbnail_link = '#';
-								
-								printf('<a href="%s">%s</a>', $thumbnail_link, $thumbnail );
+								if ( ! $_product->is_visible() || ( $_product instanceof WC_Product_Variation && ! $_product->parent_is_visible() ) ) {
+									echo $thumbnail;
+								}
+								else {
+									$thumbnail_link = esc_url( get_permalink( apply_filters('woocommerce_in_cart_product_id', $values['product_id'] ) ) );
+									printf('<a href="%s">%s</a>', $thumbnail_link, $thumbnail );
+								}
 							?>
 						</td>
 

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -679,7 +679,7 @@ function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
             	if ( ! is_wp_error( $term ) && $term->name )
             		$value = $term->name;
             } else {
-            	$value = ucfirst($value);
+            	$value = ucfirst( apply_filters( 'woocommerce_variation_option_name', $value ) );
             }
 
 			if ( $flat )

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -1455,7 +1455,7 @@ class Woocommerce {
 
 			if ( ! $label ) $label = ucfirst( $name );
 		} else {
-			$label = $name;
+			$label = ucfirst( $name );
 		}
 
 		return apply_filters( 'woocommerce_attribute_label', $label, $name );


### PR DESCRIPTION
Translation of attributes:

Use 'woocommerce_variation_option_name' (already used in other places for the same purpose) to allow the translation / formatting of custom variation attributes and/or item meta.

Cart.php tweak:

When a product is hidden, its thumbnail should not link to the product (same logic is used to disable product name links for hidden products, a few lines below)
