### PR TITLE
Changed label of orderby setting in product category widget.

### DIFF
--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -33,7 +33,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			'orderby' => array(
 				'type'  => 'select',
 				'std'   => 'name',
-				'label' => __( 'Title', 'woocommerce' ),
+				'label' => __( 'Order by', 'woocommerce' ),
 				'options' => array(
 					'order' => __( 'Category Order', 'woocommerce' ),
 					'name'  => __( 'Name', 'woocommerce' )


### PR DESCRIPTION
Looks like a copy/paste slip-up in the Product Category widget. Label for the order setting is currently `Title`. Changed to `Order by`.
