### PR TITLE
An Extra Comma Appears When Using A Coupon That Gives Free Shipping

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -191,8 +191,9 @@ function wc_cart_totals_coupon_label( $coupon ) {
  * @return void
  */
 function wc_cart_totals_coupon_html( $coupon ) {
-	if ( is_string( $coupon ) )
+	if ( is_string( $coupon ) ) {
 		$coupon = new WC_Coupon( $coupon );
+    }
 
 	$value  = array();
 
@@ -204,8 +205,12 @@ function wc_cart_totals_coupon_html( $coupon ) {
 
 	$value[] = apply_filters( 'woocommerce_coupon_discount_amount_html', $discount_html, $coupon );
 
-	if ( $coupon->enable_free_shipping() )
+	if ( $coupon->enable_free_shipping() ) {
 		$value[] = __( 'Free shipping coupon', 'woocommerce' );
+    }
+
+    // get rid of empty array elements
+    $value = array_filter( $value );
 
 	$value = implode( ', ', $value ) . ' <a href="' . add_query_arg( 'remove_coupon', $coupon->code, WC()->cart->get_cart_url() ) . '" class="woocommerce-remove-coupon">' . __( '[Remove]', 'woocommerce' ) . '</a>';
 


### PR DESCRIPTION
There's an annoying comma when you're using a Free Shipping coupon without a price discount. It looks fine when there is a discount but not so much when it's just free shipping. I made sure that any empty array elements are removed so there's no comma.

![checkout___wc_2_1_x](https://f.cloud.github.com/assets/1065372/2453982/b6c8b598-aee4-11e3-8641-02291352418d.png)

Originally from: https://woothemes.zendesk.com/agent/#/tickets/158290
