### PR TITLE
Replace WC_TEMPLATE_PATH with WC()->template_path()

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -41,7 +41,7 @@ class WC_Template_Loader {
 
 			$file 	= 'single-product.php';
 			$find[] = $file;
-			$find[] = WC_TEMPLATE_PATH . $file;
+			$find[] = WC()->template_path() . $file;
 
 		} elseif ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 
@@ -49,15 +49,15 @@ class WC_Template_Loader {
 
 			$file 		= 'taxonomy-' . $term->taxonomy . '.php';
 			$find[] 	= 'taxonomy-' . $term->taxonomy . '-' . $term->slug . '.php';
-			$find[] 	= WC_TEMPLATE_PATH . 'taxonomy-' . $term->taxonomy . '-' . $term->slug . '.php';
+			$find[] 	= WC()->template_path() . 'taxonomy-' . $term->taxonomy . '-' . $term->slug . '.php';
 			$find[] 	= $file;
-			$find[] 	= WC_TEMPLATE_PATH . $file;
+			$find[] 	= WC()->template_path() . $file;
 
 		} elseif ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) {
 
 			$file 	= 'archive-product.php';
 			$find[] = $file;
-			$find[] = WC_TEMPLATE_PATH . $file;
+			$find[] = WC()->template_path() . $file;
 
 		}
 
@@ -81,14 +81,14 @@ class WC_Template_Loader {
 		if ( get_post_type() !== 'product' )
 			return $template;
 
-		if ( file_exists( STYLESHEETPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php' ))
-			return STYLESHEETPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php';
-		elseif ( file_exists( TEMPLATEPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php' ))
-			return TEMPLATEPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php';
-		elseif ( file_exists( STYLESHEETPATH . '/' . 'single-product-reviews.php' ))
-			return STYLESHEETPATH . '/' . 'single-product-reviews.php';
-		elseif ( file_exists( TEMPLATEPATH . '/' . 'single-product-reviews.php' ))
-			return TEMPLATEPATH . '/' . 'single-product-reviews.php';
+		if ( file_exists( get_stylesheet_directory() . '/' . WC()->template_path() . 'single-product-reviews.php' ))
+			return get_stylesheet_directory() . '/' . WC()->template_path() . 'single-product-reviews.php';
+		elseif ( file_exists( get_template_directory() . '/' . WC()->template_path() . 'single-product-reviews.php' ))
+			return get_template_directory() . '/' . WC()->template_path() . 'single-product-reviews.php';
+		elseif ( file_exists( get_stylesheet_directory() . '/' . 'single-product-reviews.php' ))
+			return get_stylesheet_directory() . '/' . 'single-product-reviews.php';
+		elseif ( file_exists( get_template_directory() . '/' . 'single-product-reviews.php' ))
+			return get_template_directory() . '/' . 'single-product-reviews.php';
 		else
 			return WC()->plugin_path() . '/templates/single-product-reviews.php';
 	}


### PR DESCRIPTION
This replaces the deprecated constant WC_TEMPLATE_PATH with WC()->template_path().

Because this constant is created when Woocommerce is instantiated, we can not apply filters to overwrite its value in our themes or from plugins that are loaded after woocommerce. 

This change will solve that.

Same thought for TEMPLATEPATH and STYLESHEETPATH
