### PR TITLE
Adding Default Shipping Price to Tooltips

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -118,7 +118,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							'title' 		=> __( 'Cost per order', 'woocommerce' ),
 							'type' 			=> 'price',
 							'placeholder'	=> wc_format_localized_price( 0 ),
-							'description'	=> __( 'Enter a cost (excluding tax) per order, e.g. 5.00. Leave blank to disable.', 'woocommerce' ),
+							'description'	=> __( 'Enter a cost (excluding tax) per order, e.g. 5.00. Default is 0.', 'woocommerce' ),
 							'default'		=> '',
 							'desc_tip'		=> true
 						),

--- a/includes/shipping/international-delivery/class-wc-shipping-international-delivery.php
+++ b/includes/shipping/international-delivery/class-wc-shipping-international-delivery.php
@@ -102,7 +102,7 @@ class WC_Shipping_International_Delivery extends WC_Shipping_Flat_Rate {
 							'title'			=> __( 'Cost', 'woocommerce' ),
 							'type' 			=> 'price',
 							'placeholder'	=> wc_format_localized_price( 0 ),
-							'description'	=> __( 'Cost excluding tax. Enter an amount, e.g. 2.50.', 'woocommerce' ),
+							'description'	=> __( 'Cost excluding tax. Enter an amount, e.g. 2.50. Default is 0', 'woocommerce' ),
 							'default'		=> '',
 							'desc_tip'		=> true
 						),


### PR DESCRIPTION
In #3634 we added a default price of `0` to Flat Rate Shipping & International Shipping. I'm modifying the tooltips which mention that shipping is disabled (which is no longer the case).

cc @seanreloaded
