### PR TITLE
Pass $args to woocommerce_before_template_part action

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -605,11 +605,11 @@ function woocommerce_get_template( $template_name, $args = array(), $template_pa
 
 	$located = woocommerce_locate_template( $template_name, $template_path, $default_path );
 
-	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located );
+	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located, $args );
 
 	include( $located );
 
-	do_action( 'woocommerce_after_template_part', $template_name, $template_path, $located );
+	do_action( 'woocommerce_after_template_part', $template_name, $template_path, $located, $args );
 }
 
 


### PR DESCRIPTION
You can use those $args in the templates (for instance the $order is passed to the thankyou.php) but of all the variables passed to the `woocommerce_before_template_part` (and the `woocommerce_after_template_part`) the $args aren't included.  
