### PR TITLE
Add missing doctype for emails

### DIFF
--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -76,6 +76,7 @@ $header_content_h1 = "
 	line-height: 150%;
 ";
 ?>
+<!DOCTYPE html>
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
Add missing doctype in the email header, fixes printing issue to make it fit on one page.
