### PR TITLE
Install pages enhancements to help reduce conflicts with other eCommerce plugins.

### DIFF
--- a/admin/woocommerce-admin-install.php
+++ b/admin/woocommerce-admin-install.php
@@ -159,8 +159,16 @@ function woocommerce_create_page( $slug, $option, $page_title = '', $page_conten
 
 	if ( $option_value > 0 && get_post( $option_value ) )
 		return;
-
-	$page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM " . $wpdb->posts . " WHERE post_name = %s LIMIT 1;", $slug ) );
+	
+	$page_found = null;
+	if ( strlen($page_content) > 0 ) {
+		// Search for an existing page with the specified page content (typically a shortcode)
+		$page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM " . $wpdb->posts . " WHERE post_type='page' AND post_content LIKE %s LIMIT 1;", "%{$page_content}%" ) );
+	} else {
+		// Search for an existing page with the specified page slug
+		$page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM " . $wpdb->posts . " WHERE post_type='page' AND post_name = %s LIMIT 1;", $slug ) );
+	}
+	
 	if ( $page_found ) {
 		if ( ! $option_value )
 			update_option( $option, $page_found );


### PR DESCRIPTION
When attempting to install a new page:
- only search for pages (ignore posts and other custom post types)
- search for an existing page with the specified page content (typically a shortcode), or if no page content is specified, search for an existing page with the specified page slug.

Should fix #3100 and will also help ensure that WooCommerce only attempts to reuse existing pages that have the WooCommerce shortcodes on them, thus reducing conflicts with other eCommerce plugins.
