### PR TITLE
Add template for single order view in my account

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-view-order.php
+++ b/includes/shortcodes/class-wc-shortcode-view-order.php
@@ -53,34 +53,10 @@ class WC_Shortcode_View_Order {
 
 		$status = get_term_by('slug', $order->status, 'shop_order_status');
 
-		echo '<p class="order-info">'
-		. sprintf( __( 'Order <mark class="order-number">%s</mark> made on <mark class="order-date">%s</mark>', 'woocommerce'), $order->get_order_number(), date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ) )
-		. '. ' . sprintf( __( 'Order status: <mark class="order-status">%s</mark>', 'woocommerce' ), __( $status->name, 'woocommerce' ) )
-		. '.</p>';
-
-		$notes = $order->get_customer_order_notes();
-		if ($notes) :
-			?>
-			<h2><?php _e( 'Order Updates', 'woocommerce' ); ?></h2>
-			<ol class="commentlist notes">
-				<?php foreach ($notes as $note) : ?>
-				<li class="comment note">
-					<div class="comment_container">
-						<div class="comment-text">
-							<p class="meta"><?php echo date_i18n(__( 'l jS \o\f F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
-							<div class="description">
-								<?php echo wpautop(wptexturize($note->comment_content)); ?>
-							</div>
-			  				<div class="clear"></div>
-			  			</div>
-						<div class="clear"></div>
-					</div>
-				</li>
-				<?php endforeach; ?>
-			</ol>
-			<?php
-		endif;
-
-		do_action( 'woocommerce_view_order', $order_id );
+		woocommerce_get_template( 'myaccount/view-order.php', array(
+			'order_id'	=> $order_id,
+			'order'		=> $order,
+			'status'	=> $status
+		) );
 	}
 }

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * View Order
+ *
+ * Shows the details of a particular order on the account page 
+ *
+ * @author    WooThemes
+ * @package   WooCommerce/Templates
+ * @version   2.0.15
+ */
+
+echo '<p class="order-info">'
+. sprintf( __( 'Order <mark class="order-number">%s</mark> made on <mark class="order-date">%s</mark>', 'woocommerce'), $order->get_order_number(), date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ) )
+. '. ' . sprintf( __( 'Order status: <mark class="order-status">%s</mark>', 'woocommerce' ), __( $status->name, 'woocommerce' ) )
+. '.</p>';
+
+$notes = $order->get_customer_order_notes();
+if ($notes) :
+	?>
+	<h2><?php _e( 'Order Updates', 'woocommerce' ); ?></h2>
+	<ol class="commentlist notes">
+		<?php foreach ($notes as $note) : ?>
+		<li class="comment note">
+			<div class="comment_container">
+				<div class="comment-text">
+					<p class="meta"><?php echo date_i18n(__( 'l jS \o\f F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
+					<div class="description">
+						<?php echo wpautop(wptexturize($note->comment_content)); ?>
+					</div>
+					<div class="clear"></div>
+				</div>
+				<div class="clear"></div>
+			</div>
+		</li>
+		<?php endforeach; ?>
+	</ol>
+	<?php
+endif;
+
+do_action( 'woocommerce_view_order', $order_id );


### PR DESCRIPTION
Currently, this HTML is hard coded in the shortcode definition making it difficult to override. Since the rest of the account area is setup this way, this seems to make sense.

Note: I wasn't able to test this, but it looks simple enough.
