### PR TITLE
Fix spelling errors in action/hook names

### DIFF
--- a/admin/woocommerce-admin-functions.php
+++ b/admin/woocommerce-admin-functions.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * @access public
  * @return void
  */
-function woocomerce_check_download_folder_protection() {
+function woocommerce_check_download_folder_protection() {
 	$upload_dir 		= wp_upload_dir();
 	$downloads_url 		= $upload_dir['basedir'] . '/woocommerce_uploads';
 	$download_method	= get_option('woocommerce_file_download_method');

--- a/admin/woocommerce-admin-hooks.php
+++ b/admin/woocommerce-admin-hooks.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * @see woocommerce_untrash_post()
  * @see woocommerce_preview_emails()
  * @see woocommerce_prevent_admin_access()
- * @see woocomerce_check_download_folder_protection()
+ * @see woocommerce_check_download_folder_protection()
  * @see woocommerce_ms_protect_download_rewite_rules()
  */
 add_action('delete_post', 'woocommerce_delete_post');
@@ -28,7 +28,7 @@ add_action('wp_trash_post', 'woocommerce_trash_post');
 add_action('untrash_post', 'woocommerce_untrash_post');
 add_action('admin_init', 'woocommerce_preview_emails');
 add_action('admin_init', 'woocommerce_prevent_admin_access');
-add_action('woocommerce_settings_saved', 'woocomerce_check_download_folder_protection');
+add_action('woocommerce_settings_saved', 'woocommerce_check_download_folder_protection');
 add_filter('mod_rewrite_rules', 'woocommerce_ms_protect_download_rewite_rules');
 
 /**

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1611,7 +1611,7 @@ class WC_Cart {
 				}
 			}
 
-			return apply_filters( 'woocomerce_cart_needs_shipping', $needs_shipping );
+			return apply_filters( 'woocommerce_cart_needs_shipping', $needs_shipping );
 		}
 
 		/**
@@ -1633,7 +1633,7 @@ class WC_Cart {
 
 			$show_shipping = true;
 
-			return apply_filters( 'woocomerce_cart_ready_to_calc_shipping', $show_shipping );
+			return apply_filters( 'woocommerce_cart_ready_to_calc_shipping', $show_shipping );
 
 		}
 

--- a/classes/widgets/class-wc-widget-login.php
+++ b/classes/widgets/class-wc-widget-login.php
@@ -65,7 +65,7 @@ class WC_Widget_Login extends WP_Widget {
 
 			$user = get_user_by('id', get_current_user_id());
 
-			$logged_in_title = apply_filters( 'woocomerce_login_widget_logged_in_title', sprintf( $logged_in_title, ucwords( $user->display_name ) ) );
+			$logged_in_title = apply_filters( 'woocommerce_login_widget_logged_in_title', sprintf( $logged_in_title, ucwords( $user->display_name ) ) );
 
 			if ( $logged_in_title )
 				echo $before_title . $logged_in_title . $after_title;
@@ -94,7 +94,7 @@ class WC_Widget_Login extends WP_Widget {
 
 		} else {
 
-			$logged_out_title = apply_filters( 'woocomerce_login_widget_logged_out_title', $logged_out_title );
+			$logged_out_title = apply_filters( 'woocommerce_login_widget_logged_out_title', $logged_out_title );
 
 			if ( $logged_out_title )
 				echo $before_title . $logged_out_title . $after_title;


### PR DESCRIPTION
woocommerce is spelled incorrectly.

Note some of these are action/hook names so compatibility issues if anyone is using them, but
they really should update their code.

Some are new to 2.0beta, but some are in 1.x.
