### PR TITLE
Added check that product has been requested in WC_Query.product_query.

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -335,6 +335,10 @@ class WC_Query {
 	 */
 	public function product_query( $q ) {
 
+		// Check that product post type has been requested
+		if ( $q->get( 'post_type' ) != 'product' )
+    		return;
+
 		// Meta query
 		$meta_query = $this->get_meta_query( $q->get( 'meta_query' ) );
 


### PR DESCRIPTION
When requesting taxonomy term archive for your custom post type and that
taxonomy is shared with product post type, post_type query variable gets
rewritten.
