### PR TITLE
Implements Iterator and Countable to WC Cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -11,16 +11,19 @@
  * @category	Class
  * @author 		WooThemes
  */
-class WC_Cart {
+class WC_Cart implements Iterator, Countable {
 
 	/** @var array Contains an array of cart items. */
-	public $cart_contents;
+	public $cart_contents = array();
 
 	/** @var array Contains an array of coupon codes applied to the cart. */
-	public $applied_coupons;
+	public $applied_coupons = array();
 
 	/** @var array Contains an array of coupon code discounts after they have been applied. */
-	public $coupon_discount_amounts;
+	public $coupon_discount_amounts = array();
+
+	/** @var array Contains an array of coupon usage counts after they have been applied. */
+	public $coupon_applied_count = array();
 
 	/** @var float The total cost of the cart items. */
 	public $cart_contents_total;
@@ -70,8 +73,11 @@ class WC_Cart {
 	/** @var WC_Tax */
 	public $tax;
 
+	/** @var array cart_session_data */
+	public $cart_session_data = array();
+
 	/** @var array An array of fees. */
-	public $fees;
+	public $fees = array();
 
 	/**
 	 * Constructor for the cart class. Loads options and hooks in the init method.
@@ -80,18 +86,35 @@ class WC_Cart {
 	 * @return void
 	 */
 	public function __construct() {
-		$this->tax                = new WC_Tax();
-		$this->prices_include_tax = get_option( 'woocommerce_prices_include_tax' ) == 'yes';
-		$this->round_at_subtotal  = get_option('woocommerce_tax_round_at_subtotal') == 'yes';
-		$this->tax_display_cart   = get_option( 'woocommerce_tax_display_cart' );
-		$this->dp                 = (int) get_option( 'woocommerce_price_num_decimals' );
-
-		$this->display_totals_ex_tax = $this->tax_display_cart == 'excl' ? true : false;
-		$this->display_cart_ex_tax   = $this->tax_display_cart == 'excl' ? true : false;
+		$this->tax                   = new WC_Tax();
+		$this->prices_include_tax    = get_option( 'woocommerce_prices_include_tax' ) == 'yes';
+		$this->round_at_subtotal     = get_option('woocommerce_tax_round_at_subtotal') == 'yes';
+		$this->tax_display_cart      = get_option( 'woocommerce_tax_display_cart' );
+		$this->dp                    = absint( get_option( 'woocommerce_price_num_decimals' ) );
+		$this->display_totals_ex_tax = $this->tax_display_cart == 'excl';
+		$this->display_cart_ex_tax   = $this->tax_display_cart == 'excl';
+		
+		// Array of data the cart calculates and stores in the session with defaults
+		$this->cart_session_data = array(
+			'cart_contents_total'     => 0,
+			'cart_contents_weight'    => 0,
+			'cart_contents_count'     => 0,
+			'cart_contents_tax'       => 0,
+			'total'                   => 0,
+			'subtotal'                => 0,
+			'subtotal_ex_tax'         => 0,
+			'tax_total'               => 0,
+			'taxes'                   => array(),
+			'shipping_taxes'          => array(),
+			'discount_cart'           => 0,
+			'discount_total'          => 0,
+			'shipping_total'          => 0,
+			'shipping_tax_total'      => 0,
+			'coupon_discount_amounts' => array(),
+		);
 
 		add_action( 'init', array( $this, 'init' ), 5 ); // Get cart on init
 	}
-
 
     /**
 	 * Loads the cart data from the PHP session during WordPress init and hooks in other methods.
@@ -102,9 +125,9 @@ class WC_Cart {
     public function init() {
 		$this->get_cart_from_session();
 
-		add_action('woocommerce_check_cart_items', array( $this, 'check_cart_items' ), 1 );
-		add_action('woocommerce_check_cart_items', array( $this, 'check_cart_coupons' ), 1 );
-		add_action('woocommerce_after_checkout_validation', array( $this, 'check_customer_coupons' ), 1 );
+		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_items' ), 1 );
+		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_coupons' ), 1 );
+		add_action( 'woocommerce_after_checkout_validation', array( $this, 'check_customer_coupons' ), 1 );
     }
 
  	/*-----------------------------------------------------------------------------------*/
@@ -118,108 +141,74 @@ class WC_Cart {
 		 * @return void
 		 */
 		public function get_cart_from_session() {
-			global $woocommerce;
 
-			// Load the coupons
-			$this->applied_coupons         = ( empty( $woocommerce->session->coupon_codes ) ) ? array() : array_filter( (array) $woocommerce->session->coupon_codes );
-			$this->coupon_discount_amounts = ( empty( $woocommerce->session->coupon_amounts ) ) ? array() : array_filter( (array) $woocommerce->session->coupon_amounts );
+			// Load cart session data from session
+			foreach ( $this->cart_session_data as $key => $default ) {
+				$this->$key = WC()->session->get( $key, $default );
+			}
+
+			// Load coupons
+			$this->applied_coupons = array_filter( WC()->session->get( 'applied_coupons', array() ) );
 
 			// Load the cart
-			if ( isset( $woocommerce->session->cart ) && is_array( $woocommerce->session->cart ) ) {
-				$cart = $woocommerce->session->cart;
+			$cart = WC()->session->get( 'cart', array() );
 
+			$update_cart_session = false;
+
+			if ( is_array( $cart ) ) {
 				foreach ( $cart as $key => $values ) {
-
 					$_product = get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
 
 					if ( ! empty( $_product ) && $_product->exists() && $values['quantity'] > 0 ) {
 
-						// Put session data into array. Run through filter so other plugins can load their own session data
-						$this->cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', array(
-							'product_id'	=> $values['product_id'],
-							'variation_id'	=> $values['variation_id'],
-							'variation' 	=> $values['variation'],
-							'quantity' 		=> $values['quantity'],
-							'data'			=> $_product
-						), $values, $key );
+						if ( ! $_product->is_purchasable() ) {
+
+							// Flag to indicate the stored cart should be update
+							$update_cart_session = true;
+							wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $_product->get_title() ), 'error' );
+
+						} else {
+
+							// Put session data into array. Run through filter so other plugins can load their own session data
+							$this->cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', array(
+								'product_id'	=> $values['product_id'],
+								'variation_id'	=> $values['variation_id'],
+								'variation' 	=> $values['variation'],
+								'quantity' 		=> $values['quantity'],
+								'data'			=> $_product
+							), $values, $key );
+
+						}
 					}
 				}
 			}
 
-			if ( empty( $this->cart_contents ) || ! is_array( $this->cart_contents ) )
-				$this->cart_contents = array();
+			if ( $update_cart_session )
+				WC()->session->cart = $this->get_cart_for_session();
 
-			if ( sizeof( $this->cart_contents ) > 0 )
-				$this->set_cart_cookies();
-			else
-				$this->set_cart_cookies( false );
+			$this->set_cart_cookies( sizeof( $this->cart_contents ) > 0 );
 
 			// Trigger action
 			do_action( 'woocommerce_cart_loaded_from_session', $this );
 
-			// Load totals
-			$this->cart_contents_total 	= isset( $woocommerce->session->cart_contents_total ) ? $woocommerce->session->cart_contents_total : 0;
-			$this->cart_contents_weight = isset( $woocommerce->session->cart_contents_weight ) ? $woocommerce->session->cart_contents_weight : 0;
-			$this->cart_contents_count 	= isset( $woocommerce->session->cart_contents_count ) ? $woocommerce->session->cart_contents_count : 0;
-			$this->cart_contents_tax 	= isset( $woocommerce->session->cart_contents_tax ) ? $woocommerce->session->cart_contents_tax : 0;
-			$this->total 				= isset( $woocommerce->session->total ) ? $woocommerce->session->total : 0;
-			$this->subtotal 			= isset( $woocommerce->session->subtotal ) ? $woocommerce->session->subtotal : 0;
-			$this->subtotal_ex_tax 		= isset( $woocommerce->session->subtotal_ex_tax ) ? $woocommerce->session->subtotal_ex_tax : 0;
-			$this->tax_total 			= isset( $woocommerce->session->tax_total ) ? $woocommerce->session->tax_total : 0;
-			$this->taxes 				= isset( $woocommerce->session->taxes ) ? $woocommerce->session->taxes : array();
-			$this->shipping_taxes		= isset( $woocommerce->session->shipping_taxes ) ? $woocommerce->session->shipping_taxes : array();
-			$this->discount_cart 		= isset( $woocommerce->session->discount_cart ) ? $woocommerce->session->discount_cart : 0;
-			$this->discount_total 		= isset( $woocommerce->session->discount_total ) ? $woocommerce->session->discount_total : 0;
-			$this->shipping_total 		= isset( $woocommerce->session->shipping_total ) ? $woocommerce->session->shipping_total : 0;
-			$this->shipping_tax_total 	= isset( $woocommerce->session->shipping_tax_total ) ? $woocommerce->session->shipping_tax_total : 0;
-
 			// Queue re-calc if subtotal is not set
-			if ( ! $this->subtotal && sizeof( $this->cart_contents ) > 0 )
+			if ( ( ! $this->subtotal && sizeof( $this->cart_contents ) > 0 ) || $update_cart_session )
 				$this->calculate_totals();
 		}
 
