### PR TITLE
Downloadable File Fixes/Tweaks

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -285,11 +285,11 @@ class WC_Product {
 				}
 
 				// Filter URL
-				$downloadable_files[ $key ]['file'] = apply_filters( 'woocommerce_file_download_path', $downloadable_files[ $key ]['file'], $this->id, $key );
+				$downloadable_files[ $key ]['file'] = apply_filters( 'woocommerce_file_download_path', $downloadable_files[ $key ]['file'], $this, $key );
 			}
 		}
 
-		return apply_filters( 'woocommerce_product_files', $downloadable_files, $this->id );
+		return apply_filters( 'woocommerce_product_files', $downloadable_files, $this );
 	}
 
 	/**
@@ -308,7 +308,7 @@ class WC_Product {
 		}
 
 		// allow overriding based on the particular file being requested
-		return apply_filters( 'woocommerce_product_file', $file, $this->id, $download_id );
+		return apply_filters( 'woocommerce_product_file', $file, $this, $download_id );
 	}
 
 	/**
@@ -327,7 +327,7 @@ class WC_Product {
 		}
 
 		// allow overriding based on the particular file being requested
-		return apply_filters( 'woocommerce_product_file_download_path', $file_path, $this->id, $download_id );
+		return apply_filters( 'woocommerce_product_file_download_path', $file_path, $this, $download_id );
 	}
 
 	/**

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -94,8 +94,9 @@ function wc_downloadable_file_permission( $download_id, $product_id, $order ) {
 
 	return $result ? $wpdb->insert_id : false;
 }
-add_action('woocommerce_order_status_completed', 'woocommerce_downloadable_product_permissions');
-add_action('woocommerce_order_status_processing', 'woocommerce_downloadable_product_permissions');
+
+add_action('woocommerce_order_status_completed', 'wc_downloadable_product_permissions');
+add_action('woocommerce_order_status_processing', 'wc_downloadable_product_permissions');
 
 
 /**
@@ -116,10 +117,11 @@ function wc_downloadable_product_permissions( $order_id ) {
 			$_product = $order->get_product_from_item( $item );
 
 			if ( $_product && $_product->exists() && $_product->is_downloadable() ) {
-				$downloads = get_post_meta( $_product->id, '_downloadable_files' ) ;
+				$downloads = $_product->get_files();
 
-				foreach ( $downloads[0] as $download_id => $download )
+				foreach ( array_keys( $downloads ) as $download_id ) {
 					wc_downloadable_file_permission( $download_id, $item['variation_id'] > 0 ? $item['variation_id'] : $item['product_id'], $order );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Hooked up new downloadable product permissions function to completed/processing actions
- WC_Product::get_files() is used rather than the underlying _downloadable_files  meta directly
- $this is passed to downloadable product filters in WC_Product in place of $this->id which doesn't afford you the particular variation when a product variation is being used.
