### PR TITLE
Fixed "Strict Standards" warning on the process_payment() declaration.

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -144,10 +144,11 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * Process the payment. Override this in your gateway.
 	 *
+	 * @param int $order_id
 	 * @access public
 	 * @return void
 	 */
-	function process_payment() {}
+	function process_payment( $order_id ) {}
 
 
 	/**


### PR DESCRIPTION
Fixed "Strict Standards" warning on the process_payment() method declaration of the WP_Payment_Gateway class.
The warning is thrown on WordPress 3.6 RC2.
