### PR TITLE
Solution for #1707 - always show payment_box details for first payment gateway

### DIFF
--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -57,6 +57,7 @@ global $woocommerce;
 				if ($available_gateways) :
 					// Chosen Method
 					if (sizeof($available_gateways)) current($available_gateways)->set_current();
+				$i = 1;
 					foreach ($available_gateways as $gateway ) :
 						?>
 						<li>
@@ -64,7 +65,8 @@ global $woocommerce;
 							<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo $gateway->get_title(); ?> <?php echo $gateway->get_icon(); ?></label>
 							<?php
 								if ( $gateway->has_fields() || $gateway->get_description() ) :
-									echo '<div class="payment_box payment_method_'.$gateway->id.'" style="display:none;">';
+									$display = ( $i > 1 ) ? 'style="display:none;"' : '';
+									echo '<div class="payment_box payment_method_'.$gateway->id.'" ' . $display . '>';
 									$gateway->payment_fields();
 									echo '</div>';
 								endif;

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -272,6 +272,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						}
 						
 					endif;
+					$i = 1;
 					foreach ($available_gateways as $gateway ) :
 						?>
 						<li>
@@ -279,13 +280,15 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo $gateway->get_title(); ?> <?php echo $gateway->get_icon(); ?></label>
 							<?php
 								if ( $gateway->has_fields() || $gateway->get_description() ) :
-									echo '<div class="payment_box payment_method_'.$gateway->id.'" style="display:none;">';
+									$display = ( $i > 1 ) ? 'style="display:none;"' : '';
+									echo '<div class="payment_box payment_method_'.$gateway->id.'" ' . $display . '>';
 									$gateway->payment_fields();
 									echo '</div>';
 								endif;
 							?>
 						</li>
 						<?php
+						$i++;
 					endforeach;
 				else :
 


### PR DESCRIPTION
this should leave the first/default (or only if there is but one payment gateway) payment box open and visible. 
