### PR TITLE
set_transient calls should have expiration to prevent autoloading

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -990,7 +990,7 @@ class WC_Product {
 
 			}
 
-			set_transient( 'wc_average_rating_' . $this->id, $average_rating, DAY_IN_SECONDS );
+			set_transient( 'wc_average_rating_' . $this->id, $average_rating, YEAR_IN_SECONDS );
 		}
 
 		return $average_rating;
@@ -1016,7 +1016,7 @@ class WC_Product {
 				AND meta_value > 0
 			", $this->id ) );
 
-			set_transient( 'wc_rating_count_' . $this->id, $count, DAY_IN_SECONDS );
+			set_transient( 'wc_rating_count_' . $this->id, $count, YEAR_IN_SECONDS );
 		}
 
 		return $count;

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -990,7 +990,7 @@ class WC_Product {
 
 			}
 
-			set_transient( 'wc_average_rating_' . $this->id, $average_rating );
+			set_transient( 'wc_average_rating_' . $this->id, $average_rating, DAY_IN_SECONDS );
 		}
 
 		return $average_rating;
@@ -1016,7 +1016,7 @@ class WC_Product {
 				AND meta_value > 0
 			", $this->id ) );
 
-			set_transient( 'wc_rating_count_' . $this->id, $count );
+			set_transient( 'wc_rating_count_' . $this->id, $count, DAY_IN_SECONDS );
 		}
 
 		return $count;

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -55,7 +55,7 @@ class WC_Cache_Helper {
 	    	if ( ! is_null( $account_page ) )
 	    		$wc_page_uris[] = '/' . $account_page->post_name;
 
-	    	set_transient( 'woocommerce_cache_excluded_uris', $wc_page_uris, DAY_IN_SECONDS );
+	    	set_transient( 'woocommerce_cache_excluded_uris', $wc_page_uris );
 		}
 
 		if ( is_array( $wc_page_uris ) )

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -55,7 +55,7 @@ class WC_Cache_Helper {
 	    	if ( ! is_null( $account_page ) )
 	    		$wc_page_uris[] = '/' . $account_page->post_name;
 
-	    	set_transient( 'woocommerce_cache_excluded_uris', $wc_page_uris );
+	    	set_transient( 'woocommerce_cache_excluded_uris', $wc_page_uris, DAY_IN_SECONDS );
 		}
 
 		if ( is_array( $wc_page_uris ) )

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -69,7 +69,7 @@ class WC_Product_Grouped extends WC_Product {
 					}
 				}
 
-				set_transient( $transient_name, $this->total_stock );
+				set_transient( $transient_name, $this->total_stock, DAY_IN_SECONDS );
 			}
 		}
 
@@ -94,7 +94,7 @@ class WC_Product_Grouped extends WC_Product {
 
 		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product&orderby=menu_order&order=ASC&fields=ids&post_status=publish&numberposts=-1' );
 
-				set_transient( $transient_name, $this->children );
+				set_transient( $transient_name, $this->children, DAY_IN_SECONDS );
 			}
 		}
 

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -69,7 +69,7 @@ class WC_Product_Grouped extends WC_Product {
 					}
 				}
 
-				set_transient( $transient_name, $this->total_stock, DAY_IN_SECONDS );
+				set_transient( $transient_name, $this->total_stock, YEAR_IN_SECONDS );
 			}
 		}
 
@@ -94,7 +94,7 @@ class WC_Product_Grouped extends WC_Product {
 
 		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product&orderby=menu_order&order=ASC&fields=ids&post_status=publish&numberposts=-1' );
 
-				set_transient( $transient_name, $this->children, DAY_IN_SECONDS );
+				set_transient( $transient_name, $this->children, YEAR_IN_SECONDS );
 			}
 		}
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -69,7 +69,7 @@ class WC_Product_Variable extends WC_Product {
 					}
 				}
 
-				set_transient( $transient_name, $this->total_stock, DAY_IN_SECONDS );
+				set_transient( $transient_name, $this->total_stock, YEAR_IN_SECONDS );
 			}
 		}
 		return apply_filters( 'woocommerce_stock_amount', $this->total_stock );
