### PR TITLE
Use is_ssl() for get_woocommerce_api_url()

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -172,7 +172,7 @@ function get_woocommerce_currencies() {
 				'CAD' => __( 'Canadian Dollars', 'woocommerce' ),
 				'CLP' => __( 'Chilean Peso', 'woocommerce' ),
 				'CNY' => __( 'Chinese Yuan', 'woocommerce' ),
-				'COP' => __( 'Colombian Peso', 'woocommerce' ),				
+				'COP' => __( 'Colombian Peso', 'woocommerce' ),
 				'CZK' => __( 'Czech Koruna', 'woocommerce' ),
 				'DKK' => __( 'Danish Krone', 'woocommerce' ),
 				'EUR' => __( 'Euros', 'woocommerce' ),
@@ -385,7 +385,7 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false ) {
  */
 function get_woocommerce_api_url( $path ) {
 
-	$url = get_home_url( null, 'wc-api/v' . WC_API::VERSION . '/', ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ) ? 'https' : 'http' );
+	$url = get_home_url( null, 'wc-api/v' . WC_API::VERSION . '/', is_ssl() ? 'https' : 'http' );
 
 	if ( ! empty( $path ) && is_string( $path ) ) {
 		$url .= ltrim( $path, '/' );


### PR DESCRIPTION
When accessing the API over OAuth for a site that has the checkout
forced over SSL, the OAuth string to sign is incorrect. This fixes that
by checking whether the current request is SSL when returning the api
URL.
