### PR TITLE
Use $_product object instead of undefined $product_id for downloadable p...

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -116,7 +116,7 @@ function woocommerce_downloadable_product_permissions( $order_id ) {
 			$_product = $order->get_product_from_item( $item );
 
 			if ( $_product && $_product->exists() && $_product->is_downloadable() ) {
-				$downloads = get_post_meta( $product_id, '_downloadable_files' ) ;
+				$downloads = get_post_meta( $_product->id, '_downloadable_files' ) ;
 
 				foreach ( $downloads[0] as $download_id => $download )
 					woocommerce_downloadable_file_permission( $download_id, $item['variation_id'] > 0 ? $item['variation_id'] : $item['product_id'], $order );


### PR DESCRIPTION
...ermissions. Fixes #4095
