### PR TITLE
Introduces the wc_get_log_file_path() function

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -52,7 +52,7 @@ class WC_Logger {
 			return true;
 		}
 
-		if ( $this->_handles[ $handle ] = @fopen( WC_LOG_DIR . $this->file_name( $handle ) . '.log', 'a' ) ) {
+		if ( $this->_handles[ $handle ] = @fopen( wc_get_log_file_path( $handle ), 'a' ) ) {
 			return true;
 		}
 
@@ -87,18 +87,6 @@ class WC_Logger {
 		if ( $this->open( $handle ) && is_resource( $this->_handles[ $handle ] ) ) {
 			@ftruncate( $this->_handles[ $handle ], 0 );
 		}
-	}
-
-
-	/**
-	 * file_name function.
-	 *
-	 * @access private
-	 * @param mixed $handle
-	 * @return string
-	 */
-	private function file_name( $handle ) {
-		return $handle . '-' . sanitize_file_name( wp_hash( $handle ) );
 	}
 
 }

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -234,7 +234,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 				'type'        => 'checkbox',
 				'label'       => __( 'Enable logging', 'woocommerce' ),
 				'default'     => 'no',
-				'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside <code>%s/paypal-%s.log</code>', 'woocommerce' ), WC_LOG_DIR, sanitize_file_name( wp_hash( 'paypal' ) ) ),
+				'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside <code>%s</code>', 'woocommerce' ), wc_get_log_file_path( 'paypal' ) )
 			)
 		);
 	}
@@ -298,14 +298,14 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 				'page_style'    => $this->page_style,
 				'paymentaction' => $this->paymentaction,
 				'bn'            => 'WooThemes_Cart',
-				
+
 				// Order key + ID
 				'invoice'       => $this->invoice_prefix . ltrim( $order->get_order_number(), '#' ),
 				'custom'        => serialize( array( $order_id, $order->order_key ) ),
-				
+
 				// IPN
 				'notify_url'    => $this->notify_url,
-				
+
 				// Billing Address info
 				'first_name'    => $order->billing_first_name,
 				'last_name'     => $order->billing_last_name,
@@ -769,7 +769,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 						// Mark order as refunded
 						$order->update_status( 'refunded', sprintf( __( 'Payment %s via IPN.', 'woocommerce' ), strtolower( $posted['payment_status'] ) ) );
 
-						$this->send_ipn_email_notification( 
+						$this->send_ipn_email_notification(
 							sprintf( __( 'Payment for order %s refunded/reversed', 'woocommerce' ), $order->get_order_number() ),
 							sprintf( __( 'Order %s has been marked as refunded - PayPal reason code: %s', 'woocommerce' ), $order->get_order_number(), $posted['reason_code'] )
 						);
@@ -781,16 +781,16 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 					// Mark order as refunded
 					$order->update_status( 'on-hold', sprintf( __( 'Payment %s via IPN.', 'woocommerce' ), strtolower( $posted['payment_status'] ) ) );
 
-					$this->send_ipn_email_notification( 
+					$this->send_ipn_email_notification(
 						sprintf( __( 'Payment for order %s reversed', 'woocommerce' ), $order->get_order_number() ),
 						sprintf(__( 'Order %s has been marked on-hold due to a reversal - PayPal reason code: %s', 'woocommerce' ), $order->get_order_number(), $posted['reason_code'] )
 					);
 
 				break;
 				case 'canceled_reversal' :
-					$this->send_ipn_email_notification( 
-						sprintf( __( 'Reversal cancelled for order %s', 'woocommerce' ), $order->get_order_number() ), 
-						sprintf( __( 'Order %s has had a reversal cancelled. Please check the status of payment and update the order status accordingly.', 'woocommerce' ), $order->get_order_number() ) 
+					$this->send_ipn_email_notification(
+						sprintf( __( 'Reversal cancelled for order %s', 'woocommerce' ), $order->get_order_number() ),
+						sprintf( __( 'Order %s has had a reversal cancelled. Please check the status of payment and update the order status accordingly.', 'woocommerce' ), $order->get_order_number() )
 					);
 				break;
 				default :
@@ -946,7 +946,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		}
 
 		$states = WC()->countries->get_states( $cc );
-		
+
 		if ( isset( $states[ $state ] ) ) {
 			return $states[ $state ];
 		}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -395,3 +395,14 @@ function get_woocommerce_api_url( $path ) {
 
 	return $url;
 }
+
+/**
+ * Get a log file path
+ *
+ * @since 2.2
+ * @param string $handle name
+ * @return string the log file path
+ */
+function wc_get_log_file_path( $handle ) {
+	return trailingslashit( WC_LOG_DIR ) . $handle . '-' . sanitize_file_name( wp_hash( $handle ) ) . '.log';
+}


### PR DESCRIPTION
I tried to change the path to:

``` php
define( 'WC_LOG_DIR', dirname( __FILE__ ) . '/wp-content/logs/' );
```

And I saw it wrong:

```
/var/www/wc-dev/wp-content/logs//paypal-04a54e401c5e8ca594510816bb40c689.log
```

But if I use as:

``` php
define( 'WC_LOG_DIR', dirname( __FILE__ ) . '/wp-content/logs' );
```

I'll break here:

```
if ( $this->_handles[ $handle ] = @fopen( WC_LOG_DIR . $this->file_name( $handle ) . '.log', 'a' ) ) {
    return true;
}
// will generate: /var/www/wc-dev/wp-content/logspaypal-04a54e401c5e8ca594510816bb40c689.log
```

So I created a function to standardize it and handle with this o/
Also it make simpler for any Third-party plugin to display the log path equal PayPal gateway.
