### PR TITLE
Allow filtering Payment Gateway, Shipping Methods and Integration form fields

### DIFF
--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -61,7 +61,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
      * Initialise Gateway Settings Form Fields
      */
     public function init_form_fields() {
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_payment_gateway_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'woocommerce' ),
 				'type'    => 'checkbox',
@@ -92,7 +92,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 			'account_details' => array(
 				'type'        => 'account_details'
 			),
-		);
+		));
     }
 
     /**

--- a/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -47,7 +47,7 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
      */
     public function init_form_fields() {
 
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_payment_gateway_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'woocommerce' ),
 				'type'    => 'checkbox',
@@ -75,7 +75,7 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 				'default'     => '',
 				'desc_tip'    => true,
 			),
-		);
+		));
     }
 
     /**

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -52,7 +52,7 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 		    	$shipping_methods[ $method->id ] = $method->get_title();
 	    	}
 
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_payment_gateway_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title'       => __( 'Enable COD', 'woocommerce' ),
 				'label'       => __( 'Enable Cash on Delivery', 'woocommerce' ),
@@ -91,7 +91,7 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 				'options'		=> $shipping_methods,
 				'desc_tip'      => true,
 			)
- 	   );
+ 	   ));
     }
 
 	/**

--- a/includes/gateways/mijireh/class-wc-gateway-mijireh.php
+++ b/includes/gateways/mijireh/class-wc-gateway-mijireh.php
@@ -125,7 +125,7 @@ class WC_Gateway_Mijireh extends WC_Payment_Gateway {
      * @return void
      */
     public function init_form_fields() {
-		$this->form_fields = array(
+		$this->form_fields = apply_filters('woocommerce_payment_gateway_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title' => __( 'Enable/Disable', 'woocommerce' ),
 				'type' => 'checkbox',
@@ -152,7 +152,7 @@ class WC_Gateway_Mijireh extends WC_Payment_Gateway {
 				'default' => __( 'Pay securely with your credit card.', 'woocommerce' ),
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce' ),
 				),
-		);
+		));
     }
 
 

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -116,7 +116,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
      */
     function init_form_fields() {
 
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_payment_gateway_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title'   => __( 'Enable/Disable', 'woocommerce' ),
 				'type'    => 'checkbox',
@@ -232,7 +232,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 				'default'     => 'no',
 				'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside <code>woocommerce/logs/paypal-%s.txt</code>', 'woocommerce' ), sanitize_file_name( wp_hash( 'paypal' ) ) ),
 			)
-		);
+		));
     }
 
 	/**

--- a/includes/integrations/google-analytics/class-wc-google-analytics.php
+++ b/includes/integrations/google-analytics/class-wc-google-analytics.php
@@ -58,7 +58,7 @@ class WC_Google_Analytics extends WC_Integration {
      */
     function init_form_fields() {
 
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_integration_form_fields_' . $this->id, array(
 			'ga_id' => array(
 				'title' 			=> __( 'Google Analytics ID', 'woocommerce' ),
 				'description' 		=> __( 'Log into your google analytics account to find your ID. e.g. <code>UA-XXXXX-X</code>', 'woocommerce' ),
@@ -90,7 +90,7 @@ class WC_Google_Analytics extends WC_Integration {
 				'checkboxgroup'		=> 'end',
 				'default' 			=> 'no'
 			)
-		);
+		));
 
     } // End init_form_fields()
 

--- a/includes/integrations/sharedaddy/class-wc-sharedaddy.php
+++ b/includes/integrations/sharedaddy/class-wc-sharedaddy.php
@@ -46,14 +46,14 @@ class WC_ShareDaddy extends WC_Integration {
      */
     function init_form_fields() {
 
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_integration_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title' 		=> __( 'Output ShareDaddy button?', 'woocommerce' ),
 				'description' 	=> __( 'Enable this option to show the ShareDaddy button on the product page.', 'woocommerce' ),
 				'type' 			=> 'checkbox',
 				'default' 		=> get_option('woocommerce_sharedaddy') ? get_option('woocommerce_sharedaddy') : 'no'
 			)
-		);
+		));
 
     }
 

