### PR TITLE
Add email lookup to customers endpoint, try at #4845

### DIFF
--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -185,7 +185,7 @@ class WC_API_Customers extends WC_API_Resource {
 	/**
 	 * Get the customer for the given email
 	 *
-	 * @since 2.1.3
+	 * @since 2.2
 	 * @param string $email the customer email
 	 * @param string $fields
 	 * @return array

--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -71,7 +71,7 @@ class WC_API_Customers extends WC_API_Resource {
 		);
 
 		# GET /customers/<email>
-		$routes[ $this->base . '/(?P<email>.+)' ] = array(
+		$routes[ $this->base . '/email/(?P<email>.+)' ] = array(
 			array( array( $this, 'get_customer_by_email' ),  WC_API_SERVER::READABLE ),
 		);
 
@@ -190,7 +190,7 @@ class WC_API_Customers extends WC_API_Resource {
 	 * @param string $fields
 	 * @return array
 	 */
-	function get_customer_by_email( $email, $field = null ) {
+	function get_customer_by_email( $email, $fields = null ) {
 
 		if ( is_email( $email ) ) {
 			$customer = get_user_by( 'email', $email );
@@ -201,7 +201,7 @@ class WC_API_Customers extends WC_API_Resource {
 			return new WP_Error( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer Email', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		return $this->get_customer( $customer->ID, $field );
+		return $this->get_customer( $customer->ID, $fields );
 	}
 
 	/**

--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -475,6 +475,8 @@ class WC_API_Customers extends WC_API_Resource {
 	 */
 	protected function validate_request( $id, $type, $context ) {
 
+		$id = absint( $id );
+
 		// validate ID
 		if ( empty( $id ) )
 			return new WP_Error( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce' ), array( 'status' => 404 ) );


### PR DESCRIPTION
Add email lookup customer endpoint to api, uses same /customers/<id> endpoint but allows for use of email address and looks up based on if an email or id was specified cc.

Closes #4845
