### PR TITLE
Check for Existence of Cart Before Using

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -104,7 +104,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	public function is_available() {
 		$is_available = ( 'yes' === $this->enabled ) ? true : false;
 
-		if ( 0 < $this->get_order_total() && $this->max_amount >= $this->get_order_total() ) {
+		if ( WC()->cart && 0 < $this->get_order_total() && $this->max_amount >= $this->get_order_total() ) {
 			$is_available = false;
 		}
 


### PR DESCRIPTION
check for the existence of the cart during the is_available() check before getting the order total (which otherwise will result in a PHP notice from the admin, etc)
