### PR TITLE
Added filter to modify current category of product category widget

### DIFF
--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -101,6 +101,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 		if ( is_tax('product_cat') ) {
 
 			$this->current_cat   = $wp_query->queried_object;
+			$this->current_cat   = apply_filters( 'modify_wc_widget_category', $this->current_cat );
 			$this->cat_ancestors = get_ancestors( $this->current_cat->term_id, 'product_cat' );
 
 		} elseif ( is_singular('product') ) {


### PR DESCRIPTION
I'm adding a filter to modify current category. It is useful for situations where you need to change the current category displayed.

Example of use: You need to display only the subcategories of the parent category instead of current category (because it doesn't have subcategories): 

``` php
    /* functions.php */
    function change_wc_widget_category( $current_cat ) {
        if (!projectors_is_top_category ($current_cat->term_id)) {
            $current_cat = get_term_by ('id', $current_cat->parent, 'product_cat');
        }
        return $current_cat;
    }
```
