### PR TITLE
Add filter hook to get_price_html so the price can be acted upon before it's modified.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -790,6 +790,8 @@ class WC_Product {
 	 */
 	public function get_price_html( $price = '' ) {
 
+		$this->price = apply_filters( 'woocommerce_price_pre_html', '', $this->price );
+
 		if ( $this->get_price() === '' ) {
 
 			$price = apply_filters( 'woocommerce_empty_price_html', '', $this );


### PR DESCRIPTION
The get_price function has a filter that lets you alter the price & that's all there is to it, but get_price_html currently checks conditions, alters, etc. for the price that would otherwise be inaccessible due to lack of a hook in that part of the process.

One use case that calls for the addition of this would be integrating WooCommerce with an external price database (reasons for having this setup may vary). You need access to the price before it's acted on, and this filter would provide that. This actually seems like the only change needed for that use case to work (seeing how get_price already has a filter).
