### PR TITLE
Switch download_url to non-SSL

### DIFF
--- a/classes/class-wc-customer.php
+++ b/classes/class-wc-customer.php
@@ -643,7 +643,7 @@ class WC_Customer {
 					}
 
 					$downloads[] = array(
-						'download_url' => add_query_arg( array( 'download_file' => $result->product_id, 'order' => $result->order_key, 'email' => $result->user_email, 'key' => $result->download_id ), trailingslashit( home_url( '', 'http') ) ),
+						'download_url' => add_query_arg( array( 'download_file' => $result->product_id, 'order' => $result->order_key, 'email' => $result->user_email, 'key' => $result->download_id ), trailingslashit( home_url( '', 'http' ) ) ),
 						'download_id' => $result->download_id,
 						'product_id' => $result->product_id,
 						'download_name' => $download_name,

--- a/classes/class-wc-customer.php
+++ b/classes/class-wc-customer.php
@@ -643,7 +643,7 @@ class WC_Customer {
 					}
 
 					$downloads[] = array(
-						'download_url' => add_query_arg( array( 'download_file' => $result->product_id, 'order' => $result->order_key, 'email' => $result->user_email, 'key' => $result->download_id ), trailingslashit( home_url() ) ),
+						'download_url' => add_query_arg( array( 'download_file' => $result->product_id, 'order' => $result->order_key, 'email' => $result->user_email, 'key' => $result->download_id ), trailingslashit( home_url( '', 'http') ) ),
 						'download_id' => $result->download_id,
 						'product_id' => $result->product_id,
 						'download_name' => $download_name,


### PR DESCRIPTION
Change download_url (as shown under My Account / Available Downloads) to use non-SSL (http) instead of SSL. This prevents issues with certain browsers like IE and caching security settings. I cannot see a compelling reason to serve these links over SSL.

Note that this does not change the actual link saved with the product, just the 'download handler' link WC uses.

See #2871

If someone wants SSL behavior, use `woocommerce_customer_get_downloadable_products` filter to modify these urls.
