### PR TITLE
Store transaction ID via payment_complete method

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1396,9 +1396,10 @@ class WC_Order {
 	 * Finally, record the date of payment
 	 *
 	 * @access public
+	 * @param $transaction_id string Optional transaction id to store in post meta
 	 * @return void
 	 */
-	public function payment_complete() {
+	public function payment_complete( $transaction_id = '' ) {
 
 		do_action( 'woocommerce_pre_payment_complete', $this->id );
 
@@ -1438,6 +1439,10 @@ class WC_Order {
 			$this->update_status( $new_order_status );
 
 			add_post_meta( $this->id, '_paid_date', current_time('mysql'), true );
+
+			if ( ! empty( $transaction_id ) ) {
+				add_post_meta( $this->id, '_transaction_id', $transaction_id );
+			}
 
 			$this_order = array(
 				'ID' => $this->id,

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -729,9 +729,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 					if ( ! empty( $posted['payer_email'] ) ) {
 						update_post_meta( $order->id, 'Payer PayPal address', wc_clean( $posted['payer_email'] ) );
 					}
-					if ( ! empty( $posted['txn_id'] ) ) {
-						update_post_meta( $order->id, 'Transaction ID', wc_clean( $posted['txn_id'] ) );
-					}
 					if ( ! empty( $posted['first_name'] ) ) {
 						update_post_meta( $order->id, 'Payer first name', wc_clean( $posted['first_name'] ) );
 					}
@@ -744,7 +741,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 					if ( $posted['payment_status'] == 'completed' ) {
 						$order->add_order_note( __( 'IPN payment completed', 'woocommerce' ) );
-						$order->payment_complete();
+						$txn_id = ( ! empty( $posted['txn_id'] ) ) ? wc_clean( $posted['txn_id'] : '';
+						$order->payment_complete( $txn_id );
 					} else {
 						$order->update_status( 'on-hold', sprintf( __( 'Payment pending: %s', 'woocommerce' ), $posted['pending_reason'] ) );
 					}
@@ -880,10 +878,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 					} else {
 
 						// Store PP Details
-						update_post_meta( $order->id, 'Transaction ID', wc_clean( $posted['tx'] ) );
-
 						$order->add_order_note( __( 'PDT payment completed', 'woocommerce' ) );
-						$order->payment_complete();
+						$txn_id = ( ! empty( $posted['tx'] ) ) ? wc_clean( $posted['tx'] : '';
+						$order->payment_complete( $txn_id );
 						return true;
 					}
 


### PR DESCRIPTION
As discussed in #5563, this is the preferred way to store the transaction ID.

This PR closes #5157.
