### PR TITLE
IE8 Review Order Bug

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -65,7 +65,8 @@ jQuery(document).ready(function($) {
 			data: 		data,
 			success: 	function( response ) {
 				if ( response ) {
-					$('#order_review').after(response).remove();
+					var order_output = $(response);
+					$('#order_review').html(order_output.html());
 					$('body').trigger('updated_checkout');
 				}
 			}


### PR DESCRIPTION
Review order was never appearing on IE8 because it is added with the same ID, and both were being removed. This is a little bit better implementation, and works in all browsers.

To reproduce, load a checkout page in IE8.

This fixes support ticket #20942.
