### PR TITLE
Add filter for process_product_file_download_paths()

### DIFF
--- a/includes/admin/post-types/class-wc-admin-cpt-product.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-product.php
@@ -1051,6 +1051,11 @@ class WC_Admin_CPT_Product extends WC_Admin_CPT {
 		if ( $variation_id )
 			$product_id = $variation_id;
 
+		$downloadable_files = apply_filters( 'woocommerce_downloadable_files', $downloadable_files, $product_id );
+			
+		if ( empty( $downloadable_files ) )
+			return;
+			
 		$product               = get_product( $product_id );
 		$existing_download_ids = array_keys( (array) $product->get_files() );
 		$updated_download_ids  = array_keys( (array) $downloadable_files );


### PR DESCRIPTION
Adding a new filter to the process_product_file_download_paths() method so that plugins can intercept the file list and decided whether permissions should be updated. This will be a huge help to sites that sometimes change downloadable file names but don't want existing permissions to be reset. A plugin can parse the list and remove files from the $downloadable_files array if a particular file should not have permissions reset.  This can help resolve issue https://github.com/woothemes/woocommerce/issues/4180 and issue https://github.com/woothemes/woocommerce/issues/4669 without changing the long-standing downloadable files processing behavior of WooCommerce. 
