### PR TITLE
Make possible to translate the edit-address endpoint slugs

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -60,7 +60,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		$load_address = isset( $wp->query_vars['edit-address'] ) ? sanitize_key( $wp->query_vars['edit-address'] ) : 'billing';
+		$load_address = isset( $wp->query_vars['edit-address'] ) ? wc_edit_address_i18n( sanitize_key( $wp->query_vars['edit-address'] ), true ) : 'billing';
 
 		$address = WC()->countries->get_address_fields( esc_attr( $_POST[ $load_address . '_country' ] ), $load_address . '_' );
 
@@ -267,7 +267,7 @@ class WC_Form_Handler {
 			$order_key  = $_GET['key'];
 			$order_id   = absint( $wp->query_vars['order-pay'] );
 			$order      = new WC_Order( $order_id );
-			
+
 			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
 
 			if ( $order->id == $order_id && $order->order_key == $order_key && in_array( $order->status, $valid_order_statuses ) ) {

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -67,7 +67,7 @@ class WC_Shortcode_My_Account {
 
 			} elseif ( isset( $wp->query_vars['edit-address'] ) ) {
 
-				self::edit_address( sanitize_title( $wp->query_vars['edit-address'] ) );
+				self::edit_address( wc_edit_address_i18n( sanitize_title( $wp->query_vars['edit-address'] ), true ) );
 
 			} elseif ( isset( $wp->query_vars['add-payment-method'] ) ) {
 

--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -48,6 +48,7 @@ function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 
 	// Map endpoint to options
 	$endpoint = isset( WC()->query->query_vars[ $endpoint ] ) ? WC()->query->query_vars[ $endpoint ] : $endpoint;
+	$value    = ( 'edit-address' == $endpoint ) ? wc_edit_address_i18n( $value ) : $value;
 
 	if ( get_option( 'permalink_structure' ) ) {
 		if ( strstr( $permalink, '?' ) ) {
@@ -62,6 +63,31 @@ function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 	}
 
 	return apply_filters( 'woocommerce_get_endpoint_url', $url );
+}
+
+/**
+ * Get the edit address slug translation.
+ *
+ * @param  string  $id   Address ID.
+ * @param  bool    $flip Flip the array to make it possible to retrieve the values ​​from both sides.
+ *
+ * @return string        Address slug i18n.
+ */
+function wc_edit_address_i18n( $id, $flip = false ) {
+	$slugs = apply_filters( 'woocommerce_edit_address_slugs', array(
+		'billing'  => _x( 'billing', 'edit-address-slug', 'woocommerce' ),
+		'shipping' => _x( 'shipping', 'edit-address-slug', 'woocommerce' )
+	) );
+
+	if ( $flip ) {
+		$slugs = array_flip( $slugs );
+	}
+
+	if ( ! isset( $slugs[ $id ] ) ) {
+		return $id;
+	}
+
+	return $slugs[ $id ];
 }
 
 /**
@@ -133,10 +159,10 @@ function wc_nav_menu_item_classes( $menu_items, $args ) {
 		// Unset active class for blog page
 		if ( $page_for_posts == $menu_item->object_id ) {
 			$menu_items[$key]->current = false;
-			
+
 			if ( in_array( 'current_page_parent', $classes ) )
 				unset( $classes[ array_search('current_page_parent', $classes) ] );
-			
+
 			if ( in_array( 'current-menu-item', $classes ) )
 				unset( $classes[ array_search('current-menu-item', $classes) ] );
 


### PR DESCRIPTION
To resolve the issue #4820 I created a function that helps in translating the slugs.
