### PR TITLE
Explicit currency for order prices

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -382,7 +382,7 @@ class WC_Order {
 			$tax_totals[ $code ]->is_compound       = $tax[ 'compound' ];
 			$tax_totals[ $code ]->label             = isset( $tax[ 'label' ] ) ? $tax[ 'label' ] : $tax[ 'name' ];
 			$tax_totals[ $code ]->amount           += $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ];
-			$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax_total( $tax_totals[ $code ]->amount ) );
+			$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax_total( $tax_totals[ $code ]->amount ), array('currency' => $this->get_order_currency()) );
 		}
 
 		return apply_filters( 'woocommerce_order_tax_totals', $tax_totals, $this );
@@ -661,9 +661,9 @@ class WC_Order {
 		if ( $tax_display == 'excl' ) {
 			$ex_tax_label = $this->prices_include_tax ? 1 : 0;
 
-			$subtotal = wc_price( $this->get_line_subtotal( $item ), array( 'ex_tax_label' => $ex_tax_label ) );
+			$subtotal = wc_price( $this->get_line_subtotal( $item ), array( 'ex_tax_label' => $ex_tax_label, 'currency' => $this->get_order_currency() ) );
 		} else {
-			$subtotal = wc_price( $this->get_line_subtotal( $item, true ) );
+			$subtotal = wc_price( $this->get_line_subtotal( $item, true ), array('currency' => $this->get_order_currency()) );
 		}
 
 		return apply_filters( 'woocommerce_order_formatted_line_subtotal', $subtotal, $item, $this );
@@ -722,7 +722,7 @@ class WC_Order {
 				}
 			}
 
-			$subtotal = wc_price( $subtotal );
+			$subtotal = wc_price( $subtotal, array('currency' => $this->get_order_currency()) );
 
 			if ( $tax_display == 'excl' && $this->prices_include_tax )
 				$subtotal .= ' <small>' . WC()->countries->ex_tax_or_vat() . '</small>';
@@ -753,7 +753,7 @@ class WC_Order {
 			// Remove discounts
 			$subtotal = $subtotal - $this->get_cart_discount();
 
-			$subtotal = wc_price( $subtotal );
+			$subtotal = wc_price( $subtotal, array('currency' => $this->get_order_currency()) );
 		}
 
 		return apply_filters( 'woocommerce_order_subtotal_to_display', $subtotal, $compound, $this );
@@ -777,7 +777,7 @@ class WC_Order {
 			if ( $tax_display == 'excl' ) {
 
 				// Show shipping excluding tax
-				$shipping = wc_price( $this->order_shipping );
+				$shipping = wc_price( $this->order_shipping, array('currency' => $this->get_order_currency()) );
 
 				if ( $this->order_shipping_tax > 0 && $this->prices_include_tax )
 					$tax_text = WC()->countries->ex_tax_or_vat() . ' ';
@@ -785,7 +785,7 @@ class WC_Order {
 			} else {
 
 				// Show shipping including tax
-				$shipping = wc_price( $this->order_shipping + $this->order_shipping_tax );
+				$shipping = wc_price( $this->order_shipping + $this->order_shipping_tax, array('currency' => $this->get_order_currency()) );
 
 				if ( $this->order_shipping_tax > 0 && ! $this->prices_include_tax )
 					$tax_text = WC()->countries->inc_tax_or_vat() . ' ';
@@ -811,7 +811,7 @@ class WC_Order {
 	 * @return string.
 	 */
 	public function get_cart_discount_to_display() {
-		return apply_filters( 'woocommerce_order_cart_discount_to_display', wc_price( $this->get_cart_discount() ), $this );
+		return apply_filters( 'woocommerce_order_cart_discount_to_display', wc_price( $this->get_cart_discount(), array('currency' => $this->get_order_currency()) ), $this );
 	}
 
 
@@ -822,7 +822,7 @@ class WC_Order {
 	 * @return string
 	 */
 	public function get_order_discount_to_display() {
-		return apply_filters( 'woocommerce_order_discount_to_display', wc_price( $this->get_order_discount() ), $this );
+		return apply_filters( 'woocommerce_order_discount_to_display', wc_price( $this->get_order_discount(), array('currency' => $this->get_order_currency()) ), $this );
 	}
 
 
@@ -878,14 +878,14 @@ class WC_Order {
 
 					$total_rows[ 'fee_' . $id ] = array(
 						'label' => $fee['name'],
-						'value'	=> wc_price( $fee['line_total'] )
+						'value'	=> wc_price( $fee['line_total'], array('currency' => $this->get_order_currency()) )
 					);
 
 				} else {
 
 					$total_rows[ 'fee_' . $id ] = array(
 						'label' => $fee['name'],
-						'value'	=> wc_price( $fee['line_total'] + $fee['line_tax'] )
+						'value'	=> wc_price( $fee['line_total'] + $fee['line_tax'], array('currency' => $this->get_order_currency()) )
 					);
 
 				}
@@ -903,7 +903,7 @@ class WC_Order {
 			} else {
 				$total_rows['tax'] = array(
 					'label' => WC()->countries->tax_or_vat() . ':',
-					'value'	=> wc_price( $this->get_total_tax() )
+					'value'	=> wc_price( $this->get_total_tax(), array('currency' => $this->get_order_currency()) )
 				);
 			}
 		}
@@ -929,7 +929,7 @@ class WC_Order {
 					$tax_string_array[] = sprintf( '%s %s', $tax->formatted_amount, $tax->label );
 				}
 			} else {
-				$tax_string_array[] = sprintf( '%s %s', wc_price( $this->get_total_tax() ), WC()->countries->tax_or_vat() );
+				$tax_string_array[] = sprintf( '%s %s', wc_price( $this->get_total_tax(), array('currency' => $this->get_order_currency()) ), WC()->countries->tax_or_vat() );
 			}
 
 			if ( ! empty( $tax_string_array ) )


### PR DESCRIPTION
Set the currency for the order prices to be the order's currency instead
of the shop's currency. When these are different, the order emails are
misleading.

Related to https://github.com/woothemes/woocommerce/pull/4143
