### PR TITLE
Fixed PHP multiple strict errors and PHPDoc comments in WC_Product_Variation and WC_Product_Cat_List_Walker.

### DIFF
--- a/classes/class-wc-product-variation.php
+++ b/classes/class-wc-product-variation.php
@@ -226,9 +226,10 @@ class WC_Product_Variation extends WC_Product {
 	/**
      * Get variation price HTML. Prices are not inherited from parents.
      *
+	 * @param string $price (default: '')
      * @return string containing the formatted price
      */
-	public function get_price_html() {
+	public function get_price_html( $price = '' ) {
 
 		if ( $this->price !== '' ) {
 			if ( $this->price == $this->sale_price && $this->sale_price < $this->regular_price ) {

--- a/classes/walkers/class-product-cat-dropdown-walker.php
+++ b/classes/walkers/class-product-cat-dropdown-walker.php
@@ -21,12 +21,12 @@ class WC_Product_Cat_Dropdown_Walker extends Walker {
 	 * @since 2.1.0
 	 *
 	 * @param string $output Passed by reference. Used to append additional content.
-	 * @param object $category Category data object.
+	 * @param object $cat Category data object.
 	 * @param int $depth Depth of category in reference to parents.
 	 * @param array $args
 	 * @param int $current_object_id
 	 */
-	function start_el( &$output, $category, $depth, $args, $current_object_id = 0 ) {
+	function start_el( &$output, $cat, $depth, $args, $current_object_id = 0 ) {
 
 		if ( ! empty( $args['hierarchical'] ) )
 			$pad = str_repeat('&nbsp;', $depth * 3);

--- a/classes/walkers/class-product-cat-dropdown-walker.php
+++ b/classes/walkers/class-product-cat-dropdown-walker.php
@@ -24,8 +24,9 @@ class WC_Product_Cat_Dropdown_Walker extends Walker {
 	 * @param object $category Category data object.
 	 * @param int $depth Depth of category in reference to parents.
 	 * @param array $args
+	 * @param int $current_object_id
 	 */
-	function start_el(&$output, $cat, $depth, $args) {
+	function start_el( &$output, $category, $depth, $args, $current_object_id = 0 ) {
 
 		if ( ! empty( $args['hierarchical'] ) )
 			$pad = str_repeat('&nbsp;', $depth * 3);

--- a/classes/walkers/class-product-cat-list-walker.php
+++ b/classes/walkers/class-product-cat-list-walker.php
@@ -24,7 +24,7 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @param int $depth Depth of category. Used for tab indentation.
 	 * @param array $args Will only append content if style argument value is 'list'.
 	 */
-	function start_lvl( &$output, $depth, $args ) {
+	function start_lvl( &$output, $depth = 0, $args = array() ) {
 		if ( 'list' != $args['style'] )
 			return;
 
@@ -40,7 +40,7 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @param int $depth Depth of category. Used for tab indentation.
 	 * @param array $args Will only append content if style argument value is 'list'.
 	 */
-	function end_lvl( &$output, $depth, $args ) {
+	function end_lvl( &$output, $depth = 0, $args = array() ) {
 		if ( 'list' != $args['style'] )
 			return;
 
@@ -53,11 +53,12 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @since 2.1.0
 	 *
 	 * @param string $output Passed by reference. Used to append additional content.
-	 * @param object $category Category data object.
+	 * @param object $cat Category data object.
 	 * @param int $depth Depth of category in reference to parents.
 	 * @param array $args
+	 * @param int $current_object_id
 	 */
-	function start_el( &$output, $cat, $depth, $args ) {
+	function start_el( &$output, $cat, $depth, $args, $current_object_id = 0 ) {
 
 		$output .= '<li class="cat-item cat-item-' . $cat->term_id;
 
@@ -79,11 +80,11 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @since 2.1.0
 	 *
 	 * @param string $output Passed by reference. Used to append additional content.
-	 * @param object $page Not used.
+	 * @param object $object Not used.
 	 * @param int $depth Depth of category. Not used.
 	 * @param array $args Only uses 'list' for whether should append to output.
 	 */
-	function end_el( &$output, $cat, $depth, $args ) {
+	function end_el( &$output, $object, $depth = 0, $args = array() ) {
 
 		$output .= "</li>\n";
 


### PR DESCRIPTION
Common cases where functions don't match base classes.
