### PR TITLE
REST API: Allow ordering on the resource level

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -374,12 +374,6 @@ class WC_API_Orders extends WC_API_Resource {
 			unset( $args['status'] );
 		}
 
-		// allow order change (ASC or DESC)
-		if ( ! empty( $args['order'] ) ) {
-			$query_args['order'] = $args['order'];
-			unset( $args['order'] );
-		}
-
 		$query_args = $this->merge_query_args( $query_args, $args );
 
 		return new WP_Query( $query_args );

--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -374,6 +374,12 @@ class WC_API_Orders extends WC_API_Resource {
 			unset( $args['status'] );
 		}
 
+		// allow order change (ASC or DESC)
+		if ( ! empty( $args['order'] ) ) {
+			$query_args['order'] = $args['order'];
+			unset( $args['order'] );
+		}
+
 		$query_args = $this->merge_query_args( $query_args, $args );
 
 		return new WP_Query( $query_args );

--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -151,6 +151,12 @@ class WC_API_Resource {
 		if ( ! empty( $request_args['offset'] ) )
 			$args['offset'] = $request_args['offset'];
 
+		// allow order change (ASC or DESC)
+		if ( ! empty( $request_args['order'] ) ) {
+			$args['order'] = $request_args['order'];
+			unset( $request_args['order'] );
+		}
+		
 		// resource page
 		$args['paged'] = ( isset( $request_args['page'] ) ) ? absint( $request_args['page'] ) : 1;
 


### PR DESCRIPTION
This will allow `filter[order]=ASC` to switch from DESC to ASC. Invalid values are ignored.
