### PR TITLE
Make frontend scripts safe to run on non WC pages (check for objects)

### DIFF
--- a/assets/js/frontend/add-payment-method.js
+++ b/assets/js/frontend/add-payment-method.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($){
 
+	// woocommerce_params is required to continue, ensure the object exists
+	if (typeof woocommerce_params === "undefined")
+		return false;
+
 	$('#add_payment_method')
 
 	/* Payment option selection */

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -415,6 +415,11 @@
     };
 
     $(function() {
+
+		// wc_add_to_cart_variation_params is required to continue, ensure the object exists
+		if (typeof wc_add_to_cart_variation_params === "undefined")
+			return false;
+
     	$('.variations_form').wc_variation_form();
    		$('.variations_form .variations select').change();
     });

--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// wc_add_to_cart_params is required to continue, ensure the object exists
+	if (typeof wc_add_to_cart_params === "undefined")
+		return false;
+
 	// Ajax add to cart
 	$(document).on( 'click', '.add_to_cart_button', function() {
 

--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// wc_cart_fragments_params is required to continue, ensure the object exists
+	if (typeof wc_cart_fragments_params === "undefined")
+		return false;
+
 	/** Cart Handling */
 	$supports_html5_storage = ( 'sessionStorage' in window && window['sessionStorage'] !== null );
 

--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// wc_cart_params is required to continue, ensure the object exists
+	if (typeof wc_cart_params === "undefined")
+		return false;
+
 	// Shipping calculator
 	$(document).on( 'click', '.shipping-calculator-button', function() {
 		$('.shipping-calculator-form').slideToggle('slow');

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// wc_checkout_params is required to continue, ensure the object exists
+	if (typeof wc_checkout_params === "undefined")
+		return false;
+
 	var updateTimer;
 	var dirtyInput = false;
 	var xhr;

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// wc_country_select_params is required to continue, ensure the object exists
+	if (typeof wc_country_select_params === "undefined")
+		return false;
+
 	/* State/Country select boxes */
 	var states_json = wc_country_select_params.countries.replace(/&quot;/g, '"');
 	var states = $.parseJSON( states_json );

--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// woocommerce_price_slider_params is required to continue, ensure the object exists
+	if (typeof woocommerce_price_slider_params === "undefined")
+		return false;
+
 	// Get markup ready for slider
 	$('input#min_price, input#max_price').hide();
 	$('.price_slider, .price_label').show();

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -1,5 +1,9 @@
 jQuery(document).ready(function($) {
 
+	// wc_single_product_params is required to continue, ensure the object exists
+	if (typeof wc_single_product_params === "undefined")
+		return false;
+
 	// Tabs
 	$('.woocommerce-tabs .panel').hide();
 


### PR DESCRIPTION
For a more detailed explaination of why this is helpful, see
Issue #4202. In short, from a dev ops perspective, if we want to build /
concatonate our front end scripts into a single application.js file, we
need to ensure scripts first check for dependent global object helpers
before trying to use them. For example, there are several objects
(created via PHP using `wp_localize_script`) which generate objects such
as `wc_single_product_params`. These objects will not exist on most
other pages, however these scripts attempt to execute code that
references these objects.
