### PR TITLE
Expiry date calculation based on order completion date

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -52,8 +52,10 @@ function wc_downloadable_file_permission( $download_id, $product_id, $order ) {
 	// Default value is NULL in the table schema
 	$expiry     = empty( $expiry ) ? null : absint( $expiry );
 
-	if ( $expiry )
-		$expiry = date_i18n( "Y-m-d", strtotime( 'NOW + ' . $expiry . ' DAY' ) );
+	if ( $expiry ) {
+		$order_completed_date = date_i18n( "Y-m-d", strtotime( $order->completed_date ) );
+		$expiry = date_i18n( "Y-m-d", strtotime( $order_completed_date . ' + ' . $expiry . ' DAY' ) );
+	}
 
 	$data = apply_filters( 'woocommerce_downloadable_file_permission_data', array(
 		'download_id'			=> $download_id,


### PR DESCRIPTION
Consider I'm selling video course which is divided in 3 parts. And I'm going to upload these videos one-by-one at interval of 3 weeks. These videos will be available for download for 1 year that means the download link should get expire in 1 year.

I've created a downloadable product & uploaded 1st video & started selling on my site. Some people bought video course. After 3 weeks when I'm going to upload next video, they will get access to that video for 1 year calculated from NOW, but they paid for the video course 3 weeks earlier. 

Why should they get access for 1 year from NOW? Don't you think expiry date should be calculated based on order completion date instead of file upload date?

Your thoughts? 
