### PR TITLE
Fix variation download file url save for Amazon S3 extension.

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -1451,7 +1451,7 @@ class WC_Meta_Box_Product_Data {
 
 					$files         = array();
 					$file_names    = isset( $_POST['_wc_variation_file_names'][ $variation_id ] ) ? array_map( 'wc_clean', $_POST['_wc_variation_file_names'][ $variation_id ] ) : array();
-					$file_urls     = isset( $_POST['_wc_variation_file_urls'][ $variation_id ] ) ? array_map( 'esc_url_raw', array_map( 'trim', $_POST['_wc_variation_file_urls'][ $variation_id ] ) ) : array();
+					$file_urls     = isset( $_POST['_wc_variation_file_urls'][ $variation_id ] ) ? array_map( 'wc_clean', $_POST['_wc_variation_file_urls'][ $variation_id ] ) : array();
 					$file_url_size = sizeof( $file_urls );
 
 					for ( $ii = 0; $ii < $file_url_size; $ii ++ ) {


### PR DESCRIPTION
Currently the variation save uses esc_url_raw, change to wc_clean as normal products to allow use of shortcodes in the path as the Amazon extension uses them.
