### PR TITLE
(#3477) Initialize address formats to the stores locale, instead of use a default.

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1039,6 +1039,10 @@ class WC_Countries {
 	 * @return void
 	 */
 	public function get_address_fields( $country, $type = 'billing_' ) {
+
+		if (!$country)
+            $country = $this->get_base_country();
+		
 		$fields     = $this->get_default_address_fields();
 		$locale		= $this->get_country_locale();
 


### PR DESCRIPTION
If the user has not entered an address yet, then the address fields will be displayed in a default order, because the $country will be empty. To fix this and initialize address formats to the stores locale, the $country variable is set to the base_country if it has no value
