### PR TITLE
Make easier for 3rd party plugins to get reports and charts info

### DIFF
--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -13,76 +13,72 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
- * Reports page
+ * Returns the definitions for the reports and charts
  *
- * Handles the display of the reports page in admin.
- *
- * @access public
- * @return void
+ * @return array
  */
-function woocommerce_reports() {
-
-	$charts            = array(
-		'sales'          => array(
-			'title'         => __( 'Sales', 'woocommerce' ),
-			'charts'        => array(
-				array(
+function woocommerce_get_reports_charts() {
+	$charts = array(
+		'sales'     => array(
+			'title'  => __( 'Sales', 'woocommerce' ),
+			'charts' => array(
+				"overview"          => array(
 					'title'       => __( 'Overview', 'woocommerce' ),
 					'description' => '',
 					'hide_title'  => true,
 					'function'    => 'woocommerce_sales_overview'
 				),
-				array(
+				"sales_by_day"      => array(
 					'title'       => __( 'Sales by day', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_daily_sales'
 				),
-				array(
+				"sales_by_month"    => array(
 					'title'       => __( 'Sales by month', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_monthly_sales'
 				),
-				array(
+				"product_sales"     => array(
 					'title'       => __( 'Product Sales', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_product_sales'
 				),
-				array(
+				"top_sellers"       => array(
 					'title'       => __( 'Top sellers', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_top_sellers'
 				),
-				array(
+				"top_earners"       => array(
 					'title'       => __( 'Top earners', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_top_earners'
 				),
-				array(
+				"sales_by_category" => array(
 					'title'       => __( 'Sales by category', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_category_sales'
-				)			)
+				) )
 		),
-		'coupons'        => array(
-			'title'         => __( 'Coupons', 'woocommerce' ),
-			'charts'        => array(
-				array(
+		'coupons'   => array(
+			'title'  => __( 'Coupons', 'woocommerce' ),
+			'charts' => array(
+				"overview"            => array(
 					'title'       => __( 'Overview', 'woocommerce' ),
 					'description' => '',
 					'hide_title'  => true,
 					'function'    => 'woocommerce_coupons_overview'
 				),
-				array(
+				"discounts_by_coupon" => array(
 					'title'       => __( 'Discounts by coupon', 'woocommerce' ),
 					'description' => '',
 					'function'    => 'woocommerce_coupon_discounts'
 				)
 			)
 		),
-		'customers'      => array(
-			'title'         => __( 'Customers', 'woocommerce' ),
-			'charts'        => array(
-				array(
+		'customers' => array(
+			'title'  => __( 'Customers', 'woocommerce' ),
+			'charts' => array(
+				"overview" => array(
 					'title'       => __( 'Overview', 'woocommerce' ),
 					'description' => '',
 					'hide_title'  => true,
@@ -90,10 +86,10 @@ function woocommerce_reports() {
 				),
 			)
 		),
-		'stock'          => array(
-			'title'         => __( 'Stock', 'woocommerce' ),
-			'charts'        => array(
-				array(
+		'stock'     => array(
+			'title'  => __( 'Stock', 'woocommerce' ),
+			'charts' => array(
+				"overview" => array(
 					'title'       => __( 'Overview', 'woocommerce' ),
 					'description' => '',
 					'hide_title'  => true,
@@ -104,20 +100,33 @@ function woocommerce_reports() {
 	);
 
 	if ( get_option( 'woocommerce_calc_taxes' ) == 'yes' ) {
-		$charts['sales']['charts'][] = array(
+		$charts['sales']['charts']["taxes_by_month"] = array(
 			'title'       => __( 'Taxes by month', 'woocommerce' ),
 			'description' => '',
 			'function'    => 'woocommerce_monthly_taxes'
 		);
 	}
 
-	$charts = apply_filters( 'woocommerce_reports_charts', $charts );
+	return apply_filters( 'woocommerce_reports_charts', $charts );
+}
+
+/**
+ * Reports page
+ *
+ * Handles the display of the reports page in admin.
+ *
+ * @access public
+ * @return void
+ */
+function woocommerce_reports() {
+
+	$charts = woocommerce_get_reports_charts();
 
 	$first_tab      = array_keys($charts);
 	$first_chart    = array_keys($charts[$first_tab[0]]['charts']);
 
 	$current_tab 	= isset( $_GET['tab'] ) ? sanitize_title( urldecode( $_GET['tab'] ) ) : $first_tab[0];
-	$current_chart 	= isset( $_GET['chart'] ) ? absint( urldecode( $_GET['chart'] ) ) : $first_chart[0];
+	$current_chart 	= isset( $_GET['chart'] ) ?  sanitize_title( urldecode( $_GET['chart'] ) ) : $first_chart[0];
 
     ?>
 	<div class="wrap woocommerce">
@@ -158,7 +167,7 @@ function woocommerce_reports() {
 			<br class="clear" />
 			<?php
 		}
-
+		
 		if ( isset( $charts[ $current_tab ][ 'charts' ][ $current_chart ] ) ) {
 
 			$chart = $charts[ $current_tab ][ 'charts' ][ $current_chart ];


### PR DESCRIPTION
Current situation:

If you need to link to a specific chart from outside the reports page, pretty much your only\* option is to hardcode the full link, including the chart ID. But the ID now is  just the array index, and it will change every time you add a chart, or a plugin or theme decides to change the order of the charts. What's worst, from 1.6 to 2.0.8 it changed 2 times, so it's really hard to maintain a 3rd part plugin that requires such link. 

(*) There's an insane option too: 
1) Hook into woocommerce_reports_charts
2) Open an output buffer and call woocommerce_reports(), and then discard the output buffer.
3) Loop through the array and use the chart name or callback function to get the array index. Take into account that the name could be localized and the callback function could have been changed by another plugin.

What this small patch does:
1) Extract the reports and charts definition to a new woocommerce_get_reports_charts() function so third party plugins can get easily the data.

2) Add a string key to each chart so it's easier and more reliable to identify them, because order, name and function can change, with some degree of certainty that the key won't change in the future.
