### PR TITLE
Introduce woocommerce_product_backorders_allowed filter

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -536,7 +536,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	public function backorders_allowed() {
-		return $this->backorders === 'yes' || $this->backorders === 'notify' ? true : false;
+		return apply_filters( 'woocommerce_product_backorders_allowed', $this->backorders === 'yes' || $this->backorders === 'notify' ? true : false, $this->id );
 	}
 
 	/**


### PR DESCRIPTION
An example use case would be a store that sells both retail and wholesale and they only want the Wholesale Customer role to be able to backorder products. 
