### PR TITLE
    updating billing email under each order in admin panel should update the woocommerce_downloadable_product_permissions table as well.

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_downloads.php
+++ b/admin/post-types/writepanels/writepanel-order_downloads.php
@@ -209,7 +209,7 @@ function woocommerce_order_downloads_save( $post_id, $post ) {
 
 		// Order data
 		$order_key 				= get_post_meta( $post->ID, '_order_key', true );
-		$customer_email 		= get_post_meta( $post->ID, '_billing_email', true );
+		$customer_email 		= $_POST['_billing_email'];
 		$customer_user 			= get_post_meta( $post->ID, '_customer_user', true );
 		$product_ids_count 		= sizeof( $product_ids );
 

--- a/readme.txt
+++ b/readme.txt
@@ -176,7 +176,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Tweak - New System Status report layout, now plugin list is better visually and very better to read
 * Tweak - content-widget-product.php template for product lists inside core widgets
 * Fix - Changed MyException to Exception in Checkout class as MyException class does not exist in WooCommerce
-* Fix - Default cat widget styling on non-wc pages.
+* Fix - Default cart widget styling on non-wc pages.
 * Refactor - Taken out Piwik integration, use http://wordpress.org/extend/plugins/woocommerce-piwik-integration/ from now on
 * Refactor - Taken out ShareYourCart integration, use http://wordpress.org/extend/plugins/shareyourcart/ from now on
 * Refactor - Moved woocommerce_get_formatted_product_name function into WC_Product class


### PR DESCRIPTION
At the moment, when administator update billing address under each order (in admin -> woocommerce -> orders), the woocommerce_order_downloads_save function is called but it uses the old "_billing_email" meta instead of the new one from the $_POST var.
