### PR TITLE
Remove need for min-width:150px; in shipping setting admin panel.

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -97,7 +97,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				'title' 	=> __( 'Shipping Display Mode', 'woocommerce' ),
 				'desc' 		=> __( 'This controls how multiple shipping methods are displayed on the frontend.', 'woocommerce' ),
 				'id' 		=> 'woocommerce_shipping_method_format',
-				'css' 		=> 'min-width:150px;',
 				'default'	=> '',
 				'type' 		=> 'radio',
 				'options' => array(


### PR DESCRIPTION
Doesn't affect the standard WordPress display but if you are using MP6 makes extended width radio buttons.
