### PR TITLE
IMPORTANT MERGE: Product classes (read notes!)

### DIFF
--- a/admin/post-types/product.php
+++ b/admin/post-types/product.php
@@ -115,7 +115,7 @@ add_filter('manage_edit-product_columns', 'woocommerce_edit_product_columns');
  */
 function woocommerce_custom_product_columns( $column ) {
 	global $post, $woocommerce;
-	$product = new WC_Product($post->ID);
+	$product = get_product($post);
 
 	switch ($column) {
 		case "thumb" :
@@ -712,7 +712,7 @@ function woocommerce_admin_product_quick_edit_save( $post_id, $post ) {
 
 	global $woocommerce, $wpdb;
 
-	$product = new WC_Product( $post_id );
+	$product = get_product( $post );
 
 	// Save fields
 	if(isset($_POST['_sku'])) update_post_meta($post_id, '_sku', esc_html(stripslashes($_POST['_sku'])));
@@ -1003,7 +1003,7 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 
 	global $woocommerce, $wpdb;
 
-	$product = new WC_Product( $post_id );
+	$product = get_product( $post );
 
 	// Save fields
 	if ( ! empty( $_REQUEST['change_weight'] ) && isset( $_REQUEST['_weight'] ) )

--- a/admin/post-types/writepanels/writepanel-order_downloads.php
+++ b/admin/post-types/writepanels/writepanel-order_downloads.php
@@ -36,7 +36,7 @@ function woocommerce_order_downloads_meta_box() {
 				if ( $download_permissions && sizeof( $download_permissions ) > 0 ) foreach ( $download_permissions as $download ) {
 
 					if ( ! $product || $product->id != $download->product_id ) {
-						$product = new WC_Product( absint( $download->product_id ) );
+						$product = get_product( absint( $download->product_id ) );
 						$file_count = $loop = 0;
 					}
 

--- a/admin/post-types/writepanels/writepanel-product_data.php
+++ b/admin/post-types/writepanels/writepanel-product_data.php
@@ -820,7 +820,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 		else
 			update_post_meta( $post_id, '_price', stripslashes( $_POST['_regular_price'] ) );
 
-		if ( $date_from && strtotime( $date_from ) < strtotime( 'NOW', current_time( 'timestamp' ) ) )
+		if ( $_POST['_sale_price'] != '' && $date_from && strtotime( $date_from ) < strtotime( 'NOW', current_time( 'timestamp' ) ) )
 			update_post_meta( $post_id, '_price', stripslashes($_POST['_sale_price']) );
 
 		if ( $date_to && strtotime( $date_to ) < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {

--- a/admin/woocommerce-admin-functions.php
+++ b/admin/woocommerce-admin-functions.php
@@ -83,7 +83,8 @@ function woocommerce_ms_protect_download_rewite_rules( $rewrite ) {
  * @return void
  */
 function woocommerce_delete_post( $id ) {
-
+	global $woocommerce;
+	
 	if ( ! current_user_can( 'delete_posts' ) ) return;
 
 	if ( $id > 0 ) :
@@ -103,7 +104,8 @@ function woocommerce_delete_post( $id ) {
 		endif;
 
 	endif;
-
+	
+	$woocommerce->clear_product_transients();
 	delete_transient( 'woocommerce_processing_order_count' );
 }
 

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -125,10 +125,7 @@ class WC_Cart {
 
 				foreach ( $cart as $key => $values ) {
 
-					if ( $values['variation_id'] > 0 )
-						$_product = new WC_Product_Variation( $values['variation_id'] );
-					else
-						$_product = new WC_Product( $values['product_id'] );
+					$_product = get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
 
 					if ( $_product->exists() && $values['quantity'] > 0 ) {
 
@@ -738,10 +735,7 @@ class WC_Cart {
 			// See if this product and its options is already in the cart
 			$cart_item_key = $this->find_product_in_cart( $cart_id );
 
-			if ( $variation_id > 0 )
-				$product_data = new WC_Product_Variation( $variation_id );
-			else
-				$product_data = new WC_Product( $product_id );
+			$product_data = get_product( $variation_id ? $variation_id : $product_id );
 
 			// Force quantity to 1 if sold individually
 			if ( $product_data->is_sold_individually() )

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -491,7 +491,7 @@ class WC_Cart {
 			if ( ! $flat ) $return .= '<dl class="variation">';
 
 			// Variation data
-			if ( $cart_item['data'] instanceof WC_Product_Variation && is_array( $cart_item['variation'] ) ) {
+			if ( ! empty( $cart_item['data']->variation_id ) && is_array( $cart_item['variation'] ) ) {
 
 				$variation_list = array();
 

--- a/classes/class-wc-customer.php
+++ b/classes/class-wc-customer.php
@@ -488,7 +488,7 @@ class WC_Customer {
 					if ( ! $_product || $_product->id != $result->product_id ) :
 						// new product
 						$file_number = 0;
-						$_product = new WC_Product( $result->product_id );
+						$_product = get_product( $result->product_id );
 					endif;
 
 					if ( ! $_product->exists() ) continue;

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -850,12 +850,7 @@ class WC_Order {
 	 * @return WC_Product
 	 */
 	function get_product_from_item( $item ) {
-
-		if (isset($item['variation_id']) && $item['variation_id']>0) :
-			$_product = new WC_Product_Variation( $item['variation_id'] );
-		else :
-			$_product = new WC_Product( $item['product_id'] );
-		endif;
+		$_product = get_product( $item['variation_id'] ? $item['variation_id'] : $item['product_id'] );
 
 		return $_product;
 
@@ -1126,7 +1121,7 @@ class WC_Order {
 		global $wpdb;
 
 	 	$download_file = $variation_id > 0 ? $variation_id : $product_id;
-		$_product = new WC_Product( $download_file );
+		$_product = get_product( $download_file );
 
 	 	$user_email = $this->billing_email;
 

--- a/classes/class-wc-product-external.php
+++ b/classes/class-wc-product-external.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * External Product Class
+ *
+ * External products cannot be bought; they link offsite.
+ *
+ * @class 		WC_Product
+ * @version		1.7.0
+ * @package		WooCommerce/Classes/Products
+ * @author 		WooThemes
+ */
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+class WC_Product_External extends WC_Product {
+
+	/**
+	 * __construct function.
+	 * 
+	 * @access public
+	 * @param mixed $product
+	 */
+	function __construct( $product ) {
+
+		if ( is_object( $product ) ) {
+			$this->id = absint( $product->ID );
+			$this->post = $product;
+		} else {
+			$this->id = absint( $product );
+		}
+		
+		$this->product_type = 'external';
+		$this->product_custom_fields = get_post_custom( $this->id );
+		
+		// Load data from custom fields
+		$this->load_product_data( array(
+			'sku'			=> '',
+			'downloadable' 	=> 'no',
+			'virtual' 		=> 'no',
+			'price' 		=> '',
+			'visibility'	=> 'hidden',
+			'stock'			=> 0,
+			'stock_status'	=> 'instock',
+			'backorders'	=> 'no',
+			'manage_stock'	=> 'no',
+			'sale_price'	=> '',
+			'regular_price' => '',
+			'weight'		=> '',
+			'length'		=> '',
+			'width'		=> '',
+			'height'		=> '',
+			'tax_status'	=> 'taxable',
+			'tax_class'		=> '',
+			'upsell_ids'	=> array(),
+			'crosssell_ids' => array(),
+			'sale_price_dates_from' => '',
+			'sale_price_dates_to' 	=> '',
+			'featured'		=> 'no'
+		) );
+		
+		$this->check_sale_price();
+	}
+
+	/**
+	 * Returns false if the product cannot be bought.
+	 *
+	 * @access public
+	 * @return cool
+	 */
+	function is_purchasable() {
+		return apply_filters( 'woocommerce_is_purchasable', false, $this );
+	}
+}

--- a/classes/class-wc-product-external.php
+++ b/classes/class-wc-product-external.php
@@ -18,6 +18,7 @@ class WC_Product_External extends WC_Product {
 	 * 
 	 * @access public
 	 * @param mixed $product
+	 * @param array $args Contains arguments to set up this product
 	 */
 	function __construct( $product, $args ) {
 

--- a/classes/class-wc-product-external.php
+++ b/classes/class-wc-product-external.php
@@ -19,7 +19,7 @@ class WC_Product_External extends WC_Product {
 	 * @access public
 	 * @param mixed $product
 	 */
-	function __construct( $product ) {
+	function __construct( $product, $args ) {
 
 		parent::__construct( $product );
 		

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Product Factory Class
+ *
+ * The WooCommerce product factory creating the right product object
+ *
+ * @class 		WC_Product_Factory
+ * @version		1.7
+ * @package		WooCommerce/Classes
+ * @author 		WooThemes
+ */
+
+class WC_Product_Factory {
+	public function __construct() {
+	}
+
+	public function get_product( $the_product = false, $args ) {
+		global $post;
+	
+		if ( false === $the_product )
+			$the_product = $post;
+		elseif ( is_numeric( $the_product ) )
+			$the_product = get_post( $the_product );
+			
+		$product_id 	= absint( $the_product->ID );
+		$terms 			= get_the_terms( $product_id, 'product_type' );
+		$product_type 	= isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
+		
+		// Filter classname so that the class can be overridden if extended.
+		$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_' . $product_type, $product_type, $post_type, $product_id );
+		
+		if ( class_exists( $classname ) ) {
+			return new $classname( $the_product, $args );
+		} else {
+			// Use simple
+			return new WC_Product_Simple( $the_product );
+		}
+	}
+}

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -26,6 +26,7 @@ class WC_Product_Factory {
 		$product_id 	= absint( $the_product->ID );
 		$terms 			= get_the_terms( $product_id, 'product_type' );
 		$product_type 	= isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
+		$post_type 		= $the_product->post_type;
 		
 		// Filter classname so that the class can be overridden if extended.
 		$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_' . $product_type, $product_type, $post_type, $product_id );

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -18,15 +18,21 @@ class WC_Product_Factory {
 	public function get_product( $the_product = false, $args ) {
 		global $post;
 	
-		if ( false === $the_product )
+		if ( false === $the_product ) {
 			$the_product = $post;
-		elseif ( is_numeric( $the_product ) )
+		} elseif ( is_numeric( $the_product ) ) {
 			$the_product = get_post( $the_product );
+		}
 			
 		$product_id 	= absint( $the_product->ID );
-		$terms 			= get_the_terms( $product_id, 'product_type' );
-		$product_type 	= isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
 		$post_type 		= $the_product->post_type;
+
+		if ( 'product_variation' == $post_type ) {
+			$product_type = 'variation';
+		} else {
+			$terms 			= get_the_terms( $product_id, 'product_type' );
+			$product_type 	= isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
+		}
 		
 		// Filter classname so that the class can be overridden if extended.
 		$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_' . $product_type, $product_type, $post_type, $product_id );

--- a/classes/class-wc-product-grouped.php
+++ b/classes/class-wc-product-grouped.php
@@ -27,12 +27,7 @@ class WC_Product_Grouped extends WC_Product {
 	 */
 	function __construct( $product ) {
 		
-		if ( is_object( $product ) ) {
-			$this->id = absint( $product->ID );
-			$this->post = $product;
-		} else {
-			$this->id = absint( $product );
-		}
+		parent::__construct( $product );
 		
 		$this->product_type = 'grouped';
 		$this->product_custom_fields = get_post_custom( $this->id );

--- a/classes/class-wc-product-grouped.php
+++ b/classes/class-wc-product-grouped.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Grouped Product Class
+ *
+ * Grouped products cannot be purchased - they are wrappers for other products.
+ *
+ * @class 		WC_Product_Grouped
+ * @version		1.7.0
+ * @package		WooCommerce/Classes/Products
+ * @author 		WooThemes
+ */
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+class WC_Product_Grouped extends WC_Product {
+
+	/** @var array Array of child products/posts/variations. */
+	var $children;
+
+	/** @var string The product's total stock, including that of its children. */
+	var $total_stock;
+	
+	/**
+	 * __construct function.
+	 * 
+	 * @access public
+	 * @param mixed $product
+	 */
+	function __construct( $product ) {
+		
+		if ( is_object( $product ) ) {
+			$this->id = absint( $product->ID );
+			$this->post = $product;
+		} else {
+			$this->id = absint( $product );
+		}
+		
+		$this->product_type = 'grouped';
+		$this->product_custom_fields = get_post_custom( $this->id );
+
+		// Load data from custom fields
+		$this->load_product_data( array(
+			'sku'			=> '',
+			'downloadable' 	=> 'no',
+			'virtual' 		=> 'no',
+			'price' 		=> '',
+			'visibility'	=> 'hidden',
+			'stock'			=> 0,
+			'stock_status'	=> 'instock',
+			'backorders'	=> 'no',
+			'manage_stock'	=> 'no',
+			'sale_price'	=> '',
+			'regular_price' => '',
+			'weight'		=> '',
+			'length'		=> '',
+			'width'		=> '',
+			'height'		=> '',
+			'tax_status'	=> 'taxable',
+			'tax_class'		=> '',
+			'upsell_ids'	=> array(),
+			'crosssell_ids' => array(),
+			'sale_price_dates_from' => '',
+			'sale_price_dates_to' 	=> '',
+			'featured'		=> 'no'
+		) );
+		
+		$this->check_sale_price();
+	}
+
+    /**
+     * Get total stock.
+     *
+     * This is the stock of parent and children combined.
+     *
+     * @access public
+     * @return int
+     */
+    function get_total_stock() {
+
+        if ( is_null( $this->total_stock ) ) {
+
+        	$transient_name = 'wc_product_total_stock_' . $this->id;
+
+        	if ( false === ( $this->total_stock = get_transient( $transient_name ) ) ) {
+		        $this->total_stock = $this->stock;
+
+				if ( sizeof( $this->get_children() ) > 0 ) {
+					foreach ($this->get_children() as $child_id) {
+						$stock = get_post_meta( $child_id, '_stock', true );
+
+						if ( $stock != '' ) {
+							$this->total_stock += intval( $stock );
+						}
+					}
+				}
+
+				set_transient( $transient_name, $this->total_stock );
+			}
+		}
+
+		return apply_filters( 'woocommerce_stock_amount', $this->total_stock );
+    }
+
+	/**
+	 * Return the products children posts.
+	 *
+	 * @access public
+	 * @return array
+	 */
+	function get_children() {
+
+		if ( ! is_array( $this->children ) ) {
+
+			$this->children = array();
+
+			$transient_name = 'wc_product_children_ids_' . $this->id;
+
+        	if ( false === ( $this->children = get_transient( $transient_name ) ) ) {
+
+		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product&orderby=menu_order&order=ASC&fields=ids&post_status=any&numberposts=-1' );
+
+				set_transient( $transient_name, $this->children );
+
+			}
+		}
+
+		return (array) $this->children;
+	}
+
+
+	/**
+	 * get_child function.
+	 *
+	 * @access public
+	 * @param mixed $child_id
+	 * @return object WC_Product or WC_Product_variation
+	 */
+	function get_child( $child_id ) {
+		return get_product( $child_id );
+	}
+
+
+	/**
+	 * Returns whether or not the product has any child product.
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	function has_child() {
+		return sizeof( $this->get_children() ) ? true : false;
+	}
+
+
+	/**
+	 * Returns whether or not the product is on sale.
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	function is_on_sale() {
+		if ($this->has_child()) :
+
+			foreach ($this->get_children() as $child_id) :
+				$sale_price = get_post_meta( $child_id, '_sale_price', true );
+				if ( $sale_price!=="" && $sale_price >= 0 ) return true;
+			endforeach;
+
+		else :
+
+			if ( $this->sale_price && $this->sale_price==$this->price ) return true;
+
+		endif;
+		return false;
+	}
+
+
+	/**
+	 * Returns false if the product cannot be bought.
+	 *
+	 * @access public
+	 * @return cool
+	 */
+	function is_purchasable() {
+		return apply_filters( 'woocommerce_is_purchasable', false, $this );
+	}
+
+
+	/**
+	 * Returns the price in html format.
+	 *
+	 * @access public
+	 * @param string $price (default: '')
+	 * @return string
+	 */
+	function get_price_html( $price = '' ) {
+
+		$child_prices = array();
+
+		foreach ( $this->get_children() as $child_id ) $child_prices[] = get_post_meta( $child_id, '_price', true );
+
+		$child_prices = array_unique( $child_prices );
+
+		if ( ! empty( $child_prices ) ) {
+			$min_price = min( $child_prices );
+		} else {
+			$min_price = '';
+		}
+
+		if ( sizeof( $child_prices ) > 1 ) $price .= $this->get_price_html_from_text();
+
+		$price .= woocommerce_price( $min_price );
+
+		$price = apply_filters( 'woocommerce_grouped_price_html', $price, $this );
+
+		return apply_filters( 'woocommerce_get_price_html', $price, $this );
+	}
+
+
+    /**
+     * Checks sale data to see if the product is due to go on sale/sale has expired, and updates the main price.
+     *
+     * @access public
+     * @return void
+     */
+    function check_sale_price() {
+
+    	if ( $this->sale_price_dates_from && $this->sale_price_dates_from < current_time('timestamp') ) {
+
+    		if ( $this->sale_price && $this->price !== $this->sale_price ) {
+
+    			// Update price
+    			$this->price = $this->sale_price;
+    			update_post_meta( $this->id, '_price', $this->price );
+
+    			// Grouped product prices and sale status are affected by children
+    			$this->grouped_product_sync();
+    		}
+
+    	}
+
+    	if ( $this->sale_price_dates_to && $this->sale_price_dates_to < current_time('timestamp') ) {
+
+    		if ( $this->regular_price && $this->price !== $this->regular_price ) {
+
+    			$this->price = $this->regular_price;
+    			update_post_meta( $this->id, '_price', $this->price );
+
+				// Sale has expired - clear the schedule boxes
+				update_post_meta( $this->id, '_sale_price', '' );
+				update_post_meta( $this->id, '_sale_price_dates_from', '' );
+				update_post_meta( $this->id, '_sale_price_dates_to', '' );
+
+				// Grouped product prices and sale status are affected by children
+    			$this->grouped_product_sync();
+			}
+
+    	}
+    }
+
+
+	/**
+	 * Sync grouped products with the childs lowest price (so they can be sorted by price accurately).
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function grouped_product_sync() {
+		global $wpdb, $woocommerce;
+		$post_parent = $wpdb->get_var( $wpdb->prepare( "SELECT post_parent FROM $wpdb->posts WHERE ID = %d;"), $this->id );
+
+		if (!$post_parent) return;
+
+		$children_by_price = get_posts( array(
+			'post_parent' 	=> $post_parent,
+			'orderby' 	=> 'meta_value_num',
+			'order'		=> 'asc',
+			'meta_key'	=> '_price',
+			'posts_per_page' => 1,
+			'post_type' 	=> 'product',
+			'fields' 		=> 'ids'
+		));
+		if ($children_by_price) :
+			foreach ($children_by_price as $child) :
+				$child_price = get_post_meta($child, '_price', true);
+				update_post_meta( $post_parent, '_price', $child_price );
+			endforeach;
+		endif;
+
+		$woocommerce->clear_product_transients( $this->id );
+	}
+}

--- a/classes/class-wc-product-grouped.php
+++ b/classes/class-wc-product-grouped.php
@@ -25,7 +25,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * @access public
 	 * @param mixed $product
 	 */
-	function __construct( $product ) {
+	function __construct( $product, $args ) {
 		
 		parent::__construct( $product );
 		

--- a/classes/class-wc-product-grouped.php
+++ b/classes/class-wc-product-grouped.php
@@ -24,6 +24,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * 
 	 * @access public
 	 * @param mixed $product
+	 * @param array $args Contains arguments to set up this product
 	 */
 	function __construct( $product, $args ) {
 		

--- a/classes/class-wc-product-simple.php
+++ b/classes/class-wc-product-simple.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * External Product Class
+ * Simple Product Class
  *
- * External products cannot be bought; they link offsite.
+ * The default product type kinda product
  *
- * @class 		WC_Product_External
+ * @class 		WC_Product_Simple
  * @version		1.7.0
  * @package		WooCommerce/Classes/Products
  * @author 		WooThemes
  */
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-class WC_Product_External extends WC_Product {
+class WC_Product_Simple extends WC_Product {
 
 	/**
 	 * __construct function.
@@ -23,7 +23,7 @@ class WC_Product_External extends WC_Product {
 
 		parent::__construct( $product );
 		
-		$this->product_type = 'external';
+		$this->product_type = 'simple';
 		$this->product_custom_fields = get_post_custom( $this->id );
 		
 		// Load data from custom fields
@@ -53,15 +53,5 @@ class WC_Product_External extends WC_Product {
 		) );
 		
 		$this->check_sale_price();
-	}
-
-	/**
-	 * Returns false if the product cannot be bought.
-	 *
-	 * @access public
-	 * @return cool
-	 */
-	function is_purchasable() {
-		return apply_filters( 'woocommerce_is_purchasable', false, $this );
 	}
 }

--- a/classes/class-wc-product-simple.php
+++ b/classes/class-wc-product-simple.php
@@ -19,7 +19,7 @@ class WC_Product_Simple extends WC_Product {
 	 * @access public
 	 * @param mixed $product
 	 */
-	function __construct( $product ) {
+	function __construct( $product, $args ) {
 
 		parent::__construct( $product );
 		

--- a/classes/class-wc-product-simple.php
+++ b/classes/class-wc-product-simple.php
@@ -18,6 +18,7 @@ class WC_Product_Simple extends WC_Product {
 	 * 
 	 * @access public
 	 * @param mixed $product
+	 * @param array $args Contains arguments to set up this product
 	 */
 	function __construct( $product, $args ) {
 

--- a/classes/class-wc-product-variable.php
+++ b/classes/class-wc-product-variable.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * Variable Product Class
+ *
+ * The WooCommerce product class handles individual product data.
+ *
+ * @class 		WC_Product_Variable
+ * @version		1.7.0
+ * @package		WooCommerce/Classes/Products
+ * @author 		WooThemes
+ */
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+class WC_Product_Variable extends WC_Product {
+	
+	/** @var array Array of child products/posts/variations. */
+	var $children;
+
+	/** @var string The product's total stock, including that of its children. */
+	var $total_stock;
+	
+	/** @var string Used for variation prices. */
+	var $min_variation_price;
+
+	/** @var string Used for variation prices. */
+	var $max_variation_price;
+
+	/** @var string Used for variation prices. */
+	var $min_variation_regular_price;
+
+	/** @var string Used for variation prices. */
+	var $max_variation_regular_price;
+
+	/** @var string Used for variation prices. */
+	var $min_variation_sale_price;
+
+	/** @var string Used for variation prices. */
+	var $max_variation_sale_price;
+	
+	/**
+	 * __construct function.
+	 * 
+	 * @access public
+	 * @param mixed $product
+	 */
+	function __construct( $product ) {
+
+		if ( is_object( $product ) ) {
+			$this->id = absint( $product->ID );
+			$this->post = $product;
+		} else {
+			$this->id = absint( $product );
+		}
+		
+		$this->product_type = 'variable';
+		$this->product_custom_fields = get_post_custom( $this->id );
+
+		// Load data from custom fields
+		$this->load_product_data( array(
+			'sku'			=> '',
+			'downloadable' 	=> 'no',
+			'virtual' 		=> 'no',
+			'price' 		=> '',
+			'visibility'	=> 'hidden',
+			'stock'			=> 0,
+			'stock_status'	=> 'instock',
+			'backorders'	=> 'no',
+			'manage_stock'	=> 'no',
+			'sale_price'	=> '',
+			'regular_price' => '',
+			'weight'		=> '',
+			'length'		=> '',
+			'width'			=> '',
+			'height'		=> '',
+			'tax_status'	=> 'taxable',
+			'tax_class'		=> '',
+			'upsell_ids'	=> array(),
+			'crosssell_ids' => array(),
+			'sale_price_dates_from' => '',
+			'sale_price_dates_to' 	=> '',
+			'featured'		=> 'no',
+			'min_variation_price'	=> '',
+			'max_variation_price'	=> '',
+			'min_variation_regular_price'	=> '',
+			'max_variation_regular_price'	=> '',
+			'min_variation_sale_price'	=> '',
+			'max_variation_sale_price'	=> '',
+		) );
+		
+		$this->check_sale_price();
+	}
+
+    /**
+     * Get total stock.
+     *
+     * This is the stock of parent and children combined.
+     *
+     * @access public
+     * @return int
+     */
+    function get_total_stock() {
+
+        if ( is_null( $this->total_stock ) ) {
+
+        	$transient_name = 'wc_product_total_stock_' . $this->id;
+
+        	if ( false === ( $this->total_stock = get_transient( $transient_name ) ) ) {
+		        $this->total_stock = $this->stock;
+
+				if ( sizeof( $this->get_children() ) > 0 ) {
+					foreach ($this->get_children() as $child_id) {
+						$stock = get_post_meta( $child_id, '_stock', true );
+
+						if ( $stock != '' ) {
+							$this->total_stock += intval( $stock );
+						}
+					}
+				}
+
+				set_transient( $transient_name, $this->total_stock );
+			}
+		}
+
+		return apply_filters( 'woocommerce_stock_amount', $this->total_stock );
+    }
+
+	/**
+	 * Reduce stock level of the product.
+	 *
+	 * @access public
+	 * @param int $by (default: 1) Amount to reduce by.
+	 * @return int Stock
+	 */
+	function reduce_stock( $by = 1 ) {
+		global $woocommerce;
+
+		if ( $this->managing_stock() ) {
+			$this->stock = $this->stock - $by;
+			$this->total_stock = $this->get_total_stock() - $by;
+			update_post_meta($this->id, '_stock', $this->stock);
+
+			// Out of stock attribute
+			if ($this->managing_stock() && !$this->backorders_allowed() && $this->get_total_stock()<=0) :
+				update_post_meta($this->id, '_stock_status', 'outofstock');
+			endif;
+
+			$woocommerce->clear_product_transients( $this->id ); // Clear transient
+
+			return apply_filters( 'woocommerce_stock_amount', $this->stock );
+		}
+	}
+
+
+	/**
+	 * Increase stock level of the product.
+	 *
+	 * @access public
+	 * @param int $by (default: 1) Amount to increase by
+	 * @return int Stock
+	 */
+	function increase_stock( $by = 1 ) {
+		global $woocommerce;
+
+		if ($this->managing_stock()) :
+			$this->stock = $this->stock + $by;
+			$this->total_stock = $this->get_total_stock() + $by;
+			update_post_meta($this->id, '_stock', $this->stock);
+
+			// Out of stock attribute
+			if ($this->managing_stock() && ($this->backorders_allowed() || $this->get_total_stock()>0)) :
+				update_post_meta($this->id, '_stock_status', 'instock');
+			endif;
+
+			$woocommerce->clear_product_transients( $this->id ); // Clear transient
+
+			return apply_filters( 'woocommerce_stock_amount', $this->stock );
+		endif;
+	}
+	
+	
+	/**
+	 * Return the products children posts.
+	 *
+	 * @access public
+	 * @return array
+	 */
+	function get_children() {
+
+		if (!is_array($this->children)) :
+
+			$this->children = array();
+
+			$transient_name = 'wc_product_children_ids_' . $this->id;
+
+        	if ( false === ( $this->children = get_transient( $transient_name ) ) ) :
+
+		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product_variation&orderby=menu_order&order=ASC&fields=ids&post_status=any&numberposts=-1' );
+
+				set_transient( $transient_name, $this->children );
+
+			endif;
+
+		endif;
+
+		return (array) $this->children;
+	}
+
+
+	/**
+	 * get_child function.
+	 *
+	 * @access public
+	 * @param mixed $child_id
+	 * @return object WC_Product or WC_Product_variation
+	 */
+	function get_child( $child_id ) {
+		return get_product( $child_id, $this->id, $this->product_custom_fields );
+	}
+
+
+	/**
+	 * Returns whether or not the product has any child product.
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	function has_child() {
+		return sizeof( $this->get_children() ) ? true : false;
+	}
+
+
+	/**
+	 * Returns whether or not the product is on sale.
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	function is_on_sale() {
+		if ($this->has_child()) :
+
+			foreach ($this->get_children() as $child_id) :
+				$sale_price = get_post_meta( $child_id, '_sale_price', true );
+				if ( $sale_price!=="" && $sale_price >= 0 ) return true;
+			endforeach;
+
+		else :
+
+			if ( $this->sale_price && $this->sale_price==$this->price ) return true;
+
+		endif;
+		return false;
+	}
+
+	/**
+	 * Returns the price in html format.
+	 *
+	 * @access public
+	 * @param string $price (default: '')
+	 * @return string
+	 */
+	function get_price_html( $price = '' ) {
+
+		// Ensure variation prices are synced with variations
+		if ( $this->min_variation_price === '' || $this->min_variation_regular_price === '' ) {
+			$this->variable_product_sync();
+			$this->price = $this->min_variation_price;
+		}
+
+		// Get the price
+		if ($this->price > 0) {
+			if ( $this->is_on_sale() && isset( $this->min_variation_price ) && $this->min_variation_regular_price !== $this->get_price() ) {
+
+				if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
+					$price .= $this->get_price_html_from_text();
+
+				$price .= $this->get_price_html_from_to( $this->min_variation_regular_price, $this->get_price() );
+
+				$price = apply_filters( 'woocommerce_variable_sale_price_html', $price, $this );
+
+			} else {
+
+				if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
+					$price .= $this->get_price_html_from_text();
+
+				$price .= woocommerce_price( $this->get_price() );
+
+				$price = apply_filters('woocommerce_variable_price_html', $price, $this);
+
+			}
+		} elseif ($this->price === '' ) {
+
+			$price = apply_filters('woocommerce_variable_empty_price_html', '', $this);
+
+		} elseif ($this->price == 0 ) {
+
+			if ( $this->is_on_sale() && isset( $this->min_variation_regular_price ) && $this->min_variation_regular_price !== $this->get_price() ) {
+
+				if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
+					$price .= $this->get_price_html_from_text();
+
+				$price .= $this->get_price_html_from_to( $this->min_variation_regular_price, __( 'Free!', 'woocommerce' ) );
+
+				$price = apply_filters( 'woocommerce_variable_free_sale_price_html', $price, $this );
+
+			} else {
+
+				if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
+					$price .= $this->get_price_html_from_text();
+
+				$price .= __( 'Free!', 'woocommerce' );
+
+				$price = apply_filters( 'woocommerce_variable_free_price_html', $price, $this );
+
+			}
+
+		}
+
+		return apply_filters( 'woocommerce_get_price_html', $price, $this );
+	}
+
+
+    /**
+     * Return an array of attributes used for variations, as well as their possible values.
+     *
+     * @access public
+     * @return array of attributes and their available values
+     */
+    function get_variation_attributes() {
+
+	    $variation_attributes = array();
+
+        if ( ! $this->has_child() )
+        	return $variation_attributes;
+
+        $attributes = $this->get_attributes();
+
+        foreach ( $attributes as $attribute ) {
+            if ( ! $attribute['is_variation'] )
+            	continue;
+
+            $values = array();
+            $attribute_field_name = 'attribute_' . sanitize_title( $attribute['name'] );
+
+            foreach ( $this->get_children() as $child_id ) {
+
+                if ( get_post_status( $child_id ) != 'publish' )
+                	continue; // Disabled
+
+            	$child = $this->get_child( $child_id );
+
+                $child_variation_attributes = $child->get_variation_attributes();
+
+                foreach ( $child_variation_attributes as $name => $value )
+                    if ( $name == $attribute_field_name )
+                    	$values[] = $value;
+            }
+
+            // empty value indicates that all options for given attribute are available
+            if ( in_array( '', $values ) ) {
+
+            	$values = array();
+
+            	// Get all options
+            	if ( $attribute['is_taxonomy'] ) {
+	            	$post_terms = wp_get_post_terms( $this->id, $attribute['name'] );
+					foreach ( $post_terms as $term )
+						$values[] = $term->slug;
+				} else {
+					$values = explode( '|', $attribute['value'] );
+				}
+
+				$values = array_unique( array_map( 'trim', $values ) );
+
+			// Order custom attributes (non taxonomy) as defined
+            } else {
+
+	            if ( ! $attribute['is_taxonomy'] ) {
+	            	$options 	= array_map( 'trim', explode( '|', $attribute['value'] ) );
+	            	$values 	= array_intersect( $options, $values );
+	            }
+
+            }
+
+            $variation_attributes[ $attribute['name'] ] = array_unique( $values );
+        }
+
+        return $variation_attributes;
+    }
+
+    /**
+     * If set, get the default attributes for a variable product.
+     *
+     * @access public
+     * @return array
+     */
+    function get_variation_default_attributes() {
+
+    	$default = isset( $this->product_custom_fields['_default_attributes'][0] ) ? $this->product_custom_fields['_default_attributes'][0] : '';
+
+	    return apply_filters( 'woocommerce_product_default_attributes', (array) maybe_unserialize( $default ), $this );
+    }
+
+    /**
+     * Get an array of available variations for the current product.
+     *
+     * @access public
+     * @return array
+     */
+    function get_available_variations() {
+
+	    $available_variations = array();
+
+		foreach ( $this->get_children() as $child_id ) {
+
+			$variation = $this->get_child( $child_id );
+
+			if ( $variation instanceof WC_Product_Variation ) {
+
+				if ( get_post_status( $variation->get_variation_id() ) != 'publish' || ! $variation->is_visible() )
+					continue; // Disabled or hidden
+
+				$variation_attributes 	= $variation->get_variation_attributes();
+				$availability 			= $variation->get_availability();
+				$availability_html 		= empty( $availability['availability'] ) ? '' : apply_filters( 'woocommerce_stock_html', '<p class="stock ' . esc_attr( $availability['class'] ) . '">'. wp_kses_post( $availability['availability'] ).'</p>', wp_kses_post( $availability['availability'] ) );
+
+				if ( has_post_thumbnail( $variation->get_variation_id() ) ) {
+					$attachment_id = get_post_thumbnail_id( $variation->get_variation_id() );
+
+					$attachment = wp_get_attachment_image_src( $attachment_id, apply_filters( 'single_product_large_thumbnail_size', 'shop_single' )  );
+					$image = $attachment ? current( $attachment ) : '';
+
+					$attachment = wp_get_attachment_image_src( $attachment_id, 'full'  );
+					$image_link = $attachment ? current( $attachment ) : '';
+
+					$image_title = get_the_title( $attachment_id );
+				} else {
+					$image = $image_link = $image_title = '';
+				}
+
+				$available_variations[] = apply_filters( 'woocommerce_available_variation', array(
+					'variation_id' 			=> $child_id,
+					'attributes' 			=> $variation_attributes,
+					'image_src' 			=> $image,
+					'image_link' 			=> $image_link,
+					'image_title'			=> $image_title,
+					'price_html' 			=> $this->min_variation_price != $this->max_variation_price ? '<span class="price">' . $variation->get_price_html() . '</span>' : '',
+					'availability_html' 	=> $availability_html,
+					'sku' 					=> $variation->get_sku(),
+					'weight'				=> $variation->get_weight() . ' ' . esc_attr( get_option('woocommerce_weight_unit' ) ),
+					'dimensions'			=> $variation->get_dimensions(),
+					'min_qty' 				=> 1,
+					'max_qty' 				=> $this->backorders_allowed() ? '' : $variation->stock,
+					'backorders_allowed' 	=> $this->backorders_allowed(),
+					'is_in_stock'			=> $variation->is_in_stock(),
+					'is_downloadable' 		=> $variation->is_downloadable() ,
+					'is_virtual' 			=> $variation->is_virtual(),
+					'is_sold_individually' 	=> $variation->is_sold_individually() ? 'yes' : 'no',
+				), $this, $variation );
+			}
+		}
+
+		return $available_variations;
+    }
+
+
+	/**
+	 * Sync variable product prices with the childs lowest/highest prices.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function variable_product_sync() {
+		global $woocommerce;
+
+		$children = get_posts( array(
+			'post_parent' 	=> $this->id,
+			'posts_per_page'=> -1,
+			'post_type' 	=> 'product_variation',
+			'fields' 		=> 'ids',
+			'post_status'	=> 'publish'
+		));
+
+		$this->min_variation_price = $this->min_variation_regular_price = $this->min_variation_sale_price = $this->max_variation_price = $this->max_variation_regular_price = $this->max_variation_sale_price = '';
+
+		if ($children) {
+			foreach ( $children as $child ) {
+
+				$child_price 			= get_post_meta( $child, '_price', true );
+				$child_regular_price 	= get_post_meta( $child, '_regular_price', true );
+				$child_sale_price 		= get_post_meta( $child, '_sale_price', true );
+				
+				// Regular prices
+				if ( ! is_numeric( $this->min_variation_regular_price ) || $child_regular_price < $this->min_variation_regular_price ) 
+					$this->min_variation_regular_price = $child_regular_price;
+					
+				if ( ! is_numeric( $this->max_variation_regular_price ) || $child_regular_price > $this->max_variation_regular_price ) 
+					$this->max_variation_regular_price = $child_regular_price;
+				
+				// Sale prices
+				if ( $child_price == $child_sale_price ) {
+					if ( $child_sale_price !== '' && ( ! is_numeric( $this->min_variation_sale_price ) || $child_sale_price < $this->min_variation_sale_price ) ) 
+						$this->min_variation_sale_price = $child_sale_price;
+					
+					if ( $child_sale_price !== '' && ( ! is_numeric( $this->max_variation_sale_price ) || $child_sale_price > $this->max_variation_sale_price ) ) 
+						$this->max_variation_sale_price = $child_sale_price;
+				}
+			}
+
+	    	$this->min_variation_price = $this->min_variation_sale_price === '' || $this->min_variation_regular_price < $this->min_variation_sale_price ? $this->min_variation_regular_price : $this->min_variation_sale_price;
+	    	
+			$this->max_variation_price = $this->max_variation_sale_price === '' || $this->max_variation_regular_price > $this->max_variation_sale_price ? $this->max_variation_regular_price : $this->max_variation_sale_price;
+		}
+
+		update_post_meta( $this->id, '_price', $this->min_variation_price );
+		update_post_meta( $this->id, '_min_variation_price', $this->min_variation_price );
+		update_post_meta( $this->id, '_max_variation_price', $this->max_variation_price );
+		update_post_meta( $this->id, '_min_variation_regular_price', $this->min_variation_regular_price );
+		update_post_meta( $this->id, '_max_variation_regular_price', $this->max_variation_regular_price );
+		update_post_meta( $this->id, '_min_variation_sale_price', $this->min_variation_sale_price );
+		update_post_meta( $this->id, '_max_variation_sale_price', $this->max_variation_sale_price );
+
+		$woocommerce->clear_product_transients( $this->id );
+	}
+}

--- a/classes/class-wc-product-variable.php
+++ b/classes/class-wc-product-variable.php
@@ -45,12 +45,7 @@ class WC_Product_Variable extends WC_Product {
 	 */
 	function __construct( $product ) {
 
-		if ( is_object( $product ) ) {
-			$this->id = absint( $product->ID );
-			$this->post = $product;
-		} else {
-			$this->id = absint( $product );
-		}
+		parent::__construct( $product );
 		
 		$this->product_type = 'variable';
 		$this->product_custom_fields = get_post_custom( $this->id );

--- a/classes/class-wc-product-variable.php
+++ b/classes/class-wc-product-variable.php
@@ -414,7 +414,7 @@ class WC_Product_Variable extends WC_Product {
 
 			$variation = $this->get_child( $child_id );
 
-			if ( $variation instanceof WC_Product_Variation ) {
+			if ( ! empty( $variation->variation_id ) ) {
 
 				if ( get_post_status( $variation->get_variation_id() ) != 'publish' || ! $variation->is_visible() )
 					continue; // Disabled or hidden

--- a/classes/class-wc-product-variable.php
+++ b/classes/class-wc-product-variable.php
@@ -43,7 +43,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @access public
 	 * @param mixed $product
 	 */
-	function __construct( $product ) {
+	function __construct( $product, $args ) {
 
 		parent::__construct( $product );
 		

--- a/classes/class-wc-product-variable.php
+++ b/classes/class-wc-product-variable.php
@@ -42,6 +42,7 @@ class WC_Product_Variable extends WC_Product {
 	 * 
 	 * @access public
 	 * @param mixed $product
+	 * @param array $args Contains arguments to set up this product
 	 */
 	function __construct( $product, $args ) {
 
@@ -209,7 +210,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return object WC_Product or WC_Product_variation
 	 */
 	function get_child( $child_id ) {
-		return get_product( $child_id, $this->id, $this->product_custom_fields );
+		return get_product( $child_id, array( 'parent_id' => $this->id, 'meta' => $this->product_custom_fields ) );
 	}
 
 

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -65,7 +65,9 @@ class WC_Product_Variation extends WC_Product {
 	 * @param array $parent_custom_fields (default: '') Array of the parent products meta data
 	 * @return void
 	 */
-	function __construct( $variation, $parent_id = '', $parent_custom_fields = '' ) {
+	function __construct( $variation, $args ) {
+		$parent_id = $args['parent_id'];
+		$parent_custom_fields = $args['meta'];
 
 		if ( is_object( $variation ) ) {
 			$this->variation_id = absint( $variation->ID );

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -65,9 +65,13 @@ class WC_Product_Variation extends WC_Product {
 	 * @param array $parent_custom_fields (default: '') Array of the parent products meta data
 	 * @return void
 	 */
-	function __construct( $variation_id, $parent_id = '', $parent_custom_fields = '' ) {
+	function __construct( $variation, $parent_id = '', $parent_custom_fields = '' ) {
 
-		$this->variation_id = intval( $variation_id );
+		if ( is_object( $variation ) ) {
+			$this->variation_id = absint( $variation->ID );
+		} else {
+			$this->variation_id = absint( $variation );
+		}
 
 		$product_custom_fields = get_post_custom( $this->variation_id );
 
@@ -324,7 +328,7 @@ class WC_Product_Variation extends WC_Product {
 				if ( ! $this->is_in_stock() ) {
 
 					// Check parent
-					$parent_product = new WC_Product( $this->id );
+					$parent_product = get_product( $this->id );
 
 					// Only continue if the parent has backorders off
 					if ( ! $parent_product->backorders_allowed() && $parent_product->get_total_stock() <= 0 ) {

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -61,8 +61,7 @@ class WC_Product_Variation extends WC_Product {
 	 *
 	 * @access public
 	 * @param int $variation_id ID of the variation to load
-	 * @param int $parent_id (default: '') ID of the parent product
-	 * @param array $parent_custom_fields (default: '') Array of the parent products meta data
+	 * @param array $args Array of the arguments containing parent product data
 	 * @return void
 	 */
 	function __construct( $variation, $args ) {

--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Product Class
+ * Abstract Product Class
  *
  * The WooCommerce product class handles individual product data.
  *
@@ -11,7 +11,7 @@
  */
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-class WC_Product {
+abstract class WC_Product {
 
 	/** @var int The product (post) ID. */
 	var $id;
@@ -111,44 +111,12 @@ class WC_Product {
 	 * @param mixed $product
 	 */
 	function __construct( $product ) {
-		
 		if ( is_object( $product ) ) {
 			$this->id = absint( $product->ID );
 			$this->post = $product;
 		} else {
 			$this->id = absint( $product );
 		}
-		
-		$this->product_type = 'simple';
-		$this->product_custom_fields = get_post_custom( $this->id );
-		
-		// Load data from custom fields
-		$this->load_product_data( array(
-			'sku'			=> '',
-			'downloadable' 	=> 'no',
-			'virtual' 		=> 'no',
-			'price' 		=> '',
-			'visibility'	=> 'hidden',
-			'stock'			=> 0,
-			'stock_status'	=> 'instock',
-			'backorders'	=> 'no',
-			'manage_stock'	=> 'no',
-			'sale_price'	=> '',
-			'regular_price' => '',
-			'weight'		=> '',
-			'length'		=> '',
-			'width'			=> '',
-			'height'		=> '',
-			'tax_status'	=> 'taxable',
-			'tax_class'		=> '',
-			'upsell_ids'	=> array(),
-			'crosssell_ids' => array(),
-			'sale_price_dates_from' => '',
-			'sale_price_dates_to' 	=> '',
-			'featured'		=> 'no'
-		) );
-
-		$this->check_sale_price();
 	}
 	
 	

--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -9,6 +9,8 @@
  * @package		WooCommerce/Classes
  * @author 		WooThemes
  */
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
 class WC_Product {
 
 	/** @var int The product (post) ID. */
@@ -19,9 +21,6 @@ class WC_Product {
 
 	/** @var array Array of product attributes. */
 	var $attributes;
-
-	/** @var array Array of child products/posts/variations. */
-	var $children;
 
 	/** @var object The actual post object. */
 	var $post;
@@ -86,32 +85,11 @@ class WC_Product {
 	/** @var string The product's type (simple, variable etc). */
 	var $product_type;
 
-	/** @var string The product's total stock, including that of its children. */
-	var $total_stock;
-
 	/** @var string Date a sale starts. */
 	var $sale_price_dates_from;
 
 	/** @var string Data a sale ends. */
 	var $sale_price_dates_to;
-
-	/** @var string Used for variation prices. */
-	var $min_variation_price;
-
-	/** @var string Used for variation prices. */
-	var $max_variation_price;
-
-	/** @var string Used for variation prices. */
-	var $min_variation_regular_price;
-
-	/** @var string Used for variation prices. */
-	var $max_variation_regular_price;
-
-	/** @var string Used for variation prices. */
-	var $min_variation_sale_price;
-
-	/** @var string Used for variation prices. */
-	var $max_variation_sale_price;
 
 	/** @var string "Yes" for featured products. */
 	var $featured;
@@ -125,19 +103,27 @@ class WC_Product {
 	/** @var string Formatted LxWxH. */
 	var $dimensions;
 
+
 	/**
-	 * Loads all product data from custom fields.
-	 *
-	 * @param int $id ID of the product to load
+	 * __construct function.
+	 * 
+	 * @access public
+	 * @param mixed $product
 	 */
-	function __construct( $id ) {
-
-		$this->id = absint( $id );
-
+	function __construct( $product ) {
+		
+		if ( is_object( $product ) ) {
+			$this->id = absint( $product->ID );
+			$this->post = $product;
+		} else {
+			$this->id = absint( $product );
+		}
+		
+		$this->product_type = 'simple';
 		$this->product_custom_fields = get_post_custom( $this->id );
-
-		// Define the data we're going to load: Key => Default value
-		$load_data = array(
+		
+		// Load data from custom fields
+		$this->load_product_data( array(
 			'sku'			=> '',
 			'downloadable' 	=> 'no',
 			'virtual' 		=> 'no',
@@ -151,7 +137,7 @@ class WC_Product {
 			'regular_price' => '',
 			'weight'		=> '',
 			'length'		=> '',
-			'width'		=> '',
+			'width'			=> '',
 			'height'		=> '',
 			'tax_status'	=> 'taxable',
 			'tax_class'		=> '',
@@ -159,32 +145,27 @@ class WC_Product {
 			'crosssell_ids' => array(),
 			'sale_price_dates_from' => '',
 			'sale_price_dates_to' 	=> '',
-			'min_variation_price'	=> '',
-			'max_variation_price'	=> '',
-			'min_variation_regular_price'	=> '',
-			'max_variation_regular_price'	=> '',
-			'min_variation_sale_price'	=> '',
-			'max_variation_sale_price'	=> '',
 			'featured'		=> 'no'
-		);
+		) );
 
-		// Load the data from the custom fields
-		foreach ($load_data as $key => $default) $this->$key = (isset($this->product_custom_fields['_' . $key][0]) && $this->product_custom_fields['_' . $key][0]!=='') ? $this->product_custom_fields['_' . $key][0] : $default;
-
-		// Get product type
-		$transient_name = 'wc_product_type_' . $this->id;
-
-		if ( false === ( $this->product_type = get_transient( $transient_name ) ) ) :
-			$terms = wp_get_object_terms( $id, 'product_type', array('fields' => 'names') );
-			$this->product_type = (isset($terms[0])) ? sanitize_title($terms[0]) : 'simple';
-			set_transient( $transient_name, $this->product_type );
-		endif;
-
-		// Check sale dates
 		$this->check_sale_price();
 	}
-
-
+	
+	
+	/**
+	 * Load the data from the custom fields
+	 * 
+	 * @access public
+	 * @param mixed $fields
+	 * @return void
+	 */
+	function load_product_data( $fields ) {
+		if ( $fields )
+			foreach ( $fields as $key => $default ) 
+				$this->$key = isset( $this->product_custom_fields[ '_' . $key ][0] ) && $this->product_custom_fields[ '_' . $key ][0] !== '' ? $this->product_custom_fields[ '_' . $key ][0] : $default;
+	}
+	
+	
 	/**
      * Get SKU (Stock-keeping unit) - product unique ID.
      *
@@ -196,88 +177,28 @@ class WC_Product {
 
 
     /**
-     * Get total stock.
+     * Returns number of items available for sale.
      *
-     * This is the stock of parent and children combined.
+     * @access public
+     * @return int
+     */
+    function get_stock_quantity() {
+    	if ( ! $this->managing_stock() )
+    		return '';
+
+        return apply_filters( 'woocommerce_stock_amount', $this->stock );
+    }
+    
+    
+    /**
+     * Get total stock.
      *
      * @access public
      * @return int
      */
     function get_total_stock() {
-
-        if ( is_null( $this->total_stock ) ) {
-
-        	$transient_name = 'wc_product_total_stock_' . $this->id;
-
-        	if ( false === ( $this->total_stock = get_transient( $transient_name ) ) ) {
-		        $this->total_stock = $this->stock;
-
-				if ( sizeof( $this->get_children() ) > 0 ) {
-					foreach ($this->get_children() as $child_id) {
-						$stock = get_post_meta( $child_id, '_stock', true );
-
-						if ( $stock != '' ) {
-							$this->total_stock += intval( $stock );
-						}
-					}
-				}
-
-				set_transient( $transient_name, $this->total_stock );
-			}
-		}
-
-		return apply_filters( 'woocommerce_stock_amount', $this->total_stock );
+		return $this->get_stock_quantity();
     }
-
-	/**
-	 * Return the products children posts.
-	 *
-	 * @access public
-	 * @return array
-	 */
-	function get_children() {
-
-		if (!is_array($this->children)) :
-
-			$this->children = array();
-
-			if ($this->is_type('variable') || $this->is_type('grouped')) :
-
-				$child_post_type = ($this->is_type('variable')) ? 'product_variation' : 'product';
-
-				$transient_name = 'wc_product_children_ids_' . $this->id;
-
-	        	if ( false === ( $this->children = get_transient( $transient_name ) ) ) :
-
-			        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=' . $child_post_type . '&orderby=menu_order&order=ASC&fields=ids&post_status=any&numberposts=-1' );
-
-					set_transient( $transient_name, $this->children );
-
-				endif;
-
-			endif;
-
-		endif;
-
-		return (array) $this->children;
-	}
-
-
-	/**
-	 * get_child function.
-	 *
-	 * @access public
-	 * @param mixed $child_id
-	 * @return object WC_Product or WC_Product_variation
-	 */
-	function get_child( $child_id ) {
-		if ($this->is_type('variable')) :
-			$child = new WC_Product_Variation( $child_id, $this->id, $this->product_custom_fields );
-		else :
-			$child = new WC_Product( $child_id );
-		endif;
-		return $child;
-	}
 
 
 	/**
@@ -290,20 +211,18 @@ class WC_Product {
 	function reduce_stock( $by = 1 ) {
 		global $woocommerce;
 
-		if ($this->managing_stock()) :
+		if ( $this->managing_stock() ) {
 			$this->stock = $this->stock - $by;
-			$this->total_stock = $this->get_total_stock() - $by;
-			update_post_meta($this->id, '_stock', $this->stock);
+			update_post_meta( $this->id, '_stock', $this->stock );
 
 			// Out of stock attribute
-			if ($this->managing_stock() && !$this->backorders_allowed() && $this->get_total_stock()<=0) :
-				update_post_meta($this->id, '_stock_status', 'outofstock');
-			endif;
+			if ( $this->managing_stock() && ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
+				update_post_meta( $this->id, '_stock_status', 'outofstock' );
 
 			$woocommerce->clear_product_transients( $this->id ); // Clear transient
 
-			return apply_filters( 'woocommerce_stock_amount', $this->stock );
-		endif;
+			return $this->get_stock_quantity();
+		}
 	}
 
 
@@ -317,20 +236,18 @@ class WC_Product {
 	function increase_stock( $by = 1 ) {
 		global $woocommerce;
 
-		if ($this->managing_stock()) :
+		if ( $this->managing_stock() ) {
 			$this->stock = $this->stock + $by;
-			$this->total_stock = $this->get_total_stock() + $by;
-			update_post_meta($this->id, '_stock', $this->stock);
+			update_post_meta( $this->id, '_stock', $this->stock );
 
 			// Out of stock attribute
-			if ($this->managing_stock() && ($this->backorders_allowed() || $this->get_total_stock()>0)) :
+			if ( $this->managing_stock() && ( $this->backorders_allowed() || $this->get_total_stock() > 0 ) )
 				update_post_meta($this->id, '_stock_status', 'instock');
-			endif;
 
 			$woocommerce->clear_product_transients( $this->id ); // Clear transient
 
-			return apply_filters( 'woocommerce_stock_amount', $this->stock );
-		endif;
+			return $this->get_stock_quantity();
+		}
 	}
 
 
@@ -344,8 +261,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_type( $type ) {
-		if ( is_array( $type ) && in_array( $this->product_type, $type ) ) return true;
-		if ( $this->product_type == $type ) return true;
+		if ( $this->product_type == $type || ( is_array( $type ) && in_array( $this->product_type, $type ) ) ) return true;
 		return false;
 	}
 
@@ -357,7 +273,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_downloadable() {
-		if ( $this->downloadable == 'yes' ) return true; else return false;
+		return $this->downloadable == 'yes' ? true : false;
 	}
 
 
@@ -390,14 +306,16 @@ class WC_Product {
 	 */
 	function get_file_download_path( $download_id ) {
 		
-		$file_path = '';
-		$file_paths = apply_filters( 'woocommerce_file_download_paths', get_post_meta( $this->id, '_file_paths', true ), $this->id, null, null );
+		$file_paths = isset( $this->product_custom_fields['_file_paths'][0] ) ? $this->product_custom_fields['_file_paths'][0] : '';
+		$file_paths = apply_filters( 'woocommerce_file_download_paths', $file_paths, $this->id, null, null );
 
 		if ( ! $download_id && count( $file_paths ) == 1 ) {
 			// backwards compatibility for old-style download URLs and template files
 			$file_path = array_shift( $file_paths );
 		} elseif ( isset( $file_paths[ $download_id ] ) ) {
 			$file_path = $file_paths[ $download_id ];
+		} else {
+			$file_path = '';
 		}
 
 		// allow overriding based on the particular file being requested
@@ -412,7 +330,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_virtual() {
-		if ( $this->virtual == 'yes' ) return true; else return false;
+		return $this->virtual == 'yes' ? true : false;
 	}
 
 
@@ -423,9 +341,10 @@ class WC_Product {
 	 * @return bool
 	 */
 	function needs_shipping() {
-		if ( $this->is_virtual() ) return false; else return true;
+		return $this->is_virtual() ? false : true;
 	}
-
+	
+	
 	/**
 	 * Check if a product is sold individually (no quantities)
 	 *
@@ -443,7 +362,17 @@ class WC_Product {
 		return apply_filters( 'woocommerce_is_sold_individually', $return, $this );
 	}
 
-
+	/**
+	 * get_children function.
+	 * 
+	 * @access public
+	 * @return bool
+	 */
+	function get_children() {
+		return array();
+	}
+	
+	
 	/**
 	 * Returns whether or not the product has any child product.
 	 *
@@ -451,7 +380,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function has_child() {
-		return sizeof( $this->get_children() ) ? true : false;
+		return false;
 	}
 
 
@@ -463,8 +392,8 @@ class WC_Product {
 	 */
 	function exists() {
 		global $wpdb;
-		if ( $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID = %d LIMIT 1;", $this->id ) ) > 0 ) return true;
-		return false;
+		
+		return $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID = %d LIMIT 1;", $this->id ) ) > 0 ? true : false;
 	}
 
 
@@ -475,8 +404,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_taxable() {
-		if ($this->tax_status=='taxable' && get_option('woocommerce_calc_taxes')=='yes') return true;
-		return false;
+		return $this->tax_status == 'taxable' && get_option('woocommerce_calc_taxes') == 'yes' ? true : false;
 	}
 
 
@@ -487,8 +415,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_shipping_taxable() {
-		if ($this->tax_status=='taxable' || $this->tax_status=='shipping') return true;
-		return false;
+		return $this->tax_status=='taxable' || $this->tax_status=='shipping' ? true : false;
 	}
 
 
@@ -584,8 +511,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function backorders_allowed() {
-		if ($this->backorders=='yes' || $this->backorders=='notify') return true;
-		return false;
+		return $this->backorders=='yes' || $this->backorders=='notify' ? true : false;
 	}
 
 
@@ -596,8 +522,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function backorders_require_notification() {
-		if ($this->managing_stock() && $this->backorders=='notify') return true;
-		return false;
+		return $this->managing_stock() && $this->backorders=='notify' ? true : false;
 	}
 
 
@@ -609,23 +534,8 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_on_backorder( $qty_in_cart = 0 ) {
-		if ( $this->managing_stock() && $this->backorders_allowed() && ( $this->get_total_stock() - $qty_in_cart ) < 0 ) return true;
-		return false;
+		return $this->managing_stock() && $this->backorders_allowed() && ( $this->get_total_stock() - $qty_in_cart ) < 0 ? true : false;
 	}
-
-
-    /**
-     * Returns number of items available for sale.
-     *
-     * @access public
-     * @return int
-     */
-    function get_stock_quantity() {
-    	if ( get_option( 'woocommerce_manage_stock' ) == 'no' || ! $this->managing_stock() )
-    		return '';
-
-        return apply_filters( 'woocommerce_stock_amount', $this->stock );
-    }
 
 
 	/**
@@ -636,17 +546,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function has_enough_stock( $quantity ) {
-
-		if (!$this->managing_stock()) return true;
-
-		if ($this->backorders_allowed()) return true;
-
-		if ($this->stock >= $quantity) :
-			return true;
-		endif;
-
-		return false;
-
+		return ! $this->managing_stock() || $this->backorders_allowed() || $this->stock >= $quantity ? true : false;
 	}
 
 
@@ -718,7 +618,7 @@ class WC_Product {
 			endif;
 		endif;
 
-		return apply_filters( 'woocommerce_get_availability', array( 'availability' => $availability, 'class' => $class), $this );
+		return apply_filters( 'woocommerce_get_availability', array( 'availability' => $availability, 'class' => $class ), $this );
 	}
 
 
@@ -729,7 +629,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_featured() {
-		if ($this->featured=='yes') return true; else return false;
+		return $this->featured == 'yes' ? true : false;
 	}
 
 
@@ -744,19 +644,19 @@ class WC_Product {
 		$visible = true;
 
 		// Out of stock visibility
-		if (get_option('woocommerce_hide_out_of_stock_items')=='yes' && !$this->is_in_stock()) $visible = false;
+		if ( get_option( 'woocommerce_hide_out_of_stock_items' ) == 'yes' && ! $this->is_in_stock() ) $visible = false;
 
 		// visibility setting
-		elseif ($this->visibility=='hidden') $visible = false;
-		elseif ($this->visibility=='visible') $visible = true;
+		elseif ( $this->visibility == 'hidden' ) $visible = false;
+		elseif ( $this->visibility == 'visible' ) $visible = true;
 
 		// Visibility in loop
-		elseif ($this->visibility=='search' && is_search()) $visible = true;
-		elseif ($this->visibility=='search' && !is_search()) $visible = false;
-		elseif ($this->visibility=='catalog' && is_search()) $visible = false;
-		elseif ($this->visibility=='catalog' && !is_search()) $visible = true;
+		elseif ( $this->visibility == 'search' && is_search() ) $visible = true;
+		elseif ( $this->visibility == 'search' && ! is_search() ) $visible = false;
+		elseif ( $this->visibility == 'catalog' && is_search() ) $visible = false;
+		elseif ( $this->visibility == 'catalog' && ! is_search() ) $visible = true;
 
-		return apply_filters('woocommerce_product_is_visible', $visible, $this->id);
+		return apply_filters( 'woocommerce_product_is_visible', $visible, $this->id );
 	}
 
 
@@ -767,19 +667,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_on_sale() {
-		if ($this->has_child()) :
-
-			foreach ($this->get_children() as $child_id) :
-				$sale_price = get_post_meta( $child_id, '_sale_price', true );
-				if ( $sale_price!=="" && $sale_price >= 0 ) return true;
-			endforeach;
-
-		else :
-
-			if ( $this->sale_price && $this->sale_price==$this->price ) return true;
-
-		endif;
-		return false;
+		return $this->sale_price && $this->sale_price == $this->price ? true : false;
 	}
 
 
@@ -790,7 +678,7 @@ class WC_Product {
 	 * @return string
 	 */
 	function get_weight() {
-		if ($this->weight) return $this->weight;
+		if ( $this->weight ) return $this->weight;
 	}
 
 
@@ -845,10 +733,6 @@ class WC_Product {
 		if ( ! $this->exists() )
 			$purchasable = false;
 
-		// External and grouped products cannot be bought
-		elseif ( $this->is_type( array( 'grouped', 'external' ) ) )
-			$purchasable = false;
-
 		// Other products types need a price to be set
 		elseif ( $this->get_price() === '' )
 			$purchasable = false;
@@ -889,7 +773,7 @@ class WC_Product {
 	 * @return string
 	 */
 	function get_tax_class() {
-		return apply_filters('woocommerce_product_tax_class', $this->tax_class, $this);
+		return apply_filters( 'woocommerce_product_tax_class', $this->tax_class, $this );
 	}
 
 
@@ -912,118 +796,41 @@ class WC_Product {
 	 * @return string
 	 */
 	function get_price_html( $price = '' ) {
-		if ( $this->is_type( 'grouped' ) ) {
 
-			$child_prices = array();
+		if ( $this->price > 0 ) {
+			if ( $this->is_on_sale() && isset( $this->regular_price ) ) {
 
-			foreach ( $this->get_children() as $child_id ) $child_prices[] = get_post_meta( $child_id, '_price', true );
+				$price .= $this->get_price_html_from_to( $this->regular_price, $this->get_price() );
 
-			$child_prices = array_unique( $child_prices );
+				$price = apply_filters( 'woocommerce_sale_price_html', $price, $this );
 
-			if ( ! empty( $child_prices ) ) {
-				$min_price = min( $child_prices );
 			} else {
-				$min_price = '';
-			}
 
-			if ( sizeof( $child_prices ) > 1 ) $price .= $this->get_price_html_from_text();
+				$price .= woocommerce_price( $this->get_price() );
 
-			$price .= woocommerce_price( $min_price );
-
-			$price = apply_filters( 'woocommerce_grouped_price_html', $price, $this );
-
-		} elseif ( $this->is_type( 'variable' ) ) {
-
-			// Ensure variation prices are synced with variations
-			if ( $this->min_variation_price === '' || $this->min_variation_regular_price === '' ) {
-				$this->variable_product_sync();
-				$this->price = $this->min_variation_price;
-			}
-
-			// Get the price
-			if ($this->price > 0) {
-				if ( $this->is_on_sale() && isset( $this->min_variation_price ) && $this->min_variation_regular_price !== $this->get_price() ) {
-
-					if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
-						$price .= $this->get_price_html_from_text();
-
-					$price .= $this->get_price_html_from_to( $this->min_variation_regular_price, $this->get_price() );
-
-					$price = apply_filters( 'woocommerce_variable_sale_price_html', $price, $this );
-
-				} else {
-
-					if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
-						$price .= $this->get_price_html_from_text();
-
-					$price .= woocommerce_price( $this->get_price() );
-
-					$price = apply_filters('woocommerce_variable_price_html', $price, $this);
-
-				}
-			} elseif ($this->price === '' ) {
-
-				$price = apply_filters('woocommerce_variable_empty_price_html', '', $this);
-
-			} elseif ($this->price == 0 ) {
-
-				if ( $this->is_on_sale() && isset( $this->min_variation_regular_price ) && $this->min_variation_regular_price !== $this->get_price() ) {
-
-					if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
-						$price .= $this->get_price_html_from_text();
-
-					$price .= $this->get_price_html_from_to( $this->min_variation_regular_price, __( 'Free!', 'woocommerce' ) );
-
-					$price = apply_filters( 'woocommerce_variable_free_sale_price_html', $price, $this );
-
-				} else {
-
-					if ( ! $this->min_variation_price || $this->min_variation_price !== $this->max_variation_price )
-						$price .= $this->get_price_html_from_text();
-
-					$price .= __( 'Free!', 'woocommerce' );
-
-					$price = apply_filters( 'woocommerce_variable_free_price_html', $price, $this );
-
-				}
+				$price = apply_filters( 'woocommerce_price_html', $price, $this );
 
 			}
-		} else {
-			if ( $this->price > 0 ) {
-				if ( $this->is_on_sale() && isset( $this->regular_price ) ) {
+		} elseif ($this->price === '' ) {
 
-					$price .= $this->get_price_html_from_to( $this->regular_price, $this->get_price() );
+			$price = apply_filters( 'woocommerce_empty_price_html', '', $this );
 
-					$price = apply_filters( 'woocommerce_sale_price_html', $price, $this );
+		} elseif ($this->price == 0 ) {
 
-				} else {
+			if ( $this->is_on_sale() && isset( $this->regular_price ) ) {
 
-					$price .= woocommerce_price( $this->get_price() );
+				$price .= $this->get_price_html_from_to( $this->regular_price, __( 'Free!', 'woocommerce' ) );
 
-					$price = apply_filters( 'woocommerce_price_html', $price, $this );
+				$price = apply_filters( 'woocommerce_free_sale_price_html', $price, $this );
 
-				}
-			} elseif ($this->price === '' ) {
+			} else {
 
-				$price = apply_filters( 'woocommerce_empty_price_html', '', $this );
+				$price = __( 'Free!', 'woocommerce' );
 
-			} elseif ($this->price == 0 ) {
-
-				if ( $this->is_on_sale() && isset( $this->regular_price ) ) {
-
-					$price .= $this->get_price_html_from_to( $this->regular_price, __( 'Free!', 'woocommerce' ) );
-
-					$price = apply_filters( 'woocommerce_free_sale_price_html', $price, $this );
-
-				} else {
-
-					$price = __( 'Free!', 'woocommerce' );
-
-					$price = apply_filters( 'woocommerce_free_price_html', $price, $this );
-
-				}
+				$price = apply_filters( 'woocommerce_free_price_html', $price, $this );
 
 			}
+
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
@@ -1061,10 +868,12 @@ class WC_Product {
 	 */
 	function get_rating_html( $location = '' ) {
 
-		if ($location) $location = '_'.$location;
-		$star_size = apply_filters('woocommerce_star_rating_size'.$location, 16);
+		if ( $location ) 
+			$location = '_' . $location;
+			
+		$star_size = apply_filters( 'woocommerce_star_rating_size' . $location, 16 );
 
-		if ( false === ( $average_rating = get_transient( 'wc_average_rating_' . $this->id ) ) ) :
+		if ( false === ( $average_rating = get_transient( 'wc_average_rating_' . $this->id ) ) ) {
 
 			global $wpdb;
 
@@ -1085,21 +894,18 @@ class WC_Product {
 				AND comment_approved = '1'
 			"), $this->id );
 
-			if ( $count>0 ) :
+			if ( $count > 0 )
 				$average_rating = number_format($ratings / $count, 2);
-			else :
+			else
 				$average_rating = '';
-			endif;
 
 			set_transient( 'wc_average_rating_' . $this->id, $average_rating );
+		}
 
-		endif;
-
-		if ( $average_rating>0 ) :
-			return '<div class="star-rating" title="'.sprintf(__( 'Rated %s out of 5', 'woocommerce' ), $average_rating).'"><span style="width:'.($average_rating*$star_size).'px"><span class="rating">'.$average_rating.'</span> '.__( 'out of 5', 'woocommerce' ).'</span></div>';
-		else :
+		if ( $average_rating > 0 )
+			return '<div class="star-rating" title="' . sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $average_rating ) . '"><span style="width:' . ( $average_rating * $star_size ) . 'px"><span class="rating">' . $average_rating . '</span> ' . __( 'out of 5', 'woocommerce' ) . '</span></div>';
+		else
 			return '';
-		endif;
 	}
 
 
@@ -1162,10 +968,13 @@ class WC_Product {
 	 * @return string
 	 */
 	function get_shipping_class() {
-		if ( ! $this->shipping_class ) :
+		if ( ! $this->shipping_class ) {
 			$classes = get_the_terms( $this->id, 'product_shipping_class' );
-			if ($classes && !is_wp_error($classes)) $this->shipping_class = current($classes)->slug; else $this->shipping_class = '';
-		endif;
+			if ( $classes && ! is_wp_error( $classes ) ) 
+				$this->shipping_class = current( $classes )->slug; 
+			else 
+				$this->shipping_class = '';
+		}
 		return $this->shipping_class;
 	}
 
@@ -1292,7 +1101,6 @@ class WC_Product {
 				$this->attributes = maybe_unserialize( maybe_unserialize( $this->product_custom_fields['_product_attributes'][0] ));
 			else
 				$this->attributes = array();
-
 		}
 
 		return (array) $this->attributes;
@@ -1306,11 +1114,12 @@ class WC_Product {
 	 * @return mixed
 	 */
 	function has_attributes() {
-		if (sizeof($this->get_attributes())>0) :
-			foreach ($this->get_attributes() as $attribute) :
-				if (isset($attribute['is_visible']) && $attribute['is_visible']) return true;
-			endforeach;
-		endif;
+		if ( sizeof( $this->get_attributes() ) > 0 ) {
+			foreach ( $this->get_attributes() as $attribute ) {
+				if ( isset( $attribute['is_visible'] ) && $attribute['is_visible'] ) 
+					return true;
+			}
+		}
 		return false;
 	}
 
@@ -1322,8 +1131,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function enable_dimensions_display() {
-		if (get_option('woocommerce_enable_dimension_product_attributes')=='yes') return true;
-		return false;
+		return get_option( 'woocommerce_enable_dimension_product_attributes' ) == 'yes' ? true : false;
 	}
 
 
@@ -1334,8 +1142,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function has_dimensions() {
-		if ($this->get_dimensions()) return true;
-		return false;
+		return $this->get_dimensions() ? true : false;
 	}
 
 
@@ -1346,8 +1153,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function has_weight() {
-		if ($this->get_weight()) return true;
-		return false;
+		return $this->get_weight() ? true : false;
 	}
 
 
@@ -1358,18 +1164,18 @@ class WC_Product {
 	 * @return string
 	 */
 	function get_dimensions() {
-		if (!$this->dimensions) :
+		if ( ! $this->dimensions ) :
 			$this->dimensions = '';
 
 			// Show length
-			if ($this->length) {
+			if ( $this->length ) {
 				$this->dimensions = $this->length;
 				// Show width also
-				if ($this->width) {
-					$this->dimensions .= ' × '.$this->width;
+				if ( $this->width ) {
+					$this->dimensions .= ' x ' . $this->width;
 					// Show height also
-					if ($this->height) {
-						$this->dimensions .= ' × '.$this->height;
+					if ( $this->height ) {
+						$this->dimensions .= ' x ' . $this->height;
 					}
 				}
 				// Append the unit
@@ -1387,154 +1193,10 @@ class WC_Product {
 	 * @return void
 	 */
 	function list_attributes() {
-		woocommerce_get_template('single-product/product-attributes.php', array(
+		woocommerce_get_template( 'single-product/product-attributes.php', array(
 			'product' => $this
-		));
+		) );
 	}
-
-
-    /**
-     * Return an array of attributes used for variations, as well as their possible values.
-     *
-     * @access public
-     * @return array of attributes and their available values
-     */
-    function get_variation_attributes() {
-
-	    $variation_attributes = array();
-
-        if ( ! $this->is_type('variable') || ! $this->has_child() )
-        	return $variation_attributes;
-
-        $attributes = $this->get_attributes();
-
-        foreach ( $attributes as $attribute ) {
-            if ( ! $attribute['is_variation'] )
-            	continue;
-
-            $values = array();
-            $attribute_field_name = 'attribute_' . sanitize_title( $attribute['name'] );
-
-            foreach ( $this->get_children() as $child_id ) {
-
-                if ( get_post_status( $child_id ) != 'publish' )
-                	continue; // Disabled
-
-            	$child = $this->get_child( $child_id );
-
-                $child_variation_attributes = $child->get_variation_attributes();
-
-                foreach ( $child_variation_attributes as $name => $value )
-                    if ( $name == $attribute_field_name )
-                    	$values[] = $value;
-            }
-
-            // empty value indicates that all options for given attribute are available
-            if ( in_array( '', $values ) ) {
-
-            	$values = array();
-
-            	// Get all options
-            	if ( $attribute['is_taxonomy'] ) {
-	            	$post_terms = wp_get_post_terms( $this->id, $attribute['name'] );
-					foreach ( $post_terms as $term )
-						$values[] = $term->slug;
-				} else {
-					$values = explode( '|', $attribute['value'] );
-				}
-
-				$values = array_unique( array_map( 'trim', $values ) );
-
-			// Order custom attributes (non taxonomy) as defined
-            } else {
-
-	            if ( ! $attribute['is_taxonomy'] ) {
-	            	$options 	= array_map( 'trim', explode( '|', $attribute['value'] ) );
-	            	$values 	= array_intersect( $options, $values );
-	            }
-
-            }
-
-            $variation_attributes[ $attribute['name'] ] = array_unique( $values );
-        }
-
-        return $variation_attributes;
-    }
-
-    /**
-     * If set, get the default attributes for a variable product.
-     *
-     * @access public
-     * @return array
-     */
-    function get_variation_default_attributes() {
-
-    	$default = isset( $this->product_custom_fields['_default_attributes'][0] ) ? $this->product_custom_fields['_default_attributes'][0] : '';
-
-	    return apply_filters( 'woocommerce_product_default_attributes', (array) maybe_unserialize( $default ), $this );
-    }
-
-    /**
-     * Get an array of available variations for the current product.
-     *
-     * @access public
-     * @return array
-     */
-    function get_available_variations() {
-
-	    $available_variations = array();
-
-		foreach ( $this->get_children() as $child_id ) {
-
-			$variation = $this->get_child( $child_id );
-
-			if ( $variation instanceof WC_Product_Variation ) {
-
-				if ( get_post_status( $variation->get_variation_id() ) != 'publish' || ! $variation->is_visible() )
-					continue; // Disabled or hidden
-
-				$variation_attributes 	= $variation->get_variation_attributes();
-				$availability 			= $variation->get_availability();
-				$availability_html 		= empty( $availability['availability'] ) ? '' : apply_filters( 'woocommerce_stock_html', '<p class="stock ' . esc_attr( $availability['class'] ) . '">'. wp_kses_post( $availability['availability'] ).'</p>', wp_kses_post( $availability['availability'] ) );
-
-				if ( has_post_thumbnail( $variation->get_variation_id() ) ) {
-					$attachment_id = get_post_thumbnail_id( $variation->get_variation_id() );
-
-					$attachment = wp_get_attachment_image_src( $attachment_id, apply_filters( 'single_product_large_thumbnail_size', 'shop_single' )  );
-					$image = $attachment ? current( $attachment ) : '';
-
-					$attachment = wp_get_attachment_image_src( $attachment_id, 'full'  );
-					$image_link = $attachment ? current( $attachment ) : '';
-
-					$image_title = get_the_title( $attachment_id );
-				} else {
-					$image = $image_link = $image_title = '';
-				}
-
-				$available_variations[] = apply_filters( 'woocommerce_available_variation', array(
-					'variation_id' 			=> $child_id,
-					'attributes' 			=> $variation_attributes,
-					'image_src' 			=> $image,
-					'image_link' 			=> $image_link,
-					'image_title'			=> $image_title,
-					'price_html' 			=> $this->min_variation_price != $this->max_variation_price ? '<span class="price">' . $variation->get_price_html() . '</span>' : '',
-					'availability_html' 	=> $availability_html,
-					'sku' 					=> $variation->get_sku(),
-					'weight'				=> $variation->get_weight() . ' ' . esc_attr( get_option('woocommerce_weight_unit' ) ),
-					'dimensions'			=> $variation->get_dimensions(),
-					'min_qty' 				=> 1,
-					'max_qty' 				=> $this->backorders_allowed() ? '' : $variation->stock,
-					'backorders_allowed' 	=> $this->backorders_allowed(),
-					'is_in_stock'			=> $variation->is_in_stock(),
-					'is_downloadable' 		=> $variation->is_downloadable() ,
-					'is_virtual' 			=> $variation->is_virtual(),
-					'is_sold_individually' 	=> $variation->is_sold_individually() ? 'yes' : 'no',
-				), $this, $variation );
-			}
-		}
-
-		return $available_variations;
-    }
 
 
     /**
@@ -1568,17 +1230,14 @@ class WC_Product {
      * @return void
      */
     function check_sale_price() {
-
+    
     	if ( $this->sale_price_dates_from && $this->sale_price_dates_from < current_time('timestamp') ) {
 
     		if ( $this->sale_price && $this->price !== $this->sale_price ) {
-
+	    		
     			// Update price
     			$this->price = $this->sale_price;
     			update_post_meta( $this->id, '_price', $this->price );
-
-    			// Grouped product prices and sale status are affected by children
-    			$this->grouped_product_sync();
     		}
 
     	}
@@ -1594,103 +1253,8 @@ class WC_Product {
 				update_post_meta( $this->id, '_sale_price', '' );
 				update_post_meta( $this->id, '_sale_price_dates_from', '' );
 				update_post_meta( $this->id, '_sale_price_dates_to', '' );
-
-				// Grouped product prices and sale status are affected by children
-    			$this->grouped_product_sync();
 			}
 
     	}
     }
-
-
-	/**
-	 * Sync grouped products with the childs lowest price (so they can be sorted by price accurately).
-	 *
-	 * @access public
-	 * @return void
-	 */
-	function grouped_product_sync() {
-		global $wpdb, $woocommerce;
-		$post_parent = $wpdb->get_var( $wpdb->prepare( "SELECT post_parent FROM $wpdb->posts WHERE ID = %d;"), $this->id );
-
-		if (!$post_parent) return;
-
-		$children_by_price = get_posts( array(
-			'post_parent' 	=> $post_parent,
-			'orderby' 	=> 'meta_value_num',
-			'order'		=> 'asc',
-			'meta_key'	=> '_price',
-			'posts_per_page' => 1,
-			'post_type' 	=> 'product',
-			'fields' 		=> 'ids'
-		));
-		if ($children_by_price) :
-			foreach ($children_by_price as $child) :
-				$child_price = get_post_meta($child, '_price', true);
-				update_post_meta( $post_parent, '_price', $child_price );
-			endforeach;
-		endif;
-
-		$woocommerce->clear_product_transients( $this->id );
-	}
-
-
-	/**
-	 * Sync variable product prices with the childs lowest/highest prices.
-	 *
-	 * @access public
-	 * @return void
-	 */
-	function variable_product_sync() {
-		global $woocommerce;
-
-		$children = get_posts( array(
-			'post_parent' 	=> $this->id,
-			'posts_per_page'=> -1,
-			'post_type' 	=> 'product_variation',
-			'fields' 		=> 'ids',
-			'post_status'	=> 'publish'
-		));
-
-		$this->min_variation_price = $this->min_variation_regular_price = $this->min_variation_sale_price = $this->max_variation_price = $this->max_variation_regular_price = $this->max_variation_sale_price = '';
-
-		if ($children) {
-			foreach ( $children as $child ) {
-
-				$child_price 			= get_post_meta( $child, '_price', true );
-				$child_regular_price 	= get_post_meta( $child, '_regular_price', true );
-				$child_sale_price 		= get_post_meta( $child, '_sale_price', true );
-				
-				// Regular prices
-				if ( ! is_numeric( $this->min_variation_regular_price ) || $child_regular_price < $this->min_variation_regular_price ) 
-					$this->min_variation_regular_price = $child_regular_price;
-					
-				if ( ! is_numeric( $this->max_variation_regular_price ) || $child_regular_price > $this->max_variation_regular_price ) 
-					$this->max_variation_regular_price = $child_regular_price;
-				
-				// Sale prices
-				if ( $child_price == $child_sale_price ) {
-					if ( $child_sale_price !== '' && ( ! is_numeric( $this->min_variation_sale_price ) || $child_sale_price < $this->min_variation_sale_price ) ) 
-						$this->min_variation_sale_price = $child_sale_price;
-					
-					if ( $child_sale_price !== '' && ( ! is_numeric( $this->max_variation_sale_price ) || $child_sale_price > $this->max_variation_sale_price ) ) 
-						$this->max_variation_sale_price = $child_sale_price;
-				}
-			}
-
-	    	$this->min_variation_price = $this->min_variation_sale_price === '' || $this->min_variation_regular_price < $this->min_variation_sale_price ? $this->min_variation_regular_price : $this->min_variation_sale_price;
-	    	
-			$this->max_variation_price = $this->max_variation_sale_price === '' || $this->max_variation_regular_price > $this->max_variation_sale_price ? $this->max_variation_regular_price : $this->max_variation_sale_price;
-		}
-
-		update_post_meta( $this->id, '_price', $this->min_variation_price );
-		update_post_meta( $this->id, '_min_variation_price', $this->min_variation_price );
-		update_post_meta( $this->id, '_max_variation_price', $this->max_variation_price );
-		update_post_meta( $this->id, '_min_variation_regular_price', $this->min_variation_regular_price );
-		update_post_meta( $this->id, '_max_variation_regular_price', $this->max_variation_regular_price );
-		update_post_meta( $this->id, '_min_variation_sale_price', $this->min_variation_sale_price );
-		update_post_meta( $this->id, '_max_variation_sale_price', $this->max_variation_sale_price );
-
-		$woocommerce->clear_product_transients( $this->id );
-	}
 }

--- a/classes/class-wc-product.php
+++ b/classes/class-wc-product.php
@@ -393,7 +393,7 @@ class WC_Product {
 	function exists() {
 		global $wpdb;
 		
-		return $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID = %d LIMIT 1;", $this->id ) ) > 0 ? true : false;
+		return ! empty( $this->post ) || $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID = %d LIMIT 1;", $this->id ) ) > 0 ? true : false;
 	}
 
 

--- a/classes/integrations/shareyourcart/class.shareyourcart-wp-woocommerce.php
+++ b/classes/integrations/shareyourcart/class.shareyourcart-wp-woocommerce.php
@@ -192,7 +192,7 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
     }
       
     private function _getProductDetails($product_id){
-        $product = new WC_Product($product_id);
+        $product = get_product($product_id);
 
 		//WooCommerce actually echoes the image
         ob_start();

--- a/languages/woocommerce-nb_NO.po
+++ b/languages/woocommerce-nb_NO.po
@@ -2532,7 +2532,7 @@ msgstr "Dette kontrolerer beskrivelsen kunden får i kassen."
 #: classes/gateways/paypal/class-wc-paypal.php:116
 #@ woocommerce
 msgid "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account"
-msgstr "Betala via PayPal; du kan betale med ditt kredittkort hvis du ikke har paypal-konto."
+msgstr "Betale via PayPal; du kan betale med ditt kredittkort hvis du ikke har paypal-konto."
 
 #: classes/gateways/paypal/class-wc-paypal.php:119
 #@ woocommerce
@@ -10829,7 +10829,7 @@ msgstr "Avansert"
 #: admin/post-types/writepanels/writepanel-product_data.php:91
 #@ woocommerce
 msgid "SKU refers to a Stock-keeping unit, a unique identifier for each distinct product and service that can be purchased."
-msgstr "SKU refererer til en lagerhold enhet (Stock-keeping unit), en unig identifikasjon for hvert enkelt produkt og service som kan kjøpes."
+msgstr "SKU refererer til en lagerhold enhet (Stock-keeping unit), en unik identifikasjon for hvert enkelt produkt og service som kan kjøpes."
 
 #: admin/post-types/writepanels/writepanel-product_data.php:143
 #@ woocommerce
@@ -11326,4 +11326,3 @@ msgstr "Brukernavn eller e-post adresse"
 #@ woocommerce
 msgid "1.6.3"
 msgstr "1.6.3"
-

--- a/shortcodes/shortcode-init.php
+++ b/shortcodes/shortcode-init.php
@@ -415,11 +415,11 @@ function woocommerce_product_add_to_cart( $atts ) {
 
 	} elseif ($product_data->post_type=='product_variation') {
 
-		$product = new WC_Product( $product_data->post_parent );
+		$product = get_product( $product_data->post_parent );
 
 		$GLOBALS['product'] = $product;
 
-		$variation = new WC_Product_Variation( $product_data->ID );
+		$variation = get_product( $product_data );
 
 		ob_start();
 		?>
@@ -474,7 +474,7 @@ function woocommerce_product_add_to_cart_url( $atts ){
 
 	if ($product_data->post_type!=='product') return;
 
-	$_product = new WC_Product( $product_data->ID );
+	$_product = get_product( $product_data );
 
 	return esc_url( $_product->add_to_cart_url() );
 }

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -49,7 +49,7 @@ global $woocommerce;
 							<?php
 								$thumbnail = apply_filters( 'woocommerce_in_cart_product_thumbnail', $_product->get_image(), $values, $cart_item_key );
 								
-								if ( ! $_product->is_visible() || ( $_product instanceof WC_Product_Variation && ! $_product->parent_is_visible() ) )
+								if ( ! $_product->is_visible() || ( ! empty( $_product->variation_id ) && ! $_product->parent_is_visible() ) )
 									echo $thumbnail;
 								else
 									printf('<a href="%s">%s</a>', esc_url( get_permalink( apply_filters('woocommerce_in_cart_product_id', $values['product_id'] ) ) ), $thumbnail );
@@ -59,7 +59,7 @@ global $woocommerce;
 						<!-- Product Name -->
 						<td class="product-name">
 							<?php
-								if ( ! $_product->is_visible() || ( $_product instanceof WC_Product_Variation && ! $_product->parent_is_visible() ) )
+								if ( ! $_product->is_visible() || ( ! empty( $_product->variation_id ) && ! $_product->parent_is_visible() ) )
 									echo apply_filters( 'woocommerce_in_cart_product_title', $_product->get_title(), $values, $cart_item_key );
 								else
 									printf('<a href="%s">%s</a>', esc_url( get_permalink( apply_filters('woocommerce_in_cart_product_id', $values['product_id'] ) ) ), apply_filters('woocommerce_in_cart_product_title', $_product->get_title(), $values, $cart_item_key ) );

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 global $product;
 
-if ( ! $product->is_purchasable() && ! in_array( $product->product_type, array( 'external', 'grouped' ) ) ) return;
+if ( ! $product->is_purchasable() ) return;
 ?>
 
 <?php if ( ! $product->is_in_stock() ) : ?>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -40,11 +40,7 @@ $order = new WC_Order( $order_id );
 
 			foreach($order->get_items() as $item) :
 
-				if (isset($item['variation_id']) && $item['variation_id'] > 0) :
-					$_product = new WC_Product_Variation( $item['variation_id'] );
-				else :
-					$_product = new WC_Product( $item['product_id'] );
-				endif;
+				$_product = get_product( $item['variation_id'] ? $item['variation_id'] : $item['product_id'] );
 
 				echo '
 					<tr class = "' . esc_attr( apply_filters('woocommerce_order_table_item_class', 'order_table_item', $item, $order ) ) . '">

--- a/widgets/widget-recent_reviews.php
+++ b/widgets/widget-recent_reviews.php
@@ -80,7 +80,7 @@ class WooCommerce_Widget_Recent_Reviews extends WP_Widget {
 
 			foreach ( (array) $comments as $comment) {
 
-				$_product = new WC_Product( $comment->comment_post_ID );
+				$_product = get_product( $comment->comment_post_ID );
 
 				$star_size = intval( apply_filters( 'woocommerce_star_rating_size_recent_reviews', 16 ) );
 

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -513,7 +513,7 @@ function woocommerce_link_all_variations() {
 
 	$variations = array();
 
-	$_product = new WC_Product( $post_id );
+	$_product = get_product( $post_id );
 
 	// Put variation attributes into an array
 	foreach ( $_product->get_attributes() as $attribute ) {
@@ -696,7 +696,7 @@ function woocommerce_grant_access_to_download() {
 	$file_count = 0;
 	
 	$order 		= new WC_Order( $order_id );
-	$product 	= new WC_Product( $product_id );
+	$product 	= get_product( $product_id );
 
 	$user_email = sanitize_email( $order->billing_email );
 
@@ -839,10 +839,7 @@ function woocommerce_ajax_add_order_item() {
 	if ( ! $post || ( $post->post_type !== 'product' && $post->post_type !== 'product_variation' ) )
 		die();
 	
-	if ( $post->post_type != "product" )
-		$_product = new WC_Product_Variation( $post->ID );
-	else
-		$_product = new WC_Product( $post->ID );
+	$_product = get_product( $post->ID );
 	
 	$order = new WC_Order( $order_id );
 	$class = 'new_row';
@@ -1199,7 +1196,7 @@ function woocommerce_calc_line_taxes() {
 			
 			// Get product details
 			if ( get_post_type( $item_id ) == 'product' ) {
-				$_product			= new WC_Product( $item_id );
+				$_product			= get_product( $item_id );
 				$item_tax_status 	= $_product->get_tax_status();
 			} else {
 				$item_tax_status 	= 'taxable';

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -547,7 +547,7 @@ function woocommerce_link_all_variations() {
     foreach( $_product->get_children() as $child_id ) {
     	$child = $_product->get_child( $child_id );
 
-        if ( $child instanceof WC_Product_Variation ) {
+        if ( ! empty( $child->variation_id ) ) {
             $available_variations[] = $child->get_variation_attributes();
         }
     }

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -60,7 +60,7 @@ function get_product( $the_product = false, $parent_id = '', $meta = '' ) {
 			return new $classname( $the_product );
 		} else {
 			// Use simple
-			return new WC_Product( $the_product );
+			return new WC_Product_Simple( $the_product );
 		}
 	}
 }

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -28,8 +28,8 @@ add_filter( 'woocommerce_stock_amount', 'absint' ); // Stock amounts are integer
  * @return void
  */
 function get_product( $the_product = false, $args = array() ) {
-	$factory = new WC_Product_Factory();
-	return $factory->get_product( $the_product, $args );
+	global $woocommerce;
+	return $woocommerce->product_factory->get_product( $the_product, $args );
 }
 
 /**

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -20,7 +20,7 @@ add_filter( 'woocommerce_coupon_code', 'strtolower' ); // Coupons case-insensiti
 add_filter( 'woocommerce_stock_amount', 'absint' ); // Stock amounts are integers by default
 
 /**
- * Main function for returning products. 
+ * Main function for returning products, uses the WC_Product_Factory class. 
  * 
  * @access public
  * @param mixed $the_product Post object or post ID of the product.
@@ -29,40 +29,13 @@ add_filter( 'woocommerce_stock_amount', 'absint' ); // Stock amounts are integer
  * @return void
  */
 function get_product( $the_product = false, $parent_id = '', $meta = '' ) {
-	global $post;
+	$args = array(
+		'parent_id' => $parent_id,
+		'meta'      => $meta,
+	);
 	
-	if ( false === $the_product )
-		$the_product = $post;
-	elseif ( is_numeric( $the_product ) )
-		$the_product = get_post( $the_product );
-		
-	$product_id 	= absint( $the_product->ID );
-	$post_type 		= $the_product->post_type;
-	
-	if ( $post_type == 'product_variation' ) {
-		// Filter classname so that the class can be overridden if extended.
-		$classname = apply_filters( 'woocommerce_product_variation_class', 'WC_Product_Variation', $product_id );
-		
-		if ( class_exists( $classname ) ) {
-			return new $classname( $the_product, $parent_id, $meta );
-		} else {
-			// Use simple
-			return new WC_Product_Variation( $the_product, $parent_id, $meta );
-		}
-	} else {
-		$terms 			= get_the_terms( $product_id, 'product_type' );
-		$product_type 	= isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
-		
-		// Filter classname so that the class can be overridden if extended.
-		$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_' . $product_type, $product_type, $post_type, $product_id );
-		
-		if ( class_exists( $classname ) ) {
-			return new $classname( $the_product );
-		} else {
-			// Use simple
-			return new WC_Product_Simple( $the_product );
-		}
-	}
+	$factory = new WC_Product_Factory();
+	return $factory->get_product( $the_product, $parent_id, $meta );
 }
 
 /**

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -24,18 +24,12 @@ add_filter( 'woocommerce_stock_amount', 'absint' ); // Stock amounts are integer
  * 
  * @access public
  * @param mixed $the_product Post object or post ID of the product.
- * @param string $parent_id (default: '') Used when calling variations
- * @param string $meta (default: '') Used when calling variations
+ * @param array $args (default: array()) Contains all arguments to be used to get this product.
  * @return void
  */
-function get_product( $the_product = false, $parent_id = '', $meta = '' ) {
-	$args = array(
-		'parent_id' => $parent_id,
-		'meta'      => $meta,
-	);
-	
+function get_product( $the_product = false, $args = array() ) {
 	$factory = new WC_Product_Factory();
-	return $factory->get_product( $the_product, $parent_id, $meta );
+	return $factory->get_product( $the_product, $args );
 }
 
 /**

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -46,7 +46,7 @@ function woocommerce_redirects() {
 	// Redirect to the product page if we have a single product
 	if (is_search() && is_post_type_archive('product') && get_option('woocommerce_redirect_on_single_search_result')=='yes') {
 		if ($wp_query->post_count==1) {
-			$product = new WC_Product($wp_query->post->ID);
+			$product = get_product( $wp_query->post );
 			if ($product->is_visible()) wp_safe_redirect( get_permalink($product->id), 302 );
 			exit;
 		}
@@ -246,7 +246,7 @@ function woocommerce_add_to_cart_action( $url = false ) {
 	
 	$product_id			= apply_filters('woocommerce_add_to_cart_product_id', absint( $_REQUEST['add-to-cart'] ) );
 	$was_added_to_cart 	= false;
-	$adding_to_cart 	= new WC_Product( $product_id );
+	$adding_to_cart 	= get_product( $product_id );
     
     // Variable product handling
     if ( $adding_to_cart->is_type( 'variable' ) ) {
@@ -843,7 +843,7 @@ function woocommerce_download_product() {
 		$order_key 		= urldecode( $_GET['order'] );
 		$email 			= sanitize_email( str_replace( ' ', '+', urldecode( $_GET['email'] ) ) );
 		$download_id 	= isset( $_GET['key'] ) ? urldecode( $_GET['key'] ) : '';  // backwards compatibility for existing download URLs
-		$_product	 	= new WC_Product( $product_id );
+		$_product	 	= get_product( $product_id );
 
 		if ( ! is_email( $email) )
 			wp_die( __( 'Invalid email address.', 'woocommerce' ) . ' <a href="' . home_url() . '">' . __( 'Go to homepage &rarr;', 'woocommerce' ) . '</a>' );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -172,6 +172,7 @@ class Woocommerce {
 		include( 'classes/class-wc-countries.php' );			// Defines countries and states
 		include( 'classes/class-wc-order.php' );				// Single order class
 		
+		include( 'classes/class-wc-product-factory.php' );		// Product factory
 		include( 'classes/class-wc-product.php' );				// Product class abstract
 		include( 'classes/class-wc-product-simple.php' );		// Simple product type class
 		include( 'classes/class-wc-product-external.php' );		// External product type class

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -171,8 +171,13 @@ class Woocommerce {
 		include( 'widgets/widget-init.php' );					// Widget classes
 		include( 'classes/class-wc-countries.php' );			// Defines countries and states
 		include( 'classes/class-wc-order.php' );				// Single order class
+		
 		include( 'classes/class-wc-product.php' );				// Product class
+		include( 'classes/class-wc-product-external.php' );		// External product type class
+		include( 'classes/class-wc-product-variable.php' );		// Variable product type class
+		include( 'classes/class-wc-product-grouped.php' );		// Grouped product type class
 		include( 'classes/class-wc-product-variation.php' );	// Product variation class
+		
 		include( 'classes/class-wc-tax.php' );					// Tax class
 		include( 'classes/class-wc-settings-api.php' );			// Settings API
 
@@ -499,7 +504,7 @@ class Woocommerce {
 		if ( is_int( $post ) ) $post = get_post( $post );
 		if ( $post->post_type !== 'product' ) return;
 		unset( $GLOBALS['product'] );
-		$GLOBALS['product'] = new WC_Product( $post->ID );
+		$GLOBALS['product'] = get_product( $post );
 		return $GLOBALS['product'];
 	}
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -80,6 +80,11 @@ class Woocommerce {
 	var $shipping;
 
 	/**
+	 * @var WC_Product_Factory
+	 */
+	var $product_factory;
+
+	/**
 	 * @var WC_Cart
 	 */
 	var $cart;
@@ -296,6 +301,7 @@ class Woocommerce {
 		// Load class instances
 		$this->payment_gateways 	= new WC_Payment_gateways();	// Payment gateways. Loads and stores payment methods
 		$this->shipping 			= new WC_Shipping();			// Shipping class. loads and stores shipping methods
+		$this->product_factory 		= new WC_Product_Factory();     // Product Factory to create new product instances
 		$this->countries 			= new WC_Countries();			// Countries class
 		$this->integrations			= new WC_Integrations();		// Integrations class
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -172,7 +172,8 @@ class Woocommerce {
 		include( 'classes/class-wc-countries.php' );			// Defines countries and states
 		include( 'classes/class-wc-order.php' );				// Single order class
 		
-		include( 'classes/class-wc-product.php' );				// Product class
+		include( 'classes/class-wc-product.php' );				// Product class abstract
+		include( 'classes/class-wc-product-simple.php' );		// Simple product type class
 		include( 'classes/class-wc-product-external.php' );		// External product type class
 		include( 'classes/class-wc-product-variable.php' );		// Variable product type class
 		include( 'classes/class-wc-product-grouped.php' );		// Grouped product type class


### PR DESCRIPTION
This change will break any plugin directly calling the WC_Product class:
- This got changed into an abstract and should always be called through the Product Factory or get_product() function introduced by this merge.
- We will create documentation for this when this version comes closer to release.

In other words: If you use this development version on a live site, there is a chance things will break. ;)
