### PR TITLE
Add stock set, increase and reduce action hooks

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -162,6 +162,8 @@ class WC_Product {
 			$this->stock = intval( $amount );
 			update_post_meta( $this->id, '_stock', $this->stock );
 
+			do_action( 'woocommerce_set_stock', $this );
+
 			// Out of stock attribute
 			if ( ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
 				$this->set_stock_status( 'outofstock' );
@@ -188,6 +190,8 @@ class WC_Product {
 			$this->stock = $this->stock - $by;
 			update_post_meta( $this->id, '_stock', $this->stock );
 
+			do_action( 'woocommerce_reduce_stock', $this, $by );
+
 			// Out of stock attribute
 			if ( ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
 				$this->set_stock_status( 'outofstock' );
@@ -211,6 +215,8 @@ class WC_Product {
 		if ( $this->managing_stock() ) {
 			$this->stock = $this->stock + $by;
 			update_post_meta( $this->id, '_stock', $this->stock );
+
+			do_action( 'woocommerce_increase_stock', $this, $by );
 
 			// Out of stock attribute
 			if ( $this->backorders_allowed() || $this->get_total_stock() > 0 )

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -162,7 +162,7 @@ class WC_Product {
 			$this->stock = intval( $amount );
 			update_post_meta( $this->id, '_stock', $this->stock );
 
-			do_action( 'woocommerce_set_stock', $this );
+			do_action( 'woocommerce_product_set_stock', $this );
 
 			// Out of stock attribute
 			if ( ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
@@ -190,7 +190,7 @@ class WC_Product {
 			$this->stock = $this->stock - $by;
 			update_post_meta( $this->id, '_stock', $this->stock );
 
-			do_action( 'woocommerce_reduce_stock', $this, $by );
+			do_action( 'woocommerce_product_reduce_stock', $this, $by );
 
 			// Out of stock attribute
 			if ( ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
@@ -216,7 +216,7 @@ class WC_Product {
 			$this->stock = $this->stock + $by;
 			update_post_meta( $this->id, '_stock', $this->stock );
 
-			do_action( 'woocommerce_increase_stock', $this, $by );
+			do_action( 'woocommerce_product_increase_stock', $this, $by );
 
 			// Out of stock attribute
 			if ( $this->backorders_allowed() || $this->get_total_stock() > 0 )


### PR DESCRIPTION
This commit adds 3 new action hooks (in `abstract-wc-product.php`): 
1. `woocommerce_product_set_stock` - triggered right after product stock has been set with the `set_stock` method.
2. `woocommerce_product_increase_stock` - triggered right after product stock has been increased with the `increase_stock` method
3. `woocommerce_product_reduce_stock` - triggered right after product stock has been reduced with the `reduce_stock` method.

The latter two hooks receive an extra argument `$by` which simply indicates the quantity the stock was reduced or increased by.

These hooks can be very useful when you want to trigger actions based on product stock changes. I am myself writing a plugin that very much benefits from these hooks.
