### PR TITLE
Update woocommerce-ru_RU.po

### DIFF
--- a/i18n/languages/woocommerce-ru_RU.po
+++ b/i18n/languages/woocommerce-ru_RU.po
@@ -578,7 +578,7 @@ msgstr "Токантинс"
 
 #: i18n/states/CA.php:13
 msgid "Alberta"
-msgstr "Алберта"
+msgstr "Альберта"
 
 #: i18n/states/CA.php:14
 msgid "British Columbia"
@@ -590,7 +590,7 @@ msgstr "Манитоба"
 
 #: i18n/states/CA.php:16
 msgid "New Brunswick"
-msgstr "Нью-Брвнсуик"
+msgstr "Нью-Брансуик"
 
 #: i18n/states/CA.php:17
 msgid "Newfoundland"
@@ -598,7 +598,7 @@ msgstr "Ньюфаундленд"
 
 #: i18n/states/CA.php:18
 msgid "Northwest Territories"
-msgstr "Северо-западные территории"
+msgstr "Северо-западные Территории"
 
 #: i18n/states/CA.php:19
 msgid "Nova Scotia"
@@ -626,7 +626,7 @@ msgstr "Саскачеван"
 
 #: i18n/states/CA.php:25
 msgid "Yukon Territory"
-msgstr "Территория Юкон"
+msgstr "Юкон"
 
 #: i18n/states/CN.php:13
 msgid "Yunnan / &#20113;&#21335;"

--- a/i18n/languages/woocommerce-ru_RU.po
+++ b/i18n/languages/woocommerce-ru_RU.po
@@ -7203,7 +7203,7 @@ msgstr "&nbsp;&ndash; Страница %s"
 #: templates/checkout/form-shipping.php:55
 #: templates/single-product/tabs/additional-information.php:14
 msgid "Additional Information"
-msgstr "Дополнительная инфомация"
+msgstr "Дополнительная информация"
 
 #: includes/wc-template-functions.php:998
 msgid "Reviews (%d)"

--- a/i18n/languages/woocommerce-ru_RU.po
+++ b/i18n/languages/woocommerce-ru_RU.po
@@ -39,11 +39,11 @@ msgstr "Кнопка Цена товара/Корзина"
 
 #: assets/js/admin/editor_plugin_lang.php:7
 msgid "Product by SKU/ID"
-msgstr "Товар по ИТП/ID"
+msgstr "Товар по Артикулу/ID"
 
 #: assets/js/admin/editor_plugin_lang.php:8
 msgid "Products by SKU/ID"
-msgstr "Товары по ИТП/ID"
+msgstr "Товары по Артикулу/ID"
 
 #: assets/js/admin/editor_plugin_lang.php:9
 msgid "Product categories"
@@ -8336,7 +8336,7 @@ msgstr "Этого товара нет в наличии, заказ недос�
 
 #: templates/single-product/meta.php:23
 msgid "SKU:"
-msgstr "ИТП:"
+msgstr "Артикул:"
 
 #: templates/single-product/meta.php:23
 msgid "n/a"

--- a/i18n/languages/woocommerce-ru_RU.po
+++ b/i18n/languages/woocommerce-ru_RU.po
@@ -8336,7 +8336,7 @@ msgstr "Этого товара нет в наличии, заказ недос�
 
 #: templates/single-product/meta.php:23
 msgid "SKU:"
-msgstr "Кол-во:"
+msgstr "ИТП:"
 
 #: templates/single-product/meta.php:23
 msgid "n/a"


### PR DESCRIPTION
"SKU:" translation to Russian is incorrect ("Кол-во" means "quantity").
In other places, "SKU" is translated as "ИТП", so I placed the same translation here.
(Need to re-compile .mo file)