-
 		/**
 		 * Sets the php session data for the cart and coupons.
-		 *
-		 * @access public
-		 * @return void
 		 */
 		public function set_session() {
-			global $woocommerce;
-
 			// Set cart and coupon session data
-			$cart_session = array();
+			$cart_session = $this->get_cart_for_session();
 
-			if ( $this->cart_contents ) {
-				foreach ( $this->cart_contents as $key => $values ) {
+			WC()->session->set( 'cart', $cart_session );
+			WC()->session->set( 'applied_coupons', $this->applied_coupons );
+			WC()->session->set( 'coupon_discount_amounts', $this->coupon_discount_amounts );
 
-					$cart_session[ $key ] = $values;
-
-					// Unset product object
-					unset( $cart_session[ $key ]['data'] );
-				}
-			}
-
-			$woocommerce->session->cart           = $cart_session;
-			$woocommerce->session->coupon_codes   = $this->applied_coupons;
-			$woocommerce->session->coupon_amounts = $this->coupon_discount_amounts;
-
-			// Store totals to avoid re-calc on page load
-			$woocommerce->session->cart_contents_total  = $this->cart_contents_total;
-			$woocommerce->session->cart_contents_weight = $this->cart_contents_weight;
-			$woocommerce->session->cart_contents_count  = $this->cart_contents_count;
-			$woocommerce->session->cart_contents_tax    = $this->cart_contents_tax;
-			$woocommerce->session->total                = $this->total;
-			$woocommerce->session->subtotal             = $this->subtotal;
-			$woocommerce->session->subtotal_ex_tax      = $this->subtotal_ex_tax;
-			$woocommerce->session->tax_total            = $this->tax_total;
-			$woocommerce->session->shipping_taxes       = $this->shipping_taxes;
-			$woocommerce->session->taxes                = $this->taxes;
-			$woocommerce->session->discount_cart        = $this->discount_cart;
-			$woocommerce->session->discount_total       = $this->discount_total;
-			$woocommerce->session->shipping_total       = $this->shipping_total;
-			$woocommerce->session->shipping_tax_total   = $this->shipping_tax_total;
+			foreach ( $this->cart_session_data as $key => $default )
+				WC()->session->set( $key, $this->$key );
 
 			if ( get_current_user_id() )
 				$this->persistent_cart_update();
@@ -235,12 +224,10 @@ class WC_Cart {
 		 * @return void
 		 */
 		public function empty_cart( $clear_persistent_cart = true ) {
-			global $woocommerce;
-
 			$this->cart_contents = array();
 			$this->reset();
 
-			unset( $woocommerce->session->order_awaiting_payment, $woocommerce->session->coupon_codes, $woocommerce->session->coupon_amounts, $woocommerce->session->cart );
+			unset( WC()->session->order_awaiting_payment, WC()->session->applied_coupons, WC()->session->coupon_discount_amounts, WC()->session->cart );
 
 			if ( $clear_persistent_cart && get_current_user_id() )
 				$this->persistent_cart_destroy();
@@ -259,13 +246,10 @@ class WC_Cart {
 		 * @return void
 		 */
 		public function persistent_cart_update() {
-			global $woocommerce;
-
 			update_user_meta( get_current_user_id(), '_woocommerce_persistent_cart', array(
-				'cart' => $woocommerce->session->cart,
+				'cart' => WC()->session->cart,
 			) );
 		}
-
 
 		/**
 		 * Delete the persistent cart permanently.
@@ -285,12 +269,10 @@ class WC_Cart {
 		 * Coupons enabled function. Filterable.
 		 *
 		 * @access public
-		 * @return void
+		 * @return bool
 		 */
 		public function coupons_enabled() {
-			$coupons_enabled = get_option( 'woocommerce_enable_coupons' ) == 'no' ? false : true;
-
-			return apply_filters( 'woocommerce_coupons_enabled', $coupons_enabled );
+			return apply_filters( 'woocommerce_coupons_enabled', get_option( 'woocommerce_enable_coupons' ) == 'yes' );
 		}
 
 		/**
@@ -303,7 +285,6 @@ class WC_Cart {
 			return apply_filters( 'woocommerce_cart_contents_count', $this->cart_contents_count );
 		}
 
-
 		/**
 		 * Check all cart items for errors.
 		 *
@@ -311,20 +292,17 @@ class WC_Cart {
 		 * @return void
 		 */
 		public function check_cart_items() {
-			global $woocommerce;
-
 			$result = $this->check_cart_item_validity();
 
 			if ( is_wp_error( $result ) )
-				wc_add_error( $result->get_error_message() );
+				wc_add_notice( $result->get_error_message(), 'error' );
 
 			// Check item stock
 			$result = $this->check_cart_item_stock();
 
 			if ( is_wp_error( $result ) )
-				wc_add_error( $result->get_error_message() );
+				wc_add_notice( $result->get_error_message(), 'error' );
 		}
-
 
 		/**
 		 * Check cart coupons for errors.
@@ -333,20 +311,18 @@ class WC_Cart {
 		 * @return void
 		 */
 		public function check_cart_coupons() {
-			if ( ! empty( $this->applied_coupons ) ) {
-				foreach ( $this->applied_coupons as $key => $code ) {
-					$coupon = new WC_Coupon( $code );
+			foreach ( $this->applied_coupons as $code ) {
+				$coupon = new WC_Coupon( $code );
 
-					if ( is_wp_error( $coupon->is_valid() ) ) {
+				if ( ! $coupon->is_valid() ) {
+					// Error message
+					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_INVALID_REMOVED );
 
-						$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_INVALID_REMOVED );
+					// Remove the coupon
+					$this->remove_coupon( $code );
 
-						// Remove the coupon
-						unset( $this->applied_coupons[ $key ] );
-
-						WC()->session->set( 'coupon_codes', $this->applied_coupons );
-						WC()->session->set( 'refresh_totals', true );
-					}
+					// Flag totals for refresh
+					WC()->session->set( 'refresh_totals', true );
 				}
 			}
 		}
@@ -361,75 +337,20 @@ class WC_Cart {
 			$quantities = array();
 
 			foreach ( $this->get_cart() as $cart_item_key => $values ) {
-
-				if ( $values['data']->managing_stock() ) {
-
-					if ( $values['variation_id'] > 0 ) {
-
-						if ( $values['data']->variation_has_stock ) {
-
-							// Variation has stock levels defined so its handled individually
-							$quantities[ $values['variation_id'] ] = isset( $quantities[ $values['variation_id'] ] ) ? $quantities[ $values['variation_id'] ] + $values['quantity'] : $values['quantity'];
-
-						} else {
-
-							// Variation has no stock levels defined so use parents
-							$quantities[ $values['product_id'] ] = isset( $quantities[ $values['product_id'] ] ) ? $quantities[ $values['product_id'] ] + $values['quantity'] : $values['quantity'];
-
-						}
-
-					} else {
-
-						$quantities[ $values['product_id'] ] = isset( $quantities[ $values['product_id'] ] ) ? $quantities[ $values['product_id'] ] + $values['quantity'] : $values['quantity'];
-
-					}
-
+				if ( $values['variation_id'] > 0 && $values['data']->variation_has_stock ) {
+					// Variation has stock levels defined so its handled individually
+					$quantities[ $values['variation_id'] ] = isset( $quantities[ $values['variation_id'] ] ) ? $quantities[ $values['variation_id'] ] + $values['quantity'] : $values['quantity'];
+				} else {
+					$quantities[ $values['product_id'] ] = isset( $quantities[ $values['product_id'] ] ) ? $quantities[ $values['product_id'] ] + $values['quantity'] : $values['quantity'];
 				}
-
 			}
+
 			return $quantities;
 		}
 
 		/**
-		 * Check for user coupons (now that we have billing email). If a coupon is invalid, add an error.
-		 *
-		 * @access public
-		 * @param array $posted
-		 */
-		public function check_customer_coupons( $posted ) {
-			if ( ! empty( $this->applied_coupons ) ) {
-				foreach ( $this->applied_coupons as $key => $code ) {
-					$coupon = new WC_Coupon( $code );
-
-					if ( ! is_wp_error( $coupon->is_valid() ) && is_array( $coupon->customer_email ) && sizeof( $coupon->customer_email ) > 0 ) {
-
-						$coupon->customer_email = array_map( 'sanitize_email', $coupon->customer_email );
-
-						if ( is_user_logged_in() ) {
-							$current_user = wp_get_current_user();
-							$check_emails[] = $current_user->user_email;
-						}
-						$check_emails[] = $posted['billing_email'];
-
-						$check_emails = array_map( 'sanitize_email', array_map( 'strtolower', $check_emails ) );
-
-						if ( 0 == sizeof( array_intersect( $check_emails, $coupon->customer_email ) ) ) {
-							$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED );
-
-							// Remove the coupon
-							unset( $this->applied_coupons[ $key ] );
-
-							WC()->session->set( 'coupon_codes', $this->applied_coupons );
-							WC()->session->set( 'refresh_totals', true );
-						}
-					}
-				}
-			}
-		}
-
-		/**
 		 * Looks through cart items and checks the posts are not trashed or deleted.
-		 * @return bool or WP_ERROR
+		 * @return bool|WP_Error
 		 */
 		public function check_cart_item_validity() {
 			foreach ( $this->get_cart() as $cart_item_key => $values ) {
@@ -450,7 +371,7 @@ class WC_Cart {
 		 * Looks through the cart to check each item is in stock. If not, add an error.
 		 *
 		 * @access public
-		 * @return bool or WP_ERROR
+		 * @return bool|WP_Error
 		 */
 		public function check_cart_item_stock() {
 			global $wpdb;
@@ -564,8 +485,6 @@ class WC_Cart {
 		 * @return string
 		 */
 		public function get_item_data( $cart_item, $flat = false ) {
-			global $woocommerce;
-
 			$item_data = array();
 
 			// Variation data
@@ -575,22 +494,28 @@ class WC_Cart {
 
 				foreach ( $cart_item['variation'] as $name => $value ) {
 
-					if ( ! $value )
+					if ( '' === $value )
 						continue;
 
+					$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( $name ) ) );
+
 					// If this is a term slug, get the term's nice name
-		            if ( taxonomy_exists( esc_attr( str_replace( 'attribute_', '', $name ) ) ) ) {
-		            	$term = get_term_by( 'slug', $value, esc_attr( str_replace( 'attribute_', '', $name ) ) );
-		            	if ( ! is_wp_error( $term ) && $term->name )
+		            if ( taxonomy_exists( $taxonomy ) ) {
+		            	$term = get_term_by( 'slug', $value, $taxonomy );
+		            	if ( ! is_wp_error( $term ) && $term && $term->name ) {
 		            		$value = $term->name;
+		            	}
+		            	$label = wc_attribute_label( $taxonomy );
 
 		            // If this is a custom option slug, get the options name
 		            } else {
-		            	$value = apply_filters( 'woocommerce_variation_option_name', $value );
+						$value              = apply_filters( 'woocommerce_variation_option_name', $value );
+						$product_attributes = $cart_item['data']->get_attributes();
+						$label              = wc_attribute_label( $product_attributes[ str_replace( 'attribute_', '', urldecode( $name ) ) ]['name'] );
 					}
 
 					$item_data[] = array(
-						'key'   => wc_attribute_label( str_replace( 'attribute_', '', $name ) ),
+						'key'   => $label,
 						'value' => $value
 					);
 				}
@@ -624,11 +549,13 @@ class WC_Cart {
 						echo esc_html( $data['key'] ) . ': ' . wp_kses_post( $data['value'] ) . "\n";
 
 				} else {
-					woocommerce_get_template( 'cart/cart-item-data.php', array( 'item_data' => $item_data ) );
+					wc_get_template( 'cart/cart-item-data.php', array( 'item_data' => $item_data ) );
 				}
 
 				return ob_get_clean();
 			}
+
+			return '';
 		}
 
 		/**
@@ -639,8 +566,8 @@ class WC_Cart {
 		public function get_cross_sells() {
 			$cross_sells = array();
 			$in_cart = array();
-			if ( sizeof( $this->cart_contents) > 0 ) {
-				foreach ( $this->cart_contents as $cart_item_key => $values ) {
+			if ( sizeof( $this->get_cart() ) > 0 ) {
+				foreach ( $this->get_cart() as $cart_item_key => $values ) {
 					if ( $values['quantity'] > 0 ) {
 						$cross_sells = array_merge( $values['data']->get_cross_sells(), $cross_sells );
 						$in_cart[] = $values['product_id'];
@@ -657,8 +584,8 @@ class WC_Cart {
 		 * @return string url to page
 		 */
 		public function get_cart_url() {
-			$cart_page_id = woocommerce_get_page_id('cart');
-			if ( $cart_page_id ) return apply_filters( 'woocommerce_get_cart_url', get_permalink( $cart_page_id ) );
+			$cart_page_id = wc_get_page_id( 'cart' );
+			return apply_filters( 'woocommerce_get_cart_url', $cart_page_id ? get_permalink( $cart_page_id ) : '' );
 		}
 
 		/**
@@ -667,7 +594,7 @@ class WC_Cart {
 		 * @return string url to page
 		 */
 		public function get_checkout_url() {
-			$checkout_page_id = woocommerce_get_page_id('checkout');
+			$checkout_page_id = wc_get_page_id( 'checkout' );
 			$checkout_url     = '';
 			if ( $checkout_page_id ) {
 				if ( is_ssl() || get_option('woocommerce_force_ssl_checkout') == 'yes' )
@@ -681,13 +608,12 @@ class WC_Cart {
 		/**
 		 * Gets the url to remove an item from the cart.
 		 *
+		 * @param string	cart_item_key	contains the id of the cart item
 		 * @return string url to page
 		 */
 		public function get_remove_url( $cart_item_key ) {
-			global $woocommerce;
-			$cart_page_id = woocommerce_get_page_id('cart');
-			if ($cart_page_id)
-				return apply_filters( 'woocommerce_get_remove_url', wp_nonce_url( add_query_arg( 'remove_item', $cart_item_key, get_permalink( $cart_page_id ) ), 'woocommerce-cart' ) );
+			$cart_page_id = wc_get_page_id('cart');
+			return apply_filters( 'woocommerce_get_remove_url', $cart_page_id ? wp_nonce_url( add_query_arg( 'remove_item', $cart_item_key, get_permalink( $cart_page_id ) ), 'woocommerce-cart' ) : '' );
 		}
 
 		/**
@@ -697,6 +623,25 @@ class WC_Cart {
 		 */
 		public function get_cart() {
 			return array_filter( (array) $this->cart_contents );
+		}
+
+		/**
+		 * Returns the contents of the cart in an array without the 'data' element.
+		 *
+		 * @return array contents of the cart
+		 */
+		private function get_cart_for_session() {
+
+			$cart_session = array();
+
+			if ( $this->get_cart() ) {
+				foreach ( $this->get_cart() as $key => $values ) {
+					$cart_session[ $key ] = $values;
+					unset( $cart_session[ $key ]['data'] ); // Unset product object
+				}
+			}
+
+			return $cart_session;
 		}
 
 		/**
@@ -716,25 +661,10 @@ class WC_Cart {
 		}
 
 		/**
-		 * Returns the cart and shipping taxes, merged & formatted.
-		 *
-		 * @return array merged taxes
-		 */
-		public function get_formatted_taxes() {
-			$taxes = $this->get_taxes();
-
-			foreach ( $taxes as $key => $tax )
-				if ( is_numeric( $tax ) )
-					$taxes[ $key ] = woocommerce_price( $tax );
-
-			return apply_filters( 'woocommerce_cart_formatted_taxes', $taxes, $this );
-		}
-
-		/**
 		 * Get taxes, merged by code, formatted ready for output.
 		 *
 		 * @access public
-		 * @return void
+		 * @return array
 		 */
 		public function get_tax_totals() {
 			$taxes      = $this->get_taxes();
@@ -744,15 +674,18 @@ class WC_Cart {
 
 				$code = $this->tax->get_rate_code( $key );
 
-				if ( ! isset( $tax_totals[ $code ] ) ) {
-					$tax_totals[ $code ] = new stdClass();
-					$tax_totals[ $code ]->amount = 0;
-				}
+				if ( $code ) {
+					if ( ! isset( $tax_totals[ $code ] ) ) {
+						$tax_totals[ $code ] = new stdClass();
+						$tax_totals[ $code ]->amount = 0;
+					}
 
-				$tax_totals[ $code ]->is_compound       = $this->tax->is_compound( $key );
-				$tax_totals[ $code ]->label             = $this->tax->get_rate_label( $key );
-				$tax_totals[ $code ]->amount           += $tax;
-				$tax_totals[ $code ]->formatted_amount  = woocommerce_price( $tax_totals[ $code ]->amount );
+	                $tax_totals[ $code ]->tax_rate_id       = $key;
+					$tax_totals[ $code ]->is_compound       = $this->tax->is_compound( $key );
+					$tax_totals[ $code ]->label             = $this->tax->get_rate_label( $key );
+					$tax_totals[ $code ]->amount           += wc_round_tax_total( $tax );
+					$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax_total( $tax_totals[ $code ]->amount ) );
+				}
 			}
 
 			return apply_filters( 'woocommerce_cart_tax_totals', $tax_totals, $this );
@@ -772,10 +705,13 @@ class WC_Cart {
 	     */
 	    public function find_product_in_cart( $cart_id = false ) {
 	        if ( $cart_id !== false )
-	        	foreach ( $this->cart_contents as $cart_item_key => $cart_item )
-	        		if ( $cart_item_key == $cart_id )
-	        			return $cart_item_key;
-	    }
+	        	if ( is_array( $this->cart_contents ) )
+	        		foreach ( $this->cart_contents as $cart_item_key => $cart_item )
+	        			if ( $cart_item_key == $cart_id )
+	        				return $cart_item_key;
+
+			return '';
+		}
 
 		/**
 	     * Generate a unique ID for the cart item being added.
@@ -786,13 +722,13 @@ class WC_Cart {
 	     * @param array $cart_item_data other cart item data passed which affects this items uniqueness in the cart
 	     * @return string cart item key
 	     */
-	    public function generate_cart_id( $product_id, $variation_id = '', $variation = '', $cart_item_data = array() ) {
-
+	    public function generate_cart_id( $product_id, $variation_id = 0, $variation = array(), $cart_item_data = array() ) {
 	        $id_parts = array( $product_id );
 
-	        if ( $variation_id ) $id_parts[] = $variation_id;
+	        if ( $variation_id && 0 != $variation_id )
+	        	$id_parts[] = $variation_id;
 
-	        if ( is_array( $variation ) ) {
+	        if ( is_array( $variation ) && ! empty( $variation ) ) {
 	            $variation_key = '';
 	            foreach ( $variation as $key => $value ) {
 	                $variation_key .= trim( $key ) . trim( $value );
@@ -823,20 +759,28 @@ class WC_Cart {
 		 * @return bool
 		 */
 		public function add_to_cart( $product_id, $quantity = 1, $variation_id = '', $variation = '', $cart_item_data = array() ) {
-			global $woocommerce;
 
-			if ( $quantity <= 0 ) return false;
+			if ( $quantity <= 0 ) {
+				return false;
+			}
 
 			// Load cart item data - may be added by other plugins
 			$cart_item_data = (array) apply_filters( 'woocommerce_add_cart_item_data', $cart_item_data, $product_id, $variation_id );
-
+			
 			// Generate a ID based on product ID, variation ID, variation data, and other cart item data
-			$cart_id = $this->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
-
+			$cart_id        = $this->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
+			
 			// See if this product and its options is already in the cart
-			$cart_item_key = $this->find_product_in_cart( $cart_id );
+			$cart_item_key  = $this->find_product_in_cart( $cart_id );
 
-			$product_data = get_product( $variation_id ? $variation_id : $product_id );
+			// Ensure we don't add a variation to the cart directly by variation ID
+			if ( 'product_variation' == get_post_type( $product_id ) ) {
+				$variation_id = $product_id;
+				$product_id   = wp_get_post_parent_id( $variation_id );
+			}
+			
+			// Get the product
+			$product_data   = get_product( $variation_id ? $variation_id : $product_id );
 
 			if ( ! $product_data )
 				return false;
@@ -847,31 +791,35 @@ class WC_Cart {
 
 			// Check product is_purchasable
 			if ( ! $product_data->is_purchasable() ) {
-				wc_add_error( sprintf( __( 'Sorry, &quot;%s&quot; cannot be purchased.', 'woocommerce' ), $product_data->get_title() ) );
+				wc_add_notice( sprintf( __( 'Sorry, &quot;%s&quot; cannot be purchased.', 'woocommerce' ), $product_data->get_title() ), 'error' );
 				return false;
 			}
 
 			// Stock check - only check if we're managing stock and backorders are not allowed
 			if ( ! $product_data->is_in_stock() ) {
 
-				wc_add_error( sprintf( __( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woocommerce' ), $product_data->get_title() ) );
+				wc_add_notice( sprintf( __( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woocommerce' ), $product_data->get_title() ), 'error' );
 
 				return false;
 			} elseif ( ! $product_data->has_enough_stock( $quantity ) ) {
 
-				wc_add_error( sprintf(__( 'You cannot add that amount of &quot;%s&quot; to the cart because there is not enough stock (%s remaining).', 'woocommerce' ), $product_data->get_title(), $product_data->get_stock_quantity() ));
+				wc_add_notice( sprintf(__( 'You cannot add that amount of &quot;%s&quot; to the cart because there is not enough stock (%s remaining).', 'woocommerce' ), $product_data->get_title(), $product_data->get_stock_quantity() ), 'error' );
 
 				return false;
-
 			}
 
 			// Downloadable/virtual qty check
 			if ( $product_data->is_sold_individually() ) {
 				$in_cart_quantity = $cart_item_key ? $this->cart_contents[$cart_item_key]['quantity'] : 0;
 
-				// If its greater than 0, its already in the cart
+				// If it's greater than 0, it's already in the cart
 				if ( $in_cart_quantity > 0 ) {
-					wc_add_error( sprintf('<a href="%s" class="button">%s</a> %s', get_permalink(woocommerce_get_page_id('cart')), __( 'View Cart &rarr;', 'woocommerce' ), __( 'You already have this item in your cart.', 'woocommerce' ) ) );
+					wc_add_notice( sprintf(
+						'<a href="%s" class="button wc-forward">%s</a> %s',
+						$this->get_cart_url(),
+						__( 'View Cart', 'woocommerce' ),
+						sprintf( __( 'You cannot add another &quot;%s&quot; to your cart.', 'woocommerce' ), $product_data->get_title() )
+					), 'error' );
 					return false;
 				}
 			}
@@ -885,7 +833,12 @@ class WC_Cart {
 				if ( $variation_id && $product_data->variation_has_stock ) {
 
 					if ( isset( $product_qty_in_cart[ $variation_id ] ) && ! $product_data->has_enough_stock( $product_qty_in_cart[ $variation_id ] + $quantity ) ) {
-						wc_add_error( sprintf(__( '<a href="%s" class="button">%s</a> You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce' ), get_permalink(woocommerce_get_page_id('cart')), __( 'View Cart &rarr;', 'woocommerce' ), $product_data->get_stock_quantity(), $product_qty_in_cart[ $variation_id ] ));
+						wc_add_notice( sprintf(
+							'<a href="%s" class="button wc-forward">%s</a> %s',
+							$this->get_cart_url(),
+							__( 'View Cart', 'woocommerce' ),
+							sprintf( __( 'You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce' ), $product_data->get_stock_quantity(), $product_qty_in_cart[ $variation_id ] )
+						), 'error' );
 						return false;
 					}
 
@@ -893,7 +846,12 @@ class WC_Cart {
 				} else {
 
 					if ( isset( $product_qty_in_cart[ $product_id ] ) && ! $product_data->has_enough_stock( $product_qty_in_cart[ $product_id ] + $quantity ) ) {
-						wc_add_error( sprintf(__( '<a href="%s" class="button">%s</a> You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce' ), get_permalink(woocommerce_get_page_id('cart')), __( 'View Cart &rarr;', 'woocommerce' ), $product_data->get_stock_quantity(), $product_qty_in_cart[ $product_id ] ));
+						wc_add_notice( sprintf(
+							'<a href="%s" class="button wc-forward">%s</a> %s',
+							$this->get_cart_url(),
+							__( 'View Cart', 'woocommerce' ),
+							sprintf( __( 'You cannot add that amount to the cart &mdash; we have %s in stock and you already have %s in your cart.', 'woocommerce' ), $product_data->get_stock_quantity(), $product_qty_in_cart[ $product_id ] )
+						), 'error' );
 						return false;
 					}
 
@@ -942,9 +900,9 @@ class WC_Cart {
 
 			if ( $quantity == 0 || $quantity < 0 ) {
 				do_action( 'woocommerce_before_cart_item_quantity_zero', $cart_item_key );
-				unset( $this->cart_contents[$cart_item_key] );
+				unset( $this->cart_contents[ $cart_item_key ] );
 			} else {
-				$this->cart_contents[$cart_item_key]['quantity'] = $quantity;
+				$this->cart_contents[ $cart_item_key ]['quantity'] = $quantity;
 				do_action( 'woocommerce_after_cart_item_quantity_update', $cart_item_key, $quantity );
 			}
 
@@ -960,15 +918,15 @@ class WC_Cart {
 		 * @return void
 		 */
 		private function set_cart_cookies( $set = true ) {
-			if ( ! headers_sent() ) {
-				if ( $set ) {
-					setcookie( "woocommerce_items_in_cart", "1", 0, COOKIEPATH, COOKIE_DOMAIN, false );
-					setcookie( "woocommerce_cart_hash", md5( json_encode( $this->get_cart() ) ), 0, COOKIEPATH, COOKIE_DOMAIN, false );
-				} else {
-					setcookie( "woocommerce_items_in_cart", "0", time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-					setcookie( "woocommerce_cart_hash", "0", time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-				}
+			if ( $set ) {
+				wc_setcookie( 'woocommerce_items_in_cart', 1 );
+				wc_setcookie( 'woocommerce_cart_hash', md5( json_encode( $this->get_cart() ) ) );
+			} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) {
+				wc_setcookie( 'woocommerce_items_in_cart', 0, time() - 3600 );
+				wc_setcookie( 'woocommerce_cart_hash', '', time() - 3600 );
 			}
+
+			do_action( 'woocommerce_set_cart_cookies', $set );
 		}
 
     /*-----------------------------------------------------------------------------------*/
@@ -982,339 +940,10 @@ class WC_Cart {
 		 * @return void
 		 */
 		private function reset() {
-			global $woocommerce;
-
-			$this->total = $this->cart_contents_total = $this->cart_contents_weight = $this->cart_contents_count = $this->cart_contents_tax = $this->tax_total = $this->shipping_tax_total = $this->subtotal = $this->subtotal_ex_tax = $this->discount_total = $this->discount_cart = $this->shipping_total = $this->fee_total = 0;
-			$this->shipping_taxes = $this->taxes = $this->coupon_discount_amounts = array();
-
-			unset( $woocommerce->session->cart_contents_total, $woocommerce->session->cart_contents_weight, $woocommerce->session->cart_contents_count, $woocommerce->session->cart_contents_tax, $woocommerce->session->total, $woocommerce->session->subtotal, $woocommerce->session->subtotal_ex_tax, $woocommerce->session->tax_total, $woocommerce->session->taxes, $woocommerce->session->shipping_taxes, $woocommerce->session->discount_cart, $woocommerce->session->discount_total, $woocommerce->session->shipping_total, $woocommerce->session->shipping_tax_total );
-		}
-
-		/**
-		 * Function to apply discounts to a product and get the discounted price (before tax is applied).
-		 *
-		 * @access public
-		 * @param mixed $values
-		 * @param mixed $price
-		 * @param bool $add_totals (default: false)
-		 * @return float price
-		 */
-		public function get_discounted_price( $values, $price, $add_totals = false ) {
-
-			if ( ! $price ) return $price;
-
-			if ( ! empty( $this->applied_coupons ) ) {
-				foreach ( $this->applied_coupons as $code ) {
-					$coupon = new WC_Coupon( $code );
-
-					if ( $coupon->apply_before_tax() && $coupon->is_valid() ) {
-
-						switch ( $coupon->type ) {
-
-							case "fixed_product" :
-							case "percent_product" :
-
-								$this_item_is_discounted = false;
-
-								$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
-								$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
-
-								// Specific products get the discount
-								if ( sizeof( $coupon->product_ids ) > 0 ) {
-
-									if ( in_array( $values['product_id'], $coupon->product_ids ) || in_array( $values['variation_id'], $coupon->product_ids ) || in_array( $values['data']->get_parent(), $coupon->product_ids ) )
-										$this_item_is_discounted = true;
-
-								// Category discounts
-								} elseif ( sizeof($coupon->product_categories ) > 0 ) {
-
-									if ( sizeof( array_intersect( $product_cats, $coupon->product_categories ) ) > 0 )
-										$this_item_is_discounted = true;
-
-								} else {
-
-									// No product ids - all items discounted
-									$this_item_is_discounted = true;
-
-								}
-
-								// Specific product ID's excluded from the discount
-								if ( sizeof( $coupon->exclude_product_ids ) > 0 )
-									if ( in_array( $values['product_id'], $coupon->exclude_product_ids ) || in_array( $values['variation_id'], $coupon->exclude_product_ids ) || in_array( $values['data']->get_parent(), $coupon->exclude_product_ids ) )
-										$this_item_is_discounted = false;
-
-								// Specific categories excluded from the discount
-								if ( sizeof( $coupon->exclude_product_categories ) > 0 )
-									if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
-										$this_item_is_discounted = false;
-
-								// Sale Items excluded from discount
-								if ( $coupon->exclude_sale_items == 'yes' )
-									if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
-										$this_item_is_discounted = false;
-
-								// Apply filter
-								$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = true, $coupon );
-
-								// Apply the discount
-								if ( $this_item_is_discounted ) {
-									if ( $coupon->type=='fixed_product' ) {
-
-										if ( $price < $coupon->amount ) {
-											$discount_amount = $price;
-										} else {
-											$discount_amount = $coupon->amount;
-										}
-
-										$price = $price - $coupon->amount;
-
-										if ( $price < 0 ) $price = 0;
-
-										if ( $add_totals ) {
-											$this->discount_cart = $this->discount_cart + ( $discount_amount * $values['quantity'] );
-											$this->increase_coupon_discount_amount( $code, $discount_amount * $values['quantity'] );
-										}
-
-									} elseif ( $coupon->type == 'percent_product' ) {
-
-										$percent_discount = ( $values['data']->get_price() / 100 ) * $coupon->amount;
-
-										if ( $add_totals ) {
-											$this->discount_cart = $this->discount_cart + ( $percent_discount * $values['quantity'] );
-											$this->increase_coupon_discount_amount( $code, $percent_discount * $values['quantity'] );
-										}
-
-										$price = $price - $percent_discount;
-
-									}
-								}
-
-							break;
-
-							case "fixed_cart" :
-
-								/**
-								 * This is the most complex discount - we need to divide the discount between rows based on their price in
-								 * proportion to the subtotal. This is so rows with different tax rates get a fair discount, and so rows
-								 * with no price (free) don't get discount too.
-								 */
-
-								// Get item discount by dividing item cost by subtotal to get a %
-								if ( $this->subtotal_ex_tax )
-									$discount_percent = ( $values['data']->get_price_excluding_tax() * $values['quantity'] ) / $this->subtotal_ex_tax;
-								else
-									$discount_percent = 0;
-
-								// Use pence to help prevent rounding errors
-								$coupon_amount_pence = $coupon->amount * 100;
-
-								// Work out the discount for the row
-								$item_discount = $coupon_amount_pence * $discount_percent;
-
-								// Work out discount per item
-								$item_discount = $item_discount / $values['quantity'];
-
-								// Pence
-								$price = $price * 100;
-
-								// Check if discount is more than price
-								if ( $price < $item_discount )
-									$discount_amount = $price;
-								else
-									$discount_amount = $item_discount;
-
-								// Take discount off of price (in pence)
-								$price = $price - $discount_amount;
-
-								// Back to pounds
-								$price = $price / 100;
-
-								// Cannot be below 0
-								if ( $price < 0 )
-									$price = 0;
-
-								// Add coupon to discount total (once, since this is a fixed cart discount and we don't want rounding issues)
-								if ( $add_totals ) {
-									$this->discount_cart = $this->discount_cart + ( ( $discount_amount * $values['quantity'] ) / 100 );
-									$this->increase_coupon_discount_amount( $code, ( $discount_amount * $values['quantity'] ) / 100 );
-								}
-
-							break;
-
-							case "percent" :
-
-								$percent_discount = ( $values['data']->get_price() / 100 ) * $coupon->amount;
-
-								if ( $add_totals ) {
-									$this->discount_cart = $this->discount_cart + ( $percent_discount * $values['quantity'] );
-									$this->increase_coupon_discount_amount( $code, $percent_discount * $values['quantity'] );
-								}
-
-								$price = $price - $percent_discount;
-
-							break;
-
-						}
-					}
-				}
+			foreach ( $this->cart_session_data as $key => $default ) {
+				$this->$key = $default;
+				unset( WC()->session->$key );
 			}
-
-			return apply_filters( 'woocommerce_get_discounted_price', $price, $values, $this );
-		}
-
-		/**
-		 * Function to apply product discounts after tax.
-		 *
-		 * @access public
-		 * @param mixed $values
-		 * @param mixed $price
-		 */
-		public function apply_product_discounts_after_tax( $values, $price ) {
-
-			if ( ! empty( $this->applied_coupons) ) {
-				foreach ( $this->applied_coupons as $code ) {
-					$coupon = new WC_Coupon( $code );
-
-					do_action( 'woocommerce_product_discount_after_tax_' . $coupon->type, $coupon, $values, $price );
-
-					if ( ! $coupon->is_valid() ) continue;
-
-					if ( $coupon->type != 'fixed_product' && $coupon->type != 'percent_product' ) continue;
-
-					if ( ! $coupon->apply_before_tax() ) {
-
-						$product_cats = wp_get_post_terms( $values['product_id'], 'product_cat', array("fields" => "ids") );
-						$product_ids_on_sale = woocommerce_get_product_ids_on_sale();
-
-						$this_item_is_discounted = false;
-
-						// Specific products get the discount
-						if ( sizeof( $coupon->product_ids ) > 0 ) {
-
-							if (in_array($values['product_id'], $coupon->product_ids) || in_array($values['variation_id'], $coupon->product_ids) || in_array($values['data']->get_parent(), $coupon->product_ids))
-								$this_item_is_discounted = true;
-
-						// Category discounts
-						} elseif ( sizeof( $coupon->product_categories ) > 0 ) {
-
-							if ( sizeof( array_intersect( $product_cats, $coupon->product_categories ) ) > 0 )
-								$this_item_is_discounted = true;
-
-						} else {
-
-							// No product ids - all items discounted
-							$this_item_is_discounted = true;
-
-						}
-
-						// Specific product ID's excluded from the discount
-						if ( sizeof( $coupon->exclude_product_ids ) > 0 )
-							if ( in_array( $values['product_id'], $coupon->exclude_product_ids ) || in_array( $values['variation_id'], $coupon->exclude_product_ids ) || in_array( $values['data']->get_parent(), $coupon->exclude_product_ids ) )
-								$this_item_is_discounted = false;
-
-						// Specific categories excluded from the discount
-						if ( sizeof( $coupon->exclude_product_categories ) > 0 )
-							if ( sizeof( array_intersect( $product_cats, $coupon->exclude_product_categories ) ) > 0 )
-								$this_item_is_discounted = false;
-
-						// Sale Items excluded from discount
-						if ( $coupon->exclude_sale_items == 'yes' )
-							if ( in_array( $values['product_id'], $product_ids_on_sale, true ) || in_array( $values['variation_id'], $product_ids_on_sale, true ) || in_array( $values['data']->get_parent(), $product_ids_on_sale, true ) )
-								$this_item_is_discounted = false;
-
-						// Apply filter
-						$this_item_is_discounted = apply_filters( 'woocommerce_item_is_discounted', $this_item_is_discounted, $values, $before_tax = false, $coupon );
-
-						// Apply the discount
-						if ( $this_item_is_discounted ) {
-							if ( $coupon->type == 'fixed_product' ) {
-
-								if ( $price < $coupon->amount )
-									$discount_amount = $price;
-								else
-									$discount_amount = $coupon->amount;
-
-								$this->discount_total = $this->discount_total + ( $discount_amount * $values['quantity'] );
-								$this->increase_coupon_discount_amount( $code, $discount_amount * $values['quantity'] );
-
-							} elseif ( $coupon->type == 'percent_product' ) {
-								$this->discount_total = $this->discount_total + round( ( $price / 100 ) * $coupon->amount, $this->dp );
-								$this->increase_coupon_discount_amount( $code, round( ( $price / 100 ) * $coupon->amount, $this->dp ) );
-							}
-						}
-					}
-				}
-			}
-
-		}
-
-		/**
-		 * Function to apply cart discounts after tax.
-		 *
-		 * @access public
-		 */
-		public function apply_cart_discounts_after_tax() {
-
-			$pre_discount_total = number_format( $this->cart_contents_total + $this->tax_total + $this->shipping_tax_total + $this->shipping_total + $this->fee_total, $this->dp, '.', '' );
-
-			if ( $this->applied_coupons ) {
-				foreach ( $this->applied_coupons as $code ) {
-					$coupon = new WC_Coupon( $code );
-
-					do_action( 'woocommerce_cart_discount_after_tax_' . $coupon->type, $coupon );
-
-					if ( ! $coupon->apply_before_tax() && $coupon->is_valid() ) {
-
-						switch ( $coupon->type ) {
-
-							case "fixed_cart" :
-
-								if ( $coupon->amount > $pre_discount_total )
-									$coupon->amount = $pre_discount_total;
-
-								$pre_discount_total = $pre_discount_total - $coupon->amount;
-
-								$this->discount_total = $this->discount_total + $coupon->amount;
-
-								$this->increase_coupon_discount_amount( $code, $coupon->amount );
-
-							break;
-
-							case "percent" :
-
-								$percent_discount = round( ( round( $this->cart_contents_total + $this->tax_total + $this->fee_total, $this->dp ) / 100 ) * $coupon->amount, $this->dp );
-
-								if ( $coupon->amount > $percent_discount )
-									$coupon->amount = $percent_discount;
-
-								$pre_discount_total = $pre_discount_total - $percent_discount;
-
-								$this->discount_total = $this->discount_total + $percent_discount;
-
-								$this->increase_coupon_discount_amount( $code, $percent_discount );
-
-							break;
-
-						}
-
-					}
-				}
-			}
-		}
-
-		/**
-		 * Store how much discount each coupon grants.
-		 *
-		 * @access private
-		 * @param mixed $code
-		 * @param mixed $amount
-		 * @return void
-		 */
-		private function increase_coupon_discount_amount( $code, $amount ) {
-			if ( empty( $this->coupon_discount_amounts[ $code ] ) )
-				$this->coupon_discount_amounts[ $code ] = 0;
-
-			$this->coupon_discount_amounts[ $code ] += $amount;
 		}
 
 		/**
@@ -1323,271 +952,240 @@ class WC_Cart {
 		 * @access public
 		 */
 		public function calculate_totals() {
-			global $woocommerce;
 
 			$this->reset();
 
 			do_action( 'woocommerce_before_calculate_totals', $this );
 
-			if ( sizeof( $this->get_cart() ) == 0 )
+			if ( sizeof( $this->get_cart() ) == 0 ) {
+				$this->set_session();
 				return;
+			}
 
-			// Get count of all items + weights + subtotal (we may need this for discounts)
-			$subtotal       = 0;
-			$subtotal_tax   = 0;
 			$tax_rates      = array();
+			$shop_tax_rates = array();
 
+			/**
+			 * Calculate subtotals for items. This is done first so that discount logic can use the values.
+			 */
 			foreach ( $this->get_cart() as $cart_item_key => $values ) {
 
 				$_product = $values['data'];
 
 				// Count items + weight
-				$this->cart_contents_weight = $this->cart_contents_weight + ( $_product->get_weight() * $values['quantity'] );
-				$this->cart_contents_count  = $this->cart_contents_count + $values['quantity'];
+				$this->cart_contents_weight += $_product->get_weight() * $values['quantity'];
+				$this->cart_contents_count  += $values['quantity'];
 
-				// Line price
-				$line_price                 = $_product->get_price() * $values['quantity'];
+				// Prices
+				$base_price = $_product->get_price();
+				$line_price = $_product->get_price() * $values['quantity'];
+				
+				$line_subtotal = 0;
+				$line_subtotal_tax = 0;
 
+				/**
+				 * No tax to calculate
+				 */
 				if ( ! $_product->is_taxable() ) {
-					$subtotal += $line_price;
-				} else {
+
+					// Subtotal is the undiscounted price
+					$this->subtotal += $line_price;
+					$this->subtotal_ex_tax += $line_price;
+
+				/**
+				 * Prices include tax
+				 *
+				 * To prevent rounding issues we need to work with the inclusive price where possible
+				 * otherwise we'll see errors such as when working with a 9.99 inc price, 20% VAT which would
+				 * be 8.325 leading to totals being 1p off
+				 *
+				 * Pre tax coupons come off the price the customer thinks they are paying - tax is calculated
+				 * afterwards.
+				 *
+				 * e.g. $100 bike with $10 coupon = customer pays $90 and tax worked backwards from that
+				 */
+				} elseif ( $this->prices_include_tax ) {
 
 					// Get base tax rates
 					if ( empty( $shop_tax_rates[ $_product->tax_class ] ) )
 						$shop_tax_rates[ $_product->tax_class ] = $this->tax->get_shop_base_rate( $_product->tax_class );
 
+					// Get item tax rates
+					if ( empty( $tax_rates[ $_product->get_tax_class() ] ) )
+						$tax_rates[ $_product->get_tax_class() ] = $this->tax->get_rates( $_product->get_tax_class() );
+
 					$base_tax_rates = $shop_tax_rates[ $_product->tax_class ];
+					$item_tax_rates = $tax_rates[ $_product->get_tax_class() ];
+
+					/**
+					 * ADJUST TAX - Calculations when base tax is not equal to the item tax
+					 */
+					if ( $item_tax_rates !== $base_tax_rates ) {
+
+						// Work out a new base price without the shop's base tax
+						$taxes                 = $this->tax->calc_tax( $line_price, $base_tax_rates, true, true );
+
+						// Now we have a new item price (excluding TAX)
+						$line_subtotal         = $line_price - array_sum( $taxes );
+
+						// Now add modifed taxes
+						$tax_result            = $this->tax->calc_tax( $line_subtotal, $item_tax_rates );
+						$line_subtotal_tax     = array_sum( $tax_result );
+
+					/**
+					 * Regular tax calculation (customer inside base and the tax class is unmodified
+					 */
+					} else {
+
+						// Calc tax normally
+						$taxes                 = $this->tax->calc_tax( $line_price, $item_tax_rates, true );
+						$line_subtotal_tax     = array_sum( $taxes );
+						$line_subtotal         = $line_price - array_sum( $taxes );
+					}
+
+				/**
+				 * Prices exclude tax
+				 *
+				 * This calculation is simpler - work with the base, untaxed price.
+				 */
+				} else {
 
 					// Get item tax rates
 					if ( empty( $tax_rates[ $_product->get_tax_class() ] ) )
 						$tax_rates[ $_product->get_tax_class() ] = $this->tax->get_rates( $_product->get_tax_class() );
 
-					$item_tax_rates = $tax_rates[ $_product->get_tax_class() ];
+					$item_tax_rates        = $tax_rates[ $_product->get_tax_class() ];
 
-					if ( $this->prices_include_tax ) {
-
-						// ADJUST BASE if tax rate is different (different region or modified tax class)
-						if ( $item_tax_rates !== $base_tax_rates ) {
-							// Work out a new base price without the shop's base tax
-							$line_tax     = array_sum( $this->tax->calc_tax( $line_price, $base_tax_rates, true ) );
-
-							// Now we have a new item price (excluding TAX)
-							$line_price   = $this->tax->round( $line_price - $line_tax );
-
-							// Now add taxes for the users location
-							$line_tax     = array_sum( $this->tax->calc_tax( $line_price, $item_tax_rates, false ) );
-							$line_tax     = $this->round_at_subtotal ? $line_tax : $this->tax->round( $line_tax );
-
-							// Add to main subtotal
-							$subtotal     += $line_price;
-							$subtotal_tax += $line_tax;
-						} else {
-							// Calc tax normally
-							$line_tax     = array_sum( $this->tax->calc_tax( $line_price, $item_tax_rates, true ) );
-							$line_tax     = $this->round_at_subtotal ? $line_tax : $this->tax->round( $line_tax );
-
-							// Add to main subtotal
-							$subtotal     += $line_price - $line_tax;
-							$subtotal_tax += $line_tax;
-						}
-
-					} else {
-
-						if ( $_product->is_taxable() ) {
-							$taxes        = $this->tax->calc_tax( $line_price, $item_tax_rates, false );
-							$line_tax     = $this->round_at_subtotal ? array_sum( $taxes ) : $this->tax->get_tax_total( $taxes );
-							$subtotal_tax += $line_tax;
-						}
-
-						$subtotal     += $line_price;
-					}
-
+					// Base tax for line before discount - we will store this in the order data
+					$taxes                 = $this->tax->calc_tax( $line_price, $item_tax_rates );
+					$line_subtotal_tax     = array_sum( $taxes );
+					$line_subtotal         = $line_price;
 				}
 
+				// Add to main subtotal
+				$this->subtotal        += $line_subtotal + $line_subtotal_tax;
+				$this->subtotal_ex_tax += $line_subtotal;
 			}
 
-			$this->subtotal        = $subtotal + $subtotal_tax;
-			$this->subtotal_ex_tax = $subtotal;
+			/**
+			 * Calculate totals for items
+			 */
+			foreach ( $this->get_cart() as $cart_item_key => $values ) {
 
-			// Now calc the main totals, including discounts
-			if ( $this->prices_include_tax ) {
+				$_product = $values['data'];
+
+				// Prices
+				$base_price = $_product->get_price();
+				$line_price = $_product->get_price() * $values['quantity'];
 
 				/**
-				 * Calculate totals for items
+				 * No tax to calculate
 				 */
-				foreach ( $this->get_cart() as $cart_item_key => $values ) {
+				if ( ! $_product->is_taxable() ) {
+
+					// Discounted Price (price with any pre-tax discounts applied)
+					$discounted_price      = $this->get_discounted_price( $values, $base_price, true );
+					$discounted_tax_amount = 0;
+					$tax_amount            = 0;
+					$line_subtotal_tax     = 0;
+					$line_subtotal         = $line_price;
+					$line_tax              = 0;
+					$line_total            = $this->tax->round( $discounted_price * $values['quantity'] );
+
+				/**
+				 * Prices include tax
+				 */
+				} elseif ( $this->prices_include_tax ) {
+
+					$base_tax_rates = $shop_tax_rates[ $_product->tax_class ];
+					$item_tax_rates = $tax_rates[ $_product->get_tax_class() ];
 
 					/**
-					 * Prices include tax
-					 *
-					 * To prevent rounding issues we need to work with the inclusive price where possible
-					 * otherwise we'll see errors such as when working with a 9.99 inc price, 20% VAT which would
-					 * be 8.325 leading to totals being 1p off
-					 *
-					 * Pre tax coupons come off the price the customer thinks they are paying - tax is calculated
-					 * afterwards.
-					 *
-					 * e.g. $100 bike with $10 coupon = customer pays $90 and tax worked backwards from that
-					 *
-					 * Used this excellent article for reference:
-					 *	http://developer.practicalecommerce.com/articles/1473-Coding-for-Tax-Calculations-Everything-You-Never-Wanted-to-Know-Part-2
+					 * ADJUST TAX - Calculations when base tax is not equal to the item tax
 					 */
-					$_product = $values['data'];
+					if ( $item_tax_rates !== $base_tax_rates ) {
 
-					// Prices
-					$base_price = $_product->get_price();
-					$line_price = $_product->get_price() * $values['quantity'];
+						// Work out a new base price without the shop's base tax
+						$taxes             = $this->tax->calc_tax( $line_price, $base_tax_rates, true, true );
 
-					// Base Price Adjustment
-					if ( ! $_product->is_taxable() ) {
+						// Now we have a new item price (excluding TAX)
+						$line_subtotal     = $line_price - array_sum( $taxes );
 
-						// Discounted Price (price with any pre-tax discounts applied)
-						$discounted_price 		= $this->get_discounted_price( $values, $base_price, true );
-						$discounted_tax_amount 	= 0;
-						$tax_amount 			= 0;
-						$line_subtotal_tax		= 0;
-						$line_subtotal			= $line_price;
+						// Now add modifed taxes
+						$taxes             = $this->tax->calc_tax( $line_subtotal, $item_tax_rates );
+						$line_subtotal_tax = array_sum( $taxes );
 
-					} else {
+						// Adjusted price (this is the price including the new tax rate)
+						$adjusted_price    = ( $line_subtotal + $line_subtotal_tax ) / $values['quantity'];
 
-						// Get base tax rates
-						if ( empty( $shop_tax_rates[ $_product->tax_class ] ) )
-							$shop_tax_rates[ $_product->tax_class ] = $this->tax->get_shop_base_rate( $_product->tax_class );
-
-						$base_tax_rates = $shop_tax_rates[ $_product->tax_class ];
-
-						// Get item tax rates
-						if ( empty( $tax_rates[ $_product->get_tax_class() ] ) )
-							$tax_rates[ $_product->get_tax_class() ] = $this->tax->get_rates( $_product->get_tax_class() );
-
-						$item_tax_rates = $tax_rates[ $_product->get_tax_class() ];
-
-						/**
-						 * ADJUST TAX - Calculations when customer is OUTSIDE the shop base country/state and prices INCLUDE tax
-						 * 	OR
-						 * ADJUST TAX - Calculations when a tax class is modified
-						 */
-						if ( $_product->get_tax_class() !== $_product->tax_class || ( $woocommerce->customer->is_customer_outside_base() && ( defined('WOOCOMMERCE_CHECKOUT') || $woocommerce->customer->has_calculated_shipping() ) ) ) {
-
-							// Work out a new base price without the shop's base tax
-							$line_tax              = array_sum( $this->tax->calc_tax( $line_price, $base_tax_rates, true ) );
-
-							// Now we have a new item price (excluding TAX)
-							$line_subtotal         = $this->tax->round( $line_price - $line_tax );
-
-							// Now add taxes for the users location
-							$line_subtotal_tax     = array_sum( $this->tax->calc_tax( $line_subtotal, $item_tax_rates, false ) );
-							$line_subtotal_tax     = $this->round_at_subtotal ? $line_subtotal_tax : $this->tax->round( $line_subtotal_tax );
-
-							// Adjusted price (this is the price including the new tax rate)
-							$adjusted_price        = ( $line_subtotal + $line_subtotal_tax ) / $values['quantity'];
-
-							// Apply discounts
-							$discounted_price      = $this->get_discounted_price( $values, $adjusted_price, true );
-							$discounted_taxes      = $this->tax->calc_tax( $discounted_price * $values['quantity'], $item_tax_rates, true );
-							$discounted_tax_amount = array_sum( $discounted_taxes ); // Sum taxes
-
-						/**
-						 * Regular tax calculation (customer inside base and the tax class is unmodified
-						 */
-						} else {
-
-							// Calc tax normally
-							$line_subtotal_tax     = array_sum( $this->tax->calc_tax( $line_price, $item_tax_rates, true ) );
-							$line_subtotal_tax     = $this->round_at_subtotal ? $line_subtotal_tax : $this->tax->round( $line_subtotal_tax );
-
-							// Subtotal
-							$line_subtotal         = $line_price - $line_subtotal_tax;
-
-							// Calc prices and tax (discounted)
-							$discounted_price      = $this->get_discounted_price( $values, $base_price, true );
-							$discounted_taxes      = $this->tax->calc_tax( $discounted_price * $values['quantity'], $item_tax_rates, true );
-							$discounted_tax_amount = array_sum( $discounted_taxes ); // Sum taxes
-						}
-
-						// Tax rows - merge the totals we just got
-						foreach ( array_keys( $this->taxes + $discounted_taxes ) as $key ) {
-						    $this->taxes[ $key ] = ( isset( $discounted_taxes[ $key ] ) ? $discounted_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
-						}
-					}
-
-					// Line prices
-					$line_tax 		= $this->round_at_subtotal ? $discounted_tax_amount : $this->tax->round( $discounted_tax_amount );
-					$line_total 	= $this->tax->round( ( $discounted_price * $values['quantity'] ) - $line_tax );
-
-					// Add any product discounts (after tax)
-					$this->apply_product_discounts_after_tax( $values, $line_total + $discounted_tax_amount );
-
-					// Cart contents total is based on discounted prices and is used for the final total calculation
-					$this->cart_contents_total 	= $this->cart_contents_total + $line_total;
-
-					// Store costs + taxes for lines
-					$this->cart_contents[ $cart_item_key ]['line_total'] 		= $line_total;
-					$this->cart_contents[ $cart_item_key ]['line_tax'] 			= $line_tax;
-					$this->cart_contents[ $cart_item_key ]['line_subtotal'] 	= $line_subtotal;
-					$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $line_subtotal_tax;
-				}
-
-			} else {
-
-				foreach ( $this->get_cart() as $cart_item_key => $values ) {
+						// Apply discounts
+						$discounted_price  = $this->get_discounted_price( $values, $adjusted_price, true );
+						$discounted_taxes  = $this->tax->calc_tax( $discounted_price * $values['quantity'], $item_tax_rates, true );
+						$line_tax          = array_sum( $discounted_taxes );
+						$line_total        = ( $discounted_price * $values['quantity'] ) - $line_tax;
 
 					/**
-					 * Prices exclude tax
-					 *
-					 * This calculation is simpler - work with the base, untaxed price.
+					 * Regular tax calculation (customer inside base and the tax class is unmodified
 					 */
-					$_product = $values['data'];
-
-					// Prices
-					$base_price = $_product->get_price();
-					$line_price = $_product->get_price() * $values['quantity'];
-
-					// Discounted Price (base price with any pre-tax discounts applied
-					$discounted_price = $this->get_discounted_price( $values, $base_price, true );
-
-					// Taxes
-					if ( ! $_product->is_taxable() ) {
-						$discounted_tax_amount 	= 0;
-						$line_subtotal_tax      = 0;
 					} else {
 
-						// Get item tax rates
-						if ( empty( $tax_rates[ $_product->get_tax_class() ] ) )
-							$tax_rates[ $_product->get_tax_class() ] = $this->tax->get_rates( $_product->get_tax_class() );
+						// Work out a new base price without the shop's base tax
+						$taxes             = $this->tax->calc_tax( $line_price, $item_tax_rates, true );
 
-						$item_tax_rates        = $tax_rates[ $_product->get_tax_class() ];
+						// Now we have a new item price (excluding TAX)
+						$line_subtotal     = $line_price - array_sum( $taxes );
+						$line_subtotal_tax = array_sum( $taxes );
 
-						// Base tax for line before discount - we will store this in the order data
-						$line_subtotal_tax     = array_sum( $this->tax->calc_tax( $line_price, $item_tax_rates, false ) );
-
-						// Now calc product rates
-						$discounted_taxes      = $this->tax->calc_tax( $discounted_price * $values['quantity'], $item_tax_rates, false );
-						$discounted_tax_amount = array_sum( $discounted_taxes );
-
-						// Tax rows - merge the totals we just got
-						foreach ( array_keys( $this->taxes + $discounted_taxes ) as $key ) {
-						    $this->taxes[ $key ] = ( isset( $discounted_taxes[ $key ] ) ? $discounted_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
-						}
+						// Calc prices and tax (discounted)
+						$discounted_price = $this->get_discounted_price( $values, $base_price, true );
+						$discounted_taxes = $this->tax->calc_tax( $discounted_price * $values['quantity'], $item_tax_rates, true );
+						$line_tax         = array_sum( $discounted_taxes );
+						$line_total       = ( $discounted_price * $values['quantity'] ) - $line_tax;
 					}
 
-					// Line prices
-					$line_tax			= $discounted_tax_amount;
-					$line_subtotal		= $line_price;
-					$line_total 		= $discounted_price * $values['quantity'];
+					// Tax rows - merge the totals we just got
+					foreach ( array_keys( $this->taxes + $discounted_taxes ) as $key ) {
+					    $this->taxes[ $key ] = ( isset( $discounted_taxes[ $key ] ) ? $discounted_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
+					}
 
-					// Add any product discounts (after tax)
-					$this->apply_product_discounts_after_tax( $values, $line_total + $line_tax );
+				/**
+				 * Prices exclude tax
+				 */
+				} else {
 
-					// Cart contents total is based on discounted prices and is used for the final total calculation
-					$this->cart_contents_total 	= $this->cart_contents_total + $line_total;
+					$item_tax_rates        = $tax_rates[ $_product->get_tax_class() ];
 
-					// Store costs + taxes for lines
-					$this->cart_contents[ $cart_item_key ]['line_total'] 		= $line_total;
-					$this->cart_contents[ $cart_item_key ]['line_tax'] 			= $line_tax;
-					$this->cart_contents[ $cart_item_key ]['line_subtotal'] 	= $line_subtotal;
-					$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $line_subtotal_tax;
+					// Work out a new base price without the shop's base tax
+					$taxes                 = $this->tax->calc_tax( $line_price, $item_tax_rates );
+
+					// Now we have the item price (excluding TAX)
+					$line_subtotal         = $line_price;
+					$line_subtotal_tax     = array_sum( $taxes );
+
+					// Now calc product rates
+					$discounted_price      = $this->get_discounted_price( $values, $base_price, true );
+					$discounted_taxes      = $this->tax->calc_tax( $discounted_price * $values['quantity'], $item_tax_rates );
+					$discounted_tax_amount = array_sum( $discounted_taxes );
+					$line_tax              = $discounted_tax_amount;
+					$line_total            = $discounted_price * $values['quantity'];
+
+					// Tax rows - merge the totals we just got
+					foreach ( array_keys( $this->taxes + $discounted_taxes ) as $key ) {
+					    $this->taxes[ $key ] = ( isset( $discounted_taxes[ $key ] ) ? $discounted_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
+					}
 				}
+
+				// Add any product discounts (after tax)
+				$this->apply_product_discounts_after_tax( $values, $line_total + $line_tax );
+
+				// Cart contents total is based on discounted prices and is used for the final total calculation
+				$this->cart_contents_total += $line_total;
+
+				// Store costs + taxes for lines
+				$this->cart_contents[ $cart_item_key ]['line_total'] 		= $line_total;
+				$this->cart_contents[ $cart_item_key ]['line_tax'] 			= $line_tax;
+				$this->cart_contents[ $cart_item_key ]['line_subtotal'] 	= $line_subtotal;
+				$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $line_subtotal_tax;
 			}
 
 			// Only calculate the grand total + shipping if on the cart/checkout
@@ -1599,24 +1197,19 @@ class WC_Cart {
 				// Trigger the fees API where developers can add fees to the cart
 				$this->calculate_fees();
 
-				// Total up/round taxes
+				// Total up/round taxes and shipping taxes
 				if ( $this->round_at_subtotal ) {
 					$this->tax_total          = $this->tax->get_tax_total( $this->taxes );
-					$this->taxes              = array_map( array( $this->tax, 'round' ), $this->taxes );
-				} else {
-					$this->tax_total          = array_sum( $this->taxes );
-				}
-
-				// Total up/round taxes for shipping
-				if ( $this->round_at_subtotal ) {
 					$this->shipping_tax_total = $this->tax->get_tax_total( $this->shipping_taxes );
+					$this->taxes              = array_map( array( $this->tax, 'round' ), $this->taxes );
 					$this->shipping_taxes     = array_map( array( $this->tax, 'round' ), $this->shipping_taxes );
 				} else {
+					$this->tax_total          = array_sum( $this->taxes );
 					$this->shipping_tax_total = array_sum( $this->shipping_taxes );
 				}
 
 				// VAT exemption done at this point - so all totals are correct before exemption
-				if ( $woocommerce->customer->is_vat_exempt() )
+				if ( WC()->customer->is_vat_exempt() )
 					$this->remove_taxes();
 
 				// Cart Discounts (after tax)
@@ -1626,7 +1219,7 @@ class WC_Cart {
 				do_action( 'woocommerce_calculate_totals', $this );
 
 				// Grand Total - Discounted product prices, discounted tax, shipping cost + tax, and any discounts to be added after tax (e.g. store credit)
-				$this->total = max( 0, apply_filters( 'woocommerce_calculated_total', number_format( $this->cart_contents_total + $this->tax_total + $this->shipping_tax_total + $this->shipping_total - $this->discount_total + $this->fee_total, $this->dp, '.', '' ), $this ) );
+				$this->total = max( 0, apply_filters( 'woocommerce_calculated_total', round( $this->cart_contents_total + $this->tax_total + $this->shipping_tax_total + $this->shipping_total - $this->discount_total + $this->fee_total, $this->dp ), $this ) );
 
 			} else {
 
@@ -1634,7 +1227,7 @@ class WC_Cart {
 				$this->tax_total = $this->tax->get_tax_total( $this->taxes );
 
 				// VAT exemption done at this point - so all totals are correct before exemption
-				if ( $woocommerce->customer->is_vat_exempt() )
+				if ( WC()->customer->is_vat_exempt() )
 					$this->remove_taxes();
 
 				// Cart Discounts (after tax)
@@ -1671,8 +1264,7 @@ class WC_Cart {
 		 * @return bool
 		 */
 		public function needs_payment() {
-			$needs_payment = ( $this->total > 0 ) ? true : false;
-			return apply_filters( 'woocommerce_cart_needs_payment', $needs_payment, $this );
+			return apply_filters( 'woocommerce_cart_needs_payment', $this->total > 0, $this );
 		}
 
     /*-----------------------------------------------------------------------------------*/
@@ -1686,17 +1278,15 @@ class WC_Cart {
 		 * @return void
 		 */
 		public function calculate_shipping() {
-			global $woocommerce;
-
 			if ( $this->needs_shipping() && $this->show_shipping() ) {
-				$woocommerce->shipping->calculate_shipping( $this->get_shipping_packages() );
+				WC()->shipping->calculate_shipping( $this->get_shipping_packages() );
 			} else {
-				$woocommerce->shipping->reset_shipping();
+				WC()->shipping->reset_shipping();
 			}
 
 			// Get totals for the chosen shipping method
-			$this->shipping_total 		= $woocommerce->shipping->shipping_total;	// Shipping Total
-			$this->shipping_taxes		= $woocommerce->shipping->shipping_taxes;	// Shipping Taxes
+			$this->shipping_total 		= WC()->shipping->shipping_total;	// Shipping Total
+			$this->shipping_taxes		= WC()->shipping->shipping_taxes;	// Shipping Taxes
 		}
 
 		/**
@@ -1714,20 +1304,18 @@ class WC_Cart {
 		 * @return array of cart items
 		 */
 		public function get_shipping_packages() {
-			global $woocommerce;
-
 			// Packages array for storing 'carts'
 			$packages = array();
 
 			$packages[0]['contents']                 = $this->get_cart();		// Items in the package
 			$packages[0]['contents_cost']            = 0;						// Cost of items in the package, set below
-			$packages[0]['applied_coupons']          = $this->applied_coupons; 	// Applied coupons - some, like free shipping, affect costs
-			$packages[0]['destination']['country']   = $woocommerce->customer->get_shipping_country();
-			$packages[0]['destination']['state']     = $woocommerce->customer->get_shipping_state();
-			$packages[0]['destination']['postcode']  = $woocommerce->customer->get_shipping_postcode();
-			$packages[0]['destination']['city']      = $woocommerce->customer->get_shipping_city();
-			$packages[0]['destination']['address']   = $woocommerce->customer->get_shipping_address();
-			$packages[0]['destination']['address_2'] = $woocommerce->customer->get_shipping_address_2();
+			$packages[0]['applied_coupons']          = $this->applied_coupons;
+			$packages[0]['destination']['country']   = WC()->customer->get_shipping_country();
+			$packages[0]['destination']['state']     = WC()->customer->get_shipping_state();
+			$packages[0]['destination']['postcode']  = WC()->customer->get_shipping_postcode();
+			$packages[0]['destination']['city']      = WC()->customer->get_shipping_city();
+			$packages[0]['destination']['address']   = WC()->customer->get_shipping_address();
+			$packages[0]['destination']['address_2'] = WC()->customer->get_shipping_address_2();
 
 			foreach ( $this->get_cart() as $item )
 				if ( $item['data']->needs_shipping() )
@@ -1766,14 +1354,12 @@ class WC_Cart {
 		 * @return bool
 		 */
 		public function show_shipping() {
-			global $woocommerce;
-
 			if ( get_option('woocommerce_calc_shipping') == 'no' || ! is_array( $this->cart_contents ) )
 				return false;
 
 			if ( get_option( 'woocommerce_shipping_cost_requires_address' ) == 'yes' ) {
-				if ( ! $woocommerce->customer->has_calculated_shipping() ) {
-					if ( ! $woocommerce->customer->get_shipping_country() || ( ! $woocommerce->customer->get_shipping_state() && ! $woocommerce->customer->get_shipping_postcode() ) )
+				if ( ! WC()->customer->has_calculated_shipping() ) {
+					if ( ! WC()->customer->get_shipping_country() || ( ! WC()->customer->get_shipping_state() && ! WC()->customer->get_shipping_postcode() ) )
 						return false;
 				}
 			}
@@ -1790,37 +1376,35 @@ class WC_Cart {
 		 * @return bool
 		 */
 		public function ship_to_billing_address_only() {
-			if ( get_option('woocommerce_ship_to_billing_address_only') == 'yes' ) return true; else return false;
+			return get_option('woocommerce_ship_to_billing_address_only') == 'yes';
 		}
 
 		/**
 		 * Gets the shipping total (after calculation).
 		 *
-		 * @return mixed price or string for the shipping total
+		 * @return string price or string for the shipping total
 		 */
 		public function get_cart_shipping_total() {
-			global $woocommerce;
-
 			if ( isset( $this->shipping_total ) ) {
 				if ( $this->shipping_total > 0 ) {
 
 					// Display varies depending on settings
 					if ( $this->tax_display_cart == 'excl' ) {
 
-						$return = woocommerce_price( $this->shipping_total );
+						$return = wc_price( $this->shipping_total );
 
 						if ( $this->shipping_tax_total > 0 && $this->prices_include_tax ) {
-							$return .= ' <small>' . $woocommerce->countries->ex_tax_or_vat() . '</small>';
+							$return .= ' <small>' . WC()->countries->ex_tax_or_vat() . '</small>';
 						}
 
 						return $return;
 
 					} else {
 
-						$return = woocommerce_price( $this->shipping_total + $this->shipping_tax_total );
+						$return = wc_price( $this->shipping_total + $this->shipping_tax_total );
 
 						if ( $this->shipping_tax_total > 0 && ! $this->prices_include_tax ) {
-							$return .= ' <small>' . $woocommerce->countries->inc_tax_or_vat() . '</small>';
+							$return .= ' <small>' . WC()->countries->inc_tax_or_vat() . '</small>';
 						}
 
 						return $return;
@@ -1831,6 +1415,8 @@ class WC_Cart {
 					return __( 'Free!', 'woocommerce' );
 				}
 			}
+
+			return '';
 		}
 
     /*-----------------------------------------------------------------------------------*/
@@ -1838,17 +1424,82 @@ class WC_Cart {
 	/*-----------------------------------------------------------------------------------*/
 
 		/**
+		 * Check for user coupons (now that we have billing email). If a coupon is invalid, add an error.
+		 *
+		 * Checks two types of coupons:
+		 *  1. Where a list of customer emails are set (limits coupon usage to those defined)
+		 *  2. Where a usage_limit_per_user is set (limits coupon usage to a number based on user ID and email)
+		 *
+		 * @access public
+		 * @param array $posted
+		 */
+		public function check_customer_coupons( $posted ) {
+			if ( ! empty( $this->applied_coupons ) ) {
+				foreach ( $this->applied_coupons as $code ) {
+					$coupon = new WC_Coupon( $code );
+
+					if ( $coupon->is_valid() ) {
+
+						// Limit to defined email addresses
+						if ( is_array( $coupon->customer_email ) && sizeof( $coupon->customer_email ) > 0 ) {
+							$coupon->customer_email = array_map( 'sanitize_email', $coupon->customer_email );
+
+							if ( is_user_logged_in() ) {
+								$current_user   = wp_get_current_user();
+								$check_emails[] = $current_user->user_email;
+							}
+							$check_emails[] = $posted['billing_email'];
+							$check_emails   = array_map( 'sanitize_email', array_map( 'strtolower', $check_emails ) );
+
+							if ( 0 == sizeof( array_intersect( $check_emails, $coupon->customer_email ) ) ) {
+								$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED );
+
+								// Remove the coupon
+								$this->remove_coupon( $code );
+
+								// Flag totals for refresh
+								WC()->session->set( 'refresh_totals', true );
+							}
+						}
+
+						// Usage limits per user - check against billing and user email and user ID
+						if ( $coupon->usage_limit_per_user > 0 ) {
+							$used_by = get_post_meta( $this->id, '_used_by' );
+
+							if ( is_user_logged_in() ) {
+								$current_user   = wp_get_current_user();
+								$check_emails[] = $current_user->user_email;
+							}
+							$check_emails[] = $posted['billing_email'];
+							$check_emails   = array_map( 'sanitize_email', array_map( 'strtolower', $check_emails ) );
+
+							$usage_count    = sizeof( array_keys( $used_by, get_current_user_id() ) );
+
+							foreach ( $check_emails as $check_email )
+								$usage_count    = $usage_count + sizeof( array_keys( $used_by, $check_email ) );
+
+							if ( $usage_count >= $coupon->usage_limit_per_user ) {
+								$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED );
+
+								// Remove the coupon
+								$this->remove_coupon( $code );
+
+								// Flag totals for refresh
+								WC()->session->set( 'refresh_totals', true );
+							}
+						}
+					}
+				}
+			}
+		}
+
+		/**
 		 * Returns whether or not a discount has been applied.
 		 *
 		 * @return bool
 		 */
 		public function has_discount( $coupon_code ) {
-
-			// Sanitize coupon code
-			$coupon_code = apply_filters( 'woocommerce_coupon_code', $coupon_code );
-
-			// Check if its set
-			return in_array( $coupon_code, $this->applied_coupons );
+			return in_array( apply_filters( 'woocommerce_coupon_code', $coupon_code ), $this->applied_coupons );
 		}
 
 		/**
@@ -1858,8 +1509,6 @@ class WC_Cart {
 		 * @return bool	True if the coupon is applied, false if it does not exist or cannot be applied
 		 */
 		public function add_discount( $coupon_code ) {
-			global $woocommerce;
-
 			// Coupons are globally disabled
 			if ( ! $this->coupons_enabled() )
 				return false;
@@ -1874,7 +1523,7 @@ class WC_Cart {
 
 				// Check it can be used with cart
 				if ( ! $the_coupon->is_valid() ) {
-					wc_add_error( $the_coupon->get_error_message() );
+					wc_add_notice( $the_coupon->get_error_message(), 'error' );
 					return false;
 				}
 
@@ -1891,13 +1540,12 @@ class WC_Cart {
 
 				if ( $this->applied_coupons ) {
 					foreach ( $this->applied_coupons as $code ) {
+						$coupon = new WC_Coupon( $code );
 
-						$existing_coupon = new WC_Coupon( $code );
-
-						if ( $existing_coupon->individual_use == 'yes' && false === apply_filters( 'woocommerce_apply_with_individual_use_coupon', false, $the_coupon, $existing_coupon, $this->applied_coupons ) ) {
+						if ( $coupon->individual_use == 'yes' && false === apply_filters( 'woocommerce_apply_with_individual_use_coupon', false, $the_coupon, $coupon, $this->applied_coupons ) ) {
 
 							// Reject new coupon
-							$existing_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED_INDIV_USE_ONLY );
+							$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED_INDIV_USE_ONLY );
 
 							return false;
 						}
@@ -1934,95 +1582,212 @@ class WC_Cart {
 		}
 
 		/**
-		 * Gets the array of applied coupon codes.
-		 *
-		 * @param  Type Type of coupons to get. Can be 'cart' or 'order' which are before and after tax respectively.
+		 * Get array of applied coupon objects and codes.
+		 * @param  string Type of coupons to get. Can be 'cart' or 'order' which are before and after tax respectively.
 		 * @return array of applied coupons
 		 */
-		public function get_applied_coupons( $type = '' ) {
+		public function get_coupons( $type = null ) {
 			$coupons = array();
 
-			if ( 'cart' == $type ) {
+			if ( 'cart' == $type || is_null( $type ) ) {
 				if ( $this->applied_coupons ) {
-					foreach ( $this->applied_coupons as $index => $code ) {
+					foreach ( $this->applied_coupons as $code ) {
 						$coupon = new WC_Coupon( $code );
-						if ( $coupon->is_valid() && $coupon->apply_before_tax() )
-							$coupons[] = $code;
+
+						if ( $coupon->apply_before_tax() )
+							$coupons[ $code ] = $coupon;
 					}
 				}
-			} elseif ( 'order' == $type ) {
+			}
+
+			if ( 'order' == $type || is_null( $type ) ) {
 				if ( $this->applied_coupons ) {
-					foreach ( $this->applied_coupons as $index => $code ) {
+					foreach ( $this->applied_coupons as $code ) {
 						$coupon = new WC_Coupon( $code );
-						if ( $coupon->is_valid() && ! $coupon->apply_before_tax() )
-							$coupons[] = $code;
+
+						if ( ! $coupon->apply_before_tax() )
+							$coupons[ $code ] = $coupon;
 					}
 				}
-			} else {
-				$coupons = array_filter( (array) $this->applied_coupons );
 			}
 
 			return $coupons;
 		}
 
 		/**
+		 * Gets the array of applied coupon codes.
+		 *
+		 * @return array of applied coupons
+		 */
+		public function get_applied_coupons() {
+			return $this->applied_coupons;
+		}
+
+		/**
 		 * Remove coupons from the cart of a defined type. Type 1 is before tax, type 2 is after tax.
 		 *
-		 * @params int type - 0 for all, 1 for before tax, 2 for after tax
+		 * @params string type - cart for before tax, order for after tax
 		 */
-		public function remove_coupons( $type = 0 ) {
-			global $woocommerce;
+		public function remove_coupons( $type = null ) {
 
-			if ( 1 == $type ) {
+			if ( 'cart' == $type || 1 == $type ) {
 				if ( $this->applied_coupons ) {
-					foreach ( $this->applied_coupons as $index => $code ) {
+					foreach ( $this->applied_coupons as $code ) {
 						$coupon = new WC_Coupon( $code );
-						if ( $coupon->is_valid() && $coupon->apply_before_tax() ) unset( $this->applied_coupons[ $index ] );
+
+						if ( $coupon->apply_before_tax() )
+							$this->remove_coupon( $code );
 					}
 				}
-
-				WC()->session->set( 'coupon_codes', $this->applied_coupons );
-
-			} elseif ( $type == 2 ) {
+			} elseif ( 'order' == $type || 2 == $type ) {
 				if ( $this->applied_coupons ) {
-					foreach ( $this->applied_coupons as $index => $code ) {
+					foreach ( $this->applied_coupons as $code ) {
 						$coupon = new WC_Coupon( $code );
-						if ( $coupon->is_valid() && ! $coupon->apply_before_tax() ) unset( $this->applied_coupons[ $index ] );
+
+						if ( ! $coupon->apply_before_tax() )
+							$this->remove_coupon( $code );
 					}
 				}
-
-				WC()->session->set( 'coupon_codes', $this->applied_coupons );
-
 			} else {
-				unset( $woocommerce->session->coupon_codes, $woocommerce->session->coupon_amounts );
-				$this->applied_coupons = array();
+				$this->applied_coupons = $this->coupon_discount_amounts = $this->coupon_applied_count = array();
+				WC()->session->set( 'applied_coupons', array() );
+				WC()->session->set( 'coupon_discount_amounts', array() );
 			}
 		}
 
 		/**
 		 * Remove a single coupon by code
+		 * @param  string $coupon_code Code of the coupon to remove
+		 * @return bool
 		 */
 		public function remove_coupon( $coupon_code ) {
-
 			// Coupons are globally disabled
 			if ( ! $this->coupons_enabled() )
 				return false;
 
-			// Sanitize coupon code
-			$coupon_code = apply_filters( 'woocommerce_coupon_code', $coupon_code );
-
 			// Get the coupon
-			$the_coupon = new WC_Coupon( $coupon_code );
+			$coupon_code  = apply_filters( 'woocommerce_coupon_code', $coupon_code );
+			$position     = array_search( $coupon_code, $this->applied_coupons );
 
-			$coupon_index = array_search( $coupon_code, $this->applied_coupons );
+			if ( $position !== false )
+				unset( $this->applied_coupons[ $position ] );
 
-			if ( $coupon_index >= 0 ) {
-				unset( $this->applied_coupons[ $coupon_index ] );
+			WC()->session->set( 'applied_coupons', $this->applied_coupons );
 
-				$the_coupon->add_coupon_message( WC_Coupon::WC_COUPON_REMOVED );
+			return true;
+		}
+
+		/**
+		 * Function to apply discounts to a product and get the discounted price (before tax is applied).
+		 *
+		 * @access public
+		 * @param mixed $values
+		 * @param mixed $price
+		 * @param bool $add_totals (default: false)
+		 * @return float price
+		 */
+		public function get_discounted_price( $values, $price, $add_totals = false ) {
+			if ( ! $price )
+				return $price;
+
+			if ( ! empty( $this->applied_coupons ) ) {
+				foreach ( $this->applied_coupons as $code ) {
+					$coupon = new WC_Coupon( $code );
+
+					if ( $coupon->apply_before_tax() && $coupon->is_valid() ) {
+						if ( $coupon->is_valid_for_product( $values['data'] ) || $coupon->is_valid_for_cart() ) {
+
+							$discount_amount       = $coupon->get_discount_amount( $price, $values, $single = true );
+							$price                 = max( $price - $discount_amount, 0 );
+
+							if ( $add_totals ) {
+								$this->discount_cart += $discount_amount * $values['quantity'];
+								$this->increase_coupon_discount_amount( $code, $discount_amount * $values['quantity'] );
+								$this->increase_coupon_applied_count( $code, $values['quantity'] );
+							}
+						}
+					}
+				}
 			}
 
-			WC()->session->set( 'coupon_codes', $this->applied_coupons );
+			return apply_filters( 'woocommerce_get_discounted_price', $price, $values, $this );
+		}
+
+		/**
+		 * Function to apply cart discounts after tax.
+		 *
+		 * @access public
+		 */
+		public function apply_cart_discounts_after_tax() {
+			$pre_discount_total = round( $this->cart_contents_total + $this->tax_total + $this->shipping_tax_total + $this->shipping_total + $this->fee_total, $this->dp );
+
+			if ( $this->applied_coupons ) {
+				foreach ( $this->applied_coupons as $code ) {
+					$coupon = new WC_Coupon( $code );
+
+					do_action( 'woocommerce_cart_discount_after_tax_' . $coupon->type, $coupon );
+
+					if ( $coupon->is_valid() && ! $coupon->apply_before_tax() && $coupon->is_valid_for_cart() ) {
+						$discount_amount       = $coupon->get_discount_amount( $pre_discount_total );
+						$pre_discount_total    = $pre_discount_total - $discount_amount;
+						$this->discount_total += $discount_amount;
+						$this->increase_coupon_discount_amount( $code, $discount_amount );
+						$this->increase_coupon_applied_count( $code );
+					}
+				}
+			}
+		}
+
+		/**
+		 * Function to apply product discounts after tax.
+		 *
+		 * @access public
+		 * @param mixed $values
+		 * @param mixed $price
+		 */
+		public function apply_product_discounts_after_tax( $values, $price ) {
+			if ( ! empty( $this->applied_coupons ) ) {
+				foreach ( $this->applied_coupons as $code ) {
+					$coupon = new WC_Coupon( $code );
+
+					do_action( 'woocommerce_product_discount_after_tax_' . $coupon->type, $coupon, $values, $price );
+
+					if ( $coupon->is_valid() && ! $coupon->apply_before_tax() && $coupon->is_valid_for_product( $values['data'] ) ) {
+						$discount_amount       = $coupon->get_discount_amount( $price, $values );
+						$this->discount_total += $discount_amount;
+						$this->increase_coupon_discount_amount( $code, $discount_amount );
+						$this->increase_coupon_applied_count( $code, $values['quantity'] );
+					}
+				}
+			}
+		}
+
+		/**
+		 * Store how much discount each coupon grants.
+		 *
+		 * @access private
+		 * @param mixed $code
+		 * @param mixed $amount
+		 */
+		private function increase_coupon_discount_amount( $code, $amount ) {
+			if ( empty( $this->coupon_discount_amounts[ $code ] ) )
+				$this->coupon_discount_amounts[ $code ] = 0;
+
+			$this->coupon_discount_amounts[ $code ] += $amount;
+		}
+
+		/**
+		 * Store how many times each coupon is applied to cart/items
+		 *
+		 * @access private
+		 * @param mixed $code
+		 * @param mixed $amount
+		 */
+		private function increase_coupon_applied_count( $code, $count = 1 ) {
+			if ( empty( $this->coupon_applied_count[ $code ] ) )
+				$this->coupon_applied_count[ $code ] = 0;
+
+			$this->coupon_applied_count[ $code ] += $count;
 		}
 
  	/*-----------------------------------------------------------------------------------*/
@@ -2038,17 +1803,23 @@ class WC_Cart {
 		 * @param string $tax_class (default: '')
 		 */
 		public function add_fee( $name, $amount, $taxable = false, $tax_class = '' ) {
-			if ( empty( $this->fees ) )
-				$this->fees = array();
+
+			$new_fee_id = sanitize_title( $name );
+
+			// Only add each fee once
+			foreach ( $this->fees as $fee ) {
+				if ( $fee->id == $new_fee_id ) {
+					return;
+				}
+			}
 
 			$new_fee 			= new stdClass();
-			$new_fee->id 		= sanitize_title( $name );
+			$new_fee->id 		= $new_fee_id;
 			$new_fee->name 		= esc_attr( $name );
 			$new_fee->amount	= (float) esc_attr( $amount );
 			$new_fee->tax_class	= $tax_class;
 			$new_fee->taxable	= $taxable ? true : false;
 			$new_fee->tax		= 0;
-
 			$this->fees[] 		= $new_fee;
 		}
 
@@ -2056,7 +1827,7 @@ class WC_Cart {
 		 * get_fees function.
 		 *
 		 * @access public
-		 * @return void
+		 * @return array
 		 */
 		public function get_fees() {
 			return array_filter( (array) $this->fees );
@@ -2071,21 +1842,23 @@ class WC_Cart {
 			do_action( 'woocommerce_cart_calculate_fees', $this );
 
 			// If fees were added, total them and calculate tax
-			if ( $fees = $this->get_fees() ) {
-				foreach ( $fees as $fee ) {
+			if ( ! empty( $this->fees ) ) {
+				foreach ( $this->fees as $fee_key => $fee ) {
 					$this->fee_total += $fee->amount;
 
 					if ( $fee->taxable ) {
 						// Get tax rates
 						$tax_rates = $this->tax->get_rates( $fee->tax_class );
 						$fee_taxes = $this->tax->calc_tax( $fee->amount, $tax_rates, false );
+						
+						if ( ! empty( $fee_taxes ) ) {
+							// Set the tax total for this fee
+							$this->fees[ $fee_key ]->tax = array_sum( $fee_taxes );
 
-						// Store
-						$fee->tax  = array_sum( $fee_taxes );
-
-						// Tax rows - merge the totals we just got
-						foreach ( array_keys( $this->taxes + $fee_taxes ) as $key ) {
-						    $this->taxes[ $key ] = ( isset( $fee_taxes[ $key ] ) ? $fee_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
+							// Tax rows - merge the totals we just got
+							foreach ( array_keys( $this->taxes + $fee_taxes ) as $key ) {
+								$this->taxes[ $key ] = ( isset( $fee_taxes[ $key ] ) ? $fee_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
+							}
 						}
 					}
 				}
@@ -2120,7 +1893,7 @@ class WC_Cart {
 		 * @return string formatted price
 		 */
 		public function get_total() {
-			return apply_filters( 'woocommerce_cart_total', woocommerce_price( $this->total ) );
+			return apply_filters( 'woocommerce_cart_total', wc_price( $this->total ) );
 		}
 
 		/**
@@ -2130,8 +1903,9 @@ class WC_Cart {
 		 */
 		public function get_total_ex_tax() {
 			$total = $this->total - $this->tax_total - $this->shipping_tax_total;
-			if ( $total < 0 ) $total = 0;
-			return apply_filters( 'woocommerce_cart_total_ex_tax', woocommerce_price( $total ) );
+			if ( $total < 0 )
+				$total = 0;
+			return apply_filters( 'woocommerce_cart_total_ex_tax', wc_price( $total ) );
 		}
 
 		/**
@@ -2141,9 +1915,9 @@ class WC_Cart {
 		 */
 		public function get_cart_total() {
 			if ( ! $this->prices_include_tax ) {
-				$cart_contents_total = woocommerce_price( $this->cart_contents_total );
+				$cart_contents_total = wc_price( $this->cart_contents_total );
 			} else {
-				$cart_contents_total = woocommerce_price( $this->cart_contents_total + $this->tax_total );
+				$cart_contents_total = wc_price( $this->cart_contents_total + $this->tax_total );
 			}
 
 			return apply_filters( 'woocommerce_cart_contents_total', $cart_contents_total );
@@ -2156,13 +1930,12 @@ class WC_Cart {
 		 * @return string formatted price
 		 */
 		public function get_cart_subtotal( $compound = false ) {
-			global $woocommerce;
 
 			// If the cart has compound tax, we want to show the subtotal as
 			// cart + shipping + non-compound taxes (after discount)
 			if ( $compound ) {
 
-				$cart_subtotal = woocommerce_price( $this->cart_contents_total + $this->shipping_total + $this->get_taxes_total( false ) );
+				$cart_subtotal = wc_price( $this->cart_contents_total + $this->shipping_total + $this->get_taxes_total( false, false ) );
 
 			// Otherwise we show cart items totals only (before discount)
 			} else {
@@ -2170,18 +1943,18 @@ class WC_Cart {
 				// Display varies depending on settings
 				if ( $this->tax_display_cart == 'excl' ) {
 
-					$cart_subtotal = woocommerce_price( $this->subtotal_ex_tax );
+					$cart_subtotal = wc_price( $this->subtotal_ex_tax );
 
 					if ( $this->tax_total > 0 && $this->prices_include_tax ) {
-						$cart_subtotal .= ' <small>' . $woocommerce->countries->ex_tax_or_vat() . '</small>';
+						$cart_subtotal .= ' <small>' . WC()->countries->ex_tax_or_vat() . '</small>';
 					}
 
 				} else {
 
-					$cart_subtotal = woocommerce_price( $this->subtotal );
+					$cart_subtotal = wc_price( $this->subtotal );
 
 					if ( $this->tax_total > 0 && !$this->prices_include_tax ) {
-						$cart_subtotal .= ' <small>' . $woocommerce->countries->inc_tax_or_vat() . '</small>';
+						$cart_subtotal .= ' <small>' . WC()->countries->inc_tax_or_vat() . '</small>';
 					}
 
 				}
@@ -2193,7 +1966,7 @@ class WC_Cart {
 		/**
 		 * Get the product row price per item.
 		 *
-		 * @params object product
+		 * @param WC_Product $_product
 		 * @return string formatted price
 		 */
 		public function get_product_price( $_product ) {
@@ -2202,7 +1975,7 @@ class WC_Cart {
 			else
 				$product_price = $_product->get_price_including_tax();
 
-			return apply_filters( 'woocommerce_cart_product_price', woocommerce_price( $product_price ), $_product );
+			return apply_filters( 'woocommerce_cart_product_price', wc_price( $product_price ), $_product );
 		}
 
 		/**
@@ -2212,17 +1985,14 @@ class WC_Cart {
 		 *
 		 * When on the checkout (review order), this will get the subtotal based on the customer's tax rate rather than the base rate
 		 *
-		 * @params object product
-		 * @params int quantity
+		 * @param WC_Product $_product
+		 * @param int quantity
 		 * @return string formatted price
 		 */
 		public function get_product_subtotal( $_product, $quantity ) {
-			global $woocommerce;
 
 			$price 			= $_product->get_price();
 			$taxable 		= $_product->is_taxable();
-			$base_tax_rates = $this->tax->get_shop_base_rate( $_product->tax_class );
-			$tax_rates 		= $this->tax->get_rates( $_product->get_tax_class() ); // This will get the base rate unless we're on the checkout page
 
 			// Taxable
 			if ( $taxable ) {
@@ -2230,18 +2000,18 @@ class WC_Cart {
 				if ( $this->tax_display_cart == 'excl' ) {
 
 					$row_price        = $_product->get_price_excluding_tax( $quantity );
-					$product_subtotal = woocommerce_price( $row_price );
+					$product_subtotal = wc_price( $row_price );
 
 					if ( $this->prices_include_tax && $this->tax_total > 0 )
-						$product_subtotal .= ' <small class="tax_label">' . $woocommerce->countries->ex_tax_or_vat() . '</small>';
+						$product_subtotal .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 
 				} else {
 
 					$row_price        = $_product->get_price_including_tax( $quantity );
-					$product_subtotal = woocommerce_price( $row_price );
+					$product_subtotal = wc_price( $row_price );
 
 					if ( ! $this->prices_include_tax && $this->tax_total > 0 )
-						$product_subtotal .= ' <small class="tax_label">' . $woocommerce->countries->inc_tax_or_vat() . '</small>';
+						$product_subtotal .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
 
 				}
 
@@ -2249,7 +2019,7 @@ class WC_Cart {
 			} else {
 
 				$row_price        = $price * $quantity;
-				$product_subtotal = woocommerce_price( $row_price );
+				$product_subtotal = wc_price( $row_price );
 
 			}
 
@@ -2262,18 +2032,18 @@ class WC_Cart {
 		 * @return string formatted price
 		 */
 		public function get_cart_tax() {
-			$return = false;
-			$cart_total_tax = $this->tax_total + $this->shipping_tax_total;
-			if ( $cart_total_tax > 0 ) $return = woocommerce_price( $cart_total_tax );
-			return apply_filters( 'woocommerce_get_cart_tax', $return );
+			$cart_total_tax = wc_round_tax_total( $this->tax_total + $this->shipping_tax_total );
+
+			return apply_filters( 'woocommerce_get_cart_tax', $cart_total_tax ? wc_price( $cart_total_tax ) : '' );
 		}
 
 		/**
 		 * Get tax row amounts with or without compound taxes includes.
-		 *
+		 * @param  boolean $compound True if getting compound taxes
+		 * @param  boolean $display  True if getting total to display
 		 * @return float price
 		 */
-		public function get_taxes_total( $compound = true ) {
+		public function get_taxes_total( $compound = true, $display = true ) {
 			$total = 0;
 			foreach ( $this->taxes as $key => $tax ) {
 				if ( ! $compound && $this->tax->is_compound( $key ) ) continue;
@@ -2283,7 +2053,10 @@ class WC_Cart {
 				if ( ! $compound && $this->tax->is_compound( $key ) ) continue;
 				$total += $tax;
 			}
-			return $total;
+			if ( $display )
+				return wc_round_tax_total( $total );
+			else
+				return $total;
 		}
 
 		/**
@@ -2293,7 +2066,7 @@ class WC_Cart {
 		 */
 		public function get_discounts_before_tax() {
 			if ( $this->discount_cart ) {
-				$discounts_before_tax = woocommerce_price( $this->discount_cart );
+				$discounts_before_tax = wc_price( $this->discount_cart );
 			} else {
 				$discounts_before_tax = false;
 			}
@@ -2307,7 +2080,7 @@ class WC_Cart {
 		 */
 		public function get_discounts_after_tax() {
 			if ( $this->discount_total ) {
-				$discounts_after_tax = woocommerce_price( $this->discount_total );
+				$discounts_after_tax = wc_price( $this->discount_total );
 			} else {
 				$discounts_after_tax = false;
 			}
@@ -2321,10 +2094,70 @@ class WC_Cart {
 		 */
 		public function get_total_discount() {
 			if ( $this->discount_total || $this->discount_cart ) {
-				$total_discount = woocommerce_price( $this->discount_total + $this->discount_cart );
+				$total_discount = wc_price( $this->discount_total + $this->discount_cart );
 			} else {
 				$total_discount = false;
 			}
 			return apply_filters( 'woocommerce_cart_total_discount', $total_discount, $this );
+		}
+		
+		/**
+		* Current position of the array.
+		*
+		* @link http://php.net/manual/en/iterator.current.php
+		*
+		* @return mixed
+		*/
+		public function current() {
+			return current( $this->cart_contents );
+		}
+		
+		/**
+		* Key of the current element.
+		*
+		* @link http://php.net/manual/en/iterator.key.php
+		*
+		* @return mixed
+		*/
+		public function key() {
+			return key( $this->cart_contents );
+		}
+		
+		/**
+		* Move the internal point of the container array to the next item
+		*
+		* @link http://www.php.net/manual/en/iterator.rewind.php
+		*
+		* @return void
+		*/
+		public function next() {
+			next( $this->cart_contents );
+		}
+		
+		
+		/**
+		*  Rewind the Iterator to the first element
+		*
+		* @link http://php.net/manual/en/iterator.next.php
+		*
+		* @return void
+		*/
+		public function rewind() {
+			reset( $this->cart_contents );
+		}
+		
+		/**
+		* Is the current key valid?
+		*
+		* @link http://php.net/manual/en/iterator.rewind.php
+		*
+		* @return bool
+		*/
+		public function valid() {
+			return isset( $this->cart_contents[ $this->key() ] );
+		}
+		
+		public function count() {
+			return $this->cart_contents;
 		}
 }

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -762,35 +762,52 @@ class WC_Checkout {
 					return $current_user->user_email;
 			}
 
-			$default_billing_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_country()) ? $woocommerce->customer->get_country() : $woocommerce->countries->get_base_country());
+			$default_billing_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_country()) ? $woocommerce->customer->get_country() : $woocommerce->countries->get_base_country(), 'billing' );
 
-			$default_shipping_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_shipping_country()) ? $woocommerce->customer->get_shipping_country() : $woocommerce->countries->get_base_country());
+			$default_shipping_country = apply_filters('default_checkout_country', ($woocommerce->customer->get_shipping_country()) ? $woocommerce->customer->get_shipping_country() : $woocommerce->countries->get_base_country(), 'shipping' );
 
 			if ( $woocommerce->customer->has_calculated_shipping() ) {
-				$default_billing_state  = apply_filters('default_checkout_state', $woocommerce->customer->get_state());
-				$default_shipping_state = apply_filters('default_checkout_state', $woocommerce->customer->get_shipping_state());
+				$default_billing_state  = apply_filters('default_checkout_state', $woocommerce->customer->get_state(), 'billing' );
+				$default_shipping_state = apply_filters('default_checkout_state', $woocommerce->customer->get_shipping_state(), 'shipping' );
 			} else {
-				$default_billing_state  = apply_filters('default_checkout_state', '');
-				$default_shipping_state = apply_filters('default_checkout_state', '');
+				$default_billing_state  = apply_filters('default_checkout_state', '', 'billing' );
+				$default_shipping_state = apply_filters('default_checkout_state', '', 'shipping' );
 			}
-
-			if ( $input == "billing_country" )
-				return $default_billing_country;
-
-			if ( $input == "billing_state" )
-				return $default_billing_state;
-
-			if ( $input == "billing_postcode" )
-				return $woocommerce->customer->get_postcode() ? $woocommerce->customer->get_postcode() : '';
-
-			if ( $input == "shipping_country" )
-				return $default_shipping_country;
-
-			if ( $input == "shipping_state" )
-				return $default_shipping_state;
-
-			if ( $input == "shipping_postcode" )
-				return $woocommerce->customer->get_shipping_postcode() ? $woocommerce->customer->get_shipping_postcode() : '';
+			
+			switch ( $input ) {
+				
+				case 'billing_country' :
+					return $default_billing_country;
+					
+				break;
+				
+				case  'shipping_country' :
+					return	$default_shipping_country;
+				break;
+				
+				case 'billing_state' :
+					return $default_billing_state;
+				break;
+				
+				case 'shipping_state' :
+					return $default_shipping_state;	
+				break;
+				
+				case 'billing_postcode' :
+					$default_billing_postcode = $woocommerce->customer->get_postcode() ? $woocommerce->customer->get_postcode() : '';
+					return apply_filters( 'default_checkout_postcode', $default_billing_postcode, 'billing' );
+				break;
+				
+				case 'shipping_postcode' :
+					$default_shipping_postcode = $woocommerce->customer->get_shipping_postcode() ? $woocommerce->customer->get_shipping_postcode() : '';
+					return apply_filters( 'default_checkout_postcode', 	$default_shipping_postcode, 'shipping' );
+				break;
+				
+				default :
+					return apply_filters( 'default_checkout_' . $input, '', $input );
+				break;
+				
+			}
 		}
 	}
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1734,10 +1734,14 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="select" ' . implode( ' ', $custom_attributes ) . '>
 						' . $options . '
-					</selec
+					</select>';
+		break;
+		
+		default :
+			
 			$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
 
-			break;
+		break;
 		}
 
 		if ( $args['return'] ) return $field; else echo $field;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1734,13 +1734,8 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="select" ' . implode( ' ', $custom_attributes ) . '>
 						' . $options . '
-					</select>
-				</p>' . $after;
-
-			break;
-		default :
-			//Change to ref array instead apply_filters(), it's more easy to get the variable, and empty 
-			$field = apply_filters_ref_array( 'woocommerce_form_field_' . $args['type'], array( $key, $args, $value ) );
+					</selec
+			$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
 
 			break;
 		}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1739,8 +1739,8 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 			break;
 		default :
-
-			$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
+			//Change to ref array instead apply_filters(), it's more easy to get the variable, and empty 
+			$field = apply_filters_ref_array( 'woocommerce_form_field_' . $args['type'], array( $key, $args, $value ) );
 
 			break;
 		}


### PR DESCRIPTION
For WC Cart I think is best to implements Iterator and Countable because WC Cart in the template and on other class such as Shipping Class, we are iterate cart content by access that to WC::get_cart(), now when WC Cart implement Iterator and Countable, the WC Cart object can be iterated. To do it just like this 

```
  foreach( WC()->cart as $cart_item_key => $cart_item ) {
     //you can get product just like the old method

    $_product = $cart_item['data'];
  }
```

To count or check the count of cart content you can do like this `count(WC()->cart)`. It's nice..
