### PR TITLE
Dashboard: Fixes # of "out of stock" products

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -116,7 +116,7 @@ class WC_Admin_Dashboard {
 				AND posts.post_type IN ('product', 'product_variation')
 				AND posts.post_status = 'publish'
 				AND (
-					postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$stock}' AND postmeta.meta_value != ''
+					postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$nostock}' AND postmeta.meta_value != ''
 				)
 				AND (
 					( postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes' ) OR ( posts.post_type = 'product_variation' )


### PR DESCRIPTION
Use woocommerce_notify_no_stock_amount rather than woocommerce_notify_low_stock_amount to count out of stock products
