### PR TITLE
Fix completing order payment for an order containing a deleted product

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1303,7 +1303,7 @@ class WC_Order {
 
 						$_product = $this->get_product_from_item( $item );
 
-						if ( ( $_product->is_downloadable() && $_product->is_virtual() ) || ! apply_filters( 'woocommerce_order_item_needs_processing', true, $_product, $this->id ) ) {
+						if ( false !== $_product && ( $_product->is_downloadable() && $_product->is_virtual() ) || ! apply_filters( 'woocommerce_order_item_needs_processing', true, $_product, $this->id ) ) {
 							$order_needs_processing = false;
 							continue;
 						}


### PR DESCRIPTION
When marking payment as complete on an order which contains a product that has
since been deleted, a fatal error will be thrown because the product is assumed
to exist.

The specific error is `PHP Fatal error: Call to a member function is_downloadable()`.
It occurs when checking if the order status should be set as completed or processing,
by determining if the product on the order is downloadable and virtual.

This patch short-circuits the logic to avoid calling member functions on `$_product`
when it is not an object (specifically, when it is `false`, which is the value when the
product has been deleted.)

The order will remain as "processing" if the product has since been deleted.
