### PR TITLE
Make is_account_page() more flexible.

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -388,7 +388,7 @@ if ( ! function_exists( 'is_account_page' ) ) {
 	 * @return bool
 	 */
 	function is_account_page() {
-		return ( is_page( woocommerce_get_page_id( 'myaccount' ) ) || is_page( woocommerce_get_page_id( 'edit_address' ) ) || is_page( woocommerce_get_page_id( 'view_order' ) ) || is_page( woocommerce_get_page_id( 'change_password' ) ) ) ? true : false;
+		return ( is_page( woocommerce_get_page_id( 'myaccount' ) ) || is_page( woocommerce_get_page_id( 'edit_address' ) ) || is_page( woocommerce_get_page_id( 'view_order' ) ) || is_page( woocommerce_get_page_id( 'change_password' ) ) || apply_filters('woocommerce_is_account_page', false) ) ? true : false;
 	}
 }
 if ( ! function_exists( 'is_order_received_page' ) ) {


### PR DESCRIPTION
My plugin has placed several additional pages under My Account and without them recognized as an account page they are not in SSL, do not get account page css styling, etc.

While is_account_page() is already wrapped in a !function_exists() that is useless because the function is defined in the WC constructor which is too early to override. The only way to override is to mess with plugin load order.
