### PR TITLE
Deprecate WP_TEMPLATE_PATH

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -41,7 +41,7 @@ class WC_Template_Loader {
 
 			$file 	= 'single-product.php';
 			$find[] = $file;
-			$find[] = WC_TEMPLATE_PATH . $file;
+			$find[] = WC()->template_path() . $file;
 
 		} elseif ( is_product_taxonomy() ) {
 
@@ -54,17 +54,17 @@ class WC_Template_Loader {
 			}
 
 			$find[] = 'taxonomy-' . $term->taxonomy . '-' . $term->slug . '.php';
-			$find[] = WC_TEMPLATE_PATH . 'taxonomy-' . $term->taxonomy . '-' . $term->slug . '.php';
+			$find[] = WC()->template_path() . 'taxonomy-' . $term->taxonomy . '-' . $term->slug . '.php';
 			$find[] = 'taxonomy-' . $term->taxonomy . '.php';
-			$find[] = WC_TEMPLATE_PATH . 'taxonomy-' . $term->taxonomy . '.php';
+			$find[] = WC()->template_path() . 'taxonomy-' . $term->taxonomy . '.php';
 			$find[] = $file;
-			$find[] = WC_TEMPLATE_PATH . $file;
+			$find[] = WC()->template_path() . $file;
 
 		} elseif ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) {
 
 			$file 	= 'archive-product.php';
 			$find[] = $file;
-			$find[] = WC_TEMPLATE_PATH . $file;
+			$find[] = WC()->template_path() . $file;
 
 		}
 
@@ -89,14 +89,14 @@ class WC_Template_Loader {
 		if ( get_post_type() !== 'product' )
 			return $template;
 
-		if ( file_exists( STYLESHEETPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php' ))
-			return STYLESHEETPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php';
-		elseif ( file_exists( TEMPLATEPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php' ))
-			return TEMPLATEPATH . '/' . WC_TEMPLATE_PATH . 'single-product-reviews.php';
-		elseif ( file_exists( STYLESHEETPATH . '/' . 'single-product-reviews.php' ))
-			return STYLESHEETPATH . '/' . 'single-product-reviews.php';
-		elseif ( file_exists( TEMPLATEPATH . '/' . 'single-product-reviews.php' ))
-			return TEMPLATEPATH . '/' . 'single-product-reviews.php';
+		if ( file_exists( get_stylesheet_directory() . '/' . WC()->template_path() . 'single-product-reviews.php' ))
+			return get_stylesheet_directory() . '/' . WC()->template_path() . 'single-product-reviews.php';
+		elseif ( file_exists( get_template_directory() . '/' . WC()->template_path() . 'single-product-reviews.php' ))
+			return get_template_directory() . '/' . WC()->template_path() . 'single-product-reviews.php';
+		elseif ( file_exists( get_stylesheet_directory() . '/' . 'single-product-reviews.php' ))
+			return get_stylesheet_directory() . '/' . 'single-product-reviews.php';
+		elseif ( file_exists( get_template_directory() . '/' . 'single-product-reviews.php' ))
+			return get_template_directory() . '/' . 'single-product-reviews.php';
 		else
 			return WC()->plugin_path() . '/templates/single-product-reviews.php';
 	}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -157,8 +157,8 @@ final class WooCommerce {
 		}
 		else switch( $key ) {
 			case 'template_url':
-				_deprecated_argument( 'Woocommerce->template_url', '2.1', 'WC_TEMPLATE_PATH constant' );
-				return WC_TEMPLATE_PATH;
+				_deprecated_argument( 'Woocommerce->template_url', '2.1', 'Use WC()->template_path()' );
+				return $this->template_path();
 			case 'messages':
 				_deprecated_argument( 'Woocommerce->messages', '2.1', 'Use wc_get_notices' );
 				return wc_get_notices( 'success' );
@@ -231,6 +231,10 @@ final class WooCommerce {
 		define( 'WC_VERSION', $this->version );
 		define( 'WOOCOMMERCE_VERSION', WC_VERSION ); // Backwards compat
 
+		/**
+		 * @deprecated 2.2 
+		 * @deprecated Use WC()->template_path()
+		 */
 		if ( ! defined( 'WC_TEMPLATE_PATH' ) ) {
 			define( 'WC_TEMPLATE_PATH', $this->template_path() );
 		}


### PR DESCRIPTION
This solves https://github.com/woothemes/woocommerce/issues/5483

Also the WordPress core guys have deprecated STYLESHEETPATH and TEMPLATEPATH (https://core.trac.wordpress.org/changeset/28563) (for version 4.0). 

It will be great to deprecate WP_TEMPLATE_PATH too, basically for the same reason as TEMPLATEPATH and TEMPLATEPATH and a few other reasons.
