### PR TITLE
Remove comment exclusion in order notes meta box

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-notes.php
@@ -27,7 +27,11 @@ class WC_Meta_Box_Order_Notes {
 			'type' 		=> 'order_note'
 		);
 
+		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+
 		$notes = get_comments( $args );
+
+		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
 
 		echo '<ul class="order_notes">';
 


### PR DESCRIPTION
Currently, `WC_Comments::exclude_order_comments` ([here](https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-comments.php#L48)) filters out `shop_order` comments from any comments query, unless the global `$typenow` is `shop_order` or the current user can `manage_options`.

`manage_options` is far more exclusive than any `*_shop_order` cap. So custom user roles that have access to orders, but not to WooCommerce settings, wouldn't have access to order notes, even when editing an order. This PR fixes that the same way that `WC_API_Orders::get_order_notes` does in the API, by wrapping `get_comments` with a removal and re-adding of the `exclude_order_comments` filter in the actual order notes meta box.
