### PR TITLE
Remove esc_url_raw to allow for using of amazon s3 and other shortcodes

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -1262,7 +1262,7 @@ class WC_Meta_Box_Product_Data {
 				$files = array();
 
 				$file_names    = isset( $_POST['_wc_file_names'] ) ? array_map( 'wc_clean', $_POST['_wc_file_names'] ) : array();
-				$file_urls     = isset( $_POST['_wc_file_urls'] ) ? array_map( 'trim', $_POST['_wc_file_urls'] ) : array();
+				$file_urls     = isset( $_POST['_wc_file_urls'] ) ? array_map( 'wc_clean', $_POST['_wc_file_urls'] ) : array();
 				$file_url_size = sizeof( $file_urls );
 
 				for ( $i = 0; $i < $file_url_size; $i ++ ) {

--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -1262,7 +1262,7 @@ class WC_Meta_Box_Product_Data {
 				$files = array();
 
 				$file_names    = isset( $_POST['_wc_file_names'] ) ? array_map( 'wc_clean', $_POST['_wc_file_names'] ) : array();
-				$file_urls     = isset( $_POST['_wc_file_urls'] ) ? array_map( 'esc_url_raw', array_map( 'trim', $_POST['_wc_file_urls'] ) ) : array();
+				$file_urls     = isset( $_POST['_wc_file_urls'] ) ? array_map( 'trim', $_POST['_wc_file_urls'] ) : array();
 				$file_url_size = sizeof( $file_urls );
 
 				for ( $i = 0; $i < $file_url_size; $i ++ ) {


### PR DESCRIPTION
Remove the esc_url_raw map to allow using shortcodes in the file url field, the amazon s3 extension uses shortcodes for resolving file urls.
