### PR TITLE
Removing HTML Decoding From Email From Name

### DIFF
--- a/includes/abstracts/abstract-wc-email.php
+++ b/includes/abstracts/abstract-wc-email.php
@@ -383,7 +383,7 @@ abstract class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	function get_from_name() {
-		return wp_specialchars_decode( get_option( 'woocommerce_email_from_name' ), ENT_QUOTES );
+		return wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name' ) ), ENT_QUOTES );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-email.php
+++ b/includes/abstracts/abstract-wc-email.php
@@ -383,7 +383,7 @@ abstract class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	function get_from_name() {
-		return get_option( 'woocommerce_email_from_name' );
+		return wp_specialchars_decode( get_option( 'woocommerce_email_from_name' ), ENT_QUOTES );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-email.php
+++ b/includes/abstracts/abstract-wc-email.php
@@ -383,7 +383,7 @@ abstract class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	function get_from_name() {
-		return wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name' ) ) );
+		return get_option( 'woocommerce_email_from_name' );
 	}
 
 	/**


### PR DESCRIPTION
There's some HTML decoding stuff going on with the email from name but then you can't have a store called "Patrick's awesome store" or something like that.

**Before:**
![your_wc_2 0 x_order_receipt_from_27_08_2013_-_patrick r_woothemes com_-_woothemes_mail](https://f.cloud.github.com/assets/1065372/1036481/d7186e70-0f3d-11e3-8ae3-f27ad3bdd972.png)

**After**
![_wc_2 0 x__new_customer_order___14118__-_27_08_2013_-_patrick r_woothemes com_-_woothemes_mail](https://f.cloud.github.com/assets/1065372/1036482/db6ecfd2-0f3d-11e3-973d-163bf51fce91.png)

Reference: https://woothemes.zendesk.com/agent/#/tickets/92100
