### PR TITLE
Fix delete tax row for dynamically inserted tax rows

### DIFF
--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -854,9 +854,10 @@ jQuery( function($){
 
 	// Delete a tax row
 	$('#tax_rows').on('click','a.delete_tax_row',function(){
-		$tax_row = $(this).closest('.tax_row');
 
-		var tax_row_id = $tax_row.attr( 'data-order_item_id' )
+		var $tax_row = $(this).closest('.tax_row');
+
+		var tax_row_id = $tax_row.attr( 'data-order_item_id' );
 
 		var data = {
 			tax_row_id: tax_row_id,

--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -853,7 +853,7 @@ jQuery( function($){
 	});
 
 	// Delete a tax row
-	$('a.delete_tax_row').click(function(){
+	$('#tax_rows').on('click','a.delete_tax_row',function(){
 		$tax_row = $(this).closest('.tax_row');
 
 		var tax_row_id = $tax_row.attr( 'data-order_item_id' )


### PR DESCRIPTION
When a tax row is dynamically inserted on the _Edit Order_ screen, it can not be deleted until the page is refreshed (because the event handler is bound only on page document ready).

This commit delegates the event handler from an element which is guaranteed to exist on page load (`#tax_rows`), so that dynamically inserted tax rows can also be dynamically deleted.
