### PR TITLE
Check if posted data is_array before doing wc_clean in checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -487,7 +487,7 @@ class WC_Checkout {
 						$this->posted[ $key ] = isset( $_POST[ $key ] ) ? wp_strip_all_tags( wp_check_invalid_utf8( stripslashes( $_POST[ $key ] ) ) ) : '';
 					break;
 					default :
-						$this->posted[ $key ] = isset( $_POST[ $key ] ) ? wc_clean( $_POST[ $key ] ) : '';
+						$this->posted[ $key ] = isset( $_POST[ $key ] ) ? ( is_array( $_POST[ $key ] ) ? array_map( 'wc_clean', $_POST[ $key ] ) : wc_clean( $_POST[ $key ] ) ) : '';
 					break;
 				}
 


### PR DESCRIPTION
Not all data that is posted in checkout may be of string type. In some cases, arrays of strings are posted instead. This PR fixes warnings caused by Array to string conversion when WooCommerce tries to `wc_clean` arrays.
