### PR TITLE
Fix wc addons page

### DIFF
--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -26,9 +26,15 @@ class WC_Admin_Addons {
 
 		if ( false === ( $addons = get_transient( 'woocommerce_addons_html_' . $view ) ) ) {
 
+			// Send through cookies to bypass spoofing checks
+			foreach ( $_COOKIE as $name => $value ) {
+    			$cookies[] = new WP_Http_Cookie( array( 'name' => $name, 'value' => $value ) );
+			}
+
 			$raw_addons = wp_remote_get( 'http://www.woothemes.com/product-category/woocommerce-extensions/' . $view . '?orderby=popularity', array(
 					'user-agent' => 'woocommerce-addons-page',
-					'timeout'    => 3
+					'timeout'    => 3,
+					'cookies' => $cookies,
 				) );
 
 			if ( ! is_wp_error( $raw_addons ) ) {

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -36,7 +36,6 @@ class WC_Admin_Addons {
 					'timeout'    => 5,
 					'cookies' => $cookies,
 				) );
-			error_log( print_r( $raw_addons, true ) );
 
 			if ( ! is_wp_error( $raw_addons ) ) {
 

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -33,9 +33,10 @@ class WC_Admin_Addons {
 
 			$raw_addons = wp_remote_get( 'http://www.woothemes.com/product-category/woocommerce-extensions/' . $view . '?orderby=popularity', array(
 					'user-agent' => 'woocommerce-addons-page',
-					'timeout'    => 3,
+					'timeout'    => 5,
 					'cookies' => $cookies,
 				) );
+			error_log( print_r( $raw_addons, true ) );
 
 			if ( ! is_wp_error( $raw_addons ) ) {
 


### PR DESCRIPTION
Make the add-ons page load correctly by sending through the current browser cookies, this bypasses the spoofing checks on wp engine.
