### PR TITLE
add filter to is_purchasable() for variations

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -255,7 +255,7 @@ class WC_Product_Variation extends WC_Product {
 		else
 			$purchasable = parent::is_purchasable();
 
-		return $purchasable;
+		return apply_filters( 'woocommerce_variation_is_purchasable', $purchasable, $this->variation_id, $this->id );
 	}
 
 	/**

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -255,7 +255,7 @@ class WC_Product_Variation extends WC_Product {
 		else
 			$purchasable = parent::is_purchasable();
 
-		return apply_filters( 'woocommerce_variation_is_purchasable', $purchasable, $this->variation_id, $this->id );
+		return apply_filters( 'woocommerce_variation_is_purchasable', $purchasable, $this );
 	}
 
 	/**


### PR DESCRIPTION
I didn't fully understand why each variation's `is_purchasable()` was determined by the parent product's `is_purchasable()` status. 

Anyway, I didn't want to set _all_ the variations to purchasable if the parent product had 1 NYP variation. It seemed to make more sense to have control over each variation individually, so I added a filter. 
