### PR TITLE
Add additional hook to grouped product add-to-cart template

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -60,6 +60,8 @@ foreach ( $product->get_children() as $child_id ) {
 
 					?></label></td>
 
+					<?php do_action ( 'woocommerce_grouped_product_list_before_price', $child_product['product'] ); ?>
+
 					<td class="price"><?php echo $child_product['product']->get_price_html(); ?>
 					<?php echo apply_filters( 'woocommerce_stock_html', '<small class="stock '.$child_product['availability']['class'].'">'.$child_product['availability']['availability'].'</small>', $child_product['availability']['availability'] ); ?>
 					</td>


### PR DESCRIPTION
This adds an additional action to the grouped product page template so that plugins can add additional columns to the table. This has been done predominantly to allow the display of MSRP prices (See ticket 23748). 

Matching PR to the extensions repo to follow for the changes to the MSRP plugin itself.
