### PR TITLE
REST API OAuth signature issue fix when using filter params

### DIFF
--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -184,6 +184,15 @@ class WC_API_Authentication {
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );
 		unset( $params['oauth_signature'] );
 
+		// remove filters and convert them from array to strings to void normalize issues
+		if ( isset( $params['filter'] ) ) {
+			$filters = $params['filter'];
+			unset( $params['filter'] );
+			foreach ( $filters as $filter => $filter_value ) {
+				$params['filter[' . $filter . ']'] = $filter_value;
+			}
+		}
+
 		// normalize parameter key/values
 		array_walk( $params, array( $this, 'normalize_parameters' ) );
 


### PR DESCRIPTION
When you do a call using filter[] params it gets converted to arrays as soon as it goes through as GET or POST vars which causes OAuth authentication to not work due to normalization errors.

This converts it back to normal string params to generating the signature.

As discussed https://github.com/kloon/WooCommerce-REST-API-Client-Library/issues/1
