### PR TITLE
REST API: fix for generating API keys for different user

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -236,7 +236,7 @@ class WC_Admin_Profile {
 
 		if ( current_user_can( 'edit_user', $user_id ) ) {
 
-			$user = wp_get_current_user();
+			$user = get_userdata( $user_id );
 
 			// creating/deleting key
 			if ( isset( $_POST['woocommerce_generate_api_key'] ) ) {


### PR DESCRIPTION
Despite documentation it was impossible to add API keys to the other user in admin/user page. It was caused by checking if API keys are set on current_user, instead of the one denoted by $user_id parameter.

If my understanding is incorrect, just reject my request.

thanks for doing awesome job :+1: 
