### PR TITLE
Add action filter in inventory product data

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -330,7 +330,8 @@ class WC_Meta_Box_Product_Data {
 				do_action('woocommerce_product_options_sold_individually');
 
 				echo '</div>';
-
+				
+				do_action( 'woocommerce_product_options_inventory_product_data' );
 				?>
 
 			</div>

--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-product-data.php
@@ -317,7 +317,9 @@ class WC_Meta_Box_Product_Data {
 					echo '</div>';
 
 				}
-
+				
+				do_action('woocommerce_product_options_stock_status');
+				
 				echo '</div>';
 
 				echo '<div class="options_group show_if_simple show_if_variable">';


### PR DESCRIPTION
Allows plugins to add meta fields after stock status/backorders even if woocommerce_manage_stock is turned off.
