### PR TITLE
Replaced hard coded date format

### DIFF
--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
 
 <?php do_action( 'woocommerce_email_before_order_table', $order, true ); ?>
 
-<h2><?php printf( __( 'Order: %s', 'woocommerce'), $order->get_order_number() ); ?> (<?php printf( '<time datetime="%s">%s</time>', date_i18n( 'c', strtotime( $order->order_date ) ), date_i18n( __( 'jS F Y', 'woocommerce' ), strtotime( $order->order_date ) ) ); ?>)</h2>
+<h2><?php printf( __( 'Order: %s', 'woocommerce'), $order->get_order_number() ); ?> (<?php printf( '<time datetime="%s">%s</time>', date_i18n( 'c', strtotime( $order->order_date ) ), date_i18n( ( get_option('date_format'), 'woocommerce' ), strtotime( $order->order_date ) ) ); ?>)</h2>
 
 <table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
 	<thead>


### PR DESCRIPTION
Instead of the hard coded date format the date format from the admin panel is now used with get_option('date_format'). A more uniform solution to my idea, I don't know how to replace all date related functions in the project in this way though...
