### PR TITLE
Fix woocommerce_add_order_item() return value & improve 'woocommerce_new_order_item' params.

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -1928,7 +1928,7 @@ function woocommerce_add_order_item( $order_id, $item ) {
 
 	$item_id = absint( $wpdb->insert_id );
 
-	do_action( 'woocommerce_new_order_item', $item_id );
+	do_action( 'woocommerce_new_order_item', $item_id, $item, $order_id );
 
 	return $item_id;
 }

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -1926,9 +1926,11 @@ function woocommerce_add_order_item( $order_id, $item ) {
 		)
 	);
 
-	do_action( 'woocommerce_new_order_item', absint( $wpdb->insert_id ) );
+	$item_id = absint( $wpdb->insert_id );
 
-	return absint( $wpdb->insert_id );
+	do_action( 'woocommerce_new_order_item', $item_id );
+
+	return $item_id;
 }
 
 /**


### PR DESCRIPTION
If a plugin hooks to `'woocommerce_new_order_item'` and run some sort of `$wpdb` insert query or calls a function which runs an insert query, like `woocommerce_add_order_item_meta()`, then the item ID returned by `woocommerce_add_order_item()` will actually be the ID of a different DB entry (because `woocommerce_add_order_item()` returns `$wpdb->insert_id`). 

This pull request fixes that.

It also adds extra params for the 'woocommerce_new_order_item' hook.
