### PR TITLE
array_search returns false when not found. 

### DIFF
--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -126,8 +126,12 @@ function woocommerce_nav_menu_item_classes( $menu_items, $args ) {
 		// Unset active class for blog page
 		if ( $page_for_posts == $menu_item->object_id ) {
 			$menu_items[$key]->current = false;
-			unset( $classes[ array_search('current_page_parent', $classes) ] );
-			unset( $classes[ array_search('current-menu-item', $classes) ] );
+			
+			if ( in_array( 'current_page_parent', $classes ) )
+				unset( $classes[ array_search('current_page_parent', $classes) ] );
+			
+			if ( in_array( 'current-menu-item', $classes ) )
+				unset( $classes[ array_search('current-menu-item', $classes) ] );
 
 		// Set active state if this is the shop page link
 		} elseif ( is_shop() && $shop_page == $menu_item->object_id ) {


### PR DESCRIPTION
This causes the first CSS class in the $classes array to be removed ( twice ).  This was inadvertently removing some of the custom classes defined in the Menu Builder of WordPress.
