### PR TITLE
Added no prefix option to get_order_number function

### DIFF
--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -269,11 +269,17 @@ class WC_Order {
 	 * Gets the order number for display (by default, order ID)
 	 *
 	 * @access public
-	 * @return string
-	 */
-	function get_order_number() {
-		return apply_filters( 'woocommerce_order_number', _x( '#', 'hash before order number', 'woocommerce' ) . $this->id, $this );
-	}
+	 * @param bool $prefix
+   * @return string
+   */
+  function get_order_number( $prefix = TRUE ) {
+    if($prefix) {
+      return apply_filters( 'woocommerce_order_number', _x( '#', 'hash before order number', 'woocommerce' ) . $this->id, $this );
+    }
+    else {
+      return apply_filters( 'woocommerce_order_number', $this->id, $this );
+    }
+  }
 
 	/**
 	 * Get a formatted billing address for the order.


### PR DESCRIPTION
Added no prefix option to get_order_number function. Defaults to prefix as it was before.
