### PR TITLE
Make scripts that use global objects safe on non WC pages.

### DIFF
--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// woocommerce_params is required to continue, ensure the object exists
+	if (typeof woocommerce_params === "undefined")
+		return false;
+
 	/** Cart Handling */
 	$supports_html5_storage = ( 'sessionStorage' in window && window['sessionStorage'] !== null );
 

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// woocommerce_params is required to continue, ensure the object exists
+	if (typeof woocommerce_params === "undefined")
+		return false;
+
 	var updateTimer;
 	var dirtyInput = false;
 	var xhr;

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -348,7 +348,7 @@ jQuery(document).ready(function($) {
 	/* Localisation */
 	var locale_json;
 	if (typeof woocommerce_params.locale !== "undefined")
-		woocommerce_params.locale.replace(/&quot;/g, '"');
+		locale_json = woocommerce_params.locale.replace(/&quot;/g, '"');
 
 	var locale = $.parseJSON( locale_json );
 	var required = ' <abbr class="required" title="' + woocommerce_params.i18n_required_text + '">*</abbr>';

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -346,7 +346,10 @@ jQuery(document).ready(function($) {
 	});
 
 	/* Localisation */
-	var locale_json = woocommerce_params.locale.replace(/&quot;/g, '"');
+	var locale_json;
+	if (typeof woocommerce_params.locale !== "undefined")
+		woocommerce_params.locale.replace(/&quot;/g, '"');
+
 	var locale = $.parseJSON( locale_json );
 	var required = ' <abbr class="required" title="' + woocommerce_params.i18n_required_text + '">*</abbr>';
 

--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// woocommerce_price_slider_params is required to continue, ensure the object exists
+	if (typeof woocommerce_price_slider_params === "undefined")
+		return false;
+
 	// Get markup ready for slider
 	$('input#min_price, input#max_price').hide();
 	$('.price_slider, .price_label').show();

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// woocommerce_params is required to continue, ensure the object exists
+	if (typeof woocommerce_params === "undefined")
+		return false;
+
 	// Placeholder
 	$('.woocommerce textarea[placeholder], .woocommerce-page textarea[placeholder], .woocommerce input[placeholder], .woocommerce-page input[placeholder]').placeholder();
 


### PR DESCRIPTION
This commit allows the scripts to bail out immediately if the dependent
global woocommerce objects are not present on the page.

Linked to Issue #4202
