### PR TITLE
Update abstract-wc-product.php

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -401,7 +401,8 @@ class WC_Product {
 	 * @return bool
 	 */
 	public function is_taxable() {
-		return $this->tax_status == 'taxable' && get_option( 'woocommerce_calc_taxes' ) == 'yes' ? true : false;
+		$taxable = $this->tax_status == 'taxable' && get_option( 'woocommerce_calc_taxes' ) == 'yes' ? true : false;
+		return apply_filters( 'woocommerce_product_is_taxable', $taxable, $this );
 	}
 
 	/**


### PR DESCRIPTION
Added a filter to the is_taxable() method so that plugins can better control what is and isn't taxable based on various conditions, such as customer's billing or shipping address, etc. This is necessary for some drop shippers to handle applying taxes correctly. Right now the only other way to get this done appears to be by using one of the actions in calculate_totals(), which requires lot of code replication. Using this new filter would make the task infinitely more simplified.  
