### PR TITLE
Adding WPLANG to System Status

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -40,7 +40,7 @@
 		</tr>
 		<tr>
 			<td><?php _e( 'Web Server Info','woocommerce' ); ?>:</td>
-			<td><?php echo esc_html( $_SERVER['SERVER_SOFTWARE'] );  ?></td>
+			<td><?php echo esc_html( $_SERVER['SERVER_SOFTWARE'] ); ?></td>
 		</tr>
 		<tr>
 			<td><?php _e( 'PHP Version','woocommerce' ); ?>:</td>
@@ -63,8 +63,12 @@
 			?></td>
 		</tr>
 		<tr>
-			<td><?php _e( 'WP Debug Mode','woocommerce' ); ?>:</td>
+			<td><?php _e( 'WP Debug Mode', 'woocommerce' ); ?>:</td>
 			<td><?php if ( defined('WP_DEBUG') && WP_DEBUG ) echo '<mark class="yes">' . __( 'Yes', 'woocommerce' ) . '</mark>'; else echo '<mark class="no">' . __( 'No', 'woocommerce' ) . '</mark>'; ?></td>
+		</tr>
+		<tr>
+			<td><?php _e( 'WP Language', 'woocommerce' ); ?>:</td>
+			<td><?php if ( defined( 'WPLANG' ) && WPLANG ) echo WPLANG; else  _e( 'Default', 'woocommerce' ); ?></td>
 		</tr>
 		<tr>
 			<td><?php _e( 'WP Max Upload Size','woocommerce' ); ?>:</td>


### PR DESCRIPTION
It takes an extra step when customers don't tell WooThemes what language they're using and the WPLANG constant also affects RTL support. It should be included when customers submit their system status for a more complete picture of what's going on.

It should look like this:
![woocommerce_status__test__wordpress](https://f.cloud.github.com/assets/1065372/927744/077d10d6-ffa6-11e2-8ea9-a200f523986b.png)

Inspired by: https://woothemes.zendesk.com/agent/#/tickets/84875
