### PR TITLE
polish up attributes section confusing tips.

### DIFF
--- a/i18n/languages/woocommerce-admin-ar.po
+++ b/i18n/languages/woocommerce-admin-ar.po
@@ -3409,7 +3409,7 @@ msgstr "حقل نص"
 
 #: admin/woocommerce-admin-attributes.php:259
 #: admin/woocommerce-admin-attributes.php:392
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr "هذا يحدد كيف تختار قيمة الصفة للمنتج. <strong>حقل نص</strong> لتختار القيم في صفحة المنتج، بينما <strong>قائمة منسدلة</strong> تمكنك من إضافة قيم محددة، لتستخدمها هي فقط في صفحة المنتج. إذا كانت الصفة لمنتج متغير أختر  <strong>قائمة منسدلة</strong>."
 
 #: admin/woocommerce-admin-attributes.php:264
@@ -3431,7 +3431,7 @@ msgstr "معرف القيمة"
 
 #: admin/woocommerce-admin-attributes.php:272
 #: admin/woocommerce-admin-attributes.php:402
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr "هذا يحدد ترتيب القيم في والواجهة. إذا أخترت ترتيب مخصص، يمكنك سحب وإفلات القيم لترتيبها في صفحة القيم."
 
 #: admin/woocommerce-admin-attributes.php:277

--- a/i18n/languages/woocommerce-admin-nn_NO.po
+++ b/i18n/languages/woocommerce-admin-nn_NO.po
@@ -3404,7 +3404,7 @@ msgstr "Tekst"
 
 #: admin/woocommerce-admin-attributes.php:258
 #: admin/woocommerce-admin-attributes.php:391
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr "Avgjer korleis du vel vareeigenskapar. <strong>Tekst</strong> gjev høve til å skriva inn direkte på varesida, medan du kan laga utval med <strong>vel</strong>-eigenskapar. Viss du planlegg å bruka ein eigenskap for variantar, bør du bruka <strong>vel</strong>."
 
 #: admin/woocommerce-admin-attributes.php:263
@@ -3426,7 +3426,7 @@ msgstr "Vilkår-ID"
 
 #: admin/woocommerce-admin-attributes.php:271
 #: admin/woocommerce-admin-attributes.php:401
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr "Avgjer kva sortering som blir brukt på framsida av nettbutikken for denne eigenskapen. Viss du bruker eiga  sortering, kan du dra og sleppa termane i denne eigenskapen"
 
 #: admin/woocommerce-admin-attributes.php:276

--- a/i18n/languages/woocommerce-admin-sk_SK.po
+++ b/i18n/languages/woocommerce-admin-sk_SK.po
@@ -690,7 +690,7 @@ msgstr "Text"
 
 #: admin/woocommerce-admin-attributes.php:259
 #: admin/woocommerce-admin-attributes.php:392
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr "Tu zadajte spôsob výberu vlastností produktov. <strong>Text</strong> umožňuje ručné zadanie na stránke produktu, pričom voľba <strong>vybrať</strong> vlastnosť ponúkne iba voľby určené v tejto časti. Ak plánujete používať vlastnosti pre varianty použite voľbu <strong>vybrať</strong>"
 
 #: admin/woocommerce-admin-attributes.php:264
@@ -712,7 +712,7 @@ msgstr "ID vlastnosti"
 
 #: admin/woocommerce-admin-attributes.php:272
 #: admin/woocommerce-admin-attributes.php:402
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr "Určuje radenie na stránke pre túto vlastnosť. Ak použijete vlastné radenie, môžete použiť funkciu ťahaj a pusť."
 
 #: admin/woocommerce-admin-attributes.php:277

--- a/i18n/languages/woocommerce-admin.pot
+++ b/i18n/languages/woocommerce-admin.pot
@@ -229,7 +229,7 @@ msgstr ""
 
 #: includes/admin/class-wc-admin-attributes.php:266
 #: includes/admin/class-wc-admin-attributes.php:394
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr ""
 
 #: includes/admin/class-wc-admin-attributes.php:271
