### PR TITLE
woocommerce should not make the login page to 'remember me' by default

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -648,7 +648,7 @@ class WC_Form_Handler {
 				}
 
 				$creds['user_password'] = $_POST['password'];
-				$creds['remember']      = true;
+				$creds['remember']      = $_POST['rememberme'];
 				$secure_cookie          = is_ssl() ? true : false;
 				$user                   = wp_signon( apply_filters( 'woocommerce_login_credentials', $creds ), $secure_cookie );
 

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -34,7 +34,10 @@ global $woocommerce; ?>
 				<label for="password"><?php _e( 'Password', 'woocommerce' ); ?> <span class="required">*</span></label>
 				<input class="input-text" type="password" name="password" id="password" />
 			</p>
-
+			<p class="form-row">
+				<label for="remember">
+				<input name="rememberme" type="checkbox" id="rememberme" value="forever" /> <?php _e( 'Remember Me', 'woocommerce' ); ?></label>
+			</p>
 			<p class="form-row">
 				<?php wp_nonce_field( 'woocommerce-login' ) ?>
 				<input type="submit" class="button" name="login" value="<?php _e( 'Login', 'woocommerce' ); ?>" /> <a class="lost_password" href="<?php echo esc_url( woocommerce_get_endpoint_url( 'lost-password', '', get_permalink( woocommerce_get_page_id( 'myaccount' ) ) ) ); ?>"><?php _e( 'Lost Password?', 'woocommerce' ); ?></a>


### PR DESCRIPTION
wordpress gives user an option to 'remember me' with a checkbox. This should be the correct behavior. However, woocommerce makes rememberme true by default which is wrong. User has the right to choose if they want the cookie to be kept for 2 days or 2 weeks - http://codex.wordpress.org/Function_Reference/wp_set_auth_cookie
