### PR TITLE
Returning False Instead of Empty Array for Countries Without States

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -547,7 +547,7 @@ class WC_Countries {
 	 * @return array of states
 	 */
 	public function get_states( $cc ) {
-		return ( isset( $this->states[ $cc ] ) ) ? $this->states[ $cc ] : array();
+		return ( isset( $this->states[ $cc ] ) ) ? $this->states[ $cc ] : false;
 	}
 
 


### PR DESCRIPTION
Right now if you go to the checkout page for a country without states (like the UK) there is a text field but no pre entered data. You have to retype in the county data (Ugh!). If you return `false` in `get_states` instead of an empty array you correctly hit the `else` conditional in `woocommerce_form_field`.
https://github.com/woothemes/woocommerce/blob/v2.1.3/includes/wc-template-functions.php#L1696-L1705

Ref: https://woothemes.zendesk.com/agent/#/tickets/152959
