### PR TITLE
Use correct variable for OAuth parameter check

### DIFF
--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -108,7 +108,7 @@ class WC_API_Authentication {
 		// check for required OAuth parameters
 		foreach ( $param_names as $param_name ) {
 
-			if ( empty( $params ) )
+			if ( empty( $params[ $param_name ] ) )
 				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce' ), $param_name ), 404 );
 		}
 


### PR DESCRIPTION
At the moment, the OAuth parameters are not actually validated for existence. This patch fixes that. :)
