### PR TITLE
Add Naira Currency and Symbol to Woocommerce

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -163,6 +163,7 @@ function get_woocommerce_currencies() {
 				'KRW' => __( 'South Korean Won', 'woocommerce' ),
 				'MYR' => __( 'Malaysian Ringgits', 'woocommerce' ),
 				'MXN' => __( 'Mexican Peso', 'woocommerce' ),
+				'NGN' => __( 'Nigerian Naira', 'woocommerce' ),
 				'NOK' => __( 'Norwegian Krone', 'woocommerce' ),
 				'NZD' => __( 'New Zealand Dollar', 'woocommerce' ),
 				'PHP' => __( 'Philippine Pesos', 'woocommerce' ),
@@ -241,6 +242,7 @@ function get_woocommerce_currency_symbol( $currency = '' ) {
 		case 'GBP' : $currency_symbol = '&pound;'; break;
 		case 'RON' : $currency_symbol = 'lei'; break;
 		case 'VND' : $currency_symbol = '&#8363;'; break;
+		case 'NGN' : $currency_symbol = '&#8358;'; break;
 		default    : $currency_symbol = ''; break;
 	}
 


### PR DESCRIPTION
Naira is the official currency for Nigeria. A lot of Nigeria businesses are using Woocommerce to power their eCommerce sites.
This pull request add the Naira Sign and Symbol to Woocommerce.
