### PR TITLE
Adde cart item key to woocommerce_add_order_item_meta action

### DIFF
--- a/classes/class-wc-checkout.php
+++ b/classes/class-wc-checkout.php
@@ -278,7 +278,7 @@ class WC_Checkout {
 			 		woocommerce_add_order_item_meta( $item_id, apply_filters( 'woocommerce_backordered_item_meta_name', __( 'Backordered', 'woocommerce' ), $cart_item_key, $order_id ), $values['quantity'] - max( 0, $_product->get_total_stock() ) );
 
 			 	// Allow plugins to add order item meta
-			 	do_action( 'woocommerce_add_order_item_meta', $item_id, $values );
+			 	do_action( 'woocommerce_add_order_item_meta', $item_id, $values, $cart_item_key );
 		 	}
 		}
 


### PR DESCRIPTION
The cart item key is passed in almost every core hook that passes the cart values.

There are many valid reasons to know the cart item key of the order item that is being created. For consistency alone, it should be there.
