### PR TITLE
Make IP Address Clickable within the order screen

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -142,7 +142,7 @@ class WC_Meta_Box_Order_Data {
 					echo __( 'Order number', 'woocommerce' ) . ' ' . esc_html( $order->get_order_number() ) . '. ';
 
 					if ( $ip_address = get_post_meta( $post->ID, '_customer_ip_address', true ) )
-						echo __( 'Customer IP:', 'woocommerce' ) . ' ' . esc_html( $ip_address );
+						echo __( 'Customer IP:', 'woocommerce' ) . ' <a href="http://ip-adress.com/ip_tracer/' .$ip_address. '" target="top"> ' . esc_html( $ip_address ) . '</a>';
 				?></p>
 
 				<div class="order_data_column_container">


### PR DESCRIPTION
A problem with fraud orders and downloads is that people will use stolen credit cards and use the billing address and name of the cardholder.  This change will allow admins to click the IP address to see the geo location of the purchaser based on their IP.  So if someone from Hawaii orders something with a New York IP the store admins will know that it has a higher risk of being a fraud order.

Thanks
