### PR TITLE
Issue #2826 - PayPal Payment Data not Stored

### DIFF
--- a/classes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/classes/gateways/paypal/class-wc-gateway-paypal.php
@@ -655,15 +655,15 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 					 // Store PP Details
 	                if ( ! empty( $posted['payer_email'] ) )
-	                	update_post_meta( $order_id, 'Payer PayPal address', $posted['payer_email'] );
+	                	update_post_meta( $order->id, 'Payer PayPal address', $posted['payer_email'] );
 	                if ( ! empty( $posted['txn_id'] ) )
-	                	update_post_meta( $order_id, 'Transaction ID', $posted['txn_id'] );
+	                	update_post_meta( $order->id, 'Transaction ID', $posted['txn_id'] );
 	                if ( ! empty( $posted['first_name'] ) )
-	                	update_post_meta( $order_id, 'Payer first name', $posted['first_name'] );
+	                	update_post_meta( $order->id, 'Payer first name', $posted['first_name'] );
 	                if ( ! empty( $posted['last_name'] ) )
-	                	update_post_meta( $order_id, 'Payer last name', $posted['last_name'] );
+	                	update_post_meta( $order->id, 'Payer last name', $posted['last_name'] );
 	                if ( ! empty( $posted['payment_type'] ) )
-	                	update_post_meta( $order_id, 'Payment type', $posted['payment_type'] );
+	                	update_post_meta( $order->id, 'Payment type', $posted['payment_type'] );
 
 	            	// Payment completed
 	                $order->add_order_note( __( 'IPN payment completed', 'woocommerce' ) );


### PR DESCRIPTION
PP Payment Details aren't being stored on posts meta table, because of a probably misstyped
variable on class-wc-gateway-paypal.php, in the function successful_request (Lines 658 to 666).

Replaced $order_id (non existent variable) by $order->id to correct the issue.
