### PR TITLE
Rename new woocommerce_order_item_quantity filter

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -163,7 +163,7 @@ class WC_Product {
 		if ( $this->managing_stock() ) {
 
 			// Update stock amount
-			$this->stock = intval( $amount );
+			$this->stock = apply_filters( 'woocommerce_stock_amount', $amount );
 
 			// Update meta
 			update_post_meta( $this->id, '_stock', $this->stock );
@@ -924,7 +924,7 @@ class WC_Product {
 
 	/**
 	 * Functions for getting parts of a price, in html, used by get_price_html.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_price_html_from_text() {

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -50,7 +50,7 @@ $order = new WC_Order( $order_id );
 							else
 								echo apply_filters( 'woocommerce_order_item_name', sprintf( '<a href="%s">%s</a>', get_permalink( $item['product_id'] ), $item['name'] ), $item );
 
-							echo apply_filters( 'woocommerce_order_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
+							echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
 
 							$item_meta->display();
 


### PR DESCRIPTION
Renaming to avoid clash with pre-existing filter of the same name:
https://github.com/woothemes/woocommerce/blob/cdb1ad5e9ebcc440a459690ebf6862c374b01dbf/includes/class-wc-order.php#L1470
