### PR TITLE
Moving Multisite to it's Own Line in the System Status

### DIFF
--- a/admin/woocommerce-admin-status.php
+++ b/admin/woocommerce-admin-status.php
@@ -91,8 +91,12 @@ function woocommerce_status_report() {
             </tr>
             <tr>
                 <td><?php _e( 'WP Version','woocommerce' ); ?>:</td>
-                <td><?php if ( is_multisite() ) echo 'WPMU'; else echo 'WP'; ?> <?php echo bloginfo('version'); ?></td>
+                <td><?php echo bloginfo('version'); ?></td>
             </tr>
+			<tr>
+				<td><?php _e( 'WP Multisite Enabled','woocommerce' ); ?>:</td>
+				<td><?php if ( is_multisite() ) echo __( 'Yes', 'woocommerce' ); else echo __( 'No', 'woocommerce' ); ?></td>
+			</tr>
             <tr>
                 <td><?php _e( 'Web Server Info','woocommerce' ); ?>:</td>
                 <td><?php echo esc_html( $_SERVER['SERVER_SOFTWARE'] );  ?></td>


### PR DESCRIPTION
I moved the Multisite system status information from the WordPress version line to it's own line.

I actually had no idea that we displayed information about multisite until I wondered why there were two `WP`s in `WP Version` row:
http://cld.wthms.co/RJQf

To make this easier for everyone (devs, and regular users as well) I thought it would be a good idea to move this information onto it's own line to make it immediately obvious what it is. I removed the information from the `WP Version` row and added a row right beneath it:
http://cld.wthms.co/r4uf

If you do have multisite enabled it will look like this:
http://cld.wthms.co/h05j
