### PR TITLE
add filters to $sections in ouput_sections #4816

### DIFF
--- a/includes/admin/settings/class-wc-settings-page.php
+++ b/includes/admin/settings/class-wc-settings-page.php
@@ -53,7 +53,7 @@ class WC_Settings_Page {
 	public function output_sections() {
 		global $current_section;
 
-		$sections = $this->get_sections();
+		$sections = apply_filters( 'woocommerce_sections_' . $this->id . '_array', $this->get_sections() );
 
 		if ( empty( $sections ) )
 			return;


### PR DESCRIPTION
Addresses the issue raised in https://github.com/woothemes/woocommerce/issues/4816 where extending an existing settings page will prevent injecting a section into the page nav
