### PR TITLE
Valid order statuses improvements

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -245,11 +245,13 @@ class WC_Form_Handler {
 			ob_start();
 
 			// Pay for existing order
-			$order_key 	= $_GET['key'];
-			$order_id 	= absint( $wp->query_vars['order-pay'] );
-			$order 		= new WC_Order( $order_id );
+			$order_key  = $_GET['key'];
+			$order_id   = absint( $wp->query_vars['order-pay'] );
+			$order      = new WC_Order( $order_id );
+			
+			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 
-			if ( $order->id == $order_id && $order->order_key == $order_key && in_array( $order->status, array( 'pending', 'failed' ) ) ) {
+			if ( $order->id == $order_id && $order->order_key == $order_key && in_array( $order->status, $valid_order_statuses ) ) {
 
 				// Set customer location to order location
 				if ( $order->billing_country ) {

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1379,7 +1379,9 @@ class WC_Order {
 			unset( WC()->session->order_awaiting_payment );
 		}
 
-		if ( $this->id && ( 'on-hold' == $this->status || 'pending' == $this->status || 'failed' == $this->status ) ) {
+		$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment_complete', array( 'on-hold', 'pending', 'failed' ), $this );
+
+		if ( $this->id && in_array( $this->status, $valid_order_statuses ) ) {
 
 			$order_needs_processing = true;
 


### PR DESCRIPTION
This PR addresses an issue where it was possible to filter the valid order statuses for payment on my-orders.php, checkout and in order class, but not in the actual pay_action in `wc-form-handler.php`.

Also, it introduces the `woocommerce_valid_order_statuses_for_payment_complete` filter which further allows developers to decide which order statuses are valid for completing a payment.
