### PR TITLE
shop order - fixes non object error on comments when order is in the tra...

### DIFF
--- a/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
@@ -193,9 +193,13 @@ class WC_Admin_CPT_Shop_Order extends WC_Admin_CPT {
 
 				if ( $post->comment_count ) {
 
+					// check the status of the post
+					( $post->post_status !== 'trash' ) ? $status = '' : $status = 'post-trashed';
+
 					$latest_notes = get_comments( array(
-						'post_id' => $post->ID,
-						'number'  => 1
+						'post_id'	=> $post->ID,
+						'number'	=> 1,
+						'status'	=> $status
 					) );
 
 					$latest_note = current( $latest_notes );


### PR DESCRIPTION
In the order page if the order is in the trash, comment notes is causing non object error because by default get_comments does not look at comments which is tied to posts that are in the trash.

This fix checks to see if the post is in the trash and handle accordingly.
