### PR TITLE
Fix invalid argument() when saving an order

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -809,8 +809,8 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 	}
 
 	// Save meta
-	$meta_keys 		= isset( $_POST['meta_key'] ) ? $_POST['meta_key'] : '';
-	$meta_values 	= isset( $_POST['meta_value'] ) ? $_POST['meta_value'] : '';
+	$meta_keys 		= isset( $_POST['meta_key'] ) ? $_POST['meta_key'] : array();
+	$meta_values 	= isset( $_POST['meta_value'] ) ? $_POST['meta_value'] : array();
 
 	foreach ( $meta_keys as $id => $value ) {
 		$wpdb->update(


### PR DESCRIPTION
( ! ) Warning: Invalid argument supplied for foreach() in C:\wamp\www\woocommerce\wp-content\plugins\woocommerce\admin\post-types\writepanels\writepanel-order_data.php on line 815
