### PR TITLE
Fix posibility to select default value on checkout

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1600,7 +1600,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		if ( is_string( $args['label_class'] ) )
 			$args['label_class'] = array( $args['label_class'] );
 
-		if ( is_null( $value ) )
+		if ( empty( $value ) )
 			$value = $args['default'];
 
 		// Custom attribute handling


### PR DESCRIPTION
Problem: function woocommerce_form_field( $key, $args, $value = null ) is used to generate billing and shipping form with three arguments in templates/checkout/form-billing.php and templates/checkout/form-shipping.php. So $value variable is never equals NULL and it's impossible to change with add_filter value of element with key "default" in array $args.
[sorry for my english]
