### PR TITLE
order item count fix and tr class filters in 2.1.12

### DIFF
--- a/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
+++ b/includes/admin/post-types/class-wc-admin-cpt-shop_order.php
@@ -152,7 +152,7 @@ class WC_Admin_CPT_Shop_Order extends WC_Admin_CPT {
 			break;
 			case 'order_items' :
 
-				printf( '<a href="#" class="show_order_items">' . _n( '%d item', '%d items', sizeof( $the_order->get_items() ), 'woocommerce' ) . '</a>', sizeof( $the_order->get_items() ) );
+				echo '<a href="#" class="show_order_items">' . apply_filters( 'woocommerce_admin_order_item_count', sprintf( _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ), $the_order->get_item_count() ), $the_order ) . '</a>';
 
 				if ( sizeof( $the_order->get_items() ) > 0 ) {
 
@@ -163,7 +163,7 @@ class WC_Admin_CPT_Shop_Order extends WC_Admin_CPT {
 						$item_meta      = new WC_Order_Item_Meta( $item['item_meta'] );
 						$item_meta_html = $item_meta->display( true, true );
 						?>
-						<tr>
+						<tr class="<?php echo apply_filters( 'woocommerce_admin_order_item_class', '', $item ); ?>">
 							<td class="qty"><?php echo absint( $item['qty'] ); ?></td>
 							<td class="name">
 								<?php if ( wc_product_sku_enabled() && $_product && $_product->get_sku() ) echo $_product->get_sku() . ' - '; ?><?php echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item ); ?>

--- a/includes/admin/post-types/meta-boxes/views/html-order-item.php
+++ b/includes/admin/post-types/meta-boxes/views/html-order-item.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 ?>
-<tr class="item <?php if ( ! empty( $class ) ) echo $class; ?>" data-order_item_id="<?php echo $item_id; ?>">
+<tr class="item <?php echo apply_filters( 'woocommerce_admin_html_order_item_class', ( ! empty( $class ) ? $class : '' ), $item ); ?>" data-order_item_id="<?php echo $item_id; ?>">
 	<td class="check-column"><input type="checkbox" /></td>
 	<td class="thumb">
 		<?php if ( $_product ) : ?>


### PR DESCRIPTION
Contains fixes and filters from #5662 and #5663 into 2.1.12. Since the file structure in the master branch is different, this should help speed things up quite a bit.

Filters are needed to resolve tickets related to bundled/composited admin item count and bundled/composited line item appearance.
