### PR TITLE
Show limited formatting buttons on short description field editor

### DIFF
--- a/admin/post-types/writepanels/writepanels-init.php
+++ b/admin/post-types/writepanels/writepanels-init.php
@@ -160,10 +160,9 @@ add_action( 'pre_post_update', 'woocommerce_pre_post_update' );
 function woocommerce_product_short_description_meta_box( $post ) {
 
 	$settings = array(
-		'quicktags' 	=> array( 'buttons' => 'em,strong,link' ),
 		'textarea_name'	=> 'excerpt',
-		'quicktags' 	=> true,
-		'tinymce' 		=> true,
+		'quicktags' 	=> array( 'buttons' => 'em,strong,link' ),
+		'tinymce' 	=> array( 'theme_advanced_buttons1' => 'bold,italic,link,unlink' ),
 		'editor_css'	=> '<style>#wp-excerpt-editor-container .wp-editor-area{height:175px; width:100%;}</style>'
 		);
 


### PR DESCRIPTION
In the [woocommerce_product_short_description_meta_box](https://github.com/woothemes/woocommerce/blob/c8852bcf408538ca043b04f0dba3c95e8123b0de/admin/post-types/writepanels/writepanels-init.php#L163) function I assume the intent is to display a limited number of formatting buttons on the product short description field. However, since `quicktags` is specified twice in the `$settings` array (the second instance having a value of `true`) our minimal set of buttons get clobbered and we end up with the WordPress default set of buttons. This commit fixes that problem and also reduces the number of formatting buttons in the TinyMCE editor to match.
