### PR TITLE
taxonomy class fix

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -863,7 +863,7 @@ class Woocommerce {
 		register_taxonomy( 'product_shipping_class',
 	        apply_filters( 'woocommerce_taxonomy_objects_product_shipping_class', array('product', 'product_variation') ),
 	        apply_filters( 'woocommerce_taxonomy_args_product_shipping_class', array(
-	            'hierarchical' 			=> true,
+	            'hierarchical' 			=> false,
 	            'update_count_callback' => '_update_post_term_count',
 	            'label' 				=> __( 'Shipping Classes', 'woocommerce'),
 	            'labels' => array(
@@ -909,7 +909,7 @@ class Woocommerce {
 			foreach ($attribute_taxonomies as $tax) {
 
 		    	$name = $this->attribute_taxonomy_name( $tax->attribute_name );
-		    	$hierarchical = true;
+		    	$hierarchical = false;
 		    	if ($name) {
 
 		    		$label = ( isset( $tax->attribute_label ) && $tax->attribute_label ) ? $tax->attribute_label : $tax->attribute_name;


### PR DESCRIPTION
Please let me know if I'm wrong, but I don't see any reason for attributes or shipping classes to be hierarchical. This change would allows us to create a general query to get "Categories" with:

``` PHP
$taxonomies = get_object_taxonomies($post_type->name, 'objects');
  foreach($taxonomies as $tax) {
    if($tax->hierarchical == true) {
      // 'Product Categories'}
```
