### PR TITLE
Populate $current_user when users create an account during checkout

### DIFF
--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -359,7 +359,7 @@ class WC_Checkout {
 	 * @return void
 	 */
 	public function process_checkout() {
-		global $wpdb, $woocommerce;
+		global $wpdb, $woocommerce, $current_user;
 
 		$woocommerce->verify_nonce( 'process_checkout' );
 
@@ -622,6 +622,9 @@ class WC_Checkout {
 
 		                if ( ! $this->customer_id )
 		                	throw new MyException( '<strong>' . __( 'ERROR', 'woocommerce' ) . '</strong>: ' . __( 'Couldn&#8217;t register you&hellip; please contact us if you continue to have problems.', 'woocommerce' ) );
+
+                        // Set the global user object
+                        $current_user = get_user_by ( 'id', $this->customer_id );
 
 	                    // Action
 	                    do_action( 'woocommerce_created_customer', $this->customer_id );


### PR DESCRIPTION
Currently - if a user chooses to have an account created for them during checkout, WC sets up their auth cookie so that they are logged in, but doesn't set up the global $current_user object. The result is that any code that runs in the same page request, and uses standard WP functions such as wp_get_current_user() fails to recognise them as a registered user. 

A possibly similar fix is needed to process_registration in woocommerce-functions.php. We probably could have got away without it - since the code did a redirect virtually straight after, but now it seems there's an hook called it seems sensible to set up the $current_user object there as well?

I can prepare a revised pull request if required?
