### PR TITLE
Add product download access grant/revoke hooks.

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -87,7 +87,7 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 	// Downloadable product - give access to the customer
 	$result = $wpdb->insert( $wpdb->prefix . 'woocommerce_downloadable_product_permissions',
 		$data,
-		$format )
+		$format
 	);
 
 	do_action( 'woocommerce_grant_product_download_access', $data );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -55,8 +55,8 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 	if ( $expiry )
 		$expiry = date_i18n( "Y-m-d", strtotime( 'NOW + ' . $expiry . ' DAY' ) );
 
-    $data = array(
-    	'download_id'			=> $download_id,
+	$data = apply_filters( 'woocommerce_downloadable_file_permission_data', array(
+		'download_id'			=> $download_id,
 		'product_id' 			=> $product_id,
 		'user_id' 				=> absint( $order->user_id ),
 		'user_email' 			=> $user_email,
@@ -65,10 +65,10 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 		'downloads_remaining' 	=> $limit,
 		'access_granted'		=> current_time( 'mysql' ),
 		'download_count'		=> 0
-    );
+	));
 
-    $format = array(
-    	'%s',
+	$format = apply_filters( 'woocommerce_downloadable_file_permission_format', array(
+		'%s',
 		'%s',
 		'%s',
 		'%s',
@@ -77,23 +77,25 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 		'%s',
 		'%s',
 		'%d'
-    );
+	));
 
-    if ( ! is_null( $expiry ) ) {
-        $data['access_expires'] = $expiry;
-        $format[] = '%s';
-    }
+	if ( ! is_null( $expiry ) ) {
+			$data['access_expires'] = $expiry;
+			$format[] = '%s';
+	}
 
 	// Downloadable product - give access to the customer
 	$result = $wpdb->insert( $wpdb->prefix . 'woocommerce_downloadable_product_permissions',
-        apply_filters( 'woocommerce_downloadable_file_permission_data', $data ),
-        apply_filters( 'woocommerce_downloadable_file_permission_format', $format )
-    );
+		$data,
+		$format )
+	);
 
-    return $result ? $wpdb->insert_id : false;
+	do_action( 'woocommerce_grant_product_download_access', $data );
+
+	return $result ? $wpdb->insert_id : false;
 }
 add_action('woocommerce_order_status_completed', 'woocommerce_downloadable_product_permissions');
-add_action( 'woocommerce_order_status_processing', 'woocommerce_downloadable_product_permissions' );
+add_action('woocommerce_order_status_processing', 'woocommerce_downloadable_product_permissions');
 
 
 /**
@@ -133,6 +135,9 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 	endforeach;
 
 	update_post_meta( $order_id,  __( 'Download Permissions Granted', 'woocommerce' ), 1);
+
+	do_action( 'woocommerce_grant_product_download_permissions', $order_id );
+
 }
 
 /**
@@ -311,14 +316,14 @@ add_action( 'woocommerce_cancel_unpaid_orders', 'woocommerce_cancel_unpaid_order
 function woocommerce_processing_order_count() {
 	if ( false === ( $order_count = get_transient( 'woocommerce_processing_order_count' ) ) ) {
 		$order_statuses = get_terms( 'shop_order_status' );
-	    $order_count = false;
-	    foreach ( $order_statuses as $status ) {
-	        if( $status->slug === 'processing' ) {
-	            $order_count += $status->count;
-	            break;
-	        }
-	    }
-	    $order_count = apply_filters( 'woocommerce_admin_menu_count', intval( $order_count ) );
+			$order_count = false;
+			foreach ( $order_statuses as $status ) {
+					if( $status->slug === 'processing' ) {
+							$order_count += $status->count;
+							break;
+					}
+			}
+			$order_count = apply_filters( 'woocommerce_admin_menu_count', intval( $order_count ) );
 		set_transient( 'woocommerce_processing_order_count', $order_count );
 	}
 

--- a/woocommerce-ajax.php
+++ b/woocommerce-ajax.php
@@ -778,6 +778,8 @@ function woocommerce_revoke_access_to_download() {
 
 	$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE order_id = %d AND product_id = %d AND download_id = %d;", $order_id, $product_id, $download_id ) );
 
+	do_action( 'woocommerce_ajax_revoke_access_to_product_download', $download_id, $product_id, $order_id );
+
 	die();
 }
 


### PR DESCRIPTION
This pull request adds 3 new hooks:
- `woocommerce_grant_product_download_access` - it is fired when `woocommerce_downloadable_file_permission()` is called, which means that it fires for a single file. It receives the `$data` array from the function as it's parameter.
- `woocommerce_grant_product_download_permissions` - it is fired when `woocommerce_downloadable_product_permissions` is called, which means it can be used to trigger an action once all permissions to all downloads have been granted. It receives the $order_id as a single parameter.
- `woocommerce_ajax_revoke_access_to_product_download` - it is fired when access to a download is revoked from the admin panel via ajax. It receives 3 parameters: `$download_id`, `$product_id` and `$order_id`. As a sidenote: there is no other way to revoke access to a download, as far as I know.

Feel free to suggest better names for the actions if you think they are not the best ones. I tried to follow the usual woocommerce pattern, but I'm not sure if I did it right as there are no written instructions for that AFAIK.

PS. I did also fix some of the formatting issues with `wc-order-functions.php` file. It had mixed tabs/spaces for identation and identation was messed up in a few cases.
