### PR TITLE
Update class-wc-countries.php for Japanese State

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -725,7 +725,7 @@ class WC_Countries {
 				),
 				'JP' => array(
 					'state'		=> array(
-						'label'    => __( 'Province', 'woocommerce' )
+						'label'    => __( 'Prefecture', 'woocommerce' )
 					)
 				),
 				'KR' => array(


### PR DESCRIPTION
I don't use the word of Province for the largest administrative divisions of Japan, like the state in USA.
Sometimes I use the word of State for 都道府県. But I search some site, It seems to say that "Prefecture"
 is formally. Perhaps Prefecture is best.

Please check following site.
1. One of Most Popular Japanese to English dictionary site:
http://ejje.weblio.jp/content/%E9%83%BD%E9%81%93%E5%BA%9C%E7%9C%8C
1. Official Japanese law Translation site(Please click 都道府県)
   http://www.japaneselawtranslation.go.jp/dict/list?re=02&ft=1&dn=1&ky=%E9%83%BD%E9%81%93%E5%BA%9C%E7%9C%8C&x=63&y=8&co=1
