### PR TITLE
Removed 'widget_text' from array of force_ssl filtered objects.

### DIFF
--- a/includes/class-wc-https.php
+++ b/includes/class-wc-https.php
@@ -20,7 +20,7 @@ class WC_HTTPS {
 		if ( get_option( 'woocommerce_force_ssl_checkout' ) == 'yes' ) {
 			if ( ! is_admin() || defined('DOING_AJAX') ) {
 				// HTTPS urls with SSL on
-				$filters = array( 'post_thumbnail_html', 'widget_text', 'wp_get_attachment_url', 'wp_get_attachment_image_attributes', 'wp_get_attachment_url', 'option_stylesheet_url', 'option_template_url', 'script_loader_src', 'style_loader_src', 'template_directory_uri', 'stylesheet_directory_uri', 'site_url' );
+				$filters = array( 'post_thumbnail_html', 'wp_get_attachment_url', 'wp_get_attachment_image_attributes', 'wp_get_attachment_url', 'option_stylesheet_url', 'option_template_url', 'script_loader_src', 'style_loader_src', 'template_directory_uri', 'stylesheet_directory_uri', 'site_url' );
 
 				foreach ( $filters as $filter )
 					add_filter( $filter, 'WC_HTTPS::force_https_url' );


### PR DESCRIPTION
Forcing SSL for all content in the text widget prevents adding links third party sites that do not support SSL. (ie. Partner sites). Furthermore, it's the assumed responsibility of the individual entering HTML into the text widget to ensure site security when referencing to outside sites.
