### PR TITLE
use base_country for tax calculations in manually created orders

### DIFF
--- a/admin/woocommerce-admin-init.php
+++ b/admin/woocommerce-admin-init.php
@@ -458,6 +458,7 @@ function woocommerce_admin_scripts() {
 			'search_products_nonce' 		=> wp_create_nonce("search-products"),
 			'calendar_image'				=> $woocommerce->plugin_url().'/assets/images/calendar.png',
 			'post_id'						=> $post->ID,
+			'base_country'					=> $woocommerce->countries->get_base_country(),
 			'currency_format_num_decimals'	=> absint( get_option( 'woocommerce_price_num_decimals' ) ),
 			'currency_format_symbol'		=> get_woocommerce_currency_symbol(),
 			'currency_format_decimal_sep'	=> esc_attr( stripslashes( get_option( 'woocommerce_price_decimal_sep' ) ) ),

--- a/assets/js/admin/write-panels.js
+++ b/assets/js/admin/write-panels.js
@@ -306,16 +306,24 @@ jQuery( function($){
 
 			var $items = $('#order_items_list').find('tr.item, tr.fee');
 
-			var country = $('#_shipping_country').val();
-			if (country) {
+			var shipping_country = $('#_shipping_country').val();
+			var billing_country = $('#_billing_country').val();
+			
+			if (shipping_country) {
+				var country = shipping_country;
 				var state = $('#_shipping_state').val();
 				var postcode = $('#_shipping_postcode').val();
 				var city = $('#_shipping_city').val();
-			} else {
-				country = $('#_billing_country').val();
+			} else if(billing_country) {
+				var country = billing_country;
 				var state = $('#_billing_state').val();
 				var postcode = $('#_billing_postcode').val();
 				var city = $('#_billing_city').val();
+			} else {
+				var country = woocommerce_writepanel_params.base_country;
+				var state = '';
+				var postcode = '';
+				var city = '';
 			}
 
 			// Get items and values


### PR DESCRIPTION
problem: 1.create manually an order. 2. add an item and click on the "Calc taxes" button. the js alert says that it will use the base country if no billing/shipping country was specified in the address. unfortunatly this functionality wasn't yet programmed in the javascript. 

solution: added  "woocommerce_writepanel_params.base_country" to the params. then included the caluclation code in the js file.

note: i'm not sure if this has any influence on other calculations. thanks for checking.
