### PR TITLE
Breadcrumb

### DIFF
--- a/templates/shop/breadcrumb.php
+++ b/templates/shop/breadcrumb.php
@@ -11,11 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 global $post, $wp_query;
 
-if( ! $home )
-	$home = _x( 'Home', 'breadcrumb', 'woocommerce' );
-
-$home_link = home_url();
-
 if ( get_option('woocommerce_prepend_shop_page_to_urls') == "yes" && woocommerce_get_page_id( 'shop' ) && get_option( 'page_on_front' ) !== woocommerce_get_page_id( 'shop' ) )
 	$prepend =  $before . '<a href="' . get_permalink( woocommerce_get_page_id('shop') ) . '">' . get_the_title( woocommerce_get_page_id('shop') ) . '</a> ' . $after . $delimiter;
 else
@@ -23,7 +18,11 @@ else
 
 if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_front' ) == woocommerce_get_page_id( 'shop' ) ) ) || is_paged() ) {
 
-	echo $wrap_before . $before  . '<a class="home" href="' . $home_link . '">' . $home . '</a> '  . $after . $delimiter ;
+	echo $wrap_before;
+
+	if ( ! empty( $home ) ) {
+		echo $before . '<a class="home" href="' . home_url() . '">' . $home . '</a>' . $after . $delimiter;
+	}
 
 	if ( is_category() ) {
 

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -951,7 +951,7 @@ if ( ! function_exists( 'woocommerce_breadcrumb' ) ) {
 			'wrap_after'  => '</div>',
 			'before'      => '',
 			'after'       => '',
-			'home'        => null,
+			'home'        => _x( 'Home', 'breadcrumb', 'woocommerce' ),
 		) );
 
 		$args = wp_parse_args( $args, $defaults );

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -945,16 +945,16 @@ if ( ! function_exists( 'woocommerce_breadcrumb' ) ) {
 	 */
 	function woocommerce_breadcrumb( $args = array() ) {
 
-		$defaults = array(
-			'delimiter'  => ' &rsaquo; ',
-			'wrap_before'  => '<div id="breadcrumb" itemprop="breadcrumb">',
-			'wrap_after' => '</div>',
-			'before'   => '',
-			'after'   => '',
-			'home'    => null
-		);
+		$defaults = apply_filters( 'woocommerce_breadcrumb_defaults', array(
+			'delimiter'   => ' &rsaquo; ',
+			'wrap_before' => '<div id="breadcrumb" itemprop="breadcrumb">',
+			'wrap_after'  => '</div>',
+			'before'      => '',
+			'after'       => '',
+			'home'        => null,
+		) );
 
-		$args = wp_parse_args( $args, $defaults  );
+		$args = wp_parse_args( $args, $defaults );
 
 		woocommerce_get_template( 'shop/breadcrumb.php', $args );
 	}


### PR DESCRIPTION
Added new filter `woocommerce_breadcrumb_defaults` because having to copy over the whole `woocommerce_breadcrumb()` function just for changing the delimiter is not very DRY.

The `home` setting no longer defaults to `null` but the "Home" text, like before. However, setting the `home` option to a falsy value now gives you the option to omit a home link from the breadcrumb which can be useful.

Also, something I didn't change yet, the default `wrap_before` setting should not use an `id` attribute. As soon as you include the breadcrumb twice, your HTML gets invalid. I would love to change that to a class, but would that cause backwards compatibility issues with themes?
