### PR TITLE
added back order list time when less than 24 hours

### DIFF
--- a/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
@@ -124,10 +124,15 @@ class WC_Admin_CPT_Shop_Order extends WC_Admin_CPT {
 				if ( '0000-00-00 00:00:00' == $post->post_date ) {
 					$t_time = $h_time = __( 'Unpublished', 'woocommerce' );
 				} else {
-					$t_time    = get_the_time( __( 'Y/m/d g:i:s A', 'woocommerce' ), $post );
-					$gmt_time  = strtotime( $post->post_date_gmt . ' UTC' );
+					$t_time = get_the_time( __( 'Y/m/d g:i:s A', 'woocommerce' ), $post );
+
+					$gmt_time = strtotime( $post->post_date_gmt . ' UTC' );
 					$time_diff = current_time( 'timestamp', 1 ) - $gmt_time;
-					$h_time    = get_the_time( __( 'Y/m/d', 'woocommerce' ), $post );
+
+					if ( $time_diff > 0 && $time_diff < 24*60*60 )
+						$h_time = sprintf( __( '%s ago', 'woocommerce' ), human_time_diff( $gmt_time, current_time( 'timestamp', 1 ) ) );
+					else
+						$h_time = get_the_time( __( 'Y/m/d', 'woocommerce' ), $post );
 				}
 
 				echo '<abbr title="' . esc_attr( $t_time ) . '">' . esc_html( apply_filters( 'post_date_column_time', $h_time, $post ) ) . '</abbr>';


### PR DESCRIPTION
So back in 2.0.20 we had this feature of order list showing the time when the order is less than 24 hours old.  This was a great feature and I am not too sure why this was taken out after 2.1.  I have looked through the history and did not find where/why it was changed.

But just in case it was taken out by accident, this PR puts it back in.
