### PR TITLE
Allow variations JS to be used on multiple products in the same form

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -42,7 +42,7 @@
 				// On clicking the reset variation button
 				.on( 'click', '.reset_variations', function( event ) {
 
-					$(this).closest('form.variations_form').find('.variations select').val('').change();
+					$(this).closest('.variations_form').find('.variations select').val('').change();
 
 					var $sku 		= $(this).closest('.product').find('.sku');
 					var $weight 	= $(this).closest('.product').find('.product_weight');
@@ -63,7 +63,7 @@
 				// Upon changing an option
 				.on( 'change', '.variations select', function( event ) {
 
-					$variation_form = $(this).closest('form.variations_form');
+					$variation_form = $(this).closest('.variations_form');
 					$variation_form.find('input[name=variation_id]').val('').change();
 
 					$variation_form
@@ -81,7 +81,7 @@
 				// Upon gaining focus
 				.on( 'focusin touchstart', '.variations select', function( event ) {
 
-					$variation_form = $(this).closest('form.variations_form');
+					$variation_form = $(this).closest('.variations_form');
 
 					$variation_form
 						.trigger( 'woocommerce_variation_select_focusin' )
@@ -221,7 +221,7 @@
 				// Disable option fields that are unavaiable for current set of attributes
 				.on( 'update_variation_values', function( event, variations ) {
 
-			    	$variation_form = $(this).closest('form.variations_form');
+			    	$variation_form = $(this).closest('.variations_form');
 
 			        // Loop through selects and disable/enable options based on selections
 			        $variation_form.find('.variations select').each(function( index, el ) {
@@ -410,8 +410,8 @@
     };
 
     $(function() {
-    	$('form.variations_form').wc_variation_form();
-   		$('form.variations_form .variations select').change();
+    	$('.variations_form').wc_variation_form();
+   		$('.variations_form .variations select').change();
     });
 
 })( jQuery, window, document );


### PR DESCRIPTION
The variations JS was changed some time ago, in order to allow multiple variations forms under the same page.

To further increase the quality of the core code, the variations JS script must allow multiple variable products under the same <strong>form</strong>. 

This is a big problem for extensions such as Product Bundles and Composite Products: To use the variations JS, both extensions must place all items in their own forms, while using a separate form for posting data. This is a major issue, because:

1) JS hacks are required to copy-paste variation data from the bundled item forms to the form that gets submitted.

2) To support extensions such as Addons and Name-Your-Price in Bundles/Composites, the same copy-paste hacks must be used.

no. 2 is a big issue with Addons, because in some cases cloning fields is hard / impossible to do in a clean way (file inputs, for example). It also makes maintenance a constant problem.

The solution is simple and only requires the <code>form</code> tag to be removed from the jQuery selectors, and simply relying on the class. This will make it possible to nest multiple <code>class="variations_form cart"</code> divs under the same form, without having to rely on hacky cloning.

The change doesn't affect anything, as far as I can tell. However all extensions that want to make it possible to nest multiple products under the same form should follow the same logic and remove the <code>form</code> tag from any jQuery selectors. At the moment, only the Products Add-ons and Name Your Price extensions affect bundled/composited products, so it won't be hard to make similar changes there.

This change doesn't affect current Composites / Bundles versions, however, once the extensions get updated to use a single form, they <strong> will not be backwards compatible with older WC versions</strong>. So it would be nice to see this in 2.0.15, in order to hopefully get this issue out of the way before 2.1 arrives.
