### PR TITLE
Issue 1950

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -13,7 +13,7 @@ global $woocommerce;
 
 $woocommerce->show_messages();
 
-do_action( 'woocommerce_before_checkout_form' );
+do_action( 'woocommerce_before_checkout_form', $checkout );
 
 // If checkout registration is disabled and not logged in, the user cannot checkout
 if ( ! $checkout->enable_signup && ! $checkout->enable_guest_checkout && ! is_user_logged_in() ) {
@@ -56,4 +56,4 @@ $get_checkout_url = apply_filters( 'woocommerce_get_checkout_url', $woocommerce-
 
 </form>
 
-<?php do_action( 'woocommerce_after_checkout_form' ); ?>
+<?php do_action( 'woocommerce_after_checkout_form', $checkout ); ?>


### PR DESCRIPTION
Your changes to Issue 1950 were not really complete. To be consistent with the
other changes you made, $checkout should also be passed to
woocommerce_before_checkout_form and woocommerce_after_checkout_form. That was actually 1/2 the point of the issue. I did not remove the $checkout that you are passing to
woocommerce_before_checkout_billing_form or woocommerce_after_checkout_billing_form, however, they are not needed or useful for Issue 1950. If you wish, I could remove them.

See 
https://github.com/woothemes/woocommerce/issues/1950#issuecomment-12049990
