### PR TITLE
Changing Standards to Always Require Braces

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -86,8 +86,9 @@ final class WooCommerce {
 	 * @return WooCommerce - Main instance
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) )
+		if ( is_null( self::$_instance ) ) {
 			self::$_instance = new self();
+		}
 		return self::$_instance;
 	}
 
@@ -116,8 +117,9 @@ final class WooCommerce {
 	 */
 	public function __construct() {
 		// Auto-load classes on demand
-		if ( function_exists( "__autoload" ) )
+		if ( function_exists( "__autoload" ) ) {
 			spl_autoload_register( "__autoload" );
+		}
 
 		spl_autoload_register( array( $this, 'autoload' ) );
 
@@ -149,8 +151,9 @@ final class WooCommerce {
 	 * @return mixed
 	 */
 	public function __get( $key ) {
-		if ( method_exists( $this, $key ) )
+		if ( method_exists( $this, $key ) ) {
 			return $this->$key();
+		}
 		else switch( $key ) {
 			case 'template_url':
 				_deprecated_argument( 'Woocommerce->template_url', '2.1', 'WC_TEMPLATE_PATH constant' );
@@ -251,18 +254,22 @@ final class WooCommerce {
 		define( 'WC_VERSION', $this->version );
 		define( 'WOOCOMMERCE_VERSION', WC_VERSION ); // Backwards compat
 
-		if ( ! defined( 'WC_TEMPLATE_PATH' ) )
+		if ( ! defined( 'WC_TEMPLATE_PATH' ) ) {
 			define( 'WC_TEMPLATE_PATH', $this->template_path() );
+		}
 		
-		if ( ! defined( 'WC_ROUNDING_PRECISION' ) )
+		if ( ! defined( 'WC_ROUNDING_PRECISION' ) ) {
 			define( 'WC_ROUNDING_PRECISION', 4 );
+		}
 
 		// 1 = PHP_ROUND_HALF_UP, 2 = PHP_ROUND_HALF_DOWN
-		if ( ! defined( 'WC_TAX_ROUNDING_MODE' ) )
+		if ( ! defined( 'WC_TAX_ROUNDING_MODE' ) ) {
 			define( 'WC_TAX_ROUNDING_MODE', get_option( 'woocommerce_prices_include_tax' ) == 'yes' ? 2 : 1 ); 
+		}
 
-		if ( ! defined( 'WC_DELIMITER' ) )
+		if ( ! defined( 'WC_DELIMITER' ) ) {
 			define( 'WC_DELIMITER', '|' );
+		}
 	}
 
 	/**
@@ -275,14 +282,17 @@ final class WooCommerce {
 		include( 'includes/class-wc-comments.php' );
 		include( 'includes/class-wc-post-data.php' );
 
-		if ( is_admin() )
+		if ( is_admin() ) {
 			include_once( 'includes/admin/class-wc-admin.php' );
+		}
 
-		if ( defined('DOING_AJAX') )
+		if ( defined('DOING_AJAX') ) {
 			$this->ajax_includes();
+		}
 
-		if ( ! is_admin() || defined('DOING_AJAX') )
+		if ( ! is_admin() || defined('DOING_AJAX') ) {
 			$this->frontend_includes();
+		}
 
 		// Query class
 		$this->query = include( 'includes/class-wc-query.php' );				// The main query class
@@ -455,20 +465,24 @@ final class WooCommerce {
 		// IIS
 		if ( ! isset($_SERVER['REQUEST_URI'] ) ) {
 			$_SERVER['REQUEST_URI'] = substr( $_SERVER['PHP_SELF'], 1 );
-			if ( isset( $_SERVER['QUERY_STRING'] ) )
+			if ( isset( $_SERVER['QUERY_STRING'] ) ) {
 				$_SERVER['REQUEST_URI'].='?'.$_SERVER['QUERY_STRING'];
+			}
 		}
 
 		// NGINX Proxy
-		if ( ! isset( $_SERVER['REMOTE_ADDR'] ) && isset( $_SERVER['HTTP_REMOTE_ADDR'] ) )
+		if ( ! isset( $_SERVER['REMOTE_ADDR'] ) && isset( $_SERVER['HTTP_REMOTE_ADDR'] ) ) {
 			$_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_REMOTE_ADDR'];
+		}
 
-		if ( ! isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTP_HTTPS'] ) )
+		if ( ! isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTP_HTTPS'] ) ) {
 			$_SERVER['HTTPS'] = $_SERVER['HTTP_HTTPS'];
+		}
 
 		// Support for hosts which don't use HTTPS, and use HTTP_X_FORWARDED_PROTO
-		if ( ! isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' )
+		if ( ! isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ) {
 			$_SERVER['HTTPS'] = '1';
+		}
 	}
 
 	/** Helper functions ******************************************************/


### PR DESCRIPTION
See #4309 for a discussion about WordPress changing their PHP coding standards. This PR adds all of the braces in the `woocommerce.php` file. There may be more.

Props to @NikV for bringing this to our attention. :)
