### PR TITLE
Add user ID to shipping packages

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1298,6 +1298,7 @@ class WC_Cart {
 			$packages[0]['contents']                 = $this->get_cart();		// Items in the package
 			$packages[0]['contents_cost']            = 0;						// Cost of items in the package, set below
 			$packages[0]['applied_coupons']          = $this->applied_coupons;
+			$packages[0]['user']['ID']               = get_current_user_id();
 			$packages[0]['destination']['country']   = WC()->customer->get_shipping_country();
 			$packages[0]['destination']['state']     = WC()->customer->get_shipping_state();
 			$packages[0]['destination']['postcode']  = WC()->customer->get_shipping_postcode();


### PR DESCRIPTION
The attached small patch adds the current user ID to the shipping packages by default. This is useful for shipping plugins that may offer different pricing models for different users (Based on role, customer loyalty etc. etc.).

It does also mean that the shipping cache will be hit less often than currently, but potentially more accurately. 

Note: This can be achieved by filtering the packages via the filter 'woocommerce_cart_shipping_packages' - so I'm not 100% convinced this belongs in WC core - but thought I'd propose it for consideration.
