### PR TITLE
Add an option to create missing WooCommerce pages from tools page

### DIFF
--- a/admin/woocommerce-admin-status.php
+++ b/admin/woocommerce-admin-status.php
@@ -630,6 +630,11 @@ function woocommerce_status_tools() {
 			'button'	=> __('Clear all sessions','woocommerce'),
 			'desc'		=> __( '<strong class="red">Warning</strong> This tool will delete all customer session data from the database, including any current live carts.', 'woocommerce' ),
 		),
+		'install_pages' => array(
+			'name'		=> __( 'Install WooCommerce Pages', 'woocommerce' ),
+			'button'	=> __( 'Install pages', 'woocommerce' ),
+			'desc'		=> __( '<strong class="red">Note</strong> This tool will install all the missing WooCommerce pages. Pages already defined and set up will not be replaced.', 'woocommerce' ),
+		),
 	) );
 
 	if ( ! empty( $_GET['action'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'debug_action' ) ) {
@@ -710,6 +715,11 @@ function woocommerce_status_tools() {
 
 				wp_cache_flush();
 
+			break;
+			case "install_pages" :
+				require_once( 'woocommerce-admin-install.php' );
+				woocommerce_create_pages();
+				echo '<div class="updated"><p>' . __( 'All missing WooCommerce pages was installed successfully.', 'woocommerce' ) . '</p></div>';
 			break;
 			default:
 				$action = esc_attr( $_GET['action'] );

--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 
 = 2.0.20 =
 * Tweaked paypal request
+* Feature - Ability to recreate missing WooCommerce pages from tools menu
 
 = 2.0.19 - 04/11/2013 =
 * Fix - get_item_subtotal() logic


### PR DESCRIPTION
Add an option to install missing pages from the tools menu, got a couple of tickets where pages was missing and we had to recreate them manually, automated with this.
