### PR TITLE
Don't trailingslash Order Cancel URLs with a Query String

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1112,7 +1112,13 @@ class WC_Order {
 	 */
 	public function get_cancel_order_url( $redirect = '' ) {
 		$cancel_endpoint = get_permalink( wc_get_page_id( 'cart' ) );
-		$cancel_endpoint = trailingslashit( $cancel_endpoint ? $cancel_endpoint : home_url() );
+		if ( ! $cancel_endpoint ) {
+			$cancel_endpoint = home_url();
+		}
+
+		if ( false === strpos( $cancel_endpoint, '?' ) ) {
+			$cancel_endpoint = trailingslashit( $cancel_endpoint );
+		}
 
 		return apply_filters('woocommerce_get_cancel_order_url', wp_nonce_url( add_query_arg( array( 'cancel_order' => 'true', 'order' => $this->order_key, 'order_id' => $this->id, 'redirect' => $redirect ), $cancel_endpoint ), 'woocommerce-cancel_order' ) );
 	}


### PR DESCRIPTION
With non-pretty permalinks enabled, this was producing a URI like http://example.com/?page_id=7/  That final unnecessary trailing slash messes up some redirect gateways that are passed the cancel URL
