### PR TITLE
Backward compatible variable_product_sync()

### DIFF
--- a/includes/admin/post-types/writepanels/writepanel-product-type-variable.php
+++ b/includes/admin/post-types/writepanels/writepanel-product-type-variable.php
@@ -829,7 +829,7 @@ function process_product_meta_variable( $post_id ) {
 	}
 
 	// Update parent if variable so price sorting works and stays in sync with the cheapest child
-	WC_Product_Variable::variable_product_sync( $post_id );
+	WC_Product_Variable::sync( $post_id );
 
 	// Update default attribute options setting
 	$default_attributes = array();

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -463,7 +463,15 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Sync variable product prices with the children lowest/highest prices.
 	 */
-	public static function variable_product_sync( $product_id ) {
+	public function variable_product_sync( $product_id = '' ) {
+		self::sync( $product_id );
+	}
+
+
+	/**
+	 * Sync variable product prices with the children lowest/highest prices.
+	 */
+	public static function sync( $product_id ) {
 		$children = get_posts( array(
 			'post_parent' 	=> $product_id,
 			'posts_per_page'=> -1,

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -464,6 +464,10 @@ class WC_Product_Variable extends WC_Product {
 	 * Sync variable product prices with the children lowest/highest prices.
 	 */
 	public function variable_product_sync( $product_id = '' ) {
+
+		if ( empty( $product_id ) )
+			$product_id = $this->id;
+
 		self::sync( $product_id );
 	}
 


### PR DESCRIPTION
To avoid breaking any extensions using `WC_Product_Variable::variable_product_sync()`:
1. Adds new static `WC_Product_Variable::sync()` instead of making `WC_Product_Variable::variable_product_sync()` static
2. Makes the `$product_id` param optional on existing method

Related: woothemes/woocommerce-subscriptions#179
