### PR TITLE
Add encompassing hooks to cart and mini-cart

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 global $woocommerce;
 ?>
 
+<?php do_action( 'woocommerce_before_cart' ); ?>
+
 <?php $woocommerce->show_messages(); ?>
 
 <form action="<?php echo esc_url( $woocommerce->cart->get_cart_url() ); ?>" method="post">
@@ -149,3 +151,5 @@ global $woocommerce;
 	<?php woocommerce_shipping_calculator(); ?>
 
 </div>
+
+<?php do_action( 'woocommerce_after_cart' ); ?>

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 global $woocommerce;
 ?>
+
+<?php do_action( 'woocommerce_before_mini_cart' ); ?>
+
 <ul class="cart_list product_list_widget <?php echo $args['list_class']; ?>">
 
 	<?php if ( sizeof( $woocommerce->cart->get_cart() ) > 0 ) : ?>
@@ -67,3 +70,5 @@ global $woocommerce;
 	</p>
 
 <?php endif; ?>
+
+<?php do_action( 'woocommerce_after_mini_cart' ); ?>


### PR DESCRIPTION
> I want to be sure I'm not missing something, but I need to selectively add/remove some filters so they only execute during the display of the Cart Widget.
> 
> For Cart and Checkout pages, there are 
> 'woocommerce_before_cart_contents' / 'woocommerce_after_cart_contents'
> and 'woocommerce_review_order_before_cart_contents' / 'woocommerce_review_order_after_cart_contents'
> 
> However there is no equiv for the Cart Widget (mini-cart). Not sure if this is due to Ajax or what, but I need to be able to modify stuff only within the scope of the Cart Widget.
> 
> Would class-wc-widget-cart widget() be where to add a before/after hook to fire? Or in templates/mini-cart.php?
> 
> Now that I look at this some more, I believe the normal cart.php needs a before/after hook that all encompasses. There is currently a 'woocommerce_before_cart_table' but the ending hook is variable depending on whether there is shipping or not. The 'final' hook could be 'woocommerce_after_cart_totals' or 'woocommerce_after_shipping_calculator'.

Duplicate: #2509
