### PR TITLE
Preserve existing loop when altering main loop

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -126,6 +126,8 @@ class WC_Shortcodes {
 	 */
 	public static function product_category( $atts ) {
 		global $woocommerce_loop;
+		
+		$existing_loop = $woocommerce_loop;
 
 		if ( empty( $atts ) ) return '';
 
@@ -192,6 +194,9 @@ class WC_Shortcodes {
 		<?php endif;
 
 		wp_reset_postdata();
+		
+		//using woocommerce_reset_loop() here doesn't work.
+		$woocommerce_loop = $existing_loop;
 
 		return '<div class="woocommerce columns-' . $columns . '">' . ob_get_clean() . '</div>';
 	}


### PR DESCRIPTION
I came across a scenario where I was using the `product_category` shortcode on the Shop page content to display categories at the top of the shop page - like products from a featured category.

I noticed that setting the `columns` attribute in the shortcode affected not only the shortcode's loop, but the main loop further down the page.

I'm not sure that using such a method as I have here is best, but I wanted to bring this up so that it can be addressed. I'd assume that this issue exists in other instances where the main `$woocommerce_loop` is altered.

I did notice that `woocommerce_reset_loop()` is used in other scenarios to "_Reset the loop's index and columns when we're done outputting a product loop_" (from the comments of that function). I attempted to use that function at the end of the `product_category()` function before it returned. However, it did not have the desired effect.
