### PR TITLE
Change quick/bulk edit stock quantity field type to number

### DIFF
--- a/includes/admin/views/html-bulk-edit-product.php
+++ b/includes/admin/views/html-bulk-edit-product.php
@@ -239,7 +239,7 @@
 					</span>
 				</label>
 				<label class="alignright">
-					<input type="text" name="_stock" class="text stock" placeholder="<?php _e( 'Stock Qty', 'woocommerce' ); ?>" value="">
+					<input type="number" name="_stock" class="text stock" placeholder="<?php _e( 'Stock Qty', 'woocommerce' ); ?>" step="any" value="">
 				</label>
 			</div>
 

--- a/includes/admin/views/html-quick-edit-product.php
+++ b/includes/admin/views/html-quick-edit-product.php
@@ -154,7 +154,7 @@
 				<label class="stock_qty_field">
 				    <span class="title"><?php _e( 'Stock Qty', 'woocommerce' ); ?></span>
 				    <span class="input-text-wrap">
-						<input type="text" name="_stock" class="text stock" value="">
+						<input type="number" name="_stock" class="text stock" step="any" value="">
 					</span>
 				</label>
 			<?php endif; ?>


### PR DESCRIPTION
To have more consistent behavior/UI across different places where an admin user can edit stock quantity, I have changed the quick and bulk editing stock quantity field types to `number` instead of `text`. This way, the field type is the same as when on the Edit Product screen.
