### PR TITLE
Notice fix and Checkout Shipping Method classes

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -549,6 +549,7 @@ abstract class WC_Settings_API {
 			'title'             => '',
 			'disabled'          => false,
 			'class'             => '',
+			'css'               => '',
 			'placeholder'       => '',
 			'type'              => 'text',
 			'desc_tip'          => false,

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -25,11 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 				$method = current( $available_methods );
 
 				echo wp_kses_post( wc_cart_totals_shipping_method_label( $method ) ); ?>
-				<input type="hidden" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" value="<?php echo esc_attr( $method->id ); ?>" />
+				<input type="hidden" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" value="<?php echo esc_attr( $method->id ); ?>" class="shipping_method" />
 
 			<?php elseif ( get_option('woocommerce_shipping_method_format') == 'select' ) : ?>
 
-				<select name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>">
+				<select name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" class="shipping_method">
 					<?php foreach ( $available_methods as $method ) : ?>
 						<option value="<?php echo esc_attr( $method->id ); ?>" <?php selected( $method->id, $chosen_method ); ?>><?php echo wp_kses_post( wc_cart_totals_shipping_method_label( $method ) ); ?></option>
 					<?php endforeach; ?>
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 				<ul id="shipping_method">
 					<?php foreach ( $available_methods as $method ) : ?>
 						<li>
-							<input type="radio" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>" value="<?php echo esc_attr( $method->id ); ?>" <?php checked( $method->id, $chosen_method ); ?> />
+							<input type="radio" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>" value="<?php echo esc_attr( $method->id ); ?>" <?php checked( $method->id, $chosen_method ); ?> class="shipping_method" />
 							<label for="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>"><?php echo wp_kses_post( wc_cart_totals_shipping_method_label( $method ) ); ?></label>
 						</li>
 					<?php endforeach; ?>


### PR DESCRIPTION
Two minor tweaks:
- Fixes an admin notice for missing default 'css' argument
- Adds a single class to the checkout shipping method elements for convenience in collecting all of them via CSS selector
