### PR TITLE
Add Product Meta Data to Post Class

### DIFF
--- a/includes/helpers/class-wc-post-class-helper.php
+++ b/includes/helpers/class-wc-post-class-helper.php
@@ -23,6 +23,27 @@ class WC_Post_Class_Helper extends WC_Helper {
 			if ( $product->is_featured() ) {
 				$classes[] = 'featured';
 			}
+			if ( $product->is_downloadable() ) {
+				$classes[] = 'downloadable';
+			}
+			if ( $product->is_virtual() ) {
+				$classes[] = 'virtual';
+			}
+			if ( $product->is_sold_individually() ) {
+				$classes[] = 'sold-individually';
+			}
+			if ( $product->is_taxable() ) {
+				$classes[] = 'taxable';
+			}
+			if ( $product->is_shipping_taxable() ) {
+				$classes[] = 'shipping-taxable';
+			}
+			if ( $product->is_purchasable() ) {
+				$classes[] = 'purchasable';
+			}
+			if ( isset( $product->product_type ) ) {
+				$classes[] = "product-type-".$product->product_type;
+			}
 			$classes[] = $product->stock_status;
 		}
 


### PR DESCRIPTION
Hi there,

It would be great it we could add more product meta data to the post class. Having extra classes like `virtual`, `downloadable`, `product-type-simple`, `product-type-subscription`, etc would be great for styling purposes.

https://woothemes.zendesk.com/agent/#/tickets/70264
