### PR TITLE
bugfix in get_related() - return trash posts

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1217,8 +1217,8 @@ class WC_Product {
 
 		// when query is OR - need to check against excluded ids again
 		if ( apply_filters( 'woocommerce_product_related_posts_relate_by_tag', true, $this->id ) ) {
-			$query['where'] .= " {$andor} ( tt.taxonomy = 'product_tag' AND t.term_id IN ( " . implode( ',', $tags_array ) . " ) )";
-			$query['where'] .= " AND p.ID NOT IN ( " . implode( ',', $exclude_ids ) . " )";
+			$query['where'] .= " {$andor} ( ( tt.taxonomy = 'product_tag' AND t.term_id IN ( " . implode( ',', $tags_array ) . " ) )";
+			$query['where'] .= " AND p.ID NOT IN ( " . implode( ',', $exclude_ids ) . " ) )";
 		}
 
 		$query['orderby']  = " ORDER BY RAND()";


### PR DESCRIPTION
Right now i use this fix

```
add_filter( 'woocommerce_product_related_posts_query', 'related_products_fix_query_brackets' );

function related_products_fix_query_brackets( $query )
{
    $query['where'] = preg_replace
    (
        "/\( tt.taxonomy = 'product_cat' AND t.term_id IN \([\s\S]+?\) \) OR \( tt.taxonomy = 'product_tag' AND t.term_id IN \([\s\S]+?\) \) AND p.ID NOT IN \([\s\S]+?\)/",
        '( $0 )',
        $query['where']
    );
    return $query;
}
```
