### PR TITLE
Fix invisible variations when get_price is filtered and set to (double) 0.

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -230,7 +230,7 @@ class WC_Product_Variation extends WC_Product {
 			$visible = false;
 
 		// Price not set
-		elseif ( $this->get_price() == "" )
+		elseif ( $this->get_price() === "" )
 			$visible = false;
 
 		return apply_filters( 'woocommerce_variation_is_visible', $visible, $this->variation_id, $this->id );


### PR DESCRIPTION
When filtering get_price on a variation and setting its value to (double) 0, then it becomes invisible unless we explicitly return a '0' string when the calculated filtered price is zero.

Oddly enough, setting a variation price to 0 in core doesn't hide that variation, so I assume that the price never gets converted to double.
