### PR TITLE
Fix result count display when posts_per_page is set to -1

### DIFF
--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -26,7 +26,7 @@ if ( ! woocommerce_products_will_display() )
 
 	if ( 1 == $total ) {
 		_e( 'Showing the single result', 'woocommerce' );
-	} elseif ( $total <= $per_page ) {
+	} elseif ( $total <= $per_page || -1 == $per_page ) {
 		printf( __( 'Showing all %d results', 'woocommerce' ), $total );
 	} else {
 		printf( _x( 'Showing %1$d–%2$d of %3$d results', '%1$d = first, %2$d = last, %3$d = total', 'woocommerce' ), $first, $last, $total );


### PR DESCRIPTION
When your posts_per_page is set to -1 the display is output as `Showing 1–-1 of 15 results` when displaying all items when it would be better to show `Showing all 15 results`
