### PR TITLE
fixed: 'PHP Fatal error:  Internal Zend error - Missing class informatio...

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -97,7 +97,7 @@ class WC_Install {
 		$this->create_roles();
 
 		// Register post types
-		$post_types = include( 'class-wc-post-types.php' );
+		$post_types = new WC_Post_types();
 		$post_types->register_taxonomies();
 
 		$this->create_terms();

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -13,7 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * @category	Class
  * @author 		WooThemes
  */
-if ( ! class_exists( 'WC_Post_types' ) ) :
 
 class WC_Post_types {
 
@@ -362,7 +361,5 @@ class WC_Post_types {
 			);
 	}
 }
-
-endif;
 
 return new WC_Post_types();


### PR DESCRIPTION
...n for  in /var/www/wp-woo/wp-content/plugins/woocommerce/includes/class-wc-post-types.php on line 18'
