### PR TITLE
Added description parameter to the woocommerce_form_field function

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1551,6 +1551,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		$defaults = array(
 			'type'              => 'text',
 			'label'             => '',
+			'description'       => '',
 			'placeholder'       => '',
 			'maxlength'         => false,
 			'required'          => false,
@@ -1610,6 +1611,9 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<input type="hidden" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" value="' . current( array_keys($countries ) ) . '" ' . implode( ' ', $custom_attributes ) . ' class="country_to_state" />';
 
+				if ( $args['description'] )
+					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
 				$field .= '</p>' . $after;
 
 			} else {
@@ -1626,6 +1630,9 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<noscript><input type="submit" name="woocommerce_checkout_update_totals" value="' . __( 'Update country', 'woocommerce' ) . '" /></noscript>';
 
+				if ( $args['description'] )
+					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
 				$field .= '</p>' . $after;
 
 			}
@@ -1658,6 +1665,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				if ( $args['label'] )
 					$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label'] . $required . '</label>';
 				$field .= '<input type="hidden" class="hidden" name="' . esc_attr( $key )  . '" id="' . esc_attr( $key ) . '" value="" ' . implode( ' ', $custom_attributes ) . ' placeholder="' . esc_attr( $args['placeholder'] ) . '" />';
+				
+				if ( $args['description'] )
+					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
 				$field .= '</p>' . $after;
 
 			} elseif ( is_array( $states ) ) {
@@ -1673,6 +1684,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 					$field .= '<option value="' . esc_attr( $ckey ) . '" '.selected( $value, $ckey, false ) .'>'.__( $cvalue, 'woocommerce' ) .'</option>';
 
 				$field .= '</select>';
+				
+				if ( $args['description'] )
+					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
 				$field .= '</p>' . $after;
 
 			} else {
@@ -1682,6 +1697,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				if ( $args['label'] )
 					$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required . '</label>';
 				$field .= '<input type="text" class="input-text ' . implode( ' ', $args['input_class'] ) .'" value="' . esc_attr( $value ) . '"  placeholder="' . esc_attr( $args['placeholder'] ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+				
+				if ( $args['description'] )
+					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
 				$field .= '</p>' . $after;
 
 			}
@@ -1694,16 +1713,24 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			if ( $args['label'] )
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required  . '</label>';
 
-			$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text ' . implode( ' ', $args['input_class'] ) .'" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>
-				</p>' . $after;
+			$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text ' . implode( ' ', $args['input_class'] ) .'" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>';
+				
+			if ( $args['description'] )
+				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+			
+			$field .= '</p>' . $after;
 
 			break;
 		case "checkbox" :
 
 			$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $key ) . '_field">
 					<input type="' . esc_attr( $args['type'] ) . '" class="input-checkbox" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" value="1" '.checked( $value, 1, false ) .' />
-					<label for="' . esc_attr( $key ) . '" class="checkbox ' . implode( ' ', $args['label_class'] ) .'" ' . implode( ' ', $custom_attributes ) . '>' . $args['label'] . $required . '</label>
-				</p>' . $after;
+					<label for="' . esc_attr( $key ) . '" class="checkbox ' . implode( ' ', $args['label_class'] ) .'" ' . implode( ' ', $custom_attributes ) . '>' . $args['label'] . $required . '</label>';
+			
+			if ( $args['description'] )
+				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
+			$field .= '</p>' . $after;
 
 			break;
 		case "password" :
@@ -1713,8 +1740,12 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			if ( $args['label'] )
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required . '</label>';
 
-			$field .= '<input type="password" class="input-text ' . implode( ' ', $args['input_class'] ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />
-				</p>' . $after;
+			$field .= '<input type="password" class="input-text ' . implode( ' ', $args['input_class'] ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+			
+			if ( $args['description'] )
+				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
+			$field .= '</p>' . $after;
 
 			break;
 		case "text" :
@@ -1724,8 +1755,12 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			if ( $args['label'] )
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label'] . $required . '</label>';
 
-			$field .= '<input type="text" class="input-text ' . implode( ' ', $args['input_class'] ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" '.$args['maxlength'].' value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />
-				</p>' . $after;
+			$field .= '<input type="text" class="input-text ' . implode( ' ', $args['input_class'] ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" '.$args['maxlength'].' value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+			
+			if ( $args['description'] )
+				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
+			$field .= '</p>' . $after;
 
 			break;
 		case "select" :
@@ -1743,8 +1778,12 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="select" ' . implode( ' ', $custom_attributes ) . '>
 						' . $options . '
-					</select>
-				</p>' . $after;
+					</select>';
+					
+				if ( $args['description'] )
+					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
+				
+				$field .= '</p>' . $after;
 
 			break;
 		default :


### PR DESCRIPTION
With this it is possible to add a short description below every checkout billing and shipping input field.
A sample screenshot can be seen here.
https://www.evernote.com/shard/s3/sh/c5fe354b-5647-4e6a-ba1f-0ce3346b94e7/ffd95aa5196bf4740338a3ac2aa307db
