### PR TITLE
Filter to allow modification of wp_editor settings for product short description

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-short-description.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-short-description.php
@@ -31,7 +31,7 @@ class WC_Meta_Box_Product_Short_Description {
 			'editor_css'	=> '<style>#wp-excerpt-editor-container .wp-editor-area{height:175px; width:100%;}</style>'
 		);
 
-		wp_editor( htmlspecialchars_decode( $post->post_excerpt ), 'excerpt', $settings );
+		wp_editor( htmlspecialchars_decode( $post->post_excerpt ), 'excerpt', apply_filters( 'woocommerce_product_short_description_editor_settings', $settings ) );
 	}
 
 }


### PR DESCRIPTION
To make things simpler for my client (and to reduce the risk of them making a mess of the carefully crafter product archive pages on the front end of their site) I wanted to remove the "Add Media" button from above the TinyMCE editor in the Product Short Description meta box.

I was debating whether to just make a pull request to simply remove the media buttons y default, but though some people might actually have good reasons to place images and stuff within their short descriptions. So I decided to make this filterable. See example use case below:

``` php
add_filter( 'woocommerce_product_short_description_editor_settings', 'remove_short_desc_media_buttons' );
function remove_short_desc_media_buttons( $settings ) {
    $settings[ 'media_buttons' ] = false;
    return $settings;
}
```

Don't know if you agree with the name I've given to the filter? Maybe it's a bit long, but at least it's descriptive! Feel free to change it if you prefer something shorter.
