### PR TITLE
Stop error notices in shipping calculator

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -105,9 +105,9 @@ class WC_Countries {
 			$this->load_country_states();
 		}
 		if ( $cc ) {
-			return isset( $this->states[ $cc ] ) ? $this->states[ $cc ] : false;
+			return isset( $this->states[ $cc ] ) ? $this->states[ $cc ] : array();
 		} else {
-			return $this->states;
+			return array();
 		}
 	}
 
@@ -560,7 +560,7 @@ class WC_Countries {
 			'postcode'	=> '#billing_postcode_field, #shipping_postcode_field',
 			'city'		=> '#billing_city_field, #shipping_city_field'
 		);
-		
+
 		return apply_filters( 'woocommerce_country_locale_field_selectors', $locale_fields );
 	}
 


### PR DESCRIPTION
When load the cart page the following errors appear:

```
<b>Notice</b>:  Array to string conversion in <b>/var/www/woocommerce-dev/wp-includes/formatting.php</b> on line <b>584</b><br />
<option value="AF" >Array</option><br />
<b>Notice</b>:  Array to string conversion in <b>/var/www/woocommerce-dev/wp-includes/formatting.php</b> on line <b>584</b><br />
<option value="AT" >Array</option><br />
<b>Notice</b>:  Array to string conversion in <b>/var/www/woocommerce-dev/wp-includes/formatting.php</b> on line <b>584</b><br />
<option value="BE" >Array</option><br />
<b>Notice</b>:  Array to string conversion in <b>/var/www/woocommerce-dev/wp-includes/formatting.php</b> on line <b>584</b><br />
<option value="BI" >Array</option><br />
....
```

This because the `WC()->customer->get_shipping_country()` is empty: https://github.com/woothemes/woocommerce/blob/master/templates/cart/shipping-calculator.php#L38-L41

To maintain the same behavior we had before we need to test whether this coming empty.
Besides always returns an array to maintain the consistency of the method.
