### PR TITLE
Missing hook details for new rating after title

### DIFF
--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -45,6 +45,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			 * woocommerce_single_product_summary hook
 			 *
 			 * @hooked woocommerce_template_single_title - 5
+			 * @hooked woocommerce_template_single_rating - 10
 			 * @hooked woocommerce_template_single_price - 10
 			 * @hooked woocommerce_template_single_excerpt - 20
 			 * @hooked woocommerce_template_single_add_to_cart - 30


### PR DESCRIPTION
Missing hook details in the comment for new rating after title on single product pages
