### PR TITLE
Encapsulate formatted product name

### DIFF
--- a/admin/post-types/writepanels/writepanel-coupon_data.php
+++ b/admin/post-types/writepanels/writepanel-coupon_data.php
@@ -79,10 +79,9 @@ function woocommerce_coupon_data_meta_box( $post ) {
 						$product_ids = array_map( 'absint', explode( ',', $product_ids ) );
 						foreach ( $product_ids as $product_id ) {
 
-							$product      = get_product( $product_id );
-							$product_name = woocommerce_get_formatted_product_name( $product );
+							$product = get_product( $product_id );
 
-							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . wp_kses_post( $product_name ) . '</option>';
+							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . wp_kses_post( $product->get_formatted_name() ) . '</option>';
 						}
 					}
 				?>
@@ -99,10 +98,9 @@ function woocommerce_coupon_data_meta_box( $post ) {
 						$product_ids = array_map( 'absint', explode( ',', $product_ids ) );
 						foreach ( $product_ids as $product_id ) {
 
-							$product      = get_product( $product_id );
-							$product_name = woocommerce_get_formatted_product_name( $product );
+							$product = get_product( $product_id );
 
-							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $product_name ) . '</option>';
+							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $product->get_formatted_name() ) . '</option>';
 						}
 					}
 				?>

--- a/admin/post-types/writepanels/writepanel-order_downloads.php
+++ b/admin/post-types/writepanels/writepanel-order_downloads.php
@@ -76,9 +76,8 @@ function woocommerce_order_downloads_meta_box() {
 						if ( $products ) foreach ( $products as $product ) {
 
 							$product_object = get_product( $product->ID );
-							$product_name   = woocommerce_get_formatted_product_name( $product_object );
 
-							echo '<option value="' . esc_attr( $product->ID ) . '">' . esc_html( $product_name ) . '</option>';
+							echo '<option value="' . esc_attr( $product->ID ) . '">' . esc_html( $product_object->get_formatted_name() ) . '</option>';
 
 						}
 					?>

--- a/admin/post-types/writepanels/writepanel-product_data.php
+++ b/admin/post-types/writepanels/writepanel-product_data.php
@@ -526,10 +526,9 @@ function woocommerce_product_data_box() {
 					if ( $product_ids ) {
 						foreach ( $product_ids as $product_id ) {
 
-							$product      = get_product( $product_id );
-							$product_name = woocommerce_get_formatted_product_name( $product );
+							$product = get_product( $product_id );
 
-							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $product_name ) . '</option>';
+							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $product->get_formatted_name() ) . '</option>';
 						}
 					}
 				?>
@@ -543,10 +542,9 @@ function woocommerce_product_data_box() {
 					if ( $product_ids ) {
 						foreach ( $product_ids as $product_id ) {
 
-							$product      = get_product( $product_id );
-							$product_name = woocommerce_get_formatted_product_name( $product );
+							$product = get_product( $product_id );
 
-							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $product_name ) . '</option>';
+							echo '<option value="' . esc_attr( $product_id ) . '" selected="selected">' . esc_html( $product->get_formatted_name() ) . '</option>';
 						}
 					}
 				?>

