### PR TITLE
Allow payment gateways to validate their fields through checkout->pay 

### DIFF
--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -510,6 +510,8 @@ function woocommerce_pay_action() {
 				update_post_meta( $order_id, '_payment_method', $payment_method);
 				if (isset($available_gateways) && isset($available_gateways[$payment_method])) :
 					$payment_method_title = $available_gateways[$payment_method]->get_title();
+                    // Payment Method Field Validation
+                    $available_gateways[$payment_method]->validate_fields();
 				endif;
 				update_post_meta( $order_id, '_payment_method_title', $payment_method_title);
 


### PR DESCRIPTION
At the moment there is no validation through woocommerce_pay_action for payment gateways.
