### PR TITLE
Dashboard order items count and discussion about item count.

### DIFF
--- a/admin/woocommerce-admin-dashboard.php
+++ b/admin/woocommerce-admin-dashboard.php
@@ -237,6 +237,8 @@ function woocommerce_dashboard_recent_orders() {
 			<li>
 				<span class="order-status '.sanitize_title($this_order->status).'">'.ucwords(__($this_order->status, 'woocommerce')).'</span> <a href="'.admin_url('post.php?post='.$order->ID).'&action=edit">' . get_the_time( __( 'l jS \of F Y h:i:s A', 'woocommerce' ), $order->ID ) . '</a><br />
 				<small>'.sizeof($this_order->get_items()).' '._n('item', 'items', sizeof($this_order->get_items()), 'woocommerce').' <span class="order-cost">'.__('Total:', 'woocommerce' ) . ' ' . woocommerce_price($this_order->order_total).'</span></small>
+				<span class="order-status ' . sanitize_title( $this_order->status ) . '">' . ucwords( __($this_order->status, 'woocommerce') ) . '</span> <a href="' . admin_url( 'post.php?post='.$order->ID ) . '&action=edit">' . get_the_time( __( 'l jS \of F Y h:i:s A', 'woocommerce' ), $order->ID ) . '</a><br />
+				<small>' . apply_filters( 'woocommerce_dashboard_recent_orders_count', sizeof( $this_order->get_items() ), $this_order ) . ' ' . _n('item', 'items', apply_filters( 'woocommerce_dashboard_recent_orders_count', sizeof( $this_order->get_items() ), $this_order ), 'woocommerce' ) . ' <span class="order-cost">'.__('Total:', 'woocommerce' ) . ' ' . woocommerce_price($this_order->order_total).'</span></small>
 			</li>';
 
 		endforeach;

--- a/admin/woocommerce-admin-dashboard.php
+++ b/admin/woocommerce-admin-dashboard.php
@@ -235,8 +235,6 @@ function woocommerce_dashboard_recent_orders() {
 
 			echo '
 			<li>
-				<span class="order-status '.sanitize_title($this_order->status).'">'.ucwords(__($this_order->status, 'woocommerce')).'</span> <a href="'.admin_url('post.php?post='.$order->ID).'&action=edit">' . get_the_time( __( 'l jS \of F Y h:i:s A', 'woocommerce' ), $order->ID ) . '</a><br />
-				<small>'.sizeof($this_order->get_items()).' '._n('item', 'items', sizeof($this_order->get_items()), 'woocommerce').' <span class="order-cost">'.__('Total:', 'woocommerce' ) . ' ' . woocommerce_price($this_order->order_total).'</span></small>
 				<span class="order-status ' . sanitize_title( $this_order->status ) . '">' . ucwords( __($this_order->status, 'woocommerce') ) . '</span> <a href="' . admin_url( 'post.php?post='.$order->ID ) . '&action=edit">' . get_the_time( __( 'l jS \of F Y h:i:s A', 'woocommerce' ), $order->ID ) . '</a><br />
 				<small>' . apply_filters( 'woocommerce_dashboard_recent_orders_count', sizeof( $this_order->get_items() ), $this_order ) . ' ' . _n('item', 'items', apply_filters( 'woocommerce_dashboard_recent_orders_count', sizeof( $this_order->get_items() ), $this_order ), 'woocommerce' ) . ' <span class="order-cost">'.__('Total:', 'woocommerce' ) . ' ' . woocommerce_price($this_order->order_total).'</span></small>
 			</li>';


### PR DESCRIPTION
There have been requests to adapt the reported number of order items in the case of Product Bundles. There are cases where bundled items should not be counted as separate items (or the opposite, depending on scope), and although the necessary cart filter exists, this is not the case here.

Important: 

The existing code only counts line-items and does not take into account the line item quantities. So, technically, the item count is not accurate as it is anyway. Is this intentional?
