### PR TITLE
Fixed fatal error in paypal gateway

### DIFF
--- a/classes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/classes/gateways/paypal/class-wc-gateway-paypal.php
@@ -539,7 +539,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
         if ( 'yes' == $this->debug ) {
         	$this->log->add( 'paypal', 'Received invalid response from PayPal' );
         	if ( is_wp_error( $response ) )
-        		$this->log->add( 'paypal', 'Error response: ' . $result->get_error_message() );
+        		$this->log->add( 'paypal', 'Error response: ' . $response->get_error_message() );
         }
 
         return false;


### PR DESCRIPTION
This line (542) should use `$response` instead of the not existing `$result`.

The fatal error only occurs when debugging is enabled and the communication with Paypal API failed for some reason. But in this case, it results in a fatal php error: Call to a member function get_error_message() on a non-object

btw: the actual http error message that it should have written to the log in my case was "Unknown SSL protocol error in connection to www.paypal.com:443" - can't tell why this happened. probably just a network hickup since the next request went though... so it's a rather rare case, but still a fatal php error.
