### PR TITLE
Adding woocommerce_terms_is_checked Filter

### DIFF
--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -170,10 +170,12 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			echo apply_filters('woocommerce_order_button_html', '<input type="submit" class="button alt" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" />' );
 			?>
 
-			<?php if ( wc_get_page_id( 'terms' ) > 0 && apply_filters( 'woocommerce_checkout_show_terms', true ) ) { ?>
+			<?php if ( wc_get_page_id( 'terms' ) > 0 && apply_filters( 'woocommerce_checkout_show_terms', true ) ) { 
+				$terms_is_checked = apply_filters( 'woocommerce_terms_is_checked', isset( $_POST['terms'] ) );
+				?>
 				<p class="form-row terms">
 					<label for="terms" class="checkbox"><?php _e( 'I have read and accept the', 'woocommerce' ); ?> <a href="<?php echo esc_url( get_permalink(wc_get_page_id('terms')) ); ?>" target="_blank"><?php _e( 'terms &amp; conditions', 'woocommerce' ); ?></a></label>
-					<input type="checkbox" class="input-checkbox" name="terms" <?php checked( isset( $_POST['terms'] ), true ); ?> id="terms" />
+					<input type="checkbox" class="input-checkbox" name="terms" <?php checked( $terms_is_checked, true ); ?> id="terms" />
 				</p>
 			<?php } ?>
 


### PR DESCRIPTION
There's no way for a plugin or snippet to automatically make the Terms & Conditions checkbox checked by default. The default state of a checkbox probably shouldn't be theme dependent (controlled solely via theme overrides).

Once this filter is in place you can hook into it like this:
https://gist.github.com/BFTrick/7789974
