### PR TITLE
Update get_report function to accept dir parameter

### DIFF
--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -151,11 +151,12 @@ class WC_Admin_Reports {
 	/**
 	 * Get a report from our reports subfolder
 	 */
-	public static function get_report( $name ) {
+	public static function get_report( $name, $directory = null ) {
+		$directory = isset($directory) ? $directory : dirname(__FILE__);
 		$name  = sanitize_title( str_replace( '_', '-', $name ) );
 		$class = 'WC_Report_' . str_replace( '-', '_', $name );
 
-		include_once( 'reports/class-wc-report-' . $name . '.php' );
+		include_once( $directory . '/reports/class-wc-report-' . $name . '.php' );
 
 		if ( ! class_exists( $class ) )
 			return;

--- a/includes/admin/views/html-admin-page-reports.php
+++ b/includes/admin/views/html-admin-page-reports.php
@@ -48,7 +48,8 @@
 			echo '<p>' . $report['description'] . '</p>';
 
 		if ( $report['callback'] && ( is_callable( $report['callback'] ) ) )
-			call_user_func( $report['callback'], $current_report );
+			$callback_parm = isset($report['callback_parm']) ? $report['callback_parm'] : null;
+			call_user_func( $report['callback'], $current_report, $callback_parm );
 	}
 	?>
 </div>


### PR DESCRIPTION
Add additional optional parameter to get_report to allow a directory to be passed in.  Default to the current directory.

This will allow 3rd party plugins to use this function to extend the reporting.  Currently this can only include files in the woocommerce plugin directory itself.
