### PR TITLE
Fixes blank page error

### DIFF
--- a/includes/abstracts/abstract-wc-email.php
+++ b/includes/abstracts/abstract-wc-email.php
@@ -463,7 +463,9 @@ abstract class WC_Email extends WC_Settings_API {
 			return $content;
 
 		$dom = new DOMDocument();
-		@$dom->loadHTML( $content );
+		libxml_use_internal_errors( true );
+    		@$dom->loadHTML( $content );
+    		libxml_clear_errors();
 
 		foreach( $this->get_style_inline_tags() as $tag ) {
 			$nodes = $dom->getElementsByTagName($tag);


### PR DESCRIPTION
Fix to avoid blank page error, apparently prevents a memory exausted condition.

Error source: 
http://wordpress.org/support/topic/blank-page-after-return-form-cielo-buypage?replies=15

Some info:
http://stackoverflow.com/questions/8379829/domdocument-php-memory-leak

Another people using the same code: http://nathanstaines.com/articles/wordpress-word-count/

Cheers,
Gabriel
