### PR TITLE
add hook for displaying custom meta rows in order-item-html.php

### DIFF
--- a/admin/post-types/writepanels/order-item-html.php
+++ b/admin/post-types/writepanels/order-item-html.php
@@ -28,6 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 				echo '<br/>' . woocommerce_get_formatted_variation( $_product->variation_data, true );
 		?>
 		<table class="meta" cellspacing="0">
+			
 			<tfoot>
 				<tr>
 					<td colspan="4"><button class="add_order_item_meta button"><?php _e( 'Add&nbsp;meta', 'woocommerce' ); ?></button></td>
@@ -36,6 +37,9 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			<tbody class="meta_items">
 			<?php
 				if ( $metadata = $order->has_meta( $item_id )) {
+
+					do_action('woocommerce_display_order_item_meta', absint( $item_id ) ); 
+
 					foreach ( $metadata as $meta ) {
 
 						// Skip hidden core fields


### PR DESCRIPTION
I have item order meta that I'd like to only display and not make available for edit.  Specifically the custom project ID kicked back by a third-party fulfillment company.  I don't want anyone to accidentally change that bit of meta, but I do want it visible.  

Like so:
http://www.diigo.com/item/image/1xt6v/5ibj
