### PR TITLE
Moved woocommerce_round_tax_total() to Formatting

### DIFF
--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -28,8 +28,8 @@ class WC_Admin_Reports {
 	public function output() {
 		$reports        = $this->get_reports();
 		$first_tab      = array_keys( $reports );
-		$current_tab    = ! empty( $_GET['tab'] ) ? sanitize_title( urldecode( $_GET['tab'] ) ) : $first_tab[0];
-		$current_report = isset( $_GET['report'] ) ? sanitize_title( urldecode( $_GET['report'] ) ) : current( array_keys( $reports[ $current_tab ]['reports'] ) );
+		$current_tab    = ! empty( $_GET['tab'] ) ? sanitize_title( $_GET['tab'] ) : $first_tab[0];
+		$current_report = isset( $_GET['report'] ) ? sanitize_title( $_GET['report'] ) : current( array_keys( $reports[ $current_tab ]['reports'] ) );
 
 		include_once( 'reports/class-wc-admin-report.php' );
 		include_once( 'views/html-admin-page-reports.php' );

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -125,8 +125,8 @@ class WC_Admin_Settings {
 		self::get_settings_pages();
 
 		// Get current tab/section
-		$current_tab     = empty( $_GET['tab'] ) ? 'general' : sanitize_text_field( urldecode( $_GET['tab'] ) );
-		$current_section = empty( $_REQUEST['section'] ) ? '' : sanitize_text_field( urldecode( $_REQUEST['section'] ) );
+		$current_tab     = empty( $_GET['tab'] ) ? 'general' : sanitize_text_field( $_GET['tab'] );
+		$current_section = empty( $_REQUEST['section'] ) ? '' : sanitize_text_field( $_REQUEST['section'] );
 
 	    // Save settings if data has been posted
 	    if ( ! empty( $_POST ) )
@@ -134,10 +134,10 @@ class WC_Admin_Settings {
 
 	    // Add any posted messages
 	    if ( ! empty( $_GET['wc_error'] ) )
-	    	self::add_error( urldecode( stripslashes( $_GET['wc_error'] ) ) );
+	    	self::add_error( stripslashes( $_GET['wc_error'] ) );
 
 	     if ( ! empty( $_GET['wc_message'] ) )
-	    	self::add_message( urldecode( stripslashes( $_GET['wc_message'] ) ) );
+	    	self::add_message( stripslashes( $_GET['wc_message'] ) );
 
 	    self::show_messages();
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -57,7 +57,7 @@ class WC_AJAX {
 			'term_ordering'                       				=> false,
 			'product_ordering'                    				=> false
 		);
-		
+
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
 			add_action( 'wp_ajax_woocommerce_' . $ajax_event, array( $this, $ajax_event ) );
 
@@ -78,7 +78,7 @@ class WC_AJAX {
 	 * Get a refreshed cart fragment
 	 */
 	public function get_refreshed_fragments() {
-		
+
 		$this->json_headers();
 
 		// Get mini cart
@@ -252,7 +252,7 @@ class WC_AJAX {
 	 * Process ajax checkout form
 	 */
 	public function checkout() {
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) 
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) )
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 
 		$woocommerce_checkout = WC()->checkout();
@@ -265,10 +265,10 @@ class WC_AJAX {
 	 * Feature a product from admin
 	 */
 	public function feature_product() {
-		if ( ! current_user_can('edit_products') ) 
+		if ( ! current_user_can('edit_products') )
 			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ) );
 
-		if ( ! check_admin_referer('woocommerce-feature-product')) 
+		if ( ! check_admin_referer('woocommerce-feature-product'))
 			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ) );
 
 		$post_id = isset( $_GET['product_id'] ) && (int) $_GET['product_id'] ? (int) $_GET['product_id'] : '';
@@ -1306,7 +1306,7 @@ class WC_AJAX {
 
 		$this->json_headers();
 
-		$term = (string) wc_clean( urldecode( stripslashes( $_GET['term'] ) ) );
+		$term = (string) wc_clean( stripslashes( $_GET['term'] ) );
 
 		if (empty($term)) die();
 
@@ -1409,7 +1409,7 @@ class WC_AJAX {
 
 		$this->json_headers();
 
-		$term = wc_clean( urldecode( stripslashes( $_GET['term'] ) ) );
+		$term = wc_clean( stripslashes( $_GET['term'] ) );
 
 		if ( empty( $term ) )
 			die();
@@ -1449,7 +1449,7 @@ class WC_AJAX {
 	 * @see WC_AJAX::json_search_products()
 	 */
 	public function json_search_downloadable_products_and_variations() {
-		$term = (string) wc_clean( urldecode( stripslashes( $_GET['term'] ) ) );
+		$term = (string) wc_clean( stripslashes( $_GET['term'] ) );
 
 		$args = array(
 			'post_type' 		=> array( 'product', 'product_variation' ),
@@ -1484,7 +1484,7 @@ class WC_AJAX {
 	public function json_search_customer_name( $query ) {
 		global $wpdb;
 
-		$term = wc_clean( urldecode( stripslashes( $_GET['term'] ) ) );
+		$term = wc_clean( stripslashes( $_GET['term'] ) );
 
 		$query->query_from  .= " LEFT JOIN {$wpdb->usermeta} as meta2 ON ({$wpdb->users}.ID = meta2.user_id) ";
 		$query->query_from  .= " LEFT JOIN {$wpdb->usermeta} as meta3 ON ({$wpdb->users}.ID = meta3.user_id) ";

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -27,10 +27,10 @@ class WC_Download_Handler {
 
 			global $wpdb;
 
-			$product_id           = (int) urldecode($_GET['download_file']);
-			$order_key            = urldecode( $_GET['order'] );
-			$email                = sanitize_email( str_replace( ' ', '+', urldecode( $_GET['email'] ) ) );
-			$download_id          = isset( $_GET['key'] ) ? preg_replace( '/\s+/', ' ', urldecode( $_GET['key'] ) ) : '';
+			$product_id           = (int) $_GET['download_file'];
+			$order_key            = $_GET['order'];
+			$email                = sanitize_email( str_replace( ' ', '+', $_GET['email'] ) );
+			$download_id          = isset( $_GET['key'] ) ? preg_replace( '/\s+/', ' ', $_GET['key'] ) : '';
 			$_product             = get_product( $product_id );
 
 			if ( ! is_email( $email) )

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -227,7 +227,7 @@ class WC_Form_Handler {
 			ob_start();
 
 			// Pay for existing order
-			$order_key 	= urldecode( $_GET['key'] );
+			$order_key 	= $_GET['key'];
 			$order_id 	= absint( $wp->query_vars['order-pay'] );
 			$order 		= new WC_Order( $order_id );
 
@@ -465,12 +465,12 @@ class WC_Form_Handler {
 	public function cancel_order() {
 		if ( isset( $_GET['cancel_order'] ) && isset( $_GET['order'] ) && isset( $_GET['order_id'] ) ) {
 
-			$order_key        = urldecode( $_GET['order'] );
+			$order_key        = $_GET['order'];
 			$order_id         = absint( $_GET['order_id'] );
 			$order            = new WC_Order( $order_id );
 			$user_can_cancel  = current_user_can( 'cancel_order', $order_id );
 			$order_can_cancel = in_array( $order->status, apply_filters( 'woocommerce_valid_order_statuses_for_cancel', array( 'pending', 'failed' ) ) );
-			$redirect         = urldecode( $_GET['redirect'] );
+			$redirect         = $_GET['redirect'];
 
 			if ( $user_can_cancel && $order_can_cancel && $order->id == $order_id && $order->order_key == $order_key && wp_verify_nonce( $_GET['_wpnonce'], 'woocommerce-cancel_order' ) ) {
 

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -89,7 +89,7 @@ class WC_Query {
 	 * Get any errors from querystring
 	 */
 	public function get_errors() {
-		if ( ! empty( $_GET['wc_error'] ) && ( $error = sanitize_text_field( urldecode( $_GET['wc_error'] ) ) ) && ! wc_has_notice( $error, 'error' ) )
+		if ( ! empty( $_GET['wc_error'] ) && ( $error = sanitize_text_field( $_GET['wc_error'] ) ) && ! wc_has_notice( $error, 'error' ) )
 			wc_add_notice( $error, 'error' );
 	}
 

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -78,7 +78,7 @@ class WC_Shortcode_Checkout {
 		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) && $order_id ) {
 
 			// Pay for existing order
-			$order_key            = urldecode( $_GET[ 'key' ] );
+			$order_key            = $_GET[ 'key' ];
 			$order                = new WC_Order( $order_id );
 			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -69,7 +69,7 @@ function wc_get_template_part( $slug, $name = '' ) {
 
 	// Allow 3rd party plugin filter template file from their plugin
 	$template = apply_filters( 'wc_get_template_part', $template, $slug, $name );
-	
+
 	if ( $template )
 		load_template( $template, false );
 }
@@ -315,7 +315,7 @@ function wc_print_js() {
 
 	if ( ! empty( $wc_queued_js ) ) {
 
-		echo "<!-- WooCommerce JavaScript-->\n<script type=\"text/javascript\">\njQuery(document).ready(function($) {";
+		echo "<!-- WooCommerce JavaScript -->\n<script type=\"text/javascript\">\njQuery(function($) {";
 
 		// Sanitize
 		$wc_queued_js = wp_check_invalid_utf8( $wc_queued_js );

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -175,9 +175,6 @@ function woocommerce_get_weight( $weight, $to_unit ) {
 function woocommerce_trim_zeros( $price ) {
 	return wc_trim_zeros( $price );
 }
-function woocommerce_round_tax_total( $tax ) {
-	return wc_round_tax_total( $tax );
-}
 function woocommerce_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	return wc_format_decimal( $number, $dp, $trim_zeros );
 }

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -154,6 +154,17 @@ function wc_trim_zeros( $price ) {
 }
 
 /**
+ * Alias of wc_round_tax_total()
+ *
+ * @access public
+ * @param  mixed $price
+ * @return string
+ */
+function woocommerce_round_tax_total( $tax ) {
+	return wc_round_tax_total( $tax );
+}
+
+/**
  * Round a tax amount
  *
  * @access public


### PR DESCRIPTION
woocommerce_round_tax_total() is not actually a deprecated function. In
WC 2.0, the round() method was used from the WC_Tax class.

Moved woocommerce_round_tax_total() from wc-deprecated-functions.php to
wc-formatting-functions.php.
