### PR TITLE
Avoid a "method should not be called statically" notice

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -49,7 +49,7 @@ class WC_Post_Data {
 	/**
 	 * When a post status changes
 	 */
-	public function transition_post_status( $new_status, $old_status, $post ) {
+	public static function transition_post_status( $new_status, $old_status, $post ) {
 		if ( ( 'publish' === $new_status || 'publish' === $old_status ) && in_array( $post->post_type, array( 'product', 'product_variation' ) ) ) {
 			self::delete_product_query_transients();
 		}


### PR DESCRIPTION
Declare `WC_Post_Data::transition_post_status()` as `static`. Avoids a
PHP notice.

Fixes #5705

P.S. — Sorry I forgot to create the tickets before I made the commits, and therefore didn't include the ticket number in the actual commit message.
