### PR TITLE
Fix markup on form-pay.php

### DIFF
--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -60,8 +60,8 @@ global $woocommerce;
 
 					foreach ( $available_gateways as $gateway ) {
 						?>
-						<li id="payment_method_<?php echo $gateway->id; ?>" >
-							<input type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php if ($gateway->chosen) echo 'checked="checked"'; ?> />
+						<li class="payment_method_<?php echo $gateway->id; ?>">
+							<input id="payment_method_<?php echo $gateway->id; ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php if ($gateway->chosen) echo 'checked="checked"'; ?> />
 							<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo $gateway->get_title(); ?> <?php echo $gateway->get_icon(); ?></label>
 							<?php
 								if ( $gateway->has_fields() || $gateway->get_description() ) {


### PR DESCRIPTION
Payment method fields were not displaying on the "Checkout -> Pay" page in WC 2.1 because `checkout.js` uses a `input#payment_method_{name}` selector, which is fine with the payment method markup used in the `review-order.php` template, but not with the markup used in the `form-pay.php` template.

This moves the `#payment_method_{name}` attribute from the `<li/>` elements to the `<input/>` element so that `checkout.js` correctly displays a payment method's fields.
