### PR TITLE
Add filter for default layered nav query type

### DIFF
--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -1414,11 +1414,10 @@ function woocommerce_layered_nav_init( ) {
 
 		    		$_chosen_attributes[ $taxonomy ]['terms'] = explode( ',', $_GET[ $name ] );
 
-		    		if ( ! empty( $_GET[ $query_type_name ] ) && $_GET[ $query_type_name ] == 'or' )
-		    			$_chosen_attributes[ $taxonomy ]['query_type'] = 'or';
-		    		else
-		    			$_chosen_attributes[ $taxonomy ]['query_type'] = 'and';
-
+		    		if ( empty( $_GET[ $query_type_name ] ) || ! in_array( strtolower( $_GET[ $query_type_name ] ), array( 'and', 'or' ) ) )
+						$_chosen_attributes[ $taxonomy ]['query_type'] = apply_filters( 'woocommerce_layered_nav_default_type', 'and' );
+					else
+						$_chosen_attributes[ $taxonomy ]['query_type'] = $_GET[ $query_type_name ];
 				}
 			}
 	    }


### PR DESCRIPTION
Instead of hard coding the default query type to 'and', this would allow us to filter it. This is definitely an edge case, but I'm building my own layered nav widget that uses 'or' queries, and it's a bit of a pain to have to specify `query_type_` parameters for every attribute.

Thanks for taking a look.