@@ -251,7 +251,7 @@ msgstr ""
 
 #: includes/admin/class-wc-admin-attributes.php:279
 #: includes/admin/class-wc-admin-attributes.php:404
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 #: includes/admin/class-wc-admin-attributes.php:284

--- a/i18n/languages/woocommerce-en_GB.po
+++ b/i18n/languages/woocommerce-en_GB.po
@@ -11391,7 +11391,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:258
 #: admin/woocommerce-admin-attributes.php:391
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:263
@@ -11417,7 +11417,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:271
 #: admin/woocommerce-admin-attributes.php:401
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:309

--- a/i18n/languages/woocommerce-id_ID.po
+++ b/i18n/languages/woocommerce-id_ID.po
@@ -2893,7 +2893,7 @@ msgstr "Teks"
 #: admin/woocommerce-admin-attributes.php:258
 #: admin/woocommerce-admin-attributes.php:391
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr "Menentukan bagaimana Anda memilih atribut untuk produk. <strong>Teks</strong> memungkinkan pemasukan data secara manual lewat halaman produk, dimana <strong>select</strong> istilah atribut dapat didefinisikan dari bagian ini. Jika Anda berencana untuk menggunakan atribut untuk variasi, pergunakan <strong>select</strong>."
 
 #: admin/woocommerce-admin-attributes.php:276
@@ -10913,7 +10913,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:271
 #: admin/woocommerce-admin-attributes.php:401
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:309

--- a/i18n/languages/woocommerce-lt_LT.po
+++ b/i18n/languages/woocommerce-lt_LT.po
@@ -4352,7 +4352,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:266
 #: admin/woocommerce-admin-attributes.php:399
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:271
@@ -4378,7 +4378,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:279
 #: admin/woocommerce-admin-attributes.php:409
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:284

--- a/i18n/languages/woocommerce-pl_PL.po
+++ b/i18n/languages/woocommerce-pl_PL.po
@@ -11509,7 +11509,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:258
 #: admin/woocommerce-admin-attributes.php:391
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:263
@@ -11535,7 +11535,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:271
 #: admin/woocommerce-admin-attributes.php:401
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:309

--- a/i18n/languages/woocommerce-pt_BR.po
+++ b/i18n/languages/woocommerce-pt_BR.po
@@ -120,7 +120,7 @@ msgstr "Atributos permitem que você defina os dados extra do produto, como tama
 #: admin/woocommerce-admin-attributes.php:259
 #: admin/woocommerce-admin-attributes.php:392
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr "Determina como você seleciona atributos para os produtos. <strong>Texto</strong> permite fazer entrada manual através da página do produto, ao passo que termos <strong>Select</strong> pode ser definido a partir desta seção. Se você planeja usar um atributo para variações use <strong>select</strong>."
 
 #: admin/woocommerce-admin-attributes.php:405
@@ -9515,7 +9515,7 @@ msgstr "ID do Termo"
 #: admin/woocommerce-admin-attributes.php:272
 #: admin/woocommerce-admin-attributes.php:402
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr "Determinar a ordem de classificação na frente do site para esse atributo. Se está usando ordenação customizada, você pode arrastar e soltar os termos nesse atributo"
 
 #: admin/woocommerce-admin-attributes.php:310

--- a/i18n/languages/woocommerce-pt_PT.po
+++ b/i18n/languages/woocommerce-pt_PT.po
@@ -119,7 +119,7 @@ msgstr "Atributos permitem que você defina os dados extra do produto, como tama
 #: admin/woocommerce-admin-attributes.php:267
 #: admin/woocommerce-admin-attributes.php:400
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr "Determina como você seleciona atributos para os produtos. <strong>Texto</strong> permite fazer entrada manual através da página do produto, ao passo que termos <strong>Select</strong> pode ser definido a partir desta seção. Se você planeia usar um atributo para variações use <strong>select</strong>."
 
 #: admin/woocommerce-admin-attributes.php:413
