### PR TITLE
get_cart_total() should honor the 'tax_display_cart' option

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1937,7 +1937,7 @@ class WC_Cart {
 		 * @return string formatted price
 		 */
 		public function get_cart_total() {
-			if ( ! $this->prices_include_tax ) {
+			if ( ! $this->prices_include_tax && ! $this->tax_display_cart ) {
 				$cart_contents_total = wc_price( $this->cart_contents_total );
 			} else {
 				$cart_contents_total = wc_price( $this->cart_contents_total + $this->tax_total );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1937,7 +1937,7 @@ class WC_Cart {
 		 * @return string formatted price
 		 */
 		public function get_cart_total() {
-			if ( ! $this->prices_include_tax && ! $this->tax_display_cart ) {
+			if ( ! $this->prices_include_tax && $this->tax_display_cart == 'excl' ) {
 				$cart_contents_total = wc_price( $this->cart_contents_total );
 			} else {
 				$cart_contents_total = wc_price( $this->cart_contents_total + $this->tax_total );


### PR DESCRIPTION
If prices are entered without taxes (prices_include_tax == false) and the option 'tax_display_cart' is active (tax_display_cart == true), the method should return the gross total.

Theme in use: flatsome
Error appears: cart contents in the top right corner shows net prices although 'tax_display_cart' is active. It's currently the only place in my shop where net prices are displayed.
