### PR TITLE
Tweaking New Order Email Description

### DIFF
--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -24,7 +24,7 @@ class WC_Email_New_Order extends WC_Email {
 
 		$this->id 				= 'new_order';
 		$this->title 			= __( 'New order', 'woocommerce' );
-		$this->description		= __( 'New order emails are sent when an order is received/paid by a customer.', 'woocommerce' );
+		$this->description		= __( 'New order emails are sent when an order is received', 'woocommerce' );
 
 		$this->heading 			= __( 'New customer order', 'woocommerce' );
 		$this->subject      	= __( '[{blogname}] New customer order ({order_number}) - {order_date}', 'woocommerce' );

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -24,7 +24,7 @@ class WC_Email_New_Order extends WC_Email {
 
 		$this->id 				= 'new_order';
 		$this->title 			= __( 'New order', 'woocommerce' );
-		$this->description		= __( 'New order emails are sent when an order is received', 'woocommerce' );
+		$this->description		= __( 'New order emails are sent when an order is received.', 'woocommerce' );
 
 		$this->heading 			= __( 'New customer order', 'woocommerce' );
 		$this->subject      	= __( '[{blogname}] New customer order ({order_number}) - {order_date}', 'woocommerce' );


### PR DESCRIPTION
The description for the New Order Email is vague & confusing.

> New order emails are sent when an order is received/paid by a customer.

This makes it seem that getting a new order email has something to do with getting paid but you can receive a new order email without being paid (like checking out with the bank transfer payment gateway).

I tweaked the description to remove the payment wording since that's only confusing.

Ticket: https://woothemes.zendesk.com/agent/#/tickets/99722
