### PR TITLE
Prevent ambiguous column error

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -250,7 +250,8 @@ class WC_Query {
 	 * @return string
 	 */
 	public function exclude_protected_products( $where ) {
-		$where .= " AND post_password = ''";
+		global $wpdb;
+		$where .= " AND {$wpdb->posts}.post_password = ''";
     	return $where;
 	}
 


### PR DESCRIPTION
In some cases (e.g. when WP_Query::get_posts() includes a join on the posts table) an ambiguous column error would occur if the table is not explicitly defined.
