### PR TITLE
Add filters to product images and product thumbnails

### DIFF
--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -16,11 +16,14 @@ global $post, $woocommerce;
 
 	<?php if ( has_post_thumbnail() ) : ?>
 
-		<a class="woocommerce-main-image zoom" itemprop="image" href="<?php echo wp_get_attachment_url( get_post_thumbnail_id() ); ?>" rel="prettyPhoto[product-gallery]" title="<?php echo get_the_title( get_post_thumbnail_id() ); ?>"><?php echo get_the_post_thumbnail( $post->ID, apply_filters( 'single_product_large_thumbnail_size', 'shop_single' ) ) ?></a>
+		<?php
+		echo apply_filters( 'woocommerce_product_image_with_link', '<a class="woocommerce-main-image zoom" itemprop="image" href="' . wp_get_attachment_url( get_post_thumbnail_id() ) . '" rel="prettyPhoto[product-gallery]" title="' . get_the_title( get_post_thumbnail_id() ) . '">' . get_the_post_thumbnail( $post->ID, apply_filters( 'single_product_large_thumbnail_size', 'shop_single' ) ) . '</a>', $post->ID );
+		?>
 
 	<?php else : ?>
-
-		<img src="<?php echo woocommerce_placeholder_img_src(); ?>" alt="Placeholder" />
+		<?php
+		echo apply_filters( 'woocommerce_product_image_placeholder', '<img src="' . woocommerce_placeholder_img_src() . '" alt="Placeholder" />', $post->ID );
+		?>
 
 	<?php endif; ?>
 

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -35,7 +35,9 @@ if ( $attachment_ids ) {
 			if ( ! $attachment_url )
 				continue;
 
-			printf( '<a href="%s" title="%s" rel="prettyPhoto[product-gallery]" class="%s">%s</a>', esc_attr( $attachment_url ), esc_attr( get_the_title( $id ) ), implode( ' ', $classes ), wp_get_attachment_image( $id, apply_filters( 'single_product_small_thumbnail_size', 'shop_thumbnail' ) ) );
+			$image = apply_filters( 'single_product_thumbnail_image', sprintf( '<a href="%s" title="%s" rel="prettyPhoto[product-gallery]" class="%s">%s</a>', esc_attr( $attachment_url ), esc_attr( get_the_title( $id ) ), implode( ' ', $classes ), wp_get_attachment_image( $id, apply_filters( 'single_product_small_thumbnail_size', 'shop_thumbnail' ) ) ), $id );
+			
+			echo $image;
 
 			$loop++;
 		}


### PR DESCRIPTION
Adding filters to both the product images and thumbnails allows 3rd party developers to further customize the HTML output.

Here are a list of things that this filter would allow:
1. Change out prettyPhoto with some other lightbox
2. If we wanted to use Timthumb script or some other imaging script to dynamically generate the images
3. If we wanted to add different REL attributes or even rename REL to DATA-REL to pass validation

Thanks!
