### PR TITLE
Normalize the woocommerce_email_attachments filter return type

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -343,7 +343,7 @@ class WC_Emails {
 		$headers = apply_filters('woocommerce_email_headers', '', 'low_stock', $product);
 
 		// Attachments
-		$attachments = apply_filters('woocommerce_email_attachments', '', 'low_stock', $product);
+		$attachments = apply_filters('woocommerce_email_attachments', array(), 'low_stock', $product);
 
 		// Send the mail
 		wp_mail( get_option('woocommerce_stock_email_recipient'), $subject, $message, $headers, $attachments );
@@ -375,7 +375,7 @@ class WC_Emails {
 		$headers = apply_filters('woocommerce_email_headers', '', 'no_stock', $product);
 
 		// Attachments
-		$attachments = apply_filters('woocommerce_email_attachments', '', 'no_stock', $product);
+		$attachments = apply_filters('woocommerce_email_attachments', array(), 'no_stock', $product);
 
 		// Send the mail
 		wp_mail( get_option('woocommerce_stock_email_recipient'), $subject, $message, $headers, $attachments );
@@ -420,7 +420,7 @@ class WC_Emails {
 		$headers = apply_filters('woocommerce_email_headers', '', 'backorder', $args);
 
 		// Attachments
-		$attachments = apply_filters('woocommerce_email_attachments', '', 'backorder', $args);
+		$attachments = apply_filters('woocommerce_email_attachments', array(), 'backorder', $args);
 
 		// Send the mail
 		wp_mail( get_option('woocommerce_stock_email_recipient'), $subject, $message, $headers, $attachments );


### PR DESCRIPTION
In the WC_Email::get_attachments() the return is a array: https://github.com/woothemes/woocommerce/blob/master/includes/abstracts/abstract-wc-email.php#L240-L248

I believe it is good to normalize it and everyone working with array.
Array is better and simpler to work with the filter and add new attachments.
