### PR TITLE
Fixing County Typo

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -74,7 +74,7 @@ class WC_Admin_Profile {
 						),
 					'billing_state' => array(
 							'label' => __( 'State/County', 'woocommerce' ),
-							'description' => __( 'Country or state code', 'woocommerce' ),
+							'description' => __( 'State/County or state code', 'woocommerce' ),
 						),
 					'billing_country' => array(
 							'label' => __( 'Country', 'woocommerce' ),


### PR DESCRIPTION
Fixing a typo with `country` when it should be `county`. While I was in there I made the string consistent with the shipping State/County description.

![county-typo](https://f.cloud.github.com/assets/1065372/1647847/3010e1b2-5956-11e3-8801-dcdabf566ff6.png)
