### PR TITLE
Transaction id method

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -262,4 +262,15 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		</fieldset>
 		<?php
 	}
+
+	/**
+	 * Override this method from a gateway class to return the name of the
+	 * field that the transaction id is stored in.
+	 *
+	 * @access public
+	 * @return string
+	 */
+	public function get_transaction_id_field_name() {
+		return '';
+	}
 }

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -730,7 +730,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 						update_post_meta( $order->id, 'Payer PayPal address', wc_clean( $posted['payer_email'] ) );
 					}
 					if ( ! empty( $posted['txn_id'] ) ) {
-						update_post_meta( $order->id, 'Transaction ID', wc_clean( $posted['txn_id'] ) );
+						update_post_meta( $order->id, $this->get_transaction_id_field_name(), wc_clean( $posted['txn_id'] ) );
 					}
 					if ( ! empty( $posted['first_name'] ) ) {
 						update_post_meta( $order->id, 'Payer first name', wc_clean( $posted['first_name'] ) );
@@ -880,7 +880,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 					} else {
 
 						// Store PP Details
-						update_post_meta( $order->id, 'Transaction ID', wc_clean( $posted['tx'] ) );
+						update_post_meta( $order->id, $this->get_transaction_id_field_name(), wc_clean( $posted['tx'] ) );
 
 						$order->add_order_note( __( 'PDT payment completed', 'woocommerce' ) );
 						$order->payment_complete();
@@ -952,5 +952,16 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		}
 
 		return $state;
+	}
+
+	/**
+	 * Returns the name of the field the transaction id is stored in
+	 * Override method from the WC_Payment_Gateway abstract
+	 *
+	 * @access public
+	 * @return string
+	 */
+	public function get_transaction_id_field_name() {
+		return 'Transaction ID';
 	}
 }


### PR DESCRIPTION
Closes #5561 - thanks @maxrice for the suggestion, this looks cleaner indeed.

Second stab at #5157. I don't think that the field name should be standardised as that will be hard to maintain backwards compatibility with. It's probably not a good idea to change field names like that.

So my proposal is to include a stub on the abstract gateway class that can be overridden through the new `get_transaction_id_field_name()` method on that same class. If the gateway supports it, the field name can easily be accessed.

Downside to this approach is that each gateway needs to explicitly add compatibility for this, but that would be the case for any other way to standardise this. It's just a minor change for gateways though, as it only requires them to override the method (as demonstrated in the PayPal gateway in this pull request).
