### PR TITLE
Frontend security improvements

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -72,7 +72,7 @@ class WC_Download_Handler {
 				if ( ! is_user_logged_in() )
 					wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . wp_login_url( get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) . '">' . __( 'Login &rarr;', 'woocommerce' ) . '</a>', __( 'Log in to Download Files', 'woocommerce' ) );
 
-				elseif ( $user_id != get_current_user_id() )
+				elseif ( !current_user_can( 'download_file', $download_result ) )
 					wp_die( __( 'This is not your download link.', 'woocommerce' ) );
 
 			}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -83,6 +83,11 @@ class WC_Shortcode_Checkout {
 			$order                = new WC_Order( $order_id );
 			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 
+			if ( !current_user_can( 'pay_for_order', $order_id ) ) {
+				echo '<div class="woocommerce-error">' . __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . get_permalink( woocommerce_get_page_id( 'myaccount' ) ).'">'. __( 'My Account &rarr;', 'woocommerce' ) .'</a>' . '</div>';
+				return;
+			}
+
 			if ( $order->id == $order_id && $order->order_key == $order_key ) {
 
 				if ( in_array( $order->status, $valid_order_statuses ) ) {

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -98,7 +98,7 @@ class WC_Shortcode_My_Account {
 		$user_id      	= get_current_user_id();
 		$order 			= new WC_Order( $order_id );
 
-		if ( $order->user_id != $user_id ) {
+		if ( !current_user_can( 'view_order', $order_id ) ) {
 			echo '<div class="woocommerce-error">' . __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . get_permalink( woocommerce_get_page_id( 'myaccount' ) ).'">'. __( 'My Account &rarr;', 'woocommerce' ) .'</a>' . '</div>';
 			return;
 		}

--- a/includes/shortcodes/class-wc-shortcode-view-order.php
+++ b/includes/shortcodes/class-wc-shortcode-view-order.php
@@ -46,7 +46,7 @@ class WC_Shortcode_View_Order {
 			return;
 		}
 
-		if ( $order->user_id != $user_id ) {
+		if ( !current_user_can( 'view_order', $order_id ) ) {
 			echo '<div class="woocommerce-error">' . __( 'Invalid order.', 'woocommerce' ) . ' <a href="'.get_permalink( woocommerce_get_page_id('myaccount') ).'">'. __( 'My Account &rarr;', 'woocommerce' ) .'</a>' . '</div>';
 			return;
 		}

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -258,3 +258,59 @@ function woocommerce_customer_bought_product( $customer_email, $user_id, $produc
 		)
 	);
 }
+
+/**
+ * woocommerce_customer_has_capability
+ *
+ * Checks if a user has a certain capability 
+ *
+ * @access public
+ * @param array $allcaps
+ * @param array $caps
+ * @param array $args
+ * @return bool
+ */
+function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
+  if ( isset( $caps[0] ) ) {
+    switch ( $caps[0] ) {
+
+      case 'view_order':
+        $user_id = $args[1];
+        $order = new WC_Order( $args[2] );
+
+        if ( $user_id == $order->user_id )
+          $allcaps['view_order'] = true;
+
+        break;
+
+      case 'pay_for_order':
+        $user_id = $args[1];
+        $order = new WC_Order( $args[2] );
+
+        if ( $user_id == $order->user_id )
+          $allcaps['pay_for_order'] = true;
+
+        break;
+
+      case 'order_again':
+        $user_id = $args[1];
+        $order = new WC_Order( $args[2] );
+
+        if ( $user_id == $order->user_id )
+          $allcaps['order_again'] = true;
+
+        break;
+
+      case 'cancel_order':
+        $user_id = $args[1];
+        $order = new WC_Order( $args[2] );
+
+        if ( $user_id == $order->user_id )
+          $allcaps['cancel_order'] = true;
+
+        break;
+    }
+  }
+  return $allcaps;
+}
+add_filter( 'user_has_cap', 'woocommerce_customer_has_capability', 11, 3);

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -313,4 +313,4 @@ function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
   }
   return $allcaps;
 }
-add_filter( 'user_has_cap', 'woocommerce_customer_has_capability', 11, 3);
+add_filter( 'user_has_cap', 'woocommerce_customer_has_capability', 10, 3);

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -309,6 +309,15 @@ function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
           $allcaps['cancel_order'] = true;
 
         break;
+
+      case 'download_file':
+        $user_id = $args[1];
+        $download = $args[2]
+
+        if ( $user_id == $download->user_id )
+          $allcaps['download_file'] = true;
+
+        break;
     }
   }
   return $allcaps;

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -312,7 +312,7 @@ function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
 
       case 'download_file':
         $user_id = $args[1];
-        $download = $args[2]
+        $download = $args[2];
 
         if ( $user_id == $download->user_id )
           $allcaps['download_file'] = true;

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -9,6 +9,8 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
+wc_print_messages();
+
 ?>
 
 <p class="cart-empty"><?php _e( 'Your cart is currently empty.', 'woocommerce' ) ?></p>


### PR DESCRIPTION
This pull request addresses a few frontend security concerns and allows plugin and theme authors to override the security checks to implement custom security behaviors.

The following changes were made:
1. Add `wc_print_messages()` to `cart-empty.php`. This is a small convenience improvement. Sometimes there is a messages queued to be displayed, but the user is redirected to his cart page. When cart was empty, the message would not have been displayed. The first commit addresses this issue.
2. Add security checks for `cancel_order` and `pay_for_order` actions. Up until now, if a user somehow had access to the order ID and wpnonce, he could have canceled someone else's order. The same goes for paying for an order.
3. Replace hardcoded security checks (`$order->user_id != $user_id`) with `current_user_can` checks to allow plugin and theme authors implement custom security checks/routines. For example, see https://github.com/ragulka/woocommerce/compare/security-improvements?expand=1#L0R359. The default implementation still checks the current user ID against $order->user_id, but now it can be overriden by adding a filter to `user_has_cap`. A use-case for this would be if a shop owner wants to let certain users view each other's orders, for ex. in a B2B e-commerce site.
4. Provide default security checks by adding a filter to `user_has_cap`.
