### PR TITLE
Ensure product exists in the downloads panel.

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_downloads.php
+++ b/admin/post-types/writepanels/writepanel-order_downloads.php
@@ -41,7 +41,7 @@ function woocommerce_order_downloads_meta_box() {
 					}
 
 					// don't show permissions to files that have since been removed
-					if ( ! $product->exists() || ! $product->has_file( $download->download_id ) )
+					if ( ! $product || ! $product->exists() || ! $product->has_file( $download->download_id ) )
 						continue;
 
 					include( 'order-download-permission-html.php' );


### PR DESCRIPTION
An error will be thrown if there is no product when displaying the download information of an order.
