### PR TITLE
Empty prices on sale bug fix & get_terms args filter on product categories dropdown function

### DIFF
--- a/classes/abstracts/abstract-wc-product.php
+++ b/classes/abstracts/abstract-wc-product.php
@@ -637,7 +637,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	function is_on_sale() {
-		return isset( $this->sale_price ) && $this->sale_price == $this->price ? true : false;
+		return ( $this->sale_price !== "" && $this->sale_price >= 0 ) ? true : false;
 	}
 
 

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -1541,7 +1541,7 @@ function woocommerce_product_dropdown_categories( $show_counts = 1, $hierarchica
 	elseif ( $orderby )
 		$r['orderby'] = $orderby;
 
-	$terms = get_terms( 'product_cat', $r );
+	$terms = get_terms( 'product_cat', apply_filters( 'woocommerce_product_category_dropdown_term_args', $r ) );
 
 	if (!$terms) return;
 


### PR DESCRIPTION
Fix bug where when sale and regular prices empty the products are displayed as on sale

Fixes #3189 
Fixes #3218 
