### PR TITLE
Corrected duplicated settings_page() content

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -45,7 +45,7 @@ class WC_Admin_Menus {
 	    if ( current_user_can( 'manage_woocommerce' ) )
 	    	$menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' );
 
-	    $main_page = add_menu_page( __( 'WooCommerce', 'woocommerce' ), __( 'WooCommerce', 'woocommerce' ), 'manage_woocommerce', 'woocommerce' , array( $this, 'settings_page' ), null, '55.5' );
+	    $main_page = add_menu_page( __( 'WooCommerce', 'woocommerce' ), __( 'WooCommerce', 'woocommerce' ), 'manage_woocommerce', 'woocommerce' , null, null, '55.5' );
 
 	    add_submenu_page( 'edit.php?post_type=product', __( 'Attributes', 'woocommerce' ), __( 'Attributes', 'woocommerce' ), 'manage_product_terms', 'product_attributes', array( $this, 'attributes_page' ) );
 	}


### PR DESCRIPTION
Replaced duplicated call to `array( $this, 'settings_page' )` with `null` to prevent the HTML from being printed to the admin settings twice.
