### PR TITLE
Removed unnecessary esc_url, switched to add_query_arg

### DIFF
--- a/admin/post-types/writepanels/writepanel-order_data.php
+++ b/admin/post-types/writepanels/writepanel-order_data.php
@@ -525,9 +525,9 @@ function woocommerce_order_totals_meta_box( $post ) {
 
 				$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' LIMIT 1;", $item['name'] ) );
 
-				$link = $post_id ? admin_url( 'post.php?post=' . $post_id . '&action=edit' ) : admin_url( 'edit.php?s=' . esc_url( $item['name'] ) . '&post_status=all&post_type=shop_coupon' );
+				$link = $post_id ? add_query_arg( array( 'post' => $post_id, 'action' => 'edit' ), admin_url( 'post.php' ) ) : add_query_arg( array( 's' => $item['name'], 'post_status' => 'all', 'post_type' => 'shop_coupon' ), admin_url( 'edit.php' ) );
 
-				echo '<li class="tips code" data-tip="' . esc_attr( woocommerce_price( $item['discount_amount'] ) ) . '"><a href="' . $link . '"><span>' . esc_html( $item['name'] ). '</span></a></li>';
+				echo '<li class="tips code" data-tip="' . esc_attr( woocommerce_price( $item['discount_amount'] ) ) . '"><a href="' . esc_url( $link ) . '"><span>' . esc_html( $item['name'] ). '</span></a></li>';
 
 			}
 		?>


### PR DESCRIPTION
On Admin Order screen in the order totals meta box, when a coupon is output where the ID is not found, the coupon name is wrapped in esc_url() which inserts an unnecessary "http://" before the coupon code. I went ahead and converted this line to use add_query_arg() instead and moved esc_url() to the href where the line of HTML is being output.
