### PR TITLE
fix case-insensitive matching for coupon posts with uppercase chars

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -138,7 +138,7 @@ class WC_Coupon {
 			$coupon             = get_post( $coupon_id );
 			$this->post_title   = apply_filters( 'woocommerce_coupon_code', $coupon->post_title );
 
-            if ( empty( $coupon ) || $this->code !== $coupon->post_title )
+            if ( empty( $coupon ) || $this->code !== $this->post_title )
             	return;
 
             $this->id                   = $coupon->ID;


### PR DESCRIPTION
This was causing coupon codes like 'Foobar1234' not to work since they were getting matched against the filtered, case-insensitive 'foobar1234'
