### PR TITLE
[product_category] shortcode: Remove ordering query args

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -194,7 +194,12 @@ class WC_Shortcodes {
 		woocommerce_reset_loop();
 		wp_reset_postdata();
 
-		return '<div class="woocommerce columns-' . $columns . '">' . ob_get_clean() . '</div>';
+		$return = '<div class="woocommerce columns-' . $columns . '">' . ob_get_clean() . '</div>';
+
+		// Remove ordering query arguments
+		WC()->query->remove_ordering_args();
+
+		return $return;
 	}
 
 


### PR DESCRIPTION
When using the `[product_category]` shortcode with orderby arguments of 'popularity' or 'rating' the `orderby` query clauses are affected for the remaining WP_Queries on the page.

There are many ways to duplicate the issue, but one would be to use the shortcode `[product_category category="appliances" orderby="popularity"]` on the same page as the Recently Viewed widget and you will notice a database error where the widget should be.

The reason for the issue is that the ordering args are only removed once on the `wp` action which runs before the shortcode is rendered. https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-query.php#L62
