### PR TITLE
Add System Status Copy Button

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -1,6 +1,7 @@
 <div class="woocommerce-message">
 	<div class="squeezer">
 		<h4><?php _e( 'Please include this information when requesting support:', 'woocommerce' ); ?> </h4>
+		<p class="submit"><a href="#" class="button-primary debug-report"><?php _e( 'Copy the System Report', 'woocommerce' ); ?></a></p>
 		<p class="submit"><a href="#" download="wc_report.txt" class="button-primary debug-report"><?php _e( 'Download System Report File', 'woocommerce' ); ?></a></p>
 	</div>
 </div>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -2,9 +2,9 @@
 	<div class="squeezer">
 		<h4><?php _e( 'Please include this information when requesting support:', 'woocommerce' ); ?> </h4>
 		<p class="submit"><a href="#" class="button-primary debug-report"><?php _e( 'Copy the System Report', 'woocommerce' ); ?></a></p>
-		<p class="submit"><a href="#" download="wc_report.txt" class="button-primary debug-report"><?php _e( 'Download System Report File', 'woocommerce' ); ?></a></p>
 	</div>
 </div>
+<textarea id="debug-report" readonly="readonly"></textarea>
 <br/>
 <table class="wc_status_table widefat" cellspacing="0">
 
@@ -541,8 +541,7 @@
 		} );
 
 		try {
-			var blob = new Blob( [ report ], { type: "text/plain;charset=" + document.characterSet } );
-			saveAs( blob, jQuery(this).attr('download') );
+			jQuery("#debug-report").val( report ).show().focus().select();
 			return false;
 		} catch(e){ console.log( e ); }
 


### PR DESCRIPTION
Initially from: #3781

> With our ticket submission process we ask users to copy and paste the contents of a text field so there isn't a real reason to make the users download the file in the first place.
> 
> So we would take the process from:
> download file --> open file --> copy content --> paste into support form
> 
> to:
> copy content --> paste into support form

We might as well take out the download button since that wont be used very often anymore.

Note - there was some consideration for using [ZeroClipboard](https://github.com/zeroclipboard/zeroclipboard) (which is what GitHub uses to copy SHA keys) but there are some IE8 issues so I think we should leave it out for now. Once IE8 issues are taken care of or we drop support for IE8 we should think about implementing a button that automagically copies the text to the clipboard.
