### PR TITLE
Added needed states for Spain

### DIFF
--- a/i18n/states/ES.php
+++ b/i18n/states/ES.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Spain states
+ *
+ * @author   	Samuel Aguilera
+ * @category 	i18n
+ * @package 	WooCommerce/i18n
+ * @version     2.0.11
+ */
+global $states;
+
+$states["ES"] = array(
+    'C' => __('A Coru&ntilde;a', 'woocommerce'),
+    'VI' => __('&Aacute;lava', 'woocommerce'),
+    'AB' => __('Albacete', 'woocommerce'),
+    'A' => __('Alicante', 'woocommerce'),
+    'AL' => __('Almer&iacute;a', 'woocommerce'),
+    'O' => __('Asturias', 'woocommerce'),
+    'AV' => __('&Aacute;vila', 'woocommerce'),
+    'BA' => __('Badajoz', 'woocommerce'),
+    'PM' => __('Baleares', 'woocommerce'),
+    'B' => __('Barcelona', 'woocommerce'),
+    'BU' => __('Burgos', 'woocommerce'),
+    'CC' => __('C&aacute;ceres', 'woocommerce'),
+    'CA' => __('C&aacute;diz', 'woocommerce'),
+    'S' => __('Cantabria', 'woocommerce'),
+    'CS' => __('Castell&oacute;n', 'woocommerce'),
+    'EA' => __('Ceuta', 'woocommerce'),
+    'CR' => __('Ciudad Real', 'woocommerce'),
+    'CO' => __('C&oacute;rdoba', 'woocommerce'),
+    'CU' => __('Cuenca', 'woocommerce'),
+    'GI' => __('Girona', 'woocommerce'),
+    'GR' => __('Granada', 'woocommerce'),
+    'GU' => __('Guadalajara', 'woocommerce'),
+    'SS' => __('Guip&uacute;zcoa', 'woocommerce'),
+    'H' => __('Huelva', 'woocommerce'),
+    'HU' => __('Huesca', 'woocommerce'),
+    'J' => __('Ja&eacute;n', 'woocommerce'),
+    'LO' => __('La Rioja', 'woocommerce'),
+    'GC' => __('Las Palmas', 'woocommerce'),
+    'LE' => __('Le&oacute;n', 'woocommerce'),
+    'L' => __('Lleida', 'woocommerce'),
+    'LU' => __('Lugo', 'woocommerce'),
+    'M' => __('Madrid', 'woocommerce'),
+    'MA' => __('M&aacute;laga', 'woocommerce'),
+    'ML' => __('Melilla', 'woocommerce'),
+    'MU' => __('Murcia', 'woocommerce'),
+    'NA' => __('Navarra', 'woocommerce'),
+    'OR' => __('Ourense', 'woocommerce'),
+    'P' => __('Palencia', 'woocommerce'),
+    'PO' => __('Pontevedra', 'woocommerce'),
+    'SA' => __('Salamanca', 'woocommerce'),
+    'TF' => __('Santa Cruz de Tenerife', 'woocommerce'),
+    'SG' => __('Segovia', 'woocommerce'),
+    'SE' => __('Sevilla', 'woocommerce'),
+    'SO' => __('Soria', 'woocommerce'),
+    'T' => __('Tarragona', 'woocommerce'),
+    'TE' => __('Teruel', 'woocommerce'),
+    'TO' => __('Toledo', 'woocommerce'),
+    'V' => __('Valencia', 'woocommerce'),
+    'VA' => __('Valladolid', 'woocommerce'),
+    'BI' => __('Vizcaya', 'woocommerce'),
+    'ZA' => __('Zamora', 'woocommerce'),
+    'Z' => __('Zaragoza', 'woocommerce')
+); 


### PR DESCRIPTION
This is needed to apply VAT exclusion (required by spanish law) to Las Palmas, Baleares, Ceuta and Melilla.
