### PR TITLE
patch shop_order.php for issue 2958

### DIFF
--- a/admin/post-types/shop_order.php
+++ b/admin/post-types/shop_order.php
@@ -132,7 +132,7 @@ function woocommerce_custom_order_columns( $column ) {
 			} else {
 				$t_time = get_the_time( __( 'Y/m/d g:i:s A', 'woocommerce' ), $post );
 
-				$gmt_time = strtotime( $post->post_date_gmt );
+				$gmt_time = strtotime( $post->post_date_gmt . ' UTC' );
 				$time_diff = current_time('timestamp', 1) - $gmt_time;
 
 				if ( $time_diff > 0 && $time_diff < 24*60*60 )


### PR DESCRIPTION
adds `UTC` to the variable passed to `strtotime` to ensure that the `strtotime` function does not assume the local timezone when converting. see issue 2958 for further explanation.
