### PR TITLE
Correcting Cart Template Class Names

### DIFF
--- a/templates/cart/cart-item-data.php
+++ b/templates/cart/cart-item-data.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 		foreach ( $item_data as $data ) :
 			$key = sanitize_text_field( $data['key'] );
 	?>
-		<dt class="variation-<?php echo $key; ?>"><?php echo wp_kses_post( $data['key'] ); ?>:</dt>
-		<dd class="variation-<?php echo $key; ?>"><?php echo wp_kses_post( wpautop( $data['value'] ) ); ?></dd>
+		<dt class="variation-<?php echo sanitize_html_class( $key ); ?>"><?php echo wp_kses_post( $data['key'] ); ?>:</dt>
+		<dd class="variation-<?php echo sanitize_html_class( $key ); ?>"><?php echo wp_kses_post( wpautop( $data['value'] ) ); ?></dd>
 	<?php endforeach; ?>
 </dl>


### PR DESCRIPTION
Following up #4600 we decided to add class names to the cart meta data. I'm further updating this by adding some sanitization for class names that might be more than one word which were adding spaces in the class names.

![cart___woocommerce_github-2](https://f.cloud.github.com/assets/1065372/2252191/4708b294-9da5-11e3-89b2-6ba2e1465351.png)

From: https://woothemes.zendesk.com/agent/#/tickets/149704
