### PR TITLE
Check product exists before accessing methods when sending order email

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -29,12 +29,12 @@ foreach ( $items as $item ) :
 			echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
 
 			// SKU
-			if ( $show_sku && $_product->get_sku() ) {
+			if ( $show_sku && is_object( $_product ) && $_product->get_sku() ) {
 				echo ' (#' . $_product->get_sku() . ')';
 			}
 
 			// File URLs
-			if ( $show_download_links && $_product->exists() && $_product->is_downloadable() ) {
+			if ( $show_download_links && is_object( $_product ) && $_product->exists() && $_product->is_downloadable() ) {
 
 				$download_files = $order->get_item_downloads( $item );
 				$i              = 0;
@@ -62,7 +62,7 @@ foreach ( $items as $item ) :
 		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
 	</tr>
 
-	<?php if ( $show_purchase_note && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) : ?>
+	<?php if ( $show_purchase_note && is_object( $_product ) && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) : ?>
 		<tr>
 			<td colspan="3" style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo apply_filters( 'the_content', $purchase_note ); ?></td>
 		</tr>


### PR DESCRIPTION
In a similar vein to #4681, in WC 2.1, when a store manager has deleted a product or variation, the `email-order-items.php` template will throw a fatal error.

This happens when sending renewal order emails in Subscriptions, but could also affect order emails sent by other extensions and even those sent by WC core (though it's very unlikely).

Check out ZD ticket 147998 for a customer who's had a hell of a time because of this (and PayPal retrying IPN requests ~18 times because the fatal error was causing IPN requests to fail).

On a related note, in the hope of preventing these type of issues, I'm going to add code to Subscriptions to:
1. prevent permanently deleting subscription products
2. remove the permanently delete UI elements for subscription and variable subscription products
3. hide the "Remove" button on subscription variations.

I think that preventative measure is much better than refactoring all the code base in WC and other extensions which may require a product to exist.
