### PR TITLE
Add Plain Text Flag Gateways

### DIFF
--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -54,7 +54,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
     	add_action( 'woocommerce_thankyou_bacs', array( $this, 'thankyou_page' ) );
 
     	// Customer Emails
-    	add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 2 );
+    	add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
     }
 
     /**
@@ -217,9 +217,10 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
      * @access public
      * @param WC_Order $order
      * @param bool $sent_to_admin
+     * @param bool $plain_text
      * @return void
      */
-    public function email_instructions( $order, $sent_to_admin ) {
+    public function email_instructions( $order, $sent_to_admin, $plain_text ) {
 
     	if ( $sent_to_admin || $order->status !== 'on-hold' || $order->payment_method !== 'bacs' )
     		return;

--- a/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -39,7 +39,7 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
     	add_action( 'woocommerce_thankyou_cheque', array( $this, 'thankyou_page' ) );
 
     	// Customer Emails
-    	add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 2 );
+    	add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
     }
 
     /**
@@ -92,8 +92,9 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
      * @access public
      * @param WC_Order $order
      * @param bool $sent_to_admin
+     * @param bool $plain_text
      */
-	public function email_instructions( $order, $sent_to_admin ) {
+	public function email_instructions( $order, $sent_to_admin, $plain_text ) {
     	if ( $sent_to_admin || $order->status !== 'on-hold' || $order->payment_method !== 'cheque' )
     		return;
 


### PR DESCRIPTION
The bacs & cheque gateways may at some point need to do some processing with the `$plain_text` flag. We might as well pass it into the function. The `$plain_text` var is already being calculated wherever the `woocommerce_email_before_order_table` hook is being called.
