### PR TITLE
Tax total for fees are already flat and calculated

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1844,7 +1844,7 @@ class WC_Cart {
 
 							// Tax rows - merge the totals we just got
 							foreach ( array_keys( $this->taxes ) as $key ) {
-							    $this->taxes[ $key ] = $fee->tax + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
+								$this->taxes[ $key ] = ( isset( $fee_taxes[ $key ] ) ? $fee_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
 							}
 						}
 					}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1840,7 +1840,6 @@ class WC_Cart {
 						$fee_taxes = $this->tax->calc_tax( $fee->amount, $tax_rates, false );
 						
 						if ( ! empty( $fee_taxes ) ) {
-							$fee->tax = array_sum( $fee_taxes );
 
 							// Tax rows - merge the totals we just got
 							foreach ( array_keys( $this->taxes ) as $key ) {

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1844,7 +1844,7 @@ class WC_Cart {
 
 							// Tax rows - merge the totals we just got
 							foreach ( array_keys( $this->taxes ) as $key ) {
-							    $this->taxes[ $key ] = ( isset( $fee_taxes['taxes'][ $key ] ) ? $fee_taxes['taxes'][ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
+							    $this->taxes[ $key ] = $fee->tax + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
 							}
 						}
 					}


### PR DESCRIPTION
The fee tax was already a float and no longer an array, so flattening it made it calculate wrong. The fee tax totals never got added up to the tax total. This commit fixes that.

Potentially solves #4620 (cc @niklashogefjord)

Small plugin to replicate the issue:

``` php
<?php

/*
Plugin Name: WC Fees API test 
*/

add_action( 'woocommerce_before_calculate_totals', 'wc_fees_api_calculate_totals', 10, 1 );

function wc_fees_api_calculate_totals( $totals ) {
    global $woocommerce;
    $woocommerce->cart->add_fee('test fee', 25, true );
}
```

Can you verify please @mikejolley to see if this fix was really short sighted from my end or actually fixes this issue?
