### PR TITLE
Making Sure the User Doesn't Submit Garbage to woocommerce_sort_product_tabs Function

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -988,9 +988,16 @@ if ( ! function_exists( 'woocommerce_sort_product_tabs' ) ) {
 	 * Sort tabs by priority
 	 *
 	 * @access public
+	 * @param mixed $tabs
 	 * @return void
 	 */
 	function woocommerce_sort_product_tabs( $tabs = array() ) {
+
+		// Make sure the $tabs parameter is an array
+		if ( ! is_array( $tabs ) ) {
+			trigger_error( "Function woocommerce_sort_product_tabs() expects an array as the first parameter. Defaulting to empty array." );
+			$tabs = array( );
+		}
 
 		// Re-order tabs by priority
 		if ( ! function_exists( '_sort_priority_callback' ) ) {


### PR DESCRIPTION
It's possible for a extension or a user to do something to send the `woocommerce_sort_product_tabs` function any type of parameter when it expects an array.

This pull request checks to make sure it's an array. If it isn't it throws up a warning and it converts the problem variable into an empty array.
