### PR TITLE
Cart coupon filters

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -197,7 +197,9 @@ function wc_cart_totals_coupon_html( $coupon ) {
 	if ( $coupon->enable_free_shipping() )
 		$value[] = __( 'Free shipping coupon', 'woocommerce' );
 
-	echo implode( ', ', $value ) . ' <a href="' . add_query_arg( 'remove_coupon', $coupon->code, WC()->cart->get_cart_url() ) . '" class="woocommerce-remove-coupon">' . __( '[Remove]', 'woocommerce' ) . '</a>';
+	$value = implode( ', ', $value ) . ' <a href="' . add_query_arg( 'remove_coupon', $coupon->code, WC()->cart->get_cart_url() ) . '" class="woocommerce-remove-coupon">' . __( '[Remove]', 'woocommerce' ) . '</a>';
+
+	echo apply_filters( 'woocommerce_cart_totals_coupon_html', $value, $coupon );
 }
 
 /**

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -186,8 +186,13 @@ function wc_cart_totals_coupon_html( $coupon ) {
 
 	$value  = array();
 
-	if ( ! empty( WC()->cart->coupon_discount_amounts[ $coupon->code ] ) )
-		$value[] = '-' . wc_price( WC()->cart->coupon_discount_amounts[ $coupon->code ] );
+	if ( ! empty( WC()->cart->coupon_discount_amounts[ $coupon->code ] ) ) {
+		$discount_html = '-' . wc_price( WC()->cart->coupon_discount_amounts[ $coupon->code ] );
+	} else {
+		$discount_html = '';
+	}
+
+	$value[] = apply_filters( 'woocommerce_coupon_discount_amount_html', $discount_html, $coupon );
 
 	if ( $coupon->enable_free_shipping() )
 		$value[] = __( 'Free shipping coupon', 'woocommerce' );


### PR DESCRIPTION
At the moment, it's impossible for an extension to display a coupon amount that is not stored in `WC()->cart->coupon_discount_amounts` because there is no way to hook into `wc_cart_totals_coupon_html()`.

This can cause problems. For example, when purchasing a subscription, discounts for the recurring total are stored in `WC()->cart->recurring_coupon_discount_amounts` not in `WC()->cart->coupon_discount_amounts` (to ensure totals are calculated correctly).

This patch adds two new filters which plugin devs can use to hook into `wc_cart_totals_coupon_html()`.

Two filters are added because:
1. adding just `woocommerce_cart_totals_coupon_html` would require either duplicating much of the `wc_cart_totals_coupon_html()` function's code or some regex madness just to change the coupon amount being displayed (as the entire discount string, including "[Remove]" link is passed through it)
2. adding just `woocommerce_coupon_discount_amount_html` would mean _only_ the discount amount could be changed, but while I was here, I figured I'd make it possible for plugin devs to change the "Free shipping coupon" string, the "[Remove]" link and anything else.
