### PR TITLE
woocommerce_get_product_terms bypasses caching

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -1171,7 +1171,7 @@ function woocommerce_get_product_terms( $object_id, $taxonomy, $fields = 'all' )
 		return array();
 
 	$terms 			= array();
-	$object_terms 	= wp_get_object_terms( $object_id, $taxonomy );
+	$object_terms 	= get_the_terms( $object_id, $taxonomy );
 	$all_terms 		= array_flip( get_terms( $taxonomy, array( 'menu_order' => 'ASC', 'fields' => 'ids' ) ) );
 
 	switch ( $fields ) {


### PR DESCRIPTION
`wp_get_object_terms()` bypasses the object caching API. Without the option of caching, the performance of shops with 10,000's of products is dramatically slower.
