### PR TITLE
Add WC_Order::needs_payment() function & filter

### DIFF
--- a/classes/class-wc-order.php
+++ b/classes/class-wc-order.php
@@ -1538,4 +1538,21 @@ class WC_Order {
 
 	}
 
+	/**
+	 * Checks if an order needs payment, based on status and order total
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function needs_payment() {
+
+		$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $this );
+
+		if ( in_array( $this->status, $valid_order_statuses ) && $this->get_total() > 0 )
+			$needs_payment = true;
+		else
+			$needs_payment = false;
+
+		return apply_filters( 'woocommerce_order_needs_payment', $needs_payment, $this, $valid_order_statuses );
+	}
 }

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -50,7 +50,7 @@ global $woocommerce;
 	</table>
 
 	<div id="payment">
-		<?php if ($order->order_total > 0) : ?>
+		<?php if ( $order->needs_payment() ) : ?>
 		<ul class="payment_methods methods">
 			<?php
 				if ( $available_gateways = $woocommerce->payment_gateways->get_available_payment_gateways() ) {

--- a/woocommerce-functions.php
+++ b/woocommerce-functions.php
@@ -606,7 +606,7 @@ function woocommerce_pay_action() {
 				$woocommerce->customer->set_city( $order->billing_city );
 
 			// Update payment method
-			if ( $order->order_total > 0 ) {
+			if ( $order->needs_payment() ) {
 				$payment_method = woocommerce_clean( $_POST['payment_method'] );
 
 				$available_gateways = $woocommerce->payment_gateways->get_available_payment_gateways();


### PR DESCRIPTION
There is currently no way for an extension to require payment via the "Pay" shortcode if an order has a $0 total (which makes perfect sense, until you have a pesky Subscriptions extension which uses an order with a $0 total for free trials).

This adds a new `WC_Order::needs_payment()` function as well as a `'woocommerce_order_needs_payment'` filter.

I looked at updating all instance of the `'woocommerce_valid_order_statuses_for_payment'` filter being used, but currently the `WC_Order::needs_payment()` function is a little different to that as it checks both for a valid status and the order total. So decided to leave them be for now.
