### PR TITLE
Small optimization for showing the sorting selection

### DIFF
--- a/templates/loop/sorting.php
+++ b/templates/loop/sorting.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 global $woocommerce, $wp_query;
 
-if ( ! woocommerce_products_will_display() ||  1 == $wp_query->found_posts )
+if ( 1 == $wp_query->found_posts || ! woocommerce_products_will_display() )
 	return;
 ?>
 <form class="woocommerce-ordering" method="get">


### PR DESCRIPTION
The found posts check clearly is much cheaper than the other function call. By switching the `if` conditions, if only a single product was found the `woocommerce_products_will_display()` function will not even be called.
