### PR TITLE
Move the wc_ship_to_billing_address_only() function to wc-order-functions.php

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -289,11 +289,3 @@ function wc_cart_totals_shipping_method_label( $method ) {
 
 	return apply_filters( 'woocommerce_cart_shipping_method_full_label', $label, $method );
 }
-
-/**
- * See if we only ship to billing addresses
- * @return bool
- */
-function wc_ship_to_billing_address_only() {
-	return 'billing_only' === get_option( 'woocommerce_ship_to_destination' );
-}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -363,3 +363,11 @@ function wc_delete_shop_order_transients( $post_id = 0 ) {
 
 	do_action( 'woocommerce_delete_shop_order_transients', $post_id );
 }
+
+/**
+ * See if we only ship to billing addresses
+ * @return bool
+ */
+function wc_ship_to_billing_address_only() {
+	return 'billing_only' === get_option( 'woocommerce_ship_to_destination' );
+}


### PR DESCRIPTION
This needs to be present in the admin, so that the actions of sending order emails to work correctly.

```
Fatal error: Call to undefined function wc_ship_to_billing_address_only() in wp-content/plugins/woocommerce/templates/emails/plain/email-addresses.php on line 17
```
