### PR TITLE
Option to disable single search result redirect

### DIFF
--- a/admin/settings/settings-init.php
+++ b/admin/settings/settings-init.php
@@ -503,6 +503,14 @@ $woocommerce_settings['catalog'] = apply_filters('woocommerce_catalog_settings',
 		'checkboxgroup'		=> 'end'
 	),
 
+	array(
+		'title' => __( 'Product Search', 'woocommerce' ),
+		'desc'     => __( 'Redirect to the product page on a single matching search result', 'woocommerce' ),
+		'id'     => 'woocommerce_redirect_on_single_search_result',
+		'default'     => 'yes',
+		'type'     => 'checkbox'
+   ),
+   
 	array( 'type' => 'sectionend', 'id' => 'catalog_options' ),
 
 	array(	'title' => __( 'Product Data', 'woocommerce' ), 'type' => 'title', 'desc' => __( 'The following options affect the fields available on the edit product page.', 'woocommerce' ), 'id' => 'product_data_options' ),

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -68,7 +68,7 @@ function woocommerce_template_redirect() {
 	}
 
 	// Redirect to the product page if we have a single product
-	elseif ( is_search() && is_post_type_archive( 'product' ) ) {
+	elseif ( is_search() && is_post_type_archive( 'product' ) && get_option('woocommerce_redirect_on_single_search_result')=='yes' ) {
 		if ( $wp_query->post_count == 1 ) {
 			$product = get_product( $wp_query->post );
 			if ( $product->is_visible() )


### PR DESCRIPTION
Adding back the settings option to enable / disable the redirect to product page on single search result based on code from the [original pull request](https://github.com/woothemes/woocommerce/pull/609), though I changed it to default to enabled. The change also adds two language strings, “Product Search” as a title, and “Redirect to the product page on a single matching search result”.

It looks like:

![image](https://f.cloud.github.com/assets/517889/281079/13a7a0fc-916e-11e2-9f45-4d036510f03b.png)

I added it back because in my WooCommerce implementation, I customized the search results page to have more than just the product results, so even if only one product is matched, I still want the results page to show up. I am guessing there are others who could use that option also.
