### PR TITLE
Make checkout form multipart

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -24,7 +24,7 @@ if ( ! $checkout->enable_signup && ! $checkout->enable_guest_checkout && ! is_us
 // filter hook for include new pages inside the payment method
 $get_checkout_url = apply_filters( 'woocommerce_get_checkout_url', WC()->cart->get_checkout_url() ); ?>
 
-<form name="checkout" method="post" class="checkout" action="<?php echo esc_url( $get_checkout_url ); ?>">
+<form name="checkout" method="post" class="checkout" action="<?php echo esc_url( $get_checkout_url ); ?>" enctype="multipart/form-data">
 
 	<?php if ( sizeof( $checkout->checkout_fields ) > 0 ) : ?>
 


### PR DESCRIPTION
It is sometimes desirable to be able to attach files to orders in checkout (especially with the Fees API). This PR simply allows uploading files with the checkout form by adding `enctype="multipart/form-data"` to the checkout form.

A sample use case would be if a store owner wants to offer an option to print a photo on the package/item for an extra fee.
