### PR TITLE
Only check DOING_AJAX for AJAX requests

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -206,10 +206,7 @@ if ( ! function_exists( 'is_ajax' ) ) {
 	 * @return bool
 	 */
 	function is_ajax() {
-		if ( defined('DOING_AJAX') )
-			return true;
-
-		return ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest' ) ? true : false;
+		return defined( 'DOING_AJAX' );
 	}
 }
 


### PR DESCRIPTION
Not sure why, but some hosts are setting the HTTP_X_REQUESTED_WITH header for seemingly non-ajax requests. Could be MT, could be cloudflare, we don’t know.

I think is ready for the next maintenance release, @mikejolley?
