### PR TITLE
Fix woocommerce_cancel_unpaid_orders() comparion date

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -2411,7 +2411,7 @@ function woocommerce_cancel_unpaid_orders() {
 	if ( $held_duration == '' )
 		return;
 
-	$date = date( "Y-m-d H:i:s", strtotime( '+' . absint( $held_duration ) . ' MINUTES', current_time( 'timestamp' ) ) );
+	$date = date( "Y-m-d H:i:s", strtotime( '-' . absint( $held_duration ) . ' MINUTES', current_time( 'timestamp' ) ) );
 
 	$unpaid_orders = $wpdb->get_col( $wpdb->prepare( "
 		SELECT posts.ID


### PR DESCRIPTION
Cancel orders placed more than an hour in the past, not orders placed between now & 1 hour in the future. Otherwise, any order in the process of being paid when the 'woocommerce_cancel_unpaid_orders' fires will immediately be cancelled. For example, in the minute or two it takes to go to PayPal & checkout.
