### PR TITLE
Make the Local Pickup Tooltip More Descriptive

### DIFF
--- a/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
+++ b/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
@@ -88,7 +88,7 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 			'codes' => array(
 				'title'			=> __( 'Zip/Post Codes', 'woocommerce' ),
 				'type' 			=> 'textarea',
-				'description'	=> __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
+				'description'	=> __( 'What zip/post codes are available for local pickup? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
 				'default'		=> '',
 				'desc_tip'		=> true,
 				'placeholder'	=> '12345, 56789 etc'


### PR DESCRIPTION
The existing tool tip mentioned `delivery` which doesn't make much sense with local pickup. I tweaked the wording to make the tooltip make more sense.
