### PR TITLE
Add 'woocommerce_sort_countries' filter

### DIFF
--- a/classes/class-wc-countries.php
+++ b/classes/class-wc-countries.php
@@ -357,8 +357,9 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_allowed_countries() {
-
-		asort( $this->countries );
+		
+		if ( apply_filters('woocommerce_sort_countries', true ) )
+			asort( $this->countries );
 
 		if ( get_option('woocommerce_allowed_countries') !== 'specific' )
 			return $this->countries;
@@ -498,7 +499,8 @@ class WC_Countries {
 	 */
 	public function country_dropdown_options( $selected_country = '', $selected_state = '', $escape = false ) {
 
-		asort($this->countries);
+		if ( apply_filters('woocommerce_sort_countries', true ) )
+			asort( $this->countries );
 
 		if ( $this->countries ) foreach ( $this->countries as $key=>$value) :
 			if ( $states =  $this->get_states($key) ) :


### PR DESCRIPTION
Make checkout countries sorting optional.

Use case:

I have used existing woocommerce_countries filter to redefine the country list placing the most used countries first. However, woocommerce insists on sorting the countries.

So with this filter I can optionally fix this by simply adding:

``` php
                add_filter( 'woocommerce_sort_countries', '__return_false' );
```
