### PR TITLE
Status page log title should not assume action for title

### DIFF
--- a/includes/admin/views/html-admin-page-status-logs.php
+++ b/includes/admin/views/html-admin-page-status-logs.php
@@ -1,7 +1,7 @@
 <?php if ( $logs ) : ?>
 	<div id="log-viewer-select">
 		<div class="alignleft">
-			<h3><?php printf( __( 'Viewing %s (%s)', 'woocommerce' ), esc_html( $viewed_log ), date_i18n( get_option( 'date_format') . ' ' . get_option( 'time_format'), filemtime( WC_LOG_DIR . $viewed_log ) ) ); ?></h3>
+			<h3><?php printf( __( 'Log file: %s (%s)', 'woocommerce' ), esc_html( $viewed_log ), date_i18n( get_option( 'date_format') . ' ' . get_option( 'time_format'), filemtime( WC_LOG_DIR . $viewed_log ) ) ); ?></h3>
 		</div>
 		<div class="alignright">
 			<form action="<?php echo admin_url( 'admin.php?page=wc-status&tab=logs' ); ?>" method="post">


### PR DESCRIPTION
I agree with the issue described in #5710. The title should not assume the action, but describe the actual content of the page, making it clear that there is a log file opened.
