### PR TITLE
Add 'woocommerce_product_added_to_cart' 

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -574,6 +574,7 @@ class WC_Form_Handler {
 
 	        	if ( $passed_validation ) {
 					if ( WC()->cart->add_to_cart( $product_id, $quantity, $variation_id, $variations ) ) {
+						do_action( 'woocommerce_product_added_to_cart', $product_id );
 						wc_add_to_cart_message( $product_id );
 						$was_added_to_cart = true;
 						$added_to_cart[] = $product_id;


### PR DESCRIPTION
Add 'woocommerce_product_added_to_cart'  action in form add after validation. Simliar to 'woocommerce_ajax_added_to_cart'

This will allow plugins to hook in after a product has been added to the cart.  
