### PR TITLE
Allows to pass in cols and rows as custom attributes for textareas in woocommerce_form_field()

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1695,7 +1695,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			if ( $args['label'] )
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required  . '</label>';
 
-			$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text" id="' . esc_attr( $key ) . '" placeholder="' . $args['placeholder'] . '" cols="5" rows="2" ' . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>
+			$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text" id="' . esc_attr( $key ) . '" placeholder="' . $args['placeholder'] . '"' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>
 				</p>' . $after;
 
 			break;


### PR DESCRIPTION
Allows to pass in cols and rows as custom attributes for textareas in woocommerce_form_field(). 
You might want to set the size, especially the height, of a textarea with cols and rows rather than px or ems. I prefer to set the height with rows most times.

Example usage (changing rows and cols of order comments field on the checkout page):

```
function custom_override_checkout_fields( $fields ) {

    $fields['order']['order_comments']['custom_attributes'] = array('cols' => 20, 'rows' => 9);

    return $fields;
}
add_filter( 'woocommerce_checkout_fields' , 'custom_override_checkout_fields' );
```
