### PR TITLE
Update 'post_date_gmt' when changing order date

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -792,7 +792,9 @@ function woocommerce_process_shop_order_meta( $post_id, $post ) {
 		$date = strtotime( $_POST['order_date'] . ' ' . (int) $_POST['order_date_hour'] . ':' . (int) $_POST['order_date_minute'] . ':00' );
 	}
 
-	$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->posts SET post_date = %s WHERE ID = %s", date_i18n( 'Y-m-d H:i:s', $date ), $post_id ) );
+	$date = date_i18n( 'Y-m-d H:i:s', $date );
+
+	$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->posts SET post_date = %s, post_date_gmt = %s WHERE ID = %s", $date, get_gmt_from_date( $date ), $post_id ) );
 
 
 	// Tax rows

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Fix - Google Analytics no longer identifies users using custom vars
 * Fix - Use version_compare to check for required jQuery
 * Fix - Made gateway abstract compatible with implementations to prevent strict notices
+* Fix - Update order's GMT date ('post_date_gmt') when changing the order date via the "Edit Order" screen
 
 = 2.0.13 - 19/07/2013 =
 * Tweak - Allow users with edit rights to add draft products to cart (and nobody else)


### PR DESCRIPTION
When changing an order's date via the "Edit Order" screen, the `post_date` column was being updated, but not the `post_date_gmt` column. This fixes that.
