### PR TITLE
	 Hooks for consistency between variation-admin-html.php and writepanel-product-type-variable.php

### DIFF
--- a/admin/post-types/writepanels/writepanel-product-type-variable.php
+++ b/admin/post-types/writepanels/writepanel-product-type-variable.php
@@ -212,11 +212,11 @@ function variable_product_type_options() {
 						if ( $attribute['is_taxonomy'] ) {
 							$post_terms = wp_get_post_terms( $post->ID, $attribute['name'] );
 							foreach ( $post_terms as $term )
-								echo '<option ' . selected( $variation_selected_value, $term->slug, false ) . ' value="' . esc_attr( $term->slug ) . '">' . esc_html( $term->name ) . '</option>';
+								echo '<option ' . selected( $variation_selected_value, $term->slug, false ) . ' value="' . esc_attr( $term->slug ) . '">' . apply_filters( 'woocommerce_variation_option_name', esc_html( $term->name ) ) . '</option>';
 						} else {
 							$options = explode( '|', $attribute['value'] );
 							foreach ( $options as $option )
-								echo '<option ' . selected( $variation_selected_value, $option, false ) . ' value="' . esc_attr( $option ) . '">' . ucfirst( esc_html( $option ) ) . '</option>';
+								echo '<option ' . selected( $variation_selected_value, $option, false ) . ' value="' . esc_attr( $option ) . '">' . ucfirst( apply_filters( 'woocommerce_variation_option_name', esc_html( $option ) ) ) . '</option>';
 						}
 
 						echo '</select>';


### PR DESCRIPTION
variation-admin-html.php already allows filtering the variation dropdown descriptions in metaboxes. No such hook exists in writepanel-product-type-variable.php to take care of the variation descriptions in the Default Selections dropdown.
