### PR TITLE
Removing Extra Slashes When Order Meta is Saved in Admin

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-items.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-items.php
@@ -172,6 +172,7 @@ class WC_Meta_Box_Order_Items {
 
 		foreach ( $meta_keys as $id => $meta_key ) {
 			$meta_value = ( empty( $meta_values[ $id ] ) && ! is_numeric( $meta_values[ $id ] ) ) ? '' : $meta_values[ $id ];
+			$meta_value = stripslashes( $meta_value );
 			$wpdb->update(
 				$wpdb->prefix . "woocommerce_order_itemmeta",
 				array(


### PR DESCRIPTION
Under [certain conditions](http://stackoverflow.com/questions/2496455/why-are-post-variables-getting-escaped-in-php) it's possible for the server to add extra slashes to the order item meta that's being saved on the admin pages. This can happen every time the order is saved and can break the item order meta.

![extra-slashes-in-order-meta](https://f.cloud.github.com/assets/1065372/1484041/39ca077c-4701-11e3-801d-768e282b3fd4.png)

You can add a simple [stripslashes function](http://www.php.net/manual/en/function.stripslashes.php) call and that fixes it.

ref: https://woothemes.zendesk.com/agent/#/tickets/115184
