### PR TITLE
add woocommerce_get_variation_price_html filter

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -252,7 +252,7 @@ class WC_Product_Variation extends WC_Product {
 			$price = apply_filters( 'woocommerce_variation_empty_price_html', '', $this );
 		}
 
-		return $price;
+		return apply_filters( 'woocommerce_get_variation_price_html', $price, $this );
 	}
 
     /**


### PR DESCRIPTION
Add a catch-all filter to the end of the `get_price_html()` method for product variations.. which better mimics the `get_price_html()` for simple products.

This will allow me to filter the whole string in one swoop from Name Your Price.
