### PR TITLE
Add woocommerce_my_account_edit_address_field_value filter hook and validate custom address type postcode field

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -78,7 +78,7 @@ class WC_Form_Handler {
 			if ( isset($field['required']) && $field['required'] && empty($_POST[$key]) ) wc_add_error( $field['label'] . ' ' . __( 'is a required field.', 'woocommerce' ) );
 
 			// Postcode
-			if ( substr_compare($key, 'postcode', strlen($key) - strlen('postcode'), strlen('postcode')) === 0 ) :
+			if ( strlen($key) >= 8 && substr_compare($key, 'postcode', strlen($key) - 8, 8) === 0 ) :
 				if ( ! WC_Validation::is_postcode( $_POST[$key], $_POST[ $load_address . '_country' ] ) ) :
 					wc_add_error( __( 'Please enter a valid postcode/ZIP.', 'woocommerce' ) );
 				else :

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -78,7 +78,7 @@ class WC_Form_Handler {
 			if ( isset($field['required']) && $field['required'] && empty($_POST[$key]) ) wc_add_error( $field['label'] . ' ' . __( 'is a required field.', 'woocommerce' ) );
 
 			// Postcode
-			if ($key=='billing_postcode' || $key=='shipping_postcode') :
+			if ( substr_compare($key, 'postcode', strlen($key) - strlen('postcode'), strlen('postcode')) === 0 ) :
 				if ( ! WC_Validation::is_postcode( $_POST[$key], $_POST[ $load_address . '_country' ] ) ) :
 					wc_add_error( __( 'Please enter a valid postcode/ZIP.', 'woocommerce' ) );
 				else :

--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -30,7 +30,7 @@ get_currentuserinfo();
 
 		<?php
 		foreach ($address as $key => $field) :
-			$value = (isset($_POST[$key])) ? $_POST[$key] : get_user_meta( get_current_user_id(), $key, true );
+			$value = apply_filters( 'woocommerce_my_account_edit_address_field_value', (isset($_POST[$key])) ? $_POST[$key] : get_user_meta( get_current_user_id(), $key, true ), $key, $load_address );
 
 			// Default values
 			if (!$value && ($key=='billing_email' || $key=='shipping_email')) $value = $current_user->user_email;


### PR DESCRIPTION
1st commit: Allows developers to override the address field value before displaying it on the edit form. This can be useful when the address needs to be loaded from a different source than user meta (for example, an external API).

Note: There are at least 3 more places where this kind of filtering may be needed, but they are already covered by existing hooks:
- filtering the displayed formatted address on My account page can already be covered by the`myaccount_my_address_formatted_fields` filter hook
- filtering the address returned by clicking the "Load billing address" button on Edit Order view can be achieved by using the `woocommerce_found_customer_details` filter hook.
- filtering the value displayed in the checkout form can be achieved with `woocommerce_checkout_get_value` filter hook

2nd commit: Validates any field that ends with postcode as a postcode field, when processing edit-address form after submit. This change actually is something that was (accidentally) left out from one of my previous PRs.
