### PR TITLE
Update class-wc-query.php

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -701,7 +701,7 @@ class WC_Query {
 									array(
 										'taxonomy' 	=> $attribute,
 										'terms' 	=> $value,
-										'field' 	=> 'id'
+										'field' 	=> 'term_id'
 									)
 								)
 							)


### PR DESCRIPTION
Use 'term_id' instead of 'id' for the tax_query as described in WP codex: http://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters.

This update makes 'Layered Nav' widget compatible with WPML. 
