### PR TITLE
Add WC Email send filtering based on object

### DIFF
--- a/classes/abstracts/abstract-wc-email.php
+++ b/classes/abstracts/abstract-wc-email.php
@@ -268,7 +268,10 @@ abstract class WC_Email extends WC_Settings_API {
 	 * @return bool
 	 */
 	function is_enabled() {
-		if ( $this->enabled == "yes" )
+		
+		$enabled = apply_filters( 'woocommerce_email_enabled_' . $this->id, $this->enabled, $this->object );
+
+		if ( $enabled == "yes" )
 			return true;
 	}
 


### PR DESCRIPTION
In my plugin I generate my own emails for subscription orders (order contains a subscription product type)

There does not appear to be anyway using WC Email to accomplish this so this filter is an elegant solution. The is_enabled() method now uses a filter which gets passed the associated email object so the filter can decide to override the email sending.

Using this filter, I can now hook

`woocommerce_email_enabled_customer_completed_order`
`woocommerce_email_enabled_new_order`

examine the order and conditionally disable the email for orders with subscriptions. For regular merchandise I want to use the built in transactional emails.
