### PR TITLE
Updated the get_download_url() function - fixes #5424

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1238,7 +1238,7 @@ class WC_Order {
 		return add_query_arg( array(
 			'download_file' => $product_id,
 			'order'         => $this->order_key,
-			'email'         => $this->billing_email,
+			'email'         => urlencode( $this->billing_email ),
 			'key'           => $download_id
 		), trailingslashit( home_url() ) );
 	}


### PR DESCRIPTION
Updated the get_download_url function to encode email address when building the args. This way URLs will remain valid when redirecting from non-SSL to SSL-secure site.
