### PR TITLE
Change on sale meta query from NUMERIC to DECIMAL

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -54,7 +54,7 @@ function woocommerce_get_product_ids_on_sale() {
 			'key'        => '_sale_price',
 			'value'      => 0,
 			'compare'    => '>',
-			'type'       => 'NUMERIC',
+			'type'       => 'DECIMAL',
 		) ),
 		'fields'         => 'id=>parent',
 	) );


### PR DESCRIPTION
On Sale meta query used NUMERIC type and this excluded sale prices define 0.xx changed to DECIMAL to match everything defined > 0
