### PR TITLE
Update abstract-wc-shipping-method.php

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -180,7 +180,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 				$ship_to_countries = array_intersect( $this->countries, array_keys( WC()->countries->get_shipping_countries() ) );
 			break;
 			case 'excluding' :
-				$ship_to_countries = array_diff( $this->countries, array_keys( WC()->countries->get_shipping_countries() ) );
+				$ship_to_countries = array_diff( array_keys( WC()->countries->get_shipping_countries() ), $this->countries );
 			break;
 			default :
 				$ship_to_countries = array_keys( WC()->countries->get_shipping_countries() );


### PR DESCRIPTION
The order is backward so if you use the default 'is_available' function for your extensions, the 'excluding' option will always deny every country because this line returns an empty array.
