### PR TITLE
Added "Demo Store" Class to Body

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -174,6 +174,10 @@ function wc_body_class( $classes ) {
 		$classes[] = 'woocommerce-page';
 	}
 
+	if ( get_option( 'woocommerce_demo_store' ) != 'no' ) {
+		$classes[] = 'woocommerce-demo-store';
+	}
+
 	return array_unique( $classes );
 }
 


### PR DESCRIPTION
Adding "woocommerce-demo-store" class to body when option "woocommerce_demo_store" is enabled.
(Handy to push down content to allow for banner, etc.)
