### PR TITLE
Google Analytics, Add to cart event uniformity for shop and single.

### DIFF
--- a/includes/integrations/google-analytics/class-wc-google-analytics.php
+++ b/includes/integrations/google-analytics/class-wc-google-analytics.php
@@ -291,7 +291,7 @@ class WC_Google_Analytics extends WC_Integration {
 		$parameters = array();
 		// Add single quotes to allow jQuery to be substituted into _trackEvent parameters
 		$parameters['category'] = "'" . __( 'Products', 'woocommerce' ) . "'";
-		$parameters['action'] 	= "'" . __( 'Add to Cart', 'woocommerce' ) . "'";
+		$parameters['action'] 	= "'" . __( 'Add to cart', 'woocommerce' ) . "'";
 		$parameters['label'] 	= "($(this).data('product_sku')) ? ('SKU: ' + $(this).data('product_sku')) : ('#' + $(this).data('product_id'))"; // Product SKU or ID
 
 		$this->event_tracking_code( $parameters, '.add_to_cart_button:not(.product_type_variable, .product_type_grouped)' );


### PR DESCRIPTION
Make both the Single Product and Shop Loop add to cart to use the same case so it is seen as one even and not two in google analytics. 
