### PR TITLE
Added wc_print_notices() to form-pay.php

### DIFF
--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -10,6 +10,8 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 global $woocommerce;
+
+wc_print_notices();
 ?>
 <form id="order_review" method="post">
 


### PR DESCRIPTION
Added wc_print_notices() to form-pay.php so that extensions can introduce messages or errors into the pay page when necessary. This helps when the payment flow needs to be interrupted and prevented before payment is actually processed ( similar to the flow of the checkout page ). 
