### PR TITLE
Add $data array to woocommerce_downloadable_file_permission_format

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -77,7 +77,7 @@ function woocommerce_downloadable_file_permission( $download_id, $product_id, $o
 		'%s',
 		'%s',
 		'%d'
-	));
+	), $data);
 
 	if ( ! is_null( $expiry ) ) {
 			$data['access_expires'] = $expiry;


### PR DESCRIPTION
It makes sense to provide downloadable file permission's `$data` to the `woocommerce_downloadable_file_permission_format` filter because the `$data` may have been filtered before by the `woocommerce_downloadable_file_permission_data` filter. And unless you have access to the `$data` array, there is no way to reliably provide the format.

For example, consider that the data is changed in the `woocommerce_downloadable_file_permission_data` filter based on the user_id and it requires changing the data format as well. How do you know that you are dealing with the same user's download permissions format, when you do not have access to the data?
