### PR TITLE
Add has_shipping_method() convenience function

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -348,13 +348,13 @@ class WC_Order {
 	 * @return void
 	 */
 	public function has_shipping_method( $method_id ) {
-		$shipping_methods = $this->get_shipping_methods;
+		$shipping_methods = $this->get_shipping_methods();
 		$has_method = false;
 		
 		if ( !$shipping_methods )
 			return false;
 
-		foreach ( $this->get_shipping_methods as $shipping_method ) {
+		foreach ( $shipping_methods as $shipping_method ) {
 			if ( $shipping_method['method_id'] == $method_id )
 				$has_method = true;
 		}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -343,6 +343,26 @@ class WC_Order {
 	}
 
 	/**
+	 * Check whether this order has a specific shipping method or not
+	 *
+	 * @return void
+	 */
+	public function has_shipping_method( $method_id ) {
+		$shipping_methods = $this->get_shipping_methods;
+		$has_method = false;
+		
+		if ( !$shipping_methods )
+			return false;
+
+		foreach ( $this->get_shipping_methods as $shipping_method ) {
+			if ( $shipping_method['method_id'] == $method_id )
+				$has_method = true;
+		}
+
+		return $has_method;
+	}
+
+	/**
 	 * Get taxes, merged by code, formatted ready for output.
 	 *
 	 * @access public


### PR DESCRIPTION
Allow checking whether the order has a shipping method or not. It should make it easier for plugin/extension developers to check if their shipping method is applied for the order.
