### PR TITLE
Use handler for add-to-cart button text also

### DIFF
--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -25,7 +25,9 @@ global $product;
 			'class' => ''
 		);
 
-		switch ( $product->product_type ) {
+		$handler = apply_filters( 'woocommerce_add_to_cart_handler', $product->product_type, $product );
+
+		switch ( $handler ) {
 			case "variable" :
 				$link['url'] 	= apply_filters( 'variable_add_to_cart_url', get_permalink( $product->id ) );
 				$link['label'] 	= apply_filters( 'variable_add_to_cart_text', __( 'Select options', 'woocommerce' ) );


### PR DESCRIPTION
Use the add to cart handler filter introduced with SHA: bd78ca6 to also provide a way for extensions to use core WC add to cart button text (more details on original hook in #2539).

I've used the same hook name for both places, as they're closely related.
