### PR TITLE
Fix warning in new rest api key generation

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -268,7 +268,7 @@ class WC_Admin_Profile {
 				// permissions
 				if ( empty( $user->woocommerce_api_key_permissions ) ) {
 
-					$permissions = ( ! in_array( $_POST['woocommerce_api_key_permissions'], array( 'read', 'write', 'read_write' ) ) ) ? 'read' : $_POST['woocommerce_api_key_permissions'];
+					$permissions = ( isset( $_POST['woocommerce_api_key_permissions'] ) && ! in_array( $_POST['woocommerce_api_key_permissions'], array( 'read', 'write', 'read_write' ) ) ) ? 'read' : $_POST['woocommerce_api_key_permissions'];
 
 					update_user_meta( $user_id, 'woocommerce_api_key_permissions', $permissions );
 


### PR DESCRIPTION
Fix a warning when generating new API keys for the REST API #4055
