### PR TITLE
Add some hooks for the different product tabs

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -329,6 +329,8 @@ class WC_Meta_Box_Product_Data {
 
 				echo '</div>';
 
+				do_action( 'woocommerce_product_inventory_options' );
+
 				?>
 
 			</div>
@@ -380,6 +382,7 @@ class WC_Meta_Box_Product_Data {
 					do_action( 'woocommerce_product_options_shipping' );
 
 				echo '</div>';
+				do_action( 'woocommerce_product_shipping_options' );
 				?>
 
 			</div>
@@ -577,6 +580,7 @@ class WC_Meta_Box_Product_Data {
 
 					<button type="button" class="button save_attributes"><?php _e( 'Save attributes', 'woocommerce' ); ?></button>
 				</p>
+				<?php do_action( 'woocommerce_product_attribute_options' ); ?>
 			</div>
 			<div id="linked_product_data" class="panel woocommerce_options_panel">
 
@@ -694,6 +698,7 @@ class WC_Meta_Box_Product_Data {
 					do_action( 'woocommerce_product_options_reviews' );
 
 				echo '</div>';
+				do_action( 'woocommerce_product_advanced_options' );
 				?>
 
 			</div>


### PR DESCRIPTION
Current there is no hooks for adding something at the end of a product tab, there are hooks in very weird places and to get that to work you need to use a hack to close a div first in your hook, which is not clean. Also the hooks in the inventory tab all falls in a manage stock if statement, making no hooks available if you have manage stock disabled.
