### PR TITLE
Cat image esc_url breaks existing cat images with spaces

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -318,7 +318,7 @@ class WC_Admin_Taxonomies {
 			else
 				$image = wc_placeholder_img_src();
 
-			$columns .= '<img src="' . esc_url( $image ) . '" alt="Thumbnail" class="wp-post-image" height="48" width="48" />';
+			$columns .= '<img src="' . $image . '" alt="Thumbnail" class="wp-post-image" height="48" width="48" />';
 
 		}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1486,7 +1486,7 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 		}
 
 		if ( $image )
-			echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $category->name ) . '" width="' . esc_attr( $dimensions['width'] ) . '" height="' . esc_attr( $dimensions['height'] ) . '" />';
+			echo '<img src="' . $image . '" alt="' . esc_attr( $category->name ) . '" width="' . esc_attr( $dimensions['width'] ) . '" height="' . esc_attr( $dimensions['height'] ) . '" />';
 	}
 }
 


### PR DESCRIPTION
@mikejolley

Just noticed this bug on customer site today that we have upgraded to 2.1 (2.1.2) - After updating from 2.0.20 - any existing category image with a space in the title cannot show see screen shot https://www.dropbox.com/s/igw645s7qlp6vsi/Screenshot%202014-02-17%2018.12.46.png

If the cat image has no space in title it shows.

The issue is cause by escaping the cat image url -
in wc2.0.20
$columns .= '<img src="' . $image . '" alt="Thumbnail" class="wp-post-image" height="48" width="48" />';

in 2.1
$columns .= '<img src="' . esc_url( $image ) . '" alt="Thumbnail" class="wp-post-image" height="48" width="48" />';

That code removes the space and the image cannot show on the front end or in taxonomy=product_cat&post_type=product

The easy fix is to remove esc_url - which we have so our client sites cat images can show - doing that fixes the situation immediately - tried to find another way around it - but no luck.
