### PR TITLE
Prevents 'undefined' from showing up in Lightbox

### DIFF
--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -68,7 +68,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 		$title_reply = __( 'Be the first to review', 'woocommerce' ).' &ldquo;'.$post->post_title.'&rdquo;';
 
-		echo '<p class="noreviews">'.__( 'There are no reviews yet, would you like to <a href="#review_form" class="inline show_review_form">submit yours</a>?', 'woocommerce' ).'</p>';
+		echo '<p class="noreviews">'.__( 'There are no reviews yet, would you like to <a href="#review_form" class="inline show_review_form" title="' . __( 'Add Your Review', 'woocommerce' ) . '">submit yours</a>?', 'woocommerce' ).'</p>';
 
 	endif;
 


### PR DESCRIPTION
The title attribute was not defined in one of the links to the reviews lightbox, causing the lightbox to display 'undefined' on the description area.

See here: http://t.noronha.me/OqYI
