### PR TITLE
Admin metabox billing information save fix

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-data.php
@@ -357,7 +357,7 @@ class WC_Meta_Box_Order_Data {
 		update_post_meta( $post_id, '_customer_user', absint( $_POST['customer_user'] ) );
 
 		if ( self::$billing_fields )
-			foreach ( self::$shipping_fields as $key => $field )
+			foreach ( self::$billing_fields as $key => $field )
 				update_post_meta( $post_id, '_billing_' . $key, wc_clean( $_POST[ '_billing_' . $key ] ) );
 
 		if ( self::$shipping_fields )


### PR DESCRIPTION
Some Billing Details will not save if updated from the admin metabox because its taking the keys from the shipping fields.  If a billing field exists where a shipping one does not, the value does not save (ex: email address).
