### PR TITLE
Only allow a fee to be added once

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1775,8 +1775,18 @@ class WC_Cart {
 		 * @param string $tax_class (default: '')
 		 */
 		public function add_fee( $name, $amount, $taxable = false, $tax_class = '' ) {
+
+			$new_fee_id = sanitize_title( $name );
+
+			// Only add each fee once
+			foreach ( $this->fees as $fee ) {
+				if ( $fee->id == $new_fee_id ) {
+					return;
+				}
+			}
+
 			$new_fee 			= new stdClass();
-			$new_fee->id 		= sanitize_title( $name );
+			$new_fee->id 		= $new_fee_id;
 			$new_fee->name 		= esc_attr( $name );
 			$new_fee->amount	= (float) esc_attr( $amount );
 			$new_fee->tax_class	= $tax_class;


### PR DESCRIPTION
When `WC_Cart->calculate_totals()` is run, order and line totals are effectively calculated from a base of 0. This allows plugins, like Subscriptions, to recalculate totals by call `WC_Cart->calculate_totals()` multiple times within the same request.

However, if `WC_Cart->add_fee()` is hooked to a function inside of `WC_Cart->calculate_totals()`, like `woocommerce_cart_calculate_fees`, then the fee will be added to the cart, even if it has already been added.

This patch prevents the same fee from being added more than once. It determines uniqueness using the psuedo-ID created by sanitising the fee's name. Therefore a plugin can still add a fee multiple times, but it would need to do be explicit to do so.

I'm not sure if there's a reason identical fees should be allowed to accumulate, and in any case, I've added a patch to Subscriptions to prevent duplicate fees (woothemes/woocommerce-subscriptions@08f9eac) so it won't affect it, but I preventing accumulation in core would avoid issues for other plugins that recalculate cart totals.
