### PR TITLE
Update class-wc-frontend-scripts.php

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -102,7 +102,7 @@ class WC_Frontend_Scripts {
 
 		if ( $lightbox_en && ( is_product() || ( ! empty( $post->post_content ) && strstr( $post->post_content, '[product_page' ) ) ) ) {
 			wp_enqueue_script( 'prettyPhoto', $assets_path . 'js/prettyPhoto/jquery.prettyPhoto' . $suffix . '.js', array( 'jquery' ), '3.1.5', true );
-			wp_enqueue_script( 'prettyPhoto-init', $assets_path . 'js/prettyPhoto/jquery.prettyPhoto.init' . $suffix . '.js', array( 'jquery' ), WC_VERSION, true );
+			wp_enqueue_script( 'prettyPhoto-init', $assets_path . 'js/prettyPhoto/jquery.prettyPhoto.init' . $suffix . '.js', array( 'jquery','prettyPhoto' ), WC_VERSION, true );
 			wp_enqueue_style( 'woocommerce_prettyPhoto_css', $assets_path . 'css/prettyPhoto.css' );
 		}
 


### PR DESCRIPTION
See also https://github.com/bassjobsen/wp-defer-loading/issues/14 prettyPhoto-init is not only dependent of jquery, but also of prettyPhoto. The dependency of prettyPhoto is not set.
