### PR TITLE
Fix for issue #4986. Translation broken in admin.

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -428,14 +428,16 @@ final class WooCommerce {
 
 		// Frontend Locale
 		if ( ! is_admin() || is_ajax() ) {
-			load_plugin_textdomain( 'woocommerce', false, plugin_basename( dirname( __FILE__ ) ) . "/i18n/languages" );
 			load_textdomain( 'woocommerce', WP_LANG_DIR . "/woocommerce/woocommerce-$locale.mo" );
-		}
-
-		// Admin Locale
-		if ( is_admin() ) {
+			load_plugin_textdomain( 'woocommerce', false, plugin_basename( dirname( __FILE__ ) ) . "/i18n/languages" );
+		} elseif ( is_admin() ) {
+			// Admin Locale
 			load_textdomain( 'woocommerce', WP_LANG_DIR . "/woocommerce/woocommerce-admin-$locale.mo" );
 			load_textdomain( 'woocommerce', dirname( __FILE__ ) . "/i18n/languages/woocommerce-admin-$locale.mo" );
+
+			// A LOT of strings used in Admin are still in the frontend language file, so we need to load it in admin too
+			load_textdomain( 'woocommerce', WP_LANG_DIR . "/woocommerce/woocommerce-$locale.mo" );
+			load_plugin_textdomain( 'woocommerce', false, plugin_basename( dirname( __FILE__ ) ) . "/i18n/languages" );
 		}
 	}
 


### PR DESCRIPTION
Issue detail: https://github.com/woothemes/woocommerce/issues/4986

This happens because there are a lot of strings of admin that resides in the frontend .mo file. And changes made in https://github.com/woothemes/woocommerce/commit/bb8fd9b50d0740569665466bb1fcf949138063a0#diff-355207be481b8c53c1d92f0c86ab1086 removes a line that loads the frontend .mo file at both sides, admin and frontend (if you have it at WP_LANG_DIR).

Changed loading preference too, in frontend loading, (custom) translation stored at WP_LANG_DIR must be loaded first (as it does in admin).
