### PR TITLE
Change the address format in plain text emails for new lines

### DIFF
--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -12,11 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 echo "\n" . __( 'Billing address', 'woocommerce' ) . ":\n";
-echo preg_replace( '#<br\s*/?>#i', ', ', $order->get_formatted_billing_address() ) . "\n\n";
+echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address() ) . "\n\n";
 
 if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) {
 
 	echo __( 'Shipping address', 'woocommerce' ) . ":\n";
 
-	echo preg_replace( '#<br\s*/?>#i', ', ', $shipping ) . "\n\n";
+	echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n\n";
 }


### PR DESCRIPTION
I was talking with @BFTrick about the #5565 and well agreed that could be better.  
I do not know what was the reason for using commas, but visually new line is perhaps simplest to view the email address...
