### PR TITLE
Setting Default Shipping Rates for Flat Rate Shipping

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -324,8 +324,9 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 			$cost 	= $this->cost;
 			$fee 	= $this->fee;
 		} elseif ( is_null( $cost ) ) {
-			// No match
-			return null;
+			// Set rates to 0 if nothing is set by the user
+			$cost 	= 0;
+			$fee 	= 0;
 		}
 
 		// Shipping for whole order


### PR DESCRIPTION
Some users that activate the Flat Rate Shipping or the International Flat Rate Shipping method accidentally forget to add a fee and then they see a confusing error message (`there are no shipping options available for your country`). Since the user clearly wants to use these methods we should set a default fee of `0`.

Then it will show up like this:

![default shipping fees](https://f.cloud.github.com/assets/1065372/963014/1f07fff0-04fa-11e3-9709-802d38f75527.png)

This is better than seeing a confusing error message and having no way to checkout.

Reference: https://woothemes.zendesk.com/agent/#/tickets/87178
