### PR TITLE
Give Shipping Methods Control Over Their Cart Full Label

### DIFF
--- a/templates/cart/shipping-methods.php
+++ b/templates/cart/shipping-methods.php
@@ -31,6 +31,7 @@ if ( $available_methods ) {
 		} elseif ( $method->id !== 'free_shipping' ) {
 			$method->full_label .= ' (' . __( 'Free', 'woocommerce' ) . ')';
 		}
+		$method->full_label = apply_filters( 'woocommerce_cart_shipping_method_full_label', $method->full_label, $method );
 	}
 
 	// Print a single available shipping method as plain text


### PR DESCRIPTION
The idea is to give shipping methods more control over their cart full label by adding a filter to the cart shipping methods template.

Actually I was somewhat surprised that the code to generate the full labels is entirely within the template file; it seems perhaps a little involved to live within a template file?  I played around with moving that logic into the new WC_Shipping_Rate class as a get_full_label() method, to reduce the complexity within the template, but then I wasn't sure whether there might be good reason that code should be where it currently is.  

Either way having a means for plugins to control the final label display is a important, especially with 2.0 now automatically adding the '(Free)' text.
