### PR TITLE
Add woocommerce_delete_product_transients action

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -125,6 +125,8 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		}
 
 	}
+
+	do_action( 'woocommerce_delete_product_transients', $post_id );
 }
 
 /**


### PR DESCRIPTION
Some background information:

When a shop page contains many variable items with a large number of variations, even a reasonably fast server may take a long time to render the page.

The same happens if a product bundle contains a few variable items with a large number of variations (>50). A client has a couple bundles, each containing multiple instances of the same variable product containing around 30 variations, each instance with different variation filtering settings. Shop page loads are noticeably slow.

I have traced the slowdown to function <code>get_available_variations()</code> and contemplated for a few seconds about the possibility of adding a transient there: If a transient is added there, the contained filters will only have effect in different calls of <code>get_available_variations()</code> only if a unique (filterable?) parameter is passed into <code>get_available_variations()</code> to modify the transient name depending on the scope. And of course properly delete all these when needed.

Instead of making any changes to the core, I have experimented with the idea of allowing the creation of <code>get_available_variations()</code> transients when the function is called inside a bundle, <strong>only in problematic cases, by adding a specific meta to the bundle product that enables this</strong>. 

However, the created transients will need to be cleaned when i) the bundled variable product is altered, ii) the main bundle settings are altered, iii) all other cases that trigger a transient cleaning. Hence the need for a <code>woocommerce_delete_product_transients</code> action. When a post_id is passed to <code>wc_delete_product_transients</code>, this can also be done by hooking into the <code>clean_post_cache</code> action, but an action hook is necessary otherwise.

Thoughts/comments? Would it make sense to go all the way and think about unique-named transients for <code>get_available_variations()</code>? 
