### PR TITLE
Order note comments

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_notes.php
+++ b/admin/post-types/writepanels/writepanel-order_notes.php
@@ -24,7 +24,7 @@ function woocommerce_order_notes_meta_box() {
 	$args = array(
 		'post_id' 	=> $post->ID,
 		'approve' 	=> 'approve',
-		'type' 		=> ''
+		'type' 		=> 'order_note'
 	);
 
 	$notes = get_comments( $args );


### PR DESCRIPTION
Make the order note comments more specific to order notes allowing other
plugins to use comments and not have them appearing in the order notes
list.
