### PR TITLE
woocommerce.php PHPDoc cleanup: correct @returns and @deprecated markup

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -48,7 +48,7 @@ final class WooCommerce {
 	 * @since 2.1
 	 * @static
 	 * @see WC()
-	 * @return Main WooCommerce instance
+	 * @return WooCommerce - Main instance
 	 */
 	public static function instance() {
 		if ( is_null( self::$_instance ) )
@@ -76,9 +76,8 @@ final class WooCommerce {
 
 	/**
 	 * WooCommerce Constructor.
-	 *
 	 * @access public
-	 * @return void
+	 * @return WooCommerce
 	 */
 	public function __construct() {
 		// Auto-load classes on demand
@@ -485,8 +484,7 @@ final class WooCommerce {
 
 	/**
 	 * Init the mailer and call the notifications for the current filter.
-	 *
-	 * @param array $args (default: array())
+	 * @internal param array $args (default: array())
 	 * @return void
 	 */
 	public function send_transactional_email() {
@@ -535,173 +533,275 @@ final class WooCommerce {
 
 	/** Deprecated methods *********************************************************/
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param $image_size
+	 * @return array
+	 */
 	public function get_image_size( $image_size ) {
 		_deprecated_function( 'Woocommerce->get_image_size', '2.1', 'wc_get_image_size()' );
 		return wc_get_image_size( $image_size );
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @return WC_Logger
+	 */
 	public function logger() {
 		_deprecated_function( 'Woocommerce->logger', '2.1', 'new WC_Logger()' );
 		return new WC_Logger();
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @return WC_Validation
+	 */
 	public function validation() {
 		_deprecated_function( 'Woocommerce->validation', '2.1', 'new WC_Validation()' );
 		return new WC_Validation();
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param $post
+	 * @return WC_Product
+	 */
 	public function setup_product_data( $post ) {
 		_deprecated_function( 'Woocommerce->setup_product_data', '2.1', 'wc_setup_product_data' );
 		return wc_setup_product_data( $post );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Transient_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Transient_Helper helper
+	 * @param $content
+	 * @return string
+	 */
 	public function force_ssl( $content ) {
 		_deprecated_function( 'Woocommerce->force_ssl', '2.1', 'WC_HTTPS::force_https_url' );
 		return WC_HTTPS::force_https_url( $content );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Transient_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Transient_Helper helper
+	 * @param int $post_id
+	 */
 	public function clear_product_transients( $post_id = 0 ) {
 		_deprecated_function( 'Woocommerce->clear_product_transients', '2.1', 'wc_delete_product_transients' );
 		wc_delete_product_transients( $post_id );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Inline_Javascript_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Inline_Javascript_Helper helper
+	 * @param $code
+	 */
 	public function add_inline_js( $code ) {
 		_deprecated_function( 'Woocommerce->add_inline_js', '2.1', 'wc_enqueue_js' );
 		wc_enqueue_js( $code );
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param      $action
+	 * @param bool $referer
+	 * @param bool $echo
+	 * @return string
+	 */
 	public function nonce_field( $action, $referer = true , $echo = true ) {
 		_deprecated_function( 'Woocommerce->nonce_field', '2.1', 'wp_nonce_field' );
 		return wp_nonce_field('woocommerce-' . $action, '_wpnonce', $referer, $echo );
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param        $action
+	 * @param string $url
+	 * @return string
+	 */
 	public function nonce_url( $action, $url = '' ) {
 		_deprecated_function( 'Woocommerce->nonce_url', '2.1', 'wp_nonce_url' );
 		return wp_nonce_url( $url , 'woocommerce-' . $action );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Nonce_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Nonce_Helper helper
+	 * @param        $action
+	 * @param string $method
+	 * @param bool   $error_message
+	 * @return bool
+	 */
 	public function verify_nonce( $action, $method = '_POST', $error_message = false ) {
 		_deprecated_function( 'Woocommerce->verify_nonce', '2.1', 'WC_Nonce_Helper->verify_nonce' );
 		return wp_verify_nonce( $$_method[ '_wpnonce' ], 'woocommerce-' . $action );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Shortcode_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Shortcode_Helper helper
+	 * @param       $function
+	 * @param array $atts
+	 * @param array $wrapper
+	 * @return string
+	 */
 	public function shortcode_wrapper( $function, $atts = array(), $wrapper = array( 'class' => 'woocommerce', 'before' => null, 'after' => null ) ) {
 		_deprecated_function( 'Woocommerce->shortcode_wrapper', '2.1', 'WC_Shortcodes::shortcode_wrapper' );
 		return WC_Shortcodes::shortcode_wrapper( $function, $atts, $wrapper );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	 * @return object
+	 */
 	public function get_attribute_taxonomies() {
 		_deprecated_function( 'Woocommerce->get_attribute_taxonomies', '2.1', 'wc_get_attribute_taxonomies' );
 		return wc_get_attribute_taxonomies();
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	 * @param $name
+	 * @return string
+	 */
 	public function attribute_taxonomy_name( $name ) {
 		_deprecated_function( 'Woocommerce->attribute_taxonomy_name', '2.1', 'wc_attribute_taxonomy_name' );
 		return wc_attribute_taxonomy_name( $name );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	 * @param $name
+	 * @return string
+	 */
 	public function attribute_label( $name ) {
 		_deprecated_function( 'Woocommerce->attribute_label', '2.1', 'wc_attribute_label' );
 		return wc_attribute_label( $name );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	 * @param $name
+	 * @return string
+	 */
 	public function attribute_orderby( $name ) {
 		_deprecated_function( 'Woocommerce->attribute_orderby', '2.1', 'wc_attribute_orderby' );
 		return wc_attribute_orderby( $name );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Attribute_Helper helper
+	 * @return array
+	 */
 	public function get_attribute_taxonomy_names() {
 		_deprecated_function( 'Woocommerce->get_attribute_taxonomy_names', '2.1', 'wc_get_attribute_taxonomy_names' );
 		return wc_get_attribute_taxonomy_names();
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @return array
+	 */
 	public function get_coupon_discount_types() {
 		_deprecated_function( 'Woocommerce->get_coupon_discount_types', '2.1', 'wc_get_coupon_types' );
 		return wc_get_coupon_types();
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param string $type
+	 * @return string
+	 */
 	public function get_coupon_discount_type( $type = '' ) {
 		_deprecated_function( 'Woocommerce->get_coupon_discount_type', '2.1', 'wc_get_coupon_type' );
 		return wc_get_coupon_type( $type );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Body_Class_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Body_Class_Helper helper
+	 * @param $class
+	 */
 	public function add_body_class( $class ) {
 		_deprecated_function( 'Woocommerce->add_body_class', '2.1' );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Body_Class_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Body_Class_Helper helper
+	 * @param $classes
+	 */
 	public function output_body_class( $classes ) {
 		_deprecated_function( 'Woocommerce->output_body_class', '2.1' );
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param $error
+	 */
 	public function add_error( $error ) {
 		_deprecated_function( 'Woocommerce->add_error', '2.1', 'wc_add_error' );
 		wc_add_error( $error );
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @param $message
+	 */
 	public function add_message( $message ) {
 		_deprecated_function( 'Woocommerce->add_message', '2.1', 'wc_add_message' );
 		wc_add_message( $message );
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 */
 	public function clear_messages() {
 		_deprecated_function( 'Woocommerce->clear_messages', '2.1', 'wc_clear_messages' );
 		wc_clear_messages();
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @return int
+	 */
 	public function error_count() {
 		_deprecated_function( 'Woocommerce->error_count', '2.1', 'wc_error_count' );
 		return wc_error_count();
 	}
 
-	// Deprecated 2.1.0
+	/**
+	 * @deprecated 2.1.0
+	 * @return int
+	 */
 	public function message_count() {
 		_deprecated_function( 'Woocommerce->message_count', '2.1', 'wc_message_count' );
 		return wc_message_count();
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	 * @return mixed
+	 */
 	public function get_errors() {
 		_deprecated_function( 'Woocommerce->get_errors', '2.1', 'WC_Messages_Helper->get_errors' );
 		return $this->session->get( 'wc_errors', array() );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	 * @return mixed
+	 */
 	public function get_messages() {
 		_deprecated_function( 'Woocommerce->get_messages', '2.1', 'WC_Messages_Helper->get_messages' );
 		return $this->session->get( 'wc_messages', array() );
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	 */
 	public function show_messages() {
 		_deprecated_function( 'Woocommerce->show_messages', '2.1', 'wc_print_messages()' );
 		wc_print_messages();
 	}
 
-	// Deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	/**
+	 * @deprecated 2.1.0 Access via the WC_Messages_Helper helper
+	 */
 	public function set_messages() {
 		_deprecated_function( 'Woocommerce->set_messages', '2.1' );
 	}
@@ -719,5 +819,5 @@ function WC() {
 	return WooCommerce::instance();
 }
 
-// Global for backwards compatibilty.
+// Global for backwards compatibility.
 $GLOBALS['woocommerce'] = WC();


### PR DESCRIPTION
Having @deprecated helps detecting them at the code level rather than waiting for _deprecated_function() to happen.
