### PR TITLE
Update abstract-wc-email.php

### DIFF
--- a/includes/abstracts/abstract-wc-email.php
+++ b/includes/abstracts/abstract-wc-email.php
@@ -542,18 +542,20 @@ abstract class WC_Email extends WC_Settings_API {
 	 * @param mixed $message
 	 * @param string $headers
 	 * @param string $attachments
-	 * @return void
+	 * @return bool
 	 */
 	function send( $to, $subject, $message, $headers, $attachments ) {
 		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		add_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );
 
-		wp_mail( $to, $subject, $message, $headers, $attachments );
+		$return = wp_mail( $to, $subject, $message, $headers, $attachments );
 
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );
+		
+		return $return;
 	}
 
     /**


### PR DESCRIPTION
wp_mail does return a bool just in case something goes wrong with the function so it might be nice to carry it through. While extending this class I thought it might be a good idea to double check everything I can.
