### PR TITLE
Filter Request: Login Credentials

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -624,7 +624,7 @@ class WC_Form_Handler {
 				$creds['user_password'] = $_POST['password'];
 				$creds['remember']      = true;
 				$secure_cookie          = is_ssl() ? true : false;
-				$user                   = wp_signon( $creds, $secure_cookie );
+				$user                   = wp_signon( apply_filters( 'woocommerce_login_credentials', $creds ), $secure_cookie );
 
 				if ( is_wp_error( $user ) ) {
 					throw new Exception( $user->get_error_message() );


### PR DESCRIPTION
I'm trying to add a "remember me" option to my login form. WordPress supports this, but it's hardcoded to always on in the WC form handler. Since you can't tell a difference in PHP between an unchecked checkbox and no checkbox at all, this seems like the simplest alternative that maintains backwards compatibility. Thanks.
