### PR TITLE
Introduce woocommerce_{$setting}_form_fields filter.

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -36,9 +36,7 @@ abstract class WC_Settings_API {
 
   /** Allow getting private variables **/
   public function __get($name) {
-    // For now, only return form_fields
-    if ($name == 'form_fields')
-      return $this->{$name};
+    return $this->{$name};
   }
 
 	/**

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -17,13 +17,29 @@ abstract class WC_Settings_API {
 	public $settings = array();
 
 	/** @var array Array of form option fields. */
-	public $form_fields = array();
+	private $form_fields = array();
 
 	/** @var array Array of validation errors. */
 	public $errors = array();
 
 	/** @var array Sanitized fields after validation. */
 	public $sanitized_fields = array();
+
+  /** Private property setting override **/
+  public function __set($name, $value) {
+    // Allow filtering form_fields being set
+    if ($name == 'form_fields') {
+      $value = apply_filters( $this->plugin_id . $this->id . '_form_fields', $value );
+    }
+    $this->{$name} = $value;
+  }
+
+  /** Allow getting private variables **/
+  public function __get($name) {
+    // For now, only return form_fields
+    if ($name == 'form_fields')
+      return $this->{$name};
+  }
 
 	/**
 	 * Admin Options


### PR DESCRIPTION
Second take on #3790. I thought long and hard about the different approaches and I came to the conclusion that using `__set` and `__get` is the most reliable way to go here. It may not be the most elegant solution, but it assures that $this->form_fields will always be up to date with the filtered version of form_fields.

Another approach that I considered was introducing `get_form_fields` / `set_form_fields` methods. They are of course, more elegant, but would still mean that we are on the mercy of extension developers.
