### PR TITLE
Update class-wc-meta-box-coupon-data.php

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/post-types/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -201,6 +201,7 @@ class WC_Meta_Box_Coupon_Data {
 				do_action( 'woocommerce_coupon_options_usage_limit' );
 
 			?></div>
+			<?php do_action( 'woocommerce_coupon_data_panels' ); ?>
 			<div class="clear"></div>
 		</div>
 		<?php


### PR DESCRIPTION
Introduce `woocommerce_coupon_data_panels` action.

If someone wants to add a new tab to the Coupons data meta box, they can use the `woocommerce_coupon_data_tabs` filter to register a new tab. These tabs accept a `target` key that lets you specify the `div` ID to reveal when the tab is clicked on. It turns out, however, that there is no way to actually add the `div` to the page, making the filter for custom tabs only good for removing tabs.
