### PR TITLE
Fixed and improved column for featured status

### DIFF
--- a/admin/post-types/product.php
+++ b/admin/post-types/product.php
@@ -243,11 +243,14 @@ function woocommerce_custom_product_columns( $column ) {
 				echo implode( ', ', $termlist );
 			}
 		break;
-		case "featured" :
-			$url = wp_nonce_url( admin_url('admin-ajax.php?action=woocommerce-feature-product&product_id=' . $post->ID), 'woocommerce-feature-product' );
-			echo '<a href="'.$url.'" title="'.__( 'Change', 'woocommerce' ) .'">';
-			if ($the_product->is_featured()) echo '<a href="'.$url.'"><img src="'.$woocommerce->plugin_url().'/assets/images/featured.png" alt="yes" height="14" width="14" />';
-			else echo '<img src="'.$woocommerce->plugin_url().'/assets/images/featured-off.png" alt="no" height="14" width="14" />';
+		case 'featured':
+			$url = wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce-feature-product&product_id=' . $post->ID ), 'woocommerce-feature-product' );
+			echo '<a href="' . $url . '" title="'. __( 'Toggle featured', 'woocommerce' ) . '">';
+			if ( $the_product->is_featured() ) {
+				echo '<img src="' . $woocommerce->plugin_url() . '/assets/images/featured.png" alt="'. __( 'yes', 'woocommerce' ) . '" height="14" width="14" />';
+			} else {
+				echo '<img src="' . $woocommerce->plugin_url() . '/assets/images/featured-off.png" alt="'. __( 'no', 'woocommerce' ) . '" height="14" width="14" />';
+			}
 			echo '</a>';
 		break;
 		case "is_in_stock" :


### PR DESCRIPTION
- Bugfix: if the product was featured a double opening anchor tag would be used around the star image, breaking the link.
- Changed the title attribute from "Change" to "Toggle featured".
- Made alt attributes of the images translatable ("yes" and "no").
- Coding standards.

Also, Mike, I guess the star image is supposed to be an ajax request but that's not what's happening. The page gets reloaded completely when you click a star (already the case before my change).
