### PR TITLE
Use 'include' parameter to show siblings/children of current category. Fixes #891

### DIFF
--- a/includes/walkers/class-product-cat-list-walker.php
+++ b/includes/walkers/class-product-cat-list-walker.php
@@ -117,45 +117,42 @@ class WC_Product_Cat_List_Walker extends Walker {
 		if ( !$element )
 			return;
 
-		if ( ! $args[0]['show_children_only'] || ( $args[0]['show_children_only'] && ( $element->parent == 0 || $args[0]['current_category'] == $element->parent || in_array( $element->parent, $args[0]['current_category_ancestors'] ) ) ) ) {
+		$id_field = $this->db_fields['id'];
 
-			$id_field = $this->db_fields['id'];
+		//display this element
+		if ( is_array( $args[0] ) )
+			$args[0]['has_children'] = ! empty( $children_elements[$element->$id_field] );
+		$cb_args = array_merge( array(&$output, $element, $depth), $args);
+		call_user_func_array(array(&$this, 'start_el'), $cb_args);
 
-			//display this element
-			if ( is_array( $args[0] ) )
-				$args[0]['has_children'] = ! empty( $children_elements[$element->$id_field] );
-			$cb_args = array_merge( array(&$output, $element, $depth), $args);
-			call_user_func_array(array(&$this, 'start_el'), $cb_args);
+		$id = $element->$id_field;
 
-			$id = $element->$id_field;
+		// descend only when the depth is right and there are children for this element
+		if ( ($max_depth == 0 || $max_depth > $depth+1 ) && isset( $children_elements[$id]) ) {
 
-			// descend only when the depth is right and there are children for this element
-			if ( ($max_depth == 0 || $max_depth > $depth+1 ) && isset( $children_elements[$id]) ) {
+			foreach( $children_elements[ $id ] as $child ){
 
-				foreach( $children_elements[ $id ] as $child ){
-
-					if ( !isset($newlevel) ) {
-						$newlevel = true;
-						//start the child delimiter
-						$cb_args = array_merge( array(&$output, $depth), $args);
-						call_user_func_array(array(&$this, 'start_lvl'), $cb_args);
-					}
-					$this->display_element( $child, $children_elements, $max_depth, $depth + 1, $args, $output );
+				if ( !isset($newlevel) ) {
+					$newlevel = true;
+					//start the child delimiter
+					$cb_args = array_merge( array(&$output, $depth), $args);
+					call_user_func_array(array(&$this, 'start_lvl'), $cb_args);
 				}
-				unset( $children_elements[ $id ] );
+				$this->display_element( $child, $children_elements, $max_depth, $depth + 1, $args, $output );
 			}
-
-			if ( isset($newlevel) && $newlevel ){
-				//end the child delimiter
-				$cb_args = array_merge( array(&$output, $depth), $args);
-				call_user_func_array(array(&$this, 'end_lvl'), $cb_args);
-			}
-
-			//end this element
-			$cb_args = array_merge( array(&$output, $element, $depth), $args);
-			call_user_func_array(array(&$this, 'end_el'), $cb_args);
-
+			unset( $children_elements[ $id ] );
 		}
+
+		if ( isset($newlevel) && $newlevel ){
+			//end the child delimiter
+			$cb_args = array_merge( array(&$output, $depth), $args);
+			call_user_func_array(array(&$this, 'end_lvl'), $cb_args);
+		}
+
+		//end this element
+		$cb_args = array_merge( array(&$output, $element, $depth), $args);
+		call_user_func_array(array(&$this, 'end_el'), $cb_args);
+			
 	}
 
 }

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -88,7 +88,8 @@ class WC_Widget_Product_Categories extends WC_Widget {
 
 		if ( $title )
 			echo $before_title . $title . $after_title;
-
+		
+		$dropdown_args = array();
 		$cat_args = array( 'show_count' => $c, 'hierarchical' => $h, 'taxonomy' => 'product_cat' );
 
 		// Menu Order
@@ -120,7 +121,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 		}
 		
 		// Show Siblings and Children Only
-		if ( $s ) {
+		if ( $s && $this->current_cat ) {
 		
 			if ( $this->current_cat->parent == 0 ) {
 				$category_children = $this->current_cat->term_id;


### PR DESCRIPTION
See #891 for more details.
