### PR TITLE
Change capability to add order note to edit_shop_order 

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1250,7 +1250,7 @@ class WC_Order {
 
 		$is_customer_note = intval( $is_customer_note );
 
-		if ( is_user_logged_in() && current_user_can( 'manage_woocommerce' ) ) {
+		if ( is_user_logged_in() && current_user_can( 'edit_shop_order', $this->id ) ) {
 			$user                 = get_user_by( 'id', get_current_user_id() );
 			$comment_author       = $user->display_name;
 			$comment_author_email = $user->user_email;


### PR DESCRIPTION
When a user that can't `manage_options`, but can edit a `shop_order` leaves an order note, the note was saved with comment_author `WooCommerce`. This PR changes the required capability to `edit_shop_order`.
