### PR TITLE
Send Proper Status Codes on wp_die (Fixes #5656)

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -318,11 +318,11 @@ class WC_AJAX {
 	 */
 	public static function feature_product() {
 		if ( ! current_user_can( 'edit_products' ) ) {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ) );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', 403 );
 		}
 
 		if ( ! check_admin_referer( 'woocommerce-feature-product' ) ) {
-			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ) );
+			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', 403 );
 		}
 
 		$post_id = ! empty( $_GET['product_id'] ) ? (int) $_GET['product_id'] : '';
@@ -351,11 +351,11 @@ class WC_AJAX {
 	 */
 	public static function mark_order_complete() {
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ) );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', 403 );
 		}
 
 		if ( ! check_admin_referer( 'woocommerce-mark-order-complete' ) ) {
-			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ) );
+			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', 403 );
 		}
 
 		$order_id = isset( $_GET['order_id'] ) && (int) $_GET['order_id'] ? (int) $_GET['order_id'] : '';
@@ -376,11 +376,11 @@ class WC_AJAX {
 	 */
 	public static function mark_order_processing() {
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ) );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', 403 );
 		}
 
 		if ( ! check_admin_referer( 'woocommerce-mark-order-processing' ) ) {
-			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ) );
+			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', 403 );
 		}
 
 		$order_id = isset( $_GET['order_id'] ) && (int) $_GET['order_id'] ? (int) $_GET['order_id'] : '';

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -318,11 +318,11 @@ class WC_AJAX {
 	 */
 	public static function feature_product() {
 		if ( ! current_user_can( 'edit_products' ) ) {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', 403 );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', array( 'response' => 403 ) );
 		}
 
 		if ( ! check_admin_referer( 'woocommerce-feature-product' ) ) {
-			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', 403 );
+			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', array( 'response' => 403 ) );
 		}
 
 		$post_id = ! empty( $_GET['product_id'] ) ? (int) $_GET['product_id'] : '';
@@ -351,11 +351,11 @@ class WC_AJAX {
 	 */
 	public static function mark_order_complete() {
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', 403 );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', array( 'response' => 403 ) );
 		}
 
 		if ( ! check_admin_referer( 'woocommerce-mark-order-complete' ) ) {
-			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', 403 );
+			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', array( 'response' => 403 ) );
 		}
 
 		$order_id = isset( $_GET['order_id'] ) && (int) $_GET['order_id'] ? (int) $_GET['order_id'] : '';
@@ -376,11 +376,11 @@ class WC_AJAX {
 	 */
 	public static function mark_order_processing() {
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
-			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', 403 );
+			wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce' ), '', array( 'response' => 403 ) );
 		}
 
 		if ( ! check_admin_referer( 'woocommerce-mark-order-processing' ) ) {
-			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', 403 );
+			wp_die( __( 'You have taken too long. Please go back and retry.', 'woocommerce' ), '', array( 'response' => 403 ) );
 		}
 
 		$order_id = isset( $_GET['order_id'] ) && (int) $_GET['order_id'] ? (int) $_GET['order_id'] : '';

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -39,7 +39,7 @@ class WC_Download_Handler {
 			$_product             = get_product( $product_id );
 
 			if ( ! is_email( $email) ) {
-				wp_die( __( 'Invalid email address.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 403 );
+				wp_die( __( 'Invalid email address.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 403 ) );
 			}
 
 			$query = "
@@ -64,7 +64,7 @@ class WC_Download_Handler {
 			$download_result = $wpdb->get_row( $wpdb->prepare( $query, $args ) );
 
 			if ( ! $download_result ) {
-				wp_die( __( 'Invalid download.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
+				wp_die( __( 'Invalid download.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 404 ) );
 			}
 
 			$download_id 			= $download_result->download_id;
@@ -77,31 +77,31 @@ class WC_Download_Handler {
 			if ( $user_id && get_option( 'woocommerce_downloads_require_login' ) == 'yes' ) {
 
 				if ( ! is_user_logged_in() ) {
-					wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . esc_url( wp_login_url( get_permalink( wc_get_page_id( 'myaccount' ) ) ) ) . '" class="wc-forward">' . __( 'Login', 'woocommerce' ) . '</a>', __( 'Log in to Download Files', 'woocommerce' ), '', 403 );
+					wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . esc_url( wp_login_url( get_permalink( wc_get_page_id( 'myaccount' ) ) ) ) . '" class="wc-forward">' . __( 'Login', 'woocommerce' ) . '</a>', __( 'Log in to Download Files', 'woocommerce' ), '', array( 'response' => 403 ) );
 				} elseif ( ! current_user_can( 'download_file', $download_result ) ) {
-					wp_die( __( 'This is not your download link.', 'woocommerce' ), '', 403 );
+					wp_die( __( 'This is not your download link.', 'woocommerce' ), '', array( 'response' => 403 ) );
 				}
 
 			}
 
 			if ( ! get_post( $product_id ) ) {
-				wp_die( __( 'Product no longer exists.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
+				wp_die( __( 'Product no longer exists.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 404 ) );
 			}
 
 			if ( $order_id ) {
 				$order = new WC_Order( $order_id );
 
 				if ( ! $order->is_download_permitted() || $order->post_status != 'publish' ) {
-					wp_die( __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
+					wp_die( __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 404 ) );
 				}
 			}
 
 			if ( $downloads_remaining == '0' ) {
-				wp_die( __( 'Sorry, you have reached your download limit for this file', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 403 );
+				wp_die( __( 'Sorry, you have reached your download limit for this file', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 403 ) );
 			}
 
 			if ( $access_expires > 0 && strtotime( $access_expires) < current_time( 'timestamp' ) ) {
-				wp_die( __( 'Sorry, this download has expired', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 403 );
+				wp_die( __( 'Sorry, this download has expired', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 403 ) );
 			}
 
 			if ( $downloads_remaining > 0 ) {
@@ -145,7 +145,7 @@ class WC_Download_Handler {
 		$file_download_method = apply_filters( 'woocommerce_file_download_method', get_option( 'woocommerce_file_download_method' ), $product_id );
 
 		if ( ! $file_path ) {
-			wp_die( __( 'No file defined', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
+			wp_die( __( 'No file defined', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 404 ) );
 		}
 
 		// Redirect to the file...
@@ -306,7 +306,7 @@ class WC_Download_Handler {
         if ( $remote_file ) {
         	self::readfile_chunked( $file_path ) or header( 'Location: ' . $file_path );
         } else {
-        	self::readfile_chunked( $file_path ) or wp_die( __( 'File not found', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
+        	self::readfile_chunked( $file_path ) or wp_die( __( 'File not found', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 404 ) );
         }
 
         exit;

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -39,7 +39,7 @@ class WC_Download_Handler {
 			$_product             = get_product( $product_id );
 
 			if ( ! is_email( $email) ) {
-				wp_die( __( 'Invalid email address.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+				wp_die( __( 'Invalid email address.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 403 );
 			}
 
 			$query = "
@@ -64,7 +64,7 @@ class WC_Download_Handler {
 			$download_result = $wpdb->get_row( $wpdb->prepare( $query, $args ) );
 
 			if ( ! $download_result ) {
-				wp_die( __( 'Invalid download.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+				wp_die( __( 'Invalid download.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
 			}
 
 			$download_id 			= $download_result->download_id;
@@ -77,31 +77,31 @@ class WC_Download_Handler {
 			if ( $user_id && get_option( 'woocommerce_downloads_require_login' ) == 'yes' ) {
 
 				if ( ! is_user_logged_in() ) {
-					wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . esc_url( wp_login_url( get_permalink( wc_get_page_id( 'myaccount' ) ) ) ) . '" class="wc-forward">' . __( 'Login', 'woocommerce' ) . '</a>', __( 'Log in to Download Files', 'woocommerce' ) );
+					wp_die( __( 'You must be logged in to download files.', 'woocommerce' ) . ' <a href="' . esc_url( wp_login_url( get_permalink( wc_get_page_id( 'myaccount' ) ) ) ) . '" class="wc-forward">' . __( 'Login', 'woocommerce' ) . '</a>', __( 'Log in to Download Files', 'woocommerce' ), '', 403 );
 				} elseif ( ! current_user_can( 'download_file', $download_result ) ) {
-					wp_die( __( 'This is not your download link.', 'woocommerce' ) );
+					wp_die( __( 'This is not your download link.', 'woocommerce' ), '', 403 );
 				}
 
 			}
 
 			if ( ! get_post( $product_id ) ) {
-				wp_die( __( 'Product no longer exists.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+				wp_die( __( 'Product no longer exists.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
 			}
 
 			if ( $order_id ) {
 				$order = new WC_Order( $order_id );
 
 				if ( ! $order->is_download_permitted() || $order->post_status != 'publish' ) {
-					wp_die( __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+					wp_die( __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
 				}
 			}
 
 			if ( $downloads_remaining == '0' ) {
-				wp_die( __( 'Sorry, you have reached your download limit for this file', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+				wp_die( __( 'Sorry, you have reached your download limit for this file', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 403 );
 			}
 
 			if ( $access_expires > 0 && strtotime( $access_expires) < current_time( 'timestamp' ) ) {
-				wp_die( __( 'Sorry, this download has expired', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+				wp_die( __( 'Sorry, this download has expired', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 403 );
 			}
 
 			if ( $downloads_remaining > 0 ) {
@@ -145,7 +145,7 @@ class WC_Download_Handler {
 		$file_download_method = apply_filters( 'woocommerce_file_download_method', get_option( 'woocommerce_file_download_method' ), $product_id );
 
 		if ( ! $file_path ) {
-			wp_die( __( 'No file defined', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+			wp_die( __( 'No file defined', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
 		}
 
 		// Redirect to the file...
@@ -306,7 +306,7 @@ class WC_Download_Handler {
         if ( $remote_file ) {
         	self::readfile_chunked( $file_path ) or header( 'Location: ' . $file_path );
         } else {
-        	self::readfile_chunked( $file_path ) or wp_die( __( 'File not found', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>' );
+        	self::readfile_chunked( $file_path ) or wp_die( __( 'File not found', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', 404 );
         }
 
         exit;


### PR DESCRIPTION
Somewhat subjectively (and potentially incomplete) sends proper status codes when the wp_die function is used.

Fixes #5656
