### PR TITLE
fixes date display on customer list page

### DIFF
--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -171,7 +171,7 @@ class WC_Report_Customer_List extends WP_List_Table {
 				if ( $order_ids ) {
 					$order = new WC_Order( $order_ids[0] );
 
-					echo '<a href="' . admin_url( 'post.php?post=' . $order->id . '&action=edit' ) . '">' . $order->get_order_number() . '</a> &ndash; ' . date_i18n( get_option( 'date_format', strtotime( $order->order_date ) ) );
+					echo '<a href="' . admin_url( 'post.php?post=' . $order->id . '&action=edit' ) . '">' . $order->get_order_number() . '</a> &ndash; ' . date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) );
 				} else echo '-';
 
 			break;


### PR DESCRIPTION
current date was displayed for all customers/order because of misplaced parentheses
