### PR TITLE
Product Variations Order Again Bug Fix and Stock Quantity Filters

### DIFF
--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -275,7 +275,7 @@ class WC_Checkout {
 
 			 	// Add line item meta for backorder status
 			 	if ( $_product->backorders_require_notification() && $_product->is_on_backorder( $values['quantity'] ) )
-			 		woocommerce_add_order_item_meta( $item_id, __( 'Backordered', 'woocommerce' ), $values['quantity'] - max( 0, $_product->get_total_stock() ) );
+			 		woocommerce_add_order_item_meta( $item_id, apply_filters( 'woocommerce_backordered_item_meta_name', __( 'Backordered', 'woocommerce' ), $cart_item_key, $order_id ), $values['quantity'] - max( 0, $_product->get_total_stock() ) );
 
 			 	//allow plugins to add order item meta
 			 	do_action( 'woocommerce_add_order_item_meta', $item_id, $values );

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -1457,7 +1457,9 @@ class WC_Order {
 
 						$old_stock = $_product->stock;
 
-						$new_quantity = $_product->reduce_stock( $item['qty'] );
+						$qty = apply_filters( 'woocommerce_order_item_quantity', $item['qty'], $this, $item );
+
+						$new_quantity = $_product->reduce_stock( $qty );
 
 						$this->add_order_note( sprintf( __( 'Item #%s stock reduced from %s to %s.', 'woocommerce' ), $item['product_id'], $old_stock, $new_quantity) );
 

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -45,7 +45,7 @@ global $woocommerce;
 
 				<?php echo $woocommerce->cart->get_item_data( $cart_item ); ?>
 
-				<span class="quantity"><?php printf( '%s &times; %s', $cart_item['quantity'], $product_price ); ?></span>
+				<?php echo apply_filters( 'woocommerce_widget_cart_item_quantity', '<span class="quantity">' . sprintf( '%s &times; %s', $cart_item['quantity'], $product_price ) . '</span>', $cart_item, $cart_item_key ); ?>
 			</li>
 
 		<?php endforeach; ?>

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -168,7 +168,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 						if ($_product->exists() && $values['quantity']>0) :
 							echo '
 								<tr class="' . esc_attr( apply_filters('woocommerce_checkout_table_item_class', 'checkout_table_item', $values, $item_id ) ) . '">
-									<td class="product-name">' . $_product->get_title() . ' <strong class="product-quantity">&times; ' . $values['quantity'] . '</strong>' . $woocommerce->cart->get_item_data( $values ) . '</td>
+									<td class="product-name">' . apply_filters( 'woocommerce_checkout_item_name', $_product->get_title() . ' <strong class="product-quantity">&times; ' . $values['quantity'] . '</strong>' . $woocommerce->cart->get_item_data( $values ), $values, $item_id ) . '</td>
 									<td class="product-total">' . apply_filters( 'woocommerce_checkout_item_subtotal', $woocommerce->cart->get_product_subtotal( $_product, $values['quantity'] ), $values, $item_id ) . '</td>
 								</tr>';
 						endif;

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -45,7 +45,8 @@ $order = new WC_Order( $order_id );
 					<tr class = "' . esc_attr( apply_filters('woocommerce_order_table_item_class', 'order_table_item', $item, $order ) ) . '">
 						<td class="product-name">';
 
-				echo '<a href="'.get_permalink( $item['product_id'] ).'">' . $item['name'] . '</a> <strong class="product-quantity">&times; ' . $item['qty'] . '</strong>';
+				$product_name = '<a href="'.get_permalink( $item['product_id'] ).'">' . $item['name'] . '</a> <strong class="product-quantity">&times; ' . $item['qty'] . '</strong>';
+				echo apply_filters( 'woocommerce_order_table_item_name', $product_name, $item );
 
 				$item_meta = new WC_Order_Item_Meta( $item['item_meta'] );
 				$item_meta->display();

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -1157,7 +1157,8 @@ function woocommerce_ajax_reduce_order_item_stock() {
 			if ( $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
 
 				$old_stock 		= $_product->stock;
-				$new_quantity 	= $_product->reduce_stock( $order_item_qty[ $item_id ] );
+				$stock_change   = apply_filters( 'woocommerce_reduce_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
+				$new_quantity 	= $_product->reduce_stock( $stock_change );
 
 				$return[] = sprintf( __( 'Item #%s stock reduced from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity );
 				$order->add_order_note( sprintf( __( 'Item #%s stock reduced from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity) );
@@ -1209,7 +1210,8 @@ function woocommerce_ajax_increase_order_item_stock() {
 			if ( $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
 
 				$old_stock 		= $_product->stock;
-				$new_quantity 	= $_product->increase_stock( $order_item_qty[ $item_id ] );
+				$stock_change   = apply_filters( 'woocommerce_restore_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
+				$new_quantity 	= $_product->increase_stock( $stock_change );
 
 				$return[] = sprintf( __( 'Item #%s stock increased from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity );
 				$order->add_order_note( sprintf( __( 'Item #%s stock increased from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity ) );

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -853,15 +853,17 @@ function woocommerce_order_again() {
 		$quantity     = (int) $item['qty'];
 		$variation_id = (int) $item['variation_id'];
 		$variations   = array();
-		foreach ( $item['item_meta'] as $meta ) {
-			if ( ! substr( $meta['meta_name'], 0, 3) === 'pa_' ) continue;
-			$variations[$meta['meta_name']] = $meta['meta_value'];
+		$cart_item_data = apply_filters( 'woocommerce_order_again_cart_item_data', array(), $item, $order );
+
+		foreach ( $item['item_meta'] as $meta_name => $meta_value ) {
+			if ( 'pa_' === substr( $meta_name, 0, 3 ) )
+				$variations[ $meta_name ] = $meta_value[0];
 		}
 
 		// Add to cart validation
-		if ( ! apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity, $variation_id, $variations ) ) continue;
+		if ( ! apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity, $variation_id, $variations, $cart_item_data ) ) continue;
 
-		$woocommerce->cart->add_to_cart( $product_id, $quantity, $variation_id, $variations );
+		$woocommerce->cart->add_to_cart( $product_id, $quantity, $variation_id, $variations, $cart_item_data );
 	}
 
 	do_action( 'woocommerce_ordered_again', $order->id );

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -244,9 +244,9 @@ function woocommerce_update_cart_action() {
 					continue;
 
 				// Sanitize
-				$quantity = preg_replace( "/[^0-9\.]/", "", $cart_totals[ $cart_item_key ]['qty'] );
+				$quantity = apply_filters( 'woocommerce_stock_amount_cart_item', preg_replace( "/[^0-9\.]/", "", $cart_totals[ $cart_item_key ]['qty'] ), $cart_item_key );
 
-				if ( $quantity == "" )
+				if ( "" === $quantity )
 					continue;
 
 				// Update cart validation


### PR DESCRIPTION
- Fixed a bug introduced with the new order item meta data structure of WC 2.0: product variations could not be "ordered again"
- Improved the order again support for products with custom item meta data
- Added a number of filters related to product stock to allow for improved control over the stock handling and display
