### PR TITLE
recount terms when product transients are flushed see #4738

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -103,13 +103,7 @@ class WC_Admin_Status {
 				break;
 				case "recount_terms" :
 
-					$product_cats = get_terms( 'product_cat', array( 'hide_empty' => false, 'fields' => 'id=>parent' ) );
-
-					_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), false, false );
-
-					$product_tags = get_terms( 'product_tag', array( 'hide_empty' => false, 'fields' => 'id=>parent' ) );
-
-					_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
+					wc_do_term_recount();
 
 					echo '<div class="updated"><p>' . __( 'Terms successfully recounted', 'woocommerce' ) . '</p></div>';
 				break;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -127,6 +127,9 @@ function wc_delete_product_transients( $post_id = 0 ) {
 
 	}
 
+	// recount terms
+	wc_do_term_recount();
+
 	do_action( 'woocommerce_delete_product_transients', $post_id );
 }
 

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -384,6 +384,22 @@ function wc_terms_clauses( $clauses, $taxonomies, $args ) {
 add_filter( 'terms_clauses', 'wc_terms_clauses', 10, 3 );
 
 /**
+ * Function that handles the term recount
+ * @return void
+ */
+function wc_do_term_recount() {
+	$product_cats = get_terms( 'product_cat', array( 'hide_empty' => false, 'fields' => 'id=>parent' ) );
+
+	_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), false, false );
+
+	$product_tags = get_terms( 'product_tag', array( 'hide_empty' => false, 'fields' => 'id=>parent' ) );
+
+	_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
+
+	return;
+}
+
+/**
  * Function for recounting product terms, ignoring hidden products.
  * @param  array  $terms
  * @param  string  $taxonomy


### PR DESCRIPTION
When product is updated/published, it is best to recount term.  Since wc_delete_product_transients() is fired whenever that happens, I decided to piggyback that and fire the wc_do_term_recount() within it.  This way we don't need to add that function again everywhere we see wc_delete_product_transients().
