### PR TITLE
Update class-wc-product-variable.php Validation missing. All variations are showing.

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -367,6 +367,10 @@ class WC_Product_Variable extends WC_Product {
 		foreach ( $this->get_children() as $child_id ) {
 
 			$variation = $this->get_child( $child_id );
+			
+			if ( ! $variation->variation_is_visible() )
+				continue; // Disabled or hidden			
+			
 
 			if ( ! empty( $variation->variation_id ) ) {
 				$variation_attributes 	= $variation->get_variation_attributes();


### PR DESCRIPTION
Function get_available_variations is not validating if the variation is visible, resulting in disabled and out of stock variations showing.
