### PR TITLE
Use product_type slug not sanitized term name

### DIFF
--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -43,7 +43,7 @@ class WC_Product_Factory {
 				$product_type = 'variation';
 			} else {
 				$terms        = get_the_terms( $product_id, 'product_type' );
-				$product_type = ! empty( $terms ) && isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
+				$product_type = ! empty( $terms ) && isset( current( $terms )->slug ) ? current( $terms )->slug : 'simple';
 			}
 
 			$classname = 'WC_Product_' . ucfirst( $product_type );

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -46,7 +46,7 @@ class WC_Product_Factory {
 				$product_type = ! empty( $terms ) && isset( current( $terms )->slug ) ? current( $terms )->slug : 'simple';
 			}
 
-			$classname = 'WC_Product_' . ucfirst( $product_type );
+			$classname = 'WC_Product_' . preg_replace( '/(?<=_)(.)/e', "strtoupper( '$1' )", ucfirst( $product_type ) );
 		} else {
 			$classname = false;
 			$product_type = false;


### PR DESCRIPTION
As mentioned [here](https://github.com/woothemes/woocommerce/commit/b2a868301c622d03702f58285cb6d97972511953#commitcomment-2663540), if there is no reason `WC_Product_Factory->get_product()` needs to use `sanitize_title( current( $terms )->name )` instead of `current( $terms )->slug`, then I think using the slug is a better option - slugs are effectively a pre-sanitised name and can also be set when creating the term to allow for custom class names which:
1. can have class names conforming to coding standards - e.g. `WC_Product_Variable_Subscription` rather than `WC_Product_Variable-subscription` which would be created by sanitising the name
2. do not require use of the `woocommerce_product_class` filter
