### PR TITLE
Minor fix to stop warnings in HHVM

### DIFF
--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -33,8 +33,10 @@ class WC_Product_Factory {
 		if ( ! $the_product )
 			return false;
 
-		$product_id = absint( $the_product->ID );
-		$post_type  = $the_product->post_type;
+		if ( is_object ( $the_product ) ) {
+			$product_id = absint( $the_product->ID );
+			$post_type  = $the_product->post_type;
+		}
 
 		if ( in_array( $post_type, array( 'product', 'product_variation' ) ) ) {
 			if ( isset( $args['product_type'] ) ) {


### PR DESCRIPTION
HHVM is a bit weird and will throw these warnings otherwise:

HipHop Warning: Cannot access property on non-object in /home/_____/public_html/wp-content/plugins/woocommerce/classes/class-wc-product-factory.php on line 36
HipHop Warning: Cannot access property on non-object in /home/_____/public_html/wp-content/plugins/woocommerce/classes/class-wc-product-factory.php on line 37

(HHVM is a JIT-compiled PHP interpreter created by Facebook.  In production, I've found that my pages are generated roughly 60% faster simply by switching.  https://github.com/facebook/hhvm/)
