### PR TITLE
Fix parse error

### DIFF
--- a/includes/abstracts/abstract-wc-email.php
+++ b/includes/abstracts/abstract-wc-email.php
@@ -90,7 +90,7 @@ abstract class WC_Email extends WC_Settings_API {
         '/&(bull|#149|#8226);/i',                // Bullet
         '/&(pound|#163);/i',                     // Pound sign
         '/&(euro|#8364);/i',                     // Euro sign
-        '/&#36;/'                                // Dollar sign
+        '/&#36;/',                               // Dollar sign
         '/&[^&;]+;/i',                           // Unknown/unhandled entities
         '/[ ]{2,}/'                              // Runs of spaces, post-handling
     );


### PR DESCRIPTION
Full error: 

```
PHP Parse error:  syntax error, unexpected ''/&[^&;]+;/i'' (T_CONSTANT_ENCAPSED_STRING), expecting ')' in /wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-email.php on line 94
```
