### PR TITLE
Add permalinks_enabled data to API index

### DIFF
--- a/includes/api/class-wc-api-server.php
+++ b/includes/api/class-wc-api-server.php
@@ -425,15 +425,16 @@ class WC_API_Server {
 			'wc_version'  => WC()->version,
 			'routes'      => array(),
 			'meta'        => array(
-				'timezone'       => wc_timezone_string(),
-				'currency'       => get_woocommerce_currency(),
-				'currency_format'   => get_woocommerce_currency_symbol(),
-				'tax_included'   => ( 'yes' === get_option( 'woocommerce_prices_include_tax' ) ),
-				'weight_unit'    => get_option( 'woocommerce_weight_unit' ),
-				'dimension_unit' => get_option( 'woocommerce_dimension_unit' ),
-				'ssl_enabled'    => ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ),
-				'links'          => array(
-					'help'    => 'http://docs.woothemes.com/document/woocommerce-rest-api/',
+				'timezone'			 => wc_timezone_string(),
+				'currency'       	 => get_woocommerce_currency(),
+				'currency_format'    => get_woocommerce_currency_symbol(),
+				'tax_included'   	 => ( 'yes' === get_option( 'woocommerce_prices_include_tax' ) ),
+				'weight_unit'    	 => get_option( 'woocommerce_weight_unit' ),
+				'dimension_unit' 	 => get_option( 'woocommerce_dimension_unit' ),
+				'ssl_enabled'    	 => ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ),
+				'permalinks_enabled' => ( '' !== get_option( 'permalink_structure' ) ),
+				'links'          	 => array(
+					'help' => 'http://docs.woothemes.com/document/woocommerce-rest-api/',
 				),
 			),
 		) );


### PR DESCRIPTION
Can be used to determine what URL structure should be used, currently if you make calls using pretty permalink format it 404's when site does not have it enabled.
