### PR TITLE
Fixing Unescaped Character in Date Function

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -118,7 +118,7 @@ class WC_Shortcode_My_Account {
 				<li class="comment note">
 					<div class="comment_container">
 						<div class="comment-text">
-							<p class="meta"><?php echo date_i18n(__( 'l jS \of F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
+							<p class="meta"><?php echo date_i18n(__( 'l jS \o\f F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
 							<div class="description">
 								<?php echo wpautop( wptexturize( $note->comment_content ) ); ?>
 							</div>

--- a/includes/shortcodes/class-wc-shortcode-view-order.php
+++ b/includes/shortcodes/class-wc-shortcode-view-order.php
@@ -67,7 +67,7 @@ class WC_Shortcode_View_Order {
 				<li class="comment note">
 					<div class="comment_container">
 						<div class="comment-text">
-							<p class="meta"><?php echo date_i18n(__( 'l jS \of F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
+							<p class="meta"><?php echo date_i18n(__( 'l jS \o\f F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
 							<div class="description">
 								<?php echo wpautop(wptexturize($note->comment_content)); ?>
 							</div>

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -34,7 +34,7 @@ global $woocommerce;
 			<li class="comment note">
 				<div class="comment_container">
 					<div class="comment-text">
-						<p class="meta"><?php echo date_i18n(__( 'l jS \of F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
+						<p class="meta"><?php echo date_i18n(__( 'l jS \o\f F Y, h:ia', 'woocommerce' ), strtotime($note->comment_date)); ?></p>
 						<div class="description">
 							<?php echo wpautop( wptexturize( wp_kses_post( $note->comment_content ) ) ); ?>
 						</div>


### PR DESCRIPTION
As per the [php.net docs](http://us1.php.net/manual/en/function.date.php#example-681) any function that uses php date syntax should escape _every_ literal character not just the first character.

The `f` character doesn't do anything in the php date function so when we have `... \of ...` the `o` escapes correctly and the function still prints the `f` correctly but as soon as someone tries to translate `\of` to anything else like `\de` (Spanish) there are problems:
![screen shot 2013-09-06 at 15 07 15](https://f.cloud.github.com/assets/1065372/1099327/6e718a4c-1734-11e3-98cf-e67055db1153.png)

reference: https://woothemes.zendesk.com/agent/#/tickets/95195
