### PR TITLE
Introduce 'woocommerce_get_order_item_totals_excl_free_fees' filter

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -972,7 +972,7 @@ class WC_Order {
 
 		if ( $fees = $this->get_fees() )
 			foreach( $fees as $id => $fee ) {
-				if ( $fee['line_total'] + $fee['line_tax'] == 0 ) {
+				if ( apply_filters( 'woocommerce_get_order_item_totals_excl_free_fees', $fee['line_total'] + $fee['line_tax'] == 0, $id ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
The new filter will allow plugins that add order item meta to choose to
display the free fee items on order details pages and emails.
