### PR TITLE
Added repository field to the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "title": "WooCommerce",
   "version": "2.2.0",
   "homepage": "http://www.woothemes.com/woocommerce/",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/woothemes/woocommerce.git"
+  },
   "main": "Gruntfile.js",
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
This is especially useful for the `npm docs` command ([source](https://www.npmjs.org/doc/package.json.html#repository), might use in the future), but will also stop `npm install` from moaning about it...
