### PR TITLE
Show Widgets on any Taxonomy Page

### DIFF
--- a/classes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/classes/widgets/class-wc-widget-layered-nav-filters.php
@@ -53,7 +53,7 @@ class WC_Widget_Layered_Nav_Filters extends WP_Widget {
 
 		extract( $args );
 
-		if ( ! is_post_type_archive( 'product' ) && is_array( $_attributes_array ) && ! is_tax( array_merge( $_attributes_array, array( 'product_cat', 'product_tag' ) ) ) )
+		if ( ! is_post_type_archive( 'product' ) && is_array( $_attributes_array ) && ! is_tax( get_object_taxonomies( 'product' ) ) )
 			return;
 
 		$current_term 	= $_attributes_array && is_tax( $_attributes_array ) ? get_queried_object()->term_id : '';

--- a/classes/widgets/class-wc-widget-layered-nav.php
+++ b/classes/widgets/class-wc-widget-layered-nav.php
@@ -53,7 +53,7 @@ class WC_Widget_Layered_Nav extends WP_Widget {
 
 		extract( $args );
 
-		if ( ! is_post_type_archive( 'product' ) && ! is_tax( array_merge( $_attributes_array, array( 'product_cat', 'product_tag' ) ) ) )
+		if ( ! is_post_type_archive( 'product' ) && ! is_tax( get_object_taxonomies( 'product' ) ) )
 			return;
 
 		$current_term 	= $_attributes_array && is_tax( $_attributes_array ) ? get_queried_object()->term_id : '';

--- a/classes/widgets/class-wc-widget-price-filter.php
+++ b/classes/widgets/class-wc-widget-price-filter.php
@@ -56,7 +56,7 @@ class WC_Widget_Price_Filter extends WP_Widget {
 
 		global $_chosen_attributes, $wpdb, $woocommerce, $wp_query, $wp;
 
-		if (!is_tax( 'product_cat' ) && !is_post_type_archive('product') && !is_tax( 'product_tag' )) return; // Not on product page - return
+		if ( ! is_post_type_archive('product') && ! is_tax( get_object_taxonomies( 'product' ) ) ) return; // Not on product page - return
 
 		if ( sizeof( $woocommerce->query->unfiltered_product_ids ) == 0 ) return; // None shown - return
 


### PR DESCRIPTION
Displaying the widgets on any product taxonomy page. This useful if a user has custom taxonomies.

Ref: https://woothemes.zendesk.com/agent/#/tickets/108908
