### PR TITLE
Make $checkout available after customer details

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -46,7 +46,7 @@ $get_checkout_url = apply_filters( 'woocommerce_get_checkout_url', WC()->cart->g
 
 		</div>
 
-		<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
+		<?php do_action( 'woocommerce_checkout_after_customer_details', $checkout ); ?>
 
 		<h3 id="order_review_heading"><?php _e( 'Your order', 'woocommerce' ); ?></h3>
 


### PR DESCRIPTION
Enable access to checkout fields after customer details

do_action( 'woocommerce_checkout_after_customer_details', $checkout )
