### PR TITLE
Fix coupon checks in cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -337,7 +337,7 @@ class WC_Cart {
 				foreach ( $this->applied_coupons as $key => $code ) {
 					$coupon = new WC_Coupon( $code );
 
-					if ( is_wp_error( $coupon->is_valid() ) ) {
+					if ( $coupon->is_valid() ) {
 
 						$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_INVALID_REMOVED );
 
@@ -401,7 +401,7 @@ class WC_Cart {
 				foreach ( $this->applied_coupons as $key => $code ) {
 					$coupon = new WC_Coupon( $code );
 
-					if ( ! is_wp_error( $coupon->is_valid() ) && is_array( $coupon->customer_email ) && sizeof( $coupon->customer_email ) > 0 ) {
+					if ( $coupon->is_valid() && is_array( $coupon->customer_email ) && sizeof( $coupon->customer_email ) > 0 ) {
 
 						$coupon->customer_email = array_map( 'sanitize_email', $coupon->customer_email );
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -337,7 +337,7 @@ class WC_Cart {
 				foreach ( $this->applied_coupons as $key => $code ) {
 					$coupon = new WC_Coupon( $code );
 
-					if ( $coupon->is_valid() ) {
+					if ( ! $coupon->is_valid() ) {
 
 						$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_INVALID_REMOVED );
 


### PR DESCRIPTION
The `WC_Coupon->is_valid()` method will only ever return [`true`](https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-coupon.php#L378) or [`false`](https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-coupon.php#L391), never an instance of `WP_Error` (even if an extension returned a `WP_Error` via the [`'woocommerce_coupon_is_valid'`](https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-coupon.php#L375) hook).

As a result, invalid coupons will appear valid to the cart when it checks to see if they are an instance of a `WP_Error` object in `check_cart_coupons()` & `check_customer_coupons()`.

This fixes that.
