### PR TITLE
Using Spaces After Text

### DIFF
--- a/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
+++ b/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
@@ -39,7 +39,7 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 		$this->init_settings();
 
 		// Define user set variables
-		$this->title = $this->get_option( 'title' );
+		$this->title        = $this->get_option( 'title' );
 		$this->type         = $this->get_option( 'type' );
 		$this->fee          = $this->get_option( 'fee' );
 		$this->type         = $this->get_option( 'type' );

--- a/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
+++ b/includes/shipping/local-delivery/class-wc-shipping-local-delivery.php
@@ -21,7 +21,7 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 	 * @return void
 	 */
 	function __construct() {
-		$this->id			= 'local_delivery';
+		$this->id           = 'local_delivery';
 		$this->method_title = __( 'Local Delivery', 'woocommerce' );
 		$this->init();
 	}
@@ -39,13 +39,13 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 		$this->init_settings();
 
 		// Define user set variables
-		$this->title		= $this->get_option( 'title' );
-		$this->type 		= $this->get_option( 'type' );
-		$this->fee			= $this->get_option( 'fee' );
-		$this->type			= $this->get_option( 'type' );
-		$this->codes		= $this->get_option( 'codes' );
-		$this->availability	= $this->get_option( 'availability' );
-		$this->countries	= $this->get_option( 'countries' );
+		$this->title = $this->get_option( 'title' );
+		$this->type         = $this->get_option( 'type' );
+		$this->fee          = $this->get_option( 'fee' );
+		$this->type         = $this->get_option( 'type' );
+		$this->codes        = $this->get_option( 'codes' );
+		$this->availability = $this->get_option( 'availability' );
+		$this->countries    = $this->get_option( 'countries' );
 
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
 	}
@@ -70,15 +70,16 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 			foreach ( WC()->cart->get_cart() as $item_id => $values ) {
 				$_product = $values['data'];
 
-				if ( $values['quantity'] > 0 && $_product->needs_shipping() )
+				if ( $values['quantity'] > 0 && $_product->needs_shipping() ) {
 					$shipping_total += $this->fee * $values['quantity'];
+                }
 			}
 		}
 
 		$rate = array(
-			'id' 		=> $this->id,
-			'label' 	=> $this->title,
-			'cost' 		=> $shipping_total
+			'id'    => $this->id,
+			'label' => $this->title,
+			'cost'  => $shipping_total
 		);
 
 		$this->add_rate($rate);
@@ -93,67 +94,67 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 	function init_form_fields() {
 		$this->form_fields = array(
 			'enabled' => array(
-				'title'			=> __( 'Enable', 'woocommerce' ),
-				'type'			=> 'checkbox',
-				'label'			=> __( 'Enable local delivery', 'woocommerce' ),
-				'default'		=> 'no'
+				'title'       => __( 'Enable', 'woocommerce' ),
+				'type'        => 'checkbox',
+				'label'       => __( 'Enable local delivery', 'woocommerce' ),
+				'default'     => 'no'
 			),
 			'title' => array(
-				'title'			=> __( 'Title', 'woocommerce' ),
-				'type'			=> 'text',
-				'description'	=> __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
-				'default'		=> __( 'Local Delivery', 'woocommerce' ),
-				'desc_tip'		=> true,
+				'title'       => __( 'Title', 'woocommerce' ),
+				'type'        => 'text',
+				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
+				'default'     => __( 'Local Delivery', 'woocommerce' ),
+				'desc_tip'    => true,
 			),
 			'type' => array(
-				'title'			=> __( 'Fee Type', 'woocommerce' ),
-				'type'			=> 'select',
-				'description'	=> __( 'How to calculate delivery charges', 'woocommerce' ),
-				'default'		=> 'fixed',
-				'options'		=> array(
-					'fixed'		=> __( 'Fixed amount', 'woocommerce' ),
-					'percent'	=> __( 'Percentage of cart total', 'woocommerce' ),
-					'product'	=> __( 'Fixed amount per product', 'woocommerce' ),
+				'title'       => __( 'Fee Type', 'woocommerce' ),
+				'type'        => 'select',
+				'description' => __( 'How to calculate delivery charges', 'woocommerce' ),
+				'default'     => 'fixed',
+				'options'     => array(
+					'fixed'       => __( 'Fixed amount', 'woocommerce' ),
+					'percent'     => __( 'Percentage of cart total', 'woocommerce' ),
+					'product'     => __( 'Fixed amount per product', 'woocommerce' ),
 				),
-				'desc_tip'		=> true,
+				'desc_tip'    => true,
 			),
 			'fee' => array(
-				'title'			=> __( 'Delivery Fee', 'woocommerce' ),
-				'type' 			=> 'price',
-				'description'	=> __( 'What fee do you want to charge for local delivery, disregarded if you choose free. Leave blank to disable.', 'woocommerce' ),
-				'default'		=> '',
-				'desc_tip'		=> true,
-				'placeholder'	=> wc_format_localized_price( 0 )
+				'title'       => __( 'Delivery Fee', 'woocommerce' ),
+				'type'        => 'price',
+				'description' => __( 'What fee do you want to charge for local delivery, disregarded if you choose free. Leave blank to disable.', 'woocommerce' ),
+				'default'     => '',
+				'desc_tip'    => true,
+				'placeholder' => wc_format_localized_price( 0 )
 			),
 			'codes' => array(
-				'title'			=> __( 'Zip/Post Codes', 'woocommerce' ),
-				'type'			=> 'textarea',
-				'description'	=> __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
-				'default'		=> '',
-				'desc_tip'		=> true,
-				'placeholder'	=> '12345, 56789 etc'
+				'title'       => __( 'Zip/Post Codes', 'woocommerce' ),
+				'type'        => 'textarea',
+				'description' => __( 'What zip/post codes would you like to offer delivery to? Separate codes with a comma. Accepts wildcards, e.g. P* will match a postcode of PE30.', 'woocommerce' ),
+				'default'     => '',
+				'desc_tip'    => true,
+				'placeholder' => '12345, 56789 etc'
 			),
 			'availability' => array(
-							'title'			=> __( 'Method availability', 'woocommerce' ),
-							'type'			=> 'select',
-							'default'		=> 'all',
-							'class'			=> 'availability',
-							'options'		=> array(
-								'all'		=> __( 'All allowed countries', 'woocommerce' ),
-								'specific'	=> __( 'Specific Countries', 'woocommerce' )
-							)
-						),
+				'title'       => __( 'Method availability', 'woocommerce' ),
+				'type'        => 'select',
+				'default'     => 'all',
+					'class'       => 'availability',
+					'options'     => array(
+					'all'         => __( 'All allowed countries', 'woocommerce' ),
+					'specific'    => __( 'Specific Countries', 'woocommerce' )
+				)
+			),
 			'countries' => array(
-							'title'			=> __( 'Specific Countries', 'woocommerce' ),
-							'type'			=> 'multiselect',
-							'class'			=> 'chosen_select',
-							'css'			=> 'width: 450px;',
-							'default'		=> '',
-							'options'		=> WC()->countries->get_shipping_countries(),
-							'custom_attributes' => array(
-								'data-placeholder' => __( 'Select some countries', 'woocommerce' )
-							)
-						)
+				'title'       => __( 'Specific Countries', 'woocommerce' ),
+				'type'        => 'multiselect',
+				'class'       => 'chosen_select',
+				'css'         => 'width: 450px;',
+				'default'     => '',
+				'options'     => WC()->countries->get_shipping_countries(),
+				'custom_attributes' => array(
+					'data-placeholder' => __( 'Select some countries', 'woocommerce' )
+				)
+			)
 		);
 	}
 
