### PR TITLE
Introduce `woocommerce_thankyou_order_received_text` filter

### DIFF
--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -33,7 +33,7 @@ if ( $order ) : ?>
 
 	<?php else : ?>
 
-		<p><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ) ); ?></p>
+		<p><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ), $order ); ?></p>
 
 		<ul class="order_details">
 			<li class="order">
@@ -64,6 +64,6 @@ if ( $order ) : ?>
 
 <?php else : ?>
 
-	<p><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ) ); ?></p>
+	<p><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ), null ); ?></p>
 
 <?php endif; ?>

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -33,7 +33,7 @@ if ( $order ) : ?>
 
 	<?php else : ?>
 
-		<p><?php _e( 'Thank you. Your order has been received.', 'woocommerce' ); ?></p>
+		<p><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ) ); ?></p>
 
 		<ul class="order_details">
 			<li class="order">
@@ -64,6 +64,6 @@ if ( $order ) : ?>
 
 <?php else : ?>
 
-	<p><?php _e( 'Thank you. Your order has been received.', 'woocommerce' ); ?></p>
+	<p><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'woocommerce' ) ); ?></p>
 
 <?php endif; ?>


### PR DESCRIPTION
It is sometimes desirable to change the thank you text that appears on the thank you page without modifying/overriding the thankyou.php template file.

An example use case would be a plugin, that does not touch the templates, but may need to display a different message based on whatever information is available at that time (order status, payment method, etc).

For example - one may want to display a different message based on the order status. If it's on-hold, display "Your order has been received and is now on-hold". If it's processing, display "Your order has been received and is now being processed" - etc..
