### PR TITLE
Add new payment complete actions

### DIFF
--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -1280,6 +1280,8 @@ class WC_Order {
 	public function payment_complete() {
 		global $woocommerce;
 
+		do_action( 'woocommerce_pre_payment_complete', $this->id );
+
 		if ( ! empty( $woocommerce->session->order_awaiting_payment ) )
 			unset( $woocommerce->session->order_awaiting_payment );
 
@@ -1325,6 +1327,11 @@ class WC_Order {
 				$this->reduce_order_stock(); // Payment is complete so reduce stock levels
 
 			do_action( 'woocommerce_payment_complete', $this->id );
+
+		} else {
+
+			do_action( 'woocommerce_payment_complete_order_status_' . $this->status, $this->id );
+
 		}
 	}
 


### PR DESCRIPTION
Adds two new actions to `WC_Order::payment_complete()` method:
1. an action at the start of the function to allow extensions to modify things _before_ the `payment_complete()` routine runs
2. a `'woocommerce_payment_complete_order_status_' . $order->status` action called when the `payment_complete()` function is called, but doesn't need to do anything because the order status is not 'on-hold', 'pending' or 'failed'. Some extensions do [unintended things with the standard checkout/payment flow](http://docs.woothemes.com/document/subscribers-view/#section-5), and this action will allow for it to be done in a more robust way (without imposing extra requirements on payment gateways).

I'll submit identical patch to the 2.1/master branch now.
