### PR TITLE
Check wc_checkout_params.is_checkout against string '1' instead of int 1

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -391,7 +391,7 @@ jQuery( function( $ ) {
 	});
 
 	// Update on page load
-	if ( wc_checkout_params.is_checkout === 1 ) {
+	if ( wc_checkout_params.is_checkout === '1' ) {
 		$( 'body' ).trigger( 'init_checkout' );
 	}
 


### PR DESCRIPTION
In checkout.js,  `wc_checkout_params.is_checkout` was being strict compared to `1`, but it is a string (`'1'`).

This was causing `'init_checkout'` not to be triggered on page load. I
noticed this when the taxes for an order weren’t being shown on the
checkout page until changing the billing address.

Introduced in b85b1ab03bd5974bf2fa7ae01580faff49b2559e

Steps to reproduce:
- Add an item to your cart
- Go to the checkout page
- The order details won't be updated until you tab through some of the billing address fields

Expected result:
- The order details should be refreshed on page load

Note: I'm not sure if I'm supposed to regenerate the `.min` file, or how to do it, so I guess I'll leave that up to you.
