### PR TITLE
Updated to include coupon on woocommerce_item_is_discounted filter.

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -982,7 +982,7 @@ class WC_Cart {
 										$this_item_is_discounted = false;
 
 								// Apply filter
-								$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = true );
+								$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = true, $coupon );
 
 								// Apply the discount
 								if ( $this_item_is_discounted ) {
@@ -1142,7 +1142,7 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 						// Apply filter
-						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false );
+						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );
 
 						// Apply the discount
 						if ( $this_item_is_discounted ) {


### PR DESCRIPTION
This updates the woocommerce_item_is_discounted filter to include the coupon that was used to calculate the default value. This allows those who hook into the filter to have access to the same information that was used to derive the initial value, and thus can be presumed to be of value to those filtered-in functions.
