### PR TITLE
Fix post_class filter expecting too many args

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -482,7 +482,7 @@ class Woocommerce {
 			add_action( 'wp_head', array( $this, 'generator' ) );
 			add_action( 'wp_head', array( $this, 'wp_head' ) );
 			add_filter( 'body_class', array( $this, 'output_body_class' ) );
-			add_filter( 'post_class', array( $this, 'post_class' ), 20, 3 );
+			add_filter( 'post_class', array( $this, 'post_class' ), 20, 1 );
 			add_action( 'wp_footer', array( $this, 'output_inline_js' ), 25 );
 
 			// HTTPS urls with SSL on
@@ -1928,12 +1928,10 @@ class Woocommerce {
 	 * @since 2.0
 	 * @access public
 	 * @param array $classes
-	 * @param string|array $class
-	 * @param int $post_id
 	 * @return array
 	 */
-	public function post_class( $classes, $class, $post_id ) {
-		$product = get_product( $post_id );
+	public function post_class( $classes ) {
+		$product = get_product( $post->ID );
 
 		if ( $product ) {
 			if ( $product->is_on_sale() ) {


### PR DESCRIPTION
Current Wordpress offers only one argument to post_class filters. This patch avoids a warning in the error log when the filter expects three but doesn't get them.

The second one wasn't being used so removing it does no harm. The third ($post_id) was being used but Wordpress documentation for post_class filters at http://codex.wordpress.org/Function_Reference/post_class#Add_Classes_By_Filters shows it is available as $post->ID.
