### PR TITLE
update_status function in class-wc-order.php will cause undesirable post insertion if we don't check if the order id exist

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1195,7 +1195,7 @@ class WC_Order {
 
 			wp_set_object_terms( $this->id, array( $new_status->slug ), 'shop_order_status', false );
 
-			if ( $this->status != $new_status->slug ) {
+			if ( $this->id && $this->status != $new_status->slug ) {
 
 				// Status was changed
 				do_action( 'woocommerce_order_status_' . $new_status->slug, $this->id );


### PR DESCRIPTION
we need $this->id check in the update_status function to prevent an empty WC_Order object from calling it. If $this->id doesn't exists, update_status will insert another row in wp_posts because line 1226: wp_update_post(array('ID' => $this->id)) triggers it.
