### PR TITLE
wc_ delimiter to identify start of uniquid

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -369,7 +369,7 @@ class WC_Checkout {
 		update_post_meta( $order_id, '_order_shipping_tax', 	woocommerce_format_decimal( woocommerce_round_tax_total( WC()->cart->shipping_tax_total ) ) );
 		update_post_meta( $order_id, '_order_total', 			woocommerce_format_decimal( WC()->cart->total, get_option( 'woocommerce_price_num_decimals' ) ) );
 
-		update_post_meta( $order_id, '_order_key', 				apply_filters('woocommerce_generate_order_key', uniqid('order_') ) );
+		update_post_meta( $order_id, '_order_key', 				'wc_' . apply_filters('woocommerce_generate_order_key', uniqid('order_') ) );
 		update_post_meta( $order_id, '_customer_user', 			absint( $this->customer_id ) );
 		update_post_meta( $order_id, '_order_currency', 		get_woocommerce_currency() );
 		update_post_meta( $order_id, '_prices_include_tax', 	get_option( 'woocommerce_prices_include_tax' ) );


### PR DESCRIPTION
I need to determine if an _order_key was generated by WooCommerce, or if it is unique. A delimiter prefixing the _order_key, like wc_ for example, would allow this determination to always be correct.

Another possibility might be to simply use order_ as the prefix delimiter:

``` php
'order_' . apply_filters('woocommerce_generate_order_key', uniqid() ) );
```

I personally like the wc_ prefix better, since it differentiates a WooCommerce order key value from other shopping cart order key values that may exist with the same _order_key post meta key.
