### PR TITLE
Date format error fixed

### DIFF
--- a/i18n/languages/woocommerce-es_ES.po
+++ b/i18n/languages/woocommerce-es_ES.po
@@ -3883,7 +3883,7 @@ msgstr "Actualizaciones del Pedido"
 # @ woocommerce
 #: classes/shortcodes/class-wc-shortcode-view-order.php:71
 msgid "l jS \\of F Y, h:ia"
-msgstr "l jS \\de F Y, h:ia"
+msgstr "l j \\d\\e F Y, h:ia"
 
 # @ woocommerce
 #: classes/widgets/class-wc-widget-best-sellers.php:31


### PR DESCRIPTION
Previous format displayed (when the timezone is set to America/Tijuana):
Martes 20th dAmerica/Tijuana agosto 2013, 05:53pm

New format displays:
Martes 20 de agosto 2013, 05:53pm

Adding .st, .nd, .rd, .th next to the number is not correct in spanish.
