### PR TITLE
Add stock action hooks to Variable Products, Product Variations and admin area.

### DIFF
--- a/includes/admin/post-types/class-wc-admin-cpt-product.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-product.php
@@ -604,6 +604,8 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 				update_post_meta( $post_id, '_manage_stock', 'no' );
 				update_post_meta( $post_id, '_stock', '0' );
 			}
+
+			do_action( 'woocommerce_product_set_stock', $product );
 		}
 
 		do_action( 'woocommerce_product_quick_edit_save', $product );
@@ -753,6 +755,8 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 			if ( ! empty( $_REQUEST['change_stock'] ) ) {
 				update_post_meta( $post_id, '_stock', (int) $_REQUEST['_stock'] );
 				update_post_meta( $post_id, '_manage_stock', 'yes' );
+
+				do_action( 'woocommerce_product_set_stock', $product );
 			}
 
 			if ( ! empty( $_REQUEST['_manage_stock'] ) ) {
@@ -762,6 +766,8 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 				} else {
 					update_post_meta( $post_id, '_manage_stock', 'no' );
 					update_post_meta( $post_id, '_stock', '0' );
+					
+					do_action( 'woocommerce_product_set_stock', $product );
 				}
 			}
 

--- a/includes/admin/post-types/writepanels/writepanel-product_data.php
+++ b/includes/admin/post-types/writepanels/writepanel-product_data.php
@@ -942,12 +942,18 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 			update_post_meta( $post_id, '_manage_stock', 'no' );
 			update_post_meta( $post_id, '_backorders', 'no' );
 
+			do_action( 'woocommerce_product_set_stock', $post );
+			do_action( 'woocommerce_product_set_stock_status', $post_id, stripslashes( $_POST['_stock_status'] ) );			
+
 		} elseif ( $product_type == 'external' ) {
 
 			update_post_meta( $post_id, '_stock_status', 'instock' );
 			update_post_meta( $post_id, '_stock', '' );
 			update_post_meta( $post_id, '_manage_stock', 'no' );
 			update_post_meta( $post_id, '_backorders', 'no' );
+
+			do_action( 'woocommerce_product_set_stock', $post );
+			do_action( 'woocommerce_product_set_stock_status', $post_id, 'instock' );
 
 		} elseif ( ! empty( $_POST['_manage_stock'] ) ) {
 
@@ -957,9 +963,14 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 			update_post_meta( $post_id, '_backorders', stripslashes( $_POST['_backorders'] ) );
 			update_post_meta( $post_id, '_manage_stock', 'yes' );
 
+			do_action( 'woocommerce_product_set_stock', $post );
+			do_action( 'woocommerce_product_set_stock_status', $post_id, stripslashes( $_POST['_stock_status'] ) );
+
 			// Check stock level
-			if ( $product_type !== 'variable' && $_POST['_backorders'] == 'no' && (int) $_POST['_stock'] < 1 )
+			if ( $product_type !== 'variable' && $_POST['_backorders'] == 'no' && (int) $_POST['_stock'] < 1 ) {
 				update_post_meta( $post_id, '_stock_status', 'outofstock' );
+				do_action( 'woocommerce_product_set_stock_status', $post_id, 'outofstock' );
+			}
 
 		} else {
 
@@ -968,12 +979,16 @@ function woocommerce_process_product_meta( $post_id, $post ) {
 			update_post_meta( $post_id, '_stock_status', stripslashes( $_POST['_stock_status'] ) );
 			update_post_meta( $post_id, '_backorders', stripslashes( $_POST['_backorders'] ) );
 			update_post_meta( $post_id, '_manage_stock', 'no' );
+			
+			do_action( 'woocommerce_product_set_stock', $post );
+			do_action( 'woocommerce_product_set_stock_status', $post_id, stripslashes( $_POST['_stock_status'] ) );
 
 		}
 
 	} else {
 
 		update_post_meta( $post_id, '_stock_status', stripslashes( $_POST['_stock_status'] ) );
+		do_action( 'woocommerce_product_set_stock_status', $post_id, stripslashes( $_POST['_stock_status'] ) );
 
 	}
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -81,6 +81,8 @@ class WC_Product_Variable extends WC_Product {
 			$this->total_stock = intval( $amount );
 			update_post_meta( $this->id, '_stock', $this->stock );
 
+			do_action( 'woocommerce_product_set_stock', $this );
+
 			// Check parents out of stock attribute
 			if ( ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
 				$this->set_stock_status( 'outofstock' );
@@ -108,6 +110,8 @@ class WC_Product_Variable extends WC_Product {
 			$this->total_stock = $this->get_total_stock() - $by;
 			update_post_meta($this->id, '_stock', $this->stock);
 
+			do_action( 'woocommerce_product_reduce_stock', $this, $by );
+
 			// Out of stock attribute
 			if ( ! $this->backorders_allowed() && $this->get_total_stock() <= 0 )
 				$this->set_stock_status( 'outofstock' );
@@ -133,6 +137,8 @@ class WC_Product_Variable extends WC_Product {
 			$this->stock = $this->stock + $by;
 			$this->total_stock = $this->get_total_stock() + $by;
 			update_post_meta($this->id, '_stock', $this->stock);
+
+			do_action( 'woocommerce_product_increase_stock', $this, $by );
 
 			// Out of stock attribute
 			if ( $this->backorders_allowed() || $this->get_total_stock() > 0 )

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -298,6 +298,8 @@ class WC_Product_Variation extends WC_Product {
 				update_post_meta( $this->variation_id, '_stock', $this->stock );
 				$woocommerce->get_helper( 'transient' )->clear_product_transients( $this->id ); // Clear transient
 
+				do_action( 'woocommerce_product_set_stock', $this );
+
 				// Check parents out of stock attribute
 				if ( ! $this->is_in_stock() ) {
 
@@ -337,6 +339,8 @@ class WC_Product_Variation extends WC_Product {
 				update_post_meta( $this->variation_id, '_stock', $this->stock );
 				$woocommerce->get_helper( 'transient' )->clear_product_transients( $this->id ); // Clear transient
 
+				do_action( 'woocommerce_product_reduce_stock', $this, $by );
+
 				// Check parents out of stock attribute
 				if ( ! $this->is_in_stock() ) {
 
@@ -373,6 +377,8 @@ class WC_Product_Variation extends WC_Product {
 				$this->total_stock 	= $this->total_stock + $by;
 				update_post_meta( $this->variation_id, '_stock', $this->stock );
 				$woocommerce->get_helper( 'transient' )->clear_product_transients( $this->id ); // Clear transient
+
+				do_action( 'woocommerce_product_increase_stock', $this, $by );
 
 				// Parents out of stock attribute
 				if ( $this->is_in_stock() )


### PR DESCRIPTION
My previous pull request https://github.com/woothemes/woocommerce/pull/3564 left out some places where the a product's stock is either set, increased or reduced. This pull request addresses those places and also adds the `woocommerce_product_set_stock` hook to admin area.
