### PR TITLE
Make custom post types and taxonomies available for widgets.

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -20,8 +20,8 @@ class WC_Post_types {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 5 );
-		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
+		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 0 );
+		add_action( 'init', array( __CLASS__, 'register_post_types' ), 0 );
 	}
 
 	/**


### PR DESCRIPTION
Hi, before 2.1, custom post types and taxonomies were available for widgets since they were registered on init 0 in `Woocommerce->init_taxonomy();` called from `add_action( 'init', array( $this, 'init' ), 0 );`

Since widgets_init action is fired on init 1 (in /wp-includes/default-widgets.php) this was ok.

In 2.1, custom post types and taxonomies are now registered in init 5

```
add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 5 );
add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
```

as a result, they are unavailable for widgets.

You can see this in WC own widgets:
1. edit `woocommerce/includes/widgets/class-wc-widget-products.php`
2 . after
`public function __construct() {`
paste
`var_dump( get_terms( 'product_cat' ) );`
3. load Appearance > Widgets, you'll see an "Invalid taxonomy" error.

This commit solves this issue registering custom post types and taxonomies on 0 making them available for widgets.
