### PR TITLE
fix for issue #5531

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -186,6 +186,8 @@ class WC_Query {
 			$wp_post_types['product']->ID 			= $shop_page->ID;
 			$wp_post_types['product']->post_title 	= $shop_page->post_title;
 			$wp_post_types['product']->post_name 	= $shop_page->post_name;
+            $wp_post_types['product']->post_type    = $shop_page->post_type;
+            $wp_post_types['product']->ancestors    = get_ancestors( $shop_page->ID, $shop_page->post_type );
 
 			// Fix conditional Functions like is_front_page
 			$q->is_singular = false;

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -186,8 +186,8 @@ class WC_Query {
 			$wp_post_types['product']->ID 			= $shop_page->ID;
 			$wp_post_types['product']->post_title 	= $shop_page->post_title;
 			$wp_post_types['product']->post_name 	= $shop_page->post_name;
-            $wp_post_types['product']->post_type    = $shop_page->post_type;
-            $wp_post_types['product']->ancestors    = get_ancestors( $shop_page->ID, $shop_page->post_type );
+			$wp_post_types['product']->post_type    = $shop_page->post_type;
+			$wp_post_types['product']->ancestors    = get_ancestors( $shop_page->ID, $shop_page->post_type );
 
 			// Fix conditional Functions like is_front_page
 			$q->is_singular = false;


### PR DESCRIPTION
Some plugins or themes when using WordPress native function like get_queried_object() may expect having access to post_type or it's ancestors. In this specific issue both was needed. So like you have already added ID, post_title and post_name... I just appended post_type and ancestors.
