### PR TITLE
Fix for WooCommerce 2+ for the ID property

### DIFF
--- a/classes/abstracts/abstract-wc-product.php
+++ b/classes/abstracts/abstract-wc-product.php
@@ -35,8 +35,11 @@ class WC_Product {
 			$product = get_product( $product );
 		}
 
-		if ( is_object( $product ) ) {
+		if ( $product instanceof WP_Post ) {
 			$this->id   = absint( $product->ID );
+			$this->post = $product;
+		} elseif ( $product instanceof WC_Product ) {
+			$this->id   = absint( $product->id );
 			$this->post = $product;
 		} else {
 			$this->id   = absint( $product );


### PR DESCRIPTION
As get_product() returns an instance of WC_Product the code expects the ID to be in uppercase ( due to it expecting an instance of WP_Post ).

This causes the property to not correct set as WC_Product's ID property is in lower case.

When the property isn't correct set it breaks the magic method __get ( which in turn stops the correct return values of calls to SKU or any other meta. Including updating stock ).
