### PR TITLE
Adds an index to the foreign key in table woocommerce_tax_rate_locations

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -403,6 +403,7 @@ class WC_Install {
 	  tax_rate_id bigint(20) NOT NULL,
 	  location_type varchar(40) NOT NULL,
 	  PRIMARY KEY  (location_id),
+      KEY tax_rate_id (tax_rate_id),
 	  KEY location_type (location_type),
 	  KEY location_type_code (location_type,location_code)
 	) $collate;


### PR DESCRIPTION
The index is missing for the foreign key on the table woocommerce_tax_rate_locations. When there are a number of entries in this table, such as there would be for a state like California, the tax rate class queries grind to a halt becoming a significant bottleneck for the application.
