### PR TITLE
New hook: woocommerce_before_single_variation_price

### DIFF
--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -80,6 +80,7 @@ global $woocommerce, $product, $post;
 		<?php do_action('woocommerce_before_add_to_cart_button'); ?>
 
 		<div class="single_variation_wrap" style="display:none;">
+			<?php do_action('woocommerce_before_single_variation_price'); ?>
 			<div class="single_variation"></div>
 			<div class="variations_button">
 				<input type="hidden" name="variation_id" value="" />


### PR DESCRIPTION
It will allow printing a text before the calculated price, for example

```
// A GOOD way:
            add_action( 'woocommerce_before_single_variation_price',
                function () {
                    echo esc_html__( 'Price for the selected size:', 'mydomain' );
                }
            );
```

Doing the same using `woocommerce_before_add_to_cart_button` is much worse because have to surround it with a DIV - to hide/show:

```
// A BAD way:
            add_action( 'woocommerce_before_add_to_cart_button',
                function () {
                    ?>
                    <div class="single_variation_wrap" style="display:none;">
                        <?php echo esc_html__( 'Price for the selected size:', 'mydomain' ); ?>
                    </div>
                <?php
                }
            );
```
