### PR TITLE
Add option to enable/disable Payments

### DIFF
--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -65,6 +65,16 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 			array(	'title' => __( 'Checkout Process', 'woocommerce' ), 'type' => 'title', 'id' => 'checkout_process_options' ),
 
 			array(
+				'title' => __( 'Payments', 'woocommerce' ),
+				'desc'          => __( 'Enable payments', 'woocommerce' ),
+				'id'            => 'woocommerce_enable_coupons',
+				'default'       => 'yes',
+				'type'          => 'checkbox',
+				'desc_tip'		=>  __( 'If disabled, customers can place orders without paying. Useful if you simply want to accept orders and handle payments outside of WooCommerce.', 'woocommerce' ),
+				'autoload'      => false
+			),
+
+			array(
 				'title' => __( 'Coupons', 'woocommerce' ),
 				'desc'          => __( 'Enable the use of coupons', 'woocommerce' ),
 				'id'            => 'woocommerce_enable_coupons',

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -266,6 +266,16 @@ class WC_Cart {
 	/*-----------------------------------------------------------------------------------*/
 
 		/**
+		 * Payments enabled function. Filterable.
+		 *
+		 * @access public
+		 * @return bool
+		 */
+		public function payments_enabled() {
+			return apply_filters( 'woocommerce_payments_enabled', get_option( 'woocommerce_enable_payments' ) == 'yes' );
+		}
+
+		/**
 		 * Coupons enabled function. Filterable.
 		 *
 		 * @access public
@@ -1271,7 +1281,7 @@ class WC_Cart {
 		 * @return bool
 		 */
 		public function needs_payment() {
-			return apply_filters( 'woocommerce_cart_needs_payment', $this->total > 0, $this );
+			return apply_filters( 'woocommerce_cart_needs_payment', $this->payments_enabled() && $this->total > 0, $this );
 		}
 
     /*-----------------------------------------------------------------------------------*/


### PR DESCRIPTION
**Motivation**
I've built a few stores now that require this. What this basically means is that some businesses do not intend to collect any payments online. They use the store to simply accept orders.

The whole payment process is handled outside of the shop. Because of that - they do not require any kind of payment gateways, or anything related to payments in the shop, for that matter. They do not event want to present any kind of payment options to the customer, as these may be confusing (example - customer will actually pay in cash when picking up the order).

**Proposal**
Perhaps we could add an "Accept Payments" or "Enable Payments" checkbox to Checkout settings, very much like the "Enable taxes and tax calculations" and "Enable shipping" checkboxes/settings. 

Disabling payments would then mean that once a customer goes to checkout, no payment options are presented to her, and she can simply place the order. Placing the order would then reduce stock and set the order status to processing or on-hold (depending on the requirements of the specific store - perhaps make it an option or at least filterable). No payment method data would be set on the order.

Further processing of the order will then take place outside of the WooCommerce store, perhaps simply manually sending an invoice, or perhaps there are contracts with the customer that allow her to order without paying in advance - this is really outside the scope of WooCommerce and up to the store owner.

**Implementation**
Obviously, we'd need to add a checkbox to the Checkout settings and store this value. Then, once a customer reaches checkout, we'd need to check if payments are enabled and if not, then simply not display any payment options. This could even be done by filtering the value of `$cart->needs_payment`.

If `needs_payment` is false, then WooCommerce will simply call `$order->payment_complete()`. This in turn will set the order status to either `processing` or `completed` - based on whether WC thinks it needs processing or not. The status being set can also be filtered via `woocommerce_payment_complete_order_status`, which should help if store owner wants to leave the orders to `on-hold`.
