### PR TITLE
Adding Category & Tag Classes to Product Page

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -235,6 +235,23 @@ if ( ! function_exists( 'wc_product_post_class' ) ) {
 			if ( isset( $product->product_type ) ) {
 				$classes[] = "product-type-" . $product->product_type;
 			}
+
+			// add category slugs
+			$categories = wp_get_post_terms( $product->id, "product_cat" );
+			if ( ! empty( $categories ) ) {
+				foreach ($categories as $key => $value) {
+					$classes[] = "category-" . $value->slug;
+				}
+			}
+
+			// add tag slugs
+			$tags = wp_get_post_terms( $product->id, "product_tag" );
+			if ( ! empty( $tags ) ) {
+				foreach ($tags as $key => $value) {
+					$classes[] = "tag-" . $value->slug;
+				}
+			}
+
 			$classes[] = $product->stock_status;
 		}
 


### PR DESCRIPTION
By default WordPress will add category & tag classes to their article tags for generic posts. We should do the same with our products. This will add more flexibility for styling.

![bilbos_ring___woocommerce_github](https://f.cloud.github.com/assets/1065372/1211691/8322e516-260d-11e3-90b4-e06c4331a673.png)

Reference: https://woothemes.zendesk.com/agent/#/tickets/101838
