### PR TITLE
Add radio type support to woocommerce_form_field

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1473,7 +1473,7 @@ if ( ! function_exists( 'woocommerce_product_subcategories' ) ) {
 
 			echo $after;
 		}
-		
+
 		return true;
 	}
 }
@@ -1633,7 +1633,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				if ( $args['description'] )
 					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 				$field .= '</p>' . $after;
 
 			} else {
@@ -1652,7 +1652,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				if ( $args['description'] )
 					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 				$field .= '</p>' . $after;
 
 			}
@@ -1685,10 +1685,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				if ( $args['label'] )
 					$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label'] . $required . '</label>';
 				$field .= '<input type="hidden" class="hidden" name="' . esc_attr( $key )  . '" id="' . esc_attr( $key ) . '" value="" ' . implode( ' ', $custom_attributes ) . ' placeholder="' . esc_attr( $args['placeholder'] ) . '" />';
-				
+
 				if ( $args['description'] )
 					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 				$field .= '</p>' . $after;
 
 			} elseif ( is_array( $states ) ) {
@@ -1704,10 +1704,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 					$field .= '<option value="' . esc_attr( $ckey ) . '" '.selected( $value, $ckey, false ) .'>'.__( $cvalue, 'woocommerce' ) .'</option>';
 
 				$field .= '</select>';
-				
+
 				if ( $args['description'] )
 					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 				$field .= '</p>' . $after;
 
 			} else {
@@ -1717,10 +1717,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				if ( $args['label'] )
 					$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required . '</label>';
 				$field .= '<input type="text" class="input-text ' . implode( ' ', $args['input_class'] ) .'" value="' . esc_attr( $value ) . '"  placeholder="' . esc_attr( $args['placeholder'] ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
-				
+
 				if ( $args['description'] )
 					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 				$field .= '</p>' . $after;
 
 			}
@@ -1734,10 +1734,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required  . '</label>';
 
 			$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text ' . implode( ' ', $args['input_class'] ) .'" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>';
-				
+
 			if ( $args['description'] )
 				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-			
+
 			$field .= '</p>' . $after;
 
 			break;
@@ -1746,10 +1746,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $key ) . '_field">
 					<input type="' . esc_attr( $args['type'] ) . '" class="input-checkbox" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" value="1" '.checked( $value, 1, false ) .' />
 					<label for="' . esc_attr( $key ) . '" class="checkbox ' . implode( ' ', $args['label_class'] ) .'" ' . implode( ' ', $custom_attributes ) . '>' . $args['label'] . $required . '</label>';
-			
+
 			if ( $args['description'] )
 				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 			$field .= '</p>' . $after;
 
 			break;
@@ -1761,10 +1761,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required . '</label>';
 
 			$field .= '<input type="password" class="input-text ' . implode( ' ', $args['input_class'] ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
-			
+
 			if ( $args['description'] )
 				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 			$field .= '</p>' . $after;
 
 			break;
@@ -1776,10 +1776,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				$field .= '<label for="' . esc_attr( $key ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label'] . $required . '</label>';
 
 			$field .= '<input type="text" class="input-text ' . implode( ' ', $args['input_class'] ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" '.$args['maxlength'].' value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
-			
+
 			if ( $args['description'] )
 				$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 			$field .= '</p>' . $after;
 
 			break;
@@ -1799,11 +1799,28 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '" class="select" ' . implode( ' ', $custom_attributes ) . '>
 						' . $options . '
 					</select>';
-					
+
 				if ( $args['description'] )
 					$field .= '<span class="description">' . esc_attr( $args['description'] ) . '</span>';
-				
+
 				$field .= '</p>' . $after;
+
+			break;
+		case "radio" :
+
+			$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $key ) . '_field">';
+
+			if ( $args['label'] )
+				$field .= '<label for="' . esc_attr( current( array_keys( $args['options'] ) ) ) . '" class="' . implode( ' ', $args['label_class'] ) .'">' . $args['label']. $required  . '</label>';
+
+			if ( ! empty( $args['options'] ) ) {
+				foreach ( $args['options'] as $option_key => $option_text ) {
+					$field .= '<input type="radio" class="input-radio" value="' . esc_attr( $option_key ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $key ) . '_' . esc_attr( $option_key ) . '"' . checked( $value, $option_key, false ) . ' />';
+					$field .= '<label for="' . esc_attr( $key ) . '_' . esc_attr( $option_key ) . '" class="radio ' . implode( ' ', $args['label_class'] ) .'">' . $option_text . '</label>';
+				}
+			}
+
+			$field .= '</p>' . $after;
 
 			break;
 		default :


### PR DESCRIPTION
Even though the core itself does not use the `radio` type much, plugins sometimes may want to use the `radio` field type and since `woocommerce_form_field` is a general form field generator function, I think it makes sense to add support for this type as well.

This PR simply adds support for the `radio` type. As it stands, it does not suggest any styling, but it does add radio-button specific classes to the options and their labels.
