### PR TITLE
Google Analytics item tracking order ID bug fix.

### DIFF
--- a/classes/integrations/google-analytics/class-wc-google-analytics.php
+++ b/classes/integrations/google-analytics/class-wc-google-analytics.php
@@ -214,7 +214,7 @@ class WC_Google_Analytics extends WC_Integration {
 				$_product = $order->get_product_from_item( $item );
 
 				$code .= "_gaq.push(['_addItem',";
-				$code .= "'" . esc_js( $order_id ) . "',";
+				$code .= "'" . esc_js( $order->get_order_number() ) . "',";
 				$code .= "'" . esc_js( $_product->get_sku() ? __( 'SKU:', 'woocommerce' ) . ' ' . $_product->get_sku() : $_product->id ) . "',";
 				$code .= "'" . esc_js( $item['name'] ) . "',";
 


### PR DESCRIPTION
Google Analytics's item tracking was still using `$order_id` while transaction tracking's ID has already changed two `$order->get_order_number()`. So they wasn't syncing.
