### PR TITLE
Updated to patch "woocommerce_downloadable_product_name" filter

### DIFF
--- a/classes/class-wc-customer.php
+++ b/classes/class-wc-customer.php
@@ -642,13 +642,6 @@ class WC_Customer {
 							$previous_result['download_id'],
 							0
 						);
-						/*$downloads[ count( $downloads ) - 1 ]['download_name'] = apply_filters(
-							'woocommerce_downloadable_product_name',
-							$downloads[ count( $downloads ) - 1 ]['download_name'] . ' &mdash; ' . sprintf( __( 'File %d', 'woocommerce' ), $file_number ),
-							$_product,
-							$result->download_id,
-							0
-						);*/
 					}
 
 					$downloads[] = array(

--- a/classes/class-wc-customer.php
+++ b/classes/class-wc-customer.php
@@ -633,13 +633,22 @@ class WC_Customer {
 
 					// Rename previous download with file number if there are multiple files only
 					if ( $file_number == 1 ) {
-						$downloads[ count( $downloads ) - 1 ]['download_name'] = apply_filters(
+						$previous_result = &$downloads[count($downloads)-1];
+						$previous_product = get_product($previous_result['product_id']);
+						$previous_result['download_name'] = apply_filters(
+							'woocommerce_downloadable_product_name',
+							$previous_result['download_name']. ' &mdash; ' . sprintf( __('File %d', 'woocommerce' ), $file_number ),
+							$previous_product,
+							$previous_result['download_id'],
+							0
+						);
+						/*$downloads[ count( $downloads ) - 1 ]['download_name'] = apply_filters(
 							'woocommerce_downloadable_product_name',
 							$downloads[ count( $downloads ) - 1 ]['download_name'] . ' &mdash; ' . sprintf( __( 'File %d', 'woocommerce' ), $file_number ),
 							$_product,
 							$result->download_id,
 							0
-						);
+						);*/
 					}
 
 					$downloads[] = array(


### PR DESCRIPTION
In existing master code, when the "woocommerce_downloadable_product_name" filter is being applied to the prior result (for the second file on a product), the variables passed in to the filter are for the current product, not the previous product which is being filtered.

This patch updates this condition to provide the correct filter context for replacing prior record data.
