### PR TITLE
Allow reordering of the order list with the REST api

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -374,6 +374,12 @@ class WC_API_Orders extends WC_API_Resource {
 			unset( $args['status'] );
 		}
 
+		// allow order change (ASC or DESC)
+		if ( ! empty( $args['order'] ) ) {
+			$query_args['order'] = $args['order'];
+			unset( $args['order'] );
+		}
+
 		$query_args = $this->merge_query_args( $query_args, $args );
 
 		return new WP_Query( $query_args );


### PR DESCRIPTION
This change allows `&filter[order]=ASC` to set the ordering of the results so the REST API can return values in ascending order if desired.
