### PR TITLE
Check products are purchasable when restoring cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -148,23 +148,38 @@ class WC_Cart {
 			// Load the cart
 			$cart = WC()->session->get( 'cart', array() );
 
+			$update_cart_session = false;
+
 			if ( is_array( $cart ) ) {
 				foreach ( $cart as $key => $values ) {
 					$_product = get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
 
 					if ( ! empty( $_product ) && $_product->exists() && $values['quantity'] > 0 ) {
 
-						// Put session data into array. Run through filter so other plugins can load their own session data
-						$this->cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', array(
-							'product_id'	=> $values['product_id'],
-							'variation_id'	=> $values['variation_id'],
-							'variation' 	=> $values['variation'],
-							'quantity' 		=> $values['quantity'],
-							'data'			=> $_product
-						), $values, $key );
+						if ( ! $_product->is_purchasable() ) {
+
+							// Flag to indicate the stored cart should be update
+							$update_cart_session = true;
+							wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $_product->get_title() ), 'error' );
+
+						} else {
+
+							// Put session data into array. Run through filter so other plugins can load their own session data
+							$this->cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', array(
+								'product_id'	=> $values['product_id'],
+								'variation_id'	=> $values['variation_id'],
+								'variation' 	=> $values['variation'],
+								'quantity' 		=> $values['quantity'],
+								'data'			=> $_product
+							), $values, $key );
+
+						}
 					}
 				}
 			}
+
+			if ( $update_cart_session )
+				WC()->session->cart = $this->cart_contents;
 
 			$this->set_cart_cookies( sizeof( $this->cart_contents ) > 0 );
 
@@ -172,7 +187,7 @@ class WC_Cart {
 			do_action( 'woocommerce_cart_loaded_from_session', $this );
 
 			// Queue re-calc if subtotal is not set
-			if ( ! $this->subtotal && sizeof( $this->cart_contents ) > 0 )
+			if ( ( ! $this->subtotal && sizeof( $this->cart_contents ) > 0 ) || $update_cart_session )
 				$this->calculate_totals();
 		}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -179,7 +179,7 @@ class WC_Cart {
 			}
 
 			if ( $update_cart_session )
-				WC()->session->cart = $this->cart_contents;
+				WC()->session->cart = $this->get_cart_for_session();
 
 			$this->set_cart_cookies( sizeof( $this->cart_contents ) > 0 );
 
@@ -196,15 +196,7 @@ class WC_Cart {
 		 */
 		public function set_session() {
 			// Set cart and coupon session data
-			$cart_session = array();
-
-			if ( $this->cart_contents ) {
-				foreach ( $this->cart_contents as $key => $values ) {
-					$cart_session[ $key ] = $values;
-
-					unset( $cart_session[ $key ]['data'] ); // Unset product object
-				}
-			}
+			$cart_session = $this->get_cart_for_session();
 
 			WC()->session->set( 'cart', $cart_session );
 			WC()->session->set( 'applied_coupons', $this->applied_coupons );
@@ -624,6 +616,25 @@ class WC_Cart {
 		 */
 		public function get_cart() {
 			return array_filter( (array) $this->cart_contents );
+		}
+
+		/**
+		 * Returns the contents of the cart in an array without the 'data' element.
+		 *
+		 * @return array contents of the cart
+		 */
+		private function get_cart_for_session() {
+
+			$cart_session = array();
+
+			if ( $this->get_cart() ) {
+				foreach ( $this->get_cart() as $key => $values ) {
+					$cart_session[ $key ] = $values;
+					unset( $cart_session[ $key ]['data'] ); // Unset product object
+				}
+			}
+
+			return $cart_session;
 		}
 
 		/**


### PR DESCRIPTION
Version of #4082 that is:
- for the master branch (so in different file and using the new `wc_add_notice()` function)
- includes a new `WC_Cart::get_cart_for_session()` method based on @mikejolley's [feedback](https://github.com/woothemes/woocommerce/pull/4082#issuecomment-28489465).

All tested and working.

From #4082: 

> Because `WC_Product::is_purchasable()` is only called when adding a product to the cart, it's possible to purchase products that aren't purchasable (but were purchasable when they were first added to the cart).
> 
> This patch checks all of the cart's contents when restoring the cart from the session to make sure that each of them is purchasable. If they're not, it removes them from the cart session, doesn't add them to the cart and display's an error message notifying the customer that the item was removed.
> 
> It's tested & working, but I'm not sure what I've done to remove the item from the cart session is the best approach i.e. [`$woocommerce->session->cart = $this->cart_contents`](https://github.com/thenbrent/woocommerce/commit/1d599b5#diff-6d49d784315a8c9815e4f600dafe95e6L150). If it is and this is merged as is, I'll patch WC 2.1 too.
> 
> Relates to ZD ticket 116028.
