### PR TITLE
Disable order owner check for payment link if guest checkout enabled

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -83,7 +83,7 @@ class WC_Shortcode_Checkout {
 			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 
 			if ( ! current_user_can( 'pay_for_order', $order_id ) && 'no' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
-				echo '<div class="woocommerce-error">' . __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . get_permalink( wc_get_page_id( 'myaccount' ) ) . '" class="wc-forward">' . __( 'My Account', 'woocommerce' ) . '</a>' . '</div>';
+				echo '<div class="woocommerce-error">' . __( 'Invalid order. If you have an account please log in and try again.', 'woocommerce' ) . ' <a href="' . get_permalink( wc_get_page_id( 'myaccount' ) ) . '" class="wc-forward">' . __( 'My Account', 'woocommerce' ) . '</a>' . '</div>';
 				return;
 			}
 

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -82,7 +82,7 @@ class WC_Shortcode_Checkout {
 			$order                = new WC_Order( $order_id );
 			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 
-			if ( ! current_user_can( 'pay_for_order', $order_id ) && 'no' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
+			if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
 				echo '<div class="woocommerce-error">' . __( 'Invalid order. If you have an account please log in and try again.', 'woocommerce' ) . ' <a href="' . get_permalink( wc_get_page_id( 'myaccount' ) ) . '" class="wc-forward">' . __( 'My Account', 'woocommerce' ) . '</a>' . '</div>';
 				return;
 			}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -82,7 +82,7 @@ class WC_Shortcode_Checkout {
 			$order                = new WC_Order( $order_id );
 			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 
-			if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
+			if ( ! current_user_can( 'pay_for_order', $order_id ) && 'no' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
 				echo '<div class="woocommerce-error">' . __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . get_permalink( wc_get_page_id( 'myaccount' ) ) . '" class="wc-forward">' . __( 'My Account', 'woocommerce' ) . '</a>' . '</div>';
 				return;
 			}

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -300,7 +300,7 @@ function wc_customer_has_capability( $allcaps, $caps, $args ) {
 				}
 
 				$order = new WC_Order( $order_id );
-				if ( $user_id == $order->user_id || empty( $order->user_id ) || 'no' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
+				if ( $user_id == $order->user_id || empty( $order->user_id ) || 'yes' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
 					$allcaps['pay_for_order'] = true;
 				}
 

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -300,8 +300,7 @@ function wc_customer_has_capability( $allcaps, $caps, $args ) {
 				}
 
 				$order = new WC_Order( $order_id );
-
-				if ( $user_id == $order->user_id ) {
+				if ( $user_id == $order->user_id || empty( $order->user_id ) || 'no' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
 					$allcaps['pay_for_order'] = true;
 				}
 

--- a/includes/wc-customer-functions.php
+++ b/includes/wc-customer-functions.php
@@ -300,7 +300,7 @@ function wc_customer_has_capability( $allcaps, $caps, $args ) {
 				}
 
 				$order = new WC_Order( $order_id );
-				if ( $user_id == $order->user_id || empty( $order->user_id ) || 'yes' == get_option( 'woocommerce_enable_guest_checkout' ) ) {
+				if ( $user_id == $order->user_id || empty( $order->user_id ) ) {
 					$allcaps['pay_for_order'] = true;
 				}
 


### PR DESCRIPTION
As per #4957, if you have guest checkout enabled you should not force the customer be logged in. Most affect orders created in backend and assigned to a customer, customer will get pay link but becuase they are not logged in will get invalid order message.

Propose ignoring this check when guest checkouts is enabled.
