### PR TITLE
Registration error handler and my_account_message hook

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -655,7 +655,7 @@ class WC_Form_Handler {
 
 			try {
 				$creds  = array();
-				
+
 				$validation_error = new WP_Error();
 				$validation_error = apply_filters( 'woocommerce_process_login_errors', $validation_error, $_POST['username'], $_POST['password'] );
 
@@ -778,10 +778,17 @@ class WC_Form_Handler {
 
 			WC()->verify_nonce( 'register' );
 
+			$validation_error = new WP_Error();
+			$validation_error = apply_filters( 'woocommerce_process_registration_errors', $validation_error, $_POST['username'], $_POST['password'], $_POST['email'] );
+
+			if ( $validation_error->get_error_code() ) {
+				throw new Exception( '<strong>' . __( 'Error', 'woocommerce' ) . ':</strong> ' . $validation_error->get_error_message() );
+			}
+
 			$username   = ! empty( $_POST['username'] ) ? wc_clean( $_POST['username'] ) : '';
 			$email      = ! empty( $_POST['email'] ) ? wc_clean( $_POST['email'] ) : '';
 			$password   = ! empty( $_POST['password'] ) ? wc_clean( $_POST['password'] ) : '';
-			
+
 			// Anti-spam trap
 			if ( ! empty( $_POST['email_2'] ) ) {
 				wc_add_notice( '<strong>' . __( 'ERROR', 'woocommerce' ) . '</strong>: ' . __( 'Anti-spam field was filled in.', 'woocommerce' ), 'error' );

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -34,7 +34,7 @@ class WC_Shortcode_My_Account {
 
 		if ( ! is_user_logged_in() ) {
 
-			$message = apply_filters( 'login_message', '' );
+			$message = apply_filters( 'my_account_message', '' );
 
 			if ( ! empty( $message ) )
 


### PR DESCRIPTION
To block registration spam, and authenticate the $_POST values, a
woocommerce_process_registration_errors filter hook is needed.

WordPress has a login_message filter, which causes a duplicate message
on the My Account login page since WC uses the same filter hook name. A
different filter hook name, such as my_account_message, would eliminate
this issue.
