### PR TITLE
Clarifying The Coupon Email Restriction Tool Tip

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -165,7 +165,7 @@ class WC_Meta_Box_Coupon_Data {
 				echo '</div><div class="options_group">';
 
 				// Customers
-				woocommerce_wp_text_input( array( 'id' => 'customer_email', 'label' => __( 'Email restrictions', 'woocommerce' ), 'placeholder' => __( 'No restrictions', 'woocommerce' ), 'description' => __( 'List of emails to check against the customer\'s billing email when an order is placed.', 'woocommerce' ), 'value' => implode(', ', (array) get_post_meta( $post->ID, 'customer_email', true ) ), 'desc_tip' => true, 'type' => 'email', 'class' => '', 'custom_attributes' => array(
+				woocommerce_wp_text_input( array( 'id' => 'customer_email', 'label' => __( 'Email restrictions', 'woocommerce' ), 'placeholder' => __( 'No restrictions', 'woocommerce' ), 'description' => __( 'List of emails to check against the customer\'s billing email when an order is placed. Separate email addresses with commas.', 'woocommerce' ), 'value' => implode(', ', (array) get_post_meta( $post->ID, 'customer_email', true ) ), 'desc_tip' => true, 'type' => 'email', 'class' => '', 'custom_attributes' => array(
 						'multiple' 	=> 'multiple'
 					) ) );
 


### PR DESCRIPTION
Right now the tool tip for the Coupon Email Restriction field just says this:

> List of emails to check against the customer\'s billing email when an order is placed.

Some users are confused since they don't know how to separate the emails. Do they use commas, semi colons, spaces, something else?

When you input a semi colon the field turns red but some users give up before they even type something in. Or they could use commas and just hope they're right rather than knowing.

![edit_coupon__wc_2_1_x__wordpress](https://cloud.githubusercontent.com/assets/1065372/2572693/e396001c-b916-11e3-8bf5-7697d3d368a6.png)

From: ZD 162212
