### PR TITLE
Normalize both key and value before generating OAuth signature

### DIFF
--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -197,8 +197,9 @@ class WC_API_Authentication {
 		array_walk( $params, array( $this, 'normalize_parameters' ) );
 
 		// sort parameters
-		if ( ! uksort( $params, 'strcmp' ) )
+		if ( ! uksort( $params, 'strcmp' ) ) {
 			throw new Exception( __( 'Invalid Signature - failed to sort parameters', 'woocommerce' ), 401 );
+		}
 
 		// form query string
 		$query_params = array();
@@ -210,15 +211,17 @@ class WC_API_Authentication {
 
 		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
 
-		if ( $params['oauth_signature_method'] !== 'HMAC-SHA1' && $params['oauth_signature_method'] !== 'HMAC-SHA256' )
+		if ( $params['oauth_signature_method'] !== 'HMAC-SHA1' && $params['oauth_signature_method'] !== 'HMAC-SHA256' ) {
 			throw new Exception( __( 'Invalid Signature - signature method is invalid', 'woocommerce' ), 401 );
+		}
 
 		$hash_algorithm = strtolower( str_replace( 'HMAC-', '', $params['oauth_signature_method'] ) );
 
 		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $user->woocommerce_api_consumer_secret, true ) );
 
-		if ( $signature !== $consumer_signature )
+		if ( $signature !== $consumer_signature ) {
 			throw new Exception( __( 'Invalid Signature - provided signature does not match', 'woocommerce' ), 401 );
+		}
 	}
 
 	/**

--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -194,7 +194,7 @@ class WC_API_Authentication {
 		}
 
 		// normalize parameter key/values
-		array_walk( $params, array( $this, 'normalize_parameters' ) );
+		$params = $this->normalize_parameters( $params );
 
 		// sort parameters
 		if ( ! uksort( $params, 'strcmp' ) ) {
@@ -225,18 +225,35 @@ class WC_API_Authentication {
 	}
 
 	/**
-	 * Normalize each parameter by assuming each parameter may have already been encoded, so attempt to decode, and then
-	 * re-encode according to RFC 3986
+	 * Normalize each parameter by assuming each parameter may have already been
+	 * encoded, so attempt to decode, and then re-encode according to RFC 3986
+	 *
+	 * Note both the key and value is normalized so a filter param like:
+	 *
+	 * 'filter[period]' => 'week'
+	 *
+	 * is encoded to:
+	 *
+	 * 'filter%5Bperiod%5D' => 'week'
+	 *
+	 * This conforms to the OAuth 1.0a spec which indicates the entire query string
+	 * should be URL encoded
 	 *
 	 * @since 2.1
 	 * @see rawurlencode()
-	 * @param string $key
-	 * @param string $value
+	 * @param array $parameters un-normalized pararmeters
+	 * @return array normalized parameters
 	 */
-	private function normalize_parameters( &$key, &$value ) {
+	private function normalize_parameters( $parameters ) {
 
-		$key = rawurlencode( rawurldecode( $key ) );
-		$value = rawurlencode( rawurldecode( $value ) );
+		$normalized_parameters = array();
+
+		foreach ( $parameters as $key => $value ) {
+
+			$normalized_parameters[ rawurlencode( rawurldecode( $key ) ) ] = rawurlencode( rawurldecode( $value ) );
+		}
+
+		return $normalized_parameters;
 	}
 
 	/**

--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -250,7 +250,11 @@ class WC_API_Authentication {
 
 		foreach ( $parameters as $key => $value ) {
 
-			$normalized_parameters[ rawurlencode( rawurldecode( $key ) ) ] = rawurlencode( rawurldecode( $value ) );
+			// percent symbols (%) must be double-encoded
+			$key   = str_replace( '%', '%25', rawurlencode( rawurldecode( $key ) ) );
+			$value = str_replace( '%', '%25', rawurlencode( rawurldecode( $value ) ) );
+
+			$normalized_parameters[ $key ] = $value;
 		}
 
 		return $normalized_parameters;


### PR DESCRIPTION
The existing OAuth code uses `array_walk` to normalize parameters (URL decode/encode) prior to generating the OAuth signature, but doesn't appear to properly normalize the parameter key which is likely due to this:

> Only the values of the array may potentially be changed; its structure cannot be altered, i.e., the programmer cannot add, unset or reorder elements. If the callback does not respect this requirement, the behavior of this function is undefined, and unpredictable.

see [`array_walk`](http://us2.php.net/array_walk)

Because the OAuth 1.0a spec indicates that the full query string should be normalized prior to generating the signature, our implementation is not correct.

This pull fixes that by properly normalizing both the parameter key and value properly (URL decoding, then re-encoding, and double-encoding %) which ensures the implementation conforms to the spec. This is particularly important for clients using 3rd party libraries (say, Ruby or iOS OAuth libs) that match the spec.

This can potentially break some integrations that are coded against this bug, but I think it's better to fix it now rather than wait.

cc @kloon - wanted to get your input on this as you'll need to update the PHP client library to match this :)
