### PR TITLE
E_STRICT in php5.4 for reference types.

### DIFF
--- a/admin/settings/settings-save.php
+++ b/admin/settings/settings-save.php
@@ -165,7 +165,8 @@ function woocommerce_update_options( $options ) {
 				parse_str( $value['id'], $option_array );
 
 	    		// Option name is first key
-	    		$option_name = current( array_keys( $option_array ) );
+	    		$option_keys = array_keys( $option_array );
+	    		$option_name = current( $option_keys );
 
 	    		// Get old option value
 	    		if ( ! isset( $update_options[ $option_name ] ) )

--- a/admin/woocommerce-admin-reports.php
+++ b/admin/woocommerce-admin-reports.php
@@ -122,9 +122,10 @@ function woocommerce_reports() {
 
 	$charts = woocommerce_get_reports_charts();
 
-	$first_tab      = array_keys( $charts );
-	$current_tab 	= isset( $_GET['tab'] ) ? sanitize_title( urldecode( $_GET['tab'] ) ) : $first_tab[0];
-	$current_chart 	= isset( $_GET['chart'] ) ?  sanitize_title( urldecode( $_GET['chart'] ) ) : current( array_keys( $charts[ $current_tab ]['charts'] ) );
+	$first_tab       = array_keys( $charts );
+	$current_tab     = isset( $_GET['tab'] ) ? sanitize_title( urldecode( $_GET['tab'] ) ) : $first_tab[0];
+	$charts_tab_keys = array_keys( $charts[ $current_tab ]['charts'] );
+	$current_chart   = isset( $_GET['chart'] ) ? sanitize_title( urldecode( $_GET['chart'] ) ) : current( $charts_tab_keys );
     ?>
 	<div class="wrap woocommerce">
 		<div class="icon32 icon32-woocommerce-reports" id="icon-woocommerce"><br /></div><h2 class="nav-tab-wrapper woo-nav-tab-wrapper">
@@ -1598,16 +1599,16 @@ function woocommerce_coupon_discounts() {
 					}
 
 					if ( $coupon_totals ) {
+						$coupon_max_keys = array_keys( $coupon_totals, max( $coupon_totals ) );
+						$top_coupon_name = current( $coupon_max_keys );
+						$top_coupon_sales = $coupon_totals[ $top_coupon_name ];
 
-						$top_coupon_name = current( array_keys( $coupon_totals, max( $coupon_totals ) ) );
-						$top_coupon_sales = $coupon_totals[$top_coupon_name];
-
-						$worst_coupon_name = current( array_keys( $coupon_totals, min( $coupon_totals ) ) );
-						$worst_coupon_sales = $coupon_totals[$worst_coupon_name];
+						$coupon_min_keys = array_keys( $coupon_totals, min( $coupon_totals ) );
+						$worst_coupon_name = current( $coupon_min_keys );
+						$worst_coupon_sales = $coupon_totals[ $worst_coupon_name ];
 
 						$median_coupon_sales = array_values( $coupon_totals );
-						sort($median_coupon_sales);
-
+						sort( $median_coupon_sales );
 					} else {
 						$top_coupon_name = $top_coupon_sales = $worst_coupon_name = $worst_coupon_sales = $median_coupon_sales = '';
 					}

--- a/admin/woocommerce-admin-settings.php
+++ b/admin/woocommerce-admin-settings.php
@@ -488,7 +488,8 @@ function woocommerce_settings_get_option( $option_name, $default = '' ) {
 		parse_str( $option_name, $option_array );
 
 		// Option name is first key
-		$option_name = current( array_keys( $option_array ) );
+		$option_keys = array_keys( $option_array );
+		$option_name = current( $option_keys );
 
 		// Get value
 		$option_values = get_option( $option_name, '' );
@@ -834,13 +835,16 @@ function woocommerce_admin_fields( $options ) {
             	$country_setting = (string) woocommerce_settings_get_option( $value['id'] );
 
             	$countries = $woocommerce->countries->countries;
-            	if (strstr($country_setting, ':')) :
-            		$country = current(explode(':', $country_setting));
-            		$state = end(explode(':', $country_setting));
-            	else :
+
+            	if ( strstr( $country_setting, ':' ) ) {
+            		$exploded_settings = explode( ':', $country_setting );
+            		$country = current( $exploded_settings );
+            		$state = end( $exploded_settings );
+            	} else {
             		$country = $country_setting;
             		$state = '*';
-            	endif;
+            	}
+
             	?><tr valign="top">
 					<th scope="row" class="titledesc">
 						<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?></label>

--- a/classes/integrations/sharethis/class-wc-sharethis.php
+++ b/classes/integrations/sharethis/class-wc-sharethis.php
@@ -86,8 +86,8 @@ class WC_ShareThis extends WC_Integration {
     	global $post;
 
     	if ( $this->publisher_id ) {
-
-    		$thumbnail = ( $thumbnail_id = get_post_thumbnail_id( $post->ID ) ) ? current(wp_get_attachment_image_src( $thumbnail_id, 'large' )) : '';
+    		$attachment_image_src = wp_get_attachment_image_src( $thumbnail_id, 'large' );
+    		$thumbnail = ( $thumbnail_id = get_post_thumbnail_id( $post->ID ) ) ? current( $attachment_image_src ) : '';
 
     		$sharethis = ( is_ssl() ) ? 'https://ws.sharethis.com/button/buttons.js' : 'http://w.sharethis.com/button/buttons.js';
 

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -16,7 +16,8 @@ foreach ($items as $item) :
 	// Get/prep product data
 	$_product = $order->get_product_from_item( $item );
 	$item_meta = new WC_Order_Item_Meta( $item['item_meta'] );
-	$image = ($show_image) ? '<img src="'. current(wp_get_attachment_image_src( get_post_thumbnail_id( $_product->id ), 'thumbnail')) .'" alt="Product Image" height="'.$image_size[1].'" width="'.$image_size[0].'" style="vertical-align:middle; margin-right: 10px;" />' : '';
+	$attachment_image_src = wp_get_attachment_image_src( get_post_thumbnail_id( $_product->id ), 'thumbnail' );
+	$image = ( $show_image ) ? '<img src="' . current( $attachment_image_src ) . '" alt="Product Image" height="' . $image_size[1] . '" width="' . $image_size[0] . '" style="vertical-align:middle; margin-right: 10px;" />' : '';
 
 	?>
 	<tr>

--- a/templates/shop/breadcrumb.php
+++ b/templates/shop/breadcrumb.php
@@ -135,7 +135,8 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 
 		} else {
 
-			$cat = current( get_the_category() );
+			$the_category = get_the_category();
+			$cat = current( $the_category );
 			echo get_category_parents( $cat, true, $delimiter );
 			echo $before . get_the_title() . $after;
 

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -1074,8 +1074,10 @@ function woocommerce_download_product() {
 			$remote_file = false;
 
 			// Remove Query String
-			if ( strstr( $file_path, '?' ) )
-				$file_path = current( explode( '?', $file_path ) );
+			if ( strstr( $file_path, '?' ) ) {
+				$exploded_file_path = explode( '?', $file_path );
+				$file_path = current( $exploded_file_path );
+			}
 
 			$file_path   = realpath( $file_path );
 		}
@@ -1118,8 +1120,10 @@ function woocommerce_download_product() {
 
 		$file_name = basename( $file_path );
 
-		if ( strstr( $file_name, '?' ) )
-			$file_name = current( explode( '?', $file_name ) );
+		if ( strstr( $file_name, '?' ) ) {
+			$exploded_file_name = explode( '?', $file_name );
+			$file_name = current( $exploded_file_name );
+		}
 
 		header( "Robots: none" );
 		header( "Content-Type: " . $ctype );

--- a/woocommerce-template.php
+++ b/woocommerce-template.php
@@ -1320,9 +1320,11 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				if ( $args['label'] )
 					$field .= '<label class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']  . '</label>';
 
-				$field .= '<strong>' . current( array_values( $woocommerce->countries->get_allowed_countries() ) ) . '</strong>';
+				$allowed_country_values = array_values( $woocommerce->countries->get_allowed_countries() );
+				$field .= '<strong>' . current( $allowed_country_values ) . '</strong>';
 
-				$field .= '<input type="hidden" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" value="' . current( array_keys( $woocommerce->countries->get_allowed_countries() ) ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+				$allowed_country_keys = array_keys( $woocommerce->countries->get_allowed_countries() );
+				$field .= '<input type="hidden" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" value="' . current( $allowed_country_keys ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 
 				$field .= '</p>' . $after;
 


### PR DESCRIPTION
In admin/woocommerce-admin-settings.php, line 839:

$state = end(explode(':', $country_setting));

end variable is by reference.

This causes an error:
Strict Standards: Only variables should be passed by reference in...
From Version 5.4 and up since E_STRICT is now part of E_ALL ...

A workaround is:
error_reporting(E_ALL ^ E_STRICT);

Should a temp variable take place?
