### PR TITLE
Added new filters to format the address

### DIFF
--- a/admin/woocommerce-admin-users.php
+++ b/admin/woocommerce-admin-users.php
@@ -72,7 +72,7 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 
 		break;
 		case "woocommerce_billing_address" :
-			$address = array(
+			$address = apply_filters( 'woocommerce_user_column_billing_address', array(
 				'first_name' 	=> get_user_meta( $user_id, 'billing_first_name', true ),
 				'last_name'		=> get_user_meta( $user_id, 'billing_last_name', true ),
 				'company'		=> get_user_meta( $user_id, 'billing_company', true ),
@@ -82,7 +82,7 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 				'state'			=> get_user_meta( $user_id, 'billing_state', true ),
 				'postcode'		=> get_user_meta( $user_id, 'billing_postcode', true ),
 				'country'		=> get_user_meta( $user_id, 'billing_country', true )
-			);
+			), $user_id );
 
 			$formatted_address = $woocommerce->countries->get_formatted_address( $address );
 
@@ -94,7 +94,7 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 			$value = wpautop( $value );
 		break;
 		case "woocommerce_shipping_address" :
-			$address = array(
+			$address = apply_filters( 'woocommerce_user_column_shipping_address', array(
 				'first_name' 	=> get_user_meta( $user_id, 'shipping_first_name', true ),
 				'last_name'		=> get_user_meta( $user_id, 'shipping_last_name', true ),
 				'company'		=> get_user_meta( $user_id, 'shipping_company', true ),
@@ -104,7 +104,7 @@ function woocommerce_user_column_values( $value, $column_name, $user_id ) {
 				'state'			=> get_user_meta( $user_id, 'shipping_state', true ),
 				'postcode'		=> get_user_meta( $user_id, 'shipping_postcode', true ),
 				'country'		=> get_user_meta( $user_id, 'shipping_country', true )
-			);
+			), $user_id );
 
 			$formatted_address = $woocommerce->countries->get_formatted_address( $address );
 

--- a/classes/class-wc-countries.php
+++ b/classes/class-wc-countries.php
@@ -647,7 +647,7 @@ class WC_Countries {
 			'{state_upper}'      => strtoupper( $full_state ),
 			'{postcode_upper}'   => strtoupper( $postcode ),
 			'{country_upper}'    => strtoupper( $full_country ),
-		) ) ;
+		), $args ) ;
 
 		$replace = array_map( 'esc_html', $replace );
 

--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -294,8 +294,8 @@ class WC_Order {
 			global $woocommerce;
 
 			// Formatted Addresses
-			$address = array(
-				'first_name' 	=> $this->billing_first_name,
+			$address = apply_filters( 'woocommerce_order_formatted_billing_address', array(
+				'first_name'	=> $this->billing_first_name,
 				'last_name'		=> $this->billing_last_name,
 				'company'		=> $this->billing_company,
 				'address_1'		=> $this->billing_address_1,
@@ -304,7 +304,7 @@ class WC_Order {
 				'state'			=> $this->billing_state,
 				'postcode'		=> $this->billing_postcode,
 				'country'		=> $this->billing_country
-			);
+			), $this );
 
 			$this->formatted_billing_address = $woocommerce->countries->get_formatted_address( $address );
 		}
@@ -347,7 +347,7 @@ class WC_Order {
 				global $woocommerce;
 
 				// Formatted Addresses
-				$address = array(
+				$address = apply_filters( 'woocommerce_order_formatted_shipping_address', array(
 					'first_name' 	=> $this->shipping_first_name,
 					'last_name'		=> $this->shipping_last_name,
 					'company'		=> $this->shipping_company,
@@ -357,7 +357,7 @@ class WC_Order {
 					'state'			=> $this->shipping_state,
 					'postcode'		=> $this->shipping_postcode,
 					'country'		=> $this->shipping_country
-				);
+				), $this );
 
 				$this->formatted_shipping_address = $woocommerce->countries->get_formatted_address( $address );
 			}

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -46,7 +46,7 @@ $col = 1;
 		</header>
 		<address>
 			<?php
-				$address = array(
+				$address = apply_filters( 'woocommerce_my_address_formatted_address', array(
 					'first_name' 	=> get_user_meta( $customer_id, $name . '_first_name', true ),
 					'last_name'		=> get_user_meta( $customer_id, $name . '_last_name', true ),
 					'company'		=> get_user_meta( $customer_id, $name . '_company', true ),
@@ -56,7 +56,7 @@ $col = 1;
 					'state'			=> get_user_meta( $customer_id, $name . '_state', true ),
 					'postcode'		=> get_user_meta( $customer_id, $name . '_postcode', true ),
 					'country'		=> get_user_meta( $customer_id, $name . '_country', true )
-				);
+				), $customer_id, $name );
 
 				$formatted_address = $woocommerce->countries->get_formatted_address( $address );
 


### PR DESCRIPTION
When adding new address fields in checkout is complicated add information on order_shop, my-address page, emails and so on.

Added some new filters to help in this task.
I believe the filters will facilitate to address the specific needs of each country or store.

Example: https://gist.github.com/claudiosmweb/94b30eaca0eb71dad52c
