### PR TITLE
Use post_class() in product loop

### DIFF
--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -29,7 +29,11 @@ if ( ! $product->is_visible() )
 $woocommerce_loop['loop']++;
 
 // Extra post classes
-$classes = array( 'product' );
+$classes = array();
+if ( $product->is_featured() )
+	$classes[] = 'featured';
+if ( $product->is_on_sale() )
+	$classes[] = 'onsale';
 if ( 0 == ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] || 1 == $woocommerce_loop['columns'] )
 	$classes[] = 'first';
 if ( 0 == $woocommerce_loop['loop'] % $woocommerce_loop['columns'] )

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -27,13 +27,15 @@ if ( ! $product->is_visible() )
 
 // Increase loop count
 $woocommerce_loop['loop']++;
+
+// Extra post classes
+$classes = array( 'product' );
+if ( 0 == ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] || 1 == $woocommerce_loop['columns'] )
+	$classes[] = 'first';
+if ( 0 == $woocommerce_loop['loop'] % $woocommerce_loop['columns'] )
+	$classes[] = 'last';
 ?>
-<li class="product<?php
-    if ( ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] == 0 || $woocommerce_loop['columns'] == 1)
-        echo ' first';
-	if ( $woocommerce_loop['loop'] % $woocommerce_loop['columns'] == 0 )
-		echo ' last';
-	?>">
+<li <?php post_class( $classes ); ?>>
 
 	<?php do_action( 'woocommerce_before_shop_loop_item' ); ?>
 

--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -11,6 +11,14 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
+global $product;
+
+// Extra post classes
+$classes = array();
+if ( $product->is_featured() )
+	$classes[] = 'featured';
+if ( $product->is_on_sale() )
+	$classes[] = 'onsale';
 ?>
 
 <?php
@@ -22,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 	 do_action( 'woocommerce_before_single_product' );
 ?>
 
-<div itemscope itemtype="http://schema.org/Product" id="product-<?php the_ID(); ?>" <?php post_class(); ?>>
+<div itemscope itemtype="http://schema.org/Product" id="product-<?php the_ID(); ?>" <?php post_class( $classes ); ?>>
 
 	<?php
 		/**


### PR DESCRIPTION
Use [`post_class()`](http://codex.wordpress.org/Function_Reference/post_class) in the Loop too instead of only on single product pages.

Update: I also added two extra classes for products that are featured or on sale. This helps styling a lot. Say you want to give products on sale a different background color, the `<span class="onsale">` alone in the "sale-flash.php" template is not going to help much since it is contained within the product `div` or `li`.
