### PR TITLE
Add tax_rate_id to objects returned from cart->tax_totals

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -768,7 +768,8 @@ class WC_Cart {
 					$tax_totals[ $code ] = new stdClass();
 					$tax_totals[ $code ]->amount = 0;
 				}
-
+                
+                $tax_totals[ $code ]->tax_rate_id       = $key;
 				$tax_totals[ $code ]->is_compound       = $this->tax->is_compound( $key );
 				$tax_totals[ $code ]->label             = $this->tax->get_rate_label( $key );
 				$tax_totals[ $code ]->amount           += $tax;


### PR DESCRIPTION
It would be nice to have the tax rate id returned along with other tax data in the woocommerce_cart_tax_totals hook. 
