### PR TITLE
Fix link header issue

### DIFF
--- a/includes/api/class-wc-api-server.php
+++ b/includes/api/class-wc-api-server.php
@@ -576,7 +576,7 @@ class WC_API_Server {
 	}
 
 	/**
-	 * Returns the request URL with the page query parmeter set to the specified page
+	 * Returns the request URL with the page query parameter set to the specified page
 	 *
 	 * @since 2.1
 	 * @param int $page
@@ -590,8 +590,10 @@ class WC_API_Server {
 		// add provided page query param
 		$request = urldecode( add_query_arg( 'page', $page, $request ) );
 
-		// return full URL
-		return get_woocommerce_api_url( str_replace( '/wc-api/v1/', '', $request ) );
+		// get the home host
+		$host = parse_url( get_home_url(), PHP_URL_HOST );
+
+		return set_url_scheme( "http://{$host}{$request}" );
 	}
 
 	/**


### PR DESCRIPTION
When WordPress is running inside of a sub-directory,
get_woocommerce_api_url() returns the domain along with the
sub-directory path, which results in a duplicate path when the API
request string is added. This commit fixes this by fetching only the
home host and adding the request path to it. set_url_scheme() is used
to set the scheme to either http or https based on the request itself
instead of basing it on whether force_ssl_checkout is enabled or not.
