### PR TITLE
Fix hide cart if empty

### DIFF
--- a/classes/widgets/class-wc-widget-cart.php
+++ b/classes/widgets/class-wc-widget-cart.php
@@ -79,10 +79,10 @@ class WC_Widget_Cart extends WP_Widget {
 
 		if ( $hide_if_empty && sizeof( $woocommerce->cart->get_cart() ) == 0 ) {
 			$woocommerce->add_inline_js( "
-				jQuery('.hide_cart_widget_if_empty').closest('.widget').hide();
+				jQuery('.hide_cart_widget_if_empty').closest('.widget_shopping_cart').hide();
 
 				jQuery('body').bind('adding_to_cart', function(){
-					jQuery('.hide_cart_widget_if_empty').closest('.widget').fadeIn();
+					jQuery('.hide_cart_widget_if_empty').closest('.widget_shopping_cart').fadeIn();
 				});
 			" );
 		}


### PR DESCRIPTION
jQuery should use classname of '.widget_shopping_cart', not '.widget'.

TwentyTen theme does not label widgets using the generic .widget class. TwentyEleven/TwentyTwelve does. That is why this worked for @coenjacobs but not me.

See #2642