@@ -196,18 +197,18 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 
 			$found_match = false;
 
-			if ( in_array( $this->clean( $package['destination']['postcode'] ), $codes ) )
+			if ( in_array( $this->clean( $package['destination']['postcode'] ), $codes ) ) {
 				$found_match = true;
+            }
 
 
 			// Pattern match
 			if ( ! $found_match ) {
 
 				$customer_postcode = $this->clean( $package['destination']['postcode'] );
-
 				foreach ($codes as $c) {
-					$pattern = '/^'.str_replace('_', '[0-9a-zA-Z]', $c).'$/i';
-					if(preg_match($pattern, $customer_postcode)) {
+					$pattern = '/^' . str_replace( '_', '[0-9a-zA-Z]', $c ) . '$/i';
+					if ( preg_match( $pattern, $customer_postcode ) ) {
 						$found_match = true;
 						break;
 					}
@@ -224,26 +225,31 @@ class WC_Shipping_Local_Delivery extends WC_Shipping_Method {
 
 				for ( $i = 0; $i <= $customer_postcode_length; $i++ ) {
 
-					if ( in_array( $customer_postcode, $codes ) )
+					if ( in_array( $customer_postcode, $codes ) ) {
 						$found_match = true;
+                    }
 
 					$customer_postcode = substr( $customer_postcode, 0, -2 ) . '*';
 				}
 			}
 
-			if ( ! $found_match )
+			if ( ! $found_match ) {
 				return false;
+            }
 		}
 
 		// Either post codes not setup, or post codes are in array... so lefts check countries for backwards compatibility.
-		if ( $this->availability == 'specific' )
+		if ( $this->availability == 'specific' ) {
 			$ship_to_countries = $this->countries;
-		else
+		} else {
 			$ship_to_countries = array_keys( WC()->countries->get_shipping_countries() );
+        }
 
-		if (is_array($ship_to_countries))
-			if (!in_array( $package['destination']['country'] , $ship_to_countries))
+		if (is_array($ship_to_countries)) {
+			if (!in_array( $package['destination']['country'] , $ship_to_countries)){
 				return false;
+            }
+        }
 
 		// Yay! We passed!
 		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', true );


### PR DESCRIPTION
Using spaces after text is better for alignment since it will always line. With tabs it depends on your settings. I also fixed a couple conditionals that didn't have brackets.

Old: 
![class-wc-shipping-local-delivery_php_-__users_patrick_documents_woothemes_woocommerce_wp-content_plugins_woocommerce](https://cloud.githubusercontent.com/assets/1065372/2585159/8ba7e9e2-b9e8-11e3-8879-69317e0bd1be.png)

New & Shiny: 
![droplr_draw_app](https://cloud.githubusercontent.com/assets/1065372/2585168/aae8caba-b9e8-11e3-8029-3b40b285be55.png)
