### PR TITLE
Order Item Meta values filter

### DIFF
--- a/classes/class-wc-order-item-meta.php
+++ b/classes/class-wc-order-item-meta.php
@@ -61,9 +61,9 @@ class WC_Order_Item_Meta {
 		            }
 
 					if ( $flat )
-						$meta_list[] = esc_attr( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) . ': ' . $meta_value );
+						$meta_list[] = esc_attr( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) . ': ' . apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ) );
 					else
-						$meta_list[] = '<dt>' . wp_kses_post( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) ) . ':</dt><dd>' . wp_kses_post( $meta_value ) . '</dd>';
+						$meta_list[] = '<dt>' . wp_kses_post( $woocommerce->attribute_label( str_replace( 'attribute_', '', $meta_key ) ) ) . ':</dt><dd>' . wp_kses_post( apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ) ) . '</dd>';
 
 				}
 			}


### PR DESCRIPTION
Although filters exist almost universally in WC Core to modify variations/meta descriptions (woocommerce_variation_option_name) before checkout, there is no way to filter this information in the case of purchased/ordered items.

All calls to show order options names/values and other meta keys/values are done through here, so, fortunately, this seems to be the only place to add such a filter.
