### PR TITLE
Fix notice that occurs from external function call

### DIFF
--- a/includes/admin/settings/class-wc-settings-integrations.php
+++ b/includes/admin/settings/class-wc-settings-integrations.php
@@ -44,7 +44,7 @@ class WC_Settings_Integrations extends WC_Settings_Page {
 
 		$integrations = WC()->integrations->get_integrations();
 
-		if ( ! $current_section )
+		if ( ! $current_section && ! empty( $integrations ) )
 			$current_section = current( $integrations )->id;
 
 		foreach ( $integrations as $integration ) {


### PR DESCRIPTION
Resolves https://github.com/woothemes/woocommerce/issues/5506.

This checks to see if the `integrations` array has any values before getting it's current value.
