### PR TITLE
Filter JSON search customers query

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1438,12 +1438,12 @@ class WC_AJAX {
 
 		add_action( 'pre_user_query', array( $this, 'json_search_customer_name' ) );
 
-		$customers_query = new WP_User_Query( array(
+		$customers_query = new WP_User_Query( apply_filters( 'woocommerce_json_search_customers_query', array(
 			'fields'			=> 'all',
 			'orderby'			=> 'display_name',
 			'search'			=> '*' . $term . '*',
 			'search_columns'	=> array( 'ID', 'user_login', 'user_email', 'user_nicename' )
-		) );
+		) ) );
 
 		remove_action( 'pre_user_query', array( $this, 'json_search_customer_name' ) );
 


### PR DESCRIPTION
Because the json_search_customer_name action is in the scope of $this, and there's no instance of it to allow remove_action() to play nicely with, it's really difficult to modify this query.  And, unfortunately, it's quite non-performant on large user tables.

One possible option would be to allow users to filter this query directly.  This PR reflects that approach.

For reference: https://gist.github.com/curtismchale/9470986, #5095
