### PR TITLE
Clear cached API reports when deleting shop order transients

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -351,6 +351,9 @@ function wc_delete_shop_order_transients( $post_id = 0 ) {
 		}
 	}
 
+	// clear API report transient
+	$transients_to_clear[] = 'wc_admin_report';
+
 	// Clear transients where we have names
 	foreach( $transients_to_clear as $transient ) {
 		delete_transient( $transient );


### PR DESCRIPTION
This PR fixes an issue with the API where newly-placed orders aren't reflected in the /reports/sales endpoint because the API report transient wasn't cleared.
