### PR TITLE
On product search include post_excerpt

### DIFF
--- a/classes/class-wc-query.php
+++ b/classes/class-wc-query.php
@@ -99,7 +99,8 @@ class WC_Query {
 		$this->product_query( $q );
 		
 		if ( is_search() ) {
-		    add_filter('posts_where', array( $this, 'search_post_excerpt') );
+		    add_filter( 'posts_where', array( $this, 'search_post_excerpt' ) );
+		    add_filter( 'wp', array( $this, 'remove_posts_where' ) );
 		}
 
 		// We're on a shop page so queue the woocommerce_get_products_in_view function
@@ -265,6 +266,16 @@ class WC_Query {
 		remove_filter( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
 	}
 
+	/**
+	 * Remove the posts_where filter
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function remove_posts_where() {		
+		remove_filter( 'posts_where', array( $this, 'search_post_excerpt' ) );
+	}
+	
 
 	/**
 	 * Get an unpaginated list all product ID's (both filtered and unfiltered). Makes use of transients.

--- a/classes/class-wc-query.php
+++ b/classes/class-wc-query.php
@@ -13,19 +13,19 @@ class WC_Query {
 	public $unfiltered_product_ids 	= array();
 
 	/** @public array Filtered product ids (after layered nav) */
-	public $filtered_product_ids 		= array();
+	public $filtered_product_ids 	= array();
 
 	/** @public array Product IDs that match the layered nav + price filter */
-	public $post__in 					= array();
+	public $post__in 		= array();
 
 	/** @public array The meta query for the page */
-	public $meta_query 				= '';
+	public $meta_query 		= '';
 
 	/** @public array Post IDs matching layered nav only */
-	public $layered_nav_post__in 		= array();
+	public $layered_nav_post__in 	= array();
 
 	/** @public array Stores post IDs matching layered nav, so price filter can find max price in view */
-	public $layered_nav_product_ids 	= array();
+	public $layered_nav_product_ids = array();
 
 	/**
 	 * Constructor for the query class. Hooks in methods.
@@ -78,15 +78,15 @@ class WC_Query {
 			$wp_post_types['product']->post_name 	= $shop_page->post_name;
 
 			// Fix conditional Functions like is_front_page
-	        $q->is_singular = false;
-	        $q->is_post_type_archive = true;
-	        $q->is_archive = true;
+			$q->is_singular = false;
+			$q->is_post_type_archive = true;
+			$q->is_archive = true;
 
-	        // Fix WP SEO
-	        if ( function_exists( 'wpseo_get_value' ) ) {
-	       		add_filter( 'wpseo_metadesc', array( $this, 'wpseo_metadesc' ) );
-	       		add_filter( 'wpseo_metakey', array( $this, 'wpseo_metakey' ) );
-	       	}
+			// Fix WP SEO
+			if ( function_exists( 'wpseo_get_value' ) ) {
+				add_filter( 'wpseo_metadesc', array( $this, 'wpseo_metadesc' ) );
+				add_filter( 'wpseo_metakey', array( $this, 'wpseo_metakey' ) );
+			}
 
 		} else {
 
@@ -96,13 +96,13 @@ class WC_Query {
 
 		}
 
-	    $this->product_query( $q );
+		$this->product_query( $q );
 
-	    // We're on a shop page so queue the woocommerce_get_products_in_view function
-	    add_action( 'wp', array( $this, 'get_products_in_view' ), 2);
+		// We're on a shop page so queue the woocommerce_get_products_in_view function
+		add_action( 'wp', array( $this, 'get_products_in_view' ), 2);
 
-	    // And remove the pre_get_posts hook
-	    $this->remove_product_query();
+		// And remove the pre_get_posts hook
+		$this->remove_product_query();
 	}
 
 
@@ -160,30 +160,30 @@ class WC_Query {
 		if 	( ! $query->is_post_type_archive( 'product' ) && ! $query->is_tax( get_object_taxonomies( 'product' ) ) )
 	   		return $posts;
 
-	    $filtered_posts = array();
-	    $queried_post_ids = array();
+		$filtered_posts = array();
+		$queried_post_ids = array();
 
-	    foreach ( $posts as $post ) {
-	    	if ( in_array( $post->ID, $this->post__in ) ) {
-	    		$filtered_posts[] = $post;
-	    		$queried_post_ids[] = $post->ID;
-	    	}
-	    }
-
-	    $query->posts = $filtered_posts;
-		$query->post_count = count( $filtered_posts );
-
-		// Ensure filters are set
-		$this->unfiltered_product_ids = $queried_post_ids;
-		$this->filtered_product_ids = $queried_post_ids;
-
-		if ( sizeof( $this->layered_nav_post__in ) > 0 ) {
-			$this->layered_nav_product_ids = array_intersect( $this->unfiltered_product_ids, $this->layered_nav_post__in );
-		} else {
-			$this->layered_nav_product_ids = $this->unfiltered_product_ids;
+		foreach ( $posts as $post ) {
+		    if ( in_array( $post->ID, $this->post__in ) ) {
+			    $filtered_posts[] = $post;
+			    $queried_post_ids[] = $post->ID;
+		    }
 		}
 
-	    return $filtered_posts;
+		$query->posts = $filtered_posts;
+		    $query->post_count = count( $filtered_posts );
+
+		    // Ensure filters are set
+		    $this->unfiltered_product_ids = $queried_post_ids;
+		    $this->filtered_product_ids = $queried_post_ids;
+
+		    if ( sizeof( $this->layered_nav_post__in ) > 0 ) {
+			    $this->layered_nav_product_ids = array_intersect( $this->unfiltered_product_ids, $this->layered_nav_post__in );
+		    } else {
+			    $this->layered_nav_product_ids = $this->unfiltered_product_ids;
+		    }
+
+		return $filtered_posts;
 	}
 
 
@@ -198,8 +198,8 @@ class WC_Query {
 
 		// Meta query
 		$meta_query = (array) $q->get( 'meta_query' );
-	    $meta_query[] = $this->visibility_meta_query();
-	    $meta_query[] = $this->stock_status_meta_query();
+		$meta_query[] = $this->visibility_meta_query();
+		$meta_query[] = $this->stock_status_meta_query();
 
 		// Ordering
 		$ordering = $this->get_catalog_ordering_args();
@@ -217,17 +217,17 @@ class WC_Query {
 		if ( ! $q->is_tax( 'product_cat' ) && ! $q->is_tax( 'product_tag' ) )
 			$q->set( 'post_type', 'product' );
 		$q->set( 'meta_query', $meta_query );
-	    $q->set( 'post__in', $post__in );
-	    $q->set( 'posts_per_page', $q->get( 'posts_per_page' ) ? $q->get( 'posts_per_page' ) : apply_filters( 'loop_shop_per_page', get_option( 'posts_per_page' ) ) );
+		$q->set( 'post__in', $post__in );
+		$q->set( 'posts_per_page', $q->get( 'posts_per_page' ) ? $q->get( 'posts_per_page' ) : apply_filters( 'loop_shop_per_page', get_option( 'posts_per_page' ) ) );
 
-	    // Set a special variable
-	    $q->set( 'wc_query', true );
+		// Set a special variable
+		$q->set( 'wc_query', true );
 
-	    // Store variables
-	    $this->post__in = $post__in;
-	    $this->meta_query = $meta_query;
+		// Store variables
+		$this->post__in = $post__in;
+		$this->meta_query = $meta_query;
 
-	    do_action( 'woocommerce_product_query', $q, $this );
+		do_action( 'woocommerce_product_query', $q, $this );
 	}
 
 
@@ -265,7 +265,7 @@ class WC_Query {
 
 		if ( false === ( $unfiltered_product_ids = get_transient( $transient_name ) ) ) {
 
-			// Get all visible posts, regardless of filters
+		    // Get all visible posts, regardless of filters
 		    $unfiltered_product_ids = get_posts(
 				array_merge(
 					$current_wp_query,
@@ -359,13 +359,13 @@ class WC_Query {
 	public function visibility_meta_query( $compare = 'IN' ) {
 		if ( is_search() ) $in = array( 'visible', 'search' ); else $in = array( 'visible', 'catalog' );
 
-	    $meta_query = array(
-	        'key' => '_visibility',
-	        'value' => $in,
-	        'compare' => $compare
-	    );
+		$meta_query = array(
+		    'key' => '_visibility',
+		    'value' => $in,
+		    'compare' => $compare
+		);
 
-	    return $meta_query;
+		return $meta_query;
 	}
 
 

--- a/classes/class-wc-query.php
+++ b/classes/class-wc-query.php
@@ -97,14 +97,38 @@ class WC_Query {
 		}
 
 		$this->product_query( $q );
+		
+		if ( is_search() ) {
+		    add_filter('posts_where', array( $this, 'search_post_excerpt') );
+		}
 
 		// We're on a shop page so queue the woocommerce_get_products_in_view function
 		add_action( 'wp', array( $this, 'get_products_in_view' ), 2);
-
+	
 		// And remove the pre_get_posts hook
 		$this->remove_product_query();
 	}
 
+	/**
+	 * search_post_excerpt function. 
+	 *
+	 * @access public
+	 * @param string $where (default: '')
+	 * @return string (modified where clause)
+	 */
+	public function search_post_excerpt( $where = '' ) {
+		global $wp_the_query;
+	    
+		// If this is not a WC Query, do not modify the query
+		if ( empty( $wp_the_query->query_vars['wc_query'] ) )
+		    return $where;
+
+		$where = preg_replace(
+		    "/post_title\s+LIKE\s*(\'[^\']+\')/",
+		    "post_title LIKE $1) OR (post_excerpt LIKE $1", $where );		
+	    
+		return $where;
+	}
 
 	/**
 	 * wpseo_metadesc function.


### PR DESCRIPTION
When adding a product,  WC made the design decision to map the 'Product Short Description' to the post_excerpt field. However WC fails to include the post_excerpt field in any search results. (Wordpress does not make this easy)

This patch modifies the search query (only during is_search() and during a WC shop loop) to include post_excerpt in the query.

This allows the WC Product Search widget to actually returns results based on text entered in the Product Short Description.
