### PR TITLE
Allow using custom address types

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -714,6 +714,10 @@ class WC_Checkout {
 
 		} else {
 
+			$value = apply_filters( 'woocommerce_checkout_get_value', null, $input );
+
+			if ( $value ) return $value;
+
 			if ( is_user_logged_in() ) {
 
 				$current_user = wp_get_current_user();

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1123,10 +1123,9 @@ class WC_Countries {
 				'clear'			=> true
 			);
 
-			$address_fields = apply_filters( 'woocommerce_billing_fields', $address_fields, $country );
-		} else {
-			$address_fields = apply_filters( 'woocommerce_shipping_fields', $address_fields, $country );
 		}
+
+		$address_fields = apply_filters( 'woocommerce_' . $type . 'fields', $address_fields, $country );
 
 		// Return
 		return $address_fields;

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -55,7 +55,7 @@ class WC_Form_Handler {
 
 		if ( $user_id <= 0 ) return;
 
-		$load_address = isset( $wp->query_vars['edit-address'] ) sanitize_key( $wp->query_vars['edit-address'] ) : 'billing';
+		$load_address = isset( $wp->query_vars['edit-address'] ) ? sanitize_key( $wp->query_vars['edit-address'] ) : 'billing';
 
 		$address = $woocommerce->countries->get_address_fields( esc_attr( $_POST[ $load_address . '_country' ] ), $load_address . '_' );
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -55,7 +55,7 @@ class WC_Form_Handler {
 
 		if ( $user_id <= 0 ) return;
 
-		$load_address = ( $wp->query_vars['edit-address'] == 'billing' || $wp->query_vars['edit-address'] == 'shipping' ) ? $wp->query_vars['edit-address'] : 'billing';
+		$load_address = isset( $wp->query_vars['edit-address'] ) sanitize_key( $wp->query_vars['edit-address'] ) : 'billing';
 
 		$address = $woocommerce->countries->get_address_fields( esc_attr( $_POST[ $load_address . '_country' ] ), $load_address . '_' );
 
@@ -98,7 +98,7 @@ class WC_Form_Handler {
 
 			wc_add_message( __( 'Address changed successfully.', 'woocommerce' ) );
 
-			do_action( 'woocommerce_customer_save_address', $user_id );
+			do_action( 'woocommerce_customer_save_address', $user_id, $load_address );
 
 			wp_safe_redirect( get_permalink( woocommerce_get_page_id('myaccount') ) );
 			exit;

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -151,7 +151,7 @@ class WC_Shortcode_My_Account {
 	private function edit_address( $load_address = 'billing' ) {
 		global $woocommerce;
 
-		$load_address = ( $load_address == 'billing' || $load_address == 'shipping' ) ? $load_address : 'billing';
+		$load_address = sanitize_key( $load_address );
 
 		$address = $woocommerce->countries->get_address_fields( get_user_meta( get_current_user_id(), $load_address . '_country', true ), $load_address . '_' );
 

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -15,15 +15,15 @@ $customer_id = get_current_user_id();
 
 if ( get_option('woocommerce_ship_to_billing_address_only') == 'no' ) {
 	$page_title = apply_filters( 'woocommerce_my_account_my_address_title', __( 'My Addresses', 'woocommerce' ) );
-	$get_addresses    = array(
+	$get_addresses    = apply_filters( 'woocommerce_my_account_get_addresses', array(
 		'billing' => __( 'Billing Address', 'woocommerce' ),
 		'shipping' => __( 'Shipping Address', 'woocommerce' )
-	);
+	), $customer_id );
 } else {
 	$page_title = apply_filters( 'woocommerce_my_account_my_address_title', __( 'My Address', 'woocommerce' ) );
-	$get_addresses    = array(
+	$get_addresses    = apply_filters( 'woocommerce_my_account_get_addresses', array(
 		'billing' =>  __( 'Billing Address', 'woocommerce' )
-	);
+	), $customer_id );
 }
 
 $col = 1;


### PR DESCRIPTION
This PR allows filtering the address list that gets loaded on `my-addresses.php` and thus, displaying custom addresses. It also adds support for editing and saving those addresses.

There are no user-visible modifications here, only some improvements that allow developers to add new address types.

It also adds a new filter: `woocommerce_checkout_get_value` that allows overriding the default value that gets loaded to checkout form. A use case may be where an address field needs to be loaded from somewhere else than user meta ( I am working on a plugin that needs to do that).
