### PR TITLE
Cart/Order Item Preambles

### DIFF
--- a/admin/woocommerce-admin-dashboard.php
+++ b/admin/woocommerce-admin-dashboard.php
@@ -227,16 +227,16 @@ function woocommerce_dashboard_recent_orders() {
 	    'post_status'     => 'publish'
 	);
 	$orders = get_posts( $args );
-	if ($orders) :
+	if ( $orders ) :
 		echo '<ul class="recent-orders">';
-		foreach ($orders as $order) :
+		foreach ( $orders as $order ) :
 
 			$this_order = new WC_Order( $order->ID );
 
 			echo '
 			<li>
-				<span class="order-status '.sanitize_title($this_order->status).'">'.ucwords(__($this_order->status, 'woocommerce')).'</span> <a href="'.admin_url('post.php?post='.$order->ID).'&action=edit">' . get_the_time( __( 'l jS \of F Y h:i:s A', 'woocommerce' ), $order->ID ) . '</a><br />
-				<small>'.sizeof($this_order->get_items()).' '._n('item', 'items', sizeof($this_order->get_items()), 'woocommerce').' <span class="order-cost">'.__('Total:', 'woocommerce' ) . ' ' . woocommerce_price($this_order->order_total).'</span></small>
+				<span class="order-status ' . sanitize_title( $this_order->status ) . '">' . ucwords( __($this_order->status, 'woocommerce') ) . '</span> <a href="' . admin_url( 'post.php?post='.$order->ID ) . '&action=edit">' . get_the_time( __( 'l jS \of F Y h:i:s A', 'woocommerce' ), $order->ID ) . '</a><br />
+				<small>' . apply_filters( 'woocommerce_dashboard_recent_orders_count', sizeof( $this_order->get_items() ), $this_order ) . ' ' . _n('item', 'items', apply_filters( 'woocommerce_dashboard_recent_orders_count', sizeof( $this_order->get_items() ), $this_order ), 'woocommerce' ) . ' <span class="order-cost">'.__('Total:', 'woocommerce' ) . ' ' . woocommerce_price($this_order->order_total).'</span></small>
 			</li>';
 
 		endforeach;

--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -278,7 +278,7 @@ class WC_Checkout {
 			 		woocommerce_add_order_item_meta( $item_id, apply_filters( 'woocommerce_backordered_item_meta_name', __( 'Backordered', 'woocommerce' ), $cart_item_key, $order_id ), $values['quantity'] - max( 0, $_product->get_total_stock() ) );
 
 			 	// Allow plugins to add order item meta
-			 	do_action( 'woocommerce_add_order_item_meta', $item_id, $values );
+			 	do_action( 'woocommerce_add_order_item_meta', $item_id, $values, $cart_item_key );
 		 	}
 		}
 

--- a/classes/class-wc-order-item-meta.php
+++ b/classes/class-wc-order-item-meta.php
@@ -61,9 +61,9 @@ class WC_Order_Item_Meta {
 		            }
 
 					if ( $flat )
-						$meta_list[] = esc_attr( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) . ': ' . $meta_value );
+						$meta_list[] = esc_attr( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) . ': ' . apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ) );
 					else
-						$meta_list[] = '<dt>' . wp_kses_post( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) ) . ':</dt><dd>' . wp_kses_post( $meta_value ) . '</dd>';
+						$meta_list[] = '<dt>' . wp_kses_post( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) ) . ':</dt><dd>' . wp_kses_post( apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ) ) . '</dd>';
 
 				}
 			}

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -63,6 +63,10 @@ $woocommerce->show_messages();
 						<!-- Product Name -->
 						<td class="product-name">
 							<?php
+								// Pre-title meta
+								echo apply_filters( 'woocommerce_before_in_cart_product_title', '', $values, $cart_item_key );
+
+								// Title
 								if ( ! $_product->is_visible() || ( ! empty( $_product->variation_id ) && ! $_product->parent_is_visible() ) )
 									echo apply_filters( 'woocommerce_in_cart_product_title', $_product->get_title(), $values, $cart_item_key );
 								else

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -122,6 +122,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							echo '
 								<tr class="' . esc_attr( apply_filters('woocommerce_checkout_table_item_class', 'checkout_table_item', $values, $cart_item_key ) ) . '">
 									<td class="product-name">' .
+										apply_filters( 'woocommerce_checkout_before_product_title', '', $values, $cart_item_key ) . ' ' .
 										apply_filters( 'woocommerce_checkout_product_title', $_product->get_title(), $_product ) . ' ' .
 										apply_filters( 'woocommerce_checkout_item_quantity', '<strong class="product-quantity">&times; ' . $values['quantity'] . '</strong>', $values, $cart_item_key ) .
 										$woocommerce->cart->get_item_data( $values ) .

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -25,6 +25,9 @@ foreach ($items as $item) :
 			// Show title/image etc
 			echo 	apply_filters( 'woocommerce_order_product_image', $image, $_product, $show_image);
 
+			// Product name preamble
+			echo 	apply_filters( 'woocommerce_order_before_product_title', '', $item, $order );
+
 			// Product name
 			echo 	apply_filters( 'woocommerce_order_product_title', $item['name'], $_product );
 

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -44,6 +44,7 @@ $order = new WC_Order( $order_id );
 				echo '
 					<tr class = "' . esc_attr( apply_filters( 'woocommerce_order_table_item_class', 'order_table_item', $item, $order ) ) . '">
 						<td class="product-name">' .
+							apply_filters( 'woocommerce_order_table_before_product_title', '', $item ) . ' ' .
 							apply_filters( 'woocommerce_order_table_product_title', '<a href="' . get_permalink( $item['product_id'] ) . '">' . $item['name'] . '</a>', $item ) . ' ' .
 							apply_filters( 'woocommerce_order_table_item_quantity', '<strong class="product-quantity">&times; ' . $item['qty'] . '</strong>', $item );
 


### PR DESCRIPTION
Contributions:

1) Preambles

Title preambles can be used by extensions to add information before product titles.
This is useful in cases where cart/order items are the "values" of parent
product properties (e.g. Composite Products extension - https://trello.com/card/composite-products/4eea190569963dd4135c83f3/321).

Hooking into the title itself to add this information will not suffice, because preambles should be nested in their own html block, outside the link anchor tags of product titles.

Example: A computer is added to the cart and
"Product X" is the chosen option for a "Mainboard" property. The
preamble allows developers to add a formatted "Computer Mainboard: "
string before the product title, where 'Computer' is the name of the
parent product/collection and 'Mainboard' is the property that this product corresponds
to.

Example 2: http://www.somewherewarm.net/PreamblesEx.jpg ( Title 1/2/3 = Property Preambles of the 'BTO' Composite Product. The products are listed right below, as usual, with their corresponding quantities. )

2) Filters

The 3 other commits are minor additions to keep consistency with other action / filter hooks. There is also a filter added to the dashboard recent orders widget item count (there have been requests to adapt the reported number of order items reported in the case of Product Bundles)

Note that the existing code only counts line-items and does not take into account the line item quantities. So, technically, the item count is not accurate as it is. Not sure if this is intentional or not.
