### PR TITLE
Fix rounding bug with pre-tax product % coupon

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -503,7 +503,6 @@ class WC_Coupon {
 
 		} elseif ( $this->type == 'percent_product' || $this->type == 'percent' ) {
 
-			$discount = ( $discounting_amount / 100 ) * $this->amount;
 			$discount = round( ( $discounting_amount / 100 ) * $this->amount, WC()->cart->dp );
 
 		} elseif ( $this->type == 'fixed_cart' ) {

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -504,6 +504,7 @@ class WC_Coupon {
 		} elseif ( $this->type == 'percent_product' || $this->type == 'percent' ) {
 
 			$discount = ( $discounting_amount / 100 ) * $this->amount;
+			$discount = round( ( $discounting_amount / 100 ) * $this->amount, WC()->cart->dp );
 
 		} elseif ( $this->type == 'fixed_cart' ) {
 			if ( ! is_null( $cart_item ) ) {


### PR DESCRIPTION
Same as #4602 for master branch (i.e. 2.1).
