### PR TITLE
include product_id for extended customization of wc_add_to_cart_message

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -103,7 +103,7 @@ function wc_add_to_cart_message( $product_id ) {
 
 	endif;
 
-	wc_add_notice( apply_filters( 'wc_add_to_cart_message', $message ) );
+	wc_add_notice( apply_filters( 'wc_add_to_cart_message', $message, $product_id ) );
 }
 
 /**


### PR DESCRIPTION
since the `wc_add_to_cart_message` function is itself doing evaluations based on the `$product_id` variable, it makes sense to pass this to the filter aswell
