### PR TITLE
Update class-wc-emails.php

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -123,8 +123,7 @@ class WC_Emails {
 			
 			if(!is_a($path,'WC_Email'))
 			{
-			echo $path.'<br>';	
-			$this->email[$class] = include($path);
+				$this->email[$class] = include($path);
 			}
 		}	
 	}

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -108,15 +108,25 @@ class WC_Emails {
 		// Include email classes
 		include_once( 'abstracts/abstract-wc-email.php' );
 
-		$this->emails['WC_Email_New_Order']                 = include( 'emails/class-wc-email-new-order.php' );
-		$this->emails['WC_Email_Customer_Processing_Order'] = include( 'emails/class-wc-email-customer-processing-order.php' );
-		$this->emails['WC_Email_Customer_Completed_Order']  = include( 'emails/class-wc-email-customer-completed-order.php' );
-		$this->emails['WC_Email_Customer_Invoice']          = include( 'emails/class-wc-email-customer-invoice.php' );
-		$this->emails['WC_Email_Customer_Note']             = include( 'emails/class-wc-email-customer-note.php' );
-		$this->emails['WC_Email_Customer_Reset_Password']   = include( 'emails/class-wc-email-customer-reset-password.php' );
-		$this->emails['WC_Email_Customer_New_Account']      = include( 'emails/class-wc-email-customer-new-account.php' );
-
-		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );
+		$this->emails = apply_filters( 'woocommerce_email_classes',
+		array(
+		'WC_Email_New_Order'                 => 'emails/class-wc-email-new-order.php' ,
+		'WC_Email_Customer_Processing_Order' => 'emails/class-wc-email-customer-processing-order.php' ,
+		'WC_Email_Customer_Completed_Order'  => 'emails/class-wc-email-customer-completed-order.php' ,
+		'WC_Email_Customer_Invoice'          => 'emails/class-wc-email-customer-invoice.php' ,
+		'WC_Email_Customer_Note'             => 'emails/class-wc-email-customer-note.php' ,
+		'WC_Email_Customer_Reset_Password'   => 'emails/class-wc-email-customer-reset-password.php' ,
+		'WC_Email_Customer_New_Account'      => 'emails/class-wc-email-customer-new-account.php'
+		));
+		foreach($this->emails as $class=>$path)
+		{
+			
+			if(!is_a($path,'WC_Email'))
+			{
+			echo $path.'<br>';	
+			$this->email[$class] = include($path);
+			}
+		}	
 	}
 
 	/**


### PR DESCRIPTION
possible fix for https://github.com/woothemes/woocommerce/issues/4914 and https://github.com/bassjobsen/WooCommerce-TrustPilot/issues/1.

I wonder if the idea of include to set the class is good. This disables the option to extent a mail class without initiate it (and set the action hooks).
