### PR TITLE
Allow get_availability to accept quantity parameter.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -165,7 +165,7 @@ class WC_Product {
 	/**
 	 * Set stock level of the product.
 	 *
-	 * Uses queries rather than update_post_meta so we can do this in one query (to avoid stock issues). 
+	 * Uses queries rather than update_post_meta so we can do this in one query (to avoid stock issues).
 	 * We cannot rely on the original loaded value in case another order was made since then.
 	 *
 	 * @param int $amount (default: null)
@@ -207,7 +207,7 @@ class WC_Product {
 	}
 
 	/**
-	 * Reduce stock level of the product. 
+	 * Reduce stock level of the product.
 	 *
 	 * @param int $amount (default: 1) Amount to reduce by.
 	 * @return int new stock level
@@ -223,7 +223,7 @@ class WC_Product {
 	 * @return int new stock level
 	 */
 	public function increase_stock( $amount = 1 ) {
-		return $this->set_stock( $amount, 'add' );		
+		return $this->set_stock( $amount, 'add' );
 	}
 
 	/**
@@ -583,9 +583,9 @@ class WC_Product {
 
 		if ( $this->managing_stock() ) {
 
-			if ( $this->is_in_stock() && $this->get_total_stock() >= $quantity ) {
+			if ( $this->is_in_stock() ) {
 
-				if ( $this->get_total_stock() > get_option( 'woocommerce_notify_no_stock_amount' ) ) {
+				if ( $this->get_total_stock() > get_option( 'woocommerce_notify_no_stock_amount' ) && $this->get_total_stock() >= $quantity ) {
 
 					$format_option = get_option( 'woocommerce_stock_format' );
 

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -577,12 +577,13 @@ class WC_Product {
 	 * @access public
 	 * @return string
 	 */
-	public function get_availability() {
+	public function get_availability( $quantity = 1 ) {
 
 		$availability = $class = "";
 
 		if ( $this->managing_stock() ) {
-			if ( $this->is_in_stock() ) {
+
+			if ( $this->is_in_stock() && $this->get_total_stock() >= $quantity ) {
 
 				if ( $this->get_total_stock() > get_option( 'woocommerce_notify_no_stock_amount' ) ) {
 


### PR DESCRIPTION
In some cases where a product must be sold in multiples (extensions such as Bundles may enforce a certain/min quantity on a product, for example), it might help to have availability information taking a min quantity into account.

For example, a product sold in a bundle in fixed increments of 2 should appear as out of stock / on backorder _inside the bundle_ if there is only 1 item left. In these cases, `get_availability` can be re-used by adding a quantity parameter, without having to filter it, or simply re-write it from scratch for something so simple.
