### PR TITLE
Linking Plugin Name to the Plugin Url in the System Status

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -190,6 +190,12 @@
 
 					if ( ! empty( $plugin_data['Name'] ) ) {
 
+						// link the plugin name to the plugin url if available
+						$plugin_name = $plugin_data['Name'];
+						if ( ! empty( $plugin_data['PluginURI'] ) ) {
+							$plugin_name = '<a href="' . $plugin_data['PluginURI'] . '" title="' . __( 'Visit plugin homepage' , 'woocommerce' ) . '">' . $plugin_name . '</a>';
+						}
+
 						if ( strstr( $dirname, 'woocommerce' ) ) {
 
 							if ( false === ( $version_data = get_transient( $plugin . '_version_data' ) ) ) {
@@ -214,7 +220,7 @@
 								$version_string = ' &ndash; <strong style="color:red;">' . $version_data['version'] . ' ' . __( 'is available', 'woocommerce' ) . '</strong>';
 						}
 
-						$wc_plugins[] = $plugin_data['Name'] . ' ' . __( 'by', 'woocommerce' ) . ' ' . $plugin_data['Author'] . ' ' . __( 'version', 'woocommerce' ) . ' ' . $plugin_data['Version'] . $version_string;
+						$wc_plugins[] = $plugin_name . ' ' . __( 'by', 'woocommerce' ) . ' ' . $plugin_data['Author'] . ' ' . __( 'version', 'woocommerce' ) . ' ' . $plugin_data['Version'] . $version_string;
 
 					}
 				}


### PR DESCRIPTION
As the title says - this pull adds links the plugin name to the plugin url (from the main plugin file). 

This will make it one step easier for customers or support to click directly to a plugin. The end result looks like this:

![system status with plugin name linking to plugin URL](https://f.cloud.github.com/assets/1065372/883531/b10d94fe-f989-11e2-84da-c5496aa2b862.png)
