### PR TITLE
hooks for security and customization

### DIFF
--- a/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
@@ -616,6 +616,8 @@ class WC_Admin_CPT_Shop_Order extends WC_Admin_CPT {
 	public function delete_order_items( $postid ) {
 		global $wpdb;
 
+		do_action( 'woocommerce_before_delete_order_items', $postid );
+
 		if ( get_post_type( $postid ) == 'shop_order' )
 		{
 			$wpdb->query( "
@@ -625,6 +627,8 @@ class WC_Admin_CPT_Shop_Order extends WC_Admin_CPT {
 				WHERE {$wpdb->prefix}woocommerce_order_items.order_id = '{$postid}';
 				" );
 		}
+
+		do_action( 'woocommerce_after_delete_order_items', $postid );
 	}
 
 	/**

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -631,6 +631,11 @@ class WC_Form_Handler {
 			try {
 				$creds = array();
 
+				$result = apply_filters( 'woocommerce_process_login_before_error', '', $_POST['username'], $_POST['password'] );
+
+				if ( ! empty( $result ) )
+					throw new Exception( '<strong>' . __( 'Error', 'woocommerce' ) . ':</strong> ' . $result );
+
 				if ( empty( $_POST['username'] ) )
 					throw new Exception( '<strong>' . __( 'Error', 'woocommerce' ) . ':</strong> ' . __( 'Username is required.', 'woocommerce' ) );
 				if ( empty( $_POST['password'] ) )

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -746,6 +746,11 @@ class WC_Form_Handler {
 
 			WC()->verify_nonce( 'register' );
 
+			$result = apply_filters( 'woocommerce_process_registration_before_error', '', $_POST['username'], $_POST['password'], $_POST['email'] );
+
+			if ( ! empty( $result ) )
+				wc_add_error( '<strong>' . __( 'ERROR', 'woocommerce' ) . '</strong>: ' . $result );
+
 			$username   = ! empty( $_POST['username'] ) ? woocommerce_clean( $_POST['username'] ) : '';
 			$email      = ! empty( $_POST['email'] ) ? woocommerce_clean( $_POST['email'] ) : '';
 			$password   = ! empty( $_POST['password'] ) ? woocommerce_clean( $_POST['password'] ) : '';

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -53,6 +53,9 @@ global $woocommerce; ?>
 
 		<h2><?php _e( 'Register', 'woocommerce' ); ?></h2>
 
+		<?php do_action( 'woocommerce_registration_message' ); ?>
+		<?php do_action( 'woocommerce_registration_enqueue_scripts' ); ?>
+
 		<form method="post" class="register">
 
 			<?php if ( get_option( 'woocommerce_registration_generate_username' ) == 'no' ) : ?>

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -25,6 +25,9 @@ global $woocommerce; ?>
 
 		<h2><?php _e( 'Login', 'woocommerce' ); ?></h2>
 
+		<?php do_action( 'woocommerce_login_message' ); ?>
+		<?php do_action( 'woocommerce_login_enqueue_scripts' ); ?>
+
 		<form method="post" class="login">
 			<p class="form-row form-row-wide">
 				<label for="username"><?php _e( 'Username or email address', 'woocommerce' ); ?> <span class="required">*</span></label>
@@ -34,6 +37,7 @@ global $woocommerce; ?>
 				<label for="password"><?php _e( 'Password', 'woocommerce' ); ?> <span class="required">*</span></label>
 				<input class="input-text" type="password" name="password" id="password" />
 			</p>
+			<?php do_action('woocommerce_login_form'); ?>
 
 			<p class="form-row">
 				<?php wp_nonce_field( 'woocommerce-login' ) ?>
@@ -69,11 +73,10 @@ global $woocommerce; ?>
 				<label for="reg_password"><?php _e( 'Password', 'woocommerce' ); ?> <span class="required">*</span></label>
 				<input type="password" class="input-text" name="password" id="reg_password" value="<?php if ( ! empty( $_POST['password'] ) ) esc_attr_e( $_POST['password'] ); ?>" />
 			</p>
+			<?php do_action( 'woocommerce_register_form' ); ?>
 
 			<!-- Spam Trap -->
 			<div style="left:-999em; position:absolute;"><label for="trap"><?php _e( 'Anti-spam', 'woocommerce' ); ?></label><input type="text" name="email_2" id="trap" tabindex="-1" /></div>
-
-			<?php do_action( 'register_form' ); ?>
 
 			<p class="form-row">
 				<?php wp_nonce_field( 'woocommerce-register', 'register') ?>

--- a/templates/shop/form-login.php
+++ b/templates/shop/form-login.php
@@ -16,6 +16,9 @@ if (is_user_logged_in()) return;
 <form method="post" class="login" <?php if ( $hidden ) echo 'style="display:none;"'; ?>>
 	<?php if ( $message ) echo wpautop( wptexturize( $message ) ); ?>
 
+	<?php do_action( 'woocommerce_shop_login_message' ); ?>
+	<?php do_action( 'woocommerce_shop_login_enqueue_scripts' ); ?>
+
 	<p class="form-row form-row-first">
 		<label for="username"><?php _e( 'Username or email', 'woocommerce' ); ?> <span class="required">*</span></label>
 		<input type="text" class="input-text" name="username" id="username" />
@@ -24,6 +27,7 @@ if (is_user_logged_in()) return;
 		<label for="password"><?php _e( 'Password', 'woocommerce' ); ?> <span class="required">*</span></label>
 		<input class="input-text" type="password" name="password" id="password" />
 	</p>
+	<?php do_action('woocommerce_shop_login_form'); ?>
 	<div class="clear"></div>
 
 	<p class="form-row">


### PR DESCRIPTION
In addition to the added hooks, I am proposing to change the name and position of register_form to woocommerce_register_form, since WordPress already uses register_form. The woocommerce_register_form allows that specific form to be targeted.

The other hooks for the forms allow custom messages, scripts, and security functions to handle processing, and stop the process if needed.

The woocommerce_before_delete_order_items hook allows other plugins/extensions to cleanup order specific items if an order is deleted. I use this in my API Manager extension.
