### PR TITLE
Adding IDs to Email Header Template

### DIFF
--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -87,11 +87,13 @@ $header_content_h1 = "
         	<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
             	<tr>
                 	<td align="center" valign="top">
-                		<?php
-                			if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
-                				echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name' ) . '" /></p>';
-                			}
-                		?>
+						<div id="template_header_image">
+	                		<?php
+	                			if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
+	                				echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name' ) . '" /></p>';
+	                			}
+	                		?>
+						</div>
                     	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_container" style="<?php echo $template_container; ?>">
                         	<tr>
                             	<td align="center" valign="top">


### PR DESCRIPTION
Adding a wrapper div with an ID to the email-header.php template. Useful for styling & jQuery shenanigans.

Normally it's a good practice to put styles inline for emails but there are some cases where you don't always want to do that and an ID is much more useful.
