### PR TITLE
Order Total bug in admin

### DIFF
--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -453,7 +453,8 @@ jQuery( function($){
 
 			// Tax
 			if (woocommerce_writepanel_params.round_at_subtotal=='yes') {
-				cart_tax = accounting.toFixed( cart_tax, 2 );
+				cart_tax = parseFloat( accounting.toFixed( cart_tax, 2 ) );
+				
 			}
 
 			// Total


### PR DESCRIPTION
This bug is related to the cart_tax total in the amended file. It is caused by the way JS intereprets the + operator when faced with a "0.00" string generated by  accounting.toFixed( cart_tax, 2 )

To replicate the bug, use the following tax settings:

![Screen Shot 2013-02-14 at 11 27 28](https://f.cloud.github.com/assets/488297/156501/9aa212b2-7699-11e2-8bab-19fa0b1a5d91.PNG)

Then when adding an order through the admin, you'll notice that hitting the 'Calc Totals' button results in varying unexpected behaviour, the most severe of which is when an item value is 99.00 or some other amount ending in .00 - if this item has zero tax, the order total has a "0.00" string appended to it, resulting in an order total of 990.00!

This patch fixes that - I think it's the best place for it  but I'm not 100% familiar with the admin JS so you may wish to look it over.

Cheers,
Neil
