### PR TITLE
Add Blank Index Files for Obsurity

### DIFF
--- a/assets/css/index.php
+++ b/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/fonts/index.php
+++ b/assets/fonts/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/images/icons/credit-cards/index.php
+++ b/assets/images/icons/credit-cards/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/images/icons/index.php
+++ b/assets/images/icons/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/images/index.php
+++ b/assets/images/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/images/welcome/index.php
+++ b/assets/images/welcome/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/admin/index.php
+++ b/assets/js/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/chosen/index.php
+++ b/assets/js/chosen/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/frontend/index.php
+++ b/assets/js/frontend/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/index.php
+++ b/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/jquery-blockui/index.php
+++ b/assets/js/jquery-blockui/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/jquery-cookie/index.php
+++ b/assets/js/jquery-cookie/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/jquery-payment/index.php
+++ b/assets/js/jquery-payment/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/jquery-tiptip/index.php
+++ b/assets/js/jquery-tiptip/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/prettyPhoto/index.php
+++ b/assets/js/prettyPhoto/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/dummy-data/index.php
+++ b/dummy-data/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/i18n/index.php
+++ b/i18n/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/i18n/languages/alt/index.php
+++ b/i18n/languages/alt/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/i18n/languages/index.php
+++ b/i18n/languages/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/i18n/makepot/extract/index.php
+++ b/i18n/makepot/extract/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/i18n/makepot/pomo/index.php
+++ b/i18n/makepot/pomo/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/i18n/states/index.php
+++ b/i18n/states/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/abstracts/index.php
+++ b/includes/abstracts/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/importers/index.php
+++ b/includes/admin/importers/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/importers/samples/index.php
+++ b/includes/admin/importers/samples/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/index.php
+++ b/includes/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/post-types/index.php
+++ b/includes/admin/post-types/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/post-types/meta-boxes/index.php
+++ b/includes/admin/post-types/meta-boxes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/post-types/meta-boxes/views/index.php
+++ b/includes/admin/post-types/meta-boxes/views/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/reports/index.php
+++ b/includes/admin/reports/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/settings/index.php
+++ b/includes/admin/settings/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/views/index.php
+++ b/includes/admin/views/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/api/index.php
+++ b/includes/api/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/emails/index.php
+++ b/includes/emails/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/bacs/index.php
+++ b/includes/gateways/bacs/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/cheque/index.php
+++ b/includes/gateways/cheque/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/cod/index.php
+++ b/includes/gateways/cod/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/index.php
+++ b/includes/gateways/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/mijireh/assets/css/index.php
+++ b/includes/gateways/mijireh/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/mijireh/assets/images/index.php
+++ b/includes/gateways/mijireh/assets/images/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/mijireh/assets/index.php
+++ b/includes/gateways/mijireh/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/mijireh/assets/js/index.php
+++ b/includes/gateways/mijireh/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/mijireh/includes/index.php
+++ b/includes/gateways/mijireh/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/mijireh/index.php
+++ b/includes/gateways/mijireh/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/gateways/paypal/index.php
+++ b/includes/gateways/paypal/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/libraries/index.php
+++ b/includes/libraries/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shipping/flat-rate/index.php
+++ b/includes/shipping/flat-rate/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shipping/free-shipping/index.php
+++ b/includes/shipping/free-shipping/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shipping/index.php
+++ b/includes/shipping/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shipping/international-delivery/index.php
+++ b/includes/shipping/international-delivery/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shipping/local-delivery/index.php
+++ b/includes/shipping/local-delivery/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shipping/local-pickup/index.php
+++ b/includes/shipping/local-pickup/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/shortcodes/index.php
+++ b/includes/shortcodes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/updates/index.php
+++ b/includes/updates/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/walkers/index.php
+++ b/includes/walkers/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/widgets/index.php
+++ b/includes/widgets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/cart/index.php
+++ b/templates/cart/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/checkout/index.php
+++ b/templates/checkout/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/emails/index.php
+++ b/templates/emails/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/emails/plain/index.php
+++ b/templates/emails/plain/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/index.php
+++ b/templates/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/loop/index.php
+++ b/templates/loop/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/myaccount/index.php
+++ b/templates/myaccount/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/notices/index.php
+++ b/templates/notices/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/order/index.php
+++ b/templates/order/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/shop/index.php
+++ b/templates/shop/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/single-product/add-to-cart/index.php
+++ b/templates/single-product/add-to-cart/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/single-product/index.php
+++ b/templates/single-product/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/templates/single-product/tabs/index.php
+++ b/templates/single-product/tabs/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.


### PR DESCRIPTION
Since WordPress adds blank `index.php` files for obscurity we should probably follow suit. We already have one in the root directory of WooCommerce and we might as well add them in other directories as well. There probably isn't too much "secret" content in these directories but it doesn't hurt to add extra obscurity.

![index-woocommerce-templates-directory](https://f.cloud.github.com/assets/1065372/1651713/caba01b4-5ae9-11e3-8a73-2ceb7fa4b524.png)
