### PR TITLE
Fix for Russian date format

### DIFF
--- a/i18n/languages/woocommerce-admin-ru_RU.po
+++ b/i18n/languages/woocommerce-admin-ru_RU.po
@@ -1937,11 +1937,11 @@ msgstr "Неопубликованное"
 
 #: includes/admin/post-types/class-wc-admin-cpt-shop_order.php:127
 msgid "Y/m/d g:i:s A"
-msgstr "Г/м/д g:i:s A"
+msgstr "d/m/Y g:i:s"
 
 #: includes/admin/post-types/class-wc-admin-cpt-shop_order.php:130
 msgid "Y/m/d"
-msgstr "Г/м/д"
+msgstr "d/m/Y"
 
 #: includes/admin/post-types/class-wc-admin-cpt-shop_order.php:151
 #: includes/admin/post-types/class-wc-admin-cpt-shop_order.php:189


### PR DESCRIPTION
This two strings should not be translatable, since this is date format for PHP. I've changed the format as Russian use them.