@@ -107,7 +107,7 @@ class WC_Product_Variable extends WC_Product {
 
 		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product_variation&orderby=menu_order&order=ASC&fields=ids&post_status=any&numberposts=-1' );
 
-				set_transient( $transient_name, $this->children, DAY_IN_SECONDS );
+				set_transient( $transient_name, $this->children, YEAR_IN_SECONDS );
 
 			}
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -69,7 +69,7 @@ class WC_Product_Variable extends WC_Product {
 					}
 				}
 
-				set_transient( $transient_name, $this->total_stock );
+				set_transient( $transient_name, $this->total_stock, DAY_IN_SECONDS );
 			}
 		}
 		return apply_filters( 'woocommerce_stock_amount', $this->total_stock );
@@ -107,7 +107,7 @@ class WC_Product_Variable extends WC_Product {
 
 		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product_variation&orderby=menu_order&order=ASC&fields=ids&post_status=any&numberposts=-1' );
 
-				set_transient( $transient_name, $this->children );
+				set_transient( $transient_name, $this->children, DAY_IN_SECONDS );
 
 			}
 

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -444,7 +444,7 @@ class WC_Query {
 				)
 			);
 
-			set_transient( $transient_name, $unfiltered_product_ids, DAY_IN_SECONDS );
+			set_transient( $transient_name, $unfiltered_product_ids, YEAR_IN_SECONDS );
 		}
 
 		// Store the variable

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -444,7 +444,7 @@ class WC_Query {
 				)
 			);
 
-			set_transient( $transient_name, $unfiltered_product_ids );
+			set_transient( $transient_name, $unfiltered_product_ids, DAY_IN_SECONDS );
 		}
 
 		// Store the variable

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -25,7 +25,7 @@ function wc_get_attribute_taxonomies() {
 
 		$attribute_taxonomies = $wpdb->get_results( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies" );
 
-		set_transient( $transient_name, $attribute_taxonomies );
+		set_transient( $transient_name, $attribute_taxonomies, DAY_IN_SECONDS );
 	}
 
 	return apply_filters( 'woocommerce_attribute_taxonomies', $attribute_taxonomies );

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -25,7 +25,7 @@ function wc_get_attribute_taxonomies() {
 
 		$attribute_taxonomies = $wpdb->get_results( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies" );
 
-		set_transient( $transient_name, $attribute_taxonomies, DAY_IN_SECONDS );
+		set_transient( $transient_name, $attribute_taxonomies );
 	}
 
 	return apply_filters( 'woocommerce_attribute_taxonomies', $attribute_taxonomies );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -319,7 +319,7 @@ function wc_processing_order_count() {
 					}
 			}
 			$order_count = apply_filters( 'woocommerce_admin_menu_count', intval( $order_count ) );
-		set_transient( 'woocommerce_processing_order_count', $order_count );
+		set_transient( 'woocommerce_processing_order_count', $order_count, DAY_IN_SECONDS );
 	}
 
 	return $order_count;

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -319,7 +319,7 @@ function wc_processing_order_count() {
 					}
 			}
 			$order_count = apply_filters( 'woocommerce_admin_menu_count', intval( $order_count ) );
-		set_transient( 'woocommerce_processing_order_count', $order_count, DAY_IN_SECONDS );
+		set_transient( 'woocommerce_processing_order_count', $order_count, YEAR_IN_SECONDS );
 	}
 
 	return $order_count;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -163,7 +163,7 @@ function wc_get_product_ids_on_sale() {
 
 	$product_ids_on_sale = array_unique( array_map( 'absint', array_merge( wp_list_pluck( $on_sale_posts, 'ID' ), array_diff( wp_list_pluck( $on_sale_posts, 'post_parent' ), array( 0 ) ) ) ) );
 
-	set_transient( 'wc_products_onsale', $product_ids_on_sale, DAY_IN_SECONDS );
+	set_transient( 'wc_products_onsale', $product_ids_on_sale, YEAR_IN_SECONDS );
 
 	return $product_ids_on_sale;
 }