@@ -9966,7 +9966,7 @@ msgstr "ID do Termo"
 #: admin/woocommerce-admin-attributes.php:280
 #: admin/woocommerce-admin-attributes.php:410
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr "Determinar a ordem de classificação na frente do site para este atributo. Se está a usar ordem personalizada, você pode arrastar e soltar os termos neste atributo"
 
 #: admin/woocommerce-admin-attributes.php:318

--- a/i18n/languages/woocommerce-ru_RU.po
+++ b/i18n/languages/woocommerce-ru_RU.po
@@ -11510,7 +11510,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:258
 #: admin/woocommerce-admin-attributes.php:391
 #@ woocommerce
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:263
@@ -11536,7 +11536,7 @@ msgstr ""
 #: admin/woocommerce-admin-attributes.php:271
 #: admin/woocommerce-admin-attributes.php:401
 #@ woocommerce
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 #: admin/woocommerce-admin-attributes.php:309

--- a/i18n/languages/woocommerce-tr_TR.po
+++ b/i18n/languages/woocommerce-tr_TR.po
@@ -11270,7 +11270,7 @@ msgstr ""
 # @ woocommerce
 #: admin/woocommerce-admin-attributes.php:258
 #: admin/woocommerce-admin-attributes.php:391
-msgid "Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>."
+msgid "Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list."
 msgstr ""
 
 # @ woocommerce
@@ -11296,7 +11296,7 @@ msgstr ""
 # @ woocommerce
 #: admin/woocommerce-admin-attributes.php:271
 #: admin/woocommerce-admin-attributes.php:401
-msgid "Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute"
+msgid "Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute."
 msgstr ""
 
 # @ woocommerce

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -262,7 +262,7 @@ class WC_Admin_Attributes {
 									<option value="text" <?php selected( $att_type, 'text' ); ?>><?php _e( 'Text', 'woocommerce' ) ?></option>
 									<?php do_action('woocommerce_admin_attribute_types'); ?>
 								</select>
-								<p class="description"><?php _e( 'Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>.', 'woocommerce' ); ?></p>
+								<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
 							</td>
 						</tr>
 						<tr class="form-field form-required">
@@ -275,7 +275,7 @@ class WC_Admin_Attributes {
 									<option value="name" <?php selected( $att_orderby, 'name' ); ?>><?php _e( 'Name', 'woocommerce' ) ?></option>
 									<option value="id" <?php selected( $att_orderby, 'id' ); ?>><?php _e( 'Term ID', 'woocommerce' ) ?></option>
 								</select>
-								<p class="description"><?php _e( 'Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute', 'woocommerce' ); ?></p>
+								<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
 							</td>
 						</tr>
 					</tbody>
@@ -390,7 +390,7 @@ class WC_Admin_Attributes {
 										<option value="text"><?php _e( 'Text', 'woocommerce' ) ?></option>
 										<?php do_action('woocommerce_admin_attribute_types'); ?>
 									</select>
-									<p class="description"><?php _e( 'Determines how you select attributes for products. <strong>Text</strong> allows manual entry via the product page, whereas <strong>select</strong> attribute terms can be defined from this section. If you plan on using an attribute for variations use <strong>select</strong>.', 'woocommerce' ); ?></p>
+									<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
 								</div>
 
 								<div class="form-field">
@@ -400,7 +400,7 @@ class WC_Admin_Attributes {
 										<option value="name"><?php _e( 'Name', 'woocommerce' ) ?></option>
 										<option value="id"><?php _e( 'Term ID', 'woocommerce' ) ?></option>
 									</select>
-									<p class="description"><?php _e( 'Determines the sort order on the frontend for this attribute. If using custom ordering, you can drag and drop the terms in this attribute', 'woocommerce' ); ?></p>
+									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
 								</div>
 
 								<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button" value="<?php _e( 'Add Attribute', 'woocommerce' ); ?>"></p>


### PR DESCRIPTION
Clean up hint description under the woocommerce -> attribute page. It is currently misleading and confusing. 

It also says "If you plan on using an attribute for variations, use select" - this sentence is misleading. You can still use "text" but you just don't get the pre-selected terms thats all.
