### PR TITLE
Move return class after class definition. Fixes PHP 5.5 fatal errors.

### DIFF
--- a/includes/helpers/class-wc-attribute-helper.php
+++ b/includes/helpers/class-wc-attribute-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Attribute_Helper();
-
 class WC_Attribute_Helper extends WC_Helper {
 	/**
 	 * Get attribute taxonomies.
@@ -94,3 +92,5 @@ class WC_Attribute_Helper extends WC_Helper {
 		return $taxonomy_names;
 	}
 }
+
+return new WC_Attribute_Helper();

--- a/includes/helpers/class-wc-body-class-helper.php
+++ b/includes/helpers/class-wc-body-class-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Body_Class_Helper();
-
 class WC_Body_Class_Helper extends WC_Helper {
 	private $_body_classes = array();
 	
@@ -34,3 +32,5 @@ class WC_Body_Class_Helper extends WC_Helper {
 		return $classes;
 	}
 }
+
+return new WC_Body_Class_Helper();

--- a/includes/helpers/class-wc-inline-javascript-helper.php
+++ b/includes/helpers/class-wc-inline-javascript-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Inline_Javascript_Helper();
-
 class WC_Inline_Javascript_Helper extends WC_Helper {
 	protected $_inline_js;
 	
@@ -41,3 +39,5 @@ class WC_Inline_Javascript_Helper extends WC_Helper {
 		}
 	}
 }
+
+return new WC_Inline_Javascript_Helper();

--- a/includes/helpers/class-wc-post-class-helper.php
+++ b/includes/helpers/class-wc-post-class-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Post_Class_Helper();
-
 class WC_Post_Class_Helper extends WC_Helper {
 	/**
 	 * Adds extra post classes for products
@@ -53,3 +51,5 @@ class WC_Post_Class_Helper extends WC_Helper {
 		return $classes;
 	}
 }
+
+return new WC_Post_Class_Helper();

--- a/includes/helpers/class-wc-shortcode-helper.php
+++ b/includes/helpers/class-wc-shortcode-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Shortcode_Helper();
-
 class WC_Shortcode_Helper extends WC_Helper {
 	/**
 	 * Shortcode Wrapper
@@ -32,3 +30,5 @@ class WC_Shortcode_Helper extends WC_Helper {
 		return ob_get_clean();
 	}
 }
+
+return new WC_Shortcode_Helper();

--- a/includes/helpers/class-wc-template-helper.php
+++ b/includes/helpers/class-wc-template-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Template_Helper();
-
 class WC_Template_Helper extends WC_Helper {
 	public $template_url;
 
@@ -89,3 +87,5 @@ class WC_Template_Helper extends WC_Helper {
 			return $woocommerce->plugin_path() . '/templates/single-product-reviews.php';
 	}
 }
+
+return new WC_Template_Helper();

--- a/includes/helpers/class-wc-transient-helper.php
+++ b/includes/helpers/class-wc-transient-helper.php
@@ -1,7 +1,5 @@
 <?php
 
-return new WC_Transient_Helper();
-
 class WC_Transient_Helper extends WC_Helper {
 	/**
 	 * Clear all transients cache for product data.
@@ -63,3 +61,5 @@ class WC_Transient_Helper extends WC_Helper {
 		}
 	}
 }
+
+return new WC_Transient_Helper();


### PR DESCRIPTION
This is needed otherwise it will result in a fatal error for PHP 5.5
