### PR TITLE
Add "show_price" attribute to [add_to_cart] shortcode

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -491,7 +491,11 @@ class WC_Shortcodes {
 		?>
 		<p class="product woocommerce" style="<?php echo $atts['style']; ?>">
 
-			<?php echo $product->get_price_html(); ?>
+			<?php 
+				if(isset($atts['show_price']) && $atts['show_price'] == 'yes'){
+					echo $product->get_price_html();
+				} 
+			?>
 
 			<?php woocommerce_template_loop_add_to_cart(); ?>
 


### PR DESCRIPTION
Add "show_price" attribute to [add_to_cart] shortcode. Ex: [add_to_cart id="xx" show_price="yes"]. If show price isn't set, then price is displayed.
