### PR TITLE
Strip trailing whitespace

### DIFF
--- a/admin/importers/importers-init.php
+++ b/admin/importers/importers-init.php
@@ -14,7 +14,7 @@ register_importer( 'woocommerce_tax_rate_csv', __( 'WooCommerce Tax Rates (CSV)'
 
 /**
  * woocommerce_tax_rates_importer function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -25,7 +25,7 @@ function woocommerce_tax_rates_importer() {
 
 	if ( ! class_exists( 'WP_Importer' ) ) {
 		$class_wp_importer = ABSPATH . 'wp-admin/includes/class-wp-importer.php';
-		if ( file_exists( $class_wp_importer ) ) 
+		if ( file_exists( $class_wp_importer ) )
 			require $class_wp_importer;
 	}
 

--- a/admin/importers/tax-rates-importer.php
+++ b/admin/importers/tax-rates-importer.php
@@ -7,12 +7,12 @@
  * @package 	WooCommerce/Admin/Importers
  * @version     1.7.0
  */
- 
+
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( class_exists( 'WP_Importer' ) ) {
 	class WC_CSV_Tax_Rates_Import extends WP_Importer {
-		
+
 		var $id;
 		var $file_url;
 		var $import_page;
@@ -20,17 +20,17 @@ if ( class_exists( 'WP_Importer' ) ) {
 		var $posts = array();
 		var $imported;
 		var $skipped;
-	
+
 		/**
 		 * __construct function.
-		 * 
+		 *
 		 * @access public
 		 * @return void
 		 */
 		public function __construct() {
 			$this->import_page = 'woocommerce_tax_rate_csv';
 		}
-	
+
 		/**
 		 * Registered callback function for the WordPress Importer
 		 *
@@ -38,13 +38,13 @@ if ( class_exists( 'WP_Importer' ) ) {
 		 */
 		function dispatch() {
 			$this->header();
-	
+
 			if ( ! empty( $_POST['delimiter'] ) )
 				$this->delimiter = stripslashes( trim( $_POST['delimiter'] ) );
-	
-			if ( ! $this->delimiter ) 
+
+			if ( ! $this->delimiter )
 				$this->delimiter = ',';
-	
+
 			$step = empty( $_GET['step'] ) ? 0 : (int) $_GET['step'];
 			switch ( $step ) {
 				case 0:
@@ -58,26 +58,26 @@ if ( class_exists( 'WP_Importer' ) ) {
 							$file = get_attached_file( $this->id );
 						else
 							$file = ABSPATH . $this->file_url;
-		
+
 						add_filter( 'http_request_timeout', array( &$this, 'bump_request_timeout' ) );
-		
+
 						if ( function_exists( 'gc_enable' ) )
 							gc_enable();
-		
+
 						@set_time_limit(0);
 						@ob_flush();
 						@flush();
-		
+
 						$this->import( $file );
 					}
 					break;
 			}
 			$this->footer();
 		}
-	
+
 		/**
 		 * format_data_from_csv function.
-		 * 
+		 *
 		 * @access public
 		 * @param mixed $data
 		 * @param mixed $enc
@@ -89,134 +89,134 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 		/**
 		 * import function.
-		 * 
+		 *
 		 * @access public
 		 * @param mixed $file
 		 * @return void
 		 */
 		function import( $file ) {
 			global $woocommerce, $wpdb;
-	
+
 			$this->imported = $this->skipped = 0;
-			
+
 			if ( ! is_file($file) ) {
 				echo '<p><strong>' . __( 'Sorry, there has been an error.', 'woocommerce' ) . '</strong><br />';
 				echo __( 'The file does not exist, please try again.', 'woocommerce' ) . '</p>';
 				$this->footer();
 				die();
 			}
-	
+
 			$new_rates = array();
-	
+
 			if ( ( $handle = fopen( $file, "r" ) ) !== FALSE ) {
-			
+
 				$header = fgetcsv( $handle, 0, $this->delimiter );
-				
+
 				if ( sizeof( $header ) == 6 ) {
-					
+
 					$rates = get_option( 'woocommerce_tax_rates' );
-					
+
 					while ( ( $row = fgetcsv( $handle, 0, $this->delimiter ) ) !== FALSE ) {
-		            
+
 						$rate = array();
-						
+
 						list( $rate['countries'], $rate['class'], $rate['label'], $rate['rate'], $rate['compound'], $rate['shipping'] ) = $row;
-						
+
 						$parsed_countries 	= array();
 						$rate['countries'] 	= array_map( 'trim', explode( '|', $rate['countries'] ) );
-						
+
 						foreach( $rate['countries'] as $country ) {
 							if ( strstr( $country, ':' ) ) {
 								list( $country, $state ) = array_map( 'trim', explode( ':', $country ) );
-								
+
 								if ( ! isset( $parsed_countries[ $country ] ) )
 									$parsed_countries[ $country ] = array();
-								
+
 								$parsed_countries[ $country ][] = $state;
 							} else {
-								
+
 								if ( ! isset( $parsed_countries[ $country ] ) )
 									$parsed_countries[ $country ] = array();
-									
+
 								$parsed_countries[ $country ][] = '*';
 							}
 						}
-						
+
 						$rate['countries']	= $parsed_countries;
 						$rate['shipping'] 	= $rate['shipping'] ? 'yes' : 'no';
 						$rate['compound'] 	= $rate['compound'] ? 'yes' : 'no';
-						
+
 						$new_rates[] = $rate;
-						
+
 						unset( $rate, $row );
-						
+
 						$this->imported++;
 				    }
-				    
+
 				    $rates = array_merge( $rates, $new_rates );
-			
+
 					update_option( 'woocommerce_tax_rates', $rates );
-					
+
 				} elseif ( sizeof( $header ) == 8 ) {
-					
+
 					$rates = get_option( 'woocommerce_local_tax_rates' );
-					
+
 					while ( ( $row = fgetcsv( $handle, 0, $this->delimiter ) ) !== FALSE ) {
-		            
+
 						$rate = array();
-						
+
 						list( $rate['country'], $rate['state'], $rate['postcode'], $rate['class'], $rate['label'], $rate['rate'], $rate['compound'], $rate['shipping'] ) = $row;
-						
+
 						if ( ! $rate['country'] || ! $rate['postcode'] || ! $rate['rate'] ) {
 							$this->skipped++;
 							continue;
 						}
-						
+
 						$rate['state']		= $rate['state'] ? $rate['state'] : '*';
 						$rate['shipping'] 	= $rate['shipping'] ? 'yes' : 'no';
 						$rate['compound'] 	= $rate['compound'] ? 'yes' : 'no';
 						$rate['postcode'] 	= array_map( 'trim', explode( '|', $rate['postcode'] ) );
-						
+
 						$new_rates[] = $rate;
-						
+
 						unset( $rate, $row );
-						
+
 						$this->imported++;
 				    }
-				    
+
 				    $rates = array_merge( $rates, $new_rates );
-			
+
 					update_option( 'woocommerce_local_tax_rates', $rates );
-					
+
 				} else {
-					
+
 					echo '<p><strong>' . __( 'Sorry, there has been an error.', 'woocommerce' ) . '</strong><br />';
 					echo __( 'The CSV is invalid.', 'woocommerce' ) . '</p>';
 					$this->footer();
 					die();
-				
+
 				}
-			    
+
 			    fclose( $handle );
 			}
-			
+
 			// Show Result
 			echo '<div class="updated settings-error below-h2"><p>
 				'.sprintf( __( 'Import complete - imported <strong>%s</strong> tax rates and skipped <strong>%s</strong>.', 'woocommerce' ), $this->imported, $this->skipped ).'
 			</p></div>';
-	
+
 			$this->import_end();
 		}
-	
+
 		/**
 		 * Performs post-import cleanup of files and the cache
 		 */
 		function import_end() {
 			echo '<p>' . __( 'All done!', 'woocommerce' ) . ' <a href="' . admin_url('admin.php?page=woocommerce_settings&tab=tax') . '">' . __( 'View Tax Rates', 'woocommerce' ) . '</a>' . '</p>';
-	
+
 			do_action( 'import_end' );
 		}
-	
+
 		/**
 		 * Handles the CSV upload and initial parsing of the file to prepare for
 		 * displaying author import options
@@ -224,40 +224,40 @@ if ( class_exists( 'WP_Importer' ) ) {
 		 * @return bool False if error uploading or invalid file, true otherwise
 		 */
 		function handle_upload() {
-	
+
 			if ( empty( $_POST['file_url'] ) ) {
-	
+
 				$file = wp_import_handle_upload();
-	
+
 				if ( isset( $file['error'] ) ) {
 					echo '<p><strong>' . __( 'Sorry, there has been an error.', 'woocommerce' ) . '</strong><br />';
 					echo esc_html( $file['error'] ) . '</p>';
 					return false;
 				}
-	
+
 				$this->id = (int) $file['id'];
-	
+
 			} else {
-	
+
 				if ( file_exists( ABSPATH . $_POST['file_url'] ) ) {
-	
+
 					$this->file_url = esc_attr( $_POST['file_url'] );
-	
+
 				} else {
-	
+
 					echo '<p><strong>' . __( 'Sorry, there has been an error.', 'woocommerce' ) . '</strong></p>';
 					return false;
-	
+
 				}
-	
+
 			}
-	
+
 			return true;
 		}
-			
+
 		/**
 		 * header function.
-		 * 
+		 *
 		 * @access public
 		 * @return void
 		 */
@@ -268,32 +268,32 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 		/**
 		 * footer function.
-		 * 
+		 *
 		 * @access public
 		 * @return void
 		 */
 		function footer() {
 			echo '</div>';
 		}
-	
+
 		/**
 		 * greet function.
-		 * 
+		 *
 		 * @access public
 		 * @return void
 		 */
 		function greet() {
 			global $woocommerce;
-			
+
 			echo '<div class="narrow">';
 			echo '<p>' . __( 'Hi there! Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click "Upload file and import".', 'woocommerce' ).'</p>';
-			
+
 			echo '<p>' . sprintf( __( 'Tax rates need to be defined with columns in a specific order (6 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), $woocommerce->plugin_url() . '/admin/importers/samples/sample_tax_rates.csv' ) . '</p>';
-			
+
 			echo '<p>' . sprintf( __( 'Local tax rates also need to be defined with columns in a specific order (8 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), $woocommerce->plugin_url() . '/admin/importers/samples/sample_local_tax_rates.csv' ) . '</p>';
-	
+
 			$action = 'admin.php?import=woocommerce_tax_rate_csv&step=1';
-	
+
 			$bytes = apply_filters( 'import_upload_size_limit', wp_max_upload_size() );
 			$size = wp_convert_bytes_to_hr( $bytes );
 			$upload_dir = wp_upload_dir();
@@ -336,10 +336,10 @@ if ( class_exists( 'WP_Importer' ) ) {
 				</form>
 				<?php
 			endif;
-	
+
 			echo '</div>';
 		}
-	
+
 		/**
 		 * Added to http_request_timeout filter to force timeout at 60 seconds during import
 		 * @return int 60

--- a/admin/includes/class-cssmin.php
+++ b/admin/includes/class-cssmin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * CssMin - A (simple) css minifier with benefits
- * 
+ *
  * --
  * Copyright (c) 2011 Joe Scylla <joe.scylla@gmail.com>
  *
@@ -11,10 +11,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  * --
- * 
+ *
  * @package		CssMin
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -31,12 +31,12 @@
  * @license		http://opensource.org/licenses/mit-license.php MIT License
  * @version		3.0.1
  */
- 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 
- 
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
 /**
  * Abstract definition of a CSS token class.
- * 
+ *
  * Every token has to extend this class.
  *
  * @package		CssMin/Tokens
@@ -50,7 +50,7 @@ abstract class aCssToken
 	{
 	/**
 	 * Returns the token as string.
-	 * 
+	 *
 	 * @return string
 	 */
 	abstract public function __toString();
@@ -68,7 +68,7 @@ abstract class aCssToken
  */
 abstract class aCssRulesetStartToken extends aCssToken
 	{
-	
+
 	}
 
 /**
@@ -85,7 +85,7 @@ abstract class aCssRulesetEndToken extends aCssToken
 	{
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -96,10 +96,10 @@ abstract class aCssRulesetEndToken extends aCssToken
 
 /**
  * Abstract definition of a parser plugin.
- * 
- * Every parser plugin have to extend this class. A parser plugin contains the logic to parse one or aspects of a 
+ *
+ * Every parser plugin have to extend this class. A parser plugin contains the logic to parse one or aspects of a
  * stylesheet.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -111,25 +111,25 @@ abstract class aCssParserPlugin
 	{
 	/**
 	 * Plugin configuration.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $configuration = array();
 	/**
 	 * The CssParser of the plugin.
-	 * 
+	 *
 	 * @var CssParser
 	 */
 	protected $parser = null;
 	/**
 	 * Plugin buffer.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $buffer = "";
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param CssParser $parser The CssParser object of this plugin.
 	 * @param array $configuration Plugin configuration [optional]
 	 * @return void
@@ -141,19 +141,19 @@ abstract class aCssParserPlugin
 		}
 	/**
 	 * Returns the array of chars triggering the parser plugin.
-	 * 
+	 *
 	 * @return array
 	 */
 	abstract public function getTriggerChars();
 	/**
 	 * Returns the array of states triggering the parser plugin or FALSE if every state will trigger the parser plugin.
-	 * 
+	 *
 	 * @return array
 	 */
 	abstract public function getTriggerStates();
 	/**
 	 * Parser routine of the plugin.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -163,9 +163,9 @@ abstract class aCssParserPlugin
 	}
 
 /**
- * Abstract definition of a minifier plugin class. 
- * 
- * Minifier plugin process the parsed tokens one by one to apply changes to the token. Every minifier plugin has to 
+ * Abstract definition of a minifier plugin class.
+ *
+ * Minifier plugin process the parsed tokens one by one to apply changes to the token. Every minifier plugin has to
  * extend this class.
  *
  * @package		CssMin/Minifier/Plugins
@@ -179,19 +179,19 @@ abstract class aCssMinifierPlugin
 	{
 	/**
 	 * Plugin configuration.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $configuration = array();
 	/**
 	 * The CssMinifier of the plugin.
-	 * 
+	 *
 	 * @var CssMinifier
 	 */
 	protected $minifier = null;
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param CssMinifier $minifier The CssMinifier object of this plugin.
 	 * @param array $configuration Plugin configuration [optional]
 	 * @return void
@@ -203,25 +203,25 @@ abstract class aCssMinifierPlugin
 		}
 	/**
 	 * Apply the plugin to the token.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
 	abstract public function apply(aCssToken &$token);
 	/**
 	 * --
-	 * 
+	 *
 	 * @return array
 	 */
 	abstract public function getTriggerTokens();
 	}
 
 /**
- * Abstract definition of a minifier filter class. 
- * 
+ * Abstract definition of a minifier filter class.
+ *
  * Minifier filters allows a pre-processing of the parsed token to add, edit or delete tokens. Every minifier filter
  * has to extend this class.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -233,19 +233,19 @@ abstract class aCssMinifierFilter
 	{
 	/**
 	 * Filter configuration.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $configuration = array();
 	/**
 	 * The CssMinifier of the filter.
-	 * 
+	 *
 	 * @var CssMinifier
 	 */
 	protected $minifier = null;
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param CssMinifier $minifier The CssMinifier object of this plugin.
 	 * @param array $configuration Filter configuration [optional]
 	 * @return void
@@ -257,7 +257,7 @@ abstract class aCssMinifierFilter
 		}
 	/**
 	 * Filter the tokens.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -266,9 +266,9 @@ abstract class aCssMinifierFilter
 
 /**
  * Abstract formatter definition.
- * 
+ *
  * Every formatter have to extend this class.
- * 
+ *
  * @package		CssMin/Formatter
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -280,25 +280,25 @@ abstract class aCssFormatter
 	{
 	/**
 	 * Indent string.
-	 * 
+	 *
 	 * @var string
 	 */
 	protected $indent = "    ";
 	/**
 	 * Declaration padding.
-	 * 
+	 *
 	 * @var integer
 	 */
 	protected $padding = 0;
 	/**
 	 * Tokens.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $tokens = array();
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param array $tokens Array of CssToken
 	 * @param string $indent Indent string [optional]
 	 * @param integer $padding Declaration value padding [optional]
@@ -311,7 +311,7 @@ abstract class aCssFormatter
 		}
 	/**
 	 * Returns the array of aCssToken as formatted string.
-	 * 
+	 *
 	 * @return string
 	 */
 	abstract public function __toString();
@@ -331,31 +331,31 @@ abstract class aCssDeclarationToken extends aCssToken
 	{
 	/**
 	 * Is the declaration flagged as important?
-	 * 
+	 *
 	 * @var boolean
 	 */
 	public $IsImportant = false;
 	/**
 	 * Is the declaration flagged as last one of the ruleset?
-	 * 
+	 *
 	 * @var boolean
 	 */
 	public $IsLast = false;
 	/**
 	 * Property name of the declaration.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Property = "";
 	/**
 	 * Value of the declaration.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Value = "";
 	/**
-	 * Set the properties of the @font-face declaration. 
-	 * 
+	 * Set the properties of the @font-face declaration.
+	 *
 	 * @param string $property Property of the declaration
 	 * @param string $value Value of the declaration
 	 * @param boolean $isImportant Is the !important flag is set?
@@ -371,7 +371,7 @@ abstract class aCssDeclarationToken extends aCssToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -392,7 +392,7 @@ abstract class aCssDeclarationToken extends aCssToken
  */
 abstract class aCssAtBlockStartToken extends aCssToken
 	{
-	
+
 	}
 
 /**
@@ -409,7 +409,7 @@ abstract class aCssAtBlockEndToken extends aCssToken
 	{
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -420,7 +420,7 @@ abstract class aCssAtBlockEndToken extends aCssToken
 
 /**
  * {@link aCssFromatter Formatter} returning the CSS source in {@link http://goo.gl/etzLs Whitesmiths indent style}.
- * 
+ *
  * @package		CssMin/Formatter
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -432,7 +432,7 @@ class CssWhitesmithsFormatter extends aCssFormatter
 	{
 	/**
 	 * Implements {@link aCssFormatter::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -528,11 +528,11 @@ class CssWhitesmithsFormatter extends aCssFormatter
 	}
 
 /**
- * This {@link aCssMinifierPlugin} will process var-statement and sets the declaration value to the variable value. 
- * 
+ * This {@link aCssMinifierPlugin} will process var-statement and sets the declaration value to the variable value.
+ *
  * This plugin only apply the variable values. The variable values itself will get parsed by the
  * {@link CssVariablesMinifierFilter}.
- * 
+ *
  * Example:
  * <code>
  * @variables
@@ -541,7 +541,7 @@ class CssWhitesmithsFormatter extends aCssFormatter
  * 		}
  * color: var(defaultColor);
  * </code>
- * 
+ *
  * Will get converted to:
  * <code>
  * color:black;
@@ -558,19 +558,19 @@ class CssVariablesMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Regular expression matching a value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = "/var\((.+)\)/iSU";
 	/**
 	 * Parsed variables.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $variables = null;
 	/**
 	 * Returns the variables.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getVariables()
@@ -579,7 +579,7 @@ class CssVariablesMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -614,7 +614,7 @@ class CssVariablesMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -628,7 +628,7 @@ class CssVariablesMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Sets the variables.
-	 * 
+	 *
 	 * @param array $variables Variables to set
 	 * @return void
 	 */
@@ -639,10 +639,10 @@ class CssVariablesMinifierPlugin extends aCssMinifierPlugin
 	}
 
 /**
- * This {@link aCssMinifierFilter minifier filter} will parse the variable declarations out of @variables at-rule 
- * blocks. The variables will get store in the {@link CssVariablesMinifierPlugin} that will apply the variables to 
+ * This {@link aCssMinifierFilter minifier filter} will parse the variable declarations out of @variables at-rule
+ * blocks. The variables will get store in the {@link CssVariablesMinifierPlugin} that will apply the variables to
  * declaration.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -654,7 +654,7 @@ class CssVariablesMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -734,9 +734,9 @@ class CssVariablesMinifierFilter extends aCssMinifierFilter
 
 /**
  * {@link aCssParserPlugin Parser plugin} for preserve parsing url() values.
- * 
+ *
  * This plugin return no {@link aCssToken CssToken} but ensures that url() values will get parsed properly.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -748,7 +748,7 @@ class CssUrlParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -757,7 +757,7 @@ class CssUrlParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -766,7 +766,7 @@ class CssUrlParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -810,9 +810,9 @@ class CssUrlParserPlugin extends aCssParserPlugin
 
 /**
  * {@link aCssParserPlugin Parser plugin} for preserve parsing string values.
- * 
+ *
  * This plugin return no {@link aCssToken CssToken} but ensures that string values will get parsed properly.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -824,13 +824,13 @@ class CssStringParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Current string delimiter char.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $delimiterChar = null;
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -839,7 +839,7 @@ class CssStringParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -848,7 +848,7 @@ class CssStringParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -881,7 +881,7 @@ class CssStringParserPlugin extends aCssParserPlugin
 		// End of string
 		elseif ($char === $this->delimiterChar && $state === "T_STRING")
 			{
-			// If the Previous char is a escape char count the amount of the previous escape chars. If the amount of 
+			// If the Previous char is a escape char count the amount of the previous escape chars. If the amount of
 			// escape chars is uneven do not end the string
 			if ($previousChar == "\\")
 				{
@@ -911,7 +911,7 @@ class CssStringParserPlugin extends aCssParserPlugin
 
 /**
  * This {@link aCssMinifierFilter minifier filter} sorts the ruleset declarations of a ruleset by name.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Rowan Beentje <http://assanka.net>
@@ -923,7 +923,7 @@ class CssSortRulesetPropertiesMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value larger than 0 will rebuild the array
 	 */
@@ -955,7 +955,7 @@ class CssSortRulesetPropertiesMinifierFilter extends aCssMinifierFilter
 			$declarations = array_slice($tokens, $startIndex + 1, $endIndex - $startIndex - 1);
 			// Check whether a sort is required
 			$sortRequired = $lastPropertyName = false;
-			foreach ($declarations as $declaration)	
+			foreach ($declarations as $declaration)
 				{
 				if ($lastPropertyName)
 					{
@@ -990,7 +990,7 @@ class CssSortRulesetPropertiesMinifierFilter extends aCssMinifierFilter
 		}
 	/**
 	 * User defined sort function.
-	 * 
+	 *
 	 * @return integer
 	 */
 	public static function userDefinedSort1($a, $b)
@@ -1001,7 +1001,7 @@ class CssSortRulesetPropertiesMinifierFilter extends aCssMinifierFilter
 
 /**
  * This {@link aCssToken CSS token} represents the start of a ruleset.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1013,14 +1013,14 @@ class CssRulesetStartToken extends aCssRulesetStartToken
 	{
 	/**
 	 * Array of selectors.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $Selectors = array();
 	/**
 	 * Set the properties of a ruleset token.
-	 * 
-	 * @param array $selectors Selectors of the ruleset 
+	 *
+	 * @param array $selectors Selectors of the ruleset
 	 * @return void
 	 */
 	public function __construct(array $selectors = array())
@@ -1029,7 +1029,7 @@ class CssRulesetStartToken extends aCssRulesetStartToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -1040,8 +1040,8 @@ class CssRulesetStartToken extends aCssRulesetStartToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing ruleset block with including declarations.
- * 
- * Found rulesets will add a {@link CssRulesetStartToken} and {@link CssRulesetEndToken} to the 
+ *
+ * Found rulesets will add a {@link CssRulesetStartToken} and {@link CssRulesetEndToken} to the
  * parser; including declarations as {@link CssRulesetDeclarationToken}.
  *
  * @package		CssMin/Parser/Plugins
@@ -1055,7 +1055,7 @@ class CssRulesetParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -1064,7 +1064,7 @@ class CssRulesetParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -1073,13 +1073,13 @@ class CssRulesetParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Selectors.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $selectors = array();
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -1179,7 +1179,7 @@ class CssRulesetParserPlugin extends aCssParserPlugin
  */
 class CssRulesetEndToken extends aCssRulesetEndToken
 	{
-	
+
 	}
 
 /**
@@ -1196,13 +1196,13 @@ class CssRulesetDeclarationToken extends aCssDeclarationToken
 	{
 	/**
 	 * Media types of the declaration.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $MediaTypes = array("all");
 	/**
-	 * Set the properties of a ddocument- or at-rule @media level declaration. 
-	 * 
+	 * Set the properties of a ddocument- or at-rule @media level declaration.
+	 *
 	 * @param string $property Property of the declaration
 	 * @param string $value Value of the declaration
 	 * @param mixed $mediaTypes Media types of the declaration
@@ -1218,10 +1218,10 @@ class CssRulesetDeclarationToken extends aCssDeclarationToken
 	}
 
 /**
- * This {@link aCssMinifierFilter minifier filter} sets the IsLast property of any last declaration in a ruleset, 
- * @font-face at-rule or @page at-rule block. If the property IsLast is TRUE the decrations will get stringified 
+ * This {@link aCssMinifierFilter minifier filter} sets the IsLast property of any last declaration in a ruleset,
+ * @font-face at-rule or @page at-rule block. If the property IsLast is TRUE the decrations will get stringified
  * without tailing semicolon.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1233,7 +1233,7 @@ class CssRemoveLastDelarationSemiColonMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -1244,7 +1244,7 @@ class CssRemoveLastDelarationSemiColonMinifierFilter extends aCssMinifierFilter
 			$current	= get_class($tokens[$i]);
 			$next		= isset($tokens[$i+1]) ? get_class($tokens[$i+1]) : false;
 			if (($current === "CssRulesetDeclarationToken" && $next === "CssRulesetEndToken") ||
-				($current === "CssAtFontFaceDeclarationToken" && $next === "CssAtFontFaceEndToken") || 
+				($current === "CssAtFontFaceDeclarationToken" && $next === "CssAtFontFaceEndToken") ||
 				($current === "CssAtPageDeclarationToken" && $next === "CssAtPageEndToken"))
 				{
 				$tokens[$i]->IsLast = true;
@@ -1255,7 +1255,7 @@ class CssRemoveLastDelarationSemiColonMinifierFilter extends aCssMinifierFilter
 	}
 
 /**
- * This {@link aCssMinifierFilter minifier filter} will remove any empty rulesets (including @keyframes at-rule block 
+ * This {@link aCssMinifierFilter minifier filter} will remove any empty rulesets (including @keyframes at-rule block
  * rulesets).
  *
  * @package		CssMin/Minifier/Filters
@@ -1269,7 +1269,7 @@ class CssRemoveEmptyRulesetsMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -1295,9 +1295,9 @@ class CssRemoveEmptyRulesetsMinifierFilter extends aCssMinifierFilter
 	}
 
 /**
- * This {@link aCssMinifierFilter minifier filter} will remove any empty @font-face, @keyframes, @media and @page 
+ * This {@link aCssMinifierFilter minifier filter} will remove any empty @font-face, @keyframes, @media and @page
  * at-rule blocks.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1309,7 +1309,7 @@ class CssRemoveEmptyAtBlocksMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -1337,7 +1337,7 @@ class CssRemoveEmptyAtBlocksMinifierFilter extends aCssMinifierFilter
 
 /**
  * This {@link aCssMinifierFilter minifier filter} will remove any comments from the array of parsed tokens.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1349,7 +1349,7 @@ class CssRemoveCommentsMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -1370,7 +1370,7 @@ class CssRemoveCommentsMinifierFilter extends aCssMinifierFilter
 
 /**
  * CSS Parser.
- * 
+ *
  * @package		CssMin/Parser
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1382,57 +1382,57 @@ class CssParser
 	{
 	/**
 	 * Parse buffer.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $buffer = "";
 	/**
 	 * {@link aCssParserPlugin Plugins}.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $plugins = array();
 	/**
 	 * Source to parse.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $source = "";
 	/**
 	 * Current state.
-	 * 
+	 *
 	 * @var integer
 	 */
 	private $state = "T_DOCUMENT";
 	/**
 	 * Exclusive state.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $stateExclusive = false;
 	/**
 	 * Media types state.
-	 * 
+	 *
 	 * @var mixed
 	 */
 	private $stateMediaTypes = false;
 	/**
 	 * State stack.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $states = array("T_DOCUMENT");
 	/**
 	 * Parsed tokens.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $tokens = array();
 	/**
 	 * Constructer.
-	 * 
+	 *
 	 *  Create instances of the used {@link aCssParserPlugin plugins}.
-	 * 
+	 *
 	 * @param string $source CSS source [optional]
 	 * @param array $plugins Plugin configuration [optional]
 	 * @return void
@@ -1478,7 +1478,7 @@ class CssParser
 		}
 	/**
 	 * Append a token to the array of tokens.
-	 * 
+	 *
 	 * @param aCssToken $token Token to append
 	 * @return void
 	 */
@@ -1488,7 +1488,7 @@ class CssParser
 		}
 	/**
 	 * Clears the current buffer.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function clearBuffer()
@@ -1497,7 +1497,7 @@ class CssParser
 		}
 	/**
 	 * Returns and clear the current buffer.
-	 * 
+	 *
 	 * @param string $trim Chars to use to trim the returned buffer
 	 * @param boolean $tolower if TRUE the returned buffer will get converted to lower case
 	 * @return string
@@ -1510,7 +1510,7 @@ class CssParser
 		}
 	/**
 	 * Returns the current buffer.
-	 * 
+	 *
 	 * @param string $trim Chars to use to trim the returned buffer
 	 * @param boolean $tolower if TRUE the returned buffer will get converted to lower case
 	 * @return string
@@ -1530,16 +1530,16 @@ class CssParser
 		}
 	/**
 	 * Returns the current media types state.
-	 * 
+	 *
 	 * @return array
-	 */	
+	 */
 	public function getMediaTypes()
 		{
 		return $this->stateMediaTypes;
 		}
 	/**
 	 * Returns the CSS source.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getSource()
@@ -1548,7 +1548,7 @@ class CssParser
 		}
 	/**
 	 * Returns the current state.
-	 * 
+	 *
 	 * @return integer The current state
 	 */
 	public function getState()
@@ -1557,8 +1557,8 @@ class CssParser
 		}
 	/**
 	 * Returns a plugin by class name.
-	 * 
-	 * @param string $name Class name of the plugin 
+	 *
+	 * @param string $name Class name of the plugin
 	 * @return aCssParserPlugin
 	 */
 	public function getPlugin($class)
@@ -1576,7 +1576,7 @@ class CssParser
 		}
 	/**
 	 * Returns the parsed tokens.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTokens()
@@ -1585,7 +1585,7 @@ class CssParser
 		}
 	/**
 	 * Returns if the current state equals the passed state.
-	 * 
+	 *
 	 * @param integer $state State to compare with the current state
 	 * @return boolean TRUE is the state equals to the passed state; FALSE if not
 	 */
@@ -1595,7 +1595,7 @@ class CssParser
 		}
 	/**
 	 * Parse the CSS source and return a array with parsed tokens.
-	 * 
+	 *
 	 * @param string $source CSS source
 	 * @return array Array with tokens
 	 */
@@ -1604,7 +1604,7 @@ class CssParser
 		// Reset
 		$this->source = "";
 		$this->tokens = array();
-		// Create a global and plugin lookup table for trigger chars; set array of plugins as local variable and create 
+		// Create a global and plugin lookup table for trigger chars; set array of plugins as local variable and create
 		// several helper variables for plugin handling
 		$globalTriggerChars		= "";
 		$plugins				= $this->plugins;
@@ -1658,7 +1658,7 @@ class CssParser
 			// Extended processing only if the current char is a global trigger char
 			if (strpos($globalTriggerChars, $c) !== false)
 				{
-				// Exclusive state is set; process with the exclusive plugin 
+				// Exclusive state is set; process with the exclusive plugin
 				if ($exclusive)
 					{
 					$tPluginIndex = $pluginIndex[$exclusive];
@@ -1710,7 +1710,7 @@ class CssParser
 		}
 	/**
 	 * Remove the last state of the state stack and return the removed stack value.
-	 * 
+	 *
 	 * @return integer Removed state value
 	 */
 	public function popState()
@@ -1721,7 +1721,7 @@ class CssParser
 		}
 	/**
 	 * Adds a new state onto the state stack.
-	 * 
+	 *
 	 * @param integer $state State to add onto the state stack.
 	 * @return integer The index of the added state in the state stacks
 	 */
@@ -1733,37 +1733,37 @@ class CssParser
 		}
 	/**
 	 * Sets/restores the buffer.
-	 * 
+	 *
 	 * @param string $buffer Buffer to set
 	 * @return void
-	 */	
+	 */
 	public function setBuffer($buffer)
 		{
 		$this->buffer = $buffer;
 		}
 	/**
 	 * Set the exclusive state.
-	 * 
+	 *
 	 * @param string $exclusive Exclusive state
 	 * @return void
-	 */	
+	 */
 	public function setExclusive($exclusive)
 		{
-		$this->stateExclusive = $exclusive; 
+		$this->stateExclusive = $exclusive;
 		}
 	/**
 	 * Set the media types state.
-	 * 
+	 *
 	 * @param array $mediaTypes Media types state
 	 * @return void
-	 */	
+	 */
 	public function setMediaTypes(array $mediaTypes)
 		{
-		$this->stateMediaTypes = $mediaTypes; 
+		$this->stateMediaTypes = $mediaTypes;
 		}
 	/**
 	 * Sets the current state in the state stack; equals to {@link CssParser::popState()} + {@link CssParser::pushState()}.
-	 * 
+	 *
 	 * @param integer $state State to set
 	 * @return integer
 	 */
@@ -1776,7 +1776,7 @@ class CssParser
 		}
 	/**
 	 * Removes the exclusive state.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function unsetExclusive()
@@ -1785,7 +1785,7 @@ class CssParser
 		}
 	/**
 	 * Removes the media types state.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function unsetMediaTypes()
@@ -1796,7 +1796,7 @@ class CssParser
 
 /**
  * {@link aCssFromatter Formatter} returning the CSS source in {@link http://goo.gl/j4XdU OTBS indent style} (The One True Brace Style).
- * 
+ *
  * @package		CssMin/Formatter
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1808,7 +1808,7 @@ class CssOtbsFormatter extends aCssFormatter
 	{
 	/**
 	 * Implements {@link aCssFormatter::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -1911,7 +1911,7 @@ class CssNullToken extends aCssToken
 	{
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -1922,7 +1922,7 @@ class CssNullToken extends aCssToken
 
 /**
  * CSS Minifier.
- * 
+ *
  * @package		CssMin/Minifier
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -1934,27 +1934,27 @@ class CssMinifier
 	{
 	/**
 	 * {@link aCssMinifierFilter Filters}.
-	 *  
+	 *
 	 * @var array
 	 */
 	private $filters = array();
 	/**
 	 * {@link aCssMinifierPlugin Plugins}.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $plugins = array();
 	/**
 	 * Minified source.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $minified = "";
 	/**
 	 * Constructer.
-	 * 
+	 *
 	 * Creates instances of {@link aCssMinifierFilter filters} and {@link aCssMinifierPlugin plugins}.
-	 * 
+	 *
 	 * @param string $source CSS source [optional]
 	 * @param array $filters Filter configuration [optional]
 	 * @param array $plugins Plugin configuration [optional]
@@ -1965,7 +1965,7 @@ class CssMinifier
 		$filters = array_merge(array
 			(
 			"ImportImports"					=> false,
-			"RemoveComments"				=> true, 
+			"RemoveComments"				=> true,
 			"RemoveEmptyRulesets"			=> true,
 			"RemoveEmptyAtBlocks"			=> true,
 			"ConvertLevel3Properties"		=> false,
@@ -2026,7 +2026,7 @@ class CssMinifier
 		}
 	/**
 	 * Returns the minified Source.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getMinified()
@@ -2035,7 +2035,7 @@ class CssMinifier
 		}
 	/**
 	 * Returns a plugin by class name.
-	 * 
+	 *
 	 * @param string $name Class name of the plugin
 	 * @return aCssMinifierPlugin
 	 */
@@ -2054,7 +2054,7 @@ class CssMinifier
 		}
 	/**
 	 * Minifies the CSS source.
-	 * 
+	 *
 	 * @param string $source CSS source
 	 * @return string
 	 */
@@ -2132,7 +2132,7 @@ class CssMinifier
 
 /**
  * CssMin - A (simple) css minifier with benefits
- * 
+ *
  * --
  * Copyright (c) 2011 Joe Scylla <joe.scylla@gmail.com>
  *
@@ -2142,10 +2142,10 @@ class CssMinifier
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -2154,7 +2154,7 @@ class CssMinifier
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  * --
- * 
+ *
  * @package		CssMin
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -2166,25 +2166,25 @@ class CssMin
 	{
 	/**
 	 * Index of classes
-	 * 
+	 *
 	 * @var array
 	 */
 	private static $classIndex = array();
 	/**
 	 * Parse/minify errors
-	 * 
+	 *
 	 * @var array
 	 */
 	private static $errors = array();
 	/**
 	 * Verbose output.
-	 * 
+	 *
 	 * @var boolean
 	 */
 	private static $isVerbose = false;
 	/**
 	 * {@link http://goo.gl/JrW54 Autoload} function of CssMin.
-	 * 
+	 *
 	 * @param string $class Name of the class
 	 * @return void
 	 */
@@ -2197,7 +2197,7 @@ class CssMin
 		}
 	/**
 	 * Return errors
-	 * 
+	 *
 	 * @return array of {CssError}.
 	 */
 	public static function getErrors()
@@ -2206,7 +2206,7 @@ class CssMin
 		}
 	/**
 	 * Returns if there were errors.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public static function hasErrors()
@@ -2215,7 +2215,7 @@ class CssMin
 		}
 	/**
 	 * Initialises CssMin.
-	 * 
+	 *
 	 * @return void
 	 */
 	public static function initialise()
@@ -2243,8 +2243,8 @@ class CssMin
 				}
 			}
 		krsort(self::$classIndex);
-		// Only use autoloading if spl_autoload_register() is available and no __autoload() is defined (because 
-		// __autoload() breaks if spl_autoload_register() is used. 
+		// Only use autoloading if spl_autoload_register() is available and no __autoload() is defined (because
+		// __autoload() breaks if spl_autoload_register() is used.
 		if (function_exists("spl_autoload_register") && !is_callable("__autoload"))
 			{
 			spl_autoload_register(array(__CLASS__, "autoload"));
@@ -2263,7 +2263,7 @@ class CssMin
 		}
 	/**
 	 * Minifies CSS source.
-	 * 
+	 *
 	 * @param string $source CSS source
 	 * @param array $filters Filter configuration [optional]
 	 * @param array $plugins Plugin configuration [optional]
@@ -2277,7 +2277,7 @@ class CssMin
 		}
 	/**
 	 * Parse the CSS source.
-	 * 
+	 *
 	 * @param string $source CSS source
 	 * @param array $plugins Plugin configuration [optional]
 	 * @return array Array of aCssToken
@@ -2290,7 +2290,7 @@ class CssMin
 		}
 	/**
 	 * --
-	 * 
+	 *
 	 * @param boolean $to
 	 * @return boolean
 	 */
@@ -2301,7 +2301,7 @@ class CssMin
 		}
 	/**
 	 * --
-	 * 
+	 *
 	 * @param CssError $error
 	 * @return void
 	 */
@@ -2318,9 +2318,9 @@ class CssMin
 CssMin::initialise();
 
 /**
- * This {@link aCssMinifierFilter minifier filter} import external css files defined with the @import at-rule into the 
- * current stylesheet. 
- * 
+ * This {@link aCssMinifierFilter minifier filter} import external css files defined with the @import at-rule into the
+ * current stylesheet.
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -2332,13 +2332,13 @@ class CssImportImportsMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Array with already imported external stylesheets.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $imported = array();
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -2447,9 +2447,9 @@ class CssImportImportsMinifierFilter extends aCssMinifierFilter
 								}
 							}
 						/*
-						 * If the media types of the @media at-rule equals the media types defined in the @import 
+						 * If the media types of the @media at-rule equals the media types defined in the @import
 						 * at-rule remove the CssAtMediaStartToken and CssAtMediaEndToken token
-						 */ 
+						 */
 						for($ii = 0, $ll = count($import); $ii < $ll; $ii++)
 							{
 							if (get_class($import[$ii]) === "CssAtMediaStartToken" && count(array_diff($tokens[$i]->MediaTypes, $import[$ii]->MediaTypes)) === 0)
@@ -2522,10 +2522,10 @@ class CssImportImportsMinifierFilter extends aCssMinifierFilter
 
 /**
  * {@link aCssParserPlugin Parser plugin} for preserve parsing expression() declaration values.
- * 
- * This plugin return no {@link aCssToken CssToken} but ensures that expression() declaration values will get parsed 
+ *
+ * This plugin return no {@link aCssToken CssToken} but ensures that expression() declaration values will get parsed
  * properly.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -2537,19 +2537,19 @@ class CssExpressionParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Count of left braces.
-	 * 
+	 *
 	 * @var integer
 	 */
 	private $leftBraces = 0;
 	/**
 	 * Count of right braces.
-	 * 
+	 *
 	 * @var integer
 	 */
 	private $rightBraces = 0;
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -2558,7 +2558,7 @@ class CssExpressionParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -2567,7 +2567,7 @@ class CssExpressionParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -2608,7 +2608,7 @@ class CssExpressionParserPlugin extends aCssParserPlugin
 
 /**
  * CSS Error.
- * 
+ *
  * @package		CssMin
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -2620,31 +2620,31 @@ class CssError
 	{
 	/**
 	 * File.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $File = "";
 	/**
 	 * Line.
-	 * 
+	 *
 	 * @var integer
 	 */
 	public $Line = 0;
 	/**
 	 * Error message.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Message = "";
 	/**
 	 * Source.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Source = "";
 	/**
 	 * Constructor triggering the error.
-	 * 
+	 *
 	 * @param string $message Error message
 	 * @param string $source Corresponding line [optional]
 	 * @return void
@@ -2658,9 +2658,9 @@ class CssError
 		}
 	/**
 	 * Returns the error as formatted string.
-	 * 
+	 *
 	 * @return string
-	 */	
+	 */
 	public function __toString()
 		{
 		return $this->Message . ($this->Source ? ": <br /><code>" . $this->Source . "</code>": "") . "<br />in file " . $this->File . " at line " . $this->Line;
@@ -2669,12 +2669,12 @@ class CssError
 
 /**
  * This {@link aCssMinifierPlugin} will convert a color value in rgb notation to hexadecimal notation.
- * 
+ *
  * Example:
  * <code>
  * color: rgb(200,60%,5);
  * </code>
- * 
+ *
  * Will get converted to:
  * <code>
  * color:#c89905;
@@ -2691,13 +2691,13 @@ class CssConvertRgbColorsMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Regular expression matching the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = "/rgb\s*\(\s*([0-9%]+)\s*,\s*([0-9%]+)\s*,\s*([0-9%]+)\s*\)/iS";
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -2720,7 +2720,7 @@ class CssConvertRgbColorsMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -2736,19 +2736,19 @@ class CssConvertRgbColorsMinifierPlugin extends aCssMinifierPlugin
 
 /**
  * This {@link aCssMinifierPlugin} will convert named color values to hexadecimal notation.
- * 
+ *
  * Example:
  * <code>
  * color: black;
  * border: 1px solid indigo;
  * </code>
- * 
+ *
  * Will get converted to:
  * <code>
  * color:#000;
  * border:1px solid #4b0082;
  * </code>
- * 
+ *
  * @package		CssMin/Minifier/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -2758,26 +2758,26 @@ class CssConvertRgbColorsMinifierPlugin extends aCssMinifierPlugin
  */
 class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 	{
-	
+
 	/**
 	 * Regular expression matching the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = null;
 	/**
 	 * Regular expression replacing the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reReplace = "\"\${1}\" . \$this->transformation[strtolower(\"\${2}\")] . \"\${3}\"";
 	/**
 	 * Transformation table used by the {@link CssConvertNamedColorsMinifierPlugin::$reReplace replace regular expression}.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $transformation = array
-		( 
+		(
 		"aliceblue"						=> "#f0f8ff",
 		"antiquewhite"					=> "#faebd7",
 		"aqua"							=> "#0ff",
@@ -2917,10 +2917,10 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 		);
 	/**
 	 * Overwrites {@link aCssMinifierPlugin::__construct()}.
-	 * 
+	 *
 	 * The constructor will create the {@link CssConvertNamedColorsMinifierPlugin::$reReplace replace regular expression}
 	 * based on the {@link CssConvertNamedColorsMinifierPlugin::$transformation transformation table}.
-	 * 
+	 *
 	 * @param CssMinifier $minifier The CssMinifier object of this plugin.
 	 * @param array $configuration Plugin configuration [optional]
 	 * @return void
@@ -2932,7 +2932,7 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -2953,7 +2953,7 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -2970,7 +2970,7 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 /**
  * This {@link aCssMinifierFilter minifier filter} triggers on CSS Level 3 properties and will add declaration tokens
  * with browser-specific properties.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -2981,9 +2981,9 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 class CssConvertLevel3PropertiesMinifierFilter extends aCssMinifierFilter
 	{
 	/**
-	 * Css property transformations table. Used to convert CSS3 and proprietary properties to the browser-specific 
+	 * Css property transformations table. Used to convert CSS3 and proprietary properties to the browser-specific
 	 * counterparts.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $transformations = array
@@ -3193,7 +3193,7 @@ class CssConvertLevel3PropertiesMinifierFilter extends aCssMinifierFilter
 		);
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value large than 0 will rebuild the array
 	 */
@@ -3241,9 +3241,9 @@ class CssConvertLevel3PropertiesMinifierFilter extends aCssMinifierFilter
 		return $r;
 		}
 	/**
-	 * Transforms the Internet Explorer specific declaration property "filter" to Internet Explorer 8+ compatible 
-	 * declaratiopn property "-ms-filter". 
-	 * 
+	 * Transforms the Internet Explorer specific declaration property "filter" to Internet Explorer 8+ compatible
+	 * declaratiopn property "-ms-filter".
+	 *
 	 * @param aCssToken $token
 	 * @return array
 	 */
@@ -3257,7 +3257,7 @@ class CssConvertLevel3PropertiesMinifierFilter extends aCssMinifierFilter
 		}
 	/**
 	 * Transforms "opacity: {value}" into browser specific counterparts.
-	 * 
+	 *
 	 * @param aCssToken $token
 	 * @return array
 	 */
@@ -3277,7 +3277,7 @@ class CssConvertLevel3PropertiesMinifierFilter extends aCssMinifierFilter
 		}
 	/**
 	 * Transforms "white-space: pre-wrap" into browser specific counterparts.
-	 * 
+	 *
 	 * @param aCssToken $token
 	 * @return array
 	 */
@@ -3309,7 +3309,7 @@ class CssConvertLevel3PropertiesMinifierFilter extends aCssMinifierFilter
 
 /**
  * This {@link aCssMinifierFilter minifier filter} will convert @keyframes at-rule block to browser specific counterparts.
- * 
+ *
  * @package		CssMin/Minifier/Filters
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3321,7 +3321,7 @@ class CssConvertLevel3AtKeyframesMinifierFilter extends aCssMinifierFilter
 	{
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
-	 * 
+	 *
 	 * @param array $tokens Array of objects of type aCssToken
 	 * @return integer Count of added, changed or removed tokens; a return value larger than 0 will rebuild the array
 	 */
@@ -3378,17 +3378,17 @@ class CssConvertLevel3AtKeyframesMinifierFilter extends aCssMinifierFilter
 
 /**
  * This {@link aCssMinifierPlugin} will convert a color value in hsl notation to hexadecimal notation.
- * 
+ *
  * Example:
  * <code>
  * color: hsl(232,36%,48%);
  * </code>
- * 
+ *
  * Will get converted to:
  * <code>
  * color:#4e5aa7;
  * </code>
- * 
+ *
  * @package		CssMin/Minifier/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3400,13 +3400,13 @@ class CssConvertHslColorsMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Regular expression matching the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = "/^hsl\s*\(\s*([0-9]+)\s*,\s*([0-9]+)\s*%\s*,\s*([0-9]+)\s*%\s*\)/iS";
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -3420,7 +3420,7 @@ class CssConvertHslColorsMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -3434,9 +3434,9 @@ class CssConvertHslColorsMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Convert a HSL value to hexadecimal notation.
-	 * 
+	 *
 	 * Based on: {@link http://www.easyrgb.com/index.php?X=MATH&H=19#text19}.
-	 * 
+	 *
 	 * @param integer $hue Hue
 	 * @param integer $saturation Saturation
 	 * @param integer $lightness Lightnesss
@@ -3472,7 +3472,7 @@ class CssConvertHslColorsMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Apply hue to a rgb color value.
-	 * 
+	 *
 	 * @param integer $v1 Value 1
 	 * @param integer $v2 Value 2
 	 * @param integer $hue Hue
@@ -3506,13 +3506,13 @@ class CssConvertHslColorsMinifierPlugin extends aCssMinifierPlugin
 
 /**
  * This {@link aCssMinifierPlugin} will convert the font-weight values normal and bold to their numeric notation.
- * 
+ *
  * Example:
  * <code>
  * font-weight: normal;
  * font: bold 11px monospace;
  * </code>
- * 
+ *
  * Will get converted to:
  * <code>
  * font-weight:400;
@@ -3530,8 +3530,8 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Array of included declaration properties this plugin will process; others declaration properties will get
-	 * ignored. 
-	 * 
+	 * ignored.
+	 *
 	 * @var array
 	 */
 	private $include = array
@@ -3541,19 +3541,19 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 		);
 	/**
 	 * Regular expression matching the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = null;
 	/**
 	 * Regular expression replace the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reReplace = "\"\${1}\" . \$this->transformation[\"\${2}\"] . \"\${3}\"";
 	/**
 	 * Transformation table used by the {@link CssConvertFontWeightMinifierPlugin::$reReplace replace regular expression}.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $transformation = array
@@ -3563,10 +3563,10 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 		);
 	/**
 	 * Overwrites {@link aCssMinifierPlugin::__construct()}.
-	 * 
+	 *
 	 * The constructor will create the {@link CssConvertFontWeightMinifierPlugin::$reReplace replace regular expression}
 	 * based on the {@link CssConvertFontWeightMinifierPlugin::$transformation transformation table}.
-	 * 
+	 *
 	 * @param CssMinifier $minifier The CssMinifier object of this plugin.
 	 * @return void
 	 */
@@ -3577,7 +3577,7 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -3591,7 +3591,7 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -3607,21 +3607,21 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 
 /**
  * This {@link aCssMinifierPlugin} will compress several unit values to their short notations. Examples:
- * 
+ *
  * <code>
  * padding: 0.5em;
  * border: 0px;
  * margin: 0 0 0 0;
  * </code>
- * 
+ *
  * Will get compressed to:
- * 
+ *
  * <code>
  * padding:.5px;
  * border:0;
  * margin:0;
  * </code>
- * 
+ *
  * --
  *
  * @package		CssMin/Minifier/Plugins
@@ -3635,7 +3635,7 @@ class CssCompressUnitValuesMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Regular expression used for matching and replacing unit values.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $re = array
@@ -3646,13 +3646,13 @@ class CssCompressUnitValuesMinifierPlugin extends aCssMinifierPlugin
 		);
 	/**
 	 * Regular expression matching the value.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = "/(^| |-)0\.([0-9]+?)(0+)?(%|em|ex|px|in|cm|mm|pt|pc)|(^| )-?(\.?)0(%|em|ex|px|in|cm|mm|pt|pc)|(^0\s0\s0\s0$)|(^0\s0\s0$)|(^0\s0$)/iS";
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -3669,7 +3669,7 @@ class CssCompressUnitValuesMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -3685,10 +3685,10 @@ class CssCompressUnitValuesMinifierPlugin extends aCssMinifierPlugin
 
 /**
  * This {@link aCssMinifierPlugin} compress the content of expresssion() declaration values.
- * 
- * For compression of expressions {@link https://github.com/rgrove/jsmin-php/ JSMin} will get used. JSMin have to be 
- * already included or loadable via {@link http://goo.gl/JrW54 PHP autoloading}. 
- * 
+ *
+ * For compression of expressions {@link https://github.com/rgrove/jsmin-php/ JSMin} will get used. JSMin have to be
+ * already included or loadable via {@link http://goo.gl/JrW54 PHP autoloading}.
+ *
  * @package		CssMin/Minifier/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3700,7 +3700,7 @@ class CssCompressExpressionValuesMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -3717,7 +3717,7 @@ class CssCompressExpressionValuesMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -3732,19 +3732,19 @@ class CssCompressExpressionValuesMinifierPlugin extends aCssMinifierPlugin
 	}
 
 /**
- * This {@link aCssMinifierPlugin} will convert hexadecimal color value with 6 chars to their 3 char hexadecimal 
- * notation (if possible). 
- * 
+ * This {@link aCssMinifierPlugin} will convert hexadecimal color value with 6 chars to their 3 char hexadecimal
+ * notation (if possible).
+ *
  * Example:
  * <code>
  * color: #aabbcc;
  * </code>
- * 
+ *
  * Will get converted to:
  * <code>
  * color:#abc;
  * </code>
- * 
+ *
  * @package		CssMin/Minifier/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3756,13 +3756,13 @@ class CssCompressColorValuesMinifierPlugin extends aCssMinifierPlugin
 	{
 	/**
 	 * Regular expression matching 6 char hexadecimal color values.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $reMatch = "/\#([0-9a-f]{6})/iS";
 	/**
 	 * Implements {@link aCssMinifierPlugin::minify()}.
-	 * 
+	 *
 	 * @param aCssToken $token Token to process
 	 * @return boolean Return TRUE to break the processing of this token; FALSE to continue
 	 */
@@ -3780,7 +3780,7 @@ class CssCompressColorValuesMinifierPlugin extends aCssMinifierPlugin
 		}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerTokens()
@@ -3796,7 +3796,7 @@ class CssCompressColorValuesMinifierPlugin extends aCssMinifierPlugin
 
 /**
  * This {@link aCssToken CSS token} represents a CSS comment.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3808,14 +3808,14 @@ class CssCommentToken extends aCssToken
 	{
 	/**
 	 * Comment as Text.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Comment = "";
 	/**
 	 * Set the properties of a comment token.
-	 * 
-	 * @param string $comment Comment including comment delimiters 
+	 *
+	 * @param string $comment Comment including comment delimiters
 	 * @return void
 	 */
 	public function __construct($comment)
@@ -3824,7 +3824,7 @@ class CssCommentToken extends aCssToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -3835,9 +3835,9 @@ class CssCommentToken extends aCssToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing comments.
- * 
+ *
  * Adds a {@link CssCommentToken} to the parser if a comment was found.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3849,7 +3849,7 @@ class CssCommentParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -3858,7 +3858,7 @@ class CssCommentParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -3867,13 +3867,13 @@ class CssCommentParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Stored buffer for restore.
-	 * 
+	 *
 	 * @var string
 	 */
 	private $restoreBuffer = "";
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -3916,13 +3916,13 @@ class CssAtVariablesStartToken extends aCssAtBlockStartToken
 	{
 	/**
 	 * Media types of the @variables at-rule block.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $MediaTypes = array();
 	/**
 	 * Set the properties of a @variables at-rule token.
-	 * 
+	 *
 	 * @param array $mediaTypes Media types
 	 * @return void
 	 */
@@ -3932,7 +3932,7 @@ class CssAtVariablesStartToken extends aCssAtBlockStartToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -3943,10 +3943,10 @@ class CssAtVariablesStartToken extends aCssAtBlockStartToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @variables at-rule block with including declarations.
- * 
- * Found @variables at-rule blocks will add a {@link CssAtVariablesStartToken} and {@link CssAtVariablesEndToken} to the 
+ *
+ * Found @variables at-rule blocks will add a {@link CssAtVariablesStartToken} and {@link CssAtVariablesEndToken} to the
  * parser; including declarations as {@link CssAtVariablesDeclarationToken}.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -3958,7 +3958,7 @@ class CssAtVariablesParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -3967,7 +3967,7 @@ class CssAtVariablesParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -3976,7 +3976,7 @@ class CssAtVariablesParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -4060,7 +4060,7 @@ class CssAtVariablesEndToken extends aCssAtBlockEndToken
 	{
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4071,7 +4071,7 @@ class CssAtVariablesEndToken extends aCssAtBlockEndToken
 
 /**
  * This {@link aCssToken CSS token} represents a declaration of a @variables at-rule block.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4083,7 +4083,7 @@ class CssAtVariablesDeclarationToken extends aCssDeclarationToken
 	{
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4106,13 +4106,13 @@ class CssAtPageStartToken extends aCssAtBlockStartToken
 	{
 	/**
 	 * Selector.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Selector = "";
 	/**
 	 * Sets the properties of the @page at-rule.
-	 * 
+	 *
 	 * @param string $selector Selector
 	 * @return void
 	 */
@@ -4122,7 +4122,7 @@ class CssAtPageStartToken extends aCssAtBlockStartToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4133,10 +4133,10 @@ class CssAtPageStartToken extends aCssAtBlockStartToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @page at-rule block with including declarations.
- * 
- * Found @page at-rule blocks will add a {@link CssAtPageStartToken} and {@link CssAtPageEndToken} to the 
+ *
+ * Found @page at-rule blocks will add a {@link CssAtPageStartToken} and {@link CssAtPageEndToken} to the
  * parser; including declarations as {@link CssAtPageDeclarationToken}.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4148,7 +4148,7 @@ class CssAtPageParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -4157,7 +4157,7 @@ class CssAtPageParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -4166,7 +4166,7 @@ class CssAtPageParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -4255,12 +4255,12 @@ class CssAtPageParserPlugin extends aCssParserPlugin
  */
 class CssAtPageEndToken extends aCssAtBlockEndToken
 	{
-	
+
 	}
 
 /**
  * This {@link aCssToken CSS token} represents a declaration of a @page at-rule block.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4270,7 +4270,7 @@ class CssAtPageEndToken extends aCssAtBlockEndToken
  */
 class CssAtPageDeclarationToken extends aCssDeclarationToken
 	{
-	
+
 	}
 
 /**
@@ -4287,7 +4287,7 @@ class CssAtMediaStartToken extends aCssAtBlockStartToken
 	{
 	/**
 	 * Sets the properties of the @media at-rule.
-	 * 
+	 *
 	 * @param array $mediaTypes Media types
 	 * @return void
 	 */
@@ -4297,7 +4297,7 @@ class CssAtMediaStartToken extends aCssAtBlockStartToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4308,8 +4308,8 @@ class CssAtMediaStartToken extends aCssAtBlockStartToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @media at-rule block.
- * 
- * Found @media at-rule blocks will add a {@link CssAtMediaStartToken} and {@link CssAtMediaEndToken} to the parser. 
+ *
+ * Found @media at-rule blocks will add a {@link CssAtMediaStartToken} and {@link CssAtMediaEndToken} to the parser.
  * This plugin will also set the the current media types using {@link CssParser::setMediaTypes()} and
  * {@link CssParser::unsetMediaTypes()}.
  *
@@ -4324,7 +4324,7 @@ class CssAtMediaParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -4333,7 +4333,7 @@ class CssAtMediaParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -4342,7 +4342,7 @@ class CssAtMediaParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -4390,7 +4390,7 @@ class CssAtMediaParserPlugin extends aCssParserPlugin
  */
 class CssAtMediaEndToken extends aCssAtBlockEndToken
 	{
-	
+
 	}
 
 /**
@@ -4407,19 +4407,19 @@ class CssAtKeyframesStartToken extends aCssAtBlockStartToken
 	{
 	/**
 	 * Name of the at-rule.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $AtRuleName = "keyframes";
 	/**
 	 * Name
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Name = "";
 	/**
 	 * Sets the properties of the @page at-rule.
-	 * 
+	 *
 	 * @param string $selector Selector
 	 * @return void
 	 */
@@ -4433,7 +4433,7 @@ class CssAtKeyframesStartToken extends aCssAtBlockStartToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4444,7 +4444,7 @@ class CssAtKeyframesStartToken extends aCssAtBlockStartToken
 
 /**
  * This {@link aCssToken CSS token} represents the start of a ruleset of a @keyframes at-rule block.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4456,14 +4456,14 @@ class CssAtKeyframesRulesetStartToken extends aCssRulesetStartToken
 	{
 	/**
 	 * Array of selectors.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $Selectors = array();
 	/**
 	 * Set the properties of a ruleset token.
-	 * 
-	 * @param array $selectors Selectors of the ruleset 
+	 *
+	 * @param array $selectors Selectors of the ruleset
 	 * @return void
 	 */
 	public function __construct(array $selectors = array())
@@ -4472,7 +4472,7 @@ class CssAtKeyframesRulesetStartToken extends aCssRulesetStartToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4483,7 +4483,7 @@ class CssAtKeyframesRulesetStartToken extends aCssRulesetStartToken
 
 /**
  * This {@link aCssToken CSS token} represents the end of a ruleset of a @keyframes at-rule block.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4493,7 +4493,7 @@ class CssAtKeyframesRulesetStartToken extends aCssRulesetStartToken
  */
 class CssAtKeyframesRulesetEndToken extends aCssRulesetEndToken
 	{
-	
+
 	}
 
 /**
@@ -4508,12 +4508,12 @@ class CssAtKeyframesRulesetEndToken extends aCssRulesetEndToken
  */
 class CssAtKeyframesRulesetDeclarationToken extends aCssDeclarationToken
 	{
-	
+
 	}
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @keyframes at-rule blocks, rulesets and declarations.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4529,13 +4529,13 @@ class CssAtKeyframesParserPlugin extends aCssParserPlugin
 	private $atRuleName = "";
 	/**
 	 * Selectors.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $selectors = array();
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -4544,7 +4544,7 @@ class CssAtKeyframesParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -4553,7 +4553,7 @@ class CssAtKeyframesParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -4562,7 +4562,7 @@ class CssAtKeyframesParserPlugin extends aCssParserPlugin
 	public function parse($index, $char, $previousChar, $state)
 		{
 		// Start of @keyframes at-rule block
-		if ($char === "@" && $state === "T_DOCUMENT" && strtolower(substr($this->parser->getSource(), $index, 10)) === "@keyframes") 
+		if ($char === "@" && $state === "T_DOCUMENT" && strtolower(substr($this->parser->getSource(), $index, 10)) === "@keyframes")
 			{
 			$this->atRuleName = "keyframes";
 			$this->parser->pushState("T_AT_KEYFRAMES::NAME");
@@ -4652,7 +4652,7 @@ class CssAtKeyframesParserPlugin extends aCssParserPlugin
 		elseif ($char === "}" && $state === "T_AT_KEYFRAMES_RULESET")
 			{
 			$this->parser->clearBuffer();
-			
+
 			$this->parser->popState();
 			$this->parser->appendToken(new CssAtKeyframesRulesetEndToken());
 			}
@@ -4683,12 +4683,12 @@ class CssAtKeyframesParserPlugin extends aCssParserPlugin
  */
 class CssAtKeyframesEndToken extends aCssAtBlockEndToken
 	{
-	
+
 	}
 
 /**
  * This {@link aCssToken CSS token} represents a @import at-rule.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4700,19 +4700,19 @@ class CssAtImportToken extends aCssToken
 	{
 	/**
 	 * Import path of the @import at-rule.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Import = "";
 	/**
 	 * Media types of the @import at-rule.
-	 * 
+	 *
 	 * @var array
 	 */
 	public $MediaTypes = array();
 	/**
 	 * Set the properties of a @import at-rule token.
-	 * 
+	 *
 	 * @param string $import Import path
 	 * @param array $mediaTypes Media types
 	 * @return void
@@ -4724,7 +4724,7 @@ class CssAtImportToken extends aCssToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4735,9 +4735,9 @@ class CssAtImportToken extends aCssToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @import at-rule.
- * 
+ *
  * If a @import at-rule was found this plugin will add a {@link CssAtImportToken} to the parser.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4749,7 +4749,7 @@ class CssAtImportParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -4758,7 +4758,7 @@ class CssAtImportParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -4767,7 +4767,7 @@ class CssAtImportParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -4831,7 +4831,7 @@ class CssAtFontFaceStartToken extends aCssAtBlockStartToken
 	{
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -4842,10 +4842,10 @@ class CssAtFontFaceStartToken extends aCssAtBlockStartToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @font-face at-rule block with including declarations.
- * 
- * Found @font-face at-rule blocks will add a {@link CssAtFontFaceStartToken} and {@link CssAtFontFaceEndToken} to the 
+ *
+ * Found @font-face at-rule blocks will add a {@link CssAtFontFaceStartToken} and {@link CssAtFontFaceEndToken} to the
  * parser; including declarations as {@link CssAtFontFaceDeclarationToken}.
- * 
+ *
  * @package		CssMin/Parser/Plugins
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4857,7 +4857,7 @@ class CssAtFontFaceParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -4866,7 +4866,7 @@ class CssAtFontFaceParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -4875,7 +4875,7 @@ class CssAtFontFaceParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char
@@ -4963,7 +4963,7 @@ class CssAtFontFaceParserPlugin extends aCssParserPlugin
  */
 class CssAtFontFaceEndToken extends aCssAtBlockEndToken
 	{
-	
+
 	}
 
 /**
@@ -4978,12 +4978,12 @@ class CssAtFontFaceEndToken extends aCssAtBlockEndToken
  */
 class CssAtFontFaceDeclarationToken extends aCssDeclarationToken
 	{
-	
+
 	}
 
 /**
  * This {@link aCssToken CSS token} represents a @charset at-rule.
- * 
+ *
  * @package		CssMin/Tokens
  * @link		http://code.google.com/p/cssmin/
  * @author		Joe Scylla <joe.scylla@gmail.com>
@@ -4995,13 +4995,13 @@ class CssAtCharsetToken extends aCssToken
 	{
 	/**
 	 * Charset of the @charset at-rule.
-	 * 
+	 *
 	 * @var string
 	 */
 	public $Charset = "";
 	/**
-	 * Set the properties of @charset at-rule token. 
-	 * 
+	 * Set the properties of @charset at-rule token.
+	 *
 	 * @param string $charset Charset of the @charset at-rule token
 	 * @return void
 	 */
@@ -5011,7 +5011,7 @@ class CssAtCharsetToken extends aCssToken
 		}
 	/**
 	 * Implements {@link aCssToken::__toString()}.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function __toString()
@@ -5022,7 +5022,7 @@ class CssAtCharsetToken extends aCssToken
 
 /**
  * {@link aCssParserPlugin Parser plugin} for parsing @charset at-rule.
- * 
+ *
  * If a @charset at-rule was found this plugin will add a {@link CssAtCharsetToken} to the parser.
  *
  * @package		CssMin/Parser/Plugins
@@ -5036,7 +5036,7 @@ class CssAtCharsetParserPlugin extends aCssParserPlugin
 	{
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerChars()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerChars()
@@ -5045,7 +5045,7 @@ class CssAtCharsetParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::getTriggerStates()}.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getTriggerStates()
@@ -5054,7 +5054,7 @@ class CssAtCharsetParserPlugin extends aCssParserPlugin
 		}
 	/**
 	 * Implements {@link aCssParserPlugin::parse()}.
-	 * 
+	 *
 	 * @param integer $index Current index
 	 * @param string $char Current char
 	 * @param string $previousChar Previous char

--- a/admin/includes/class-wc-csv-exporter.php
+++ b/admin/includes/class-wc-csv-exporter.php
@@ -10,23 +10,23 @@
  * @package		WooCommerce/Classes
  * @author 		WooThemes
  */
- 
+
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class WC_CSV_Exporter {
-	
+
 	/**
 	 * @var mixed
 	 * @access private
 	 */
 	private $_csv = '';
-	
+
 	/**
 	 * @var string
 	 * @access private
 	 */
 	private $_filename = '';
-	
+
 	/**
 	 * @var string
 	 * @access private
@@ -35,80 +35,80 @@ class WC_CSV_Exporter {
 
 	/**
 	 * __construct function.
-	 * 
+	 *
 	 * @access public
 	 * @param bool $output (default: true)
-	 * @param mixed $filename	 
+	 * @param mixed $filename
 	 * @return void
 	 */
 	function __construct( $columns = array(), $output = true, $filename = '' ) {
 		$this->_csv = '';
 		$this->_filename = $filename ? $filename : 'export.csv';
-		
+
 		if ( $this->_output = $output )
 			$this->start();
-			
+
 		if ( $columns )
 			$this->set_columns( $columns );
 	}
-	
+
 	function set_filename( $filename ) {
 		$this->_filename = $filename ? $filename : 'export.csv';
 	}
-	
+
 	/**
 	 * set_columns function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function set_columns( $columns = array() ) {
-		$this->add_row( $columns );	
+		$this->add_row( $columns );
 		unset( $columns );
 	}
-	
+
 	/**
 	 * add_row function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function add_row( $row ) {
-		
+
 		$row = implode( ',', array_map( array( &$this, 'wrap_column' ), $row ) ) . "\n";
-		
-		if ( $this->_output ) 
+
+		if ( $this->_output )
 			fwrite( $this->_csv, $row );
 		else
 			$this->_csv += $row;
-			
+
 		unset( $row );
 	}
-	
+
 	/**
 	 * start function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function start() {
 		if ( headers_sent() )
 			wp_die( 'Headers already sent' );
-			
+
 		@set_time_limit(0);
 		@ob_clean();
-		
+
 		header( "Content-Type: text/csv; charset=UTF-8" );
 		header( "Content-Disposition: attachment; filename={$this->_filename}" );
 		header( "Pragma: no-cache" );
 		header( "Expires: 0" );
-		
+
 		$this->_csv = fopen( 'php://output', 'w') ;
 	}
-	
+
 	/**
 	 * end function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -116,10 +116,10 @@ class WC_CSV_Exporter {
 		fclose( $this->_csv );
 		exit;
 	}
-	
+
 	/**
 	 * wrap_column function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $data
 	 * @return void
@@ -127,5 +127,5 @@ class WC_CSV_Exporter {
 	function wrap_column( $data ) {
 		return '"' . str_replace( '"', '""', $data ) . '"';
 	}
-	
+
 }

--- a/admin/includes/notice-install.php
+++ b/admin/includes/notice-install.php
@@ -1,5 +1,5 @@
-<?php 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 	
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<div class="squeezer">

--- a/admin/includes/notice-installed.php
+++ b/admin/includes/notice-installed.php
@@ -1,5 +1,5 @@
-<?php 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 	
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<div class="squeezer">

--- a/admin/includes/notice-update.php
+++ b/admin/includes/notice-update.php
@@ -1,5 +1,5 @@
-<?php 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 	
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<div class="squeezer">

--- a/admin/includes/notice-updated.php
+++ b/admin/includes/notice-updated.php
@@ -1,5 +1,5 @@
-<?php 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly 	
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<div class="squeezer">

--- a/admin/includes/updates/woocommerce-update-1.7.php
+++ b/admin/includes/updates/woocommerce-update-1.7.php
@@ -16,21 +16,21 @@ global $wpdb, $woocommerce;
 $existing_file_paths = $wpdb->get_results( "SELECT * FROM ". $wpdb->postmeta . " WHERE meta_key = '_file_path'" );
 
 if ( $existing_file_paths ) {
-	
+
 	foreach( $existing_file_paths as $existing_file_path ) {
-		
+
 		$existing_file_path->meta_value = trim( $existing_file_path->meta_value );
-		
-		if ( $existing_file_path->meta_value ) 
+
+		if ( $existing_file_path->meta_value )
 			$file_paths = maybe_serialize( array( md5( $existing_file_path->meta_value ) => $existing_file_path->meta_value ) );
-		else 
+		else
 			$file_paths = '';
-		
+
 		$wpdb->query( $wpdb->prepare( "UPDATE " . $wpdb->postmeta . " SET meta_key = '_file_paths', meta_value = %s WHERE meta_id = %d", $file_paths, $existing_file_path->meta_id ) );
-		
+
 		$wpdb->query( $wpdb->prepare( "UPDATE " . $wpdb->prefix . "woocommerce_downloadable_product_permissions SET download_id = %s WHERE product_id = %d", md5( $existing_file_path->meta_value ), $existing_file_path->post_id ) );
 	}
-	
+
 }
 
 // Update table primary keys
@@ -45,11 +45,11 @@ $shop_page_id 	= woocommerce_get_page_id( 'shop' );
 if ( empty( $permalinks ) && $shop_page_id > 0 ) {
 
 	$base_slug 		= $shop_page_id > 0 && get_page( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
-	
+
 	$category_base 	= get_option('woocommerce_prepend_shop_page_to_urls') == "yes" ? trailingslashit( $base_slug ) : '';
 	$category_slug 	= get_option('woocommerce_product_category_slug') ? get_option('woocommerce_product_category_slug') : _x( 'product-category', 'slug', 'woocommerce' );
 	$tag_slug 		= get_option('woocommerce_product_tag_slug') ? get_option('woocommerce_product_tag_slug') : _x( 'product-tag', 'slug', 'woocommerce' );
-	
+
 	if ( 'yes' == get_option('woocommerce_prepend_shop_page_to_products') ) {
 		$product_base = trailingslashit( $base_slug );
 	} else {
@@ -59,8 +59,8 @@ if ( empty( $permalinks ) && $shop_page_id > 0 ) {
 			$product_base = trailingslashit( _x('product', 'slug', 'woocommerce') );
 		}
 	}
-	
-	if ( get_option('woocommerce_prepend_category_to_products') == 'yes' ) 
+
+	if ( get_option('woocommerce_prepend_category_to_products') == 'yes' )
 		$product_base .= trailingslashit('%product_cat%');
 
 	$permalinks = array(
@@ -69,8 +69,8 @@ if ( empty( $permalinks ) && $shop_page_id > 0 ) {
 		'attribute_base' 	=> untrailingslashit( $category_base ),
 		'tag_base' 			=> untrailingslashit( $category_base . $tag_slug )
 	);
-	
-	update_option( 'woocommerce_permalinks', $permalinks );	
+
+	update_option( 'woocommerce_permalinks', $permalinks );
 }
 
 // Update subcat display settings
@@ -98,28 +98,28 @@ $order_item_rows = $wpdb->get_results( "
 " );
 
 foreach ( $order_item_rows as $order_item_row ) {
-	
+
 	$order_items = (array) maybe_unserialize( $order_item_row->meta_value );
-	
+
 	foreach ( $order_items as $order_item ) {
-		
+
 		if ( ! isset( $order_item['line_total'] ) && isset( $order_item['taxrate'] ) && isset( $order_item['cost'] ) ) {
 			$order_item['line_tax'] 			= number_format( ( $order_item['cost'] * $order_item['qty'] ) * ( $order_item['taxrate'] / 100 ), 2, '.', '' );
 			$order_item['line_total'] 			= $order_item['cost'] * $order_item['qty'];
 			$order_item['line_subtotal_tax'] 	= $order_item['line_tax'];
 			$order_item['line_subtotal'] 		= $order_item['line_total'];
 		}
-		
+
 		$order_item['line_tax'] 			= isset( $order_item['line_tax'] ) ? $order_item['line_tax'] : 0;
 		$order_item['line_total']			= isset( $order_item['line_total'] ) ? $order_item['line_total'] : 0;
 		$order_item['line_subtotal_tax'] 	= isset( $order_item['line_subtotal_tax'] ) ? $order_item['line_subtotal_tax'] : 0;
 		$order_item['line_subtotal'] 		= isset( $order_item['line_subtotal'] ) ? $order_item['line_subtotal'] : 0;
-		
+
 		$item_id = woocommerce_add_order_item( $order_item_row->post_id, array(
 	 		'order_item_name' 		=> $order_item['name'],
 	 		'order_item_type' 		=> 'line_item'
 	 	) );
-	 	
+
 	 	// Add line item meta
 	 	if ( $item_id ) {
 		 	woocommerce_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
@@ -130,9 +130,9 @@ foreach ( $order_item_rows as $order_item_row ) {
 		 	woocommerce_add_order_item_meta( $item_id, '_line_subtotal_tax', woocommerce_format_decimal( $order_item['line_subtotal_tax'] ) );
 		 	woocommerce_add_order_item_meta( $item_id, '_line_total', woocommerce_format_decimal( $order_item['line_total'] ) );
 		 	woocommerce_add_order_item_meta( $item_id, '_line_tax', woocommerce_format_decimal( $order_item['line_tax'] ) );
-		 	
+
 		 	$meta_rows = array();
-			
+
 			// Insert meta
 			if ( ! empty( $order_item['item_meta'] ) ) {
 				foreach ( $order_item['item_meta'] as $key => $meta ) {
@@ -144,7 +144,7 @@ foreach ( $order_item_rows as $order_item_row ) {
 					}
 				}
 			}
-			
+
 			// Insert meta rows at once
 			if ( sizeof( $meta_rows ) > 0 ) {
 				$wpdb->query( $wpdb->prepare( "
@@ -152,7 +152,7 @@ foreach ( $order_item_rows as $order_item_row ) {
 					VALUES " . implode( ',', $meta_rows ) . ";
 				", $order_item_row->post_id ) );
 			}
-			
+
 			// Delete from DB (rename)
 			$wpdb->query( $wpdb->prepare( "
 				UPDATE {$wpdb->postmeta}
@@ -161,7 +161,7 @@ foreach ( $order_item_rows as $order_item_row ) {
 				AND post_id = %d
 			", $order_item_row->post_id ) );
 	 	}
-		
+
 		unset( $meta_rows, $item_id, $order_item );
 	}
 }
@@ -174,27 +174,27 @@ $order_tax_rows = $wpdb->get_results( "
 " );
 
 foreach ( $order_tax_rows as $order_tax_row ) {
-	
+
 	$order_taxes = (array) maybe_unserialize( $order_tax_row->meta_value );
-	
+
 	if ( $order_taxes ) {
 		foreach( $order_taxes as $order_tax ) {
-		
+
 			if ( ! isset( $order_tax['label'] ) || ! isset( $order_tax['cart_tax'] ) || ! isset( $order_tax['shipping_tax'] ) )
 				continue;
-			
+
 			$item_id = woocommerce_add_order_item( $order_tax_row->post_id, array(
 		 		'order_item_name' 		=> $order_tax['label'],
 		 		'order_item_type' 		=> 'tax'
 		 	) );
-		 	
+
 		 	// Add line item meta
 		 	if ( $item_id ) {
 			 	woocommerce_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
 			 	woocommerce_add_order_item_meta( $item_id, 'tax_amount', woocommerce_clean( $order_tax['cart_tax'] ) );
 			 	woocommerce_add_order_item_meta( $item_id, 'shipping_tax_amount', woocommerce_clean( $order_tax['shipping_tax'] ) );
 			}
-			
+
 			// Delete from DB (rename)
 			$wpdb->query( $wpdb->prepare( "
 				UPDATE {$wpdb->postmeta}
@@ -202,7 +202,7 @@ foreach ( $order_tax_rows as $order_tax_row ) {
 				WHERE meta_key = '_order_taxes'
 				AND post_id = %d
 			", $order_tax_row->post_id ) );
-			
+
 			unset( $tax_amount );
 		}
 	}

--- a/admin/post-types/product.php
+++ b/admin/post-types/product.php
@@ -78,7 +78,7 @@ function woocommerce_edit_product_columns( $columns ) {
 
 	if ( empty( $columns ) && ! is_array( $columns ) )
 		$columns = array();
-		
+
 	unset( $columns['title'], $columns['comments'], $columns['date'] );
 
 	$columns["cb"] = "<input type=\"checkbox\" />";
@@ -1010,34 +1010,34 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 		update_post_meta( $post_id, '_weight', esc_html( stripslashes( $_REQUEST['_weight'] ) ) );
 
 	if ( ! empty( $_REQUEST['change_dimensions'] ) ) {
-		if ( isset( $_REQUEST['_length'] ) ) 
+		if ( isset( $_REQUEST['_length'] ) )
 			update_post_meta( $post_id, '_length', esc_html( stripslashes( $_REQUEST['_length'] ) ) );
-		if ( isset( $_REQUEST['_width'] ) ) 
+		if ( isset( $_REQUEST['_width'] ) )
 			update_post_meta( $post_id, '_width', esc_html( stripslashes( $_REQUEST['_width'] ) ) );
-		if ( isset( $_REQUEST['_height'] ) ) 
+		if ( isset( $_REQUEST['_height'] ) )
 			update_post_meta( $post_id, '_height', esc_html( stripslashes( $_REQUEST['_height'] ) ) );
 	}
 
-	if ( ! empty( $_REQUEST['_stock_status'] ) ) 
+	if ( ! empty( $_REQUEST['_stock_status'] ) )
 		update_post_meta( $post_id, '_stock_status', stripslashes( $_REQUEST['_stock_status'] ) );
 
-	if ( ! empty( $_REQUEST['_visibility'] ) ) 
+	if ( ! empty( $_REQUEST['_visibility'] ) )
 		update_post_meta( $post_id, '_visibility', stripslashes( $_REQUEST['_visibility'] ) );
 
-	if ( ! empty( $_REQUEST['_featured'] ) ) 
+	if ( ! empty( $_REQUEST['_featured'] ) )
 		update_post_meta( $post_id, '_featured', stripslashes( $_REQUEST['_featured'] ) );
 
 	// Handle price - remove dates and set to lowest
 	if ( $product->is_type( 'simple' ) || $product->is_type( 'external' ) ) {
 
 		$price_changed = false;
-		
+
 		if ( ! empty( $_REQUEST['change_regular_price'] ) ) {
-			
+
 			$old_price = $product->regular_price;
 			$change_regular_price = absint( $_REQUEST['change_regular_price'] );
 			$regular_price = esc_attr( stripslashes( $_REQUEST['_regular_price'] ) );
-		
+
 			switch ( $change_regular_price ) {
 				case 1 :
 					$new_price = $regular_price;
@@ -1050,7 +1050,7 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 						$new_price = $old_price + $regular_price;
 					}
 				break;
-				case 3 : 
+				case 3 :
 					if ( strstr( $regular_price, '%' ) ) {
 						$percent = str_replace( '%', '', $regular_price ) / 100;
 						$new_price = $old_price - ( $old_price * $percent );
@@ -1059,20 +1059,20 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 					}
 				break;
 			}
-			
+
 			if ( isset( $new_price ) && $new_price != $product->regular_price ) {
 				$price_changed = true;
 				update_post_meta( $post_id, '_regular_price', $new_price );
 				$product->regular_price = $new_price;
 			}
 		}
-		
+
 		if ( ! empty( $_REQUEST['change_sale_price'] ) ) {
-			
+
 			$old_price = $product->sale_price;
 			$change_sale_price = absint( $_REQUEST['change_sale_price'] );
 			$sale_price = esc_attr( stripslashes( $_REQUEST['_sale_price'] ) );
-		
+
 			switch ( $change_sale_price ) {
 				case 1 :
 					$new_price = $sale_price;
@@ -1085,7 +1085,7 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 						$new_price = $old_price + $sale_price;
 					}
 				break;
-				case 3 : 
+				case 3 :
 					if ( strstr( $sale_price, '%' ) ) {
 						$percent = str_replace( '%', '', $sale_price ) / 100;
 						$new_price = $old_price - ( $old_price * $percent );
@@ -1093,7 +1093,7 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 						$new_price = $old_price - $sale_price;
 					}
 				break;
-				case 4 : 
+				case 4 :
 					if ( strstr( $sale_price, '%' ) ) {
 						$percent = str_replace( '%', '', $sale_price ) / 100;
 						$new_price = $product->regular_price - ( $product->regular_price * $percent );
@@ -1102,18 +1102,18 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 					}
 				break;
 			}
-			
+
 			if ( isset( $new_price ) && $new_price != $product->sale_price ) {
 				$price_changed = true;
 				update_post_meta( $post_id, '_sale_price', $new_price );
 				$product->sale_price = $new_price;
 			}
 		}
-		
+
 		if ( $price_changed ) {
 			update_post_meta( $post_id, '_sale_price_dates_from', '' );
 			update_post_meta( $post_id, '_sale_price_dates_to', '' );
-			
+
 			if ( $product->regular_price < $product->sale_price ) {
 				$product->sale_price = '';
 				update_post_meta( $post_id, '_sale_price', '' );
@@ -1129,22 +1129,22 @@ function woocommerce_admin_product_bulk_edit_save( $post_id, $post ) {
 
 	// Handle stock
 	if ( ! $product->is_type( 'grouped' ) ) {
-		
+
 		if ( ! empty( $_REQUEST['change_stock'] ) ) {
 			update_post_meta( $post_id, '_stock', (int) $_REQUEST['_stock'] );
-			update_post_meta( $post_id, '_manage_stock', 'yes' );	
+			update_post_meta( $post_id, '_manage_stock', 'yes' );
 		}
-		
+
 		if ( ! empty( $_REQUEST['_manage_stock'] ) ) {
 
 			if ( $_REQUEST['_manage_stock'] == 'yes' ) {
-				update_post_meta( $post_id, '_manage_stock', 'yes' );					
+				update_post_meta( $post_id, '_manage_stock', 'yes' );
 			} else {
 				update_post_meta( $post_id, '_manage_stock', 'no' );
 				update_post_meta( $post_id, '_stock', '0' );
 			}
 		}
-		
+
 	}
 
 	// Clear transient
@@ -1181,18 +1181,18 @@ add_filter( 'views_edit-product', 'woocommerce_default_sorting_link' );
 
 /**
  * woocommerce_disable_checked_ontop function.
- * 
+ *
  * @access public
  * @param mixed $args
  * @param mixed $post_id
  * @return void
  */
 function woocommerce_disable_checked_ontop( $args ) {
-	
+
 	if ( $args['taxonomy'] == 'product_cat' ) {
 		$args['checked_ontop'] = false;
 	}
-	
+
 	return $args;
 }
 

--- a/admin/post-types/shop_coupon.php
+++ b/admin/post-types/shop_coupon.php
@@ -56,34 +56,34 @@ function woocommerce_custom_coupon_columns( $column ) {
 		case "products" :
 			$product_ids = get_post_meta( $post->ID, 'product_ids', true );
 			$product_ids = $product_ids ? array_map( 'absint', explode( ',', $product_ids ) ) : array();
-			if ( sizeof( $product_ids ) > 0 ) 
-				echo esc_html( implode( ', ', $product_ids ) ); 
-			else 
+			if ( sizeof( $product_ids ) > 0 )
+				echo esc_html( implode( ', ', $product_ids ) );
+			else
 				echo '&ndash;';
 		break;
 		case "usage_limit" :
 			$usage_limit = get_post_meta( $post->ID, 'usage_limit', true );
-			
-			if ( $usage_limit ) 
-				echo esc_html( $usage_limit ); 
-			else 
+
+			if ( $usage_limit )
+				echo esc_html( $usage_limit );
+			else
 				echo '&ndash;';
 		break;
 		case "usage" :
 			$usage_count = absint( get_post_meta( $post->ID, 'usage_count', true ) );
 			$usage_limit = esc_html( get_post_meta($post->ID, 'usage_limit', true) );
-			
-			if ( $usage_limit ) 
+
+			if ( $usage_limit )
 				printf( __( '%s / %s', 'woocommerce' ), $usage_count, $usage_limit );
 			else
 				printf( __( '%s / &infin;', 'woocommerce' ), $usage_count );
 		break;
 		case "expiry_date" :
 			$expiry_date = get_post_meta($post->ID, 'expiry_date', true);
-			
-			if ( $expiry_date ) 
-				echo esc_html( date_i18n( 'F j, Y', strtotime( $expiry_date ) ) ); 
-			else 
+
+			if ( $expiry_date )
+				echo esc_html( date_i18n( 'F j, Y', strtotime( $expiry_date ) ) );
+			else
 				echo '&ndash;';
 		break;
 		case "description" :

--- a/admin/post-types/shop_order.php
+++ b/admin/post-types/shop_order.php
@@ -76,16 +76,16 @@ function woocommerce_custom_order_columns( $column ) {
 		break;
 		case "order_title" :
 
-			if ( $order->user_id ) 
+			if ( $order->user_id )
 				$user_info = get_userdata( $order->user_id );
 
 			if ( ! empty( $user_info ) ) {
 
             	$user = '<a href="user-edit.php?user_id=' . absint( $user_info->ID ) . '">';
 
-            	if ( $user_info->first_name || $user_info->last_name ) 
+            	if ( $user_info->first_name || $user_info->last_name )
             		$user .= esc_html( $user_info->first_name . ' ' . $user_info->last_name );
-            	else 
+            	else
             		$user .= esc_html( $user_info->display_name );
 
             	$user .= '</a>';
@@ -98,7 +98,7 @@ function woocommerce_custom_order_columns( $column ) {
 
            	if ( $order->billing_email )
         		echo '<small class="meta">' . __( 'Email:', 'woocommerce' ) . ' ' . '<a href="' . esc_url( 'mailto:' . $order->billing_email ) . '">' . esc_html( $order->billing_email ) . '</a></small>';
-        	
+
         	if ( $order->billing_phone )
         		echo '<small class="meta">' . __( 'Tel:', 'woocommerce' ) . ' ' . esc_html( $order->billing_phone ) . '</small>';
 
@@ -394,7 +394,7 @@ add_filter( "manage_edit-shop_order_sortable_columns", 'woocommerce_custom_shop_
  */
 function woocommerce_custom_shop_order_orderby( $vars ) {
 	global $typenow, $wp_query;
-    if ( $typenow != 'shop_order' ) 
+    if ( $typenow != 'shop_order' )
     	return $vars;
 
     // Sorting
@@ -443,9 +443,9 @@ function woocommerce_shop_order_search_custom_fields( $wp ) {
 	) ) );
 
 	// Query matching custom fields - this seems faster than meta_query
-	$post_ids = $wpdb->get_col( 
-		$wpdb->prepare( 
-			"SELECT post_id FROM " . $wpdb->postmeta . " WHERE meta_key IN ('" . implode( "','", $search_fields ) . "') AND meta_value LIKE '%%%s%%'", esc_attr( $_GET['s'] ) 
+	$post_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT post_id FROM " . $wpdb->postmeta . " WHERE meta_key IN ('" . implode( "','", $search_fields ) . "') AND meta_value LIKE '%%%s%%'", esc_attr( $_GET['s'] )
 		)
 	);
 
@@ -473,7 +473,7 @@ function woocommerce_shop_order_search_custom_fields( $wp ) {
 
 	// Add ID
 	$search_order_id = str_replace( 'Order #', '', $_GET['s'] );
-	if ( is_numeric( $search_order_id ) ) 
+	if ( is_numeric( $search_order_id ) )
 		$post_ids[] = $search_order_id;
 
 	// Add blank ID so not all results are returned if the search finds nothing

--- a/admin/post-types/writepanels/order-download-permission-html.php
+++ b/admin/post-types/writepanels/order-download-permission-html.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div class="wc-metabox closed">

--- a/admin/post-types/writepanels/order-fee-html.php
+++ b/admin/post-types/writepanels/order-fee-html.php
@@ -1,16 +1,16 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <tr class="fee" data-order_item_id="<?php echo $item_id; ?>">
 	<td class="check-column"><input type="checkbox" /></td>
-	
+
 	<td class="thumb"></td>
-	
+
 	<td class="name">
 		<input type="text" placeholder="<?php _e( 'Fee Name', 'woocommerce' ); ?>" name="order_item_name[<?php echo absint( $item_id ); ?>]" value="<?php if ( isset( $item['name'] ) ) echo esc_attr( $item['name'] ); ?>" />
 		<input type="hidden" class="order_item_id" name="order_item_id[]" value="<?php echo esc_attr( $item_id ); ?>" />
 	</td>
-	
+
 	<td class="tax_class" width="1%">
 		<select class="tax_class" name="order_item_tax_class[<?php echo absint( $item_id ); ?>]" title="<?php _e( 'Tax class', 'woocommerce' ); ?>">
 			<?php $tax_class = isset( $item['tax_class'] ) ? sanitize_title( $item['tax_class'] ) : ''; ?>
@@ -18,15 +18,15 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			<optgroup label="<?php _e( 'Taxable', 'woocommerce' ); ?>">
 				<?php
 				$tax_classes = array_filter( array_map( 'trim', explode( "\n", get_option('woocommerce_tax_classes' ) ) ) );
-				
+
 				$classes_options = array();
 				$classes_options[''] = __( 'Standard', 'woocommerce' );
-				
-				if ( $tax_classes ) 
+
+				if ( $tax_classes )
 					foreach ( $tax_classes as $class )
 						$classes_options[ sanitize_title( $class ) ] = $class;
-				
-				foreach ( $classes_options as $value => $name ) 
+
+				foreach ( $classes_options as $value => $name )
 					echo '<option value="' . esc_attr( $value ) . '" ' . selected( $value, $tax_class, false ) . '>'. esc_html( $name ) . '</option>';
 				?>
 			</optgroup>

--- a/admin/post-types/writepanels/order-item-html.php
+++ b/admin/post-types/writepanels/order-item-html.php
@@ -1,30 +1,30 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <tr class="item <?php if ( ! empty( $class ) ) echo $class; ?>" data-order_item_id="<?php echo $item_id; ?>">
 	<td class="check-column"><input type="checkbox" /></td>
 	<td class="thumb">
 		<a href="<?php echo esc_url( admin_url( 'post.php?post=' . absint( $_product->id ) . '&action=edit' ) ); ?>" class="tips" data-tip="<?php
-			
+
 			echo '<strong>' . __( 'Product ID:', 'woocommerce' ) . '</strong> ' . absint( $item['product_id'] );
-			
-			if ( $item['variation_id'] ) 
-				echo '<br/><strong>' . __( 'Variation ID:', 'woocommerce' ) . '</strong> ' . absint( $item['variation_id'] ); 
-			
-			if ( $_product->get_sku() ) 
+
+			if ( $item['variation_id'] )
+				echo '<br/><strong>' . __( 'Variation ID:', 'woocommerce' ) . '</strong> ' . absint( $item['variation_id'] );
+
+			if ( $_product->get_sku() )
 				echo '<br/><strong>' . __( 'Product SKU:', 'woocommerce' ).'</strong> ' . esc_html( $_product->get_sku() );
-			
+
 		?>"><?php echo $_product->get_image(); ?></a>
 	</td>
 	<td class="name">
 
 		<?php if ( $_product->get_sku() ) echo esc_html( $_product->get_sku() ) . ' &ndash; '; ?>
-		
+
 		<a target="_blank" href="<?php echo esc_url( admin_url( 'post.php?post='. absint( $_product->id ) .'&action=edit' ) ); ?>"><?php echo esc_html( $item['name'] ); ?></a>
 		<input type="hidden" class="order_item_id" name="order_item_id[]" value="<?php echo esc_attr( $item_id ); ?>" />
-		
+
 		<?php
-			if ( isset( $_product->variation_data ) ) 
+			if ( isset( $_product->variation_data ) )
 				echo '<br/>' . woocommerce_get_formatted_variation( $_product->variation_data, true );
 		?>
 		<table class="meta" cellspacing="0">
@@ -37,9 +37,9 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			<?php
 				if ( $metadata = $order->has_meta( $item_id )) {
 					foreach ( $metadata as $meta ) {
-						
+
 						// Skip hidden core fields
-						if ( in_array( $meta['meta_key'], apply_filters( 'woocommerce_hidden_order_itemmeta', array( 
+						if ( in_array( $meta['meta_key'], apply_filters( 'woocommerce_hidden_order_itemmeta', array(
 							'_qty',
 							'_tax_class',
 							'_product_id',
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 							'_line_total',
 							'_line_tax'
 						) ) ) ) continue;
-						
+
 						// Handle serialised fields
 						if ( is_serialized( $meta['meta_value'] ) ) {
 							if ( is_serialized_string( $meta['meta_value'] ) ) {
@@ -62,8 +62,8 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 						$meta['meta_key'] = esc_attr( $meta['meta_key'] );
 						$meta['meta_value'] = esc_textarea( $meta['meta_value'] ); // using a <textarea />
-						$meta['meta_id'] = (int) $meta['meta_id'];			
-							
+						$meta['meta_id'] = (int) $meta['meta_id'];
+
 						echo '<tr data-meta_id="' . $meta['meta_id'] . '">
 							<td><input type="text" name="meta_key[' . $meta['meta_id'] . ']" value="' . $meta['meta_key'] . '" /></td>
 							<td><input type="text" name="meta_value[' . $meta['meta_id'] . ']" value="' . $meta['meta_value'] . '" /></td>
@@ -82,17 +82,17 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 		<select class="tax_class" name="order_item_tax_class[<?php echo absint( $item_id ); ?>]" title="<?php _e( 'Tax class', 'woocommerce' ); ?>">
 			<?php
 			$item_value = isset( $item['tax_class'] ) ? sanitize_title( $item['tax_class'] ) : '';
-			
+
 			$tax_classes = array_filter( array_map( 'trim', explode( "\n", get_option('woocommerce_tax_classes' ) ) ) );
-			
+
 			$classes_options = array();
 			$classes_options[''] = __( 'Standard', 'woocommerce' );
-			
-			if ( $tax_classes ) 
+
+			if ( $tax_classes )
 				foreach ( $tax_classes as $class )
 					$classes_options[ sanitize_title( $class ) ] = $class;
-			
-			foreach ( $classes_options as $value => $name ) 
+
+			foreach ( $classes_options as $value => $name )
 				echo '<option value="' . esc_attr( $value ) . '" ' . selected( $value, $item_value, false ) . '>'. esc_html( $name ) . '</option>';
 			?>
 		</select>
@@ -104,13 +104,13 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 	<td class="line_cost" width="1%">
 		<label><?php _e( 'Total', 'woocommerce' ); ?>: <input type="number" step="any" min="0" name="line_total[<?php echo absint( $item_id ); ?>]" placeholder="0.00" value="<?php if ( isset( $item['line_total'] ) ) echo esc_attr( $item['line_total'] ); ?>" class="line_total" /></label>
-		
+
 		<span class="subtotal"><label><?php _e( 'Subtotal', 'woocommerce' ); ?>: <input type="number" step="any" min="0" name="line_subtotal[<?php echo absint( $item_id ); ?>]" placeholder="0.00" value="<?php if ( isset( $item['line_subtotal'] ) ) echo esc_attr( $item['line_subtotal'] ); ?>" class="line_subtotal" /></label></span>
 	</td>
 
 	<td class="line_tax" width="1%">
 		<input type="number" step="any" min="0" name="line_tax[<?php echo absint( $item_id ); ?>]" placeholder="0.00" value="<?php if ( isset( $item['line_tax'] ) ) echo esc_attr( $item['line_tax'] ); ?>" class="line_tax" />
-		
+
 		<span class="subtotal"><input type="number" step="any" min="0" name="line_subtotal_tax[<?php echo absint( $item_id ); ?>]" placeholder="0.00" value="<?php if ( isset( $item['line_subtotal_tax'] ) ) echo esc_attr( $item['line_subtotal_tax'] ); ?>" class="line_subtotal_tax" /></span>
 	</td>
 

--- a/admin/post-types/writepanels/order-tax-html.php
+++ b/admin/post-types/writepanels/order-tax-html.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div class="tax_row" data-order_item_id="<?php echo $item_id; ?>">

--- a/admin/post-types/writepanels/variation-admin-html.php
+++ b/admin/post-types/writepanels/variation-admin-html.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
 <div class="woocommerce_variation wc-metabox closed">
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			foreach ( $parent_data['attributes'] as $attribute ) {
 
 				// Only deal with attributes that are variations
-				if ( ! $attribute['is_variation'] ) 
+				if ( ! $attribute['is_variation'] )
 					continue;
 
 				// Get current value for variation (if set)
@@ -60,7 +60,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 								<td>&nbsp;</td>
 							</tr>
 						<?php endif; ?>
-						
+
 						<tr>
 							<td>
 								<label><?php _e( 'Price:', 'woocommerce' ); ?></label>
@@ -68,10 +68,10 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 							</td>
 							<td>
 								<label><?php _e( 'Sale Price:', 'woocommerce' ); ?> <a href="#" class="sale_schedule"><?php _e( 'Schedule', 'woocommerce' ); ?></a><a href="#" class="cancel_sale_schedule" style="display:none"><?php _e( 'Cancel schedule', 'woocommerce' ); ?></a></label>
-								<input type="number" size="5" name="variable_sale_price[<?php echo $loop; ?>]" value="<?php if ( isset( $_sale_price ) ) echo esc_attr( $_sale_price ); ?>" step="any" min="0" /> 
+								<input type="number" size="5" name="variable_sale_price[<?php echo $loop; ?>]" value="<?php if ( isset( $_sale_price ) ) echo esc_attr( $_sale_price ); ?>" step="any" min="0" />
 							</td>
 						</tr>
-						
+
 						<tr class="sale_price_dates_fields" style="display:none">
 							<td>
 								<label><?php _e( 'Sale start date:', 'woocommerce' ) ?></label>
@@ -82,7 +82,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 								<input type="text" name="variable_sale_price_dates_to[<?php echo $loop; ?>]" value="<?php echo ! empty( $_sale_price_dates_to ) ? date_i18n( 'Y-m-d', $_sale_price_dates_to ) : ''; ?>" placeholder="<?php echo _x('To&hellip;', 'placeholder', 'woocommerce') ?> YYYY-MM-DD" maxlength="10" pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])" />
 							</td>
 						</tr>
-						
+
 						<?php if ( get_option( 'woocommerce_enable_weight', true ) !== 'no' || get_option( 'woocommerce_enable_dimensions', true ) !== 'no' ) : ?>
 							<tr>
 								<?php if ( get_option( 'woocommerce_enable_weight', true ) !== 'no' ) : ?>
@@ -116,11 +116,11 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 									'selected'			=> isset( $shipping_class ) ? esc_attr( $shipping_class ) : '',
 									'echo'				=> 0
 								);
-								
+
 								echo wp_dropdown_categories( $args );
 							?></td>
 							<td>
-								<label><?php _e( 'Tax class:', 'woocommerce' ); ?></label> 
+								<label><?php _e( 'Tax class:', 'woocommerce' ); ?></label>
 								<select name="variable_tax_class[<?php echo $loop; ?>]"><?php
 									foreach ( $parent_data['tax_class_options'] as $key => $value )
 										echo '<option value="' . esc_attr( $key ) . '" ' . selected( $key, $_tax_class, false ) . '>' . esc_html( $value ) . '</option>';
@@ -131,7 +131,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 							<td rowspan="2">
 								<div class="file_path_field">
 									<label><?php _e( 'File paths:', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'Enter one or more File Paths, one per line, to make this variation a downloadable product, or leave blank.', 'woocommerce' ); ?>" href="#">[?]</a></label>
-									<textarea style="float:left;" class="short file_paths" cols="20" rows="2" placeholder="<?php _e( 'File paths/URLs, one per line', 'woocommerce' ); ?>" name="variable_file_paths[<?php echo $loop; ?>]" wrap="off"><?php if ( isset( $_file_paths ) ) echo esc_textarea( $_file_paths ); ?></textarea> 
+									<textarea style="float:left;" class="short file_paths" cols="20" rows="2" placeholder="<?php _e( 'File paths/URLs, one per line', 'woocommerce' ); ?>" name="variable_file_paths[<?php echo $loop; ?>]" wrap="off"><?php if ( isset( $_file_paths ) ) echo esc_textarea( $_file_paths ); ?></textarea>
 									<input type="button"  class="upload_file_button button" value="<?php _e( 'Upload a file', 'woocommerce' ); ?>" title="<?php _e( 'Upload', 'woocommerce' ); ?>" />
 								</div>
 							</td>

--- a/admin/post-types/writepanels/writepanel-coupon_data.php
+++ b/admin/post-types/writepanels/writepanel-coupon_data.php
@@ -35,9 +35,9 @@ function woocommerce_coupon_data_meta_box( $post ) {
 
 			// Description
 			woocommerce_wp_text_input( array( 'id' => 'coupon_description', 'label' => __( 'Coupon description', 'woocommerce' ), 'description' => __( 'Optionally enter a description for this coupon for your reference.', 'woocommerce' ), 'value' => $post->post_excerpt, 'name' => 'excerpt' ) );
-			
+
 			echo '</div><div class="options_group">';
-			
+
 			// Type
     		woocommerce_wp_select( array( 'id' => 'discount_type', 'label' => __( 'Discount type', 'woocommerce' ), 'options' => $woocommerce->get_coupon_discount_types() ) );
 
@@ -46,7 +46,7 @@ function woocommerce_coupon_data_meta_box( $post ) {
 					'step' 	=> 'any',
 					'min'	=> '0'
 				)  ) );
-			
+
 			// Free Shipping
 			woocommerce_wp_checkbox( array( 'id' => 'free_shipping', 'label' => __( 'Enable free shipping', 'woocommerce' ), 'description' => sprintf(__( 'Check this box if the coupon grants free shipping. The <a href="%s">free shipping method</a> must be enabled with the "must use coupon" setting checked.', 'woocommerce' ), admin_url('admin.php?page=woocommerce_settings&tab=shipping&section=WC_Free_Shipping')) ) );
 
@@ -55,7 +55,7 @@ function woocommerce_coupon_data_meta_box( $post ) {
 
 			// Apply before tax
 			woocommerce_wp_checkbox( array( 'id' => 'apply_before_tax', 'label' => __( 'Apply before tax', 'woocommerce' ), 'description' => __( 'Check this box if the coupon should be applied before calculating cart tax.', 'woocommerce' ) ) );
-			
+
 			echo '</div><div class="options_group">';
 
 			// minimum spend
@@ -78,10 +78,10 @@ function woocommerce_coupon_data_meta_box( $post ) {
 							$title 	= get_the_title( $product_id );
 							$sku 	= get_post_meta( $product_id, '_sku', true );
 
-							if ( ! $title ) 
+							if ( ! $title )
 								continue;
 
-							if ( ! empty( $sku ) ) 
+							if ( ! empty( $sku ) )
 								$sku = ' (SKU: ' . $sku . ')';
 
 							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $title . $sku ) . '</option>';
@@ -103,10 +103,10 @@ function woocommerce_coupon_data_meta_box( $post ) {
 							$title 	= get_the_title( $product_id );
 							$sku 	= get_post_meta( $product_id, '_sku', true );
 
-							if ( ! $title ) 
+							if ( ! $title )
 								continue;
 
-							if ( ! empty( $sku ) ) 
+							if ( ! empty( $sku ) )
 								$sku = ' (SKU: ' . $sku . ')';
 
 							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $title . $sku ) . '</option>';
@@ -183,11 +183,11 @@ function woocommerce_coupon_data_meta_box( $post ) {
  */
 function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 	global $wpdb, $woocommerce_errors;
-	
+
 	// Ensure coupon code is correctly formatted
 	$post->post_title = apply_filters( 'woocommerce_coupon_code', $post->post_title );
 	$wpdb->update( $wpdb->posts, array( 'post_title' => $post->post_title ), array( 'ID' => $post_id ) );
-	
+
 	// Check for dupe coupons
 	$coupon_found = $wpdb->get_var( $wpdb->prepare( "
 		SELECT $wpdb->posts.ID
@@ -197,7 +197,7 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 	    AND $wpdb->posts.post_title = '%s'
 	    AND $wpdb->posts.ID != %s
 	 ", $post->post_title, $post_id ) );
-	 
+
 	if ( $coupon_found )
 		$woocommerce_errors[] = __( 'Coupon code already exists - customers will use the latest coupon with this code.', 'woocommerce' );
 

--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -23,7 +23,7 @@ function woocommerce_order_data_meta_box($post) {
 	global $post, $wpdb, $thepostid, $theorder, $order_status, $woocommerce;
 
 	$thepostid = absint( $post->ID );
-	
+
 	if ( ! is_object( $theorder ) )
 		$theorder = new WC_Order( $thepostid );
 
@@ -176,16 +176,16 @@ function woocommerce_order_data_meta_box($post) {
 						// Display values
 						echo '<div class="address">';
 
-							if ( $order->get_formatted_billing_address() ) 
-								echo '<p><strong>' . __( 'Address', 'woocommerce' ) . ':</strong><br/> ' . $order->get_formatted_billing_address() . '</p>'; 
-							else 
+							if ( $order->get_formatted_billing_address() )
+								echo '<p><strong>' . __( 'Address', 'woocommerce' ) . ':</strong><br/> ' . $order->get_formatted_billing_address() . '</p>';
+							else
 								echo '<p class="none_set"><strong>' . __( 'Address', 'woocommerce' ) . ':</strong> ' . __( 'No billing address set.', 'woocommerce' ) . '</p>';
 
-							foreach ( $billing_data as $key => $field ) { 
-								if ( empty( $field['show'] ) ) 
+							foreach ( $billing_data as $key => $field ) {
+								if ( empty( $field['show'] ) )
 									continue;
 								$field_name = 'billing_' . $key;
-								if ( $order->$field_name ) 
+								if ( $order->$field_name )
 									echo '<p><strong>' . esc_html( $field['label'] ) . ':</strong> ' . esc_html( $order->$field_name ) . '</p>';
 							}
 
@@ -195,7 +195,7 @@ function woocommerce_order_data_meta_box($post) {
 						echo '<div class="edit_address"><p><button class="button load_customer_billing">'.__( 'Load billing address', 'woocommerce' ).'</button></p>';
 
 						foreach ( $billing_data as $key => $field ) {
-							if ( ! isset( $field['type'] ) ) 
+							if ( ! isset( $field['type'] ) )
 								$field['type'] = 'text';
 							switch ( $field['type'] ) {
 								case "select" :
@@ -260,16 +260,16 @@ function woocommerce_order_data_meta_box($post) {
 						// Display values
 						echo '<div class="address">';
 
-							if ( $order->get_formatted_shipping_address() ) 
-								echo '<p><strong>' . __( 'Address', 'woocommerce' ) . ':</strong><br/> ' . $order->get_formatted_shipping_address() . '</p>'; 
-							else 
+							if ( $order->get_formatted_shipping_address() )
+								echo '<p><strong>' . __( 'Address', 'woocommerce' ) . ':</strong><br/> ' . $order->get_formatted_shipping_address() . '</p>';
+							else
 								echo '<p class="none_set"><strong>' . __( 'Address', 'woocommerce' ) . ':</strong> ' . __( 'No shipping address set.', 'woocommerce' ) . '</p>';
 
-							if ( $shipping_data ) foreach ( $shipping_data as $key => $field ) { 
-								if ( empty( $field['show'] ) ) 
+							if ( $shipping_data ) foreach ( $shipping_data as $key => $field ) {
+								if ( empty( $field['show'] ) )
 									continue;
 								$field_name = 'shipping_' . $key;
-								if ( $order->$field_name ) 
+								if ( $order->$field_name )
 									echo '<p><strong>' . esc_html( $field['label'] ) . ':</strong> ' . esc_html( $order->$field_name ) . '</p>';
 							}
 
@@ -279,7 +279,7 @@ function woocommerce_order_data_meta_box($post) {
 						echo '<div class="edit_address"><p><button class="button load_customer_shipping">' . __( 'Load shipping address', 'woocommerce' ) . '</button> <button class="button billing-same-as-shipping">'. __( 'Copy from billing', 'woocommerce' ) . '</button></p>';
 
 						if ( $shipping_data ) foreach ( $shipping_data as $key => $field ) {
-							if ( ! isset( $field['type'] ) ) 
+							if ( ! isset( $field['type'] ) )
 								$field['type'] = 'text';
 							switch ( $field['type'] ) {
 								case "select" :
@@ -315,7 +315,7 @@ function woocommerce_order_items_meta_box( $post ) {
 		$theorder = new WC_Order( $thepostid );
 
 	$order = $theorder;
-	
+
 	$data = get_post_custom( $post->ID );
 	?>
 	<div class="woocommerce_order_items_wrapper">
@@ -324,7 +324,7 @@ function woocommerce_order_items_meta_box( $post ) {
 				<tr>
 					<th><input type="checkbox" class="check-column" /></th>
 					<th class="item" colspan="2"><?php _e( 'Item', 'woocommerce' ); ?></th>
-					
+
 					<?php do_action( 'woocommerce_admin_order_item_headers' ); ?>
 
 					<th class="tax_class"><?php _e( 'Tax Class', 'woocommerce' ); ?>&nbsp;<a class="tips" data-tip="<?php _e( 'Tax class for the line item', 'woocommerce' ); ?>." href="#">[?]</a></th>
@@ -339,29 +339,29 @@ function woocommerce_order_items_meta_box( $post ) {
 			<tbody id="order_items_list">
 
 				<?php
-					// List order items 
+					// List order items
 					$order_items = $order->get_items( array( 'line_item', 'fee' ) );
-					
+
 					foreach ( $order_items as $item_id => $item ) {
-						
+
 						switch ( $item['type'] ) {
 							case 'line_item' :
 								$_product 	= $order->get_product_from_item( $item );
 								$item_meta 	= $order->get_item_meta( $item_id );
-						
+
 								include( 'order-item-html.php' );
 							break;
-							case 'fee' : 
+							case 'fee' :
 								include( 'order-fee-html.php' );
 							break;
 						}
-						
+
 					}
 				?>
 			</tbody>
 		</table>
 	</div>
-	
+
 	<p class="bulk_actions">
 		<select>
 			<option value=""><?php _e( 'Actions', 'woocommerce' ); ?></option>
@@ -388,7 +388,7 @@ function woocommerce_order_items_meta_box( $post ) {
 				<option value="increase_stock"><?php _e( 'Increase Line Stock', 'woocommerce' ); ?></option>
 			</optgroup>
 		</select>
-		
+
 		<button type="button" class="button do_bulk_action"><?php _e( 'Apply', 'woocommerce' ); ?></button>
 	</p>
 
@@ -456,9 +456,9 @@ function woocommerce_order_actions_meta_box($post) {
 					else
 						$delete_text = __( 'Move to Trash', 'woocommerce' );
 					?><a class="submitdelete deletion" href="<?php echo esc_url( get_delete_post_link( $post->ID ) ); ?>"><?php echo $delete_text; ?></a><?php
-				} 
+				}
 			?></div>
-			
+
 			<input type="submit" class="button save_order button-primary tips" name="save" value="<?php _e( 'Save Order', 'woocommerce' ); ?>" data-tip="<?php _e( 'Save/update the order', 'woocommerce' ); ?>" />
 		</li>
 	</ul>
@@ -475,10 +475,10 @@ function woocommerce_order_actions_meta_box($post) {
  */
 function woocommerce_order_totals_meta_box( $post ) {
 	global $woocommerce, $theorder;
-	
+
 	if ( ! is_object( $theorder ) )
 		$theorder = new WC_Order( $post->ID );
-		
+
 	$order = $theorder;
 
 	$data = get_post_custom( $post->ID );
@@ -490,7 +490,7 @@ function woocommerce_order_totals_meta_box( $post ) {
 			<li class="left">
 				<label><?php _e( 'Cart Discount:', 'woocommerce' ); ?>&nbsp;<a class="tips" data-tip="<?php _e( 'Discounts before tax - calculated by comparing subtotals to totals.', 'woocommerce' ); ?>" href="#">[?]</a></label>
 				<input type="number" step="any" min="0" id="_cart_discount" name="_cart_discount" placeholder="0.00" value="<?php
-					if ( isset( $data['_cart_discount'][0] ) ) 
+					if ( isset( $data['_cart_discount'][0] ) )
 						echo esc_attr( $data['_cart_discount'][0] );
 				?>" class="calculated" />
 			</li>
@@ -498,7 +498,7 @@ function woocommerce_order_totals_meta_box( $post ) {
 			<li class="right">
 				<label><?php _e( 'Order Discount:', 'woocommerce' ); ?>&nbsp;<a class="tips" data-tip="<?php _e( 'Discounts after tax - user defined.', 'woocommerce' ); ?>" href="#">[?]</a></label>
 				<input type="number" step="any" min="0" id="_order_discount" name="_order_discount" placeholder="0.00" value="<?php
-					if ( isset( $data['_order_discount'][0] ) ) 
+					if ( isset( $data['_order_discount'][0] ) )
 						echo esc_attr( $data['_order_discount'][0] );
 				?>" />
 			</li>
@@ -509,19 +509,19 @@ function woocommerce_order_totals_meta_box( $post ) {
 	<div class="totals_group">
 		<h4><?php _e( 'Shipping', 'woocommerce' ); ?></h4>
 		<ul class="totals">
-			
+
 			<li class="wide">
 				<label><?php _e( 'Label:', 'woocommerce' ); ?></label>
-				<input type="text" id="_shipping_method_title" name="_shipping_method_title" placeholder="<?php _e( 'The shipping title the customer sees', 'woocommerce' ); ?>" value="<?php 
-					if ( isset( $data['_shipping_method_title'][0] ) ) 
+				<input type="text" id="_shipping_method_title" name="_shipping_method_title" placeholder="<?php _e( 'The shipping title the customer sees', 'woocommerce' ); ?>" value="<?php
+					if ( isset( $data['_shipping_method_title'][0] ) )
 						echo esc_attr( $data['_shipping_method_title'][0] );
 				?>" class="first" />
 			</li>
-			
+
 			<li class="left">
 				<label><?php _e( 'Cost:', 'woocommerce' ); ?></label>
-				<input type="number" step="any" min="0" id="_order_shipping" name="_order_shipping" placeholder="0.00 <?php _e( '(ex. tax)', 'woocommerce' ); ?>" value="<?php 
-					if ( isset( $data['_order_shipping'][0] ) ) 
+				<input type="number" step="any" min="0" id="_order_shipping" name="_order_shipping" placeholder="0.00 <?php _e( '(ex. tax)', 'woocommerce' ); ?>" value="<?php
+					if ( isset( $data['_order_shipping'][0] ) )
 						echo esc_attr( $data['_order_shipping'][0] );
 				?>" class="first" />
 			</li>
@@ -574,7 +574,7 @@ function woocommerce_order_totals_meta_box( $post ) {
 			<li class="left">
 				<label><?php _e( 'Sales Tax:', 'woocommerce' ); ?>&nbsp;<a class="tips" data-tip="<?php _e( 'Total tax for line items + fees.', 'woocommerce' ); ?>" href="#">[?]</a></label>
 				<input type="number" step="any" min="0" id="_order_tax" name="_order_tax" placeholder="0.00" value="<?php
-					if ( isset( $data['_order_tax'][0] ) ) 
+					if ( isset( $data['_order_tax'][0] ) )
 						echo esc_attr( $data['_order_tax'][0] );
 				?>" class="calculated" />
 			</li>
@@ -582,7 +582,7 @@ function woocommerce_order_totals_meta_box( $post ) {
 			<li class="right">
 				<label><?php _e( 'Shipping Tax:', 'woocommerce' ); ?></label>
 				<input type="number" step="any" min="0" id="_order_shipping_tax" name="_order_shipping_tax" placeholder="0.00" value="<?php
-					if ( isset( $data['_order_shipping_tax'][0] ) ) 
+					if ( isset( $data['_order_shipping_tax'][0] ) )
 						echo esc_attr( $data['_order_shipping_tax'][0] );
 				?>" />
 			</li>
@@ -597,7 +597,7 @@ function woocommerce_order_totals_meta_box( $post ) {
 			<li class="left">
 				<label><?php _e( 'Order Total:', 'woocommerce' ); ?></label>
 				<input type="number" step="any" min="0" id="_order_total" name="_order_total" placeholder="0.00" value="<?php
-					if ( isset( $data['_order_total'][0] ) ) 
+					if ( isset( $data['_order_total'][0] ) )
 						echo esc_attr( $data['_order_total'][0] );
 				?>" class="calculated" />
 			</li>
@@ -733,95 +733,95 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 
 	// Tax rows
 	if ( isset( $_POST['order_taxes_id'] ) ) {
-		
+
 		$get_values = array( 'order_taxes_id', 'order_taxes_label', 'order_taxes_compound', 'order_taxes_amount', 'order_taxes_shipping_amount' );
 
 		foreach( $get_values as $value )
 			$$value = isset( $_POST[ $value ] ) ? $_POST[ $value ] : array();
 
 		foreach( $order_taxes_id as $item_id ) {
-			
+
 			$item_id = absint( $item_id );
 
-			if ( ! $order_taxes_label[ $item_id ] ) 
+			if ( ! $order_taxes_label[ $item_id ] )
 				$order_taxes_label[ $item_id ] = $woocommerce->countries->tax_or_vat();
 
 			if ( isset( $order_taxes_label[ $item_id ] ) )
-				$wpdb->update( 
-					$wpdb->prefix . "woocommerce_order_items", 
-					array( 'order_item_name' => woocommerce_clean( $order_taxes_label[ $item_id ] ) ), 
-					array( 'order_item_id' => $item_id ), 
-					array( '%s' ), 
-					array( '%d' ) 
+				$wpdb->update(
+					$wpdb->prefix . "woocommerce_order_items",
+					array( 'order_item_name' => woocommerce_clean( $order_taxes_label[ $item_id ] ) ),
+					array( 'order_item_id' => $item_id ),
+					array( '%s' ),
+					array( '%d' )
 				);
-			
+
 			if ( isset( $order_taxes_compound[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, 'compound', isset( $order_taxes_compound[ $item_id ] ) ? 1 : 0 );
-			
+
 			if ( isset( $order_taxes_amount[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, 'tax_amount', woocommerce_clean( $order_taxes_amount[ $item_id ] ) );
-		 		
+
 		 	if ( isset( $order_taxes_shipping_amount[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, 'shipping_tax_amount', woocommerce_clean( $order_taxes_shipping_amount[ $item_id ] ) );
 		}
 	}
-	
+
 
 	// Order items + fees
 	if ( isset( $_POST['order_item_id'] ) ) {
-	
+
 		$get_values = array( 'order_item_id', 'order_item_name', 'order_item_qty', 'line_subtotal', 'line_subtotal_tax', 'line_total', 'line_tax', 'order_item_tax_class' );
-		
+
 		foreach( $get_values as $value )
 			$$value = isset( $_POST[ $value ] ) ? $_POST[ $value ] : array();
 
 		foreach ( $order_item_id as $item_id ) {
-			
+
 			$item_id = absint( $item_id );
-			
+
 			if ( isset( $order_item_name[ $item_id ] ) )
-				$wpdb->update( 
-					$wpdb->prefix . "woocommerce_order_items", 
-					array( 'order_item_name' => woocommerce_clean( $order_item_name[ $item_id ] ) ), 
-					array( 'order_item_id' => $item_id ), 
-					array( '%s' ), 
-					array( '%d' ) 
+				$wpdb->update(
+					$wpdb->prefix . "woocommerce_order_items",
+					array( 'order_item_name' => woocommerce_clean( $order_item_name[ $item_id ] ) ),
+					array( 'order_item_id' => $item_id ),
+					array( '%s' ),
+					array( '%d' )
 				);
-		 		
+
 			if ( isset( $order_item_qty[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, '_qty', apply_filters( 'woocommerce_stock_amount', $order_item_qty[ $item_id ] ) );
-		 	
+
 		 	if ( isset( $item_tax_class[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, '_tax_class', woocommerce_clean( $item_tax_class[ $item_id ] ) );
-		 	
+
 		 	if ( isset( $line_subtotal[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, '_line_subtotal', woocommerce_clean( $line_subtotal[ $item_id ] ) );
-		 	
+
 		 	if ( isset(  $line_subtotal_tax[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, '_line_subtotal_tax', woocommerce_clean( $line_subtotal_tax[ $item_id ] ) );
-		 	
+
 		 	if ( isset( $line_total[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, '_line_total', woocommerce_clean( $line_total[ $item_id ] ) );
-		 	
+
 		 	if ( isset( $line_tax[ $item_id ] ) )
 		 		woocommerce_update_order_item_meta( $item_id, '_line_tax', woocommerce_clean( $line_tax[ $item_id ] ) );
 		}
 	}
-	
+
 	// Save meta
 	$meta_keys 		= isset( $_POST['meta_key'] ) ? $_POST['meta_key'] : '';
 	$meta_values 	= isset( $_POST['meta_value'] ) ? $_POST['meta_value'] : '';
-	
+
 	foreach ( $meta_keys as $id => $value ) {
-		$wpdb->update( 
-			$wpdb->prefix . "woocommerce_order_itemmeta", 
-			array( 
+		$wpdb->update(
+			$wpdb->prefix . "woocommerce_order_itemmeta",
+			array(
 				'meta_key' => $value,
 				'meta_value' => empty( $meta_values[ $id ] ) ? '' : $meta_values[ $id ]
-			), 
-			array( 'meta_id' => $id ), 
-			array( '%s', '%s' ), 
-			array( '%d' ) 
+			),
+			array( 'meta_id' => $id ),
+			array( '%s', '%s' ),
+			array( '%d' )
 		);
 	}
 
@@ -830,7 +830,7 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 
 	// Order status
 	$order->update_status( $_POST['order_status'] );
-	
+
 	// Handle button actions
 	if ( ! empty( $_POST['order_email'] ) ) {
 

--- a/admin/post-types/writepanels/writepanel-order_downloads.php
+++ b/admin/post-types/writepanels/writepanel-order_downloads.php
@@ -41,12 +41,12 @@ function woocommerce_order_downloads_meta_box() {
 					}
 
 					// don't show permissions to files that have since been removed
-					if ( ! $product->exists() || ! $product->has_file( $download->download_id ) ) 
+					if ( ! $product->exists() || ! $product->has_file( $download->download_id ) )
 						continue;
-						
+
 					$loop++;
 					$file_count++;
-					
+
 					include( 'order-download-permission-html.php' );
 				}
 			?>
@@ -77,7 +77,7 @@ function woocommerce_order_downloads_meta_box() {
 
 							$sku = get_post_meta( $product->ID, '_sku', true );
 
-							if ( $sku ) 
+							if ( $sku )
 								$sku = ' SKU: ' . $sku;
 
 							echo '<option value="' . esc_attr( $product->ID ) . '">' . esc_html( $product->post_title . ' (#' . $product->ID . '' . $sku . ')' ) . '</option>';
@@ -123,9 +123,9 @@ function woocommerce_order_downloads_meta_box() {
 				    jQuery('.order_download_permissions .wc-metaboxes').append( response );
 
 				} else {
-				
+
 					alert('<?php _e( 'Could not grant access - the user may already have permission for this file.', 'woocommerce' ); ?>');
-				
+
 				}
 
 				jQuery( ".date-picker" ).datepicker({
@@ -215,7 +215,7 @@ function woocommerce_order_downloads_save( $post_id, $post ) {
 		$customer_email 		= get_post_meta( $post->ID, '_billing_email', true );
 		$customer_user 			= get_post_meta( $post->ID, '_customer_user', true );
 		$product_ids_count 		= sizeof( $product_ids );
-		
+
 		for ( $i = 0; $i < $product_ids_count; $i ++ ) {
 
             $data = array(
@@ -239,8 +239,8 @@ function woocommerce_order_downloads_save( $post_id, $post ) {
 					'order_id' 		=> $post_id,
 					'product_id' 	=> absint( $product_ids[$i] ),
 					'download_id'	=> woocommerce_clean( $download_ids[$i] )
-					), 
-				$format, array( '%d', '%d', '%s' ) 
+					),
+				$format, array( '%d', '%d', '%s' )
 			);
 
 		}

--- a/admin/post-types/writepanels/writepanel-order_notes.php
+++ b/admin/post-types/writepanels/writepanel-order_notes.php
@@ -34,7 +34,7 @@ function woocommerce_order_notes_meta_box() {
 	if ( $notes ) {
 		foreach( $notes as $note ) {
 			$note_classes = get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ? array( 'customer-note', 'note' ) : array( 'note' );
-			
+
 			?>
 			<li rel="<?php echo absint( $note->comment_ID ) ; ?>" class="<?php echo implode( ' ', $note_classes ); ?>">
 				<div class="note_content">

--- a/admin/post-types/writepanels/writepanel-product-type-variable.php
+++ b/admin/post-types/writepanels/writepanel-product-type-variable.php
@@ -52,7 +52,7 @@ function variable_product_type_options() {
 	$tax_class_options = array();
 	$tax_class_options['parent'] = __( 'Same as parent', 'woocommerce' );
 	$tax_class_options[''] = __( 'Standard', 'woocommerce' );
-	if ( $tax_classes ) 
+	if ( $tax_classes )
 		foreach ( $tax_classes as $class )
 			$tax_class_options[ sanitize_title( $class ) ] = esc_attr( $class );
 	?>
@@ -103,19 +103,19 @@ function variable_product_type_options() {
 					'height' 	=> get_post_meta( $post->ID, '_height', true ),
 					'tax_class' => get_post_meta( $post->ID, '_tax_class', true )
 				);
-	
+
 				if ( ! $parent_data['weight'] )
 					$parent_data['weight'] = '0.00';
-					
+
 				if ( ! $parent_data['length'] )
 					$parent_data['length'] = '0';
-					
+
 				if ( ! $parent_data['width'] )
 					$parent_data['width'] = '0';
-					
+
 				if ( ! $parent_data['height'] )
 					$parent_data['height'] = '0';
-		
+
 				// Get variations
 				$args = array(
 					'post_type'		=> 'product_variation',
@@ -128,19 +128,19 @@ function variable_product_type_options() {
 				$variations = get_posts( $args );
 				$loop = 0;
 				if ( $variations ) foreach ( $variations as $variation ) {
-					
+
 					$variation_id 			= absint( $variation->ID );
 					$variation_post_status 	= esc_attr( $variation->post_status );
 					$variation_data 		= get_post_custom( $variation_id );
 					$variation_data['variation_post_id'] = $variation_id;
-					
+
 					// Grab shipping classes
 					$shipping_classes = get_the_terms( $variation_id, 'product_shipping_class' );
 					$shipping_class = ( $shipping_classes && ! is_wp_error( $shipping_classes ) ) ? current( $shipping_classes )->term_id : '';
-										
-					$variation_fields = array( 
+
+					$variation_fields = array(
 						'_sku',
-						'_stock', 
+						'_stock',
 						'_price',
 						'_regular_price',
 						'_sale_price',
@@ -158,28 +158,28 @@ function variable_product_type_options() {
 						'_sale_price_dates_from',
 						'_sale_price_dates_to'
 					);
-					
+
 					foreach ( $variation_fields as $field )
 						$$field = isset( $variation_data[ $field ][0] ) ? $variation_data[ $field ][0] : '';
-					
+
 					// Price backwards compat
 					if ( $_regular_price == '' && $_price )
 						$_regular_price = $_price;
-						
+
 					// Get image
 					$image = '';
 					$image_id = absint( $_thumbnail_id );
 					if ( $image_id )
 						$image = wp_get_attachment_url( $image_id );
-				
+
 					// Format file paths
 					$_file_paths = maybe_unserialize( $_file_paths );
-					if ( is_array( $_file_paths ) ) 
+					if ( is_array( $_file_paths ) )
 						$_file_paths = implode( "\n", $_file_paths );
-						
+
 					include( 'variation-admin-html.php' );
-					
-					$loop++; 
+
+					$loop++;
 				}
 				?>
 			</div>
@@ -196,7 +196,7 @@ function variable_product_type_options() {
 					foreach ( $attributes as $attribute ) {
 
 						// Only deal with attributes that are variations
-						if ( ! $attribute['is_variation'] ) 
+						if ( ! $attribute['is_variation'] )
 							continue;
 
 						// Get current value for variation (if set)
@@ -235,9 +235,9 @@ function variable_product_type_options() {
 		jQuery('#variable_product_options').on('click', 'button.add_variation', function(){
 
 			jQuery('.woocommerce_variations').block({ message: null, overlayCSS: { background: '#fff url(<?php echo $woocommerce->plugin_url(); ?>/assets/images/ajax-loader.gif) no-repeat center', opacity: 0.6 } });
-			
+
 			var loop = jQuery('.woocommerce_variation').size();
-			
+
 			var data = {
 				action: 'woocommerce_add_variation',
 				post_id: <?php echo $post->ID; ?>,
@@ -248,7 +248,7 @@ function variable_product_type_options() {
 			jQuery.post('<?php echo admin_url('admin-ajax.php'); ?>', data, function(response) {
 
 				jQuery('.woocommerce_variations').append( response );
-				
+
 				jQuery(".tips").tipTip({
 			    	'attribute' : 'data-tip',
 			    	'fadeIn' : 50,
@@ -379,7 +379,7 @@ function variable_product_type_options() {
 		jQuery('a.bulk_edit').click(function() {
 			var field_to_edit = jQuery('select#field_to_edit').val();
 			var input_tag = jQuery('select#field_to_edit :selected').attr('rel') ? jQuery('select#field_to_edit :selected').attr('rel') : 'input';
-			
+
 			var value = prompt("<?php _e( 'Enter a value', 'woocommerce' ); ?>");
 			jQuery(input_tag + '[name^="' + field_to_edit + '"]').val( value );
 			return false;
@@ -572,7 +572,7 @@ function process_product_meta_variable( $post_id ) {
 
 		for ( $i = 0; $i <= $max_loop; $i ++ ) {
 
-			if ( ! isset( $variable_post_id[ $i ] ) ) 
+			if ( ! isset( $variable_post_id[ $i ] ) )
 				continue;
 
 			$variation_id = absint( $variable_post_id[ $i ] );
@@ -599,15 +599,15 @@ function process_product_meta_variable( $post_id ) {
 					'post_type' 	=> 'product_variation',
 					'menu_order' 	=> $variable_menu_order[ $i ]
 				);
-				
+
 				$variation_id = wp_insert_post( $variation );
-				
+
 				do_action( 'woocommerce_create_product_variation', $variation_id );
 
 			} else {
 
 				$wpdb->update( $wpdb->posts, array( 'post_status' => $post_status, 'post_title' => $variation_post_title, 'menu_order' => $variable_menu_order[ $i ] ), array( 'ID' => $variation_id ) );
-				
+
 				do_action( 'woocommerce_update_product_variation', $variation_id );
 
 			}
@@ -625,22 +625,22 @@ function process_product_meta_variable( $post_id ) {
 
 			update_post_meta( $variation_id, '_virtual', woocommerce_clean( $is_virtual ) );
 			update_post_meta( $variation_id, '_downloadable', woocommerce_clean( $is_downloadable ) );
-			
+
 			// Price handling
 			$regular_price 	= woocommerce_clean( $variable_regular_price[ $i ] );
 			$sale_price 	= woocommerce_clean( $variable_sale_price[ $i ] );
 			$date_from 		= woocommerce_clean( $variable_sale_price_dates_from[ $i ] );
 			$date_to		= woocommerce_clean( $variable_sale_price_dates_to[ $i ] );
-			
+
 			update_post_meta( $variation_id, '_regular_price', $regular_price );
 			update_post_meta( $variation_id, '_sale_price', $sale_price );
-			
+
 			// Save Dates
 			if ( $date_from )
 				update_post_meta( $variation_id, '_sale_price_dates_from', strtotime( $date_from ) );
 			else
 				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
-	
+
 			if ( $date_to )
 				update_post_meta( $variation_id, '_sale_price_dates_to', strtotime( $date_to ) );
 			else
@@ -657,13 +657,13 @@ function process_product_meta_variable( $post_id ) {
 
 			if ( $date_from && strtotime( $date_from ) < strtotime( 'NOW', current_time( 'timestamp' ) ) )
 				update_post_meta( $variation_id, '_price', $sale_price );
-	
+
 			if ( $date_to && strtotime( $date_to ) < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
 				update_post_meta( $variation_id, '_price', $regular_price );
 				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
 				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
 			}
-					
+
 			if ( $variable_tax_class[ $i ] !== 'parent' )
 				update_post_meta( $variation_id, '_tax_class', woocommerce_clean( $variable_tax_class[ $i ] ) );
 			else
@@ -672,13 +672,13 @@ function process_product_meta_variable( $post_id ) {
 			if ( $is_downloadable == 'yes' ) {
 				update_post_meta( $variation_id, '_download_limit', woocommerce_clean( $variable_download_limit[ $i ] ) );
 				update_post_meta( $variation_id, '_download_expiry', woocommerce_clean( $variable_download_expiry[ $i ] ) );
-				
+
 				$_file_paths = array();
 				$file_paths = str_replace( "\r\n", "\n", $variable_file_paths[ $i ] );
 				$file_paths = trim( preg_replace( "/\n+/", "\n", $file_paths ) );
 				if ( $file_paths ) {
 					$file_paths = explode( "\n", $file_paths );
-	
+
 					foreach ( $file_paths as $file_path ) {
 						$file_path = woocommerce_clean( $file_path );
 						$_file_paths[ md5( $file_path ) ] = $file_path;
@@ -700,7 +700,7 @@ function process_product_meta_variable( $post_id ) {
 			wp_set_object_terms( $variation_id, $variable_shipping_class[ $i ], 'product_shipping_class');
 
 			// Remove old taxonomies attributes so data is kept up to date
-			if ( $variation_id ) 
+			if ( $variation_id )
 				$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->postmeta WHERE meta_key LIKE %s AND post_id = %d;", 'attribute_%', $variation_id ) );
 
 			// Update taxonomies
@@ -714,7 +714,7 @@ function process_product_meta_variable( $post_id ) {
 				}
 
 			}
-			
+
 			do_action( 'woocommerce_save_product_variation', $variation_id );
 
 		 }
@@ -740,20 +740,20 @@ function process_product_meta_variable( $post_id ) {
 			$child_price 			= get_post_meta( $child, '_price', true );
 			$child_regular_price 	= get_post_meta( $child, '_regular_price', true );
 			$child_sale_price 		= get_post_meta( $child, '_sale_price', true );
-			
+
 			// Regular prices
-			if ( ! is_numeric( $lowest_regular_price ) || $child_regular_price < $lowest_regular_price ) 
+			if ( ! is_numeric( $lowest_regular_price ) || $child_regular_price < $lowest_regular_price )
 				$lowest_regular_price = $child_regular_price;
-				
-			if ( ! is_numeric( $highest_regular_price ) || $child_regular_price > $highest_regular_price ) 
+
+			if ( ! is_numeric( $highest_regular_price ) || $child_regular_price > $highest_regular_price )
 				$highest_regular_price = $child_regular_price;
-			
+
 			// Sale prices
 			if ( $child_price == $child_sale_price ) {
-				if ( $child_sale_price !== '' && ( ! is_numeric( $lowest_sale_price ) || $child_sale_price < $lowest_sale_price ) ) 
+				if ( $child_sale_price !== '' && ( ! is_numeric( $lowest_sale_price ) || $child_sale_price < $lowest_sale_price ) )
 					$lowest_sale_price = $child_sale_price;
-				
-				if ( $child_sale_price !== '' && ( ! is_numeric( $highest_sale_price ) || $child_sale_price > $highest_sale_price ) ) 
+
+				if ( $child_sale_price !== '' && ( ! is_numeric( $highest_sale_price ) || $child_sale_price > $highest_sale_price ) )
 					$highest_sale_price = $child_sale_price;
 			}
 		}

--- a/admin/post-types/writepanels/writepanel-product_data.php
+++ b/admin/post-types/writepanels/writepanel-product_data.php
@@ -9,7 +9,7 @@
  * @package 	WooCommerce/Admin/WritePanels
  * @version     1.7.0
  */
- 
+
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /** Variable products */
@@ -69,9 +69,9 @@ function woocommerce_product_data_box() {
 	<div class="panel-wrap product_data">
 
 		<span class="type_box"> &mdash; <?php echo $type_box; ?></span>
-		
+
 		<div class="wc-tabs-back"></div>
-		
+
 		<ul class="product_data_tabs wc-tabs" style="display:none;">
 
 			<li class="active general_options hide_if_grouped"><a href="#general_product_data"><?php _e( 'General', 'woocommerce' ); ?></a></li>
@@ -146,9 +146,9 @@ function woocommerce_product_data_box() {
 
 				// File URL
 				$file_paths = get_post_meta( $post->ID, '_file_paths', true );
-				if ( is_array( $file_paths ) ) 
+				if ( is_array( $file_paths ) )
 					$file_paths = implode( "\n", $file_paths );
-				
+
 				echo '<p class="form-field"><label for="_file_paths">' . __( 'File paths (one per line)', 'woocommerce' ) . ':</label>
 					<textarea style="float:left;height:5em;" id="_file_paths" class="short file_paths" cols="20" rows="3" placeholder="' . __( 'File paths/URLs, one per line', 'woocommerce' ) . '" name="_file_paths" wrap="off">' . esc_textarea( $file_paths ) . '</textarea>
 					<input type="button" class="upload_file_button button" value="' . __( 'Upload a file', 'woocommerce' ) . '" />
@@ -169,27 +169,27 @@ function woocommerce_product_data_box() {
 				do_action( 'woocommerce_product_options_downloads' );
 
 			echo '</div>';
-			
+
 			echo '<div class="options_group show_if_simple show_if_variable">';
-			
+
 				// Tax
 				woocommerce_wp_select( array( 'id' => '_tax_status', 'label' => __( 'Tax Status', 'woocommerce' ), 'options' => array(
 					'taxable' 	=> __( 'Taxable', 'woocommerce' ),
 					'shipping' 	=> __( 'Shipping only', 'woocommerce' ),
 					'none' 		=> __( 'None', 'woocommerce' )
 				) ) );
-	
+
 				$tax_classes = array_filter( array_map( 'trim', explode( "\n", get_option( 'woocommerce_tax_classes' ) ) ) );
 				$classes_options = array();
 				$classes_options[''] = __( 'Standard', 'woocommerce' );
-	    		if ( $tax_classes ) 
+	    		if ( $tax_classes )
 	    			foreach ( $tax_classes as $class )
 	    				$classes_options[ sanitize_title( $class ) ] = esc_html( $class );
-	
+
 				woocommerce_wp_select( array( 'id' => '_tax_class', 'label' => __( 'Tax Class', 'woocommerce' ), 'options' => $classes_options ) );
-	
+
 				do_action( 'woocommerce_product_options_tax' );
-			
+
 			echo '</div>';
 
 			do_action( 'woocommerce_product_options_general_product_data' );
@@ -199,7 +199,7 @@ function woocommerce_product_data_box() {
 		<div id="inventory_product_data" class="panel woocommerce_options_panel">
 
 			<?php
-			
+
 			echo '<div class="options_group">';
 
 			if (get_option('woocommerce_manage_stock')=='yes') {
@@ -242,9 +242,9 @@ function woocommerce_product_data_box() {
 				echo '</div>';
 
 			}
-			
+
 			echo '</div>';
-			
+
 			echo '<div class="options_group show_if_simple show_if_variable">';
 
 			// Individual product
@@ -259,11 +259,11 @@ function woocommerce_product_data_box() {
 		</div>
 
 		<div id="shipping_product_data" class="panel woocommerce_options_panel">
-			
+
 			<?php
-			
+
 			echo '<div class="options_group">';
-				
+
 				// Weight
 				if( get_option('woocommerce_enable_weight', true) !== 'no' ) :
 					woocommerce_wp_text_input( array( 'id' => '_weight', 'label' => __( 'Weight', 'woocommerce' ) . ' ('.get_option('woocommerce_weight_unit').')', 'placeholder' => '0.00', 'description' => __( 'Weight in decimal form', 'woocommerce' ), 'type' => 'number', 'custom_attributes' => array(
@@ -294,7 +294,7 @@ function woocommerce_product_data_box() {
 				do_action( 'woocommerce_product_options_dimensions' );
 
 			echo '</div>';
-			
+
 			echo '<div class="options_group">';
 
 				// Shipping Class
@@ -313,7 +313,7 @@ function woocommerce_product_data_box() {
 				?><p class="form-field dimensions_field"><label for="product_shipping_class"><?php _e( 'Shipping class', 'woocommerce' ); ?></label> <?php wp_dropdown_categories( $args ); ?> <span class="description"><?php _e( 'Shipping classes are used by certain shipping methods to group similar products.', 'woocommerce' ); ?></span></p><?php
 
 				do_action( 'woocommerce_product_options_shipping' );
-				
+
 			echo '</div>';
 			?>
 
@@ -344,7 +344,7 @@ function woocommerce_product_data_box() {
 				    		if ( ! taxonomy_exists( $attribute_taxonomy_name ) ) continue;
 
 				    		// Get product data values for current taxonomy - this contains ordering and visibility data
-				    		if ( isset( $attributes[ $attribute_taxonomy_name ] ) ) 
+				    		if ( isset( $attributes[ $attribute_taxonomy_name ] ) )
 				    			$attribute = $attributes[ $attribute_taxonomy_name ];
 
 				    		$position = empty( $attribute['position'] ) ? 0 : absint( $attribute['position'] );
@@ -487,14 +487,14 @@ function woocommerce_product_data_box() {
 					    }
 					?>
 				</select>
-				
+
 				<button type="button" class="button save_attributes"><?php _e( 'Save attributes', 'woocommerce' ); ?></button>
 			</p>
 		</div>
 		<div id="linked_product_data" class="panel woocommerce_options_panel">
-			
+
 			<div class="options_group">
-			
+
 			<p class="form-field"><label for="upsell_ids"><?php _e( 'Up-Sells', 'woocommerce' ); ?></label>
 			<select id="upsell_ids" name="upsell_ids[]" class="ajax_chosen_select_products" multiple="multiple" data-placeholder="<?php _e( 'Search for a product&hellip;', 'woocommerce' ); ?>">
 				<?php
@@ -503,11 +503,11 @@ function woocommerce_product_data_box() {
 						foreach ( $product_ids as $product_id ) {
 							$title 	= get_the_title( $product_id );
 							$sku 	= get_post_meta( $product_id, '_sku', true );
-							
-							if ( ! $title ) 
+
+							if ( ! $title )
 								continue;
-								
-							if ( ! empty( $sku ) ) 
+
+							if ( ! empty( $sku ) )
 								$sku = ' (SKU: ' . $sku . ')';
 
 							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $title . $sku ) . '</option>';
@@ -524,11 +524,11 @@ function woocommerce_product_data_box() {
 						foreach ( $product_ids as $product_id ) {
 							$title 	= get_the_title( $product_id );
 							$sku 	= get_post_meta( $product_id, '_sku', true );
-							
-							if ( ! $title ) 
+
+							if ( ! $title )
 								continue;
-								
-							if ( ! empty( $sku ) ) 
+
+							if ( ! empty( $sku ) )
 								$sku = ' (SKU: ' . $sku . ')';
 
 							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $title . $sku ) . '</option>';
@@ -536,11 +536,11 @@ function woocommerce_product_data_box() {
 					}
 				?>
 			</select> <img class="help_tip" data-tip='<?php _e( 'Cross-sells are products which you promote in the cart, based on the current product.', 'woocommerce' ) ?>' src="<?php echo $woocommerce->plugin_url(); ?>/assets/images/help.png" /></p>
-			
+
 			</div>
 
 			<?php
-			
+
 			echo '<div class="options_group grouping show_if_simple show_if_external">';
 
 				// List Grouped products
@@ -563,7 +563,7 @@ function woocommerce_product_data_box() {
 					if ( $grouped_products ) {
 						foreach ( $grouped_products as $product ) {
 
-							if ( $product->ID == $post->ID ) 
+							if ( $product->ID == $post->ID )
 								continue;
 
 							$post_parents[ $product->ID ] = $product->post_title;
@@ -572,14 +572,14 @@ function woocommerce_product_data_box() {
 				}
 
 				woocommerce_wp_select( array( 'id' => 'parent_id', 'label' => __( 'Grouping', 'woocommerce' ), 'value' => absint( $post->post_parent ), 'options' => $post_parents, 'desc_tip' => true, 'description' => __( 'Set this option to make this product part of a grouped product.', 'woocommerce' ) ) );
-				
+
 				woocommerce_wp_hidden_input( array( 'id' => 'previous_parent_id', 'value' => absint( $post->post_parent ) ) );
 
 				do_action( 'woocommerce_product_options_grouping' );
 
 			echo '</div>';
 			?>
-			
+
 			<?php do_action( 'woocommerce_product_options_related' ); ?>
 
 		</div>
@@ -616,7 +616,7 @@ function woocommerce_product_data_box() {
 		</div>
 
 		<?php do_action( 'woocommerce_product_write_panels' ); ?>
-		
+
 		<div class="clear"></div>
 
 	</div>
@@ -650,7 +650,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 
 	// Set transient for product type
 	set_transient( 'wc_product_type_' . $post_id, $product_type );
-	
+
 	// Update post meta
 	update_post_meta( $post_id, '_regular_price', stripslashes( $_POST['_regular_price'] ) );
 	update_post_meta( $post_id, '_sale_price', stripslashes( $_POST['_sale_price'] ) );
@@ -658,7 +658,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 	update_post_meta( $post_id, '_tax_class', stripslashes( $_POST['_tax_class'] ) );
 	update_post_meta( $post_id, '_visibility', stripslashes( $_POST['_visibility'] ) );
 	update_post_meta( $post_id, '_purchase_note', stripslashes( $_POST['_purchase_note'] ) );
-	update_post_meta( $post_id, '_featured', isset( $_POST['_featured'] ) ? 'yes' : 'no' ); 
+	update_post_meta( $post_id, '_featured', isset( $_POST['_featured'] ) ? 'yes' : 'no' );
 
 	// Dimensions
 	if ( $is_virtual == 'no' ) {
@@ -709,20 +709,20 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 	if ( isset( $_POST['attribute_names'] ) ) {
 		$attribute_names = $_POST['attribute_names'];
 		$attribute_values = $_POST['attribute_values'];
-		
-		if ( isset( $_POST['attribute_visibility'] ) ) 
+
+		if ( isset( $_POST['attribute_visibility'] ) )
 			$attribute_visibility = $_POST['attribute_visibility'];
-			
-		if ( isset( $_POST['attribute_variation'] ) ) 
+
+		if ( isset( $_POST['attribute_variation'] ) )
 			$attribute_variation = $_POST['attribute_variation'];
-		
+
 		$attribute_is_taxonomy = $_POST['attribute_is_taxonomy'];
 		$attribute_position = $_POST['attribute_position'];
 
 		$attribute_names_count = sizeof( $attribute_names );
 
 		for ( $i=0; $i < $attribute_names_count; $i++ ) {
-			if ( ! $attribute_names[ $i ] ) 
+			if ( ! $attribute_names[ $i ] )
 				continue;
 
 			$is_visible 	= isset( $attribute_visibility[ $i ] ) ? 1 : 0;
@@ -800,17 +800,17 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 	update_post_meta( $post_id, '_product_attributes', $attributes );
 
 	// Sales and prices
-	if ( in_array( $product_type, array( 'variable', 'grouped' ) ) ) { 
-		
+	if ( in_array( $product_type, array( 'variable', 'grouped' ) ) ) {
+
 		// Variable and grouped products have no prices
 		update_post_meta( $post_id, '_regular_price', '' );
 		update_post_meta( $post_id, '_sale_price', '' );
 		update_post_meta( $post_id, '_sale_price_dates_from', '' );
 		update_post_meta( $post_id, '_sale_price_dates_to', '' );
 		update_post_meta( $post_id, '_price', '' );
-		
+
 	} else {
-	
+
 		$date_from = isset( $_POST['_sale_price_dates_from'] ) ? $_POST['_sale_price_dates_from'] : '';
 		$date_to = isset( $_POST['_sale_price_dates_to'] ) ? $_POST['_sale_price_dates_to'] : '';
 
@@ -846,21 +846,21 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 
 	// Update parent if grouped so price sorting works and stays in sync with the cheapest child
 	if ( $post->post_parent > 0 || $product_type == 'grouped' || $_POST['previous_parent_id'] > 0 ) {
-		
+
 		$clear_parent_ids = array();
-		
+
 		if ( $post->post_parent > 0 )
 			$clear_parent_ids[] = $post->post_parent;
-			
+
 		if ( $product_type == 'grouped' )
 			$clear_parent_ids[] = $post_id;
-			
+
 		if ( $_POST['previous_parent_id'] > 0 )
 			$clear_parent_ids[] = absint( $_POST['previous_parent_id'] );
 
 		if ( $clear_parent_ids ) {
 			foreach( $clear_parent_ids as $clear_id ) {
-				
+
 				$children_by_price = get_posts( array(
 					'post_parent' 	=> $clear_id,
 					'orderby' 		=> 'meta_value_num',
@@ -876,7 +876,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 						update_post_meta( $clear_id, '_price', $child_price );
 					}
 				}
-		
+
 				// Clear cache/transients
 				$woocommerce->clear_product_transients( $clear_id );
 			}
@@ -889,7 +889,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 	} else {
 		update_post_meta( $post_id, '_sold_individually', '' );
 	}
-	
+
 	// Stock Data
 	if ( get_option('woocommerce_manage_stock') == 'yes' ) {
 
@@ -940,7 +940,7 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 		$upsells = array();
 		$ids = $_POST['upsell_ids'];
 		foreach ( $ids as $id )
-			if ( $id && $id > 0 ) 
+			if ( $id && $id > 0 )
 				$upsells[] = $id;
 
 		update_post_meta( $post_id, '_upsell_ids', $upsells );
@@ -953,9 +953,9 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 		$crosssells = array();
 		$ids = $_POST['crosssell_ids'];
 		foreach ( $ids as $id )
-			if ( $id && $id > 0 ) 
+			if ( $id && $id > 0 )
 				$crosssells[] = $id;
-	
+
 		update_post_meta( $post_id, '_crosssell_ids', $crosssells );
 	} else {
 		delete_post_meta( $post_id, '_crosssell_ids' );
@@ -965,11 +965,11 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 	if ( $is_downloadable == 'yes' ) {
 
 		$_download_limit = absint( $_POST['_download_limit'] );
-		if ( ! $_download_limit ) 
+		if ( ! $_download_limit )
 			$_download_limit = ''; // 0 or blank = unlimited
 
 		$_download_expiry = absint( $_POST['_download_expiry'] );
-		if ( ! $_download_expiry ) 
+		if ( ! $_download_expiry )
 			$_download_expiry = ''; // 0 or blank = unlimited
 
 		// file paths will be stored in an array keyed off md5(file path)
@@ -991,17 +991,17 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 
 			update_post_meta( $post_id, '_file_paths', $_file_paths );
 		}
-		if ( isset( $_POST['_download_limit'] ) ) 
+		if ( isset( $_POST['_download_limit'] ) )
 			update_post_meta( $post_id, '_download_limit', esc_attr( $_download_limit ) );
-		if ( isset( $_POST['_download_expiry'] ) ) 
+		if ( isset( $_POST['_download_expiry'] ) )
 			update_post_meta( $post_id, '_download_expiry', esc_attr( $_download_expiry ) );
 	}
 
 	// Product url
 	if ( $product_type == 'external' ) {
-		if ( isset( $_POST['_product_url'] ) && $_POST['_product_url'] ) 
+		if ( isset( $_POST['_product_url'] ) && $_POST['_product_url'] )
 			update_post_meta( $post_id, '_product_url', esc_attr( $_POST['_product_url'] ) );
-		if ( isset( $_POST['_button_text'] ) && $_POST['_button_text'] ) 
+		if ( isset( $_POST['_button_text'] ) && $_POST['_button_text'] )
 			update_post_meta( $post_id, '_button_text', esc_attr( $_POST['_button_text'] ) );
 	}
 
@@ -1024,12 +1024,12 @@ add_action('woocommerce_process_product_meta', 'woocommerce_process_product_meta
  * @return void
  */
 function woocommerce_change_insert_into_post( $translation, $original ) {
-    if ( ! isset( $_REQUEST['from'] ) ) 
+    if ( ! isset( $_REQUEST['from'] ) )
     	return $translation;
 
 	$original = strtolower( $original );
 
-    if ( $_REQUEST['from'] == 'wc01' && ( $original == 'insert into post' || $original == 'use this image' ) ) 
+    if ( $_REQUEST['from'] == 'wc01' && ( $original == 'insert into post' || $original == 'use this image' ) )
     	return __( 'Use this file', 'woocommerce' );
 
     return $translation;

--- a/admin/post-types/writepanels/writepanel-product_images.php
+++ b/admin/post-types/writepanels/writepanel-product_images.php
@@ -23,30 +23,30 @@ function woocommerce_product_images_box() {
 	?>
 	<div id="product_images_container">
 		<ul class="product_images">
-			<?php 
+			<?php
 				$thumbnail_id 	= get_post_thumbnail_id( $post->ID );
-				
+
 				if ( $thumbnail_id )
 					echo '<li class="image" data-post_id="' . $thumbnail_id . '">
 						' . wp_get_attachment_image( $thumbnail_id, 'full' ) . '
-						<span class="loading"></span> 
+						<span class="loading"></span>
 						<ul class="actions">
 							<li><a href="#" class="delete">' . __( 'Delete', 'woocommerce' ) . '</a></li>
 							<li><a href="' . admin_url( 'media-upload.php?post_id=' . $post->ID . '&attachment_id=' . $thumbnail_id . '&tab=library&width=640&height=553&TB_iframe=1' ) . '" class="view thickbox" onclick="return false;">' . __( 'View', 'woocommerce' ) . '</a></li>
 						</ul>
 					</li>';
-		
-				$attachments =& get_children( 'post_parent=' . $post->ID . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' ); 
-				
+
+				$attachments =& get_children( 'post_parent=' . $post->ID . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' );
+
 				foreach ( $attachments as $attachment_id => $attachment ) {
 					if ( $thumbnail_id == $attachment_id )
 						continue;
-						
+
 					$exclude_class = get_post_meta( $attachment_id, '_woocommerce_exclude_image', true ) == 1 ? 'excluded' : '';
 
 					echo '<li class="image ' . $exclude_class . '" data-post_id="' . $attachment_id . '">
 						' . wp_get_attachment_image( $attachment_id, 'full' ) . '
-						<span class="loading"></span> 
+						<span class="loading"></span>
 						<ul class="actions">
 							<li><a href="#" class="delete">' . __( 'Delete', 'woocommerce' ) . '</a></li>
 							<li><a href="' . admin_url( 'media-upload.php?post_id=' . $post->ID . '&attachment_id=' . $attachment_id . '&tab=library&width=640&height=553&TB_iframe=1' ) . '" class="view thickbox" onclick="return false;">' . __( 'View', 'woocommerce' ) . '</a></li>
@@ -56,14 +56,14 @@ function woocommerce_product_images_box() {
 			?>
 		</ul>
 	</div>
-	
+
 	<!-- Uploader section -->
 	<div id="plupload-upload-ui" class="hide-if-no-js">
 		<div id="drag-drop-area">
 			<p class="drag-drop-info"><?php _e('Drop files here'); ?></p>
 			<p><?php _ex('or', 'Uploader: Drop files here - or - Select Files'); ?></p>
 			<p class="drag-drop-buttons"><input id="plupload-browse-button" type="button" value="<?php esc_attr_e('Select Files'); ?>" class="button" /></p>
-		</div>	
+		</div>
 	</div>
 	<?php
 	// Drag and drop code adapted from Drag & Drop Featured Image by Jonathan Lundström
@@ -72,7 +72,7 @@ function woocommerce_product_images_box() {
 		'browse_button'       => 'plupload-browse-button',
 		'container'           => 'plupload-upload-ui',
 		'drop_element'        => 'drag-drop-area',
-		'file_data_name'      => 'async-upload',            
+		'file_data_name'      => 'async-upload',
 		'multiple_queues'     => true,
 		'max_file_size'       => wp_max_upload_size() . 'b',
 		'url'                 => admin_url('admin-ajax.php'),
@@ -89,11 +89,11 @@ function woocommerce_product_images_box() {
 	);
 
 	// Apply filters to initiate plupload:
-	$plupload_init = apply_filters( 'plupload_init', $plupload_init ); 
+	$plupload_init = apply_filters( 'plupload_init', $plupload_init );
 	?>
 	<script type="text/javascript">
 		jQuery(document).ready(function($){
-			
+
 			function product_images_container_init() {
 				// Attribute ordering
 				$('#product_images_container ul.product_images').sortable({
@@ -111,27 +111,27 @@ function woocommerce_product_images_box() {
 					stop:function(event,ui){
 						ui.item.removeAttr('style');
 					},
-					update: function(event, ui) {	
+					update: function(event, ui) {
 						$('#product_images_container ul li.image').css('cursor','default');
 						$('#product_images_container ul.product_images').sortable('disable');
-						
+
 						var post_id				= <?php echo $post->ID; ?>;
 						var attachment_id 		= ui.item.attr( 'data-post_id' );
 						var prev_attachment_id 	= ui.item.prev().attr( 'data-post_id' );
-						var next_attachment_id 	= ui.item.next().attr( 'data-post_id' );	
-									
+						var next_attachment_id 	= ui.item.next().attr( 'data-post_id' );
+
 						// show spinner
 						ui.item.addClass('loading');
-						
+
 						// go do the sorting stuff via ajax
-						jQuery.post( ajaxurl, { 
-								action: 'woocommerce_product_image_ordering', 
-								post_id: post_id, 
-								attachment_id: attachment_id, 
-								prev_attachment_id: prev_attachment_id, 
+						jQuery.post( ajaxurl, {
+								action: 'woocommerce_product_image_ordering',
+								post_id: post_id,
+								attachment_id: attachment_id,
+								prev_attachment_id: prev_attachment_id,
 								next_attachment_id: next_attachment_id,
 								_ajax_nonce: '<?php echo wp_create_nonce( 'product-image-ordering' ); ?>'
-							}, function( response ) {		
+							}, function( response ) {
 								ui.item.removeClass('loading');
 								$('#product_images_container ul li.image').css('cursor','move');
 								$('#product_images_container ul.product_images').sortable('enable');
@@ -140,51 +140,51 @@ function woocommerce_product_images_box() {
 					}
 				});
 			}
-			
+
 			product_images_container_init();
-			
+
 			// Delete images
 			$('#product_images_container').on( 'click', 'a.delete', function() {
-				
+
 				$image = $(this).closest('li.image');
-				
+
 				var attachment_id = $image.attr('data-post_id');
-				
+
 				if ( attachment_id ) {
-				
+
 					$image.addClass('loading');
-				
+
 					var answer = confirm('<?php _e( 'Are you sure you want to remove this attachment?', 'woocommerce' ); ?>');
-					
+
 					if ( answer ) {
-						jQuery.post( ajaxurl, { 
-								action: 'woocommerce_product_image_delete', 
+						jQuery.post( ajaxurl, {
+								action: 'woocommerce_product_image_delete',
 								post_id: <?php echo $post->ID; ?>,
-								attachment_id: attachment_id, 
+								attachment_id: attachment_id,
 								_ajax_nonce: '<?php echo wp_create_nonce( 'product-image-delete' ); ?>'
-							}, function( response ) {		
+							}, function( response ) {
 								$image.remove();
 							}
 						);
 					} else {
-						
+
 						$image.removeClass('loading');
-						
+
 					}
-				
+
 				}
-				
+
 				return false;
 			} );
-			
-		
+
+
 			// Drag and drop uploading of images
 			var uploader = new plupload.Uploader(<?php echo json_encode( $plupload_init ); ?>);
 
 			// Check for drag'n'drop functionality:
 			uploader.bind('Init', function(up){
 				var uploaddiv = $('#plupload-upload-ui');
-				
+
 				// Add classes and bind actions:
 				if(up.features.dragdrop){
 					uploaddiv.addClass('drag-drop');
@@ -200,11 +200,11 @@ function woocommerce_product_images_box() {
 
 			// Initiate uploading script:
 			uploader.init();
-			
+
 			// File queue handler
 			uploader.bind('FilesAdded', function(up, files){
 				var hundredmb = 100 * 1024 * 1024, max = parseInt(up.settings.max_file_size, 10);
-				
+
 				// Loop through files:
 				plupload.each(files, function(file){
 					if ( max > hundredmb && file.size > hundredmb && up.runtime != 'html5' ) {
@@ -215,22 +215,22 @@ function woocommerce_product_images_box() {
 				// Refresh and start:
 				up.refresh();
 				up.start();
-				
+
 				// Block the UI
 				$('#product_images_container').block({ message: null, overlayCSS: { background: '#fff url(' + woocommerce_writepanel_params.plugin_url + '/assets/images/ajax-loader.gif) no-repeat center', opacity: 0.6 } });
 			});
-			
+
 			// Handle new uploads
 			uploader.bind( 'FileUploaded', function( up, file, response ) {
 
 				response = $.parseJSON( response.response );
 
 				if ( response.error ) {
-				
+
 					alert( response.error );
-					
+
 				} else {
-				
+
 					$('#product_images_container ul').append('<li class="image" data-post_id="' + response.post_id + '">\
 						<img src="' + response.src + '" />\
 						<span class="loading"></span>\
@@ -239,46 +239,46 @@ function woocommerce_product_images_box() {
 							<li><a href="' + response.edit_url + '" class="view thickbox" onclick="return false;"><?php _e( 'View', 'woocommerce' )  ?></a></li>\
 						</ul>\
 					</li>');
-				
+
 				}
-				
+
 				$('#product_images_container').unblock();
 			});
-			
-			
+
+
 			// Refresh images when a thickbox (images) closes
 			var loading_product_images = false;
-			
+
 			jQuery(document).bind( 'tb_unload', function() {
 				if ( loading_product_images )
 					return;
-				
+
 				loading_product_images = true;
-				
+
 				// Block
 				$('#product_images_container').block({ message: null, overlayCSS: { background: '#fff url(' + woocommerce_writepanel_params.plugin_url + '/assets/images/ajax-loader.gif) no-repeat center', opacity: 0.6 } });
-				
+
 				// Re-load images
-				jQuery.post( ajaxurl, { 
-						action: 'woocommerce_product_image_refresh', 
-						post_id: <?php echo $post->ID; ?>, 
+				jQuery.post( ajaxurl, {
+						action: 'woocommerce_product_image_refresh',
+						post_id: <?php echo $post->ID; ?>,
 						_ajax_nonce: '<?php echo wp_create_nonce( 'product-image-refresh' ); ?>'
-					}, function( response ) {		
+					}, function( response ) {
 						if ( response ) {
 							$("#product_images_container").html(response);
 						}
-						
+
 						// Re-init
 						product_images_container_init();
-						
+
 						// Unblock
 						$('#product_images_container').unblock();
-						
+
 						loading_product_images = false;
 					}
 				);
 			} );
-			
+
 		});
 	</script>
 	<?php

--- a/admin/post-types/writepanels/writepanels-init.php
+++ b/admin/post-types/writepanels/writepanels-init.php
@@ -9,7 +9,7 @@
  * @package 	WooCommerce/Admin/WritePanels
  * @version     1.7.0
  */
- 
+
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /** Product data writepanel */
@@ -49,7 +49,7 @@ function woocommerce_meta_boxes() {
 	remove_meta_box( 'product_shipping_classdiv', 'product', 'side' );
 	remove_meta_box( 'pageparentdiv', 'product', 'side' );
 	remove_meta_box( 'postimagediv', 'product', 'side' );
-	
+
 	// Excerpt
 	if ( function_exists('wp_editor') ) {
 		remove_meta_box( 'postexcerpt', 'product', 'normal' );
@@ -223,9 +223,9 @@ add_filter('wp_insert_post_data', 'woocommerce_order_data');
 
 
 /**
- * Grant downloadable file access to any newly added files on any existing 
+ * Grant downloadable file access to any newly added files on any existing
  * orders for this product that have previously been granted downloadable file access
- * 
+ *
  * @access public
  * @param int $product_id product identifier
  * @param int $variation_id optional product variation identifier
@@ -234,7 +234,7 @@ add_filter('wp_insert_post_data', 'woocommerce_order_data');
 function woocommerce_process_product_file_download_paths( $product_id, $variation_id, $file_paths ) {
 	global $wpdb;
 
-	if ( $variation_id ) 
+	if ( $variation_id )
 		$product_id = $variation_id;
 
 	// determine whether any new files have been added
@@ -248,10 +248,10 @@ function woocommerce_process_product_file_download_paths( $product_id, $variatio
 		foreach ( $existing_permissions as $existing_permission ) {
 			$order = new WC_Order( $existing_permission->order_id );
 
-			if ( $order->id ) { 
+			if ( $order->id ) {
 				foreach ( $new_download_ids as $new_download_id ) {
 					// grant permission if it doesn't already exist
-					if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT true FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE order_id = %d AND product_id = %d AND download_id = %s", $order->id, $product_id, $new_download_id ) ) ) { 
+					if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT true FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE order_id = %d AND product_id = %d AND download_id = %s", $order->id, $product_id, $new_download_id ) ) ) {
 						woocommerce_downloadable_file_permission( $new_download_id, $product_id, $order );
 					}
 				}
@@ -313,21 +313,21 @@ add_action( 'admin_notices', 'woocommerce_meta_boxes_show_errors' );
  */
 function woocommerce_wp_text_input( $field ) {
 	global $thepostid, $post, $woocommerce;
-	
+
 	$thepostid 				= empty( $thepostid ) ? $post->ID : $thepostid;
 	$field['placeholder'] 	= isset( $field['placeholder'] ) ? $field['placeholder'] : '';
 	$field['class'] 		= isset( $field['class'] ) ? $field['class'] : 'short';
 	$field['value'] 		= isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
 	$field['name'] 			= isset( $field['name'] ) ? $field['name'] : $field['id'];
 	$field['type'] 			= isset( $field['type'] ) ? $field['type'] : 'text';
-	
+
 	// Custom attribute handling
 	$custom_attributes = array();
-	
+
 	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) )
 		foreach ( $field['custom_attributes'] as $attribute => $value )
 			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-				
+
 	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field"><label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label><input type="' . esc_attr( $field['type'] ) . '" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
 
 	if ( ! empty( $field['description'] ) ) {
@@ -352,11 +352,11 @@ function woocommerce_wp_text_input( $field ) {
  */
 function woocommerce_wp_hidden_input( $field ) {
 	global $thepostid, $post;
-	
+
 	$thepostid = empty( $thepostid ) ? $post->ID : $thepostid;
 	$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
 	$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
-	
+
 	echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) .  '" /> ';
 }
 

--- a/admin/settings/settings-init.php
+++ b/admin/settings/settings-init.php
@@ -341,11 +341,11 @@ if ( $shop_page_id > 0 && sizeof(get_pages("child_of=$shop_page_id")) > 0 )
 
 $woocommerce_settings['pages'] = apply_filters('woocommerce_page_settings', array(
 
-	array( 
-		'name' => __( 'Page Setup', 'woocommerce' ), 
-		'type' => 'title', 
-		'desc' => sprintf( __( 'Set up core WooCommerce pages here, for example the base page. The base page can also be used in your %sproduct permalinks%s.', 'woocommerce' ), '<a target="_blank" href="' . admin_url( 'options-permalink.php' ) . '">', '</a>' ), 
-		'id' => 'page_options' 
+	array(
+		'name' => __( 'Page Setup', 'woocommerce' ),
+		'type' => 'title',
+		'desc' => sprintf( __( 'Set up core WooCommerce pages here, for example the base page. The base page can also be used in your %sproduct permalinks%s.', 'woocommerce' ), '<a target="_blank" href="' . admin_url( 'options-permalink.php' ) . '">', '</a>' ),
+		'id' => 'page_options'
 	),
 
 	array(
@@ -515,7 +515,7 @@ $woocommerce_settings['catalog'] = apply_filters('woocommerce_catalog_settings',
 		)),
 		'desc_tip'	=>  true,
 	),
-	
+
 	array(
 		'name' => __( 'Shop Page Display', 'woocommerce' ),
 		'desc' 		=> __( 'This controls what is shown on the product archive.', 'woocommerce' ),
@@ -530,7 +530,7 @@ $woocommerce_settings['catalog'] = apply_filters('woocommerce_catalog_settings',
 		),
 		'desc_tip'	=>  true,
 	),
-	
+
 	array(
 		'name' => __( 'Default Category Display', 'woocommerce' ),
 		'desc' 		=> __( 'This controls what is shown on category archives.', 'woocommerce' ),
@@ -936,7 +936,7 @@ $woocommerce_settings['payment_gateways'] = apply_filters('woocommerce_payment_g
 
 $tax_classes = array_filter( array_map( 'trim', explode( "\n", get_option( 'woocommerce_tax_classes' ) ) ) );
 $classes_options = array();
-if ( $tax_classes ) 
+if ( $tax_classes )
 	foreach ( $tax_classes as $class )
 		$classes_options[ sanitize_title( $class ) ] = esc_html( $class );
 
@@ -951,7 +951,7 @@ $woocommerce_settings['tax'] = apply_filters('woocommerce_tax_settings', array(
 		'std' 		=> 'no',
 		'type' 		=> 'checkbox'
 	),
-	
+
 	array(
 		'name' => __( 'Calculation Settings', 'woocommerce' ),
 		'desc' 		=> __( 'Calculate tax based on the customer shipping address', 'woocommerce' ),
@@ -960,7 +960,7 @@ $woocommerce_settings['tax'] = apply_filters('woocommerce_tax_settings', array(
 		'type' 		=> 'checkbox',
 		'checkboxgroup'		=> 'start'
 	),
-	
+
 	array(
 		'desc' 		=> __( 'Round tax at subtotal level, instead of rounding per line', 'woocommerce' ),
 		'id' 		=> 'woocommerce_tax_round_at_subtotal',
@@ -968,7 +968,7 @@ $woocommerce_settings['tax'] = apply_filters('woocommerce_tax_settings', array(
 		'type' 		=> 'checkbox',
 		'checkboxgroup'		=> ''
 	),
-	
+
 	array(
 		'desc'          => sprintf( __( 'Display the tax total when tax is %s', 'woocommerce' ), woocommerce_price( 0 ) ),
 		'id'            => 'woocommerce_display_cart_taxes_if_zero',
@@ -1015,7 +1015,7 @@ $woocommerce_settings['tax'] = apply_filters('woocommerce_tax_settings', array(
 		'options' 	=> array( '' => 'Shipping tax class based on cart items', 'standard' => __( 'Standard', 'woocommerce' ) ) + $classes_options,
 		'desc_tip'	=>  true,
 	),
-	
+
 	array(
 		'name' 		=> __( 'Additional Tax classes', 'woocommerce' ),
 		'desc' 		=> __( 'List additonal tax classes below (1 per line). This is in addition to the default <code>Standard Rate</code>.', 'woocommerce' ),

--- a/admin/settings/settings-save.php
+++ b/admin/settings/settings-save.php
@@ -21,39 +21,39 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 function woocommerce_update_options( $options ) {
 
-    if ( empty( $_POST ) ) 
+    if ( empty( $_POST ) )
     	return false;
 
     foreach ( $options as $value ) {
-    	
+
     	if ( ! isset( $value['id'] ) )
     		continue;
-    	
+
     	$type = isset( $value['type'] ) ? sanitize_title( $value['type'] ) : '';
-    
+
     	switch ( $type ) {
-    	
+
 	    	// Standard types
 	    	case "checkbox" :
-	    		
+
 	    		if ( isset( $_POST[$value['id']] ) ) {
 	            	update_option( $value['id'], 'yes' );
 	            } else {
 	                update_option( $value['id'], 'no' );
 	            }
-	            
+
 	    	break;
-	    	
+
 	    	case "textarea" :
-	    	
+
 		    	if ( isset( $_POST[$value['id']] ) ) {
 	            	update_option( $value['id'], wp_kses_post( $_POST[ $value['id'] ] ) );
 	            } else {
 	                delete_option( $value['id'] );
 	            }
-            
+
 	    	break;
-	    	
+
 	    	case "text" :
 	    	case 'email':
             case 'number':
@@ -62,7 +62,7 @@ function woocommerce_update_options( $options ) {
 	    	case "single_select_page" :
 	    	case "single_select_country" :
 	    	case 'radio' :
-	    	
+
 	    		if ( $value['id'] == 'woocommerce_price_thousand_sep' || $value['id'] == 'woocommerce_price_decimal_sep' ) {
 
 					// price separators get a special treatment as they should allow a spaces (don't trim)
@@ -71,19 +71,19 @@ function woocommerce_update_options( $options ) {
 					} else {
 		                delete_option( $value['id'] );
 		            }
-		            
+
 		        } else {
-			        
+
 			       if ( isset( $_POST[$value['id']] ) ) {
 		            	update_option( $value['id'], woocommerce_clean( $_POST[ $value['id'] ] ) );
 		            } else {
 		                delete_option( $value['id'] );
-		            } 
-			        
+		            }
+
 		        }
-	    	
+
 	    	break;
-	    	
+
 	    	// Special types
 	    	case "tax_rates" :
 
@@ -97,36 +97,36 @@ function woocommerce_update_options( $options ) {
 	    		$tax_compound 		= isset( $_POST['tax_compound'] ) ? $_POST['tax_compound'] : array();
 	    		$tax_label 			= isset( $_POST['tax_label'] ) ? $_POST['tax_label'] : array();
 				$tax_classes_count	= sizeof( $tax_classes );
-				
+
 				for ( $i = 0; $i < $tax_classes_count; $i ++ ) {
-	
+
 					if ( isset( $tax_classes[ $i ] ) && isset( $tax_countries[ $i ] ) && isset( $tax_rate[ $i ] ) && is_numeric( $tax_rate[ $i ] ) ) {
-	
+
 						$rate = woocommerce_clean( $tax_rate[ $i ] );
 						$rate = number_format( $rate, 4, '.', '' );
-	
+
 						$class = woocommerce_clean( $tax_classes[ $i ] );
-						
+
 						$shipping = empty( $tax_shipping[ $i ] ) ? 'no' : 'yes';
 						$compound = empty( $tax_compound[ $i ] ) ? 'no' : 'yes';
-	
+
 						// Handle countries
 						$counties_array = array();
 						$countries = $tax_countries[ $i ];
 						if ( $countries ) foreach ( $countries as $country ) {
-	
+
 							$country = woocommerce_clean( $country );
 							$state = '*';
-	
+
 							if ( strstr( $country, ':' ) ) {
 								$cr = explode( ':', $country );
 								$country = current( $cr );
 								$state = end( $cr );
 							}
-	
+
 							$counties_array[ woocommerce_clean( $country ) ][] = woocommerce_clean( $state );
 						}
-	
+
 						$tax_rates[] = array(
 							'countries' => $counties_array,
 							'rate' 		=> $rate,
@@ -137,9 +137,9 @@ function woocommerce_update_options( $options ) {
 						);
 					}
 				}
-	
+
 				update_option( 'woocommerce_tax_rates', $tax_rates );
-	
+
 	    		// Local tax rates saving
 	    		$local_tax_rates 	= array();
 	    		$tax_classes 		= isset( $_POST['local_tax_class'] ) ? $_POST['local_tax_class'] : array();
@@ -153,36 +153,36 @@ function woocommerce_update_options( $options ) {
 	    		$tax_label 			= isset( $_POST['local_tax_label'] ) ? $_POST['local_tax_label'] : array();
 				$tax_classes_count	= sizeof( $tax_classes );
 				for ( $i = 0; $i < $tax_classes_count; $i ++ ) {
-	
+
 					if ( isset( $tax_classes[ $i ] ) && isset( $tax_countries[ $i ] ) && isset( $tax_rate[ $i ] ) && is_numeric( $tax_rate[ $i ] ) ) {
-	
+
 						$rate = woocommerce_clean( $tax_rate[ $i ] );
 						$rate = number_format( $rate, 4, '.', '' );
-	
+
 						$class = woocommerce_clean( $tax_classes[ $i ] );
-	
+
 						if ( ! empty( $tax_shipping[ $i ] ) ) $shipping = 'yes'; else $shipping = 'no';
 						if ( ! empty( $tax_compound[ $i ] ) ) $compound = 'yes'; else $compound = 'no';
-	
+
 						// Handle country
 						$country = woocommerce_clean( $tax_countries[ $i ] );
 						$state = '*';
-	
+
 						if ( strstr( $country, ':' ) ) {
 							$cr = explode( ':', $country );
 							$country = current( $cr );
 							$state = end( $cr );
 						}
-	
+
 						// Handle postcodes/cities
 						$location_type = $tax_location_type[ $i ] == 'city' ? 'city' : 'postcode';
 						$locations = explode( "\n", $tax_location[ $i ] );
 						$locations = array_filter( array_map( 'woocommerce_clean', $locations ) );
-						
+
 						if ( $location_type == 'city' ) {
 							$locations = array_map( 'sanitize_title', $locations );
 						}
-	
+
 						$local_tax_rates[] = array(
 							'country' => $country,
 							'state' => $state,
@@ -196,55 +196,55 @@ function woocommerce_update_options( $options ) {
 						);
 					}
 				}
-	
+
 				update_option( 'woocommerce_local_tax_rates', $local_tax_rates );
-			
+
 	    	break;
-	    	
+
 	    	case "multi_select_countries" :
-	    		
+
 	    		// Get countries array
-				if ( isset( $_POST[ $value['id'] ] ) ) 
-					$selected_countries = array_map( 'woocommerce_clean', (array) $_POST[ $value['id'] ] ); 
-				else 
+				if ( isset( $_POST[ $value['id'] ] ) )
+					$selected_countries = array_map( 'woocommerce_clean', (array) $_POST[ $value['id'] ] );
+				else
 					$selected_countries = array();
-					
+
 				update_option( $value['id'], $selected_countries );
-			
+
 	    	break;
-	    	
+
 	    	case "image_width" :
 
 		    	if ( isset( $_POST[$value['id'] . '_width'] ) ) {
-	              	
+
 	              	update_option( $value['id'] . '_width', woocommerce_clean( $_POST[ $value['id'] . '_width'] ) );
 	            	update_option( $value['id'] . '_height', woocommerce_clean( $_POST[ $value['id'] . '_height'] ) );
-					
+
 					if ( isset( $_POST[ $value['id'] . '_crop'] ) )
 						update_option( $value['id'] . '_crop', 1 );
 					else
 						update_option( $value['id'].'_crop', 0 );
-					
+
 	            } else {
 	                update_option( $value['id'] . '_width', $value['std'] );
 	            	update_option( $value['id'] . '_height', $value['std'] );
 	            	update_option( $value['id'] . '_crop', 1 );
 	            }
-            
+
 	    	break;
-	    	
+
 	    	// Custom handling
 	    	default :
-	    	
+
 	    		do_action( 'woocommerce_update_option_' . $type, $value );
-	    	
+
 	    	break;
 
     	}
-    	
+
     	// Custom handling
     	do_action( 'woocommerce_update_option', $value );
-    	
+
     }
     return true;
 }

--- a/admin/settings/settings-tax-rates.php
+++ b/admin/settings/settings-tax-rates.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 function woocommerce_tax_rates_setting() {
 	global $woocommerce;
-	
+
 	woocommerce_export_tax_rates();
 
 	$tax_classes 		= array_filter( array_map( 'trim', explode( "\n", get_option( 'woocommerce_tax_classes' ) ) ) );
@@ -28,12 +28,12 @@ function woocommerce_tax_rates_setting() {
 	?><tr valign="top">
 		<th scope="row" class="titledesc"><?php _e( 'Tax Rates', 'woocommerce' ) ?></th>
 	    <td class="forminp">
-	    
+
 		    <a class="button export_rates" href="<?php echo add_query_arg( 'wc_export_tax_rates', 1 ); ?>"><?php _e( 'Export rates', 'woocommerce' ); ?></a>
 	    	<a class="button import_rates" href="<?php echo admin_url( 'admin.php?import=woocommerce_tax_rate_csv' ); ?>"><?php _e( 'Import rates', 'woocommerce' ); ?></a>
-	    					
+
 	    	<p style="margin-top:0;"><?php _e( 'Define tax rates for countries and states below. You can also export and import from CSV files.', 'woocommerce' ); ?></p>
-	    		    	
+
 	    	<table class="taxrows widefat" cellspacing="0">
 	    		<thead>
 	    			<tr>
@@ -53,8 +53,8 @@ function woocommerce_tax_rates_setting() {
 	    				</th>
 	    				<th colspan="6">
 	    					<small><?php _e( 'All matching rates will be applied, and non-compound rates will be summed.', 'woocommerce' ); ?></small>
-	    					
-	    					<a href="#" class="dupe button"><?php _e( 'Duplicate selected', 'woocommerce' ); ?></a> 
+
+	    					<a href="#" class="dupe button"><?php _e( 'Duplicate selected', 'woocommerce' ); ?></a>
 	    					<a href="#" class="remove button"><?php _e( 'Delete selected', 'woocommerce' ); ?></a>
 	    				</th>
 	    			</tr>
@@ -102,7 +102,7 @@ function woocommerce_tax_rates_setting() {
 
 	    		</tbody>
 	    	</table>
-	    	
+
 	    	<?php if ( empty( $local_tax_rates ) ) : ?>
 	    	<p style="margin: 1em 0 0;"><a href="#" data-tip="<?php _e( 'Add local tax rates to define rules for specific zip codes and cities.', 'woocommerce' ); ?>" class="tips toggle_local_tax_rates">+ <?php _e( 'Local tax rates', 'woocommerce' ); ?></a></p>
 	    	<?php endif; ?>
@@ -113,9 +113,9 @@ function woocommerce_tax_rates_setting() {
 	    <td class="forminp">
 	    	<a class="button export_rates" href="<?php echo add_query_arg( 'wc_export_tax_rates', 2 ); ?>"><?php _e( 'Export rates', 'woocommerce' ); ?></a>
 	    	<a class="button import_rates" href="<?php echo admin_url( 'admin.php?import=woocommerce_tax_rate_csv' ); ?>"><?php _e( 'Import rates', 'woocommerce' ); ?></a>
-	    					
+
 	    	<p style="margin-top:0;"><?php _e( 'Define local tax rates for specific post/zip codes below. You can also export and import from CSV files.', 'woocommerce' ); ?></p>
-	    	
+
 	    	<table class="taxrows widefat" cellspacing="0">
 	    		<thead>
 	    			<tr>
@@ -139,10 +139,10 @@ function woocommerce_tax_rates_setting() {
 	    		</tfoot>
 	    		<tbody id="local_tax_rates">
 
-	    			<?php 
-	    			$i = -1; 
-	    			if ($local_tax_rates && is_array($local_tax_rates)) foreach( $local_tax_rates as $rate ) : 
-	    				$i++; 
+	    			<?php
+	    			$i = -1;
+	    			if ($local_tax_rates && is_array($local_tax_rates)) foreach( $local_tax_rates as $rate ) :
+	    				$i++;
 		    			$rate['locations'] = isset( $rate['locations'] ) ? $rate['locations'] : $rate['postcode']; // Backwards compat
 		    			$rate['location_type'] = isset( $rate['location_type'] ) ? $rate['location_type'] : 'postcode';
 		    			?>
@@ -374,7 +374,7 @@ function woocommerce_tax_rates_setting() {
 			}
 			return false;
 		});
-		
+
 		// Show local rates
 		jQuery( 'a.toggle_local_tax_rates' ).click(function(){
 			jQuery(this).closest('p').hide();
@@ -414,7 +414,7 @@ function woocommerce_tax_row_label( $selected ) {
 			$states_count+=sizeof($value);
 		endif;
 
-		if ( ! in_array( $country, $counties_array ) ) 
+		if ( ! in_array( $country, $counties_array ) )
 			$counties_array[] = esc_html( $woocommerce->countries->countries[ $country ] );
 
 	endforeach;
@@ -446,33 +446,33 @@ function woocommerce_tax_row_label( $selected ) {
 
 /**
  * woocommerce_export_tax_rates function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_export_tax_rates() {
-	
+
 	if ( empty( $_GET['wc_export_tax_rates'] ) )
 		return;
-		
+
 	global $woocommerce;
-	
+
 	if ( ! class_exists('WC_CSV_Exporter') )
 		include( $woocommerce->plugin_path() . '/admin/includes/class-wc-csv-exporter.php' );
 
 	$export = absint( $_GET['wc_export_tax_rates'] );
-		
+
 	if ( $export == 1 ) {
-	
+
 		$tax_rates = get_option('woocommerce_tax_rates');
-		
+
 		$csv = new WC_CSV_Exporter( array( 'countries', 'class', 'label', 'rate', 'compound', 'shipping' ), true, 'tax_rates.csv' );
-		
+
 		if ( $tax_rates )
 			foreach( $tax_rates as $rate ) {
-			
+
 				$countries = array();
-				
+
 				foreach ( $rate['countries'] as $country => $states ) {
 					foreach( $states as $state ) {
 						if ( $state == '*' ) {
@@ -482,8 +482,8 @@ function woocommerce_export_tax_rates() {
 						}
 					}
 				}
-			
-				$csv->add_row( array( 
+
+				$csv->add_row( array(
 					implode( ' | ', $countries ),
 					$rate['class'],
 					$rate['label'],
@@ -492,18 +492,18 @@ function woocommerce_export_tax_rates() {
 					$rate['shipping'] == 'yes' ? 1 : 0
 				) );
 			}
-		
+
 		$csv->end();
-	
+
 	} else {
 
 		$tax_rates = get_option('woocommerce_local_tax_rates');
-				
+
 		$csv = new WC_CSV_Exporter( array( 'country', 'state', 'postcode', 'class', 'label', 'rate', 'compound', 'shipping' ), true, 'local_tax_rates.csv' );
-		
+
 		if ( $tax_rates )
 			foreach( $tax_rates as $rate ) {
-				$csv->add_row( array( 
+				$csv->add_row( array(
 					$rate['country'],
 					$rate['state'],
 					implode( ' | ', $rate['postcode'] ),
@@ -514,8 +514,8 @@ function woocommerce_export_tax_rates() {
 					$rate['shipping'] == 'yes' ? 1 : 0
 				) );
 			}
-		
+
 		$csv->end();
-	
+
 	}
 }

--- a/admin/woocommerce-admin-attributes.php
+++ b/admin/woocommerce-admin-attributes.php
@@ -298,7 +298,7 @@ function woocommerce_add_attribute() {
 				        					</td>
 				        					<td><?php echo esc_html( $tax->attribute_name ); ?></td>
 				        					<td><?php echo esc_html( ucwords( $tax->attribute_type ) ); ?></td>
-				        					<td><?php 
+				        					<td><?php
 					        					switch ( $tax->attribute_orderby ) {
 						        					case 'name' :
 						        						_e( 'Name', 'woocommerce' );
@@ -306,7 +306,7 @@ function woocommerce_add_attribute() {
 						        					case 'id' :
 						        						_e( 'Term ID', 'woocommerce' );
 						        					break;
-						        					default: 
+						        					default:
 						        						_e( 'Custom ordering', 'woocommerce' );
 						        					break;
 					        					}
@@ -364,7 +364,7 @@ function woocommerce_add_attribute() {
 								</select>
 								<p class="description"><?php _e( 'Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>.', 'woocommerce' ); ?></p>
 							</div>
-							
+
 							<div class="form-field">
 								<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
 								<select name="attribute_orderby" id="attribute_orderby">

--- a/admin/woocommerce-admin-dashboard.php
+++ b/admin/woocommerce-admin-dashboard.php
@@ -44,7 +44,7 @@ function woocommerce_init_dashboard_widgets() {
 		wp_add_dashboard_widget( 'woocommerce_dashboard_recent_orders', __( 'WooCommerce Recent Orders', 'woocommerce' ), 'woocommerce_dashboard_recent_orders');
 		wp_add_dashboard_widget( 'woocommerce_dashboard_recent_reviews', __( 'WooCommerce Recent Reviews', 'woocommerce' ), 'woocommerce_dashboard_recent_reviews' );
 	}
-	
+
 	if ( current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'publish_shop_orders' ) ) {
 		wp_add_dashboard_widget( 'woocommerce_dashboard_sales', $sales_heading, 'woocommerce_dashboard_sales' );
 	}

--- a/admin/woocommerce-admin-functions.php
+++ b/admin/woocommerce-admin-functions.php
@@ -84,7 +84,7 @@ function woocommerce_ms_protect_download_rewite_rules( $rewrite ) {
  */
 function woocommerce_delete_post( $id ) {
 	global $woocommerce;
-	
+
 	if ( ! current_user_can( 'delete_posts' ) ) return;
 
 	if ( $id > 0 ) :
@@ -104,7 +104,7 @@ function woocommerce_delete_post( $id ) {
 		endif;
 
 	endif;
-	
+
 	$woocommerce->clear_product_transients();
 	delete_transient( 'woocommerce_processing_order_count' );
 }
@@ -265,7 +265,7 @@ function woocommerce_add_shortcode_button() {
 
 /**
  * woocommerce_add_tinymce_lang function.
- * 
+ *
  * @access public
  * @param mixed $arr
  * @return void
@@ -330,9 +330,9 @@ function woocommerce_refresh_mce( $ver ) {
  */
 function woocommerce_create_term( $term_id, $tt_id = '', $taxonomy = '' ) {
 
-	if ( ! $taxonomy == 'product_cat' && ! strstr( $taxonomy, 'pa_' ) ) 
+	if ( ! $taxonomy == 'product_cat' && ! strstr( $taxonomy, 'pa_' ) )
 		return;
-	
+
 	$meta_name = strstr( $taxonomy, 'pa_' ) ? 'order_' . esc_attr( $taxonomy ) : 'order';
 
 	update_woocommerce_term_meta( $term_id, $meta_name, 0 );
@@ -350,7 +350,7 @@ function woocommerce_delete_term( $term_id ) {
 
 	$term_id = (int) $term_id;
 
-	if ( ! $term_id ) 
+	if ( ! $term_id )
 		return;
 
 	global $wpdb;

--- a/admin/woocommerce-admin-init.php
+++ b/admin/woocommerce-admin-init.php
@@ -141,7 +141,7 @@ add_action( 'admin_head', 'woocommerce_admin_menu_highlight' );
 
 /**
  * woocommerce_admin_notices_styles function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -151,7 +151,7 @@ function woocommerce_admin_notices_styles() {
 		wp_enqueue_style( 'woocommerce-activation', plugins_url(  '/assets/css/activation.css', dirname( __FILE__ ) ) );
 		add_action( 'admin_notices', 'woocommerce_admin_install_notices' );
 	}
-		
+
 }
 
 add_action( 'admin_print_styles', 'woocommerce_admin_notices_styles' );
@@ -159,38 +159,38 @@ add_action( 'admin_print_styles', 'woocommerce_admin_notices_styles' );
 
 /**
  * woocommerce_admin_install_notices function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_admin_install_notices() {
 	global $woocommerce;
-	
+
 	if ( get_option( 'woocommerce_needs_update' ) == 1 ) {
-		
+
 		include( 'includes/notice-update.php' );
-		
+
 	} elseif ( get_option( 'woocommerce_updated' ) == 1 ) {
-	
+
 		include( 'includes/notice-updated.php' );
-		
+
 		update_option( 'woocommerce_updated', 0 );
 		update_option( 'woocommerce_installed', 0 );
-		
+
 	} elseif ( get_option( 'woocommerce_installed' ) == 1 ) {
-		
+
 		if ( get_option( 'skip_install_woocommerce_pages' ) != 1 && woocommerce_get_page_id( 'shop' ) < 1 && ! isset( $_GET['install_woocommerce_pages'] ) && !isset( $_GET['skip_install_woocommerce_pages'] ) ) {
-		
+
 			include( 'includes/notice-install.php' );
-			
+
 		} elseif ( ! isset( $_GET['page'] ) || $_GET['page'] != 'woocommerce_settings' ) {
-		
+
 			include( 'includes/notice-installed.php' );
-			
+
 			update_option( 'woocommerce_installed', 0 );
-			
+
 		}
-		
+
 	}
 }
 
@@ -232,7 +232,7 @@ function woocommerce_admin_init() {
 		include_once( 'woocommerce-admin-users.php' );
 
 	}
-	
+
 	// Register importers
 	if ( defined( 'WP_LOAD_IMPORTERS' ) ) {
 		include_once( 'importers/importers-init.php' );
@@ -313,7 +313,7 @@ function install_woocommerce() {
 
 /**
  * update_woocommerce function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -354,19 +354,19 @@ function woocommerce_admin_scripts() {
 
 	// Register scripts
 	wp_register_script( 'woocommerce_admin', $woocommerce->plugin_url() . '/assets/js/admin/woocommerce_admin' . $suffix . '.js', array( 'jquery', 'jquery-blockui', 'jquery-placeholder', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-tiptip' ), $woocommerce->version );
-	
+
 	wp_register_script( 'jquery-blockui', $woocommerce->plugin_url() . '/assets/js/jquery-blockui/jquery.blockUI' . $suffix . '.js', array( 'jquery' ), $woocommerce->version, true );
-	
+
 	wp_register_script( 'jquery-placeholder', $woocommerce->plugin_url() . '/assets/js/jquery-placeholder/jquery.placeholder' . $suffix . '.js', array( 'jquery' ), $woocommerce->version, true );
-	
+
 	wp_register_script( 'jquery-tiptip', $woocommerce->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip' . $suffix . '.js', array( 'jquery' ), $woocommerce->version, true );
-	
+
 	wp_register_script( 'jquery-ui-datepicker',  $woocommerce->plugin_url() . '/assets/js/admin/ui-datepicker.js', array('jquery','jquery-ui-core'), $woocommerce->version );
-	
+
 	wp_register_script( 'woocommerce_writepanel', $woocommerce->plugin_url() . '/assets/js/admin/write-panels'.$suffix.'.js', array('jquery', 'jquery-ui-datepicker'), $woocommerce->version );
-	
+
 	wp_register_script( 'ajax-chosen', $woocommerce->plugin_url() . '/assets/js/chosen/ajax-chosen.jquery'.$suffix.'.js', array('jquery', 'chosen'), $woocommerce->version );
-	
+
 	wp_register_script( 'chosen', $woocommerce->plugin_url() . '/assets/js/chosen/chosen.jquery'.$suffix.'.js', array('jquery'), $woocommerce->version );
 
 	// Get admin screen id
@@ -433,7 +433,7 @@ function woocommerce_admin_scripts() {
 			'get_customer_details_nonce' 	=> wp_create_nonce("get-customer-details"),
 			'search_products_nonce' 		=> wp_create_nonce("search-products"),
 			'calendar_image'				=> $woocommerce->plugin_url().'/assets/images/calendar.png',
-			'post_id'						=> $post->ID, 
+			'post_id'						=> $post->ID,
 			'currency_format_num_decimals'	=> absint( get_option( 'woocommerce_price_num_decimals' ) ),
 			'currency_format_symbol'		=> get_woocommerce_currency_symbol(),
 			'currency_format_decimal_sep'	=> esc_attr( stripslashes( get_option( 'woocommerce_price_decimal_sep' ) ) ),
@@ -618,7 +618,7 @@ function woocommerce_exclude_image_from_product_page_field( $fields, $object ) {
 
 	$parent = get_post( $object->post_parent );
 
-	if ( $parent->post_type !== 'product' ) 
+	if ( $parent->post_type !== 'product' )
 		return $fields;
 
 	$exclude_image = get_post_meta( absint( $object->ID ), '_woocommerce_exclude_image', true );
@@ -769,7 +769,7 @@ add_filter( 'admin_comment_types_dropdown', 'woocommerce_admin_comment_types_dro
 
 /**
  * woocommerce_permalink_settings function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -779,12 +779,12 @@ function woocommerce_permalink_settings() {
 
 	$permalinks = get_option( 'woocommerce_permalinks' );
 	$product_permalink = $permalinks['product_base'];
-	
+
 	// Get shop page
 	$shop_page_id 	= woocommerce_get_page_id( 'shop' );
 	$base_slug 		= ( $shop_page_id > 0 && get_page( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
 	$product_base 	= _x( 'product', 'default-slug', 'woocommerce' );
-	
+
 	$structures = array(
 		0 => '',
 		1 => '/' . trailingslashit( $product_base ),
@@ -826,7 +826,7 @@ function woocommerce_permalink_settings() {
 			jQuery('input.wctog').change(function() {
 				jQuery('#woocommerce_permalink_structure').val( jQuery(this).val() );
 			});
-			
+
 			jQuery('#woocommerce_permalink_structure').focus(function(){
 				jQuery('#woocommerce_custom_selection').click();
 			});
@@ -837,7 +837,7 @@ function woocommerce_permalink_settings() {
 
 /**
  * woocommerce_permalink_settings_init function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -845,7 +845,7 @@ function woocommerce_permalink_settings_init() {
 
 	// Add a section to the permalinks page
 	add_settings_section( 'woocommerce-permalink', __( 'Product permalink base', 'woocommerce' ), 'woocommerce_permalink_settings', 'permalink' );
-	
+
 	// Add our settings
 	add_settings_field(
 		'woocommerce_product_category_slug',      	// id
@@ -874,40 +874,40 @@ add_action( 'admin_init', 'woocommerce_permalink_settings_init' );
 
 /**
  * woocommerce_permalink_settings_save function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_permalink_settings_save() {
 	if ( ! is_admin() )
 		return;
-	
+
 	// We need to save the options ourselves; settings api does not trigger save for the permalinks page
 	if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) ) {
 		// Cat and tag bases
 		$woocommerce_product_category_slug = woocommerce_clean( $_POST['woocommerce_product_category_slug'] );
 		$woocommerce_product_tag_slug = woocommerce_clean( $_POST['woocommerce_product_tag_slug'] );
 		$woocommerce_product_attribute_slug = woocommerce_clean( $_POST['woocommerce_product_attribute_slug'] );
-		
+
 		$permalinks = get_option( 'woocommerce_permalinks' );
-		if ( ! $permalinks ) 
+		if ( ! $permalinks )
 			$permalinks = array();
-		
+
 		$permalinks['category_base'] 	= untrailingslashit( $woocommerce_product_category_slug );
 		$permalinks['tag_base'] 		= untrailingslashit( $woocommerce_product_tag_slug );
 		$permalinks['attribute_base'] 	= untrailingslashit( $woocommerce_product_attribute_slug );
-		
+
 		// Product base
 		$product_permalink = woocommerce_clean( $_POST['product_permalink'] );
-		
+
 		if ( $product_permalink == 'custom' ) {
 			$product_permalink = woocommerce_clean( $_POST['product_permalink_structure'] );
 		} elseif ( empty( $product_permalink ) ) {
 			$product_permalink = false;
 		}
-		
+
 		$permalinks['product_base'] = untrailingslashit( $product_permalink );
-		
+
 		update_option( 'woocommerce_permalinks', $permalinks );
 	}
 }
@@ -916,7 +916,7 @@ add_action( 'before_woocommerce_init', 'woocommerce_permalink_settings_save' );
 
 /**
  * woocommerce_product_category_slug_input function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -929,7 +929,7 @@ function woocommerce_product_category_slug_input() {
 
 /**
  * woocommerce_product_tag_slug_input function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -942,7 +942,7 @@ function woocommerce_product_tag_slug_input() {
 
 /**
  * woocommerce_product_attribute_slug_input function.
- * 
+ *
  * @access public
  * @return void
  */

--- a/admin/woocommerce-admin-install.php
+++ b/admin/woocommerce-admin-install.php
@@ -20,12 +20,12 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 function do_install_woocommerce() {
 	global $woocommerce_settings, $woocommerce;
-	
+
 	// Do install
 	woocommerce_default_options();
 	woocommerce_tables_install();
 	woocommerce_init_roles();
-	
+
 	// Register post types
 	$woocommerce->init_taxonomy();
 
@@ -34,7 +34,7 @@ function do_install_woocommerce() {
 
 	// Install files and folders for uploading files and prevent hotlinking
 	$upload_dir =  wp_upload_dir();
-	
+
 	$files = array(
 		array(
 			'base' 		=> $upload_dir['basedir'] . '/woocommerce_uploads',
@@ -57,7 +57,7 @@ function do_install_woocommerce() {
 			'content' 	=> ''
 		)
 	);
-	
+
 	foreach ( $files as $file ) {
 		if ( wp_mkdir_p( $file['base'] ) && ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
 			if ( $file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'w' ) ) {
@@ -77,19 +77,19 @@ function do_install_woocommerce() {
 
 		if ( ( ! empty( $colors['primary'] ) && ! empty( $colors['secondary'] ) && ! empty( $colors['highlight'] ) && ! empty( $colors['content_bg'] ) && ! empty( $colors['subtext'] ) ) && ( $colors['primary'] != '#ad74a2' || $colors['secondary'] != '#f7f6f7' || $colors['highlight'] != '#85ad74' || $colors['content_bg'] != '#ffffff' || $colors['subtext'] != '#777777' ) )
 			woocommerce_compile_less_styles();
-			
+
 	}
 
 	// Queue upgrades
 	$current_version = get_option( 'woocommerce_version', null );
 	$current_db_version = get_option( 'woocommerce_db_version', null );
-	
+
 	if ( version_compare( $current_db_version, '1.7', '<' ) && null !== $current_version ) {
 		update_option( 'woocommerce_needs_update', 1 );
 	} else {
 		update_option( 'woocommerce_db_version', $woocommerce->version );
 	}
-	
+
 	// Update version
 	update_option( 'woocommerce_version', $woocommerce->version );
 }
@@ -223,9 +223,9 @@ function woocommerce_tables_install() {
 
 	$collate = '';
     if ( $wpdb->has_cap( 'collation' ) ) {
-		if( ! empty($wpdb->charset ) ) 
+		if( ! empty($wpdb->charset ) )
 			$collate .= "DEFAULT CHARACTER SET $wpdb->charset";
-		if( ! empty($wpdb->collate ) ) 
+		if( ! empty($wpdb->collate ) )
 			$collate .= " COLLATE $wpdb->collate";
     }
 
@@ -255,7 +255,7 @@ CREATE TABLE ". $wpdb->prefix . "woocommerce_termmeta (
 ) $collate;
 ";
     dbDelta( $sql );
-    
+
     // Table for storing user and guest download permissions
     // KEY(order_id, product_id, download_id) used for organizing downloads on the My Account page
     $sql = "
@@ -275,19 +275,19 @@ CREATE TABLE ". $wpdb->prefix . "woocommerce_downloadable_product_permissions (
 ) $collate;
 ";
     dbDelta( $sql );
-    
+
     // Order line items are stored in a table to make them easily queryable for reports
     $sql = "
 CREATE TABLE ". $wpdb->prefix . "woocommerce_order_items (
   order_item_id bigint(20) NOT NULL auto_increment,
   order_item_name longtext NOT NULL DEFAULT '',
   order_item_type varchar(200) NOT NULL DEFAULT '',
-  order_id bigint(20) NOT NULL, 
+  order_id bigint(20) NOT NULL,
   PRIMARY KEY  (order_item_id)
 ) $collate;
 ";
     dbDelta( $sql );
-    
+
     // Order line item meta is stored in a table for storing extra data.
     $sql = "
 CREATE TABLE ". $wpdb->prefix . "woocommerce_order_itemmeta (

--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -333,9 +333,9 @@ function woocommerce_sales_overview() {
 		AND 	tax.taxonomy		= 'shop_order_status'
 		AND		term.slug			IN ('" . implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "')
 	" );
-	
+
 	$order_items = absint( $wpdb->get_var( "
-		SELECT SUM( order_item_meta.meta_value ) 
+		SELECT SUM( order_item_meta.meta_value )
 		FROM {$wpdb->prefix}woocommerce_order_items as order_items
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID
@@ -401,15 +401,15 @@ function woocommerce_sales_overview() {
 
 	$start_date = strtotime( date('Ymd', strtotime( date('Ym', current_time('timestamp') ) . '01' ) ) );
 	$end_date = strtotime( date('Ymd', current_time( 'timestamp' ) ) );
-	
+
 	// Blank date ranges to begin
 	$order_counts = $order_amounts = array();
 
 	$count = 0;
-	
+
 	$days = ( $end_date - $start_date ) / ( 60 * 60 * 24 );
-	
-	if ( $days == 0 ) 
+
+	if ( $days == 0 )
 		$days = 1;
 
 	while ( $count < $days ) {
@@ -419,7 +419,7 @@ function woocommerce_sales_overview() {
 
 		$count++;
 	}
-	
+
 	// Get order ids and dates in range
 	$orders = $wpdb->get_results( "
 		SELECT posts.ID, posts.post_date FROM {$wpdb->posts} AS posts
@@ -456,10 +456,10 @@ function woocommerce_sales_overview() {
 	}
 
 	$order_counts_array = $order_amounts_array = array();
-	
+
 	foreach ( $order_counts as $key => $count )
 		$order_counts_array[] = array( esc_js( $key ), esc_js( $count ) );
-	
+
 	foreach ( $order_amounts as $key => $amount )
 		$order_amounts_array[] = array( esc_js( $key ), esc_js( $amount ) );
 
@@ -529,24 +529,24 @@ function woocommerce_daily_sales() {
 	$start_date = isset( $_POST['start_date'] ) ? $_POST['start_date'] : '';
 	$end_date	= isset( $_POST['end_date'] ) ? $_POST['end_date'] : '';
 
-	if ( ! $start_date) 
+	if ( ! $start_date)
 		$start_date = date( 'Ymd', strtotime( date('Ym', current_time( 'timestamp' ) ) . '01' ) );
-	if ( ! $end_date) 
+	if ( ! $end_date)
 		$end_date = date( 'Ymd', current_time( 'timestamp' ) );
 
 	$start_date = strtotime( $start_date );
 	$end_date = strtotime( $end_date );
-	
+
 	$total_sales = $total_orders = $order_items = 0;
 
 	// Blank date ranges to begin
 	$order_counts = $order_amounts = array();
 
 	$count = 0;
-	
+
 	$days = ( $end_date - $start_date ) / ( 60 * 60 * 24 );
-	
-	if ( $days == 0 ) 
+
+	if ( $days == 0 )
 		$days = 1;
 
 	while ( $count < $days ) {
@@ -556,16 +556,16 @@ function woocommerce_daily_sales() {
 
 		$count++;
 	}
-	
+
 	// Get order ids and dates in range
 	$orders = $wpdb->get_results( "
 		SELECT posts.ID, posts.post_date, meta.meta_value AS total_sales FROM {$wpdb->posts} AS posts
-		
+
 		LEFT JOIN {$wpdb->postmeta} AS meta ON posts.ID = meta.post_id
 		LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID = rel.object_ID
 		LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 		LEFT JOIN {$wpdb->terms} AS term USING( term_id )
-		
+
 		WHERE 	meta.meta_key 		= '_order_total'
 		AND 	posts.post_type 	= 'shop_order'
 		AND 	posts.post_status 	= 'publish'
@@ -573,33 +573,33 @@ function woocommerce_daily_sales() {
 		AND		term.slug			IN ('" . implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "')
 		AND 	post_date > '" . date('Y-m-d', $start_date ) . "'
 		AND 	post_date < '" . date('Y-m-d', strtotime('+1 day', $end_date ) ) . "'
-		
+
 		GROUP BY posts.ID
 		ORDER BY post_date ASC
 	" );
-	
+
 	if ( $orders ) {
-	
+
 		$total_orders = sizeof( $orders );
-	
+
 		foreach ( $orders as $order ) {
-			
+
 			// get order timestamp
 			$time = strtotime( date( 'Ymd', strtotime( $order->post_date ) ) ) . '000';
 
 			// Add order total
 			$total_sales += $order->total_sales;
-			
+
 			// Get items
 			$order_items += absint( $wpdb->get_var( $wpdb->prepare( "
-				SELECT SUM( order_item_meta.meta_value ) 
+				SELECT SUM( order_item_meta.meta_value )
 				FROM {$wpdb->prefix}woocommerce_order_items as order_items
 				LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 				WHERE	order_id = %d
 				AND 	order_items.order_item_type = 'line_item'
 				AND 	order_item_meta.meta_key = '_qty'
 			", $order->ID ) ) );
-			
+
 			// Set times
 			if ( isset( $order_counts[ $time ] ) )
 				$order_counts[ $time ]++;
@@ -656,7 +656,7 @@ function woocommerce_daily_sales() {
 	<?php
 
 	$order_counts_array = $order_amounts_array = array();
-	
+
 	foreach ( $order_counts as $key => $count )
 		$order_counts_array[] = array( esc_js( $key ), esc_js( $count ) );
 
@@ -728,7 +728,7 @@ function woocommerce_monthly_sales() {
 	global $start_date, $end_date, $woocommerce, $wpdb, $wp_locale;
 
 	$first_year = $wpdb->get_var( "SELECT post_date FROM $wpdb->posts WHERE post_date != 0 ORDER BY post_date ASC LIMIT 1;" );
-	
+
 	$first_year = $first_year ? date( 'Y', strtotime( $first_year ) ) : date('Y');
 
 	$current_year 	= isset( $_POST['show_year'] ) ? $_POST['show_year'] : date( 'Y', current_time( 'timestamp' ) );
@@ -769,7 +769,7 @@ function woocommerce_monthly_sales() {
 
 		// Count order items
 		$order_items += absint( $wpdb->get_var( "
-			SELECT SUM( order_item_meta.meta_value ) 
+			SELECT SUM( order_item_meta.meta_value )
 			FROM {$wpdb->prefix}woocommerce_order_items as order_items
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 			LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID
@@ -789,7 +789,7 @@ function woocommerce_monthly_sales() {
 		<p><label for="show_year"><?php _e( 'Year:', 'woocommerce' ); ?></label>
 		<select name="show_year" id="show_year">
 			<?php
-				for ( $i = $first_year; $i <= date( 'Y' ); $i++ ) 
+				for ( $i = $first_year; $i <= date( 'Y' ); $i++ )
 					printf('<option value="%s" %s>%s</option>', $i, selected( $current_year, $i, false ), $i );
 			?>
 		</select> <input type="submit" class="button" value="<?php _e( 'Show', 'woocommerce' ); ?>" /></p>
@@ -833,10 +833,10 @@ function woocommerce_monthly_sales() {
 	<?php
 
 	$order_counts_array = $order_amounts_array = array();
-	
+
 	foreach ( $order_counts as $key => $count )
 		$order_counts_array[] = array( esc_js( $key ), esc_js( $count ) );
-	
+
 	foreach ( $order_amounts as $key => $amount )
 		$order_amounts_array[] = array( esc_js( $key ), esc_js( $amount ) );
 
@@ -901,7 +901,7 @@ function woocommerce_top_sellers() {
 	$start_date = isset( $_POST['start_date'] ) ? $_POST['start_date'] : '';
 	$end_date	= isset( $_POST['end_date'] ) ? $_POST['end_date'] : '';
 
-	if ( ! $start_date ) 
+	if ( ! $start_date )
 		$start_date = date( 'Ymd', strtotime( date( 'Ym', current_time( 'timestamp' ) ) . '01' ) );
 	if ( ! $end_date )
 		 $end_date = date( 'Ymd', current_time( 'timestamp' ) );
@@ -912,10 +912,10 @@ function woocommerce_top_sellers() {
 	// Get order ids and dates in range
 	$order_items = $wpdb->get_results( "
 		SELECT order_item_meta_2.meta_value as product_id, SUM( order_item_meta.meta_value ) as item_quantity FROM {$wpdb->prefix}woocommerce_order_items as order_items
-		
+
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id
-		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID		
+		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID
 		LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID = rel.object_ID
 		LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 		LEFT JOIN {$wpdb->terms} AS term USING( term_id )
@@ -931,7 +931,7 @@ function woocommerce_top_sellers() {
 		AND 	order_item_meta_2.meta_key = '_product_id'
 		GROUP BY order_item_meta_2.meta_value
 	" );
-	
+
 	$found_products = array();
 
 	if ( $order_items ) {
@@ -961,7 +961,7 @@ function woocommerce_top_sellers() {
 				foreach ( $found_products as $product_id => $sales ) {
 					$width = $sales > 0 ? ( $sales / $max_sales ) * 100 : 0;
 					$product_title = get_the_title( $product_id );
-					
+
 					if ( $product_title ) {
 						$product_name = '<a href="' . get_permalink( $product_id ) . '">'. __( $product_title ) .'</a>';
 						$orders_link = admin_url( 'edit.php?s&post_status=all&post_type=shop_order&action=-1&s=' . urlencode( $product_title ) . '&shop_order_status=completed,processing,on-hold' );
@@ -997,21 +997,21 @@ function woocommerce_top_earners() {
 	$start_date = isset( $_POST['start_date'] ) ? $_POST['start_date'] : '';
 	$end_date	= isset( $_POST['end_date'] ) ? $_POST['end_date'] : '';
 
-	if ( ! $start_date ) 
+	if ( ! $start_date )
 		$start_date = date( 'Ymd', strtotime( date('Ym', current_time( 'timestamp' ) ) . '01' ) );
-	if ( ! $end_date ) 
+	if ( ! $end_date )
 		$end_date = date( 'Ymd', current_time( 'timestamp' ) );
 
 	$start_date = strtotime( $start_date );
 	$end_date = strtotime( $end_date );
-	
+
 	// Get order ids and dates in range
 	$order_items = $wpdb->get_results( "
 		SELECT order_item_meta_2.meta_value as product_id, SUM( order_item_meta.meta_value ) as line_total FROM {$wpdb->prefix}woocommerce_order_items as order_items
-		
+
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id
-		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID		
+		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID
 		LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID = rel.object_ID
 		LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 		LEFT JOIN {$wpdb->terms} AS term USING( term_id )
@@ -1035,7 +1035,7 @@ function woocommerce_top_earners() {
 			$found_products[ $order_item->product_id ] = $order_item->line_total;
 		}
 	}
-	
+
 	asort( $found_products );
 	$found_products = array_reverse( $found_products, true );
 	$found_products = array_slice( $found_products, 0, 25, true );
@@ -1058,7 +1058,7 @@ function woocommerce_top_earners() {
 					$width = $sales > 0 ? ( round( $sales ) / round( $max_sales ) ) * 100 : 0;
 
 					$product_title = get_the_title( $product_id );
-					
+
 					if ( $product_title ) {
 						$product_name = '<a href="'.get_permalink( $product_id ).'">'. __( $product_title ) .'</a>';
 						$orders_link = admin_url( 'edit.php?s&post_status=all&post_type=shop_order&action=-1&s=' . urlencode( $product_title ) . '&shop_order_status=completed,processing,on-hold' );
@@ -1113,22 +1113,22 @@ function woocommerce_product_sales() {
 
 		// Get order items
 		$order_items = $wpdb->get_results( "
-			SELECT order_item_meta_2.meta_value as product_id, posts.post_date, SUM( order_item_meta.meta_value ) as item_quantity, SUM( order_item_meta_3.meta_value ) as line_total 
+			SELECT order_item_meta_2.meta_value as product_id, posts.post_date, SUM( order_item_meta.meta_value ) as item_quantity, SUM( order_item_meta_3.meta_value ) as line_total
 			FROM {$wpdb->prefix}woocommerce_order_items as order_items
-			
+
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta_3 ON order_items.order_item_id = order_item_meta_3.order_item_id
-			LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID		
+			LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID
 			LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID = rel.object_ID
 			LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 			LEFT JOIN {$wpdb->terms} AS term USING( term_id )
-	
+
 			WHERE 	posts.post_type 	= 'shop_order'
 			AND 	order_item_meta_2.meta_value IN ('" . implode( "','", array_merge( $chosen_product_ids, $children_ids ) ) . "')
 			AND 	posts.post_status 	= 'publish'
 			AND 	tax.taxonomy		= 'shop_order_status'
-			AND		term.slug			IN ('" . implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "') 
+			AND		term.slug			IN ('" . implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "')
 			AND 	order_items.order_item_type = 'line_item'
 			AND 	order_item_meta.meta_key = '_qty'
 			AND 	order_item_meta_2.meta_key = '_product_id'
@@ -1138,27 +1138,27 @@ function woocommerce_product_sales() {
 		" );
 
 		$found_products = array();
-	
+
 		if ( $order_items ) {
 			foreach ( $order_items as $order_item ) {
-				
+
 				if ( $order_item->line_total == 0 && $order_item->item_quantity == 0 )
 					continue;
-				
+
 				// Get date
 				$date 	= date( 'Ym', strtotime( $order_item->post_date ) );
-				
+
 				// Set values
 				$product_sales[ $date ] 	= isset( $product_sales[ $date ] ) ? $product_sales[ $date ] + $order_item->item_quantity : $order_item->item_quantity;
 				$product_totals[ $date ] 	= isset( $product_totals[ $date ] ) ? $product_totals[ $date ] + $order_item->line_total : $order_item->line_total;
-	
-				if ( $product_sales[ $date ] > $max_sales ) 
+
+				if ( $product_sales[ $date ] > $max_sales )
 					$max_sales = $product_sales[ $date ];
-					
-				if ( $product_totals[ $date ] > $max_totals ) 
+
+				if ( $product_totals[ $date ] > $max_totals )
 					$max_totals = $product_totals[ $date ];
 			}
-		}		
+		}
 		?>
 		<h4><?php printf( __( 'Sales for %s:', 'woocommerce' ), implode( ', ', $chosen_product_titles ) ); ?></h4>
 		<table class="bar_chart">
@@ -1174,9 +1174,9 @@ function woocommerce_product_sales() {
 						foreach ( $product_sales as $date => $sales ) {
 							$width = ($sales>0) ? (round($sales) / round($max_sales)) * 100 : 0;
 							$width2 = ($product_totals[$date]>0) ? (round($product_totals[$date]) / round($max_totals)) * 100 : 0;
-	
+
 							$orders_link = admin_url( 'edit.php?s&post_status=all&post_type=shop_order&action=-1&s=' . urlencode( implode( ' ', $chosen_product_titles ) ) . '&m=' . date( 'Ym', strtotime( $date . '01' ) ) . '&shop_order_status=completed,processing,on-hold' );
-	
+
 							echo '<tr><th><a href="' . esc_url( $orders_link ) . '">' . date_i18n( 'F', strtotime( $date . '01' ) ) . '</a></th>
 							<td width="1%"><span>' . esc_html( $sales ) . '</span><span class="alt">' . woocommerce_price( $product_totals[ $date ] ) . '</span></td>
 							<td class="bars">
@@ -1198,7 +1198,7 @@ function woocommerce_product_sales() {
 			<p><select id="product_ids" name="product_ids[]" class="ajax_chosen_select_products" multiple="multiple" data-placeholder="<?php _e( 'Search for a product&hellip;', 'woocommerce' ); ?>" style="width: 400px;"></select> <input type="submit" style="vertical-align: top;" class="button" value="<?php _e( 'Show', 'woocommerce' ); ?>" /></p>
 			<script type="text/javascript">
 				jQuery(function(){
-				
+
 					// Ajax Chosen Product Selectors
 					jQuery("select.ajax_chosen_select_products").ajaxChosen({
 					    method: 	'GET',
@@ -1219,7 +1219,7 @@ function woocommerce_product_sales() {
 
 					    return terms;
 					});
-					
+
 				});
 			</script>
 		</form>
@@ -1700,22 +1700,22 @@ function woocommerce_monthly_taxes() {
 		" );
 
 		$tax_rows = $wpdb->get_results( "
-			SELECT 		
+			SELECT
 				order_items.order_item_name as name,
-				SUM( order_item_meta.meta_value ) as tax_amount, 
+				SUM( order_item_meta.meta_value ) as tax_amount,
 				SUM( order_item_meta_2.meta_value ) as shipping_tax_amount,
 				SUM( order_item_meta.meta_value + order_item_meta_2.meta_value ) as total_tax_amount
-			
+
 			FROM 		{$wpdb->prefix}woocommerce_order_items as order_items
-			
+
 			LEFT JOIN 	{$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 			LEFT JOIN 	{$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id
-		
-			LEFT JOIN 	{$wpdb->posts} AS posts ON order_items.order_id = posts.ID	
+
+			LEFT JOIN 	{$wpdb->posts} AS posts ON order_items.order_id = posts.ID
 			LEFT JOIN 	{$wpdb->term_relationships} AS rel ON posts.ID = rel.object_ID
 			LEFT JOIN 	{$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 			LEFT JOIN 	{$wpdb->terms} AS term USING( term_id )
-		
+
 			WHERE 		order_items.order_item_type = 'tax'
 			AND 		posts.post_type 	= 'shop_order'
 			AND 		posts.post_status 	= 'publish'
@@ -1724,10 +1724,10 @@ function woocommerce_monthly_taxes() {
 			AND			'{$month}' = date_format( posts.post_date,'%%Y%%m' )
 			AND 		order_item_meta.meta_key = 'tax_amount'
 			AND 		order_item_meta_2.meta_key = 'shipping_tax_amount'
-			
+
 			GROUP BY 	order_items.order_item_name
 		" );
-		
+
 		if ( $tax_rows ) {
 			foreach ( $tax_rows as $tax_row ) {
 				$tax_row_labels[] = $tax_row->name;
@@ -1864,19 +1864,19 @@ function woocommerce_monthly_taxes() {
 								<td class="total_row">' . woocommerce_price( $tax['total_tax'] ) . '</td>
 								<td class="total_row">' . woocommerce_price( $tax['gross'] - $tax['shipping'] - $tax['total_tax'] ) . '</td>';
 
-							
-							
+
+
 							foreach ( $tax_row_labels as $label ) {
-								
+
 								$row_total = 0;
-								
+
 								foreach ( $tax['tax_rows'] as $tax_row ) {
 									if ( $tax_row->name == $label ) {
 										$row_total = $tax_row->total_tax_amount;
 									}
 								}
-							
-								echo '<td class="tax_row">' . woocommerce_price( $row_total ) . '</td>';	
+
+								echo '<td class="tax_row">' . woocommerce_price( $row_total ) . '</td>';
 							}
 
 							echo '</tr>';
@@ -1899,7 +1899,7 @@ function woocommerce_monthly_taxes() {
 
 /**
  * woocommerce_category_sales function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1911,7 +1911,7 @@ function woocommerce_category_sales() {
 
 	$current_year 	= isset( $_POST['show_year'] ) 	? $_POST['show_year'] 	: date( 'Y', current_time( 'timestamp' ) );
 	$start_date 	= strtotime( $current_year . '0101' );
-	
+
 	$categories = get_terms( 'product_cat', array( 'parent' => 0 ) );
 	?>
 	<form method="post" action="" class="report_filters">
@@ -1919,11 +1919,11 @@ function woocommerce_category_sales() {
 			<label for="show_year"><?php _e( 'Show:', 'woocommerce' ); ?></label>
 			<select name="show_year" id="show_year">
 				<?php
-					for ( $i = $first_year; $i <= date( 'Y' ); $i++ ) 
+					for ( $i = $first_year; $i <= date( 'Y' ); $i++ )
 						printf( '<option value="%s" %s>%s</option>', $i, selected( $current_year, $i, false ), $i );
 				?>
 			</select>
-		
+
 			<select multiple="multiple" class="chosen_select" id="show_categories" name="show_categories[]" style="width: 300px;">
 				<?php
 					foreach ( $categories as $category ) {
@@ -1931,7 +1931,7 @@ function woocommerce_category_sales() {
 							$prepend = '&mdash; ';
 						else
 							$prepend = '';
-						
+
 						echo '<option value="' . $category->term_id . '" ' . selected( ! empty( $_POST['show_categories'] ) && in_array( $category->term_id, $_POST['show_categories'] ), true ) . '>' . $prepend . $category->name . '</option>';
 					}
 				?>
@@ -1946,14 +1946,14 @@ function woocommerce_category_sales() {
 
 	// Get order items
 	$start_date = date( 'Ym', strtotime( date( 'Ym', strtotime( '-1 year', $start_date ) ) . '01' ) );
-	
+
 	$order_items = $wpdb->get_results( "
-		SELECT order_item_meta_2.meta_value as product_id, posts.post_date, SUM( order_item_meta.meta_value ) as line_total 
+		SELECT order_item_meta_2.meta_value as product_id, posts.post_date, SUM( order_item_meta.meta_value ) as line_total
 		FROM {$wpdb->prefix}woocommerce_order_items as order_items
-		
+
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id
-		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID		
+		LEFT JOIN {$wpdb->posts} AS posts ON order_items.order_id = posts.ID
 		LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID = rel.object_ID
 		LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 		LEFT JOIN {$wpdb->terms} AS term USING( term_id )
@@ -1961,7 +1961,7 @@ function woocommerce_category_sales() {
 		WHERE 	posts.post_type 	= 'shop_order'
 		AND 	posts.post_status 	= 'publish'
 		AND 	tax.taxonomy		= 'shop_order_status'
-		AND		term.slug			IN ('" . implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "') 
+		AND		term.slug			IN ('" . implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "')
 		AND		date_format(posts.post_date,'%%Y%%m') >= '{$start_date}'
 		AND 	order_items.order_item_type = 'line_item'
 		AND 	order_item_meta.meta_key = '_line_total'
@@ -1969,23 +1969,23 @@ function woocommerce_category_sales() {
 		GROUP BY order_items.order_id
 		ORDER BY posts.post_date ASC
 	" );
-		
+
 	if ( $order_items ) {
 		foreach ( $order_items as $order_item ) {
-			
+
 			$month = date( 'm', strtotime( $order_item->post_date ) ) - 1;
-			
+
 			$item_sales[ $month ][ $order_item->product_id ] = isset( $item_sales[ $month ][ $order_item->product_id ] ) ? $item_sales[ $month ][ $order_item->product_id ] + $order_item->line_total : $order_item->line_total;
 		}
 	}
-	
+
 	if ( ! empty( $_POST['show_categories'] ) && sizeof( $_POST['show_categories'] ) > 0 ) {
-	
+
 		$show_categories = $include_categories = array_map( 'absint', $_POST['show_categories'] );
-		
+
 		foreach( $show_categories as $cat )
 			$include_categories = array_merge( $include_categories, get_term_children( $cat, 'product_cat' ) );
-		
+
 		$categories = get_terms( 'product_cat', array( 'include' => array_unique( $include_categories ) ) );
 		?>
 		<div class="woocommerce-wide-reports-wrap">
@@ -1993,10 +1993,10 @@ function woocommerce_category_sales() {
 				<thead>
 					<tr>
 						<th><?php _e( 'Category', 'woocommerce' ); ?></th>
-						<?php 
+						<?php
 							$column_count = 0;
-							for ( $count = 0; $count < 12; $count++ ) : 
-								if ( $count >= date ( 'm' ) && $current_year == date( 'Y' ) )	
+							for ( $count = 0; $count < 12; $count++ ) :
+								if ( $count >= date ( 'm' ) && $current_year == date( 'Y' ) )
 									continue;
 								$column_count++;
 								?>
@@ -2009,34 +2009,34 @@ function woocommerce_category_sales() {
 					// While outputting, lets store them for the chart
 					$chart_data = $month_totals = $category_totals = array();
 					$top_cat = $bottom_cat = $top_cat_name = $bottom_cat_name = '';
-					
+
 					for ( $count = 0; $count < 12; $count++ )
 						if ( $count >= date( 'm' ) && $current_year == date( 'Y' ) )
 							break;
 						else
 							$month_totals[ $count ] = 0;
-					
+
 					foreach ( $categories as $category ) {
-						
+
 						$cat_total = 0;
 						$category_chart_data = $term_ids = array();
-						
+
 						$term_ids 		= get_term_children( $category->term_id, 'product_cat' );
 						$term_ids[] 	= $category->term_id;
 						$product_ids 	= get_objects_in_term( $term_ids, 'product_cat' );
-						
+
 						if ( $category->parent > 0 )
 							$prepend = '&mdash; ';
 						else
 							$prepend = '';
-						
+
 						$category_sales_html = '<tr><th>' . $prepend . $category->name . '</th>';
-		
+
 						for ( $count = 0; $count < 12; $count++ ) {
-							
-							if ( $count >= date( 'm' ) && $current_year == date( 'Y' ) )	
+
+							if ( $count >= date( 'm' ) && $current_year == date( 'Y' ) )
 								continue;
-						
+
 							if ( ! empty( $item_sales[ $count ] ) ) {
 								$matches = array_intersect_key( $item_sales[ $count ], array_flip( $product_ids ) );
 								$total = array_sum( $matches );
@@ -2044,41 +2044,41 @@ function woocommerce_category_sales() {
 							} else {
 								$total = 0;
 							}
-								
+
 							$month_totals[ $count ] += $total;
-							
+
 							$category_sales_html .= '<td>' . woocommerce_price( $total ) . '</td>';
-							
+
 							$category_chart_data[] = array( strtotime( date( 'Ymd', strtotime( '2012-' . ( $count + 1 ) . '-01' ) ) ) . '000', $total );
 						}
-						
+
 						if ( $cat_total == 0 )
 							continue;
-						
+
 						$category_totals[] = $cat_total;
-						
+
 						$category_sales_html .= '<td><strong>' . woocommerce_price( $cat_total ) . '</strong></td>';
-						
+
 						$category_sales_html .= '</tr>';
-						
+
 						echo $category_sales_html;
-						
+
 						$chart_data[ $category->name ] = $category_chart_data;
-						
+
 						if ( $cat_total > $top_cat ) {
 							$top_cat = $cat_total;
 							$top_cat_name = $category->name;
 						}
-						
+
 						if ( $cat_total < $bottom_cat || $bottom_cat === '' ) {
 							$bottom_cat = $cat_total;
 							$bottom_cat_name = $category->name;
 						}
-		
+
 					}
-					
+
 					sort( $category_totals );
-					
+
 					echo '<tr><th><strong>' . __( 'Total', 'woocommerce' ) . '</strong></th>';
 					for ( $count = 0; $count < 12; $count++ )
 						if ( $count >= date( 'm' ) && $current_year == date( 'Y' ) )
@@ -2086,11 +2086,11 @@ function woocommerce_category_sales() {
 						else
 							echo '<td><strong>' . woocommerce_price( $month_totals[ $count ] ) . '</strong></td>';
 					echo '<td><strong>' .  woocommerce_price( array_sum( $month_totals ) ) . '</strong></td></tr>';
-					
+
 				?></tbody>
 			</table>
 		</div>
-		
+
 		<div id="poststuff" class="woocommerce-reports-wrap">
 			<div class="woocommerce-reports-sidebar">
 				<div class="postbox">
@@ -2128,10 +2128,10 @@ function woocommerce_category_sales() {
 							if ( sizeof( $category_totals ) == 0 )
 								echo __( 'N/A', 'woocommerce' );
 							elseif ( sizeof( $category_totals ) % 2 )
-								echo woocommerce_price( 
-									( 
-										$category_totals[ floor( sizeof( $category_totals ) / 2 ) ] + $category_totals[ ceil( sizeof( $category_totals ) / 2 ) ] 
-									) / 2 
+								echo woocommerce_price(
+									(
+										$category_totals[ floor( sizeof( $category_totals ) / 2 ) ] + $category_totals[ ceil( sizeof( $category_totals ) / 2 ) ]
+									) / 2
 								);
 							else
 								echo woocommerce_price( $category_totals[ sizeof( $category_totals ) / 2 ] );
@@ -2151,7 +2151,7 @@ function woocommerce_category_sales() {
 		</div>
 		<script type="text/javascript">
 			jQuery(function(){
-				
+
 				<?php
 					// Variables
 					foreach ( $chart_data as $name => $data ) {
@@ -2159,17 +2159,17 @@ function woocommerce_category_sales() {
 						echo 'var ' . $varname . ' = jQuery.parseJSON( \'' . json_encode( $data ) . '\' );';
 					}
 				?>
-	
+
 				var placeholder = jQuery("#placeholder");
-	
-				var plot = jQuery.plot(placeholder, [ 
-					<?php 
+
+				var plot = jQuery.plot(placeholder, [
+					<?php
 					$labels = array();
-					
+
 					foreach ( $chart_data as $name => $data ) {
 						$labels[] = '{ label: "' . esc_js( $name ) . '", data: ' . 'cat_' . str_replace( '-', '_', sanitize_title( $name ) ) . '_data }';
 					}
-					
+
 					echo implode( ',', $labels );
 					?>
 				], {
@@ -2196,9 +2196,9 @@ function woocommerce_category_sales() {
 					},
 					yaxes: [ { min: 0, tickDecimals: 2 } ]
 			 	});
-	
+
 			 	placeholder.resize();
-	
+
 				<?php woocommerce_tooltip_js(); ?>
 			});
 		</script>
@@ -2215,7 +2215,7 @@ function woocommerce_category_sales() {
 
 /**
  * woocommerce_coupon_sales function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -2227,42 +2227,42 @@ function woocommerce_coupon_sales() {
 
 	$current_year 	= isset( $_POST['show_year'] ) 	? $_POST['show_year'] 	: date( 'Y', current_time( 'timestamp' ) );
 	$start_date 	= strtotime( $current_year . '0101' );
-	
+
 	$order_statuses = implode( "','", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) );
-	
-	
+
+
 	$coupons = $wpdb->get_col( "
 								SELECT DISTINCT meta.meta_value FROM {$wpdb->postmeta} AS meta
 								LEFT JOIN {$wpdb->posts} AS posts ON posts.ID = meta.post_id
 								LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID=rel.object_ID
 								LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 								LEFT JOIN {$wpdb->terms} AS term USING( term_id )
-								
+
 								WHERE	meta.meta_key		= 'coupons'
 								AND		posts.post_type		= 'shop_order'
 								AND		posts.post_status	= 'publish'
 								AND		tax.taxonomy		= 'shop_order_status'
 								AND		term.slug			IN ('{$order_statuses}')
 							" );
-	
-	 
-	
+
+
+
 	?>
-	
+
 	<form method="post" action="" class="report_filters">
 		<p>
 			<label for="show_year"><?php _e( 'Show:', 'woocommerce' ); ?></label>
 			<select name="show_year" id="show_year">
 				<?php
-					for ( $i = $first_year; $i <= date( 'Y' ); $i++ ) 
+					for ( $i = $first_year; $i <= date( 'Y' ); $i++ )
 						printf( '<option value="%s" %s>%s</option>', $i, selected( $current_year, $i, false ), $i );
 				?>
 			</select>
-		
+
 			<select multiple="multiple" class="chosen_select" id="show_coupons" name="show_coupons[]" style="width: 300px;">
 				<?php
 					foreach ( $coupons as $coupon ) {
-						
+
 						echo '<option value="' . $coupon . '" ' . selected( ! empty( $_POST['show_coupons'] ) && in_array( $coupon, $_POST['show_coupons'] ), true ) . '>' . $coupon . '</option>';
 					}
 				?>
@@ -2271,25 +2271,25 @@ function woocommerce_coupon_sales() {
 			<input type="submit" class="button" value="<?php _e( 'Show', 'woocommerce' ); ?>" />
 		</p>
 	</form>
-	
+
 	<?php
-	
+
 	if ( ! empty( $_POST['show_coupons'] ) && count( $_POST['show_coupons'] ) > 0 ) :
-	
+
 	$coupons = $_POST['show_coupons'];
-	
+
 	$coupon_sales = $monthly_totals = array();
 
 	foreach( $coupons as $coupon ) :
-	
+
 		$monthly_sales = $wpdb->get_results( $wpdb->prepare( "
 			SELECT SUM(postmeta.meta_value) AS order_total, date_format(posts.post_date, '%%Y%%m') as month FROM {$wpdb->posts} AS posts
-			
+
 			INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID=postmeta.post_ID
 			INNER JOIN {$wpdb->term_relationships} AS rel ON posts.ID=rel.object_ID
 			INNER JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 			INNER JOIN {$wpdb->terms} AS term USING( term_id )
-			
+
 			WHERE	postmeta.meta_key	= '_order_total'
 			AND 	tax.taxonomy		= 'shop_order_status'
 			AND		term.slug			IN ('{$order_statuses}')
@@ -2298,18 +2298,18 @@ function woocommerce_coupon_sales() {
 			AND		'{$current_year}'	= date_format(posts.post_date,'%%Y')
 			AND		posts.ID			IN (
 												SELECT post_id FROM {$wpdb->postmeta} AS meta
-												
+
 												WHERE 	meta.meta_key 		= 'coupons'
 												AND		meta.meta_value		= '%s'
 											)
 			GROUP BY month", $coupon ), OBJECT );
-		
+
 		foreach( $monthly_sales as $sales ) {
 			$month = $sales->month;
 			$coupon_sales[$coupon][$month] = $sales->order_total;
 		}
-		
-		
+
+
 	endforeach;
 	?>
 	<div class="woocommerce-wide-reports-wrap">
@@ -2317,16 +2317,16 @@ function woocommerce_coupon_sales() {
 			<thead>
 				<tr>
 					<th><?php _e( 'Coupon', 'woocommerce' ); ?></th>
-					<?php 
+					<?php
 						$column_count = 0;
-						for ( $count = 0; $count < 12; $count++ ) : 
-							if ( $count >= date ( 'm' ) && $current_year == date( 'Y' ) )	
+						for ( $count = 0; $count < 12; $count++ ) :
+							if ( $count >= date ( 'm' ) && $current_year == date( 'Y' ) )
 								continue;
 							$month = date( 'Ym', strtotime( date( 'Ym', strtotime( '+ '. $count . ' MONTH', $start_date ) ) . '01' ) );
-							
+
 							// set elements before += them below
 							$monthly_totals[$month] = 0;
-							
+
 							$column_count++;
 							?>
 							<th><?php echo date( 'F', strtotime( '2012-' . ( $count + 1 ) . '-01' ) ); ?></th>
@@ -2334,61 +2334,61 @@ function woocommerce_coupon_sales() {
 					<th><strong><?php _e( 'Total', 'woocommerce' ); ?></strong></th>
 				</tr>
 			</thead>
-			
+
 			<tbody><?php
-				
+
 				// save data for chart while outputting
 				$chart_data = $coupon_totals = array();
-				
+
 				foreach( $coupon_sales as $coupon_code => $sales ) {
-					
+
 					echo '<tr><th>' . esc_html( $coupon_code ) . '</th>';
-					
+
 					for ( $count = 0; $count < 12; $count ++ ) {
-						
-						if ( $count >= date ( 'm' ) && $current_year == date( 'Y' ) )	
+
+						if ( $count >= date ( 'm' ) && $current_year == date( 'Y' ) )
 								continue;
-						
+
 						$month = date( 'Ym', strtotime( date( 'Ym', strtotime( '+ '. $count . ' MONTH', $start_date ) ) . '01' ) );
-						
+
 						$amount = isset( $sales[$month] ) ? $sales[$month] : 0;
 						echo '<td>' . woocommerce_price( $amount ) . '</td>';
-						
+
 						$monthly_totals[$month] += $amount;
-						
+
 						$chart_data[$coupon_code][] = array( strtotime( date( 'Ymd', strtotime( $month . '01' ) ) ) . '000', $amount );
-				
+
 					}
-						
+
 					echo '<td><strong>' . woocommerce_price( array_sum( $sales ) ) . '</strong></td>';
-					
+
 					// total sales across all months
 					$coupon_totals[$coupon_code] = array_sum( $sales );
-					
+
 					echo '</tr>';
-					
+
 				}
-				
+
 				$top_coupon_name = current( array_keys( $coupon_totals, max( $coupon_totals ) ) );
 				$top_coupon_sales = $coupon_totals[$top_coupon_name];
-				
+
 				$worst_coupon_name = current( array_keys( $coupon_totals, min( $coupon_totals ) ) );
 				$worst_coupon_sales = $coupon_totals[$worst_coupon_name];
-				
+
 				$median_coupon_sales = array_values( $coupon_totals );
 				sort($median_coupon_sales);
-				
+
 				echo '<tr><th><strong>' . __( 'Total', 'woocommerce' ) . '</strong></th>';
-				
+
 				foreach( $monthly_totals as $month => $totals )
 					echo '<td><strong>' . woocommerce_price( $totals ) . '</strong></td>';
-				
+
 				echo '<td><strong>' .  woocommerce_price( array_sum( $monthly_totals ) ) . '</strong></td></tr>';
-				
+
 			?></tbody>
 		</table>
 	</div>
-	
+
 	<div id="poststuff" class="woocommerce-reports-wrap">
 		<div class="woocommerce-reports-sidebar">
 			<div class="postbox">
@@ -2423,13 +2423,13 @@ function woocommerce_coupon_sales() {
 						if ( count( $median_coupon_sales ) == 2 )
 							echo __( 'N/A', 'woocommerce' );
 						elseif ( count( $median_coupon_sales ) % 2 )
-							echo woocommerce_price( 
-								( 
-									$median_coupon_sales[ floor( count( $median_coupon_sales ) / 2 ) ] + $median_coupon_sales[ ceil( count( $median_coupon_sales ) / 2 ) ] 
-								) / 2 
+							echo woocommerce_price(
+								(
+									$median_coupon_sales[ floor( count( $median_coupon_sales ) / 2 ) ] + $median_coupon_sales[ ceil( count( $median_coupon_sales ) / 2 ) ]
+								) / 2
 							);
 						else
-							
+
 							echo woocommerce_price( $median_coupon_sales[ count( $median_coupon_sales ) / 2 ] );
 					?></p>
 				</div>
@@ -2447,7 +2447,7 @@ function woocommerce_coupon_sales() {
 	</div>
 	<script type="text/javascript">
 		jQuery(function(){
-			
+
 			<?php
 				// Variables
 				foreach ( $chart_data as $name => $data ) {
@@ -2458,14 +2458,14 @@ function woocommerce_coupon_sales() {
 
 			var placeholder = jQuery("#placeholder");
 
-			var plot = jQuery.plot(placeholder, [ 
-				<?php 
+			var plot = jQuery.plot(placeholder, [
+				<?php
 				$labels = array();
-				
+
 				foreach ( $chart_data as $name => $data ) {
 					$labels[] = '{ label: "' . esc_js( $name ) . '", data: ' . 'coupon_' . str_replace( '-', '_', sanitize_title( $name ) ) . '_data }';
 				}
-				
+
 				echo implode( ',', $labels );
 				?>
 			], {

--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -31,7 +31,7 @@ if ( ! function_exists( 'woocommerce_settings' ) ) {
 	 */
 	function woocommerce_settings() {
 	    global $woocommerce, $woocommerce_settings;
-	    
+
 	    do_action( 'woocommerce_settings_start' );
 
 	    // Get current tab/section
@@ -96,23 +96,23 @@ if ( ! function_exists( 'woocommerce_settings' ) ) {
 
 				// If saving a shipping methods options, load 'er up
 				if ( $current_tab == 'shipping' && class_exists( $current_section ) ) {
-					
+
 					$current_section_class = new $current_section();
 					do_action( 'woocommerce_update_options_' . $current_tab . '_' . $current_section_class->id );
-				
+
 				// If saving an email's options, load theme
 				} elseif ( $current_tab == 'email' ) {
-					
+
 					// Load mailer
 					$mailer 	= $woocommerce->mailer();
-					
+
 					if ( class_exists( $current_section ) ) {
 						$current_section_class = new $current_section();
 						do_action( 'woocommerce_update_options_' . $current_tab . '_' . $current_section_class->id );
 					} else {
 						do_action( 'woocommerce_update_options_' . $current_tab . '_' . $current_section );
 					}
-					
+
 				} else {
 
 					// Save section only
@@ -247,7 +247,7 @@ if ( ! function_exists( 'woocommerce_settings' ) ) {
 							woocommerce_admin_fields( $woocommerce_settings[$current_tab] );
 						break;
 						case "email" :
-						
+
 							$current = $current_section ? '' : 'class="current"';
 
 							$links = array( '<a href="' . admin_url( 'admin.php?page=woocommerce_settings&tab=email' ) . '" ' . $current . '>' . __( 'Email Options', 'woocommerce' ) . '</a>' );
@@ -267,7 +267,7 @@ if ( ! function_exists( 'woocommerce_settings' ) ) {
 							}
 
 							echo '<ul class="subsubsub"><li>' . implode( ' | </li><li>', $links ) . '</li></ul><br class="clear" />';
-							
+
 							// Specific email options
 							if ( $current_section ) {
 								foreach ( $email_templates as $email ) {
@@ -511,10 +511,10 @@ function woocommerce_admin_fields( $options ) {
     	if ( ! isset( $value['std'] ) ) $value['std'] = '';
     	if ( ! isset( $value['desc'] ) ) $value['desc'] = '';
     	if ( ! isset( $value['desc_tip'] ) ) $value['desc_tip'] = false;
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $value['custom_attributes'] ) && is_array( $value['custom_attributes'] ) )
 			foreach ( $value['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -532,13 +532,13 @@ function woocommerce_admin_fields( $options ) {
 		} else {
 			$description = $tip = '';
 		}
-		
+
 		if ( $description && in_array( $value['type'], array( 'textarea', 'radio' ) ) ) {
 			$description = '<p style="margin-top:0">' . wp_kses_post( $description ) . '</p>';
 		} elseif ( $description ) {
 			$description = '<span class="description">' . wp_kses_post( $description ) . '</span>';
 		}
-		
+
 		if ( $tip && in_array( $value['type'], array( 'checkbox' ) ) ) {
 			$tip = '<span class="help_tip" data-tip="' . esc_attr( $tip ) . '">[?]</span>';
 		} elseif ( $tip ) {
@@ -547,7 +547,7 @@ function woocommerce_admin_fields( $options ) {
 
 		// Switch based on type
         switch( $value['type'] ) {
-        	
+
         	// Section Titles
             case 'title':
             	if ( ! empty( $value['name'] ) ) echo '<h3>' . esc_html( $value['name'] ) . '</h3>';
@@ -555,49 +555,49 @@ function woocommerce_admin_fields( $options ) {
             	echo '<table class="form-table">'. "\n\n";
             	if ( ! empty( $value['id'] ) ) do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) );
             break;
-            
+
             // Section Ends
             case 'sectionend':
             	if ( ! empty( $value['id'] ) ) do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) . '_end' );
             	echo '</table>';
             	if ( ! empty( $value['id'] ) ) do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) . '_after' );
             break;
-            
+
             // Standard text inputs and subtypes like 'number'
             case 'text':
             case 'email':
             case 'number':
             case 'color' :
-            
+
             	$type 			= $value['type'];
             	$class 			= '';
             	$option_value 	= get_option( $value['id'], null ) !== null ? esc_attr( stripslashes( get_option($value['id'] ) ) ) : esc_attr( $value['std'] );
-            	
+
             	if ( $value['type'] == 'color' ) {
             		$type = 'text';
             		$value['class'] .= 'colorpick';
 	            	$description .= '<div id="colorPickerDiv_' . esc_attr( $value['id'] ) . '" class="colorpickdiv" style="z-index: 100;background:#eee;border:1px solid #ccc;position:absolute;display:none;"></div>';
             	}
-            
+
             	?><tr valign="top">
 					<th scope="row" class="titledesc">
 						<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['name'] ); ?></label>
 						<?php echo $tip; ?>
 					</th>
                     <td class="forminp forminp-<?php echo sanitize_title( $value['type'] ) ?>">
-                    	<input 
-                    		name="<?php echo esc_attr( $value['id'] ); ?>" 
-                    		id="<?php echo esc_attr( $value['id'] ); ?>" 
-                    		type="<?php echo esc_attr( $type ); ?>" 
-                    		style="<?php echo esc_attr( $value['css'] ); ?>" 
-                    		value="<?php echo $option_value; ?>" 
+                    	<input
+                    		name="<?php echo esc_attr( $value['id'] ); ?>"
+                    		id="<?php echo esc_attr( $value['id'] ); ?>"
+                    		type="<?php echo esc_attr( $type ); ?>"
+                    		style="<?php echo esc_attr( $value['css'] ); ?>"
+                    		value="<?php echo $option_value; ?>"
                     		class="<?php echo esc_attr( $value['class'] ); ?>"
-                    		<?php echo implode( ' ', $custom_attributes ); ?> 
+                    		<?php echo implode( ' ', $custom_attributes ); ?>
                     		/> <?php echo $description; ?>
                     </td>
                 </tr><?php
-            break; 
-            
+            break;
+
             // Textarea
             case 'textarea':
             	?><tr valign="top">
@@ -607,41 +607,41 @@ function woocommerce_admin_fields( $options ) {
 					</th>
                     <td class="forminp forminp-<?php echo sanitize_title( $value['type'] ) ?>">
                     	<?php echo $description; ?>
-                    	
-                        <textarea 
-                        	name="<?php echo esc_attr( $value['id'] ); ?>" 
-                        	id="<?php echo esc_attr( $value['id'] ); ?>" 
-                        	style="<?php echo esc_attr( $value['css'] ); ?>" 
+
+                        <textarea
+                        	name="<?php echo esc_attr( $value['id'] ); ?>"
+                        	id="<?php echo esc_attr( $value['id'] ); ?>"
+                        	style="<?php echo esc_attr( $value['css'] ); ?>"
                         	class="<?php echo esc_attr( $value['class'] ); ?>"
                         	<?php echo implode( ' ', $custom_attributes ); ?>
-                        	><?php 
-                        		if ( false !== get_option($value['id'] ) ) 
-                        			echo esc_textarea( stripslashes( get_option( $value['id'] ) ) ); 
-                        		else 
-                        			echo esc_textarea( $value['std'] ); 
+                        	><?php
+                        		if ( false !== get_option($value['id'] ) )
+                        			echo esc_textarea( stripslashes( get_option( $value['id'] ) ) );
+                        		else
+                        			echo esc_textarea( $value['std'] );
                         	?></textarea>
                     </td>
                 </tr><?php
             break;
-            
+
             // Select boxes
             case 'select' :
             case 'multiselect' :
-            
+
             	$option_value = get_option( $value['id'] );
             	if ( ! $option_value )
 					$option_value = $value['std'];
-            
+
             	?><tr valign="top">
 					<th scope="row" class="titledesc">
 						<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['name'] ); ?></label>
 						<?php echo $tip; ?>
 					</th>
                     <td class="forminp forminp-<?php echo sanitize_title( $value['type'] ) ?>">
-                    	<select 
-                    		name="<?php echo esc_attr( $value['id'] ); ?>" 
-                    		id="<?php echo esc_attr( $value['id'] ); ?>" 
-                    		style="<?php echo esc_attr( $value['css'] ); ?>" 
+                    	<select
+                    		name="<?php echo esc_attr( $value['id'] ); ?>"
+                    		id="<?php echo esc_attr( $value['id'] ); ?>"
+                    		style="<?php echo esc_attr( $value['css'] ); ?>"
                     		class="<?php echo esc_attr( $value['class'] ); ?>"
                     		<?php echo implode( ' ', $custom_attributes ); ?>
                     		<?php if ( $value['type'] == 'multiselect' ) echo 'multiple="multiple"'; ?>
@@ -649,13 +649,13 @@ function woocommerce_admin_fields( $options ) {
 	                    	<?php
 		                        foreach ( $value['options'] as $key => $val ) {
 		                        	?>
-		                        	<option value="<?php echo esc_attr( $key ); ?>" <?php 
-		                        		
+		                        	<option value="<?php echo esc_attr( $key ); ?>" <?php
+
 			                        	if ( is_array( $option_value ) )
-			                        		selected( in_array( $key, $option_value ), true ); 
+			                        		selected( in_array( $key, $option_value ), true );
 			                        	else
-			                        		selected( $option_value, $key ); 
-		                        	
+			                        		selected( $option_value, $key );
+
 		                        	?>><?php echo $val ?></option>
 		                        	<?php
 		                        }
@@ -664,14 +664,14 @@ function woocommerce_admin_fields( $options ) {
                     </td>
                 </tr><?php
             break;
-            
+
             // Radio inputs
             case 'radio' :
-            
+
             	$option_value = get_option( $value['id'] );
             	if ( ! $option_value )
 					$option_value = $value['std'];
-            
+
             	?><tr valign="top">
 					<th scope="row" class="titledesc">
 						<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['name'] ); ?></label>
@@ -685,11 +685,11 @@ function woocommerce_admin_fields( $options ) {
                     			foreach ( $value['options'] as $key => $val ) {
 		                        	?>
 		                        	<li>
-		                        		<label><input 
-			                        		name="<?php echo esc_attr( $value['id'] ); ?>" 
-			                        		value="<?php echo $key; ?>" 
-			                        		type="radio" 
-				                    		style="<?php echo esc_attr( $value['css'] ); ?>" 
+		                        		<label><input
+			                        		name="<?php echo esc_attr( $value['id'] ); ?>"
+			                        		value="<?php echo $key; ?>"
+			                        		type="radio"
+				                    		style="<?php echo esc_attr( $value['css'] ); ?>"
 				                    		class="<?php echo esc_attr( $value['class'] ); ?>"
 				                    		<?php echo implode( ' ', $custom_attributes ); ?>
 				                    		<?php checked( $key, $option_value ); ?>
@@ -703,7 +703,7 @@ function woocommerce_admin_fields( $options ) {
                     </td>
                 </tr><?php
             break;
-            
+
             // Checkbox input
             case 'checkbox' :
 
@@ -733,15 +733,15 @@ function woocommerce_admin_fields( $options ) {
 
             	?>
 		            <legend class="screen-reader-text"><span><?php echo esc_html( $value['name'] ) ?></span></legend>
-					
+
 					<label for="<?php echo $value['id'] ?>">
-					<input 
-						name="<?php echo esc_attr( $value['id'] ); ?>" 
-						id="<?php echo esc_attr( $value['id'] ); ?>" 
-						type="checkbox" 
-						value="1" 
-						<?php checked(get_option($value['id']), 'yes'); ?> 
-						<?php echo implode( ' ', $custom_attributes ); ?> 
+					<input
+						name="<?php echo esc_attr( $value['id'] ); ?>"
+						id="<?php echo esc_attr( $value['id'] ); ?>"
+						type="checkbox"
+						value="1"
+						<?php checked(get_option($value['id']), 'yes'); ?>
+						<?php echo implode( ' ', $custom_attributes ); ?>
 					/> <?php echo wp_kses_post( $value['desc'] ) ?></label> <?php echo $tip; ?><br />
 				<?php
 
@@ -758,14 +758,14 @@ function woocommerce_admin_fields( $options ) {
 				}
 
             break;
-            
+
             // Image width settings
             case 'image_width' :
-            	
+
             	$width 	= get_option( $value['id'] . '_width', null ) !== null ? esc_attr( stripslashes( get_option( $value['id'] . '_width' ) ) ) : esc_attr( $value['std'] );
             	$height = get_option( $value['id'] . '_height', null ) !== null ? esc_attr( stripslashes( get_option( $value['id'] . '_height' ) ) ) : esc_attr( $value['std'] );
             	$crop 	= get_option( $value['id'] . '_crop', null ) !== null ? checked( get_option( $value['id'] . '_crop'), 1, false ) : checked( 1, 1, false );
-            	            	
+
             	?><tr valign="top">
 					<th scope="row" class="titledesc"><?php echo esc_html( $value['name'] ) ?></th>
                     <td class="forminp">
@@ -779,7 +779,7 @@ function woocommerce_admin_fields( $options ) {
                     	<?php echo $description; ?></td>
                 </tr><?php
             break;
-            
+
             // Single page selects
             case 'single_select_page' :
 
@@ -790,10 +790,10 @@ function woocommerce_admin_fields( $options ) {
             				   'show_option_none' 	=> ' ',
             				   'class'				=> $value['class'],
             				   'echo' 				=> false,
-            				   'selected'			=> absint( get_option( $value['id'] ) ) 
+            				   'selected'			=> absint( get_option( $value['id'] ) )
             				   );
 
-            	if( isset( $value['args'] ) ) 
+            	if( isset( $value['args'] ) )
             		$args = wp_parse_args( $value['args'], $args );
 
             	?><tr valign="top" class="single_select_page">
@@ -803,7 +803,7 @@ function woocommerce_admin_fields( $options ) {
 			        </td>
                	</tr><?php
             break;
-            
+
             // Single country selects
             case 'single_select_country' :
             	$countries = $woocommerce->countries->countries;
@@ -826,7 +826,7 @@ function woocommerce_admin_fields( $options ) {
                		</td>
                	</tr><?php
             break;
-            
+
             // Country multiselects
             case 'multi_select_countries' :
             	$countries = $woocommerce->countries->countries;
@@ -840,7 +840,7 @@ function woocommerce_admin_fields( $options ) {
                     <td class="forminp">
 	                    <select multiple="multiple" name="<?php echo esc_attr( $value['id'] ); ?>[]" style="width:450px;" data-placeholder="<?php _e( 'Choose countries&hellip;', 'woocommerce' ); ?>" title="Country" class="chosen_select">
 				        	<?php
-				        		if ( $countries ) 
+				        		if ( $countries )
 				        			foreach ( $countries as $key => $val )
 	                    				echo '<option value="'.$key.'" ' . selected( in_array( $key, $selections ), true, false ).'>' . $val . '</option>';
 	                    	?>
@@ -848,7 +848,7 @@ function woocommerce_admin_fields( $options ) {
                		</td>
                	</tr><?php
             break;
-            
+
             // Default: run an action
             default:
             	do_action( 'woocommerce_admin_field_' . $value['type'], $value );

--- a/admin/woocommerce-admin-status.php
+++ b/admin/woocommerce-admin-status.php
@@ -46,7 +46,7 @@ function woocommerce_status() {
 					break;
 					case "reset_roles" :
 						// Remove then re-add caps and roles
-						woocommerce_remove_roles();						
+						woocommerce_remove_roles();
 						woocommerce_init_roles();
 
 						echo '<div class="updated"><p>' . __( 'Roles successfully reset', 'woocommerce' ) . '</p></div>';
@@ -253,7 +253,7 @@ function woocommerce_status() {
                 <tr>
                     <td><?php _e('PHP Version','woocommerce')?></td>
                     <td><?php
-                    	if ( function_exists( 'phpversion' ) ) 
+                    	if ( function_exists( 'phpversion' ) )
                     		echo esc_html( phpversion() );
                     ?></td>
                 </tr>
@@ -334,7 +334,7 @@ function woocommerce_status() {
             		$posting['fsockopen_curl']['note'] = __( 'Your server does not have fsockopen or cURL enabled - PayPal IPN and other scripts which communicate with other servers will not work. Contact your hosting provider.', 'woocommerce' ). '</mark>';
             		$posting['fsockopen_curl']['success'] = false;
             	}
-            	
+
             	// SOAP
             	$posting['soap_client']['name'] = __( 'SOAP Client','woocommerce' );
 				if ( class_exists( 'SoapClient' ) ) {

--- a/admin/woocommerce-admin-taxonomies.php
+++ b/admin/woocommerce-admin-taxonomies.php
@@ -39,7 +39,7 @@ function woocommerce_add_category_fields() {
 			<button type="submit" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
 		</div>
 		<script type="text/javascript">
-			
+
 			 // Only show the "remove image" button when needed
 			 if ( ! jQuery('#product_cat_thumbnail_id').val() )
 				 jQuery('.remove_image_button').hide();
@@ -100,7 +100,7 @@ add_action( 'product_cat_add_form_fields', 'woocommerce_add_category_fields' );
  */
 function woocommerce_edit_category_fields( $term, $taxonomy ) {
 	global $woocommerce;
-	
+
 	$display_type	= get_woocommerce_term_meta( $term->term_id, 'display_type', true );
 	$image 			= '';
 	$thumbnail_id 	= absint( get_woocommerce_term_meta( $term->term_id, 'thumbnail_id', true ) );
@@ -186,7 +186,7 @@ add_action( 'product_cat_edit_form_fields', 'woocommerce_edit_category_fields', 
 function woocommerce_category_fields_save( $term_id, $tt_id, $taxonomy ) {
 	if ( isset( $_POST['display_type'] ) )
 		update_woocommerce_term_meta( $term_id, 'display_type', esc_attr( $_POST['display_type'] ) );
-		
+
 	if ( isset( $_POST['product_cat_thumbnail_id'] ) )
 		update_woocommerce_term_meta( $term_id, 'thumbnail_id', absint( $_POST['product_cat_thumbnail_id'] ) );
 }

--- a/admin/woocommerce-admin-update.php
+++ b/admin/woocommerce-admin-update.php
@@ -20,24 +20,24 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 function do_update_woocommerce() {
 	global $woocommerce;
-	
+
 	// Do updates
 	$current_db_version = get_option( 'woocommerce_db_version' );
-	
+
 	if ( version_compare( $current_db_version, '1.4', '<' ) ) {
 		include( 'includes/updates/woocommerce-update-1.4.php' );
 		update_option( 'woocommerce_db_version', '1.4' );
 	}
-	
+
 	if ( version_compare( $current_db_version, '1.5', '<' ) ) {
 		include( 'includes/updates/woocommerce-update-1.5.php' );
 		update_option( 'woocommerce_db_version', '1.5' );
 	}
-	
+
 	if ( version_compare( $current_db_version, '1.7', '<' ) ) {
 		include( 'includes/updates/woocommerce-update-1.7.php' );
 		update_option( 'woocommerce_db_version', '1.7' );
 	}
-	
+
 	update_option( 'woocommerce_db_version', $woocommerce->version );
 }

--- a/admin/woocommerce-admin-users.php
+++ b/admin/woocommerce-admin-users.php
@@ -73,9 +73,9 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 
 			$formatted_address = $woocommerce->countries->get_formatted_address( $address );
 
-			if ( ! $formatted_address ) 
-				$value = __( 'N/A', 'woocommerce' ); 
-			else 
+			if ( ! $formatted_address )
+				$value = __( 'N/A', 'woocommerce' );
+			else
 				$value = $formatted_address;
 
 			$value = wpautop( $value );
@@ -95,9 +95,9 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 
 			$formatted_address = $woocommerce->countries->get_formatted_address( $address );
 
-			if ( ! $formatted_address ) 
-				$value = __( 'N/A', 'woocommerce' ); 
-			else 
+			if ( ! $formatted_address )
+				$value = __( 'N/A', 'woocommerce' );
+			else
 				$value = $formatted_address;
 
 			$value = wpautop( $value );
@@ -106,9 +106,9 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 
 			$paying_customer = get_user_meta( $user_id, 'paying_customer', true );
 
-			if ( $paying_customer ) 
+			if ( $paying_customer )
 				$value = '<img src="' . $woocommerce->plugin_url() . '/assets/images/success.png" alt="yes" />';
-			else 
+			else
 				$value = '<img src="' . $woocommerce->plugin_url() . '/assets/images/success-off.png" alt="no" />';
 
 		break;

--- a/assets/js/admin/editor_plugin_lang.php
+++ b/assets/js/admin/editor_plugin_lang.php
@@ -1,5 +1,5 @@
 <?php
-	
+
 $strings = 'tinyMCE.addI18n({' . _WP_Editors::$mce_locale . ':{
     woocommerce:{
         insert: "' . esc_js( __( 'Insert Shortcode', 'woocommerce' ) ) . '",

--- a/classes/abstracts/abstract-wc-product.php
+++ b/classes/abstracts/abstract-wc-product.php
@@ -106,7 +106,7 @@ abstract class WC_Product {
 
 	/**
 	 * __construct function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $product
 	 */
@@ -118,22 +118,22 @@ abstract class WC_Product {
 			$this->id = absint( $product );
 		}
 	}
-	
-	
+
+
 	/**
 	 * Load the data from the custom fields
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $fields
 	 * @return void
 	 */
 	function load_product_data( $fields ) {
 		if ( $fields )
-			foreach ( $fields as $key => $default ) 
+			foreach ( $fields as $key => $default )
 				$this->$key = isset( $this->product_custom_fields[ '_' . $key ][0] ) && $this->product_custom_fields[ '_' . $key ][0] !== '' ? $this->product_custom_fields[ '_' . $key ][0] : $default;
 	}
-	
-	
+
+
 	/**
      * Get SKU (Stock-keeping unit) - product unique ID.
      *
@@ -156,8 +156,8 @@ abstract class WC_Product {
 
         return apply_filters( 'woocommerce_stock_amount', $this->stock );
     }
-    
-    
+
+
     /**
      * Get total stock.
      *
@@ -263,17 +263,17 @@ abstract class WC_Product {
 
 		return false;
 	}
-	
-	
+
+
 	/**
 	 * Get file download path identified by $download_id
-	 * 
+	 *
 	 * @access public
 	 * @param string $download_id file identifier
 	 * @return array
 	 */
 	function get_file_download_path( $download_id ) {
-		
+
 		$file_paths = isset( $this->product_custom_fields['_file_paths'][0] ) ? $this->product_custom_fields['_file_paths'][0] : '';
 		$file_paths = apply_filters( 'woocommerce_file_download_paths', $file_paths, $this->id, null, null );
 
@@ -311,8 +311,8 @@ abstract class WC_Product {
 	function needs_shipping() {
 		return $this->is_virtual() ? false : true;
 	}
-	
-	
+
+
 	/**
 	 * Check if a product is sold individually (no quantities)
 	 *
@@ -332,15 +332,15 @@ abstract class WC_Product {
 
 	/**
 	 * get_children function.
-	 * 
+	 *
 	 * @access public
 	 * @return bool
 	 */
 	function get_children() {
 		return array();
 	}
-	
-	
+
+
 	/**
 	 * Returns whether or not the product has any child product.
 	 *
@@ -360,7 +360,7 @@ abstract class WC_Product {
 	 */
 	function exists() {
 		global $wpdb;
-		
+
 		return ! empty( $this->post ) || $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID = %d LIMIT 1;", $this->id ) ) > 0 ? true : false;
 	}
 
@@ -836,9 +836,9 @@ abstract class WC_Product {
 	 */
 	function get_rating_html( $location = '' ) {
 
-		if ( $location ) 
+		if ( $location )
 			$location = '_' . $location;
-			
+
 		$star_size = apply_filters( 'woocommerce_star_rating_size' . $location, 16 );
 
 		if ( false === ( $average_rating = get_transient( 'wc_average_rating_' . $this->id ) ) ) {
@@ -938,9 +938,9 @@ abstract class WC_Product {
 	function get_shipping_class() {
 		if ( ! $this->shipping_class ) {
 			$classes = get_the_terms( $this->id, 'product_shipping_class' );
-			if ( $classes && ! is_wp_error( $classes ) ) 
-				$this->shipping_class = current( $classes )->slug; 
-			else 
+			if ( $classes && ! is_wp_error( $classes ) )
+				$this->shipping_class = current( $classes )->slug;
+			else
 				$this->shipping_class = '';
 		}
 		return $this->shipping_class;
@@ -1084,7 +1084,7 @@ abstract class WC_Product {
 	function has_attributes() {
 		if ( sizeof( $this->get_attributes() ) > 0 ) {
 			foreach ( $this->get_attributes() as $attribute ) {
-				if ( isset( $attribute['is_visible'] ) && $attribute['is_visible'] ) 
+				if ( isset( $attribute['is_visible'] ) && $attribute['is_visible'] )
 					return true;
 			}
 		}
@@ -1198,11 +1198,11 @@ abstract class WC_Product {
      * @return void
      */
     function check_sale_price() {
-    
+
     	if ( $this->sale_price_dates_from && $this->sale_price_dates_from < current_time('timestamp') ) {
 
     		if ( $this->sale_price && $this->price !== $this->sale_price ) {
-	    		
+
     			// Update price
     			$this->price = $this->sale_price;
     			update_post_meta( $this->id, '_price', $this->price );

--- a/classes/abstracts/abstract-wc-session.php
+++ b/classes/abstracts/abstract-wc-session.php
@@ -13,7 +13,7 @@ abstract class WC_Session {
 
     /**
      * save_data function to be implemented
-     * 
+     *
      * @access public
      * @return void
      */
@@ -29,10 +29,10 @@ abstract class WC_Session {
     	// When leaving or ending page load, store data
     	add_action( 'shutdown', array( &$this, 'save_data' ), 20 );
     }
-    
+
     /**
      * __get function.
-     * 
+     *
      * @access public
      * @param mixed $property
      * @return mixed
@@ -40,10 +40,10 @@ abstract class WC_Session {
     public function __get( $property ) {
         return isset( $this->_data[ $property ] ) ? $this->_data[ $property ] : null;
     }
- 
+
     /**
      * __set function.
-     * 
+     *
      * @access public
      * @param mixed $property
      * @param mixed $value
@@ -52,10 +52,10 @@ abstract class WC_Session {
     public function __set( $property, $value ) {
         $this->_data[ $property ] = $value;
     }
-    
+
      /**
      * __isset function.
-     * 
+     *
      * @access public
      * @param mixed $property
      * @return bool
@@ -63,10 +63,10 @@ abstract class WC_Session {
     public function __isset( $property ) {
         return isset( $this->_data[ $property ] );
     }
-    
+
     /**
      * __unset function.
-     * 
+     *
      * @access public
      * @param mixed $property
      * @return void

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -53,7 +53,7 @@ class WC_Cart {
 
 	/** @var float Discounts after tax. */
 	var $discount_total;
-	
+
 	/** @var float Total for additonal fees. */
 	var $fee_total;
 
@@ -68,7 +68,7 @@ class WC_Cart {
 
 	/** @var WC_Tax */
 	var $tax;
-	
+
 	/** @var array An array of fees. */
 	var $fees;
 
@@ -240,7 +240,7 @@ class WC_Cart {
 
 			$this->cart_contents = array();
 			$this->reset();
-			
+
 			unset( $woocommerce->session->order_awaiting_payment, $woocommerce->session->coupons, $woocommerce->session->cart );
 
 			if ( $clear_persistent_cart && get_current_user_id() )
@@ -749,17 +749,17 @@ class WC_Cart {
 
 			// Stock check - only check if we're managing stock and backorders are not allowed
 			if ( ! $product_data->is_in_stock() ) {
-			
+
 				$woocommerce->add_error( sprintf( __( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woocommerce' ), $product_data->get_title() ) );
-				
+
 				return false;
 			} elseif ( ! $product_data->has_enough_stock( $quantity ) ) {
-			
+
 				$woocommerce->add_error( sprintf(__( 'You cannot add that amount of &quot;%s&quot; to the cart because there is not enough stock (%s remaining).', 'woocommerce' ), $product_data->get_title(), $product_data->get_stock_quantity() ));
-				
+
 				return false;
-				
-			} 
+
+			}
 
 			// Downloadable/virtual qty check
 			if ( $product_data->is_sold_individually() ) {
@@ -1380,19 +1380,19 @@ class WC_Cart {
 					}
 				}
 			}
-			
+
 			// Add fees
 			foreach ( $this->get_fees() as $fee ) {
 				$this->fee_total += $fee->amount;
-				
+
 				if ( $fee->taxable ) {
 					// Get tax rates
 					$tax_rates 				= $this->tax->get_rates();
 					$fee_taxes				= $this->tax->calc_tax( $fee->amount, $tax_rates, false );
-					
+
 					// Store
 					$fee->tax 				= array_sum( $fee_taxes );
-					
+
 					// Tax rows - merge the totals we just got
 					foreach ( array_keys( $this->taxes + $fee_taxes ) as $key ) {
 					    $this->taxes[ $key ] = ( isset( $fee_taxes[ $key ] ) ? $fee_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
@@ -1407,7 +1407,7 @@ class WC_Cart {
 			if ( $woocommerce->customer->is_vat_exempt() ) {
 				$this->shipping_tax_total = $this->tax_total = 0;
 				$this->taxes = $this->shipping_taxes = array();
-				
+
 				foreach ( $this->cart_contents as $cart_item_key => $item )
 					$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $this->cart_contents[ $cart_item_key ]['line_tax'] = 0;
 			}
@@ -1440,8 +1440,8 @@ class WC_Cart {
 			 * Based on discounted product prices, discounted tax, shipping cost + tax, and any discounts to be added after tax (e.g. store credit)
 			 */
 			$this->total = apply_filters( 'woocommerce_calculated_total', number_format( $this->cart_contents_total + $this->tax_total + $this->shipping_tax_total + $this->shipping_total - $this->discount_total + $this->fee_total, $this->dp, '.', '' ), $this );
-			
-			if ( $this->total < 0 ) 
+
+			if ( $this->total < 0 )
 				$this->total = 0;
 		}
 
@@ -1673,7 +1673,7 @@ class WC_Cart {
 				}
 
 				$this->applied_coupons[] = $coupon_code;
-				
+
 				// Choose free shipping
 				if ( $the_coupon->enable_free_shipping() ) {
 					$woocommerce->session->chosen_shipping_method = 'free_shipping';
@@ -1741,7 +1741,7 @@ class WC_Cart {
 
 		/**
 		 * add_fee function.
-		 * 
+		 *
 		 * @access public
 		 * @param mixed $name
 		 * @param mixed $amount
@@ -1750,10 +1750,10 @@ class WC_Cart {
 		 * @return void
 		 */
 		function add_fee( $name, $amount, $taxable = false, $tax_class = '' ) {
-			
-			if ( empty( $this->fees ) ) 
+
+			if ( empty( $this->fees ) )
 				$this->fees = array();
-				
+
 			$new_fee 			= new stdClass();
 			$new_fee->id 		= sanitize_title( $name );
 			$new_fee->name 		= esc_attr( $name );
@@ -1761,13 +1761,13 @@ class WC_Cart {
 			$new_fee->tax_class	= $tax_class;
 			$new_fee->taxable	= $taxable ? true : false;
 			$new_fee->tax		= 0;
-			
+
 			$this->fees[] 		= $new_fee;
 		}
-		
+
 		/**
 		 * get_fees function.
-		 * 
+		 *
 		 * @access public
 		 * @return void
 		 */

--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -122,7 +122,7 @@ class WC_Checkout {
 	function process_checkout() {
 		global $wpdb, $woocommerce;
 
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) 
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) )
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 
 		$woocommerce->verify_nonce( 'process_checkout' );
@@ -142,7 +142,7 @@ class WC_Checkout {
 		$this->posted['shipping_method']	= isset( $_POST['shipping_method'] ) ? woocommerce_clean( $_POST['shipping_method'] ) : '';
 
 		// Ship to billing only option
-		if ( $woocommerce->cart->ship_to_billing_address_only() ) 
+		if ( $woocommerce->cart->ship_to_billing_address_only() )
 			$this->posted['shiptobilling'] = 1;
 
 		// Update customer shipping and payment method to posted method
@@ -398,7 +398,7 @@ class WC_Checkout {
 					'post_password'	=> uniqid( 'order_' )	// Protects the post just in case
 				) );
 
-				if ( $woocommerce->error_count() > 0 ) 
+				if ( $woocommerce->error_count() > 0 )
 					throw new MyException();
 
 				// Insert or update the post data
@@ -431,15 +431,15 @@ class WC_Checkout {
 					else
 						do_action( 'woocommerce_new_order', $order_id ); // Inserted successfully
 				}
-				
+
 				// DELETE ANY ITEMS IN CURRENT ORDER
-				
+
 				$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id IN ( SELECT order_item_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d )", $order_id ) );
-				
+
 				$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order_id ) );
-	
+
 				// SAVE LINE ITEMS
-				
+
 				foreach ( $woocommerce->cart->get_cart() as $cart_item_key => $values ) {
 
 					$_product = $values['data'];
@@ -449,7 +449,7 @@ class WC_Checkout {
 				 		'order_item_name' 		=> $_product->get_title(),
 				 		'order_item_type' 		=> 'line_item'
 				 	) );
-				 	
+
 				 	// Add line item meta
 				 	if ( $item_id ) {
 					 	woocommerce_add_order_item_meta( $item_id, '_qty', apply_filters( 'woocommerce_stock_amount', $values['quantity'] ) );
@@ -460,39 +460,39 @@ class WC_Checkout {
 					 	woocommerce_add_order_item_meta( $item_id, '_line_subtotal_tax', woocommerce_format_decimal( $values['line_subtotal_tax'] ) );
 					 	woocommerce_add_order_item_meta( $item_id, '_line_total', woocommerce_format_decimal( $values['line_total'] ) );
 					 	woocommerce_add_order_item_meta( $item_id, '_line_tax', woocommerce_format_decimal( $values['line_tax'] ) );
-					 	
+
 					 	// Store variation data in meta so admin can view it
 						if ( $values['variation'] && is_array( $values['variation'] ) )
 							foreach ( $values['variation'] as $key => $value )
 								woocommerce_add_order_item_meta( $item_id, esc_attr( str_replace( 'attribute_', '', $key ) ), $value );
-					 	
+
 					 	// Add line item meta for backorder status
 					 	if ( $_product->backorders_require_notification() && $_product->is_on_backorder( $values['quantity'] ) )
 					 		woocommerce_add_order_item_meta( $item_id, __( 'Backordered', 'woocommerce' ), $values['quantity'] - max( 0, $_product->get_total_stock() ) );
-				 	
+
 					 	//allow plugins to add order item meta
 					 	do_action( 'woocommerce_add_order_item_meta', $item_id, $values );
 				 	}
 				}
-				
+
 				// Store fees
 				foreach ( $woocommerce->cart->get_fees() as $fee ) {
 					$item_id = woocommerce_add_order_item( $order_id, array(
 				 		'order_item_name' 		=> $fee->name,
 				 		'order_item_type' 		=> 'fee'
 				 	) );
-				 	
+
 				 	if ( $fee->taxable )
 				 		woocommerce_add_order_item_meta( $item_id, '_tax_class', $fee->tax_class );
 				 	else
 				 		woocommerce_add_order_item_meta( $item_id, '_tax_class', '0' );
-				 		
+
 				 	woocommerce_add_order_item_meta( $item_id, '_line_total', woocommerce_format_decimal( $fee->amount ) );
 					woocommerce_add_order_item_meta( $item_id, '_line_tax', woocommerce_format_decimal( $fee->tax ) );
 				}
-				
+
 				// UPDATE USER META
-				
+
 				// Save billing and shipping first, also save to user meta if logged in
 				if ( $this->checkout_fields['billing'] ) {
 					foreach ( $this->checkout_fields['billing'] as $key => $field ) {
@@ -507,7 +507,7 @@ class WC_Checkout {
 							// Special fields
 							switch ( $key ) {
 								case "billing_email" :
-									if ( ! email_exists( $this->posted[ $key ] ) ) 
+									if ( ! email_exists( $this->posted[ $key ] ) )
 										wp_update_user( array ( 'ID' => $user_id, 'user_email' => $this->posted[ $key ] ) ) ;
 								break;
 								case "billing_first_name" :
@@ -541,11 +541,11 @@ class WC_Checkout {
 				}
 
 				// Save any other user meta
-				if ( $user_id ) 
+				if ( $user_id )
 					do_action( 'woocommerce_checkout_update_user_meta', $user_id, $this->posted );
-				
+
 				// UPDATE ORDER META
-				
+
 				// Get better formatted shipping method (title)
 				$shipping_method = $this->posted['shipping_method'];
 				if ( isset( $available_methods[ $this->posted['shipping_method'] ] ) )
@@ -555,15 +555,15 @@ class WC_Checkout {
 				$payment_method = $this->posted['payment_method'];
 				if ( isset( $available_gateways[ $this->posted['payment_method'] ] ) )
 					$payment_method = $available_gateways[ $this->posted['payment_method'] ]->get_title();
-					
+
 				// Store tax rows
 				foreach ( array_keys( $woocommerce->cart->taxes + $woocommerce->cart->shipping_taxes ) as $key ) {
-					
+
 					$item_id = woocommerce_add_order_item( $order_id, array(
 				 		'order_item_name' 		=> $woocommerce->cart->tax->get_rate_label( $key ),
 				 		'order_item_type' 		=> 'tax'
 				 	) );
-				 	
+
 				 	// Add line item meta
 				 	if ( $item_id ) {
 					 	woocommerce_add_order_item_meta( $item_id, 'compound', absint( $woocommerce->cart->tax->is_compound( $key ) ? 1 : 0 ) );
@@ -677,10 +677,10 @@ class WC_Checkout {
 				}
 
 			} catch ( Exception $e ) {
-				
+
 				if ( ! empty( $e ) )
 					$woocommerce->add_error( $e );
-				
+
 			}
 
 		} // endif
@@ -722,7 +722,7 @@ class WC_Checkout {
 
 		} elseif ( is_user_logged_in() ) {
 
-			if ( $meta = get_user_meta( get_current_user_id(), $input, true ) ) 
+			if ( $meta = get_user_meta( get_current_user_id(), $input, true ) )
 				return $meta;
 
 			$current_user = wp_get_current_user();

--- a/classes/class-wc-countries.php
+++ b/classes/class-wc-countries.php
@@ -480,7 +480,7 @@ class WC_Countries {
 
 		asort( $this->countries );
 
-		if ( get_option('woocommerce_allowed_countries') !== 'specific' ) 
+		if ( get_option('woocommerce_allowed_countries') !== 'specific' )
 			return $this->countries;
 
 		$allowed_countries = array();
@@ -492,17 +492,17 @@ class WC_Countries {
 
 		return $allowed_countries;
 	}
-	
-	
+
+
 	/**
 	 * get_allowed_country_states function.
-	 * 
+	 *
 	 * @access public
 	 * @return array
 	 */
 	function get_allowed_country_states() {
 
-		if ( get_option('woocommerce_allowed_countries') !== 'specific' ) 
+		if ( get_option('woocommerce_allowed_countries') !== 'specific' )
 			return $this->states;
 
 		$allowed_states = array();
@@ -510,7 +510,7 @@ class WC_Countries {
 		$allowed_countries_raw = get_option( 'woocommerce_specific_allowed_countries' );
 
 		foreach ( $allowed_countries_raw as $country )
-			if ( ! empty( $this->states[ $country ] ) ) 
+			if ( ! empty( $this->states[ $country ] ) )
 				$allowed_states[ $country ] = $this->states[ $country ];
 
 		return $allowed_states;
@@ -740,7 +740,7 @@ class WC_Countries {
 		$full_country 	= ( isset( $this->countries[ $country ] ) ) ? $this->countries[ $country ] : $country;
 
 		// Country is not needed if the same as base
-		if ( $country == $this->get_base_country() ) 
+		if ( $country == $this->get_base_country() )
 			$format = str_replace( '{country}', '', $format );
 
 		// Handle full state name
@@ -769,7 +769,7 @@ class WC_Countries {
 			'{postcode_upper}'   => strtoupper( $postcode ),
 			'{country_upper}'    => strtoupper( $full_country ),
 		) ) ;
-		
+
 		$replace = array_map( 'esc_html', $replace );
 
 		$formatted_address = str_replace( array_keys( $replace ), $replace, $format );

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -76,12 +76,12 @@ class WC_Coupon {
 		global $wpdb;
 
 		$this->code 	= apply_filters( 'woocommerce_coupon_code', $code );
-		
+
 		// Coupon data lets developers create coupons through code
 		$coupon_data 	= apply_filters( 'woocommerce_get_shop_coupon_data', false, $code );
 
         if ( $coupon_data ) {
-        
+
             $this->id 							= absint( $coupon_data['id'] );
             $this->type 						= esc_html( $coupon_data['type'] );
             $this->amount 						= esc_html( $coupon_data['amount'] );
@@ -97,19 +97,19 @@ class WC_Coupon {
             $this->exclude_product_categories 	= is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
             $this->minimum_amount 				= esc_html( $coupon_data['minimum_amount'] );
             $this->customer_email 				= esc_html( $coupon_data['customer_email'] );
-            
+
             return true;
-            
+
         } else {
-        
+
             $coupon_id 	= $wpdb->get_var( $wpdb->prepare( apply_filters( 'woocommerce_coupon_code_query', "SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon'" ), $this->code ) );
-            
-			if ( $coupon_id ) 
-				$coupon = get_post( $coupon_id ); 
-				
+
+			if ( $coupon_id )
+				$coupon = get_post( $coupon_id );
+
 			$coupon->post_title = apply_filters( 'woocommerce_coupon_code', $coupon->post_title );
 
-            if ( empty( $coupon ) || $coupon->post_status !== 'publish' || $this->code !== $coupon->post_title ) 
+            if ( empty( $coupon ) || $coupon->post_status !== 'publish' || $this->code !== $coupon->post_title )
             	return false;
 
             $this->id 					= $coupon->ID;
@@ -132,7 +132,7 @@ class WC_Coupon {
             	'customer_email'				=> array()
             );
 
-            foreach ( $load_data as $key => $default ) 
+            foreach ( $load_data as $key => $default )
             	$this->$key = isset( $this->coupon_custom_fields[ $key ][0] ) && $this->coupon_custom_fields[ $key ][0] !== '' ? $this->coupon_custom_fields[ $key ][0] : $default;
 
             // Alias
@@ -149,7 +149,7 @@ class WC_Coupon {
 
             return true;
         }
-        
+
         return false;
 	}
 
@@ -244,7 +244,7 @@ class WC_Coupon {
 				$valid_for_cart = false;
 				if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 					foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-						
+
 						if ( in_array( $cart_item['product_id'], $this->product_ids ) || in_array( $cart_item['variation_id'], $this->product_ids ) || in_array( $cart_item['data']->get_parent(), $this->product_ids ) )
 							$valid_for_cart = true;
 					}
@@ -260,10 +260,10 @@ class WC_Coupon {
 				$valid_for_cart = false;
 				if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 					foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-	
+
 						$product_cats = wp_get_post_terms($cart_item['product_id'], 'product_cat', array("fields" => "ids"));
-	
-						if ( sizeof( array_intersect( $product_cats, $this->product_categories ) ) > 0 ) 
+
+						if ( sizeof( array_intersect( $product_cats, $this->product_categories ) ) > 0 )
 							$valid_for_cart = true;
 					}
 				}
@@ -297,10 +297,10 @@ class WC_Coupon {
 					$valid_for_cart = true;
 					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-	
+
 							$product_cats = wp_get_post_terms( $cart_item['product_id'], 'product_cat', array( "fields" => "ids" ) );
-	
-							if ( sizeof( array_intersect( $product_cats, $this->exclude_product_categories ) ) > 0 ) 
+
+							if ( sizeof( array_intersect( $product_cats, $this->exclude_product_categories ) ) > 0 )
 								$valid_for_cart = false;
 						}
 					}

--- a/classes/class-wc-customer.php
+++ b/classes/class-wc-customer.php
@@ -10,10 +10,10 @@
  * @author 		WooThemes
  */
 class WC_Customer {
-	
+
 	/** Stores customer data as an array */
 	protected $_data;
-	
+
 	/**
 	 * Constructor for the customer class loads the customer data.
 	 *
@@ -22,7 +22,7 @@ class WC_Customer {
 	 */
 	function __construct() {
 		global $woocommerce;
-		
+
 		if ( empty( $woocommerce->session->customer ) ) {
 
 			$default = apply_filters( 'woocommerce_customer_default_location', get_option( 'woocommerce_default_country' ) );
@@ -50,18 +50,18 @@ class WC_Customer {
 				'is_vat_exempt' 		=> false,
 				'calculated_shipping'	=> false
 			);
-				
+
 		} else {
 			$this->_data = $woocommerce->session->customer;
 		}
-		
+
 		// When leaving or ending page load, store data
     	add_action( 'shutdown', array( &$this, 'save_data' ), 10 );
 	}
 
     /**
      * __get function.
-     * 
+     *
      * @access public
      * @param mixed $property
      * @return mixed
@@ -69,10 +69,10 @@ class WC_Customer {
     public function __get( $property ) {
         return isset( $this->_data[ $property ] ) ? $this->_data[ $property ] : null;
     }
- 
+
     /**
      * __set function.
-     * 
+     *
      * @access public
      * @param mixed $property
      * @param mixed $value
@@ -81,10 +81,10 @@ class WC_Customer {
     public function __set( $property, $value ) {
         $this->_data[ $property ] = $value;
     }
-	
+
 	/**
 	 * save_data function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -156,11 +156,11 @@ class WC_Customer {
 	 */
 	function is_customer_outside_base() {
 		list( $country, $state, $postcode, $city ) = $this->get_taxable_address();
-		
+
 		if ( $country ) {
 
 			$default = get_option('woocommerce_default_country');
-			
+
         	if ( strstr( $default, ':' ) ) {
 	    		list( $default_country, $default_state ) = explode( ':', $default );
 	    	} else {
@@ -220,11 +220,11 @@ class WC_Customer {
 		$validation = $woocommerce->validation();
 		if (isset($this->_data['postcode']) && $this->_data['postcode'] !== false) return $validation->format_postcode( $this->_data['postcode'], $this->get_country());
 	}
-	
-	
+
+
 	/**
 	 * Get the city from the current session.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -234,17 +234,17 @@ class WC_Customer {
 
 	/**
 	 * Gets the address from the current session.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function get_address() {
 		if ( isset( $this->_data['address'] ) ) return $this->_data['address'];
 	}
-		
+
 	/**
 	 * Gets the address_2 from the current session.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -285,41 +285,41 @@ class WC_Customer {
 		$validation = $woocommerce->validation();
 		if (isset($this->_data['shipping_postcode'])) return $validation->format_postcode( $this->_data['shipping_postcode'], $this->get_shipping_country());
 	}
-	
-	
+
+
 	/**
 	 * Gets the city from the current session.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function get_shipping_city() {
 		if ( isset( $this->_data['shipping_city'] ) ) return $this->_data['shipping_city'];
 	}
-	
+
 	/**
 	 * Gets the address from the current session.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function get_shipping_address() {
 		if ( isset( $this->_data['shipping_address'] ) ) return $this->_data['shipping_address'];
 	}
-		
+
 	/**
 	 * Gets the address_2 from the current session.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function get_shipping_address_2() {
 		if ( isset( $this->_data['shipping_address_2'] ) ) return $this->_data['shipping_address_2'];
 	}
-	
+
 	/**
 	 * get_taxable_address function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -338,10 +338,10 @@ class WC_Customer {
 		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city ) );
 	}
 
-	
+
 	/**
 	 * Sets session data for the location.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $country
 	 * @param mixed $state
@@ -433,14 +433,14 @@ class WC_Customer {
 	 * @param mixed $country
 	 * @param string $state (default: '')
 	 * @param string $postcode (default: '')
-	 * @param string $city (default: '')	 
+	 * @param string $city (default: '')
 	 * @return void
 	 */
 	function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$this->_data['shipping_country'] = $country;
 		$this->_data['shipping_state'] = $state;
 		$this->_data['shipping_postcode'] = $postcode;
-		$this->_data['shipping_city'] = $city;	
+		$this->_data['shipping_city'] = $city;
 	}
 
 
@@ -528,7 +528,7 @@ class WC_Customer {
 
 	/**
 	 * calculated_shipping function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $calculated
 	 * @return void
@@ -536,7 +536,7 @@ class WC_Customer {
 	function calculated_shipping( $calculated = true ) {
 		$this->_data['calculated_shipping'] = $calculated;
 	}
-	
+
 
 	/**
 	 * Gets a user's downloadable products if they are logged in.
@@ -554,7 +554,7 @@ class WC_Customer {
 			$user_info = get_userdata( get_current_user_id() );
 
 			$results = $wpdb->get_results( $wpdb->prepare("SELECT * FROM ".$wpdb->prefix."woocommerce_downloadable_product_permissions WHERE user_id = '%s' ORDER BY order_id, product_id, download_id", get_current_user_id()) );
-			
+
 			$_product = null;
 			$order = null;
 			$file_number = 0;
@@ -578,7 +578,7 @@ class WC_Customer {
 					endif;
 
 					if ( ! $_product->exists() ) continue;
-					
+
 					if ( ! $_product->has_file( $result->download_id ) ) continue;
 
 					// Download name will be 'Product Name' for products with a single downloadable file, and 'Product Name - File X' for products with multiple files

--- a/classes/class-wc-logger.php
+++ b/classes/class-wc-logger.php
@@ -86,11 +86,11 @@ class WC_Logger {
 		if ( $this->open( $handle ) )
 			ftruncate( $this->handles[ $handle ], 0 );
 	}
-	
-	
+
+
 	/**
 	 * file_name function.
-	 * 
+	 *
 	 * @access private
 	 * @param mixed $handle
 	 * @return void

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -386,23 +386,23 @@ class WC_Order {
 
 	/**
 	 * Return an array of items/products within this order.
-	 * 
+	 *
 	 * @access public
 	 * @param string $type Types of line items to get (array or string)
 	 * @return void
 	 */
 	function get_items( $type = '' ) {
 		global $wpdb, $woocommerce;
-		
+
 		if ( empty( $type ) )
 			$type = array( 'line_item' );
-			
+
 		if ( ! is_array( $type ) ) {
 			$type = array( $type );
 		}
-		
+
 		$type = array_map( 'esc_attr', $type );
-		
+
 		$line_items = $wpdb->get_results( $wpdb->prepare( "
 			SELECT 		order_item_id, order_item_name, order_item_type
 			FROM 		{$wpdb->prefix}woocommerce_order_items
@@ -410,16 +410,16 @@ class WC_Order {
 			AND 		order_item_type IN ( '" . implode( "','", $type ) . "' )
 			ORDER BY 	order_item_id
 		", $this->id ) );
-		
+
 		$items = array();
-		
+
 		foreach ( $line_items as $item ) {
-			
+
 			// Place line item into array to return
 			$items[ $item->order_item_id ]['name'] = $item->order_item_name;
 			$items[ $item->order_item_id ]['type'] = $item->order_item_type;
 			$items[ $item->order_item_id ]['item_meta'] = $this->get_item_meta( $item->order_item_id );
-			
+
 			// Put meta into item array
 			foreach( $items[ $item->order_item_id ]['item_meta'] as $name => $value ) {
 				$key = substr( $name, 0, 1 ) == '_' ? substr( $name, 1 ) : $name;
@@ -438,10 +438,10 @@ class WC_Order {
 	function get_fees() {
 		return $this->get_items( 'fee' );
 	}
-	
+
 	/**
 	 * Return an array of taxes within this order.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -451,21 +451,21 @@ class WC_Order {
 
 	/**
 	 * has_meta function for order items.
-	 * 
+	 *
 	 * @access public
 	 * @return array of meta data
 	 */
 	function has_meta( $order_item_id ) {
 		global $wpdb;
-		
+
 		return $wpdb->get_results( $wpdb->prepare("SELECT meta_key, meta_value, meta_id, order_item_id
 			FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d
 			ORDER BY meta_key,meta_id", absint( $order_item_id ) ), ARRAY_A );
 	}
-	
+
 	/**
 	 * Get order item meta.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $item_id
 	 * @param string $key (default: '')
@@ -555,11 +555,11 @@ class WC_Order {
 	function get_total() {
 		return apply_filters( 'woocommerce_order_amount_total', number_format( (double) $this->order_total, 2, '.', '' ) );
 	}
-	
-	
+
+
 	/**
 	 * get_order_total function. Alias for get_total()
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -885,19 +885,19 @@ class WC_Order {
 				'label' => __( 'Shipping:', 'woocommerce' ),
 				'value'	=> $this->get_shipping_to_display()
 			);
-			
+
 		if ( $fees = $this->get_fees() )
 			foreach( $fees as $id => $fee ) {
-				
+
 				if ( $this->display_cart_ex_tax || ! $this->prices_include_tax ) {
-				
+
 					$total_rows[ 'fee_' . $id ] = array(
 						'label' => $fee['name'],
 						'value'	=> woocommerce_price( $fee['line_total'] )
 					);
-					
+
 				} else {
-					
+
 					$total_rows[ 'fee_' . $id ] = array(
 						'label' => $fee['name'],
 						'value'	=> woocommerce_price( $fee['line_total'] + $fee['line_tax'] )
@@ -905,31 +905,31 @@ class WC_Order {
 
 				}
 			}
-		
+
 		// Tax for tax exclusive prices
 		if ( $this->display_cart_ex_tax || ! $this->prices_include_tax ) {
-			
+
 			if ( $this->get_total_tax() > 0 ) {
-	
+
 				if ( sizeof( $this->get_taxes() ) > 0 ) {
-	
+
 					$has_compound_tax = false;
-	
+
 					foreach ( $this->get_taxes() as $tax ) {
 						if ( $tax[ 'compound' ] ) {
 							$has_compound_tax = true;
 							continue;
 						}
-	
+
 						if ( ( $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ] ) == 0 )
 							continue;
-	
+
 						$total_rows[ sanitize_title( $tax[ 'name' ] ) ] = array(
 							'label' => $tax[ 'name' ] . ':',
 							'value'	=> woocommerce_price( ( $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ] ) )
 						);
 					}
-	
+
 					if ( $has_compound_tax ) {
 						if ( $subtotal = $this->get_subtotal_to_display( true ) ) {
 							$total_rows['subtotal'] = array(
@@ -938,14 +938,14 @@ class WC_Order {
 							);
 						}
 					}
-	
+
 					foreach ( $this->get_taxes() as $tax ) {
 						if ( ! $tax[ 'compound' ] )
 							continue;
-	
+
 						if ( ( $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ] ) == 0 )
 							continue;
-	
+
 						$total_rows[ sanitize_title( $tax[ 'name' ] ) ] = array(
 							'label' => $tax[ 'name' ] . ':',
 							'value'	=> woocommerce_price( ( $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ] ) )
@@ -957,14 +957,14 @@ class WC_Order {
 						'value'	=> woocommerce_price( $this->get_total_tax() )
 					);
 				}
-	
+
 			} elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) {
 				$total_rows['tax'] = array(
 					'label' => $woocommerce->countries->tax_or_vat(),
 					'value'	=> _x( 'N/A', 'Relating to tax', 'woocommerce' )
 				);
 			}
-		
+
 		}
 
 		if ( $this->get_order_discount() > 0 )
@@ -977,37 +977,37 @@ class WC_Order {
 			'label' => __( 'Order Total:', 'woocommerce' ),
 			'value'	=> $this->get_formatted_order_total()
 		);
-		
+
 		// Tax for inclusive prices
 		if ( ! $this->display_cart_ex_tax && $this->prices_include_tax ) {
-		
+
 			$tax_string_array = array();
-		
+
 			if ( $this->get_total_tax() > 0 ) {
-	
+
 				if ( sizeof( $this->get_taxes() ) > 0 ) {
-					
+
 					foreach ( $this->get_taxes() as $tax ) {
-					
+
 						if ( ( $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ] ) == 0 )
 							continue;
-							
+
 						$tax_string_array[] = sprintf( '%s %s', woocommerce_price( ( $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ] ) ), $tax[ 'name' ] );
 					}
-					
+
 				} else {
-					
+
 					$tax_string_array[] = sprintf( '%s %s', woocommerce_price( $this->get_total_tax() ), $woocommerce->countries->tax_or_vat() );
 
 				}
-				
+
 			} elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) {
-				
+
 				$tax_string_array[] = sprintf( '%s %s', woocommerce_price( 0 ), $woocommerce->countries->tax_or_vat() );
 
 			}
-					
-			$total_rows['order_total']['value'] .= ' ' . sprintf( __( '(Includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) );		
+
+			$total_rows['order_total']['value'] .= ' ' . sprintf( __( '(Includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) );
 		}
 
 		return apply_filters( 'woocommerce_get_order_item_totals', $total_rows, $this );
@@ -1029,7 +1029,7 @@ class WC_Order {
 	function email_order_items_table( $show_download_links = false, $show_sku = false, $show_purchase_note = false, $show_image = false, $image_size = array( 32, 32 ), $plain_text = false ) {
 
 		ob_start();
-		
+
 		$template = $plain_text ? 'emails/plain/email-order-items.php' : 'emails/email-order-items.php';
 
 		woocommerce_get_template( $template, array(
@@ -1049,7 +1049,7 @@ class WC_Order {
 
 	/**
 	 * Checks if product download is permitted
-	 * 
+	 *
 	 * @access public
 	 * @return bool
 	 */
@@ -1186,12 +1186,12 @@ class WC_Order {
 	 */
 	function update_status( $new_status_slug, $note = '' ) {
 
-		if ( $note ) 
+		if ( $note )
 			$note .= ' ';
 
 		$old_status = get_term_by( 'slug', sanitize_title( $this->status ), 'shop_order_status' );
 		$new_status = get_term_by( 'slug', sanitize_title( $new_status_slug ), 'shop_order_status' );
-		
+
 		if ( $new_status ) {
 
 			wp_set_object_terms( $this->id, array( $new_status->slug ), 'shop_order_status', false );
@@ -1202,7 +1202,7 @@ class WC_Order {
 				do_action( 'woocommerce_order_status_' . $new_status->slug, $this->id );
 				do_action( 'woocommerce_order_status_' . $this->status . '_to_' . $new_status->slug, $this->id );
 				do_action( 'woocommerce_order_status_changed', $this->id, $this->status, $new_status->slug );
-				
+
 				$this->add_order_note( $note . sprintf( __( 'Order status changed from %s to %s.', 'woocommerce' ), __( $old_status->name, 'woocommerce' ), __( $new_status->name, 'woocommerce' ) ) );
 
 				// Record the completed date of the order
@@ -1239,7 +1239,7 @@ class WC_Order {
 	 */
 	function cancel_order( $note = '' ) {
 		global $woocommerce;
-		
+
 		unset( $woocommerce->session->order_awaiting_payment );
 
 		$this->update_status('cancelled', $note);
@@ -1261,7 +1261,7 @@ class WC_Order {
 	 */
 	function payment_complete() {
 		global $woocommerce;
-		
+
 		unset( $woocommerce->session->order_awaiting_payment );
 
 		if ( $this->status == 'on-hold' || $this->status == 'pending' || $this->status == 'failed' ) {
@@ -1269,9 +1269,9 @@ class WC_Order {
 			$order_needs_processing = true;
 
 			if ( sizeof( $this->get_items() ) > 0 ) {
-			
+
 				foreach( $this->get_items() as $item ) {
-				
+
 					if ( $item['product_id'] > 0 ) {
 
 						$_product = $this->get_product_from_item( $item );
@@ -1545,16 +1545,16 @@ class WC_Order_Item_Meta {
 		global $woocommerce;
 
 		if ( ! empty( $this->meta ) ) {
-			
+
 			$output = $flat ? '' : '<dl class="variation">';
 
 			$meta_list = array();
 
 			foreach ( $this->meta as $meta_key => $meta_value ) {
-			
-				if ( ! $meta_value || ( ! empty( $hideprefix ) && substr( $meta_key, 0, 1 ) == $hideprefix ) )  
+
+				if ( ! $meta_value || ( ! empty( $hideprefix ) && substr( $meta_key, 0, 1 ) == $hideprefix ) )
 					continue;
-					
+
 				// Get first value
 				$meta_value = $meta_value[0];
 
@@ -1579,12 +1579,12 @@ class WC_Order_Item_Meta {
 			else
 				$output .= implode( '', $meta_list );
 
-			if ( ! $flat ) 
+			if ( ! $flat )
 				$output .= '</dl>';
 
-			if ( $return ) 
-				return $output; 
-			else 
+			if ( $return )
+				return $output;
+			else
 				echo $output;
 		}
 	}

--- a/classes/class-wc-product-external.php
+++ b/classes/class-wc-product-external.php
@@ -15,7 +15,7 @@ class WC_Product_External extends WC_Product {
 
 	/**
 	 * __construct function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $product
 	 * @param array $args Contains arguments to set up this product
@@ -23,10 +23,10 @@ class WC_Product_External extends WC_Product {
 	function __construct( $product, $args ) {
 
 		parent::__construct( $product );
-		
+
 		$this->product_type = 'external';
 		$this->product_custom_fields = get_post_custom( $this->id );
-		
+
 		// Load data from custom fields
 		$this->load_product_data( array(
 			'sku'			=> '',
@@ -52,7 +52,7 @@ class WC_Product_External extends WC_Product {
 			'sale_price_dates_to' 	=> '',
 			'featured'		=> 'no'
 		) );
-		
+
 		$this->check_sale_price();
 	}
 

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -17,13 +17,13 @@ class WC_Product_Factory {
 
 	public function get_product( $the_product = false, $args = array() ) {
 		global $post;
-	
+
 		if ( false === $the_product ) {
 			$the_product = $post;
 		} elseif ( is_numeric( $the_product ) ) {
 			$the_product = get_post( $the_product );
 		}
-			
+
 		$product_id 	= absint( $the_product->ID );
 		$post_type 		= $the_product->post_type;
 
@@ -33,10 +33,10 @@ class WC_Product_Factory {
 			$terms 			= get_the_terms( $product_id, 'product_type' );
 			$product_type 	= ! empty( $terms ) && isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
 		}
-		
+
 		// Filter classname so that the class can be overridden if extended.
 		$classname = apply_filters( 'woocommerce_product_class', 'WC_Product_' . $product_type, $product_type, $post_type, $product_id );
-		
+
 		if ( class_exists( $classname ) ) {
 			return new $classname( $the_product, $args );
 		} else {

--- a/classes/class-wc-product-grouped.php
+++ b/classes/class-wc-product-grouped.php
@@ -18,18 +18,18 @@ class WC_Product_Grouped extends WC_Product {
 
 	/** @var string The product's total stock, including that of its children. */
 	var $total_stock;
-	
+
 	/**
 	 * __construct function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $product
 	 * @param array $args Contains arguments to set up this product
 	 */
 	function __construct( $product, $args ) {
-		
+
 		parent::__construct( $product );
-		
+
 		$this->product_type = 'grouped';
 		$this->product_custom_fields = get_post_custom( $this->id );
 
@@ -58,7 +58,7 @@ class WC_Product_Grouped extends WC_Product {
 			'sale_price_dates_to' 	=> '',
 			'featured'		=> 'no'
 		) );
-		
+
 		$this->check_sale_price();
 	}
 

--- a/classes/class-wc-product-simple.php
+++ b/classes/class-wc-product-simple.php
@@ -15,7 +15,7 @@ class WC_Product_Simple extends WC_Product {
 
 	/**
 	 * __construct function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $product
 	 * @param array $args Contains arguments to set up this product
@@ -23,10 +23,10 @@ class WC_Product_Simple extends WC_Product {
 	function __construct( $product, $args ) {
 
 		parent::__construct( $product );
-		
+
 		$this->product_type = 'simple';
 		$this->product_custom_fields = get_post_custom( $this->id );
-		
+
 		// Load data from custom fields
 		$this->load_product_data( array(
 			'sku'			=> '',
@@ -52,7 +52,7 @@ class WC_Product_Simple extends WC_Product {
 			'sale_price_dates_to' 	=> '',
 			'featured'		=> 'no'
 		) );
-		
+
 		$this->check_sale_price();
 	}
 }

--- a/classes/class-wc-product-variable.php
+++ b/classes/class-wc-product-variable.php
@@ -12,13 +12,13 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class WC_Product_Variable extends WC_Product {
-	
+
 	/** @var array Array of child products/posts/variations. */
 	var $children;
 
 	/** @var string The product's total stock, including that of its children. */
 	var $total_stock;
-	
+
 	/** @var string Used for variation prices. */
 	var $min_variation_price;
 
@@ -36,10 +36,10 @@ class WC_Product_Variable extends WC_Product {
 
 	/** @var string Used for variation prices. */
 	var $max_variation_sale_price;
-	
+
 	/**
 	 * __construct function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $product
 	 * @param array $args Contains arguments to set up this product
@@ -47,7 +47,7 @@ class WC_Product_Variable extends WC_Product {
 	function __construct( $product, $args ) {
 
 		parent::__construct( $product );
-		
+
 		$this->product_type = 'variable';
 		$this->product_custom_fields = get_post_custom( $this->id );
 
@@ -82,7 +82,7 @@ class WC_Product_Variable extends WC_Product {
 			'min_variation_sale_price'	=> '',
 			'max_variation_sale_price'	=> '',
 		) );
-		
+
 		$this->check_sale_price();
 	}
 
@@ -172,8 +172,8 @@ class WC_Product_Variable extends WC_Product {
 			return apply_filters( 'woocommerce_stock_amount', $this->stock );
 		endif;
 	}
-	
-	
+
+
 	/**
 	 * Return the products children posts.
 	 *
@@ -484,26 +484,26 @@ class WC_Product_Variable extends WC_Product {
 				$child_price 			= get_post_meta( $child, '_price', true );
 				$child_regular_price 	= get_post_meta( $child, '_regular_price', true );
 				$child_sale_price 		= get_post_meta( $child, '_sale_price', true );
-				
+
 				// Regular prices
-				if ( ! is_numeric( $this->min_variation_regular_price ) || $child_regular_price < $this->min_variation_regular_price ) 
+				if ( ! is_numeric( $this->min_variation_regular_price ) || $child_regular_price < $this->min_variation_regular_price )
 					$this->min_variation_regular_price = $child_regular_price;
-					
-				if ( ! is_numeric( $this->max_variation_regular_price ) || $child_regular_price > $this->max_variation_regular_price ) 
+
+				if ( ! is_numeric( $this->max_variation_regular_price ) || $child_regular_price > $this->max_variation_regular_price )
 					$this->max_variation_regular_price = $child_regular_price;
-				
+
 				// Sale prices
 				if ( $child_price == $child_sale_price ) {
-					if ( $child_sale_price !== '' && ( ! is_numeric( $this->min_variation_sale_price ) || $child_sale_price < $this->min_variation_sale_price ) ) 
+					if ( $child_sale_price !== '' && ( ! is_numeric( $this->min_variation_sale_price ) || $child_sale_price < $this->min_variation_sale_price ) )
 						$this->min_variation_sale_price = $child_sale_price;
-					
-					if ( $child_sale_price !== '' && ( ! is_numeric( $this->max_variation_sale_price ) || $child_sale_price > $this->max_variation_sale_price ) ) 
+
+					if ( $child_sale_price !== '' && ( ! is_numeric( $this->max_variation_sale_price ) || $child_sale_price > $this->max_variation_sale_price ) )
 						$this->max_variation_sale_price = $child_sale_price;
 				}
 			}
 
 	    	$this->min_variation_price = $this->min_variation_sale_price === '' || $this->min_variation_regular_price < $this->min_variation_sale_price ? $this->min_variation_regular_price : $this->min_variation_sale_price;
-	    	
+
 			$this->max_variation_price = $this->max_variation_sale_price === '' || $this->max_variation_regular_price > $this->max_variation_sale_price ? $this->max_variation_regular_price : $this->max_variation_sale_price;
 		}
 

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -34,7 +34,7 @@ class WC_Product_Variation extends WC_Product {
 
 	/** @var bool True if the variation has a price. */
 	var $variation_has_price;
-	
+
 	/** @var bool True if the variation has a regular price. */
 	var $variation_has_regular_price;
 
@@ -148,7 +148,7 @@ class WC_Product_Variation extends WC_Product {
 			$this->variation_has_height = true;
 			$this->height = $product_custom_fields['_height'][0];
 		}
-		
+
 		if ( isset( $product_custom_fields['_downloadable'][0] ) && $product_custom_fields['_downloadable'][0] == 'yes' ) {
 			$this->downloadable = 'yes';
 		} else {
@@ -165,42 +165,42 @@ class WC_Product_Variation extends WC_Product {
 			$this->variation_has_tax_class = true;
 			$this->tax_class = $product_custom_fields['_tax_class'][0];
 		}
-		
+
 		if ( isset( $product_custom_fields['_price'][0] ) && $product_custom_fields['_price'][0] !== '' ) {
 			$this->variation_has_price = true;
 			$this->price = $product_custom_fields['_price'][0];
 		}
-		
+
 		if ( isset( $product_custom_fields['_regular_price'][0] ) && $product_custom_fields['_regular_price'][0] !== '' ) {
 			$this->variation_has_regular_price = true;
 			$this->regular_price = $product_custom_fields['_regular_price'][0];
 		}
-		
+
 		if ( isset( $product_custom_fields['_sale_price'][0] ) && $product_custom_fields['_sale_price'][0] !== '' ) {
 			$this->variation_has_sale_price = true;
 			$this->sale_price = $product_custom_fields['_sale_price'][0];
 		}
-		
+
 		// Backwards compat for prices
 		if ( $this->variation_has_price && ! $this->variation_has_regular_price ) {
 			update_post_meta( $this->variation_id, '_regular_price', $this->price );
 			$this->variation_has_regular_price = true;
 			$this->regular_price = $this->price;
-			
+
 			if ( $this->variation_has_sale_price && $this->sale_price < $this->regular_price ) {
 				update_post_meta( $this->variation_id, '_price', $this->sale_price );
 				$this->price = $this->sale_price;
 			}
 		}
-		
+
 		if ( isset( $product_custom_fields['_sale_price_dates_from'][0] ) )
 			$this->sale_price_dates_from = $product_custom_fields['_sale_price_dates_from'][0];
-			
+
 		if ( isset( $product_custom_fields['_sale_price_dates_to'][0] ) )
 			$this->sale_price_dates_from = $product_custom_fields['_sale_price_dates_to'][0];
-		
+
 		$this->total_stock = $this->stock;
-		
+
 		// Check sale dates
 		$this->check_sale_price();
 	}
@@ -384,7 +384,7 @@ class WC_Product_Variation extends WC_Product {
 	function get_shipping_class() {
 		if ( ! $this->variation_shipping_class ) {
 			$classes = get_the_terms( $this->variation_id, 'product_shipping_class' );
-			
+
 			if ( $classes && ! is_wp_error( $classes ) ) {
 				$this->variation_shipping_class = esc_attr( current( $classes )->slug );
 			} else {
@@ -418,13 +418,13 @@ class WC_Product_Variation extends WC_Product {
 
 	/**
 	 * Get file download path identified by $download_id
-	 * 
+	 *
 	 * @access public
 	 * @param string $download_id file identifier
 	 * @return array
 	 */
 	function get_file_download_path( $download_id ) {
-		
+
 		$file_path = '';
 		$file_paths = apply_filters( 'woocommerce_file_download_paths', get_post_meta( $this->variation_id, '_file_paths', true ), $this->variation_id, null, null );
 
@@ -438,7 +438,7 @@ class WC_Product_Variation extends WC_Product {
 		// allow overriding based on the particular file being requested
 		return apply_filters( 'woocommerce_file_download_path', $file_path, $this->variation_id, $download_id );
 	}
-	
+
     /**
      * Checks sale data to see if the product is due to go on sale/sale has expired, and updates the main price.
      *

--- a/classes/class-wc-query.php
+++ b/classes/class-wc-query.php
@@ -69,7 +69,7 @@ class WC_Query {
 			// Get the actual WP page to avoid errors and let us use is_front_page()
 			// This is hacky but works. Awaiting http://core.trac.wordpress.org/ticket/21096
 			global $wp_post_types;
-			
+
 			$shop_page 	= get_post( woocommerce_get_page_id('shop') );
 			$q->is_page = true;
 
@@ -81,7 +81,7 @@ class WC_Query {
 	        $q->is_singular = false;
 	        $q->is_post_type_archive = true;
 	        $q->is_archive = true;
-	        
+
 	        // Fix WP SEO
 	        if ( function_exists( 'wpseo_get_value' ) ) {
 	       		add_filter( 'wpseo_metadesc', array( &$this, 'wpseo_metadesc' ) );
@@ -104,11 +104,11 @@ class WC_Query {
 	    // And remove the pre_get_posts hook
 	    $this->remove_product_query();
 	}
-	
+
 
 	/**
 	 * wpseo_metadesc function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $meta
 	 * @return void
@@ -116,11 +116,11 @@ class WC_Query {
 	function wpseo_metadesc() {
 		return wpseo_get_value( 'metadesc', woocommerce_get_page_id('shop') );
 	}
-	
-	
+
+
 	/**
 	 * wpseo_metakey function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -310,7 +310,7 @@ class WC_Query {
 	 */
 	function get_catalog_ordering_args() {
 		global $woocommerce;
-		
+
 		$current_order = ( isset( $woocommerce->session->orderby ) ) ? $woocommerce->session->orderby : apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby' ) );
 
 		switch ( $current_order ) {

--- a/classes/class-wc-session-transients.php
+++ b/classes/class-wc-session-transients.php
@@ -11,17 +11,17 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-class WC_Session_Transients extends WC_Session {	
-	
+class WC_Session_Transients extends WC_Session {
+
 	/** customer_id */
 	private $_customer_id;
-	
+
 	/** cookie name */
 	private $_cookie;
-	
+
 	/** cookie expiration time */
 	private $_cookie_expires;
-	
+
 	/**
 	 * Constructor for the session class.
 	 *
@@ -30,19 +30,19 @@ class WC_Session_Transients extends WC_Session {
 	 */
 	public function __construct() {
 		parent::__construct();
-		
+
 		$this->_cookie				= 'wc_session_cookie_' . COOKIEHASH;
 		$this->_cookie_expiration	= apply_filters( 'wc_session_transients_expiration', 172800 ); // 48 hours default
 		$this->_customer_id 		= $this->get_customer_id();
 		$this->_data 				= maybe_unserialize( get_transient( 'wc_session_' . $this->_customer_id ) );
-    	
+
     	if ( false === $this->_data )
     		$this->_data = array();
     }
-	
+
 	/**
 	 * get_customer_id function.
-	 * 
+	 *
 	 * @access private
 	 * @return mixed
 	 */
@@ -55,32 +55,32 @@ class WC_Session_Transients extends WC_Session {
 			return $this->create_customer_id();
 		}
 	}
-	
+
 	/**
 	 * get_session_cookie function.
-	 * 
+	 *
 	 * @access private
 	 * @return mixed
 	 */
 	private function get_session_cookie() {
-		if ( ! isset( $_COOKIE[ $this->_cookie ] ) ) 
+		if ( ! isset( $_COOKIE[ $this->_cookie ] ) )
 			return false;
-		
+
 		list( $customer_id, $expires, $hash ) = explode( '|', $_COOKIE[ $this->_cookie ] );
-		
+
 		// Validate hash
 		$data 	= $customer_id . $expires;
 		$rehash = hash_hmac( 'md5', $data, wp_hash( $data ) );
 
 		if ( $hash != $rehash )
 			return false;
-			
+
 		return $customer_id;
 	}
-	
+
 	/**
 	 * Create a unqiue customer ID and store it in a cookie, along with its hashed value and expirey date. Stored for 48hours.
-	 * 
+	 *
 	 * @access private
 	 * @return void
 	 */
@@ -90,15 +90,15 @@ class WC_Session_Transients extends WC_Session {
 		$data 			= $customer_id . $expires;
 		$hash 			= hash_hmac( 'md5', $data, wp_hash( $data ) );
 		$value 			= $customer_id . '|' . $expires . '|' . $hash;
-		
+
 		setcookie( $this->_cookie, $value, $expires, COOKIEPATH, COOKIE_DOMAIN, false, true );
 
 		return $customer_id;
 	}
-    
+
     /**
      * save_data function.
-     * 
+     *
      * @access public
      * @return void
      */

--- a/classes/class-wc-settings-api.php
+++ b/classes/class-wc-settings-api.php
@@ -193,10 +193,10 @@ class WC_Settings_API {
     	$data['css'] 			= isset( $data['css'] ) ? $data['css'] : '';
     	$data['placeholder'] 	= isset( $data['placeholder'] ) ? $data['placeholder'] : '';
     	$data['type'] 			= isset( $data['type'] ) ? $data['type'] : 'text';
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) )
 			foreach ( $data['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -233,10 +233,10 @@ class WC_Settings_API {
     	$data['disabled']		= empty( $data['disabled'] ) ? false : true;
     	$data['class'] 			= isset( $data['class'] ) ? $data['class'] : '';
     	$data['css'] 			= isset( $data['css'] ) ? $data['css'] : '';
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) )
 			foreach ( $data['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -274,10 +274,10 @@ class WC_Settings_API {
     	if ( ! isset( $this->settings[$key] ) ) $this->settings[$key] = '';
     	$data['class']			= isset( $data['class'] ) ? $data['class'] : '';
     	$data['css'] 			= isset( $data['css'] ) ? $data['css'] : '';
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) )
 			foreach ( $data['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -315,10 +315,10 @@ class WC_Settings_API {
     	$data['disabled']		= empty( $data['disabled'] ) ? false : true;
     	$data['class'] 		= isset( $data['class'] ) ? $data['class'] : '';
     	$data['css'] 		= isset( $data['css'] ) ? $data['css'] : '';
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) )
 			foreach ( $data['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -354,10 +354,10 @@ class WC_Settings_API {
     	$data['options'] 		= isset( $data['options'] ) ? (array) $data['options'] : array();
     	$data['class'] 			= isset( $data['class'] ) ? $data['class'] : '';
     	$data['css'] 			= isset( $data['css'] ) ? $data['css'] : '';
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) )
 			foreach ( $data['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -400,10 +400,10 @@ class WC_Settings_API {
     	$data['options'] 		= isset( $data['options'] ) ? (array) $data['options'] : array();
     	$data['class'] 			= isset( $data['class'] ) ? $data['class'] : '';
     	$data['css'] 			= isset( $data['css'] ) ? $data['css'] : '';
-    	
+
     	// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) )
 			foreach ( $data['custom_attributes'] as $attribute => $attribute_value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
@@ -474,7 +474,7 @@ class WC_Settings_API {
     	$this->sanitized_fields = array();
 
     	foreach ( $form_fields as $k => $v ) {
-    		if ( empty( $v['type'] ) ) 
+    		if ( empty( $v['type'] ) )
     			$v['type'] == 'text'; // Default to "text" field type.
 
     		if ( method_exists( $this, 'validate_' . $v['type'] . '_field' ) ) {

--- a/classes/class-wc-tax.php
+++ b/classes/class-wc-tax.php
@@ -35,35 +35,35 @@ class WC_Tax {
 
 			if ( ! empty( $tax_rates ) ) {
 				foreach( $tax_rates as $rate ) {
-	
+
 					// Standard Rate?
-					if ( empty( $rate['class'] ) ) 
+					if ( empty( $rate['class'] ) )
 						$rate['class'] = '*';
-	
+
 					// Add entry for each country/state - each will hold all matching rates
 					if ( ! empty( $rate['countries'] ) ) {
 						foreach( $rate['countries'] as $country => $states ) {
 							if ( $states ) {
 								foreach ( $states as $state ) {
-		
+
 									if ( empty( $rate['label'] ) ) {
 										$rate['label'] = $woocommerce->countries->tax_or_vat();
-					
+
 										// Add % to label
 										if ( $rate['rate'] > 0 || $rate['rate'] === 0 )
 											$rate['label'] .= ' (' . rtrim( rtrim( $rate['rate'], '0' ), '.' ) . '%)';
 									}
-		
+
 									$flat_rates[ $index ] = $rate;
-		
+
 									$parsed_rates[ $country ][ $state ][ $rate['class'] ][ $index ] = array(
 										'label' 	=> $rate['label'],
 										'rate' 		=> $rate['rate'],
 										'shipping' 	=> $rate['shipping'],
 										'compound' 	=> $rate['compound']
 									);
-									
-									$index++;		
+
+									$index++;
 								}
 							}
 						}
@@ -73,32 +73,32 @@ class WC_Tax {
 
 			if ( ! empty( $local_tax_rates ) ) {
 				foreach( $local_tax_rates as $rate ) {
-	
+
 					// Standard Rate?
-					if ( empty( $rate['class'] ) ) 
+					if ( empty( $rate['class'] ) )
 						$rate['class'] = '*';
-	
+
 					if ( empty( $rate['label'] ) ) {
 						$rate['label'] = $woocommerce->countries->tax_or_vat();
-	
+
 						// Add % to label
 						if ( $rate['rate'] > 0 || $rate['rate'] === 0 )
 							$rate['label'] .= ' (' . rtrim( rtrim( $rate['rate'], '0' ), '.' ) . '%)';
 					}
-					
+
 					// Backwards compat
 					if ( empty( $rate['locations'] ) && isset( $rate['postcode'] ) )
 						$rate['locations'] = $rate['postcode'];
-						
+
 					if ( empty( $rate['location_type'] ) )
 						$rate['location_type'] = 'postcode';
-						
+
 					// Postcodes -> Uppercase
 					if ( $rate['location_type'] == 'postcode' )
 				    	$rate['locations'] = array_map( 'strtoupper', (array) $rate['locations'] );
-	
+
 					$flat_rates[ $index ] = $rate;
-	
+
 					$parsed_rates[ $rate['country'] ][ $rate['state'] ][ $rate['class'] ][ $index ] = array(
 						'label' 		=> $rate['label'],
 						'rate' 			=> $rate['rate'],
@@ -118,17 +118,17 @@ class WC_Tax {
 			do_action( 'woocommerce_get_tax_rates', $this );
 		}
 	}
-	
+
 	/**
 	 * Searches for all matching country/state/postcode tax rates.
-	 * 
+	 *
 	 * @access public
 	 * @param string $args (default: '')
 	 * @return array
 	 */
 	function find_rates( $args = '' ) {
 		$this->get_tax_rates();
-		
+
 		$defaults = array(
 			'country' 	=> '',
 			'state' 	=> '',
@@ -141,14 +141,14 @@ class WC_Tax {
 
 		extract( $args, EXTR_SKIP );
 
-		if ( ! $country ) 
+		if ( ! $country )
 			return array();
 
 		$state = $state ? $state : '*';
 		$tax_class = $tax_class ? $tax_class : '*';
 		$city = sanitize_title( $city );
 		$tax_class = sanitize_title( $tax_class );
-		
+
 		$found_rates = array();
 
 		// Look for a state specific rule
@@ -178,36 +178,36 @@ class WC_Tax {
 			foreach ( $found_rates as $key => $rate ) {
 
 				if ( ! empty( $rate['locations'] ) && $rate['location_type'] == 'postcode' ) {
-	
+
 					// Local rate
 					if ( $postcode ) {
-					
+
 						// Check if postcode matches up
-						if ( in_array( $postcode, $rate['locations'] ) || sizeof( $rate['locations'] ) == 0 ) 
+						if ( in_array( $postcode, $rate['locations'] ) || sizeof( $rate['locations'] ) == 0 )
 							$matched_tax_rates[ $key ] = $rate;
-	
+
 						// Check postcode ranges
 						if ( is_numeric( $postcode ) ) {
 							foreach ( $rate['locations'] as $rate_postcode ) {
 								if ( strstr( $rate_postcode, '-' ) ) {
 									$parts = array_map( 'trim', explode( '-', $rate_postcode ) );
 									if ( sizeof( $parts ) == 2 && is_numeric( $parts[0] ) && is_numeric( $parts[1] ) )
-										if ( $postcode >= $parts[0] && $postcode <= $parts[1] ) 
+										if ( $postcode >= $parts[0] && $postcode <= $parts[1] )
 											$matched_tax_rates[ $key ] = $rate;
 								}
 							}
 						}
 					}
-					
+
 				} elseif ( ! empty( $rate['locations'] ) && $rate['location_type'] == 'city' ) {
-										
+
 					// Local rate
 					if ( $city ) {
 						// Check if city matches up
-						if ( in_array( $city, $rate['locations'] ) || sizeof( $rate['locations'] ) == 0 ) 
+						if ( in_array( $city, $rate['locations'] ) || sizeof( $rate['locations'] ) == 0 )
 							$matched_tax_rates[ $key ] = $rate;
 					}
-					
+
 				} else {
 					// Standard rate
 					$matched_tax_rates[ $key ] = $rate;
@@ -228,20 +228,20 @@ class WC_Tax {
 	 */
 	function get_rates( $tax_class = '' ) {
 		global $woocommerce;
-		
+
 		$this->get_tax_rates();
 
 		$tax_class = sanitize_title( $tax_class );
 
 		/* Checkout uses customer location for the tax rates. Also, if shipping has been calculated, use the customers address. */
 		if ( ( defined('WOOCOMMERCE_CHECKOUT') && WOOCOMMERCE_CHECKOUT ) || $woocommerce->customer->has_calculated_shipping() ) {
-			
+
 			list( $country, $state, $postcode, $city ) = $woocommerce->customer->get_taxable_address();
 
 			$matched_tax_rates = $this->find_rates( array(
-				'country' 	=> $country, 
-				'state' 	=> $state, 
-				'postcode' 	=> $postcode, 
+				'country' 	=> $country,
+				'state' 	=> $state,
+				'postcode' 	=> $postcode,
 				'city' 		=> $city,
 				'tax_class' => $tax_class
 			) );
@@ -275,9 +275,9 @@ class WC_Tax {
 		$state 		= $woocommerce->countries->get_base_state();
 
 		return $this->find_rates( array(
-			'country' 	=> $country, 
-			'state' 	=> $state, 
-			'tax_class' => $tax_class 
+			'country' 	=> $country,
+			'state' 	=> $state,
+			'tax_class' => $tax_class
 		) );
 	}
 
@@ -289,7 +289,7 @@ class WC_Tax {
 	 */
 	function get_shipping_tax_rates( $tax_class = null ) {
 		global $woocommerce;
-		
+
 		// See if we have an explicitly set shipping tax class
 		if ( $shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' ) ) {
 			$tax_class = $shipping_tax_class == 'standard' ? '' : $shipping_tax_class;
@@ -298,11 +298,11 @@ class WC_Tax {
 		$this->get_tax_rates();
 
 		if ( ( defined('WOOCOMMERCE_CHECKOUT') && WOOCOMMERCE_CHECKOUT ) || $woocommerce->customer->has_calculated_shipping() ) {
-		
+
 			list( $country, $state, $postcode, $city ) = $woocommerce->customer->get_taxable_address();
 
 		} else {
-			
+
 			// Prices which include tax should always use the base rate if we don't know where the user is located
 			// Prices exlcuding tax however should just not add any taxes, as they will be added during checkout
 			if ( $woocommerce->cart->prices_include_tax ) {
@@ -323,14 +323,14 @@ class WC_Tax {
 
 			// This will be per item shipping
 			$rates = $this->find_rates( array(
-				'country' 	=> $country, 
-				'state' 	=> $state, 
-				'postcode' 	=> $postcode, 
+				'country' 	=> $country,
+				'state' 	=> $state,
+				'postcode' 	=> $postcode,
 				'city' 		=> $city,
-				'tax_class' => $tax_class 
+				'tax_class' => $tax_class
 			) );
 
-			if ( $rates ) 
+			if ( $rates )
 				foreach ( $rates as $key => $rate )
 					if ( isset( $rate['shipping'] ) && $rate['shipping'] == 'yes' )
 						$matched_tax_rates[ $key ] = $rate;
@@ -338,13 +338,13 @@ class WC_Tax {
 			if ( sizeof( $matched_tax_rates ) == 0 ) {
 				// Get standard rate
 				$rates = $this->find_rates( array(
-					'country' 	=> $country, 
-					'state' 	=> $state, 
+					'country' 	=> $country,
+					'state' 	=> $state,
 					'city' 		=> $city,
-					'postcode' 	=> $postcode, 
+					'postcode' 	=> $postcode,
 				) );
 
-				if ( $rates ) 
+				if ( $rates )
 					foreach ( $rates as $key => $rate )
 						if ( isset( $rate['shipping'] ) && $rate['shipping'] == 'yes' )
 							$matched_tax_rates[ $key ] = $rate;
@@ -360,7 +360,7 @@ class WC_Tax {
 			$rates = false;
 
 			// Loop cart and find the highest tax band
-			if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) 
+			if ( sizeof( $woocommerce->cart->get_cart() ) > 0 )
 				foreach ( $woocommerce->cart->get_cart() as $item )
 					$found_tax_classes[] = $item['data']->get_tax_class();
 
@@ -371,10 +371,10 @@ class WC_Tax {
 
 				if ( in_array( '', $found_tax_classes ) ) {
 					$rates = $this->find_rates( array(
-						'country' 	=> $country, 
-						'state' 	=> $state, 
+						'country' 	=> $country,
+						'state' 	=> $state,
 						'city' 		=> $city,
-						'postcode' 	=> $postcode, 
+						'postcode' 	=> $postcode,
 					) );
 				} else {
 					$tax_classes = array_filter( array_map( 'trim', explode( "\n", get_option( 'woocommerce_tax_classes' ) ) ) );
@@ -382,11 +382,11 @@ class WC_Tax {
 					foreach ( $tax_classes as $tax_class ) {
 						if ( in_array( $tax_class, $found_tax_classes ) ) {
 							$rates = $this->find_rates( array(
-								'country' 	=> $country, 
-								'state' 	=> $state, 
-								'postcode' 	=> $postcode, 
+								'country' 	=> $country,
+								'state' 	=> $state,
+								'postcode' 	=> $postcode,
 								'city' 		=> $city,
-								'tax_class' => $tax_class 
+								'tax_class' => $tax_class
 							) );
 							break;
 						}
@@ -397,11 +397,11 @@ class WC_Tax {
 			} elseif ( sizeof( $found_tax_classes ) == 1 ) {
 
 				$rates = $this->find_rates( array(
-					'country' 	=> $country, 
-					'state' 	=> $state, 
-					'postcode' 	=> $postcode, 
+					'country' 	=> $country,
+					'state' 	=> $state,
+					'postcode' 	=> $postcode,
 					'city' 		=> $city,
-					'tax_class' => $found_tax_classes[0] 
+					'tax_class' => $found_tax_classes[0]
 				) );
 
 			}
@@ -409,13 +409,13 @@ class WC_Tax {
 			// If no class rate are found, use standard rates
 			if ( ! $rates )
 				$rates = $this->find_rates( array(
-					'country' 	=> $country, 
-					'state' 	=> $state, 
-					'postcode' 	=> $postcode, 
+					'country' 	=> $country,
+					'state' 	=> $state,
+					'postcode' 	=> $postcode,
 					'city' 		=> $city,
 				) );
 
-			if ( $rates ) 
+			if ( $rates )
 				foreach ( $rates as $key => $rate )
 					if ( isset( $rate['shipping'] ) && $rate['shipping'] == 'yes' )
 						$matched_tax_rates[ $key ] = $rate;
@@ -613,7 +613,7 @@ class WC_Tax {
 	 */
 	function get_rate_label( $key ) {
 		$label = empty( $this->rates[ $key ]['label'] ) ? '' : $this->rates[ $key ]['label'];
-		
+
 		return apply_filters( 'woocommerce_rate_label', $label, $key, $this );
 	}
 

--- a/classes/emails/class-wc-email-customer-completed-order.php
+++ b/classes/emails/class-wc-email-customer-completed-order.php
@@ -19,23 +19,23 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	 * Constructor
 	 */
 	function __construct() {
-		
+
 		$this->id 				= 'customer_completed_order';
 		$this->title 			= __( 'Completed order', 'woocommerce' );
 		$this->description		= __( 'Order complete emails are sent to the customer when the order is marked complete and usual indicates that the order has been shipped.', 'woocommerce' );
-		
+
 		$this->heading 			= __( 'Your order is complete', 'woocommerce' );
 		$this->subject      	= __( 'Your {blogname} order from {order_date} is complete', 'woocommerce' );
-		
+
 		$this->heading_downloadable	= __( 'Your order is complete - download your files', 'woocommerce' );
 		$this->subject_downloadable = __( 'Your {blogname} order from {order_date} is complete - download your files', 'woocommerce' );
-		
+
 		$this->template_html 	= 'emails/customer-completed-order.php';
 		$this->template_plain 	= 'emails/plain/customer-completed-order.php';
-		
+
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_completed_notification', array( &$this, 'trigger' ) );
-		
+
 		// Call parent constuctor
 		parent::__construct();
 
@@ -46,33 +46,33 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 	/**
 	 * trigger function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function trigger( $order_id ) {
 		global $woocommerce;
-		
+
 		if ( $order_id ) {
 			$this->object 		= new WC_Order( $order_id );
 			$this->recipient	= $this->object->billing_email;
-			
+
 			$this->find[] = '{order_date}';
 			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
-			
+
 			$this->find[] = '{order_number}';
 			$this->replace[] = $this->object->get_order_number();
 		}
-		
+
 		if ( ! $this->is_enabled() || ! $this->get_recipient() )
 			return;
-			
+
 		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 	}
-	
+
 	/**
 	 * get_subject function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -85,7 +85,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 	/**
 	 * get_heading function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -98,7 +98,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -110,10 +110,10 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -125,7 +125,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
     /**
      * Initialise Settings Form Fields
      *

--- a/classes/emails/class-wc-email-customer-invoice.php
+++ b/classes/emails/class-wc-email-customer-invoice.php
@@ -14,35 +14,35 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class WC_Email_Customer_Invoice extends WC_Email {
-	
+
 	var $find;
 	var $replace;
-	
+
 	/**
 	 * Constructor
 	 */
 	function __construct() {
-		
+
 		$this->id 				= 'customer_invoice';
 		$this->title 			= __( 'Customer invoice', 'woocommerce' );
 		$this->description		= __( 'Customer invoice emails can be sent to the user containing order info and payment links.', 'woocommerce' );
 
 		$this->template_html 	= 'emails/customer-invoice.php';
 		$this->template_plain 	= 'emails/plain/customer-invoice.php';
-		
+
 		$this->subject 			= __( 'Invoice for order {order_number} from {order_date}', 'woocommerce');
 		$this->heading      	= __( 'Invoice for order {order_number}', 'woocommerce');
-		
+
 		$this->subject_paid 	= __( 'Your {blogname} order from {order_date}', 'woocommerce');
 		$this->heading_paid     = __( 'Order {order_number} details', 'woocommerce');
-		
+
 		// Call parent constuctor
 		parent::__construct();
 	}
 
 	/**
 	 * trigger function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -52,27 +52,27 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		if ( ! is_object( $order ) ) {
 			$order = new WC_Order( absint( $order ) );
 		}
-		
+
 		if ( $order ) {
 			$this->object 		= $order;
 			$this->recipient	= $this->object->billing_email;
-			
+
 			$this->find[] = '{order_date}';
 			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
-			
+
 			$this->find[] = '{order_number}';
 			$this->replace[] = $this->object->get_order_number();
 		}
-		
+
 		if ( ! $this->is_enabled() || ! $this->get_recipient() )
 			return;
-			
+
 		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 	}
-	
+
 	/**
 	 * get_subject function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -85,7 +85,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 
 	/**
 	 * get_heading function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -98,7 +98,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -110,10 +110,10 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -125,7 +125,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
     /**
      * Initialise Settings Form Fields
      *

--- a/classes/emails/class-wc-email-customer-new-account.php
+++ b/classes/emails/class-wc-email-customer-new-account.php
@@ -14,11 +14,11 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class WC_Email_Customer_New_Account extends WC_Email {
-	
+
 	var $user_login;
 	var $user_email;
 	var $user_pass;
-	
+
 	/**
 	 * Constructor
 	 *
@@ -26,14 +26,14 @@ class WC_Email_Customer_New_Account extends WC_Email {
 	 * @return void
 	 */
 	function __construct() {
-		
+
 		$this->id 				= 'customer_new_account';
 		$this->title 			= __( 'New account', 'woocommerce' );
 		$this->description		= __( 'Customer new account emails are sent when a customer signs up via the checkout or My Account page.', 'woocommerce' );
 
 		$this->template_html 	= 'emails/customer-new-account.php';
 		$this->template_plain 	= 'emails/plain/customer-new-account.php';
-		
+
 		$this->subject 			= __( 'Your account on {blogname}', 'woocommerce');
 		$this->heading      	= __( 'Welcome to {blogname}', 'woocommerce');
 
@@ -43,31 +43,31 @@ class WC_Email_Customer_New_Account extends WC_Email {
 
 	/**
 	 * trigger function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function trigger( $user_id, $user_pass = '' ) {
 		global $woocommerce;
-		
+
 		if ( $user_id ) {
 			$this->object 		= new WP_User( $user_id );
-			
+
 			$this->user_pass	= $user_pass;
 			$this->user_login 	= stripslashes( $this->object->user_login );
 			$this->user_email 	= stripslashes( $this->object->user_email );
 			$this->recipient	= $this->user_email;
 		}
-		
+
 		if ( ! $this->is_enabled() || ! $this->get_recipient() )
 			return;
-			
+
 		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 	}
 
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -81,10 +81,10 @@ class WC_Email_Customer_New_Account extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */

--- a/classes/emails/class-wc-email-customer-note.php
+++ b/classes/emails/class-wc-email-customer-note.php
@@ -14,9 +14,9 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class WC_Email_Customer_Note extends WC_Email {
-	
+
 	var $customer_note;
-	
+
 	/**
 	 * Constructor
 	 *
@@ -24,64 +24,64 @@ class WC_Email_Customer_Note extends WC_Email {
 	 * @return void
 	 */
 	function __construct() {
-		
+
 		$this->id 				= 'customer_note';
 		$this->title 			= __( 'Customer note', 'woocommerce' );
 		$this->description		= __( 'Customer note emails are sent when you add a note to an order.', 'woocommerce' );
 
 		$this->template_html 	= 'emails/customer-note.php';
 		$this->template_plain 	= 'emails/plain/customer-note.php';
-		
+
 		$this->subject 			= __( 'Note added to your {blogname} order from {order_date}', 'woocommerce');
 		$this->heading      	= __( 'A note has been added to your order', 'woocommerce');
-		
+
 		// Triggers
 		add_action( 'woocommerce_new_customer_note_notification', array( &$this, 'trigger' ) );
-		
+
 		// Call parent constuctor
 		parent::__construct();
 	}
 
 	/**
 	 * trigger function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function trigger( $args ) {
 		global $woocommerce;
-		
+
 		if ( $args ) {
-			
+
 			$defaults = array(
 				'order_id' 		=> '',
 				'customer_note'	=> ''
 			);
-	
+
 			$args = wp_parse_args( $args, $defaults );
-	
+
 			extract( $args );
-		
+
 			$this->object 		= new WC_Order( $order_id );
 			$this->recipient	= $this->object->billing_email;
 			$this->customer_note = $customer_note;
-			
+
 			$this->find[] = '{order_date}';
 			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
-			
+
 			$this->find[] = '{order_number}';
 			$this->replace[] = $this->object->get_order_number();
 		}
-		
+
 		if ( ! $this->is_enabled() || ! $this->get_recipient() )
 			return;
-			
+
 		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 	}
 
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -94,10 +94,10 @@ class WC_Email_Customer_Note extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */

--- a/classes/emails/class-wc-email-customer-processing-order.php
+++ b/classes/emails/class-wc-email-customer-processing-order.php
@@ -23,41 +23,41 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 		$this->id 				= 'customer_processing_order';
 		$this->title 			= __( 'Processing order', 'woocommerce' );
 		$this->description		= __( 'This is an order notification sent to the customer after payment containing order details.', 'woocommerce' );
-		
+
 		$this->heading 			= __( 'Thank you for your order', 'woocommerce' );
 		$this->subject      	= __( 'Your {blogname} order receipt from {order_date}', 'woocommerce' );
-		
+
 		$this->template_html 	= 'emails/customer-processing-order.php';
 		$this->template_plain 	= 'emails/plain/customer-processing-order.php';
-		
+
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_pending_to_processing_notification', array( &$this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( &$this, 'trigger' ) );
-		
+
 		// Call parent constuctor
 		parent::__construct();
 	}
 
 	/**
 	 * trigger function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function trigger( $order_id ) {
 		global $woocommerce;
-		
+
 		if ( $order_id ) {
 			$this->object 		= new WC_Order( $order_id );
 			$this->recipient	= $this->object->billing_email;
-			
+
 			$this->find[] = '{order_date}';
 			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
-			
+
 			$this->find[] = '{order_number}';
 			$this->replace[] = $this->object->get_order_number();
 		}
-		
+
 		if ( ! $this->is_enabled() || ! $this->get_recipient() )
 			return;
 
@@ -66,7 +66,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -78,10 +78,10 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */

--- a/classes/emails/class-wc-email-new-order.php
+++ b/classes/emails/class-wc-email-new-order.php
@@ -23,13 +23,13 @@ class WC_Email_New_Order extends WC_Email {
 		$this->id 				= 'new_order';
 		$this->title 			= __( 'New order', 'woocommerce' );
 		$this->description		= __( 'New order emails are sent when an order is received/paid by a customer.', 'woocommerce' );
-		
+
 		$this->heading 			= __( 'New customer order', 'woocommerce' );
 		$this->subject      	= __( '[{blogname}] New customer order ({order_number}) - {order_date}', 'woocommerce' );
-		
+
 		$this->template_html 	= 'emails/admin-new-order.php';
 		$this->template_plain 	= 'emails/plain/admin-new-order.php';
-		
+
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_pending_to_processing_notification', array( &$this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_pending_to_completed_notification', array( &$this, 'trigger' ) );
@@ -37,36 +37,36 @@ class WC_Email_New_Order extends WC_Email {
 		add_action( 'woocommerce_order_status_failed_to_processing_notification', array( &$this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_failed_to_completed_notification', array( &$this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( &$this, 'trigger' ) );
-		
+
 		// Call parent constuctor
 		parent::__construct();
-		
+
 		// Other settings
 		$this->recipient		= $this->settings['recipient'];
-		
+
 		if ( ! $this->recipient )
 			$this->recipient = get_option( 'admin_email' );
 	}
-	
+
 	/**
 	 * trigger function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function trigger( $order_id ) {
 		global $woocommerce;
-		
+
 		if ( $order_id ) {
 			$this->object 		= new WC_Order( $order_id );
-			
+
 			$this->find[] = '{order_date}';
 			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
-			
+
 			$this->find[] = '{order_number}';
 			$this->replace[] = $this->object->get_order_number();
 		}
-		
+
 		if ( ! $this->is_enabled() || ! $this->get_recipient() )
 			return;
 
@@ -75,7 +75,7 @@ class WC_Email_New_Order extends WC_Email {
 
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -87,10 +87,10 @@ class WC_Email_New_Order extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
@@ -102,7 +102,7 @@ class WC_Email_New_Order extends WC_Email {
 		) );
 		return ob_get_clean();
 	}
-	
+
     /**
      * Initialise Settings Form Fields
      *

--- a/classes/emails/class-wc-email.php
+++ b/classes/emails/class-wc-email.php
@@ -26,40 +26,40 @@ class WC_Email extends WC_Settings_API {
 
 	/** @var string Description for the gateway. */
 	var $description;
-	
+
 	/** @var string plain text template path */
 	var $template_plain;
 
-	/** @var string html template path */	
+	/** @var string html template path */
 	var $template_html;
-	
-	/** @var string template path */	
+
+	/** @var string template path */
 	var $template_base;
-	
-	/** @var string recipients for the email */		
+
+	/** @var string recipients for the email */
 	var $recipient;
-		
+
 	/** @var string heading for the email content */
 	var $heading;
-	
+
 	/** @var string subject for the email */
 	var $subject;
-	
+
 	/** @var object this email is for, for example a customer, product, or email */
 	var $object;
-	
+
 	/** @var array strings to find in subjects/headings */
 	var $find;
-	
+
 	/** @var array strings to replace in subjects/headings */
 	var $replace;
-	
+
 	/** @var string For multipart emails */
 	var $mime_boundary;
-	
+
 	/** @var string For multipart emails */
 	var $mime_boundary_header;
-	
+
 	/** @var bool true when email is being sent */
 	var $sending;
 
@@ -75,7 +75,7 @@ class WC_Email extends WC_Settings_API {
 		// Init settings
 		$this->init_form_fields();
 		$this->init_settings();
-		
+
 		// Save settings hook
 		add_action( 'woocommerce_update_options_email_' . $this->id, array( &$this, 'process_admin_options' ) );
 
@@ -85,105 +85,105 @@ class WC_Email extends WC_Settings_API {
 		$this->subject      	= empty( $this->settings['subject'] ) ? $this->subject : $this->settings['subject'];
 		$this->email_type     	= $this->settings['email_type'];
 		$this->enabled   		= $this->settings['enabled'];
-		
+
 		// Find/replace
 		$this->find = array( '{blogname}' );
 		$this->replace = array( $this->get_blogname() );
-		
+
 		// For multipart messages
 		add_filter( 'phpmailer_init', array( &$this, 'handle_multipart' ) );
 	}
-	
+
 	/**
 	 * handle_multipart function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $mailer
 	 * @return void
 	 */
 	function handle_multipart( $mailer )  {
-		
+
 		if ( $this->sending && $this->get_email_type() == 'multipart' ) {
 			$mailer->AltBody = wordwrap( html_entity_decode( strip_tags( $this->get_content_plain() ) ), 70 );
 			$this->sending = false;
 		}
-		
+
 		return $mailer;
 	}
 
 	/**
 	 * format_string function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $string
 	 * @return string
 	 */
-	function format_string( $string ) {		
+	function format_string( $string ) {
 		return str_replace( $this->find, $this->replace, $string );
 	}
 	/**
 	 * get_subject function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_subject() {
 		return apply_filters( 'woocommerce_email_subject_' . $this->id, $this->format_string( $this->subject ), $this->object );
 	}
-	
+
 	/**
 	 * get_heading function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_heading() {
 		return apply_filters( 'woocommerce_email_heading_' . $this->id, $this->format_string( $this->heading ), $this->object );
 	}
-	
+
 	/**
 	 * get_recipient function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_recipient() {
 		return apply_filters( 'woocommerce_email_recipient_' . $this->id, $this->recipient, $this->object );
 	}
-	
+
 	/**
 	 * get_headers function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_headers() {
 		return apply_filters( 'woocommerce_email_headers', "Content-Type: " . $this->get_content_type() . "\r\n", $this->id, $this->object );
 	}
-	
+
 	/**
 	 * get_attachments function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_attachments() {
 		return apply_filters( 'woocommerce_email_attachments', '', $this->id, $this->object );
 	}
-	
+
 	/**
 	 * get_type function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_email_type() {
 		return $this->email_type ? $this->email_type : 'plain';
 	}
-	
+
 	/**
 	 * get_content_type function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -197,7 +197,7 @@ class WC_Email extends WC_Settings_API {
 				return 'text/plain';
 		}
 	}
-	
+
 	/**
 	 * Checks if this email is enabled and will be sent.
 	 *
@@ -208,10 +208,10 @@ class WC_Email extends WC_Settings_API {
 		if ( $this->enabled == "yes" )
 			return true;
 	}
-	
+
 	/**
 	 * get_blogname function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -221,14 +221,14 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * get_content function.
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	function get_content() {
-		
+
 		$this->sending = true;
-		
+
 		if ( $this->get_email_type() == 'plain' ) {
 			$email_content = html_entity_decode( strip_tags( $this->get_content_plain() ) );
 		} else {
@@ -237,66 +237,66 @@ class WC_Email extends WC_Settings_API {
 
 		return $email_content;
 	}
-	
+
 	/**
 	 * Apply inline styles to dynamic content.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $content
 	 * @return void
 	 */
 	function style_inline( $content ) {
-		
+
 		if ( ! class_exists( 'DOMDocument' ) )
 			return $content;
-		
+
 		$dom = new DOMDocument();
 		@$dom->loadHTML( $content );
-		
+
 		$nodes = $dom->getElementsByTagName('img');
-		
+
 		foreach( $nodes as $node )
 			if ( ! $node->hasAttribute( 'style' ) )
 				$node->setAttribute( "style", "display:inline; border:none; font-size:14px; font-weight:bold; height:auto; line-height:100%; outline:none; text-decoration:none; text-transform:capitalize;" );
-				
+
 		$nodes_h1 = $dom->getElementsByTagName('h1');
 		$nodes_h2 = $dom->getElementsByTagName('h2');
 		$nodes_h3 = $dom->getElementsByTagName('h3');
-		
+
 		foreach( $nodes_h1 as $node )
 			if ( ! $node->hasAttribute( 'style' ) )
 				$node->setAttribute( "style", "color: " . get_option( 'woocommerce_email_text_color' ) . "; display:block; font-family:Arial; font-size:34px; font-weight:bold; margin-top: 10px; margin-right:0; margin-bottom:10px; margin-left:0; text-align:left; line-height: 150%;" );
-				
+
 		foreach( $nodes_h2 as $node )
 			if ( ! $node->hasAttribute( 'style' ) )
 				$node->setAttribute( "style", "color: " . get_option( 'woocommerce_email_text_color' ) . "; display:block; font-family:Arial; font-size:30px; font-weight:bold; margin-top: 10px; margin-right:0; margin-bottom:10px; margin-left:0; text-align:left; line-height: 150%;" );
-		
+
 		foreach( $nodes_h3 as $node )
 			if ( ! $node->hasAttribute( 'style' ) )
 				$node->setAttribute( "style", "color: " . get_option( 'woocommerce_email_text_color' ) . "; display:block; font-family:Arial; font-size:26px; font-weight:bold; margin-top: 10px; margin-right:0; margin-bottom:10px; margin-left:0; text-align:left; line-height: 150%;" );
-				
+
 		$nodes = $dom->getElementsByTagName('a');
-		
+
 		foreach( $nodes as $node )
 			if ( ! $node->hasAttribute( 'style' ) )
 				$node->setAttribute( "style", "color: " . get_option( 'woocommerce_email_text_color' ) . "; font-weight:normal; text-decoration:underline;" );
-		
+
 		$content = $dom->saveHTML();
-				
+
 		return $content;
 	}
-	
+
 	/**
 	 * get_content_plain function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function get_content_plain() {}
-	
+
 	/**
 	 * get_content_html function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
@@ -321,7 +321,7 @@ class WC_Email extends WC_Settings_API {
 	function get_from_address() {
 		return sanitize_email( get_option( 'woocommerce_email_from_address' ) );
 	}
-	
+
 	/**
 	 * Send the email.
 	 *
@@ -337,14 +337,14 @@ class WC_Email extends WC_Settings_API {
 		add_filter( 'wp_mail_from', array( &$this, 'get_from_address' ) );
 		add_filter( 'wp_mail_from_name', array( &$this, 'get_from_name' ) );
 		add_filter( 'wp_mail_content_type', array( &$this, 'get_content_type' ) );
-		
+
 		wp_mail( $to, $subject, $message, $headers, $attachments );
 
 		remove_filter( 'wp_mail_from', array( &$this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( &$this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( &$this, 'get_content_type' ) );
 	}
-	
+
     /**
      * Initialise Settings Form Fields - these are generic email options most will use.
      *
@@ -387,7 +387,7 @@ class WC_Email extends WC_Settings_API {
 			)
 		);
     }
-    
+
 	/**
 	 * Admin Panel Options Processing
 	 * - Saves the options to the DB
@@ -397,17 +397,17 @@ class WC_Email extends WC_Settings_API {
 	 * @return bool
 	 */
     public function process_admin_options() {
-    	
+
     	// Save regular options
     	parent::process_admin_options();
-    	
+
     	// Save templates
 		if ( ! empty( $_POST['template_html_code'] ) && ! empty( $this->template_html ) ) {
-			
+
 			$saved	= false;
 			$file	= get_stylesheet_directory() . '/woocommerce/' . $this->template_html;
 			$code 	= stripslashes( $_POST['template_html_code'] );
-			
+
 			if ( is_writeable( $file ) ) {
 				$f = fopen( $file, 'w+' );
 				if ( $f !== FALSE ) {
@@ -416,19 +416,19 @@ class WC_Email extends WC_Settings_API {
     				$saved = true;
     			}
 			}
-			
+
 			if ( ! $saved ) {
     			$redirect = add_query_arg( 'wc_error', urlencode( __( 'Could not write to template file.', 'woocommerce' ) ) );
     			wp_redirect( $redirect );
     			exit;
-    		}  		
+    		}
 		}
 		if ( ! empty( $_POST['template_plain_code'] ) && ! empty( $this->template_plain ) ) {
-    		
+
     		$saved	= false;
 			$file	= get_stylesheet_directory() . '/woocommerce/' . $this->template_plain;
 			$code 	= stripslashes( $_POST['template_plain_code'] );
-			
+
 			if ( is_writeable( $file ) ) {
 				$f = fopen( $file, 'w+' );
 				if ( $f !== FALSE ) {
@@ -437,15 +437,15 @@ class WC_Email extends WC_Settings_API {
     				$saved = true;
     			}
 			}
-			
+
 			if ( ! $saved ) {
     			$redirect = add_query_arg( 'wc_error', __( 'Could not write to template file.', 'woocommerce' ) );
     			wp_redirect( $redirect );
     			exit;
-    		}  
+    		}
 		}
     }
-	
+
 	/**
 	 * Admin Options
 	 *
@@ -456,12 +456,12 @@ class WC_Email extends WC_Settings_API {
 	 * @access public
 	 * @return void
 	 */
-	function admin_options() { 
+	function admin_options() {
 		global $woocommerce;
-		
+
 		// Handle any actions
 		if ( ! empty( $this->template_html ) || ! empty( $this->template_plain ) ) {
-		
+
 			if ( ! empty( $_GET['move_template'] ) && ( $template = esc_attr( basename( $_GET['move_template'] ) ) ) ) {
 				if ( ! empty( $this->$template ) ) {
 					if (  wp_mkdir_p( dirname( get_stylesheet_directory() . '/woocommerce/' . $this->$template ) ) && ! file_exists( get_stylesheet_directory() . '/woocommerce/' . $this->$template ) ) {
@@ -470,7 +470,7 @@ class WC_Email extends WC_Settings_API {
 					}
 				}
 			}
-			
+
 			if ( ! empty( $_GET['delete_template'] ) && ( $template = esc_attr( basename( $_GET['delete_template'] ) ) ) ) {
 				if ( ! empty( $this->$template ) ) {
 					if ( file_exists( get_stylesheet_directory() . '/woocommerce/' . $this->$template ) ) {
@@ -479,9 +479,9 @@ class WC_Email extends WC_Settings_API {
 					}
 				}
 			}
-			
+
 		}
-			
+
 		?>
 		<h3><?php echo ( ! empty( $this->title ) ) ? $this->title : __( 'Settings','woocommerce' ) ; ?></h3>
 
@@ -490,67 +490,67 @@ class WC_Email extends WC_Settings_API {
 		<table class="form-table">
 			<?php $this->generate_settings_html(); ?>
 		</table>
-		
+
 		<?php if ( ! empty( $this->template_html ) || ! empty( $this->template_plain ) ) { ?>
 			<div id="template">
 			<?php
-				$templates = array( 
-					'template_html' 	=> __( 'HTML template', 'woocommerce' ), 
-					'template_plain' 	=> __( 'Plain text template', 'woocommerce' ) 
+				$templates = array(
+					'template_html' 	=> __( 'HTML template', 'woocommerce' ),
+					'template_plain' 	=> __( 'Plain text template', 'woocommerce' )
 				);
 				foreach ( $templates as $template => $title ) :
 					if ( empty( $this->$template ) )
 						continue;
-				
+
 					$local_file = get_stylesheet_directory() . '/woocommerce/' . $this->$template;
 					$core_file 	= $this->template_base . $this->$template;
 					?>
 					<div class="template <?php echo $template; ?>">
-					
+
 						<h4><?php echo wp_kses_post( $title ); ?></h4>
-							
+
 						<?php if ( file_exists( $local_file ) ) : ?>
-							
+
 							<p>
 								<a href="#" class="button toggle_editor"></a>
-								
+
 								<?php if ( is_writable( $local_file ) ) : ?>
 									<a href="<?php echo remove_query_arg( array( 'move_template', 'saved' ), add_query_arg( 'delete_template', $template ) ); ?>" class="delete_template button"><?php _e( 'Delete template file', 'woocommerce' ); ?></a>
 								<?php endif; ?>
 
 								<?php printf( __( 'This template has been overridden by your theme and can be found in: <code>%s</code>.', 'woocommerce' ), 'yourtheme/woocommerce/' . $this->$template ); ?>
 							</p>
-							
+
 							<div class="editor" style="display:none">
-							
+
 								<textarea class="code" cols="25" rows="20" <?php if ( ! is_writable( $local_file ) ) : ?>readonly="readonly" disabled="disabled"<?php else : ?>data-name="<?php echo $template . '_code'; ?>"<?php endif; ?>><?php echo file_get_contents( $local_file ); ?></textarea>
-								
+
 							</div>
-							
+
 						<?php elseif ( file_exists( $core_file ) ) : ?>
-							
+
 							<p>
 								<a href="#" class="button toggle_editor"></a>
-								
+
 								<?php if ( ( is_dir( get_stylesheet_directory() . '/woocommerce/emails/' ) && is_writable( get_stylesheet_directory() . '/woocommerce/emails/' ) ) || is_writable( get_stylesheet_directory() ) ) : ?>
 									<a href="<?php echo remove_query_arg( array( 'delete_template', 'saved' ), add_query_arg( 'move_template', $template ) ); ?>" class="button"><?php _e( 'Copy file to theme', 'woocommerce' ); ?></a>
 								<?php endif; ?>
 
 								<?php printf( __( 'To override and edit this email template copy <code>%s</code> to your theme folder: <code>%s</code>.', 'woocommerce' ), 'woocommerce/templates/' . $this->$template, 'yourtheme/woocommerce/' . $this->$template ); ?>
 							</p>
-							
+
 							<div class="editor" style="display:none">
-							
+
 								<textarea class="code" readonly="readonly" disabled="disabled" cols="25" rows="20"><?php echo file_get_contents( $core_file ); ?></textarea>
-								
+
 							</div>
-						
+
 						<?php else : ?>
-						
+
 							<p><?php _e( 'File was not found.', 'woocommerce' ); ?></p>
-						
+
 						<?php endif; ?>
-					
+
 					</div>
 					<?php
 				endforeach;
@@ -559,22 +559,22 @@ class WC_Email extends WC_Settings_API {
 			<?php
 			$woocommerce->add_inline_js("
 				jQuery('select.email_type').change(function(){
-					
+
 					var val = jQuery( this ).val();
-					
+
 					jQuery('.template_plain, .template_html').show();
-					
+
 					if ( val != 'multipart' && val != 'html' )
 						jQuery('.template_html').hide();
-						
+
 					if ( val != 'multipart' && val != 'plain' )
 						jQuery('.template_plain').hide();
-					
+
 				}).change();
-				
+
 				var view = '" . __( 'View template', 'woocommerce' ) . "';
 				var hide = '" . __( 'Hide template', 'woocommerce' ) . "';
-				
+
 				jQuery('a.toggle_editor').text( view ).toggle( function() {
 					jQuery( this ).text( hide ).closest('.template').find('.editor').slideToggle();
 					return false;
@@ -582,19 +582,19 @@ class WC_Email extends WC_Settings_API {
 					jQuery( this ).text( view ).closest('.template').find('.editor').slideToggle();
 					return false;
 				} );
-				
+
 				jQuery('a.delete_template').click(function(){
 					var answer = confirm('" . __( 'Are you sure you want to delete this template file?', 'woocommerce' ) . "');
-		
+
 					if (answer)
 						return true;
-					
+
 					return false;
 				});
-				
+
 				jQuery('.editor textarea').change(function(){
 					var name = jQuery(this).attr( 'data-name' );
-					
+
 					if ( name )
 						jQuery(this).attr( 'name', name );
 				});

--- a/classes/emails/class-wc-emails.php
+++ b/classes/emails/class-wc-emails.php
@@ -10,13 +10,13 @@
  * @author 		WooThemes
  */
 class WC_Emails {
-	
+
 	/**
 	 * @var array Array of email notification classes.
 	 * @access public
 	 */
 	public $emails;
-	
+
 	/**
 	 * @var string Stores the emailer's address.
 	 * @access private
@@ -28,7 +28,7 @@ class WC_Emails {
 	 * @access private
 	 */
 	private $_from_name;
-	
+
 	/**
 	 * @var mixed Content type for sent emails
 	 * @access private
@@ -42,7 +42,7 @@ class WC_Emails {
 	 * @return void
 	 */
 	function __construct() {
-		
+
 		// Include email classes
 		include_once( 'class-wc-email.php' );
 		include_once( 'class-wc-email-customer-completed-order.php' );
@@ -52,7 +52,7 @@ class WC_Emails {
 		include_once( 'class-wc-email-customer-reset-password.php' );
 		include_once( 'class-wc-email-customer-processing-order.php' );
 		include_once( 'class-wc-email-new-order.php' );
-		
+
 		$this->emails['WC_Email_New_Order'] = new WC_Email_New_Order();
 		$this->emails['WC_Email_Customer_Processing_Order'] = new WC_Email_Customer_Processing_Order();
 		$this->emails['WC_Email_Customer_Completed_Order'] = new WC_Email_Customer_Completed_Order();
@@ -60,7 +60,7 @@ class WC_Emails {
 		$this->emails['WC_Email_Customer_Note'] = new WC_Email_Customer_Note();
 		$this->emails['WC_Email_Customer_Reset_Password'] = new WC_Email_Customer_Reset_Password();
 		$this->emails['WC_Email_Customer_New_Account'] = new WC_Email_Customer_New_Account();
-		
+
 		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );
 
 		// Email Header, Footer and content hooks
@@ -72,14 +72,14 @@ class WC_Emails {
 		add_action( 'woocommerce_low_stock_notification', array( &$this, 'low_stock' ) );
 		add_action( 'woocommerce_no_stock_notification', array( &$this, 'no_stock' ) );
 		add_action( 'woocommerce_product_on_backorder_notification', array( &$this, 'backorder' ));
-		
+
 		// Let 3rd parties unhook the above via this hook
 		do_action( 'woocommerce_email', $this );
 	}
-	
+
 	/**
 	 * Return the email classes - used in admin to load settings.
-	 * 
+	 *
 	 * @access public
 	 * @return array
 	 */
@@ -96,7 +96,7 @@ class WC_Emails {
 	function get_from_name() {
 		if ( ! $this->_from_name )
 			$this->_from_name = get_option( 'woocommerce_email_from_name' );
-			
+
 		return $this->_from_name;
 	}
 
@@ -109,7 +109,7 @@ class WC_Emails {
 	function get_from_address() {
 		if ( ! $this->_from_address )
 			$this->_from_address = get_option( 'woocommerce_email_from_address' );
-			
+
 		return $this->_from_address;
 	}
 
@@ -181,15 +181,15 @@ class WC_Emails {
 	 * @return void
 	 */
 	function send( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = "", $content_type = 'text/html' ) {
-		
+
 		// Set content type
 		$this->_content_type = $content_type;
-		
+
 		// Filters for the email
 		add_filter( 'wp_mail_from', array( &$this, 'get_from_address' ) );
 		add_filter( 'wp_mail_from_name', array( &$this, 'get_from_name' ) );
 		add_filter( 'wp_mail_content_type', array( &$this, 'get_content_type' ) );
-		
+
 		// Send
 		wp_mail( $to, $subject, $message, $headers, $attachments );
 
@@ -198,7 +198,7 @@ class WC_Emails {
 		remove_filter( 'wp_mail_from_name', array( &$this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( &$this, 'get_content_type' ) );
 	}
-	
+
 	/**
 	 * Prepare and send the customer invoice email on demand.
 	 *
@@ -210,7 +210,7 @@ class WC_Emails {
 		$email = $this->emails['WC_Email_Customer_Invoice'];
 		$email->trigger( $order );
 	}
-	
+
 	/**
 	 * Customer new account welcome email.
 	 *
@@ -220,16 +220,16 @@ class WC_Emails {
 	 * @return void
 	 */
 	function customer_new_account( $user_id, $plaintext_pass ) {
-		if ( ! $user_id || ! $plaintext_pass) 
+		if ( ! $user_id || ! $plaintext_pass)
 			return;
-		
+
 		$email = $this->emails['WC_Email_Customer_New_Account'];
 		$email->trigger( $user_id, $plaintext_pass );
-	}	
-	 
+	}
+
 	/**
 	 * Add order meta to email templates.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $order
 	 * @param bool $sent_to_admin (default: false)
@@ -244,20 +244,20 @@ class WC_Emails {
 		if ( $order->customer_note )
 			$meta[ __( 'Note', 'woocommerce' ) ] = wptexturize( $order->customer_note );
 
-		if ( $show_fields ) 
+		if ( $show_fields )
 			foreach ( $show_fields as $field ) {
 				$value = get_post_meta( $order->id, $field, true );
-				if ( $value ) 
+				if ( $value )
 					$meta[ ucwords( esc_attr( $field ) ) ] = wptexturize( $value );
 			}
 
 		if ( sizeof( $meta ) > 0 ) {
-		
+
 			if ( $plain_text ) {
-				
+
 				foreach ( $meta as $key => $value )
 					echo $key . ': ' . $value . "\n";
-				
+
 			} else {
 
 				foreach ( $meta as $key => $value )

--- a/classes/gateways/cod/class-wc-cod.php
+++ b/classes/gateways/cod/class-wc-cod.php
@@ -69,13 +69,13 @@ class WC_COD extends WC_Payment_Gateway {
      */
     function init_form_fields() {
     	global $woocommerce;
-    	
+
     	$shipping_methods = array();
-    	
+
     	foreach ( $woocommerce->shipping->load_shipping_methods() as $method ) {
 	    	$shipping_methods[ $method->id ] = $method->get_title();
     	}
-    
+
     	$this->form_fields = array(
 			'enabled' => array(
 				'title' => __( 'Enable COD', 'woocommerce' ),
@@ -123,41 +123,41 @@ class WC_COD extends WC_Payment_Gateway {
 	 */
 	function is_available() {
 		global $woocommerce;
-		
+
 		if ( ! empty( $this->enable_for_methods ) ) {
-			
+
 			if ( is_page( woocommerce_get_page_id( 'pay' ) ) ) {
-				
+
 				$order_id = (int) $_GET['order_id'];
 				$order = new WC_Order( $order_id );
-		
-				if ( ! $order->shipping_method ) 
+
+				if ( ! $order->shipping_method )
 					return false;
-					
+
 				$chosen_method = $order->shipping_method;
-				
+
 			} elseif ( empty( $woocommerce->session->chosen_shipping_method ) ) {
 				return false;
 			} else {
 				$chosen_method = $woocommerce->session->chosen_shipping_method;
 			}
-				
+
 			$found = false;
-			
+
 			foreach ( $this->enable_for_methods as $method_id ) {
 				if ( strpos( $chosen_method, $method_id ) === 0 ) {
 					$found = true;
 					break;
 				}
 			}
-			
+
 			if ( ! $found )
 				return false;
 		}
-		
+
 		return parent::is_available();
 	}
-	
+
 
     /**
      * Process the payment and return the result

--- a/classes/gateways/mijireh/class-wc-mijireh-checkout.php
+++ b/classes/gateways/mijireh/class-wc-mijireh-checkout.php
@@ -231,16 +231,16 @@ class WC_Mijireh_Checkout extends WC_Payment_Gateway {
 
 		// add items to order
 		$items = $wc_order->get_items();
-		
+
 		foreach( $items as $item ) {
 			$product = $wc_order->get_product_from_item( $item );
-			
+
 			$mj_order->add_item( $item['name'], $wc_order->get_item_subtotal( $item, false, false ), $item['qty'], $product->get_sku() );
 		}
-		
+
 		// Handle fees
 		$items = $wc_order->get_fees();
-		
+
 		foreach( $items as $item ) {
 			$mj_order->add_item( $item['name'], $item['line_total'], 1, '' );
 		}
@@ -290,10 +290,10 @@ class WC_Mijireh_Checkout extends WC_Payment_Gateway {
 
 		// Set URL for mijireh payment notificatoin - use WC API
 		$mj_order->return_url 		= str_replace( 'https:', 'http:', add_query_arg( 'wc-api', 'WC_Mijireh_Checkout', home_url( '/' ) ) );
-		
+
 		// Identify woocommerce
 		$mj_order->partner_id 		= 'woo';
-		
+
 		try {
 			$mj_order->create();
 			$result = array(

--- a/classes/gateways/mijireh/includes/Address.php
+++ b/classes/gateways/mijireh/includes/Address.php
@@ -3,11 +3,11 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class Mijireh_Address extends Mijireh_Model {
-    
+
   public function __construct() {
     $this->init();
   }
-  
+
   public function init() {
     $this->_data = array(
       'first_name' => '',
@@ -22,15 +22,15 @@ class Mijireh_Address extends Mijireh_Model {
       'phone' => ''
     );
   }
-  
+
   public function validate() {
     $is_valid = $this->_check_required_fields();
     return $is_valid;
   }
-  
+
   /**
    * Return true if all of the required fields have a non-empty value
-   * 
+   *
    * @return boolean
    */
   private function _check_required_fields() {
@@ -44,5 +44,5 @@ class Mijireh_Address extends Mijireh_Model {
     }
     return $pass;
   }
-  
+
 }

--- a/classes/gateways/mijireh/includes/Item.php
+++ b/classes/gateways/mijireh/includes/Item.php
@@ -3,7 +3,7 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class Mijireh_Item extends Mijireh_Model {
-  
+
   private function _init() {
     $this->_data = array(
       'name' => null,
@@ -12,27 +12,27 @@ class Mijireh_Item extends Mijireh_Model {
       'sku' => null
     );
   }
-  
+
   private function _check_required_fields() {
     if(empty($this->_data['name'])) {
       $this->add_error('item name is required.');
     }
-    
+
     if(!is_numeric($this->_data['price'])) {
       $this->add_error('price must be a number.');
     }
   }
-  
+
   private function _check_quantity() {
     if($this->_data['quantity'] < 1) {
       $this->add_error('quantity must be greater than or equal to 1');
     }
   }
-  
+
   public function __construct() {
     $this->_init();
   }
-  
+
   public function __get($key) {
     $value = false;
     if($key == 'total') {
@@ -44,17 +44,17 @@ class Mijireh_Item extends Mijireh_Model {
     }
     return $value;
   }
-  
+
   public function get_data() {
     $data = parent::get_data();
     $data['total'] = $this->total;
     return $data;
   }
-  
+
   public function validate() {
     $this->_check_required_fields();
     $this->_check_quantity();
     return count($this->_errors) == 0;
   }
-  
+
 }

--- a/classes/gateways/mijireh/includes/Model.php
+++ b/classes/gateways/mijireh/includes/Model.php
@@ -3,13 +3,13 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class Mijireh_Model {
-  
+
   protected $_data = array();
   protected $_errors = array();
-  
+
   /**
    * Set the value of one of the keys in the private $_data array.
-   * 
+   *
    * @param string $key The key in the $_data array
    * @param string $value The value to assign to the key
    * @return boolean
@@ -22,12 +22,12 @@ class Mijireh_Model {
     }
     return $success;
   }
-  
+
   /**
    * Get the value for the key from the private $_data array.
-   * 
+   *
    * Return false if the requested key does not exist
-   * 
+   *
    * @param string $key The key from the $_data array
    * @return mixed
    */
@@ -36,29 +36,29 @@ class Mijireh_Model {
     if(array_key_exists($key, $this->_data)) {
       $value = $this->_data[$key];
     }
-    
+
     /*
     elseif(method_exists($this, $key)) {
       $value = call_user_func_array(array($this, $key), func_get_args());
     }
     */
-    
+
     return $value;
   }
-  
+
   /**
    * Return true if the given $key in the private $_data array is set
-   * 
+   *
    * @param string $key
-   * @return boolean   
+   * @return boolean
    */
   public function __isset($key) {
     return isset($this->_data[$key]);
   }
-  
+
   /**
-   * Set the value of the $_data array to null for the given key. 
-   * 
+   * Set the value of the $_data array to null for the given key.
+   *
    * @param string $key
    * @return void
    */
@@ -67,26 +67,26 @@ class Mijireh_Model {
       $this->_data[$key] = null;
     }
   }
-  
+
   /**
    * Return the private $_data array
-   * 
+   *
    * @return mixed
    */
   public function get_data() {
     return $this->_data;
   }
-  
+
   /**
    * Return true if the given $key exists in the private $_data array
-   * 
+   *
    * @param string $key
    * @return boolean
    */
   public function field_exists($key) {
     return array_key_exists($key, $this->_data);
   }
-  
+
   public function copy_from(array $data) {
     foreach($data as $key => $value) {
       if(array_key_exists($key, $this->_data)) {
@@ -94,7 +94,7 @@ class Mijireh_Model {
       }
     }
   }
-  
+
   public function clear() {
     foreach($this->_data as $key => $value) {
       if($key == 'id') {
@@ -105,21 +105,21 @@ class Mijireh_Model {
       }
     }
   }
-  
+
   public function add_error($error_message) {
     if(!empty($error_message)) {
       $this->_errors[] = $error_message;
     }
   }
-  
+
   public function clear_errors() {
     $this->_errors = array();
   }
-  
+
   public function get_errors() {
     return $this->_errors;
   }
-  
+
   public function get_error_lines($glue="\n") {
     $error_lines = '';
     if(count($this->_errors)) {
@@ -127,9 +127,9 @@ class Mijireh_Model {
     }
     return $error_lines;
   }
-  
+
   public function is_valid() {
     return count($this->_errors) == 0;
   }
-  
-} 
+
+}

--- a/classes/gateways/mijireh/includes/Order.php
+++ b/classes/gateways/mijireh/includes/Order.php
@@ -3,7 +3,7 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class Mijireh_Order extends Mijireh_Model {
-  
+
   private function _init() {
     $this->_data = array(
       'partner_id' => null,
@@ -27,19 +27,19 @@ class Mijireh_Order extends Mijireh_Model {
       'billing_address' => array()
     );
   }
-  
+
   public function __construct($order_number=null) {
     $this->_init();
     if(isset($order_number)) {
       $this->load($order_number);
     }
   }
-  
+
   public function load($order_number) {
     if(strlen(Mijireh::$access_key) < 5) {
       throw new Mijireh_Exception('missing mijireh access key');
     }
-    
+
     $rest = new Mijireh_RestJSON(Mijireh::$url);
     $rest->setupAuth(Mijireh::$access_key, '');
     try {
@@ -63,7 +63,7 @@ class Mijireh_Order extends Mijireh_Model {
       throw new Mijireh_ServerError($e->getMessage());
     }
   }
-  
+
   public function copy_from($order_data) {
     foreach($order_data as $key => $value) {
       if($key == 'items') {
@@ -100,24 +100,24 @@ class Mijireh_Order extends Mijireh_Model {
         $this->$key = $value;
       }
     }
-    
+
     if(!$this->validate()) {
       throw new Mijireh_Exception('invalid order hydration: ' . $this->get_errors_lines());
     }
-    
+
     return $this;
   }
-  
+
   public function create() {
     if(strlen(Mijireh::$access_key) < 5) {
       throw new Mijireh_Exception('missing mijireh access key');
     }
-    
+
     if(!$this->validate()) {
       $error_message = 'unable to create order: ' . $this->get_error_lines();
       throw new Mijireh_Exception($error_message);
     }
-    
+
     $rest = new Mijireh_RestJSON(Mijireh::$url);
     $rest->setupAuth(Mijireh::$access_key, '');
     try {
@@ -141,7 +141,7 @@ class Mijireh_Order extends Mijireh_Model {
       throw new Mijireh_ServerError($e->getMessage());
     }
   }
-  
+
   /**
    * If meta_data or shipping_address are empty, exclude them altogether.
    */
@@ -152,12 +152,12 @@ class Mijireh_Order extends Mijireh_Model {
     if(count($data['billing_address']) == 0) { unset($data['billing_address']); }
     return $data;
   }
-  
+
   /**
    * Add the specified item and price to the order.
-   * 
+   *
    * Return the total number of items in the order (including the one that was just added)
-   * 
+   *
    * @return int
    */
   public function add_item($name, $price=0, $quantity=1, $sku='') {
@@ -172,7 +172,7 @@ class Mijireh_Order extends Mijireh_Model {
       $item->quantity = $quantity;
       $item->sku = $sku;
     }
-    
+
     if($item->validate()) {
       $this->_data['items'][] = $item->get_data();
       return $this->item_count();
@@ -182,17 +182,17 @@ class Mijireh_Order extends Mijireh_Model {
       throw new Mijireh_Exception('unable to add invalid item to order :: ' . $errors);
     }
   }
-  
+
   public function add_meta_data($key, $value) {
     if(!is_array($this->_data['meta_data'])) {
       $this->_data['meta_data'] = array();
     }
     $this->_data['meta_data'][$key] = $value;
   }
-  
+
   /**
    * Return the value associated with the given key in the order's meta data.
-   * 
+   *
    * If the key does not exist, return false.
    */
   public function get_meta_value($key) {
@@ -202,7 +202,7 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $value;
   }
-  
+
   public function item_count() {
     $item_count = 0;
     if(is_array($this->_data['items'])) {
@@ -210,7 +210,7 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $item_count;
   }
-  
+
   public function get_items() {
     $items = array();
     foreach($this->_data['items'] as $item_data) {
@@ -218,29 +218,29 @@ class Mijireh_Order extends Mijireh_Model {
       $item->copy_from($item_data);
     }
   }
-  
+
   public function clear_items() {
     $this->_data['items'] = array();
   }
-  
+
   public function clear_meta_data() {
     $this->_data['meta_data'] = array();
   }
-  
+
   public function validate() {
     $this->_check_total();
     $this->_check_return_url();
     $this->_check_items();
     return count($this->_errors) == 0;
   }
-  
+
   /**
    * Alias for set_shipping_address()
    */
-  public function set_address(Mijireh_Address $address){ 
+  public function set_address(Mijireh_Address $address){
     $this->set_shipping_address($address);
   }
-  
+
   public function set_shipping_address(Mijireh_Address $address) {
     if($address->validate()) {
       $this->_data['shipping_address'] = $address->get_data();
@@ -249,7 +249,7 @@ class Mijireh_Order extends Mijireh_Model {
       throw new Mijireh_Exception('invalid shipping address');
     }
   }
-  
+
   public function set_billing_address(Mijireh_Address $address) {
     if($address->validate()) {
       $this->_data['billing_address'] = $address->get_data();
@@ -258,14 +258,14 @@ class Mijireh_Order extends Mijireh_Model {
       throw new Mijireh_Exception('invalid shipping address');
     }
   }
-  
+
   /**
    * Alias for get_shipping_address()
    */
   public function get_address() {
     return $this->get_shipping_address();
   }
-  
+
   public function get_shipping_address() {
     $address = false;
     if(is_array($this->_data['shipping_address'])) {
@@ -274,7 +274,7 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $address;
   }
-  
+
   public function get_billing_address() {
     $address = false;
     if(is_array($this->_data['billing_address'])) {
@@ -283,12 +283,12 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $address;
   }
-  
+
   /**
    * The order total must be greater than zero.
-   * 
+   *
    * Return true if valid, otherwise false.
-   * 
+   *
    * @return boolean
    */
   private function _check_total() {
@@ -299,12 +299,12 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $is_valid;
   }
-  
+
   /**
    * The return url must be provided and must start with http.
-   * 
+   *
    * Return true if valid, otherwise false
-   * 
+   *
    * @return boolean
    */
   private function _check_return_url() {
@@ -323,12 +323,12 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $is_valid;
   }
-  
+
   /**
    * An order must contain at least one item
-   * 
+   *
    * Return true if the order has at least one item, otherwise false.
-   * 
+   *
    * @return boolean
    */
   private function _check_items() {
@@ -339,5 +339,5 @@ class Mijireh_Order extends Mijireh_Model {
     }
     return $is_valid;
   }
-  
+
 }

--- a/classes/gateways/mijireh/includes/Rest.php
+++ b/classes/gateways/mijireh/includes/Rest.php
@@ -8,9 +8,9 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
- 
+
 class Mijireh_Rest {
-  
+
   public $curl_opts = array(
   	CURLOPT_RETURNTRANSFER => true,  // return result instead of echoing
   	CURLOPT_SSL_VERIFYPEER => false, // stop cURL from verifying the peer's certificate
@@ -18,20 +18,20 @@ class Mijireh_Rest {
   );
 
   public $base_url;
-  
+
   public $last_response;
   public $last_request;
-  
+
   public $throw_exceptions = true;
-  
+
   public function __construct($base_url, $curl_options=null) {
     if (!function_exists('curl_init')) {
   	    throw new Exception('CURL module not available! Mijireh_Rest requires CURL. See http://php.net/manual/en/book.curl.php');
   	}
-    
+
     if(isset($curl_options) && is_array($curl_options)) {
       foreach($curl_options as $key => $value) {
-        
+
         if($key == 'CURLOPT_FOLLOWLOCATION') {
           // only enable CURLOPT_FOLLOWLOCATION if safe_mode and open_base_dir are not in use
         	if(ini_get('open_basedir') == '' && !ini_get('safe_mode')) {
@@ -41,151 +41,151 @@ class Mijireh_Rest {
         else {
           $this->curl_opts[$key] = $value;
         }
-        
+
       }
     }
-    
-  	
+
+
     $this->base_url = $base_url;
   }
-  
+
   // $auth can be 'basic' or 'digest'
   public function setupAuth($user, $pass, $auth = 'basic') {
     $this->curl_opts[CURLOPT_HTTPAUTH] = constant('CURLAUTH_'.strtoupper($auth));
     $this->curl_opts[CURLOPT_USERPWD] = $user . ":" . $pass;
   }
-  
+
   public function get($url) {
     $curl = $this->prepRequest($this->curl_opts, $url);
     $body = $this->doRequest($curl);
-    
+
     $body = $this->processBody($body);
-    
+
     return $body;
   }
-  
+
   public function post($url, $data, $headers=array()) {
     $data = (is_array($data)) ? http_build_query($data) : $data;
-        
+
     $curl_opts = $this->curl_opts;
     $curl_opts[CURLOPT_CUSTOMREQUEST] = 'POST';
     $headers[] = 'Content-Length: '.strlen($data);
     $curl_opts[CURLOPT_HTTPHEADER] = $headers;
     $curl_opts[CURLOPT_POSTFIELDS] = $data;
-    
+
     $curl = $this->prepRequest($curl_opts, $url);
     $body = $this->doRequest($curl);
-    
+
     $body = $this->processBody($body);
-    
+
     return $body;
   }
-  
+
   public function put($url, $data, $headers=array()) {
-    $data = (is_array($data)) ? http_build_query($data) : $data; 
-    
+    $data = (is_array($data)) ? http_build_query($data) : $data;
+
     $curl_opts = $this->curl_opts;
     $curl_opts[CURLOPT_CUSTOMREQUEST] = 'PUT';
     $headers[] = 'Content-Length: '.strlen($data);
     $curl_opts[CURLOPT_HTTPHEADER] = $headers;
     $curl_opts[CURLOPT_POSTFIELDS] = $data;
-    
+
     $curl = $this->prepRequest($curl_opts, $url);
     $body = $this->doRequest($curl);
-    
+
     $body = $this->processBody($body);
-    
+
     return $body;
   }
-  
+
   public function delete($url) {
     $curl_opts = $this->curl_opts;
     $curl_opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
-    
+
     $curl = $this->prepRequest($curl_opts, $url);
     $body = $this->doRequest($curl);
-    
+
     $body = $this->processBody($body);
-    
+
     return $body;
   }
-  
+
   public function lastBody() {
     return $this->last_response['body'];
   }
-  
+
   public function lastStatus() {
     return $this->last_response['meta']['http_code'];
   }
-  
+
   protected function processBody($body) {
     // Override this in classes that extend Mijireh_Rest.
-    // The body of every GET/POST/PUT/DELETE response goes through 
+    // The body of every GET/POST/PUT/DELETE response goes through
     // here prior to being returned.
     return $body;
   }
-  
+
   protected function processError($body) {
     // Override this in classes that extend Mijireh_Rest.
-    // The body of every erroneous (non-2xx/3xx) GET/POST/PUT/DELETE  
+    // The body of every erroneous (non-2xx/3xx) GET/POST/PUT/DELETE
     // response goes through here prior to being used as the 'message'
     // of the resulting Mijireh_Rest_Exception
     return $body;
   }
 
-  
+
   protected function prepRequest($opts, $url) {
     if (strncmp($url, $this->base_url, strlen($this->base_url)) != 0) {
       $url = $this->base_url . $url;
     }
     $curl = curl_init($url);
-    
+
     foreach ($opts as $opt => $val) {
       @curl_setopt($curl, $opt, $val);
     }
-    
+
     $this->last_request = array(
       'url' => $url
     );
-    
+
     if (isset($opts[CURLOPT_CUSTOMREQUEST]))
       $this->last_request['method'] = $opts[CURLOPT_CUSTOMREQUEST];
     else
       $this->last_request['method'] = 'GET';
-    
+
     if (isset($opts[CURLOPT_POSTFIELDS]))
       $this->last_request['data'] = $opts[CURLOPT_POSTFIELDS];
-    
+
     return $curl;
   }
-  
+
   private function doRequest($curl) {
-    
+
     $body = curl_exec($curl);
     $meta = curl_getinfo($curl);
-    
+
     $this->last_response = array(
       'body' => $body,
       'meta' => $meta
     );
-    
+
     curl_close($curl);
-    
+
     $this->checkLastResponseForError();
-    
+
     return $body;
   }
-  
+
   protected function checkLastResponseForError() {
     if ( !$this->throw_exceptions)
       return;
-      
+
     $meta = $this->last_response['meta'];
     $body = $this->last_response['body'];
-    
+
     if (!$meta)
       return;
-    
+
     $err = null;
     switch ($meta['http_code']) {
       case 400:
@@ -213,7 +213,7 @@ class Mijireh_Rest {
         // Unprocessable Entity -- see http://www.iana.org/assignments/http-status-codes
         // This is now commonly used (in Rails, at least) to indicate
         // a response to a request that is syntactically correct,
-        // but semantically invalid (for example, when trying to 
+        // but semantically invalid (for example, when trying to
         // create a resource with some required fields missing)
         throw new Mijireh_Rest_InvalidRecord($this->processError($body));
         break;

--- a/classes/gateways/mijireh/includes/RestJSON.php
+++ b/classes/gateways/mijireh/includes/RestJSON.php
@@ -3,11 +3,11 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class Mijireh_RestJSON extends Mijireh_Rest {
-  
+
   public function post($url, $data, $headers=array()) {
     return parent::post($url, json_encode($data), $headers);
   }
-  
+
   public function put($url, $data, $headers=array()) {
     return parent::put($url, json_encode($data), $headers);
   }
@@ -21,5 +21,5 @@ class Mijireh_RestJSON extends Mijireh_Rest {
   public function processBody($body) {
     return json_decode($body, true);
   }
-  
+
 }

--- a/classes/gateways/paypal/class-wc-paypal.php
+++ b/classes/gateways/paypal/class-wc-paypal.php
@@ -14,9 +14,9 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class WC_Paypal extends WC_Payment_Gateway {
-	
+
 	var $notify_url;
-	
+
     /**
      * Constructor for the gateway.
      *
@@ -59,7 +59,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 		add_action( 'valid-paypal-standard-ipn-request', array( &$this, 'successful_request' ) );
 		add_action( 'woocommerce_receipt_paypal', array( &$this, 'receipt_page' ) );
 		add_action( 'woocommerce_update_options_payment_gateways', array( &$this, 'process_admin_options' ) );
-		
+
 		// Payment listener/API hook
 		add_action( 'woocommerce_api_wc_paypal', array( &$this, 'check_ipn_response' ) );
 
@@ -218,7 +218,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 
 		$order_id = $order->id;
 
-		if ( $this->debug == 'yes' ) 
+		if ( $this->debug == 'yes' )
 			$this->log->add( 'paypal', 'Generating payment form for order ' . $order->get_order_number() . '. Notify URL: ' . $this->notify_url );
 
 		if ( in_array( $order->billing_country, array( 'US','CA' ) ) ) {
@@ -303,9 +303,9 @@ class WC_Paypal extends WC_Payment_Gateway {
 			// Don't pass items - paypal borks tax due to prices including tax. PayPal has no option for tax inclusive pricing sadly. Pass 1 item for the order items overall
 			$item_names = array();
 
-			if ( sizeof( $order->get_items() ) > 0 ) 
+			if ( sizeof( $order->get_items() ) > 0 )
 				foreach ( $order->get_items() as $item )
-					if ( $item['qty'] ) 
+					if ( $item['qty'] )
 						$item_names[] = $item['name'] . ' x ' . $item['qty'];
 
 			$paypal_args['item_name_1'] 	= sprintf( __( 'Order %s' , 'woocommerce'), $order->get_order_number() ) . " - " . implode( ', ', $item_names );
@@ -333,32 +333,32 @@ class WC_Paypal extends WC_Payment_Gateway {
 			if ( sizeof( $order->get_items() ) > 0 ) {
 				foreach ( $order->get_items() as $item ) {
 					if ( $item['qty'] ) {
-	
+
 						$item_loop++;
-	
+
 						$product = $order->get_product_from_item( $item );
-	
+
 						$item_name 	= $item['name'];
-	
+
 						$item_meta = new WC_Order_Item_Meta( $item['item_meta'] );
 						if ( $meta = $item_meta->display( true, true ) )
 							$item_name .= ' ( ' . $meta . ' )';
-	
+
 						$paypal_args[ 'item_name_' . $item_loop ] 	= $item_name;
 						$paypal_args[ 'quantity_' . $item_loop ] 	= $item['qty'];
 						$paypal_args[ 'amount_' . $item_loop ] 		= $order->get_item_total( $item, false );
-						
-						if ( $product->get_sku() ) 
+
+						if ( $product->get_sku() )
 							$paypal_args[ 'item_number_' . $item_loop ] = $product->get_sku();
 					}
 				}
 			}
-			
+
 			// Fees
 			if ( sizeof( $order->get_fees() ) > 0 ) {
 				foreach ( $order->get_fees() as $item ) {
 					$item_loop++;
-	
+
 					$paypal_args[ 'item_name_' . $item_loop ] 	= $item['name'];
 					$paypal_args[ 'quantity_' . $item_loop ] 	= 1;
 					$paypal_args[ 'amount_' . $item_loop ] 		= $item['line_total'];
@@ -496,7 +496,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 	function check_ipn_request_is_valid() {
 		global $woocommerce;
 
-		if ( $this->debug == 'yes' ) 
+		if ( $this->debug == 'yes' )
 			$this->log->add( 'paypal', 'Checking IPN response is valid...' );
 
     	// Get recieved values from post data
@@ -522,14 +522,14 @@ class WC_Paypal extends WC_Payment_Gateway {
 		// Post back to get a response
         $response = wp_remote_post( $paypal_adr, $params );
 
-        if ( $this->debug == 'yes' ) 
+        if ( $this->debug == 'yes' )
         	$this->log->add( 'paypal', 'IPN Response: ' . print_r( $response, true ) );
 
         // check to see if the request was valid
         if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 && ( strcmp( $response['body'], "VERIFIED" ) == 0 ) ) {
-            if ( $this->debug == 'yes' ) 
+            if ( $this->debug == 'yes' )
             	$this->log->add( 'paypal', 'Received valid response from PayPal' );
-            	
+
             return true;
         }
 
@@ -582,18 +582,18 @@ class WC_Paypal extends WC_Payment_Gateway {
 
 		// Custom holds post ID
 	    if ( ! empty( $posted['invoice'] ) && ! empty( $posted['custom'] ) ) {
-		    
+
 		    $order = $this->get_paypal_order( $posted );
-		    
+
 		    // Lowercase returned variables
 	        $posted['payment_status'] 	= strtolower( $posted['payment_status'] );
 	        $posted['txn_type'] 		= strtolower( $posted['txn_type'] );
-		    
+
 		    // Sandbox fix
-	        if ( $posted['test_ipn'] == 1 && $posted['payment_status'] == 'pending' ) 
+	        if ( $posted['test_ipn'] == 1 && $posted['payment_status'] == 'pending' )
 	        	$posted['payment_status'] = 'completed';
 
-	        if ( $this->debug == 'yes' ) 
+	        if ( $this->debug == 'yes' )
 	        	$this->log->add( 'paypal', 'Payment status: ' . $posted['payment_status'] );
 
 	        // We are here so lets check status and do actions
@@ -602,7 +602,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 
 	            	// Check order not already completed
 	            	if ( $order->status == 'completed' ) {
-	            		 if ( $this->debug == 'yes' ) 
+	            		 if ( $this->debug == 'yes' )
 	            		 	$this->log->add( 'paypal', 'Aborting, Order #' . $order_id . ' is already complete.' );
 	            		 exit;
 	            	}
@@ -610,22 +610,22 @@ class WC_Paypal extends WC_Payment_Gateway {
 	            	// Check valid txn_type
 	            	$accepted_types = array( 'cart', 'instant', 'express_checkout', 'web_accept', 'masspay', 'send_money' );
 					if ( ! in_array( $posted['txn_type'], $accepted_types ) ) {
-						if ( $this->debug == 'yes' ) 
+						if ( $this->debug == 'yes' )
 							$this->log->add( 'paypal', 'Aborting, Invalid type:' . $posted['txn_type'] );
 						exit;
 					}
-					
+
 					// Validate Amount
 				    if ( $order->get_total() != $posted['mc_gross'] ) {
-				    	
-				    	if ( $this->debug == 'yes' ) 
+
+				    	if ( $this->debug == 'yes' )
 				    		$this->log->add( 'paypal', 'Payment error: Amounts do not match (gross ' . $posted['mc_gross'] . ')' );
-				    
+
 				    	// Put this order on-hold for manual checking
 				    	$order->update_status( 'on-hold', sprintf( __( 'Validation error: PayPal amounts do not match (gross %s).', 'woocommerce' ), $posted['mc_gross'] ) );
-				    	
+
 				    	exit;
-				    }	
+				    }
 
 					 // Store PP Details
 	                if ( ! empty( $posted['payer_email'] ) )
@@ -643,7 +643,7 @@ class WC_Paypal extends WC_Payment_Gateway {
 	                $order->add_order_note( __( 'IPN payment completed', 'woocommerce' ) );
 	                $order->payment_complete();
 
-	                if ( $this->debug == 'yes' ) 
+	                if ( $this->debug == 'yes' )
 	                	$this->log->add( 'paypal', 'Payment complete.' );
 
 	            break;
@@ -699,11 +699,11 @@ class WC_Paypal extends WC_Payment_Gateway {
 	    }
 
 	}
-	
+
 
 	/**
 	 * get_paypal_order function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $posted
 	 * @return void
@@ -724,19 +724,19 @@ class WC_Paypal extends WC_Payment_Gateway {
 
 		$order = new WC_Order( $order_id );
 
-		if ( ! isset( $order->id ) ) { 
+		if ( ! isset( $order->id ) ) {
 			// We have an invalid $order_id, probably because invoice_prefix has changed
 			$order_id 	= woocommerce_get_order_id_by_order_key( $order_key );
 			$order 		= new WC_Order( $order_id );
 		}
-		
+
 		// Validate key
 		if ( $order->order_key !== $order_key ) {
-        	if ( $this->debug=='yes' ) 
+        	if ( $this->debug=='yes' )
         		$this->log->add( 'paypal', 'Error: Order Key does not match invoice.' );
         	exit;
         }
-        
+
         return $order;
 	}
 

--- a/classes/integrations/google-analytics/class-wc-google-analytics.php
+++ b/classes/integrations/google-analytics/class-wc-google-analytics.php
@@ -268,7 +268,7 @@ class WC_Google_Analytics extends WC_Integration {
 	 * @return void
 	 */
 	function loop_add_to_cart() {
-		
+
 		if ( $this->disable_tracking( $this->ga_event_tracking_enabled ) ) return;
 
 		$parameters = array();
@@ -293,7 +293,7 @@ class WC_Google_Analytics extends WC_Integration {
 		global $woocommerce;
 
 		$parameters = apply_filters( 'woocommerce_ga_event_tracking_parameters', $parameters );
-		
+
 		$woocommerce->add_inline_js("
 			$('" . $selector . "').click(function() {
 				" . sprintf( "_gaq.push(['_trackEvent', %s, %s, %s]);", $parameters['category'], $parameters['action'], $parameters['label'] ) . "

--- a/classes/integrations/shareyourcart/class-shareyourcart-woocommerce-extended.php
+++ b/classes/integrations/shareyourcart/class-shareyourcart-woocommerce-extended.php
@@ -17,27 +17,27 @@ class ShareYourCartWooCommerceEx extends ShareYourCartWooCommerce {
 
 		parent::__construct();
 	}
-	
+
 	public function isCartActive() {
 		return true; //since this class has loaded, the WooCommerce plugin is active
 	}
-	
+
 	public function getSecretKey() {
 		return '2cfd496d-7812-44ba-91ce-e43c59f6c680';
 	}
-	
+
 	public function showAdminMenu() {
 		//since we have allready integrated this in our own settings page,
 		//leave this function empty
 	}
-	
+
 	/**
 	 *
 	 * Set the field value
 	 *
 	 */
 	protected function setConfigValue($field, $value) {
-	
+
 		$this->settings[$field] = $value;
 
 		//make sure to update the enabled field as well, based on the account_status
@@ -51,11 +51,11 @@ class ShareYourCartWooCommerceEx extends ShareYourCartWooCommerce {
 				parent::setConfigValue($field, $value);
 				break;
 		}
-		
+
 		//save the config in the DB
-		update_option( 'woocommerce_shareyourcart_settings', $this->settings ); 
+		update_option( 'woocommerce_shareyourcart_settings', $this->settings );
 	}
-	
+
 	/**
 	 *
 	 * Get the field value
@@ -64,15 +64,15 @@ class ShareYourCartWooCommerceEx extends ShareYourCartWooCommerce {
 	protected function getConfigValue( $field ) {
 
 		$value = ( isset( $this->settings[$field] ) ) ? $this->settings[$field] : '';
-		
+
 		//search for the global value of this field
 		//as it might have been changed by an external ShareYourCart integration
 		if($field == "plugin_current_version"){
 			$val = parent::getConfigValue($field);
-			
+
 			if(!empty($val)) $value = $val;
 		}
-		
+
 		return $value;
 	}
 }

--- a/classes/integrations/shareyourcart/class-wc-shareyourcart.php
+++ b/classes/integrations/shareyourcart/class-wc-shareyourcart.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * ShareYourCart Integration
- * 
+ *
  * Enables ShareYourCart integration.
  *
  * @class 		WC_ShareYourCart
@@ -9,77 +9,77 @@
  * @category	Integrations
  * @author		WooThemes
  */
-  
+
 class WC_ShareYourCart extends WC_Integration {
-		
-	var $ShareYourCartWooCommerce;	
-		
-	public function __construct() { 
+
+	var $ShareYourCartWooCommerce;
+
+	public function __construct() {
         $this->id					= 'shareyourcart';
         $this->method_title     	= __( 'ShareYourCart', 'woocommerce' );
         $this->method_description	= __( 'Increase your social media exposure by 10 percent! ShareYourCart helps you get more customers by motivating satisfied customers to talk with their friends about your products. For help with ShareYourCart view the <a href="http://www.woothemes.com/woocommerce-docs/user-guide/shareyourcart/" target="__blank">documentation</a>.', 'woocommerce' );
-		
+
 		// Load the settings.
 		$this->settings = ( array ) get_option( $this->plugin_id . $this->id . '_settings' ); //do not rely on the base implementation of init_settings
-		
+
 		//the classes need to be initialized
 		$this->init_share_your_cart();
-		
+
 		//hook to the admin settings page
 		add_action( 'woocommerce_update_options_integration_shareyourcart', array( &$this, 'process_forms') );
-    } 
+    }
 
 	/**
 	 * styles function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	public function styles() {
 		wp_enqueue_style( 'shareyourcart', plugins_url( 'css/style.css', __FILE__ ) );
 	}
-	
+
 	/**
 	 * init_share_your_cart function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function init_share_your_cart() {
-		
+
 		if ( empty( $this->shareYourCartWooCommerce ) ) {
 			// Share your cart api class
-			include_once('class-shareyourcart-woocommerce-extended.php'); 
-			
+			include_once('class-shareyourcart-woocommerce-extended.php');
+
 			// Init the class
 			$this->shareYourCartWooCommerce = new ShareYourCartWooCommerceEx( $this->settings );
-			
+
 			//by the time we get here, the plugins_loaded hook has allready been called
 			//so call the method manually
 			$this->shareYourCartWooCommerce->pluginsLoadedHook();
 		}
-		
+
 	}
-	
+
 	/**
-	 * process_forms function. 
-	 * 
+	 * process_forms function.
+	 *
 	 * @access public
 	 */
 	function process_forms() {
-		
+
 		//after this function completes, WooCommerce will refresh the page, so we need to save the data here
-		
+
 		//stripslashes from button_html
 		if(isset($_POST['button_html']))
 			$_POST['button_html'] = stripslashes($_POST['button_html']);
-		
+
 		//TODO: investigate why the files are not being uploaded
-		
+
 		$this->shareYourCartWooCommerce->getAdminPage($this); //get the admin page ( so that the data is processed, but do not show it )
-		$this->shareYourCartWooCommerce->getButtonCustomizationPage(); //get the customization page ( so that the data is processed, but do not show it )		
+		$this->shareYourCartWooCommerce->getButtonCustomizationPage(); //get the customization page ( so that the data is processed, but do not show it )
 	}
-	
+
 	/**
 	 * Admin Options
 	 *
@@ -89,17 +89,17 @@ class WC_ShareYourCart extends WC_Integration {
 	 * @since 1.0.0
 	 */
 	function admin_options() {
-		
+
 		if ( $this->shareYourCartWooCommerce->isActive() ) {
-			
+
 			// call this manually ( to determine if there needs to be a table update, or not )
 			$this->shareYourCartWooCommerce->install();
 		}
-		
+
 		$this->shareYourCartWooCommerce->showAdminHeader();
 		$this->shareYourCartWooCommerce->showAdminPage($this,true,false); //send this obj to the view, but do not show the footer
 		$this->shareYourCartWooCommerce->showButtonCustomizationPage(null,false,false); //do not show neither the header, nor the footer of this page
-	} 
+	}
 }
 
 /**
@@ -107,7 +107,7 @@ class WC_ShareYourCart extends WC_Integration {
  **/
 function add_shareyourcart_integration( $integrations ) {
 	if ( ! class_exists('ShareYourCartAPI') ) // Only allow this integration if we're not already using shareyourcart via another plugin
-		$integrations[] = 'WC_ShareYourCart'; 
+		$integrations[] = 'WC_ShareYourCart';
 	return $integrations;
 }
 add_filter('woocommerce_integrations', 'add_shareyourcart_integration' );

--- a/classes/integrations/shareyourcart/class.shareyourcart-wp-woocommerce.php
+++ b/classes/integrations/shareyourcart/class.shareyourcart-wp-woocommerce.php
@@ -5,10 +5,10 @@ require_once("class.shareyourcart-wp.php");
 if(!class_exists('ShareYourCartWooCommerce',false)){
 
 class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
-    
+
     public $_plugin_name  = "shareyourcart_woo_commerce";
     public $_post_user_id = 1;
-    
+
 	public function processInit(){
 	  if(isset($_REQUEST['action'])){
 		  switch($_REQUEST['action']){
@@ -22,11 +22,11 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 		  }
 	  }
 	}
-    
+
     public function isCartActive() {
       return in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) );
-    } 
-    
+    }
+
 	/*
 	 *
 	 * Extend the base class implementation
@@ -34,15 +34,15 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 	 */
 	public function pluginsLoadedHook() {
       parent::pluginsLoadedHook();
-      
+
       if(!$this->isCartActive()) return;
-      
+
       add_action('init', array(&$this, 'processInit'));
-	  
+
 	  add_action('woocommerce_before_single_product', array(&$this,'showProductButton'));
       add_action('woocommerce_cart_contents', array(&$this,'showCartButton'));
 	}
-	
+
 	/**
 	*
 	* Return the jQuery sibling selector for the product button
@@ -52,7 +52,7 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 		$selector = parent::getProductButtonPosition();
 		return (!empty($selector) ? $selector : ".summary .price .amount");
 	}
-	
+
 	/**
 	*
 	* Return the jQuery sibling selector for the cart button
@@ -62,20 +62,20 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 		$selector = parent::getCartButtonPosition();
 		return (!empty($selector) ? $selector : ".cart-subtotal .amount");
 	}
-	
+
     public function getSecretKey() {
       return 'd3ce6c18-7e45-495d-aa4c-8f63edee03a5';
     }
-    
+
     public function isSingleProduct() {
       return is_singular('product');
     }
-    
+
     protected function saveCoupon($token, $coupon_code, $coupon_value, $coupon_type, $product_unique_ids = array()) {
-	
+
 		// Create coupon
 		$post_id = $this->_saveCouponPost($coupon_code);
-      
+
 		// Set coupon meta
 		switch ($coupon_type) {
 		case 'amount':
@@ -113,16 +113,16 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 		// parent
 		parent::saveCoupon( $token, $coupon_code, $coupon_value, $coupon_type );
     }
-    
+
     public function applyCoupon($coupon_code) {
       //$this->_loadWooCommerce();
-      
+
       //global $woocommerce;
       //$woocommerce->cart->add_discount($coupon_code);
-      
+
       return;
     }
-    
+
     private function _saveCouponPost($coupon_code){
 		$new_post = array(
 			'post_title'    => $coupon_code,
@@ -139,7 +139,7 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 
 		return $post_id;
     }
-    
+
 	public function getButtonCallbackURL() {
 		global $wp_query;
 
@@ -151,7 +151,7 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 
 		return $callback_url;
 	}
-    
+
     public function buttonCallback(){
       if(!$this->isCartActive()) return;
 
@@ -166,10 +166,10 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
 
       //there is no product set, thus send the products from the shopping cart
       if(!isset($_REQUEST['p']))
-      {	
+      {
           if(empty($_SESSION['cart']))
             exit("Cart is empty");
-          
+
           foreach($_SESSION['cart'] as $cart_details){
             $params['cart'][] = $this->_getProductDetails($cart_details['product_id']);
           }
@@ -179,18 +179,18 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
           $params['cart'][] = $this->_getProductDetails($_REQUEST['p']);
       }
 
-      try 
+      try
       {
           $this->startSession($params);
-      } 
-      catch(Exception $e) 
+      }
+      catch(Exception $e)
       {
           //display the error to the user
           echo $e->getMessage();
       }
       exit;
     }
-      
+
     private function _getProductDetails($product_id){
         $product = get_product($product_id);
 
@@ -198,14 +198,14 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
         ob_start();
         echo $product->get_image(); //older WooCommerce versions might allready echo, but newer versions don't, so force it anyway
         $image = ob_get_clean();
-		
+
 		//check is image actually a HTML img entity
 		if(($doc = @DomDocument::loadHTML($image)) !== FALSE)
 		{
 			$imageTags =  $doc->getElementsByTagName('img');
 			if($imageTags->length >0 )
 				$src =  $imageTags->item(0)->getAttribute('src');
-			
+
 			//replace image only if src has been set
 			if (!empty($src))
 				$image = $src;
@@ -215,23 +215,23 @@ class ShareYourCartWooCommerce extends ShareYourCartWordpressPlugin{
             "item_name"        => $product->get_title(),
             "item_description" => $product->post->post_excerpt,
             "item_url"         => get_permalink($product_id),
-            "item_price"       => $product->price, 
+            "item_price"       => $product->price,
             "item_picture_url" => $image,
 			"item_unique_id"   => $product_id,
         );
     }
-    
+
     public function loadSessionData() {
       return;
     }
-    
+
     private function _loadWooCommerce(){
       // Sometimes the WooCommerce Class is not loaded...
-      
+
       if(!class_exists('Woocommerce', false)){
         require_once(ABSPATH . 'wp-content/plugins/woocommerce/woocommerce.php');
       }
-      
+
       // Important Classes Not included
       if(!function_exists('has_post_thumbnail')){
         require_once(ABSPATH . 'wp-includes/post-thumbnail-template.php');

--- a/classes/integrations/shareyourcart/class.shareyourcart-wp.php
+++ b/classes/integrations/shareyourcart/class.shareyourcart-wp.php
@@ -30,7 +30,7 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 			//if there is installed another plugin with a never version
 			//do not load this one further
 			if(!$this->canLoad()) return;
-			
+
 			//make sure we add this instance
 			self::$_INSTANCES []= $this;
 			$this->_PLUGIN_PATH  = WP_PLUGIN_URL.'/'.str_replace(basename( __FILE__),"",plugin_basename(__FILE__));
@@ -57,10 +57,10 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 	*
 	*/
 		protected function getPluginVersion(){
-			
+
 			return self::$_VERSION;
 		}
-		
+
 		/**
 	*
 	* Return the project's URL
@@ -109,15 +109,15 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 
 			return $plugin;
 		}
-	
+
 	/**
 	*
-	* Get the upload directory 
+	* Get the upload directory
 	*
 	*/
 	public function getUploadDir(){
 		$dir = wp_upload_dir();
-		
+
       return (!empty($dir['path']) ? $dir['path'] : parent::getUploadDir());
     }
 
@@ -131,14 +131,14 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 			if(substr($sql,0,12) == "CREATE TABLE"){
 
 				require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-				
+
 				//if this is a create table command, use the special function which compares tables
 				dbDelta($sql);
 
 			} else {
-				
+
 				global $wpdb;
-				
+
 				//use the normal query
 				$wpdb->query($sql);
 			}
@@ -154,7 +154,7 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 		protected function getRow($sql){
 
 			global $wpdb;
-			
+
 			//get the row as an associative array
 			return $wpdb->get_row($sql,ARRAY_A);
 		}
@@ -251,7 +251,7 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 		public function deactivateHook() {
 
 			if(!$this->isCartActive()) return;
-			
+
 			$message = '';
 
 			$this->deactivate($message);
@@ -275,7 +275,7 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 				//get the old app_key and client_id
 				$settings = $wpdb->get_row("SELECT app_key, client_id FROM ".$wpdb->base_prefix."shareyourcart_settings LIMIT 1");
 				if($settings) {
-					
+
 					$this->setConfigValue('appKey', $settings->app_key);
 					$this->setConfigValue('clientId', $settings->client_id);
 				}
@@ -297,7 +297,7 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 			//this hook is required by WordPress to be static
 			//so call uninstall on the first instance
 			if(!empty(self::$_INSTANCES)){
-				
+
 				self::$_INSTANCES[0]->uninstall();
 			} else {
 
@@ -315,15 +315,15 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 
 			//this is a single call function
 			if(!$this->isFirstCall(__FUNCTION__)) return;
-			
+
 			//first, check the SDK status
 			$this->checkSDKStatus();
-			
+
 			//see if we need to show the update notification
 			$notification = null;
 			if($this->hasNewerVersion())
 			$notification = "<span class='update-plugins count-$warning_count'><span class='update-count'>" . number_format_i18n(1) . "</span></span>";
-			
+
 			$page = add_menu_page(
 			__('Share your cart settings'),
 			__('ShareYourCart').$notification,
@@ -334,7 +334,7 @@ if(!class_exists('ShareYourCartWordpressPlugin',false)){
 			);
 			add_action( 'admin_head-'.$page, array(&$this, 'showAdminHeader'));
 
-			if($this->isActive()) 
+			if($this->isActive())
 			{
 				//show the rest of the menu ONLY if the plugin is active
 				$page = add_submenu_page(

--- a/classes/integrations/shareyourcart/sdk/class.shareyourcart-api.php
+++ b/classes/integrations/shareyourcart/sdk/class.shareyourcart-api.php
@@ -10,9 +10,9 @@
  */
 
 if(!class_exists('ShareYourCartAPI',false)){
- 
+
 class ShareYourCartAPI {
-    
+
     protected     $SHAREYOURCART_URL = "www.shareyourcart.com";
 	protected	  $SHAREYOURCART_SANDBOX_URL = "sandbox.shareyourcart.com";
     protected     $SHAREYOURCART_API;
@@ -27,15 +27,15 @@ class ShareYourCartAPI {
     protected     $SHAREYOURCART_CONFIGURE;
     protected     $SHAREYOURCART_BUTTON_JS;
 	protected     $SHAREYOURCART_BUTTON_URL;
-    
+
     /**
     * Constructor
     * @param null
     */
     function __construct() {
-        
+
 		$is_live = true;
-		
+
 		//check if the current object has a secret key function
 		//this is for backward compatibility
 		if(method_exists ($this,'getSecretKey')){
@@ -43,14 +43,14 @@ class ShareYourCartAPI {
 			if(empty($secretKey)){
 				throw new Exception(SyC::t('sdk',"You must specify a valid secret key"));
 			}
-			
+
 			//check if the secret key is a sandbox one
 			if(strpos($secretKey,"sndbx_") === 0){
 				$this->SHAREYOURCART_URL = $this->SHAREYOURCART_SANDBOX_URL;
 				$is_live = false;
 			}
 		}
-		
+
         $this->SHAREYOURCART_API            = (isset($_SERVER['HTTPS']) && !strcasecmp($_SERVER['HTTPS'],'on') ? 'https://' : 'http://') . $this->SHAREYOURCART_URL;
         $this->SHAREYOURCART_REGISTER       = $this->SHAREYOURCART_API.'/account/create';
         $this->SHAREYOURCART_API_REGISTER   = $this->SHAREYOURCART_API.'/account/create';
@@ -61,21 +61,21 @@ class ShareYourCartAPI {
         $this->SHAREYOURCART_API_VALIDATE   = $this->SHAREYOURCART_API.'/session/validate';
         $this->SHAREYOURCART_API_STATUS     = $this->SHAREYOURCART_API.'/sdk';
 		$this->SHAREYOURCART_API_TRANSLATION = $this->SHAREYOURCART_API.'/sdk/translation';
-        $this->SHAREYOURCART_CONFIGURE      = $this->SHAREYOURCART_API.'/configure';   
+        $this->SHAREYOURCART_CONFIGURE      = $this->SHAREYOURCART_API.'/configure';
 		$this->SHAREYOURCART_BUTTON_JS      = $this->SHAREYOURCART_API.'/js/'.($is_live ? 'button.js' : 'button_sandbox.js');
 		$this->SHAREYOURCART_BUTTON_URL     = $this->SHAREYOURCART_API.'/button';
     }
-    
+
     /**
     * startSession
     * @param array $params
-    * @return array $data  
+    * @return array $data
     */
     public function startSession($params) {
 	//make sure the session is started
 	if(session_id() == '')
             session_start();
-        
+
         $session = curl_init($this->SHAREYOURCART_API_CREATE);
 
         // Tell curl to use HTTP POST
@@ -89,45 +89,45 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         // If the operation was not succesfull, print the error
-        if($httpCode != 200) 
+        if($httpCode != 200)
             throw new Exception($response);
-        
+
         // Decode the result
         $results = json_decode($response, true);
-        
+
         // Find the token
         if(isset($results['token'])) {
-            
+
             // Link the token with the current cart ( held in session id )
             $data = array(
                 'token' => $results['token'],
                 'session_id' => session_id(),
             );
-                
+
             // A token was obtained, so redirect the browser
             header("Location: $results[session_url]", true, 302);
             return $data;
-                
+
         }
-        
+
         //show the raw response received ( for debug purposes )
         throw new Exception($response);
     }
-    
+
     /**
     * make sure the coupon is valid
-    * @param null 
+    * @param null
     */
     public function assertCouponIsValid($token, $coupon_code, $coupon_value, $coupon_type) {
-        
+
         // Verifies POST information
         if(!isset($token, $coupon_code, $coupon_value, $coupon_type)) {
-               
+
             throw new Exception(SyC::t('sdk',"At least one of the parameters is missing."));
         }
-        
+
         // Urlencode and concatenate the POST arguments
         $params = array(
             'token' => $token,
@@ -150,28 +150,28 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         //if the operation was not succesfull, print the error
-		if($httpCode != 200) 
+		if($httpCode != 200)
             throw new Exception(SyC::t('sdk',"Coupon Invalid: {coupon}", array('{coupon}' => $response)));
-        
-        $results = json_decode($response, true);    
+
+        $results = json_decode($response, true);
 
         //if the result is not valid, print it
-        if(!isset($results['valid']) || !($results['valid'] === true)) 
+        if(!isset($results['valid']) || !($results['valid'] === true))
             throw new Exception(SyC::t('sdk',"Coupon Invalid: {coupon}", array('{coupon}' => $response)));
     }
-    
+
     /**
     * register
     * @param string $secretKey
     * @param string $domain
     * @param string $email
-    * @param string $message  
-    * @return array json_decode  
+    * @param string $message
+    * @return array json_decode
     */
     public function register($secretKey, $domain, $email, &$message = null) {
-        
+
         // Urlencode and concatenate the POST arguments
         $params = array(
                 'secret_key' => $secretKey,
@@ -193,36 +193,36 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         // If the operation was not succesfull, return FALSE
         if($httpCode != 200) {
             if(isset($message)) $message = $response;
-			
-			return false;     
+
+			return false;
         }
-		
+
 		//if the caller is expecting a message
 		//let him know what happened
 		if(isset($message)){
-		
+
 			$message = SyC::t('sdk','The account has been registered');
 		}
-        
+
         // Return the response after decoding it
-        return json_decode($response, true);    
-        
+        return json_decode($response, true);
+
     }
-    
+
     /**
     * recover
     * @param string $secretKey
     * @param string $domain
     * @param string $email
-    * @param string $message  
+    * @param string $message
     * @return boolean
     */
     public function recover($secretKey, $domain, $email, &$message = null) {
-        
+
         // Urlencode and concatenate the POST arguments
         $params = array(
             'secret_key' => $secretKey,
@@ -244,36 +244,36 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         //if the operation was not succesfull, return FALSE
         if($httpCode != 200) {
             if(isset($message)) $message = $response;
-			
+
 			return false;
         }
-		
+
 		//if the caller is expecting a message
 		//let him know what happened
 		if(isset($message)){
-		
+
 			$message = (!empty($response) ? $response : SyC::t('sdk',"An email has been sent with your credentials at {email}",array('{email}' => $email)));
 		}
-        
+
         return true;
-        
+
     }
-    
+
     /**
     * setAccountStatus
     * @param string $secretKey
     * @param string $clientId
     * @param string $appKey
     * @param string $activate
-    * @param string $message  
+    * @param string $message
     * @return boolean
     */
     public function setAccountStatus($secretKey, $clientId, $appKey, $activate = true, &$message = null) {
-        
+
         // Urlencode and concatenate the POST arguments
         $params = array(
             'secret_key' => $secretKey,
@@ -295,40 +295,40 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         // Notify the caller
         if($httpCode != 200) {
             if(isset($message)) $message = $response;
-			
+
 			return false;
         }
-		
+
 		//if the caller is expecting a message
 		//let him know what happened
 		if(isset($message)){
-		
+
 			$message = (!empty($response) ? $response : ($activate ? SyC::t('sdk','The account has been enabled') : SyC::t('sdk','The account has been disabled')));
 		}
-        
+
         return true;
     }
-	
+
 	/**
     * setAccountStatus
     * @param string $secretKey
     * @param string $clientId
     * @param string $appKey
-	* @param string $message  
+	* @param string $message
     * @return array or FALSE
     */
     public function getSDKStatus($secretKey=null, $clientId=null, $appKey=null, &$message = null)
 	{
 		$params = array();
-		
+
 		if(isset($secretKey)) $params['secret_key'] = $secretKey;
         if(isset($clientId))  $params['client_id'] = $clientId;
         if(isset($appKey))    $params['app_key'] = $appKey;
-		
+
 		//make the API call
         $session = curl_init($this->SHAREYOURCART_API_STATUS);
 
@@ -343,18 +343,18 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         // Notify the caller
         if($httpCode != 200) {
             if(isset($message)) $message = $response;
-			
+
 			return false;
         }
-		
+
 		 // Decode the result
         return json_decode($response, true);
 	}
-	
+
 	/**
 	*
 	* Returns an array of messages for the SDK, in the specified language
@@ -363,7 +363,7 @@ class ShareYourCartAPI {
 	public function getSDKTranslation($lang, &$message = null)
 	{
 		$params = array('lang' => $lang);
-		
+
 		//make the API call
         $session = curl_init($this->SHAREYOURCART_API_TRANSLATION);
 
@@ -378,14 +378,14 @@ class ShareYourCartAPI {
         $response = curl_exec($session);
         $httpCode = curl_getinfo($session, CURLINFO_HTTP_CODE);
         curl_close($session);
-        
+
         // Notify the caller
         if($httpCode != 200) {
             if(isset($message)) $message = $response;
-			
+
 			return false;
         }
-		
+
 		 // Decode the result
         return json_decode($response, true);
 	}
@@ -402,7 +402,7 @@ class SyC
 	static $_messages;
 	static $_language = 'en';
 	static $loadLanguage = array('SyC','loadFileLanguage'); //variable that holds the name of the function used to load a particular language
-	
+
 	/**
 	*
 	* Change the language the SDK should be displayed in
@@ -410,11 +410,11 @@ class SyC
 	*/
 	public static function setLanguage($newLanguage = null){
 		self::$_language = $newLanguage;
-		
+
 		//reset the old messages, so that they are reloaded
-		self::$_messages = null;	
+		self::$_messages = null;
 	}
-	
+
 	/**
 	*
 	* Get the language that is currently loaded
@@ -423,7 +423,7 @@ class SyC
 	public static function getLanguage(){
 		return self::$_language;
 	}
-	
+
 	/**
 	* Return the checksum of the currently loaded translation
 	*/
@@ -431,14 +431,14 @@ class SyC
 	{
 		//load the translation from file if not done so
 		if(!isset(self::$_messages)){
-			
+
 			//load the language
 			self::$_messages = call_user_func(self::$loadLanguage,self::$_language,$category);
 		}
-		
+
 		return md5(json_encode(self::$_messages));
 	}
-	
+
 	/**
 	* Reload the language
 	*/
@@ -446,29 +446,29 @@ class SyC
 	{
 		self::$_messages = null;
 	}
-	
+
 	/*
 	* Translate the specified message
-	* 
+	*
 	*/
 	public static function t($category,$message,$params=array())
 	{
 		//load the translation from file if not done so
 		if(!isset(self::$_messages)){
-			
+
 			//load the language
 			self::$_messages = call_user_func(self::$loadLanguage,self::$_language,$category);
 		}
-		
+
 		//check if the text has a valid translation
 		if(isset(self::$_messages[$message]) && !empty(self::$_messages[$message])){
 			$message = self::$_messages[$message];
 		}
-		
+
 		//return the translated message, with the parameters replaced
 		return $params!==array() ? strtr($message,$params) : $message;
 	}
-	
+
 	/**
 	*
 	* change the language loader method
@@ -479,13 +479,13 @@ class SyC
 		//make sure the loader is ok
 		if(!is_callable($loader))
 			throw new Exception(SyC::t('sdk',"The language loader is not a valid callback"));
-		
+
 		self::$loadLanguage = $loader;
-		
+
 		//reset the old messages, so that they are reloaded with the new loader
 		self::$_messages = null;
 	}
-	
+
 	/**
 	*
 	* Function to load a language from the hard-drive.
@@ -495,24 +495,24 @@ class SyC
 	{
 		//The language is the folder name, and the category is the name of the file
 		$messageFile = dirname(__FILE__).DIRECTORY_SEPARATOR.'messages'.DIRECTORY_SEPARATOR.$lang.DIRECTORY_SEPARATOR.$category.'.php';
-			
+
 		$messages = null;
 		if(is_file($messageFile))
 		{
 			$messages=include($messageFile);
 		}
-			
+
 		//make sure we have an array for this variable
 		if(!is_array($messages)) $messages=array();
-		
+
 		return $messages;
 	}
-	
+
 	public static function relativepath($from, $to, $ps = '/' ,$ds = DIRECTORY_SEPARATOR)
-	{	
+	{
 		$arFrom = explode($ds, rtrim($from, $ds));
 		$arTo = explode($ds, rtrim($to, $ds));
-		
+
 		while(count($arFrom) && count($arTo) && ($arFrom[0] == $arTo[0]))
 		{
 			array_shift($arFrom);
@@ -581,7 +581,7 @@ class SyC
 		$length = strlen($needle);
 		return (substr($haystack, 0, $length) === $needle);
 	}
-	
+
 	/**
 	* returns TRUE if haystack ends with needle
 	*/

--- a/classes/integrations/shareyourcart/sdk/class.shareyourcart-base.php
+++ b/classes/integrations/shareyourcart/sdk/class.shareyourcart-base.php
@@ -20,19 +20,19 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	private static $_SDK_VERSION = '1.9';  //the first one is the SDK main version, while the second one is it's revision
 	protected static $_DB_VERSION = '1.1';
 	protected $SDK_ANALYTICS = true;
-	
+
 	/**
     * Constructor
     * @param null
     */
     function __construct() {
-	
+
 		//set exception handler
 		if(set_exception_handler(array(&$this,'UncaughtExceptionHandler')) !== null)
 			restore_exception_handler(); //if there allready was an exception handler, revert back to it
-	
+
 		parent::__construct();
-		
+
 		//now, add the api version to the button_js, in order to force users to download the latest
 		//JS file
 		if(!$this->isDebugMode()){
@@ -41,12 +41,12 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 			$this->SHAREYOURCART_BUTTON_JS = $this->SHAREYOURCART_API.'/js/button.dev.js';
 		}
 		$this->SHAREYOURCART_BUTTON_URL .= '?client_id='. $this->getClientId();
-		
+
 		//set the language & it's loader
 		SyC::setLanguageLoader(array(&$this,'loadLanguage'));
 		SyC::setLanguage($this->getConfigValue('lang'));
 	}
-	
+
 	/**
 	 * Execute NonQuery SQL
 	 * @param string action
@@ -96,10 +96,10 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	 * @return boolean / array
 	 */
 	protected function getCurrentProductDetails(){
-		
+
 		return FALSE;
 	}
-	
+
 	/**
 	*
 	* Return TRUE if this page describes a single product, otherwise FALSE
@@ -115,7 +115,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	public function isOutOfStock(){
 		return FALSE;
 	}
-	
+
 	/**
 	 *
 	 * Return the URL to be called when the button is pressed
@@ -159,7 +159,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	 *
 	 */
 	protected abstract function applyCoupon($coupon_code);
-	
+
 	/**
 	*
 	* Return the jQuery sibling selector for the product button
@@ -168,7 +168,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	protected function getProductButtonPosition(){
 		return $this->getConfigValue('product_button_position');
 	}
-	
+
 	/**
 	*
 	* Return the jQuery sibling selector for the cart button
@@ -177,7 +177,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	protected function getCartButtonPosition(){
 		return $this->getConfigValue('cart_button_position');
 	}
-	
+
 	/**
 	*
 	* Get the plugin version.
@@ -196,10 +196,10 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		//make sure a developer enters only a number as a version
 		if(!is_int($minor_version = $this->getPluginVersion()))
 			throw new Exception(SyC::t('sdk','The Plugin Version must be an integer'));
-		
+
 		return self::$_SDK_VERSION.'.'.$minor_version;
 	}
-	
+
 	/**
 	*
 	* Returns TRUE if the account is in debug mode
@@ -208,10 +208,10 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	public function isDebugMode()
 	{
 		$val =$this->getConfigValue('debug');
-		
+
 		return !empty($val);
 	}
-	
+
 	/**
 	*
 	* Return TRUE if there is a newer version of the plugin
@@ -221,7 +221,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	{
 		return version_compare($this->getVersion(),$this->getConfigValue('latest_version'),'<');
 	}
-	
+
 	/**
 	*
 	* Check if this instance can load, or not!
@@ -230,14 +230,14 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	*/
 	protected function canLoad()
 	{
-		$v = version_compare($this->getVersion(),$this->getConfigValue('plugin_current_version')); 
+		$v = version_compare($this->getVersion(),$this->getConfigValue('plugin_current_version'));
 		//first, check if this instance is the latest one, or not
 		if($v < 0) return false;
-			 
+
 		//save the latest version, for later reference
 		if($v > 0 )
 			$this->setConfigValue('plugin_current_version',$this->getVersion());
-			
+
 		return true;
 	}
 
@@ -275,10 +275,10 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		$appKey = $this->getAppKey();
 		$clientId = $this->getClientId();
 		if(!empty($appKey) && !empty($clientId)){
-		
+
 			$activated = $this->activate($message);
 		}
-		
+
 		//set some default value, like the button skin
 		$skin = $this->getConfigValue('button_skin');
 		if(empty($skin)){
@@ -400,11 +400,11 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		//reset the Location, as the following code might give an error
 		//and the developer needs to be aware of it
 		$headers = headers_list();
-		header('Location:'); 
+		header('Location:');
 
 		//save session details
 		$this->insertRow($this->getTableName('shareyourcart_tokens'), $data);
-		
+
 		//we can't rely on the fact that the row has been inserted, so check!
 		if($this->getSessionId($data['token']) === null)
 			throw new Exception(SyC::t('sdk','Token cannot be saved. Check your "{table_name}" table permissions.', array('{table_name}' => $this->getTableName('shareyourcart_tokens'))));
@@ -474,24 +474,24 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	 * @return boolean
 	 */
 	protected function renderButton($callback_url,$position = null) {
-		
+
 		$data = array(
 		'current_button_type' => $this->getConfigValue("button_type"),
 		'button_html' => $this->getConfigValue("button_html"),
-		
+
 		'button_img' => $this->getUrl($this->getConfigValue("btn-img")),
 		'button_img_width' => $this->getConfigValue("btn-img-width"),
 		'button_img_height' => $this->getConfigValue("btn-img-height"),
-		
+
 		'button_img_hover' => $this->getUrl($this->getConfigValue("btn-img-h")),
 		'button_img_hover_width' => $this->getConfigValue("btn-img-h-width"),
 		'button_img_hover_height' => $this->getConfigValue("btn-img-h-height"),
 
 		'is_product_page' => $this->isSingleProduct(),
-		
+
 		'position_'.(SyC::startsWith($position,"/*before*/") ? 'before' : 'after') => $position,
 		);
-		
+
 		$output = null;
 		switch ($data['current_button_type'])
 		{
@@ -545,7 +545,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	 *
 	 */
 	public function showCartButton() {
-		
+
 		echo $this->getCartButton();
 	}
 
@@ -607,11 +607,11 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	 * @return boolean
 	 */
 	public function getAdminHeader() {
-			
+
 		//this is a single call function
 		if (!$this->isFirstCall(__FUNCTION__))
 		return;
-		
+
 		//check the SDK status
 		$this->checkSDKStatus(true); //force a check, as the admin might have changed the language in the configure page, so we need to sync with it
 
@@ -642,7 +642,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		$status_message = ''; //this is to be used for good messages
 		$error_message = ''; //this is to be used for bad messages
 		$refresh = false;
-		
+
 		//check if this is a post for this particular page
 		if ($_SERVER['REQUEST_METHOD'] == 'POST' &&
 		!empty($_POST['syc-account-form'])) {
@@ -661,42 +661,42 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 				//the account did not activate, so show the error
 				$error_message = $message;
 			}
-			
+
 			//since we might have changed the status, REFRESH
 			$refresh = true;
 		}
 		//the user decided to disable the API
 		else if ($_SERVER['REQUEST_METHOD'] == 'POST' &&
 		!empty($_POST['disable-API'])){
-			
+
 			$message = '';
 			if($this->deactivate($message) == true) {
-				
+
 				$status_message = $message;
 			} else {
-			
+
 				$error_message = $message;
 			}
-			
+
 			//since we might have changed the status, REFRESH
 			$refresh = true;
 		}
 		//the user decided to activate the API
 		else if ($_SERVER['REQUEST_METHOD'] == 'POST' &&
 		!empty($_POST['enable-API'])){
-			
+
 			$message = '';
 			if($this->activate($message) == true) {
-				
+
 				$status_message = $message;
 			} else {
-			
+
 				$error_message = $message;
 			}
-			
+
 			//since we might have changed the status, REFRESH
 			$refresh = true;
-		}  
+		}
 		//check if the user want's to recover his account
 		else if (@$_REQUEST['syc-account'] === 'recover'){
 
@@ -708,22 +708,22 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 				//try to recover if the user posted the form
 				$show_form = !$this->recover($this->getSecretKey(), @$_REQUEST['domain'], @$_REQUEST['email'], $status_message);
 			}
-			
+
 			//if we need to show the form, the recovery failed
 			if($show_form)
 			{
 				//if there is a message, put the form on a new line
 				$error_message = $status_message;
 				$status_message = $this->renderView('account-recover-partial');
-			} 
-			else 
+			}
+			else
 			{
 				//Refresh in order to get rid of the GET parameter
 				$refresh = true;
 			}
 		}
 		else if (@$_REQUEST['syc-account'] === 'create'){
-			
+
 			//by default, show the form if we are here
 			$show_form = true;
 			if($_SERVER['REQUEST_METHOD'] == 'POST' &&
@@ -733,14 +733,14 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 				if(isset($_POST['syc-terms-agreement']))
 				{
 					//try to create the account if the user posted the form
-					if (!(($register = $this->register($this->getSecretKey(), @$_REQUEST['domain'], @$_REQUEST['email'], $status_message)) === false)) 
+					if (!(($register = $this->register($this->getSecretKey(), @$_REQUEST['domain'], @$_REQUEST['email'], $status_message)) === false))
 					{
 						$this->setConfigValue('appKey', @$register['app_key']);
 						$this->setConfigValue('clientId', @$register['client_id']);
-                        
+
 						$this->setConfigValue("account_status", "active");
 						$show_form = false; //no need to show the register form anymore
-						
+
 						//since we might have changed the status, REFRESH
 						$refresh = true;
 					}
@@ -751,7 +751,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 					$status_message = SyC::t('sdk',"Error. You must agree with the terms and conditions bellow");
 				}
 			}
-			
+
 			//if we need to show the form
 			if($show_form)
 			{
@@ -760,10 +760,10 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 				$status_message = $this->renderView('account-create-partial');
 			}
 		}
-		
+
 		//make sure there is a session variable setup
 		@session_start();
-		
+
 		//since switching the API status has a great impact on how the UI looks, refresh the page
 		//just to make sure the UI is using the latest value
 		if($refresh)
@@ -775,14 +775,14 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		else
 		{
 			//load the variables, if any
-		
+
 			//if there is a status message
 			if(!empty($_SESSION['_syc_status_message']))
 			{
 				$status_message = $_SESSION['_syc_status_message'];
 				unset($_SESSION['_syc_status_message']);
 			}
-		
+
 			//if there is an error message
 			if(!empty($_SESSION['_syc_error_message']))
 			{
@@ -790,7 +790,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 				unset($_SESSION['_syc_error_message']);
 			}
 		}
-		
+
 		// Display the view
 		return $this->renderView('admin-page',array(
 			'html' => $html,
@@ -830,7 +830,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 
 			//set the button position
 			$this->setConfigValue("button_position", $_POST['button_position']);
-			
+
 			//set the button height
 			$this->setConfigValue("dont_set_height", empty($_POST['show_on_single_row']));
 
@@ -842,7 +842,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 
 			//set the show'
 			$this->setConfigValue("hide_on_checkout", empty($_POST['show_on_checkout']));
-			
+
 			//set button position
 			$this->setConfigValue("product_button_position",$_POST['product_button_position']);
 			$this->setConfigValue("cart_button_position",$_POST['cart_button_position']);
@@ -851,13 +851,13 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 
 				$target_path = $this->getUploadDir();
 				if(!SyC::endsWith($target_path,'/')) $target_path .= '/'; //make sure that the path has a / in it's end
-				
+
 				$target_path = $target_path . 'button-img.png';
 
 				if(file_exists($target_path)) unlink($target_path);
-				
+
 				list($width, $height, $type, $attr) = getimagesize($_FILES['button-img']['tmp_name']);
-				
+
 				if (move_uploaded_file($_FILES['button-img']['tmp_name'], $target_path))
 				{
 					//set the button img
@@ -879,7 +879,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 				$target_path = $target_path . 'btn-img-hover.png';
 
 				if(file_exists($target_path)) unlink($target_path);
-				
+
 				list($width, $height, $type, $attr) = getimagesize($_FILES['button-img-hover']['tmp_name']);
 
 				if(move_uploaded_file($_FILES['button-img-hover']['tmp_name'], $target_path))
@@ -911,7 +911,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 			'button_html' => $this->getConfigValue("button_html"),
 			'button_img' => $this->getUrl($this->getConfigValue("btn-img")),
 			'button_img_hover' => $this->getUrl($this->getConfigValue("btn-img-h")),
-			
+
 			'html' => $html,
 			'show_header' => $show_header,
 			'show_footer' => $show_footer,
@@ -928,7 +928,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	public function getUploadDir(){
       return dirname(_FILE_). "/img/";
     }
-	
+
 	/**
 	 * showDocumentation
 	 * @param null
@@ -953,13 +953,13 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		//render the view
 		return $this->renderView('documentation',array(
 			'action_url' => $this->getButtonCallbackURL(),
-			
+
 			'html' => $html,
 			'show_header' => $show_header,
 			'show_footer' => $show_footer,
 		));
 	}
-	
+
 	/**
 	 * show the update notification
 	 * @param null
@@ -967,7 +967,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	public function showUpdateNotification(){
 		echo $this->getUpdateNotification();
 	}
-	
+
 	/**
 	 * get the update notification
 	 * @param null
@@ -1005,7 +1005,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 
 			header("HTTP/1.0 403");
 			echo $e->getMessage();
-			
+
 			if($this->isDebugMode()){
 				echo $e->getTraceAsString();
 			}
@@ -1065,21 +1065,21 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		$sql .= "PRIMARY KEY ($primaryKey));";
 
 		$this->executeNonQuery($sql);
-		
+
 		//we can't relly on the fact that the table has been properly created, so check it!
 		if(!$this->existsTable($tableName))
 			throw new Exception(SyC::t('sdk','Cannot create table "{table_name}". Check your database permissions or manually run the following SQL command and try again:<br /><strong>{sql}</strong>', array('{table_name}' => $tableName,'{sql}' => nl2br($sql))));
 	}
-	
+
 	/**
 	*
 	* existsTable
 	* @return TRUE if the table exists, otherwise false
 	*/
 	protected function existsTable($tableName){
-	
+
 		$table_details = $this->getRow("show tables like '$tableName'");
-		
+
 		//if there are table details, it means the table exists
 		return !empty($table_details);
 	}
@@ -1093,26 +1093,26 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 
 		$sql = "DROP TABLE $tableName";
 		$this->executeNonQuery($sql);
-		
+
 		//we can't relly on the fact that the table has been properly droped, so check it!
 		if($this->existsTable($tableName))
 			throw new Exception(SyC::t('sdk','Cannot drop table "{table_name}". Check your database permissions or manually run the following SQL command and try again:<br /><strong>{sql}</strong>', array('{table_name}' => $tableName, '{sql}' => nl2br($sql))));
 	}
-	
+
 	/**
 	*
 	* Render the specified views. we use special variable names here to avoid conflict when extracting data
 	*
 	*/
 	protected function renderView($_viewName_, $_data_=NULL, $_return_=true){
-		
+
 		//get information about the Top Parent class
 		$_reflection_ = new ReflectionClass(get_class($this));
 		$_viewFile_ = dirname($_reflection_->getFileName())."/views/$_viewName_.php";
-		
+
 		//check if there is a file in the specified location
 		if(!file_exists($_viewFile_)){
-			
+
 			//the view has not been overrided, so use the SDK one
 			$_viewFile_ = dirname(__FILE__) . "/views/$_viewName_.php";
 		}
@@ -1122,7 +1122,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 			extract($_data_,EXTR_PREFIX_SAME,'data');
 		else
 			$data=$_data_;
-			
+
 		//render the view
 		if($_return_)
 		{
@@ -1134,21 +1134,21 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		else
 			require($_viewFile_);
 	}
-	
+
 	/**
 	*
 	* This function is used to make sure that the created url returns a proper scheme
 	*
 	*/
 	protected function getUrl($file){
-	
+
 		//if there is no file, return an empty string
 		if(empty($file)) return $file;
-	
+
 		//test if the files is a url, as one migt send it that way
 		$parts = parse_url($file);
 		$is_url = is_array($parts) && isset($parts['scheme']);
-	
+
 		//if this is not a url, create one for it
 		if(!$is_url)
 		{
@@ -1160,19 +1160,19 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		{
 			$url = $file;
 		}
-	
+
 		//do it here. the problem is loading an insecure object over a secure page, so check for this situation
-		
+
 		if( (isset($_SERVER['HTTPS']) && !strcasecmp($_SERVER['HTTPS'],'on')) && //the page is a secure one
 		SyC::startsWith($url,'http://') //the created url is an insecure one, adjust it
 		)
 		{
 			$url = "https://".substr($url, 7);
 		}
-		
+
 		return $url;
 	}
- 
+
 
 	/**
 	*
@@ -1181,39 +1181,39 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	*
 	*/
 	public function checkSDKStatus($force = false) {
-		
+
 		//call the API at most only once every 5 minutes, not sooner
-		if(!$force && (time()-$this->getConfigValue('api_last_check')) < 5*60) 
+		if(!$force && (time()-$this->getConfigValue('api_last_check')) < 5*60)
 			return;
-		
+
 		//set the latest check time
 		$this->setConfigValue('api_last_check',time());
-		
+
 		//get an update from the API
 		$message = '';
 		if(is_array($result = $this->getSDKStatus($this->getSecretKey(), $this->getClientId(), $this->getAppKey(), $message)))
 		{
-		   
+
 			//save the data
 			$this->setConfigValue('api_version', @$result['api_version']);
 			$this->setConfigValue('latest_version', @$result['plugin_latest_version']);
 			$this->setConfigValue('download_url', @$result['plugin_download_url']);
 			$this->setConfigValue('debug', @$result['debug']);
-			
+
 			//set the current language the SDK should be displayed in
 			if(isset($result['lang'])){
 				$this->setConfigValue('lang', $result['lang']);
 				SyC::setLanguage($result['lang']);
-			
+
 				//check if there is a new translation available for this language
 				if(!empty($result['lang_checksum']) && $result['lang_checksum'] != SyC::getLanguageChecksum()){
-				
+
 					//download the translation
 					$messages = $this->getSDKTranslation(SyC::getLanguage());
-				
+
 					//save the translation
 					$this->setConfigValue('messages', $messages);
-					
+
 					//reset the loaded messages so that the new ones are being used
 					SyC::reloadLanguage();
 				}
@@ -1221,9 +1221,9 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		}else{
 			//simply log the error, for now!
 			error_log(print_r($message,true));
-		}	
+		}
 	}
-	
+
 	/**
 	*
 	* Language loader ( from the DB )
@@ -1233,18 +1233,18 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	{
 		//see if we have the language saved in the db
 		$messages = $this->getConfigValue('messages');
-		
+
 		if(empty($messages)) //no language is saved, so revert to the file one
 		{
 			$messages = SyC::loadFileLanguage($lang,$category);
 		}
-		
+
 		//make sure we have an array for this variable
 		if(!is_array($messages)) $messages=array();
-		
+
 		return $messages;
 	}
-	
+
 	/*
 	 *
 	 * Call to see if the function was called once, or not
@@ -1258,7 +1258,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 		self::$_SINGLE_FUNCTIONS_CALLS[$functionName] = true;
 		return true;
 	}
-	
+
 	/**
 	*
 	* User to catch any unhandled exceptions and print them nicelly
@@ -1267,7 +1267,7 @@ abstract class ShareYourCartBase extends ShareYourCartAPI {
 	public function UncaughtExceptionHandler(Exception $e) {
 		//@header("HTTP/1.0 403");
 		echo $e->getMessage();
-		
+
 		if($this->isDebugMode()){
 			echo $e->getTraceAsString();
 		}

--- a/classes/integrations/shareyourcart/sdk/views/admin-header.php
+++ b/classes/integrations/shareyourcart/sdk/views/admin-header.php
@@ -5,10 +5,10 @@
 
 $_reflection_ = new ReflectionClass(get_class($this));
 $_file_ = dirname($_reflection_->getFileName())."/css/admin-style.css";
-		
+
 //check if there is a file in the specified location
 if(file_exists($_file_)):?>
-		
+
 <link rel="stylesheet" type="text/css" href="<?php echo $this->getUrl($_file_); ?>" />
 
 <?php endif; ?>
@@ -29,10 +29,10 @@ if(file_exists($_file_)):?>
 
 window.onload = function() {
 document.getElementById('syc-form').addEventListener('submit', changetext, false);
-}; 
+};
 
 var changetext = function(){
 	var textarea = document.getElementById('syc_button_textarea').value;
-	document.getElementById('syc_button_textarea').value = encodeURIComponent(textarea);	
+	document.getElementById('syc_button_textarea').value = encodeURIComponent(textarea);
 }
 </script>

--- a/classes/integrations/shareyourcart/sdk/views/admin-page.php
+++ b/classes/integrations/shareyourcart/sdk/views/admin-page.php
@@ -1,4 +1,4 @@
-<?php if(!class_exists('ShareYourCartBase',false)) die('Access Denied'); 
+<?php if(!class_exists('ShareYourCartBase',false)) die('Access Denied');
 
 $admin_base_url = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
 
@@ -8,7 +8,7 @@ if($refresh)
 	//recreate the url ( but before that make sure there is no syc-account parameter in it )
 	unset($_GET['syc-account']);
 	$url =  $admin_base_url.'?'.http_build_query($_GET,'','&');
-		
+
 	@header("HTTP/1.1 302 Found");
 	@header("Location: $url");
 	echo "<meta http-equiv=\"refresh\" content=\"0; url=$url\">"; //it can happen that the headers have allready been sent, so use the html version as well
@@ -20,15 +20,15 @@ if($refresh)
 </script>
 <div class="wrap">
 <?php if($show_header):?>
-	
+
 	<?php echo $this->getUpdateNotification(); ?>
-	
+
     <h2>
         <a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart" class="shareyourcart-logo" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin-view/logo-click']);">
             <img src="<?php echo $this->getUrl(dirname(__FILE__).'/../img/shareyourcart-logo.png'); ?>"/>
         </a>
 		<div class="syc-slogan"><?php echo SyC::t('sdk','Increase your social media exposure by 10%!'); ?></div>
-		
+
 		<?php
 			if(isset($this->adminFix)) echo "<br /><br /><br /><br /><br />";
 			else echo "<br class=\"clr\" /> ";
@@ -38,29 +38,29 @@ if($refresh)
 
 	<?php if(!empty($status_message) || !empty($error_message)): ?>
 	<div class="updated settings-error"><p><strong>
-		<?php 
-			$message = @$error_message; 
-		
+		<?php
+			$message = @$error_message;
+
 			//is there a status message?
 			if(!empty($status_message))
 			{
 				//put the status message on a new line
 				if(!empty($message)) $message .= "<br /><br />";
-				
+
 				$message .= $status_message;
 			}
-		
-			echo $message; 
+
+			echo $message;
 		?>
 	</strong></p></div>
 	<?php endif; ?>
-	
+
     <p><?php echo SyC::t('sdk','{brand} helps you get more customers by motivating satisfied customers to talk with their friends about your products. Each customer that promotes your products, via social media, will receive a coupon that they can apply to their shopping cart in order to get a small discount.',array('{brand}' => '<a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart&trade;" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin-view/logo-click\']);">ShareYourCart&trade;</a>')); ?></p>
-    
+
     <br />
-    <div id="acount-options">      	
-        <form method="POST" name="account-form">       
-		<fieldset>	   		
+    <div id="acount-options">
+        <form method="POST" name="account-form">
+		<fieldset>
 		<div class="api-status" align="right">
                     <?php echo SyC::t('sdk','API Status:'); ?>
                     <?php if($this->isActive()) : ?>
@@ -74,7 +74,7 @@ if($refresh)
                     <?php else :?>
                         <input type="submit" value="<?php echo SyC::t('sdk','Enable'); ?>" name="enable-API" class="api-button" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin-view/enable-click']);" />
                     <?php endif;?>
-                </div>                
+                </div>
         <table class="form-table-api" name="shareyourcart_settings">
             <tr>
                 <th scope="row"><?php echo SyC::t('sdk','Client ID'); ?></th>
@@ -90,34 +90,34 @@ if($refresh)
             </tr>
         </table>
        <?php echo $html;?>
-        <div class="submit"><input type="submit" name="syc-account-form" class="button" value="<?php echo SyC::t('sdk','Save'); ?>" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin-view/save-click']);"></div>        
-		</fieldset>			 
-    </form>  
+        <div class="submit"><input type="submit" name="syc-account-form" class="button" value="<?php echo SyC::t('sdk','Save'); ?>" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin-view/save-click']);"></div>
+		</fieldset>
+    </form>
     </div>
-    
+
 	<?php if($this->isActive()): //show the configure part only if it is active ?>
     <br/>
     <fieldset>
     <p><?php echo SyC::t('sdk','You can choose how much of a discount to give (in fixed amount, percentage, or free shipping) and to which social media channels it should it be applied. You can also define what the advertisement should say, so that it fully benefits your sales.'); ?></p>
     <br />
  	 <form action="<?php echo $this->SHAREYOURCART_CONFIGURE; ?>" method="POST" id="configure-form" target="_blank">
-       
+
         <div class="configure-button-container" align="center">
             <input type="submit" value="<?php echo SyC::t('sdk','Configure'); ?>" id="configure-button" class="shareyourcart-button-orange" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin-view/configure-click']);" />
             <input type="hidden" name="app_key" value="<?php echo $this->getAppKey(); ?>" />
             <input type="hidden" name="client_id" value="<?php echo $this->getClientId(); ?>" />
 			<input type="hidden" name="email" value="<?php echo $this->getAdminEmail(); ?>" />
-        </div>   
-       
+        </div>
+
     </form>
     </fieldset>
-	
-	<?php if($show_footer):?>	
+
+	<?php if($show_footer):?>
 	<br />
 	<h2><?php echo SyC::t('sdk','Contact'); ?></h2>
 	<p><?php echo SyC::t('sdk',"If you've got 30 seconds, we'd {link-1} love to know what ideal outcome you'd like ShareYourCart to help bring to your business</a>, or if you have a private question, you can {link-2} contact us directly</a>", array('{link-1}' => '<a href="http://shareyourcart.uservoice.com" target="_blank" title="forum" class="api-link" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin/documentation/forum-click\']);">', '{link-2}' => '<a href="http://www.shareyourcart.com/contact" target="_blank" class="api-link" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin/documentation/contact-click\']);">')); ?></p>
 	<br />
 	<?php endif; ?>
-	
+
 	<?php endif; //show only if the cart is active ?>
 </div>

--- a/classes/integrations/shareyourcart/sdk/views/button-img.php
+++ b/classes/integrations/shareyourcart/sdk/views/button-img.php
@@ -1,6 +1,6 @@
-<?php 
+<?php
 	if(!class_exists('ShareYourCartBase',false)) die('Access Denied');
-	
+
 	// If only the hover is uploaded
     if((!$button_img or !$button_img_width or !$button_img_height) and ($button_img_hover and $button_img_hover_width and $button_img_hover_height)) {
         $button_img = $button_img_hover;
@@ -10,9 +10,9 @@
         $button_img_hover_width = null;
         $button_img_hover_height = null;
     }
-	
+
 	$callbackDataAttr = '';
-	
+
 	if(isset($callback_url) && !empty($callback_url)) {
 		$callbackDataAttr = 'data-syc-callback_url="' . $callback_url .'"';
 	}
@@ -30,7 +30,7 @@
 		height: <?php echo $button_img_height; ?>px;
 		text-indent: -9999px;
 	}
-	
+
 	<?php
 		if($button_img_hover and $button_img_hover_width and $button_img_hover_height) {
 	?>

--- a/classes/integrations/shareyourcart/sdk/views/button-settings-page.php
+++ b/classes/integrations/shareyourcart/sdk/views/button-settings-page.php
@@ -5,15 +5,15 @@
 </script>
 <div class="wrap">
 	<?php if($show_header):?>
-	
+
 	<?php echo $this->getUpdateNotification(); ?>
-	
+
     <h2>
         <a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart" class="shareyourcart-logo" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/logo-click']);">
             <img src="<?php echo $this->getUrl(dirname(__FILE__).'/../img/shareyourcart-logo.png'); ?>"/>
         </a>
 		<div class="syc-slogan"><?php echo SyC::t('sdk','Increase your social media exposure by 10%!'); ?></div>
-		<br clear="all" /> 
+		<br clear="all" />
     </h2>
 	<?php endif; ?>
 
@@ -23,14 +23,14 @@
                 </strong></p></div>
     <?php endif; ?>
 
-    <div id="visual-options">       	
-        <form method="POST" enctype="multipart/form-data" id="syc-form"> 	        	
+    <div id="visual-options">
+        <form method="POST" enctype="multipart/form-data" id="syc-form">
             <fieldset>
-                
+
                 <div class="buttonOption">
-                    
+
                     <input class="buttonOptionRadio" type="radio" value="1" id="button_type_1" <?php if ($current_button_type == '1'||$current_button_type == '') echo 'checked' ?> name="button_type" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/default-click']);" />
-                    <label class="buttonOptionLabel" for="button_type_1"><?php echo SyC::t('sdk','Use Standard Button'); ?></label>	
+                    <label class="buttonOptionLabel" for="button_type_1"><?php echo SyC::t('sdk','Use Standard Button'); ?></label>
                     <br /><br />
                     <table class="form-table shareyourcart_button_standard" name="shareyourcart_button_standard">
                         <tr align="center">
@@ -43,7 +43,7 @@
                                     <option name="blue" <?php echo $current_skin == 'blue' ? 'selected="selected"' : ''; ?> value="blue"><?php echo SyC::t('sdk','Blue'); ?></option>
 									<option name="light" <?php echo $current_skin == 'light' ? 'selected="selected"' : ''; ?> value="light"><?php echo SyC::t('sdk','Light'); ?></option>
 									<option name="dark" <?php echo $current_skin == 'dark' ? 'selected="selected"' : ''; ?> value="dark"><?php echo SyC::t('sdk','Dark'); ?></option>
-                                </select>                        
+                                </select>
                             </td>
                         </tr>
                         <tr align="center">
@@ -54,14 +54,14 @@
                                 <select name="button_position" id="button_position" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/button-position-click']);">
                                     <option name="normal" <?php echo $current_position == 'normal' ? 'selected="selected"' : ''; ?> value="normal"><?php echo SyC::t('sdk','Normal'); ?></option>
                                     <option name="floating" <?php echo $current_position == 'floating' ? 'selected="selected"' : ''; ?> value="floating"><?php echo SyC::t('sdk','Floating'); ?></option>
-                                </select>                        
+                                </select>
                             </td>
-                        </tr>		
+                        </tr>
                       <!--  <tr align="center"> since we switched to <a> on the button, this does not seem to be needed anymore
                             <td>
 								<input class="buttonCheckbox" name="show_on_single_row" <?php echo $show_on_single_row ? 'checked="checked"' : ''; ?>  type='checkbox' onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/toggle-show-on-single-row-click']);"><?php echo SyC::t('sdk','Check this if you want the button to be shown on it\'s own row'); ?></input>
                             </td>
-                        </tr> -->								
+                        </tr> -->
                     </table>
                 </div>
 
@@ -82,7 +82,7 @@
                                 <input type="hidden" name="MAX_FILE_SIZE" value="100000000000" />
                                 <input type="file" accept="image/gif, image/jpeg, image/jpg, image/png" name="button-img" id="button-img" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/upload-normal-img-click']);" />
                             </td>
-                        </tr> 
+                        </tr>
 
                         <tr align="center">
                             <th><label><?php echo SyC::t('sdk','Hover image:'); ?></label></th>
@@ -96,27 +96,27 @@
                                 <input type="hidden" name="MAX_FILE_SIZE" value="100000000000" />
                                 <input type="file" accept="image/gif, image/jpeg, image/jpg, image/png" name="button-img-hover" id="button-img-hover" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/upload-hover-img-click']);" />
                             </td>
-                        </tr>               				
+                        </tr>
                     </table>
                 </div>
 
                 <div class="buttonOption last">
                     <input class="buttonOptionRadio" type="radio" value="3" id="button_type_3" name="button_type" <?php if ($current_button_type == '3') echo 'checked' ?> onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/custom-button-click']);"/>
-                    <label class="buttonOptionLabel" for="button_type_3"><?php echo SyC::t('sdk','Build your own HTML button'); ?></label>	
+                    <label class="buttonOptionLabel" for="button_type_3"><?php echo SyC::t('sdk','Build your own HTML button'); ?></label>
                     <table class="form-table shareyourcart_button_html" name="shareyourcart_button_html">
-                        <tr>                    
+                        <tr>
                             <td>
-                                <textarea id="syc_button_textarea" class="buttonTextarea" rows="7" cols="56" name="button_html"><?php echo ($button_html!=''?$button_html:'<button>'.SyC::t('sdk','Get a {value} discount',array('{value}' => '<div class="shareyourcart-discount"></div>')).'</button>'); ?></textarea>                    
+                                <textarea id="syc_button_textarea" class="buttonTextarea" rows="7" cols="56" name="button_html"><?php echo ($button_html!=''?$button_html:'<button>'.SyC::t('sdk','Get a {value} discount',array('{value}' => '<div class="shareyourcart-discount"></div>')).'</button>'); ?></textarea>
                             </td>
-                        </tr>               			
+                        </tr>
                     </table>
 
                     <?php echo $html; ?>
-                    
+
                 </div>
-                
+
                 <br clear="all" />
-                
+
                 <hr />
                 <br />
                 <table class="form-table table-small" name="shareyourcart_settings">
@@ -125,7 +125,7 @@
                             <td>
                                 <input class="buttonCheckbox" name="show_on_product" <?php echo $show_on_product ? 'checked="checked"' : ''; ?>  type='checkbox' onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/toggle-show-on-product-click']);"><?php echo SyC::t('sdk','Product page'); ?></input>
                                 <br />
-                                <input class="buttonCheckbox" name="show_on_checkout" <?php echo $show_on_checkout ? 'checked="checked"' : ''; ?> type='checkbox' onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/toggle-show-on-checkout-click']);"><?php echo SyC::t('sdk','Checkout page'); ?></input>                        
+                                <input class="buttonCheckbox" name="show_on_checkout" <?php echo $show_on_checkout ? 'checked="checked"' : ''; ?> type='checkbox' onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/toggle-show-on-checkout-click']);"><?php echo SyC::t('sdk','Checkout page'); ?></input>
                             </td>
                         </tr>
 						<tr>
@@ -141,13 +141,13 @@
                             </td>
                         </tr>
                     </table>
-              
-                
-                <div class="submit"><input type="submit" class="button" name="syc-visual-form" id="syc-visual-form" value="<?php echo SyC::t('sdk','Save'); ?>" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/save-click']);"></div>            
-                
-            </fieldset>	
+
+
+                <div class="submit"><input type="submit" class="button" name="syc-visual-form" id="syc-visual-form" value="<?php echo SyC::t('sdk','Save'); ?>" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/button-settings-view/save-click']);"></div>
+
+            </fieldset>
             <br />
-        </form>        
+        </form>
     </div>
 
 	<?php if($show_footer):?>

--- a/classes/integrations/shareyourcart/sdk/views/documentation.php
+++ b/classes/integrations/shareyourcart/sdk/views/documentation.php
@@ -5,28 +5,28 @@
 </script>
 <div class="wrap">
 	<?php if($show_header):?>
-	
+
 	<?php echo $this->getUpdateNotification(); ?>
-	
+
     <h2>
         <a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart" class="shareyourcart-logo" onclick=" if(_gaq) _gaq.push(['_trackPageview', '/admin/documentation/logo-click']);">
             <img src="<?php echo $this->getUrl(dirname(__FILE__).'/../img/shareyourcart-logo.png'); ?>"/>
         </a>
 		<div class="syc-slogan"><?php echo SyC::t('sdk','Increase your social media exposure by 10%!'); ?></div>
-		<br clear="all" /> 
+		<br clear="all" />
     </h2>
     <?php endif; ?>
-    
+
     <div id="doc-content">
         <h2><?php echo SyC::t('sdk','Standard Button'); ?></h2>
         <p><?php echo SyC::t('sdk','In order to see the {brand} button on a <strong>post</strong> or <strong>page</strong> you can use the following shortcode:', array( '{brand}' => '<a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart&trade;" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin/documentation/logo-click\']);">ShareYourCart&trade;</a>')); ?></p>
         <pre><code>[shareyourcart]</code></pre>
-        
+
         <p><?php echo SyC::t('sdk','If you want to use the {brand} button directly in a <strong>theme</strong> or <strong>page template</strong> you have to use the following function call:', array('{brand}' => '<a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart&trade;" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin/documentation/logo-click\']);">ShareYourCart&trade;</a>')); ?></p>
         <pre><code>echo do_shortcode('[shareyourcart]');</code></pre>
 		<h3><?php echo SyC::t('sdk','Remarks'); ?></h3>
 		<ol>
-	
+
 <?php if (!(isset($action_url) && !empty($action_url))): //if no shopping cart is active ?>
 		<li><p><?php echo SyC::t('sdk','For the button to work, you need to specify the following properties in the meta description area'); ?></p>
 <pre><code><?php echo SyC::htmlIndent(nl2br(htmlspecialchars('<html xmlns="http://www.w3.org/1999/xhtml"
@@ -37,8 +37,8 @@
       <meta property="syc:price" content="$10" />
       <meta property="og:description"
           content="
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-            Proin feugiat nunc quis nibh congue luctus. 
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Proin feugiat nunc quis nibh congue luctus.
             Maecenas ac est nec turpis fermentum imperdiet.
           "/>
     ...
@@ -55,23 +55,23 @@
                     </ul>
                 </li>
 		</ol>
-		
-		
+
+
 		<h2><?php echo SyC::t('sdk','Custom Button'); ?></h2>
 		<p><?php echo SyC::t('sdk','If you want to fully style the {brand} button, use instead the following HTML code', array('{brand}' => '<a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart&trade;" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin/documentation/logo-click\']);">ShareYourCart&trade;</a>')); ?></p>
 
 <?php $custom_button = '<button class="shareyourcart-button" data-syc-layout="custom"';
-if (isset($action_url) && !empty($action_url)){	
+if (isset($action_url) && !empty($action_url)){
 	//if there is no action url, it means none of the supported shopping carts are active,
 	//so there would be no need for the callback attribute
 	$custom_button .= ' data-syc-callback_url="'.$action_url.'" ';
  }
- 
+
  $custom_button .= '>
      Get a <div class="shareyourcart-discount" ></div> discount
 </button>'; ?>
 		<pre><code><?php echo  SyC::htmlIndent(nl2br(htmlspecialchars($custom_button))); ?></code></pre>
-		
+
 <?php if (isset($action_url) && !empty($action_url)): //only show if a known shopping cart is active ?>
 		<h3><?php echo SyC::t('sdk','Remarks'); ?></h3>
 		<p><?php echo SyC::t('sdk','If you want to use the {brand} button on a product\'s page, you need to <strong>append</strong> {product-property} to the {callback-url} value, where {product-property} is the product\'s id', array('{brand}' => '<a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart&trade;" onclick=" if(_gaq) _gaq.push([\'_trackPageview\', \'/admin/documentation/logo-click\']);">ShareYourCart&trade;</a>', '{product-property}' => '<code>&p=&lt;product_id&gt;</code>', '{callback-url}' => '<strong>data-syc-callback_url</strong>')); ?></p>

--- a/classes/integrations/shareyourcart/sdk/views/page-header.php
+++ b/classes/integrations/shareyourcart/sdk/views/page-header.php
@@ -4,14 +4,14 @@
 <link rel="stylesheet" href="<?php echo $this->getUrl(dirname(__FILE__).'/../css/ie.css'); ?>" type="text/css"/>
 <![endif]-->
 
-<?php //check if there is a style outside of the SDK, and include that one as well 
+<?php //check if there is a style outside of the SDK, and include that one as well
 
 $_reflection_ = new ReflectionClass(get_class($this));
 $_file_ = dirname($_reflection_->getFileName())."/css/style.css";
-		
+
 //check if there is a file in the specified location
 if(file_exists($_file_)):?>
-		
+
 <link rel="stylesheet" type="text/css" href="<?php echo $this->getUrl($_file_); ?>" />
 
 <?php endif; ?>

--- a/classes/integrations/shareyourcart/views/admin-header.php
+++ b/classes/integrations/shareyourcart/views/admin-header.php
@@ -4,10 +4,10 @@
 
 window.onload = function() {
 document.getElementById('syc-form').addEventListener('submit', changetext, false);
-}; 
+};
 
 var changetext = function(){
 	var textarea = document.getElementById('syc_button_textarea').value;
-	document.getElementById('syc_button_textarea').value = encodeURIComponent(textarea);	
+	document.getElementById('syc_button_textarea').value = encodeURIComponent(textarea);
 }
 </script>

--- a/classes/integrations/shareyourcart/views/admin-page.php
+++ b/classes/integrations/shareyourcart/views/admin-page.php
@@ -7,13 +7,13 @@ $wcIntegration = $html; //the object is sent under the $html parameter
 //since this is a post, and is related to recovering or creating a new account, perform some special operations
 if ($refresh || ($_SERVER['REQUEST_METHOD'] == 'POST' && !empty( $_REQUEST['syc-account'] ))){
 
-	$redirect = remove_query_arg( 'saved' ); 
-	$redirect = remove_query_arg( 'wc_error', $redirect ); 
-	$redirect = remove_query_arg( 'wc_message', $redirect ); 
-	
+	$redirect = remove_query_arg( 'saved' );
+	$redirect = remove_query_arg( 'wc_error', $redirect );
+	$redirect = remove_query_arg( 'wc_message', $redirect );
+
 	//remove the syc-account argument only if the SDK commanded as such
 	if($refresh) $redirect = remove_query_arg( 'syc-account', $redirect );
-	
+
 	if ( !empty($error_message) ) $redirect = add_query_arg( 'wc_error', urlencode( esc_attr( $error_message ) ), $redirect );
 
 	wp_safe_redirect( $redirect );
@@ -26,62 +26,62 @@ if ($refresh || ($_SERVER['REQUEST_METHOD'] == 'POST' && !empty( $_REQUEST['syc-
 <?php if ( $show_header ) : ?>
 
 	<?php echo $this->getUpdateNotification(); ?>
-	
+
 	<?php if ( ! $this->getClientId() && ! $this->getAppKey() ) : //show the get started message ?>
-	
+
 		<div id="wc_get_started">
 			<span class="main"><?php _e('Setup your ShareYourCart account', 'woocommerce'); ?></span>
 			<span><?php echo $wcIntegration->method_description; ?></span>
 			<p><a href="<?php echo add_query_arg( 'syc-account', 'create', admin_url( 'admin.php?page=woocommerce&tab=integration&section=shareyourcart' ) ); ?>" class="button button-primary"><?php _e('Create an account', 'woocommerce'); ?></a> <a href="<?php echo add_query_arg( 'syc-account', 'recover', admin_url( 'admin.php?page=woocommerce&tab=integration&section=shareyourcart' ) ); ?>" class="button"><?php _e('Can\'t access your account?', 'woocommerce'); ?></a></p>
 		</div>
-	
+
 	<?php else: ?>
-	
+
 		<h3>
 			<a href="http://www.shareyourcart.com" target="_blank" title="Shareyourcart" class="shareyourcart-logo">
 				<img src="<?php echo $this->createUrl(dirname(__FILE__).'/../sdk/img/shareyourcart-logo.png'); ?>"/>
 			</a>
 		</h3>
 		<?php echo wpautop( $wcIntegration->method_description );?>
-	
+
 	<?php endif; ?>
-	
+
 <?php endif; ?>
 
 	<?php if(!empty($status_message) || !empty($error_message)): ?>
 	<div class="updated settings-error"><p><strong>
-		<?php 
-			$message = @$error_message; 
-		
+		<?php
+			$message = @$error_message;
+
 			//is there a status message?
 			if(!empty($status_message))
 			{
 				//put the status message on a new line
 				if(!empty($message)) $message .= "<br /><br />";
-				
+
 				$message .= $status_message;
 			}
-		
-			echo $message; 
+
+			echo $message;
 		?>
 	</strong></p></div>
 	<?php endif; ?>
-	 
-    
+
+
     <h3>Account Options</h3>
-    <div id="acount-options">      	     
+    <div id="acount-options">
 		<table class="form-table">
         	<tr valign="top">
         		<th class="titledesc" scope="row">
         			<?php echo SyC::t('sdk','API Status:'); ?>
-		            <?php if ( $this->isActive() ) echo SyC::t('sdk','Enabled'); else echo SyC::t('sdk','Disabled'); ?>	
+		            <?php if ( $this->isActive() ) echo SyC::t('sdk','Enabled'); else echo SyC::t('sdk','Disabled'); ?>
         		</th>
         		<td class="forminp">
         			<?php if($this->isActive()) : ?>
 			            <input class="button" type="submit" value="<?php echo SyC::t('sdk','Disable'); ?>" name="disable-API" />
 			        <?php else :?>
 			            <input class="button" type="submit" value="<?php echo SyC::t('sdk','Enable'); ?>" name="enable-API" />
-			        <?php endif;?>			
+			        <?php endif;?>
         		</td>
         	</tr>
             <tr valign="top">
@@ -96,19 +96,19 @@ if ($refresh || ($_SERVER['REQUEST_METHOD'] == 'POST' && !empty( $_REQUEST['syc-
             <tr valign="top">
             	<th class="titledesc" scope="row"><?php echo SyC::t('sdk','Configuration'); ?></th>
             	<td>
-	            	
+
 	            	<a href="<?php echo $this->SHAREYOURCART_CONFIGURE; ?>?app_key=<?php echo $this->getAppKey(); ?>&amp;client_id=<?php echo $this->getClientId(); ?>&amp;email=<?php echo $this->getAdminEmail(); ?>" class="button" target="_blank"><?php _e('Configure', 'woocommerce'); ?></a>
-	            	
-	            	<p class="description"><?php echo SyC::t('sdk','You can choose how much of a discount to give (in fixed amount, percentage, or free shipping) and to which social media channels it should it be applied. You can also define what the advertisement should say, so that it fully benefits your sales.'); ?></p>	
-	            	
+
+	            	<p class="description"><?php echo SyC::t('sdk','You can choose how much of a discount to give (in fixed amount, percentage, or free shipping) and to which social media channels it should it be applied. You can also define what the advertisement should say, so that it fully benefits your sales.'); ?></p>
+
             	</td>
             </tr>
-            <?php endif;?>	
+            <?php endif;?>
         </table>
-        
+
         <div class="submit">
         	<input type="submit" class="button button-primary" name="syc-account-form" value="<?php _e('Save changes', 'woocommerce'); ?>" />
-        </div> 
+        </div>
     </div>
-    
+
 </div>

--- a/classes/integrations/shareyourcart/views/button-settings-page.php
+++ b/classes/integrations/shareyourcart/views/button-settings-page.php
@@ -11,7 +11,7 @@
     					<legend class="screen-reader-text"><span><?php _e( 'Button style', 'woocommerce' ); ?></span></legend>
 						<p>
 							<label>
-								<input type="radio" value="1" id="button_type_1" <?php if ($current_button_type == '1'||$current_button_type == '') echo 'checked' ?> name="button_type" class="tog" /> 
+								<input type="radio" value="1" id="button_type_1" <?php if ($current_button_type == '1'||$current_button_type == '') echo 'checked' ?> name="button_type" class="tog" />
 								<?php echo SyC::t('sdk','Use Standard Button'); ?>
 							</label>
 						</p>
@@ -37,7 +37,7 @@
 								</label>
 							</li>
 						</ul>
-						
+
 						<p>
 							<label>
 								<input type="radio" value="2" id="button_type_2" name="button_type" <?php if ($current_button_type == '2') echo 'checked' ?> class="tog" />
@@ -51,7 +51,7 @@
 									<?php if ( ! empty( $button_img ) ): ?>
 										<img src="<?php echo $button_img ?>" height="40" /><br/>
 									<?php endif; ?>
-									
+
 									<input type="hidden" name="MAX_FILE_SIZE" value="100000000000" />
 									<input type="file" accept="image/gif, image/jpeg, image/jpg, image/png" name="button-img" id="button-img" />
 								</label>
@@ -62,13 +62,13 @@
 									<?php if ( ! empty( $button_img_hover ) ): ?>
 										<img src="<?php echo $button_img_hover ?>" height="40" /><br/>
 									<?php endif; ?>
-									
+
 									<input type="hidden" name="MAX_FILE_SIZE" value="100000000000" />
 									<input type="file" accept="image/gif, image/jpeg, image/jpg, image/png" name="button-img-hover" id="button-img-hover" />
 								</label>
 							</li>
 						</ul>
-						
+
 						<p>
 							<label>
 								<input type="radio" value="3" id="button_type_3" name="button_type" <?php if ($current_button_type == '3') echo 'checked' ?> class="tog" />
@@ -83,12 +83,12 @@
 								</label>
 							</li>
 						</ul>
-					</fieldset>	
+					</fieldset>
         		</td>
     		</tr>
     	</table>
-    	<?php echo $html; ?> 
-    	 
+    	<?php echo $html; ?>
+
         <fieldset>
             <table class="form-table " name="shareyourcart_settings">
                 <tr>
@@ -96,7 +96,7 @@
                     <td>
                         <input class="buttonCheckbox" name="show_on_product" <?php echo $show_on_product ? 'checked="checked"' : ''; ?>  type='checkbox'><?php echo SyC::t('sdk','Product page'); ?></input>
                         <br />
-                        <input class="buttonCheckbox" name="show_on_checkout" <?php echo $show_on_checkout ? 'checked="checked"' : ''; ?> type='checkbox'><?php echo SyC::t('sdk','Checkout page'); ?></input>                        
+                        <input class="buttonCheckbox" name="show_on_checkout" <?php echo $show_on_checkout ? 'checked="checked"' : ''; ?> type='checkbox'><?php echo SyC::t('sdk','Checkout page'); ?></input>
                     </td>
                 </tr>
     			 <tr>
@@ -114,10 +114,10 @@
                     </td>
                 </tr>
             </table>
-        </fieldset> 
-        
+        </fieldset>
+
         <div class="submit">
         	<input type="submit" class="button button-primary" name="syc-visual-form" value="<?php _e('Save changes', 'woocommerce'); ?>" />
-        </div> 
+        </div>
     </div>
 </div>

--- a/classes/shipping/class-wc-flat-rate.php
+++ b/classes/shipping/class-wc-flat-rate.php
@@ -191,18 +191,18 @@ class WC_Flat_Rate extends WC_Shipping_Method {
     	$cost_per_order 	= ( isset( $this->cost_per_order ) && ! empty( $this->cost_per_order ) ) ? $this->cost_per_order : 0;
 
     	if ( $this->type == 'order' ) {
-    		
+
     		$shipping_total = $this->order_shipping( $package );
-    		
+
     		if ( ! is_null( $shipping_total ) || $cost_per_order > 0 )
 	    		$rate = array(
 					'id' 	=> $this->id,
 					'label' => $this->title,
 					'cost' 	=> $shipping_total + $cost_per_order,
 				);
-			
+
 		} elseif ( $this->type == 'class' ) {
-			
+
 			$shipping_total = $this->class_shipping( $package );
 
 			if ( ! is_null( $shipping_total ) || $cost_per_order > 0 )
@@ -211,28 +211,28 @@ class WC_Flat_Rate extends WC_Shipping_Method {
 					'label' => $this->title,
 					'cost' 	=> $shipping_total + $cost_per_order,
 				);
-			
+
 		} elseif ( $this->type == 'item' ) {
-			
+
 			$costs = $this->item_shipping( $package );
-			
+
 			if ( ! is_null( $costs ) || $cost_per_order > 0 ) {
-				
+
 				if ( ! is_array( $costs ) )
 					$costs = array();
-				
+
 				$costs['order'] = $cost_per_order;
-	
+
 				$rate = array(
 					'id' 		=> $this->id,
 					'label' 	=> $this->title,
 					'cost' 		=> $costs,
 					'calc_tax' 	=> 'per_item',
 				);
-			
+
 			}
 		}
-		
+
 		if ( ! isset( $rate ) )
 			return;
 
@@ -332,7 +332,7 @@ class WC_Flat_Rate extends WC_Shipping_Method {
 		} elseif ( is_null( $cost ) ) {
 			// No match
 			return null;
-		} 
+		}
 
 		// Shipping for whole order
 		return $cost + $this->get_fee( $fee, $package['contents_cost'] );
@@ -367,9 +367,9 @@ class WC_Flat_Rate extends WC_Shipping_Method {
     		}
 
     		$found_shipping_classes = array_unique( $found_shipping_classes );
-    		
+
     		$matched = false;
-    		
+
     		// For each found class, add up the costs and fees
     		foreach ( $found_shipping_classes as $shipping_class => $class_price ) {
     			if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
@@ -403,7 +403,7 @@ class WC_Flat_Rate extends WC_Shipping_Method {
     function item_shipping( $package ) {
 		// Per item shipping so we pass an array of costs (per item) instead of a single value
 		$costs = array();
-		
+
 		$matched = false;
 
 		// Shipping per item
@@ -412,9 +412,9 @@ class WC_Flat_Rate extends WC_Shipping_Method {
 
 			if ( $values['quantity'] > 0 && $_product->needs_shipping() ) {
 				$shipping_class = $_product->get_shipping_class();
-				
+
 				$fee = $cost = 0;
-				
+
 				if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
 					$cost 	= $this->flat_rates[ $shipping_class ]['cost'];
     				$fee	= $this->get_fee( $this->flat_rates[ $shipping_class ]['fee'], $_product->get_price() );
@@ -428,7 +428,7 @@ class WC_Flat_Rate extends WC_Shipping_Method {
 				$costs[ $item_id ] = ( ( $cost + $fee ) * $values['quantity'] );
 			}
 		}
-		
+
 		if ( $matched )
 			return $costs;
 		else

--- a/classes/shipping/class-wc-local-delivery.php
+++ b/classes/shipping/class-wc-local-delivery.php
@@ -191,29 +191,29 @@ class WC_Local_Delivery extends WC_Shipping_Method {
 				$codes[] = $this->clean( $code );
 			}
 		}
-		
+
 		if ( is_array( $codes ) ) {
-			
+
 			$found_match = false;
-			
+
 			if ( in_array( $this->clean( $package['destination']['postcode'] ), $codes ) )
 				$found_match = true;
-			
+
 			// Wildcard search
 			if ( ! $found_match ) {
-				
+
 				$customer_postcode = $this->clean( $package['destination']['postcode'] );
 				$customer_postcode_length = strlen( $customer_postcode );
-				
+
 				for ( $i = 0; $i <= $customer_postcode_length; $i++ ) {
-					
-					if ( in_array( $customer_postcode, $codes ) ) 
+
+					if ( in_array( $customer_postcode, $codes ) )
 						$found_match = true;
-					
+
 					$customer_postcode = substr( $customer_postcode, 0, -2 ) . '*';
 				}
 			}
-			
+
 			if ( ! $found_match )
 				return false;
 		}

--- a/classes/shipping/class-wc-local-pickup.php
+++ b/classes/shipping/class-wc-local-pickup.php
@@ -144,13 +144,13 @@ class WC_Local_Pickup extends WC_Shipping_Method {
 	 */
 	function is_available( $package ) {
 		global $woocommerce;
-		
+
 		$is_available = true;
-		
+
     	if ( $this->enabled == "no" ) {
-	    	
+
 	    	$is_available = false;
-	    	
+
     	} else {
 
 			// If post codes are listed, let's use them.
@@ -160,35 +160,35 @@ class WC_Local_Pickup extends WC_Shipping_Method {
 					$codes[] = $this->clean( $code );
 				}
 			}
-			
+
 			if ( is_array( $codes ) ) {
-				
+
 				$found_match = false;
-				
+
 				if ( in_array( $this->clean( $package['destination']['postcode'] ), $codes ) )
 					$found_match = true;
-				
+
 				// Wildcard search
 				if ( ! $found_match ) {
-					
+
 					$customer_postcode = $this->clean( $package['destination']['postcode'] );
 					$customer_postcode_length = strlen( $customer_postcode );
-					
+
 					for ( $i = 0; $i <= $customer_postcode_length; $i++ ) {
-						
-						if ( in_array( $customer_postcode, $codes ) ) 
+
+						if ( in_array( $customer_postcode, $codes ) )
 							$found_match = true;
-						
+
 						$customer_postcode = substr( $customer_postcode, 0, -2 ) . '*';
 					}
 				}
-				
+
 				if ( ! $found_match ) {
-					
+
 					$is_available = false;
-					
+
 				} else {
-					
+
 					$ship_to_countries = '';
 
 					if ( $this->availability == 'specific' ) {
@@ -196,56 +196,56 @@ class WC_Local_Pickup extends WC_Shipping_Method {
 					} elseif ( get_option( 'woocommerce_allowed_countries' ) == 'specific' ) {
 						$ship_to_countries = get_option( 'woocommerce_specific_allowed_countries' );
 					}
-		
+
 					if ( is_array( $ship_to_countries ) && ! in_array( $package['destination']['country'], $ship_to_countries ) ) {
 						$is_available = false;
 					}
-					
+
 				}
 			}
-		
+
 		}
 
 		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available, $package );
 	}
-	
-	
+
+
 	/**
 	 * taxable_address function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $address
 	 * @return void
 	 */
 	function taxable_address( $address ) {
 		global $woocommerce;
-		
+
 		if ( ! empty( $woocommerce->session->chosen_shipping_method ) && $woocommerce->session->chosen_shipping_method == 'local_pickup' ) {
 			if ( ! empty( $this->settings['apply_base_tax'] ) && $this->settings['apply_base_tax'] == 'yes' ) {
-				
+
 				$country 	= $woocommerce->countries->get_base_country();
 				$state 		= $woocommerce->countries->get_base_state();
-				
-				$address = array( $country, $state, '', '' );				
+
+				$address = array( $country, $state, '', '' );
 			}
 		}
 		return $address;
 	}
-	
+
 	/**
 	 * Refresh totals when chosen so we can refresh the tax if we are using local pickup.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function method_chosen( $method ) {
 		global $woocommerce;
-		
+
 		if ( $method == 'local_pickup' && ! empty( $this->settings['apply_base_tax'] ) && $this->settings['apply_base_tax'] == 'yes' ) {
 			$woocommerce->cart->calculate_totals();
 		}
 	}
-	
+
     /**
      * clean function.
      *
@@ -256,7 +256,7 @@ class WC_Local_Pickup extends WC_Shipping_Method {
     function clean( $code ) {
     	return str_replace( '-', '', sanitize_title( $code ) ) . ( strstr( $code, '*' ) ? '*' : '' );
     }
-    
+
 }
 
 /**

--- a/classes/shipping/class-wc-shipping.php
+++ b/classes/shipping/class-wc-shipping.php
@@ -181,8 +181,8 @@ class WC_Shipping {
 	 */
 	function calculate_shipping( $packages = array() ) {
 		global $woocommerce;
-		
-		if ( ! $this->enabled || empty( $packages ) ) 
+
+		if ( ! $this->enabled || empty( $packages ) )
 			return;
 
 		$this->shipping_total 	= 0;
@@ -235,10 +235,10 @@ class WC_Shipping {
 					}
 					$chosen_method = $_cheapest_method;
 				}
-				
+
 				// Store chosen method
 				$woocommerce->session->chosen_shipping_method = $chosen_method;
-				
+
 				// Do action for this chosen method
 				do_action( 'woocommerce_shipping_method_chosen', $chosen_method );
 			}
@@ -272,7 +272,7 @@ class WC_Shipping {
 			$package['rates'] = array();
 
 			foreach ( $this->load_shipping_methods( $package ) as $shipping_method ) {
-			
+
 				if ( $shipping_method->is_available( $package ) ) {
 
 					// Reset Rates
@@ -280,7 +280,7 @@ class WC_Shipping {
 
 					// Calculate Shipping for package
 					$shipping_method->calculate_shipping( $package );
-					
+
 					// Place rates in package array
 					if ( ! empty( $shipping_method->rates ) && is_array( $shipping_method->rates ) )
 						foreach ( $shipping_method->rates as $rate )
@@ -288,7 +288,7 @@ class WC_Shipping {
 				}
 
 			}
-			
+
 			// Filter the calculated rates
 			$package['rates'] = apply_filters( 'woocommerce_package_rates', $package['rates'], $package );
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 
 == Changelog ==
 
-= 1.7.0 = 
+= 1.7.0 =
 * Feature - Securi audited and secured.
 * Feature - Added sales by category report.
 * Feature - Added sales by coupon report (kudos Max Rice).
@@ -179,7 +179,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Feature - Added the option to sell products individually (only allow 1 in the cart).
 * Feature - New shop page/category archive display settings, and the ability to change display per-category.
 * Feature - Allow shipping tax classes to be defined independent of items. https://github.com/woothemes/woocommerce/issues/1625
-* Feature - Redone order item storage making them easier (and faster) to access for reporting, and querying purchases. Huge performance gains for reports. Order items are no longer serialised - they are stored in there own table with meta. Existing data can be be updated on upgrade. 
+* Feature - Redone order item storage making them easier (and faster) to access for reporting, and querying purchases. Huge performance gains for reports. Order items are no longer serialised - they are stored in there own table with meta. Existing data can be be updated on upgrade.
 * Feature - Update weights/dimensions for variations if they differ.
 * Feature - is_order_received_page() courtesy of Lee Willis.
 * Feature - Inline saving of attributes to make creating variable products easier.
@@ -1141,9 +1141,9 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 == Upgrade Notice ==
 
 = 1.7.0 =
-There are many improvements in this major release - see the changelog for full details. 
+There are many improvements in this major release - see the changelog for full details.
 
-The biggest change is that we're redone order item storage making them easier (and faster) to access for reporting and querying purchases; there are huge performance gains for reports. 
+The biggest change is that we're redone order item storage making them easier (and faster) to access for reporting and querying purchases; there are huge performance gains for reports.
 
 Order items are no longer serialised data and store in meta - they are stored in there own table with their own meta. Existing data can be be updated upon upgrade (you will be prompted). You should backup before upgrading.
 

--- a/shortcodes/shortcode-cart.php
+++ b/shortcodes/shortcode-cart.php
@@ -83,7 +83,7 @@ function woocommerce_cart( $atts ) {
 			$woocommerce->add_message(  __( 'Shipping costs updated.', 'woocommerce' ) );
 
 		}
-		
+
 		do_action( 'woocommerce_calculated_shipping' );
 	}
 

--- a/shortcodes/shortcode-init.php
+++ b/shortcodes/shortcode-init.php
@@ -55,7 +55,7 @@ function woocommerce_product_category( $atts ){
 		), $atts ) );
 
 	if ( ! $category ) return;
-	
+
 	$ordering_args = $woocommerce->query->get_catalog_ordering_args( $orderby, $order );
 
   	$args = array(
@@ -81,7 +81,7 @@ function woocommerce_product_category( $atts ){
 			)
 	    )
 	);
-	
+
 	if ( isset( $ordering_args['meta_key'] ) ) {
  		$args['meta_key'] = $ordering_args['meta_key'];
  	}
@@ -528,7 +528,7 @@ function woocommerce_sale_products( $atts ){
 
 		set_transient( 'wc_products_onsale', $product_ids_on_sale );
 	}
-		
+
 	$product_ids_on_sale[] = 0;
 
 	$meta_query = array();
@@ -551,7 +551,7 @@ function woocommerce_sale_products( $atts ){
   	ob_start();
 
 	$products = new WP_Query( $args );
-	
+
 	$woocommerce_loop['columns'] = $columns;
 
 	if ( $products->have_posts() ) : ?>
@@ -605,9 +605,9 @@ function woocommerce_best_selling_products( $atts ){
     );
 
   	ob_start();
-  	
+
 	$products = new WP_Query( $args );
-	
+
 	$woocommerce_loop['columns'] = $columns;
 
 	if ( $products->have_posts() ) : ?>
@@ -663,13 +663,13 @@ function woocommerce_top_rated_products( $atts ){
     );
 
   	ob_start();
-  	
+
   	add_filter( 'posts_clauses', 'woocommerce_order_by_rating_post_clauses' );
 
 	$products = new WP_Query( $args );
-	
+
 	remove_filter( 'posts_clauses', 'woocommerce_order_by_rating_post_clauses' );
-	
+
 	$woocommerce_loop['columns'] = $columns;
 
 	if ( $products->have_posts() ) : ?>
@@ -824,7 +824,7 @@ function woocommerce_messages_shortcode() {
 
 /**
  * woocommerce_order_by_rating_post_clauses function.
- * 
+ *
  * @access public
  * @param mixed $args
  * @return void

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -35,7 +35,7 @@ get_header('shop'); ?>
 
 		<?php if ( have_posts() ) : ?>
 
-			<?php 
+			<?php
 				/**
 				 * woocommerce_pagination hook
 				 *
@@ -43,7 +43,7 @@ get_header('shop'); ?>
 				 * @hooked woocommerce_result_count - 20
 				 * @hooked woocommerce_catalog_ordering - 30
 				 */
-				do_action( 'woocommerce_before_shop_loop' ); 
+				do_action( 'woocommerce_before_shop_loop' );
 			?>
 
 			<?php woocommerce_product_loop_start(); ?>

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -48,7 +48,7 @@ global $woocommerce;
 						<td class="product-thumbnail">
 							<?php
 								$thumbnail = apply_filters( 'woocommerce_in_cart_product_thumbnail', $_product->get_image(), $values, $cart_item_key );
-								
+
 								if ( ! $_product->is_visible() || ( ! empty( $_product->variation_id ) && ! $_product->parent_is_visible() ) )
 									echo $thumbnail;
 								else
@@ -88,7 +88,7 @@ global $woocommerce;
 								if ( $_product->is_sold_individually() ) {
 									$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', $cart_item_key );
 								} else {
-									
+
 									$step	= apply_filters( 'woocommerce_quantity_input_step', '1', $_product );
 									$min 	= apply_filters( 'woocommerce_quantity_input_min', '', $_product );
 									$max 	= apply_filters( 'woocommerce_quantity_input_max', $_product->backorders_allowed() ? '' : $_product->get_stock_quantity(), $_product );

--- a/templates/cart/shipping-methods.php
+++ b/templates/cart/shipping-methods.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Shipping Methods Display
  *
@@ -6,7 +6,7 @@
  * @package 	WooCommerce/Templates
  * @version     1.7.0
  */
- 
+
 global $woocommerce;
 
 // If at least one shipping method is available
@@ -45,7 +45,7 @@ if ( $available_methods ) {
 			echo '<option value="' . esc_attr( $method->id ) . '" ' . selected( $method->id, $woocommerce->session->chosen_shipping_method, false ) . '>' . wp_kses_post( $method->full_label ) . '</option>';
 
 		echo '</select>';
-		
+
 	// Show radio buttons for methods
 	} else {
 

--- a/templates/cart/totals.php
+++ b/templates/cart/totals.php
@@ -37,81 +37,81 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 					</tr>
 
 				<?php endif; ?>
-				
+
 				<?php if ( $woocommerce->cart->needs_shipping() && $woocommerce->cart->show_shipping() && ( $available_methods || get_option( 'woocommerce_enable_shipping_calc' ) == 'yes' ) ) : ?>
-				
+
 					<tr class="shipping">
 						<th><?php _e( 'Shipping', 'woocommerce' ); ?></th>
 						<td><?php woocommerce_get_template( 'cart/shipping-methods.php', array( 'available_methods' => $available_methods ) ); ?></td>
 					</tr>
-						
+
 				<?php endif ?>
-				
+
 				<?php foreach ( $woocommerce->cart->get_fees() as $fee ) : ?>
-					
+
 					<tr class="fee fee-<?php echo $fee->id ?>">
 						<th><?php echo $fee->name ?></th>
-						<td><?php 
+						<td><?php
 							if ( $woocommerce->cart->display_totals_ex_tax || ! $woocommerce->cart->prices_include_tax )
 								echo woocommerce_price( $fee->amount );
 							else
 								echo woocommerce_price( $fee->amount + $fee->tax );
 						?></td>
 					</tr>
-					
+
 				<?php endforeach; ?>
 
 				<?php
 					// Show the tax row if showing prices exclusive of tax only
 					if ( $woocommerce->cart->display_totals_ex_tax || ! $woocommerce->cart->prices_include_tax ) {
 						if ( $woocommerce->cart->get_cart_tax() ) {
-	
+
 							$taxes = $woocommerce->cart->get_formatted_taxes();
-	
+
 							if ( sizeof( $taxes ) > 0 ) {
-	
+
 								$has_compound_tax = false;
-	
+
 								foreach ( $taxes as $key => $tax ) {
 									if ( $woocommerce->cart->tax->is_compound( $key ) ) {
-										$has_compound_tax = true; 
+										$has_compound_tax = true;
 										continue;
 									}
-									
+
 									echo '<tr class="tax-rate tax-rate-' . $key . '">
 										<th>' . $woocommerce->cart->tax->get_rate_label( $key ) . '</th>
 										<td>' . $tax . '</td>
 									</tr>';
 								}
-	
+
 								if ( $has_compound_tax ) {
-									
+
 									echo '<tr class="order-subtotal">
 										<th><strong>' . __( 'Subtotal', 'woocommerce' ) . '</strong></th>
 										<td><strong>' . $woocommerce->cart->get_cart_subtotal( true ) . '</strong></td>
 									</tr>';
 								}
-	
+
 								foreach ( $taxes as $key => $tax ) {
-									if ( ! $woocommerce->cart->tax->is_compound( $key ) ) 
+									if ( ! $woocommerce->cart->tax->is_compound( $key ) )
 										continue;
-									
+
 									echo '<tr class="tax-rate tax-rate-' . $key . '">
 										<th>' . $woocommerce->cart->tax->get_rate_label( $key ) . '</th>
 										<td>' . $tax . '</td>
 									</tr>';
 								}
-	
-							} else { 
-								
+
+							} else {
+
 								echo '<tr class="tax">
 									<th>' . __( 'Tax', 'woocommerce' ) . '</th>
 									<td>' . $woocommerce->cart->get_cart_tax() . '</td>
 								</tr>';
 							}
-							
+
 						} elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) {
-							
+
 							echo '<tr class="tax">
 								<th>' . __( 'Tax', 'woocommerce' ) . '</th>
 								<td>' . _x( 'N/A', 'Relating to tax', 'woocommerce' ) . '</td>
@@ -121,7 +121,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 				?>
 
 				<?php if ( $woocommerce->cart->get_discounts_after_tax() ) : ?>
-				
+
 					<tr class="discount">
 						<th><?php _e( 'Order Discount', 'woocommerce' ); ?> <a href="<?php echo add_query_arg( 'remove_discounts', '2', $woocommerce->cart->get_cart_url() ) ?>"><?php _e( '[Remove]', 'woocommerce' ); ?></a></th>
 						<td>-<?php echo $woocommerce->cart->get_discounts_after_tax(); ?></td>
@@ -136,17 +136,17 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						<?php
 							// If prices are tax inclusive, show taxes here
 							if ( ! $woocommerce->cart->display_totals_ex_tax && $woocommerce->cart->prices_include_tax ) {
-								
+
 								if ( $woocommerce->cart->get_cart_tax() ) {
 									$tax_string_array = array();
 									$taxes = $woocommerce->cart->get_formatted_taxes();
-									
+
 									if ( sizeof( $taxes ) > 0 )
 										foreach ( $taxes as $key => $tax )
 											$tax_string_array[] = sprintf( '%s %s', $tax, $woocommerce->cart->tax->get_rate_label( $key ) );
 									else
 										$tax_string_array[] = sprintf( '%s tax', $tax );
-									
+
 									if ( ! empty( $tax_string_array ) ) {
 										echo '<small class="includes_tax">' . sprintf( __( '(Includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) ) . '</small>';
 									}
@@ -162,7 +162,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 		</table>
 
 		<?php if ( $woocommerce->cart->get_cart_tax() ) : ?>
-		
+
 			<p><small><?php
 
 				$estimated_text = ( $woocommerce->customer->is_customer_outside_base() && ! $woocommerce->customer->has_calculated_shipping() ) ? sprintf( ' ' . __( ' (taxes estimated for %s)', 'woocommerce' ), $woocommerce->countries->estimated_for_prefix() . __( $woocommerce->countries->countries[ $woocommerce->countries->get_base_country() ], 'woocommerce' ) ) : '';
@@ -170,7 +170,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 				printf( __( 'Note: Shipping and taxes are estimated%s and will be updated during checkout based on your billing and shipping information.', 'woocommerce' ), $estimated_text );
 
 			?></small></p>
-			
+
 		<?php endif; ?>
 
 	<?php elseif( $woocommerce->cart->needs_shipping() ) : ?>

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -42,28 +42,28 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 			<?php if ( $woocommerce->cart->needs_shipping() && $woocommerce->cart->show_shipping() ) : ?>
 
 				<?php do_action('woocommerce_review_order_before_shipping'); ?>
-	
+
 				<tr class="shipping">
 					<th colspan="2"><?php _e( 'Shipping', 'woocommerce' ); ?></th>
 					<td><?php woocommerce_get_template( 'cart/shipping-methods.php', array( 'available_methods' => $available_methods ) ); ?></td>
 				</tr>
-	
+
 				<?php do_action('woocommerce_review_order_after_shipping'); ?>
 
 			<?php endif; ?>
-			
+
 			<?php foreach ( $woocommerce->cart->get_fees() as $fee ) : ?>
-					
+
 				<tr class="fee fee-<?php echo $fee->id ?>">
 					<th colspan="2"><?php echo $fee->name ?></th>
-					<td><?php 
+					<td><?php
 						if ( $woocommerce->cart->display_totals_ex_tax || ! $woocommerce->cart->prices_include_tax )
 							echo woocommerce_price( $fee->amount );
 						else
 							echo woocommerce_price( $fee->amount + $fee->tax );
 					?></td>
 				</tr>
-				
+
 			<?php endforeach; ?>
 
 			<?php
@@ -79,7 +79,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 
 							foreach ( $taxes as $key => $tax ) {
 								if ( $woocommerce->cart->tax->is_compound( $key ) ) {
-									$has_compound_tax = true; 
+									$has_compound_tax = true;
 									continue;
 								}
 								?>
@@ -100,7 +100,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							}
 
 							foreach ( $taxes as $key => $tax ) {
-								if ( ! $woocommerce->cart->tax->is_compound( $key ) ) 
+								if ( ! $woocommerce->cart->tax->is_compound( $key ) )
 									continue;
 								?>
 								<tr class="tax-rate tax-rate-<?php echo $key; ?>">
@@ -110,7 +110,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 								<?php
 							}
 
-						} else { 
+						} else {
 							?>
 							<tr class="tax">
 								<th colspan="2" colspan="2"><?php _e( 'Tax', 'woocommerce' ); ?></th>
@@ -118,7 +118,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							</tr>
 							<?php
 						}
-						
+
 					} elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) {
 						?>
 						<tr class="tax">
@@ -148,11 +148,11 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 					<?php
 						// If prices are tax inclusive, show taxes here
 						if ( ! $woocommerce->cart->display_totals_ex_tax && $woocommerce->cart->prices_include_tax ) {
-							
+
 							if ( $woocommerce->cart->get_cart_tax() ) {
 								$tax_string_array = array();
 								$taxes = $woocommerce->cart->get_formatted_taxes();
-								
+
 								if ( sizeof( $taxes ) > 0 ) {
 									foreach ( $taxes as $key => $tax ) {
 										$tax_string_array[] = sprintf( '%s %s', $tax, $woocommerce->cart->tax->get_rate_label( $key ) );
@@ -160,14 +160,14 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 								} else {
 									$tax_string_array[] = sprintf( '%s tax', $tax );
 								}
-								
+
 								if ( ! empty( $tax_string_array ) ) {
-									?><small class="includes_tax"><?php printf( __( '(Includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) ); ?></small><?php	
+									?><small class="includes_tax"><?php printf( __( '(Includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) ); ?></small><?php
 								}
 							} elseif ( get_option( 'woocommerce_display_cart_taxes_if_zero' ) == 'yes' ) {
 								?><small class="includes_tax"><?php printf( __( '(Includes %s tax)', 'woocommerce' ), woocommerce_price( 0 ) ); ?></small><?php
 							}
-							
+
 						}
 					?>
 				</td>
@@ -206,7 +206,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 					// Chosen Method
 					if (sizeof($available_gateways)) :
 						$default_gateway = get_option('woocommerce_default_gateway');
-						
+
 						if ( isset( $woocommerce->session->chosen_payment_method ) && isset( $available_gateways[ $woocommerce->session->chosen_payment_method ] ) ) {
 							$available_gateways[ $woocommerce->session->chosen_payment_method ]->set_current();
 						} elseif ( isset( $available_gateways[ $default_gateway ] ) ) {
@@ -214,7 +214,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						} else {
 							current( $available_gateways )->set_current();
 						}
-						
+
 					endif;
 					foreach ($available_gateways as $gateway ) :
 						?>

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -21,11 +21,11 @@ $template_footer = "
 ";
 
 $credit = "
-	border:0; 
-	color: $base_lighter_40; 
-	font-family: Arial; 
-	font-size:12px; 
-	line-height:125%; 
+	border:0;
+	color: $base_lighter_40;
+	font-family: Arial;
+	font-size:12px;
+	line-height:125%;
 	text-align:center;
 ";
 ?>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -8,7 +8,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
- 
+
 // Load colours
 $bg 		= get_option( 'woocommerce_email_background_color' );
 $body		= get_option( 'woocommerce_email_body_background_color' );
@@ -22,8 +22,8 @@ $text_lighter_20 = woocommerce_hex_lighter( $text, 20 );
 
 // For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline. !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
 $wrapper = "
-	background-color: " . esc_attr( $bg ) . "; 
-	width:100%; 
+	background-color: " . esc_attr( $bg ) . ";
+	width:100%;
 	-webkit-text-size-adjust:none !important;
 	margin:0;
 	padding: 70px 0 70px 0;
@@ -31,12 +31,12 @@ $wrapper = "
 $template_container = "
 	-webkit-box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
 	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
-	-webkit-border-radius:6px !important; 
-	border-radius:6px !important; 
+	-webkit-border-radius:6px !important;
+	border-radius:6px !important;
 	background-color: " . esc_attr( $body ) . ";
 	border: 1px solid $bg_darker_10;
-	-webkit-border-radius:6px !important; 
-	border-radius:6px !important; 
+	-webkit-border-radius:6px !important;
+	border-radius:6px !important;
 ";
 $template_header = "
 	background-color: " . esc_attr( $base ) .";
@@ -46,9 +46,9 @@ $template_header = "
 	border-top-left-radius:6px !important;
 	border-top-right-radius:6px !important;
 	border-bottom: 0;
-	font-family:Arial; 
-	font-weight:bold; 
-	line-height:100%; 
+	font-family:Arial;
+	font-weight:bold;
+	line-height:100%;
 	vertical-align:middle;
 ";
 $body_content = "
@@ -64,15 +64,15 @@ $body_content_inner = "
 	text-align:left;
 ";
 $header_content_h1 = "
-	color: " . esc_attr( $base_text ) . "; 
-	margin:0; 
+	color: " . esc_attr( $base_text ) . ";
+	margin:0;
 	padding: 28px 24px;
 	text-shadow: 0 1px 0 $base_lighter_20;
-	display:block; 
-	font-family:Arial; 
-	font-size:30px; 
-	font-weight:bold; 
-	text-align:left; 
+	display:block;
+	font-family:Arial;
+	font-size:30px;
+	font-weight:bold;
+	text-align:left;
 	line-height: 150%;
 ";
 ?>

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -38,7 +38,7 @@ foreach ($items as $item) :
 					echo '<br/><small>';
 					if ( count( $download_file_urls ) > 1 ) {
 						echo sprintf( __('Download %d:', 'woocommerce' ), $i + 1 );
-					} elseif ( $i == 0 ) 
+					} elseif ( $i == 0 )
 						echo __( 'Download:', 'woocommerce' );
 					echo ' <a href="' . $download_file_url . '" target="_blank">' . $download_file_url . '</a></small>';
 				endforeach;

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 echo $email_heading . "\n\n";
 
-echo sprintf( __( 'You have received an order from %s. Their order is as follows:', 'woocommerce' ), $order->billing_first_name . ' ' . $order->billing_last_name ) . "\n\n"; 
+echo sprintf( __( 'You have received an order from %s. Their order is as follows:', 'woocommerce' ), $order->billing_first_name . ' ' . $order->billing_last_name ) . "\n\n";
 
 echo "****************************************************\n\n";
 
@@ -21,7 +21,7 @@ echo sprintf( __( 'Order date: %s', 'woocommerce'), date_i18n( __( 'jS F Y', 'wo
 
 do_action( 'woocommerce_email_order_meta', $order, true, true );
 
-echo "\n" . $order->email_order_items_table( false, true, '', '', '', true ); 
+echo "\n" . $order->email_order_items_table( false, true, '', '', '', true );
 
 echo "----------\n\n";
 
@@ -38,10 +38,10 @@ do_action( 'woocommerce_email_after_order_table', $order, true, true );
 _e( 'Customer details', 'woocommerce' );
 
 if ( $order->billing_email )
-	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n"; 
+	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n";
 
 if ( $order->billing_phone )
-	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n"; 
+	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n";
 
 woocommerce_get_template( 'emails/plain/email-addresses.php', array( 'order' => $order ) );
 

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 echo $email_heading . "\n\n";
 
-echo sprintf( __( "Hi there. Your recent order on %s has been completed. Your order details are shown below for your reference:", 'woocommerce' ), get_option( 'blogname' ) ) . "\n\n"; 
+echo sprintf( __( "Hi there. Your recent order on %s has been completed. Your order details are shown below for your reference:", 'woocommerce' ), get_option( 'blogname' ) ) . "\n\n";
 
 echo "****************************************************\n\n";
 
@@ -38,10 +38,10 @@ do_action( 'woocommerce_email_after_order_table', $order, false, true );
 echo __( 'Your details', 'woocommerce' ) . "\n\n";
 
 if ( $order->billing_email )
-	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n"; 
+	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n";
 
 if ( $order->billing_phone )
-	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n"; 
+	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n";
 
 woocommerce_get_template( 'emails/plain/email-addresses.php', array( 'order' => $order ) );
 

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 echo $email_heading . "\n\n";
 
 if ( $order->status == 'pending' )
-	echo sprintf( __( 'An order has been created for you on %s. To pay for this order please use the following link: %s', 'woocommerce' ), get_bloginfo( 'name' ), $order->get_checkout_payment_url() ) . "\n\n"; 
+	echo sprintf( __( 'An order has been created for you on %s. To pay for this order please use the following link: %s', 'woocommerce' ), get_bloginfo( 'name' ), $order->get_checkout_payment_url() ) . "\n\n";
 
 echo "****************************************************\n\n";
 

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -10,9 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 echo $email_heading . "\n\n";
 
-echo sprintf( __( "Thanks for creating an account on %s. Your username is <strong>%s</strong>.", 'woocommerce' ), $blogname, $user_login ) . "\n\n"; 
+echo sprintf( __( "Thanks for creating an account on %s. Your username is <strong>%s</strong>.", 'woocommerce' ), $blogname, $user_login ) . "\n\n";
 
-echo sprintf(__( 'You can access your account area here: %s.', 'woocommerce' ), get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) . "\n\n"; 
+echo sprintf(__( 'You can access your account area here: %s.', 'woocommerce' ), get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) . "\n\n";
 
 echo "\n****************************************************\n\n";
 

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -46,10 +46,10 @@ do_action( 'woocommerce_email_after_order_table', $order, false, true );
 echo __( 'Your details', 'woocommerce' ) . "\n\n";
 
 if ( $order->billing_email )
-	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n"; 
+	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n";
 
 if ( $order->billing_phone )
-	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n"; 
+	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n";
 
 woocommerce_get_template( 'emails/plain/email-addresses.php', array( 'order' => $order ) );
 

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 echo $email_heading . "\n\n";
 
-echo __( "Your order has been received and is now being processed. Your order details are shown below for your reference:", 'woocommerce' ) . "\n\n"; 
+echo __( "Your order has been received and is now being processed. Your order details are shown below for your reference:", 'woocommerce' ) . "\n\n";
 
 echo "****************************************************\n\n";
 
@@ -21,7 +21,7 @@ echo sprintf( __( 'Order date: %s', 'woocommerce'), date_i18n( woocommerce_date_
 
 do_action( 'woocommerce_email_order_meta', $order, false, true );
 
-echo "\n" . $order->email_order_items_table( $order->is_download_permitted(), true, ($order->status=='processing') ? true : false, '', '', true ); 
+echo "\n" . $order->email_order_items_table( $order->is_download_permitted(), true, ($order->status=='processing') ? true : false, '', '', true );
 
 echo "----------\n\n";
 
@@ -38,10 +38,10 @@ do_action( 'woocommerce_email_after_order_table', $order, false, true );
 echo __( 'Your details', 'woocommerce' ) . "\n\n";
 
 if ( $order->billing_email )
-	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n"; 
+	echo __( 'Email:', 'woocommerce' ); echo $order->billing_email. "\n";
 
 if ( $order->billing_phone )
-	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n"; 
+	echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone. "\n";
 
 woocommerce_get_template( 'emails/plain/email-addresses.php', array( 'order' => $order ) );
 

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -16,20 +16,20 @@ foreach ( $items as $item ) :
 	// Get/prep product data
 	$_product 	= $order->get_product_from_item( $item );
 	$item_meta 	= new WC_Order_Item_Meta( $item['item_meta'] );
-	
+
 	// Title, sku, qty, price
 	echo apply_filters( 'woocommerce_order_product_title', $item['name'], $_product );
 	echo $show_sku && $_product->get_sku() ? ' (#' . $_product->get_sku() . ')' : '';
-	
+
 	// Variation
 	echo $item_meta->meta ? "\n" . nl2br( $item_meta->display( true, true ) ) : '';
-	
+
 	// Quantity
 	echo "\n" . sprintf( __( 'Quantity: %s', 'woocommerce' ), $item['qty'] );
-	
+
 	// Cost
 	echo "\n" . sprintf( __( 'Cost: %s', 'woocommerce' ), $order->get_formatted_line_subtotal( $item ) );
-	
+
 	// Download URLs
 	if ( $show_download_links && $_product->exists() && $_product->is_downloadable() )
 		echo "\n" . implode( ', ', $order->get_downloadable_file_urls( $item['product_id'], $item['variation_id'], $item ) );
@@ -37,7 +37,7 @@ foreach ( $items as $item ) :
 	// Note
 	if ( $show_purchase_note && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) )
 		echo "\n" . nl2br( $purchase_note );
-	
+
 	echo "\n\n";
 
 endforeach;

--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 global $wp_query;
 
 if ( $wp_query->max_num_pages <= 1 )
-	return; 
+	return;
 ?>
 <nav class="woocommerce_pagination">
 	<?php

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -23,10 +23,10 @@ if ( ! woocommerce_products_will_display() )
 	$max		= $wp_query->found_posts;
 	$first 		= ( $per_page * $paged ) - $per_page + 1;
 	$last 		= $wp_query->get( 'posts_per_page' ) * $paged;
-	
-	if ( $last > $max ) 
+
+	if ( $last > $max )
 		$last = $max;
-		
+
 	printf( __( 'Showing %s - %s of %s results', 'woocommerce' ), $first, $last, $max );
 	?>
 </p>

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -38,15 +38,15 @@ global $woocommerce; ?>
 			<p class="form-row">
 				<?php $woocommerce->nonce_field('login', 'login') ?>
 				<input type="submit" class="button" name="login" value="<?php _e( 'Login', 'woocommerce' ); ?>" />
-				<a class="lost_password" href="<?php 
+				<a class="lost_password" href="<?php
 
 				$lost_password_page_id = woocommerce_get_page_id( 'lost_password' );
-				
-				if ( $lost_password_page_id ) 
+
+				if ( $lost_password_page_id )
 					echo esc_url( get_permalink( $lost_password_page_id ) );
-				else 
-					echo esc_url( wp_lostpassword_url( home_url() ) ); 
-				
+				else
+					echo esc_url( wp_lostpassword_url( home_url() ) );
+
 				?>"><?php _e( 'Lost Password?', 'woocommerce' ); ?></a>
 			</p>
 		</form>

--- a/templates/myaccount/my-account.php
+++ b/templates/myaccount/my-account.php
@@ -23,20 +23,20 @@ $woocommerce->show_messages(); ?>
 
 <ul class="digital-downloads">
 	<?php foreach ( $downloads as $download ) : ?>
-		
+
 		<li>
-			<?php  
+			<?php
 				do_action( 'woocommerce_available_download_start', $download );
 
 				if ( is_numeric( $download['downloads_remaining'] ) )
 					echo apply_filters( 'woocommerce_available_download_count', '<span class="count">' . sprintf( _n( '%s download remaining', '%s downloads remaining', $download['downloads_remaining'], 'woocommerce' ), $download['downloads_remaining'] ) . '</span> ', $download );
-				
+
 				echo apply_filters( 'woocommerce_available_download_link', '<a href="' . esc_url( $download['download_url'] ) . '">' . $download['download_name'] . '</a>', $download );
-			
-				do_action( 'woocommerce_available_download_end', $download ); 
+
+				do_action( 'woocommerce_available_download_end', $download );
 			?>
 		</li>
-		
+
 	<?php endforeach; ?>
 </ul>
 

--- a/templates/shop/breadcrumb.php
+++ b/templates/shop/breadcrumb.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 global $post, $wp_query;
 
-if( ! $home ) 
+if( ! $home )
 	$home = _x( 'Home', 'breadcrumb', 'woocommerce' );
 
 $home_link = home_url();
@@ -29,12 +29,12 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 
 		$cat_obj = $wp_query->get_queried_object();
 		$this_category = get_category( $cat_obj->term_id );
-		
+
 		if ( $this_category->parent != 0 ) {
 			$parent_category = get_category( $this_category->parent );
 			echo get_category_parents($parent_category, TRUE, $delimiter );
 		}
-		
+
 		echo $before . single_cat_title( '', false ) . $after;
 
 	} elseif ( is_tax('product_cat') ) {
@@ -84,7 +84,7 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 	} elseif ( is_post_type_archive('product') && get_option('page_on_front') !== woocommerce_get_page_id('shop') ) {
 
 		$_name = woocommerce_get_page_id( 'shop' ) ? get_the_title( woocommerce_get_page_id( 'shop' ) ) : '';
-		
+
 		if ( ! $_name ) {
 			$product_post_type = get_post_type_object( 'product' );
 			$_name = $product_post_type->labels->singular_name;
@@ -99,7 +99,7 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 			echo $before . '<a href="' . get_post_type_archive_link('product') . '">' . $_name . '</a>' . $after;
 
 		} else {
-		
+
 			echo $before . $_name . $after;
 
 		}
@@ -114,13 +114,13 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 				$term = current( $terms );
 				$parents = array();
 				$parent = $term->parent;
-				
+
 				while ( $parent ) {
 					$parents[] = $parent;
 					$new_parent = get_term_by( 'id', $parent, 'product_cat' );
 					$parent = $new_parent->parent;
 				}
-				
+
 				if ( ! empty( $parents ) ) {
 					$parents = array_reverse($parents);
 					foreach ( $parents as $parent ) {
@@ -128,26 +128,26 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 						echo $before . '<a href="' . get_term_link( $item->slug, 'product_cat' ) . '">' . $item->name . '</a>' . $after . $delimiter;
 					}
 				}
-				
+
 				echo $before . '<a href="' . get_term_link( $term->slug, 'product_cat' ) . '">' . $term->name . '</a>' . $after . $delimiter;
-			
+
 			}
 
 			echo $before . get_the_title() . $after;
 
 		} elseif ( get_post_type() != 'post' ) {
-			
+
 			$post_type = get_post_type_object( get_post_type() );
 			$slug = $post_type->rewrite;
 				echo $before . '<a href="' . get_post_type_archive_link( get_post_type() ) . '">' . $post_type->labels->singular_name . '</a>' . $after . $delimiter;
 			echo $before . get_the_title() . $after;
-		
+
 		} else {
-			
+
 			$cat = current( get_the_category() );
 			echo get_category_parents( $cat, true, $delimiter );
 			echo $before . get_the_title() . $after;
-		
+
 		}
 
 	} elseif ( is_404() ) {
@@ -157,14 +157,14 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 	} elseif ( ! is_single() && ! is_page() && get_post_type() != 'post' ) {
 
 		$post_type = get_post_type_object( get_post_type() );
-		
+
 		if ( $post_type )
 			echo $before . $post_type->labels->singular_name . $after;
 
 	} elseif ( is_attachment() ) {
 
 		$parent = get_post( $post->post_parent );
-		$cat = get_the_category( $parent->ID ); 
+		$cat = get_the_category( $parent->ID );
 		$cat = $cat[0];
 		echo get_category_parents( $cat, true, '' . $delimiter );
 		echo $before . '<a href="' . get_permalink( $parent ) . '">' . $parent->post_title . '</a>' . $after . $delimiter;
@@ -178,15 +178,15 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 
 		$parent_id  = $post->post_parent;
 		$breadcrumbs = array();
-		
+
 		while ( $parent_id ) {
 			$page = get_page( $parent_id );
 			$breadcrumbs[] = '<a href="' . get_permalink($page->ID) . '">' . get_the_title( $page->ID ) . '</a>';
 			$parent_id  = $page->post_parent;
 		}
-		
+
 		$breadcrumbs = array_reverse( $breadcrumbs );
-		
+
 		foreach ( $breadcrumbs as $crumb )
 			echo $crumb . '' . $delimiter;
 

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 <?php if ( comments_open() ) : ?><div id="reviews"><?php
 
 	echo '<div id="comments">';
-	
+
 	if ( get_option('woocommerce_enable_review_rating') == 'yes' ) {
 
 		$count = $wpdb->get_var( $wpdb->prepare("
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			AND comment_approved = '1'
 			AND meta_value > 0
 		"), $post->ID );
-	
+
 		$rating = $wpdb->get_var( $wpdb->prepare("
 			SELECT SUM(meta_value) FROM $wpdb->commentmeta
 			LEFT JOIN $wpdb->comments ON $wpdb->commentmeta.comment_id = $wpdb->comments.comment_ID
@@ -33,29 +33,29 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			AND comment_post_ID = %d
 			AND comment_approved = '1'
 		"), $post->ID );
-	
+
 		if ( $count > 0 ) {
-	
+
 			$average = number_format($rating / $count, 2);
-	
+
 			echo '<div itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">';
-	
+
 			echo '<div class="star-rating" title="'.sprintf(__( 'Rated %s out of 5', 'woocommerce' ), $average).'"><span style="width:'.($average*16).'px"><span itemprop="ratingValue" class="rating">'.$average.'</span> '.__( 'out of 5', 'woocommerce' ).'</span></div>';
-	
+
 			echo '<h2>'.sprintf( _n('%s review for %s', '%s reviews for %s', $count, 'woocommerce'), '<span itemprop="ratingCount" class="count">'.$count.'</span>', wptexturize($post->post_title) ).'</h2>';
-	
+
 			echo '</div>';
-	
+
 		} else {
-	
+
 			echo '<h2>'.__( 'Reviews', 'woocommerce' ).'</h2>';
-	
+
 		}
-		
+
 	} else {
-		
+
 		echo '<h2>'.__( 'Reviews', 'woocommerce' ).'</h2>';
-		
+
 	}
 
 	$title_reply = '';

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -33,7 +33,7 @@ if ( ! $product->is_purchasable() ) return;
 
 	 	<?php
 	 		if ( ! $product->is_sold_individually() )
-	 			woocommerce_quantity_input( array( 
+	 			woocommerce_quantity_input( array(
 	 				'min_value' => apply_filters( 'woocommerce_quantity_input_min', 1, $product ),
 	 				'max_value' => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product )
 	 			) );

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -14,7 +14,7 @@ global $woocommerce, $product, $post;
 <script type="text/javascript">
 	if ( ! product_variations )
 		var product_variations = new Array();
-		
+
     product_variations[ <?php echo $post->ID; ?> ] = <?php echo json_encode( $available_variations ) ?>;
 </script>
 
@@ -38,9 +38,9 @@ global $woocommerce, $product, $post;
 
 								// Get terms if this is a taxonomy - ordered
 								if ( taxonomy_exists( sanitize_title( $name ) ) ) {
-								
+
 									$orderby = $woocommerce->attribute_orderby( $name );
-								
+
 									switch ( $orderby ) {
 										case 'name' :
 											$terms = get_terms( sanitize_title($name), array('menu_order' => 'ASC', 'hide_empty' => false) );

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -17,12 +17,12 @@ global $post, $product;
 
 	<?php if ( $product->is_type( array( 'simple', 'variable' ) ) && get_option( 'woocommerce_enable_sku' ) == 'yes' && $product->get_sku() ) : ?>
 		<span itemprop="productID" class="sku_wrapper"><?php _e( 'SKU:', 'woocommerce' ); ?> <span class="sku"><?php echo $product->get_sku(); ?></span>.</span>
-	<?php endif; ?> 
+	<?php endif; ?>
 
-	<?php echo $product->get_categories( ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', sizeof( get_the_terms( $post->ID, 'product_cat' ) ), 'woocommerce' ) . ' ', '.</span>' ); ?> 
+	<?php echo $product->get_categories( ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', sizeof( get_the_terms( $post->ID, 'product_cat' ) ), 'woocommerce' ) . ' ', '.</span>' ); ?>
 
-	<?php echo $product->get_tags( ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', sizeof( get_the_terms( $post->ID, 'product_tag' ) ), 'woocommerce' ) . ' ', '.</span>' ); ?> 
-	
+	<?php echo $product->get_tags( ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', sizeof( get_the_terms( $post->ID, 'product_tag' ) ), 'woocommerce' ) . ' ', '.</span>' ); ?>
+
 	<?php do_action( 'woocommerce_product_meta_end' ); ?>
 
 </div>

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -19,13 +19,13 @@ global $post;
 		<?php echo get_avatar( $GLOBALS['comment'], $size='60' ); ?>
 
 		<div class="comment-text">
-		
+
 			<?php if ( get_option('woocommerce_enable_review_rating') == 'yes' ) : ?>
 
 				<div itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating" class="star-rating" title="<?php echo esc_attr( get_comment_meta( $GLOBALS['comment']->comment_ID, 'rating', true ) ); ?>">
 					<span style="width:<?php echo intval( get_comment_meta( $GLOBALS['comment']->comment_ID, 'rating', true ) ) * 16; ?>px"><span itemprop="ratingValue"><?php echo intval( get_comment_meta( $GLOBALS['comment']->comment_ID, 'rating', true ) ); ?></span> <?php _e( 'out of 5', 'woocommerce' ); ?></span>
 				</div>
-			
+
 			<?php endif; ?>
 
 			<?php if ($GLOBALS['comment']->comment_approved == '0') : ?>

--- a/templates/single-product/tabs/tab-attributes.php
+++ b/templates/single-product/tabs/tab-attributes.php
@@ -16,7 +16,7 @@ $show_attr = ( get_option( 'woocommerce_enable_dimension_product_attributes' ) =
 if ( $product->has_attributes() || ( $show_attr && $product->has_dimensions() ) || ( $show_attr && $product->has_weight() ) ) {
 	?>
 	<li class="attributes_tab"><a href="#tab-attributes"><?php echo apply_filters('woocommerce_product_additional_information_tab_title', __( 'Additional Information', 'woocommerce' )); ?></a></li>
-   
+
 	<?php
 }
 ?>

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'woocommerce_remove_roles' ) )
 	include_once( 'woocommerce-core-functions.php' );
 
 if ( function_exists( 'woocommerce_remove_roles' ) )
-	woocommerce_remove_roles();	
+	woocommerce_remove_roles();
 
 // Pages
 wp_delete_post( get_option('woocommerce_shop_page_id'), true );

--- a/widgets/widget-layered_nav.php
+++ b/widgets/widget-layered_nav.php
@@ -50,10 +50,10 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 		global $_chosen_attributes, $woocommerce, $_attributes_array;
-		
+
 		extract( $args );
 
-		if ( ! is_post_type_archive( 'product' ) && ! is_tax( array_merge( $_attributes_array, array( 'product_cat', 'product_tag' ) ) ) ) 
+		if ( ! is_post_type_archive( 'product' ) && ! is_tax( array_merge( $_attributes_array, array( 'product_cat', 'product_tag' ) ) ) )
 			return;
 
 		$current_term 	= $_attributes_array && is_tax( $_attributes_array ) ? get_queried_object()->term_id : '';
@@ -64,22 +64,22 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 		$query_type 	= isset( $instance['query_type'] ) ? $instance['query_type'] : 'and';
 		$display_type 	= isset( $instance['display_type'] ) ? $instance['display_type'] : 'list';
 
-		if ( ! taxonomy_exists( $taxonomy ) ) 
+		if ( ! taxonomy_exists( $taxonomy ) )
 			return;
 
 		$terms = get_terms( $taxonomy, array( 'hide_empty' => '1' ) );
 
 		if ( count( $terms ) > 0 ) {
-			
+
 			ob_start();
-			
+
 			$found = false;
-			
+
 			echo $before_widget . $before_title . $title . $after_title;
 
 			// Force found when option is selected - do not force found on taxonomy attributes
 			if ( ! $_attributes_array || ! is_tax( $_attributes_array ) )
-				if ( is_array( $_chosen_attributes ) && array_key_exists( $taxonomy, $_chosen_attributes ) ) 
+				if ( is_array( $_chosen_attributes ) && array_key_exists( $taxonomy, $_chosen_attributes ) )
 					$found = true;
 
 			if ( $display_type == 'dropdown' ) {
@@ -102,7 +102,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 					foreach ( $terms as $term ) {
 
 						// If on a term page, skip that term in widget list
-						if ( $term->term_id == $current_term ) 
+						if ( $term->term_id == $current_term )
 							continue;
 
 						// Get count based on current view - uses transients
@@ -122,10 +122,10 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 
 							$count = sizeof( array_intersect( $_products_in_term, $woocommerce->query->filtered_product_ids ) );
 
-							if ( $count > 0 ) 
+							if ( $count > 0 )
 								$found = true;
 
-							if ( $count == 0 && ! $option_is_set ) 
+							if ( $count == 0 && ! $option_is_set )
 								continue;
 
 						// If this is an OR query, show all options so search can be expanded
@@ -133,7 +133,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 
 							$count = sizeof( array_intersect( $_products_in_term, $woocommerce->query->unfiltered_product_ids ) );
 
-							if ( $count > 0 ) 
+							if ( $count > 0 )
 								$found = true;
 
 						}
@@ -180,25 +180,25 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 						$count = sizeof( array_intersect( $_products_in_term, $woocommerce->query->filtered_product_ids ) );
 
 						// skip the term for the current archive
-						if ( $current_term == $term->term_id ) 
+						if ( $current_term == $term->term_id )
 							continue;
 
-						if ( $count > 0 && $current_term !== $term->term_id ) 
+						if ( $count > 0 && $current_term !== $term->term_id )
 							$found = true;
 
-						if ( $count == 0 && ! $option_is_set ) 
+						if ( $count == 0 && ! $option_is_set )
 							continue;
 
 					// If this is an OR query, show all options so search can be expanded
 					} else {
 
 						// skip the term for the current archive
-						if ( $current_term == $term->term_id ) 
+						if ( $current_term == $term->term_id )
 							continue;
 
 						$count = sizeof( array_intersect( $_products_in_term, $woocommerce->query->unfiltered_product_ids ) );
 
-						if ( $count > 0 ) 
+						if ( $count > 0 )
 							$found = true;
 
 					}
@@ -207,12 +207,12 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 
 					$current_filter = ( isset( $_GET[ $arg ] ) ) ? explode( ',', $_GET[ $arg ] ) : array();
 
-					if ( ! is_array( $current_filter ) ) 
+					if ( ! is_array( $current_filter ) )
 						$current_filter = array();
 
 					$current_filter = array_map( 'esc_attr', $current_filter );
 
-					if ( ! in_array( $term->term_id, $current_filter ) ) 
+					if ( ! in_array( $term->term_id, $current_filter ) )
 						$current_filter[] = $term->term_id;
 
 					// Base Link decided by current page
@@ -238,7 +238,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 								if ( ! empty( $data['terms'] ) )
 									$link = add_query_arg( sanitize_title( str_replace( 'pa_', 'filter_', $name ) ), implode(',', $data['terms']), $link );
 
-								if ( $data['query_type'] == 'or' ) 
+								if ( $data['query_type'] == 'or' )
 									$link = add_query_arg( sanitize_title( str_replace( 'pa_', 'query_type_', $name ) ), 'or', $link );
 							}
 						}
@@ -253,7 +253,7 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 
 					// Current Filter = this widget
 					if ( isset( $_chosen_attributes[ $taxonomy ] ) && is_array( $_chosen_attributes[ $taxonomy ]['terms'] ) && in_array( $term->term_id, $_chosen_attributes[ $taxonomy ]['terms'] ) ) {
-						
+
 						$class = 'class="chosen"';
 
 						// Remove this term is $current_filter has more than 1 term filtered
@@ -263,10 +263,10 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 						}
 
 					} else {
-						
+
 						$class = '';
 						$link = add_query_arg( $arg, implode( ',', $current_filter ), $link );
-						
+
 					}
 
 					// Search Arg
@@ -317,15 +317,15 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 	 */
 	function update( $new_instance, $old_instance ) {
 		global $woocommerce;
-		
-		if ( empty( $new_instance['title'] ) ) 
+
+		if ( empty( $new_instance['title'] ) )
 			$new_instance['title'] = $woocommerce->attribute_label( $new_instance['attribute'] );
-		
+
 		$instance['title'] 			= strip_tags( stripslashes($new_instance['title'] ) );
 		$instance['attribute'] 		= stripslashes( $new_instance['attribute'] );
 		$instance['query_type'] 	= stripslashes( $new_instance['query_type'] );
 		$instance['display_type'] 	= stripslashes( $new_instance['display_type'] );
-		
+
 		return $instance;
 	}
 
@@ -340,10 +340,10 @@ class WooCommerce_Widget_Layered_Nav extends WP_Widget {
 	function form( $instance ) {
 		global $woocommerce;
 
-		if ( ! isset( $instance['query_type'] ) ) 
+		if ( ! isset( $instance['query_type'] ) )
 			$instance['query_type'] = 'and';
-			
-		if ( ! isset( $instance['display_type'] ) ) 
+
+		if ( ! isset( $instance['display_type'] ) )
 			$instance['display_type'] = 'list';
 		?>
 		<p><label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'woocommerce' ) ?></label>

--- a/widgets/widget-layered_nav_filters.php
+++ b/widgets/widget-layered_nav_filters.php
@@ -50,57 +50,57 @@ class WooCommerce_Widget_Layered_Nav_Filters extends WP_Widget {
 	 */
 	function widget( $args, $instance ) {
 		global $_chosen_attributes, $woocommerce, $_attributes_array;
-		
+
 		extract( $args );
 
-		if ( ! is_post_type_archive( 'product' ) && ! is_tax( array_merge( $_attributes_array, array( 'product_cat', 'product_tag' ) ) ) ) 
+		if ( ! is_post_type_archive( 'product' ) && ! is_tax( array_merge( $_attributes_array, array( 'product_cat', 'product_tag' ) ) ) )
 			return;
-			
+
 		$current_term 	= $_attributes_array && is_tax( $_attributes_array ) ? get_queried_object()->term_id : '';
 		$current_tax 	= $_attributes_array && is_tax( $_attributes_array ) ? get_queried_object()->taxonomy : '';
-		
+
 		$title = __( 'Active filters', 'woocommerce' );
 		//$title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base );
-		
+
 		// Price
 		$post_min = isset( $woocommerce->session->min_price ) ? $woocommerce->session->min_price : 0;
 		$post_max = isset( $woocommerce->session->max_price ) ? $woocommerce->session->max_price : 0;
-			
+
 		if ( count( $_chosen_attributes ) > 0 || $post_min > 0 || $post_max > 0 ) {
-			
+
 			echo $before_widget . $before_title . $title . $after_title;
 
 			echo "<ul>";
-			
+
 			// Attributes
 			foreach ( $_chosen_attributes as $taxonomy => $data ) {
-					
+
 				foreach ( $data['terms'] as $term_id ) {
 					$term 				= get_term( $term_id, $taxonomy );
 					$taxonomy_filter 	= str_replace( 'pa_', '', $taxonomy );
 					$current_filter 	= ! empty( $_GET[ 'filter_' . $taxonomy_filter ] ) ? $_GET[ 'filter_' . $taxonomy_filter ] : '';
 					$new_filter			= array_map( 'absint', explode( ',', $current_filter ) );
 					$new_filter			= array_diff( $new_filter, array( $term_id ) );
-					
+
 					$link = remove_query_arg( 'filter_' . $taxonomy_filter );
-					
+
 					if ( sizeof( $new_filter ) > 0 )
 						$link = add_query_arg( 'filter_' . $taxonomy_filter, implode( ',', $new_filter ), $link );
-					
+
 					echo '<li><a title="' . __( 'Remove filter', 'woocommerce' ) . '" href="' . $link . '">' . $term->name . '</a></li>';
 				}
 			}
-			
+
 			if ( $post_min ) {
 				$link = remove_query_arg( 'min_price' );
 				echo '<li><a title="' . __( 'Remove filter', 'woocommerce' ) . '" href="' . $link . '">' . __( 'Min', 'woocommerce' ) . ' ' . woocommerce_price( $post_min ) . '</a></li>';
 			}
-				
-			if ( $post_max ) {	
+
+			if ( $post_max ) {
 				$link = remove_query_arg( 'max_price' );
 				echo '<li><a title="' . __( 'Remove filter', 'woocommerce' ) . '" href="' . $link . '">' . __( 'Max', 'woocommerce' ) . ' ' . woocommerce_price( $post_max ) . '</a></li>';
 			}
-			
+
 			echo "</ul>";
 
 			echo $after_widget;

--- a/widgets/widget-recently_viewed.php
+++ b/widgets/widget-recently_viewed.php
@@ -173,18 +173,18 @@ class WooCommerce_Widget_Recently_Viewed extends WP_Widget {
  */
 function woocommerce_track_product_view() {
 	global $post, $product, $woocommerce;
-	
+
 	$viewed_products = $woocommerce->session->viewed_products;
 
-	if ( empty( $woocommerce->session->viewed_products ) ) 
+	if ( empty( $woocommerce->session->viewed_products ) )
 		$viewed_products = array();
 
-	if ( ! in_array( $post->ID, $viewed_products ) ) 
+	if ( ! in_array( $post->ID, $viewed_products ) )
 		$viewed_products[] = $post->ID;
 
-	if ( sizeof( $viewed_products ) > 15 ) 
+	if ( sizeof( $viewed_products ) > 15 )
 		array_shift( $viewed_products );
-		
+
 	$woocommerce->session->viewed_products = $viewed_products;
 }
 

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -122,7 +122,7 @@ function woocommerce_ajax_update_shipping_method() {
 
 	if ( ! defined('WOOCOMMERCE_CART') ) define( 'WOOCOMMERCE_CART', true );
 
-	if ( isset( $_POST['shipping_method'] ) ) 
+	if ( isset( $_POST['shipping_method'] ) )
 		$woocommerce->session->chosen_shipping_method = $_POST['shipping_method'];
 
 	$woocommerce->cart->calculate_totals();
@@ -147,7 +147,7 @@ function woocommerce_ajax_update_order_review() {
 
 	check_ajax_referer( 'update-order-review', 'security' );
 
-	if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) 
+	if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) )
 		define( 'WOOCOMMERCE_CHECKOUT', true );
 
 	if ( sizeof( $woocommerce->cart->get_cart() ) == 0 ) {
@@ -159,41 +159,41 @@ function woocommerce_ajax_update_order_review() {
 
 	$woocommerce->session->chosen_shipping_method = empty( $_POST['shipping_method'] ) ? '' : $_POST['shipping_method'];
 	$woocommerce->session->chosen_payment_method = empty( $_POST['payment_method'] ) ? '' : $_POST['payment_method'];
-	
-	if ( isset( $_POST['country'] ) ) 
+
+	if ( isset( $_POST['country'] ) )
 		$woocommerce->customer->set_country( $_POST['country'] );
-		
-	if ( isset( $_POST['state'] ) ) 
+
+	if ( isset( $_POST['state'] ) )
 		$woocommerce->customer->set_state( $_POST['state'] );
-		
-	if ( isset( $_POST['postcode'] ) ) 
+
+	if ( isset( $_POST['postcode'] ) )
 		$woocommerce->customer->set_postcode( $_POST['postcode'] );
-		
-	if ( isset( $_POST['city'] ) ) 
+
+	if ( isset( $_POST['city'] ) )
 		$woocommerce->customer->set_city( $_POST['city'] );
-				
-	if ( isset( $_POST['address'] ) ) 
+
+	if ( isset( $_POST['address'] ) )
 		$woocommerce->customer->set_address( $_POST['address'] );
-				
-	if ( isset( $_POST['address_2'] ) ) 
+
+	if ( isset( $_POST['address_2'] ) )
 		$woocommerce->customer->set_address_2( $_POST['address_2'] );
-		
-	if ( isset( $_POST['s_country'] ) ) 
+
+	if ( isset( $_POST['s_country'] ) )
 		$woocommerce->customer->set_shipping_country( $_POST['s_country'] );
-		
-	if ( isset( $_POST['s_state'] ) ) 
+
+	if ( isset( $_POST['s_state'] ) )
 		$woocommerce->customer->set_shipping_state( $_POST['s_state'] );
-		
-	if ( isset( $_POST['s_postcode'] ) ) 
+
+	if ( isset( $_POST['s_postcode'] ) )
 		$woocommerce->customer->set_shipping_postcode( $_POST['s_postcode'] );
-	
-	if ( isset( $_POST['s_city'] ) ) 
+
+	if ( isset( $_POST['s_city'] ) )
 		$woocommerce->customer->set_shipping_city( $_POST['s_city'] );
-	
-	if ( isset( $_POST['s_address'] ) ) 
+
+	if ( isset( $_POST['s_address'] ) )
 		$woocommerce->customer->set_shipping_address( $_POST['s_address'] );
-	
-	if ( isset( $_POST['s_address_2'] ) ) 
+
+	if ( isset( $_POST['s_address_2'] ) )
 		$woocommerce->customer->set_shipping_address_2( $_POST['s_address_2'] );
 
 	$woocommerce->cart->calculate_totals();
@@ -428,33 +428,33 @@ add_action('wp_ajax_woocommerce_remove_variations', 'woocommerce_remove_variatio
 
 function woocommerce_save_attributes() {
 	global $woocommerce;
-	
+
 	check_ajax_referer( 'save-attributes', 'security' );
 
 	// Get post ID
 	$post_id 	= absint( $_POST['post_id'] );
 	parse_str( $_POST['data'], $data );
-	
+
 	// Save Attributes
 	$attributes = array();
 
 	if ( isset( $data['attribute_names'] ) ) {
 		$attribute_names = $data['attribute_names'];
 		$attribute_values = $data['attribute_values'];
-		
-		if ( isset( $data['attribute_visibility'] ) ) 
+
+		if ( isset( $data['attribute_visibility'] ) )
 			$attribute_visibility = $data['attribute_visibility'];
-			
-		if ( isset( $data['attribute_variation'] ) ) 
+
+		if ( isset( $data['attribute_variation'] ) )
 			$attribute_variation = $data['attribute_variation'];
-		
+
 		$attribute_is_taxonomy = $data['attribute_is_taxonomy'];
 		$attribute_position = $data['attribute_position'];
 
 		$attribute_names_count = sizeof( $attribute_names );
 
 		for ( $i=0; $i < $attribute_names_count; $i++ ) {
-			if ( ! $attribute_names[ $i ] ) 
+			if ( ! $attribute_names[ $i ] )
 				continue;
 
 			$is_visible 	= isset( $attribute_visibility[ $i ] ) ? 1 : 0;
@@ -544,7 +544,7 @@ add_action('wp_ajax_woocommerce_save_attributes', 'woocommerce_save_attributes')
  */
 function woocommerce_add_variation() {
 	global $woocommerce;
-	
+
 	check_ajax_referer( 'add-variation', 'security' );
 
 	$post_id = intval( $_POST['post_id'] );
@@ -558,20 +558,20 @@ function woocommerce_add_variation() {
 		'post_parent' 	=> $post_id,
 		'post_type' 	=> 'product_variation'
 	);
-	
+
 	$variation_id = wp_insert_post( $variation );
-	
+
 	do_action( 'woocommerce_create_product_variation', $variation_id );
-	
+
 	if ( $variation_id ) {
-	
+
 		$variation_post_status = 'publish';
 		$variation_data = get_post_custom( $variation_id );
 		$variation_data['variation_post_id'] = $variation_id;
-		
+
 		// Get attributes
 		$attributes = (array) maybe_unserialize( get_post_meta( $post_id, '_product_attributes', true ) );
-		
+
 		// Get tax classes
 		$tax_classes = array_filter(array_map('trim', explode("\n", get_option('woocommerce_tax_classes'))));
 		$tax_class_options = array();
@@ -579,7 +579,7 @@ function woocommerce_add_variation() {
 		$tax_class_options[''] = __( 'Standard', 'woocommerce' );
 		if ($tax_classes) foreach ( $tax_classes as $class )
 			$tax_class_options[sanitize_title($class)] = $class;
-		
+
 		// Get parent data
 		$parent_data = array(
 			'id'		=> $post_id,
@@ -592,22 +592,22 @@ function woocommerce_add_variation() {
 			'height' 	=> get_post_meta( $post_id, '_height', true ),
 			'tax_class' => get_post_meta( $post_id, '_tax_class', true )
 		);
-	
+
 		if ( ! $parent_data['weight'] )
 			$parent_data['weight'] = '0.00';
-			
+
 		if ( ! $parent_data['length'] )
 			$parent_data['length'] = '0';
-			
+
 		if ( ! $parent_data['width'] )
 			$parent_data['width'] = '0';
-			
+
 		if ( ! $parent_data['height'] )
 			$parent_data['height'] = '0';
-			
+
 		$_tax_class = '';
 		$image_id = 0;
-			
+
 		include( 'admin/post-types/writepanels/variation-admin-html.php' );
 	}
 
@@ -629,7 +629,7 @@ function woocommerce_link_all_variations() {
 	if ( ! defined( 'WC_MAX_LINKED_VARIATIONS' ) ) {
 		define( 'WC_MAX_LINKED_VARIATIONS', 49 );
 	}
-	
+
 	check_ajax_referer( 'link-variations', 'security' );
 
 	@set_time_limit(0);
@@ -764,13 +764,13 @@ function woocommerce_link_all_variations() {
 		}
 
 		$added++;
-		
+
 		do_action( 'product_variation_linked', $variation_id );
 
 		if ( $added > WC_MAX_LINKED_VARIATIONS ) break;
 
 	}
-	
+
 	$woocommerce->clear_product_transients( $post_id );
 
 	echo $added;
@@ -821,7 +821,7 @@ function woocommerce_grant_access_to_download() {
 	$product_id = intval( $_POST['product_id'] );
 	$loop 		= intval( $_POST['loop'] );
 	$file_count = 0;
-	
+
 	$order 		= new WC_Order( $order_id );
 	$product 	= get_product( $product_id );
 
@@ -836,7 +836,7 @@ function woocommerce_grant_access_to_download() {
     // Default value is NULL in the table schema
 	$expiry 	= empty( $expiry ) ? null : (int) $expiry;
 
-	if ( $expiry ) 
+	if ( $expiry )
 		$expiry = date_i18n( "Y-m-d", strtotime( 'NOW + ' . $expiry . ' DAY' ) );
 
 	$wpdb->hide_errors();
@@ -844,7 +844,7 @@ function woocommerce_grant_access_to_download() {
 	$response = array();
 	if ( $file_paths ) {
 		foreach ( $file_paths as $download_id => $file_path ) {
-	
+
 		    $data = array(
 		    	'download_id'			=> $download_id,
 		        'product_id' 			=> $product_id,
@@ -856,7 +856,7 @@ function woocommerce_grant_access_to_download() {
 		        'access_granted'		=> current_time( 'mysql' ),
 		        'download_count'		=> 0
 		    );
-	
+
 		    $format = array(
 		    	'%s',
 		        '%s',
@@ -868,20 +868,20 @@ function woocommerce_grant_access_to_download() {
 		        '%s',
 		        '%d'
 		    );
-	
+
 		    if ( ! is_null( $expiry ) ) {
 		        $data['access_expires'] = $expiry;
 		        $format[] = '%s';
 		    }
-	
+
 		    // Downloadable product - give access to the customer
 		    $success = $wpdb->insert( $wpdb->prefix . 'woocommerce_downloadable_product_permissions',
 		        $data,
 		        $format
 		    );
-	
+
 			if ( $success ) {
-			
+
 				$download = new stdClass();
 				$download->product_id 	= $product_id;
 				$download->download_id 	= $download_id;
@@ -890,10 +890,10 @@ function woocommerce_grant_access_to_download() {
 				$download->download_count 		= 0;
 				$download->downloads_remaining 	= $limit;
 				$download->access_expires 		= $expiry;
-				
+
 				$loop++;
 				$file_count++;
-			
+
 				include( 'admin/post-types/writepanels/order-download-permission-html.php' );
 			}
 		}
@@ -960,20 +960,20 @@ function woocommerce_ajax_add_order_item() {
 	// Find the item
 	if ( ! is_numeric( $item_to_add ) )
 		die();
-		
+
 	$post = get_post( $item_to_add );
 
 	if ( ! $post || ( $post->post_type !== 'product' && $post->post_type !== 'product_variation' ) )
 		die();
-	
+
 	$_product = get_product( $post->ID );
-	
+
 	$order = new WC_Order( $order_id );
 	$class = 'new_row';
-	
+
 	// Set values
 	$item = array();
-	
+
 	$item['product_id'] 			= $_product->id;
 	$item['variation_id'] 			= isset( $_product->variation_id ) ? $_product->variation_id : '';
 	$item['name'] 					= $_product->get_title();
@@ -981,15 +981,15 @@ function woocommerce_ajax_add_order_item() {
 	$item['qty'] 					= 1;
 	$item['line_subtotal'] 			= number_format( (double) $_product->get_price_excluding_tax(), 2, '.', '' );
 	$item['line_subtotal_tax'] 		= '';
-	$item['line_total'] 			= number_format( (double) $_product->get_price_excluding_tax(), 2, '.', '' );	
+	$item['line_total'] 			= number_format( (double) $_product->get_price_excluding_tax(), 2, '.', '' );
 	$item['line_tax'] 				= '';
-	
+
 	// Add line item
    	$item_id = woocommerce_add_order_item( $order_id, array(
  		'order_item_name' 		=> $item['name'],
  		'order_item_type' 		=> 'line_item'
  	) );
- 	
+
  	// Add line item meta
  	if ( $item_id ) {
 	 	woocommerce_add_order_item_meta( $item_id, '_qty', $item['qty'] );
@@ -1001,7 +1001,7 @@ function woocommerce_ajax_add_order_item() {
 	 	woocommerce_add_order_item_meta( $item_id, '_line_total', $item['line_total'] );
 	 	woocommerce_add_order_item_meta( $item_id, '_line_tax', $item['line_tax'] );
  	}
-	
+
 	include( 'admin/post-types/writepanels/order-item-html.php' );
 
 	// Quit out
@@ -1024,20 +1024,20 @@ function woocommerce_ajax_add_order_fee() {
 
 	$order_id 	= absint( $_POST['order_id'] );
 	$order 		= new WC_Order( $order_id );
-	
+
 	// Add line item
    	$item_id = woocommerce_add_order_item( $order_id, array(
  		'order_item_name' 		=> '',
  		'order_item_type' 		=> 'fee'
  	) );
- 	
+
  	// Add line item meta
  	if ( $item_id ) {
 	 	woocommerce_add_order_item_meta( $item_id, '_tax_class', '' );
 	 	woocommerce_add_order_item_meta( $item_id, '_line_total', '' );
 	 	woocommerce_add_order_item_meta( $item_id, '_line_tax', '' );
  	}
-	
+
 	include( 'admin/post-types/writepanels/order-fee-html.php' );
 
 	// Quit out
@@ -1049,7 +1049,7 @@ add_action('wp_ajax_woocommerce_add_order_fee', 'woocommerce_ajax_add_order_fee'
 
 /**
  * woocommerce_ajax_remove_order_item function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1057,15 +1057,15 @@ function woocommerce_ajax_remove_order_item() {
 	global $woocommerce, $wpdb;
 
 	check_ajax_referer( 'order-item', 'security' );
-	
+
 	$order_item_ids = $_POST['order_item_ids'];
-	
+
 	if ( sizeof( $order_item_ids ) > 0 ) {
 		foreach( $order_item_ids as $id ) {
 			woocommerce_delete_order_item( absint( $id ) );
 		}
 	}
-	
+
 	die();
 }
 
@@ -1073,7 +1073,7 @@ add_action( 'wp_ajax_woocommerce_remove_order_item', 'woocommerce_ajax_remove_or
 
 /**
  * woocommerce_ajax_refund_order_item function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1084,7 +1084,7 @@ function woocommerce_ajax_refund_order_item() {
 
 	$order_id = absint( $_POST['order_id'] );
 	$order = &new WC_Order( $order_id );
-	
+
 	if ( $order ) {
 		global $woocommerce;
 		$gateways = $woocommerce->payment_gateways->get_available_payment_gateways();
@@ -1099,7 +1099,7 @@ function woocommerce_ajax_refund_order_item() {
 				$automated_refund = true;
 			}
 		}
-			
+
 		if ( sizeof( $order_item_ids ) > 0 ) {
 			$refund_amount = 0;
 
@@ -1135,7 +1135,7 @@ function woocommerce_ajax_refund_order_item() {
 			update_post_meta( $order_id, '_refund_total', woocommerce_format_total( $order_refund_total ) );
 		}
 	}
-	
+
 	die();
 }
 
@@ -1143,7 +1143,7 @@ add_action( 'wp_ajax_woocommerce_refund_order_item', 'woocommerce_ajax_refund_or
 
 /**
  * woocommerce_ajax_reduce_order_item_stock function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1151,18 +1151,18 @@ function woocommerce_ajax_reduce_order_item_stock() {
 	global $woocommerce, $wpdb;
 
 	check_ajax_referer( 'order-item', 'security' );
-	
+
 	$order_id		= absint( $_POST['order_id'] );
 	$order_item_ids	= $_POST['order_item_ids'];
 	$order_item_qty	= $_POST['order_item_qty'];
 	$order 			= new WC_Order( $order_id );
 	$order_items 	= $order->get_items();
 	$return 		= array();
-	
+
 	if ( $order && ! empty( $order_items ) && sizeof( $order_item_ids ) > 0 ) {
-		
+
 		foreach ( $order_items as $item_id => $order_item ) {
-			
+
 			// Only reduce checked items
 			if ( ! in_array( $item_id, $order_item_ids ) )
 				continue;
@@ -1173,26 +1173,26 @@ function woocommerce_ajax_reduce_order_item_stock() {
 
 				$old_stock 		= $_product->stock;
 				$new_quantity 	= $_product->reduce_stock( $order_item_qty[ $item_id ] );
-				
+
 				$return[] = sprintf( __( 'Item #%s stock reduced from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity );
 				$order->add_order_note( sprintf( __( 'Item #%s stock reduced from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity) );
 				$order->send_stock_notifications( $_product, $new_quantity, $order_item_qty[ $item_id ] );
 			}
-		} 	
-		
+		}
+
 		do_action( 'woocommerce_reduce_order_stock', $order );
-		
+
 		echo implode( ', ', $return );
 	}
-	
-	die();	
+
+	die();
 }
 
 add_action( 'wp_ajax_woocommerce_reduce_order_item_stock', 'woocommerce_ajax_reduce_order_item_stock' );
 
 /**
  * woocommerce_ajax_increase_order_item_stock function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1200,7 +1200,7 @@ function woocommerce_ajax_increase_order_item_stock() {
 	global $woocommerce, $wpdb;
 
 	check_ajax_referer( 'order-item', 'security' );
-	
+
 	$order_id		= absint( $_POST['order_id'] );
 	$order_item_ids	= $_POST['order_item_ids'];
 	$order_item_qty	= $_POST['order_item_qty'];
@@ -1209,9 +1209,9 @@ function woocommerce_ajax_increase_order_item_stock() {
 	$return 		= array();
 
 	if ( $order && ! empty( $order_items ) && sizeof( $order_item_ids ) > 0 ) {
-	
+
 		foreach ( $order_items as $item_id => $order_item ) {
-			
+
 			// Only reduce checked items
 			if ( ! in_array( $item_id, $order_item_ids ) )
 				continue;
@@ -1222,25 +1222,25 @@ function woocommerce_ajax_increase_order_item_stock() {
 
 				$old_stock 		= $_product->stock;
 				$new_quantity 	= $_product->increase_stock( $order_item_qty[ $item_id ] );
-				
+
 				$return[] = sprintf( __( 'Item #%s stock increased from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity );
 				$order->add_order_note( sprintf( __( 'Item #%s stock increased from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity ) );
 			}
-		} 	
-		
+		}
+
 		do_action( 'woocommerce_restore_order_stock', $order );
-		
+
 		echo implode( ', ', $return );
 	}
-	
-	die();	
+
+	die();
 }
 
 add_action( 'wp_ajax_woocommerce_increase_order_item_stock', 'woocommerce_ajax_increase_order_item_stock' );
 
 /**
  * woocommerce_ajax_add_order_item_meta function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1248,15 +1248,15 @@ function woocommerce_ajax_add_order_item_meta() {
 	global $woocommerce, $wpdb;
 
 	check_ajax_referer( 'order-item', 'security' );
-	
-	$meta_id = woocommerce_add_order_item_meta( absint( $_POST['order_item_id'] ), __( 'Name', 'woocommerce' ), __( 'Value', 'woocommerce' ) );	
-			
+
+	$meta_id = woocommerce_add_order_item_meta( absint( $_POST['order_item_id'] ), __( 'Name', 'woocommerce' ), __( 'Value', 'woocommerce' ) );
+
 	if ( $meta_id ) {
-		
-		echo '<tr data-meta_id="' . $meta_id . '"><td><input type="text" name="meta_key[' . $meta_id . ']" value="" /></td><td><input type="text" name="meta_value[' . $meta_id . ']" value="" /></td><td width="1%"><button class="remove_order_item_meta button">&times;</button></td></tr>';		
-		
+
+		echo '<tr data-meta_id="' . $meta_id . '"><td><input type="text" name="meta_key[' . $meta_id . ']" value="" /></td><td><input type="text" name="meta_value[' . $meta_id . ']" value="" /></td><td width="1%"><button class="remove_order_item_meta button">&times;</button></td></tr>';
+
 	}
-	
+
 	die();
 }
 
@@ -1265,7 +1265,7 @@ add_action( 'wp_ajax_woocommerce_add_order_item_meta', 'woocommerce_ajax_add_ord
 
 /**
  * woocommerce_ajax_remove_order_item_meta function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1273,11 +1273,11 @@ function woocommerce_ajax_remove_order_item_meta() {
 	global $woocommerce, $wpdb;
 
 	check_ajax_referer( 'order-item', 'security' );
-	
+
 	$meta_id = absint( $_POST['meta_id'] );
-	
+
 	$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_id = %d", $meta_id ) );
-	
+
 	die();
 }
 
@@ -1298,7 +1298,7 @@ function woocommerce_calc_line_taxes() {
 	$tax = new WC_Tax();
 
 	$taxes = $tax_rows = $item_taxes = $shipping_taxes = array();
-	
+
 	$order_id 		= absint( $_POST['order_id'] );
 	$country 		= strtoupper( esc_attr( $_POST['country'] ) );
 	$state 			= strtoupper( esc_attr( $_POST['state'] ) );
@@ -1308,19 +1308,19 @@ function woocommerce_calc_line_taxes() {
 	$items			= $_POST['items'];
 	$shipping		= $_POST['shipping'];
 	$item_tax		= 0;
-	
+
 	// Calculate sales tax first
 	if ( sizeof( $items ) > 0 ) {
 		foreach( $items as $item_id => $item ) {
-			
+
 			$item_id		= absint( $item_id );
 			$line_subtotal 	= isset( $item['line_subtotal']  ) ? esc_attr( $item['line_subtotal'] ) : '';
 			$line_total		= esc_attr( $item['line_total'] );
 			$tax_class 		= esc_attr( $item['tax_class'] );
-			
-			if ( ! $item_id || $tax_class == '0' ) 
+
+			if ( ! $item_id || $tax_class == '0' )
 				continue;
-			
+
 			// Get product details
 			if ( get_post_type( $item_id ) == 'product' ) {
 				$_product			= get_product( $item_id );
@@ -1328,72 +1328,72 @@ function woocommerce_calc_line_taxes() {
 			} else {
 				$item_tax_status 	= 'taxable';
 			}
-			
+
 			// Only calc if taxable
 			if ( $item_tax_status == 'taxable' ) {
 
 				$tax_rates = $tax->find_rates( array(
-					'country' 	=> $country, 
-					'state' 	=> $state, 
-					'postcode' 	=> $postcode, 
+					'country' 	=> $country,
+					'state' 	=> $state,
+					'postcode' 	=> $postcode,
 					'city'		=> $city,
-					'tax_class' => $tax_class 
+					'tax_class' => $tax_class
 				) );
-				
+
 				$line_subtotal_taxes = $tax->calc_tax( $line_subtotal, $tax_rates, false );
 				$line_taxes = $tax->calc_tax( $line_total, $tax_rates, false );
-				
+
 				$line_subtotal_tax = rtrim( rtrim( number_format( array_sum( $line_subtotal_taxes ), 4, '.', '' ), '0' ), '.' );
 				$line_tax = rtrim( rtrim( number_format( array_sum( $line_taxes ), 4, '.', '' ), '0' ), '.' );
-				
-				if ( $line_subtotal_tax < 0 ) 
+
+				if ( $line_subtotal_tax < 0 )
 					$line_subtotal_tax = 0;
-					
-				if ( $line_tax < 0 ) 
+
+				if ( $line_tax < 0 )
 					$line_tax = 0;
-				
+
 				$item_taxes[ $item_id ] = array(
 					'line_subtotal_tax' => $line_subtotal_tax,
 					'line_tax' 			=> $line_tax
 				);
-				
+
 				$item_tax += $line_tax;
-				
+
 				// Sum the item taxes
 				foreach ( array_keys( $taxes + $line_taxes ) as $key )
 					$taxes[ $key ] = ( isset( $line_taxes[ $key ] ) ? $line_taxes[ $key ] : 0 ) + ( isset( $taxes[ $key ] ) ? $taxes[ $key ] : 0 );
 			}
-			
+
 		}
 	}
-	
+
 	// Now calculate shipping tax
 	$matched_tax_rates = array();
 
 	$tax_rates = $tax->find_rates( array(
-		'country' 	=> $country, 
-		'state' 	=> $state, 
-		'postcode' 	=> $postcode, 
+		'country' 	=> $country,
+		'state' 	=> $state,
+		'postcode' 	=> $postcode,
 		'city'		=> $city,
 		'tax_class' => ''
 	) );
 
-	if ( $tax_rates ) 
+	if ( $tax_rates )
 		foreach ( $tax_rates as $key => $rate )
 			if ( isset( $rate['shipping'] ) && $rate['shipping'] == 'yes' )
 				$matched_tax_rates[ $key ] = $rate;
-	
+
 	$shipping_taxes = $tax->calc_shipping_tax( $shipping, $matched_tax_rates );
 	$shipping_tax = rtrim( rtrim( number_format( array_sum( $shipping_taxes ), 2, '.', '' ), '0' ), '.' );
 
 	// Remove old tax rows
 	$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id IN ( SELECT order_item_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = 'tax' )", $order_id ) );
-				
+
 	$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = 'tax'", $order_id ) );
 
 	// Now merge to keep tax rows
 	ob_start();
-	
+
 	foreach ( array_keys( $taxes + $shipping_taxes ) as $key ) {
 
 	 	$item 							= array();
@@ -1402,7 +1402,7 @@ function woocommerce_calc_line_taxes() {
 		$item['tax_amount'] 			= woocommerce_format_total( isset( $taxes[ $key ] ) ? $taxes[ $key ] : 0 );
 		$item['shipping_tax_amount'] 	= woocommerce_format_total( isset( $shipping_taxes[ $key ] ) ? $shipping_taxes[ $key ] : 0 );
 
-		if ( ! $item['name'] ) 
+		if ( ! $item['name'] )
 			$item['name'] = $woocommerce->countries->tax_or_vat();
 
 		// Add line item
@@ -1410,19 +1410,19 @@ function woocommerce_calc_line_taxes() {
 	 		'order_item_name' 		=> $item['name'],
 	 		'order_item_type' 		=> 'tax'
 	 	) );
-	 	
+
 	 	// Add line item meta
 	 	if ( $item_id ) {
 		 	woocommerce_add_order_item_meta( $item_id, 'compound', $item['compound'] );
 		 	woocommerce_add_order_item_meta( $item_id, 'tax_amount', $item['tax_amount'] );
 		 	woocommerce_add_order_item_meta( $item_id, 'shipping_tax_amount', $item['shipping_tax_amount'] );
 	 	}
-		
+
 		include( 'admin/post-types/writepanels/order-tax-html.php' );
 	}
-	
+
 	$tax_row_html = ob_get_clean();
-	
+
 	// Return
 	echo json_encode( array(
 		'item_tax' 		=> $item_tax,
@@ -1439,7 +1439,7 @@ add_action('wp_ajax_woocommerce_calc_line_taxes', 'woocommerce_calc_line_taxes')
 
 /**
  * woocommerce_add_line_tax function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1447,25 +1447,25 @@ function woocommerce_add_line_tax() {
 	global $woocommerce;
 
 	check_ajax_referer( 'calc-totals', 'security' );
-	
+
 	$order_id 	= absint( $_POST['order_id'] );
 	$order 		= new WC_Order( $order_id );
-	
+
 	// Add line item
    	$item_id = woocommerce_add_order_item( $order_id, array(
  		'order_item_name' 		=> '',
  		'order_item_type' 		=> 'tax'
  	) );
- 	
+
  	// Add line item meta
  	if ( $item_id ) {
 	 	woocommerce_add_order_item_meta( $item_id, 'compound', '' );
 	 	woocommerce_add_order_item_meta( $item_id, 'tax_amount', '' );
 	 	woocommerce_add_order_item_meta( $item_id, 'shipping_tax_amount', '' );
  	}
-	
+
 	include( 'admin/post-types/writepanels/order-tax-html.php' );
-	
+
 	// Quit out
 	die();
 }
@@ -1474,7 +1474,7 @@ add_action('wp_ajax_woocommerce_add_line_tax', 'woocommerce_add_line_tax');
 
 /**
  * woocommerce_add_line_tax function.
- * 
+ *
  * @access public
  * @return void
  */
@@ -1482,11 +1482,11 @@ function woocommerce_remove_line_tax() {
 	global $woocommerce;
 
 	check_ajax_referer( 'calc-totals', 'security' );
-	
+
 	$tax_row_id = absint( $_POST['tax_row_id'] );
-	
+
 	woocommerce_delete_order_item( $tax_row_id );
-	
+
 	// Quit out
 	die();
 }
@@ -1887,30 +1887,30 @@ add_action( 'wp_ajax_woocommerce_product_ordering', 'woocommerce_product_orderin
 
 /**
  * woocommerce_product_images_box_upload function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_product_images_box_upload() {
-	
+
 	check_ajax_referer( 'product-images-box-upload' );
-	
+
 	// Get posted data
 	$file 			= $_FILES['async-upload'];
 	$post_id 		= absint( $_POST['post_id'] );
-	
+
 	// Get size
-	$attachments =& get_children( 'post_parent=' . $post_id . '&numberposts=-1&post_type=attachment&post_mime_type=image' ); 
+	$attachments =& get_children( 'post_parent=' . $post_id . '&numberposts=-1&post_type=attachment&post_mime_type=image' );
 	$gallery_size 	= absint( sizeof( $attachments ) );
-	
+
 	// Upload
 	$upload = wp_handle_upload( $file, array( 'test_form' => false ) );
-	
+
 	if( ! isset( $upload['error'] ) && isset( $upload['file'] ) ) {
-	
+
 		// Create attachment
 		require_once( ABSPATH . 'wp-admin/includes/image.php' );
-		
+
 		$attachment_id = wp_insert_attachment( array(
 			'post_mime_type' 	=> $upload['type'],
 			'post_title' 		=> preg_replace( '/\.[^.]+$/', '', basename( $upload['file'] ) ),
@@ -1918,19 +1918,19 @@ function woocommerce_product_images_box_upload() {
 			'post_status' 		=> 'inherit',
 			'menu_order'		=> ( $gallery_size + 1 )
 		), $upload['file'], $post_id );
-		
+
 		$attachment_data = wp_generate_attachment_metadata( $attachment_id, $upload['file'] );
 		wp_update_attachment_metadata( $attachment_id, $attachment_data );
-	
+
 		// Return the result
 		$image = wp_get_attachment_image_src( $attachment_id, 'full' );
-		
+
 		$result = array(
 			'src'		=> $image[0],
 			'post_id' 	=> $attachment_id,
 			'edit_url'	=> admin_url( 'media-upload.php?post_id=' . $post_id . '&attachment_id=' . $attachment_id . '&tab=library&width=640&height=553&TB_iframe=1' )
 		);
-	
+
 	} else {
 		$result = array(
 			'error'		=> $upload['error']
@@ -1946,43 +1946,43 @@ add_action( 'wp_ajax_woocommerce_product_images_box_upload', 'woocommerce_produc
 
 /**
  * woocommerce_product_image_ordering function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_product_image_ordering() {
-	
+
 	check_ajax_referer( 'product-image-ordering' );
-	
+
 	$post_id				= isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : false;
 	$attachment_id			= isset( $_POST['attachment_id'] ) ? absint( $_POST['attachment_id'] ) : false;
 	$prev_attachment_id		= isset( $_POST['prev_attachment_id'] ) ? absint( $_POST['prev_attachment_id'] ) : false;
 	$next_attachment_id 	= isset( $_POST['next_attachment_id'] ) ? absint( $_POST['next_attachment_id'] ) : false;
-	
+
 	if ( ! $post_id || ! $attachment_id )
 		die( -1 );
-		
-	$siblings = get_children( 'post_parent=' . $post_id . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' ); 
+
+	$siblings = get_children( 'post_parent=' . $post_id . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' );
 
 	$new_positions = array(); // store new positions for ajax
 	$menu_order = 1;
 
 	foreach( $siblings as $sibling_id => $sibling ) {
-	
+
 		if ( $sibling_id == $attachment_id )
 			continue;
 
 		// if this is the post that comes after our repositioned post, set our repositioned post position and increment menu order
 		if ( $next_attachment_id && $next_attachment_id == $sibling_id ) {
-		
+
 			$attachment = array();
 			$attachment['ID'] = $attachment_id;
 			$attachment['menu_order'] = $menu_order;
-		
+
 			wp_update_post( $attachment );
-			
+
 			$new_positions[ $attachment_id ] = $menu_order;
-			
+
 			$menu_order++;
 		}
 
@@ -1995,29 +1995,29 @@ function woocommerce_product_image_ordering() {
 		$attachment['ID'] = $sibling_id;
 		$attachment['menu_order'] = $menu_order;
 		wp_update_post( $attachment );
-			
+
 		$new_positions[ $sibling_id ] = $menu_order;
 		$menu_order++;
 
 		if ( ! $next_attachment_id && $prev_attachment_id == $sibling_id ) {
-			
+
 			$attachment = array();
 			$attachment['ID'] = $attachment_id;
 			$attachment['menu_order'] = $menu_order;
-		
+
 			wp_update_post( $attachment );
-			
+
 			$new_positions[ $attachment_id ] = $menu_order;
-			
+
 			$menu_order++;
 		}
 	}
-	
+
 	// Set featured image
 	$new_positions = array_flip( $new_positions );
 	if ( isset( $new_positions[1] ) )
 		update_post_meta( $post_id, '_thumbnail_id', $new_positions[1] );
-		
+
 	die();
 }
 
@@ -2026,31 +2026,31 @@ add_action( 'wp_ajax_woocommerce_product_image_ordering', 'woocommerce_product_i
 
 /**
  * woocommerce_product_image_delete function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_product_image_delete() {
-	
+
 	check_ajax_referer( 'product-image-delete' );
-	
+
 	$post_id				= isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : false;
 	$attachment_id			= isset( $_POST['attachment_id'] ) ? absint( $_POST['attachment_id'] ) : false;
-	
+
 	if ( ! $post_id || ! $attachment_id )
 		die( -1 );
-		
+
 	wp_delete_attachment( $attachment_id );
-	
+
 	$thumbnail_id = get_post_thumbnail_id( $post_id );
-	
+
 	if ( $thumbnail_id == $attachment_id ) {
-		$attachments = get_children( 'post_parent=' . $post_id . '&numberposts=1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' ); 
+		$attachments = get_children( 'post_parent=' . $post_id . '&numberposts=1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' );
 		foreach ( $attachments as $attachment_id => $attachment ) {
 			update_post_meta( $post_id, '_thumbnail_id', $attachment_id );
 		}
 	}
-		
+
 	die();
 }
 
@@ -2058,44 +2058,44 @@ add_action( 'wp_ajax_woocommerce_product_image_delete', 'woocommerce_product_ima
 
 /**
  * woocommerce_product_image_refresh function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_product_image_refresh() {
-	
+
 	check_ajax_referer( 'product-image-refresh' );
-	
+
 	$post_id			= isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : false;
-	
+
 	if ( ! $post_id )
 		die();
 	?>
 	<ul class="product_images">
-		<?php 
+		<?php
 			$thumbnail_id 	= get_post_thumbnail_id( $post_id );
-			
+
 			if ( $thumbnail_id )
 				echo '<li class="image" data-post_id="' . $thumbnail_id . '">
 					' . wp_get_attachment_image( $thumbnail_id, 'full' ) . '
-					<span class="loading"></span> 
+					<span class="loading"></span>
 					<ul class="actions">
 						<li><a href="#" class="delete">' . __( 'Delete', 'woocommerce' ) . '</a></li>
 						<li><a href="' . admin_url( 'media-upload.php?post_id=' . $post_id . '&attachment_id=' . $thumbnail_id . '&tab=library&width=640&height=553&TB_iframe=1' ) . '" class="view thickbox" onclick="return false;">' . __( 'View', 'woocommerce' ) . '</a></li>
 					</ul>
 				</li>';
-	
-			$attachments =& get_children( 'post_parent=' . $post_id . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' ); 
-			
+
+			$attachments =& get_children( 'post_parent=' . $post_id . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image' );
+
 			foreach ( $attachments as $attachment_id => $attachment ) {
 				if ( $thumbnail_id == $attachment_id )
 					continue;
-					
+
 				$exclude_class = get_post_meta( $attachment_id, '_woocommerce_exclude_image', true ) == 1 ? 'excluded' : '';
-				
+
 				echo '<li class="image ' . $exclude_class . '" data-post_id="' . $attachment_id . '">
 					' . wp_get_attachment_image( $attachment_id, 'full' ) . '
-					<span class="loading"></span> 
+					<span class="loading"></span>
 					<ul class="actions">
 						<li><a href="#" class="delete">' . __( 'Delete', 'woocommerce' ) . '</a></li>
 						<li><a href="' . admin_url( 'media-upload.php?post_id=' . $post_id . '&attachment_id=' . $attachment_id . '&tab=library&width=640&height=553&TB_iframe=1' ) . '" class="view thickbox" onclick="return false;">' . __( 'View', 'woocommerce' ) . '</a></li>
@@ -2105,7 +2105,7 @@ function woocommerce_product_image_refresh() {
 		?>
 	</ul>
 	<?php
-	
+
 	die();
 }
 

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -20,8 +20,8 @@ add_filter( 'woocommerce_coupon_code', 'strtolower' ); // Coupons case-insensiti
 add_filter( 'woocommerce_stock_amount', 'absint' ); // Stock amounts are integers by default
 
 /**
- * Main function for returning products, uses the WC_Product_Factory class. 
- * 
+ * Main function for returning products, uses the WC_Product_Factory class.
+ *
  * @access public
  * @param mixed $the_product Post object or post ID of the product.
  * @param array $args (default: array()) Contains all arguments to be used to get this product.
@@ -375,8 +375,8 @@ if ( ! function_exists( 'is_filtered' ) ) {
 	 * @return bool
 	 */
 	function is_filtered() {
-		global $_chosen_attributes;	
-			
+		global $_chosen_attributes;
+
 		return ( sizeof( $_chosen_attributes ) > 0 || ( isset( $_GET['max_price'] ) && isset( $_GET['min_price'] ) ) ) ? true : false;
 	}
 }
@@ -557,7 +557,7 @@ function woocommerce_price( $price, $args = array() ) {
 
 	if ( get_option( 'woocommerce_price_trim_zeros' ) == 'yes' && $num_decimals > 0 )
 		$price = woocommerce_trim_zeros( $price );
-		
+
 	$return = '<span class="amount">' . sprintf( get_woocommerce_price_format(), $currency_symbol, $price ) . '</span>';
 
 	if ( $ex_tax_label && get_option( 'woocommerce_calc_taxes' ) == 'yes' )
@@ -568,7 +568,7 @@ function woocommerce_price( $price, $args = array() ) {
 
 function get_woocommerce_price_format() {
 	$currency_pos = get_option( 'woocommerce_currency_pos' );
-	
+
 	switch ( $currency_pos ) {
 		case 'left' :
 			return '%1$s%2$s';
@@ -603,10 +603,10 @@ function woocommerce_trim_zeros( $price ) {
  */
 function woocommerce_format_decimal( $number ) {
 	$number = number_format( (float) $number, get_option( 'woocommerce_price_num_decimals' ), '.', '' );
-	
+
 	if ( strstr( $number, '.' ) )
 		$number = rtrim( rtrim( $number, '0' ), '.' );
-		
+
 	return $number;
 }
 
@@ -978,7 +978,7 @@ add_action('woocommerce_order_status_completed', 'woocommerce_downloadable_produ
 
 /**
  * Grant downloadable product access to the file identified by $download_id
- * 
+ *
  * @access public
  * @param string $download_id file identifier
  * @param int $product_id product identifier
@@ -1068,11 +1068,11 @@ function woocommerce_product_post_type_link( $permalink, $post ) {
     // Abort if post is not a product
     if ( $post->post_type !== 'product' )
     	return $permalink;
-    	
+
     // Abort early if the placeholder rewrite tag isn't in the generated URL
     if ( false === strpos( $permalink, '%' ) )
     	return $permalink;
-    	
+
     // Get the custom taxonomy terms in use by this post
     $terms = get_the_terms( $post->ID, 'product_cat' );
 
@@ -1084,7 +1084,7 @@ function woocommerce_product_post_type_link( $permalink, $post ) {
         $first_term = array_shift( $terms );
         $product_cat = $first_term->slug;
     }
-    
+
     $find = array(
     	'%year%',
     	'%monthnum%',
@@ -1096,7 +1096,7 @@ function woocommerce_product_post_type_link( $permalink, $post ) {
     	'%category%',
     	'%product_cat%'
     );
-    
+
     $replace = array(
     	date_i18n( 'Y', strtotime( $post->post_date ) ),
     	date_i18n( 'm', strtotime( $post->post_date ) ),
@@ -1107,10 +1107,10 @@ function woocommerce_product_post_type_link( $permalink, $post ) {
     	$post->ID,
     	$product_cat,
     	$product_cat
-    );	
-    
+    );
+
     $replace = array_map( 'sanitize_title', $replace );
-    
+
     $permalink = str_replace( $find, $replace, $permalink );
 
     return $permalink;
@@ -1301,10 +1301,10 @@ function woocommerce_taxonomy_metadata_wpdbfix() {
 	global $wpdb;
 	$termmeta_name = 'woocommerce_termmeta';
 	$itemmeta_name = 'woocommerce_order_itemmeta';
-	
+
 	$wpdb->woocommerce_termmeta = $wpdb->prefix . $termmeta_name;
 	$wpdb->order_itemmeta = $wpdb->prefix . $itemmeta_name;
-	
+
 	$wpdb->tables[] = 'woocommerce_termmeta';
 	$wpdb->tables[] = 'order_itemmeta';
 }
@@ -1456,7 +1456,7 @@ function woocommerce_set_term_order( $term_id, $index, $taxonomy, $recursive = f
 		$index ++;
 		$index = woocommerce_set_term_order($term->term_id, $index, $taxonomy, true);
 	}
-	
+
 	clean_term_cache( $term_id, $taxonomy );
 
 	return $index;
@@ -1519,7 +1519,7 @@ function woocommerce_customer_bought_product( $customer_email, $user_id, $produc
 		return false;
 
 	return $wpdb->get_var( $wpdb->prepare( "
-		SELECT COUNT( order_items.order_item_id ) 
+		SELECT COUNT( order_items.order_item_id )
 		FROM {$wpdb->prefix}woocommerce_order_items as order_items
 		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS itemmeta ON order_items.order_item_id = itemmeta.order_item_id
 		LEFT JOIN {$wpdb->postmeta} AS postmeta ON order_items.order_id = postmeta.post_id
@@ -1530,22 +1530,22 @@ function woocommerce_customer_bought_product( $customer_email, $user_id, $produc
 		AND 	tax.taxonomy		= 'shop_order_status'
 		AND		(
 					(
-						itemmeta.meta_key = '_variation_id' 
+						itemmeta.meta_key = '_variation_id'
 						AND itemmeta.meta_value = %s
-					) OR ( 
-						itemmeta.meta_key = '_product_id' 
+					) OR (
+						itemmeta.meta_key = '_product_id'
 						AND itemmeta.meta_value = %s
 					)
 		)
-		AND 	( 
+		AND 	(
 					(
-						postmeta.meta_key = '_billing_email' 
-						AND postmeta.meta_value IN ( '" . implode( "','", array_unique( $emails ) ) . "' ) 
-					) OR ( 
-						postmeta.meta_key = '_customer_user' 
-						AND postmeta.meta_value = %s AND postmeta.meta_value > 0 
+						postmeta.meta_key = '_billing_email'
+						AND postmeta.meta_value IN ( '" . implode( "','", array_unique( $emails ) ) . "' )
+					) OR (
+						postmeta.meta_key = '_customer_user'
+						AND postmeta.meta_value = %s AND postmeta.meta_value > 0
 					)
-				) 
+				)
 	", $product_id, $product_id, $user_id ) );
 }
 
@@ -1575,24 +1575,24 @@ function woocommerce_processing_order_count() {
 
 /**
  * Get capabilities for WooCommerce - these are assigned to admin/shop manager during installation or reset
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_get_core_capabilities() {
 	$capabilities = array();
-			
+
 	$capabilities['core'] = array(
-		"manage_woocommerce", 
+		"manage_woocommerce",
 		"view_woocommerce_reports"
 	);
-	
+
 	$capability_types = array( 'product', 'shop_order', 'shop_coupon' );
-	
+
 	foreach( $capability_types as $capability_type ) {
-	
+
 		$capabilities[ $capability_type ] = array(
-			
+
 			// Post type
 			"edit_{$capability_type}",
 			"read_{$capability_type}",
@@ -1607,7 +1607,7 @@ function woocommerce_get_core_capabilities() {
 			"delete_others_{$capability_type}s",
 			"edit_private_{$capability_type}s",
 			"edit_published_{$capability_type}s",
-			
+
 			// Terms
 			"manage_{$capability_type}_terms",
 			"edit_{$capability_type}_terms",
@@ -1615,22 +1615,22 @@ function woocommerce_get_core_capabilities() {
 			"assign_{$capability_type}_terms"
 		);
 	}
-	
+
 	return $capabilities;
 }
 
 
 /**
  * woocommerce_init_roles function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_init_roles() {
 	global $wp_roles;
 
-	if ( class_exists('WP_Roles') ) 
-		if ( ! isset( $wp_roles ) ) 
+	if ( class_exists('WP_Roles') )
+		if ( ! isset( $wp_roles ) )
 			$wp_roles = new WP_Roles();
 
 	if ( is_object( $wp_roles ) ) {
@@ -1674,9 +1674,9 @@ function woocommerce_init_roles() {
 		   	'export'					=> true,
 			'import'					=> true
 		) );
-		
+
 		$capabilities = woocommerce_get_core_capabilities();
-		
+
 		foreach( $capabilities as $cap_group ) {
 			foreach( $cap_group as $cap ) {
 				$wp_roles->add_cap( 'shop_manager', $cap );
@@ -1688,28 +1688,28 @@ function woocommerce_init_roles() {
 
 /**
  * woocommerce_remove_roles function.
- * 
+ *
  * @access public
  * @return void
  */
 function woocommerce_remove_roles() {
 	global $wp_roles;
 
-	if ( class_exists('WP_Roles') ) 
-		if ( ! isset( $wp_roles ) ) 
+	if ( class_exists('WP_Roles') )
+		if ( ! isset( $wp_roles ) )
 			$wp_roles = new WP_Roles();
 
 	if ( is_object( $wp_roles ) ) {
 
 		$capabilities = woocommerce_get_core_capabilities();
-		
+
 		foreach( $capabilities as $cap_group ) {
 			foreach( $cap_group as $cap ) {
 				$wp_roles->remove_cap( 'shop_manager', $cap );
 				$wp_roles->remove_cap( 'administrator', $cap );
 			}
 		}
-		
+
 		remove_role( 'customer' );
 		remove_role( 'shop_manager' );
 	}
@@ -1718,7 +1718,7 @@ function woocommerce_remove_roles() {
 
 /**
  * Add a item to an order (for example a line item).
- * 
+ *
  * @access public
  * @param int $order_id
  * @param array $data
@@ -1726,9 +1726,9 @@ function woocommerce_remove_roles() {
  */
 function woocommerce_add_order_item( $order_id, $item ) {
 	global $wpdb;
-	
+
 	$order_id = absint( $order_id );
-	
+
 	if ( ! $order_id )
 		return false;
 
@@ -1738,45 +1738,45 @@ function woocommerce_add_order_item( $order_id, $item ) {
 	);
 
 	$item = wp_parse_args( $item, $defaults );
-	
-	$wpdb->insert( 
+
+	$wpdb->insert(
 		$wpdb->prefix . "woocommerce_order_items",
-		array( 
+		array(
 			'order_item_name' 		=> $item['order_item_name'],
 			'order_item_type' 		=> $item['order_item_type'],
 			'order_id'				=> $order_id
-		), 
+		),
 		array(
 			'%s', '%s', '%d'
 		)
 	);
-	
+
 	do_action( 'woocommerce_new_order_item', absint( $wpdb->insert_id ) );
-	
+
 	return absint( $wpdb->insert_id );
 }
 
 /**
  * woocommerce_delete_order_item function.
- * 
+ *
  * @access public
  * @param int $item_id
  * @return bool
  */
 function woocommerce_delete_order_item( $item_id ) {
 	global $wpdb;
-	
+
 	$item_id = absint( $item_id );
-	
+
 	if ( ! $item_id )
 		return false;
-	
+
 	$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d", $item_id ) );
 	$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d", $item_id ) );
-	
+
 	do_action( 'woocommerce_delete_order_item', $item_id );
-	
-	return true;	
+
+	return true;
 }
 
 /**

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -149,7 +149,7 @@ function woocommerce_nav_menu_items( $items, $args ) {
  */
 function woocommerce_update_catalog_ordering() {
 	global $woocommerce;
-	
+
 	if ( isset( $_REQUEST['sort'] ) && $_REQUEST['sort'] != '' )
 		$woocommerce->session->orderby = esc_attr( $_REQUEST['sort'] );
 }
@@ -191,9 +191,9 @@ function woocommerce_update_cart_action() {
 
 				// Sanitize
 				$quantity = preg_replace( "/[^0-9\.]/", "", $cart_totals[ $cart_item_key ]['qty'] );
-				
+
 				if ( $quantity == "" )
-					continue;				
+					continue;
 
 				// Update cart validation
 	    		$passed_validation 	= apply_filters( 'woocommerce_update_cart_validation', true, $cart_item_key, $values, $quantity );
@@ -238,19 +238,19 @@ function woocommerce_update_cart_action() {
  * @return void
  */
 function woocommerce_add_to_cart_action( $url = false ) {
-	
-	if ( empty( $_REQUEST['add-to-cart'] ) || ! is_numeric( $_REQUEST['add-to-cart'] ) ) 
+
+	if ( empty( $_REQUEST['add-to-cart'] ) || ! is_numeric( $_REQUEST['add-to-cart'] ) )
 		return;
 
 	global $woocommerce;
-	
+
 	$product_id			= apply_filters('woocommerce_add_to_cart_product_id', absint( $_REQUEST['add-to-cart'] ) );
 	$was_added_to_cart 	= false;
 	$adding_to_cart 	= get_product( $product_id );
-    
+
     // Variable product handling
     if ( $adding_to_cart->is_type( 'variable' ) ) {
-    
+
     	$variation_id 		= empty( $_REQUEST['variation_id'] ) ? '' : absint( $_REQUEST['variation_id'] );
     	$quantity 			= empty( $_REQUEST['quantity'] ) ? 1 : apply_filters( 'woocommerce_stock_amount', $_REQUEST['quantity'] );
     	$all_variations_set = true;
@@ -262,12 +262,12 @@ function woocommerce_add_to_cart_action( $url = false ) {
 			wp_redirect( get_permalink( $product_id ) );
 			exit;
 		}
-		
+
 		$attributes = (array) maybe_unserialize( get_post_meta( $product_id, '_product_attributes', true ) );
 
 		// Verify all attributes for the variable product were set
 		foreach ( $attributes as $attribute ) {
-            if ( ! $attribute['is_variation'] ) 
+            if ( ! $attribute['is_variation'] )
             	continue;
 
             $taxonomy = 'attribute_' . sanitize_title( $attribute['name'] );
@@ -302,19 +302,19 @@ function woocommerce_add_to_cart_action( $url = false ) {
     } elseif ( $adding_to_cart->is_type( 'grouped' ) ) {
 
 		if ( ! empty( $_REQUEST['quantity'] ) && is_array( $_REQUEST['quantity'] ) ) {
-		
+
 			$quantity_set = false;
 			$added_to_cart = array();
-		
+
 			foreach ( $_REQUEST['quantity'] as $item => $quantity ) {
-				if ( $quantity <= 0 ) 
+				if ( $quantity <= 0 )
 					continue;
-		
+
 				$quantity_set = true;
-		
+
 				// Add to cart validation
 				$passed_validation 	= apply_filters( 'woocommerce_add_to_cart_validation', true, $item, $quantity );
-		
+
 				if ( $passed_validation ) {
 					if ( $woocommerce->cart->add_to_cart( $item, $quantity ) ) {
 						$was_added_to_cart = true;
@@ -322,24 +322,24 @@ function woocommerce_add_to_cart_action( $url = false ) {
 					}
 				}
 			}
-			
+
 			if ( $was_added_to_cart ) {
 				woocommerce_add_to_cart_message( $added_to_cart );
 			}
-			
+
 			if ( ! $was_added_to_cart && ! $quantity_set ) {
 				$woocommerce->add_error( __( 'Please choose the quantity of items you wish to add to your cart&hellip;', 'woocommerce' ) );
 				wp_redirect( get_permalink( $product_id ) );
 				exit;
 			}
-		
+
 		} elseif ( $product_id ) {
-		
+
 			/* Link on product archives */
 			$woocommerce->add_error( __( 'Please choose a product to add to your cart&hellip;', 'woocommerce' ) );
 			wp_redirect( get_permalink( $product_id ) );
 			exit;
-		
+
 		}
 
 	// Simple Products
@@ -376,7 +376,7 @@ function woocommerce_add_to_cart_action( $url = false ) {
 			wp_safe_redirect( $woocommerce->cart->get_cart_url() );
 			exit;
 		}
-		
+
 		// Redirect to page without querystring args
 		elseif ( wp_get_referer() ) {
 			wp_safe_redirect( remove_query_arg( array( 'add-to-cart', 'quantity', 'product_id' ), wp_get_referer() ) );
@@ -396,17 +396,17 @@ function woocommerce_add_to_cart_action( $url = false ) {
  */
 function woocommerce_add_to_cart_message( $product_id ) {
 	global $woocommerce;
-	
+
 	if ( is_array( $product_id ) ) {
-	
+
 		$titles = array();
-		
+
 		foreach ( $product_id as $id ) {
 			$titles[] = get_the_title( $id );
 		}
 
 		$added_text = sprintf( __( 'Added &quot;%s&quot; to your cart.', 'woocommerce' ), join( __('&quot; and &quot;'), array_filter( array_merge( array( join( '&quot;, &quot;', array_slice( $titles, 0, -1 ) ) ), array_slice( $titles, -1 ) ) ) ) );
-		
+
 	} else {
 		$added_text = sprintf( __( '&quot;%s&quot; was successfully added to your cart.', 'woocommerce' ), get_the_title( $product_id ) );
 	}
@@ -516,13 +516,13 @@ function woocommerce_pay_action() {
 		if ( $order->id == $order_id && $order->order_key == $order_key && in_array( $order->status, array( 'pending', 'failed' ) ) ) {
 
 			// Set customer location to order location
-			if ( $order->billing_country ) 
+			if ( $order->billing_country )
 				$woocommerce->customer->set_country( $order->billing_country );
-			if ( $order->billing_state ) 
+			if ( $order->billing_state )
 				$woocommerce->customer->set_state( $order->billing_state );
-			if ( $order->billing_postcode ) 
+			if ( $order->billing_postcode )
 				$woocommerce->customer->set_postcode( $order->billing_postcode );
-			if ( $order->billing_city ) 
+			if ( $order->billing_city )
 				$woocommerce->customer->set_city( $order->billing_city );
 
 			// Update payment method
@@ -533,18 +533,18 @@ function woocommerce_pay_action() {
 
 				// Update meta
 				update_post_meta( $order_id, '_payment_method', $payment_method );
-				
+
 				if ( isset( $available_gateways[ $payment_method ] ) )
 					$payment_method_title = $available_gateways[ $payment_method ]->get_title();
-				
+
 				update_post_meta( $order_id, '_payment_method_title', $payment_method_title);
-				
+
 				// Validate
 				$available_gateways[ $payment_method ]->validate_fields();
-				
+
 				// Process
 				if ( $woocommerce->error_count() == 0 ) {
-					
+
 					$result = $available_gateways[ $payment_method ]->process_payment( $order_id );
 
 					// Redirect to success/confirmation/payment page
@@ -552,9 +552,9 @@ function woocommerce_pay_action() {
 						wp_redirect( $result['redirect'] );
 						exit;
 					}
-				
+
 				}
-				
+
 			} else {
 
 				// No payment was required for order
@@ -697,7 +697,7 @@ function woocommerce_process_registration() {
 
                 // Change role
                 wp_update_user( array ('ID' => $user_id, 'role' => 'customer') ) ;
-                
+
                 // Action
 	            do_action( 'woocommerce_created_customer', $user_id );
 
@@ -878,13 +878,13 @@ function woocommerce_download_product() {
 		$access_expires 		= $download_result->access_expires;
 
 		if ( $user_id && get_option( 'woocommerce_downloads_require_login' ) == 'yes' ) {
-		
+
 			if ( ! is_user_logged_in() )
 				wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . wp_login_url( get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) . '">' . __( 'Login &rarr;', 'woocommerce' ) . '</a>' );
-			
+
 			elseif ( $user_id != get_current_user_id() )
 				wp_die( __( 'This is not your download link.', 'woocommerce' ) );
-		
+
 		}
 
 		if ( ! get_post( $product_id ) )
@@ -892,7 +892,7 @@ function woocommerce_download_product() {
 
 		if ( $order_id ) {
 			$order = new WC_Order( $order_id );
-			
+
 			if ( ! $order->is_download_permitted() && $order->status != 'publish' )
 				wp_die( __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . home_url() . '">' . __( 'Go to homepage &rarr;', 'woocommerce' ) . '</a>' );
 		}
@@ -911,7 +911,7 @@ function woocommerce_download_product() {
 				'user_email' 	=> $email,
 				'order_key' 	=> $order_key,
 				'product_id' 	=> $product_id,
-				'download_id' 	=> $download_id 
+				'download_id' 	=> $download_id
 			), array( '%d' ), array( '%s', '%s', '%d', '%s' ) );
 		}
 
@@ -931,7 +931,7 @@ function woocommerce_download_product() {
 		if ( ! $file_path ) exit;
 
 		$file_download_method = apply_filters( 'woocommerce_file_download_method', get_option( 'woocommerce_file_download_method' ), $product_id );
-		
+
 		// Redirect to download location
 		if ( $file_download_method == 'redirect' ) {
 			header( 'Location: ' . $file_path );
@@ -980,7 +980,7 @@ function woocommerce_download_product() {
 		}
 
 		if ( $file_download_method == 'xsendfile' ) {
-			
+
 			// Path fix - kudos to Jason Judge
          	if ( getcwd() )
          		$file_path = trim( preg_replace( '`^' . getcwd() . '`' , '', $file_path ), '/' );
@@ -1024,7 +1024,7 @@ function woocommerce_download_product() {
 				$cnt = 0;
 
 				$handle = fopen( $file, 'r' );
-				if ( $handle === FALSE ) 
+				if ( $handle === FALSE )
 					return FALSE;
 
 				while ( ! feof( $handle ) ) {
@@ -1032,14 +1032,14 @@ function woocommerce_download_product() {
 					echo $buffer;
 					ob_flush();
 					flush();
-					
-					if ( $retbytes ) 
+
+					if ( $retbytes )
 						$cnt += strlen( $buffer );
 				}
 
 				$status = fclose( $handle );
 
-				if ( $retbytes && $status ) 
+				if ( $retbytes && $status )
 					return $cnt;
 
 				return $status;
@@ -1047,13 +1047,13 @@ function woocommerce_download_product() {
 		}
 
         @session_write_close();
-        if ( function_exists( 'apache_setenv' ) ) 
+        if ( function_exists( 'apache_setenv' ) )
         	@apache_setenv( 'no-gzip', 1 );
         @ini_set( 'zlib.output_compression', 'Off' );
 		@set_time_limit(0);
 		@set_magic_quotes_runtime(0);
 		@ob_end_clean();
-		if ( ob_get_level() ) 
+		if ( ob_get_level() )
 			@ob_end_clean(); // Zip corruption fix
 
 		header( "Pragma: no-cache" );
@@ -1065,7 +1065,7 @@ function woocommerce_download_product() {
 		header( "Content-Disposition: attachment; filename=\"" . basename( $file_path ) . "\";" );
 		header( "Content-Transfer-Encoding: binary" );
 
-        if ( $size = @filesize( $file_path ) ) 
+        if ( $size = @filesize( $file_path ) )
         	header( "Content-Length: " . $size );
 
         // Serve it
@@ -1213,10 +1213,10 @@ function woocommerce_check_comment_rating($comment_data) {
 
 
 /**
- * Finds an Order ID based on an order key. 
+ * Finds an Order ID based on an order key.
  *
  * @access public
- * @param string $order_key An order key has generated by 
+ * @param string $order_key An order key has generated by
  * @return int The ID of an order, or 0 if the order could not be found
  */
 function woocommerce_get_order_id_by_order_key( $order_key ) {

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -219,30 +219,30 @@ if ( ! function_exists( 'woocommerce_page_title' ) ) {
 
 	/**
 	 * woocommerce_page_title function.
-	 * 
+	 *
 	 * @access public
 	 * @return void
 	 */
 	function woocommerce_page_title() {
-		
+
 		if ( is_search() ) {
 			$page_title = sprintf( __( 'Search Results: &ldquo;%s&rdquo;', 'woocommerce' ), get_search_query() );
-			
+
 			if ( get_query_var( 'paged' ) )
 				$page_title .= sprintf( __( '&nbsp;&ndash; Page %s', 'woocommerce' ), get_query_var( 'paged' ) );
-		
+
 		} elseif ( is_tax() ) {
-			
+
 			$page_title = single_term_title( "", false );
-		
+
 		} else {
-	
+
 			$shop_page = get_post( woocommerce_get_page_id( 'shop' ) );
-	
+
 			$page_title = apply_filters( 'the_title', ( $shop_page_title = get_option( 'woocommerce_shop_page_title' ) ) ? $shop_page_title : $shop_page->post_title, $shop_page->ID );
-			
+
 		}
-				
+
 	    echo apply_filters( 'woocommerce_page_title', $page_title );
 	}
 }
@@ -260,7 +260,7 @@ if ( ! function_exists( 'woocommerce_product_loop_start' ) ) {
 		woocommerce_get_template( 'loop/loop-start.php' );
 		if ( $echo )
 			echo ob_get_clean();
-		else 
+		else
 			return ob_get_clean();
 	}
 }
@@ -277,7 +277,7 @@ if ( ! function_exists( 'woocommerce_product_loop_end' ) ) {
 		woocommerce_get_template( 'loop/loop-end.php' );
 		if ( $echo )
 			echo ob_get_clean();
-		else 
+		else
 			return ob_get_clean();
 	}
 }
@@ -433,10 +433,10 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 	 */
 	function woocommerce_catalog_ordering() {
 		global $woocommerce;
-		
+
 		if ( ! isset( $woocommerce->session->orderby ) )
 			$woocommerce->session->orderby = apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby' ) );
-			
+
 		woocommerce_get_template( 'loop/sorting.php' );
 	}
 }
@@ -673,7 +673,7 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 	 */
 	function woocommerce_quantity_input( $args = array() ) {
 		global $product;
-		
+
 		$defaults = array(
 			'input_name'  	=> 'quantity',
 			'input_value'  	=> '1',
@@ -798,10 +798,10 @@ if ( ! function_exists( 'woocommerce_output_related_products' ) ) {
 }
 
 if ( ! function_exists( 'woocommerce_related_products' ) ) {
-	 
+
 	/**
 	 * Output the related products.
-	 * 
+	 *
 	 * @access public
 	 * @param int $posts_per_page (default: 2)
 	 * @param int $columns (default: 2)
@@ -821,7 +821,7 @@ if ( ! function_exists( 'woocommerce_upsell_display' ) ) {
 
 	/**
 	 * Output product up sells.
-	 * 
+	 *
 	 * @access public
 	 * @param int $posts_per_page (default: -1)
 	 * @param int $columns (default: 2)
@@ -1005,19 +1005,19 @@ if ( ! function_exists( 'woocommerce_products_will_display' ) ) {
 	 */
 	function woocommerce_products_will_display() {
 		global $woocommerce, $wpdb;
-		
+
 		if ( ! is_product_category() && ! is_shop() )
 			return false;
-			
+
 		if ( is_search() || is_filtered() || is_paged() )
 			return true;
-			
+
 		if ( is_shop() && get_option( 'woocommerce_shop_page_display' ) != 'subcategories' )
 			return true;
-			
+
 		$term = get_queried_object();
-			
-		if ( is_product_category() ) {			
+
+		if ( is_product_category() ) {
 			switch ( get_woocommerce_term_meta( $term->term_id, 'display_type', true ) ) {
 				case 'products' :
 				case 'both' :
@@ -1029,10 +1029,10 @@ if ( ! function_exists( 'woocommerce_products_will_display' ) ) {
 				break;
 			}
 		}
-			
+
 		$parent_id 		= empty( $term->term_id ) ? 0 : $term->term_id;
 		$has_children 	= $wpdb->get_col( $wpdb->prepare( "SELECT term_id FROM {$wpdb->term_taxonomy} WHERE parent = %d", $parent_id ) );
-	
+
 		if ( $has_children ) {
 			// Check terms have products inside
 			$children = array();
@@ -1041,7 +1041,7 @@ if ( ! function_exists( 'woocommerce_products_will_display' ) ) {
 				$children[] = $term;
 			}
 			$objects = get_objects_in_term( $children, 'product_cat' );
-			
+
 			if ( sizeof( $objects ) > 0 ) {
 				return false;
 			} else {
@@ -1080,17 +1080,17 @@ if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
 
 		// Don't show when filtering, searching or when on page > 1 and ensure we're on a product archive
 		if ( is_search() || is_filtered() || is_paged() || ( ! is_product_category() && ! is_shop() ) ) return;
-		
+
 		// Check categories are enabled
 		if ( is_shop() && get_option( 'woocommerce_shop_page_display' ) == '' ) return;
-		
+
 		// Find the category + category parent, if applicable
 		$term 			= get_queried_object();
 		$parent_id 		= empty( $term->term_id ) ? 0 : $term->term_id;
-		
+
 		if ( is_product_category() ) {
 			$display_type = get_woocommerce_term_meta( $term->term_id, 'display_type', true );
-			
+
 			switch ( $display_type ) {
 				case 'products' :
 					return;
@@ -1140,7 +1140,7 @@ if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
 		if ( $product_category_found ) {
 			if ( is_product_category() ) {
 				$display_type = get_woocommerce_term_meta( $term->term_id, 'display_type', true );
-				
+
 				switch ( $display_type ) {
 					case 'subcategories' :
 						$wp_query->post_count = 0;
@@ -1158,7 +1158,7 @@ if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
 				$wp_query->post_count = 0;
 				$wp_query->max_num_pages = 0;
 			}
-			
+
 			echo esc_html( $after );
 			return true;
 		}
@@ -1252,44 +1252,44 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 		$required = ( $args['required']  ) ? ' <abbr class="required" title="' . esc_attr__( 'required', 'woocommerce'  ) . '">*</abbr>' : '';
 		$args['maxlength'] = ( $args['maxlength'] ) ? 'maxlength="' . absint( $args['maxlength'] ) . '"' : '';
-		
+
 		// Custom attribute handling
 		$custom_attributes = array();
-		
+
 		if ( ! empty( $args['custom_attributes'] ) && is_array( $args['custom_attributes'] ) )
 			foreach ( $args['custom_attributes'] as $attribute => $value )
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-		
+
 		switch ( $args['type'] ) {
 		case "country" :
-		
+
 			if ( sizeof( $woocommerce->countries->get_allowed_countries() ) == 1 ) {
-			
+
 				$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $key ) . '_field">
 						<label class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']  . '</label>';
-				
+
 				$field .= '<strong>' . current( array_values( $woocommerce->countries->get_allowed_countries() ) ) . '</strong>';
-	
+
 				$field .= '<input type="hidden" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" value="' . current( array_keys( $woocommerce->countries->get_allowed_countries() ) ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
-	
+
 				$field .= '</p>' . $after;
-				
+
 			} else {
 
 				$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $key ) . '_field">
 						<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required  . '</label>
 						<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="country_to_state country_select" ' . implode( ' ', $custom_attributes ) . '>
 							<option value="">'.__( 'Select a country&hellip;', 'woocommerce' ) .'</option>';
-	
+
 				foreach ( $woocommerce->countries->get_allowed_countries() as $ckey => $cvalue )
 					$field .= '<option value="' . $ckey . '" '.selected( $value, $ckey, false ) .'>'.__( $cvalue, 'woocommerce' ) .'</option>';
-	
+
 				$field .= '</select>';
-	
+
 				$field .= '<noscript><input type="submit" name="woocommerce_checkout_update_totals" value="' . __( 'Update country', 'woocommerce' ) . '" /></noscript>';
-	
+
 				$field .= '</p>' . $after;
-			
+
 			}
 
 			break;

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -176,7 +176,7 @@ class Woocommerce {
 		include( 'widgets/widget-init.php' );					// Widget classes
 		include( 'classes/class-wc-countries.php' );			// Defines countries and states
 		include( 'classes/class-wc-order.php' );				// Single order class
-		
+
 		include( 'classes/class-wc-product-factory.php' );		// Product factory
 		include( 'classes/abstracts/abstract-wc-product.php' );	// Product class abstract
 		include( 'classes/class-wc-product-simple.php' );		// Simple product type class
@@ -184,7 +184,7 @@ class Woocommerce {
 		include( 'classes/class-wc-product-variable.php' );		// Variable product type class
 		include( 'classes/class-wc-product-grouped.php' );		// Grouped product type class
 		include( 'classes/class-wc-product-variation.php' );	// Product variation class
-		
+
 		include( 'classes/class-wc-tax.php' );					// Tax class
 		include( 'classes/class-wc-settings-api.php' );			// Settings API
 
@@ -1625,7 +1625,7 @@ class Woocommerce {
 
 		$before 	= empty( $wrapper['before'] ) ? '<div class="' . $wrapper['class'] . '">' : $wrapper['before'];
 		$after 		= empty( $wrapper['after'] ) ? '</div>' : $wrapper['after'];
-		
+
 		echo $before;
 		call_user_func( $function, $atts );
 		echo $after;


### PR DESCRIPTION
Not sure how popular this pull request is going to be, but figured I'd give it a shot anyway.

This pull removes all trailing whitespace (at the end of a line or on a blank line ). This leads to cleaner pull requests from people that use different editors. 

I use ST2 and I have my config set to remove whitespace whenever I hit save. I have to turn that setting off each time I make a contribution to WooCommerce so that the commit log doesn't look jacked :/

However, is whitespace added deliberately? Some devs do that, so just curious.

Edit: Interesting fact :

Before
2.18 MB (2,293,634 bytes)

After
2.17 MB (2,285,535 bytes)

(Size on committed files only)

Branched from 46ca015e4fb730e498a40cf95f84487acbb1f0ac
