### PR TITLE
#2311 fix for "Exclude sale items from coupons"

### DIFF
--- a/admin/post-types/writepanels/writepanel-coupon_data.php
+++ b/admin/post-types/writepanels/writepanel-coupon_data.php
@@ -56,6 +56,9 @@ function woocommerce_coupon_data_meta_box( $post ) {
 			// Apply before tax
 			woocommerce_wp_checkbox( array( 'id' => 'apply_before_tax', 'label' => __( 'Apply before tax', 'woocommerce' ), 'description' => __( 'Check this box if the coupon should be applied before calculating cart tax.', 'woocommerce' ) ) );
 
+			// Exclude Sale Products
+			woocommerce_wp_checkbox( array( 'id' => 'exclude_sale_items', 'label' => __( 'Exclude sale item', 'woocommerce' ), 'description' => __( 'Check this box if the coupon should not apply to sale items. Be sure when ticking this box for cart coupons as the presence of any sale item in the cart will stop the coupon from applying', 'woocommerce' ) ) );
+
 			echo '</div><div class="options_group">';
 
 			// minimum spend
@@ -199,6 +202,7 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 	$expiry_date 		= woocommerce_clean( $_POST['expiry_date'] );
 	$apply_before_tax 	= isset( $_POST['apply_before_tax'] ) ? 'yes' : 'no';
 	$free_shipping 		= isset( $_POST['free_shipping'] ) ? 'yes' : 'no';
+	$exclude_sale_items	= isset( $_POST['exclude_sale_items'] ) ? 'yes' : 'no';
 	$minimum_amount 	= woocommerce_clean( $_POST['minimum_amount'] );
 	$customer_email 	= array_filter( array_map( 'trim', explode( ',', woocommerce_clean( $_POST['customer_email'] ) ) ) );
 
@@ -227,6 +231,7 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 	update_post_meta( $post_id, 'expiry_date', $expiry_date );
 	update_post_meta( $post_id, 'apply_before_tax', $apply_before_tax );
 	update_post_meta( $post_id, 'free_shipping', $free_shipping );
+	update_post_meta( $post_id, 'exclude_sale_items', $exclude_sale_items );
 	update_post_meta( $post_id, 'product_categories', $product_categories );
 	update_post_meta( $post_id, 'exclude_product_categories', $exclude_product_categories );
 	update_post_meta( $post_id, 'minimum_amount', $minimum_amount );

--- a/admin/post-types/writepanels/writepanel-coupon_data.php
+++ b/admin/post-types/writepanels/writepanel-coupon_data.php
@@ -56,9 +56,6 @@ function woocommerce_coupon_data_meta_box( $post ) {
 			// Apply before tax
 			woocommerce_wp_checkbox( array( 'id' => 'apply_before_tax', 'label' => __( 'Apply before tax', 'woocommerce' ), 'description' => __( 'Check this box if the coupon should be applied before calculating cart tax.', 'woocommerce' ) ) );
 
-			// Exclude Sale Products
-			woocommerce_wp_checkbox( array( 'id' => 'exclude_sale_items', 'label' => __( 'Exclude sale item', 'woocommerce' ), 'description' => __( 'Check this box if the coupon should not apply to sale items. Be sure when ticking this box for cart coupons as the presence of any sale item in the cart will stop the coupon from applying', 'woocommerce' ) ) );
-
 			echo '</div><div class="options_group">';
 
 			// minimum spend
@@ -202,7 +199,6 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 	$expiry_date 		= woocommerce_clean( $_POST['expiry_date'] );
 	$apply_before_tax 	= isset( $_POST['apply_before_tax'] ) ? 'yes' : 'no';
 	$free_shipping 		= isset( $_POST['free_shipping'] ) ? 'yes' : 'no';
-	$exclude_sale_items	= isset( $_POST['exclude_sale_items'] ) ? 'yes' : 'no';
 	$minimum_amount 	= woocommerce_clean( $_POST['minimum_amount'] );
 	$customer_email 	= array_filter( array_map( 'trim', explode( ',', woocommerce_clean( $_POST['customer_email'] ) ) ) );
 
@@ -231,7 +227,6 @@ function woocommerce_process_shop_coupon_meta( $post_id, $post ) {
 	update_post_meta( $post_id, 'expiry_date', $expiry_date );
 	update_post_meta( $post_id, 'apply_before_tax', $apply_before_tax );
 	update_post_meta( $post_id, 'free_shipping', $free_shipping );
-	update_post_meta( $post_id, 'exclude_sale_items', $exclude_sale_items );
 	update_post_meta( $post_id, 'product_categories', $product_categories );
 	update_post_meta( $post_id, 'exclude_product_categories', $exclude_product_categories );
 	update_post_meta( $post_id, 'minimum_amount', $minimum_amount );

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1154,7 +1154,7 @@ class WC_Cart {
 
 						// Sale Items excluded from discount
 								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
 										$this_item_is_discounted = false;
 

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -954,6 +954,7 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 								$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
+								$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 								// Specific products get the discount
 								if ( sizeof( $coupon->product_ids ) > 0 ) {
@@ -982,6 +983,11 @@ class WC_Cart {
 								// Specific categories excluded from the discount
 								if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 									if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
+										$this_item_is_discounted = false;
+
+								// Sale Items excluded from discount
+								if ( $coupon->exclude_sale_items == 'yes' )
+									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
 										$this_item_is_discounted = false;
 
 								// Apply filter
@@ -1146,6 +1152,11 @@ class WC_Cart {
 						if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 							if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 								$this_item_is_discounted = false;
+
+						// Sale Items excluded from discount
+								if ( $coupon->exclude_sale_items == 'yes' )
+									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
+										$this_item_is_discounted = false;
 
 						// Apply filter
 						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1154,7 +1154,7 @@ class WC_Cart {
 
 						// Sale Items excluded from discount
 								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
 									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
 										$this_item_is_discounted = false;
 

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -986,7 +986,7 @@ class WC_Cart {
 
 								// Sale Items excluded from discount
 								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
 										$this_item_is_discounted = false;
 

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -954,7 +954,6 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 								$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
-								$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 								// Specific products get the discount
 								if ( sizeof( $coupon->product_ids ) > 0 ) {
@@ -986,8 +985,9 @@ class WC_Cart {
 										$this_item_is_discounted = false;
 
 								// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items == 'yes' )
-									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
+								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
 										$this_item_is_discounted = false;
 
 								// Apply filter
@@ -1106,7 +1106,7 @@ class WC_Cart {
 		 * @param mixed $price
 		 */
 		public function apply_product_discounts_after_tax( $values, $price ) {
-			
+
 			if ( ! empty( $this->applied_coupons) ) {
 				foreach ( $this->applied_coupons as $code ) {
 					$coupon = new WC_Coupon( $code );
@@ -1120,7 +1120,6 @@ class WC_Cart {
 					if ( ! $coupon->apply_before_tax() ) {
 
 						$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
-						$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 						$this_item_is_discounted = false;
 
@@ -1154,8 +1153,9 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 						// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items == 'yes' )
-									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
+								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
 										$this_item_is_discounted = false;
 
 						// Apply filter

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -954,6 +954,7 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 								$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
+								$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 								// Specific products get the discount
 								if ( sizeof( $coupon->product_ids ) > 0 ) {
@@ -982,6 +983,11 @@ class WC_Cart {
 								// Specific categories excluded from the discount
 								if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 									if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
+										$this_item_is_discounted = false;
+
+								// Sale Items excluded from discount
+								if ( $coupon->exclude_sale_items == 'yes' )
+									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
 										$this_item_is_discounted = false;
 
 								// Apply filter
@@ -1100,7 +1106,7 @@ class WC_Cart {
 		 * @param mixed $price
 		 */
 		public function apply_product_discounts_after_tax( $values, $price ) {
-
+			
 			if ( ! empty( $this->applied_coupons) ) {
 				foreach ( $this->applied_coupons as $code ) {
 					$coupon = new WC_Coupon( $code );
@@ -1114,6 +1120,7 @@ class WC_Cart {
 					if ( ! $coupon->apply_before_tax() ) {
 
 						$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
+						$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 						$this_item_is_discounted = false;
 
@@ -1145,6 +1152,11 @@ class WC_Cart {
 						if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 							if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 								$this_item_is_discounted = false;
+
+						// Sale Items excluded from discount
+								if ( $coupon->exclude_sale_items == 'yes' )
+									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
+										$this_item_is_discounted = false;
 
 						// Apply filter
 						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -986,7 +986,7 @@ class WC_Cart {
 
 								// Sale Items excluded from discount
 								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
 									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
 										$this_item_is_discounted = false;
 

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -954,7 +954,6 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 								$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
-								$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 								// Specific products get the discount
 								if ( sizeof( $coupon->product_ids ) > 0 ) {
@@ -983,11 +982,6 @@ class WC_Cart {
 								// Specific categories excluded from the discount
 								if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 									if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
-										$this_item_is_discounted = false;
-
-								// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items == 'yes' )
-									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
 										$this_item_is_discounted = false;
 
 								// Apply filter
@@ -1152,11 +1146,6 @@ class WC_Cart {
 						if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 							if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 								$this_item_is_discounted = false;
-
-						// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items == 'yes' )
-									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
-										$this_item_is_discounted = false;
 
 						// Apply filter
 						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -984,12 +984,6 @@ class WC_Cart {
 									if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 										$this_item_is_discounted = false;
 
-								// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
-									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
-										$this_item_is_discounted = false;
-
 								// Apply filter
 								$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = true, $coupon );
 
@@ -1151,12 +1145,6 @@ class WC_Cart {
 						if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 							if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 								$this_item_is_discounted = false;
-
-						// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
-									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
-										$this_item_is_discounted = false;
 
 						// Apply filter
 						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -984,6 +984,12 @@ class WC_Cart {
 									if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 										$this_item_is_discounted = false;
 
+								// Sale Items excluded from discount
+								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
+									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
+										$this_item_is_discounted = false;
+
 								// Apply filter
 								$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = true, $coupon );
 
@@ -1145,6 +1151,12 @@ class WC_Cart {
 						if ( sizeof( $coupon->exclude_product_categories ) > 0 )
 							if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
 								$this_item_is_discounted = false;
+
+						// Sale Items excluded from discount
+								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
+									$product_ids_on_sale = woocommerce_get_product_ids_on_sale()
+									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
+										$this_item_is_discounted = false;
 
 						// Apply filter
 						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );

--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -954,6 +954,7 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 								$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
+								$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 								// Specific products get the discount
 								if ( sizeof( $coupon->product_ids ) > 0 ) {
@@ -985,9 +986,8 @@ class WC_Cart {
 										$this_item_is_discounted = false;
 
 								// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
-									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
+								if ( $coupon->exclude_sale_items == 'yes' )
+									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
 										$this_item_is_discounted = false;
 
 								// Apply filter
@@ -1106,7 +1106,7 @@ class WC_Cart {
 		 * @param mixed $price
 		 */
 		public function apply_product_discounts_after_tax( $values, $price ) {
-
+			
 			if ( ! empty( $this->applied_coupons) ) {
 				foreach ( $this->applied_coupons as $code ) {
 					$coupon = new WC_Coupon( $code );
@@ -1120,6 +1120,7 @@ class WC_Cart {
 					if ( ! $coupon->apply_before_tax() ) {
 
 						$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
+						$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 
 						$this_item_is_discounted = false;
 
@@ -1153,9 +1154,8 @@ class WC_Cart {
 								$this_item_is_discounted = false;
 
 						// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items() && sizeof( woocommerce_get_product_ids_on_sale() ) > 0 )
-									$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
-									if ( in_array( $values['product_id'], $product_ids_on_sale ) || in_array( $values['variation_id'], $product_ids_on_sale ) || in_array( $values['data']->get_parent(), $product_ids_on_sale ) )
+								if ( $coupon->exclude_sale_items == 'yes' )
+									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
 										$this_item_is_discounted = false;
 
 						// Apply filter

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -350,7 +350,6 @@ class WC_Coupon {
 						$error = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
 					}
 				}
-
 			}
 
 			$valid = apply_filters( 'woocommerce_coupon_is_valid', $valid, $this );

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -53,6 +53,9 @@ class WC_Coupon {
 	/** @public array Array of category ids. */
 	public $exclude_product_categories;
 
+	/** @public string "yes" if coupon does NOT apply to items on sale. */
+	public $exclude_sale_items;
+
 	/** @public string Minimum cart amount. */
 	public $minimum_amount;
 
@@ -98,6 +101,7 @@ class WC_Coupon {
             $this->free_shipping 				= esc_html( $coupon_data['free_shipping'] );
             $this->product_categories 			= is_array( $coupon_data['product_categories'] ) ? $coupon_data['product_categories'] : array();
             $this->exclude_product_categories 	= is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
+            $this->exclude_sale_items			= esc_html( $coupon_data['exclude_sale_items'] );
             $this->minimum_amount 				= esc_html( $coupon_data['minimum_amount'] );
             $this->customer_email 				= esc_html( $coupon_data['customer_email'] );
 
@@ -131,6 +135,7 @@ class WC_Coupon {
             	'free_shipping'					=> 'no',
             	'product_categories'			=> array(),
             	'exclude_product_categories'	=> array(),
+            	'exclude_sale_items'			=> 'no',
             	'minimum_amount'				=> '',
             	'customer_email'				=> array()
             );
@@ -173,6 +178,16 @@ class WC_Coupon {
 	public function enable_free_shipping() {
 		return $this->free_shipping == 'yes' ? true : false;
 	}
+/**
+	 * Check if a coupon excludes sale items.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function exclude_sale_items() {
+		return $this->exclude_sale_items == 'yes' ? true : false;
+	}
+
 
 
 	/**
@@ -301,6 +316,23 @@ class WC_Coupon {
 					}
 				}
 
+				// Exclude Sale Items
+				if ( exclude_sale_items() && sizeof( $woocommerce_get_product_ids_on_sale) > 0 ) {
+					$valid_for_cart = true;
+					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
+						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
+							if ( in_array( $cart_item['product_id'], $product_ids_on_sale ) || in_array( $cart_item['variation_id'], $product_ids_on_sale ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale ) ) {
+								$valid_for_cart = false;
+							}
+						}
+					}
+					if ( ! $valid_for_cart ) {
+						$valid = false;
+						$error = __( 'Sorry, this coupon is not applicable if your cart contains sale items.', 'woocommerce' );
+					}
+				}
+
 				// Exclude Categories
 				if ( sizeof( $this->exclude_product_categories ) > 0 ) {
 					$valid_for_cart = true;
@@ -318,6 +350,7 @@ class WC_Coupon {
 						$error = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
 					}
 				}
+
 			}
 
 			$valid = apply_filters( 'woocommerce_coupon_is_valid', $valid, $this );

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -53,6 +53,9 @@ class WC_Coupon {
 	/** @public array Array of category ids. */
 	public $exclude_product_categories;
 
+	/** @public string "yes" if coupon does NOT apply to items on sale. */
+	public $exclude_sale_items;
+
 	/** @public string Minimum cart amount. */
 	public $minimum_amount;
 
@@ -98,6 +101,7 @@ class WC_Coupon {
             $this->free_shipping 				= esc_html( $coupon_data['free_shipping'] );
             $this->product_categories 			= is_array( $coupon_data['product_categories'] ) ? $coupon_data['product_categories'] : array();
             $this->exclude_product_categories 	= is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
+            $this->exclude_sale_items			= esc_html( $coupon_data['exclude_sale_items'] );
             $this->minimum_amount 				= esc_html( $coupon_data['minimum_amount'] );
             $this->customer_email 				= esc_html( $coupon_data['customer_email'] );
 
@@ -131,6 +135,7 @@ class WC_Coupon {
             	'free_shipping'					=> 'no',
             	'product_categories'			=> array(),
             	'exclude_product_categories'	=> array(),
+            	'exclude_sale_items'			=> 'no',
             	'minimum_amount'				=> '',
             	'customer_email'				=> array()
             );
@@ -173,6 +178,16 @@ class WC_Coupon {
 	public function enable_free_shipping() {
 		return $this->free_shipping == 'yes' ? true : false;
 	}
+/**
+	 * Check if a coupon excludes sale items.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function exclude_sale_items() {
+		return $this->exclude_sale_items == 'yes' ? true : false;
+	}
+
 
 
 	/**
@@ -301,6 +316,23 @@ class WC_Coupon {
 					}
 				}
 
+				// Exclude Sale Items
+				if ( $this->exclude_sale_items == 'yes' ) {
+					$valid_for_cart = true;
+					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
+						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
+							if ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) || in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale, true ) ) {
+								$valid_for_cart = false;
+							}
+						}
+					}
+					if ( ! $valid_for_cart ) {
+						$valid = false;
+						$error = __( 'Sorry, this coupon is not applicable if your cart contains sale items.', 'woocommerce' );
+					}
+				}
+
 				// Exclude Categories
 				if ( sizeof( $this->exclude_product_categories ) > 0 ) {
 					$valid_for_cart = true;
@@ -318,6 +350,7 @@ class WC_Coupon {
 						$error = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
 					}
 				}
+
 			}
 
 			$valid = apply_filters( 'woocommerce_coupon_is_valid', $valid, $this );

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -53,9 +53,6 @@ class WC_Coupon {
 	/** @public array Array of category ids. */
 	public $exclude_product_categories;
 
-	/** @public string "yes" if coupon does NOT apply to items on sale. */
-	public $exclude_sale_items;
-
 	/** @public string Minimum cart amount. */
 	public $minimum_amount;
 
@@ -101,7 +98,6 @@ class WC_Coupon {
             $this->free_shipping 				= esc_html( $coupon_data['free_shipping'] );
             $this->product_categories 			= is_array( $coupon_data['product_categories'] ) ? $coupon_data['product_categories'] : array();
             $this->exclude_product_categories 	= is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
-            $this->exclude_sale_items			= esc_html( $coupon_data['exclude_sale_items'] );
             $this->minimum_amount 				= esc_html( $coupon_data['minimum_amount'] );
             $this->customer_email 				= esc_html( $coupon_data['customer_email'] );
 
@@ -135,7 +131,6 @@ class WC_Coupon {
             	'free_shipping'					=> 'no',
             	'product_categories'			=> array(),
             	'exclude_product_categories'	=> array(),
-            	'exclude_sale_items'			=> 'no',
             	'minimum_amount'				=> '',
             	'customer_email'				=> array()
             );
@@ -178,16 +173,6 @@ class WC_Coupon {
 	public function enable_free_shipping() {
 		return $this->free_shipping == 'yes' ? true : false;
 	}
-/**
-	 * Check if a coupon excludes sale items.
-	 *
-	 * @access public
-	 * @return void
-	 */
-	public function exclude_sale_items() {
-		return $this->exclude_sale_items == 'yes' ? true : false;
-	}
-
 
 
 	/**
@@ -316,23 +301,6 @@ class WC_Coupon {
 					}
 				}
 
-				// Exclude Sale Items
-				if ( exclude_sale_items() && sizeof( $woocommerce_get_product_ids_on_sale) > 0 ) {
-					$valid_for_cart = true;
-					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
-					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
-						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-							if ( in_array( $cart_item['product_id'], $product_ids_on_sale ) || in_array( $cart_item['variation_id'], $product_ids_on_sale ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale ) ) {
-								$valid_for_cart = false;
-							}
-						}
-					}
-					if ( ! $valid_for_cart ) {
-						$valid = false;
-						$error = __( 'Sorry, this coupon is not applicable if your cart contains sale items.', 'woocommerce' );
-					}
-				}
-
 				// Exclude Categories
 				if ( sizeof( $this->exclude_product_categories ) > 0 ) {
 					$valid_for_cart = true;
@@ -350,7 +318,6 @@ class WC_Coupon {
 						$error = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
 					}
 				}
-
 			}
 
 			$valid = apply_filters( 'woocommerce_coupon_is_valid', $valid, $this );

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -317,12 +317,12 @@ class WC_Coupon {
 				}
 
 				// Exclude Sale Items
-				if ( $this->exclude_sale_items == 'yes' ) {
+				if ( exclude_sale_items() && sizeof( $woocommerce_get_product_ids_on_sale) > 0 ) {
 					$valid_for_cart = true;
 					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-							if ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) || in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale, true ) ) {
+							if ( in_array( $cart_item['product_id'], $product_ids_on_sale ) || in_array( $cart_item['variation_id'], $product_ids_on_sale ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale ) ) {
 								$valid_for_cart = false;
 							}
 						}

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -53,9 +53,6 @@ class WC_Coupon {
 	/** @public array Array of category ids. */
 	public $exclude_product_categories;
 
-	/** @public string "yes" if coupon does NOT apply to items on sale. */
-	public $exclude_sale_items;
-
 	/** @public string Minimum cart amount. */
 	public $minimum_amount;
 
@@ -101,7 +98,6 @@ class WC_Coupon {
             $this->free_shipping 				= esc_html( $coupon_data['free_shipping'] );
             $this->product_categories 			= is_array( $coupon_data['product_categories'] ) ? $coupon_data['product_categories'] : array();
             $this->exclude_product_categories 	= is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
-            $this->exclude_sale_items			= esc_html( $coupon_data['exclude_sale_items'] );
             $this->minimum_amount 				= esc_html( $coupon_data['minimum_amount'] );
             $this->customer_email 				= esc_html( $coupon_data['customer_email'] );
 
@@ -135,7 +131,6 @@ class WC_Coupon {
             	'free_shipping'					=> 'no',
             	'product_categories'			=> array(),
             	'exclude_product_categories'	=> array(),
-            	'exclude_sale_items'			=> 'no',
             	'minimum_amount'				=> '',
             	'customer_email'				=> array()
             );
@@ -313,23 +308,6 @@ class WC_Coupon {
 					if ( ! $valid_for_cart ) {
 						$valid = false;
 						$error = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
-					}
-				}
-
-				// Exclude Sale Items
-				if ( $this->exclude_sale_items == 'yes' ) {
-					$valid_for_cart = true;
-					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
-					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
-						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-							if ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) || in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale, true ) ) {
-								$valid_for_cart = false;
-							}
-						}
-					}
-					if ( ! $valid_for_cart ) {
-						$valid = false;
-						$error = __( 'Sorry, this coupon is not applicable if your cart contains sale items.', 'woocommerce' );
 					}
 				}
 

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -317,12 +317,12 @@ class WC_Coupon {
 				}
 
 				// Exclude Sale Items
-				if ( exclude_sale_items() && sizeof( $woocommerce_get_product_ids_on_sale) > 0 ) {
+				if ( $this->exclude_sale_items == 'yes' ) {
 					$valid_for_cart = true;
 					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
 					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
 						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
-							if ( in_array( $cart_item['product_id'], $product_ids_on_sale ) || in_array( $cart_item['variation_id'], $product_ids_on_sale ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale ) ) {
+							if ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) || in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale, true ) ) {
 								$valid_for_cart = false;
 							}
 						}

--- a/classes/class-wc-coupon.php
+++ b/classes/class-wc-coupon.php
@@ -53,6 +53,9 @@ class WC_Coupon {
 	/** @public array Array of category ids. */
 	public $exclude_product_categories;
 
+	/** @public string "yes" if coupon does NOT apply to items on sale. */
+	public $exclude_sale_items;
+
 	/** @public string Minimum cart amount. */
 	public $minimum_amount;
 
@@ -98,6 +101,7 @@ class WC_Coupon {
             $this->free_shipping 				= esc_html( $coupon_data['free_shipping'] );
             $this->product_categories 			= is_array( $coupon_data['product_categories'] ) ? $coupon_data['product_categories'] : array();
             $this->exclude_product_categories 	= is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
+            $this->exclude_sale_items			= esc_html( $coupon_data['exclude_sale_items'] );
             $this->minimum_amount 				= esc_html( $coupon_data['minimum_amount'] );
             $this->customer_email 				= esc_html( $coupon_data['customer_email'] );
 
@@ -131,6 +135,7 @@ class WC_Coupon {
             	'free_shipping'					=> 'no',
             	'product_categories'			=> array(),
             	'exclude_product_categories'	=> array(),
+            	'exclude_sale_items'			=> 'no',
             	'minimum_amount'				=> '',
             	'customer_email'				=> array()
             );
@@ -308,6 +313,23 @@ class WC_Coupon {
 					if ( ! $valid_for_cart ) {
 						$valid = false;
 						$error = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );
+					}
+				}
+
+				// Exclude Sale Items
+				if ( $this->exclude_sale_items == 'yes' ) {
+					$valid_for_cart = true;
+					$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
+					if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) {
+						foreach( $woocommerce->cart->get_cart() as $cart_item_key => $cart_item ) {
+							if ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) || in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale, true ) ) {
+								$valid_for_cart = false;
+							}
+						}
+					}
+					if ( ! $valid_for_cart ) {
+						$valid = false;
+						$error = __( 'Sorry, this coupon is not applicable if your cart contains sale items.', 'woocommerce' );
 					}
 				}
 

--- a/templates/cart/totals.php
+++ b/templates/cart/totals.php
@@ -192,11 +192,4 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 
 	<?php do_action( 'woocommerce_after_cart_totals' ); ?>
 
-	<div class="debug"> 
-		<?php 
-		print_r(woocommerce_get_product_ids_on_sale() );
-		print_r( $woocommerce )
-		?>
-	</div>
-
 </div>

--- a/templates/cart/totals.php
+++ b/templates/cart/totals.php
@@ -192,4 +192,11 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 
 	<?php do_action( 'woocommerce_after_cart_totals' ); ?>
 
+	<div class="debug"> 
+		<?php 
+		print_r(woocommerce_get_product_ids_on_sale() );
+		print_r( $woocommerce )
+		?>
+	</div>
+
 </div>


### PR DESCRIPTION
'Scuse the mess of commits/reverts, I'm (super) new to git. 

This was my take to fix it, essentially repurposing the same code you use to match excluded product ID's, but comparing it against the (awesome new) array generated by the new get_woocommerce_product_ids_on_sale() function. 

Strict type matching in the is_array() was necessary to avoid problems caused by the '0' string that seems to be on the end of every product_ids_on_sale array 

Tested on 3.5.1 + the git build of WooCommerce

Hope it helps guys. 
