### PR TITLE
Variation patch & sanitized product_type names

### DIFF
--- a/admin/post-types/product.php
+++ b/admin/post-types/product.php
@@ -372,7 +372,7 @@ function woocommerce_products_by_type() {
 		$output = "<select name='product_type' id='dropdown_product_type'>";
 		$output .= '<option value="">'.__( 'Show all product types', 'woocommerce' ).'</option>';
 		foreach($terms as $term) :
-			$output .="<option value='$term->name' ";
+			$output .="<option value='" . sanitize_title( $term->name ) . "' ";
 			if ( isset( $wp_query->query['product_type'] ) ) $output .=selected($term->slug, $wp_query->query['product_type'], false);
 			$output .=">";
 

--- a/admin/post-types/writepanels/writepanel-product_data.php
+++ b/admin/post-types/writepanels/writepanel-product_data.php
@@ -30,7 +30,7 @@ function woocommerce_product_data_box() {
 	$thepostid = $post->ID;
 
 	if ( $terms = wp_get_object_terms( $post->ID, 'product_type' ) )
-		$product_type = current( $terms )->name;
+		$product_type = sanitize_title( current( $terms )->name );
 	else
 		$product_type = 'simple';
 

--- a/admin/woocommerce-admin-init.php
+++ b/admin/woocommerce-admin-init.php
@@ -454,7 +454,7 @@ function woocommerce_admin_scripts() {
 			'currency_format_decimal_sep'	=> esc_attr( stripslashes( get_option( 'woocommerce_price_decimal_sep' ) ) ),
 			'currency_format_thousand_sep'	=> esc_attr( stripslashes( get_option( 'woocommerce_price_thousand_sep' ) ) ),
 			'currency_format'				=> esc_attr( str_replace( array( '%1$s', '%2$s' ), array( '%s', '%v' ), get_woocommerce_price_format() ) ), // For accounting JS
-			'product_types'					=> get_terms( 'product_type', array( 'fields' => 'names' ) )
+			'product_types'					=> array_map( 'sanitize_title', get_terms( 'product_type', array( 'fields' => 'names' ) ) )
 		 );
 
 		wp_localize_script( 'woocommerce_writepanel', 'woocommerce_writepanel_params', $woocommerce_witepanel_params );

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -46,7 +46,8 @@ class WC_Product_Factory {
 				$product_type = ! empty( $terms ) && isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
 			}
 
-			$classname = 'WC_Product_' . preg_replace( '/(?<=_)(.)/e', "strtoupper( '$1' )", ucfirst( $product_type ) );
+			// Create a WC coding standards compliant class name e.g. WC_Product_Type_Class instead of WC_Product_type-class
+			$classname = 'WC_Product_' . preg_replace( '/-(.)/e', "'_' . strtoupper( '$1' )", ucfirst( $product_type ) );
 		} else {
 			$classname = false;
 			$product_type = false;

--- a/classes/class-wc-product-factory.php
+++ b/classes/class-wc-product-factory.php
@@ -43,7 +43,7 @@ class WC_Product_Factory {
 				$product_type = 'variation';
 			} else {
 				$terms        = get_the_terms( $product_id, 'product_type' );
-				$product_type = ! empty( $terms ) && isset( current( $terms )->name ) ? current( $terms )->name : 'simple';
+				$product_type = ! empty( $terms ) && isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
 			}
 
 			$classname = 'WC_Product_' . preg_replace( '/(?<=_)(.)/e', "strtoupper( '$1' )", ucfirst( $product_type ) );

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -655,6 +655,7 @@ function woocommerce_add_variation() {
 
 		$_tax_class = '';
 		$image_id = 0;
+		$variation = get_post( $variation_id ); // Get the variation object
 
 		include( 'admin/post-types/writepanels/variation-admin-html.php' );
 	}


### PR DESCRIPTION
Two different issues addressed with this pull request:
1. SHA: e2c50cd529 sets the `$variation` variable to a `WP_Post` object when adding a variation via ajax on the "Edit Product page. At the moment, when the `variation-admin-html.php` template is loaded on the "Edit Product" screen, `$variation` is a `WP_Post` object. When the template is loaded by `woocommerce_add_variation()` to handle an ajax call, `$variation` is an array. The `variation-admin-html.php` template doesn't use `$variation` so it doesn't affect WC core, but it does pass it as a param on the `'woocommerce_product_after_variable_attributes'`
   and `'woocommerce_variation_options'` hooks, so this commit makes the `$variation` consistent for functions using those.
2. SHA: 2eb8b26a & SHA: 9247e327 are related to #2496 and SHA: 80b4ef1, in short, `product_type` term names may have white space and other characters unsafe for use in an option field's value, a class name or hook, so this commit runs `product_type` term names that may potentially be troublesome through `sanitize_title()`.
