### PR TITLE
Variations bulk edit increase/decrease prices by fixed or percentage values and MyException fix

### DIFF
--- a/admin/post-types/writepanels/writepanel-product-type-variable.php
+++ b/admin/post-types/writepanels/writepanel-product-type-variable.php
@@ -79,7 +79,11 @@ function variable_product_type_options() {
 					<option value="toggle_virtual"><?php _e( 'Toggle &quot;Virtual&quot;', 'woocommerce' ); ?></option>
 					<option value="delete_all"><?php _e( 'Delete all variations', 'woocommerce' ); ?></option>
 					<option value="variable_regular_price"><?php _e( 'Prices', 'woocommerce' ); ?></option>
+					<option value="variable_regular_price_increase"><?php _e( 'Prices increase by (fixed amount or %)', 'woocommerce' ); ?></option>
+					<option value="variable_regular_price_decrease"><?php _e( 'Prices decrease by (fixed amount or %)', 'woocommerce' ); ?></option>
 					<option value="variable_sale_price"><?php _e( 'Sale prices', 'woocommerce' ); ?></option>
+					<option value="variable_sale_price_increase"><?php _e( 'Sale prices increase by (fixed amount or %)', 'woocommerce' ); ?></option>
+					<option value="variable_sale_price_decrease"><?php _e( 'Sale prices decrease by (fixed amount or %)', 'woocommerce' ); ?></option>
 					<option value="variable_stock"><?php _e( 'Stock', 'woocommerce' ); ?></option>
 					<option value="variable_weight"><?php _e( 'Weight', 'woocommerce' ); ?></option>
 					<option value="variable_length"><?php _e( 'Length', 'woocommerce' ); ?></option>
@@ -432,6 +436,74 @@ function variable_product_type_options() {
 				}
 				return false;
 			}
+			else if ( field_to_edit == 'variable_regular_price_increase' ) {
+				field_to_edit = 'variable_regular_price';
+				var input_tag = jQuery('select#field_to_edit :selected').attr('rel') ? jQuery('select#field_to_edit :selected').attr('rel') : 'input';
+
+				var value = prompt("<?php echo esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ); ?>");
+				jQuery(input_tag + '[name^="' + field_to_edit + '"]').each(function() {
+					var current_value = jQuery(this).val();
+
+					if ( value.indexOf("%") >= 0 ) {
+						var new_value = Number( current_value ) + ( ( Number( current_value ) / 100 ) * Number( value.replace(/\%/, "" ) ) );
+					} else {
+						var new_value = Number( current_value ) + Number ( value );
+					}
+					jQuery(this).val( new_value ).change();
+				});
+				return false;
+			}
+			else if ( field_to_edit == 'variable_regular_price_decrease' ) {
+				field_to_edit = 'variable_regular_price';
+				var input_tag = jQuery('select#field_to_edit :selected').attr('rel') ? jQuery('select#field_to_edit :selected').attr('rel') : 'input';
+
+				var value = prompt("<?php echo esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ); ?>");
+				jQuery(input_tag + '[name^="' + field_to_edit + '"]').each(function() {
+					var current_value = jQuery(this).val();
+
+					if ( value.indexOf("%") >= 0 ) {
+						var new_value = Number( current_value ) - ( ( Number( current_value ) / 100 ) * Number( value.replace(/\%/, "" ) ) );
+					} else {
+						var new_value = Number( current_value ) - Number ( value );
+					}
+					jQuery(this).val( new_value ).change();
+				});
+				return false;
+			}
+			else if ( field_to_edit == 'variable_sale_price_increase' ) {
+				field_to_edit = 'variable_sale_price';
+				var input_tag = jQuery('select#field_to_edit :selected').attr('rel') ? jQuery('select#field_to_edit :selected').attr('rel') : 'input';
+
+				var value = prompt("<?php echo esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ); ?>");
+				jQuery(input_tag + '[name^="' + field_to_edit + '"]').each(function() {
+					var current_value = jQuery(this).val();
+
+					if ( value.indexOf("%") >= 0 ) {
+						var new_value = Number( current_value ) + ( ( Number( current_value ) / 100 ) * Number( value.replace(/\%/, "" ) ) );
+					} else {
+						var new_value = Number( current_value ) + Number ( value );
+					}
+					jQuery(this).val( new_value ).change();
+				});
+				return false;
+			}
+			else if ( field_to_edit == 'variable_sale_price_decrease' ) {
+				field_to_edit = 'variable_sale_price';
+				var input_tag = jQuery('select#field_to_edit :selected').attr('rel') ? jQuery('select#field_to_edit :selected').attr('rel') : 'input';
+
+				var value = prompt("<?php echo esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ); ?>");
+				jQuery(input_tag + '[name^="' + field_to_edit + '"]').each(function() {
+					var current_value = jQuery(this).val();
+
+					if ( value.indexOf("%") >= 0 ) {
+						var new_value = Number( current_value ) - ( ( Number( current_value ) / 100 ) * Number( value.replace(/\%/, "" ) ) );
+					} else {
+						var new_value = Number( current_value ) - Number ( value );
+					}
+					jQuery(this).val( new_value ).change();
+				});
+				return false;
+			}
 			else {
 
 				var input_tag = jQuery('select#field_to_edit :selected').attr('rel') ? jQuery('select#field_to_edit :selected').attr('rel') : 'input';
@@ -439,7 +511,6 @@ function variable_product_type_options() {
 				var value = prompt("<?php echo esc_js( __( 'Enter a value', 'woocommerce' ) ); ?>");
 				jQuery(input_tag + '[name^="' + field_to_edit + '["]').val( value ).change();
 				return false;
-
 			}
 		});
 

