### PR TITLE
Enhancing nocache helper

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -76,6 +76,12 @@ class WC_Cache_Helper {
 		if ( ! defined( 'DONOTCACHEPAGE' ) )
 			define( "DONOTCACHEPAGE", "true" );
 
+		if ( ! defined( 'DONOTCACHEOBJECT' ) )
+			define( "DONOTCACHEOBJECT", "true" );
+
+		if ( ! defined( 'DONOTCACHEDB' ) )
+			define( "DONOTCACHEDB", "true" );
+
 		nocache_headers();
 	}
 


### PR DESCRIPTION
This pull request extends the `nocache` helper method to also support `DONOTCACHEOBJECT` and `DONOTCACHEDB`. This will ensure that the page is not cached in any way when used with plugins like W3 Total Cache or WP Super Cache.

The reason for this pull request is that if you enable Object Caching on plugins like W3 Total Cache or WP Super Cache the WooCommerce pages that should not be cached are still cached - resulting in strange behavior.

I'd previously opened https://github.com/woothemes/woocommerce/issues/4588, which I can close if the pull request is more helpful.

Thanks!
