### PR TITLE
Add deprecated WC_Paypal class

### DIFF
--- a/classes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/classes/gateways/paypal/class-wc-gateway-paypal.php
@@ -750,3 +750,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	}
 
 }
+
+class WC_Paypal extends WC_Gateway_Paypal {
+	public function __construct() {
+		_deprecated_function( 'WC_Paypal', '1.4', 'WC_Gateway_Paypal' );
+		parent::__construct();
+	}
+}


### PR DESCRIPTION
`WC_Paypal` was removed in WC 2.0 in favour of the new `WC_Gateway_Paypal`, this patch reintroduces the original `WC_Paypal` class as a deprecated class which just returns an instance of the new `WC_Gateway_Paypal` object (instead of causing a fatal error for any code that was attempting to access it directly).

Another patch like #2430 & #2431 aimed at making WC 2.0 more backward compatible.
