### PR TITLE
Add order email notifications for failed orders > on-hold status

### DIFF
--- a/classes/emails/class-wc-email-new-order.php
+++ b/classes/emails/class-wc-email-new-order.php
@@ -33,6 +33,7 @@ class WC_Email_New_Order extends WC_Email {
 		add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( &$this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_failed_to_processing_notification', array( &$this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_failed_to_completed_notification', array( &$this, 'trigger' ) );
+		add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( &$this, 'trigger' ) );
 		
 		// Call parent constuctor
 		parent::__construct();


### PR DESCRIPTION
We need the same notifications for failed>on-hold/processing/completed as we have for pending>on-hold/processing/completed
