### PR TITLE
Fix 'Invalid argument supplied for foreach()' when no file for download

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -980,8 +980,10 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 				$product_id = ($item['variation_id']>0) ? $item['variation_id'] : $item['product_id'];
 
 				$file_download_paths = apply_filters( 'woocommerce_file_download_paths', get_post_meta( $product_id, '_file_paths', true ), $product_id, $order_id, $item );
-				foreach ( $file_download_paths as $download_id => $file_path ) {
-					woocommerce_downloadable_file_permission( $download_id, $product_id, $order );
+				if ( !empty($file_download_paths) ) {
+					foreach ( $file_download_paths as $download_id => $file_path ) {
+						woocommerce_downloadable_file_permission( $download_id, $product_id, $order );
+					}
 				}
 
 			endif;


### PR DESCRIPTION
When checking out and finishing a downloadable order, if the product has no file path an error would appear
