### PR TITLE
Remove duplicate email actions

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -520,7 +520,7 @@ class Woocommerce {
 		add_action( 'admin_footer', array( $this, 'output_inline_js' ), 25 );
 
 		// Email Actions
-		$email_actions = array( 'woocommerce_low_stock', 'woocommerce_no_stock', 'woocommerce_product_on_backorder', 'woocommerce_order_status_pending_to_processing', 'woocommerce_order_status_pending_to_completed', 'woocommerce_order_status_pending_to_on-hold', 'woocommerce_order_status_failed_to_processing', 'woocommerce_order_status_failed_to_completed', 'woocommerce_order_status_pending_to_processing', 'woocommerce_order_status_pending_to_on-hold', 'woocommerce_order_status_completed', 'woocommerce_new_customer_note' );
+		$email_actions = array( 'woocommerce_low_stock', 'woocommerce_no_stock', 'woocommerce_product_on_backorder', 'woocommerce_order_status_pending_to_processing', 'woocommerce_order_status_pending_to_completed', 'woocommerce_order_status_pending_to_on-hold', 'woocommerce_order_status_failed_to_processing', 'woocommerce_order_status_failed_to_completed', 'woocommerce_order_status_completed', 'woocommerce_new_customer_note' );
 
 		foreach ( $email_actions as $action )
 			add_action( $action, array( $this, 'send_transactional_email') );


### PR DESCRIPTION
The `'woocommerce_order_status_pending_to_processing'` and
`'woocommerce_order_status_pending_to_on-hold'` email actions were included twice in the `$email_actions` array. Pretty sure no emails were not being duplicated though, so very minor patch.
