### PR TITLE
Add 'woocommerce_ajax_order_item' hook 

### DIFF
--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -984,6 +984,8 @@ function woocommerce_ajax_add_order_item() {
 
 	do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item );
 
+	$item = apply_filters( 'woocommerce_ajax_order_item', $item, $item_id );
+
 	include( 'admin/post-types/writepanels/order-item-html.php' );
 
 	// Quit out


### PR DESCRIPTION
The `'woocommerce_ajax_add_order_item_meta'` @maxrice added is good for adding order item meta, but it's still not possible for an extension to edit the `$item` passed to the `order-item-html.php`.

When there is a free trial and no sign up fee, Subscriptions needs to set the `$item`'s line totals to $0. This filter makes that possible.
