### PR TITLE
Apply the_content filter to taxonomy archive descriptions

### DIFF
--- a/admin/importers/tax-rates-importer.php
+++ b/admin/importers/tax-rates-importer.php
@@ -108,6 +108,8 @@ if ( class_exists( 'WP_Importer' ) ) {
 
 			$new_rates = array();
 
+			ini_set( 'auto_detect_line_endings', '1' );
+
 			if ( ( $handle = fopen( $file, "r" ) ) !== FALSE ) {
 
 				$header = fgetcsv( $handle, 0, $this->delimiter );

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -283,9 +283,9 @@ if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 	 */
 	function woocommerce_taxonomy_archive_description() {
 		if ( is_tax( array( 'product_cat', 'product_tag' ) ) && get_query_var( 'paged' ) == 0 ) {
-			$description = term_description();
+			$description = apply_filters( 'the_content', term_description() );
 			if ( $description ) {
-				echo '<div class="term-description">' . wpautop( wptexturize( $description ) ) . '</div>';
+				echo '<div class="term-description">' . $description . '</div>';
 			}
 		}
 	}


### PR DESCRIPTION
Remove wpautop and wptexturize function and rather apply the_content filter so you can use shortcodes as well in category description 
