### PR TITLE
Fix WC_Product::set_stock_status() to correctly set status

### DIFF
--- a/classes/abstracts/abstract-wc-product.php
+++ b/classes/abstracts/abstract-wc-product.php
@@ -231,7 +231,7 @@ class WC_Product {
 	 * @return void
 	 */
 	function set_stock_status( $status ) {
-		$status = 'outofstock' ? 'outofstock' : 'instock';
+		$status = ( 'outofstock' === $status ) ? 'outofstock' : 'instock';
 
 		if ( $this->stock_status != $status ) {
 			update_post_meta( $this->id, '_stock_status', $status );


### PR DESCRIPTION
Currently any time `WC_Product::set_stock_status()` is called, the product will be changed to out of stock. This fixes the conditional that causes the bug.
