### PR TITLE
Don't convert zero values to empty string in woocommerce_process_shop_order_meta()

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -881,11 +881,11 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 	$meta_keys 		= isset( $_POST['meta_key'] ) ? $_POST['meta_key'] : array();
 	$meta_values 	= isset( $_POST['meta_value'] ) ? $_POST['meta_value'] : array();
 
-	foreach ( $meta_keys as $id => $value ) {
+	foreach ( $meta_keys as $id => $meta_key ) {
 		$wpdb->update(
 			$wpdb->prefix . "woocommerce_order_itemmeta",
 			array(
-				'meta_key' => $value,
+				'meta_key' => $meta_key,
 				'meta_value' => empty( $meta_values[ $id ] ) ? '' : $meta_values[ $id ]
 			),
 			array( 'meta_id' => $id ),

--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -882,11 +882,12 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 	$meta_values 	= isset( $_POST['meta_value'] ) ? $_POST['meta_value'] : array();
 
 	foreach ( $meta_keys as $id => $meta_key ) {
+		$meta_value = ( empty( $meta_values[ $id ] ) && ! is_numeric( $meta_values[ $id ] ) ) ? '' : $meta_values[ $id ];
 		$wpdb->update(
 			$wpdb->prefix . "woocommerce_order_itemmeta",
 			array(
 				'meta_key' => $meta_key,
-				'meta_value' => empty( $meta_values[ $id ] ) ? '' : $meta_values[ $id ]
+				'meta_value' => $meta_value
 			),
 			array( 'meta_id' => $id ),
 			array( '%s', '%s' ),


### PR DESCRIPTION
PHP's `empty()` function returns true for 0, 0.00, "0.00" and other 0 variants. 

As a result, `woocommerce_process_shop_order_meta()` will convert item meta with a `0.00` or similar value to an empty string, which can break things that expect a float or number. 

These commits fix that.
