### PR TITLE
Empty $integrations array prevents defining $links

### DIFF
--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -395,7 +395,9 @@ if ( ! function_exists( 'woocommerce_settings' ) ) {
 							$integrations = $woocommerce->integrations->get_integrations();
 
 							$current_section = empty( $current_section ) ? key( $integrations ) : $current_section;
-
+							
+							$links = array();
+							
 							foreach ( $integrations as $integration ) {
 								$title = empty( $integration->method_title ) ? ucwords( $integration->id ) : ucwords( $integration->method_title );
 


### PR DESCRIPTION
Empty $integrations array prevents defining $links which causes a notice for undefined var and warning in `implode()`
