### PR TITLE
[2.1-beta-1] Remove second row of formatting buttons in product short description visual editor.

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-short-description.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-short-description.php
@@ -24,7 +24,10 @@ class WC_Meta_Box_Product_Short_Description {
 		$settings = array(
 			'textarea_name'	=> 'excerpt',
 			'quicktags' 	=> array( 'buttons' => 'em,strong,link' ),
-			'tinymce' 	=> array( 'theme_advanced_buttons1' => 'bold,italic,link,unlink' ),
+			'tinymce' 	=> array(
+				'theme_advanced_buttons1' => 'bold,italic,link,unlink',
+				'theme_advanced_buttons2' => '',
+			),
 			'editor_css'	=> '<style>#wp-excerpt-editor-container .wp-editor-area{height:175px; width:100%;}</style>'
 		);
 


### PR DESCRIPTION
Product short description should generally be kept simple. This PR keeps basic formatting options (bold, italic and links) while removing unnecessary formatting options - keeping things UI clean and simple.
