### PR TITLE
wp_insert_post should have true as $wp_error parameter

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -213,7 +213,7 @@ class WC_Checkout {
 		}
 
 		if ( $create_new_order ) {
-			$order_id = wp_insert_post( $order_data );
+			$order_id = wp_insert_post( $order_data, true );
 
 			if ( is_wp_error( $order_id ) )
 				throw new Exception( 'Error: Unable to create order. Please try again.' );

--- a/readme.txt
+++ b/readme.txt
@@ -211,6 +211,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Fix - Updated blockui to prevent errors in WP 3.6.
 * Fix - Tweaked popularity sorting to work better when no sales are present.
 * Fix - Quote encoding in email subjects.
+* Fix - Added $wp_error parameter during checkout process to ensure WP_Error object is returned on error and checkout process is properly stopped.
 * Refactor - Taken out Piwik integration, use http://wordpress.org/extend/plugins/woocommerce-piwik-integration/ from now on.
 * Refactor - Taken out ShareYourCart integration, use http://wordpress.org/extend/plugins/shareyourcart/ from now on.
 * Refactor - Moved woocommerce_get_formatted_product_name function into WC_Product class.


### PR DESCRIPTION
Add `true` as $wp_error parameter for wp_insert_post, otherwise it returns zero instead of a WP_Error object and the checkout process is not stopped.

@mikejolley - the messages from WP_Error are not displayed or logged, making debugging this difficult. Maybe we should check WP_DEBUG and display the message if it is set to true? either that or actually use the logger in WooCommerce for the first time?
