### PR TITLE
Fix rounding bug with pre-tax product % coupon

### DIFF
--- a/classes/class-wc-cart.php
+++ b/classes/class-wc-cart.php
@@ -1073,7 +1073,7 @@ class WC_Cart {
 
 									} elseif ( $coupon->type == 'percent_product' ) {
 
-										$percent_discount = ( $values['data']->get_price() / 100 ) * $coupon->amount;
+										$percent_discount = round( ( $values['data']->get_price() / 100 ) * $coupon->amount, $this->dp );
 
 										if ( $add_totals ) {
 											$this->discount_cart = $this->discount_cart + ( $percent_discount * $values['quantity'] );


### PR DESCRIPTION
When applying a Product % Discount coupon before tax, there is a rounding bug.

Coupon details: http://cl.ly/image/2G35473M0v3P

Example checkout showing rounding bug: http://cl.ly/image/28082b2Q0y2a

This patch rounds the discount before adding it in the same way the discount is rounded for a `'percent'` discount (i.e. cart % discount).
