### PR TITLE
correct address_formats in Japan

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -617,7 +617,7 @@ class WC_Countries {
 				'HU' => "{name}\n{company}\n{city}\n{address_1}\n{address_2}\n{postcode}\n{country}",
 				'IS' => $postcode_before_city,
 				'IT' => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city} {state_upper}\n{country}",
-				'JP' => "{postcode}\n{state}{city}{address_2}\n{address_1}\n{company}\n{name}\n {country}",
+				'JP' => "{postcode}\n{state}{city}{address_2}\n{address_1}\n{company}\n{last_name} {first_name}\n {country}",
 				'LI' => $postcode_before_city,
 				'NL' => $postcode_before_city,
 				'NZ' => "{name}\n{company}\n{address_1}\n{address_2}\n{city} {postcode}\n{country}",


### PR DESCRIPTION
in Japan ,the name order is last (family) name to first name.
