### PR TITLE
Transaction id field method to include in reports

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -49,6 +49,9 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	/** @var array Array of supported features such as 'default_credit_card_form' */
 	var $supports		= array( 'products' );
 
+	/** @var string Field name of the transaction id, so it can be included in reports */
+	public $transaction_id_field_name = null;
+
 	/** @var int Maximum transaction amount, zero does not define a maximum */
 	public $max_amount = 0;
 
@@ -261,5 +264,20 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			<div class="clear"></div>
 		</fieldset>
 		<?php
+	}
+
+	/**
+	 * Returns the name of the field where the transaction id is stored
+	 * This make it easier to include this data in reports for example
+	 *
+	 * @access public
+	 * @return string Name of the field or empty string if not provided
+	 */
+	public function get_transaction_id_field_name() {
+		if ( null != $this->transaction_id_field_name ) {
+			return $this->transaction_id_field_name;
+		}
+
+		return '';
 	}
 }

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -34,6 +34,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$this->method_title      = __( 'PayPal', 'woocommerce' );
 		$this->notify_url        = WC()->api_request_url( 'WC_Gateway_Paypal' );
 
+		// Set the name of the transaction id field
+		$this->transaction_id_field_name = 'Transaction ID';
+
 		// Load the settings.
 		$this->init_form_fields();
 		$this->init_settings();
@@ -730,7 +733,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 						update_post_meta( $order->id, 'Payer PayPal address', wc_clean( $posted['payer_email'] ) );
 					}
 					if ( ! empty( $posted['txn_id'] ) ) {
-						update_post_meta( $order->id, 'Transaction ID', wc_clean( $posted['txn_id'] ) );
+						update_post_meta( $order->id, $this->transaction_id_field_name, wc_clean( $posted['txn_id'] ) );
 					}
 					if ( ! empty( $posted['first_name'] ) ) {
 						update_post_meta( $order->id, 'Payer first name', wc_clean( $posted['first_name'] ) );
@@ -880,7 +883,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 					} else {
 
 						// Store PP Details
-						update_post_meta( $order->id, 'Transaction ID', wc_clean( $posted['tx'] ) );
+						update_post_meta( $order->id, $this->transaction_id_field_name, wc_clean( $posted['tx'] ) );
 
 						$order->add_order_note( __( 'PDT payment completed', 'woocommerce' ) );
 						$order->payment_complete();


### PR DESCRIPTION
This is my stab at #5157. I don't think that the field name should be standardised as that will be hard to maintain backwards compatibility with. It's probably not a good idea to change field names like that.

So my proposal is to include a field on the abstract gateway class that can be accessed through the new `get_transaction_id_field_name()` method on that same class. If the gateway supports it (it just needs to set the property), the field name can easily be accessed.

Downside to this approach is that each gateway needs to explicitly add compatibility for this, but that would be the case for any other way to standardise this. It's just a minor change for gateways though, as it only requires them to set the property (as demonstrated in the PayPal gateway in this pull request).
