### PR TITLE
Update woocommerce-ajax.php

### DIFF
--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -86,6 +86,9 @@ function woocommerce_sidebar_login_ajax_process() {
 
 	// Login
 	$user = wp_signon( $creds, $secure_cookie );
+	
+	// Filter the redirect URL.
+	$redirect_to = apply_filters('woocommerce_login_widget_redirect', $redirect_to, isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '', $user);
 
 	// Redirect filter
 	if ( $secure_cookie && strstr( $redirect_to, 'wp-admin' ) ) $redirect_to = str_replace( 'http:', 'https:', $redirect_to );


### PR DESCRIPTION
The WooCommerce login widget uses AJAX to handle the login, and that AJAX code bypasses any filtering on the redirect URL _after_ the user has logged in. This change fixes that.

The woocommerce_login_widget_redirect filter is the WooCommerce equivalent to the core WP login_redirect filter. It presumably has a different name because WooCommerce uses different login form field names to the core WP login forms, and so needs to be handled differently. Using the same field names, IMO, would have avoided the need for a special WC filter here in the first place (logging in is logging in, and there is no reason why the redirects and handling should be fundamentally different between the WC widget and the core WP login page).

This filter call passes three parameters, making it equivalent in use to the login_redirect filter.
