### PR TITLE
Improved the result-count template

### DIFF
--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -18,15 +18,18 @@ if ( ! woocommerce_products_will_display() )
 ?>
 <p class="woocommerce_result_count">
 	<?php
-	$paged 		= max( 1, $wp_query->get( 'paged' ) );
-	$per_page 	= $wp_query->get( 'posts_per_page' );
-	$max		= $wp_query->found_posts;
-	$first 		= ( $per_page * $paged ) - $per_page + 1;
-	$last 		= $wp_query->get( 'posts_per_page' ) * $paged;
+	$paged    = max( 1, $wp_query->get( 'paged' ) );
+	$per_page = $wp_query->get( 'posts_per_page' );
+	$total    = $wp_query->found_posts;
+	$first    = ( $per_page * $paged ) - $per_page + 1;
+	$last     = min( $total, $wp_query->get( 'posts_per_page' ) * $paged );
 
-	if ( $last > $max )
-		$last = $max;
-
-	printf( __( 'Showing %s - %s of %s results', 'woocommerce' ), $first, $last, $max );
+	if ( 1 == $total ) {
+		_e( 'Showing the single result', 'woocommerce' );
+	} elseif ( $total <= $per_page ) {
+		printf( __( 'Showing all %d results', 'woocommerce' ), $total );
+	} else {
+		printf( _x( 'Showing %1$d–%2$d of %3$d results', '%1$d = first, %2$d = last, %3$d = total', 'woocommerce' ), $first, $last, $total );
+	}
 	?>
 </p>


### PR DESCRIPTION
- Coding style: mid-line indenting which should be done using spaces.
- Renamed `$max` to `$total`.
- Simplified calculation of `$last`.
- Using en dash between range of values: http://en.wikipedia.org/wiki/Dash#Ranges_of_values.
- Tweaks to the “Showing 1–10 of 12 results” result text:
  - Converted `%s` to `%d`.
  - Used numbered placeholders (like `%1$d` and `%2$d`) which allows for more flexible translations since the placeholders can be swapped and repeated now.
  - Used `_x()` with comment to clarify placeholder order.
- Added two additional texts:
  - One for showing the only single result because “Showing 1–1 of 1 results” is overly verbose.
  - One for when all results are shown on the same page because “Showing 1–8 of 8 results” is a bit too verbose too.
