### PR TITLE
filter html-order-item template tr class

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<tr class="item <?php echo ( ! empty( $class ) ) ? $class : ''; ?>" data-order_item_id="<?php echo $item_id; ?>">
+<tr class="item <?php echo apply_filters( 'woocommerce_admin_html_order_item_class', ( ! empty( $class ) ? $class : '' ), $item ); ?>" data-order_item_id="<?php echo $item_id; ?>">
 	<td class="check-column"><input type="checkbox" /></td>
 	<td class="thumb">
 		<?php if ( $_product ) : ?>


### PR DESCRIPTION
See https://woothemes.zendesk.com/agent/#/tickets/187380 .

Also related to https://github.com/woothemes/woocommerce/pull/5662

Line items that correspond to "bundled" or "composited" items will benefit significantly from slightly modified CSS rules (indentation, smaller font), in order to make order processing more intuitive.

Please consider adding this into the next point release!
