### PR TITLE
Add Translatable Page Title to Download File Error Page

### DIFF
--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -1004,7 +1004,7 @@ function woocommerce_download_product() {
 		if ( $user_id && get_option( 'woocommerce_downloads_require_login' ) == 'yes' ) {
 
 			if ( ! is_user_logged_in() )
-				wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . wp_login_url( get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) . '">' . __( 'Login &rarr;', 'woocommerce' ) . '</a>' );
+				wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . wp_login_url( get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) . '">' . __( 'Login &rarr;', 'woocommerce' ) . '</a>', __( 'Log in to Download Files', 'woocommerce' ) );
 
 			elseif ( $user_id != get_current_user_id() )
 				wp_die( __( 'This is not your download link.', 'woocommerce' ) );


### PR DESCRIPTION
Hi there!

When a user attempts to download a file on a store that requires a user to be logged in they get an error message which is a bit abrasive.
http://cld.wthms.co/IGEc

We should change the default title to something a bit more friendly like "Log in to Download Files".
http://cld.wthms.co/CONm

A site owner should also be given the opportunity to change this text so I wrapped it in a translation wrapper function.

See [support ticket](https://woothemes.zendesk.com/agent/#/tickets/60893) for reference.
