### PR TITLE
Added Russian Rubles to PayPal valid currencies list

### DIFF
--- a/classes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/classes/gateways/paypal/class-wc-gateway-paypal.php
@@ -74,7 +74,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
      * @return bool
      */
     function is_valid_for_use() {
-        if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_paypal_supported_currencies', array( 'AUD', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'CZK', 'DKK', 'HUF', 'ILS', 'MYR', 'PHP', 'PLN', 'SEK', 'CHF', 'TWD', 'THB', 'GBP', 'RMB' ) ) ) ) return false;
+        if ( ! in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_paypal_supported_currencies', array( 'AUD', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'CZK', 'DKK', 'HUF', 'ILS', 'MYR', 'PHP', 'PLN', 'SEK', 'CHF', 'TWD', 'THB', 'GBP', 'RMB', 'RUB' ) ) ) ) return false;
 
         return true;
     }


### PR DESCRIPTION
Added Russian Rubles to PayPal valid currencies list. (http://finance.yahoo.com/news/paypal-launches-russian-ruble-services-163152160.html)