--- a/includes/integrations/sharethis/class-wc-sharethis.php
+++ b/includes/integrations/sharethis/class-wc-sharethis.php
@@ -58,7 +58,7 @@ class WC_ShareThis extends WC_Integration {
      */
     function init_form_fields() {
 
-    	$this->form_fields = array(
+    	$this->form_fields = apply_filters('woocommerce_integration_form_fields_' . $this->id, array(
 			'publisher_id' => array(
 				'title' 		=> __( 'ShareThis Publisher ID', 'woocommerce' ),
 				'description' 	=> sprintf( __( 'Enter your %1$sShareThis publisher ID%2$s to show social sharing buttons on product pages.', 'woocommerce' ), '<a href="http://sharethis.com/account/">', '</a>' ),
@@ -71,7 +71,7 @@ class WC_ShareThis extends WC_Integration {
 				'type' 			=> 'textarea',
 				'default' 		=> $this->default_code
 			)
-		);
+		));
 
     }
 

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -71,7 +71,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	function init_form_fields() {
 		global $woocommerce;
 
-		$this->form_fields = array(
+		$this->form_fields = apply_filters('woocommerce_shipping_method_form_fields_' . $this->id, array(
 			'enabled' => array(
 							'title' 		=> __( 'Enable/Disable', 'woocommerce' ),
 							'type' 			=> 'checkbox',
@@ -162,7 +162,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
-			);
+			));
 
 	}
 

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -70,7 +70,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 		else
 			$default_requires = '';
 
-		$this->form_fields = array(
+		$this->form_fields = apply_filters('woocommerce_shipping_method_form_fields_' . $this->id, array(
 			'enabled' => array(
 							'title' 		=> __( 'Enable/Disable', 'woocommerce' ),
 							'type' 			=> 'checkbox',
@@ -126,7 +126,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						)
-			);
+			));
 
 	}
 

--- a/includes/shipping/international-delivery/class-wc-shipping-international-delivery.php
+++ b/includes/shipping/international-delivery/class-wc-shipping-international-delivery.php
@@ -45,7 +45,7 @@ class WC_Shipping_International_Delivery extends WC_Shipping_Flat_Rate {
 	function init_form_fields() {
 		global $woocommerce;
 
-		$this->form_fields = array(
+		$this->form_fields = apply_filters('woocommerce_shipping_method_form_fields_' . $this->id, array(
 			'enabled' => array(
 							'title'			=> __( 'Enable/Disable', 'woocommerce' ),
 							'type'			=> 'checkbox',
@@ -128,7 +128,7 @@ class WC_Shipping_International_Delivery extends WC_Shipping_Flat_Rate {
 							'desc_tip'		=> true,
 							'placeholder'	=> '0.00'
 						),
-			);
+			));
 
 	}
 

--- a/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
+++ b/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
@@ -93,7 +93,7 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 	 */
 	function init_form_fields() {
 		global $woocommerce;
-		$this->form_fields = array(
+		$this->form_fields = apply_filters('woocommerce_shipping_method_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title'			=> __( 'Enable', 'woocommerce' ),
 				'type'			=> 'checkbox',
@@ -157,7 +157,7 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 							'default'		=> '',
 							'options'		=> $woocommerce->countries->get_shipping_countries()
 						)
-		);
+		));
 	}
 
 	/**

--- a/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
+++ b/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
@@ -71,7 +71,7 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 	 */
 	function init_form_fields() {
 		global $woocommerce;
-		$this->form_fields = array(
+		$this->form_fields = apply_filters('woocommerce_shipping_method_form_fields_' . $this->id, array(
 			'enabled' => array(
 				'title'			=> __( 'Enable', 'woocommerce' ),
 				'type'			=> 'checkbox',
@@ -111,7 +111,7 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 				'default'		=> '',
 				'options'		=> $woocommerce->countries->get_shipping_countries()
 			)
-		);
+		));
 	}
 
 	/**


### PR DESCRIPTION
Developers should be able to filter the form fields of gateways, shipping methods and other settings. Rationale: sometimes you need to add custom configuration for a payment gateway (or other setting). 

For example - I am working with an integration where we need to add an external ID field to every payment gateway.
Also, there is shipping method plugin that I need to extend with some extra options for my special case.

This PR adds the required filters to each built-in Integration, Payment Gateway and Shipping Method. This however, of course, is not not enough as there are a gazillion of external plugins/extensions that need to address this. For this reason, I suggest announcing this change to all extension developers and politely ask them to update their code. I think this is the least we can do to make this change more global.
