### PR TITLE
Give access to default value checkout field and change woocommerce_form_field()

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -762,35 +762,52 @@ class WC_Checkout {
 					return $current_user->user_email;
 			}
 
-			$default_billing_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_country()) ? $woocommerce->customer->get_country() : $woocommerce->countries->get_base_country());
+			$default_billing_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_country()) ? $woocommerce->customer->get_country() : $woocommerce->countries->get_base_country(), 'billing' );
 
-			$default_shipping_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_shipping_country()) ? $woocommerce->customer->get_shipping_country() : $woocommerce->countries->get_base_country());
+			$default_shipping_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_shipping_country()) ? $woocommerce->customer->get_shipping_country() : $woocommerce->countries->get_base_country(), 'shipping' );
 
 			if ( $woocommerce->customer->has_calculated_shipping() ) {
-				$default_billing_state  = apply_filters('default_checkout_state', $woocommerce->customer->get_state());
-				$default_shipping_state = apply_filters('default_checkout_state', $woocommerce->customer->get_shipping_state());
+				$default_billing_state  = apply_filters('default_checkout_state', $woocommerce->customer->get_state(), 'billing' );
+				$default_shipping_state = apply_filters('default_checkout_state', $woocommerce->customer->get_shipping_state(), 'shipping' );
 			} else {
-				$default_billing_state  = apply_filters('default_checkout_state', '');
-				$default_shipping_state = apply_filters('default_checkout_state', '');
+				$default_billing_state  = apply_filters('default_checkout_state', '', 'billing' );
+				$default_shipping_state = apply_filters('default_checkout_state', '', 'shipping' );
 			}
-
-			if ( $input == "billing_country" )
-				return $default_billing_country;
-
-			if ( $input == "billing_state" )
-				return $default_billing_state;
-
-			if ( $input == "billing_postcode" )
-				return $woocommerce->customer->get_postcode() ? $woocommerce->customer->get_postcode() : '';
-
-			if ( $input == "shipping_country" )
-				return $default_shipping_country;
-
-			if ( $input == "shipping_state" )
-				return $default_shipping_state;
-
-			if ( $input == "shipping_postcode" )
-				return $woocommerce->customer->get_shipping_postcode() ? $woocommerce->customer->get_shipping_postcode() : '';
+			
+			switch ( $input ) {
+				
+				case 'billing_country' :
+					return $default_billing_country;
+					
+				break;
+				
+				case  'shipping_country' :
+					return	$default_shipping_country;
+				break;
+				
+				case 'billing_state' :
+					return $default_billing_state;
+				break;
+				
+				case 'shipping_state' :
+					return $default_shipping_state;	
+				break;
+				
+				case 'billing_postcode' :
+					$default_billing_postcode = $woocommerce->customer->get_postcode() ? $woocommerce->customer->get_postcode() : '';
+					return apply_filters( 'default_checkout_postcode', $default_billing_postcode, 'billing' );
+				break;
+				
+				case 'shipping_postcode' :
+					$default_shipping_postcode = $woocommerce->customer->get_shipping_postcode() ? $woocommerce->customer->get_shipping_postcode() : '';
+					return apply_filters( 'default_checkout_postcode', 	$default_shipping_postcode, 'shipping' );
+				break;
+				
+				default :
+					return apply_filters( 'default_checkout_' . $input, '', $input );
+				break;
+				
+			}
 		}
 	}
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1734,10 +1734,14 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="select" ' . implode( ' ', $custom_attributes ) . '>
 						' . $options . '
-					</selec
+					</select>';
+		break;
+		
+		default :
+			
 			$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
 
-			break;
+		break;
 		}
 
 		if ( $args['return'] ) return $field; else echo $field;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1734,13 +1734,8 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="select" ' . implode( ' ', $custom_attributes ) . '>
 						' . $options . '
-					</select>
-				</p>' . $after;
-
-			break;
-		default :
-			//Change to ref array instead apply_filters(), it's more easy to get the variable, and empty 
-			$field = apply_filters_ref_array( 'woocommerce_form_field_' . $args['type'], array( $key, $args, $value ) );
+					</selec
+			$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
 
 			break;
 		}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1739,8 +1739,8 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 			break;
 		default :
-
-			$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
+			//Change to ref array instead apply_filters(), it's more easy to get the variable, and empty 
+			$field = apply_filters_ref_array( 'woocommerce_form_field_' . $args['type'], array( $key, $args, $value ) );
 
 			break;
 		}


### PR DESCRIPTION
Woocommerce seems, assumed all calculation shipping methods based state, country and postal code. Here in Indonesia and most ASEAN country using city as their based calculation.

And we are don't know other country how they calculation shipping. So, we must allow some custom default value for checkout field. Here, I change 

<code>WC_Checout::get_value()</code> and <code>woocommerce_form_field</code>.
