### PR TITLE
Add filter to control order stock reduction when payment is complete

### DIFF
--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -1333,7 +1333,8 @@ class WC_Order {
 			);
 			wp_update_post( $this_order );
 
-			$this->reduce_order_stock(); // Payment is complete so reduce stock levels
+			if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', true, $this->id ) )
+				$this->reduce_order_stock(); // Payment is complete so reduce stock levels
 
 			do_action( 'woocommerce_payment_complete', $this->id );
 		}


### PR DESCRIPTION
Adds a 'woocommerce_payment_complete_reduce_order_stock' filter that controls whether stock is reduced for an order when WC_Order::payment_complete() is called. This is needed for pre-orders because order stock is reduced immediately on initial checkout (even though payment_complete() is not called) for pre-orders that are charged at a later date. When the pre-order is completed, the gateway calls payment_complete(), which reduces the stock again.
