### PR TITLE
Display default timezone on System Status

### DIFF
--- a/admin/woocommerce-admin-status.php
+++ b/admin/woocommerce-admin-status.php
@@ -142,6 +142,17 @@ function woocommerce_status_report() {
                 		echo '<mark class="error">' . __( 'Log directory (<code>woocommerce/logs/</code>) is not writable. Logging will not be possible.', 'woocommerce' ) . '</mark>';
                 ?></td>
             </tr>
+			<tr>
+				<td><?php _e( 'Default Timezone','woocommerce' ); ?>:</td>
+				<td><?php
+					$default_timezone = date_default_timezone_get();
+					if ( 'UTC' !== $default_timezone ) {
+						echo '<mark class="error">' . sprintf( __( 'Default timezone is %s - it should be UTC', 'woocommerce' ), $default_timezone ) . '</mark>';
+					} else {
+						echo '<mark class="yes">' . sprintf( __( 'Default timezone is %s', 'woocommerce' ), $default_timezone ) . '</mark>';
+					} ?>
+				</td>
+			</tr>
             <?php
 				$posting = array();
 


### PR DESCRIPTION
When a plugin is behaving badly and calling `date_default_timezone_set()` and changing the site's timezone from UTC, it causes all sorts of issues.

This patch displays the default timezone that is set when the System Status screen is loaded. That's not a guaranteed indicator of the default timezone used everywhere on the site, but it will reveal when an offending plugin is calling `date_default_timezone_set()` on `init` or similar  site wide hook.