--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -190,7 +190,7 @@ class WC_Checkout {
 			$order_id = wp_insert_post( $order_data );
 
 			if ( is_wp_error( $order_id ) )
-				throw new MyException( 'Error: Unable to create order. Please try again.' );
+				throw new Exception( 'Error: Unable to create order. Please try again.' );
 			else
 				do_action( 'woocommerce_new_order', $order_id );
 		}
@@ -634,7 +634,7 @@ class WC_Checkout {
 		                $this->customer_id = wp_insert_user( apply_filters( 'woocommerce_new_customer_data', $new_customer_data ) );
 
 		                if ( is_wp_error( $this->customer_id ) ) {
-		                	throw new MyException( '<strong>' . __( 'ERROR', 'woocommerce' ) . '</strong>: ' . __( 'Couldn&#8217;t register you&hellip; please contact us if you continue to have problems.', 'woocommerce' ) );
+		                	throw new Exception( '<strong>' . __( 'ERROR', 'woocommerce' ) . '</strong>: ' . __( 'Couldn&#8217;t register you&hellip; please contact us if you continue to have problems.', 'woocommerce' ) );
 						}
 
                         // Set the global user object
@@ -652,14 +652,14 @@ class WC_Checkout {
 	                    wp_set_auth_cookie( $this->customer_id, true, $secure_cookie );
 
 					} else {
-						throw new MyException( $reg_errors->get_error_message() );
+						throw new Exception( $reg_errors->get_error_message() );
 					}
 
 				}
 
 				// Abort if errors are present
 				if ( $woocommerce->error_count() > 0 )
-					throw new MyException();
+					throw new Exception();
 
 				// Create the order
 				$order_id = $this->create_order();

--- a/readme.txt
+++ b/readme.txt
@@ -180,6 +180,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Refactor - Taken out Piwik integration, use http://wordpress.org/extend/plugins/woocommerce-piwik-integration/ from now on
 * Refactor - Taken out ShareYourCart integration, use http://wordpress.org/extend/plugins/shareyourcart/ from now on
 * Refactor - Moved woocommerce_get_formatted_product_name function into WC_Product class
+* Feature - Bulk edit increase / decrease variation prices by fixed or percentage values
 
 = 2.0.9 - 02/05/2013 =
 * Feature - Added is_product_taxonomy() conditonal.

--- a/readme.txt
+++ b/readme.txt
@@ -177,6 +177,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Fix - Allow layered nav to work with non pa_ prepended taxonomies
 * Fix - Better backwards compatibility with _woocommerce_exclude_image
 * Fix - is_on_sale() method now returns true for products with a sale product of 0
+* Fix - Changed MyException to Exception in Checkout class as MyException class does not exist in WooCommerce
 * Refactor - Taken out Piwik integration, use http://wordpress.org/extend/plugins/woocommerce-piwik-integration/ from now on
 * Refactor - Taken out ShareYourCart integration, use http://wordpress.org/extend/plugins/shareyourcart/ from now on
 * Refactor - Moved woocommerce_get_formatted_product_name function into WC_Product class


### PR DESCRIPTION
- Added options to the variation bulk edit to increase or decrease sale and normal prices by fixed or percentage values.
- Removed MyException from checkout class as there is no such a class in WooCommerce to handle exceptions, seems like some dodgy copy and pasting from PHP docs where there is an example to extend Exception with MyException.
