### PR TITLE
Add formatted_woocommerce_price filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 
 = 2.0.20 =
 * Tweaked paypal request
+* Tweak - formatted_woocommerce_price filter
 
 = 2.0.19 - 04/11/2013 =
 * Fix - get_item_subtotal() logic

--- a/woocommerce-core-functions.php
+++ b/woocommerce-core-functions.php
@@ -830,7 +830,7 @@ function woocommerce_price( $price, $args = array() ) {
 	$thousands_sep   = wp_specialchars_decode( stripslashes( get_option( 'woocommerce_price_thousand_sep' ) ), ENT_QUOTES );
 
 	$price           = apply_filters( 'raw_woocommerce_price', (double) $price );
-	$price           = number_format( $price, $num_decimals, $decimal_sep, $thousands_sep );
+	$price           = apply_filters( 'formatted_woocommerce_price', number_format( $price, $num_decimals, $decimal_sep, $thousands_sep ), $price, $num_decimals, $decimal_sep, $thousands_sep );
 
 	if ( get_option( 'woocommerce_price_trim_zeros' ) == 'yes' && $num_decimals > 0 )
 		$price = woocommerce_trim_zeros( $price );


### PR DESCRIPTION
Add a formatted_woocommerce_price filter so you can show prices in different formats on different pages. ie you might want to show prices on product page without decimals, but with decimals on cart page.
