### PR TITLE
Hide number input buttons in firefox 29 and later

### DIFF
--- a/assets/css/woocommerce.less
+++ b/assets/css/woocommerce.less
@@ -683,6 +683,7 @@ p.demo_store {
 			.inset_box_shadow( 0, 0, 2px, 0, @secondary );
 			font-weight:bold;
 			.border_radius_left(2px);
+			-moz-appearance: textfield; /* Hide buttons for Firefox 29 and later */
 		}
 
 		/* Hide buttons for opera */


### PR DESCRIPTION
In Firefox 29 was finally implemented the input button:
![woocommerce-cart-number-inputs](https://cloud.githubusercontent.com/assets/1264099/2897439/7fbbf7f0-d580-11e3-8a30-7944cec9e70f.png)

This hidden commit these controls.
