### PR TITLE
Cart Item / Order Item data required in woocommerce_checkout_product_title & woo commerce_order_product_title filters

### DIFF
--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -122,7 +122,7 @@ $available_methods = $woocommerce->shipping->get_available_shipping_methods();
 							echo '
 								<tr class="' . esc_attr( apply_filters('woocommerce_checkout_table_item_class', 'checkout_table_item', $values, $cart_item_key ) ) . '">
 									<td class="product-name">' .
-										apply_filters( 'woocommerce_checkout_product_title', $_product->get_title(), $_product ) . ' ' .
+										apply_filters( 'woocommerce_checkout_product_title', $_product->get_title(), $values, $cart_item_key ) . ' ' .
 										apply_filters( 'woocommerce_checkout_item_quantity', '<strong class="product-quantity">&times; ' . $values['quantity'] . '</strong>', $values, $cart_item_key ) .
 										$woocommerce->cart->get_item_data( $values ) .
 									'</td>

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -26,7 +26,7 @@ foreach ($items as $item) :
 			echo 	apply_filters( 'woocommerce_order_product_image', $image, $_product, $show_image);
 
 			// Product name
-			echo 	apply_filters( 'woocommerce_order_product_title', $item['name'], $_product );
+			echo 	apply_filters( 'woocommerce_order_product_title', $item['name'], $item );
 
 			// SKU
 			echo 	($show_sku && $_product->get_sku()) ? ' (#' . $_product->get_sku() . ')' : '';


### PR DESCRIPTION
Pending from #3181 
woocommerce_checkout_product_title - passing values['data'] is not enough, since it doesn't contain all cart data contained in values, which is necessary to establish parent-child relationships in the case of Composite Products.

Same with the woocommerce_order_product_title filter. See comments below.
