### PR TITLE
Patched the "woocommerce_downloadable_product_permissions"

### DIFF
--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -1208,7 +1208,7 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 		if ($item['product_id']>0) :
 			$_product = $order->get_product_from_item( $item );
 
-			if ( $_product->exists() && $_product->is_downloadable() ) :
+			if ( $_product && $_product->exists() && $_product->is_downloadable() ) :
 
 				$product_id = ($item['variation_id']>0) ? $item['variation_id'] : $item['product_id'];
 


### PR DESCRIPTION
We were running batch saves of all products and orders to migrate our custom downloads code (adding multiple file support before it was introduced in the plugin) and ran into issues where a fatal error would occur generating the file permissions on orders where a product had been deleted.

This patch updates the woocommerce_downloadable_product_permissions function to recognize "false" as a potential value returned from "get_product_from_item", and not to assume that the value returned is an object with the "exists" and "is_downloadable" attributes.
