### PR TITLE
fixed incorrect "order received" endpoint tooltip

### DIFF
--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -157,7 +157,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 
 			array(
 				'title' => __( 'Order Received', 'woocommerce' ),
-				'desc' 		=> __( 'Endpoint for the Checkout &rarr; Pay page', 'woocommerce' ),
+				'desc' 		=> __( 'Endpoint for the Checkout &rarr; Order Received page', 'woocommerce' ),
 				'id' 		=> 'woocommerce_checkout_order_received_endpoint',
 				'type' 		=> 'text',
 				'default'	=> 'order-received',


### PR DESCRIPTION
fixed incorrect "order received" endpoint tooltip: http://cld.wthms.co/AInb
