### PR TITLE
Fix double deleteing in clear product transients.

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -1784,6 +1784,7 @@ class Woocommerce {
 		);
 
 		foreach( $transients_to_clear as $transient ) {
+			delete_transient( 'wc_products_onsale' );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM `$wpdb->options` WHERE `option_name` = %s OR `option_name` = %s", '_transient_' . $transient, '_transient_timeout_' . $transient ) );
 		}
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -1784,8 +1784,7 @@ class Woocommerce {
 		);
 
 		foreach( $transients_to_clear as $transient ) {
-			delete_transient( 'wc_products_onsale' );
-			$wpdb->query( $wpdb->prepare( "DELETE FROM `$wpdb->options` WHERE `option_name` = %s OR `option_name` = %s", '_transient_' . $transient, '_transient_timeout_' . $transient ) );
+			delete_transient( $transient );
 		}
 
 		// Clear transients for which we don't have the name

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -1784,7 +1784,6 @@ class Woocommerce {
 		);
 
 		foreach( $transients_to_clear as $transient ) {
-			delete_transient( 'wc_products_onsale' );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM `$wpdb->options` WHERE `option_name` = %s OR `option_name` = %s", '_transient_' . $transient, '_transient_timeout_' . $transient ) );
 		}
 


### PR DESCRIPTION
For some reason the `clear_product_transients` method was using both custom DELETE statement and `delete_transient` function.

Should use `delete_transient` method to replace custom DELETE statement, so it will call all the hooks and work well with object cache.
