### PR TITLE
WC 2.0 beta: Corrected bug if a product variation does not exist anymore

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -135,7 +135,7 @@ class WC_Cart {
 
 					$_product = get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
 
-					if ( $_product->exists() && $values['quantity'] > 0 ) {
+					if ( !empty( $_product ) && $_product->exists() && $values['quantity'] > 0 ) {
 
 						// Put session data into array. Run through filter so other plugins can load their own session data
 						$this->cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', array(


### PR DESCRIPTION
I corrected a bug that appears at least in this case:
- if you have a variable product with a few variantions
- add one of the variations to the shopping cart
- then remove this variation of the product

Consequence:
- all pages where a shopping cart appears and some others in wp-admin return the following error:

```
Fatal error: Call to a member function exists() on a non-object in /domains/xxx/public_html/wp-content/plugins/woocommerce/classes/class-wc-cart.php on line 138
```
