### PR TITLE
Remove Spaces in Favor of Tabs in Shipping Classes

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -21,25 +21,25 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	 * @return void
 	 */
 	function __construct() {
-        $this->id 						= 'flat_rate';
-        $this->method_title 			= __( 'Flat Rate', 'woocommerce' );
+		$this->id 						= 'flat_rate';
+		$this->method_title 			= __( 'Flat Rate', 'woocommerce' );
 		$this->flat_rate_option 		= 'woocommerce_flat_rates';
-		$this->method_description 	    = __( 'Flat rates let you define a standard rate per item, or per order.', 'woocommerce' );
+		$this->method_description 		= __( 'Flat rates let you define a standard rate per item, or per order.', 'woocommerce' );
 
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_flat_rates' ) );
 		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'save_default_costs' ) );
 
-    	$this->init();
-    }
+		$this->init();
+	}
 
-    /**
-     * init function.
-     *
-     * @access public
-     * @return void
-     */
-    function init() {
+	/**
+	 * init function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init() {
 
 		// Load the settings.
 		$this->init_form_fields();
@@ -59,19 +59,19 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 		// Load Flat rates
 		$this->get_flat_rates();
-    }
+	}
 
 
-    /**
-     * Initialise Gateway Settings Form Fields
-     *
-     * @access public
-     * @return void
-     */
-    function init_form_fields() {
-    	global $woocommerce;
+	/**
+	 * Initialise Gateway Settings Form Fields
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init_form_fields() {
+		global $woocommerce;
 
-    	$this->form_fields = array(
+		$this->form_fields = array(
 			'enabled' => array(
 							'title' 		=> __( 'Enable/Disable', 'woocommerce' ),
 							'type' 			=> 'checkbox',
@@ -83,7 +83,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							'type' 			=> 'text',
 							'description' 	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 							'default'		=> __( 'Flat Rate', 'woocommerce' ),
-							'desc_tip'      => true
+							'desc_tip'		=> true
 						),
 			'availability' => array(
 							'title' 		=> __( 'Availability', 'woocommerce' ),
@@ -121,7 +121,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							),
 							'description'	=> __( 'Enter a cost (excluding tax) per order, e.g. 5.00. Leave blank to disable.', 'woocommerce' ),
 							'default'		=> '',
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
 			'options' => array(
@@ -129,12 +129,12 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							'type' 			=> 'textarea',
 							'description'	=> __( 'Optional extra shipping options with additional costs (one per line): Option Name | Additional Cost | Per Cost Type (order, class, or item) Example: <code>Priority Mail | 6.95 | order</code>.', 'woocommerce' ),
 							'default'		=> '',
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 							'placeholder'	=> __( 'Option Name | Additional Cost | Per Cost Type (order, class, or item)', 'woocommerce' )
 						),
 			'additional_costs' => array(
-							'title'         => __( 'Additional Costs', 'woocommerce' ),
-							'type'          => 'title',
+							'title'			=> __( 'Additional Costs', 'woocommerce' ),
+							'type'			=> 'title',
 							'description'   => __( 'Additional costs can be added below - these will all be added to the per-order cost above.', 'woocommerce' )
 						),
 			'type' => array(
@@ -148,7 +148,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							),
 						),
 			'additional_costs_table' => array(
-						'type'          => 'additional_costs_table'
+						'type'				=> 'additional_costs_table'
 						),
 			'minimum_fee' => array(
 							'title' 		=> __( 'Minimum Handling Fee', 'woocommerce' ),
@@ -159,33 +159,33 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							),
 							'description'	=> __( 'Enter a minimum fee amount. Fee\'s less than this will be increased. Leave blank to disable.', 'woocommerce' ),
 							'default'		=> '',
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
 			);
 
-    }
+	}
 
 
-    /**
-     * calculate_shipping function.
-     *
-     * @access public
-     * @param array $package (default: array())
-     * @return void
-     */
-    function calculate_shipping( $package = array() ) {
-    	global $woocommerce;
+	/**
+	 * calculate_shipping function.
+	 *
+	 * @access public
+	 * @param array $package (default: array())
+	 * @return void
+	 */
+	function calculate_shipping( $package = array() ) {
+		global $woocommerce;
 
-    	$this->rates 		= array();
-    	$cost_per_order 	= ( isset( $this->cost_per_order ) && ! empty( $this->cost_per_order ) ) ? $this->cost_per_order : 0;
+		$this->rates 		= array();
+		$cost_per_order 	= ( isset( $this->cost_per_order ) && ! empty( $this->cost_per_order ) ) ? $this->cost_per_order : 0;
 
-    	if ( $this->type == 'order' ) {
+		if ( $this->type == 'order' ) {
 
-    		$shipping_total = $this->order_shipping( $package );
+			$shipping_total = $this->order_shipping( $package );
 
-    		if ( ! is_null( $shipping_total ) || $cost_per_order > 0 )
-	    		$rate = array(
+			if ( ! is_null( $shipping_total ) || $cost_per_order > 0 )
+				$rate = array(
 					'id' 	=> $this->id,
 					'label' => $this->title,
 					'cost' 	=> $shipping_total + $cost_per_order,
@@ -196,7 +196,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 			$shipping_total = $this->class_shipping( $package );
 
 			if ( ! is_null( $shipping_total ) || $cost_per_order > 0 )
-	    		$rate = array(
+				$rate = array(
 					'id' 	=> $this->id,
 					'label' => $this->title,
 					'cost' 	=> $shipping_total + $cost_per_order,
@@ -252,9 +252,9 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 				$extra_rate = $rate;
 
-				$extra_rate['id']    = $this->id . ':' . sanitize_title( $this_option[0] );
-				$extra_rate['label'] = $this_option[0];
-				$this_cost           = $this_option[1];
+				$extra_rate['id']		= $this->id . ':' . sanitize_title( $this_option[0] );
+				$extra_rate['label']	= $this_option[0];
+				$this_cost				= $this_option[1];
 
 				// Backwards compat with yes and no
 				if ( $this_option[2] == 'yes' ) {
@@ -283,39 +283,39 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 				$this->add_rate( $extra_rate );
 			}
 		}
-    }
+	}
 
 
-    /**
-     * order_shipping function.
-     *
-     * @access public
-     * @param array $package
-     * @return float
-     */
-    function order_shipping( $package ) {
-    	$cost 	= null;
-    	$fee 	= null;
+	/**
+	 * order_shipping function.
+	 *
+	 * @access public
+	 * @param array $package
+	 * @return float
+	 */
+	function order_shipping( $package ) {
+		$cost 	= null;
+		$fee 	= null;
 
 		if ( sizeof( $this->flat_rates ) > 0 ) {
 
-    		$found_shipping_classes = $this->find_shipping_classes( $package );
+			$found_shipping_classes = $this->find_shipping_classes( $package );
 
-    		// Find most expensive class (if found)
-    		foreach ( $found_shipping_classes as $shipping_class => $products ) {
-    			if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
-    				if ( $this->flat_rates[ $shipping_class ]['cost'] > $cost ) {
-    					$cost 	= $this->flat_rates[ $shipping_class ]['cost'];
-    					$fee	= $this->flat_rates[ $shipping_class ]['fee'];
-    				}
-    			} else {
-    				// No matching classes so use defaults
-    				if ( ! empty( $this->cost ) && $this->cost > $cost ) {
-    					$cost 	= $this->cost;
-    					$fee	= $this->fee;
-    				}
-    			}
-    		}
+			// Find most expensive class (if found)
+			foreach ( $found_shipping_classes as $shipping_class => $products ) {
+				if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
+					if ( $this->flat_rates[ $shipping_class ]['cost'] > $cost ) {
+						$cost 	= $this->flat_rates[ $shipping_class ]['cost'];
+						$fee	= $this->flat_rates[ $shipping_class ]['fee'];
+					}
+				} else {
+					// No matching classes so use defaults
+					if ( ! empty( $this->cost ) && $this->cost > $cost ) {
+						$cost 	= $this->cost;
+						$fee	= $this->fee;
+					}
+				}
+			}
 
 		}
 
@@ -330,52 +330,52 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 		// Shipping for whole order
 		return $cost + $this->get_fee( $fee, $package['contents_cost'] );
-    }
+	}
 
 
-    /**
-     * class_shipping function.
-     *
-     * @access public
-     * @param array $package
-     * @return float
-     */
-    function class_shipping( $package ) {
+	/**
+	 * class_shipping function.
+	 *
+	 * @access public
+	 * @param array $package
+	 * @return float
+	 */
+	function class_shipping( $package ) {
 		$cost 	= null;
-    	$fee 	= null;
+		$fee 	= null;
 
 		if ( sizeof( $this->flat_rates ) > 0 || $this->cost !== '' ) {
 
-    		// Find shipping classes for products in the cart.
-    		$found_shipping_classes = $this->find_shipping_classes( $package );
+			// Find shipping classes for products in the cart.
+			$found_shipping_classes = $this->find_shipping_classes( $package );
 
-    		//  Store prices too, so we can calc a fee for the class.
-    		$found_shipping_classes_values = array();
+			//  Store prices too, so we can calc a fee for the class.
+			$found_shipping_classes_values = array();
 
-    		foreach ( $found_shipping_classes as $shipping_class => $products ) {
-	    		if ( ! isset( $found_shipping_classes_values[ $shipping_class ] ) )
-	    			$found_shipping_classes_values[ $shipping_class ] = 0;
+			foreach ( $found_shipping_classes as $shipping_class => $products ) {
+				if ( ! isset( $found_shipping_classes_values[ $shipping_class ] ) )
+					$found_shipping_classes_values[ $shipping_class ] = 0;
 
-	    		foreach ( $products as $product ) {
-		    		$found_shipping_classes_values[ $shipping_class ] += $product['data']->get_price() * $product['quantity'];
-	    		}
-    		}
+				foreach ( $products as $product ) {
+					$found_shipping_classes_values[ $shipping_class ] += $product['data']->get_price() * $product['quantity'];
+				}
+			}
 
-    		$matched = false;
+			$matched = false;
 
-    		// For each found class, add up the costs and fees
-    		foreach ( $found_shipping_classes_values as $shipping_class => $class_price ) {
-    			if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
-    				$cost 	+= $this->flat_rates[ $shipping_class ]['cost'];
-    				$fee	+= $this->get_fee( $this->flat_rates[ $shipping_class ]['fee'], $class_price );
-    				$matched = true;
-    			} elseif ( $this->cost !== '' ) {
-    				// Class not set so we use default rate if its set
-    				$cost 	+= $this->cost;
-    				$fee	+= $this->get_fee( $this->fee, $class_price );
-    				$matched = true;
-    			}
-    		}
+			// For each found class, add up the costs and fees
+			foreach ( $found_shipping_classes_values as $shipping_class => $class_price ) {
+				if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
+					$cost 	+= $this->flat_rates[ $shipping_class ]['cost'];
+					$fee	+= $this->get_fee( $this->flat_rates[ $shipping_class ]['fee'], $class_price );
+					$matched = true;
+				} elseif ( $this->cost !== '' ) {
+					// Class not set so we use default rate if its set
+					$cost 	+= $this->cost;
+					$fee	+= $this->get_fee( $this->fee, $class_price );
+					$matched = true;
+				}
+			}
 		}
 
 		// Total
@@ -383,17 +383,17 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 			return $cost + $fee;
 		else
 			return null;
-    }
+	}
 
 
-    /**
-     * item_shipping function.
-     *
-     * @access public
-     * @param array $package
-     * @return array
-     */
-    function item_shipping( $package ) {
+	/**
+	 * item_shipping function.
+	 *
+	 * @access public
+	 * @param array $package
+	 * @return array
+	 */
+	function item_shipping( $package ) {
 		// Per item shipping so we pass an array of costs (per item) instead of a single value
 		$costs = array();
 
@@ -410,8 +410,8 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 				if ( isset( $this->flat_rates[ $shipping_class ] ) ) {
 					$cost 	= $this->flat_rates[ $shipping_class ]['cost'];
-    				$fee	= $this->get_fee( $this->flat_rates[ $shipping_class ]['fee'], $_product->get_price() );
-    				$matched = true;
+					$fee	= $this->get_fee( $this->flat_rates[ $shipping_class ]['fee'], $_product->get_price() );
+					$matched = true;
 				} elseif ( $this->cost !== '' ) {
 					$cost 	= $this->cost;
 					$fee	= $this->get_fee( $this->fee, $_product->get_price() );
@@ -426,17 +426,17 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 			return $costs;
 		else
 			return null;
-    }
+	}
 
-    /**
-     * Finds and returns shipping classes and the products with said class.
-     *
-     * @access public
-     * @param mixed $package
-     * @return array
-     */
-    public function find_shipping_classes( $package ) {
-	    $found_shipping_classes = array();
+	/**
+	 * Finds and returns shipping classes and the products with said class.
+	 *
+	 * @access public
+	 * @param mixed $package
+	 * @return array
+	 */
+	public function find_shipping_classes( $package ) {
+		$found_shipping_classes = array();
 
 		// Find shipping classes for products in the cart
 		if ( sizeof( $package['contents'] ) > 0 ) {
@@ -452,83 +452,83 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		}
 
 		return $found_shipping_classes;
-    }
+	}
 
-    /**
-     * validate_additional_costs_field function.
-     *
-     * @access public
-     * @param mixed $key
-     * @return void
-     */
-    function validate_additional_costs_table_field( $key ) {
-	    return false;
-    }
+	/**
+	 * validate_additional_costs_field function.
+	 *
+	 * @access public
+	 * @param mixed $key
+	 * @return void
+	 */
+	function validate_additional_costs_table_field( $key ) {
+		return false;
+	}
 
-    /**
-     * generate_additional_costs_html function.
-     *
-     * @access public
-     * @return void
-     */
-    function generate_additional_costs_table_html() {
-    	global $woocommerce;
-    	ob_start();
-	    ?>
-	    <tr valign="top">
-            <th scope="row" class="titledesc"><?php _e( 'Costs', 'woocommerce' ); ?>:</th>
-            <td class="forminp" id="<?php echo $this->id; ?>_flat_rates">
-			    <table class="shippingrows widefat" cellspacing="0">
-		    		<thead>
-		    			<tr>
-		    				<th class="check-column"><input type="checkbox"></th>
-		    				<th class="shipping_class"><?php _e( 'Shipping Class', 'woocommerce' ); ?></th>
-			            	<th><?php _e( 'Cost', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'Cost, excluding tax.', 'woocommerce' ); ?>">[?]</a></th>
-			            	<th><?php _e( 'Handling Fee', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%.', 'woocommerce' ); ?>">[?]</a></th>
-		    			</tr>
-		    		</thead>
-		    		<tfoot>
-		    			<tr>
-		    				<th colspan="4"><a href="#" class="add button"><?php _e( '+ Add Cost', 'woocommerce' ); ?></a> <a href="#" class="remove button"><?php _e( 'Delete selected costs', 'woocommerce' ); ?></a></th>
-		    			</tr>
-		    		</tfoot>
-		    		<tbody class="flat_rates">
-		    			<tr>
-		    				<td></td>
-		    				<td class="flat_rate_class"><?php _e( 'Any class', 'woocommerce' ); ?></td>
-		    				<td><input type="number" step="any" min="0" value="<?php echo esc_attr( $this->cost ); ?>" name="default_cost" placeholder="<?php _e( 'N/A', 'woocommerce' ); ?>" size="4" /></td>
-				            <td><input type="text" value="<?php echo esc_attr( $this->fee ); ?>" name="default_fee" placeholder="<?php _e( 'N/A', 'woocommerce' ); ?>" size="4" /></td>
-		    			</tr>
-		            	<?php
-		            	$i = -1;
-		            	if ( $this->flat_rates ) {
-		            		foreach ( $this->flat_rates as $class => $rate ) {
-		                		$i++;
+	/**
+	 * generate_additional_costs_html function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function generate_additional_costs_table_html() {
+		global $woocommerce;
+		ob_start();
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc"><?php _e( 'Costs', 'woocommerce' ); ?>:</th>
+			<td class="forminp" id="<?php echo $this->id; ?>_flat_rates">
+				<table class="shippingrows widefat" cellspacing="0">
+					<thead>
+						<tr>
+							<th class="check-column"><input type="checkbox"></th>
+							<th class="shipping_class"><?php _e( 'Shipping Class', 'woocommerce' ); ?></th>
+							<th><?php _e( 'Cost', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'Cost, excluding tax.', 'woocommerce' ); ?>">[?]</a></th>
+							<th><?php _e( 'Handling Fee', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%.', 'woocommerce' ); ?>">[?]</a></th>
+						</tr>
+					</thead>
+					<tfoot>
+						<tr>
+							<th colspan="4"><a href="#" class="add button"><?php _e( '+ Add Cost', 'woocommerce' ); ?></a> <a href="#" class="remove button"><?php _e( 'Delete selected costs', 'woocommerce' ); ?></a></th>
+						</tr>
+					</tfoot>
+					<tbody class="flat_rates">
+						<tr>
+							<td></td>
+							<td class="flat_rate_class"><?php _e( 'Any class', 'woocommerce' ); ?></td>
+							<td><input type="number" step="any" min="0" value="<?php echo esc_attr( $this->cost ); ?>" name="default_cost" placeholder="<?php _e( 'N/A', 'woocommerce' ); ?>" size="4" /></td>
+							<td><input type="text" value="<?php echo esc_attr( $this->fee ); ?>" name="default_fee" placeholder="<?php _e( 'N/A', 'woocommerce' ); ?>" size="4" /></td>
+						</tr>
+						<?php
+						$i = -1;
+						if ( $this->flat_rates ) {
+							foreach ( $this->flat_rates as $class => $rate ) {
+								$i++;
 
-		                		echo '<tr class="flat_rate">
-		                			<th class="check-column"><input type="checkbox" name="select" /></th>
-		                			<td class="flat_rate_class">
-		                					<select name="' . esc_attr( $this->id . '_class[' . $i . ']' ) . '" class="select">';
+								echo '<tr class="flat_rate">
+									<th class="check-column"><input type="checkbox" name="select" /></th>
+									<td class="flat_rate_class">
+											<select name="' . esc_attr( $this->id . '_class[' . $i . ']' ) . '" class="select">';
 
-		                		if ( $woocommerce->shipping->get_shipping_classes() ) {
-			                		foreach ( $woocommerce->shipping->get_shipping_classes() as $shipping_class ) {
-			                			echo '<option value="'.$shipping_class->slug.'" '.selected($shipping_class->slug, $class, false).'>'.$shipping_class->name.'</option>';
-			                		}
-		                		} else {
-		                			echo '<option value="">'.__( 'Select a class&hellip;', 'woocommerce' ).'</option>';
-		                		}
+								if ( $woocommerce->shipping->get_shipping_classes() ) {
+									foreach ( $woocommerce->shipping->get_shipping_classes() as $shipping_class ) {
+										echo '<option value="'.$shipping_class->slug.'" '.selected($shipping_class->slug, $class, false).'>'.$shipping_class->name.'</option>';
+									}
+								} else {
+									echo '<option value="">'.__( 'Select a class&hellip;', 'woocommerce' ).'</option>';
+								}
 
-				                echo '</select>
-				               		</td>
-				                    <td><input type="number" step="any" min="0" value="' . esc_attr( $rate['cost'] ) . '" name="' . esc_attr( $this->id .'_cost[' . $i . ']' ) . '" placeholder="'.__( '0.00', 'woocommerce' ).'" size="4" /></td>
-				                    <td><input type="text" value="' . esc_attr( $rate['fee'] ) . '" name="' . esc_attr( $this->id .'_fee[' . $i . ']' ) . '" placeholder="'.__( '0.00', 'woocommerce' ).'" size="4" /></td>
-			                    </tr>';
-		            		}
-		            	}
-		            	?>
-		        	</tbody>
-		        </table>
-		       	<script type="text/javascript">
+								echo '</select>
+							   		</td>
+									<td><input type="number" step="any" min="0" value="' . esc_attr( $rate['cost'] ) . '" name="' . esc_attr( $this->id .'_cost[' . $i . ']' ) . '" placeholder="'.__( '0.00', 'woocommerce' ).'" size="4" /></td>
+									<td><input type="text" value="' . esc_attr( $rate['fee'] ) . '" name="' . esc_attr( $this->id .'_fee[' . $i . ']' ) . '" placeholder="'.__( '0.00', 'woocommerce' ).'" size="4" /></td>
+								</tr>';
+							}
+						}
+						?>
+					</tbody>
+				</table>
+			   	<script type="text/javascript">
 					jQuery(function() {
 
 						jQuery('#<?php echo $this->id; ?>_flat_rates').on( 'click', 'a.add', function(){
@@ -537,22 +537,22 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 							jQuery('<tr class="flat_rate">\
 								<th class="check-column"><input type="checkbox" name="select" /></th>\
-		            			<td class="flat_rate_class">\
-		            				<select name="<?php echo $this->id; ?>_class[' + size + ']" class="select">\
-			               				<?php
-			               				if ($woocommerce->shipping->get_shipping_classes()) :
-					                		foreach ($woocommerce->shipping->get_shipping_classes() as $class) :
-					                			echo '<option value="' . esc_attr( $class->slug ) . '">' . esc_js( $class->name ) . '</option>';
-					                		endforeach;
-				                		else :
-				                			echo '<option value="">'.__( 'Select a class&hellip;', 'woocommerce' ).'</option>';
-				                		endif;
-			               				?>\
-			               			</select>\
-			               		</td>\
-			                    <td><input type="number" step="any" min="0" name="<?php echo $this->id; ?>_cost[' + size + ']" placeholder="0.00" size="4" /></td>\
-			                    <td><input type="text" name="<?php echo $this->id; ?>_fee[' + size + ']" placeholder="0.00" size="4" /></td>\
-		                    </tr>').appendTo('#<?php echo $this->id; ?>_flat_rates table tbody');
+								<td class="flat_rate_class">\
+									<select name="<?php echo $this->id; ?>_class[' + size + ']" class="select">\
+						   				<?php
+						   				if ($woocommerce->shipping->get_shipping_classes()) :
+											foreach ($woocommerce->shipping->get_shipping_classes() as $class) :
+												echo '<option value="' . esc_attr( $class->slug ) . '">' . esc_js( $class->name ) . '</option>';
+											endforeach;
+										else :
+											echo '<option value="">'.__( 'Select a class&hellip;', 'woocommerce' ).'</option>';
+										endif;
+						   				?>\
+						   			</select>\
+						   		</td>\
+								<td><input type="number" step="any" min="0" name="<?php echo $this->id; ?>_cost[' + size + ']" placeholder="0.00" size="4" /></td>\
+								<td><input type="text" name="<?php echo $this->id; ?>_fee[' + size + ']" placeholder="0.00" size="4" /></td>\
+							</tr>').appendTo('#<?php echo $this->id; ?>_flat_rates table tbody');
 
 							return false;
 						});
@@ -570,19 +570,19 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 					});
 				</script>
-            </td>
-	    </tr>
-        <?php
-        return ob_get_clean();
-    }
+			</td>
+		</tr>
+		<?php
+		return ob_get_clean();
+	}
 
-    /**
-     * process_flat_rates function.
-     *
-     * @access public
-     * @return void
-     */
-    function process_flat_rates() {
+	/**
+	 * process_flat_rates function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function process_flat_rates() {
 		// Save the rates
 		$flat_rate_class = array();
 		$flat_rate_cost = array();
@@ -615,16 +615,16 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		update_option( $this->flat_rate_option, $flat_rates );
 
 		$this->get_flat_rates();
-    }
+	}
 
-    /**
-     * save_default_costs function.
-     *
-     * @access public
-     * @param mixed $values
-     * @return void
-     */
-    function save_default_costs( $fields ) {
+	/**
+	 * save_default_costs function.
+	 *
+	 * @access public
+	 * @param mixed $values
+	 * @return void
+	 */
+	function save_default_costs( $fields ) {
 	 	$default_cost = woocommerce_clean( $_POST['default_cost'] );
 	 	$default_fee  = woocommerce_clean( $_POST['default_fee'] );
 
@@ -632,17 +632,17 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	 	$fields['fee']  = $default_fee;
 
 	 	return $fields;
-    }
+	}
 
 
-    /**
-     * get_flat_rates function.
-     *
-     * @access public
-     * @return void
-     */
-    function get_flat_rates() {
-    	$this->flat_rates = array_filter( (array) get_option( $this->flat_rate_option ) );
-    }
+	/**
+	 * get_flat_rates function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function get_flat_rates() {
+		$this->flat_rates = array_filter( (array) get_option( $this->flat_rate_option ) );
+	}
 
 }

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -21,25 +21,25 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 	 * @return void
 	 */
 	function __construct() {
-        $this->id 			= 'free_shipping';
-        $this->method_title = __( 'Free Shipping', 'woocommerce' );
+		$this->id 			= 'free_shipping';
+		$this->method_title = __( 'Free Shipping', 'woocommerce' );
 		$this->init();
-    }
+	}
 
-    /**
-     * init function.
-     *
-     * @access public
-     * @return void
-     */
-    function init() {
+	/**
+	 * init function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init() {
 
 		// Load the settings.
 		$this->init_form_fields();
 		$this->init_settings();
 
 		// Define user set variables
-        $this->enabled		= $this->get_option( 'enabled' );
+		$this->enabled		= $this->get_option( 'enabled' );
 		$this->title 		= $this->get_option( 'title' );
 		$this->min_amount 	= $this->get_option( 'min_amount', 0 );
 		$this->availability = $this->get_option( 'availability' );
@@ -48,20 +48,20 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 
 		// Actions
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
-    }
+	}
 
 
-    /**
-     * Initialise Gateway Settings Form Fields
-     *
-     * @access public
-     * @return void
-     */
-    function init_form_fields() {
-    	global $woocommerce;
+	/**
+	 * Initialise Gateway Settings Form Fields
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init_form_fields() {
+		global $woocommerce;
 
-    	// Backwards compat
-    	if ( $this->get_option( 'requires_coupon' ) && $this->min_amount )
+		// Backwards compat
+		if ( $this->get_option( 'requires_coupon' ) && $this->min_amount )
 			$default_requires = 'either';
 		elseif ( $this->get_option( 'requires_coupon' ) )
 			$default_requires = 'coupon';
@@ -70,7 +70,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 		else
 			$default_requires = '';
 
-    	$this->form_fields = array(
+		$this->form_fields = array(
 			'enabled' => array(
 							'title' 		=> __( 'Enable/Disable', 'woocommerce' ),
 							'type' 			=> 'checkbox',
@@ -82,7 +82,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 							'type' 			=> 'text',
 							'description' 	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 							'default'		=> __( 'Free Shipping', 'woocommerce' ),
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 						),
 			'availability' => array(
 							'title' 		=> __( 'Method availability', 'woocommerce' ),
@@ -123,12 +123,12 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 							),
 							'description' 	=> __( 'Users will need to spend this amount to get free shipping (if enabled above).', 'woocommerce' ),
 							'default' 		=> '0',
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						)
 			);
 
-    }
+	}
 
 
 	/**
@@ -141,29 +141,29 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 	 */
 	public function admin_options() {
 
-    	?>
-    	<h3><?php _e( 'Free Shipping', 'woocommerce' ); ?></h3>
-    	<table class="form-table">
-    	<?php
-    		// Generate the HTML For the settings form.
-    		$this->generate_settings_html();
-    	?>
+		?>
+		<h3><?php _e( 'Free Shipping', 'woocommerce' ); ?></h3>
+		<table class="form-table">
+		<?php
+			// Generate the HTML For the settings form.
+			$this->generate_settings_html();
+		?>
 		</table><!--/.form-table-->
-    	<?php
-    }
+		<?php
+	}
 
 
-    /**
-     * is_available function.
-     *
-     * @access public
-     * @param mixed $package
-     * @return bool
-     */
-    function is_available( $package ) {
-    	global $woocommerce;
+	/**
+	 * is_available function.
+	 *
+	 * @access public
+	 * @param mixed $package
+	 * @return bool
+	 */
+	function is_available( $package ) {
+		global $woocommerce;
 
-    	if ( $this->enabled == "no" ) return false;
+		if ( $this->enabled == "no" ) return false;
 
 		$ship_to_countries = '';
 
@@ -226,23 +226,23 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 		}
 
 		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available );
-    }
+	}
 
 
-    /**
-     * calculate_shipping function.
-     *
-     * @access public
-     * @return array
-     */
-    function calculate_shipping() {
-    	$args = array(
-    		'id' 	=> $this->id,
-    		'label' => $this->title,
-    		'cost' 	=> 0,
-    		'taxes' => false
-    	);
-    	$this->add_rate( $args );
-    }
+	/**
+	 * calculate_shipping function.
+	 *
+	 * @access public
+	 * @return array
+	 */
+	function calculate_shipping() {
+		$args = array(
+			'id' 	=> $this->id,
+			'label' => $this->title,
+			'cost' 	=> 0,
+			'taxes' => false
+		);
+		$this->add_rate( $args );
+	}
 
 }

--- a/includes/shipping/international-delivery/class-wc-shipping-international-delivery.php
+++ b/includes/shipping/international-delivery/class-wc-shipping-international-delivery.php
@@ -24,126 +24,126 @@ class WC_Shipping_International_Delivery extends WC_Shipping_Flat_Rate {
 	 */
 	function __construct() {
 
-        $this->id 						= 'international_delivery';
-		$this->flat_rate_option	 		= 'woocommerce_international_delivery_flat_rates';
-		$this->method_title      		= __( 'International Delivery', 'woocommerce' );
-		$this->method_description   	= __( 'International delivery based on flat rate shipping.', 'woocommerce' );
+		$this->id 						= 'international_delivery';
+		$this->flat_rate_option			= 'woocommerce_international_delivery_flat_rates';
+		$this->method_title				= __( 'International Delivery', 'woocommerce' );
+		$this->method_description		= __( 'International delivery based on flat rate shipping.', 'woocommerce' );
 
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_flat_rates' ) );
 
-    	$this->init();
-    }
+		$this->init();
+	}
 
 
-    /**
-     * Initialise Gateway Settings Form Fields
-     *
-     * @access public
-     * @return void
-     */
-    function init_form_fields() {
-    	global $woocommerce;
+	/**
+	 * Initialise Gateway Settings Form Fields
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init_form_fields() {
+		global $woocommerce;
 
-    	$this->form_fields = array(
+		$this->form_fields = array(
 			'enabled' => array(
-							'title' 		=> __( 'Enable/Disable', 'woocommerce' ),
-							'type' 			=> 'checkbox',
-							'label' 		=> __( 'Enable this shipping method', 'woocommerce' ),
-							'default' 		=> 'no'
+							'title'			=> __( 'Enable/Disable', 'woocommerce' ),
+							'type'			=> 'checkbox',
+							'label'			=> __( 'Enable this shipping method', 'woocommerce' ),
+							'default'		=> 'no'
 						),
 			'title' => array(
 							'title' 		=> __( 'Method Title', 'woocommerce' ),
 							'type' 			=> 'text',
 							'description' 	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 							'default'		=> __( 'International Delivery', 'woocommerce' ),
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 						),
 			'availability' => array(
-							'title' 		=> __( 'Availability', 'woocommerce' ),
-							'type' 			=> 'select',
-							'description' 	=> '',
-							'default' 		=> 'including',
-							'options' 		=> array(
-								'including' 	=> __( 'Selected countries', 'woocommerce' ),
-								'excluding' 	=> __( 'Excluding selected countries', 'woocommerce' ),
+							'title'			=> __( 'Availability', 'woocommerce' ),
+							'type'			=> 'select',
+							'description'	=> '',
+							'default'		=> 'including',
+							'options'		=> array(
+								'including'		=> __( 'Selected countries', 'woocommerce' ),
+								'excluding'		=> __( 'Excluding selected countries', 'woocommerce' ),
 							)
 						),
 			'countries' => array(
-							'title' 		=> __( 'Countries', 'woocommerce' ),
-							'type' 			=> 'multiselect',
+							'title'			=> __( 'Countries', 'woocommerce' ),
+							'type'			=> 'multiselect',
 							'class'			=> 'chosen_select',
 							'css'			=> 'width: 450px;',
-							'default' 		=> '',
+							'default'		=> '',
 							'options'		=> $woocommerce->countries->get_shipping_countries()
 						),
 			'tax_status' => array(
-							'title' 		=> __( 'Tax Status', 'woocommerce' ),
-							'type' 			=> 'select',
-							'default' 		=> 'taxable',
+							'title'			=> __( 'Tax Status', 'woocommerce' ),
+							'type'			=> 'select',
+							'default'		=> 'taxable',
 							'options'		=> array(
-								'taxable' 	=> __( 'Taxable', 'woocommerce' ),
-								'none' 		=> __( 'None', 'woocommerce' )
+								'taxable'	=> __( 'Taxable', 'woocommerce' ),
+								'none'		=> __( 'None', 'woocommerce' )
 							)
 						),
 			'type' => array(
-							'title' 		=> __( 'Cost Added...', 'woocommerce' ),
-							'type' 			=> 'select',
-							'default' 		=> 'order',
-							'options' 		=> array(
-								'order' 	=> __( 'Per Order - charge shipping for the entire order as a whole', 'woocommerce' ),
-								'item' 		=> __( 'Per Item - charge shipping for each item individually', 'woocommerce' ),
-								'class' 	=> __( 'Per Class - charge shipping for each shipping class in an order', 'woocommerce' ),
+							'title'			=> __( 'Cost Added...', 'woocommerce' ),
+							'type'			=> 'select',
+							'default'		=> 'order',
+							'options'		=> array(
+								'order'		=> __( 'Per Order - charge shipping for the entire order as a whole', 'woocommerce' ),
+								'item'		=> __( 'Per Item - charge shipping for each item individually', 'woocommerce' ),
+								'class'		=> __( 'Per Class - charge shipping for each shipping class in an order', 'woocommerce' ),
 							),
 						),
 			'cost' => array(
-							'title' 		=> __( 'Cost', 'woocommerce' ),
-							'type' 			=> 'number',
+							'title'			=> __( 'Cost', 'woocommerce' ),
+							'type'			=> 'number',
 							'custom_attributes' => array(
 								'step'	=> 'any',
 								'min'	=> '0'
 							),
 							'description'	=> __( 'Cost excluding tax. Enter an amount, e.g. 2.50.', 'woocommerce' ),
-							'default' 		=> '',
-							'desc_tip'      => true,
+							'default'		=> '',
+							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
 			'fee' => array(
-							'title' 		=> __( 'Handling Fee', 'woocommerce' ),
-							'type' 			=> 'text',
+							'title'			=> __( 'Handling Fee', 'woocommerce' ),
+							'type'			=> 'text',
 							'description'	=> __( 'Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%. Leave blank to disable.', 'woocommerce' ),
 							'default'		=> '',
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
 			'minimum_fee' => array(
-							'title' 		=> __( 'Minimum Handling Fee', 'woocommerce' ),
-							'type' 			=> 'number',
+							'title'			=> __( 'Minimum Handling Fee', 'woocommerce' ),
+							'type'			=> 'number',
 							'custom_attributes' => array(
 								'step'	=> 'any',
 								'min'	=> '0'
 							),
 							'description'	=> __( 'Enter a minimum fee amount. Fee\'s less than this will be increased. Leave blank to disable.', 'woocommerce' ),
 							'default'		=> '',
-							'desc_tip'      => true,
+							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
 			);
 
-    }
+	}
 
 
-    /**
-     * is_available function.
-     *
-     * @access public
-     * @param mixed $package
-     * @return bool
-     */
-    function is_available( $package ) {
-    	global $woocommerce;
+	/**
+	 * is_available function.
+	 *
+	 * @access public
+	 * @param mixed $package
+	 * @return bool
+	 */
+	function is_available( $package ) {
+		global $woocommerce;
 
-    	if ($this->enabled=="no") return false;
+		if ($this->enabled=="no") return false;
 
 		if ($this->availability=='including') :
 
@@ -160,6 +160,6 @@ class WC_Shipping_International_Delivery extends WC_Shipping_Flat_Rate {
 		endif;
 
 		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', true );
-    }
+	}
 
 }

--- a/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
+++ b/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
@@ -26,13 +26,13 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 		$this->init();
 	}
 
-    /**
-     * init function.
-     *
-     * @access public
-     * @return void
-     */
-    function init() {
+	/**
+	 * init function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init() {
 
 		// Load the settings.
 		$this->init_form_fields();
@@ -92,69 +92,69 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 	 * @return void
 	 */
 	function init_form_fields() {
-    	global $woocommerce;
-    	$this->form_fields = array(
+		global $woocommerce;
+		$this->form_fields = array(
 			'enabled' => array(
-				'title' 		=> __( 'Enable', 'woocommerce' ),
-				'type' 			=> 'checkbox',
-				'label' 		=> __( 'Enable local delivery', 'woocommerce' ),
-				'default' 		=> 'no'
+				'title'			=> __( 'Enable', 'woocommerce' ),
+				'type'			=> 'checkbox',
+				'label'			=> __( 'Enable local delivery', 'woocommerce' ),
+				'default'		=> 'no'
 			),
 			'title' => array(
-				'title' 		=> __( 'Title', 'woocommerce' ),
-				'type' 			=> 'text',
-				'description' 	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
+				'title'			=> __( 'Title', 'woocommerce' ),
+				'type'			=> 'text',
+				'description'	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 				'default'		=> __( 'Local Delivery', 'woocommerce' ),
-				'desc_tip'      => true,
+				'desc_tip'		=> true,
 			),
 			'type' => array(
-				'title' 		=> __( 'Fee Type', 'woocommerce' ),
-				'type' 			=> 'select',
-				'description' 	=> __( 'How to calculate delivery charges', 'woocommerce' ),
-				'default' 		=> 'fixed',
-				'options' 		=> array(
-					'fixed' 	=> __( 'Fixed amount', 'woocommerce' ),
+				'title'			=> __( 'Fee Type', 'woocommerce' ),
+				'type'			=> 'select',
+				'description'	=> __( 'How to calculate delivery charges', 'woocommerce' ),
+				'default'		=> 'fixed',
+				'options'		=> array(
+					'fixed'		=> __( 'Fixed amount', 'woocommerce' ),
 					'percent'	=> __( 'Percentage of cart total', 'woocommerce' ),
 					'product'	=> __( 'Fixed amount per product', 'woocommerce' ),
 				),
-				'desc_tip'      => true,
+				'desc_tip'		=> true,
 			),
 			'fee' => array(
-				'title' 		=> __( 'Delivery Fee', 'woocommerce' ),
-				'type' 			=> 'number',
+				'title'			=> __( 'Delivery Fee', 'woocommerce' ),
+				'type'			=> 'number',
 				'custom_attributes' => array(
 					'step'	=> 'any',
 					'min'	=> '0'
 				),
-				'description' 	=> __( 'What fee do you want to charge for local delivery, disregarded if you choose free. Leave blank to disable.', 'woocommerce' ),
+				'description'	=> __( 'What fee do you want to charge for local delivery, disregarded if you choose free. Leave blank to disable.', 'woocommerce' ),
 				'default'		=> '',
-				'desc_tip'      => true,
+				'desc_tip'		=> true,
 				'placeholder'	=> '0.00'
 			),
 			'codes' => array(
-				'title' 		=> __( 'Zip/Post Codes', 'woocommerce' ),
-				'type' 			=> 'textarea',
-				'description' 	=> __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
+				'title'			=> __( 'Zip/Post Codes', 'woocommerce' ),
+				'type'			=> 'textarea',
+				'description'	=> __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
 				'default'		=> '',
-				'desc_tip'      => true,
+				'desc_tip'		=> true,
 				'placeholder'	=> '12345, 56789 etc'
 			),
 			'availability' => array(
-							'title' 		=> __( 'Method availability', 'woocommerce' ),
-							'type' 			=> 'select',
-							'default' 		=> 'all',
+							'title'			=> __( 'Method availability', 'woocommerce' ),
+							'type'			=> 'select',
+							'default'		=> 'all',
 							'class'			=> 'availability',
 							'options'		=> array(
-								'all' 		=> __( 'All allowed countries', 'woocommerce' ),
-								'specific' 	=> __( 'Specific Countries', 'woocommerce' )
+								'all'		=> __( 'All allowed countries', 'woocommerce' ),
+								'specific'	=> __( 'Specific Countries', 'woocommerce' )
 							)
 						),
 			'countries' => array(
-							'title' 		=> __( 'Specific Countries', 'woocommerce' ),
-							'type' 			=> 'multiselect',
+							'title'			=> __( 'Specific Countries', 'woocommerce' ),
+							'type'			=> 'multiselect',
 							'class'			=> 'chosen_select',
 							'css'			=> 'width: 450px;',
-							'default' 		=> '',
+							'default'		=> '',
 							'options'		=> $woocommerce->countries->get_shipping_countries()
 						)
 		);
@@ -171,22 +171,22 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 		<h3><?php echo $this->method_title; ?></h3>
 		<p><?php _e( 'Local delivery is a simple shipping method for delivering orders locally.', 'woocommerce' ); ?></p>
 		<table class="form-table">
-    		<?php $this->generate_settings_html(); ?>
-    	</table> <?php
+			<?php $this->generate_settings_html(); ?>
+		</table> <?php
 	}
 
 
-    /**
-     * is_available function.
-     *
-     * @access public
-     * @param array $package
-     * @return bool
-     */
-    function is_available( $package ) {
-    	global $woocommerce;
+	/**
+	 * is_available function.
+	 *
+	 * @access public
+	 * @param array $package
+	 * @return bool
+	 */
+	function is_available( $package ) {
+		global $woocommerce;
 
-    	if ($this->enabled=="no") return false;
+		if ($this->enabled=="no") return false;
 
 		// If post codes are listed, let's use them.
 		$codes = '';
@@ -234,18 +234,18 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 
 		// Yay! We passed!
 		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', true );
-    }
+	}
 
 
-    /**
-     * clean function.
-     *
-     * @access public
-     * @param mixed $code
-     * @return string
-     */
-    function clean( $code ) {
-    	return str_replace( '-', '', sanitize_title( $code ) ) . ( strstr( $code, '*' ) ? '*' : '' );
-    }
+	/**
+	 * clean function.
+	 *
+	 * @access public
+	 * @param mixed $code
+	 * @return string
+	 */
+	function clean( $code ) {
+		return str_replace( '-', '', sanitize_title( $code ) ) . ( strstr( $code, '*' ) ? '*' : '' );
+	}
 
 }

--- a/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
+++ b/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
@@ -26,13 +26,13 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 		$this->init();
 	}
 
-    /**
-     * init function.
-     *
-     * @access public
-     * @return void
-     */
-    function init() {
+	/**
+	 * init function.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	function init() {
 
 		// Load the settings.
 		$this->init_form_fields();
@@ -72,52 +72,52 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 	 * @return void
 	 */
 	function init_form_fields() {
-    	global $woocommerce;
-    	$this->form_fields = array(
+		global $woocommerce;
+		$this->form_fields = array(
 			'enabled' => array(
-				'title' 		=> __( 'Enable', 'woocommerce' ),
-				'type' 			=> 'checkbox',
-				'label' 		=> __( 'Enable local pickup', 'woocommerce' ),
-				'default' 		=> 'no'
+				'title'			=> __( 'Enable', 'woocommerce' ),
+				'type'			=> 'checkbox',
+				'label'			=> __( 'Enable local pickup', 'woocommerce' ),
+				'default'		=> 'no'
 			),
 			'title' => array(
-				'title' 		=> __( 'Title', 'woocommerce' ),
-				'type' 			=> 'text',
-				'description' 	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
+				'title'			=> __( 'Title', 'woocommerce' ),
+				'type'			=> 'text',
+				'description'	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
 				'default'		=> __( 'Local Pickup', 'woocommerce' ),
-				'desc_tip'      => true,
+				'desc_tip'	  	=> true,
 			),
 			'codes' => array(
-				'title' 		=> __( 'Zip/Post Codes', 'woocommerce' ),
+				'title'			=> __( 'Zip/Post Codes', 'woocommerce' ),
 				'type' 			=> 'textarea',
-				'description' 	=> __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
+				'description'	=> __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
 				'default'		=> '',
-				'desc_tip'      => true,
+				'desc_tip'		=> true,
 				'placeholder'	=> '12345, 56789 etc'
 			),
 			'availability' => array(
-				'title' 		=> __( 'Method availability', 'woocommerce' ),
-				'type' 			=> 'select',
-				'default' 		=> 'all',
+				'title'			=> __( 'Method availability', 'woocommerce' ),
+				'type'			=> 'select',
+				'default'		=> 'all',
 				'class'			=> 'availability',
 				'options'		=> array(
-					'all' 		=> __( 'All allowed countries', 'woocommerce' ),
-					'specific' 	=> __( 'Specific Countries', 'woocommerce' )
+					'all'		=> __( 'All allowed countries', 'woocommerce' ),
+					'specific'	=> __( 'Specific Countries', 'woocommerce' )
 				)
 			),
 			'countries' => array(
-				'title' 		=> __( 'Specific Countries', 'woocommerce' ),
-				'type' 			=> 'multiselect',
+				'title'			=> __( 'Specific Countries', 'woocommerce' ),
+				'type'			=> 'multiselect',
 				'class'			=> 'chosen_select',
 				'css'			=> 'width: 450px;',
-				'default' 		=> '',
+				'default'		=> '',
 				'options'		=> $woocommerce->countries->get_shipping_countries()
 			),
 			'apply_base_tax' => array(
-				'title' 		=> __( 'Apply base tax rate', 'woocommerce' ),
-				'type' 			=> 'checkbox',
-				'label' 		=> __( 'When this shipping method is chosen, apply the base tax rate rather than for the customer\'s given address.', 'woocommerce' ),
-				'default' 		=> 'no'
+				'title'			=> __( 'Apply base tax rate', 'woocommerce' ),
+				'type'			=> 'checkbox',
+				'label'			=> __( 'When this shipping method is chosen, apply the base tax rate rather than for the customer\'s given address.', 'woocommerce' ),
+				'default'		=> 'no'
 			),
 		);
 	}
@@ -133,8 +133,8 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 		<h3><?php echo $this->method_title; ?></h3>
 		<p><?php _e( 'Local pickup is a simple method which allows the customer to pick up their order themselves.', 'woocommerce' ); ?></p>
 		<table class="form-table">
-    		<?php $this->generate_settings_html(); ?>
-    	</table> <?php
+			<?php $this->generate_settings_html(); ?>
+		</table> <?php
 	}
 
 	/**
@@ -149,11 +149,11 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 
 		$is_available = true;
 
-    	if ( $this->enabled == "no" ) {
+		if ( $this->enabled == "no" ) {
 
-	    	$is_available = false;
+			$is_available = false;
 
-    	} else {
+		} else {
 
 			// If post codes are listed, let's use them.
 			$codes = '';
@@ -254,15 +254,15 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 		}
 	}
 
-    /**
-     * clean function.
-     *
-     * @access public
-     * @param mixed $code
-     * @return string
-     */
-    function clean( $code ) {
-    	return str_replace( '-', '', sanitize_title( $code ) ) . ( strstr( $code, '*' ) ? '*' : '' );
-    }
+	/**
+	 * clean function.
+	 *
+	 * @access public
+	 * @param mixed $code
+	 * @return string
+	 */
+	function clean( $code ) {
+		return str_replace( '-', '', sanitize_title( $code ) ) . ( strstr( $code, '*' ) ? '*' : '' );
+	}
 
 }


### PR DESCRIPTION
ZenDesk was down for 15 minutes so I decided to fix all of the whitespace in the shipping classes.

There were tons of lines that used 4 spaces instead of tabs and I made them all use tabs instead.
