### PR TITLE
add pattern matching to local delivery postcodes

### DIFF
--- a/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
+++ b/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
@@ -202,6 +202,23 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 
 			if ( in_array( $this->clean( $package['destination']['postcode'] ), $codes ) )
 				$found_match = true;
+				
+			
+			// Pattern match
+			if ( ! $found_match ) {
+				
+				$customer_postcode = $this->clean( $package['destination']['postcode'] );
+			
+				foreach ($codes as $c) {
+					$pattern = '/^'.str_replace('_', '[0-9a-zA-Z]', $c).'$/i';
+					if(preg_match($pattern, $customer_postcode)) {
+						$found_match = true;
+						break;
+					}
+				}
+				
+			}
+			
 
 			// Wildcard search
 			if ( ! $found_match ) {


### PR DESCRIPTION
I found a slight problem in the wildcard postcode matching and have implemented an improvement.  I want to deliver to postcodes starting NG2, but I do NOT want to deliver to postcodes starting NG21.  My fix allows postcodes to be specified in the following format:

NG1___, NG10___, NG11___, NG12___, NG2___, NG3___

I hope you find this addition useful.
