### PR TITLE
change ucwords to ucfirst

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -58,7 +58,7 @@ class WC_Admin_Attributes {
 
 			// Auto-generate the label or slug if only one of both was provided
 			if ( ! $attribute_label ) {
-				$attribute_label = ucwords( $attribute_name );
+				$attribute_label = ucfirst( $attribute_name );
 			}
 			if ( ! $attribute_name ) {
 				$attribute_name = woocommerce_sanitize_taxonomy_name( stripslashes( $attribute_label ) );
@@ -324,7 +324,7 @@ class WC_Admin_Attributes {
 					        					<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg('edit', $tax->attribute_id, 'admin.php?page=product_attributes') ); ?>"><?php _e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg('delete', $tax->attribute_id, 'admin.php?page=product_attributes'), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php _e( 'Delete', 'woocommerce' ); ?></a></span></div>
 					        					</td>
 					        					<td><?php echo esc_html( $tax->attribute_name ); ?></td>
-					        					<td><?php echo esc_html( ucwords( $tax->attribute_type ) ); ?></td>
+					        					<td><?php echo esc_html( ucfirst( $tax->attribute_type ) ); ?></td>
 					        					<td><?php
 						        					switch ( $tax->attribute_orderby ) {
 							        					case 'name' :

--- a/includes/admin/post-types/class-wc-admin-cpt-product.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-product.php
@@ -331,7 +331,7 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 					echo '<span class="product-type tips variable" data-tip="' . __( 'Variable', 'woocommerce' ) . '"></span>';
 				else:
 					// Assuming that we have other types in future
-					echo '<span class="product-type tips ' . $the_product->product_type . '" data-tip="' . ucwords( $the_product->product_type ) . '"></span>';
+					echo '<span class="product-type tips ' . $the_product->product_type . '" data-tip="' . ucfirst( $the_product->product_type ) . '"></span>';
 				endif;
 			break;
 			case "price":
@@ -491,7 +491,7 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 					break;
 				default :
 					// Assuming that we have other types in future
-					$output .= ucwords( $term->name );
+					$output .= ucfirst( $term->name );
 					break;
 			}
 

--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -46,7 +46,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 
 		foreach ( $payment_gateways as $gateway ) {
 
-			$title = empty( $gateway->method_title ) ? ucwords( $gateway->id ) : ucwords( $gateway->method_title );
+			$title = empty( $gateway->method_title ) ? ucfirst( $gateway->id ) : ucfirst( $gateway->method_title );
 
 			$sections[ strtolower( get_class( $gateway ) ) ] = esc_html( $title );
 		}

--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -46,7 +46,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 
 		foreach ( $payment_gateways as $gateway ) {
 
-			$title = empty( $gateway->method_title ) ? ucfirst( $gateway->id ) : ucfirst( $gateway->method_title );
+			$title = empty( $gateway->method_title ) ? ucfirst( $gateway->id ) : $gateway->method_title;
 
 			$sections[ strtolower( get_class( $gateway ) ) ] = esc_html( $title );
 		}

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -45,7 +45,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$email_templates 	= $mailer->get_emails();
 
 		foreach ( $email_templates as $email ) {
-			$title = empty( $email->title ) ? ucwords( $email->id ) : ucwords( $email->title );
+			$title = empty( $email->title ) ? ucfirst( $email->id ) : ucfirst( $email->title );
 
 			$sections[ strtolower( get_class( $email ) ) ] = esc_html( $title );
 		}

--- a/includes/admin/settings/class-wc-settings-integrations.php
+++ b/includes/admin/settings/class-wc-settings-integrations.php
@@ -48,7 +48,7 @@ class WC_Settings_Integrations extends WC_Settings_Page {
 			$current_section = current( $integrations )->id;
 
 		foreach ( $integrations as $integration ) {
-			$title = empty( $integration->method_title ) ? ucfirst( $integration->id ) : ucfirst( $integration->method_title );
+			$title = empty( $integration->method_title ) ? ucfirst( $integration->id ) : $integration->method_title;
 
 			$sections[ strtolower( $integration->id ) ] = esc_html( $title );
 		}

--- a/includes/admin/settings/class-wc-settings-integrations.php
+++ b/includes/admin/settings/class-wc-settings-integrations.php
@@ -48,7 +48,7 @@ class WC_Settings_Integrations extends WC_Settings_Page {
 			$current_section = current( $integrations )->id;
 
 		foreach ( $integrations as $integration ) {
-			$title = empty( $integration->method_title ) ? ucwords( $integration->id ) : ucwords( $integration->method_title );
+			$title = empty( $integration->method_title ) ? ucfirst( $integration->id ) : ucfirst( $integration->method_title );
 
 			$sections[ strtolower( $integration->id ) ] = esc_html( $title );
 		}

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -48,7 +48,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 			if ( ! $method->has_settings() ) continue;
 
-			$title = empty( $method->method_title ) ? ucwords( $method->id ) : ucwords( $method->method_title );
+			$title = empty( $method->method_title ) ? ucfirst( $method->id ) : ucfirst( $method->method_title );
 
 			$sections[ strtolower( get_class( $method ) ) ] = esc_html( $title );
 		}

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -48,7 +48,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 			if ( ! $method->has_settings() ) continue;
 
-			$title = empty( $method->method_title ) ? ucfirst( $method->id ) : ucfirst( $method->method_title );
+			$title = empty( $method->method_title ) ? ucfirst( $method->id ) : $method->method_title;
 
 			$sections[ strtolower( get_class( $method ) ) ] = esc_html( $title );
 		}


### PR DESCRIPTION
Should use ucfirst instead of ucwords, if at all. Ucwords may apply to English, but usually the other words' first letter is not uppercase
