### PR TITLE
The bug for woocommerce_download_product function

### DIFF
--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -1131,10 +1131,10 @@ function woocommerce_download_product() {
 
 		@session_write_close();
 		@ini_set( 'zlib.output_compression', 'Off' );
-		@ob_end_clean();
+		//@ob_end_clean();
 
-		if ( ob_get_level() )
-			@ob_end_clean(); // Zip corruption fix
+		//if ( ob_get_level() )
+		//	@ob_end_clean(); // Zip corruption fix
 
 		if ( $is_IE && is_ssl() ) {
 			// IE bug prevents download via SSL when Cache Control and Pragma no-cache headers set.


### PR DESCRIPTION
WooCommerce uses ob_end_clean to close the output buffer. We have experienced when WC does this, the zip download link will be broken. I also need to mention that the site is using the plugin "Software-Addon" which assist in managing license keys etc., and I don't believe this is causing this.

When I comment these lines, which means it does not close the output buffer, it works fine. it is obviously something in the buffer that should be a part of the intact header. if WC turns off the output buffer, it will makes the header information become imperfect (the content type of the header should be zip. But because of the imperfect header, it changes to the default value, to text).
