### PR TITLE
Stop people accessing wrapper-end.php directly

### DIFF
--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -7,6 +7,7 @@
  * @version     1.6.4
  */
 
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 $template = get_option( 'template' );
 


### PR DESCRIPTION
Noticed this missing, wasn't sure if it was intentional but thought it
best be added.
