### PR TITLE
Created a POT generator

### DIFF
--- a/i18n/languages/woocommerce-admin.pot
+++ b/i18n/languages/woocommerce-admin.pot
@@ -1,0 +1,4631 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: WooCommerce 2.0.0-beta1 Admin\n"
+"Report-Msgid-Bugs-To: https://github.com/woothemes/woocommerce/issues\n"
+"POT-Creation-Date: 2012-12-30 11:35:31+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2012-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+
+#: admin/importers/importers-init.php:13
+msgid "WooCommerce Tax Rates (CSV)"
+msgstr ""
+
+#: admin/importers/importers-init.php:13
+msgid "Import <strong>tax rates</strong> to your store via a csv file."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:103
+#: admin/importers/tax-rates-importer.php:186
+#: admin/importers/tax-rates-importer.php:226
+#: admin/importers/tax-rates-importer.php:241
+msgid "Sorry, there has been an error."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:104
+msgid "The file does not exist, please try again."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:187
+msgid "The CSV is invalid."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:198
+msgid "Import complete - imported <strong>%s</strong> tax rates and skipped <strong>%s</strong>."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:208
+msgid "All done!"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:208
+msgid "View Tax Rates"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:259
+msgid "Import Tax Rates"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:282
+msgid "Hi there! Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click \"Upload file and import\"."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:284
+msgid "Tax rates need to be defined with columns in a specific order (10 columns). <a href=\"%s\">Click here to download a sample</a>."
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:292
+msgid "Before you can upload your import file, you will need to fix the following error:"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:301
+msgid "Choose a file from your computer:"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:307
+msgid "Maximum size: %s"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:312
+msgid "OR enter path to file:"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:319
+msgid "Delimiter"
+msgstr ""
+
+#: admin/importers/tax-rates-importer.php:325
+msgid "Upload file and import"
+msgstr ""
+
+#: admin/includes/duplicate_product.php:23
+msgid "No product to duplicate has been supplied!"
+msgstr ""
+
+#: admin/includes/duplicate_product.php:43
+msgid "Product creation failed, could not find original product:"
+msgstr ""
+
+#: admin/includes/duplicate_product.php:89
+msgid "(Copy)"
+msgstr ""
+
+#: admin/includes/notice-install.php:6
+msgid "<strong>Welcome to WooCommerce</strong> &#8211; You're almost ready to start selling :)"
+msgstr ""
+
+#: admin/includes/notice-install.php:7
+msgid "Install WooCommerce Pages"
+msgstr ""
+
+#: admin/includes/notice-install.php:7
+msgid "Skip setup"
+msgstr ""
+
+#: admin/includes/notice-installed.php:6
+msgid "<strong>WooCommerce has been installed</strong> &#8211; You're ready to start selling :)"
+msgstr ""
+
+#: admin/includes/notice-installed.php:8 admin/includes/notice-updated.php:8
+#: admin/woocommerce-admin-content.php:41 admin/woocommerce-admin-init.php:81
+#: admin/woocommerce-admin-status.php:140
+msgid "Settings"
+msgstr ""
+
+#: admin/includes/notice-installed.php:8 admin/includes/notice-updated.php:8
+msgid "Docs"
+msgstr ""
+
+#: admin/includes/notice-update.php:6
+msgid "<strong>Data Update Required</strong> &#8211; We just need to update your install to the latest version"
+msgstr ""
+
+#: admin/includes/notice-update.php:7
+msgid "Run the updater"
+msgstr ""
+
+#: admin/includes/notice-update.php:12
+msgid "It is strongly recommended that you backup your database before proceeding. Are you sure you wish to run the updater now?"
+msgstr ""
+
+#: admin/includes/notice-updated.php:6
+msgid "<strong>WooCommerce has been updated</strong> &#8211; You're ready to continue selling :)"
+msgstr ""
+
+#: admin/includes/updates/woocommerce-update-2.0.php:50
+#: admin/woocommerce-admin-init.php:829
+msgctxt "slug"
+msgid "product-category"
+msgstr ""
+
+#: admin/includes/updates/woocommerce-update-2.0.php:51
+#: admin/woocommerce-admin-init.php:842
+msgctxt "slug"
+msgid "product-tag"
+msgstr ""
+
+#: admin/includes/updates/woocommerce-update-2.0.php:59
+msgctxt "slug"
+msgid "product"
+msgstr ""
+
+#: admin/post-types/product.php:31
+msgid "Make a duplicate from this product"
+msgstr ""
+
+#: admin/post-types/product.php:32
+msgid "Duplicate"
+msgstr ""
+
+#: admin/post-types/product.php:61
+msgid "Copy to a new draft"
+msgstr ""
+
+#: admin/post-types/product.php:85 admin/woocommerce-admin-taxonomies.php:295
+msgid "Image"
+msgstr ""
+
+#: admin/post-types/product.php:87
+#: admin/post-types/writepanels/writepanel-product_data.php:368
+#: admin/post-types/writepanels/writepanel-product_data.php:446
+#: admin/woocommerce-admin-attributes.php:217
+#: admin/woocommerce-admin-attributes.php:252
+#: admin/woocommerce-admin-attributes.php:290
+#: admin/woocommerce-admin-attributes.php:313
+#: admin/woocommerce-admin-attributes.php:357
+#: admin/woocommerce-admin-attributes.php:381
+#: admin/woocommerce-admin-init.php:384
+msgid "Name"
+msgstr ""
+
+#: admin/post-types/product.php:90 admin/post-types/product.php:561
+#: admin/post-types/writepanels/variation-admin-html.php:46
+#: admin/post-types/writepanels/writepanel-product_data.php:98
+#: admin/woocommerce-admin-reports.php:2038
+#: admin/woocommerce-admin-reports.php:2073
+msgid "SKU"
+msgstr ""
+
+#: admin/post-types/product.php:93
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:83
+#: admin/woocommerce-admin-content.php:62
+#: admin/woocommerce-admin-reports.php:99
+msgid "Stock"
+msgstr ""
+
+#: admin/post-types/product.php:95 admin/post-types/product.php:572
+#: admin/post-types/product.php:791 admin/woocommerce-admin-functions.php:196
+msgid "Price"
+msgstr ""
+
+#: admin/post-types/product.php:97
+msgid "Categories"
+msgstr ""
+
+#: admin/post-types/product.php:98
+msgid "Tags"
+msgstr ""
+
+#: admin/post-types/product.php:99 admin/post-types/product.php:636
+#: admin/post-types/product.php:908
+#: admin/post-types/writepanels/writepanel-product_data.php:1043
+#: admin/woocommerce-admin-init.php:397
+msgid "Featured"
+msgstr ""
+
+#: admin/post-types/product.php:100 admin/woocommerce-admin-attributes.php:235
+#: admin/woocommerce-admin-attributes.php:292
+#: admin/woocommerce-admin-attributes.php:369
+msgid "Type"
+msgstr ""
+
+#: admin/post-types/product.php:101 admin/post-types/shop_order.php:50
+msgid "Date"
+msgstr ""
+
+#: admin/post-types/product.php:150
+msgid "Edit this item inline"
+msgstr ""
+
+#: admin/post-types/product.php:150
+msgid "Quick&nbsp;Edit"
+msgstr ""
+
+#: admin/post-types/product.php:154 admin/post-types/shop_coupon.php:65
+msgid "Restore this item from the Trash"
+msgstr ""
+
+#: admin/post-types/product.php:154 admin/post-types/shop_coupon.php:65
+msgid "Restore"
+msgstr ""
+
+#: admin/post-types/product.php:156 admin/post-types/shop_coupon.php:67
+msgid "Move this item to the Trash"
+msgstr ""
+
+#: admin/post-types/product.php:156 admin/post-types/shop_coupon.php:67
+msgid "Trash"
+msgstr ""
+
+#: admin/post-types/product.php:158 admin/post-types/shop_coupon.php:69
+msgid "Delete this item permanently"
+msgstr ""
+
+#: admin/post-types/product.php:158 admin/post-types/shop_coupon.php:69
+#: admin/post-types/writepanels/writepanel-order_data.php:456
+msgid "Delete Permanently"
+msgstr ""
+
+#: admin/post-types/product.php:163
+msgid "Preview &#8220;%s&#8221;"
+msgstr ""
+
+#: admin/post-types/product.php:163
+msgid "Preview"
+msgstr ""
+
+#: admin/post-types/product.php:165
+msgid "View &#8220;%s&#8221;"
+msgstr ""
+
+#: admin/post-types/product.php:165 admin/post-types/shop_order.php:171
+msgid "View"
+msgstr ""
+
+#: admin/post-types/product.php:211
+msgid "Grouped"
+msgstr ""
+
+#: admin/post-types/product.php:213
+msgid "External/Affiliate"
+msgstr ""
+
+#: admin/post-types/product.php:217 admin/post-types/product.php:411
+#: admin/post-types/writepanels/variation-admin-html.php:166
+#: admin/post-types/writepanels/writepanel-product_data.php:52
+msgid "Virtual"
+msgstr ""
+
+#: admin/post-types/product.php:219 admin/post-types/product.php:407
+#: admin/post-types/writepanels/variation-admin-html.php:164
+#: admin/post-types/writepanels/writepanel-product_data.php:58
+msgid "Downloadable"
+msgstr ""
+
+#: admin/post-types/product.php:221
+msgid "Simple"
+msgstr ""
+
+#: admin/post-types/product.php:225 admin/post-types/product.php:391
+msgid "Variable"
+msgstr ""
+
+#: admin/post-types/product.php:248
+msgid "Toggle featured"
+msgstr ""
+
+#: admin/post-types/product.php:250
+msgid "yes"
+msgstr ""
+
+#: admin/post-types/product.php:252
+msgid "no"
+msgstr ""
+
+#: admin/post-types/product.php:259 admin/post-types/product.php:645
+#: admin/post-types/product.php:932
+#: admin/post-types/writepanels/writepanel-product_data.php:227
+msgid "In stock"
+msgstr ""
+
+#: admin/post-types/product.php:261 admin/post-types/product.php:646
+#: admin/post-types/product.php:933
+#: admin/post-types/writepanels/writepanel-product_data.php:228
+#: admin/woocommerce-admin-reports.php:2058
+msgid "Out of stock"
+msgstr ""
+
+#: admin/post-types/product.php:377
+msgid "Show all product types"
+msgstr ""
+
+#: admin/post-types/product.php:385
+#: admin/post-types/writepanels/writepanel-product_data.php:39
+msgid "Grouped product"
+msgstr ""
+
+#: admin/post-types/product.php:387
+#: admin/post-types/writepanels/writepanel-product_data.php:40
+msgid "External/Affiliate product"
+msgstr ""
+
+#: admin/post-types/product.php:389
+#: admin/post-types/writepanels/writepanel-product_data.php:38
+msgid "Simple product"
+msgstr ""
+
+#: admin/post-types/product.php:403
+msgid "Show all sub-types"
+msgstr ""
+
+#: admin/post-types/product.php:524
+msgid "[%s with SKU of %s]"
+msgstr ""
+
+#: admin/post-types/product.php:530
+msgid "[%s with ID of %d]"
+msgstr ""
+
+#: admin/post-types/product.php:556 admin/post-types/product.php:787
+#: admin/post-types/writepanels/writepanels-init.php:46
+#: admin/settings/settings-init.php:570
+msgid "Product Data"
+msgstr ""
+
+#: admin/post-types/product.php:574
+msgid "Regular price"
+msgstr ""
+
+#: admin/post-types/product.php:579 admin/post-types/product.php:815
+msgid "Sale"
+msgstr ""
+
+#: admin/post-types/product.php:581
+msgid "Sale price"
+msgstr ""
+
+#: admin/post-types/product.php:592 admin/post-types/product.php:841
+#: admin/post-types/writepanels/variation-admin-html.php:90
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:84
+#: admin/post-types/writepanels/writepanel-product_data.php:269
+msgid "Weight"
+msgstr ""
+
+#: admin/post-types/product.php:603 admin/post-types/product.php:865
+msgid "L/W/H"
+msgstr ""
+
+#: admin/post-types/product.php:605 admin/post-types/product.php:881
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:85
+#: admin/post-types/writepanels/writepanel-product_data.php:282
+msgid "Length"
+msgstr ""
+
+#: admin/post-types/product.php:606 admin/post-types/product.php:882
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:86
+#: admin/post-types/writepanels/writepanel-product_data.php:283
+#: admin/woocommerce-admin-settings.php:839
+msgid "Width"
+msgstr ""
+
+#: admin/post-types/product.php:607 admin/post-types/product.php:883
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:87
+#: admin/post-types/writepanels/writepanel-product_data.php:284
+#: admin/woocommerce-admin-settings.php:841
+msgid "Height"
+msgstr ""
+
+#: admin/post-types/product.php:617 admin/post-types/product.php:889
+msgid "Visibility"
+msgstr ""
+
+#: admin/post-types/product.php:622 admin/post-types/product.php:895
+msgid "Catalog &amp; search"
+msgstr ""
+
+#: admin/post-types/product.php:623 admin/post-types/product.php:896
+#: admin/post-types/writepanels/writepanel-product_data.php:1032
+#: admin/woocommerce-admin-content.php:46
+#: admin/woocommerce-admin-settings.php:214
+msgid "Catalog"
+msgstr ""
+
+#: admin/post-types/product.php:624 admin/post-types/product.php:897
+#: admin/post-types/writepanels/writepanel-product_data.php:1033
+msgid "Search"
+msgstr ""
+
+#: admin/post-types/product.php:625 admin/post-types/product.php:898
+#: admin/post-types/writepanels/writepanel-product_data.php:1034
+msgid "Hidden"
+msgstr ""
+
+#: admin/post-types/product.php:640 admin/post-types/product.php:926
+msgid "In stock?"
+msgstr ""
+
+#: admin/post-types/product.php:661 admin/post-types/product.php:944
+#: admin/post-types/writepanels/writepanel-product_data.php:208
+msgid "Manage stock?"
+msgstr ""
+
+#: admin/post-types/product.php:665 admin/post-types/product.php:963
+#: admin/post-types/product.php:979
+#: admin/post-types/writepanels/writepanel-product_data.php:215
+msgid "Stock Qty"
+msgstr ""
+
+#: admin/post-types/product.php:796 admin/post-types/product.php:820
+#: admin/post-types/product.php:846 admin/post-types/product.php:870
+#: admin/post-types/product.php:894 admin/post-types/product.php:913
+#: admin/post-types/product.php:931 admin/post-types/product.php:949
+#: admin/post-types/product.php:968
+msgid "— No Change —"
+msgstr ""
+
+#: admin/post-types/product.php:797 admin/post-types/product.php:821
+#: admin/post-types/product.php:847 admin/post-types/product.php:871
+#: admin/post-types/product.php:969
+msgid "Change to:"
+msgstr ""
+
+#: admin/post-types/product.php:798 admin/post-types/product.php:822
+msgid "Increase by (fixed amount or %):"
+msgstr ""
+
+#: admin/post-types/product.php:799 admin/post-types/product.php:823
+msgid "Decrease by (fixed amount or %):"
+msgstr ""
+
+#: admin/post-types/product.php:809 admin/post-types/product.php:834
+msgid "Enter price"
+msgstr ""
+
+#: admin/post-types/product.php:824
+msgid "Decrease regular price by (fixed amount or %):"
+msgstr ""
+
+#: admin/post-types/product.php:914 admin/post-types/product.php:950
+#: admin/post-types/shop_order.php:190 admin/woocommerce-admin-status.php:155
+#: admin/woocommerce-admin-status.php:317
+msgid "Yes"
+msgstr ""
+
+#: admin/post-types/product.php:915 admin/post-types/product.php:951
+#: admin/post-types/shop_order.php:192 admin/woocommerce-admin-status.php:155
+#: admin/woocommerce-admin-status.php:317
+msgid "No"
+msgstr ""
+
+#: admin/post-types/product.php:1179
+msgid "Sort Products"
+msgstr ""
+
+#: admin/post-types/product.php:1218
+msgid "Insert into product"
+msgstr ""
+
+#: admin/post-types/product.php:1219
+msgid "Uploaded to this product"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:25
+msgid "Code"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:26
+msgid "Coupon type"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:27
+#: admin/post-types/writepanels/writepanel-coupon_data.php:45
+msgid "Coupon amount"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:28
+msgid "Description"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:29
+msgid "Product IDs"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:30
+msgid "Usage / Limit"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:31
+#: admin/post-types/writepanels/writepanel-coupon_data.php:165
+msgid "Expiry date"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:56
+msgid "Edit coupon"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:114
+msgid "%s / %s"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:116
+msgid "%s / &infin;"
+msgstr ""
+
+#: admin/post-types/shop_coupon.php:149 admin/post-types/shop_order.php:282
+msgid "Show all statuses"
+msgstr ""
+
+#: admin/post-types/shop_order.php:43
+#: admin/settings/settings-payment-gateways.php:29
+#: admin/settings/settings-shipping-methods.php:31
+msgid "Status"
+msgstr ""
+
+#: admin/post-types/shop_order.php:44
+msgid "Order"
+msgstr ""
+
+#: admin/post-types/shop_order.php:45
+msgid "Billing"
+msgstr ""
+
+#: admin/post-types/shop_order.php:46
+#: admin/post-types/writepanels/writepanel-order_data.php:529
+#: admin/post-types/writepanels/writepanel-product_data.php:81
+#: admin/settings/settings-tax-rates.php:52
+#: admin/settings/settings-tax-rates.php:182
+#: admin/woocommerce-admin-content.php:49
+#: admin/woocommerce-admin-settings.php:218
+msgid "Shipping"
+msgstr ""
+
+#: admin/post-types/shop_order.php:47
+msgid "Order Total"
+msgstr ""
+
+#: admin/post-types/shop_order.php:48
+#: admin/post-types/writepanels/writepanels-init.php:71
+msgid "Order Notes"
+msgstr ""
+
+#: admin/post-types/shop_order.php:49
+msgid "Customer Notes"
+msgstr ""
+
+#: admin/post-types/shop_order.php:51
+#: admin/post-types/writepanels/writepanel-order_data.php:382
+#: admin/post-types/writepanels/writepanel-order_data.php:429
+msgid "Actions"
+msgstr ""
+
+#: admin/post-types/shop_order.php:95
+#: admin/post-types/writepanels/writepanel-order_data.php:93
+msgid "Guest"
+msgstr ""
+
+#: admin/post-types/shop_order.php:98
+msgid "Order %s"
+msgstr ""
+
+#: admin/post-types/shop_order.php:98
+msgid "made by"
+msgstr ""
+
+#: admin/post-types/shop_order.php:101
+msgid "Email:"
+msgstr ""
+
+#: admin/post-types/shop_order.php:104
+msgid "Tel:"
+msgstr ""
+
+#: admin/post-types/shop_order.php:114 admin/post-types/shop_order.php:123
+msgid "Via"
+msgstr ""
+
+#: admin/post-types/shop_order.php:131
+msgid "Unpublished"
+msgstr ""
+
+#: admin/post-types/shop_order.php:133
+msgid "Y/m/d g:i:s A"
+msgstr ""
+
+#: admin/post-types/shop_order.php:139
+msgid "%s ago"
+msgstr ""
+
+#: admin/post-types/shop_order.php:141
+msgid "Y/m/d"
+msgstr ""
+
+#: admin/post-types/shop_order.php:158
+#: admin/woocommerce-admin-dashboard.php:176
+msgid "Processing"
+msgstr ""
+
+#: admin/post-types/shop_order.php:165
+msgid "Complete"
+msgstr ""
+
+#: admin/post-types/shop_order.php:301 admin/post-types/shop_order.php:326
+msgid "Show all customers"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:6
+msgid "Revoke Access"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:7
+#: admin/post-types/writepanels/variation-admin-html.php:7
+#: admin/post-types/writepanels/writepanel-product_data.php:361
+#: admin/post-types/writepanels/writepanel-product_data.php:439
+#: admin/woocommerce-admin-init.php:386
+msgid "Click to toggle"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:9
+msgid "File %d: %s"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:9
+msgid "Downloaded %s time"
+msgid_plural "Downloaded %s times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:16
+msgid "Downloads Remaining"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:19
+#: admin/post-types/writepanels/variation-admin-html.php:141
+#: admin/post-types/writepanels/variation-admin-html.php:149
+#: admin/post-types/writepanels/writepanel-product_data.php:158
+msgid "Unlimited"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:22
+msgid "Access Expires"
+msgstr ""
+
+#: admin/post-types/writepanels/order-download-permission-html.php:23
+#: admin/post-types/writepanels/writepanel-product_data.php:164
+msgid "Never"
+msgstr ""
+
+#: admin/post-types/writepanels/order-fee-html.php:10
+msgid "Fee Name"
+msgstr ""
+
+#: admin/post-types/writepanels/order-fee-html.php:15
+#: admin/post-types/writepanels/order-item-html.php:82
+msgid "Tax class"
+msgstr ""
+
+#: admin/post-types/writepanels/order-fee-html.php:17
+#: admin/post-types/writepanels/order-tax-html.php:8
+#: admin/post-types/writepanels/writepanel-order_data.php:551
+#: admin/post-types/writepanels/writepanel-order_data.php:650
+#: admin/woocommerce-admin-reports.php:1627
+#: admin/woocommerce-admin-reports.php:2608
+#: admin/woocommerce-admin-reports.php:2617
+#: admin/woocommerce-admin-users.php:90 admin/woocommerce-admin-users.php:112
+msgid "N/A"
+msgstr ""
+
+#: admin/post-types/writepanels/order-fee-html.php:18
+#: admin/post-types/writepanels/writepanel-product_data.php:177
+msgid "Taxable"
+msgstr ""
+
+#: admin/post-types/writepanels/order-fee-html.php:23
+#: admin/post-types/writepanels/order-item-html.php:89
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:54
+#: admin/post-types/writepanels/writepanel-product_data.php:184
+#: admin/settings/settings-init.php:1026
+#: admin/settings/settings-tax-rates.php:29
+#: admin/woocommerce-admin-settings.php:256
+msgid "Standard"
+msgstr ""
+
+#: admin/post-types/writepanels/order-fee-html.php:39
+#: admin/post-types/writepanels/order-item-html.php:106
+#: admin/woocommerce-admin-reports.php:1531
+#: admin/woocommerce-admin-reports.php:1584
+#: admin/woocommerce-admin-reports.php:2321
+#: admin/woocommerce-admin-reports.php:2493
+#: admin/woocommerce-admin-reports.php:2570
+msgid "Total"
+msgstr ""
+
+#: admin/post-types/writepanels/order-item-html.php:9
+msgid "Product ID:"
+msgstr ""
+
+#: admin/post-types/writepanels/order-item-html.php:12
+msgid "Variation ID:"
+msgstr ""
+
+#: admin/post-types/writepanels/order-item-html.php:15
+msgid "Product SKU:"
+msgstr ""
+
+#: admin/post-types/writepanels/order-item-html.php:33
+msgid "Add&nbsp;meta"
+msgstr ""
+
+#: admin/post-types/writepanels/order-item-html.php:108
+msgid "Subtotal"
+msgstr ""
+
+#: admin/post-types/writepanels/order-tax-html.php:6
+msgid "Tax Rate:"
+msgstr ""
+
+#: admin/post-types/writepanels/order-tax-html.php:16
+#: admin/post-types/writepanels/writepanel-order_data.php:617
+msgid "Sales Tax:"
+msgstr ""
+
+#: admin/post-types/writepanels/order-tax-html.php:20
+#: admin/post-types/writepanels/writepanel-order_data.php:625
+msgid "Shipping Tax:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:6
+#: admin/post-types/writepanels/writepanel-product_data.php:360
+#: admin/post-types/writepanels/writepanel-product_data.php:438
+#: admin/woocommerce-admin-init.php:385
+msgid "Remove"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:20
+msgid "Any"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:46
+msgid "Enter a SKU for this variation or leave blank to use the parent product SKU."
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:57
+msgid "Stock Qty:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:57
+msgid "Enter a quantity to enable stock management for this variation, or leave blank to use the variable product stock options."
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:66
+msgid "Price:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:70
+msgid "Sale Price:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:70
+#: admin/post-types/writepanels/writepanel-product_data.php:125
+msgid "Schedule"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:70
+msgid "Cancel schedule"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:77
+msgid "Sale start date:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:78
+#: admin/post-types/writepanels/writepanel-product_data.php:136
+msgctxt "placeholder"
+msgid "From&hellip;"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:81
+msgid "Sale end date:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:82
+#: admin/post-types/writepanels/writepanel-product_data.php:137
+msgctxt "placeholder"
+msgid "To&hellip;"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:90
+msgid "Enter a weight for this variation or leave blank to use the parent product weight."
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:98
+msgid "Dimensions (L&times;W&times;H)"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:109
+msgid "Shipping class:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:113
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:53
+msgid "Same as parent"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:123
+msgid "Tax class:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:133
+msgid "File paths:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:133
+msgid "Enter one or more File Paths, one per line, to make this variation a downloadable product, or leave blank."
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:134
+#: admin/post-types/writepanels/writepanel-product_data.php:153
+msgid "File paths/URLs, one per line"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:135
+#: admin/post-types/writepanels/writepanel-product_data.php:154
+msgid "Choose a file"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:135
+msgid "Upload"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:135
+#: admin/post-types/writepanels/writepanel-product_data.php:154
+msgid "Insert file URL"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:140
+msgid "Download Limit:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:140
+#: admin/post-types/writepanels/writepanel-product_data.php:158
+msgid "Leave blank for unlimited re-downloads."
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:148
+msgid "Download Expiry:"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:148
+#: admin/post-types/writepanels/writepanel-product_data.php:164
+msgid "Enter the number of days before a download link expires, or leave blank."
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:162
+msgid "Enabled"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:164
+msgid "Enable this option if access is given to a downloadable file upon purchase of a product"
+msgstr ""
+
+#: admin/post-types/writepanels/variation-admin-html.php:166
+msgid "Enable this option if a product is not shipped or there is no shipping cost"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:37
+msgid "Coupon description"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:37
+msgid "Optionally enter a description for this coupon for your reference."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:42
+msgid "Discount type"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:45
+msgid "Enter an amount e.g. 2.99"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:51
+msgid "Enable free shipping"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:51
+msgid "Check this box if the coupon grants free shipping. The <a href=\"%s\">free shipping method</a> must be enabled with the \"must use coupon\" setting checked."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:54
+msgid "Individual use"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:54
+msgid "Check this box if the coupon cannot be used in conjunction with other coupons."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:57
+msgid "Apply before tax"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:57
+msgid "Check this box if the coupon should be applied before calculating cart tax."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:62
+msgid "Minimum amount"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:62
+msgid "No minimum"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:62
+msgid "This field allows you to set the minimum subtotal needed to use the coupon."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:71
+#: admin/woocommerce-admin-taxonomies.php:28
+#: admin/woocommerce-admin-taxonomies.php:122
+msgid "Products"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:72
+#: admin/post-types/writepanels/writepanel-order_data.php:396
+#: admin/post-types/writepanels/writepanel-product_data.php:499
+#: admin/post-types/writepanels/writepanel-product_data.php:520
+#: admin/woocommerce-admin-reports.php:1214
+msgid "Search for a product&hellip;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:91
+msgid "Products which need to be in the cart to use this coupon or, for \"Product Discounts\", which products are discounted."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:96
+msgid "Exclude products"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:97
+msgid "Search for a product…"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:116
+msgid "Products which must not be in the cart to use this coupon or, for \"Product Discounts\", which products are not discounted."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:123
+msgid "Product categories"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:124
+msgid "Any category"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:132
+msgid "A product must be in this category for the coupon to remain valid or, for \"Product Discounts\", products in these categories will be discounted."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:137
+msgid "Exclude categories"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:138
+msgid "No categories"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:146
+msgid "Product must not be in this category for the coupon to remain valid or, for \"Product Discounts\", products in these categories will not be discounted."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:152
+msgid "Customer emails"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:152
+msgid "Any customer"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:152
+msgid "Comma separate email addresses to restrict this coupon to specific billing and user emails."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:159
+msgid "Usage limit"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:159
+msgctxt "placeholder"
+msgid "Unlimited usage"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:159
+msgid "How many times this coupon can be used before it is void."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:165
+msgctxt "placeholder"
+msgid "Never expire"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:165
+msgid "The date this coupon will expire, <code>YYYY-MM-DD</code>."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-coupon_data.php:202
+msgid "Coupon code already exists - customers will use the latest coupon with this code."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:59
+msgid "Order Details"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:62
+msgid "Order number"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:67
+msgid "Customer IP:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:74
+msgid "General Details"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:76
+msgid "Order status:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:86
+msgid "Order Date:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:87
+msgid "h"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:87
+#: admin/settings/settings-init.php:629
+msgid "m"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:91
+msgid "Customer:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:131
+msgid "Customer Note:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:132
+msgid "Customer's notes about the order"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:140
+msgid "Billing Details"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:140
+#: admin/post-types/writepanels/writepanel-order_data.php:230
+#: admin/post-types/writepanels/writepanel-order_data.php:383
+#: admin/post-types/writepanels/writepanel-product_data.php:1046
+#: admin/woocommerce-admin-attributes.php:306
+msgid "Edit"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:144
+#: admin/post-types/writepanels/writepanel-order_data.php:234
+msgid "First Name"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:148
+#: admin/post-types/writepanels/writepanel-order_data.php:238
+msgid "Last Name"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:152
+#: admin/post-types/writepanels/writepanel-order_data.php:242
+#: admin/woocommerce-admin-users.php:155 admin/woocommerce-admin-users.php:204
+msgid "Company"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:156
+#: admin/post-types/writepanels/writepanel-order_data.php:246
+#: admin/woocommerce-admin-users.php:159 admin/woocommerce-admin-users.php:208
+msgid "Address 1"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:160
+#: admin/post-types/writepanels/writepanel-order_data.php:250
+#: admin/woocommerce-admin-users.php:163 admin/woocommerce-admin-users.php:212
+msgid "Address 2"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:164
+#: admin/post-types/writepanels/writepanel-order_data.php:254
+#: admin/settings/settings-tax-rates.php:42
+#: admin/settings/settings-tax-rates.php:182
+#: admin/woocommerce-admin-users.php:167 admin/woocommerce-admin-users.php:216
+msgid "City"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:168
+#: admin/post-types/writepanels/writepanel-order_data.php:258
+#: admin/woocommerce-admin-users.php:171 admin/woocommerce-admin-users.php:220
+msgid "Postcode"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:172
+#: admin/post-types/writepanels/writepanel-order_data.php:262
+#: admin/woocommerce-admin-users.php:179 admin/woocommerce-admin-users.php:228
+msgid "Country"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:175
+#: admin/post-types/writepanels/writepanel-order_data.php:265
+msgid "Select a country&hellip;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:178
+#: admin/post-types/writepanels/writepanel-order_data.php:268
+#: admin/woocommerce-admin-users.php:175 admin/woocommerce-admin-users.php:224
+msgid "State/County"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:182
+#: admin/woocommerce-admin-users.php:187
+msgid "Email"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:185
+msgid "Phone"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:193
+#: admin/post-types/writepanels/writepanel-order_data.php:195
+#: admin/post-types/writepanels/writepanel-order_data.php:277
+#: admin/post-types/writepanels/writepanel-order_data.php:279
+msgid "Address"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:195
+msgid "No billing address set."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:208
+msgid "Load billing address"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:230
+msgid "Shipping Details"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:279
+msgid "No shipping address set."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:292
+msgid "Load shipping address"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:292
+msgid "Copy from billing"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:339
+msgid "Item"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:343
+#: admin/post-types/writepanels/writepanel-product_data.php:189
+#: admin/settings/settings-tax-rates.php:182
+msgid "Tax Class"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:343
+msgid "Tax class for the line item"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:345
+msgid "Qty"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:347
+msgid "Cost"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:347
+msgid "Line subtotals are before pre-tax discounts, totals are after."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:349
+#: admin/settings/settings-tax-rates.php:352
+#: admin/settings/settings-tax-rates.php:431
+#: admin/woocommerce-admin-content.php:48
+#: admin/woocommerce-admin-settings.php:217
+msgid "Tax"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:384
+msgid "Delete Lines"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:386
+msgid "Stock Actions"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:387
+msgid "Reduce Line Stock"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:388
+msgid "Increase Line Stock"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:392
+#: admin/post-types/writepanels/writepanel-order_data.php:449
+msgid "Apply"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:398
+msgid "Add item(s)"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:399
+msgid "Add fee"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:430
+msgid "Resend order emails"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:458
+msgid "Move to Trash"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:463
+msgid "Save Order"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:463
+msgid "Save/update the order"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:488
+msgid "Discounts"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:492
+msgid "Cart Discount:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:492
+msgid "Discounts before tax - calculated by comparing subtotals to totals."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:500
+msgid "Order Discount:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:500
+msgid "Discounts after tax - user defined."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:533
+msgid "Label:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:534
+msgid "The shipping title the customer sees"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:541
+msgid "Cost:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:542
+msgid "(ex. tax)"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:549
+msgid "Method:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:571
+#: admin/post-types/writepanels/writepanel-order_data.php:573
+#: admin/post-types/writepanels/writepanel-order_data.php:666
+#: admin/post-types/writepanels/writepanel-order_data.php:668
+msgid "Other"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:584
+msgid "Tax Rows"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:609
+msgid "+ Add tax row"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:609
+msgid "These rows contain taxes for this order. This allows you to display multiple or compound taxes rather than a single total."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:613
+msgid "Tax Totals"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:617
+msgid "Total tax for line items + fees."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:636
+#: admin/post-types/writepanels/writepanels-init.php:70
+msgid "Order Totals"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:640
+msgid "Order Total:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:648
+msgid "Payment Method:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:678
+msgid "Calc taxes"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_data.php:679
+msgid "Calc totals"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_downloads.php:57
+msgid "Choose a downloadable product&hellip;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_downloads.php:89
+msgid "Grant Access"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_downloads.php:127
+msgid "Could not grant access - the user may already have permission for this file."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_downloads.php:150
+msgid "Are you sure you want to revoke access to this download?"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:44
+msgid "added %s ago"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:44
+msgid "Delete note"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:50
+msgid "There are no notes for this order yet."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:56
+msgid "Add note"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:56
+msgid "Add a note for your reference, or add a customer note (the user will be notified)."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:62
+msgid "Customer note"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:63
+msgid "Private note"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-order_notes.php:65
+#: admin/post-types/writepanels/writepanel-product_data.php:477
+msgid "Add"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:23
+msgid "Variations for variable products are defined here."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:23
+msgid "Variations"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:65
+msgid "Before adding variations, add and save some attributes on the <strong>Attributes</strong> tab."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:67
+msgid "Learn more"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:74
+#: admin/post-types/writepanels/writepanel-product_data.php:325
+msgid "Close all"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:74
+#: admin/post-types/writepanels/writepanel-product_data.php:325
+msgid "Expand all"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:75
+msgid "Bulk edit:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:77
+msgid "Toggle &quot;Enabled&quot;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:78
+msgid "Toggle &quot;Downloadable&quot;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:79
+msgid "Toggle &quot;Virtual&quot;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:80
+msgid "Delete all variations"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:81
+msgid "Prices"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:82
+msgid "Sale prices"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:88
+msgid "File Path"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:89
+msgid "Download limit"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:90
+#: admin/post-types/writepanels/writepanel-product_data.php:164
+msgid "Download Expiry"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:92
+msgid "Go"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:192
+msgid "Add Variation"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:194
+msgid "Link all variations"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:196
+msgid "Default selections:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:209
+msgid "No default"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:273
+msgid "Are you sure you want to link all variations? This will create a new variation for each and every possible combination of variation attributes (max 50 per run)."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:290
+msgid "variation added"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:292
+msgid "variations added"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:294
+msgid "No variations added"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:316
+msgid "Are you sure you want to remove this variation?"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:372
+msgid "Are you sure you want to delete all variations? This cannot be undone."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:375
+msgid "Last warning, are you sure?"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:412
+msgid "Enter a value"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:503
+#: admin/woocommerce-admin-taxonomies.php:62
+#: admin/woocommerce-admin-taxonomies.php:154
+msgid "Choose an image"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:505
+msgid "Set variation image"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:549
+msgid "Variable product"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product-type-variable.php:615
+msgid "Variation #%s of %s"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:43
+msgid "Product Type"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:53
+msgid "Virtual products are intangible and aren't shipped."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:59
+msgid "Downloadable products give access to a file upon purchase."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:77
+#: admin/woocommerce-admin-content.php:44
+#: admin/woocommerce-admin-settings.php:213
+msgid "General"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:79
+#: admin/woocommerce-admin-content.php:47
+#: admin/woocommerce-admin-settings.php:216
+msgid "Inventory"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:83
+msgid "Linked Products"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:85
+#: admin/woocommerce-admin-attributes.php:282
+#: admin/woocommerce-admin-init.php:61
+msgid "Attributes"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:87
+msgid "Advanced"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:98
+msgid "Stock Keeping Unit"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:98
+msgid "SKU refers to a Stock-keeping unit, a unique identifier for each distinct product and service that can be purchased."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:109
+msgid "Product URL"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:109
+msgid "Enter the external URL to the product."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:112
+msgid "Button text"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:112
+msgctxt "placeholder"
+msgid "Buy product"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:112
+msgid "This text will be shown on the button linking to the external product."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:119
+msgid "Regular Price"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:125
+msgid "Sale Price"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:135
+msgid "Sale Price Dates"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:138
+#: admin/post-types/writepanels/writepanel-product_data.php:1067
+msgid "Cancel"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:152
+msgid "File paths (one per line)"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:158
+msgid "Download Limit"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:176
+msgid "Tax Status"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:178
+msgid "Shipping only"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:179
+msgid "None"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:215
+msgid "Stock quantity. If this is a variable product this value will be used to control stock for all variations, unless you define stock at variation level."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:226
+msgid "Stock status"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:229
+msgid "Controls whether or not the product is listed as \"in stock\" or \"out of stock\" on the frontend."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:236
+msgid "Allow Backorders?"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:237
+msgid "Do not allow"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:238
+msgid "Allow, but notify customer"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:239
+msgid "Allow"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:240
+msgid "If managing stock, this controls whether or not backorders are allowed for this product and variations. If enabled, stock quantity can go below 0."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:251
+msgid "Sold Individually"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:251
+msgid "Enable this to only allow one of this item to be bought in a single order"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:269
+msgid "Weight in decimal form"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:280
+msgid "Dimensions"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:286
+msgid "LxWxH in decimal form"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:307
+msgid "No shipping class"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:313
+msgid "Shipping class"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:313
+msgid "Shipping classes are used by certain shipping methods to group similar products."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:376
+#: admin/post-types/writepanels/writepanel-product_data.php:452
+#: admin/woocommerce-admin-init.php:387
+msgid "Value(s)"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:378
+msgid "Select terms"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:390
+msgid "Select all"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:390
+msgid "Select none"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:392
+msgid "Add new"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:405
+msgid "Pipe separate terms"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:411
+#: admin/post-types/writepanels/writepanel-product_data.php:458
+#: admin/woocommerce-admin-init.php:389
+msgid "Visible on the product page"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:417
+#: admin/post-types/writepanels/writepanel-product_data.php:464
+#: admin/woocommerce-admin-init.php:390
+msgid "Used for variations"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:453
+#: admin/woocommerce-admin-init.php:388
+msgid "Enter some text, or some attributes by pipe (|) separating values."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:479
+msgid "Custom product attribute"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:491
+msgid "Save attributes"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:498
+msgid "Up-Sells"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:517
+msgid "Up-sells are products which you recommend instead of the currently viewed product, for example, products that are more profitable or better quality or more expensive."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:519
+msgid "Cross-Sells"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:538
+msgid "Cross-sells are products which you promote in the cart, based on the current product."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:548
+msgid "Choose a grouped product&hellip;"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:574
+msgid "Grouping"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:574
+msgid "Set this option to make this product part of a grouped product."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:594
+msgid "Purchase Note"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:594
+msgid "Enter an optional note to send the customer after purchase."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:601
+msgid "Menu order"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:601
+msgid "Custom ordering position."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:609
+msgid "Enable reviews"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:698
+msgid "Product SKU must be unique."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:1031
+msgid "Catalog/search"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:1038
+msgid "Catalog visibility:"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:1054
+msgid "Define the loops this product should be visible in. The product will still be accessible directly."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:1060
+msgid "Enable this option to feature this product."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:1062
+msgid "Featured Product"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_data.php:1066
+msgid "OK"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_images.php:42
+#: admin/post-types/writepanels/writepanel-product_images.php:102
+msgid "Delete image"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_images.php:42
+#: admin/post-types/writepanels/writepanel-product_images.php:102
+#: admin/woocommerce-admin-attributes.php:306
+msgid "Delete"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_images.php:53
+msgid "Add product gallery images"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_images.php:79
+msgid "Add Images to Product Gallery"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanel-product_images.php:81
+msgid "Add to gallery"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:47
+msgid "Product Gallery"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:55
+msgid "Product Short Description"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:64
+msgid "Reviews"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:68
+msgid "Order Data"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:69
+msgid "Order Items"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:69
+msgid "Note: if you edit quantities or remove items from the order you will need to manually update stock levels."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:72
+msgid "Downloadable Product Permissions"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:72
+msgid "Note: Permissions for order items will automatically be granted when the order status changes to processing/completed."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:73
+msgid "Order Actions"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:81
+msgid "Coupon Data"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:100
+msgid "Coupon code"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:101
+msgid "Product name"
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:185
+msgid "Allow reviews."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:186
+msgid "Allow <a href=\"%s\" target=\"_blank\">trackbacks and pingbacks</a> on this page."
+msgstr ""
+
+#: admin/post-types/writepanels/writepanels-init.php:186
+msgid "http://codex.wordpress.org/Introduction_to_Blogging#Managing_Comments"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:23
+msgid "Styles"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:43
+msgid "Primary"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:43
+msgid "Call to action buttons/price slider/layered nav UI"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:44
+msgid "Secondary"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:44
+msgid "Buttons and tabs"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:45
+msgid "Highlight"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:45
+msgid "Price labels and Sale Flashes"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:46
+msgid "Content"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:46
+msgid "Your themes page background - used for tab active states"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:47
+msgid "Subtext"
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:47
+msgid "Used for certain text and asides - breadcrumbs, small text etc."
+msgstr ""
+
+#: admin/settings/settings-frontend-styles.php:51
+msgid "To edit colours <code>woocommerce/assets/css/woocommerce-base.less</code> and <code>woocommerce.css</code> need to be writable. See <a href=\"http://codex.wordpress.org/Changing_File_Permissions\">the Codex</a> for more information."
+msgstr ""
+
+#: admin/settings/settings-init.php:18
+msgid "Localisation"
+msgstr ""
+
+#: admin/settings/settings-init.php:19
+msgid "Use informal localisation for %s"
+msgstr ""
+
+#: admin/settings/settings-init.php:27
+msgid "General Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:30
+msgid "Base Country/Region"
+msgstr ""
+
+#: admin/settings/settings-init.php:31
+msgid "This is the base country for your business. Tax rates will be based on this country."
+msgstr ""
+
+#: admin/settings/settings-init.php:40
+msgid "Currency"
+msgstr ""
+
+#: admin/settings/settings-init.php:41
+msgid "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in."
+msgstr ""
+
+#: admin/settings/settings-init.php:49
+msgid "US Dollars (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:50
+msgid "Euros (&euro;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:51
+msgid "Pounds Sterling (&pound;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:52
+msgid "Australian Dollars (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:53
+msgid "Brazilian Real (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:54
+msgid "Canadian Dollars (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:55
+msgid "Czech Koruna (&#75;&#269;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:56
+msgid "Danish Krone"
+msgstr ""
+
+#: admin/settings/settings-init.php:57
+msgid "Hong Kong Dollar (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:58
+msgid "Hungarian Forint"
+msgstr ""
+
+#: admin/settings/settings-init.php:59
+msgid "Israeli Shekel"
+msgstr ""
+
+#: admin/settings/settings-init.php:60
+msgid "Chinese Yuan (&yen;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:61
+msgid "Japanese Yen (&yen;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:62
+msgid "Malaysian Ringgits (RM)"
+msgstr ""
+
+#: admin/settings/settings-init.php:63
+msgid "Mexican Peso (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:64
+msgid "New Zealand Dollar (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:65
+msgid "Norwegian Krone"
+msgstr ""
+
+#: admin/settings/settings-init.php:66
+msgid "Philippine Pesos"
+msgstr ""
+
+#: admin/settings/settings-init.php:67
+msgid "Polish Zloty"
+msgstr ""
+
+#: admin/settings/settings-init.php:68
+msgid "Singapore Dollar (&#36;)"
+msgstr ""
+
+#: admin/settings/settings-init.php:69
+msgid "Swedish Krona"
+msgstr ""
+
+#: admin/settings/settings-init.php:70
+msgid "Swiss Franc"
+msgstr ""
+
+#: admin/settings/settings-init.php:71
+msgid "Taiwan New Dollars"
+msgstr ""
+
+#: admin/settings/settings-init.php:72
+msgid "Thai Baht"
+msgstr ""
+
+#: admin/settings/settings-init.php:73
+msgid "Turkish Lira (TL)"
+msgstr ""
+
+#: admin/settings/settings-init.php:74
+msgid "South African rand (R)"
+msgstr ""
+
+#: admin/settings/settings-init.php:75
+msgid "Romanian Leu (RON)"
+msgstr ""
+
+#: admin/settings/settings-init.php:81
+msgid "Allowed Countries"
+msgstr ""
+
+#: admin/settings/settings-init.php:82
+msgid "These are countries that you are willing to ship to."
+msgstr ""
+
+#: admin/settings/settings-init.php:90
+msgid "All Countries"
+msgstr ""
+
+#: admin/settings/settings-init.php:91 admin/settings/settings-init.php:96
+msgid "Specific Countries"
+msgstr ""
+
+#: admin/settings/settings-init.php:108
+msgid "Checkout and Accounts"
+msgstr ""
+
+#: admin/settings/settings-init.php:108
+msgid "The following options control the behaviour of the checkout process and customer accounts."
+msgstr ""
+
+#: admin/settings/settings-init.php:111 admin/woocommerce-admin-install.php:195
+msgid "Checkout"
+msgstr ""
+
+#: admin/settings/settings-init.php:112
+msgid "Enable guest checkout (no account required)"
+msgstr ""
+
+#: admin/settings/settings-init.php:120
+msgid "Show order comments section"
+msgstr ""
+
+#: admin/settings/settings-init.php:128
+msgid "Security"
+msgstr ""
+
+#: admin/settings/settings-init.php:129
+msgid "Force secure checkout"
+msgstr ""
+
+#: admin/settings/settings-init.php:135
+msgid "Force SSL (HTTPS) on the checkout pages (an SSL Certificate is required)"
+msgstr ""
+
+#: admin/settings/settings-init.php:139
+msgid "Un-force HTTPS when leaving the checkout"
+msgstr ""
+
+#: admin/settings/settings-init.php:148 admin/woocommerce-admin-content.php:75
+#: admin/woocommerce-admin-reports.php:72
+msgid "Coupons"
+msgstr ""
+
+#: admin/settings/settings-init.php:149
+msgid "Enable coupons"
+msgstr ""
+
+#: admin/settings/settings-init.php:158
+msgid "Enable coupon form on cart"
+msgstr ""
+
+#: admin/settings/settings-init.php:167
+msgid "Enable coupon form on checkout"
+msgstr ""
+
+#: admin/settings/settings-init.php:176
+msgid "Registration"
+msgstr ""
+
+#: admin/settings/settings-init.php:177
+msgid "Allow registration on the checkout page"
+msgstr ""
+
+#: admin/settings/settings-init.php:185
+msgid "Allow registration on the \"My Account\" page"
+msgstr ""
+
+#: admin/settings/settings-init.php:193
+msgid "Register using the email address for the username"
+msgstr ""
+
+#: admin/settings/settings-init.php:201
+msgid "Customer Accounts"
+msgstr ""
+
+#: admin/settings/settings-init.php:202
+msgid "Prevent customers from accessing WordPress admin"
+msgstr ""
+
+#: admin/settings/settings-init.php:210
+msgid "Clear cart when logging out"
+msgstr ""
+
+#: admin/settings/settings-init.php:218
+msgid "Allow customers to repurchase past orders"
+msgstr ""
+
+#: admin/settings/settings-init.php:227
+msgid "Styles and Scripts"
+msgstr ""
+
+#: admin/settings/settings-init.php:227
+msgid "The following options affect the styling of your store, as well as how certain features behave."
+msgstr ""
+
+#: admin/settings/settings-init.php:230
+msgid "Styling"
+msgstr ""
+
+#: admin/settings/settings-init.php:231
+msgid "Enable WooCommerce CSS styles"
+msgstr ""
+
+#: admin/settings/settings-init.php:242
+msgid "Store Notice"
+msgstr ""
+
+#: admin/settings/settings-init.php:243
+msgid "Enable the \"Demo Store\" notice on your site"
+msgstr ""
+
+#: admin/settings/settings-init.php:250
+msgid "Store Notice Text"
+msgstr ""
+
+#: admin/settings/settings-init.php:253
+msgid "This is a demo store for testing purposes &mdash; no orders shall be fulfilled."
+msgstr ""
+
+#: admin/settings/settings-init.php:259
+msgid "Scripts"
+msgstr ""
+
+#: admin/settings/settings-init.php:260
+msgid "Enable AJAX add to cart buttons on product archives"
+msgstr ""
+
+#: admin/settings/settings-init.php:268
+msgid "Enable WooCommerce lightbox on the product page"
+msgstr ""
+
+#: admin/settings/settings-init.php:276
+msgid "Enable enhanced country select boxes"
+msgstr ""
+
+#: admin/settings/settings-init.php:285
+msgid "Digital Downloads"
+msgstr ""
+
+#: admin/settings/settings-init.php:285
+msgid "The following options are specific to downloadable products."
+msgstr ""
+
+#: admin/settings/settings-init.php:288
+msgid "File Download Method"
+msgstr ""
+
+#: admin/settings/settings-init.php:289
+msgid "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect</code>/ <code>X-Sendfile</code> can be used to serve downloads instead (server requires <code>mod_xsendfile</code>)."
+msgstr ""
+
+#: admin/settings/settings-init.php:297
+msgid "Force Downloads"
+msgstr ""
+
+#: admin/settings/settings-init.php:298
+msgid "X-Accel-Redirect/X-Sendfile"
+msgstr ""
+
+#: admin/settings/settings-init.php:299
+msgid "Redirect only"
+msgstr ""
+
+#: admin/settings/settings-init.php:304
+msgid "Access Restrictions"
+msgstr ""
+
+#: admin/settings/settings-init.php:305
+msgid "Must be logged in to download files"
+msgstr ""
+
+#: admin/settings/settings-init.php:309
+msgid "This setting does not apply to guest downloads."
+msgstr ""
+
+#: admin/settings/settings-init.php:314
+msgid "Grant access to downloadable products after payment"
+msgstr ""
+
+#: admin/settings/settings-init.php:318
+msgid "Turn this option off to only grant access when an order is \"complete\", rather than \"processing\""
+msgstr ""
+
+#: admin/settings/settings-init.php:323
+msgid "Limit Quantity"
+msgstr ""
+
+#: admin/settings/settings-init.php:324
+msgid "Limit the purchasable quantity of downloadable-virtual items to 1"
+msgstr ""
+
+#: admin/settings/settings-init.php:342
+msgid "Note: The shop page has children - child pages will not work if you enable this option."
+msgstr ""
+
+#: admin/settings/settings-init.php:347
+msgid "Page Setup"
+msgstr ""
+
+#: admin/settings/settings-init.php:349
+msgid "Set up core WooCommerce pages here, for example the base page. The base page can also be used in your %sproduct permalinks%s."
+msgstr ""
+
+#: admin/settings/settings-init.php:354
+msgid "Shop Base Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:355
+msgid "This sets the base page of your shop - this is where your product archive will be."
+msgstr ""
+
+#: admin/settings/settings-init.php:365
+msgid "Base Page Title"
+msgstr ""
+
+#: admin/settings/settings-init.php:366
+msgid "This title to show on the shop base page. Leave blank to use the page title."
+msgstr ""
+
+#: admin/settings/settings-init.php:375
+msgid "Terms Page ID"
+msgstr ""
+
+#: admin/settings/settings-init.php:376
+msgid "If you define a \"Terms\" page the customer will be asked if they accept them when checking out."
+msgstr ""
+
+#: admin/settings/settings-init.php:386
+msgid "Logout link"
+msgstr ""
+
+#: admin/settings/settings-init.php:387
+msgid "Append a logout link to menus containing \"My Account\""
+msgstr ""
+
+#: admin/settings/settings-init.php:395 admin/woocommerce-admin-status.php:161
+msgid "Shop Pages"
+msgstr ""
+
+#: admin/settings/settings-init.php:395
+msgid "The following pages need selecting so that WooCommerce knows where they are. These pages should have been created upon installation of the plugin, if not you will need to create them."
+msgstr ""
+
+#: admin/settings/settings-init.php:398 admin/woocommerce-admin-status.php:172
+msgid "Cart Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:399
+msgid "Page contents: [woocommerce_cart]"
+msgstr ""
+
+#: admin/settings/settings-init.php:409 admin/woocommerce-admin-status.php:176
+msgid "Checkout Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:410
+msgid "Page contents: [woocommerce_checkout]"
+msgstr ""
+
+#: admin/settings/settings-init.php:420 admin/woocommerce-admin-status.php:180
+msgid "Pay Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:421
+msgid "Page contents: [woocommerce_pay] Parent: \"Checkout\""
+msgstr ""
+
+#: admin/settings/settings-init.php:431 admin/woocommerce-admin-status.php:184
+msgid "Thanks Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:432
+msgid "Page contents: [woocommerce_thankyou] Parent: \"Checkout\""
+msgstr ""
+
+#: admin/settings/settings-init.php:442 admin/woocommerce-admin-status.php:188
+msgid "My Account Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:443
+msgid "Page contents: [woocommerce_my_account]"
+msgstr ""
+
+#: admin/settings/settings-init.php:453 admin/woocommerce-admin-status.php:192
+msgid "Edit Address Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:454
+msgid "Page contents: [woocommerce_edit_address] Parent: \"My Account\""
+msgstr ""
+
+#: admin/settings/settings-init.php:464 admin/woocommerce-admin-status.php:196
+msgid "View Order Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:465
+msgid "Page contents: [woocommerce_view_order] Parent: \"My Account\""
+msgstr ""
+
+#: admin/settings/settings-init.php:475 admin/woocommerce-admin-status.php:200
+msgid "Change Password Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:476
+msgid "Page contents: [woocommerce_change_password] Parent: \"My Account\""
+msgstr ""
+
+#: admin/settings/settings-init.php:486
+msgid "Lost Password Page"
+msgstr ""
+
+#: admin/settings/settings-init.php:487
+msgid "Page contents: [woocommerce_lost_password] Parent: \"My Account\""
+msgstr ""
+
+#: admin/settings/settings-init.php:503
+msgid "Catalog Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:506
+msgid "Default Product Sorting"
+msgstr ""
+
+#: admin/settings/settings-init.php:507
+msgid "This controls the default sort order of the catalog."
+msgstr ""
+
+#: admin/settings/settings-init.php:513
+msgid "Default sorting"
+msgstr ""
+
+#: admin/settings/settings-init.php:514
+msgid "Sort alphabetically"
+msgstr ""
+
+#: admin/settings/settings-init.php:515
+msgid "Sort by most recent"
+msgstr ""
+
+#: admin/settings/settings-init.php:516
+msgid "Sort by price"
+msgstr ""
+
+#: admin/settings/settings-init.php:522
+msgid "Shop Page Display"
+msgstr ""
+
+#: admin/settings/settings-init.php:523
+msgid "This controls what is shown on the product archive."
+msgstr ""
+
+#: admin/settings/settings-init.php:529 admin/settings/settings-init.php:544
+msgid "Show products"
+msgstr ""
+
+#: admin/settings/settings-init.php:530 admin/settings/settings-init.php:545
+msgid "Show subcategories"
+msgstr ""
+
+#: admin/settings/settings-init.php:531 admin/settings/settings-init.php:546
+msgid "Show both"
+msgstr ""
+
+#: admin/settings/settings-init.php:537
+msgid "Default Category Display"
+msgstr ""
+
+#: admin/settings/settings-init.php:538
+msgid "This controls what is shown on category archives."
+msgstr ""
+
+#: admin/settings/settings-init.php:552
+msgid "Redirects"
+msgstr ""
+
+#: admin/settings/settings-init.php:553
+msgid "Redirect to cart after adding a product to the cart (on single product pages)"
+msgstr ""
+
+#: admin/settings/settings-init.php:561
+msgid "Redirect to the product page on a single matching search result"
+msgstr ""
+
+#: admin/settings/settings-init.php:570
+msgid "The following options affect the fields available on the edit product page."
+msgstr ""
+
+#: admin/settings/settings-init.php:573
+msgid "Product Fields"
+msgstr ""
+
+#: admin/settings/settings-init.php:574
+msgid "Enable the SKU field for products"
+msgstr ""
+
+#: admin/settings/settings-init.php:582
+msgid "Enable the weight field for products"
+msgstr ""
+
+#: admin/settings/settings-init.php:590
+msgid "Enable the dimension fields for products"
+msgstr ""
+
+#: admin/settings/settings-init.php:598
+msgid "Show weight and dimension fields in product attributes tab"
+msgstr ""
+
+#: admin/settings/settings-init.php:606
+msgid "Weight Unit"
+msgstr ""
+
+#: admin/settings/settings-init.php:607
+msgid "This controls what unit you will define weights in."
+msgstr ""
+
+#: admin/settings/settings-init.php:613
+msgid "kg"
+msgstr ""
+
+#: admin/settings/settings-init.php:614
+msgid "g"
+msgstr ""
+
+#: admin/settings/settings-init.php:615
+msgid "lbs"
+msgstr ""
+
+#: admin/settings/settings-init.php:616
+msgid "oz"
+msgstr ""
+
+#: admin/settings/settings-init.php:622
+msgid "Dimensions Unit"
+msgstr ""
+
+#: admin/settings/settings-init.php:623
+msgid "This controls what unit you will define lengths in."
+msgstr ""
+
+#: admin/settings/settings-init.php:630
+msgid "cm"
+msgstr ""
+
+#: admin/settings/settings-init.php:631
+msgid "mm"
+msgstr ""
+
+#: admin/settings/settings-init.php:632
+msgid "in"
+msgstr ""
+
+#: admin/settings/settings-init.php:633
+msgid "yd"
+msgstr ""
+
+#: admin/settings/settings-init.php:639
+msgid "Product Ratings"
+msgstr ""
+
+#: admin/settings/settings-init.php:640
+msgid "Enable the rating field on the review form"
+msgstr ""
+
+#: admin/settings/settings-init.php:649
+msgid "Ratings are required to leave a review"
+msgstr ""
+
+#: admin/settings/settings-init.php:658
+msgid "Show \"verified owner\" label for customer reviews"
+msgstr ""
+
+#: admin/settings/settings-init.php:668
+msgid "Pricing Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:668
+msgid "The following options affect how prices are displayed on the frontend."
+msgstr ""
+
+#: admin/settings/settings-init.php:671
+msgid "Currency Position"
+msgstr ""
+
+#: admin/settings/settings-init.php:672
+msgid "This controls the position of the currency symbol."
+msgstr ""
+
+#: admin/settings/settings-init.php:678
+msgid "Left"
+msgstr ""
+
+#: admin/settings/settings-init.php:679
+msgid "Right"
+msgstr ""
+
+#: admin/settings/settings-init.php:680
+msgid "Left (with space)"
+msgstr ""
+
+#: admin/settings/settings-init.php:681
+msgid "Right (with space)"
+msgstr ""
+
+#: admin/settings/settings-init.php:687
+msgid "Thousand Separator"
+msgstr ""
+
+#: admin/settings/settings-init.php:688
+msgid "This sets the thousand separator of displayed prices."
+msgstr ""
+
+#: admin/settings/settings-init.php:697
+msgid "Decimal Separator"
+msgstr ""
+
+#: admin/settings/settings-init.php:698
+msgid "This sets the decimal separator of displayed prices."
+msgstr ""
+
+#: admin/settings/settings-init.php:707
+msgid "Number of Decimals"
+msgstr ""
+
+#: admin/settings/settings-init.php:708
+msgid "This sets the number of decimal points shown in displayed prices."
+msgstr ""
+
+#: admin/settings/settings-init.php:721
+msgid "Trailing Zeros"
+msgstr ""
+
+#: admin/settings/settings-init.php:722
+msgid "Remove zeros after the decimal point. e.g. <code>$10.00</code> becomes <code>$10</code>"
+msgstr ""
+
+#: admin/settings/settings-init.php:730
+msgid "Image Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:730
+msgid "These settings affect the actual dimensions of images in your catalog - the display on the front-end will still be affected by CSS styles. After changing these settings you may need to <a href=\"%s\">regenerate your thumbnails</a>."
+msgstr ""
+
+#: admin/settings/settings-init.php:733
+msgid "Catalog Images"
+msgstr ""
+
+#: admin/settings/settings-init.php:734
+msgid "This size is usually used in product listings"
+msgstr ""
+
+#: admin/settings/settings-init.php:747
+msgid "Single Product Image"
+msgstr ""
+
+#: admin/settings/settings-init.php:748
+msgid "This is the size used by the main image on the product page."
+msgstr ""
+
+#: admin/settings/settings-init.php:761
+msgid "Product Thumbnails"
+msgstr ""
+
+#: admin/settings/settings-init.php:762
+msgid "This size is usually used for the gallery of images on the product page."
+msgstr ""
+
+#: admin/settings/settings-init.php:781
+msgid "Inventory Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:784
+msgid "Manage Stock"
+msgstr ""
+
+#: admin/settings/settings-init.php:785
+msgid "Enable stock management"
+msgstr ""
+
+#: admin/settings/settings-init.php:792
+msgid "Hold Stock (minutes)"
+msgstr ""
+
+#: admin/settings/settings-init.php:793
+msgid "Hold stock (for unpaid orders) for x minutes. When this limit is reached, the pending order will be cancelled. Leave blank to disable."
+msgstr ""
+
+#: admin/settings/settings-init.php:805
+msgid "Notifications"
+msgstr ""
+
+#: admin/settings/settings-init.php:806
+msgid "Enable low stock notifications"
+msgstr ""
+
+#: admin/settings/settings-init.php:814
+msgid "Enable out of stock notifications"
+msgstr ""
+
+#: admin/settings/settings-init.php:822
+msgid "Low Stock Threshold"
+msgstr ""
+
+#: admin/settings/settings-init.php:835
+msgid "Out Of Stock Threshold"
+msgstr ""
+
+#: admin/settings/settings-init.php:848
+msgid "Out Of Stock Visibility"
+msgstr ""
+
+#: admin/settings/settings-init.php:849
+msgid "Hide out of stock items from the catalog"
+msgstr ""
+
+#: admin/settings/settings-init.php:856
+msgid "Stock Display Format"
+msgstr ""
+
+#: admin/settings/settings-init.php:857
+msgid "This controls how stock is displayed on the frontend."
+msgstr ""
+
+#: admin/settings/settings-init.php:863
+msgid "Always show stock e.g. \"12 in stock\""
+msgstr ""
+
+#: admin/settings/settings-init.php:864
+msgid "Only show stock when low e.g. \"Only 2 left in stock\" vs. \"In Stock\""
+msgstr ""
+
+#: admin/settings/settings-init.php:865
+msgid "Never show stock amount"
+msgstr ""
+
+#: admin/settings/settings-init.php:877
+#: admin/woocommerce-admin-settings.php:320
+msgid "Shipping Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:880
+msgid "Shipping Calculations"
+msgstr ""
+
+#: admin/settings/settings-init.php:881
+msgid "Enable shipping"
+msgstr ""
+
+#: admin/settings/settings-init.php:889
+msgid "Enable the shipping calculator on the cart page"
+msgstr ""
+
+#: admin/settings/settings-init.php:897
+msgid "Hide shipping costs until an address is entered"
+msgstr ""
+
+#: admin/settings/settings-init.php:905
+msgid "Shipping Method Display"
+msgstr ""
+
+#: admin/settings/settings-init.php:906
+msgid "This controls how multiple shipping methods are displayed on the frontend."
+msgstr ""
+
+#: admin/settings/settings-init.php:912
+msgid "Radio buttons"
+msgstr ""
+
+#: admin/settings/settings-init.php:913
+msgid "Select box"
+msgstr ""
+
+#: admin/settings/settings-init.php:919
+msgid "Shipping Destination"
+msgstr ""
+
+#: admin/settings/settings-init.php:920
+msgid "Only ship to the users billing address"
+msgstr ""
+
+#: admin/settings/settings-init.php:928
+msgid "Ship to billing address by default"
+msgstr ""
+
+#: admin/settings/settings-init.php:936
+msgid "Collect shipping address even when not required"
+msgstr ""
+
+#: admin/settings/settings-init.php:954
+#: admin/woocommerce-admin-settings.php:219
+#: admin/woocommerce-admin-settings.php:355
+msgid "Payment Gateways"
+msgstr ""
+
+#: admin/settings/settings-init.php:954
+msgid "Installed payment gateways are displayed below. Drag and drop payment gateways to control their display order on the checkout."
+msgstr ""
+
+#: admin/settings/settings-init.php:972
+#: admin/woocommerce-admin-settings.php:250
+msgid "Tax Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:975
+msgid "Enable Taxes"
+msgstr ""
+
+#: admin/settings/settings-init.php:976
+msgid "Enable taxes and tax calculations"
+msgstr ""
+
+#: admin/settings/settings-init.php:983
+msgid "Prices Entered With Tax"
+msgstr ""
+
+#: admin/settings/settings-init.php:987
+msgid "This option is important as it will affect how you input prices. Changing it will not update existing products."
+msgstr ""
+
+#: admin/settings/settings-init.php:989
+msgid "Yes, I will enter prices inclusive of tax"
+msgstr ""
+
+#: admin/settings/settings-init.php:990
+msgid "No, I will enter prices exclusive of tax"
+msgstr ""
+
+#: admin/settings/settings-init.php:995
+msgid "Calculate Tax Based On:"
+msgstr ""
+
+#: admin/settings/settings-init.php:997
+msgid "This option determines which address is used to calculate tax."
+msgstr ""
+
+#: admin/settings/settings-init.php:1001
+msgid "Customer shipping address"
+msgstr ""
+
+#: admin/settings/settings-init.php:1002
+msgid "Customer billing address"
+msgstr ""
+
+#: admin/settings/settings-init.php:1003 admin/settings/settings-init.php:1015
+msgid "Shop base address"
+msgstr ""
+
+#: admin/settings/settings-init.php:1008
+msgid "Default Customer Address:"
+msgstr ""
+
+#: admin/settings/settings-init.php:1010
+msgid "This option determines the customers default address (before they input their own)."
+msgstr ""
+
+#: admin/settings/settings-init.php:1014
+msgid "No address"
+msgstr ""
+
+#: admin/settings/settings-init.php:1020
+msgid "Shipping Tax Class:"
+msgstr ""
+
+#: admin/settings/settings-init.php:1021
+msgid "Optionally control which tax class shipping gets, or leave it so shipping tax is based on the cart items themselves."
+msgstr ""
+
+#: admin/settings/settings-init.php:1031
+msgid "Rounding"
+msgstr ""
+
+#: admin/settings/settings-init.php:1032
+msgid "Round tax at subtotal level, instead of rounding per line"
+msgstr ""
+
+#: admin/settings/settings-init.php:1039
+msgid "Additional Tax Classes"
+msgstr ""
+
+#: admin/settings/settings-init.php:1040
+msgid "List additonal tax classes below (1 per line). This is in addition to the default <code>Standard Rate</code>. Tax classes can be assigned to products."
+msgstr ""
+
+#: admin/settings/settings-init.php:1044
+msgid "Reduced Rate%sZero Rate"
+msgstr ""
+
+#: admin/settings/settings-init.php:1048
+msgid "Display prices during cart/checkout:"
+msgstr ""
+
+#: admin/settings/settings-init.php:1053
+msgid "Including tax"
+msgstr ""
+
+#: admin/settings/settings-init.php:1054
+msgid "Excluding tax"
+msgstr ""
+
+#: admin/settings/settings-init.php:1066
+msgid "Email Sender Options"
+msgstr ""
+
+#: admin/settings/settings-init.php:1066
+msgid "The following options affect the sender (email address and name) used in WooCommerce emails."
+msgstr ""
+
+#: admin/settings/settings-init.php:1069
+msgid "\"From\" Name"
+msgstr ""
+
+#: admin/settings/settings-init.php:1078
+msgid "\"From\" Email Address"
+msgstr ""
+
+#: admin/settings/settings-init.php:1091
+msgid "Email Template"
+msgstr ""
+
+#: admin/settings/settings-init.php:1091
+msgid "This section lets you customise the WooCommerce emails. <a href=\"%s\" target=\"_blank\">Click here to preview your email template</a>. For more advanced control copy <code>woocommerce/templates/emails/</code> to <code>yourtheme/woocommerce/emails/</code>."
+msgstr ""
+
+#: admin/settings/settings-init.php:1094
+msgid "Header Image"
+msgstr ""
+
+#: admin/settings/settings-init.php:1095
+msgid "Enter a URL to an image you want to show in the email's header. Upload your image using the <a href=\"%s\">media uploader</a>."
+msgstr ""
+
+#: admin/settings/settings-init.php:1103
+msgid "Email Footer Text"
+msgstr ""
+
+#: admin/settings/settings-init.php:1104
+msgid "The text to appear in the footer of WooCommerce emails."
+msgstr ""
+
+#: admin/settings/settings-init.php:1108
+msgid "Powered by WooCommerce"
+msgstr ""
+
+#: admin/settings/settings-init.php:1112
+msgid "Base Colour"
+msgstr ""
+
+#: admin/settings/settings-init.php:1113
+msgid "The base colour for WooCommerce email templates. Default <code>#557da1</code>."
+msgstr ""
+
+#: admin/settings/settings-init.php:1121
+msgid "Background Colour"
+msgstr ""
+
+#: admin/settings/settings-init.php:1122
+msgid "The background colour for WooCommerce email templates. Default <code>#f5f5f5</code>."
+msgstr ""
+
+#: admin/settings/settings-init.php:1130
+msgid "Email Body Background Colour"
+msgstr ""
+
+#: admin/settings/settings-init.php:1131
+msgid "The main body background colour. Default <code>#fdfdfd</code>."
+msgstr ""
+
+#: admin/settings/settings-init.php:1139
+msgid "Email Body Text Colour"
+msgstr ""
+
+#: admin/settings/settings-init.php:1140
+msgid "The main body text colour. Default <code>#505050</code>."
+msgstr ""
+
+#: admin/settings/settings-payment-gateways.php:27
+#: admin/settings/settings-shipping-methods.php:29
+#: admin/woocommerce-admin-init.php:701
+#: admin/woocommerce-admin-taxonomies.php:27
+#: admin/woocommerce-admin-taxonomies.php:121
+msgid "Default"
+msgstr ""
+
+#: admin/settings/settings-payment-gateways.php:28
+msgid "Gateway"
+msgstr ""
+
+#: admin/settings/settings-payment-gateways.php:45
+msgid "Gateway ID"
+msgstr ""
+
+#: admin/settings/settings-shipping-methods.php:23
+msgid "Shipping Methods"
+msgstr ""
+
+#: admin/settings/settings-shipping-methods.php:25
+msgid "Drag and drop methods to control their display order."
+msgstr ""
+
+#: admin/settings/settings-shipping-methods.php:30
+msgid "Shipping Method"
+msgstr ""
+
+#: admin/settings/settings-shipping-methods.php:46
+msgid "Method ID"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:29
+msgid "Tax Rates for the \"%s\" Class"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:30
+msgid "Define tax rates for countries and states below. <a href=\"%s\">See here</a> for available country/state codes."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:36
+msgid "Country&nbsp;Code"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:36
+msgid "A 2 digit country code, e.g. US. Leave blank to apply to all."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:38
+msgid "State&nbsp;Code"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:38
+msgid "A 2 digit state code, e.g. AL. Leave blank to apply to all."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:40
+#: admin/settings/settings-tax-rates.php:182
+msgid "ZIP/Postcode"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:40
+msgid "Postcode for this rule. Semi-colon (;) separate multiple values. Leave blank to apply to all areas. Wildcards (*) can be used. Ranges for numeric postcodes (e.g. 12345-12350) will be expanded into individual postcodes."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:42
+msgid "Cities for this rule. Semi-colon (;) separate multiple values. Leave blank to apply to all cities."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:44
+msgid "Rate&nbsp;%"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:44
+msgid "Enter a tax rate (percentage) to 4 decimal places."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:46
+msgid "Tax&nbsp;Name"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:46
+msgid "Enter a name for this tax rate."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:48
+#: admin/settings/settings-tax-rates.php:182
+msgid "Priority"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:48
+msgid "Choose a priority for this tax rate. Only 1 matching rate per priority will be used. To define multiple tax rates for a single area you need to specify a different priority per rate."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:50
+#: admin/settings/settings-tax-rates.php:182
+msgid "Compound"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:50
+msgid "Choose whether or not this is a compound rate. Compound tax rates are applied on top of other tax rates."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:52
+msgid "Choose whether or not this tax rate also gets applied to shipping."
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:59
+msgid "Insert row"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:60
+msgid "Remove selected row(s)"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:62
+msgid "Export CSV"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:63
+msgid "Import CSV"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:163
+msgid "No row(s) selected"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:182
+msgid "Country Code"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:182
+msgid "State Code"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:182
+msgid "Rate %"
+msgstr ""
+
+#: admin/settings/settings-tax-rates.php:182
+msgid "Tax Name"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:43
+msgid "Slug %s is too long"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:83
+msgid "Taxonomy exists - please change the slug"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:211
+msgid "Edit Attribute"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:221
+#: admin/woocommerce-admin-attributes.php:359
+msgid "Name for the attribute (shown on the front-end)."
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:226
+#: admin/woocommerce-admin-attributes.php:291
+#: admin/woocommerce-admin-attributes.php:363
+msgid "Slug"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:230
+#: admin/woocommerce-admin-attributes.php:365
+msgid "Unique slug/reference for the attribute; must be shorter than 28 characters."
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:239
+#: admin/woocommerce-admin-attributes.php:371
+msgid "Select"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:240
+#: admin/woocommerce-admin-attributes.php:372
+msgid "Text"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:242
+#: admin/woocommerce-admin-attributes.php:374
+msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:247
+#: admin/woocommerce-admin-attributes.php:378
+msgid "Default sort order"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:251
+#: admin/woocommerce-admin-attributes.php:319
+#: admin/woocommerce-admin-attributes.php:380
+msgid "Custom ordering"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:253
+#: admin/woocommerce-admin-attributes.php:316
+#: admin/woocommerce-admin-attributes.php:382
+msgid "Term ID"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:255
+#: admin/woocommerce-admin-attributes.php:384
+msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:260
+msgid "Update"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:293
+msgid "Order by"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:294
+msgid "Terms"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:339
+msgid "Configure&nbsp;terms"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:343
+msgid "No attributes currently exist."
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:353
+msgid "Add New Attribute"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:354
+msgid "Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the \"layered nav\" widgets. Please note: you cannot rename an attribute later on."
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:387
+msgid "Add Attribute"
+msgstr ""
+
+#: admin/woocommerce-admin-attributes.php:398
+msgid "Are you sure you want to delete this attribute?"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:26
+#: admin/woocommerce-admin-reports.php:30
+#: admin/woocommerce-admin-reports.php:75
+#: admin/woocommerce-admin-reports.php:91
+#: admin/woocommerce-admin-reports.php:102
+msgid "Overview"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:29
+msgid "Thank you for using WooCommerce :) Should you need help using or extending WooCommerce please <a href=\"%s\">read the documentation</a>. For further assistance you can use the <a href=\"%s\">community forum</a> or if you have access, <a href=\"%s\">the members forum</a>."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:31
+msgid "If you are having problems, or to assist us with support, please check the status page to identify any problems with your configuration:"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:33 admin/woocommerce-admin-init.php:82
+#: admin/woocommerce-admin-status.php:41
+msgid "System Status"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:35
+msgid "If you come across a bug, or wish to contribute to the project you can also <a href=\"%s\">get involved on GitHub</a>."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:43
+msgid "Here you can set up your store and customise it to fit your needs. The sections available from the settings page include:"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:44
+msgid "General settings such as your shop base, currency, and script/styling options which affect features used in your store."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:45
+#: admin/woocommerce-admin-settings.php:215
+msgid "Pages"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:45
+msgid "This is where important store page are defined. You can also set up other pages (such as a Terms page) here."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:46
+msgid "Options for how things like price, images and weights appear in your product catalog."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:47
+msgid "Options concerning stock and stock notices."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:48
+msgid "Options concerning tax, including international and local tax rates."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:49
+msgid "This is where shipping options are defined, and shipping methods are set up."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:50
+msgid "Payment Methods"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:50
+msgid "This is where payment gateway options are defined, and individual payment gateways are set up."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:51
+#: admin/woocommerce-admin-settings.php:220
+msgid "Emails"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:51
+msgid "Here you can customise the way WooCommerce emails appear."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:52
+#: admin/woocommerce-admin-settings.php:221
+msgid "Integration"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:52
+msgid "The integration section contains options for third party services which integrate with WooCommerce."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:57 admin/woocommerce-admin-init.php:59
+msgid "Reports"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:59
+msgid "The reports section can be accessed from the left-hand navigation menu. Here you can generate reports for sales and customers."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:60
+#: admin/woocommerce-admin-reports.php:27
+#: admin/woocommerce-admin-reports.php:971
+#: admin/woocommerce-admin-reports.php:1067
+#: admin/woocommerce-admin-reports.php:1184
+msgid "Sales"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:60
+msgid "Reports for sales based on date, top sellers and top earners."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:61
+#: admin/woocommerce-admin-reports.php:88
+msgid "Customers"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:61
+msgid "Customer reports, such as signups per day."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:62
+msgid "Stock reports for low stock and out of stock items."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:67
+#: admin/woocommerce-admin-dashboard.php:142
+msgid "Orders"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:69
+msgid "The orders section can be accessed from the left-hand navigation menu. Here you can view and manage customer orders."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:70
+msgid "Orders can also be added from this section if you want to set them up for a customer manually."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:77
+msgid "Coupons can be managed from this section. Once added, customers will be able to enter coupon codes on the cart/checkout page. If a customer uses a coupon code they will be viewable when viewing orders."
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:81
+msgid "For more information:"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:82
+msgid "<a href=\"http://www.woothemes.com/woocommerce/\" target=\"_blank\">WooCommerce</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:83
+msgid "<a href=\"http://wordpress.org/extend/plugins/woocommerce/\" target=\"_blank\">Project on WordPress.org</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:84
+msgid "<a href=\"https://github.com/woothemes/woocommerce\" target=\"_blank\">Project on Github</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:85
+msgid "<a href=\"http://www.woothemes.com/woocommerce-docs/\" target=\"_blank\">WooCommerce Docs</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:86
+msgid "<a href=\"http://www.woothemes.com/extensions/woocommerce-extensions/\" target=\"_blank\">Official Extensions</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-content.php:87
+msgid "<a href=\"http://www.woothemes.com/themes/woocommerce-themes/\" target=\"_blank\">Official Themes</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:40
+msgid "Monthly Sales"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:43
+msgid "WooCommerce Right Now"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:44
+msgid "WooCommerce Recent Orders"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:45
+msgid "WooCommerce Recent Reviews"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:78
+msgid "Shop Content"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:84
+#: admin/woocommerce-admin-functions.php:194
+#: admin/woocommerce-admin-init.php:705 admin/woocommerce-admin-reports.php:970
+#: admin/woocommerce-admin-reports.php:1066
+msgid "Product"
+msgid_plural "Products"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-dashboard.php:98
+msgid "Product Category"
+msgid_plural "Product Categories"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-dashboard.php:112
+msgid "Product Tag"
+msgid_plural "Product Tags"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-dashboard.php:126
+msgid "Attribute"
+msgid_plural "Attributes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-dashboard.php:148
+msgid "Pending"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:162
+msgid "On-Hold"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:190
+msgid "Completed"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:207
+msgid "You are using <strong>WooCommerce %s</strong>."
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:238
+msgid "l jS \\of F Y h:i:s A"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:239
+msgid "item"
+msgid_plural "items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-dashboard.php:239
+msgid "Total:"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:245
+msgid "There are no product orders yet."
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:279
+msgid "out of 5"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:287
+msgid "There are no product reviews yet."
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:428
+msgid "Sold"
+msgstr ""
+
+#: admin/woocommerce-admin-dashboard.php:429
+msgid "Earned"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:184
+#: admin/woocommerce-admin-install.php:219
+msgid "Order Received"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:186
+msgid "Thank you, we are now processing your order. Your order's details are below."
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:188
+msgid "Order:"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:195
+msgid "Quantity"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:208
+msgid "Order total:"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:214
+msgid "Customer details"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:220
+msgid "Billing address"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:227
+msgid "Shipping address"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:459
+msgid "Could not compile woocommerce.less:"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:480
+#: admin/woocommerce-admin-functions.php:481
+msgid "Mark processing"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:483
+#: admin/woocommerce-admin-functions.php:484
+msgid "Mark completed"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:521
+msgid "Order status changed by bulk edit:"
+msgstr ""
+
+#: admin/woocommerce-admin-functions.php:544
+msgid "Order status changed."
+msgid_plural "%s order statuses changed."
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-init.php:57
+msgid "WooCommerce"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:81
+msgid "WooCommerce Settings"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:82
+msgid "WooCommerce Status"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:123 admin/woocommerce-admin-init.php:125
+msgctxt "Admin menu name"
+msgid "Orders"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:381
+msgid "Are you sure you want to remove the selected items? If you have previously reduced this item's stock, or this order was submitted by a customer, you will need to manually restore the item's stock."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:382
+msgid "Remove this item meta?"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:383
+msgid "Remove this attribute?"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:391
+msgid "Enter a name for the new attribute term:"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:392
+msgid "Calculate totals based on order items, discounts, and shipping?"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:393
+msgid "Calculate line taxes? This will calculate taxes based on the customers country. If no billing/shipping is set it will use the store base country."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:394
+msgid "Copy billing information to shipping information? This will remove any currently entered shipping information."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:395
+msgid "Load the customer's billing information? This will remove any currently entered billing information."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:396
+msgid "Load the customer's shipping information? This will remove any currently entered shipping information."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:400
+msgid "No customer selected"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:609
+msgid "Product updated. <a href=\"%s\">View Product</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:610 admin/woocommerce-admin-init.php:625
+#: admin/woocommerce-admin-init.php:640
+msgid "Custom field updated."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:611 admin/woocommerce-admin-init.php:626
+#: admin/woocommerce-admin-init.php:641
+msgid "Custom field deleted."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:612
+msgid "Product updated."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:613
+msgid "Product restored to revision from %s"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:614
+msgid "Product published. <a href=\"%s\">View Product</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:615
+msgid "Product saved."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:616
+msgid "Product submitted. <a target=\"_blank\" href=\"%s\">Preview Product</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:617
+msgid "Product scheduled for: <strong>%1$s</strong>. <a target=\"_blank\" href=\"%2$s\">Preview Product</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:618 admin/woocommerce-admin-init.php:633
+#: admin/woocommerce-admin-init.php:648
+msgid "M j, Y @ G:i"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:619
+msgid "Product draft updated. <a target=\"_blank\" href=\"%s\">Preview Product</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:624 admin/woocommerce-admin-init.php:627
+#: admin/woocommerce-admin-init.php:629
+msgid "Order updated."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:628
+msgid "Order restored to revision from %s"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:630
+msgid "Order saved."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:631
+msgid "Order submitted."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:632
+msgid "Order scheduled for: <strong>%1$s</strong>."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:634
+msgid "Order draft updated."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:639 admin/woocommerce-admin-init.php:642
+#: admin/woocommerce-admin-init.php:644
+msgid "Coupon updated."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:643
+msgid "Coupon restored to revision from %s"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:645
+msgid "Coupon saved."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:646
+msgid "Coupon submitted."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:647
+msgid "Coupon scheduled for: <strong>%1$s</strong>."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:649
+msgid "Coupon draft updated."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:666
+msgid "Order notes"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:681
+msgid "These settings control the permalinks used for products. These settings only apply when <strong>not using \"default\" permalinks above</strong>."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:688
+msgctxt "default-slug"
+msgid "shop"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:689
+msgctxt "default-slug"
+msgid "product"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:710
+msgid "Shop base"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:714
+msgid "Shop base with category"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:720
+msgid "Custom Base"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:722
+msgid "Enter a custom base to use. A base <strong>must</strong> be set or WordPress will use default instead."
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:750
+msgid "Product permalink base"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:755
+msgid "Product category base"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:762
+msgid "Product tag base"
+msgstr ""
+
+#: admin/woocommerce-admin-init.php:769
+msgid "Product attribute base"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:189
+msgctxt "page_slug"
+msgid "shop"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:189
+msgid "Shop"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:192
+msgctxt "page_slug"
+msgid "cart"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:192
+msgid "Cart"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:195
+msgctxt "page_slug"
+msgid "checkout"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:198
+msgctxt "page_slug"
+msgid "order-tracking"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:198
+msgid "Track your order"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:201
+msgctxt "page_slug"
+msgid "my-account"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:201
+msgid "My Account"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:204
+msgctxt "page_slug"
+msgid "lost-password"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:204
+msgid "Lost Password"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:207
+msgctxt "page_slug"
+msgid "edit-address"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:207
+msgid "Edit My Address"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:210
+msgctxt "page_slug"
+msgid "view-order"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:210
+msgid "View Order"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:213
+msgctxt "page_slug"
+msgid "change-password"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:213
+msgid "Change Password"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:216
+msgctxt "page_slug"
+msgid "pay"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:216
+msgid "Checkout &rarr; Pay"
+msgstr ""
+
+#: admin/woocommerce-admin-install.php:219
+msgctxt "page_slug"
+msgid "order-received"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:36
+msgid "Sales by day"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:41
+msgid "Sales by month"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:46
+msgid "Taxes by month"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:51
+msgid "Product Sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:56
+msgid "Top sellers"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:61
+msgid "Top earners"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:66
+msgid "Sales by category"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:81
+msgid "Discounts by coupon"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:232
+#: admin/woocommerce-admin-reports.php:496
+#: admin/woocommerce-admin-reports.php:696
+#: admin/woocommerce-admin-reports.php:872
+msgid "Sales amount"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:237
+#: admin/woocommerce-admin-reports.php:496
+#: admin/woocommerce-admin-reports.php:696
+#: admin/woocommerce-admin-reports.php:872
+msgid "Number of sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:369
+msgid "Total sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:371
+#: admin/woocommerce-admin-reports.php:377
+#: admin/woocommerce-admin-reports.php:383
+#: admin/woocommerce-admin-reports.php:389
+#: admin/woocommerce-admin-reports.php:395
+#: admin/woocommerce-admin-reports.php:401
+#: admin/woocommerce-admin-reports.php:639
+#: admin/woocommerce-admin-reports.php:645
+#: admin/woocommerce-admin-reports.php:651
+#: admin/woocommerce-admin-reports.php:657
+#: admin/woocommerce-admin-reports.php:818
+#: admin/woocommerce-admin-reports.php:824
+#: admin/woocommerce-admin-reports.php:830
+#: admin/woocommerce-admin-reports.php:836
+#: admin/woocommerce-admin-reports.php:1349
+#: admin/woocommerce-admin-reports.php:1355
+#: admin/woocommerce-admin-reports.php:1361
+#: admin/woocommerce-admin-reports.php:1790
+#: admin/woocommerce-admin-reports.php:1796
+#: admin/woocommerce-admin-reports.php:1802
+#: admin/woocommerce-admin-reports.php:1808
+#: admin/woocommerce-admin-reports.php:1814
+#: admin/woocommerce-admin-reports.php:1820
+#: admin/woocommerce-admin-reports.php:2255
+#: admin/woocommerce-admin-reports.php:2266
+#: admin/woocommerce-admin-reports.php:2277
+msgid "n/a"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:375
+msgid "Total orders"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:377
+#: admin/woocommerce-admin-reports.php:645
+#: admin/woocommerce-admin-reports.php:824
+msgid "items"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:381
+msgid "Average order total"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:387
+msgid "Average order items"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:393
+msgid "Discounts used"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:399
+msgid "Total shipping costs"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:407
+msgid "This month's sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:631
+#: admin/woocommerce-admin-reports.php:965
+#: admin/woocommerce-admin-reports.php:1061
+#: admin/woocommerce-admin-reports.php:1341
+msgid "From:"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:631
+#: admin/woocommerce-admin-reports.php:965
+#: admin/woocommerce-admin-reports.php:1061
+#: admin/woocommerce-admin-reports.php:1341
+msgid "To:"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:631
+#: admin/woocommerce-admin-reports.php:811
+#: admin/woocommerce-admin-reports.php:965
+#: admin/woocommerce-admin-reports.php:1061
+#: admin/woocommerce-admin-reports.php:1214
+#: admin/woocommerce-admin-reports.php:1341
+#: admin/woocommerce-admin-reports.php:1474
+#: admin/woocommerce-admin-reports.php:2244
+#: admin/woocommerce-admin-reports.php:2428
+msgid "Show"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:637
+msgid "Total sales in range"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:643
+msgid "Total orders in range"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:649
+msgid "Average order total in range"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:655
+msgid "Average order items in range"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:663
+msgid "Sales in range"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:805
+#: admin/woocommerce-admin-reports.php:2238
+msgid "Year:"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:816
+msgid "Total sales for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:822
+msgid "Total orders for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:828
+msgid "Average order total for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:834
+msgid "Average order items for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:842
+msgid "Monthly sales for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:985
+msgid "Product does not exist"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1082
+msgid "Product no longer exists"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1179
+msgid "Sales for %s:"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1183
+#: admin/woocommerce-admin-reports.php:2286
+msgid "Month"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1204
+msgid "No sales :("
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1347
+msgid "Total orders containing coupons"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1353
+msgid "Percent of orders containing coupons"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1359
+msgid "Total coupon discount"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1368
+msgid "Most popular coupons"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1378
+msgid "Used 1 time"
+msgid_plural "Used %d times"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-reports.php:1381
+#: admin/woocommerce-admin-reports.php:1403
+msgid "No coupons found"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1390
+msgid "Greatest discount amount"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1400
+msgid "Discounted %s"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1459
+#: admin/woocommerce-admin-reports.php:2405
+msgid "Show:"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1516
+msgid "Coupon"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1599
+msgid "Top coupon"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1607
+msgid "Worst coupon"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1615
+msgid "Discount average"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1623
+msgid "Discount median"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1643
+msgid "Monthly discounts by coupon"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1788
+msgid "Total customers"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1794
+msgid "Total customer sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1800
+msgid "Total guest sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1806
+msgid "Total customer orders"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1812
+msgid "Total guest orders"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1818
+msgid "Average orders per customer"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:1826
+msgid "Signups per day"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2023
+msgid "Low stock"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2045
+#: admin/woocommerce-admin-reports.php:2080
+msgid "%d in stock"
+msgid_plural "%d in stock"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/woocommerce-admin-reports.php:2050
+msgid "No products are low in stock."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2085
+msgid "No products are out in stock."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2249
+msgid "Total taxes for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2260
+msgid "Total product taxes for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2271
+msgid "Total shipping tax for year"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2287
+msgid "Total Sales"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2287
+msgid "This is the sum of the 'Order Total' field within your orders."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2288
+msgid "Total Shipping"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2288
+msgid "This is the sum of the 'Shipping Total' field within your orders."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2289
+msgid "Total Product Taxes"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2289
+msgid "This is the sum of the 'Cart Tax' field within your orders."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2290
+msgid "Total Shipping Taxes"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2290
+msgid "This is the sum of the 'Shipping Tax' field within your orders."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2291
+msgid "Total Taxes"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2291
+msgid "This is the sum of the 'Cart Tax' and 'Shipping Tax' fields within your orders."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2292
+msgid "Net profit"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2292
+msgid "Total sales minus shipping and tax."
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2337
+msgid "Toggle tax rows"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2483
+msgid "Category"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2585
+msgid "Top category"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2594
+msgid "Worst category"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2602
+msgid "Category sales average"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2613
+msgid "Category sales median"
+msgstr ""
+
+#: admin/woocommerce-admin-reports.php:2633
+msgid "Monthly sales by category"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:45
+msgid "Action failed. Please refresh the page and retry."
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:158
+msgid "Your settings have been saved."
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:194
+msgid "<strong>Congratulations!</strong> &#8211; WooCommerce has been installed and setup. Enjoy :)"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:238
+msgid "More functionality and gateway options available via <a href=\"%s\" target=\"_blank\">WC official extensions</a>."
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:256
+msgid "Tax Rates"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:283
+msgid "Email Options"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:408
+msgid "Save changes"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:475
+msgid "The changes you made will be lost if you navigate away from this page."
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:843
+msgid "Hard Crop"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:868
+msgid "Select a page&hellip;"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:891
+msgid "Choose a country&hellip;"
+msgstr ""
+
+#: admin/woocommerce-admin-settings.php:911
+msgid "Choose countries&hellip;"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:22
+msgid "Transients"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:23
+msgid "Clear Transients"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:24
+msgid "This tool will clear the product/shop transients cache."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:27
+msgid "Term counts"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:28
+msgid "Recount Terms"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:29
+msgid "This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:32
+msgid "Capabilities"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:33
+msgid "Reset Capabilities"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:34
+msgid "This tool will reset the admin, customer and shop_manager roles to default. Use this if your users cannot access all of the WooCommerce admin pages."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:41
+msgid "Generate report"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:50
+msgid "Product Transients Cleared"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:57
+msgid "Roles successfully reset"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:69
+msgid "Terms successfully recounted"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:78
+msgid "There was an error calling %s::%s"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:81
+msgid "There was an error calling %s"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:94
+msgid "Versions"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:100
+msgid "WooCommerce version"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:104
+msgid "WooCommerce DB version"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:108
+msgid "WordPress version"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:112
+msgid "Installed plugins"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:127
+msgid "by"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:127
+msgid "version"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:146
+msgid "Home URL"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:150
+msgid "Site URL"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:154
+msgid "Force SSL"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:168
+msgid "Shop base page"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:220
+msgid "Page not set"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:230
+msgid "Page does not contain the shortcode: %s"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:249
+msgid "Core Taxonomies"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:255
+msgid "Order Statuses"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:265
+msgid "Server Environment"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:271
+msgid "PHP Version"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:278
+msgid "Server Software"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:284
+msgid "WP Max Upload Size"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:290
+msgid "Server upload_max_filesize"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:297
+msgid "Server post_max_size"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:304
+msgid "WP Memory Limit"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:309
+msgid "%s - We recommend setting memory to at least 64MB. See: <a href=\"%s\">Increasing memory allocated to PHP</a>"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:316
+msgid "WP Debug Mode"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:320
+msgid "WC Logging"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:323
+msgid "Log directory is writable."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:325
+msgid "Log directory (<code>woocommerce/logs/</code>) is not writable. Logging will not be possible."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:332
+msgid "Remote Posting/IPN"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:340
+msgid "fsockopen/cURL"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:343
+msgid "Your server has fsockopen and cURL enabled."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:345
+msgid "Your server has fsockopen enabled, cURL is disabled."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:347
+msgid "Your server has cURL enabled, fsockopen is disabled."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:351
+msgid "Your server does not have fsockopen or cURL enabled - PayPal IPN and other scripts which communicate with other servers will not work. Contact your hosting provider."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:356
+msgid "SOAP Client"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:358
+msgid "Your server has the SOAP Client class enabled."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:361
+msgid "Your server does not have the <a href=\"%s\">SOAP Client</a> class enabled - some gateway plugins which use SOAP may not work as expected."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:366
+msgid "WP Remote Post Check"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:377
+msgid "wp_remote_post() was successful - PayPal IPN is working."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:380
+msgid "wp_remote_post() failed. PayPal IPN won't work with your server. Contact your hosting provider. Error:"
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:383
+msgid "wp_remote_post() failed. PayPal IPN may not work with your server."
+msgstr ""
+
+#: admin/woocommerce-admin-status.php:405
+msgid "Tools"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:25
+#: admin/woocommerce-admin-taxonomies.php:118
+msgid "Display type"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:29
+#: admin/woocommerce-admin-taxonomies.php:123
+msgid "Subcategories"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:30
+#: admin/woocommerce-admin-taxonomies.php:124
+msgid "Both"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:34
+#: admin/woocommerce-admin-taxonomies.php:129
+msgid "Thumbnail"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:38
+#: admin/woocommerce-admin-taxonomies.php:134
+msgid "Upload/Add image"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:39
+#: admin/woocommerce-admin-taxonomies.php:135
+msgid "Remove image"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:64
+#: admin/woocommerce-admin-taxonomies.php:156
+msgid "Use image"
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:220
+msgid "Product categories for your store can be managed here. To change the order of categories on the front-end you can drag and drop to sort them. To see more categories listed click the \"screen options\" link at the top of the page."
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:235
+msgid "Shipping classes can be used to group products of similar type. These groups can then be used by certain shipping methods to provide different rates to different products."
+msgstr ""
+
+#: admin/woocommerce-admin-taxonomies.php:363
+msgid "Configure shipping class"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:26
+msgid "Billing Address"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:27
+msgid "Shipping Address"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:28
+msgid "Paying Customer?"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:29
+msgid "Completed Orders"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:144
+msgid "Customer Billing Address"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:147 admin/woocommerce-admin-users.php:196
+msgid "First name"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:151 admin/woocommerce-admin-users.php:200
+msgid "Last name"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:176
+msgid "Country or state code"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:180 admin/woocommerce-admin-users.php:229
+msgid "2 letter Country code"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:183
+msgid "Telephone"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:193
+msgid "Customer Shipping Address"
+msgstr ""
+
+#: admin/woocommerce-admin-users.php:225
+msgid "State/County or state code"
+msgstr ""

--- a/i18n/languages/woocommerce.pot
+++ b/i18n/languages/woocommerce.pot
@@ -1,0 +1,6000 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: WooCommerce 2.0.0-beta1 Front-end\n"
+"Report-Msgid-Bugs-To: https://github.com/woothemes/woocommerce/issues\n"
+"POT-Creation-Date: 2012-12-30 11:35:30+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2012-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+
+#: assets/js/admin/editor_plugin_lang.php:5
+msgid "Insert Shortcode"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:6
+msgid "Product price/cart button"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:7
+msgid "Product by SKU/ID"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:8
+msgid "Products by SKU/ID"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:9
+msgid "Product categories"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:10
+msgid "Products by category slug"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:11
+msgid "Recent products"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:12
+msgid "Featured products"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:13
+msgid "Shop Messages"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:14
+msgid "Pages"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:15 widgets/widget-cart.php:61
+msgid "Cart"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:16
+msgid "Checkout"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:17
+msgid "Order tracking"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:18 templates/checkout/thankyou.php:32
+msgid "My Account"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:19
+msgid "Edit Address"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:20
+msgid "Change Password"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:21 woocommerce.php:941
+#: woocommerce.php:942
+msgid "View Order"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:22 templates/checkout/thankyou.php:30
+#: templates/myaccount/my-orders.php:75
+msgid "Pay"
+msgstr ""
+
+#: assets/js/admin/editor_plugin_lang.php:23
+msgid "Thankyou"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:530
+#: classes/abstracts/abstract-wc-product.php:535
+#: classes/abstracts/abstract-wc-product.php:554
+msgid "In stock"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:535
+msgid "Only %s left in stock"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:538
+msgid "%s in stock"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:545
+msgid "(backorders allowed)"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:551
+#: classes/abstracts/abstract-wc-product.php:564 templates/cart/cart.php:72
+msgid "Available on backorder"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:557
+#: classes/abstracts/abstract-wc-product.php:567
+#: classes/abstracts/abstract-wc-product.php:571
+msgid "Out of stock"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:834
+#: classes/abstracts/abstract-wc-product.php:840 classes/class-wc-cart.php:1684
+#: classes/class-wc-order.php:833 classes/class-wc-product-variable.php:272
+#: classes/class-wc-product-variable.php:281
+msgid "Free!"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:858
+msgctxt "min_price"
+msgid "From:"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:917
+#: templates/single-product/review.php:26
+#: templates/single-product-reviews.php:43
+msgid "Rated %s out of 5"
+msgstr ""
+
+#: classes/abstracts/abstract-wc-product.php:917
+#: templates/single-product/review.php:27
+#: templates/single-product-reviews.php:43 widgets/widget-recent_reviews.php:90
+msgid "out of 5"
+msgstr ""
+
+#: classes/class-wc-cart.php:337
+msgid "Sorry, it seems the coupon \"%s\" is invalid - it has now been removed from your order."
+msgstr ""
+
+#: classes/class-wc-cart.php:414
+msgid "Sorry, it seems the coupon \"%s\" is not yours - it has now been removed from your order."
+msgstr ""
+
+#: classes/class-wc-cart.php:453
+msgid "Sorry, we do not have enough \"%s\" in stock to fulfill your order (%s in stock). Please edit your cart and try again. We apologise for any inconvenience caused."
+msgstr ""
+
+#: classes/class-wc-cart.php:472 classes/class-wc-cart.php:481
+msgid "Sorry, we do not have enough \"%s\" in stock to fulfil your order (%s in stock). Please edit your cart and try again. We apologise for any inconvenience caused."
+msgstr ""
+
+#: classes/class-wc-cart.php:516
+msgid "Sorry, we do not have enough \"%s\" in stock to fulfil your order right now. Please try again in %d minutes or edit your cart and try again. We apologise for any inconvenience caused."
+msgstr ""
+
+#: classes/class-wc-cart.php:526
+msgid "Sorry, \"%s\" is not in stock. Please edit your cart and try again. We apologise for any inconvenience caused."
+msgstr ""
+
+#: classes/class-wc-cart.php:804
+msgid "Sorry, &quot;%s&quot; cannot be purchased."
+msgstr ""
+
+#: classes/class-wc-cart.php:811
+msgid "You cannot add &quot;%s&quot; to the cart because the product is out of stock."
+msgstr ""
+
+#: classes/class-wc-cart.php:816
+msgid "You cannot add that amount of &quot;%s&quot; to the cart because there is not enough stock (%s remaining)."
+msgstr ""
+
+#: classes/class-wc-cart.php:828 classes/class-wc-cart.php:842
+#: classes/class-wc-cart.php:850 templates/cart/mini-cart.php:65
+#: woocommerce-functions.php:435 woocommerce.php:1098
+msgid "View Cart &rarr;"
+msgstr ""
+
+#: classes/class-wc-cart.php:828
+msgid "You already have this item in your cart."
+msgstr ""
+
+#: classes/class-wc-cart.php:842 classes/class-wc-cart.php:850
+msgid "<a href=\"%s\" class=\"button\">%s</a> You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart."
+msgstr ""
+
+#: classes/class-wc-cart.php:1696
+msgid "via"
+msgstr ""
+
+#: classes/class-wc-cart.php:1739
+msgid "Discount code already applied!"
+msgstr ""
+
+#: classes/class-wc-cart.php:1764
+msgid "Discount code applied successfully."
+msgstr ""
+
+#: classes/class-wc-cart.php:1771
+msgid "Coupon does not exist!"
+msgstr ""
+
+#: classes/class-wc-checkout.php:60
+msgid "Account username"
+msgstr ""
+
+#: classes/class-wc-checkout.php:61
+msgctxt "placeholder"
+msgid "Username"
+msgstr ""
+
+#: classes/class-wc-checkout.php:68 classes/class-wc-checkout.php:75
+msgid "Account password"
+msgstr ""
+
+#: classes/class-wc-checkout.php:69 classes/class-wc-checkout.php:76
+msgctxt "placeholder"
+msgid "Password"
+msgstr ""
+
+#: classes/class-wc-checkout.php:85
+msgid "Order Notes"
+msgstr ""
+
+#: classes/class-wc-checkout.php:86
+msgctxt "placeholder"
+msgid "Notes about your order, e.g. special notes for delivery."
+msgstr ""
+
+#: classes/class-wc-checkout.php:142
+msgid "Order &ndash; %s"
+msgstr ""
+
+#: classes/class-wc-checkout.php:142
+msgctxt "Order date parsed by strftime"
+msgid "%b %d, %Y @ %I:%M %p"
+msgstr ""
+
+#: classes/class-wc-checkout.php:265
+msgid "Backordered"
+msgstr ""
+
+#: classes/class-wc-checkout.php:375
+msgid "Sorry, your session has expired. <a href=\"%s\">Return to homepage &rarr;</a>"
+msgstr ""
+
+#: classes/class-wc-checkout.php:427 shortcodes/shortcode-my_account.php:166
+msgid "is a required field."
+msgstr ""
+
+#: classes/class-wc-checkout.php:440
+msgid "(%s) is not a valid postcode/ZIP."
+msgstr ""
+
+#: classes/class-wc-checkout.php:461
+msgid "is not valid. Please enter one of the following:"
+msgstr ""
+
+#: classes/class-wc-checkout.php:469
+msgid "is not a valid number."
+msgstr ""
+
+#: classes/class-wc-checkout.php:476
+msgid "is not a valid email address."
+msgstr ""
+
+#: classes/class-wc-checkout.php:532
+msgid "Please enter an account username."
+msgstr ""
+
+#: classes/class-wc-checkout.php:536
+msgid "Invalid email/username."
+msgstr ""
+
+#: classes/class-wc-checkout.php:539
+msgid "An account is already registered with that username. Please choose another."
+msgstr ""
+
+#: classes/class-wc-checkout.php:549
+msgid "Please enter an account password."
+msgstr ""
+
+#: classes/class-wc-checkout.php:552 shortcodes/shortcode-lost_password.php:81
+#: shortcodes/shortcode-my_account.php:248 woocommerce-functions.php:699
+msgid "Passwords do not match."
+msgstr ""
+
+#: classes/class-wc-checkout.php:556
+msgid "An account is already registered with your email address. Please login."
+msgstr ""
+
+#: classes/class-wc-checkout.php:562
+msgid "You must accept our Terms &amp; Conditions."
+msgstr ""
+
+#: classes/class-wc-checkout.php:571
+msgid "Invalid shipping method."
+msgstr ""
+
+#: classes/class-wc-checkout.php:584
+msgid "Invalid payment method."
+msgstr ""
+
+#: classes/class-wc-checkout.php:624 widgets/widget-login.php:276
+#: widgets/widget-login.php:279 woocommerce-functions.php:671
+#: woocommerce-functions.php:673 woocommerce-functions.php:676
+#: woocommerce-functions.php:688 woocommerce-functions.php:690
+#: woocommerce-functions.php:693 woocommerce-functions.php:724
+msgid "ERROR"
+msgstr ""
+
+#: classes/class-wc-checkout.php:624 woocommerce-functions.php:724
+msgid "Couldn&#8217;t register you&hellip; please contact us if you continue to have problems."
+msgstr ""
+
+#: classes/class-wc-countries.php:36
+msgid "Afghanistan"
+msgstr ""
+
+#: classes/class-wc-countries.php:37
+msgid "&#197;land Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:38
+msgid "Albania"
+msgstr ""
+
+#: classes/class-wc-countries.php:39
+msgid "Algeria"
+msgstr ""
+
+#: classes/class-wc-countries.php:40
+msgid "American Samoa"
+msgstr ""
+
+#: classes/class-wc-countries.php:41
+msgid "Andorra"
+msgstr ""
+
+#: classes/class-wc-countries.php:42
+msgid "Angola"
+msgstr ""
+
+#: classes/class-wc-countries.php:43
+msgid "Anguilla"
+msgstr ""
+
+#: classes/class-wc-countries.php:44
+msgid "Antarctica"
+msgstr ""
+
+#: classes/class-wc-countries.php:45
+msgid "Antigua and Barbuda"
+msgstr ""
+
+#: classes/class-wc-countries.php:46
+msgid "Argentina"
+msgstr ""
+
+#: classes/class-wc-countries.php:47
+msgid "Armenia"
+msgstr ""
+
+#: classes/class-wc-countries.php:48
+msgid "Aruba"
+msgstr ""
+
+#: classes/class-wc-countries.php:49
+msgid "Australia"
+msgstr ""
+
+#: classes/class-wc-countries.php:50
+msgid "Austria"
+msgstr ""
+
+#: classes/class-wc-countries.php:51
+msgid "Azerbaijan"
+msgstr ""
+
+#: classes/class-wc-countries.php:52
+msgid "Bahamas"
+msgstr ""
+
+#: classes/class-wc-countries.php:53
+msgid "Bahrain"
+msgstr ""
+
+#: classes/class-wc-countries.php:54
+msgid "Bangladesh"
+msgstr ""
+
+#: classes/class-wc-countries.php:55
+msgid "Barbados"
+msgstr ""
+
+#: classes/class-wc-countries.php:56
+msgid "Belarus"
+msgstr ""
+
+#: classes/class-wc-countries.php:57
+msgid "Belgium"
+msgstr ""
+
+#: classes/class-wc-countries.php:58
+msgid "Belize"
+msgstr ""
+
+#: classes/class-wc-countries.php:59
+msgid "Benin"
+msgstr ""
+
+#: classes/class-wc-countries.php:60
+msgid "Bermuda"
+msgstr ""
+
+#: classes/class-wc-countries.php:61
+msgid "Bhutan"
+msgstr ""
+
+#: classes/class-wc-countries.php:62
+msgid "Bolivia"
+msgstr ""
+
+#: classes/class-wc-countries.php:63
+msgid "Bonaire, Saint Eustatius and Saba"
+msgstr ""
+
+#: classes/class-wc-countries.php:64
+msgid "Bosnia and Herzegovina"
+msgstr ""
+
+#: classes/class-wc-countries.php:65
+msgid "Botswana"
+msgstr ""
+
+#: classes/class-wc-countries.php:66
+msgid "Bouvet Island"
+msgstr ""
+
+#: classes/class-wc-countries.php:67
+msgid "Brazil"
+msgstr ""
+
+#: classes/class-wc-countries.php:68
+msgid "British Indian Ocean Territory"
+msgstr ""
+
+#: classes/class-wc-countries.php:69
+msgid "British Virgin Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:70
+msgid "Brunei"
+msgstr ""
+
+#: classes/class-wc-countries.php:71
+msgid "Bulgaria"
+msgstr ""
+
+#: classes/class-wc-countries.php:72
+msgid "Burkina Faso"
+msgstr ""
+
+#: classes/class-wc-countries.php:73
+msgid "Burundi"
+msgstr ""
+
+#: classes/class-wc-countries.php:74
+msgid "Cambodia"
+msgstr ""
+
+#: classes/class-wc-countries.php:75
+msgid "Cameroon"
+msgstr ""
+
+#: classes/class-wc-countries.php:76
+msgid "Canada"
+msgstr ""
+
+#: classes/class-wc-countries.php:77
+msgid "Cape Verde"
+msgstr ""
+
+#: classes/class-wc-countries.php:78
+msgid "Cayman Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:79
+msgid "Central African Republic"
+msgstr ""
+
+#: classes/class-wc-countries.php:80
+msgid "Chad"
+msgstr ""
+
+#: classes/class-wc-countries.php:81
+msgid "Chile"
+msgstr ""
+
+#: classes/class-wc-countries.php:82
+msgid "China"
+msgstr ""
+
+#: classes/class-wc-countries.php:83
+msgid "Christmas Island"
+msgstr ""
+
+#: classes/class-wc-countries.php:84
+msgid "Cocos (Keeling) Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:85
+msgid "Colombia"
+msgstr ""
+
+#: classes/class-wc-countries.php:86
+msgid "Comoros"
+msgstr ""
+
+#: classes/class-wc-countries.php:87
+msgid "Congo (Brazzaville)"
+msgstr ""
+
+#: classes/class-wc-countries.php:88
+msgid "Congo (Kinshasa)"
+msgstr ""
+
+#: classes/class-wc-countries.php:89
+msgid "Cook Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:90
+msgid "Costa Rica"
+msgstr ""
+
+#: classes/class-wc-countries.php:91
+msgid "Croatia"
+msgstr ""
+
+#: classes/class-wc-countries.php:92
+msgid "Cuba"
+msgstr ""
+
+#: classes/class-wc-countries.php:93
+msgid "Cura&Ccedil;ao"
+msgstr ""
+
+#: classes/class-wc-countries.php:94
+msgid "Cyprus"
+msgstr ""
+
+#: classes/class-wc-countries.php:95
+msgid "Czech Republic"
+msgstr ""
+
+#: classes/class-wc-countries.php:96
+msgid "Denmark"
+msgstr ""
+
+#: classes/class-wc-countries.php:97
+msgid "Djibouti"
+msgstr ""
+
+#: classes/class-wc-countries.php:98
+msgid "Dominica"
+msgstr ""
+
+#: classes/class-wc-countries.php:99
+msgid "Dominican Republic"
+msgstr ""
+
+#: classes/class-wc-countries.php:100
+msgid "Ecuador"
+msgstr ""
+
+#: classes/class-wc-countries.php:101
+msgid "Egypt"
+msgstr ""
+
+#: classes/class-wc-countries.php:102
+msgid "El Salvador"
+msgstr ""
+
+#: classes/class-wc-countries.php:103
+msgid "Equatorial Guinea"
+msgstr ""
+
+#: classes/class-wc-countries.php:104
+msgid "Eritrea"
+msgstr ""
+
+#: classes/class-wc-countries.php:105
+msgid "Estonia"
+msgstr ""
+
+#: classes/class-wc-countries.php:106
+msgid "Ethiopia"
+msgstr ""
+
+#: classes/class-wc-countries.php:107
+msgid "Falkland Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:108
+msgid "Faroe Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:109
+msgid "Fiji"
+msgstr ""
+
+#: classes/class-wc-countries.php:110
+msgid "Finland"
+msgstr ""
+
+#: classes/class-wc-countries.php:111
+msgid "France"
+msgstr ""
+
+#: classes/class-wc-countries.php:112
+msgid "French Guiana"
+msgstr ""
+
+#: classes/class-wc-countries.php:113
+msgid "French Polynesia"
+msgstr ""
+
+#: classes/class-wc-countries.php:114
+msgid "French Southern Territories"
+msgstr ""
+
+#: classes/class-wc-countries.php:115
+msgid "Gabon"
+msgstr ""
+
+#: classes/class-wc-countries.php:116
+msgid "Gambia"
+msgstr ""
+
+#: classes/class-wc-countries.php:117 i18n/states/US.php:23
+msgid "Georgia"
+msgstr ""
+
+#: classes/class-wc-countries.php:118
+msgid "Germany"
+msgstr ""
+
+#: classes/class-wc-countries.php:119
+msgid "Ghana"
+msgstr ""
+
+#: classes/class-wc-countries.php:120
+msgid "Gibraltar"
+msgstr ""
+
+#: classes/class-wc-countries.php:121
+msgid "Greece"
+msgstr ""
+
+#: classes/class-wc-countries.php:122
+msgid "Greenland"
+msgstr ""
+
+#: classes/class-wc-countries.php:123
+msgid "Grenada"
+msgstr ""
+
+#: classes/class-wc-countries.php:124
+msgid "Guadeloupe"
+msgstr ""
+
+#: classes/class-wc-countries.php:125
+msgid "Guam"
+msgstr ""
+
+#: classes/class-wc-countries.php:126
+msgid "Guatemala"
+msgstr ""
+
+#: classes/class-wc-countries.php:127
+msgid "Guernsey"
+msgstr ""
+
+#: classes/class-wc-countries.php:128
+msgid "Guinea"
+msgstr ""
+
+#: classes/class-wc-countries.php:129
+msgid "Guinea-Bissau"
+msgstr ""
+
+#: classes/class-wc-countries.php:130
+msgid "Guyana"
+msgstr ""
+
+#: classes/class-wc-countries.php:131
+msgid "Haiti"
+msgstr ""
+
+#: classes/class-wc-countries.php:132
+msgid "Heard Island and McDonald Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:133
+msgid "Honduras"
+msgstr ""
+
+#: classes/class-wc-countries.php:134
+msgid "Hong Kong"
+msgstr ""
+
+#: classes/class-wc-countries.php:135
+msgid "Hungary"
+msgstr ""
+
+#: classes/class-wc-countries.php:136
+msgid "Iceland"
+msgstr ""
+
+#: classes/class-wc-countries.php:137
+msgid "India"
+msgstr ""
+
+#: classes/class-wc-countries.php:138
+msgid "Indonesia"
+msgstr ""
+
+#: classes/class-wc-countries.php:139
+msgid "Iran"
+msgstr ""
+
+#: classes/class-wc-countries.php:140
+msgid "Iraq"
+msgstr ""
+
+#: classes/class-wc-countries.php:141
+msgid "Republic of Ireland"
+msgstr ""
+
+#: classes/class-wc-countries.php:142
+msgid "Isle of Man"
+msgstr ""
+
+#: classes/class-wc-countries.php:143
+msgid "Israel"
+msgstr ""
+
+#: classes/class-wc-countries.php:144
+msgid "Italy"
+msgstr ""
+
+#: classes/class-wc-countries.php:145
+msgid "Ivory Coast"
+msgstr ""
+
+#: classes/class-wc-countries.php:146
+msgid "Jamaica"
+msgstr ""
+
+#: classes/class-wc-countries.php:147
+msgid "Japan"
+msgstr ""
+
+#: classes/class-wc-countries.php:148
+msgid "Jersey"
+msgstr ""
+
+#: classes/class-wc-countries.php:149
+msgid "Jordan"
+msgstr ""
+
+#: classes/class-wc-countries.php:150
+msgid "Kazakhstan"
+msgstr ""
+
+#: classes/class-wc-countries.php:151
+msgid "Kenya"
+msgstr ""
+
+#: classes/class-wc-countries.php:152
+msgid "Kiribati"
+msgstr ""
+
+#: classes/class-wc-countries.php:153
+msgid "Kuwait"
+msgstr ""
+
+#: classes/class-wc-countries.php:154
+msgid "Kyrgyzstan"
+msgstr ""
+
+#: classes/class-wc-countries.php:155
+msgid "Laos"
+msgstr ""
+
+#: classes/class-wc-countries.php:156
+msgid "Latvia"
+msgstr ""
+
+#: classes/class-wc-countries.php:157
+msgid "Lebanon"
+msgstr ""
+
+#: classes/class-wc-countries.php:158
+msgid "Lesotho"
+msgstr ""
+
+#: classes/class-wc-countries.php:159
+msgid "Liberia"
+msgstr ""
+
+#: classes/class-wc-countries.php:160
+msgid "Libya"
+msgstr ""
+
+#: classes/class-wc-countries.php:161
+msgid "Liechtenstein"
+msgstr ""
+
+#: classes/class-wc-countries.php:162
+msgid "Lithuania"
+msgstr ""
+
+#: classes/class-wc-countries.php:163
+msgid "Luxembourg"
+msgstr ""
+
+#: classes/class-wc-countries.php:164
+msgid "Macao S.A.R., China"
+msgstr ""
+
+#: classes/class-wc-countries.php:165
+msgid "Macedonia"
+msgstr ""
+
+#: classes/class-wc-countries.php:166
+msgid "Madagascar"
+msgstr ""
+
+#: classes/class-wc-countries.php:167
+msgid "Malawi"
+msgstr ""
+
+#: classes/class-wc-countries.php:168
+msgid "Malaysia"
+msgstr ""
+
+#: classes/class-wc-countries.php:169
+msgid "Maldives"
+msgstr ""
+
+#: classes/class-wc-countries.php:170
+msgid "Mali"
+msgstr ""
+
+#: classes/class-wc-countries.php:171
+msgid "Malta"
+msgstr ""
+
+#: classes/class-wc-countries.php:172
+msgid "Marshall Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:173
+msgid "Martinique"
+msgstr ""
+
+#: classes/class-wc-countries.php:174
+msgid "Mauritania"
+msgstr ""
+
+#: classes/class-wc-countries.php:175
+msgid "Mauritius"
+msgstr ""
+
+#: classes/class-wc-countries.php:176
+msgid "Mayotte"
+msgstr ""
+
+#: classes/class-wc-countries.php:177
+msgid "Mexico"
+msgstr ""
+
+#: classes/class-wc-countries.php:178
+msgid "Micronesia"
+msgstr ""
+
+#: classes/class-wc-countries.php:179
+msgid "Moldova"
+msgstr ""
+
+#: classes/class-wc-countries.php:180
+msgid "Monaco"
+msgstr ""
+
+#: classes/class-wc-countries.php:181
+msgid "Mongolia"
+msgstr ""
+
+#: classes/class-wc-countries.php:182
+msgid "Montenegro"
+msgstr ""
+
+#: classes/class-wc-countries.php:183
+msgid "Montserrat"
+msgstr ""
+
+#: classes/class-wc-countries.php:184
+msgid "Morocco"
+msgstr ""
+
+#: classes/class-wc-countries.php:185
+msgid "Mozambique"
+msgstr ""
+
+#: classes/class-wc-countries.php:186
+msgid "Myanmar"
+msgstr ""
+
+#: classes/class-wc-countries.php:187
+msgid "Namibia"
+msgstr ""
+
+#: classes/class-wc-countries.php:188
+msgid "Nauru"
+msgstr ""
+
+#: classes/class-wc-countries.php:189
+msgid "Nepal"
+msgstr ""
+
+#: classes/class-wc-countries.php:190
+msgid "Netherlands"
+msgstr ""
+
+#: classes/class-wc-countries.php:191
+msgid "Netherlands Antilles"
+msgstr ""
+
+#: classes/class-wc-countries.php:192
+msgid "New Caledonia"
+msgstr ""
+
+#: classes/class-wc-countries.php:193
+msgid "New Zealand"
+msgstr ""
+
+#: classes/class-wc-countries.php:194
+msgid "Nicaragua"
+msgstr ""
+
+#: classes/class-wc-countries.php:195
+msgid "Niger"
+msgstr ""
+
+#: classes/class-wc-countries.php:196
+msgid "Nigeria"
+msgstr ""
+
+#: classes/class-wc-countries.php:197
+msgid "Niue"
+msgstr ""
+
+#: classes/class-wc-countries.php:198
+msgid "Norfolk Island"
+msgstr ""
+
+#: classes/class-wc-countries.php:199
+msgid "North Korea"
+msgstr ""
+
+#: classes/class-wc-countries.php:200
+msgid "Northern Mariana Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:201
+msgid "Norway"
+msgstr ""
+
+#: classes/class-wc-countries.php:202
+msgid "Oman"
+msgstr ""
+
+#: classes/class-wc-countries.php:203
+msgid "Pakistan"
+msgstr ""
+
+#: classes/class-wc-countries.php:204
+msgid "Palau"
+msgstr ""
+
+#: classes/class-wc-countries.php:205
+msgid "Palestinian Territory"
+msgstr ""
+
+#: classes/class-wc-countries.php:206
+msgid "Panama"
+msgstr ""
+
+#: classes/class-wc-countries.php:207
+msgid "Papua New Guinea"
+msgstr ""
+
+#: classes/class-wc-countries.php:208
+msgid "Paraguay"
+msgstr ""
+
+#: classes/class-wc-countries.php:209
+msgid "Peru"
+msgstr ""
+
+#: classes/class-wc-countries.php:210
+msgid "Philippines"
+msgstr ""
+
+#: classes/class-wc-countries.php:211
+msgid "Pitcairn"
+msgstr ""
+
+#: classes/class-wc-countries.php:212
+msgid "Poland"
+msgstr ""
+
+#: classes/class-wc-countries.php:213
+msgid "Portugal"
+msgstr ""
+
+#: classes/class-wc-countries.php:214
+msgid "Puerto Rico"
+msgstr ""
+
+#: classes/class-wc-countries.php:215
+msgid "Qatar"
+msgstr ""
+
+#: classes/class-wc-countries.php:216
+msgid "Reunion"
+msgstr ""
+
+#: classes/class-wc-countries.php:217
+msgid "Romania"
+msgstr ""
+
+#: classes/class-wc-countries.php:218
+msgid "Russia"
+msgstr ""
+
+#: classes/class-wc-countries.php:219
+msgid "Rwanda"
+msgstr ""
+
+#: classes/class-wc-countries.php:220
+msgid "Saint Barth&eacute;lemy"
+msgstr ""
+
+#: classes/class-wc-countries.php:221
+msgid "Saint Helena"
+msgstr ""
+
+#: classes/class-wc-countries.php:222
+msgid "Saint Kitts and Nevis"
+msgstr ""
+
+#: classes/class-wc-countries.php:223
+msgid "Saint Lucia"
+msgstr ""
+
+#: classes/class-wc-countries.php:224
+msgid "Saint Martin (French part)"
+msgstr ""
+
+#: classes/class-wc-countries.php:225
+msgid "Saint Martin (Dutch part)"
+msgstr ""
+
+#: classes/class-wc-countries.php:226
+msgid "Saint Pierre and Miquelon"
+msgstr ""
+
+#: classes/class-wc-countries.php:227
+msgid "Saint Vincent and the Grenadines"
+msgstr ""
+
+#: classes/class-wc-countries.php:228
+msgid "Samoa"
+msgstr ""
+
+#: classes/class-wc-countries.php:229
+msgid "San Marino"
+msgstr ""
+
+#: classes/class-wc-countries.php:230
+msgid "S&atilde;o Tom&eacute; and Pr&iacute;ncipe"
+msgstr ""
+
+#: classes/class-wc-countries.php:231
+msgid "Saudi Arabia"
+msgstr ""
+
+#: classes/class-wc-countries.php:232
+msgid "Senegal"
+msgstr ""
+
+#: classes/class-wc-countries.php:233
+msgid "Serbia"
+msgstr ""
+
+#: classes/class-wc-countries.php:234
+msgid "Seychelles"
+msgstr ""
+
+#: classes/class-wc-countries.php:235
+msgid "Sierra Leone"
+msgstr ""
+
+#: classes/class-wc-countries.php:236
+msgid "Singapore"
+msgstr ""
+
+#: classes/class-wc-countries.php:237
+msgid "Slovakia"
+msgstr ""
+
+#: classes/class-wc-countries.php:238
+msgid "Slovenia"
+msgstr ""
+
+#: classes/class-wc-countries.php:239
+msgid "Solomon Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:240
+msgid "Somalia"
+msgstr ""
+
+#: classes/class-wc-countries.php:241
+msgid "South Africa"
+msgstr ""
+
+#: classes/class-wc-countries.php:242
+msgid "South Georgia/Sandwich Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:243
+msgid "South Korea"
+msgstr ""
+
+#: classes/class-wc-countries.php:244
+msgid "South Sudan"
+msgstr ""
+
+#: classes/class-wc-countries.php:245
+msgid "Spain"
+msgstr ""
+
+#: classes/class-wc-countries.php:246
+msgid "Sri Lanka"
+msgstr ""
+
+#: classes/class-wc-countries.php:247
+msgid "Sudan"
+msgstr ""
+
+#: classes/class-wc-countries.php:248
+msgid "Suriname"
+msgstr ""
+
+#: classes/class-wc-countries.php:249
+msgid "Svalbard and Jan Mayen"
+msgstr ""
+
+#: classes/class-wc-countries.php:250
+msgid "Swaziland"
+msgstr ""
+
+#: classes/class-wc-countries.php:251
+msgid "Sweden"
+msgstr ""
+
+#: classes/class-wc-countries.php:252
+msgid "Switzerland"
+msgstr ""
+
+#: classes/class-wc-countries.php:253
+msgid "Syria"
+msgstr ""
+
+#: classes/class-wc-countries.php:254
+msgid "Taiwan"
+msgstr ""
+
+#: classes/class-wc-countries.php:255
+msgid "Tajikistan"
+msgstr ""
+
+#: classes/class-wc-countries.php:256
+msgid "Tanzania"
+msgstr ""
+
+#: classes/class-wc-countries.php:257
+msgid "Thailand"
+msgstr ""
+
+#: classes/class-wc-countries.php:258
+msgid "Timor-Leste"
+msgstr ""
+
+#: classes/class-wc-countries.php:259
+msgid "Togo"
+msgstr ""
+
+#: classes/class-wc-countries.php:260
+msgid "Tokelau"
+msgstr ""
+
+#: classes/class-wc-countries.php:261
+msgid "Tonga"
+msgstr ""
+
+#: classes/class-wc-countries.php:262
+msgid "Trinidad and Tobago"
+msgstr ""
+
+#: classes/class-wc-countries.php:263
+msgid "Tunisia"
+msgstr ""
+
+#: classes/class-wc-countries.php:264
+msgid "Turkey"
+msgstr ""
+
+#: classes/class-wc-countries.php:265
+msgid "Turkmenistan"
+msgstr ""
+
+#: classes/class-wc-countries.php:266
+msgid "Turks and Caicos Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:267
+msgid "Tuvalu"
+msgstr ""
+
+#: classes/class-wc-countries.php:268
+msgid "U.S. Virgin Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:269
+msgid "US Minor Outlying Islands"
+msgstr ""
+
+#: classes/class-wc-countries.php:270
+msgid "Uganda"
+msgstr ""
+
+#: classes/class-wc-countries.php:271
+msgid "Ukraine"
+msgstr ""
+
+#: classes/class-wc-countries.php:272
+msgid "United Arab Emirates"
+msgstr ""
+
+#: classes/class-wc-countries.php:273
+msgid "United Kingdom"
+msgstr ""
+
+#: classes/class-wc-countries.php:274
+msgid "United States"
+msgstr ""
+
+#: classes/class-wc-countries.php:275
+msgid "Uruguay"
+msgstr ""
+
+#: classes/class-wc-countries.php:276
+msgid "Uzbekistan"
+msgstr ""
+
+#: classes/class-wc-countries.php:277
+msgid "Vanuatu"
+msgstr ""
+
+#: classes/class-wc-countries.php:278
+msgid "Vatican"
+msgstr ""
+
+#: classes/class-wc-countries.php:279
+msgid "Venezuela"
+msgstr ""
+
+#: classes/class-wc-countries.php:280
+msgid "Vietnam"
+msgstr ""
+
+#: classes/class-wc-countries.php:281
+msgid "Wallis and Futuna"
+msgstr ""
+
+#: classes/class-wc-countries.php:282
+msgid "Western Sahara"
+msgstr ""
+
+#: classes/class-wc-countries.php:283
+msgid "Yemen"
+msgstr ""
+
+#: classes/class-wc-countries.php:284
+msgid "Zambia"
+msgstr ""
+
+#: classes/class-wc-countries.php:285
+msgid "Zimbabwe"
+msgstr ""
+
+#: classes/class-wc-countries.php:420
+msgid "to the"
+msgstr ""
+
+#: classes/class-wc-countries.php:421
+msgid "to"
+msgstr ""
+
+#: classes/class-wc-countries.php:434
+msgid "the"
+msgstr ""
+
+#: classes/class-wc-countries.php:446
+msgid "VAT"
+msgstr ""
+
+#: classes/class-wc-countries.php:446 templates/cart/totals.php:106
+#: templates/checkout/review-order.php:113
+msgid "Tax"
+msgstr ""
+
+#: classes/class-wc-countries.php:459
+msgid "(incl. VAT)"
+msgstr ""
+
+#: classes/class-wc-countries.php:459
+msgid "(incl. tax)"
+msgstr ""
+
+#: classes/class-wc-countries.php:472
+msgid "(ex. VAT)"
+msgstr ""
+
+#: classes/class-wc-countries.php:472
+msgid "(ex. tax)"
+msgstr ""
+
+#: classes/class-wc-countries.php:704 classes/class-wc-countries.php:705
+#: classes/class-wc-countries.php:727 classes/class-wc-countries.php:728
+#: classes/class-wc-countries.php:843 classes/class-wc-countries.php:844
+#: classes/class-wc-countries.php:869 classes/class-wc-countries.php:870
+msgid "Province"
+msgstr ""
+
+#: classes/class-wc-countries.php:711 classes/class-wc-countries.php:712
+msgid "Canton"
+msgstr ""
+
+#: classes/class-wc-countries.php:721 classes/class-wc-countries.php:722
+#: classes/class-wc-countries.php:850 classes/class-wc-countries.php:851
+msgid "Municipality"
+msgstr ""
+
+#: classes/class-wc-countries.php:770 classes/class-wc-countries.php:771
+msgid "Town/District"
+msgstr ""
+
+#: classes/class-wc-countries.php:774 classes/class-wc-countries.php:775
+msgid "Region"
+msgstr ""
+
+#: classes/class-wc-countries.php:875 classes/class-wc-countries.php:876
+msgid "Zip"
+msgstr ""
+
+#: classes/class-wc-countries.php:879 classes/class-wc-countries.php:880
+#: templates/cart/shipping-calculator.php:61
+msgid "State"
+msgstr ""
+
+#: classes/class-wc-countries.php:885 classes/class-wc-countries.php:886
+#: templates/cart/shipping-calculator.php:69
+msgid "Postcode"
+msgstr ""
+
+#: classes/class-wc-countries.php:889 classes/class-wc-countries.php:890
+msgid "County"
+msgstr ""
+
+#: classes/class-wc-countries.php:916 classes/class-wc-countries.php:917
+#: classes/class-wc-countries.php:987 templates/cart/shipping-calculator.php:69
+msgid "Postcode/Zip"
+msgstr ""
+
+#: classes/class-wc-countries.php:921 classes/class-wc-countries.php:922
+#: classes/class-wc-countries.php:981
+msgid "Town/City"
+msgstr ""
+
+#: classes/class-wc-countries.php:926 classes/class-wc-countries.php:927
+#: classes/class-wc-countries.php:1002
+msgid "State/County"
+msgstr ""
+
+#: classes/class-wc-countries.php:950
+msgid "First Name"
+msgstr ""
+
+#: classes/class-wc-countries.php:951
+msgctxt "placeholder"
+msgid "First Name"
+msgstr ""
+
+#: classes/class-wc-countries.php:956
+msgid "Last Name"
+msgstr ""
+
+#: classes/class-wc-countries.php:957
+msgctxt "placeholder"
+msgid "Last Name"
+msgstr ""
+
+#: classes/class-wc-countries.php:963
+msgid "Company Name"
+msgstr ""
+
+#: classes/class-wc-countries.php:964
+msgctxt "placeholder"
+msgid "Company (optional)"
+msgstr ""
+
+#: classes/class-wc-countries.php:968
+msgid "Address"
+msgstr ""
+
+#: classes/class-wc-countries.php:969
+msgctxt "placeholder"
+msgid "Address"
+msgstr ""
+
+#: classes/class-wc-countries.php:974
+msgid "Address 2"
+msgstr ""
+
+#: classes/class-wc-countries.php:975
+msgctxt "placeholder"
+msgid "Address 2 (optional)"
+msgstr ""
+
+#: classes/class-wc-countries.php:982
+msgctxt "placeholder"
+msgid "Town/City"
+msgstr ""
+
+#: classes/class-wc-countries.php:988
+msgctxt "placeholder"
+msgid "Postcode/Zip"
+msgstr ""
+
+#: classes/class-wc-countries.php:995
+msgid "Country"
+msgstr ""
+
+#: classes/class-wc-countries.php:996
+msgctxt "placeholder"
+msgid "Country"
+msgstr ""
+
+#: classes/class-wc-countries.php:1003
+msgctxt "placeholder"
+msgid "State/County"
+msgstr ""
+
+#: classes/class-wc-countries.php:1047
+msgid "Email Address"
+msgstr ""
+
+#: classes/class-wc-countries.php:1048
+msgctxt "placeholder"
+msgid "Email Address"
+msgstr ""
+
+#: classes/class-wc-countries.php:1054
+msgid "Phone"
+msgstr ""
+
+#: classes/class-wc-countries.php:1055
+msgctxt "placeholder"
+msgid "Phone"
+msgstr ""
+
+#: classes/class-wc-coupon.php:231
+msgid "Coupon usage limit has been reached."
+msgstr ""
+
+#: classes/class-wc-coupon.php:239
+msgid "This coupon has expired."
+msgstr ""
+
+#: classes/class-wc-coupon.php:247
+msgid "The minimum spend for this coupon is %s."
+msgstr ""
+
+#: classes/class-wc-coupon.php:263 classes/class-wc-coupon.php:281
+#: classes/class-wc-coupon.php:300 classes/class-wc-coupon.php:318
+msgid "Sorry, this coupon is not applicable to your cart contents."
+msgstr ""
+
+#: classes/class-wc-coupon.php:329
+msgid "Invalid coupon"
+msgstr ""
+
+#: classes/class-wc-customer.php:607 classes/class-wc-customer.php:617
+msgid "File %d"
+msgstr ""
+
+#: classes/class-wc-order.php:282
+msgctxt "hash before order number"
+msgid "#"
+msgstr ""
+
+#: classes/class-wc-order.php:828
+msgid "&nbsp;<small>%svia %s</small>"
+msgstr ""
+
+#: classes/class-wc-order.php:893
+msgid "Cart Subtotal:"
+msgstr ""
+
+#: classes/class-wc-order.php:899
+msgid "Cart Discount:"
+msgstr ""
+
+#: classes/class-wc-order.php:905
+msgid "Shipping:"
+msgstr ""
+
+#: classes/class-wc-order.php:950
+msgid "Subtotal:"
+msgstr ""
+
+#: classes/class-wc-order.php:976
+msgid "Order Discount:"
+msgstr ""
+
+#: classes/class-wc-order.php:981
+msgid "Order Total:"
+msgstr ""
+
+#: classes/class-wc-order.php:1003 templates/cart/totals.php:139
+#: templates/checkout/review-order.php:151
+msgid "(Includes %s)"
+msgstr ""
+
+#: classes/class-wc-order.php:1152 classes/class-wc-order.php:1154
+#: classes/class-wc-order.php:1157
+msgid "WooCommerce"
+msgstr ""
+
+#: classes/class-wc-order.php:1203
+msgid "Order status changed from %s to %s."
+msgstr ""
+
+#: classes/class-wc-order.php:1428 woocommerce-ajax.php:1105
+#: woocommerce-ajax.php:1106
+msgid "Item #%s stock reduced from %s to %s."
+msgstr ""
+
+#: classes/class-wc-order.php:1440
+msgid "Order item stock reduced successfully."
+msgstr ""
+
+#: classes/class-wc-product-external.php:54
+msgid "Buy product"
+msgstr ""
+
+#: classes/class-wc-settings-api.php:39 classes/emails/class-wc-email.php:545
+#: classes/integrations/class-wc-integration.php:29
+msgid "Settings"
+msgstr ""
+
+#: classes/class-wc-settings-api.php:59
+msgid "This public function needs to be overridden by your payment gateway class."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:24
+msgid "Completed order"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:25
+msgid "Order complete emails are sent to the customer when the order is marked complete and usual indicates that the order has been shipped."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:27
+msgid "Your order is complete"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:28
+msgid "Your {blogname} order from {order_date} is complete"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:30
+msgid "Your order is complete - download your files"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:31
+msgid "Your {blogname} order from {order_date} is complete - download your files"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:138
+#: classes/emails/class-wc-email-customer-invoice.php:138
+#: classes/emails/class-wc-email-new-order.php:115
+#: classes/emails/class-wc-email.php:416
+#: classes/gateways/bacs/class-wc-bacs.php:64
+#: classes/gateways/cheque/class-wc-cheque.php:59
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:160
+#: classes/gateways/paypal/class-wc-paypal.php:121
+#: classes/shipping/class-wc-flat-rate.php:83
+#: classes/shipping/class-wc-free-shipping.php:76
+#: classes/shipping/class-wc-international-delivery.php:52
+msgid "Enable/Disable"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:140
+#: classes/emails/class-wc-email-customer-invoice.php:140
+#: classes/emails/class-wc-email-new-order.php:117
+#: classes/emails/class-wc-email.php:418
+msgid "Enable this email notification"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:144
+#: classes/emails/class-wc-email-new-order.php:128
+msgid "Subject"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:146
+#: classes/emails/class-wc-email-customer-completed-order.php:153
+#: classes/emails/class-wc-email-customer-completed-order.php:160
+#: classes/emails/class-wc-email-customer-completed-order.php:167
+#: classes/emails/class-wc-email-customer-invoice.php:146
+#: classes/emails/class-wc-email-customer-invoice.php:153
+#: classes/emails/class-wc-email-customer-invoice.php:160
+#: classes/emails/class-wc-email-customer-invoice.php:167
+#: classes/emails/class-wc-email.php:424 classes/emails/class-wc-email.php:431
+msgid "Defaults to <code>%s</code>"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:151
+#: classes/emails/class-wc-email-new-order.php:135
+msgid "Email Heading"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:158
+msgid "Subject (downloadable)"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:165
+msgid "Email Heading (downloadable)"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:172
+#: classes/emails/class-wc-email-customer-invoice.php:172
+#: classes/emails/class-wc-email-new-order.php:142
+#: classes/emails/class-wc-email.php:436
+msgid "Email type"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:174
+#: classes/emails/class-wc-email-customer-invoice.php:174
+#: classes/emails/class-wc-email-new-order.php:144
+#: classes/emails/class-wc-email.php:438
+msgid "Choose which format of email to send."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:178
+#: classes/emails/class-wc-email-customer-invoice.php:178
+#: classes/emails/class-wc-email-new-order.php:148
+#: classes/emails/class-wc-email.php:442
+msgid "Plain text"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:179
+#: classes/emails/class-wc-email-customer-invoice.php:179
+#: classes/emails/class-wc-email-new-order.php:149
+#: classes/emails/class-wc-email.php:443
+msgid "HTML"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-completed-order.php:180
+#: classes/emails/class-wc-email-customer-invoice.php:180
+#: classes/emails/class-wc-email-new-order.php:150
+#: classes/emails/class-wc-email.php:444
+msgid "Multipart"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:27
+msgid "Customer invoice"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:28
+msgid "Customer invoice emails can be sent to the user containing order info and payment links."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:33
+msgid "Invoice for order {order_number} from {order_date}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:34
+msgid "Invoice for order {order_number}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:36
+msgid "Your {blogname} order from {order_date}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:37
+msgid "Order {order_number} details"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:144
+#: classes/emails/class-wc-email.php:422
+msgid "Email subject"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:151
+#: classes/emails/class-wc-email.php:429
+msgid "Email heading"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:158
+msgid "Email subject (paid)"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-invoice.php:165
+msgid "Email heading (paid)"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-new-account.php:31
+msgid "New account"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-new-account.php:32
+msgid "Customer new account emails are sent when a customer signs up via the checkout or My Account page."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-new-account.php:37
+msgid "Your account on {blogname}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-new-account.php:38
+msgid "Welcome to {blogname}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-note.php:29
+msgid "Customer note"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-note.php:30
+msgid "Customer note emails are sent when you add a note to an order."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-note.php:35
+msgid "Note added to your {blogname} order from {order_date}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-note.php:36
+msgid "A note has been added to your order"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-processing-order.php:24
+msgid "Processing order"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-processing-order.php:25
+msgid "This is an order notification sent to the customer after payment containing order details."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-processing-order.php:27
+msgid "Thank you for your order"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-processing-order.php:28
+msgid "Your {blogname} order receipt from {order_date}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-reset-password.php:35
+msgid "Reset password"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-reset-password.php:36
+msgid "Customer reset password emails are sent when a customer resets their password."
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-reset-password.php:41
+msgid "Password Reset for {blogname}"
+msgstr ""
+
+#: classes/emails/class-wc-email-customer-reset-password.php:42
+msgid "Password Reset Instructions"
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:24
+msgid "New order"
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:25
+msgid "New order emails are sent when an order is received/paid by a customer."
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:27
+msgid "New customer order"
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:28
+msgid "[{blogname}] New customer order ({order_number}) - {order_date}"
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:121
+msgid "Recipient(s)"
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:123
+msgid "Enter recipients (comma separated) for this email. Defaults to <code>%s</code>."
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:130
+msgid "This controls the email subject line. Leave blank to use the default subject: <code>%s</code>."
+msgstr ""
+
+#: classes/emails/class-wc-email-new-order.php:137
+msgid "This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:480 classes/emails/class-wc-email.php:501
+msgid "Could not write to template file."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:528
+msgid "Template file copied to theme."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:537
+msgid "Template file deleted from theme."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:557
+msgid "HTML template"
+msgstr ""
+
+#: classes/emails/class-wc-email.php:558
+msgid "Plain text template"
+msgstr ""
+
+#: classes/emails/class-wc-email.php:577
+msgid "Delete template file"
+msgstr ""
+
+#: classes/emails/class-wc-email.php:580
+msgid "This template has been overridden by your theme and can be found in: <code>%s</code>."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:595
+msgid "Copy file to theme"
+msgstr ""
+
+#: classes/emails/class-wc-email.php:598
+msgid "To override and edit this email template copy <code>%s</code> to your theme folder: <code>%s</code>."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:609
+msgid "File was not found."
+msgstr ""
+
+#: classes/emails/class-wc-email.php:634
+msgid "View template"
+msgstr ""
+
+#: classes/emails/class-wc-email.php:635
+msgid "Hide template"
+msgstr ""
+
+#: classes/emails/class-wc-email.php:646
+msgid "Are you sure you want to delete this template file?"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:245
+msgid "Note"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:280
+msgid "Product low in stock"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:285
+#: classes/emails/class-wc-emails.php:317
+#: classes/emails/class-wc-emails.php:361
+msgid "Variation #%s of %s"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:287
+#: classes/emails/class-wc-emails.php:319
+#: classes/emails/class-wc-emails.php:363
+msgid "Product #%s - %s"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:289
+msgid "is low in stock."
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:312
+msgid "Product out of stock"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:321
+msgid "is out of stock."
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:356
+msgid "Product Backorder"
+msgstr ""
+
+#: classes/emails/class-wc-emails.php:365
+msgid "%s units of %s have been backordered in order #%s."
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:28
+msgid "Bacs"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:66
+msgid "Enable Bank Transfer"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:70
+#: classes/gateways/cheque/class-wc-cheque.php:65
+#: classes/gateways/cod/class-wc-cod.php:88
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:172
+#: classes/gateways/paypal/class-wc-paypal.php:127
+#: classes/shipping/class-wc-local-delivery.php:106
+#: classes/shipping/class-wc-local-pickup.php:85
+msgid "Title"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:72
+#: classes/gateways/cheque/class-wc-cheque.php:67
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:174
+#: classes/gateways/paypal/class-wc-paypal.php:129
+#: classes/shipping/class-wc-flat-rate.php:91
+#: classes/shipping/class-wc-free-shipping.php:84
+#: classes/shipping/class-wc-international-delivery.php:60
+#: classes/shipping/class-wc-local-delivery.php:108
+#: classes/shipping/class-wc-local-pickup.php:87
+msgid "This controls the title which the user sees during checkout."
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:73
+msgid "Direct Bank Transfer"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:76
+#: classes/gateways/cheque/class-wc-cheque.php:71
+msgid "Customer Message"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:78
+msgid "Give the customer instructions for paying via BACS, and let them know that their order won't be shipping until the money is received."
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:79
+msgid "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order wont be shipped until the funds have cleared in our account."
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:82
+msgid "Account Details"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:84
+msgid "Optionally enter your bank details below for customers to pay into."
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:88
+#: classes/gateways/bacs/class-wc-bacs.php:165
+#: classes/gateways/bacs/class-wc-bacs.php:205
+msgid "Account Name"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:94
+#: classes/gateways/bacs/class-wc-bacs.php:166
+#: classes/gateways/bacs/class-wc-bacs.php:206
+msgid "Account Number"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:100
+#: classes/gateways/bacs/class-wc-bacs.php:167
+#: classes/gateways/bacs/class-wc-bacs.php:207
+msgid "Sort Code"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:106
+#: classes/gateways/bacs/class-wc-bacs.php:168
+#: classes/gateways/bacs/class-wc-bacs.php:208
+msgid "Bank Name"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:112
+#: classes/gateways/bacs/class-wc-bacs.php:169
+#: classes/gateways/bacs/class-wc-bacs.php:209
+msgid "IBAN"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:114
+#: classes/gateways/bacs/class-wc-bacs.php:120
+msgid "Your bank may require this for international payments"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:118
+msgid "BIC (formerly Swift)"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:138
+msgid "BACS Payment"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:139
+msgid "Allows payments by BACS (Bank Account Clearing System), more commonly known as direct bank/wire transfer."
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:160
+#: classes/gateways/bacs/class-wc-bacs.php:202
+msgid "Our Details"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:170
+#: classes/gateways/bacs/class-wc-bacs.php:210
+msgid "BIC"
+msgstr ""
+
+#: classes/gateways/bacs/class-wc-bacs.php:236
+msgid "Awaiting BACS payment"
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:28
+msgid "Cheque"
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:61
+msgid "Enable Cheque Payment"
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:68
+#: classes/gateways/cheque/class-wc-cheque.php:91
+msgid "Cheque Payment"
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:73
+msgid "Let the customer know the payee and where they should be sending the cheque to and that their order won't be shipping until you receive it."
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:74
+msgid "Please send your cheque to Store Name, Store Street, Store Town, Store State / County, Store Postcode."
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:92
+msgid "Allows cheque payments. Why would you take cheques in this day and age? Well you probably wouldn't but it does allow you to make test purchases for testing order emails and the 'success' pages etc."
+msgstr ""
+
+#: classes/gateways/cheque/class-wc-cheque.php:148
+msgid "Awaiting cheque payment"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:27
+#: classes/gateways/cod/class-wc-cod.php:56
+#: classes/gateways/cod/class-wc-cod.php:91
+msgid "Cash on Delivery"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:57
+msgid "Have your customers pay with cash (or by other means) upon delivery."
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:81
+msgid "Enable COD"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:82
+msgid "Enable Cash on Delivery"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:90
+msgid "Payment method title that the customer will see on your website."
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:94
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:178
+#: classes/gateways/paypal/class-wc-paypal.php:133
+#: templates/single-product/tabs/tab-description.php:15
+msgid "Description"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:96
+msgid "Payment method description that the customer will see on your website."
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:100
+msgid "Instructions"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:102
+msgid "Instructions that will be added to the thank you page."
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:106
+msgid "Enable for shipping methods"
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:111
+msgid "If COD is only available for certain methods, set it up here. Leave blank to enable for all methods."
+msgstr ""
+
+#: classes/gateways/cod/class-wc-cod.php:175
+msgid "Payment to be made upon delivery."
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:31
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:196
+msgid "Mijireh Checkout"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:145
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:321
+msgid "Mijireh error:"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:162
+msgid "Enable Mijireh Checkout"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:166
+msgid "Access Key"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:168
+msgid "The Mijireh access key for your store."
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:175
+msgid "Credit Card"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:180
+msgid "Pay securely with you credit card."
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:181
+#: classes/gateways/paypal/class-wc-paypal.php:135
+msgid "This controls the description which the user sees during checkout."
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:200
+msgid "Get started with Mijireh Checkout"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:201
+msgid "provides a fully PCI Compliant, secure way to collect and transmit credit card data to your payment gateway while keeping you in control of the design of your site. Mijireh supports a wide variety of payment gateways: Stripe, Authorize.net, PayPal, eWay, SagePay, Braintree, PayLeap, and more."
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:203
+msgid "Join for free"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:203
+msgid "Learn more about WooCommerce and Mijireh"
+msgstr ""
+
+#: classes/gateways/mijireh/class-wc-mijireh-checkout.php:207
+msgid "provides a fully PCI Compliant, secure way to collect and transmit credit card data to your payment gateway while keeping you in control of the design of your site."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:34
+#: classes/gateways/paypal/class-wc-paypal.php:130
+msgid "PayPal"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:92
+msgid "PayPal standard"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:93
+msgid "PayPal standard works by sending the user to PayPal to enter their payment information."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:105
+msgid "Gateway Disabled"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:105
+msgid "PayPal does not support your store currency."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:123
+msgid "Enable PayPal standard"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:136
+msgid "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:139
+msgid "PayPal Email"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:141
+msgid "Please enter your PayPal email address; this is needed in order to take payment."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:145
+msgid "Invoice Prefix"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:147
+msgid "Please enter a prefix for your invoice numbers. If you use your PayPal account for multiple stores ensure this prefix is unqiue as PayPal will not allow orders with the same invoice number."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:151
+msgid "Submission method"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:153
+msgid "Use form submission method."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:154
+msgid "Enable this to post order data to PayPal via a form instead of using a redirect/querystring."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:158
+msgid "Page Style"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:160
+msgid "Optionally enter the name of the page style you wish to use. These are defined within your PayPal account."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:164
+msgid "Shipping options"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:169
+msgid "Shipping details"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:171
+msgid "Send shipping details to PayPal instead of billing."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:173
+msgid "PayPal allows us to send 1 address. If you are using PayPal for shipping labels you may prefer to send the shipping address rather than billing."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:177
+msgid "Address override"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:179
+msgid "Enable \"address_override\" to prevent address information from being changed."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:180
+msgid "PayPal verifies addresses therefore this setting can cause errors (we recommend keeping it disabled)."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:184
+msgid "Gateway Testing"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:189
+msgid "PayPal sandbox"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:191
+msgid "Enable PayPal sandbox"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:193
+msgid "PayPal sandbox can be used to test payments. Sign up for a developer account <a href=\"%s\">here</a>."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:196
+msgid "Debug Log"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:198
+msgid "Enable logging"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:200
+msgid "Log PayPal events, such as IPN requests, inside <code>woocommerce/logs/paypal.txt</code>"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:309
+msgid "Order %s"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:319
+#: classes/gateways/paypal/class-wc-paypal.php:369
+msgid "Shipping via"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:410
+msgid "Thank you for your order. We are now redirecting you to PayPal to make payment."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:431
+msgid "Pay via PayPal"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:431
+msgid "Cancel order &amp; restore cart"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:485
+msgid "Thank you for your order, please click the button below to pay with PayPal."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:630
+msgid "Validation error: PayPal amounts do not match (gross %s)."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:648
+msgid "IPN payment completed"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:660
+#: classes/gateways/paypal/class-wc-paypal.php:668
+#: classes/gateways/paypal/class-wc-paypal.php:686
+msgid "Payment %s via IPN."
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:673
+#: classes/gateways/paypal/class-wc-paypal.php:691
+msgid "Order refunded/reversed"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:674
+#: classes/gateways/paypal/class-wc-paypal.php:692
+msgid "Order %s has been marked as refunded - PayPal reason code: %s"
+msgstr ""
+
+#: classes/gateways/paypal/class-wc-paypal.php:677
+#: classes/gateways/paypal/class-wc-paypal.php:695
+msgid "Payment for order %s refunded/reversed"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:26
+msgid "Google Analytics"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:27
+msgid "Google Analytics is a free service offered by Google that generates detailed statistics about the visitors to a website."
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:64
+msgid "Google Analytics ID"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:65
+msgid "Log into your google analytics account to find your ID. e.g. <code>UA-XXXXX-X</code>"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:70
+msgid "Tracking code"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:71
+msgid "Add tracking code to your site's footer. You don't need to enable this if using a 3rd party analytics plugin."
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:77
+msgid "Add eCommerce tracking code to the thankyou page"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:83
+msgid "Add event tracking code for add to cart actions"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:115
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:170
+#: woocommerce-ajax.php:1657
+msgid "Guest"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:203
+#: templates/single-product/meta.php:19
+msgid "SKU:"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:256
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:276
+#: woocommerce.php:858
+msgid "Products"
+msgstr ""
+
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:257
+#: classes/integrations/google-analytics/class-wc-google-analytics.php:277
+msgid "Add to Cart"
+msgstr ""
+
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:26
+msgid "ShareDaddy"
+msgstr ""
+
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:27
+msgid "ShareDaddy is a sharing plugin bundled with JetPack."
+msgstr ""
+
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:56
+msgid "Output ShareDaddy button?"
+msgstr ""
+
+#: classes/integrations/sharedaddy/class-wc-sharedaddy.php:57
+msgid "Enable this option to show the ShareDaddy button on the product page."
+msgstr ""
+
+#: classes/integrations/sharethis/class-wc-sharethis.php:29
+msgid "ShareThis"
+msgstr ""
+
+#: classes/integrations/sharethis/class-wc-sharethis.php:30
+msgid "ShareThis offers a sharing widget which will allow customers to share links to products with their friends."
+msgstr ""
+
+#: classes/integrations/sharethis/class-wc-sharethis.php:67
+msgid "ShareThis Publisher ID"
+msgstr ""
+
+#: classes/integrations/sharethis/class-wc-sharethis.php:68
+msgid "Enter your %1$sShareThis publisher ID%2$s to show social sharing buttons on product pages."
+msgstr ""
+
+#: classes/integrations/sharethis/class-wc-sharethis.php:73
+msgid "ShareThis Code"
+msgstr ""
+
+#: classes/integrations/sharethis/class-wc-sharethis.php:74
+msgid "You can tweak the ShareThis code by editing this option."
+msgstr ""
+
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:19
+#: classes/integrations/shareyourcart/class.shareyourcart-wp.php:329
+msgid "ShareYourCart"
+msgstr ""
+
+#: classes/integrations/shareyourcart/class-wc-shareyourcart.php:20
+msgid "Increase your social media exposure by 10 percent! ShareYourCart helps you get more customers by motivating satisfied customers to talk with their friends about your products. For help with ShareYourCart view the <a href=\"http://www.woothemes.com/woocommerce-docs/user-guide/shareyourcart/\" target=\"__blank\">documentation</a>."
+msgstr ""
+
+#: classes/integrations/shareyourcart/class.shareyourcart-wp.php:328
+msgid "Share your cart settings"
+msgstr ""
+
+#: classes/integrations/shareyourcart/class.shareyourcart-wp.php:342
+msgid "Button"
+msgstr ""
+
+#: classes/integrations/shareyourcart/class.shareyourcart-wp.php:343
+msgid "Customize Button"
+msgstr ""
+
+#: classes/integrations/shareyourcart/class.shareyourcart-wp.php:351
+#: classes/integrations/shareyourcart/class.shareyourcart-wp.php:352
+msgid "Documentation"
+msgstr ""
+
+#: classes/integrations/shareyourcart/views/admin-page.php:33
+msgid "Setup your ShareYourCart account"
+msgstr ""
+
+#: classes/integrations/shareyourcart/views/admin-page.php:35
+msgid "Create an account"
+msgstr ""
+
+#: classes/integrations/shareyourcart/views/admin-page.php:35
+msgid "Can't access your account?"
+msgstr ""
+
+#: classes/integrations/shareyourcart/views/admin-page.php:100
+msgid "Configure"
+msgstr ""
+
+#: classes/integrations/shareyourcart/views/admin-page.php:110
+#: classes/integrations/shareyourcart/views/button-settings-page.php:120
+msgid "Save changes"
+msgstr ""
+
+#: classes/integrations/shareyourcart/views/button-settings-page.php:8
+#: classes/integrations/shareyourcart/views/button-settings-page.php:11
+msgid "Button style"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:25
+msgid "Flat rate"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:28
+#: classes/shipping/class-wc-flat-rate.php:458
+msgid "Flat Rates"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:29
+msgid "Flat rates let you define a standard rate per item, or per order."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:85
+#: classes/shipping/class-wc-international-delivery.php:54
+msgid "Enable this shipping method"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:89
+#: classes/shipping/class-wc-free-shipping.php:82
+#: classes/shipping/class-wc-international-delivery.php:58
+msgid "Method Title"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:92
+msgid "Flat Rate"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:95
+msgid "Cost per order"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:101
+msgid "Enter a cost per order, e.g. 5.00. Leave blank to disable."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:105
+#: classes/shipping/class-wc-free-shipping.php:88
+#: classes/shipping/class-wc-local-delivery.php:139
+#: classes/shipping/class-wc-local-pickup.php:97
+msgid "Method availability"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:110
+#: classes/shipping/class-wc-free-shipping.php:93
+#: classes/shipping/class-wc-local-delivery.php:144
+#: classes/shipping/class-wc-local-pickup.php:102
+msgid "All allowed countries"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:111
+#: classes/shipping/class-wc-flat-rate.php:115
+#: classes/shipping/class-wc-free-shipping.php:94
+#: classes/shipping/class-wc-free-shipping.php:98
+#: classes/shipping/class-wc-local-delivery.php:145
+#: classes/shipping/class-wc-local-delivery.php:149
+#: classes/shipping/class-wc-local-pickup.php:103
+#: classes/shipping/class-wc-local-pickup.php:107
+msgid "Specific Countries"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:123
+#: classes/shipping/class-wc-international-delivery.php:82
+msgid "Calculation Type"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:128
+#: classes/shipping/class-wc-international-delivery.php:87
+msgid "Per Order - charge shipping for the entire order as a whole"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:129
+#: classes/shipping/class-wc-international-delivery.php:88
+msgid "Per Item - charge shipping for each item individually"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:130
+#: classes/shipping/class-wc-international-delivery.php:89
+msgid "Per Class - charge shipping for each shipping class in an order"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:134
+#: classes/shipping/class-wc-international-delivery.php:93
+msgid "Tax Status"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:139
+#: classes/shipping/class-wc-international-delivery.php:98
+msgid "Taxable"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:140
+#: classes/shipping/class-wc-international-delivery.php:99
+msgid "None"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:144
+#: classes/shipping/class-wc-international-delivery.php:103
+msgid "Default Cost"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:150
+#: classes/shipping/class-wc-international-delivery.php:109
+msgid "Cost excluding tax. Enter an amount, e.g. 2.50."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:154
+#: classes/shipping/class-wc-international-delivery.php:113
+msgid "Default Handling Fee"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:156
+#: classes/shipping/class-wc-international-delivery.php:115
+msgid "Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%. Leave blank to disable."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:160
+msgid "Minimum Fee"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:166
+msgid "Enter a minimum fee amount. Fee's less than this will be increased. Leave blank to disable."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:170
+msgid "Shipping Options"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:172
+msgid "Optional extra shipping options with additional costs (one per line). Example: <code>Option Name|Cost|Per-order (yes or no)</code>. Example: <code>Priority Mail|6.95|yes</code>. If per-order is set to no, it will use the \"Calculation Type\" setting."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:464 woocommerce.php:755
+msgid "Shipping Class"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:465
+msgid "Cost"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:465
+msgid "Cost, excluding tax."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:466
+msgid "Handling Fee"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:466
+msgid "Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:471
+msgid "+ Add Flat Rate"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:472
+msgid "Add rates for shipping classes here &mdash; they will override the default costs defined above."
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:472
+msgid "Delete selected rates"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:492
+#: classes/shipping/class-wc-flat-rate.php:525
+msgid "Select a class&hellip;"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:497
+#: classes/shipping/class-wc-flat-rate.php:498
+msgid "0.00"
+msgstr ""
+
+#: classes/shipping/class-wc-flat-rate.php:539
+msgid "Delete the selected rates?"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:25
+#: classes/shipping/class-wc-free-shipping.php:85
+#: classes/shipping/class-wc-free-shipping.php:143
+msgid "Free Shipping"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:78
+msgid "Enable Free Shipping"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:106
+msgid "Free Shipping Requires..."
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:110
+#: templates/order/order-details.php:110 templates/order/order-details.php:125
+msgid "N/A"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:111
+msgid "A valid free shipping coupon"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:112
+msgid "A minimum order amount (defined below)"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:113
+msgid "A minimum order amount OR a coupon"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:114
+msgid "A minimum order amount AND a coupon"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:118
+msgid "Minimum Order Amount"
+msgstr ""
+
+#: classes/shipping/class-wc-free-shipping.php:124
+msgid "Users will need to spend this amount to get free shipping (if enabled above)."
+msgstr ""
+
+#: classes/shipping/class-wc-international-delivery.php:28
+#: classes/shipping/class-wc-international-delivery.php:31
+#: classes/shipping/class-wc-international-delivery.php:61
+msgid "International Delivery"
+msgstr ""
+
+#: classes/shipping/class-wc-international-delivery.php:32
+msgid "International delivery based on flat rate shipping."
+msgstr ""
+
+#: classes/shipping/class-wc-international-delivery.php:64
+msgid "Availability"
+msgstr ""
+
+#: classes/shipping/class-wc-international-delivery.php:69
+msgid "Selected countries"
+msgstr ""
+
+#: classes/shipping/class-wc-international-delivery.php:70
+msgid "Excluding selected countries"
+msgstr ""
+
+#: classes/shipping/class-wc-international-delivery.php:74
+msgid "Countries"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:25
+#: classes/shipping/class-wc-local-delivery.php:109
+msgid "Local Delivery"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:100
+#: classes/shipping/class-wc-local-pickup.php:79
+msgid "Enable"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:102
+msgid "Enable local delivery"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:112
+msgid "Fee Type"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:114
+msgid "How to calculate delivery charges"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:117
+msgid "Fixed amount"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:118
+msgid "Percentage of cart total"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:119
+msgid "Fixed amount per product"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:123
+msgid "Delivery Fee"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:129
+msgid "What fee do you want to charge for local delivery, disregarded if you choose free. Leave blank to disable."
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:133
+#: classes/shipping/class-wc-local-pickup.php:91
+msgid "Zip/Post Codes"
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:135
+#: classes/shipping/class-wc-local-pickup.php:93
+msgid "What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30."
+msgstr ""
+
+#: classes/shipping/class-wc-local-delivery.php:168
+msgid "Local delivery is a simple shipping method for delivering orders locally."
+msgstr ""
+
+#: classes/shipping/class-wc-local-pickup.php:25
+#: classes/shipping/class-wc-local-pickup.php:88
+msgid "Local Pickup"
+msgstr ""
+
+#: classes/shipping/class-wc-local-pickup.php:81
+msgid "Enable local pickup"
+msgstr ""
+
+#: classes/shipping/class-wc-local-pickup.php:115
+msgid "Apply base tax rate"
+msgstr ""
+
+#: classes/shipping/class-wc-local-pickup.php:117
+msgid "When this shipping method is chosen, apply the base tax rate rather than for the customer's given address."
+msgstr ""
+
+#: classes/shipping/class-wc-local-pickup.php:132
+msgid "Local pickup is a simple method which allows the customer to pick up their order themselves."
+msgstr ""
+
+#: i18n/states/AU.php:13
+msgid "Australian Capital Territory"
+msgstr ""
+
+#: i18n/states/AU.php:14
+msgid "New South Wales"
+msgstr ""
+
+#: i18n/states/AU.php:15
+msgid "Northern Territory"
+msgstr ""
+
+#: i18n/states/AU.php:16
+msgid "Queensland"
+msgstr ""
+
+#: i18n/states/AU.php:17
+msgid "South Australia"
+msgstr ""
+
+#: i18n/states/AU.php:18
+msgid "Tasmania"
+msgstr ""
+
+#: i18n/states/AU.php:19
+msgid "Victoria"
+msgstr ""
+
+#: i18n/states/AU.php:20
+msgid "Western Australia"
+msgstr ""
+
+#: i18n/states/BR.php:13
+msgid "Acre"
+msgstr ""
+
+#: i18n/states/BR.php:14
+msgid "Alagoas"
+msgstr ""
+
+#: i18n/states/BR.php:15
+msgid "Amap&aacute;"
+msgstr ""
+
+#: i18n/states/BR.php:16
+msgid "Amazonas"
+msgstr ""
+
+#: i18n/states/BR.php:17
+msgid "Bahia"
+msgstr ""
+
+#: i18n/states/BR.php:18
+msgid "Cear&aacute;"
+msgstr ""
+
+#: i18n/states/BR.php:19
+msgid "Distrito Federal"
+msgstr ""
+
+#: i18n/states/BR.php:20
+msgid "Esp&iacute;rito Santo"
+msgstr ""
+
+#: i18n/states/BR.php:21
+msgid "Goi&aacute;s"
+msgstr ""
+
+#: i18n/states/BR.php:22
+msgid "Maranh&atilde;o"
+msgstr ""
+
+#: i18n/states/BR.php:23
+msgid "Mato Grosso"
+msgstr ""
+
+#: i18n/states/BR.php:24
+msgid "Mato Grosso do Sul"
+msgstr ""
+
+#: i18n/states/BR.php:25
+msgid "Minas Gerais"
+msgstr ""
+
+#: i18n/states/BR.php:26
+msgid "Par&aacute;"
+msgstr ""
+
+#: i18n/states/BR.php:27
+msgid "Para&iacute;ba"
+msgstr ""
+
+#: i18n/states/BR.php:28
+msgid "Paran&aacute;"
+msgstr ""
+
+#: i18n/states/BR.php:29
+msgid "Pernambuco"
+msgstr ""
+
+#: i18n/states/BR.php:30
+msgid "Piau&iacute;"
+msgstr ""
+
+#: i18n/states/BR.php:31
+msgid "Rio de Janeiro"
+msgstr ""
+
+#: i18n/states/BR.php:32
+msgid "Rio Grande do Norte"
+msgstr ""
+
+#: i18n/states/BR.php:33
+msgid "Rio Grande do Sul"
+msgstr ""
+
+#: i18n/states/BR.php:34
+msgid "Rond&ocirc;nia"
+msgstr ""
+
+#: i18n/states/BR.php:35
+msgid "Roraima"
+msgstr ""
+
+#: i18n/states/BR.php:36
+msgid "Santa Catarina"
+msgstr ""
+
+#: i18n/states/BR.php:37
+msgid "S&atilde;o Paulo"
+msgstr ""
+
+#: i18n/states/BR.php:38
+msgid "Sergipe"
+msgstr ""
+
+#: i18n/states/BR.php:39
+msgid "Tocantins"
+msgstr ""
+
+#: i18n/states/CA.php:13
+msgid "Alberta"
+msgstr ""
+
+#: i18n/states/CA.php:14
+msgid "British Columbia"
+msgstr ""
+
+#: i18n/states/CA.php:15
+msgid "Manitoba"
+msgstr ""
+
+#: i18n/states/CA.php:16
+msgid "New Brunswick"
+msgstr ""
+
+#: i18n/states/CA.php:17
+msgid "Newfoundland"
+msgstr ""
+
+#: i18n/states/CA.php:18
+msgid "Northwest Territories"
+msgstr ""
+
+#: i18n/states/CA.php:19
+msgid "Nova Scotia"
+msgstr ""
+
+#: i18n/states/CA.php:20
+msgid "Nunavut"
+msgstr ""
+
+#: i18n/states/CA.php:21
+msgid "Ontario"
+msgstr ""
+
+#: i18n/states/CA.php:22
+msgid "Prince Edward Island"
+msgstr ""
+
+#: i18n/states/CA.php:23
+msgid "Quebec"
+msgstr ""
+
+#: i18n/states/CA.php:24
+msgid "Saskatchewan"
+msgstr ""
+
+#: i18n/states/CA.php:25
+msgid "Yukon Territory"
+msgstr ""
+
+#: i18n/states/CN.php:13
+msgid "Yunnan / &#20113;&#21335;"
+msgstr ""
+
+#: i18n/states/CN.php:14
+msgid "Beijing / &#21271;&#20140;"
+msgstr ""
+
+#: i18n/states/CN.php:15
+msgid "Tianjin / &#22825;&#27941;"
+msgstr ""
+
+#: i18n/states/CN.php:16
+msgid "Hebei / &#27827;&#21271;"
+msgstr ""
+
+#: i18n/states/CN.php:17
+msgid "Shanxi / &#23665;&#35199;"
+msgstr ""
+
+#: i18n/states/CN.php:18
+msgid "Inner Mongolia / &#20839;&#33945;&#21476;"
+msgstr ""
+
+#: i18n/states/CN.php:19
+msgid "Liaoning / &#36797;&#23425;"
+msgstr ""
+
+#: i18n/states/CN.php:20
+msgid "Jilin / &#21513;&#26519;"
+msgstr ""
+
+#: i18n/states/CN.php:21
+msgid "Heilongjiang / &#40657;&#40857;&#27743;"
+msgstr ""
+
+#: i18n/states/CN.php:22
+msgid "Shanghai / &#19978;&#28023;"
+msgstr ""
+
+#: i18n/states/CN.php:23
+msgid "Jiangsu / &#27743;&#33487;"
+msgstr ""
+
+#: i18n/states/CN.php:24
+msgid "Zhejiang / &#27993;&#27743;"
+msgstr ""
+
+#: i18n/states/CN.php:25
+msgid "Anhui / &#23433;&#24509;"
+msgstr ""
+
+#: i18n/states/CN.php:26
+msgid "Fujian / &#31119;&#24314;"
+msgstr ""
+
+#: i18n/states/CN.php:27
+msgid "Jiangxi / &#27743;&#35199;"
+msgstr ""
+
+#: i18n/states/CN.php:28
+msgid "Shandong / &#23665;&#19996;"
+msgstr ""
+
+#: i18n/states/CN.php:29
+msgid "Henan / &#27827;&#21335;"
+msgstr ""
+
+#: i18n/states/CN.php:30
+msgid "Hubei / &#28246;&#21271;"
+msgstr ""
+
+#: i18n/states/CN.php:31
+msgid "Hunan / &#28246;&#21335;"
+msgstr ""
+
+#: i18n/states/CN.php:32
+msgid "Guangdong / &#24191;&#19996;"
+msgstr ""
+
+#: i18n/states/CN.php:33
+msgid "Guangxi Zhuang / &#24191;&#35199;&#22766;&#26063;"
+msgstr ""
+
+#: i18n/states/CN.php:34
+msgid "Hainan / &#28023;&#21335;"
+msgstr ""
+
+#: i18n/states/CN.php:35
+msgid "Chongqing / &#37325;&#24198;"
+msgstr ""
+
+#: i18n/states/CN.php:36
+msgid "Sichuan / &#22235;&#24029;"
+msgstr ""
+
+#: i18n/states/CN.php:37
+msgid "Guizhou / &#36149;&#24030;"
+msgstr ""
+
+#: i18n/states/CN.php:38
+msgid "Shaanxi / &#38485;&#35199;"
+msgstr ""
+
+#: i18n/states/CN.php:39
+msgid "Gansu / &#29976;&#32899;"
+msgstr ""
+
+#: i18n/states/CN.php:40
+msgid "Qinghai / &#38738;&#28023;"
+msgstr ""
+
+#: i18n/states/CN.php:41
+msgid "Ningxia Hui / &#23425;&#22799;"
+msgstr ""
+
+#: i18n/states/CN.php:42
+msgid "Macau / &#28595;&#38376;"
+msgstr ""
+
+#: i18n/states/CN.php:43
+msgid "Tibet / &#35199;&#34255;"
+msgstr ""
+
+#: i18n/states/CN.php:44
+msgid "Xinjiang / &#26032;&#30086;"
+msgstr ""
+
+#: i18n/states/HK.php:13
+msgid "Hong Kong Island"
+msgstr ""
+
+#: i18n/states/HK.php:14
+msgid "Kowloon"
+msgstr ""
+
+#: i18n/states/HK.php:15
+msgid "New Territories"
+msgstr ""
+
+#: i18n/states/HZ.php:13
+msgid "Auckland"
+msgstr ""
+
+#: i18n/states/HZ.php:14
+msgid "Bay of Plenty"
+msgstr ""
+
+#: i18n/states/HZ.php:15
+msgid "Canterbury"
+msgstr ""
+
+#: i18n/states/HZ.php:16
+msgid "Hawke&rsquo;s Bay"
+msgstr ""
+
+#: i18n/states/HZ.php:17
+msgid "Manawatu-Wanganui"
+msgstr ""
+
+#: i18n/states/HZ.php:18
+msgid "Marlborough"
+msgstr ""
+
+#: i18n/states/HZ.php:19
+msgid "Nelson"
+msgstr ""
+
+#: i18n/states/HZ.php:20
+msgid "Northland"
+msgstr ""
+
+#: i18n/states/HZ.php:21
+msgid "Otago"
+msgstr ""
+
+#: i18n/states/HZ.php:22
+msgid "Southland"
+msgstr ""
+
+#: i18n/states/HZ.php:23
+msgid "Taranaki"
+msgstr ""
+
+#: i18n/states/HZ.php:24
+msgid "Tasman"
+msgstr ""
+
+#: i18n/states/HZ.php:25
+msgid "Waikato"
+msgstr ""
+
+#: i18n/states/HZ.php:26
+msgid "Wellington"
+msgstr ""
+
+#: i18n/states/HZ.php:27
+msgid "West Coast"
+msgstr ""
+
+#: i18n/states/IN.php:13
+msgid "Andra Pradesh"
+msgstr ""
+
+#: i18n/states/IN.php:14
+msgid "Arunachal Pradesh"
+msgstr ""
+
+#: i18n/states/IN.php:15
+msgid "Assam"
+msgstr ""
+
+#: i18n/states/IN.php:16
+msgid "Bihar"
+msgstr ""
+
+#: i18n/states/IN.php:17
+msgid "Chhattisgarh"
+msgstr ""
+
+#: i18n/states/IN.php:18
+msgid "Goa"
+msgstr ""
+
+#: i18n/states/IN.php:19
+msgid "Gujarat"
+msgstr ""
+
+#: i18n/states/IN.php:20
+msgid "Haryana"
+msgstr ""
+
+#: i18n/states/IN.php:21
+msgid "Himachal Pradesh"
+msgstr ""
+
+#: i18n/states/IN.php:22
+msgid "Jammu and Kashmir"
+msgstr ""
+
+#: i18n/states/IN.php:23
+msgid "Jharkhand"
+msgstr ""
+
+#: i18n/states/IN.php:24
+msgid "Karnataka"
+msgstr ""
+
+#: i18n/states/IN.php:25
+msgid "Kerala"
+msgstr ""
+
+#: i18n/states/IN.php:26
+msgid "Madhya Pradesh"
+msgstr ""
+
+#: i18n/states/IN.php:27
+msgid "Maharashtra"
+msgstr ""
+
+#: i18n/states/IN.php:28
+msgid "Manipur"
+msgstr ""
+
+#: i18n/states/IN.php:29
+msgid "Meghalaya"
+msgstr ""
+
+#: i18n/states/IN.php:30
+msgid "Mizoram"
+msgstr ""
+
+#: i18n/states/IN.php:31
+msgid "Nagaland"
+msgstr ""
+
+#: i18n/states/IN.php:32
+msgid "Orissa"
+msgstr ""
+
+#: i18n/states/IN.php:33
+msgid "Punjab"
+msgstr ""
+
+#: i18n/states/IN.php:34
+msgid "Rajasthan"
+msgstr ""
+
+#: i18n/states/IN.php:35
+msgid "Sikkim"
+msgstr ""
+
+#: i18n/states/IN.php:36
+msgid "Tamil Nadu"
+msgstr ""
+
+#: i18n/states/IN.php:37
+msgid "Tripura"
+msgstr ""
+
+#: i18n/states/IN.php:38
+msgid "Uttaranchal"
+msgstr ""
+
+#: i18n/states/IN.php:39
+msgid "Uttar Pradesh"
+msgstr ""
+
+#: i18n/states/IN.php:40
+msgid "West Bengal"
+msgstr ""
+
+#: i18n/states/IN.php:41
+msgid "Andaman and Nicobar Islands"
+msgstr ""
+
+#: i18n/states/IN.php:42
+msgid "Chandigarh"
+msgstr ""
+
+#: i18n/states/IN.php:43
+msgid "Dadar and Nagar Haveli"
+msgstr ""
+
+#: i18n/states/IN.php:44
+msgid "Daman and Diu"
+msgstr ""
+
+#: i18n/states/IN.php:45
+msgid "Delhi"
+msgstr ""
+
+#: i18n/states/IN.php:46
+msgid "Lakshadeep"
+msgstr ""
+
+#: i18n/states/IN.php:47
+msgid "Pondicherry (Puducherry)"
+msgstr ""
+
+#: i18n/states/MY.php:13
+msgid "Johor"
+msgstr ""
+
+#: i18n/states/MY.php:14
+msgid "Kedah"
+msgstr ""
+
+#: i18n/states/MY.php:15
+msgid "Kelantan"
+msgstr ""
+
+#: i18n/states/MY.php:16
+msgid "Melaka"
+msgstr ""
+
+#: i18n/states/MY.php:17
+msgid "Negeri Sembilan"
+msgstr ""
+
+#: i18n/states/MY.php:18
+msgid "Pahang"
+msgstr ""
+
+#: i18n/states/MY.php:19
+msgid "Perak"
+msgstr ""
+
+#: i18n/states/MY.php:20
+msgid "Perlis"
+msgstr ""
+
+#: i18n/states/MY.php:21
+msgid "Pulau Pinang"
+msgstr ""
+
+#: i18n/states/MY.php:22
+msgid "Sabah"
+msgstr ""
+
+#: i18n/states/MY.php:23
+msgid "Sarawak"
+msgstr ""
+
+#: i18n/states/MY.php:24
+msgid "Selangor"
+msgstr ""
+
+#: i18n/states/MY.php:25
+msgid "Terengganu"
+msgstr ""
+
+#: i18n/states/MY.php:26
+msgid "W.P. Kuala Lumpur"
+msgstr ""
+
+#: i18n/states/MY.php:27
+msgid "W.P. Labuan"
+msgstr ""
+
+#: i18n/states/MY.php:28
+msgid "W.P. Putrajaya"
+msgstr ""
+
+#: i18n/states/TH.php:13
+msgid "Amnat Charoen (&#3629;&#3635;&#3609;&#3634;&#3592;&#3648;&#3592;&#3619;&#3636;&#3597;)"
+msgstr ""
+
+#: i18n/states/TH.php:14
+msgid "Ang Thong (&#3629;&#3656;&#3634;&#3591;&#3607;&#3629;&#3591;)"
+msgstr ""
+
+#: i18n/states/TH.php:15
+msgid "Ayutthaya (&#3614;&#3619;&#3632;&#3609;&#3588;&#3619;&#3624;&#3619;&#3637;&#3629;&#3618;&#3640;&#3608;&#3618;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:16
+msgid "Bangkok (&#3585;&#3619;&#3640;&#3591;&#3648;&#3607;&#3614;&#3617;&#3627;&#3634;&#3609;&#3588;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:17
+msgid "Bueng Kan (&#3610;&#3638;&#3591;&#3585;&#3634;&#3628;)"
+msgstr ""
+
+#: i18n/states/TH.php:18
+msgid "Buri Ram (&#3610;&#3640;&#3619;&#3637;&#3619;&#3633;&#3617;&#3618;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:19
+msgid "Chachoengsao (&#3593;&#3632;&#3648;&#3594;&#3636;&#3591;&#3648;&#3607;&#3619;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:20
+msgid "Chai Nat (&#3594;&#3633;&#3618;&#3609;&#3634;&#3607;)"
+msgstr ""
+
+#: i18n/states/TH.php:21
+msgid "Chaiyaphum (&#3594;&#3633;&#3618;&#3616;&#3641;&#3617;&#3636;)"
+msgstr ""
+
+#: i18n/states/TH.php:22
+msgid "Chanthaburi (&#3592;&#3633;&#3609;&#3607;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:23
+msgid "Chiang Mai (&#3648;&#3594;&#3637;&#3618;&#3591;&#3651;&#3627;&#3617;&#3656;)"
+msgstr ""
+
+#: i18n/states/TH.php:24
+msgid "Chiang Rai (&#3648;&#3594;&#3637;&#3618;&#3591;&#3619;&#3634;&#3618;)"
+msgstr ""
+
+#: i18n/states/TH.php:25
+msgid "Chonburi (&#3594;&#3621;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:26
+msgid "Chumphon (&#3594;&#3640;&#3617;&#3614;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:27
+msgid "Kalasin (&#3585;&#3634;&#3628;&#3626;&#3636;&#3609;&#3608;&#3640;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:28
+msgid "Kamphaeng Phet (&#3585;&#3635;&#3649;&#3614;&#3591;&#3648;&#3614;&#3594;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:29
+msgid "Kanchanaburi (&#3585;&#3634;&#3597;&#3592;&#3609;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:30
+msgid "Khon Kaen (&#3586;&#3629;&#3609;&#3649;&#3585;&#3656;&#3609;)"
+msgstr ""
+
+#: i18n/states/TH.php:31
+msgid "Krabi (&#3585;&#3619;&#3632;&#3610;&#3637;&#3656;)"
+msgstr ""
+
+#: i18n/states/TH.php:32
+msgid "Lampang (&#3621;&#3635;&#3611;&#3634;&#3591;)"
+msgstr ""
+
+#: i18n/states/TH.php:33
+msgid "Lamphun (&#3621;&#3635;&#3614;&#3641;&#3609;)"
+msgstr ""
+
+#: i18n/states/TH.php:34
+msgid "Loei (&#3648;&#3621;&#3618;)"
+msgstr ""
+
+#: i18n/states/TH.php:35
+msgid "Lopburi (&#3621;&#3614;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:36
+msgid "Mae Hong Son (&#3649;&#3617;&#3656;&#3630;&#3656;&#3629;&#3591;&#3626;&#3629;&#3609;)"
+msgstr ""
+
+#: i18n/states/TH.php:37
+msgid "Maha Sarakham (&#3617;&#3627;&#3634;&#3626;&#3634;&#3619;&#3588;&#3634;&#3617;)"
+msgstr ""
+
+#: i18n/states/TH.php:38
+msgid "Mukdahan (&#3617;&#3640;&#3585;&#3604;&#3634;&#3627;&#3634;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:39
+msgid "Nakhon Nayok (&#3609;&#3588;&#3619;&#3609;&#3634;&#3618;&#3585;)"
+msgstr ""
+
+#: i18n/states/TH.php:40
+msgid "Nakhon Pathom (&#3609;&#3588;&#3619;&#3611;&#3600;&#3617;)"
+msgstr ""
+
+#: i18n/states/TH.php:41
+msgid "Nakhon Phanom (&#3609;&#3588;&#3619;&#3614;&#3609;&#3617;)"
+msgstr ""
+
+#: i18n/states/TH.php:42
+msgid "Nakhon Ratchasima (&#3609;&#3588;&#3619;&#3619;&#3634;&#3594;&#3626;&#3637;&#3617;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:43
+msgid "Nakhon Sawan (&#3609;&#3588;&#3619;&#3626;&#3623;&#3619;&#3619;&#3588;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:44
+msgid "Nakhon Si Thammarat (&#3609;&#3588;&#3619;&#3624;&#3619;&#3637;&#3608;&#3619;&#3619;&#3617;&#3619;&#3634;&#3594;)"
+msgstr ""
+
+#: i18n/states/TH.php:45
+msgid "Nan (&#3609;&#3656;&#3634;&#3609;)"
+msgstr ""
+
+#: i18n/states/TH.php:46
+msgid "Narathiwat (&#3609;&#3619;&#3634;&#3608;&#3636;&#3623;&#3634;&#3626;)"
+msgstr ""
+
+#: i18n/states/TH.php:47
+msgid "Nong Bua Lam Phu (&#3627;&#3609;&#3629;&#3591;&#3610;&#3633;&#3623;&#3621;&#3635;&#3616;&#3641;)"
+msgstr ""
+
+#: i18n/states/TH.php:48
+msgid "Nong Khai (&#3627;&#3609;&#3629;&#3591;&#3588;&#3634;&#3618;)"
+msgstr ""
+
+#: i18n/states/TH.php:49
+msgid "Nonthaburi (&#3609;&#3609;&#3607;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:50
+msgid "Pathum Thani (&#3611;&#3607;&#3640;&#3617;&#3608;&#3634;&#3609;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:51
+msgid "Pattani (&#3611;&#3633;&#3605;&#3605;&#3634;&#3609;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:52
+msgid "Phang Nga (&#3614;&#3633;&#3591;&#3591;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:53
+msgid "Phatthalung (&#3614;&#3633;&#3607;&#3621;&#3640;&#3591;)"
+msgstr ""
+
+#: i18n/states/TH.php:54
+msgid "Phayao (&#3614;&#3632;&#3648;&#3618;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:55
+msgid "Phetchabun (&#3648;&#3614;&#3594;&#3619;&#3610;&#3641;&#3619;&#3603;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:56
+msgid "Phetchaburi (&#3648;&#3614;&#3594;&#3619;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:57
+msgid "Phichit (&#3614;&#3636;&#3592;&#3636;&#3605;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:58
+msgid "Phitsanulok (&#3614;&#3636;&#3625;&#3603;&#3640;&#3650;&#3621;&#3585;)"
+msgstr ""
+
+#: i18n/states/TH.php:59
+msgid "Phrae (&#3649;&#3614;&#3619;&#3656;)"
+msgstr ""
+
+#: i18n/states/TH.php:60
+msgid "Phuket (&#3616;&#3641;&#3648;&#3585;&#3655;&#3605;)"
+msgstr ""
+
+#: i18n/states/TH.php:61
+msgid "Prachin Buri (&#3611;&#3619;&#3634;&#3592;&#3637;&#3609;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:62
+msgid "Prachuap Khiri Khan (&#3611;&#3619;&#3632;&#3592;&#3623;&#3610;&#3588;&#3637;&#3619;&#3637;&#3586;&#3633;&#3609;&#3608;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:63
+msgid "Ranong (&#3619;&#3632;&#3609;&#3629;&#3591;)"
+msgstr ""
+
+#: i18n/states/TH.php:64
+msgid "Ratchaburi (&#3619;&#3634;&#3594;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:65
+msgid "Rayong (&#3619;&#3632;&#3618;&#3629;&#3591;)"
+msgstr ""
+
+#: i18n/states/TH.php:66
+msgid "Roi Et (&#3619;&#3657;&#3629;&#3618;&#3648;&#3629;&#3655;&#3604;)"
+msgstr ""
+
+#: i18n/states/TH.php:67
+msgid "Sa Kaeo (&#3626;&#3619;&#3632;&#3649;&#3585;&#3657;&#3623;)"
+msgstr ""
+
+#: i18n/states/TH.php:68
+msgid "Sakon Nakhon (&#3626;&#3585;&#3621;&#3609;&#3588;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:69
+msgid "Samut Prakan (&#3626;&#3617;&#3640;&#3607;&#3619;&#3611;&#3619;&#3634;&#3585;&#3634;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:70
+msgid "Samut Sakhon (&#3626;&#3617;&#3640;&#3607;&#3619;&#3626;&#3634;&#3588;&#3619;)"
+msgstr ""
+
+#: i18n/states/TH.php:71
+msgid "Samut Songkhram (&#3626;&#3617;&#3640;&#3607;&#3619;&#3626;&#3591;&#3588;&#3619;&#3634;&#3617;)"
+msgstr ""
+
+#: i18n/states/TH.php:72
+msgid "Saraburi (&#3626;&#3619;&#3632;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:73
+msgid "Satun (&#3626;&#3605;&#3641;&#3621;)"
+msgstr ""
+
+#: i18n/states/TH.php:74
+msgid "Sing Buri (&#3626;&#3636;&#3591;&#3627;&#3660;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:75
+msgid "Sisaket (&#3624;&#3619;&#3637;&#3626;&#3632;&#3648;&#3585;&#3625;)"
+msgstr ""
+
+#: i18n/states/TH.php:76
+msgid "Songkhla (&#3626;&#3591;&#3586;&#3621;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:77
+msgid "Sukhothai (&#3626;&#3640;&#3650;&#3586;&#3607;&#3633;&#3618;)"
+msgstr ""
+
+#: i18n/states/TH.php:78
+msgid "Suphan Buri (&#3626;&#3640;&#3614;&#3619;&#3619;&#3603;&#3610;&#3640;&#3619;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:79
+msgid "Surat Thani (&#3626;&#3640;&#3619;&#3634;&#3625;&#3598;&#3619;&#3660;&#3608;&#3634;&#3609;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:80
+msgid "Surin (&#3626;&#3640;&#3619;&#3636;&#3609;&#3607;&#3619;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:81
+msgid "Tak (&#3605;&#3634;&#3585;)"
+msgstr ""
+
+#: i18n/states/TH.php:82
+msgid "Trang (&#3605;&#3619;&#3633;&#3591;)"
+msgstr ""
+
+#: i18n/states/TH.php:83
+msgid "Trat (&#3605;&#3619;&#3634;&#3604;)"
+msgstr ""
+
+#: i18n/states/TH.php:84
+msgid "Ubon Ratchathani (&#3629;&#3640;&#3610;&#3621;&#3619;&#3634;&#3594;&#3608;&#3634;&#3609;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:85
+msgid "Udon Thani (&#3629;&#3640;&#3604;&#3619;&#3608;&#3634;&#3609;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:86
+msgid "Uthai Thani (&#3629;&#3640;&#3607;&#3633;&#3618;&#3608;&#3634;&#3609;&#3637;)"
+msgstr ""
+
+#: i18n/states/TH.php:87
+msgid "Uttaradit (&#3629;&#3640;&#3605;&#3619;&#3604;&#3636;&#3605;&#3606;&#3660;)"
+msgstr ""
+
+#: i18n/states/TH.php:88
+msgid "Yala (&#3618;&#3632;&#3621;&#3634;)"
+msgstr ""
+
+#: i18n/states/TH.php:89
+msgid "Yasothon (&#3618;&#3650;&#3626;&#3608;&#3619;)"
+msgstr ""
+
+#: i18n/states/US.php:13
+msgid "Alabama"
+msgstr ""
+
+#: i18n/states/US.php:14
+msgid "Alaska"
+msgstr ""
+
+#: i18n/states/US.php:15
+msgid "Arizona"
+msgstr ""
+
+#: i18n/states/US.php:16
+msgid "Arkansas"
+msgstr ""
+
+#: i18n/states/US.php:17
+msgid "California"
+msgstr ""
+
+#: i18n/states/US.php:18
+msgid "Colorado"
+msgstr ""
+
+#: i18n/states/US.php:19
+msgid "Connecticut"
+msgstr ""
+
+#: i18n/states/US.php:20
+msgid "Delaware"
+msgstr ""
+
+#: i18n/states/US.php:21
+msgid "District Of Columbia"
+msgstr ""
+
+#: i18n/states/US.php:22
+msgid "Florida"
+msgstr ""
+
+#: i18n/states/US.php:24
+msgid "Hawaii"
+msgstr ""
+
+#: i18n/states/US.php:25
+msgid "Idaho"
+msgstr ""
+
+#: i18n/states/US.php:26
+msgid "Illinois"
+msgstr ""
+
+#: i18n/states/US.php:27
+msgid "Indiana"
+msgstr ""
+
+#: i18n/states/US.php:28
+msgid "Iowa"
+msgstr ""
+
+#: i18n/states/US.php:29
+msgid "Kansas"
+msgstr ""
+
+#: i18n/states/US.php:30
+msgid "Kentucky"
+msgstr ""
+
+#: i18n/states/US.php:31
+msgid "Louisiana"
+msgstr ""
+
+#: i18n/states/US.php:32
+msgid "Maine"
+msgstr ""
+
+#: i18n/states/US.php:33
+msgid "Maryland"
+msgstr ""
+
+#: i18n/states/US.php:34
+msgid "Massachusetts"
+msgstr ""
+
+#: i18n/states/US.php:35
+msgid "Michigan"
+msgstr ""
+
+#: i18n/states/US.php:36
+msgid "Minnesota"
+msgstr ""
+
+#: i18n/states/US.php:37
+msgid "Mississippi"
+msgstr ""
+
+#: i18n/states/US.php:38
+msgid "Missouri"
+msgstr ""
+
+#: i18n/states/US.php:39
+msgid "Montana"
+msgstr ""
+
+#: i18n/states/US.php:40
+msgid "Nebraska"
+msgstr ""
+
+#: i18n/states/US.php:41
+msgid "Nevada"
+msgstr ""
+
+#: i18n/states/US.php:42
+msgid "New Hampshire"
+msgstr ""
+
+#: i18n/states/US.php:43
+msgid "New Jersey"
+msgstr ""
+
+#: i18n/states/US.php:44
+msgid "New Mexico"
+msgstr ""
+
+#: i18n/states/US.php:45
+msgid "New York"
+msgstr ""
+
+#: i18n/states/US.php:46
+msgid "North Carolina"
+msgstr ""
+
+#: i18n/states/US.php:47
+msgid "North Dakota"
+msgstr ""
+
+#: i18n/states/US.php:48
+msgid "Ohio"
+msgstr ""
+
+#: i18n/states/US.php:49
+msgid "Oklahoma"
+msgstr ""
+
+#: i18n/states/US.php:50
+msgid "Oregon"
+msgstr ""
+
+#: i18n/states/US.php:51
+msgid "Pennsylvania"
+msgstr ""
+
+#: i18n/states/US.php:52
+msgid "Rhode Island"
+msgstr ""
+
+#: i18n/states/US.php:53
+msgid "South Carolina"
+msgstr ""
+
+#: i18n/states/US.php:54
+msgid "South Dakota"
+msgstr ""
+
+#: i18n/states/US.php:55
+msgid "Tennessee"
+msgstr ""
+
+#: i18n/states/US.php:56
+msgid "Texas"
+msgstr ""
+
+#: i18n/states/US.php:57
+msgid "Utah"
+msgstr ""
+
+#: i18n/states/US.php:58
+msgid "Vermont"
+msgstr ""
+
+#: i18n/states/US.php:59
+msgid "Virginia"
+msgstr ""
+
+#: i18n/states/US.php:60
+msgid "Washington"
+msgstr ""
+
+#: i18n/states/US.php:61
+msgid "West Virginia"
+msgstr ""
+
+#: i18n/states/US.php:62
+msgid "Wisconsin"
+msgstr ""
+
+#: i18n/states/US.php:63
+msgid "Wyoming"
+msgstr ""
+
+#: i18n/states/US.php:64
+msgid "Armed Forces (AA)"
+msgstr ""
+
+#: i18n/states/US.php:65
+msgid "Armed Forces (AE)"
+msgstr ""
+
+#: i18n/states/US.php:66
+msgid "Armed Forces (AP)"
+msgstr ""
+
+#: i18n/states/ZA.php:13
+msgid "Eastern Cape"
+msgstr ""
+
+#: i18n/states/ZA.php:14
+msgid "Free State"
+msgstr ""
+
+#: i18n/states/ZA.php:15
+msgid "Gauteng"
+msgstr ""
+
+#: i18n/states/ZA.php:16
+msgid "KwaZulu-Natal"
+msgstr ""
+
+#: i18n/states/ZA.php:17
+msgid "Limpopo"
+msgstr ""
+
+#: i18n/states/ZA.php:18
+msgid "Mpumalanga"
+msgstr ""
+
+#: i18n/states/ZA.php:19
+msgid "Northern Cape"
+msgstr ""
+
+#: i18n/states/ZA.php:20
+msgid "North West"
+msgstr ""
+
+#: i18n/states/ZA.php:21
+msgid "Western Cape"
+msgstr ""
+
+#: i18n/strings.php:16
+msgid "pending"
+msgstr ""
+
+#: i18n/strings.php:17
+msgid "failed"
+msgstr ""
+
+#: i18n/strings.php:18
+msgid "on-hold"
+msgstr ""
+
+#: i18n/strings.php:19
+msgid "processing"
+msgstr ""
+
+#: i18n/strings.php:20
+msgid "completed"
+msgstr ""
+
+#: i18n/strings.php:21
+msgid "refunded"
+msgstr ""
+
+#: i18n/strings.php:22
+msgid "cancelled"
+msgstr ""
+
+#: shortcodes/shortcode-cart.php:46 woocommerce-ajax.php:100
+msgid "Please enter a coupon code."
+msgstr ""
+
+#: shortcodes/shortcode-cart.php:66 shortcodes/shortcode-my_account.php:171
+msgid "Please enter a valid postcode/ZIP."
+msgstr ""
+
+#: shortcodes/shortcode-cart.php:77 shortcodes/shortcode-cart.php:83
+msgid "Shipping costs updated."
+msgstr ""
+
+#: shortcodes/shortcode-checkout.php:63
+msgid "The order totals have been updated. Please confirm your order by pressing the Place Order button at the bottom of the page."
+msgstr ""
+
+#: shortcodes/shortcode-init.php:437 templates/loop/add-to-cart.php:40
+#: templates/single-product/add-to-cart/grouped.php:45
+#: templates/single-product/add-to-cart/grouped.php:75
+#: templates/single-product/add-to-cart/simple.php:42
+#: templates/single-product/add-to-cart/variable.php:84
+msgid "Add to cart"
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:76
+#: shortcodes/shortcode-my_account.php:245 widgets/widget-login.php:279
+msgid "Please enter your password."
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:91
+msgid "Your password has been reset."
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:91
+msgid "Log in"
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:112
+msgid "Enter a username or e-mail address."
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:119
+msgid "There is no user registered with that email address."
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:134
+msgid "Invalid username or e-mail."
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:148
+msgid "Password reset is not allowed for this user"
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:176
+msgid "Check your e-mail for the confirmation link."
+msgstr ""
+
+#: shortcodes/shortcode-lost_password.php:196
+#: shortcodes/shortcode-lost_password.php:201
+#: shortcodes/shortcode-lost_password.php:208
+msgid "Invalid key"
+msgstr ""
+
+#: shortcodes/shortcode-my_account.php:285 shortcodes/shortcode-pay.php:65
+#: shortcodes/shortcode-pay.php:120 woocommerce-functions.php:847
+#: woocommerce-functions.php:925
+msgid "Invalid order."
+msgstr ""
+
+#: shortcodes/shortcode-my_account.php:285
+msgid "My Account &rarr;"
+msgstr ""
+
+#: shortcodes/shortcode-my_account.php:292
+msgid "Order <mark class=\"order-number\">%s</mark> made on <mark class=\"order-date\">%s</mark>"
+msgstr ""
+
+#: shortcodes/shortcode-my_account.php:293
+msgid "Order status: <mark class=\"order-status\">%s</mark>"
+msgstr ""
+
+#: shortcodes/shortcode-my_account.php:299 templates/order/tracking.php:31
+msgid "Order Updates"
+msgstr ""
+
+#: shortcodes/shortcode-my_account.php:305
+msgid "l jS \\of F Y, h:ia"
+msgstr ""
+
+#: shortcodes/shortcode-order_tracking.php:51
+msgid "Please enter a valid order ID"
+msgstr ""
+
+#: shortcodes/shortcode-order_tracking.php:55
+msgid "Please enter a valid order email"
+msgstr ""
+
+#: shortcodes/shortcode-order_tracking.php:74
+msgid "Sorry, we could not find that order id in our database."
+msgstr ""
+
+#: shortcodes/shortcode-pay.php:60 shortcodes/shortcode-pay.php:113
+msgid "Your order has already been paid for. Please contact us if you need assistance."
+msgstr ""
+
+#: shortcodes/shortcode-pay.php:85 templates/checkout/thankyou.php:42
+#: templates/emails/customer-completed-order.php:18
+#: templates/emails/customer-invoice.php:22
+#: templates/emails/customer-note.php:22
+#: templates/emails/customer-processing-order.php:18
+msgid "Order:"
+msgstr ""
+
+#: shortcodes/shortcode-pay.php:89 templates/checkout/thankyou.php:46
+msgid "Date:"
+msgstr ""
+
+#: shortcodes/shortcode-pay.php:93 templates/checkout/thankyou.php:50
+msgid "Total:"
+msgstr ""
+
+#: shortcodes/shortcode-pay.php:98 templates/checkout/thankyou.php:55
+msgid "Payment method:"
+msgstr ""
+
+#: templates/archive-product.php:67 templates/loop-shop.php:40
+#: woocommerce-template.php:73
+msgid "No products found which match your selection."
+msgstr ""
+
+#: templates/cart/cart.php:24 templates/checkout/form-pay.php:19
+#: templates/checkout/review-order.php:21
+#: templates/emails/admin-new-order.php:22
+#: templates/emails/customer-completed-order.php:23
+#: templates/emails/customer-invoice.php:27
+#: templates/emails/customer-note.php:27
+#: templates/emails/customer-processing-order.php:23
+#: templates/order/order-details.php:20 woocommerce.php:859
+msgid "Product"
+msgstr ""
+
+#: templates/cart/cart.php:25 templates/emails/admin-new-order.php:24
+#: templates/emails/customer-completed-order.php:25
+#: templates/emails/customer-invoice.php:29
+#: templates/emails/customer-note.php:29
+#: templates/emails/customer-processing-order.php:25
+msgid "Price"
+msgstr ""
+
+#: templates/cart/cart.php:26 templates/emails/admin-new-order.php:23
+#: templates/emails/customer-completed-order.php:24
+#: templates/emails/customer-invoice.php:28
+#: templates/emails/customer-note.php:28
+#: templates/emails/customer-processing-order.php:24
+msgid "Quantity"
+msgstr ""
+
+#: templates/cart/cart.php:27 templates/checkout/review-order.php:22
+#: templates/myaccount/my-orders.php:34 templates/order/order-details.php:21
+msgid "Total"
+msgstr ""
+
+#: templates/cart/cart.php:43
+msgid "Remove this item"
+msgstr ""
+
+#: templates/cart/cart.php:123 woocommerce.php:972
+msgid "Coupon"
+msgstr ""
+
+#: templates/cart/cart.php:123 templates/checkout/form-coupon.php:26
+msgid "Apply Coupon"
+msgstr ""
+
+#: templates/cart/cart.php:130
+msgid "Update Cart"
+msgstr ""
+
+#: templates/cart/cart.php:130
+msgid "Proceed to Checkout &rarr;"
+msgstr ""
+
+#: templates/cart/cross-sells.php:35
+msgid "You may be interested in&hellip;"
+msgstr ""
+
+#: templates/cart/empty.php:14
+msgid "Your cart is currently empty."
+msgstr ""
+
+#: templates/cart/empty.php:18
+msgid "&larr; Return To Shop"
+msgstr ""
+
+#: templates/cart/mini-cart.php:52
+msgid "No products in the cart."
+msgstr ""
+
+#: templates/cart/mini-cart.php:60 templates/cart/totals.php:88
+#: templates/checkout/review-order.php:93
+msgid "Subtotal"
+msgstr ""
+
+#: templates/cart/mini-cart.php:66
+msgid "Checkout &rarr;"
+msgstr ""
+
+#: templates/cart/shipping-calculator.php:20
+msgid "Calculate Shipping"
+msgstr ""
+
+#: templates/cart/shipping-calculator.php:24 woocommerce-template.php:1290
+msgid "Select a country&hellip;"
+msgstr ""
+
+#: templates/cart/shipping-calculator.php:50 woocommerce-template.php:1333
+msgid "Select a state&hellip;"
+msgstr ""
+
+#: templates/cart/shipping-calculator.php:72
+msgid "Update Totals"
+msgstr ""
+
+#: templates/cart/shipping-methods.php:32
+msgid "Free"
+msgstr ""
+
+#: templates/cart/shipping-methods.php:66
+msgid "Please fill in your details to see available shipping methods."
+msgstr ""
+
+#: templates/cart/shipping-methods.php:68
+msgid "Sorry, it seems that there are no available shipping methods for your state. Please contact us if you require assistance or wish to make alternate arrangements."
+msgstr ""
+
+#: templates/cart/totals.php:22
+msgid "Cart Totals"
+msgstr ""
+
+#: templates/cart/totals.php:28 templates/checkout/review-order.php:27
+msgid "Cart Subtotal"
+msgstr ""
+
+#: templates/cart/totals.php:35 templates/checkout/review-order.php:34
+#: woocommerce.php:1545
+msgid "Cart Discount"
+msgstr ""
+
+#: templates/cart/totals.php:35 templates/cart/totals.php:116
+msgid "[Remove]"
+msgstr ""
+
+#: templates/cart/totals.php:44 templates/checkout/review-order.php:45
+msgid "Shipping"
+msgstr ""
+
+#: templates/cart/totals.php:116 templates/checkout/review-order.php:124
+msgid "Order Discount"
+msgstr ""
+
+#: templates/cart/totals.php:123 templates/checkout/review-order.php:133
+msgid "Order Total"
+msgstr ""
+
+#: templates/cart/totals.php:153
+msgid " (taxes estimated for %s)"
+msgstr ""
+
+#: templates/cart/totals.php:155
+msgid "Note: Shipping and taxes are estimated%s and will be updated during checkout based on your billing and shipping information."
+msgstr ""
+
+#: templates/cart/totals.php:167
+msgid "No shipping methods were found; please recalculate your shipping and enter your state/county and zip/postcode to ensure there are no other available methods for your location."
+msgstr ""
+
+#: templates/cart/totals.php:175
+msgid "Sorry, it seems that there are no available shipping methods for your location (%s)."
+msgstr ""
+
+#: templates/cart/totals.php:177
+msgid "If you require assistance or wish to make alternate arrangements please contact us."
+msgstr ""
+
+#: templates/checkout/cart-errors.php:16
+msgid "There are some issues with the items in your cart (shown above). Please go back to the cart page and resolve these issues before checking out."
+msgstr ""
+
+#: templates/checkout/cart-errors.php:20
+msgid "&larr; Return To Cart"
+msgstr ""
+
+#: templates/checkout/form-billing.php:17
+msgid "Billing &amp; Shipping"
+msgstr ""
+
+#: templates/checkout/form-billing.php:21
+#: templates/myaccount/form-edit-address.php:27
+#: templates/myaccount/my-address.php:19 templates/myaccount/my-address.php:25
+#: templates/order/order-details.php:106
+msgid "Billing Address"
+msgstr ""
+
+#: templates/checkout/form-billing.php:42
+msgid "Create an account?"
+msgstr ""
+
+#: templates/checkout/form-billing.php:51
+msgid "Create an account by entering the information below. If you are a returning customer please login at the top of the page."
+msgstr ""
+
+#: templates/checkout/form-checkout.php:20
+msgid "You must be logged in to checkout."
+msgstr ""
+
+#: templates/checkout/form-checkout.php:51
+msgid "Your order"
+msgstr ""
+
+#: templates/checkout/form-coupon.php:14
+msgid "Have a coupon?"
+msgstr ""
+
+#: templates/checkout/form-coupon.php:17
+msgid "Click here to enter your code"
+msgstr ""
+
+#: templates/checkout/form-coupon.php:22
+msgid "Coupon code"
+msgstr ""
+
+#: templates/checkout/form-login.php:14
+msgid "Already registered?"
+msgstr ""
+
+#: templates/checkout/form-login.php:17
+msgid "Click here to login"
+msgstr ""
+
+#: templates/checkout/form-login.php:22
+msgid "If you have shopped with us before, please enter your details in the boxes below. If you are a new customer please proceed to the Billing &amp; Shipping section."
+msgstr ""
+
+#: templates/checkout/form-pay.php:20
+msgid "Qty"
+msgstr ""
+
+#: templates/checkout/form-pay.php:21
+msgid "Totals"
+msgstr ""
+
+#: templates/checkout/form-pay.php:77
+msgid "Sorry, it seems that there are no available payment methods for your location. Please contact us if you require assistance or wish to make alternate arrangements."
+msgstr ""
+
+#: templates/checkout/form-pay.php:86
+msgid "Pay for order"
+msgstr ""
+
+#: templates/checkout/form-shipping.php:32
+msgid "Ship to billing address?"
+msgstr ""
+
+#: templates/checkout/form-shipping.php:35
+#: templates/myaccount/form-edit-address.php:27
+#: templates/myaccount/my-address.php:20 templates/order/order-details.php:121
+msgid "Shipping Address"
+msgstr ""
+
+#: templates/checkout/form-shipping.php:59
+#: templates/single-product/tabs/attributes.php:20
+#: templates/single-product/tabs/tab-attributes.php:18
+msgid "Additional Information"
+msgstr ""
+
+#: templates/checkout/review-order.php:217
+msgid "Please fill in your details above to see available payment methods."
+msgstr ""
+
+#: templates/checkout/review-order.php:219
+msgid "Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements."
+msgstr ""
+
+#: templates/checkout/review-order.php:229
+msgid "Since your browser does not support JavaScript, or it is disabled, please ensure you click the <em>Update Totals</em> button before placing your order. You may be charged more than the amount stated above if you fail to do so."
+msgstr ""
+
+#: templates/checkout/review-order.php:229
+msgid "Update totals"
+msgstr ""
+
+#: templates/checkout/review-order.php:235
+msgid "Place order"
+msgstr ""
+
+#: templates/checkout/review-order.php:239
+msgid "I have read and accept the"
+msgstr ""
+
+#: templates/checkout/review-order.php:239
+msgid "terms &amp; conditions"
+msgstr ""
+
+#: templates/checkout/thankyou.php:19
+msgid "Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction."
+msgstr ""
+
+#: templates/checkout/thankyou.php:23
+msgid "Please attempt your purchase again or go to your account page."
+msgstr ""
+
+#: templates/checkout/thankyou.php:25
+msgid "Please attempt your purchase again."
+msgstr ""
+
+#: templates/checkout/thankyou.php:38 templates/checkout/thankyou.php:71
+msgid "Thank you. Your order has been received."
+msgstr ""
+
+#: templates/emails/admin-new-order.php:13
+#: templates/emails/plain/admin-new-order.php:13
+msgid "You have received an order from %s. Their order is as follows:"
+msgstr ""
+
+#: templates/emails/admin-new-order.php:17
+msgid "Order: %s"
+msgstr ""
+
+#: templates/emails/admin-new-order.php:50
+#: templates/emails/customer-completed-order.php:51
+#: templates/emails/customer-note.php:55
+#: templates/emails/customer-processing-order.php:51
+#: templates/emails/plain/admin-new-order.php:38
+#: templates/order/order-details.php:88
+msgid "Customer details"
+msgstr ""
+
+#: templates/emails/admin-new-order.php:53
+#: templates/emails/customer-completed-order.php:54
+#: templates/emails/customer-note.php:58
+#: templates/emails/customer-processing-order.php:54
+#: templates/emails/plain/admin-new-order.php:41
+#: templates/emails/plain/customer-completed-order.php:41
+#: templates/emails/plain/customer-note.php:49
+#: templates/emails/plain/customer-processing-order.php:41
+#: templates/order/order-details.php:92
+msgid "Email:"
+msgstr ""
+
+#: templates/emails/admin-new-order.php:56
+#: templates/emails/customer-completed-order.php:57
+#: templates/emails/customer-note.php:61
+#: templates/emails/customer-processing-order.php:57
+#: templates/emails/plain/admin-new-order.php:44
+#: templates/emails/plain/customer-completed-order.php:44
+#: templates/emails/plain/customer-note.php:52
+#: templates/emails/plain/customer-processing-order.php:44
+msgid "Tel:"
+msgstr ""
+
+#: templates/emails/customer-completed-order.php:14
+#: templates/emails/plain/customer-completed-order.php:13
+msgid "Hi there. Your recent order on %s has been completed. Your order details are shown below for your reference:"
+msgstr ""
+
+#: templates/emails/customer-invoice.php:16
+#: templates/emails/plain/customer-invoice.php:14
+msgid "An order has been created for you on %s. To pay for this order please use the following link: %s"
+msgstr ""
+
+#: templates/emails/customer-invoice.php:16
+msgid "pay"
+msgstr ""
+
+#: templates/emails/customer-new-account.php:14
+#: templates/emails/plain/customer-new-account.php:13
+msgid "Thanks for creating an account on %s. Your username is <strong>%s</strong>."
+msgstr ""
+
+#: templates/emails/customer-new-account.php:16
+#: templates/emails/plain/customer-new-account.php:15
+msgid "You can access your account area here: %s."
+msgstr ""
+
+#: templates/emails/customer-note.php:14
+#: templates/emails/plain/customer-note.php:13
+msgid "Hello, a note has just been added to your order:"
+msgstr ""
+
+#: templates/emails/customer-note.php:18
+#: templates/emails/plain/customer-note.php:21
+msgid "For your reference, your order details are shown below."
+msgstr ""
+
+#: templates/emails/customer-processing-order.php:14
+#: templates/emails/plain/customer-processing-order.php:13
+msgid "Your order has been received and is now being processed. Your order details are shown below for your reference:"
+msgstr ""
+
+#: templates/emails/customer-reset-password.php:14
+#: templates/emails/plain/customer-reset-password.php:13
+msgid "Someone requested that the password be reset for the following account:"
+msgstr ""
+
+#: templates/emails/customer-reset-password.php:15
+#: templates/emails/plain/customer-reset-password.php:15
+msgid "Username: %s"
+msgstr ""
+
+#: templates/emails/customer-reset-password.php:16
+#: templates/emails/plain/customer-reset-password.php:16
+msgid "If this was a mistake, just ignore this email and nothing will happen."
+msgstr ""
+
+#: templates/emails/customer-reset-password.php:17
+#: templates/emails/plain/customer-reset-password.php:17
+msgid "To reset your password, visit the following address:"
+msgstr ""
+
+#: templates/emails/customer-reset-password.php:20
+msgid "Click here to reset your password"
+msgstr ""
+
+#: templates/emails/email-addresses.php:18
+#: templates/emails/plain/email-addresses.php:12
+msgid "Billing address"
+msgstr ""
+
+#: templates/emails/email-addresses.php:28
+#: templates/emails/plain/email-addresses.php:17
+msgid "Shipping address"
+msgstr ""
+
+#: templates/emails/email-order-items.php:40
+msgid "Download %d:"
+msgstr ""
+
+#: templates/emails/email-order-items.php:42
+msgid "Download:"
+msgstr ""
+
+#: templates/emails/plain/admin-new-order.php:19
+#: templates/emails/plain/customer-completed-order.php:19
+#: templates/emails/plain/customer-invoice.php:20
+#: templates/emails/plain/customer-note.php:27
+#: templates/emails/plain/customer-processing-order.php:19
+msgid "Order number: %s"
+msgstr ""
+
+#: templates/emails/plain/admin-new-order.php:20
+#: templates/emails/plain/customer-completed-order.php:20
+#: templates/emails/plain/customer-invoice.php:21
+#: templates/emails/plain/customer-note.php:28
+#: templates/emails/plain/customer-processing-order.php:20
+msgid "Order date: %s"
+msgstr ""
+
+#: templates/emails/plain/admin-new-order.php:20
+msgid "jS F Y"
+msgstr ""
+
+#: templates/emails/plain/customer-completed-order.php:38
+#: templates/emails/plain/customer-note.php:46
+#: templates/emails/plain/customer-processing-order.php:38
+msgid "Your details"
+msgstr ""
+
+#: templates/emails/plain/email-order-items.php:28
+msgid "Quantity: %s"
+msgstr ""
+
+#: templates/emails/plain/email-order-items.php:31
+msgid "Cost: %s"
+msgstr ""
+
+#: templates/loop/add-to-cart.php:19 templates/loop/add-to-cart.php:36
+msgid "Read More"
+msgstr ""
+
+#: templates/loop/add-to-cart.php:28
+msgid "Select options"
+msgstr ""
+
+#: templates/loop/add-to-cart.php:32
+msgid "View options"
+msgstr ""
+
+#: templates/loop/result-count.php:28
+msgid "Showing the single result"
+msgstr ""
+
+#: templates/loop/result-count.php:30
+msgid "Showing all %d results"
+msgstr ""
+
+#: templates/loop/result-count.php:32
+msgctxt "%1$d = first, %2$d = last, %3$d = total"
+msgid "Showing %1$d–%2$d of %3$d results"
+msgstr ""
+
+#: templates/loop/sale-flash.php:16 templates/single-product/sale-flash.php:16
+msgid "Sale!"
+msgstr ""
+
+#: templates/loop/sorting.php:21
+msgid "Default sorting"
+msgstr ""
+
+#: templates/loop/sorting.php:22
+msgid "Sort alphabetically"
+msgstr ""
+
+#: templates/loop/sorting.php:23
+msgid "Sort by most recent"
+msgstr ""
+
+#: templates/loop/sorting.php:24
+msgid "Sort by price - low to high"
+msgstr ""
+
+#: templates/loop/sorting.php:25
+msgid "Sort by price - high to low"
+msgstr ""
+
+#: templates/myaccount/form-change-password.php:20
+#: templates/myaccount/form-lost-password.php:31
+msgid "New password"
+msgstr ""
+
+#: templates/myaccount/form-change-password.php:24
+#: templates/myaccount/form-lost-password.php:35
+msgid "Re-enter new password"
+msgstr ""
+
+#: templates/myaccount/form-change-password.php:29
+#: templates/myaccount/form-lost-password.php:45
+msgid "Save"
+msgstr ""
+
+#: templates/myaccount/form-edit-address.php:43
+msgid "Save Address"
+msgstr ""
+
+#: templates/myaccount/form-login.php:26 templates/myaccount/form-login.php:40
+#: templates/shop/form-login.php:31
+msgid "Login"
+msgstr ""
+
+#: templates/myaccount/form-login.php:29
+#: templates/myaccount/form-lost-password.php:24
+#: templates/shop/form-login.php:20 widgets/widget-login.php:116
+msgid "Username or email"
+msgstr ""
+
+#: templates/myaccount/form-login.php:33 templates/myaccount/form-login.php:85
+#: templates/shop/form-login.php:24 widgets/widget-login.php:118
+msgid "Password"
+msgstr ""
+
+#: templates/myaccount/form-login.php:50 templates/shop/form-login.php:33
+msgid "Lost Password?"
+msgstr ""
+
+#: templates/myaccount/form-login.php:60 templates/myaccount/form-login.php:101
+msgid "Register"
+msgstr ""
+
+#: templates/myaccount/form-login.php:66
+msgid "Username"
+msgstr ""
+
+#: templates/myaccount/form-login.php:78
+#: templates/single-product-reviews.php:101
+msgid "Email"
+msgstr ""
+
+#: templates/myaccount/form-login.php:89
+msgid "Re-enter password"
+msgstr ""
+
+#: templates/myaccount/form-lost-password.php:22
+msgid "Lost your password? Please enter your username or email address. You will receive a link to create a new password via email."
+msgstr ""
+
+#: templates/myaccount/form-lost-password.php:28
+msgid "Enter a new password below."
+msgstr ""
+
+#: templates/myaccount/form-lost-password.php:45
+msgid "Reset Password"
+msgstr ""
+
+#: templates/myaccount/my-account.php:19
+msgid "Hello, <strong>%s</strong>. From your account dashboard you can view your recent orders, manage your shipping and billing addresses and <a href=\"%s\">change your password</a>."
+msgstr ""
+
+#: templates/myaccount/my-address.php:17
+msgid "My Addresses"
+msgstr ""
+
+#: templates/myaccount/my-address.php:23
+msgid "My Address"
+msgstr ""
+
+#: templates/myaccount/my-address.php:35
+msgid "The following addresses will be used on the checkout page by default."
+msgstr ""
+
+#: templates/myaccount/my-address.php:45 woocommerce.php:827
+#: woocommerce.php:863 woocommerce.php:900 woocommerce.php:938
+#: woocommerce.php:976
+msgid "Edit"
+msgstr ""
+
+#: templates/myaccount/my-address.php:64
+msgid "You have not set up this type of address yet."
+msgstr ""
+
+#: templates/myaccount/my-downloads.php:18
+msgid "Available downloads"
+msgstr ""
+
+#: templates/myaccount/my-downloads.php:27
+msgid "%s download remaining"
+msgid_plural "%s downloads remaining"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/myaccount/my-orders.php:26
+msgid "Recent Orders"
+msgstr ""
+
+#: templates/myaccount/my-orders.php:32 woocommerce.php:935
+msgid "Order"
+msgstr ""
+
+#: templates/myaccount/my-orders.php:33
+msgid "Ship to"
+msgstr ""
+
+#: templates/myaccount/my-orders.php:35
+msgid "Status"
+msgstr ""
+
+#: templates/myaccount/my-orders.php:64
+msgid "Click to cancel this order"
+msgstr ""
+
+#: templates/myaccount/my-orders.php:64
+msgid "Cancel"
+msgstr ""
+
+#: templates/myaccount/my-orders.php:80
+msgid "View"
+msgstr ""
+
+#: templates/order/form-tracking.php:17
+msgid "To track your order please enter your Order ID in the box below and press return. This was given to you on your receipt and in the confirmation email you should have received."
+msgstr ""
+
+#: templates/order/form-tracking.php:19
+msgid "Order ID"
+msgstr ""
+
+#: templates/order/form-tracking.php:19
+msgid "Found in your order confirmation email."
+msgstr ""
+
+#: templates/order/form-tracking.php:20
+msgid "Billing Email"
+msgstr ""
+
+#: templates/order/form-tracking.php:20
+msgid "Email you used during checkout."
+msgstr ""
+
+#: templates/order/form-tracking.php:23
+msgid "Track\""
+msgstr ""
+
+#: templates/order/order-details.php:16
+msgid "Order Details"
+msgstr ""
+
+#: templates/order/order-details.php:57
+msgid "Download file %s &rarr;"
+msgstr ""
+
+#: templates/order/order-details.php:81
+msgid "Order Again"
+msgstr ""
+
+#: templates/order/order-details.php:93
+msgid "Telephone:"
+msgstr ""
+
+#: templates/order/tracking.php:18
+msgid "Order %s which was made %s has the status &ldquo;%s&rdquo;"
+msgstr ""
+
+#: templates/order/tracking.php:18
+msgid "ago"
+msgstr ""
+
+#: templates/order/tracking.php:20
+msgid "and was completed"
+msgstr ""
+
+#: templates/order/tracking.php:20
+msgid " ago"
+msgstr ""
+
+#: templates/shop/breadcrumb.php:66
+msgid "Products tagged &ldquo;"
+msgstr ""
+
+#: templates/shop/breadcrumb.php:94 templates/shop/breadcrumb.php:196
+msgid "Search results for &ldquo;"
+msgstr ""
+
+#: templates/shop/breadcrumb.php:154
+msgid "Error 404"
+msgstr ""
+
+#: templates/shop/breadcrumb.php:200
+msgid "Posts tagged &ldquo;"
+msgstr ""
+
+#: templates/shop/breadcrumb.php:205
+msgid "Author:"
+msgstr ""
+
+#: templates/shop/breadcrumb.php:210
+msgid "Page"
+msgstr ""
+
+#: templates/single-product/add-to-cart/variable.php:30
+msgid "Choose an option"
+msgstr ""
+
+#: templates/single-product/add-to-cart/variable.php:70
+msgid "Clear selection"
+msgstr ""
+
+#: templates/single-product/meta.php:22
+msgid "Category:"
+msgid_plural "Categories:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/single-product/meta.php:24
+msgid "Tag:"
+msgid_plural "Tags:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/single-product/product-attributes.php:28
+msgid "Weight"
+msgstr ""
+
+#: templates/single-product/product-attributes.php:37
+msgid "Dimensions"
+msgstr ""
+
+#: templates/single-product/related.php:36
+msgid "Related Products"
+msgstr ""
+
+#: templates/single-product/review.php:33
+msgid "Your comment is awaiting approval"
+msgstr ""
+
+#: templates/single-product/review.php:40
+msgid "verified owner"
+msgstr ""
+
+#: templates/single-product/tabs/description.php:17
+msgid "Product Description"
+msgstr ""
+
+#: templates/single-product/tabs/tab-reviews.php:13
+#: templates/single-product-reviews.php:51
+#: templates/single-product-reviews.php:57
+msgid "Reviews"
+msgstr ""
+
+#: templates/single-product/up-sells.php:36
+msgid "You may also like&hellip;"
+msgstr ""
+
+#: templates/single-product-reviews.php:45
+msgid "%s review for %s"
+msgid_plural "%s reviews for %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/single-product-reviews.php:73
+msgid "<span class=\"meta-nav\">&larr;</span> Previous"
+msgstr ""
+
+#: templates/single-product-reviews.php:74
+msgid "Next <span class=\"meta-nav\">&rarr;</span>"
+msgstr ""
+
+#: templates/single-product-reviews.php:78
+msgid "Add Review"
+msgstr ""
+
+#: templates/single-product-reviews.php:80
+msgid "Add a review"
+msgstr ""
+
+#: templates/single-product-reviews.php:84
+msgid "Be the first to review"
+msgstr ""
+
+#: templates/single-product-reviews.php:86
+msgid "There are no reviews yet, would you like to <a href=\"#review_form\" class=\"inline show_review_form\">submit yours</a>?"
+msgstr ""
+
+#: templates/single-product-reviews.php:99
+#: widgets/widget-product_categories.php:189 woocommerce-ajax.php:1180
+msgid "Name"
+msgstr ""
+
+#: templates/single-product-reviews.php:104
+msgid "Submit Review"
+msgstr ""
+
+#: templates/single-product-reviews.php:111
+msgid "Rating"
+msgstr ""
+
+#: templates/single-product-reviews.php:112
+msgid "Rate&hellip;"
+msgstr ""
+
+#: templates/single-product-reviews.php:113
+msgid "Perfect"
+msgstr ""
+
+#: templates/single-product-reviews.php:114
+msgid "Good"
+msgstr ""
+
+#: templates/single-product-reviews.php:115
+msgid "Average"
+msgstr ""
+
+#: templates/single-product-reviews.php:116
+msgid "Not that bad"
+msgstr ""
+
+#: templates/single-product-reviews.php:117
+msgid "Very Poor"
+msgstr ""
+
+#: templates/single-product-reviews.php:122
+msgid "Your Review"
+msgstr ""
+
+#: widgets/widget-best_sellers.php:31
+msgid "Display a list of your best selling products on your site."
+msgstr ""
+
+#: widgets/widget-best_sellers.php:33
+msgid "WooCommerce Best Sellers"
+msgstr ""
+
+#: widgets/widget-best_sellers.php:71
+msgid "Best Sellers"
+msgstr ""
+
+#: widgets/widget-best_sellers.php:192 widgets/widget-cart.php:111
+#: widgets/widget-featured_products.php:172 widgets/widget-layered_nav.php:349
+#: widgets/widget-onsale.php:210 widgets/widget-price_filter.php:179
+#: widgets/widget-product_categories.php:183
+#: widgets/widget-product_search.php:91
+#: widgets/widget-product_tag_cloud.php:101
+#: widgets/widget-random_products.php:133
+#: widgets/widget-recent_products.php:169 widgets/widget-recent_reviews.php:162
+#: widgets/widget-recently_viewed.php:162
+#: widgets/widget-top_rated_products.php:184
+msgid "Title:"
+msgstr ""
+
+#: widgets/widget-best_sellers.php:195 widgets/widget-featured_products.php:175
+#: widgets/widget-onsale.php:213 widgets/widget-random_products.php:138
+#: widgets/widget-recent_products.php:172 widgets/widget-recent_reviews.php:165
+#: widgets/widget-recently_viewed.php:165
+#: widgets/widget-top_rated_products.php:187
+msgid "Number of products to show:"
+msgstr ""
+
+#: widgets/widget-best_sellers.php:199
+msgid "Hide free products"
+msgstr ""
+
+#: widgets/widget-cart.php:33
+msgid "Display the user's Cart in the sidebar."
+msgstr ""
+
+#: widgets/widget-cart.php:35
+msgid "WooCommerce Cart"
+msgstr ""
+
+#: widgets/widget-cart.php:115
+msgid "Hide if cart is empty"
+msgstr ""
+
+#: widgets/widget-featured_products.php:35
+msgid "Display a list of featured products on your site."
+msgstr ""
+
+#: widgets/widget-featured_products.php:37
+msgid "WooCommerce Featured Products"
+msgstr ""
+
+#: widgets/widget-featured_products.php:75
+msgid "Featured Products"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:31
+msgid "Shows a custom attribute in a widget which lets you narrow down the list of products when viewing product categories."
+msgstr ""
+
+#: widgets/widget-layered_nav.php:33
+msgid "WooCommerce Layered Nav"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:100
+msgid "Any %s"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:352
+msgid "Attribute:"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:363
+msgid "Display Type:"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:365
+msgid "List"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:366
+msgid "Dropdown"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:369
+msgid "Query Type:"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:371
+msgid "AND"
+msgstr ""
+
+#: widgets/widget-layered_nav.php:372
+msgid "OR"
+msgstr ""
+
+#: widgets/widget-layered_nav_filters.php:31
+msgid "Shows active layered nav filters so users can see and deactivate them."
+msgstr ""
+
+#: widgets/widget-layered_nav_filters.php:33
+msgid "WooCommerce Layered Nav Filters"
+msgstr ""
+
+#: widgets/widget-layered_nav_filters.php:62
+msgid "Active filters"
+msgstr ""
+
+#: widgets/widget-layered_nav_filters.php:93
+#: widgets/widget-layered_nav_filters.php:99
+#: widgets/widget-layered_nav_filters.php:104
+msgid "Remove filter"
+msgstr ""
+
+#: widgets/widget-layered_nav_filters.php:99
+msgid "Min"
+msgstr ""
+
+#: widgets/widget-layered_nav_filters.php:104
+msgid "Max"
+msgstr ""
+
+#: widgets/widget-login.php:31
+msgid "Display a login area and \"My Account\" links in the sidebar."
+msgstr ""
+
+#: widgets/widget-login.php:33
+msgid "WooCommerce Login"
+msgstr ""
+
+#: widgets/widget-login.php:59 widgets/widget-login.php:223
+msgid "Customer Login"
+msgstr ""
+
+#: widgets/widget-login.php:60 widgets/widget-login.php:226
+msgid "Welcome %s"
+msgstr ""
+
+#: widgets/widget-login.php:76
+msgid "My account"
+msgstr ""
+
+#: widgets/widget-login.php:77
+msgid "Change my password"
+msgstr ""
+
+#: widgets/widget-login.php:78 woocommerce-functions.php:138
+msgid "Logout"
+msgstr ""
+
+#: widgets/widget-login.php:120 woocommerce-functions.php:911
+msgid "Login &rarr;"
+msgstr ""
+
+#: widgets/widget-login.php:120
+msgid "Lost password?"
+msgstr ""
+
+#: widgets/widget-login.php:222
+msgid "Logged out title:"
+msgstr ""
+
+#: widgets/widget-login.php:225
+msgid "Logged in title:"
+msgstr ""
+
+#: widgets/widget-login.php:276 woocommerce-functions.php:671
+msgid "Please enter a username."
+msgstr ""
+
+#: widgets/widget-onsale.php:31
+msgid "Display a list of your on-sale products on your site."
+msgstr ""
+
+#: widgets/widget-onsale.php:33
+msgid "WooCommerce On-sale"
+msgstr ""
+
+#: widgets/widget-onsale.php:70
+msgid "On Sale"
+msgstr ""
+
+#: widgets/widget-price_filter.php:33
+msgid "Shows a price filter slider in a widget which lets you narrow down the list of shown products when viewing product categories."
+msgstr ""
+
+#: widgets/widget-price_filter.php:35
+msgid "WooCommerce Price Filter"
+msgstr ""
+
+#: widgets/widget-price_filter.php:136
+msgid "Min price"
+msgstr ""
+
+#: widgets/widget-price_filter.php:137
+msgid "Max price"
+msgstr ""
+
+#: widgets/widget-price_filter.php:138
+msgid "Filter"
+msgstr ""
+
+#: widgets/widget-price_filter.php:140
+msgid "Price:"
+msgstr ""
+
+#: widgets/widget-price_filter.php:162
+msgid "Filter by price"
+msgstr ""
+
+#: widgets/widget-product_categories.php:33
+msgid "A list or dropdown of product categories."
+msgstr ""
+
+#: widgets/widget-product_categories.php:35
+msgid "WooCommerce Product Categories"
+msgstr ""
+
+#: widgets/widget-product_categories.php:57 woocommerce.php:690
+#: woocommerce.php:692
+msgid "Product Categories"
+msgstr ""
+
+#: widgets/widget-product_categories.php:127
+msgid "No product categories exist."
+msgstr ""
+
+#: widgets/widget-product_categories.php:186
+msgid "Order by:"
+msgstr ""
+
+#: widgets/widget-product_categories.php:188
+msgid "Category Order"
+msgstr ""
+
+#: widgets/widget-product_categories.php:193
+msgid "Show as dropdown"
+msgstr ""
+
+#: widgets/widget-product_categories.php:196
+msgid "Show post counts"
+msgstr ""
+
+#: widgets/widget-product_categories.php:199
+msgid "Show hierarchy"
+msgstr ""
+
+#: widgets/widget-product_categories.php:202
+msgid "Only show children for the current category"
+msgstr ""
+
+#: widgets/widget-product_search.php:31
+msgid "A Search box for products only."
+msgstr ""
+
+#: widgets/widget-product_search.php:33
+msgid "WooCommerce Product Search"
+msgstr ""
+
+#: widgets/widget-product_tag_cloud.php:31
+msgid "Your most used product tags in cloud format."
+msgstr ""
+
+#: widgets/widget-product_tag_cloud.php:33
+msgid "WooCommerce Product Tags"
+msgstr ""
+
+#: widgets/widget-product_tag_cloud.php:58 woocommerce.php:721
+#: woocommerce.php:723
+msgid "Product Tags"
+msgstr ""
+
+#: widgets/widget-random_products.php:24
+msgid "WooCommerce Random Products"
+msgstr ""
+
+#: widgets/widget-random_products.php:27
+msgid "Display a list of random products on your site."
+msgstr ""
+
+#: widgets/widget-random_products.php:46
+msgid "Random Products"
+msgstr ""
+
+#: widgets/widget-random_products.php:144
+#: widgets/widget-recent_products.php:176
+msgid "Show hidden product variations"
+msgstr ""
+
+#: widgets/widget-recent_products.php:31
+msgid "Display a list of your most recent products on your site."
+msgstr ""
+
+#: widgets/widget-recent_products.php:33
+msgid "WooCommerce Recent Products"
+msgstr ""
+
+#: widgets/widget-recent_products.php:70
+msgid "New Products"
+msgstr ""
+
+#: widgets/widget-recent_reviews.php:31
+msgid "Display a list of your most recent reviews on your site."
+msgstr ""
+
+#: widgets/widget-recent_reviews.php:33
+msgid "WooCommerce Recent Reviews"
+msgstr ""
+
+#: widgets/widget-recent_reviews.php:71
+msgid "Recent Reviews"
+msgstr ""
+
+#: widgets/widget-recent_reviews.php:101
+msgctxt "by comment author"
+msgid "by %1$s"
+msgstr ""
+
+#: widgets/widget-recently_viewed.php:31
+msgid "Display a list of recently viewed products."
+msgstr ""
+
+#: widgets/widget-recently_viewed.php:33
+msgid "WooCommerce Recently Viewed Products"
+msgstr ""
+
+#: widgets/widget-recently_viewed.php:72
+msgid "Recently viewed"
+msgstr ""
+
+#: widgets/widget-top_rated_products.php:33
+msgid "Display a list of top rated products on your site."
+msgstr ""
+
+#: widgets/widget-top_rated_products.php:35
+msgid "WooCommerce Top Rated Products"
+msgstr ""
+
+#: widgets/widget-top_rated_products.php:72
+msgid "Top Rated Products"
+msgstr ""
+
+#: woocommerce-ajax.php:72
+msgid "Please enter your username and password to login."
+msgstr ""
+
+#: woocommerce-ajax.php:154
+msgid "Sorry, your session has expired."
+msgstr ""
+
+#: woocommerce-ajax.php:154
+msgid "Return to homepage &rarr;"
+msgstr ""
+
+#: woocommerce-ajax.php:282 woocommerce-ajax.php:316 woocommerce-ajax.php:339
+msgid "You do not have sufficient permissions to access this page."
+msgstr ""
+
+#: woocommerce-ajax.php:284 woocommerce-ajax.php:317 woocommerce-ajax.php:340
+msgid "You have taken too long. Please go back and retry."
+msgstr ""
+
+#: woocommerce-ajax.php:576
+msgid "Same as parent"
+msgstr ""
+
+#: woocommerce-ajax.php:577
+msgid "Standard"
+msgstr ""
+
+#: woocommerce-ajax.php:1154 woocommerce-ajax.php:1155
+msgid "Item #%s stock increased from %s to %s."
+msgstr ""
+
+#: woocommerce-ajax.php:1180
+msgid "Value"
+msgstr ""
+
+#: woocommerce-ajax.php:1492
+msgid "Delete note"
+msgstr ""
+
+#: woocommerce-ajax.php:1725
+msgid "Cross-sell"
+msgstr ""
+
+#: woocommerce-ajax.php:1725
+msgid "Up-sell"
+msgstr ""
+
+#: woocommerce-ajax.php:1730
+msgid "No products found"
+msgstr ""
+
+#: woocommerce-core-functions.php:1005 woocommerce-core-functions.php:1031
+msgid "Download Permissions Granted"
+msgstr ""
+
+#: woocommerce-core-functions.php:1144
+msgctxt "slug"
+msgid "uncategorized"
+msgstr ""
+
+#: woocommerce-core-functions.php:1326
+msgid "Select a category"
+msgstr ""
+
+#: woocommerce-core-functions.php:1330
+msgid "Uncategorized"
+msgstr ""
+
+#: woocommerce-core-functions.php:1702
+msgid "Customer"
+msgstr ""
+
+#: woocommerce-core-functions.php:1709
+msgid "Shop Manager"
+msgstr ""
+
+#: woocommerce-core-functions.php:2234
+msgid "Unpaid order cancelled - time limit reached."
+msgstr ""
+
+#: woocommerce-functions.php:172 woocommerce-functions.php:219
+msgid "Cart updated."
+msgstr ""
+
+#: woocommerce-functions.php:204
+msgid "You can only have 1 %s in your cart."
+msgstr ""
+
+#: woocommerce-functions.php:261 woocommerce-functions.php:308
+msgid "Please choose product options&hellip;"
+msgstr ""
+
+#: woocommerce-functions.php:343
+msgid "Please choose the quantity of items you wish to add to your cart&hellip;"
+msgstr ""
+
+#: woocommerce-functions.php:351
+msgid "Please choose a product to add to your cart&hellip;"
+msgstr ""
+
+#: woocommerce-functions.php:420
+msgid "Added &quot;%s&quot; to your cart."
+msgstr ""
+
+#: woocommerce-functions.php:420
+msgid "&quot; and &quot;"
+msgstr ""
+
+#: woocommerce-functions.php:423
+msgid "&quot;%s&quot; was successfully added to your cart."
+msgstr ""
+
+#: woocommerce-functions.php:431
+msgid "Continue Shopping &rarr;"
+msgstr ""
+
+#: woocommerce-functions.php:599
+msgid "Username is required."
+msgstr ""
+
+#: woocommerce-functions.php:600 woocommerce-functions.php:697
+msgid "Password is required."
+msgstr ""
+
+#: woocommerce-functions.php:673
+msgid "This username is invalid because it uses illegal characters. Please enter a valid username."
+msgstr ""
+
+#: woocommerce-functions.php:676
+msgid "This username is already registered, please choose another one."
+msgstr ""
+
+#: woocommerce-functions.php:688
+msgid "Please type your e-mail address."
+msgstr ""
+
+#: woocommerce-functions.php:690
+msgid "The email address isn&#8217;t correct."
+msgstr ""
+
+#: woocommerce-functions.php:693
+msgid "This email is already registered, please choose another one."
+msgstr ""
+
+#: woocommerce-functions.php:698
+msgid "Re-enter your password."
+msgstr ""
+
+#: woocommerce-functions.php:703
+msgid "Anti-spam field was filled in."
+msgstr ""
+
+#: woocommerce-functions.php:808
+msgid "The cart has been filled with the items from your previous order."
+msgstr ""
+
+#: woocommerce-functions.php:834
+msgid "Order cancelled by customer."
+msgstr ""
+
+#: woocommerce-functions.php:837
+msgid "Your order was cancelled."
+msgstr ""
+
+#: woocommerce-functions.php:843
+msgid "Your order is no longer pending and could not be cancelled. Please contact us if you need assistance."
+msgstr ""
+
+#: woocommerce-functions.php:877
+msgid "Invalid email address."
+msgstr ""
+
+#: woocommerce-functions.php:877 woocommerce-functions.php:899
+#: woocommerce-functions.php:919 woocommerce-functions.php:925
+#: woocommerce-functions.php:929 woocommerce-functions.php:932
+#: woocommerce-functions.php:1106
+msgid "Go to homepage &rarr;"
+msgstr ""
+
+#: woocommerce-functions.php:899
+msgid "Invalid download."
+msgstr ""
+
+#: woocommerce-functions.php:911
+msgid "You must be logged in to download files."
+msgstr ""
+
+#: woocommerce-functions.php:914
+msgid "This is not your download link."
+msgstr ""
+
+#: woocommerce-functions.php:919
+msgid "Product no longer exists."
+msgstr ""
+
+#: woocommerce-functions.php:929
+msgid "Sorry, you have reached your download limit for this file"
+msgstr ""
+
+#: woocommerce-functions.php:932
+msgid "Sorry, this download has expired"
+msgstr ""
+
+#: woocommerce-functions.php:1106
+msgid "File not found"
+msgstr ""
+
+#: woocommerce-functions.php:1182
+msgid "New products"
+msgstr ""
+
+#: woocommerce-functions.php:1190
+msgid "New products added to %s"
+msgstr ""
+
+#: woocommerce-functions.php:1198
+msgid "New products tagged %s"
+msgstr ""
+
+#: woocommerce-functions.php:1233
+msgid "You have taken too long. Please go back and refresh the page."
+msgstr ""
+
+#: woocommerce-functions.php:1236
+msgid "Please rate the product."
+msgstr ""
+
+#: woocommerce-template.php:210
+msgid "This is a demo store for testing purposes &mdash; no orders shall be fulfilled."
+msgstr ""
+
+#: woocommerce-template.php:229
+msgid "Search Results: &ldquo;%s&rdquo;"
+msgstr ""
+
+#: woocommerce-template.php:232
+msgid "&nbsp;&ndash; Page %s"
+msgstr ""
+
+#: woocommerce-template.php:955
+msgctxt "breadcrumb"
+msgid "Home"
+msgstr ""
+
+#: woocommerce-template.php:1253 woocommerce.php:1097
+msgid "required"
+msgstr ""
+
+#: woocommerce-template.php:1297
+msgid "Update country"
+msgstr ""
+
+#: woocommerce-template.php:1431
+msgid "Search for:"
+msgstr ""
+
+#: woocommerce-template.php:1432
+msgid "Search for products"
+msgstr ""
+
+#: woocommerce-template.php:1433 woocommerce.php:823
+msgid "Search"
+msgstr ""
+
+#: woocommerce.php:655
+msgctxt "slug"
+msgid "product-category"
+msgstr ""
+
+#: woocommerce.php:656
+msgctxt "slug"
+msgid "product-tag"
+msgstr ""
+
+#: woocommerce.php:658
+msgctxt "slug"
+msgid "product"
+msgstr ""
+
+#: woocommerce.php:693
+msgid "Product Category"
+msgstr ""
+
+#: woocommerce.php:694
+msgctxt "Admin menu name"
+msgid "Categories"
+msgstr ""
+
+#: woocommerce.php:695
+msgid "Search Product Categories"
+msgstr ""
+
+#: woocommerce.php:696
+msgid "All Product Categories"
+msgstr ""
+
+#: woocommerce.php:697
+msgid "Parent Product Category"
+msgstr ""
+
+#: woocommerce.php:698
+msgid "Parent Product Category:"
+msgstr ""
+
+#: woocommerce.php:699
+msgid "Edit Product Category"
+msgstr ""
+
+#: woocommerce.php:700
+msgid "Update Product Category"
+msgstr ""
+
+#: woocommerce.php:701
+msgid "Add New Product Category"
+msgstr ""
+
+#: woocommerce.php:702
+msgid "New Product Category Name"
+msgstr ""
+
+#: woocommerce.php:724
+msgid "Product Tag"
+msgstr ""
+
+#: woocommerce.php:725
+msgctxt "Admin menu name"
+msgid "Tags"
+msgstr ""
+
+#: woocommerce.php:726
+msgid "Search Product Tags"
+msgstr ""
+
+#: woocommerce.php:727
+msgid "All Product Tags"
+msgstr ""
+
+#: woocommerce.php:728
+msgid "Parent Product Tag"
+msgstr ""
+
+#: woocommerce.php:729
+msgid "Parent Product Tag:"
+msgstr ""
+
+#: woocommerce.php:730
+msgid "Edit Product Tag"
+msgstr ""
+
+#: woocommerce.php:731
+msgid "Update Product Tag"
+msgstr ""
+
+#: woocommerce.php:732
+msgid "Add New Product Tag"
+msgstr ""
+
+#: woocommerce.php:733
+msgid "New Product Tag Name"
+msgstr ""
+
+#: woocommerce.php:752 woocommerce.php:754
+msgid "Shipping Classes"
+msgstr ""
+
+#: woocommerce.php:756
+msgctxt "Admin menu name"
+msgid "Shipping Classes"
+msgstr ""
+
+#: woocommerce.php:757
+msgid "Search Shipping Classes"
+msgstr ""
+
+#: woocommerce.php:758
+msgid "All Shipping Classes"
+msgstr ""
+
+#: woocommerce.php:759
+msgid "Parent Shipping Class"
+msgstr ""
+
+#: woocommerce.php:760
+msgid "Parent Shipping Class:"
+msgstr ""
+
+#: woocommerce.php:761
+msgid "Edit Shipping Class"
+msgstr ""
+
+#: woocommerce.php:762
+msgid "Update Shipping Class"
+msgstr ""
+
+#: woocommerce.php:763
+msgid "Add New Shipping Class"
+msgstr ""
+
+#: woocommerce.php:764
+msgid "New Shipping Class Name"
+msgstr ""
+
+#: woocommerce.php:785
+msgid "Order statuses"
+msgstr ""
+
+#: woocommerce.php:786
+msgid "Order status"
+msgstr ""
+
+#: woocommerce.php:787
+msgid "Search Order statuses"
+msgstr ""
+
+#: woocommerce.php:788
+msgid "All Order statuses"
+msgstr ""
+
+#: woocommerce.php:789
+msgid "Parent Order status"
+msgstr ""
+
+#: woocommerce.php:790
+msgid "Parent Order status:"
+msgstr ""
+
+#: woocommerce.php:791
+msgid "Edit Order status"
+msgstr ""
+
+#: woocommerce.php:792
+msgid "Update Order status"
+msgstr ""
+
+#: woocommerce.php:793
+msgid "Add New Order status"
+msgstr ""
+
+#: woocommerce.php:794
+msgid "New Order status Name"
+msgstr ""
+
+#: woocommerce.php:824
+msgid "All"
+msgstr ""
+
+#: woocommerce.php:825 woocommerce.php:826
+msgid "Parent"
+msgstr ""
+
+#: woocommerce.php:828
+msgid "Update"
+msgstr ""
+
+#: woocommerce.php:829
+msgid "Add New"
+msgstr ""
+
+#: woocommerce.php:830
+msgid "New"
+msgstr ""
+
+#: woocommerce.php:860
+msgctxt "Admin menu name"
+msgid "Products"
+msgstr ""
+
+#: woocommerce.php:861
+msgid "Add Product"
+msgstr ""
+
+#: woocommerce.php:862
+msgid "Add New Product"
+msgstr ""
+
+#: woocommerce.php:864
+msgid "Edit Product"
+msgstr ""
+
+#: woocommerce.php:865
+msgid "New Product"
+msgstr ""
+
+#: woocommerce.php:866 woocommerce.php:867
+msgid "View Product"
+msgstr ""
+
+#: woocommerce.php:868
+msgid "Search Products"
+msgstr ""
+
+#: woocommerce.php:869
+msgid "No Products found"
+msgstr ""
+
+#: woocommerce.php:870
+msgid "No Products found in trash"
+msgstr ""
+
+#: woocommerce.php:871
+msgid "Parent Product"
+msgstr ""
+
+#: woocommerce.php:873
+msgid "This is where you can add new products to your store."
+msgstr ""
+
+#: woocommerce.php:896
+msgid "Variations"
+msgstr ""
+
+#: woocommerce.php:897
+msgid "Variation"
+msgstr ""
+
+#: woocommerce.php:898
+msgid "Add Variation"
+msgstr ""
+
+#: woocommerce.php:899
+msgid "Add New Variation"
+msgstr ""
+
+#: woocommerce.php:901
+msgid "Edit Variation"
+msgstr ""
+
+#: woocommerce.php:902
+msgid "New Variation"
+msgstr ""
+
+#: woocommerce.php:903 woocommerce.php:904
+msgid "View Variation"
+msgstr ""
+
+#: woocommerce.php:905
+msgid "Search Variations"
+msgstr ""
+
+#: woocommerce.php:906
+msgid "No Variations found"
+msgstr ""
+
+#: woocommerce.php:907
+msgid "No Variations found in trash"
+msgstr ""
+
+#: woocommerce.php:908
+msgid "Parent Variation"
+msgstr ""
+
+#: woocommerce.php:925
+msgctxt "Admin menu name"
+msgid "Orders"
+msgstr ""
+
+#: woocommerce.php:934
+msgid "Orders"
+msgstr ""
+
+#: woocommerce.php:936
+msgid "Add Order"
+msgstr ""
+
+#: woocommerce.php:937
+msgid "Add New Order"
+msgstr ""
+
+#: woocommerce.php:939
+msgid "Edit Order"
+msgstr ""
+
+#: woocommerce.php:940
+msgid "New Order"
+msgstr ""
+
+#: woocommerce.php:943
+msgid "Search Orders"
+msgstr ""
+
+#: woocommerce.php:944
+msgid "No Orders found"
+msgstr ""
+
+#: woocommerce.php:945
+msgid "No Orders found in trash"
+msgstr ""
+
+#: woocommerce.php:946
+msgid "Parent Orders"
+msgstr ""
+
+#: woocommerce.php:949
+msgid "This is where store orders are stored."
+msgstr ""
+
+#: woocommerce.php:971
+msgid "Coupons"
+msgstr ""
+
+#: woocommerce.php:973
+msgctxt "Admin menu name"
+msgid "Coupons"
+msgstr ""
+
+#: woocommerce.php:974
+msgid "Add Coupon"
+msgstr ""
+
+#: woocommerce.php:975
+msgid "Add New Coupon"
+msgstr ""
+
+#: woocommerce.php:977
+msgid "Edit Coupon"
+msgstr ""
+
+#: woocommerce.php:978
+msgid "New Coupon"
+msgstr ""
+
+#: woocommerce.php:979
+msgid "View Coupons"
+msgstr ""
+
+#: woocommerce.php:980
+msgid "View Coupon"
+msgstr ""
+
+#: woocommerce.php:981
+msgid "Search Coupons"
+msgstr ""
+
+#: woocommerce.php:982
+msgid "No Coupons found"
+msgstr ""
+
+#: woocommerce.php:983
+msgid "No Coupons found in trash"
+msgstr ""
+
+#: woocommerce.php:984
+msgid "Parent Coupon"
+msgstr ""
+
+#: woocommerce.php:986
+msgid "This is where you can add new coupons that customers can use in your store."
+msgstr ""
+
+#: woocommerce.php:1094
+msgid "Select an option&hellip;"
+msgstr ""
+
+#: woocommerce.php:1095
+msgid "Please select a rating"
+msgstr ""
+
+#: woocommerce.php:1096
+msgid "Sorry, no products matched your selection. Please choose a different combination."
+msgstr ""
+
+#: woocommerce.php:1546
+msgid "Cart % Discount"
+msgstr ""
+
+#: woocommerce.php:1547
+msgid "Product Discount"
+msgstr ""
+
+#: woocommerce.php:1548
+msgid "Product % Discount"
+msgstr ""
+
+#: woocommerce.php:1613
+msgid "Action failed. Please refresh the page and retry."
+msgstr ""

--- a/i18n/makepot/extract/extract.php
+++ b/i18n/makepot/extract/extract.php
@@ -1,0 +1,209 @@
+<?php
+require_once dirname( __FILE__ ) . '/../pomo/entry.php';
+require_once dirname( __FILE__ ) . '/../pomo/translations.php';
+
+class StringExtractor {
+	
+	var $rules = array();
+	var $comment_prefix = 'translators:';
+	
+	function __construct( $rules = array() ) {
+		$this->rules = $rules;
+	}
+	
+	function extract_from_directory( $dir, $excludes = array(), $includes = array(), $prefix = '' ) {
+		$old_cwd = getcwd();
+		chdir( $dir );
+		$translations = new Translations;
+		$file_names = (array) scandir( '.' );
+		foreach ( $file_names as $file_name ) {
+			if ( '.' == $file_name || '..' == $file_name ) continue;
+			if ( preg_match( '/\.php$/', $file_name ) && $this->does_file_name_match( $prefix . $file_name, $excludes, $includes ) ) {
+				$translations->merge_originals_with( $this->extract_from_file( $file_name, $prefix ) );
+			}
+			if ( is_dir( $file_name ) ) {
+				$translations->merge_originals_with( $this->extract_from_directory( $file_name, $excludes, $includes, $prefix . $file_name . '/' ) );
+			}
+		}
+		chdir( $old_cwd );
+		return $translations;
+	}
+	
+	function extract_from_file( $file_name, $prefix ) {
+		$code = file_get_contents( $file_name );
+		return $this->extract_entries( $code, $prefix . $file_name );
+	}
+	
+	function does_file_name_match( $path, $excludes, $includes ) {
+		if ( $includes ) {
+			$matched_any_include = false;
+			foreach( $includes as $include ) {
+				if ( preg_match( '|^'.$include.'$|', $path ) ) {
+					$matched_any_include = true;
+					break;
+				}
+			}
+			if ( !$matched_any_include ) return false;
+		}
+		if ( $excludes ) {
+			foreach( $excludes as $exclude ) {
+				if ( preg_match( '|^'.$exclude.'$|', $path ) ) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+	
+	function entry_from_call( $call, $file_name ) {
+		$rule = isset( $this->rules[$call['name']] )? $this->rules[$call['name']] : null;
+		if ( !$rule ) return null;
+		$entry = new Translation_Entry;
+		$multiple = array();
+		$complete = false;
+		for( $i = 0; $i < count( $rule ); ++$i ) {
+			if ( $rule[$i] && ( !isset( $call['args'][$i] ) || !is_string( $call['args'][$i] ) || '' == $call['args'][$i] ) ) return false;
+			switch( $rule[$i] ) {
+			case 'string':
+				if ( $complete ) {
+					$multiple[] = $entry;
+					$entry = new Translation_Entry;
+					$complete = false;
+				}
+				$entry->singular = $call['args'][$i];
+				$complete = true;
+				break;
+			case 'singular':
+				if ( $complete ) {
+					$multiple[] = $entry;
+					$entry = new Translation_Entry;
+					$complete = false;
+				}
+				$entry->singular = $call['args'][$i];
+				$entry->is_plural = true;
+				break;
+			case 'plural':
+				$entry->plural = $call['args'][$i];
+				$entry->is_plural = true;
+				$complete = true;
+				break;
+			case 'context':
+				$entry->context = $call['args'][$i];
+				foreach( $multiple as &$single_entry ) {
+					$single_entry->context = $entry->context;
+				}
+				break;
+			}
+		}
+		if ( isset( $call['line'] ) && $call['line'] ) {
+			$references = array( $file_name . ':' . $call['line'] );
+			$entry->references = $references;
+			foreach( $multiple as &$single_entry ) {
+				$single_entry->references = $references;
+			}
+		}
+		if ( isset( $call['comment'] ) && $call['comment'] ) {
+			$comments = rtrim( $call['comment'] ) . "\n";
+			$entry->extracted_comments = $comments;
+			foreach( $multiple as &$single_entry ) {
+				$single_entry->extracted_comments = $comments;
+			}
+		}
+		if ( $multiple && $entry ) {
+			$multiple[] = $entry;
+			return $multiple;
+		}
+		
+		return $entry;
+	}
+	
+	function extract_entries( $code, $file_name ) {
+		$translations = new Translations;
+		$function_calls = $this->find_function_calls( array_keys( $this->rules ), $code );
+		foreach( $function_calls as $call ) {
+			$entry = $this->entry_from_call( $call, $file_name );
+			if ( is_array( $entry ) )
+				foreach( $entry as $single_entry )
+					$translations->add_entry_or_merge( $single_entry );
+			elseif ( $entry)
+				$translations->add_entry_or_merge( $entry );
+		}
+		return $translations;
+	}
+	
+	/**
+	 * Finds all function calls in $code and returns an array with an associative array for each function:
+	 *	- name - name of the function
+	 *	- args - array for the function arguments. Each string literal is represented by itself, other arguments are represented by null.
+	 *  - line - line number
+	 */
+	function find_function_calls( $function_names, $code ) {
+		$tokens = token_get_all( $code );
+		$function_calls = array();
+		$latest_comment = false;
+		$in_func = false;
+		foreach( $tokens as $token ) {
+			$id = $text = null;
+			if ( is_array( $token ) ) list( $id, $text, $line ) = $token;
+			if ( T_WHITESPACE == $id ) continue;
+			if ( T_STRING == $id && in_array( $text, $function_names ) && !$in_func ) {
+				$in_func = true;
+				$paren_level = -1;
+				$args = array();
+				$func_name = $text;
+				$func_line = $line;
+				$func_comment = $latest_comment? $latest_comment : '';
+				
+				$just_got_into_func = true;
+				$latest_comment = false;
+				continue;
+			}
+			if ( T_COMMENT == $id ) {
+				$text = trim( preg_replace( '%^/\*|//%', '', preg_replace( '%\*/$%', '', $text ) ) );
+				if ( 0 === strpos( $text, $this->comment_prefix ) ) {
+					$latest_comment = $text;
+				}
+			}
+			if ( !$in_func ) continue;
+			if ( '(' == $token ) {
+				$paren_level++;
+				if ( 0 == $paren_level ) { // start of first argument
+					$just_got_into_func = false;
+					$current_argument = null;
+					$current_argument_is_just_literal = true;
+				}
+				continue;
+			}
+			if ( $just_got_into_func ) {
+				// there wasn't a opening paren just after the function name -- this means it is not a function
+				$in_func = false;
+				$just_got_into_func = false;
+			}
+			if ( ')' == $token ) {
+				if ( 0 == $paren_level ) {
+					$in_func = false;
+					$args[] = $current_argument;
+					$call = array( 'name' => $func_name, 'args' => $args, 'line' => $func_line );
+					if ( $func_comment ) $call['comment'] = $func_comment;
+					$function_calls[] = $call;
+				}
+				$paren_level--;
+				continue;
+			}
+			if ( ',' == $token && 0 == $paren_level ) {
+				$args[] = $current_argument;
+				$current_argument = null;
+				$current_argument_is_just_literal = true;
+				continue;
+			}
+			if ( T_CONSTANT_ENCAPSED_STRING == $id && $current_argument_is_just_literal ) {
+				// we can use eval safely, because we are sure $text is just a string literal
+				eval('$current_argument = '.$text.';' );
+				continue;
+			}
+			$current_argument_is_just_literal = false;
+			$current_argument = null;
+		}
+		return $function_calls;
+	}
+}

--- a/i18n/makepot/index.php
+++ b/i18n/makepot/index.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Web interface for generating the WooCommerce POT files
+ *
+ * @since 2.0
+ * @package WooCommerce
+ * @author Geert De Deckere
+ */
+
+/**
+ * Note: this file is locked by default since it should not be publicly accessible
+ * on a live website. You can unlock it by temporarily removing the following line.
+ */
+exit( 'Locked' );
+
+// Load the makepot generator
+require './makepot.php';
+$makepot = new WC_Makepot;
+
+// Regeneration requested
+if ( ! empty( $_GET['generate'] ) ) {
+	// Generate woocommerce and woocommerce-admin POT files
+	$results = array();
+	foreach ( $makepot->projects as $name => $project ) {
+		$results[ $name ] = $makepot->generate_pot( $name );
+	}
+}
+
+// Load WooCommerce POT-files info
+$pot_files = array();
+foreach( $makepot->projects as $name => $project ) {
+	$pot_files[ $name ] = array(
+		'file'        => $project['file'],
+		'file_exists' => file_exists( $project['file'] ),
+		'is_readable' => is_readable( $project['file'] ),
+		'is_writable' => is_writable( $project['file'] ),
+		'filemtime'   => ( is_readable( $project['file'] ) ) ? filemtime( $project['file'] ) : false,
+		'filesize'    => ( is_readable( $project['file'] ) ) ? filesize( $project['file'] ) : false,
+	);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+	<meta charset="utf-8">
+	<title>WooCommerce POT Generator</title>
+	<style>
+	html { font-family:monospace; }
+	ul { margin-bottom:1em; }
+	ul ul { padding-left:0; list-style:none; color:#999; }
+
+	.success { color:green; }
+	.error { color:red; }
+	.button { display:inline-block; padding:0.5em 1em; background:#ddd; font-weight:bold; color:#000; text-decoration:none; }
+	.button:hover { background:#ccc; }
+	.button.disabled { background:#eee; color:#888; cursor:default; }
+
+	@-webkit-keyframes rotate { from { -webkit-transform:rotate(0deg); } to { -webkit-transform:rotate(360deg); } }
+	   @-moz-keyframes rotate { from {    -moz-transform:rotate(0deg); } to {    -moz-transform:rotate(360deg); } }
+	        @keyframes rotate { from {         transform:rotate(0deg); } to {         transform:rotate(360deg); } }
+	.spinner { display:inline-block;
+		-webkit-animation:rotate 0.4s linear infinite;
+		   -moz-animation:rotate 0.4s linear infinite;
+		        animation:rotate 0.4s linear infinite;
+	}
+	</style>
+
+</head>
+<body>
+
+	<h1>WooCommerce <?php echo $makepot->woocommerce_version() ?> POT Generator</h1>
+
+	<?php if ( ! empty( $results ) ) { ?>
+		<ul>
+			<?php foreach ( $results as $pot_file => $succeeded ) { ?>
+				<?php if ( $succeeded ) { ?>
+					<li class="success"><strong><?php echo basename( $pot_files[ $pot_file ]['file'] ) ?> successfully generated.</strong></li>
+				<?php } else { ?>
+					<li class="error"><strong><?php echo basename( $pot_files[ $pot_file ]['file'] ) ?> could not be generated.</strong></li>
+				<?php } ?>
+			<?php } ?>
+		</ul>
+	<?php } ?>
+
+	<p>This tool will (re)generate and overwrite the following WooCommerce POT-files:</p>
+
+	<ul>
+		<?php foreach ( $pot_files as $pot_file ) { ?>
+			<li>
+				<strong><?php echo basename( $pot_file['file'] ) ?></strong>
+				<?php if ( $pot_file['is_writable'] ) { ?>
+					<strong class="success">[writable]</strong>
+				<?php } else { ?>
+					<strong class="error">[not writable]</strong>
+				<?php } ?>
+				<ul>
+					<li>Path: <?php echo dirname( $pot_file['file'] ) . '/' ?></li>
+					<li>Size: <?php echo ( $pot_file['file_exists'] ) ? number_format( $pot_file['filesize'], 0 ) . ' bytes' : '--' ?></li>
+					<li>Last updated: <?php echo ( $pot_file['filemtime'] ) ? @date( 'F jS Y H:i:s', $pot_file['filemtime'] ) : '--' ?></li>
+				</ul>
+			</li>
+		<?php } ?>
+	</ul>
+
+	<p>
+		<a id="submit" class="button" href="?generate=1">Generate POT-files now</a>
+	</p>
+
+	<script>
+	// Show a loading animation
+	document.getElementById('submit').onclick = function () {
+		this.className += ' disabled';
+		this.innerHTML = 'Generating POT-files <span class="spinner">/</span>';
+	};
+	</script>
+
+</body>
+</html>

--- a/i18n/makepot/makepot.php
+++ b/i18n/makepot/makepot.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * WooCommerce POT Generator
+ *
+ * Contains the methods for generating the woocommerce.pot and woocommerce-admin.pot files.
+ * Code is based on: http://i18n.trac.wordpress.org/browser/tools/trunk/makepot.php
+ *
+ * @class WC_Makepot
+ * @since 2.0
+ * @package WooCommerce
+ * @author Geert De Deckere
+ */
+class WC_Makepot {
+
+	/**
+	 * @var string Filesystem directory path for the WooCommerce plugin (with trailing slash)
+	 */
+	public $woocommerce_path;
+
+	/**
+	 * @var array All available projects with their settings
+	 */
+	public $projects;
+
+	/**
+	 * @var object StringExtractor
+	 */
+	public $extractor;
+
+	/**
+	 * @var array Rules for StringExtractor
+	 */
+	public $rules = array(
+		'_'               => array( 'string' ),
+		'__'              => array( 'string' ),
+		'_e'              => array( 'string' ),
+		'_c'              => array( 'string' ),
+		'_n'              => array( 'singular', 'plural' ),
+		'_n_noop'         => array( 'singular', 'plural' ),
+		'_nc'             => array( 'singular', 'plural' ),
+		'__ngettext'      => array( 'singular', 'plural' ),
+		'__ngettext_noop' => array( 'singular', 'plural' ),
+		'_x'              => array( 'string', 'context' ),
+		'_ex'             => array( 'string', 'context' ),
+		'_nx'             => array( 'singular', 'plural', null, 'context' ),
+		'_nx_noop'        => array( 'singular', 'plural', 'context' ),
+		'_n_js'           => array( 'singular', 'plural' ),
+		'_nx_js'          => array( 'singular', 'plural', 'context' ),
+		'esc_attr__'      => array( 'string' ),
+		'esc_html__'      => array( 'string' ),
+		'esc_attr_e'      => array( 'string' ),
+		'esc_html_e'      => array( 'string' ),
+		'esc_attr_x'      => array( 'string', 'context' ),
+		'esc_html_x'      => array( 'string', 'context' ),
+	);
+
+	/**
+	 * Constructor
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function __construct() {
+		// Default path
+		$this->set_woocommerce_path( '../../' );
+
+		// All available projects with their settings
+		$this->projects = array(
+			'woocommerce' => array(
+				'title'    => 'Front-end',
+				'file'     => $this->woocommerce_path . 'i18n/languages/woocommerce.pot',
+				'excludes' => array( 'admin/.*' ),
+				'includes' => array(),
+			),
+			'woocommerce-admin' => array(
+				'title'    => 'Admin',
+				'file'     => $this->woocommerce_path . 'i18n/languages/woocommerce-admin.pot',
+				'excludes' => array(),
+				'includes' => array( 'admin/.*' ),
+			),
+		);
+
+		// Ignore some strict standards notices caused by extract/extract.php
+		error_reporting(E_ALL);
+
+		// Load required files and objects
+		require_once './not-gettexted.php';
+		require_once './pot-ext-meta.php';
+		require_once './extract/extract.php';
+		$this->extractor = new StringExtractor( $this->rules );
+	}
+
+	/**
+	 * Sets the WooCommerce filesystem directory path
+	 *
+	 * @param string $path
+	 * @return void
+	 */
+	public function set_woocommerce_path( $path ) {
+		$this->woocommerce_path = realpath( $path ) . '/';
+	}
+
+	/**
+	 * POT generator
+	 *
+	 * @param string $project "woocommerce" or "woocommerce-admin"
+	 * @return bool true on success, false on error
+	 */
+	public function generate_pot( $project = 'woocommerce' ) {
+		// Unknown project
+		if ( empty( $this->projects[ $project ] ) )
+			return false;
+
+		// Project config
+		$config = $this->projects[ $project ];
+
+		// Extract translatable strings from the WooCommerce plugin
+		$originals = $this->extractor->extract_from_directory( $this->woocommerce_path, $config['excludes'], $config['includes'] );
+
+		// Build POT file
+		$pot = new PO;
+		$pot->entries = $originals->entries;
+		$pot->set_header( 'Project-Id-Version', 'WooCommerce ' . $this->woocommerce_version() . ' ' . $config['title'] );
+		$pot->set_header( 'Report-Msgid-Bugs-To', 'https://github.com/woothemes/woocommerce/issues' );
+		$pot->set_header( 'POT-Creation-Date', gmdate( 'Y-m-d H:i:s+00:00' ) );
+		$pot->set_header( 'MIME-Version', '1.0' );
+		$pot->set_header( 'Content-Type', 'text/plain; charset=UTF-8' );
+		$pot->set_header( 'Content-Transfer-Encoding', '8bit' );
+		$pot->set_header( 'PO-Revision-Date', gmdate( 'Y' ) . '-MO-DA HO:MI+ZONE' );
+		$pot->set_header( 'Last-Translator', 'FULL NAME <EMAIL@ADDRESS>' );
+		$pot->set_header( 'Language-Team', 'LANGUAGE <EMAIL@ADDRESS>' );
+
+		// Write POT file
+		return $pot->export_to_file( $config['file'] );
+	}
+
+	/**
+	 * Retrieves the WooCommerce version from the woocommerce.php file.
+	 *
+	 * @access public
+	 * @return string|false WooCommerce version number, false if not found
+	 */
+	public function woocommerce_version() {
+		// Only run this method once
+		static $version;
+		if ( null !== $version )
+			return $version;
+
+		// File that contains the WooCommerce version number
+		$file = $this->woocommerce_path . 'woocommerce.php';
+
+ 		if ( is_readable( $file ) && preg_match( '/\bVersion:\s*+(\S+)/i', file_get_contents( $file ), $matches ) )
+			$version = $matches[1];
+		else
+			$version = false;
+
+		return $version;
+	}
+
+}

--- a/i18n/makepot/not-gettexted.php
+++ b/i18n/makepot/not-gettexted.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Console application, which extracts or replaces strings for
+ * translation, which cannot be gettexted
+ *
+ * @version $Id: not-gettexted.php 19275 2012-02-10 17:47:42Z nacin $
+ * @package wordpress-i18n
+ * @subpackage tools
+ */
+// see: http://php.net/tokenizer
+if (!defined('T_ML_COMMENT'))
+	    define('T_ML_COMMENT', T_COMMENT);
+else
+	    define('T_DOC_COMMENT', T_ML_COMMENT);
+
+require_once dirname( __FILE__ ) . '/pomo/po.php';
+require_once dirname( __FILE__ ) . '/pomo/mo.php';
+
+class NotGettexted {
+	var $enable_logging = false;
+
+	var $STAGE_OUTSIDE = 0;
+	var $STAGE_START_COMMENT = 1;
+	var $STAGE_WHITESPACE_BEFORE = 2;
+	var $STAGE_STRING = 3;
+	var $STAGE_WHITESPACE_AFTER = 4;
+	var $STAGE_END_COMMENT = 4;
+
+	var $commands = array('extract' => 'command_extract', 'replace' => 'command_replace' );
+
+
+	function logmsg() {
+		$args = func_get_args();
+		if ($this->enable_logging) error_log(implode(' ', $args));
+	}
+
+	function stderr($msg, $nl=true) {
+		fwrite(STDERR, $msg.($nl? "\n" : ""));
+	}
+
+	function cli_die($msg) {
+		$this->stderr($msg);
+		exit(1);
+	}
+
+	function unchanged_token($token, $s='') {
+		return is_array($token)? $token[1] : $token;
+	}
+
+	function ignore_token($token, $s='') {
+		return '';
+	}
+
+	function list_php_files($dir) {
+		$files = array();
+		$items = scandir( $dir );
+		foreach ( (array) $items as $item ) {
+			$full_item = $dir . '/' . $item;
+			if ('.' == $item || '..' == $item)
+				continue;
+			if ('.php' == substr($item, -4))
+				$files[] = $full_item; 
+			if (is_dir($full_item))
+				$files += array_merge($files, NotGettexted::list_php_files($full_item, $files));
+		}
+		return $files;
+	}
+
+
+	function make_string_aggregator($global_array_name, $filename) {
+		$a = $global_array_name;
+		return create_function('$string, $comment_id, $line_number', 'global $'.$a.'; $'.$a.'[] = array($string, $comment_id, '.var_export($filename, true).', $line_number);');
+	}
+
+	function make_mo_replacer($global_mo_name) {
+		$m = $global_mo_name;
+		return create_function('$token, $string', 'global $'.$m.'; return var_export($'.$m.'->translate($string), true);');
+	}
+
+	function walk_tokens(&$tokens, $string_action, $other_action, $register_action=null) {
+
+		$current_comment_id = '';
+		$current_string = '';
+		$current_string_line = 0;
+
+		$result = '';
+		$line = 1;
+
+		foreach($tokens as $token) {
+			if (is_array($token)) {
+				list($id, $text) = $token;
+				$line += substr_count($text, "\n");
+				if ((T_ML_COMMENT == $id || T_COMMENT == $id) && preg_match('|/\*\s*(/?WP_I18N_[a-z_]+)\s*\*/|i', $text, $matches)) {
+					if ($this->STAGE_OUTSIDE == $stage) {
+						$stage = $this->STAGE_START_COMMENT;
+						$current_comment_id = $matches[1];
+						$this->logmsg('start comment', $current_comment_id);
+						$result .= call_user_func($other_action, $token);
+						continue;
+					}
+					if ($this->STAGE_START_COMMENT <= $stage && $stage <= $this->STAGE_WHITESPACE_AFTER && '/'.$current_comment_id == $matches[1]) {
+						$stage = $this->STAGE_END_COMMENT; 
+						$this->logmsg('end comment', $current_comment_id);
+						$result .= call_user_func($other_action, $token);
+						if (!is_null($register_action)) call_user_func($register_action, $current_string, $current_comment_id, $current_string_line);
+						continue;
+					}
+				} else if (T_CONSTANT_ENCAPSED_STRING == $id) {
+					if ($this->STAGE_START_COMMENT <= $stage && $stage < $this->STAGE_WHITESPACE_AFTER) {
+						eval('$current_string='.$text.';');
+						$this->logmsg('string', $current_string);
+						$current_string_line = $line;
+						$result .= call_user_func($string_action, $token, $current_string);
+						continue;
+					}
+				} else if (T_WHITESPACE == $id) {
+					if ($this->STAGE_START_COMMENT <= $stage && $stage < $this->STAGE_STRING) {
+						$stage = $this->STAGE_WHITESPACE_BEFORE;
+						$this->logmsg('whitespace before');
+						$result .= call_user_func($other_action, $token);
+						continue;
+					}
+					if ($this->STAGE_STRING < $stage && $stage < $this->STAGE_END_COMMENT) {
+						$stage = $this->STAGE_WHITESPACE_AFTER;
+						$this->logmsg('whitespace after');
+						$result .= call_user_func($other_action, $token);
+						continue;
+					}
+				}
+			}
+			$result .= call_user_func($other_action, $token);
+			$stage = $this->STAGE_OUTSIDE;
+			$current_comment_id = '';
+			$current_string = '';
+			$current_string_line = 0;
+		}
+		return $result;
+	}
+
+
+	function command_extract() {
+		$args = func_get_args();
+		$pot_filename = $args[0];
+		if (isset($args[1]) && is_array($args[1]))
+			$filenames = $args[1];
+		else
+			$filenames = array_slice($args, 1);
+
+		$global_name = '__entries_'.mt_rand(1, 1000);
+		$GLOBALS[$global_name] = array();
+
+		foreach($filenames as $filename) {
+			$tokens = token_get_all(file_get_contents($filename));
+			$aggregator = $this->make_string_aggregator($global_name, $filename);
+			$this->walk_tokens($tokens, array(&$this, 'ignore_token'), array(&$this, 'ignore_token'), $aggregator);
+		}
+
+		$potf = '-' == $pot_filename? STDOUT : @fopen($pot_filename, 'a');
+		if (false === $potf) {
+			$this->cli_die("Couldn't open pot file: $pot_filename");
+		}
+
+		foreach($GLOBALS[$global_name] as $item) {
+			@list($string, $comment_id, $filename, $line_number) = $item;
+			$filename = isset($filename)? preg_replace('|^\./|', '', $filename) : '';
+			$ref_line_number = isset($line_number)? ":$line_number" : '';
+			$args = array(
+				'singular' => $string,
+				'extracted_comments' => "Not gettexted string $comment_id",
+				'references' => array("$filename$ref_line_number"),
+			);
+			$entry = new Translation_Entry($args);
+			fwrite($potf, "\n".PO::export_entry($entry)."\n");
+		}
+		if ('-' != $pot_filename) fclose($potf);
+		return true;
+	}
+
+	function command_replace() {
+		$args = func_get_args();
+		$mo_filename = $args[0];
+		if (isset($args[1]) && is_array($args[1]))
+			$filenames = $args[1];
+		else
+			$filenames = array_slice($args, 1);
+
+		$global_name = '__mo_'.mt_rand(1, 1000);
+		$GLOBALS[$global_name] = new MO();
+		$replacer = $this->make_mo_replacer($global_name);
+
+		$res = $GLOBALS[$global_name]->import_from_file($mo_filename);
+		if (false === $res) {
+			$this->cli_die("Couldn't read MO file '$mo_filename'!");
+		}
+		foreach($filenames as $filename) {
+			$source = file_get_contents($filename);
+			if ( strlen($source) > 150000 ) continue;
+			$tokens = token_get_all($source);
+			$new_file = $this->walk_tokens($tokens, $replacer, array(&$this, 'unchanged_token'));
+			$f = fopen($filename, 'w');
+			fwrite($f, $new_file);
+			fclose($f);
+		}
+		return true;
+	}
+
+	function usage() {
+		$this->stderr('php i18n-comments.php COMMAND OUTPUTFILE INPUTFILES');
+		$this->stderr('Extracts and replaces strings, which cannot be gettexted');
+		$this->stderr('Commands:');
+		$this->stderr('	extract POTFILE PHPFILES appends the strings to POTFILE');
+		$this->stderr('	replace MOFILE PHPFILES replaces strings in PHPFILES with translations from MOFILE');
+	}
+
+	function cli() {
+		global $argv, $commands;
+		if (count($argv) < 4 || !in_array($argv[1], array_keys($this->commands))) {
+			$this->usage();
+			exit(1);
+		}
+		call_user_func_array(array(&$this, $this->commands[$argv[1]]), array_slice($argv, 2));
+	}
+}
+
+// run the CLI only if the file
+// wasn't included
+$included_files = get_included_files();
+if ($included_files[0] == __FILE__) {
+	error_reporting(E_ALL);
+	$not_gettexted = new NotGettexted;
+	$not_gettexted->cli();
+}
+
+?>

--- a/i18n/makepot/pomo/entry.php
+++ b/i18n/makepot/pomo/entry.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Contains Translation_Entry class
+ *
+ * @version $Id: entry.php 718 2012-10-31 00:32:02Z nbachiyski $
+ * @package pomo
+ * @subpackage entry
+ */
+
+if ( !class_exists( 'Translation_Entry' ) ):
+/**
+ * Translation_Entry class encapsulates a translatable string
+ */
+class Translation_Entry {
+
+	/**
+	 * Whether the entry contains a string and its plural form, default is false
+	 *
+	 * @var boolean
+	 */
+	var $is_plural = false;
+
+	var $context = null;
+	var $singular = null;
+	var $plural = null;
+	var $translations = array();
+	var $translator_comments = '';
+	var $extracted_comments = '';
+	var $references = array();
+	var $flags = array();
+
+	/**
+	 * @param array $args associative array, support following keys:
+	 * 	- singular (string) -- the string to translate, if omitted and empty entry will be created
+	 * 	- plural (string) -- the plural form of the string, setting this will set {@link $is_plural} to true
+	 * 	- translations (array) -- translations of the string and possibly -- its plural forms
+	 * 	- context (string) -- a string differentiating two equal strings used in different contexts
+	 * 	- translator_comments (string) -- comments left by translators
+	 * 	- extracted_comments (string) -- comments left by developers
+	 * 	- references (array) -- places in the code this strings is used, in relative_to_root_path/file.php:linenum form
+	 * 	- flags (array) -- flags like php-format
+	 */
+	function Translation_Entry($args=array()) {
+		// if no singular -- empty object
+		if (!isset($args['singular'])) {
+			return;
+		}
+		// get member variable values from args hash
+		foreach ($args as $varname => $value) {
+			$this->$varname = $value;
+		}
+		if (isset($args['plural'])) $this->is_plural = true;
+		if (!is_array($this->translations)) $this->translations = array();
+		if (!is_array($this->references)) $this->references = array();
+		if (!is_array($this->flags)) $this->flags = array();
+	}
+
+	/**
+	 * Generates a unique key for this entry
+	 *
+	 * @return string|bool the key or false if the entry is empty
+	 */
+	function key() {
+		if (is_null($this->singular)) return false;
+		// prepend context and EOT, like in MO files
+		return is_null($this->context)? $this->singular : $this->context.chr(4).$this->singular;
+	}
+
+	function merge_with(&$other) {
+		$this->flags = array_unique( array_merge( $this->flags, $other->flags ) );
+		$this->references = array_unique( array_merge( $this->references, $other->references ) );
+		if ( $this->extracted_comments != $other->extracted_comments ) {
+			$this->extracted_comments .= $other->extracted_comments;
+		}
+
+	}
+}
+endif;

--- a/i18n/makepot/pomo/mo.php
+++ b/i18n/makepot/pomo/mo.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Class for working with MO files
+ *
+ * @version $Id: mo.php 718 2012-10-31 00:32:02Z nbachiyski $
+ * @package pomo
+ * @subpackage mo
+ */
+
+require_once dirname(__FILE__) . '/translations.php';
+require_once dirname(__FILE__) . '/streams.php';
+
+if ( !class_exists( 'MO' ) ):
+class MO extends Gettext_Translations {
+
+	var $_nplurals = 2;
+
+	/**
+	 * Fills up with the entries from MO file $filename
+	 *
+	 * @param string $filename MO file to load
+	 */
+	function import_from_file($filename) {
+		$reader = new POMO_FileReader($filename);
+		if (!$reader->is_resource())
+			return false;
+		return $this->import_from_reader($reader);
+	}
+
+	function export_to_file($filename) {
+		$fh = fopen($filename, 'wb');
+		if ( !$fh ) return false;
+		$res = $this->export_to_file_handle( $fh );
+		fclose($fh);
+		return $res;
+	}
+
+	function export() {
+		$tmp_fh = fopen("php://temp", 'r+');
+		if ( !$tmp_fh ) return false;
+		$this->export_to_file_handle( $tmp_fh );
+		rewind( $tmp_fh );
+		return stream_get_contents( $tmp_fh );
+	}
+
+	function is_entry_good_for_export( $entry ) {
+		if ( empty( $entry->translations ) ) {
+			return false;
+		}
+
+		if ( !array_filter( $entry->translations ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	function export_to_file_handle($fh) {
+		$entries = array_filter( $this->entries, array( $this, 'is_entry_good_for_export' ) );
+		ksort($entries);
+		$magic = 0x950412de;
+		$revision = 0;
+		$total = count($entries) + 1; // all the headers are one entry
+		$originals_lenghts_addr = 28;
+		$translations_lenghts_addr = $originals_lenghts_addr + 8 * $total;
+		$size_of_hash = 0;
+		$hash_addr = $translations_lenghts_addr + 8 * $total;
+		$current_addr = $hash_addr;
+		fwrite($fh, pack('V*', $magic, $revision, $total, $originals_lenghts_addr,
+			$translations_lenghts_addr, $size_of_hash, $hash_addr));
+		fseek($fh, $originals_lenghts_addr);
+
+		// headers' msgid is an empty string
+		fwrite($fh, pack('VV', 0, $current_addr));
+		$current_addr++;
+		$originals_table = chr(0);
+
+		foreach($entries as $entry) {
+			$originals_table .= $this->export_original($entry) . chr(0);
+			$length = strlen($this->export_original($entry));
+			fwrite($fh, pack('VV', $length, $current_addr));
+			$current_addr += $length + 1; // account for the NULL byte after
+		}
+
+		$exported_headers = $this->export_headers();
+		fwrite($fh, pack('VV', strlen($exported_headers), $current_addr));
+		$current_addr += strlen($exported_headers) + 1;
+		$translations_table = $exported_headers . chr(0);
+
+		foreach($entries as $entry) {
+			$translations_table .= $this->export_translations($entry) . chr(0);
+			$length = strlen($this->export_translations($entry));
+			fwrite($fh, pack('VV', $length, $current_addr));
+			$current_addr += $length + 1;
+		}
+
+		fwrite($fh, $originals_table);
+		fwrite($fh, $translations_table);
+		return true;
+	}
+
+	function export_original($entry) {
+		//TODO: warnings for control characters
+		$exported = $entry->singular;
+		if ($entry->is_plural) $exported .= chr(0).$entry->plural;
+		if (!is_null($entry->context)) $exported = $entry->context . chr(4) . $exported;
+		return $exported;
+	}
+
+	function export_translations($entry) {
+		//TODO: warnings for control characters
+		return implode(chr(0), $entry->translations);
+	}
+
+	function export_headers() {
+		$exported = '';
+		foreach($this->headers as $header => $value) {
+			$exported.= "$header: $value\n";
+		}
+		return $exported;
+	}
+
+	function get_byteorder($magic) {
+		// The magic is 0x950412de
+
+		// bug in PHP 5.0.2, see https://savannah.nongnu.org/bugs/?func=detailitem&item_id=10565
+		$magic_little = (int) - 1794895138;
+		$magic_little_64 = (int) 2500072158;
+		// 0xde120495
+		$magic_big = ((int) - 569244523) & 0xFFFFFFFF;
+		if ($magic_little == $magic || $magic_little_64 == $magic) {
+			return 'little';
+		} else if ($magic_big == $magic) {
+			return 'big';
+		} else {
+			return false;
+		}
+	}
+
+	function import_from_reader($reader) {
+		$endian_string = MO::get_byteorder($reader->readint32());
+		if (false === $endian_string) {
+			return false;
+		}
+		$reader->setEndian($endian_string);
+
+		$endian = ('big' == $endian_string)? 'N' : 'V';
+
+		$header = $reader->read(24);
+		if ($reader->strlen($header) != 24)
+			return false;
+
+		// parse header
+		$header = unpack("{$endian}revision/{$endian}total/{$endian}originals_lenghts_addr/{$endian}translations_lenghts_addr/{$endian}hash_length/{$endian}hash_addr", $header);
+		if (!is_array($header))
+			return false;
+
+		extract( $header );
+
+		// support revision 0 of MO format specs, only
+		if ($revision != 0)
+			return false;
+
+		// seek to data blocks
+		$reader->seekto($originals_lenghts_addr);
+
+		// read originals' indices
+		$originals_lengths_length = $translations_lenghts_addr - $originals_lenghts_addr;
+		if ( $originals_lengths_length != $total * 8 )
+			return false;
+
+		$originals = $reader->read($originals_lengths_length);
+		if ( $reader->strlen( $originals ) != $originals_lengths_length )
+			return false;
+
+		// read translations' indices
+		$translations_lenghts_length = $hash_addr - $translations_lenghts_addr;
+		if ( $translations_lenghts_length != $total * 8 )
+			return false;
+
+		$translations = $reader->read($translations_lenghts_length);
+		if ( $reader->strlen( $translations ) != $translations_lenghts_length )
+			return false;
+
+		// transform raw data into set of indices
+		$originals    = $reader->str_split( $originals, 8 );
+		$translations = $reader->str_split( $translations, 8 );
+
+		// skip hash table
+		$strings_addr = $hash_addr + $hash_length * 4;
+
+		$reader->seekto($strings_addr);
+
+		$strings = $reader->read_all();
+		$reader->close();
+
+		for ( $i = 0; $i < $total; $i++ ) {
+			$o = unpack( "{$endian}length/{$endian}pos", $originals[$i] );
+			$t = unpack( "{$endian}length/{$endian}pos", $translations[$i] );
+			if ( !$o || !$t ) return false;
+
+			// adjust offset due to reading strings to separate space before
+			$o['pos'] -= $strings_addr;
+			$t['pos'] -= $strings_addr;
+
+			$original    = $reader->substr( $strings, $o['pos'], $o['length'] );
+			$translation = $reader->substr( $strings, $t['pos'], $t['length'] );
+
+			if ('' === $original) {
+				$this->set_headers($this->make_headers($translation));
+			} else {
+				$entry = &$this->make_entry($original, $translation);
+				$this->entries[$entry->key()] = &$entry;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Build a Translation_Entry from original string and translation strings,
+	 * found in a MO file
+	 *
+	 * @static
+	 * @param string $original original string to translate from MO file. Might contain
+	 * 	0x04 as context separator or 0x00 as singular/plural separator
+	 * @param string $translation translation string from MO file. Might contain
+	 * 	0x00 as a plural translations separator
+	 */
+	function &make_entry($original, $translation) {
+		$entry = new Translation_Entry();
+		// look for context
+		$parts = explode(chr(4), $original);
+		if (isset($parts[1])) {
+			$original = $parts[1];
+			$entry->context = $parts[0];
+		}
+		// look for plural original
+		$parts = explode(chr(0), $original);
+		$entry->singular = $parts[0];
+		if (isset($parts[1])) {
+			$entry->is_plural = true;
+			$entry->plural = $parts[1];
+		}
+		// plural translations are also separated by \0
+		$entry->translations = explode(chr(0), $translation);
+		return $entry;
+	}
+
+	function select_plural_form($count) {
+		return $this->gettext_select_plural_form($count);
+	}
+
+	function get_plural_forms_count() {
+		return $this->_nplurals;
+	}
+}
+endif;

--- a/i18n/makepot/pomo/po.php
+++ b/i18n/makepot/pomo/po.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * Class for working with PO files
+ *
+ * @version $Id: po.php 718 2012-10-31 00:32:02Z nbachiyski $
+ * @package pomo
+ * @subpackage po
+ */
+
+require_once dirname(__FILE__) . '/translations.php';
+
+define('PO_MAX_LINE_LEN', 79);
+
+ini_set('auto_detect_line_endings', 1);
+
+/**
+ * Routines for working with PO files
+ */
+if ( !class_exists( 'PO' ) ):
+class PO extends Gettext_Translations {
+
+	var $comments_before_headers = '';
+
+	/**
+	 * Exports headers to a PO entry
+	 *
+	 * @return string msgid/msgstr PO entry for this PO file headers, doesn't contain newline at the end
+	 */
+	function export_headers() {
+		$header_string = '';
+		foreach($this->headers as $header => $value) {
+			$header_string.= "$header: $value\n";
+		}
+		$poified = PO::poify($header_string);
+		if ($this->comments_before_headers)
+			$before_headers = $this->prepend_each_line(rtrim($this->comments_before_headers)."\n", '# ');
+		else
+			$before_headers = '';
+		return rtrim("{$before_headers}msgid \"\"\nmsgstr $poified");
+	}
+
+	/**
+	 * Exports all entries to PO format
+	 *
+	 * @return string sequence of mgsgid/msgstr PO strings, doesn't containt newline at the end
+	 */
+	function export_entries() {
+		//TODO sorting
+		return implode("\n\n", array_map(array('PO', 'export_entry'), $this->entries));
+	}
+
+	/**
+	 * Exports the whole PO file as a string
+	 *
+	 * @param bool $include_headers whether to include the headers in the export
+	 * @return string ready for inclusion in PO file string for headers and all the enrtries
+	 */
+	function export($include_headers = true) {
+		$res = '';
+		if ($include_headers) {
+			$res .= $this->export_headers();
+			$res .= "\n\n";
+		}
+		$res .= $this->export_entries();
+		return $res;
+	}
+
+	/**
+	 * Same as {@link export}, but writes the result to a file
+	 *
+	 * @param string $filename where to write the PO string
+	 * @param bool $include_headers whether to include tje headers in the export
+	 * @return bool true on success, false on error
+	 */
+	function export_to_file($filename, $include_headers = true) {
+		$fh = fopen($filename, 'w');
+		if (false === $fh) return false;
+		$export = $this->export($include_headers);
+		$res = fwrite($fh, $export);
+		if (false === $res) return false;
+		return fclose($fh);
+	}
+
+	/**
+	 * Text to include as a comment before the start of the PO contents
+	 *
+	 * Doesn't need to include # in the beginning of lines, these are added automatically
+	 */
+	function set_comment_before_headers( $text ) {
+		$this->comments_before_headers = $text;
+	}
+
+	/**
+	 * Formats a string in PO-style
+	 *
+	 * @static
+	 * @param string $string the string to format
+	 * @return string the poified string
+	 */
+	function poify($string) {
+		$quote = '"';
+		$slash = '\\';
+		$newline = "\n";
+
+		$replaces = array(
+			"$slash" 	=> "$slash$slash",
+			"$quote"	=> "$slash$quote",
+			"\t" 		=> '\t',
+		);
+
+		$string = str_replace(array_keys($replaces), array_values($replaces), $string);
+
+		$po = $quote.implode("${slash}n$quote$newline$quote", explode($newline, $string)).$quote;
+		// add empty string on first line for readbility
+		if (false !== strpos($string, $newline) &&
+				(substr_count($string, $newline) > 1 || !($newline === substr($string, -strlen($newline))))) {
+			$po = "$quote$quote$newline$po";
+		}
+		// remove empty strings
+		$po = str_replace("$newline$quote$quote", '', $po);
+		return $po;
+	}
+
+	/**
+	 * Gives back the original string from a PO-formatted string
+	 *
+	 * @static
+	 * @param string $string PO-formatted string
+	 * @return string enascaped string
+	 */
+	function unpoify($string) {
+		$escapes = array('t' => "\t", 'n' => "\n", '\\' => '\\');
+		$lines = array_map('trim', explode("\n", $string));
+		$lines = array_map(array('PO', 'trim_quotes'), $lines);
+		$unpoified = '';
+		$previous_is_backslash = false;
+		foreach($lines as $line) {
+			preg_match_all('/./u', $line, $chars);
+			$chars = $chars[0];
+			foreach($chars as $char) {
+				if (!$previous_is_backslash) {
+					if ('\\' == $char)
+						$previous_is_backslash = true;
+					else
+						$unpoified .= $char;
+				} else {
+					$previous_is_backslash = false;
+					$unpoified .= isset($escapes[$char])? $escapes[$char] : $char;
+				}
+			}
+		}
+		return $unpoified;
+	}
+
+	/**
+	 * Inserts $with in the beginning of every new line of $string and
+	 * returns the modified string
+	 *
+	 * @static
+	 * @param string $string prepend lines in this string
+	 * @param string $with prepend lines with this string
+	 */
+	function prepend_each_line($string, $with) {
+		$php_with = var_export($with, true);
+		$lines = explode("\n", $string);
+		// do not prepend the string on the last empty line, artefact by explode
+		if ("\n" == substr($string, -1)) unset($lines[count($lines) - 1]);
+		$res = implode("\n", array_map(create_function('$x', "return $php_with.\$x;"), $lines));
+		// give back the empty line, we ignored above
+		if ("\n" == substr($string, -1)) $res .= "\n";
+		return $res;
+	}
+
+	/**
+	 * Prepare a text as a comment -- wraps the lines and prepends #
+	 * and a special character to each line
+	 *
+	 * @access private
+	 * @param string $text the comment text
+	 * @param string $char character to denote a special PO comment,
+	 * 	like :, default is a space
+	 */
+	function comment_block($text, $char=' ') {
+		$text = wordwrap($text, PO_MAX_LINE_LEN - 3);
+		return PO::prepend_each_line($text, "#$char ");
+	}
+
+	/**
+	 * Builds a string from the entry for inclusion in PO file
+	 *
+	 * @static
+	 * @param object &$entry the entry to convert to po string
+	 * @return string|bool PO-style formatted string for the entry or
+	 * 	false if the entry is empty
+	 */
+	function export_entry(&$entry) {
+		if (is_null($entry->singular)) return false;
+		$po = array();
+		if (!empty($entry->translator_comments)) $po[] = PO::comment_block($entry->translator_comments);
+		if (!empty($entry->extracted_comments)) $po[] = PO::comment_block($entry->extracted_comments, '.');
+		if (!empty($entry->references)) $po[] = PO::comment_block(implode(' ', $entry->references), ':');
+		if (!empty($entry->flags)) $po[] = PO::comment_block(implode(", ", $entry->flags), ',');
+		if (!is_null($entry->context)) $po[] = 'msgctxt '.PO::poify($entry->context);
+		$po[] = 'msgid '.PO::poify($entry->singular);
+		if (!$entry->is_plural) {
+			$translation = empty($entry->translations)? '' : $entry->translations[0];
+			$po[] = 'msgstr '.PO::poify($translation);
+		} else {
+			$po[] = 'msgid_plural '.PO::poify($entry->plural);
+			$translations = empty($entry->translations)? array('', '') : $entry->translations;
+			foreach($translations as $i => $translation) {
+				$po[] = "msgstr[$i] ".PO::poify($translation);
+			}
+		}
+		return implode("\n", $po);
+	}
+
+	function import_from_file($filename) {
+		$f = fopen($filename, 'r');
+		if (!$f) return false;
+		$lineno = 0;
+		while (true) {
+			$res = $this->read_entry($f, $lineno);
+			if (!$res) break;
+			if ($res['entry']->singular == '') {
+				$this->set_headers($this->make_headers($res['entry']->translations[0]));
+			} else {
+				$this->add_entry($res['entry']);
+			}
+		}
+		PO::read_line($f, 'clear');
+		if ( false === $res ) {
+			return false;
+		}
+		if ( ! $this->headers && ! $this->entries ) {
+			return false;
+		}
+		return true;
+	}
+
+	function read_entry($f, $lineno = 0) {
+		$entry = new Translation_Entry();
+		// where were we in the last step
+		// can be: comment, msgctxt, msgid, msgid_plural, msgstr, msgstr_plural
+		$context = '';
+		$msgstr_index = 0;
+		$is_final = create_function('$context', 'return $context == "msgstr" || $context == "msgstr_plural";');
+		while (true) {
+			$lineno++;
+			$line = PO::read_line($f);
+			if (!$line)  {
+				if (feof($f)) {
+					if ($is_final($context))
+						break;
+					elseif (!$context) // we haven't read a line and eof came
+						return null;
+					else
+						return false;
+				} else {
+					return false;
+				}
+			}
+			if ($line == "\n") continue;
+			$line = trim($line);
+			if (preg_match('/^#/', $line, $m)) {
+				// the comment is the start of a new entry
+				if ($is_final($context)) {
+					PO::read_line($f, 'put-back');
+					$lineno--;
+					break;
+				}
+				// comments have to be at the beginning
+				if ($context && $context != 'comment') {
+					return false;
+				}
+				// add comment
+				$this->add_comment_to_entry($entry, $line);;
+			} elseif (preg_match('/^msgctxt\s+(".*")/', $line, $m)) {
+				if ($is_final($context)) {
+					PO::read_line($f, 'put-back');
+					$lineno--;
+					break;
+				}
+				if ($context && $context != 'comment') {
+					return false;
+				}
+				$context = 'msgctxt';
+				$entry->context .= PO::unpoify($m[1]);
+			} elseif (preg_match('/^msgid\s+(".*")/', $line, $m)) {
+				if ($is_final($context)) {
+					PO::read_line($f, 'put-back');
+					$lineno--;
+					break;
+				}
+				if ($context && $context != 'msgctxt' && $context != 'comment') {
+					return false;
+				}
+				$context = 'msgid';
+				$entry->singular .= PO::unpoify($m[1]);
+			} elseif (preg_match('/^msgid_plural\s+(".*")/', $line, $m)) {
+				if ($context != 'msgid') {
+					return false;
+				}
+				$context = 'msgid_plural';
+				$entry->is_plural = true;
+				$entry->plural .= PO::unpoify($m[1]);
+			} elseif (preg_match('/^msgstr\s+(".*")/', $line, $m)) {
+				if ($context != 'msgid') {
+					return false;
+				}
+				$context = 'msgstr';
+				$entry->translations = array(PO::unpoify($m[1]));
+			} elseif (preg_match('/^msgstr\[(\d+)\]\s+(".*")/', $line, $m)) {
+				if ($context != 'msgid_plural' && $context != 'msgstr_plural') {
+					return false;
+				}
+				$context = 'msgstr_plural';
+				$msgstr_index = $m[1];
+				$entry->translations[$m[1]] = PO::unpoify($m[2]);
+			} elseif (preg_match('/^".*"$/', $line)) {
+				$unpoified = PO::unpoify($line);
+				switch ($context) {
+					case 'msgid':
+						$entry->singular .= $unpoified; break;
+					case 'msgctxt':
+						$entry->context .= $unpoified; break;
+					case 'msgid_plural':
+						$entry->plural .= $unpoified; break;
+					case 'msgstr':
+						$entry->translations[0] .= $unpoified; break;
+					case 'msgstr_plural':
+						$entry->translations[$msgstr_index] .= $unpoified; break;
+					default:
+						return false;
+				}
+			} else {
+				return false;
+			}
+		}
+		if (array() == array_filter($entry->translations, create_function('$t', 'return $t || "0" === $t;'))) {
+			$entry->translations = array();
+		}
+		return array('entry' => $entry, 'lineno' => $lineno);
+	}
+
+	function read_line($f, $action = 'read') {
+		static $last_line = '';
+		static $use_last_line = false;
+		if ('clear' == $action) {
+			$last_line = '';
+			return true;
+		}
+		if ('put-back' == $action) {
+			$use_last_line = true;
+			return true;
+		}
+		$line = $use_last_line? $last_line : fgets($f);
+		$line = gp_endswith( $line, "\r\n" )? rtrim( $line, "\r\n" ) . "\n" : $line;
+		$last_line = $line;
+		$use_last_line = false;
+		return $line;
+	}
+
+	function add_comment_to_entry(&$entry, $po_comment_line) {
+		$first_two = substr($po_comment_line, 0, 2);
+		$comment = trim(substr($po_comment_line, 2));
+		if ('#:' == $first_two) {
+			$entry->references = array_merge($entry->references, preg_split('/\s+/', $comment));
+		} elseif ('#.' == $first_two) {
+			$entry->extracted_comments = trim($entry->extracted_comments . "\n" . $comment);
+		} elseif ('#,' == $first_two) {
+			$entry->flags = array_merge($entry->flags, preg_split('/,\s*/', $comment));
+		} else {
+			$entry->translator_comments = trim($entry->translator_comments . "\n" . $comment);
+		}
+	}
+
+	function trim_quotes($s) {
+		if ( substr($s, 0, 1) == '"') $s = substr($s, 1);
+		if ( substr($s, -1, 1) == '"') $s = substr($s, 0, -1);
+		return $s;
+	}
+}
+endif;

--- a/i18n/makepot/pomo/streams.php
+++ b/i18n/makepot/pomo/streams.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Classes, which help reading streams of data from files.
+ * Based on the classes from Danilo Segan <danilo@kvota.net>
+ *
+ * @version $Id: streams.php 718 2012-10-31 00:32:02Z nbachiyski $
+ * @package pomo
+ * @subpackage streams
+ */
+
+if ( !class_exists( 'POMO_Reader' ) ):
+class POMO_Reader {
+
+	var $endian = 'little';
+	var $_post = '';
+
+	function POMO_Reader() {
+		$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr');
+		$this->_pos = 0;
+	}
+
+	/**
+	 * Sets the endianness of the file.
+	 *
+	 * @param $endian string 'big' or 'little'
+	 */
+	function setEndian($endian) {
+		$this->endian = $endian;
+	}
+
+	/**
+	 * Reads a 32bit Integer from the Stream
+	 *
+	 * @return mixed The integer, corresponding to the next 32 bits from
+	 * 	the stream of false if there are not enough bytes or on error
+	 */
+	function readint32() {
+		$bytes = $this->read(4);
+		if (4 != $this->strlen($bytes))
+			return false;
+		$endian_letter = ('big' == $this->endian)? 'N' : 'V';
+		$int = unpack($endian_letter, $bytes);
+		return array_shift($int);
+	}
+
+	/**
+	 * Reads an array of 32-bit Integers from the Stream
+	 *
+	 * @param integer count How many elements should be read
+	 * @return mixed Array of integers or false if there isn't
+	 * 	enough data or on error
+	 */
+	function readint32array($count) {
+		$bytes = $this->read(4 * $count);
+		if (4*$count != $this->strlen($bytes))
+			return false;
+		$endian_letter = ('big' == $this->endian)? 'N' : 'V';
+		return unpack($endian_letter.$count, $bytes);
+	}
+
+
+	function substr($string, $start, $length) {
+		if ($this->is_overloaded) {
+			return mb_substr($string, $start, $length, 'ascii');
+		} else {
+			return substr($string, $start, $length);
+		}
+	}
+
+	function strlen($string) {
+		if ($this->is_overloaded) {
+			return mb_strlen($string, 'ascii');
+		} else {
+			return strlen($string);
+		}
+	}
+
+	function str_split($string, $chunk_size) {
+		if (!function_exists('str_split')) {
+			$length = $this->strlen($string);
+			$out = array();
+			for ($i = 0; $i < $length; $i += $chunk_size)
+				$out[] = $this->substr($string, $i, $chunk_size);
+			return $out;
+		} else {
+			return str_split( $string, $chunk_size );
+		}
+	}
+
+
+	function pos() {
+		return $this->_pos;
+	}
+
+	function is_resource() {
+		return true;
+	}
+
+	function close() {
+		return true;
+	}
+}
+endif;
+
+if ( !class_exists( 'POMO_FileReader' ) ):
+class POMO_FileReader extends POMO_Reader {
+	function POMO_FileReader($filename) {
+		parent::POMO_Reader();
+		$this->_f = fopen($filename, 'rb');
+	}
+
+	function read($bytes) {
+		return fread($this->_f, $bytes);
+	}
+
+	function seekto($pos) {
+		if ( -1 == fseek($this->_f, $pos, SEEK_SET)) {
+			return false;
+		}
+		$this->_pos = $pos;
+		return true;
+	}
+
+	function is_resource() {
+		return is_resource($this->_f);
+	}
+
+	function feof() {
+		return feof($this->_f);
+	}
+
+	function close() {
+		return fclose($this->_f);
+	}
+
+	function read_all() {
+		$all = '';
+		while ( !$this->feof() )
+			$all .= $this->read(4096);
+		return $all;
+	}
+}
+endif;
+
+if ( !class_exists( 'POMO_StringReader' ) ):
+/**
+ * Provides file-like methods for manipulating a string instead
+ * of a physical file.
+ */
+class POMO_StringReader extends POMO_Reader {
+
+	var $_str = '';
+
+	function POMO_StringReader($str = '') {
+		parent::POMO_Reader();
+		$this->_str = $str;
+		$this->_pos = 0;
+	}
+
+
+	function read($bytes) {
+		$data = $this->substr($this->_str, $this->_pos, $bytes);
+		$this->_pos += $bytes;
+		if ($this->strlen($this->_str) < $this->_pos) $this->_pos = $this->strlen($this->_str);
+		return $data;
+	}
+
+	function seekto($pos) {
+		$this->_pos = $pos;
+		if ($this->strlen($this->_str) < $this->_pos) $this->_pos = $this->strlen($this->_str);
+		return $this->_pos;
+	}
+
+	function length() {
+		return $this->strlen($this->_str);
+	}
+
+	function read_all() {
+		return $this->substr($this->_str, $this->_pos, $this->strlen($this->_str));
+	}
+
+}
+endif;
+
+if ( !class_exists( 'POMO_CachedFileReader' ) ):
+/**
+ * Reads the contents of the file in the beginning.
+ */
+class POMO_CachedFileReader extends POMO_StringReader {
+	function POMO_CachedFileReader($filename) {
+		parent::POMO_StringReader();
+		$this->_str = file_get_contents($filename);
+		if (false === $this->_str)
+			return false;
+		$this->_pos = 0;
+	}
+}
+endif;
+
+if ( !class_exists( 'POMO_CachedIntFileReader' ) ):
+/**
+ * Reads the contents of the file in the beginning.
+ */
+class POMO_CachedIntFileReader extends POMO_CachedFileReader {
+	function POMO_CachedIntFileReader($filename) {
+		parent::POMO_CachedFileReader($filename);
+	}
+}
+endif;

--- a/i18n/makepot/pomo/translations.php
+++ b/i18n/makepot/pomo/translations.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Class for a set of entries for translation and their associated headers
+ *
+ * @version $Id: translations.php 718 2012-10-31 00:32:02Z nbachiyski $
+ * @package pomo
+ * @subpackage translations
+ */
+
+require_once dirname(__FILE__) . '/entry.php';
+
+if ( !class_exists( 'Translations' ) ):
+class Translations {
+	var $entries = array();
+	var $headers = array();
+
+	/**
+	 * Add entry to the PO structure
+	 *
+	 * @param object &$entry
+	 * @return bool true on success, false if the entry doesn't have a key
+	 */
+	function add_entry($entry) {
+		if (is_array($entry)) {
+			$entry = new Translation_Entry($entry);
+		}
+		$key = $entry->key();
+		if (false === $key) return false;
+		$this->entries[$key] = &$entry;
+		return true;
+	}
+
+	function add_entry_or_merge($entry) {
+		if (is_array($entry)) {
+			$entry = new Translation_Entry($entry);
+		}
+		$key = $entry->key();
+		if (false === $key) return false;
+		if (isset($this->entries[$key]))
+			$this->entries[$key]->merge_with($entry);
+		else
+			$this->entries[$key] = &$entry;
+		return true;
+	}
+
+	/**
+	 * Sets $header PO header to $value
+	 *
+	 * If the header already exists, it will be overwritten
+	 *
+	 * TODO: this should be out of this class, it is gettext specific
+	 *
+	 * @param string $header header name, without trailing :
+	 * @param string $value header value, without trailing \n
+	 */
+	function set_header($header, $value) {
+		$this->headers[$header] = $value;
+	}
+
+	function set_headers(&$headers) {
+		foreach($headers as $header => $value) {
+			$this->set_header($header, $value);
+		}
+	}
+
+	function get_header($header) {
+		return isset($this->headers[$header])? $this->headers[$header] : false;
+	}
+
+	function translate_entry(&$entry) {
+		$key = $entry->key();
+		return isset($this->entries[$key])? $this->entries[$key] : false;
+	}
+
+	function translate($singular, $context=null) {
+		$entry = new Translation_Entry(array('singular' => $singular, 'context' => $context));
+		$translated = $this->translate_entry($entry);
+		return ($translated && !empty($translated->translations))? $translated->translations[0] : $singular;
+	}
+
+	/**
+	 * Given the number of items, returns the 0-based index of the plural form to use
+	 *
+	 * Here, in the base Translations class, the commong logic for English is implmented:
+	 * 	0 if there is one element, 1 otherwise
+	 *
+	 * This function should be overrided by the sub-classes. For example MO/PO can derive the logic
+	 * from their headers.
+	 *
+	 * @param integer $count number of items
+	 */
+	function select_plural_form($count) {
+		return 1 == $count? 0 : 1;
+	}
+
+	function get_plural_forms_count() {
+		return 2;
+	}
+
+	function translate_plural($singular, $plural, $count, $context = null) {
+		$entry = new Translation_Entry(array('singular' => $singular, 'plural' => $plural, 'context' => $context));
+		$translated = $this->translate_entry($entry);
+		$index = $this->select_plural_form($count);
+		$total_plural_forms = $this->get_plural_forms_count();
+		if ($translated && 0 <= $index && $index < $total_plural_forms &&
+				is_array($translated->translations) &&
+				isset($translated->translations[$index]))
+			return $translated->translations[$index];
+		else
+			return 1 == $count? $singular : $plural;
+	}
+
+	/**
+	 * Merge $other in the current object.
+	 *
+	 * @param Object &$other Another Translation object, whose translations will be merged in this one
+	 * @return void
+	 **/
+	function merge_with(&$other) {
+		foreach( $other->entries as $entry ) {
+			$this->entries[$entry->key()] = $entry;
+		}
+	}
+
+	function merge_originals_with(&$other) {
+		foreach( $other->entries as $entry ) {
+			if ( !isset( $this->entries[$entry->key()] ) )
+				$this->entries[$entry->key()] = $entry;
+			else
+				$this->entries[$entry->key()]->merge_with($entry);
+		}
+	}
+}
+
+class Gettext_Translations extends Translations {
+	/**
+	 * The gettext implmentation of select_plural_form.
+	 *
+	 * It lives in this class, because there are more than one descendand, which will use it and
+	 * they can't share it effectively.
+	 *
+	 */
+	function gettext_select_plural_form($count) {
+		if (!isset($this->_gettext_select_plural_form) || is_null($this->_gettext_select_plural_form)) {
+			list( $nplurals, $expression ) = $this->nplurals_and_expression_from_header($this->get_header('Plural-Forms'));
+			$this->_nplurals = $nplurals;
+			$this->_gettext_select_plural_form = $this->make_plural_form_function($nplurals, $expression);
+		}
+		return call_user_func($this->_gettext_select_plural_form, $count);
+	}
+
+	function nplurals_and_expression_from_header($header) {
+		if (preg_match('/^\s*nplurals\s*=\s*(\d+)\s*;\s+plural\s*=\s*(.+)$/', $header, $matches)) {
+			$nplurals = (int)$matches[1];
+			$expression = trim($this->parenthesize_plural_exression($matches[2]));
+			return array($nplurals, $expression);
+		} else {
+			return array(2, 'n != 1');
+		}
+	}
+
+	/**
+	 * Makes a function, which will return the right translation index, according to the
+	 * plural forms header
+	 */
+	function make_plural_form_function($nplurals, $expression) {
+		$expression = str_replace('n', '$n', $expression);
+		$func_body = "
+			\$index = (int)($expression);
+			return (\$index < $nplurals)? \$index : $nplurals - 1;";
+		return create_function('$n', $func_body);
+	}
+
+	/**
+	 * Adds parantheses to the inner parts of ternary operators in
+	 * plural expressions, because PHP evaluates ternary oerators from left to right
+	 *
+	 * @param string $expression the expression without parentheses
+	 * @return string the expression with parentheses added
+	 */
+	function parenthesize_plural_exression($expression) {
+		$expression .= ';';
+		$res = '';
+		$depth = 0;
+		for ($i = 0; $i < strlen($expression); ++$i) {
+			$char = $expression[$i];
+			switch ($char) {
+				case '?':
+					$res .= ' ? (';
+					$depth++;
+					break;
+				case ':':
+					$res .= ') : (';
+					break;
+				case ';':
+					$res .= str_repeat(')', $depth) . ';';
+					$depth= 0;
+					break;
+				default:
+					$res .= $char;
+			}
+		}
+		return rtrim($res, ';');
+	}
+
+	function make_headers($translation) {
+		$headers = array();
+		// sometimes \ns are used instead of real new lines
+		$translation = str_replace('\n', "\n", $translation);
+		$lines = explode("\n", $translation);
+		foreach($lines as $line) {
+			$parts = explode(':', $line, 2);
+			if (!isset($parts[1])) continue;
+			$headers[trim($parts[0])] = trim($parts[1]);
+		}
+		return $headers;
+	}
+
+	function set_header($header, $value) {
+		parent::set_header($header, $value);
+		if ('Plural-Forms' == $header) {
+			list( $nplurals, $expression ) = $this->nplurals_and_expression_from_header($this->get_header('Plural-Forms'));
+			$this->_nplurals = $nplurals;
+			$this->_gettext_select_plural_form = $this->make_plural_form_function($nplurals, $expression);
+		}
+	}
+}
+endif;
+
+if ( !class_exists( 'NOOP_Translations' ) ):
+/**
+ * Provides the same interface as Translations, but doesn't do anything
+ */
+class NOOP_Translations {
+	var $entries = array();
+	var $headers = array();
+
+	function add_entry($entry) {
+		return true;
+	}
+
+	function set_header($header, $value) {
+	}
+
+	function set_headers(&$headers) {
+	}
+
+	function get_header($header) {
+		return false;
+	}
+
+	function translate_entry(&$entry) {
+		return false;
+	}
+
+	function translate($singular, $context=null) {
+		return $singular;
+	}
+
+	function select_plural_form($count) {
+		return 1 == $count? 0 : 1;
+	}
+
+	function get_plural_forms_count() {
+		return 2;
+	}
+
+	function translate_plural($singular, $plural, $count, $context = null) {
+			return 1 == $count? $singular : $plural;
+	}
+
+	function merge_with(&$other) {
+	}
+}
+endif;

--- a/i18n/makepot/pot-ext-meta.php
+++ b/i18n/makepot/pot-ext-meta.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Console application, which adds metadata strings from
+ * a WordPress extension to a POT file
+ *
+ * @version $Id: pot-ext-meta.php 19937 2012-05-21 21:40:14Z nacin $
+ * @package wordpress-i18n
+ * @subpackage tools
+ */
+
+require_once dirname( __FILE__ ) . '/pomo/po.php';
+require_once dirname( __FILE__ ) . '/makepot.php';
+
+class PotExtMeta {
+
+	var $headers = array(
+		'Plugin Name',
+		'Theme Name',
+		'Plugin URI',
+		'Theme URI',
+		'Description',
+		'Author',
+		'Author URI',
+		'Tags',
+	);
+
+
+	function usage() {
+		fwrite(STDERR, "Usage: php pot-ext-meta.php EXT POT\n");
+		fwrite(STDERR, "Adds metadata from a WordPress theme or plugin file EXT to POT file\n");
+		exit(1);
+	}
+
+	function load_from_file($ext_filename) {
+		$source = MakePOT::get_first_lines($ext_filename);
+		$pot = '';
+		foreach($this->headers as $header) {
+			$string = MakePOT::get_addon_header($header, $source);
+			if (!$string) continue;
+			$args = array(
+				'singular' => $string,
+				'extracted_comments' => $header.' of the plugin/theme',
+			);
+			$entry = new Translation_Entry($args);
+			$pot .= "\n".PO::export_entry($entry)."\n";
+		}
+		return $pot;
+	}
+
+	function append( $ext_filename, $pot_filename, $headers = null ) {
+		if ( $headers )
+			$this->headers = (array) $headers;
+		if ( is_dir( $ext_filename ) ) {
+			$pot = implode('', array_map(array(&$this, 'load_from_file'), glob("$ext_filename/*.php")));
+		} else {
+			$pot = $this->load_from_file($ext_filename);
+		}
+		$potf = '-' == $pot_filename? STDOUT : fopen($pot_filename, 'a');
+		if (!$potf) return false;
+		fwrite($potf, $pot);
+		if ('-' != $pot_filename) fclose($potf);
+		return true;
+	}
+}
+
+$included_files = get_included_files();
+if ($included_files[0] == __FILE__) {
+	ini_set('display_errors', 1);
+	$potextmeta = new PotExtMeta;
+	if (!isset($argv[1])) {
+		$potextmeta->usage();
+	}
+	$potextmeta->append( $argv[1], isset( $argv[2] ) ? $argv[2] : '-', isset( $argv[3] ) ? $argv[3] : null );
+}
+
+?>


### PR DESCRIPTION
You only need to look at two files really:
- `makepot/makepot.php` for the custom `WC_Makepot` class.
- `makepot/index.php` for the web interface, just browse to `wp-content/plugins/woocommerce/i18n/makepot/` to use it after unlocking it.

The other files contain required classes and are copied over without modification from the [WordPress i18n tools](http://i18n.trac.wordpress.org/browser/tools/trunk).

Related: #2051

Cc: @Ramoonus
