### PR TITLE
Hint on documentation of function get_product()

### DIFF
--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -19,7 +19,7 @@ class WC_Product_Factory {
 	 * @access public
 	 * @param bool $the_product (default: false)
 	 * @param array $args (default: array())
-	 * @return WC_Product_Simple
+	 * @return WC_Product
 	 */
 	public function get_product( $the_product = false, $args = array() ) {
 		global $post;

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -25,7 +25,7 @@ add_filter( 'woocommerce_stock_amount', 'intval' ); // Stock amounts are integer
  * @access public
  * @param mixed $the_product Post object or post ID of the product.
  * @param array $args (default: array()) Contains all arguments to be used to get this product.
- * @return void
+ * @return WC_Product_Simple
  */
 function get_product( $the_product = false, $args = array() ) {
 	global $woocommerce;

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -25,7 +25,7 @@ add_filter( 'woocommerce_stock_amount', 'intval' ); // Stock amounts are integer
  * @access public
  * @param mixed $the_product Post object or post ID of the product.
  * @param array $args (default: array()) Contains all arguments to be used to get this product.
- * @return WC_Product_Simple
+ * @return WC_Product
  */
 function get_product( $the_product = false, $args = array() ) {
 	global $woocommerce;


### PR DESCRIPTION
The hint actual says that return void, changed to WC_Product_Simple because $woocommerce->product_factory->get_product() returns WC_Product_Simple, this change is useful for IDEs autocomplete hints