@@ -206,7 +206,7 @@ function wc_get_featured_product_ids() {
 	$parent_ids           = array_values( $featured );
 	$featured_product_ids = array_unique( array_merge( $product_ids, $parent_ids ) );
 
-	set_transient( 'wc_featured_products', $featured_product_ids, DAY_IN_SECONDS );
+	set_transient( 'wc_featured_products', $featured_product_ids, YEAR_IN_SECONDS );
 
 	return $featured_product_ids;
 }

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -163,7 +163,7 @@ function wc_get_product_ids_on_sale() {
 
 	$product_ids_on_sale = array_unique( array_map( 'absint', array_merge( wp_list_pluck( $on_sale_posts, 'ID' ), array_diff( wp_list_pluck( $on_sale_posts, 'post_parent' ), array( 0 ) ) ) ) );
 
-	set_transient( 'wc_products_onsale', $product_ids_on_sale );
+	set_transient( 'wc_products_onsale', $product_ids_on_sale, DAY_IN_SECONDS );
 
 	return $product_ids_on_sale;
 }
@@ -206,7 +206,7 @@ function wc_get_featured_product_ids() {
 	$parent_ids           = array_values( $featured );
 	$featured_product_ids = array_unique( array_merge( $product_ids, $parent_ids ) );
 
-	set_transient( 'wc_featured_products', $featured_product_ids );
+	set_transient( 'wc_featured_products', $featured_product_ids, DAY_IN_SECONDS );
 
 	return $featured_product_ids;
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1354,7 +1354,7 @@ if ( ! function_exists( 'woocommerce_products_will_display' ) ) {
 			}
 		}
 
-		set_transient( 'wc_products_will_display_' . $parent_id, $products_will_display );
+		set_transient( 'wc_products_will_display_' . $parent_id, $products_will_display, DAY_IN_SECONDS );
 
 		return $products_will_display;
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1354,7 +1354,7 @@ if ( ! function_exists( 'woocommerce_products_will_display' ) ) {
 			}
 		}
 
-		set_transient( 'wc_products_will_display_' . $parent_id, $products_will_display, DAY_IN_SECONDS );
+		set_transient( 'wc_products_will_display_' . $parent_id, $products_will_display, YEAR_IN_SECONDS );
 
 		return $products_will_display;
 	}

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -524,7 +524,7 @@ function wc_change_term_counts( $terms, $taxonomies, $args ) {
 
 	// Update transient
 	if ( $term_counts != $o_term_counts )
-		set_transient( 'wc_term_counts', $term_counts, DAY_IN_SECONDS );
+		set_transient( 'wc_term_counts', $term_counts, YEAR_IN_SECONDS );
 
 	return $terms;
 }

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -524,7 +524,7 @@ function wc_change_term_counts( $terms, $taxonomies, $args ) {
 
 	// Update transient
 	if ( $term_counts != $o_term_counts )
-		set_transient( 'wc_term_counts', $term_counts );
+		set_transient( 'wc_term_counts', $term_counts, DAY_IN_SECONDS );
 
 	return $terms;
 }

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -186,7 +186,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 
 							$_products_in_term = get_objects_in_term( $term->term_id, $taxonomy );
 
-							set_transient( $transient_name, $_products_in_term, DAY_IN_SECONDS );
+							set_transient( $transient_name, $_products_in_term, YEAR_IN_SECONDS );
 						}
 
 						$option_is_set = ( isset( $_chosen_attributes[ $taxonomy ] ) && in_array( $term->term_id, $_chosen_attributes[ $taxonomy ]['terms'] ) );

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -186,7 +186,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 
 							$_products_in_term = get_objects_in_term( $term->term_id, $taxonomy );
 
-							set_transient( $transient_name, $_products_in_term );
+							set_transient( $transient_name, $_products_in_term, DAY_IN_SECONDS );
 						}
 
 						$option_is_set = ( isset( $_chosen_attributes[ $taxonomy ] ) && in_array( $term->term_id, $_chosen_attributes[ $taxonomy ]['terms'] ) );


### PR DESCRIPTION
Props @kloon for pointing this one out to me (from [`set_transient()` documentation](https://codex.wordpress.org/Function_Reference/set_transient)):

> NB: transients that never expire are autoloaded, whereas transients with an expiration time are not autoloaded. Consider this when adding transients that may not be needed on every page, and thus do not need to be autoloaded, impacting page performance.

Defaulting to `DAY_IN_SECONDS` constant if there is not expiration value set.

@mikejolley Happy with these values or is there something I'm missing?
