### PR TITLE
Add support for Google Adwords Remarketing features in Google Analytics

### DIFF
--- a/includes/integrations/google-analytics/class-wc-google-analytics.php
+++ b/includes/integrations/google-analytics/class-wc-google-analytics.php
@@ -36,6 +36,7 @@ class WC_Google_Analytics extends WC_Integration {
 		$this->ga_standard_tracking_enabled 	= $this->get_option( 'ga_standard_tracking_enabled' );
 		$this->ga_ecommerce_tracking_enabled 	= $this->get_option( 'ga_ecommerce_tracking_enabled' );
 		$this->ga_event_tracking_enabled		= $this->get_option( 'ga_event_tracking_enabled' );
+		$this->ga_doubleclick_cookie_enabled	= $this->get_option( 'ga_doubleclick_cookie_enabled' );
 
 		// Actions
 		add_action( 'woocommerce_update_options_integration_google_analytics', array( $this, 'process_admin_options') );
@@ -89,6 +90,13 @@ class WC_Google_Analytics extends WC_Integration {
 				'type' 				=> 'checkbox',
 				'checkboxgroup'		=> 'end',
 				'default' 			=> 'no'
+			),
+			'ga_doubleclick_cookie_enabled' => array(
+				'label' 			=> __( 'Use Doubleclick third-party cookie for Google Adwords Remarketing', 'woocommerce' ),
+				'description' 		=> __( 'You must have a remarketing campaign created in Google Adwords for this to function properly', 'woocommerce' ),
+				'type' 				=> 'checkbox',
+				'checkboxgroup'		=> 'end',
+				'default' 			=> 'no'
 			)
 		);
 
@@ -138,7 +146,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 			(function() {
 				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+				".($this->ga_doubleclick_cookie_enabled == "no" ? "ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';" : "ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';")."
 				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 			})();
 
@@ -244,7 +252,7 @@ class WC_Google_Analytics extends WC_Integration {
 
 			(function() {
 				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+				".($this->ga_doubleclick_cookie_enabled == "no" ? "ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';" : "ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';")."
 				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 			})();
 		";


### PR DESCRIPTION
Google Adwords Remarketing campaigns require the use of different Google Analytics code which enables a third-party cookie from DoubleClick to allow additional data to be tracked within Google Analytics

The option I added to enable/disable the new code may not be entirely necessary - I think the DoubleClick code may work with any site, regardless of Google Adwords status. However, it does involve an additional third-party cookie that some site owners may not want. Better safe than sorry. Having that option visible will also inform users that Adwords Remarketing is supported.