--- a/classes/abstracts/abstract-wc-product.php
+++ b/classes/abstracts/abstract-wc-product.php
@@ -1274,11 +1274,11 @@ class WC_Product {
 
 
 	/**
-	 * Get product name with extra details such as SKU price and attributes. Used within admin.
+	 * Get product name with SKU or ID. Used within admin.
 	 *
 	 * @access public
 	 * @param mixed $product
-	 * @return void
+	 * @return string Formatted product name
 	 */
 	function get_formatted_name() {
 

--- a/classes/abstracts/abstract-wc-product.php
+++ b/classes/abstracts/abstract-wc-product.php
@@ -1271,4 +1271,22 @@ class WC_Product {
 
 		return $image;
     }
+
+
+	/**
+	 * Get product name with extra details such as SKU price and attributes. Used within admin.
+	 *
+	 * @access public
+	 * @param mixed $product
+	 * @return void
+	 */
+	function get_formatted_name() {
+
+		if ( $this->get_sku() )
+			$identifier = $this->get_sku();
+		else
+			$identifier = '#' . $this->id;
+
+		return sprintf( __( '%s &ndash; %s', 'woocommerce' ), $identifier, $this->get_title() );
+	}
 }

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -452,4 +452,25 @@ class WC_Product_Variation extends WC_Product {
 		// allow overriding based on the particular file being requested
 		return apply_filters( 'woocommerce_file_download_path', $file_path, $this->variation_id, $download_id );
 	}
+
+
+	/**
+	 * Get product name with extra details such as SKU price and attributes. Used within admin.
+	 *
+	 * @access public
+	 * @param mixed $product
+	 * @return void
+	 */
+	function get_formatted_name() {
+
+		if ( $this->get_sku() )
+			$identifier = $this->get_sku();
+		else
+			$identifier = '#' . $this->variation_id;
+
+		$attributes = $this->get_variation_attributes();
+		$extra_data = ' &ndash; ' . implode( ', ', $attributes ) . ' &ndash; ' . woocommerce_price( $this->get_price() );
+
+		return sprintf( __( '%s &ndash; %s%s', 'woocommerce' ), $identifier, $this->get_title(), $extra_data );
+	}
 }

--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -455,13 +455,13 @@ class WC_Product_Variation extends WC_Product {
 
 
 	/**
-	 * Get product name with extra details such as SKU price and attributes. Used within admin.
+	 * Get product name with extra details such as SKU, price and attributes. Used within admin.
 	 *
 	 * @access public
 	 * @param mixed $product
-	 * @return void
+	 * @return string Formatted product name, including attributes and price
 	 */
-	function get_formatted_name() {
+	public function get_formatted_name() {
 
 		if ( $this->get_sku() )
 			$identifier = $this->get_sku();

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -1607,7 +1607,7 @@ function woocommerce_json_search_products( $x = '', $post_types = array('product
 
 		$product = get_product( $post );
 
-		$found_products[ $post ] = woocommerce_get_formatted_product_name( $product );
+		$found_products[ $post ] = $product->get_formatted_name();
 
 	}
 

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -245,6 +245,7 @@ function woocommerce_get_weight( $weight, $to_unit ) {
  *
  * @access public
  * @param mixed $product
+ * @deprecated 2.1
  * @return void
  */
 function woocommerce_get_formatted_product_name( $product ) {

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -248,24 +248,10 @@ function woocommerce_get_weight( $weight, $to_unit ) {
  * @return void
  */
 function woocommerce_get_formatted_product_name( $product ) {
-	if ( ! $product || ! is_object( $product ) )
-		return;
 
-	if ( $product->get_sku() )
-		$identifier = $product->get_sku();
-	elseif ( $product->is_type( 'variation' ) )
-		$identifier = '#' . $product->variation_id;
-	else
-		$identifier = '#' . $product->id;
+	_deprecated_function( __FUNCTION__, '2.1', 'WC_Product::get_formatted_name()' );
 
-	if ( $product->is_type( 'variation' ) ) {
-		$attributes = $product->get_variation_attributes();
-		$extra_data = ' &ndash; ' . implode( ', ', $attributes ) . ' &ndash; ' . woocommerce_price( $product->get_price() );
-	} else {
-		$extra_data = '';
-	}
-
-	return sprintf( __( '%s &ndash; %s%s', 'woocommerce' ), $identifier, $product->get_title(), $extra_data );
+	return $product->get_formatted_name();
 }
 
 


### PR DESCRIPTION
Patches for #2788. As discussed there, this just moves `woocommerce_get_formatted_product_name()` code into `WC_Product` & `WC_Product_Variation` classes and puts it in the new `get_formatted_name()` function.

SHA: 9e71cd699fb also updates all uses of `woocommerce_get_formatted_product_name()` in core code.

Didn't see a 2.1 branch, so just set this to merge with master.
