### PR TITLE
Limit Plugin Version Data Transient Name to 45 Chars

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -239,7 +239,7 @@
 											$version      = preg_replace( '~[^0-9,.]~' , '' ,stristr( $cl_line , "version" ) );
 											$update       = trim( str_replace( "*" , "" , $cl_lines[ $line_num + 1 ] ) );
 											$version_data = array( 'date' => $date , 'version' => $version , 'update' => $update , 'changelog' => $changelog );
-											set_transient( $plugin . '_version_data', $version_data , 60*60*12 );
+											set_transient( substr( $plugin . '_version_data', 0, 45 ), $version_data , 60*60*12 );
 											break;
 										}
 									}


### PR DESCRIPTION
Transient names can only be 45 chars long, because plugin slugs are long this will almost always exceed 45 characters. Per #4851 this seems to be causing notices to appear on some times.

Solves #4851
