### PR TITLE
Add Product Title Preambles in template files.

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -63,6 +63,10 @@ $woocommerce->show_messages();
 						<!-- Product Name -->
 						<td class="product-name">
 							<?php
+								// Title preamble
+								echo apply_filters( 'woocommerce_before_in_cart_product_title', '', $values, $cart_item_key );
+
+								// Title
 								if ( ! $_product->is_visible() || ( ! empty( $_product->variation_id ) && ! $_product->parent_is_visible() ) )
 									echo apply_filters( 'woocommerce_in_cart_product_title', $_product->get_title(), $values, $cart_item_key );
 								else

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -122,6 +122,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							echo '
 								<tr class="' . esc_attr( apply_filters('woocommerce_checkout_table_item_class', 'checkout_table_item', $values, $cart_item_key ) ) . '">
 									<td class="product-name">' .
+										apply_filters( 'woocommerce_checkout_before_product_title', '', $values, $cart_item_key ) . ' ' .
 										apply_filters( 'woocommerce_checkout_product_title', $_product->get_title(), $_product ) . ' ' .
 										apply_filters( 'woocommerce_checkout_item_quantity', '<strong class="product-quantity">&times; ' . $values['quantity'] . '</strong>', $values, $cart_item_key ) .
 										$woocommerce->cart->get_item_data( $values ) .

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -22,6 +22,9 @@ foreach ($items as $item) :
 	<tr>
 		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee; word-wrap:break-word;"><?php
 
+			// Product title preamble
+			echo   apply_filters( 'woocommerce_order_before_product_title', '', $item, $order );
+
 			// Show title/image etc
 			echo 	apply_filters( 'woocommerce_order_product_image', $image, $_product, $show_image);
 

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -44,6 +44,7 @@ $order = new WC_Order( $order_id );
 				echo '
 					<tr class = "' . esc_attr( apply_filters( 'woocommerce_order_table_item_class', 'order_table_item', $item, $order ) ) . '">
 						<td class="product-name">' .
+							apply_filters( 'woocommerce_order_table_before_product_title', '', $item ) . ' ' .
 							apply_filters( 'woocommerce_order_table_product_title', '<a href="' . get_permalink( $item['product_id'] ) . '">' . $item['name'] . '</a>', $item ) . ' ' .
 							apply_filters( 'woocommerce_order_table_item_quantity', '<strong class="product-quantity">&times; ' . $item['qty'] . '</strong>', $item );
 


### PR DESCRIPTION
Title preambles may be used by extensions to add information before product titles. This is only useful in cases where the position of the Product Meta (after the product title + variation data) is inappropriate.

The Composite Products extension - https://trello.com/card/composite-products/4eea190569963dd4135c83f3/321 - is a good example. Each Composite Product has a number of Properties mapped to possible product choices. When a product chosen for a property gets added to the cart, there needs to be some way to quickly convey this information right before the title of the product.

Example: A "Computer" (Composite Product) is added to the cart and
"Product X" is the chosen option for a "Mainboard" property. With a preamble filter in place, it is possible to add a formatted "Computer Mainboard: "
string before the product title, where 'Computer' is the name of the
parent product/collection and 'Mainboard' is the property that this product corresponds
to.

Example 2: http://www.somewherewarm.net/PreamblesEx.jpg ( Title 1/2/3 = Property Preambles of the 'BTO' Composite Product. The products are listed right below, as usual, with their corresponding quantities. )

Discussion:

Since the title filters may be used to add this information, adding more filters may be considered as overkill. 

However, what's important here is that Preambles should be added outside any html anchor tags that surround titles and should ideally be in their own html span or div tags, depending on the information that needs to be added.

In this sense, review-orders.php, email-order-items.php and order-details.php may not need to be touched, since the Product Titles are either output without any html around them, or the html tags around the title are passed in the hook, as part of the title.

However, in the case of cart.php, the existing title filter is inside the html anchor tags. This means that the preamble info would be wrapped in an anchor tag, which does not make sense.

Also, if the title filters are used to add preambles and other extensions filter the title when preamble info has been added, there may be issues.

So, in the end, the pull request does not touch/use the title filters at all.

Thoughts? Ideas? What would be the best and safest way to add this information, without wrapping them in title anchors and without risking filter scope mixups?
