### PR TITLE
Fix and filter for exclude settings on coupons

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -154,7 +154,7 @@ class WC_Meta_Box_Coupon_Data {
 					<?php
 						$category_ids = (array) get_post_meta( $post->ID, 'exclude_product_categories', true );
 
-						$categories = get_terms( 'product_cat', 'orderby=name&hide_empty=0' );
+						$categories = get_terms( apply_filters( 'woocommerce_coupon_exclude_categories_admin', array( 'product_cat' ) ), 'orderby=name&hide_empty=0' );
 						if ( $categories ) foreach ( $categories as $cat ) {
 							echo '<option value="' . esc_attr( $cat->term_id ) . '"' . selected( in_array( $cat->term_id, $category_ids ), true, false ) . '>' . esc_html( $cat->name ) . '</option>';
 						}

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -374,7 +374,7 @@ class WC_Coupon {
 					$product_ids_on_sale = wc_get_product_ids_on_sale();
 					if ( sizeof( WC()->cart->get_cart() ) > 0 ) {
 						foreach( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-							if ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) || in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale, true ) ) {
+							if ( in_array( $cart_item['product_id'], $product_ids_on_sale ) || in_array( $cart_item['variation_id'], $product_ids_on_sale ) || in_array( $cart_item['data']->get_parent(), $product_ids_on_sale ) ) {
 								$valid_for_cart = false;
 							}
 						}

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -391,7 +391,7 @@ class WC_Coupon {
 					if ( sizeof( WC()->cart->get_cart() ) > 0 ) {
 						foreach( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 
-							$product_cats = wp_get_post_terms( $cart_item['product_id'], 'product_cat', array( "fields" => "ids" ) );
+							$product_cats = wp_get_post_terms( $cart_item['product_id'], apply_filters( 'woocommerce_coupon_exclude_categories', array( 'product_cat' ) ), array( "fields" => "ids" ) );
 
 							if ( sizeof( array_intersect( $product_cats, $this->exclude_product_categories ) ) > 0 )
 								$valid_for_cart = false;


### PR DESCRIPTION
Add filter to use other excluded category(s) in coupons like tax in product brand plugin and fix for exclude sale issue #4825 
