### PR TITLE
Adding Brackets Around if Statement

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WooCommerce Admin.
  *
- * @class 		WC_Admin 
+ * @class 		WC_Admin
  * @author 		WooThemes
  * @category 	Admin
  * @package 	WooCommerce/Admin
@@ -102,8 +102,9 @@ class WC_Admin {
 	 */
 	public function preview_emails() {
 		if ( isset( $_GET['preview_woocommerce_mail'] ) ) {
-			if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'preview-mail') )
+			if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'preview-mail') ) {
 				die( 'Security check' );
+			}
 
 			global $email_heading;
 


### PR DESCRIPTION
Just adding some brackets where they should be according to the [WP standards](http://make.wordpress.org/core/handbook/coding-standards/php/#brace-style).
