### PR TITLE
Enable third-party Doubleclick cookie for Google Adwords Remarketing

### DIFF
--- a/includes/integrations/google-analytics/class-wc-google-analytics.php
+++ b/includes/integrations/google-analytics/class-wc-google-analytics.php
@@ -31,11 +31,12 @@ class WC_Google_Analytics extends WC_Integration {
 		$this->init_settings();
 
 		// Define user set variables
-		$this->ga_id 							= $this->get_option( 'ga_id' );
+		$this->ga_id 				= $this->get_option( 'ga_id' );
 		$this->ga_set_domain_name               = $this->get_option( 'ga_set_domain_name' );
 		$this->ga_standard_tracking_enabled 	= $this->get_option( 'ga_standard_tracking_enabled' );
 		$this->ga_ecommerce_tracking_enabled 	= $this->get_option( 'ga_ecommerce_tracking_enabled' );
-		$this->ga_event_tracking_enabled		= $this->get_option( 'ga_event_tracking_enabled' );
+		$this->ga_event_tracking_enabled	= $this->get_option( 'ga_event_tracking_enabled' );
+		$this->ga_doubleclick_cookie_enabled	= $this->get_option( 'ga_doubleclick_cookie_enabled' );
 
 		// Actions
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options') );
@@ -89,6 +90,13 @@ class WC_Google_Analytics extends WC_Integration {
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> 'end',
 				'default' 			=> 'no'
+			),
+			'ga_doubleclick_cookie_enabled' => array(
+				'label' 			=> __( 'Use Doubleclick third-party cookie for Google Adwords Remarketing', 'woocommerce' ),
+				'description' 		=> 'You must have a remarketing campaign created in Google Adwords for this to function properly',
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> 'end',
+				'default' 			=> 'no'
 			)
 		);
 
@@ -138,7 +146,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 			(function() {
 				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+				".($this->ga_doubleclick_cookie_enabled == "no" ? "ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';" : "ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';")."
 				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 			})();
 
@@ -244,7 +252,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 			(function() {
 				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+				".($this->ga_doubleclick_cookie_enabled == "no" ? "ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';" : "ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';")."
 				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 			})();
 		";


### PR DESCRIPTION
When Google Analytics is used with Google Merchant Center and Google Adwords to create a remarketing campaign, it is recommended to use the Doubleclick code for additional stats tracking in Google Analytics, instead of their default code.
