### PR TITLE
Add option to show price including or excluding taxes, partially fixes #...

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -765,7 +765,15 @@ class WC_Product {
 	 */
 	public function get_price_html( $price = '' ) {
 
-        $display_price = get_option( 'woocommerce_tax_display_shop' ) == 'excl' ? $this->get_price_excluding_tax() : $this->get_price_including_tax();
+
+        if( get_option( 'woocommerce_tax_display_shop' ) == 'excl' or !$possibly_with_tax)
+        {
+            $display_price = $this->get_price();
+        }
+        else
+        {
+            $display_price = $this->get_price_including_tax();
+        }
 
 		if ( $this->get_price() === '' ) {
 

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -763,7 +763,7 @@ class WC_Product {
 	 * @param string $price (default: '')
 	 * @return string
 	 */
-	public function get_price_html( $price = '' ) {
+	public function get_price_html( $price = '', $possibly_with_tax = true ) {
 
 
         if( get_option( 'woocommerce_tax_display_shop' ) == 'excl' or !$possibly_with_tax)

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -765,6 +765,8 @@ class WC_Product {
 	 */
 	public function get_price_html( $price = '' ) {
 
+        $display_price = get_option( 'woocommerce_tax_display_shop' ) == 'excl' ? $this->get_price_excluding_tax() : $this->get_price_including_tax();
+
 		if ( $this->get_price() === '' ) {
 
 			$price = apply_filters( 'woocommerce_empty_price_html', '', $this );
@@ -773,13 +775,13 @@ class WC_Product {
 
 			if ( $this->is_on_sale() && $this->get_regular_price() ) {
 
-				$price .= $this->get_price_html_from_to( $this->get_regular_price(), $this->get_price() );
+				$price .= $this->get_price_html_from_to( $this->get_regular_price(), $display_price );
 
 				$price = apply_filters( 'woocommerce_sale_price_html', $price, $this );
 
 			} else {
 
-				$price .= woocommerce_price( $this->get_price() );
+				$price .= woocommerce_price( $display_price );
 
 				$price = apply_filters( 'woocommerce_price_html', $price, $this );
 

--- a/includes/admin/post-types/class-wc-admin-cpt-product.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-product.php
@@ -335,7 +335,7 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 				endif;
 			break;
 			case "price":
-				echo $the_product->get_price_html() ? $the_product->get_price_html() : '<span class="na">&ndash;</span>';
+				echo $the_product->get_price_html('', false) ? $the_product->get_price_html('', false) : '<span class="na">&ndash;</span>';
 			break;
 			case "product_cat" :
 			case "product_tag" :

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -152,6 +152,18 @@ class WC_Settings_Tax extends WC_Settings_Page {
 				'autoload'      => false
 			),
 
+            array(
+                'title'   => __( 'Display prices in shop:', 'woocommerce' ),
+                'id'      => 'woocommerce_tax_display_shop',
+                'default' => 'excl',
+                'type'    => 'select',
+                'options' => array(
+                    'incl'   => __( 'Including tax', 'woocommerce' ),
+                    'excl'   => __( 'Excluding tax', 'woocommerce' ),
+                ),
+                'autoload'      => false
+            ),
+
 			array( 'type' => 'sectionend', 'id' => 'tax_options' ),
 
 		)); // End tax settings


### PR DESCRIPTION
...1506

It was not possible to enter prices excluding tax but show them including tax. 
I added an option to the tax settings and made get_price_html() show a price based on that.
