### PR TITLE
New filters & a new function for customising tax display on the Cart page

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -2043,6 +2043,7 @@ class WC_Cart {
 
 		/**
 		 * Get tax row amounts with or without compound taxes includes.
+		 *
 		 * @param  boolean $compound True if getting compound taxes
 		 * @param  boolean $display  True if getting total to display
 		 * @return float price
@@ -2057,10 +2058,10 @@ class WC_Cart {
 				if ( ! $compound && $this->tax->is_compound( $key ) ) continue;
 				$total += $tax;
 			}
-			if ( $display )
-				return wc_round_tax_total( $total );
-			else
-				return $total;
+			if ( $display ) {
+				$total = wc_round_tax_total( $total );
+			}
+			return apply_filters( 'woocommerce_cart_taxes_total', $total, $compound, $display, $this );
 		}
 
 		/**

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -170,6 +170,16 @@ function wc_cart_totals_shipping_html() {
 }
 
 /**
+ * Get taxes total
+ *
+ * @access public
+ * @return void
+ */
+function wc_cart_totals_taxes_total_html() {
+	echo apply_filters( 'woocommerce_cart_totals_taxes_total_html', wc_price( WC()->cart->get_taxes_total() ) );
+}
+
+/**
  * Get a coupon label
  *
  * @access public

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -57,7 +57,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			<?php else : ?>
 				<tr class="tax-total">
 					<th><?php echo esc_html( WC()->countries->tax_or_vat() ); ?></th>
-					<td><?php echo wc_price( WC()->cart->get_taxes_total() ); ?></td>
+					<td><?php echo wc_cart_totals_taxes_total_html(); ?></td>
 				</tr>
 			<?php endif; ?>
 		<?php endif; ?>


### PR DESCRIPTION
When the **Display Tax Totals** setting is set to **As a single total** (i.e. http://cl.ly/image/3P2Z1D0T0S28) there is no way to hook into to the tax total to filter the output displayed on the cart page (`cart-totals.php`).

That means Subscriptions cannot display the correct tax total string. e.g. it should look like this: http://cl.ly/image/0L1i16170U34 but instead looks like this: http://cl.ly/image/3g2s210O1C3e.

This pull request fixes that by wrapping the call to `wc_price( WC()->cart->get_taxes_total() )` in a new `wc_cart_totals_taxes_total_html()` function and passing it through a new `'woocommerce_cart_totals_taxes_total_html'` filter.

It also introduces a related `'woocommerce_cart_taxes_total'` filter for customising the actual total.

Relates to ZD ticket 160027.
