### PR TITLE
Fix _wc_session_expires autoloading

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -45,7 +45,13 @@ class WC_Session_Handler extends WC_Session {
 			// Update session if its close to expiring
 			if ( time() > $this->_session_expiring ) {
 				$this->set_session_expiration();
-				update_option( '_wc_session_expires_' . $this->_customer_id, $this->_session_expiration );
+				$session_expiry_option = '_wc_session_expires_' . $this->_customer_id;
+				// Check if option exists first to avoid auloading cleaned up sessions
+				if ( false === get_option( $session_expiry_option ) ) {
+					add_option( $session_expiry_option, $this->_session_expiration, '', 'no' );
+				} else {
+					update_option( $session_expiry_option, $this->_session_expiration );
+				}
 			}
 
 		} else {


### PR DESCRIPTION
We discovered in excess of 10k rows autoloading.

After a cleanup is run it will delete all session options from the options table, however in the constructor of the session handler class it check for the cookie on the customer's computer and then just call an update_option on the session expires option based on the cookie data, resulting in an autoloading option being added as it was removed prior with the cleanup.

This PR first checks if the option exists before updating it and if not exist adds it without autoloading it.
