### PR TITLE
Product image gallery metabox should use thumbnail images

### DIFF
--- a/admin/post-types/writepanels/writepanel-product_images.php
+++ b/admin/post-types/writepanels/writepanel-product_images.php
@@ -37,7 +37,7 @@ function woocommerce_product_images_box() {
 				if ( $attachments )
 					foreach ( $attachments as $attachment_id ) {
 						echo '<li class="image" data-attachment_id="' . $attachment_id . '">
-							' . wp_get_attachment_image( $attachment_id, 'full' ) . '
+							' . wp_get_attachment_image( $attachment_id, 'thumbnail' ) . '
 							<ul class="actions">
 								<li><a href="#" class="delete" title="' . __( 'Delete image', 'woocommerce' ) . '">' . __( 'Delete', 'woocommerce' ) . '</a></li>
 							</ul>


### PR DESCRIPTION
Full size images in the product image gallery metabox take a long time to load, especially if there are a lot of them or if they're very large.
