### PR TITLE
Introduce `woocommerce_order_status_name` filter

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-order-data.php
@@ -158,7 +158,7 @@ class WC_Meta_Box_Order_Data {
 							<?php
 								$statuses = (array) get_terms( 'shop_order_status', array( 'hide_empty' => 0, 'orderby' => 'id' ) );
 								foreach ( $statuses as $status ) {
-									echo '<option value="' . esc_attr( $status->slug ) . '" ' . selected( $status->slug, $order->status, false ) . '>' . esc_html__( $status->name, 'woocommerce' ) . '</option>';
+									echo '<option value="' . esc_attr( $status->slug ) . '" ' . selected( $status->slug, $order->status, false ) . '>' . esc_html( apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status ) ) . '</option>';
 								}
 							?>
 						</select></p>

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1311,7 +1311,7 @@ class WC_Order {
 				do_action( 'woocommerce_order_status_changed', $this->id, $this->status, $new_status->slug );
 
 				if ( $old_status ) {
-					$this->add_order_note( $note . sprintf( __( 'Order status changed from %s to %s.', 'woocommerce' ), __( $old_status->name, 'woocommerce' ), __( $new_status->name, 'woocommerce' ) ) );
+					$this->add_order_note( $note . sprintf( __( 'Order status changed from %s to %s.', 'woocommerce' ), __( $old_status->name, 'woocommerce' ), $old_status ), apply_filters( 'woocommerce_order_status_name', __( $new_status->name, 'woocommerce' ), $new_status ) ) );
 				}
 
 				// Record the completed date of the order

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -110,7 +110,7 @@ class WC_Shortcode_Checkout {
 
 					$status = get_term_by('slug', $order->status, 'shop_order_status');
 
-					wc_add_notice( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), $status->name ), 'error' );
+					wc_add_notice( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status ) ), 'error' );
 				}
 
 			} else {
@@ -161,7 +161,7 @@ class WC_Shortcode_Checkout {
 
 					$status = get_term_by('slug', $order->status, 'shop_order_status');
 
-					wc_add_notice( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), $status->name ), 'error' );
+					wc_add_notice( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status ) ), 'error' );
 				}
 
 			} else {

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -56,7 +56,7 @@ if ( $customer_orders ) : ?>
 						<time datetime="<?php echo date( 'Y-m-d', strtotime( $order->order_date ) ); ?>" title="<?php echo esc_attr( strtotime( $order->order_date ) ); ?>"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ); ?></time>
 					</td>
 					<td class="order-status" style="text-align:left; white-space:nowrap;">
-						<?php echo ucfirst( __( $status->name, 'woocommerce' ) ); ?>
+						<?php echo ucfirst( apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status ) ); ?>
 					</td>
 					<td class="order-total">
 						<?php echo sprintf( _n( '%s for %s item', '%s for %s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count ); ?>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -9,7 +9,7 @@
  * @version   2.0.15
  */
 
-echo '<p class="order-info">' . sprintf( __( 'Order <mark class="order-number">%s</mark> was placed on <mark class="order-date">%s</mark> and is currently <mark class="order-status">%s</mark>.', 'woocommerce' ), $order->get_order_number(), date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ), __( $status->name, 'woocommerce' ) ) . '</p>';
+echo '<p class="order-info">' . sprintf( __( 'Order <mark class="order-number">%s</mark> was placed on <mark class="order-date">%s</mark> and is currently <mark class="order-status">%s</mark>.', 'woocommerce' ), $order->get_order_number(), date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ), apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status ) ) . '</p>';
 
 if ( $notes = $order->get_customer_order_notes() ) :
 	?>

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -15,7 +15,7 @@ global $woocommerce;
 <?php
 	$status = get_term_by( 'slug', $order->status, 'shop_order_status' );
 
-	$order_status_text = sprintf( __( 'Order %s which was made %s has the status &ldquo;%s&rdquo;', 'woocommerce' ), $order->get_order_number(), human_time_diff( strtotime( $order->order_date ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'woocommerce' ), __( $status->name, 'woocommerce' ) );
+	$order_status_text = sprintf( __( 'Order %s which was made %s has the status &ldquo;%s&rdquo;', 'woocommerce' ), $order->get_order_number(), human_time_diff( strtotime( $order->order_date ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'woocommerce' ), apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status ) );
 
 	if ( $order->status === 'completed' ) $order_status_text .= ' ' . __( 'and was completed', 'woocommerce' ) . ' ' . human_time_diff( strtotime( $order->completed_date ), current_time( 'timestamp' ) ) . __( ' ago', 'woocommerce' );
 


### PR DESCRIPTION
Whenever order status was displayed, the name was translated using `__()`.
However, the translation domain was always `woocommerce`. This means that
custom statuses added by 3rd party plugins/themes were never translated.
This filter allows developers to override the status name with their own translation.

A use case is as follows: a plugin author adds a new custom order status and calls it 'unconfirmed'. A shop owner has a shop, that's in Germany. The shop owner sees the status name in the order screen in admin as "unconfrmed" - in english, although it should be translated. The same happens when a custome ris viewing her recent orders - all other information is translated, but the order status is "unconfirmed" - again, untranslated.

This happens because of `__( $status->name, 'woocommerce' )`. Sure, WooCommerce knows about the built-in status names, but a 3rd party developer cannot add his custom status name translation to WooCommerce translations. He needs to supply it himself. 

Using `apply_filters( 'woocommerce_order_status_name', __( $status->name, 'woocommerce' ), $status )` he can hook into the filter, look at the status and return the appropriate translation. Example:

``` php
function my_status_name( $name, $status ) {
  if ($status->slug == 'unconfirmed') 
    $name = __( $status->name, 'my-plugin-domain' );
  return $name;
}
add_filter( 'woocommerce_order_status_name', 'my_status_name', 10, 2 );
```
