### PR TITLE
Two filters for term ids in sales by category reports

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -638,7 +638,6 @@ class WC_Meta_Box_Product_Data {
 								'order' 		=> 'asc',
 								'post_parent' 	=> 0,
 								'include' 		=> $posts_in,
-                                'suppress_filters' => 0,                                
 							);
 							$grouped_products = get_posts( $args );
 

--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -638,6 +638,7 @@ class WC_Meta_Box_Product_Data {
 								'order' 		=> 'asc',
 								'post_parent' 	=> 0,
 								'include' 		=> $posts_in,
+                                'suppress_filters' => 0,                                
 							);
 							$grouped_products = get_posts( $args );
 

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -39,6 +39,7 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 			$category       = get_term( $category, 'product_cat' );
 			$term_ids 		= get_term_children( $category->term_id, 'product_cat' );
 			$term_ids[] 	= $category->term_id;
+            $term_ids = apply_filters('woocommerce_term_ids_sales_by_category_legend', $term_ids);
 			$total          = 0;
 			$product_ids 	= array_unique( get_objects_in_term( $term_ids, 'product_cat' ) );
 
@@ -247,6 +248,7 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 				$category       = get_term( $category, 'product_cat' );
 				$term_ids 		= get_term_children( $category->term_id, 'product_cat' );
 				$term_ids[] 	= $category->term_id;
+                $term_ids = apply_filters('woocommerce_term_ids_sales_by_category_chart', $term_ids);
 				$product_ids 	= array_unique( get_objects_in_term( $term_ids, 'product_cat' ) );
 				$category_total = 0;
 				$category_chart_data = array();


### PR DESCRIPTION
This will be used by third parties in order to include additional products that are included under the selected categories but not directly.
e.g. in WooCommerce Multilingual this will be used to include the categories in all languages when building the report hence including products purchased in any language.
