### PR TITLE
use archive-product templ. for prod attribute page

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -53,7 +53,8 @@ class WC_Template_Loader {
 			$find[] 	= $file;
 			$find[] 	= WC_TEMPLATE_PATH . $file;
 
-		} elseif ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) {
+		} elseif ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) )
+			|| ( get_post_type() == 'product' && is_tax() ) ) {
 
 			$file 	= 'archive-product.php';
 			$find[] = $file;


### PR DESCRIPTION
#5520

This commit catches requests for 'product attribute' pages
and chooses to use 'archive-product.php' rather than 'archive.php'.

wp-includes/query.php only sets is_post_type_archive when the
query contains the proper post_type argument, which isn't the
case for 'Product Attribute Base' pages. However, it does set
is_archive and is_tax.
