### PR TITLE
Don't run data upgrade on first install

### DIFF
--- a/admin/woocommerce-admin-install.php
+++ b/admin/woocommerce-admin-install.php
@@ -84,9 +84,9 @@ function do_install_woocommerce() {
 	update_option( 'woocommerce_version', $woocommerce->version );
 
 	// Queue upgrades
-	$current_db_version = get_option( 'woocommerce_db_version' );
+	$current_db_version = get_option( 'woocommerce_db_version', null );
 	
-	if ( version_compare( $current_db_version, '1.7', '<' ) ) {
+	if ( version_compare( $current_db_version, '1.7', '<' ) && null !== $current_db_version ) {
 		update_option( 'woocommerce_needs_update', 1 );
 	} else {
 		update_option( 'woocommerce_db_version', $woocommerce->version );


### PR DESCRIPTION
At the moment, when WooCommerce is installed for the first time, the database upgrade notice will be displayed instead of the installation notice. 

This is because `get_option( 'woocommerce_db_version' )` returns `false` which evaluates to less than 1.7 with `version_compare( $current_db_version, '1.7', '<' )` on [line 89](https://github.com/woothemes/woocommerce/blob/master/admin/woocommerce-admin-install.php#L87). 

This fixes that.
