### PR TITLE
add a class to the variable pricing table row

### DIFF
--- a/admin/post-types/writepanels/variation-admin-html.php
+++ b/admin/post-types/writepanels/variation-admin-html.php
@@ -67,7 +67,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 							</tr>
 						<?php endif; ?>
 
-						<tr>
+						<tr class="variable_pricing">
 							<td>
 								<label><?php echo __( 'Regular Price:', 'woocommerce' ) . ' ('.get_woocommerce_currency_symbol().')'; ?></label>
 								<input type="number" size="5" name="variable_regular_price[<?php echo $loop; ?>]" value="<?php if ( isset( $_regular_price ) ) echo esc_attr( $_regular_price ); ?>" step="any" min="0" placeholder="<?php _e( 'Variation price (required)', 'woocommerce' ); ?>" />


### PR DESCRIPTION
I'm working on adding the admin phase of NYP support for variable products. It'll be easier to jquery select the price row if it has a class identifier instead of an unlabeled `<tr>`.  I'll need to hide the regular/sales prices and swap in my suggested/min price inputs.
