### PR TITLE
Show accurate log name for PayPal

### DIFF
--- a/classes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/classes/gateways/paypal/class-wc-gateway-paypal.php
@@ -210,7 +210,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 							'type' => 'checkbox',
 							'label' => __( 'Enable logging', 'woocommerce' ),
 							'default' => 'no',
-							'description' => __( 'Log PayPal events, such as IPN requests, inside <code>woocommerce/logs/paypal.txt</code>' ),
+							'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside <code>woocommerce/logs/paypal-%s.txt</code>' ), sanitize_file_name( wp_hash( 'paypal' ) ) ),
 						)
 			);
 


### PR DESCRIPTION
Change the PayPal log path displayed on _WooCommerce > Settings > Payment Gateways > PayPal_ to accurately reflect the file name (i.e. include the hash).
