### PR TITLE
wc_add_order_item_meta() the _line_total doesn't use the correct total

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -101,7 +101,7 @@ class WC_Order {
 	 	
 	 	// Set line item totals, either passed in or from the product
 	 	wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( isset( $args['totals']['subtotal'] ) ? $args['totals']['subtotal'] : $product->get_price_excluding_tax( $qty ) ) );
-	 	wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( isset( $args['totals']['total'] ) ? $args['total']['subtotal_tax'] : $product->get_price_excluding_tax( $qty ) ) );
+	 	wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( isset( $args['totals']['total'] ) ? $args['totals']['total'] : $product->get_price_excluding_tax( $qty ) ) );
 	 	wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( isset( $args['totals']['subtotal_tax'] ) ? $args['totals']['subtotal_tax'] : 0 ) );
 	 	wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( isset( $args['totals']['tax'] ) ? $args['totals']['tax'] : 0 ) );
 


### PR DESCRIPTION
in the `add_product()` method of the Order class there is:

```
// Set line item totals, either passed in or from the product
wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( isset( $args['totals']['subtotal'] ) ? $args['totals']['subtotal'] : $product->get_price_excluding_tax( $qty ) ) );
wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( isset( $args['totals']['total'] ) ? $args['total']['subtotal_tax'] : $product->get_price_excluding_tax( $qty ) ) );
wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( isset( $args['totals']['subtotal_tax'] ) ? $args['totals']['subtotal_tax'] : 0 ) );
wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( isset( $args['totals']['tax'] ) ? $args['totals']['tax'] : 0 ) );
```

The 2nd one is line 104 and if the line total is set, you save the subtotal_tax in its place? 

I came across it because I am tracking down the reason the order item's _line_subtotal is "0" while the line_total is "" for the items I have in a containing product. (I'm working on a Mix and Match thing like a 6 pack). 

I'm manipulating the price of the contained items (similar to Composites) and was seeing the order admin screen show that the line_subtotal != line_total which looked weird when $0 != $0. The _line_subtotal meta was correctly "0" but the _line_total was a null string "", I think because it was trying to use the `$args['total']['subtotal_tax']` as the value.

![image](https://cloud.githubusercontent.com/assets/507025/3444290/1040b9b4-012d-11e4-83e4-63cb68542331.png)
