### PR TITLE
Don't assume the database prefix is wp_

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -257,7 +257,7 @@ class WC_Tax {
 						AND (
 							locations2.location_type = 'city' AND locations2.location_code = %s
 							OR 0 = (
-								SELECT COUNT(*) FROM wp_woocommerce_tax_rate_locations as sublocations
+								SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rate_locations as sublocations
 								WHERE sublocations.location_type = 'city'
 								AND sublocations.tax_rate_id = tax_rates.tax_rate_id
 							)
@@ -267,7 +267,7 @@ class WC_Tax {
 						locations.location_type = 'city'
 						AND locations.location_code = %s
 						AND 0 = (
-								SELECT COUNT(*) FROM wp_woocommerce_tax_rate_locations as sublocations
+								SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rate_locations as sublocations
 								WHERE sublocations.location_type = 'postcode'
 								AND sublocations.tax_rate_id = tax_rates.tax_rate_id
 							)


### PR DESCRIPTION
Use `$wpdb->prefix` instead. It was inconsistent with the rest of the
query anyway.

Fixes #5703
