### PR TITLE
Show selected attributes based on id and not slug in product edit pages.

### DIFF
--- a/admin/post-types/writepanels/writepanel-product_data.php
+++ b/admin/post-types/writepanels/writepanel-product_data.php
@@ -384,7 +384,7 @@ function woocommerce_product_data_box() {
 							        					$all_terms = get_terms( $attribute_taxonomy_name, 'orderby=name&hide_empty=0' );
 						        						if ( $all_terms ) {
 							        						foreach ( $all_terms as $term ) {
-							        							$has_term = has_term( $term->slug, $attribute_taxonomy_name, $thepostid ) ? 1 : 0;
+							        							$has_term = has_term( $term->term_id, $attribute_taxonomy_name, $thepostid ) ? 1 : 0;
 							        							echo '<option value="' . $term->slug . '" ' . selected( $has_term, 1, false ) . '>' . $term->name . '</option>';
 															}
 														}


### PR DESCRIPTION
has_term when sent a string matches on term id, term slug and term name, when you have a size attribute with a term called X-Large and id of 20, and also a term called 20, then you search on slug it selects both X-Large and 20.

Changed to search on using the term_id, as when only integers are passed to has_term it will only search on the id field.
