### PR TITLE
order item count is wrong

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -30,7 +30,7 @@ class WC_Admin_Post_Types {
 		add_filter( 'manage_edit-product_columns', array( $this, 'product_columns' ) );
 		add_filter( 'manage_edit-shop_coupon_columns', array( $this, 'shop_coupon_columns' ) );
 		add_filter( 'manage_edit-shop_order_columns', array( $this, 'shop_order_columns' ) );
-		
+
 		add_action( 'manage_product_posts_custom_column', array( $this, 'render_product_columns' ), 2 );
 		add_action( 'manage_shop_coupon_posts_custom_column', array( $this, 'render_shop_coupon_columns' ), 2 );
 		add_action( 'manage_shop_order_posts_custom_column', array( $this, 'render_shop_order_columns' ), 2 );
@@ -51,7 +51,7 @@ class WC_Admin_Post_Types {
 		add_action( 'load-edit.php', array( $this, 'bulk_action' ) );
 		add_action( 'admin_notices', array( $this, 'bulk_admin_notices' ) );
 
-		// Order Search 
+		// Order Search
 		add_filter( 'get_search_query', array( $this, 'shop_order_search_label' ) );
 		add_filter( 'query_vars', array( $this, 'add_custom_query_var' ) );
 		add_action( 'parse_query', array( $this, 'shop_order_search_custom_fields' ) );
@@ -472,7 +472,7 @@ class WC_Admin_Post_Types {
 			break;
 			case 'order_items' :
 
-				printf( '<a href="#" class="show_order_items">' . _n( '%d item', '%d items', sizeof( $the_order->get_items() ), 'woocommerce' ) . '</a>', sizeof( $the_order->get_items() ) );
+				printf( '<a href="#" class="show_order_items">' . _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ) . '</a>', $the_order->get_item_count() );
 
 				if ( sizeof( $the_order->get_items() ) > 0 ) {
 
@@ -676,7 +676,7 @@ class WC_Admin_Post_Types {
 		unset( $columns['comments'] );
 
 		return wp_parse_args( $custom, $columns );
-	}		
+	}
 
 	/**
 	 * Remove edit from the bulk actions.
@@ -2044,7 +2044,7 @@ class WC_Admin_Post_Types {
 				}
 			}
 		}
-	}	
+	}
 }
 
 endif;

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -472,7 +472,7 @@ class WC_Admin_Post_Types {
 			break;
 			case 'order_items' :
 
-				printf( '<a href="#" class="show_order_items">' . _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ) . '</a>', $the_order->get_item_count() );
+				echo '<a href="#" class="show_order_items">' . apply_filters( 'woocommerce_order_item_count', sprintf( _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ), $the_order->get_item_count() ), $the_order ) . '</a>';
 
 				if ( sizeof( $the_order->get_items() ) > 0 ) {
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -472,7 +472,7 @@ class WC_Admin_Post_Types {
 			break;
 			case 'order_items' :
 
-				echo '<a href="#" class="show_order_items">' . apply_filters( 'woocommerce_order_item_count', sprintf( _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ), $the_order->get_item_count() ), $the_order ) . '</a>';
+				echo '<a href="#" class="show_order_items">' . apply_filters( 'woocommerce_admin_order_item_count', sprintf( _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ), $the_order->get_item_count() ), $the_order ) . '</a>';
 
 				if ( sizeof( $the_order->get_items() ) > 0 ) {
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -483,7 +483,7 @@ class WC_Admin_Post_Types {
 						$item_meta      = new WC_Order_Item_Meta( $item['item_meta'] );
 						$item_meta_html = $item_meta->display( true, true );
 						?>
-						<tr>
+						<tr class="<?php echo apply_filters( 'woocommerce_admin_order_item_class', '', $item ); ?>">
 							<td class="qty"><?php echo absint( $item['qty'] ); ?></td>
 							<td class="name">
 								<?php if ( wc_product_sku_enabled() && $_product && $_product->get_sku() ) echo $_product->get_sku() . ' - '; ?><?php echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item ); ?>


### PR DESCRIPTION
Order item count is wrong when using `size_of` and comes out unfiltered. This had been fixed at some point by introducing `order->get_item_count`, which takes quantities into account _and_ filters the output.

In addition to this:
1. It would be very helpful to filter the whole string displayed in the column, to allow including additional information about item count, where this need arises (see comment below).
2. By filtering the tr class, we can customise the styling of the item list (related to https://github.com/woothemes/woocommerce/pull/5663).

Please consider adding this into the next point release! Thanks :)
