### PR TITLE
RE issue: #5613 - Typo in error message

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -587,7 +587,7 @@ class WC_Checkout {
 		if ( WC()->cart->needs_shipping() ) {
 
 			if ( ! in_array( WC()->customer->get_shipping_country(), array_keys( WC()->countries->get_shipping_countries() ) ) )
-				wc_add_notice( sprintf( __( 'Unfortunately <strong>we do not ship to %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . WC()->customer->get_shipping_country() ), 'error' );
+				wc_add_notice( sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . WC()->customer->get_shipping_country() ), 'error' );
 
 			// Validate Shipping Methods
 			$packages               = WC()->shipping->get_packages();

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -586,7 +586,7 @@ class WC_Checkout {
 
 		if ( WC()->cart->needs_shipping() ) {
 
-			if ( ! in_array( WC()->customer->get_shipping_country(), array_keys( WC()->countries->get_shipping_countries() ) ) )
+			if ( ! in_array( WC()->customer->get_shipping_country(), array_keys( WC()->countries->get_shipping_countries() ) ) ) 
 				wc_add_notice( sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . WC()->customer->get_shipping_country() ), 'error' );
 
 			// Validate Shipping Methods


### PR DESCRIPTION
Removing the word "to" hard-coded in the error message generated when a user selects a country the site won't ship to.

The function already dynamically inserts either "to" or "to the" via WC()->countries->shipping_to_prefix().
