### PR TITLE
Allow extensions to run core WC add-to-cart handlers

### DIFF
--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -278,9 +278,9 @@ function woocommerce_add_to_cart_action( $url = false ) {
 
 	global $woocommerce;
 
-	$product_id			= apply_filters('woocommerce_add_to_cart_product_id', absint( $_REQUEST['add-to-cart'] ) );
-	$was_added_to_cart 	= false;
-	$adding_to_cart 	= get_product( $product_id );
+	$product_id          = apply_filters( 'woocommerce_add_to_cart_product_id', absint( $_REQUEST['add-to-cart'] ) );
+	$was_added_to_cart   = false;
+	$adding_to_cart      = get_product( $product_id );
 	$add_to_cart_handler = apply_filters( 'woocommerce_add_to_cart_handler', $adding_to_cart->product_type, $adding_to_cart );
 
     // Variable product handling

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -281,9 +281,10 @@ function woocommerce_add_to_cart_action( $url = false ) {
 	$product_id			= apply_filters('woocommerce_add_to_cart_product_id', absint( $_REQUEST['add-to-cart'] ) );
 	$was_added_to_cart 	= false;
 	$adding_to_cart 	= get_product( $product_id );
+	$add_to_cart_handler = apply_filters( 'woocommerce_add_to_cart_handler', $adding_to_cart->product_type, $adding_to_cart );
 
     // Variable product handling
-    if ( $adding_to_cart->is_type( 'variable' ) ) {
+    if ( 'variable' === $add_to_cart_handler ) {
 
     	$variation_id       = empty( $_REQUEST['variation_id'] ) ? '' : absint( $_REQUEST['variation_id'] );
     	$quantity           = empty( $_REQUEST['quantity'] ) ? 1 : apply_filters( 'woocommerce_stock_amount', $_REQUEST['quantity'] );
@@ -345,7 +346,7 @@ function woocommerce_add_to_cart_action( $url = false ) {
        }
 
     // Grouped Products
-    } elseif ( $adding_to_cart->is_type( 'grouped' ) ) {
+    } elseif ( 'grouped' === $add_to_cart_handler ) {
 
 		if ( ! empty( $_REQUEST['quantity'] ) && is_array( $_REQUEST['quantity'] ) ) {
 


### PR DESCRIPTION
Rather than determining how to handle a product being added to the cart based on its type, create a handler flag which extensions can set in order to run core WC handlers for different product types.

For example, with this patch, a `'variable_subscription'` product could choose to run the WC core `'variable'` add-to-cart routine, and avoid having to duplicate that code, using a function like this: 

``` php
function eg_add_to_cart_handler( $handler, $product ) {

    if ( 'variable_subscription' === $handler )
        $handler = 'variable';

    return $handler;
}
add_filter( 'woocommerce_add_to_cart_handler', 'eg_add_to_cart_handler', 10, 2 );
```

There will be no change for core WC products.
