### PR TITLE
Optimization for woocommerce_change_term_counts()

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -2070,6 +2070,8 @@ add_action( 'woocommerce_product_set_stock_status', 'woocommerce_recount_after_s
 
 /**
  * woocommerce_change_term_counts function.
+ * Overrides the original term count for product categories and tags with the product count
+ * that takes catalog visibility into account.
  *
  * @access public
  * @param mixed $terms
@@ -2083,6 +2085,9 @@ function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
 		return $terms;
 
 	foreach ( $terms as &$term ) {
+		// If the original term count is zero, there's no way the product count could be higher.
+		if ( empty( $term->count )) continue;
+
 		$count = get_woocommerce_term_meta( $term->term_id, 'product_count_' . $taxonomies[0] , true );
 
 		if ( $count != '' )

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -2086,7 +2086,7 @@ function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
 
 	foreach ( $terms as &$term ) {
 		// If the original term count is zero, there's no way the product count could be higher.
-		if ( empty( $term->count )) continue;
+		if ( empty( $term->count ) ) continue;
 
 		$count = get_woocommerce_term_meta( $term->term_id, 'product_count_' . $taxonomies[0] , true );
 


### PR DESCRIPTION
If the original term count is zero, this means no published products are found for the category or tag. In that case the custom WooCommerce product count, stored as term meta, will always be zero too. The custom product count just takes into account catalog visibility, but the first condition is for the product to be published.

Since the `woocommerce_change_term_counts()` functions is hooked to the `get_terms` filter, it is important to optimize. The `get_woocommerce_term_meta()` would be called for each product category or tag, which generates one extra database query per term.

I'd like to optimize it some more. Will come back to this later.
