### PR TITLE
Add is_store_notice_showing Conditional

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -189,6 +189,19 @@ if ( ! function_exists( 'is_ajax' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_store_notice_showing' ) ) {
+
+	/**
+	 * is_store_notice_showing - Returns true when store notice is active.
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	function is_store_notice_showing() {
+		return get_option( 'woocommerce_demo_store' ) !== 'no' ? true : false;
+	}
+}
+
 if ( ! function_exists( 'is_filtered' ) ) {
 
 	/**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -158,7 +158,7 @@ function wc_body_class( $classes ) {
 		$classes[] = 'woocommerce-page';
 	}
 
-	if ( get_option( 'woocommerce_demo_store' ) != 'no' ) {
+	if ( is_store_notice_showing() ) {
 		$classes[] = 'woocommerce-demo-store';
 	}
 
@@ -342,7 +342,7 @@ if ( ! function_exists( 'woocommerce_demo_store' ) ) {
 	 * @return void
 	 */
 	function woocommerce_demo_store() {
-		if ( get_option( 'woocommerce_demo_store' ) == 'no' )
+		if ( !is_store_notice_showing() )
 			return;
 
 		$notice = get_option( 'woocommerce_demo_store_notice' );

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Feature - Option to install missing WooCommerce pages from tools page.
 * Feature - New notices API for adding errors/notices
 * Feature - Compatible with WordPress 3.8 default theme 'TwentyFourteen'.
+* Feature - Added is_store_notice_showing conditional.
 * Tweak - Added pagination to tax rate screens.
 * Tweak - Added filter to check the 'Create account' checkbox on checkout by default.
 * Tweak - Update CPT parameters for 'product_variation' and 'shop_coupon' to be no longer public.


### PR DESCRIPTION
- Added public is_store_notice_showing conditional to `includes/wc-conditional-functions.php`
- Replaced two instances of  `get_option( 'woocommerce_demo_store' )` with the new conditional
