### PR TITLE
Set "Create new account" ceckbox checked as default

### DIFF
--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -39,7 +39,7 @@ global $woocommerce;
 	<?php if ( $checkout->enable_guest_checkout ) : ?>
 
 		<p class="form-row form-row-wide">
-			<input class="input-checkbox" id="createaccount" <?php checked($checkout->get_value('createaccount'), true) ?> type="checkbox" name="createaccount" value="1" /> <label for="createaccount" class="checkbox"><?php _e( 'Create an account?', 'woocommerce' ); ?></label>
+			<input class="input-checkbox" id="createaccount" <?php checked($checkout->get_value('createaccount'), true) ?> type="checkbox" name="createaccount" value="1" checked="checked"/> <label for="createaccount" class="checkbox"><?php _e( 'Create an account?', 'woocommerce' ); ?></label>
 		</p>
 
 	<?php endif; ?>


### PR DESCRIPTION
Set the "Create a new account" checkbox for new customers to "checked" as
default because it is better for the shop owner and the customer to have
a user account for each customer.

See #3097
