### PR TITLE
Fixed Strict Standars notices on start_el() method in the walker classes

### DIFF
--- a/includes/walkers/class-product-cat-dropdown-walker.php
+++ b/includes/walkers/class-product-cat-dropdown-walker.php
@@ -25,7 +25,7 @@ class WC_Product_Cat_Dropdown_Walker extends Walker {
 	 * @param int $depth Depth of category in reference to parents.
 	 * @param array $args
 	 */
-	function start_el(&$output, $cat, $depth, $args) {
+	function start_el( &$output, $cat, $depth = 0, $args = array(), $current_object_id = 0 ) {
 
 		if ( ! empty( $args['hierarchical'] ) )
 			$pad = str_repeat('&nbsp;', $depth * 3);

--- a/includes/walkers/class-product-cat-list-walker.php
+++ b/includes/walkers/class-product-cat-list-walker.php
@@ -57,7 +57,7 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @param int $depth Depth of category in reference to parents.
 	 * @param array $args
 	 */
-	function start_el( &$output, $cat, $depth, $args ) {
+	function start_el( &$output, $cat, $depth = 0, $args = array(), $current_object_id = 0 ) {
 
 		$output .= '<li class="cat-item cat-item-' . $cat->term_id;
 


### PR DESCRIPTION
Fixed Strict Standars notices on start_el() method in WC_Product_Cat_List_Walker and WC_Product_Cat_Dropdown_Walker classes.
![woocommerce](https://f.cloud.github.com/assets/3339350/900609/358a6fb4-fb69-11e2-83f1-35faf49b4824.png)
