### PR TITLE
Fix issue where oAuth signature is wrong when running site from a subfolder

### DIFF
--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -178,7 +178,7 @@ class WC_API_Authentication {
 
 		$http_method = strtoupper( WC()->api->server->method );
 
-		$base_request_uri = rawurlencode( get_home_url( null, '/wc-api/v1' . WC()->api->server->path, 'http' ) );
+		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . WC()->api->server->path );
 
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );

--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -178,7 +178,7 @@ class WC_API_Authentication {
 
 		$http_method = strtoupper( WC()->api->server->method );
 
-		$base_request_uri = rawurlencode( get_home_url( null, parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ), 'http' ) );
+		$base_request_uri = rawurlencode( get_home_url( null, '/wc-api/v1' . WC()->api->server->path, 'http' ) );
 
 		// get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );


### PR DESCRIPTION
When running your site from a subfolder like http://mysite.com/folder the signature is worked out based on http://mysite.com/folder/folder/ due to the use of get_home_url and parse_url combined.
