### PR TITLE
Adding Filters to Email Templates

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -201,9 +201,7 @@ class WC_Emails {
 		$styles = apply_filters( 'woocommerce_email_styles', $styles );
 
 		// escape all values
-		foreach( $styles as $key => $value ) {
-			$styles[$key] = wp_kses( $value, array() );
-		}
+		array_walk_recursive( $styles, 'sanitize_text_field' );
 
 		return $styles;
 	}

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -177,6 +177,7 @@ class WC_Emails {
 		$styles['base_color']      = get_option( 'woocommerce_email_base_color' );
 		$styles['base_text_color'] = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
 		$styles['text_color']      = get_option( 'woocommerce_email_text_color' );
+		$styles['width']           = 600;
 
 		return apply_filters( 'woocommerce_email_styles', $styles );
 	}
@@ -199,7 +200,7 @@ class WC_Emails {
 	 * @return void
 	 */
 	function email_footer() {
-		wc_get_template( 'emails/email-footer.php' );
+		wc_get_template( 'emails/email-footer.php', array( 'styles' => $this->get_styles() ) );
 	}
 
 	/**

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -187,6 +187,12 @@ class WC_Emails {
 		$styles['footer_text_size']     = '12px';
 		$styles['font_family']          = 'Arial';
 
+		// box shadow
+		$styles['box_shadow']['offset'] = '0px 0px';
+		$styles['box_shadow']['blur']   = '0px';
+		$styles['box_shadow']['spread'] = '3px';
+		$styles['box_shadow']['color']  = 'rgba(0,0,0,0.025)';
+
 		// everything else
 		$styles['width']                = 600;
 		$styles['border_radius']        = '6px';

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -165,6 +165,23 @@ class WC_Emails {
 	}
 
 	/**
+	* Get email styles.
+	*
+	* @access public
+	* @return string
+	*/
+	function get_styles() {
+
+		$styles['bg']              = get_option( 'woocommerce_email_background_color' );
+		$styles['body_bg']         = get_option( 'woocommerce_email_body_background_color' );
+		$styles['base_color']      = get_option( 'woocommerce_email_base_color' );
+		$styles['base_text_color'] = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
+		$styles['text_color']      = get_option( 'woocommerce_email_text_color' );
+
+		return apply_filters( 'woocommerce_email_styles', $styles );
+	}
+
+	/**
 	 * Get the email header.
 	 *
 	 * @access public
@@ -172,7 +189,7 @@ class WC_Emails {
 	 * @return void
 	 */
 	function email_header( $email_heading ) {
-		wc_get_template( 'emails/email-header.php', array( 'email_heading' => $email_heading ) );
+		wc_get_template( 'emails/email-header.php', array( 'email_heading' => $email_heading, 'styles' => $this->get_styles() ) );
 	}
 
 	/**

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -190,7 +190,15 @@ class WC_Emails {
 		// everything else
 		$styles['width']             = 600;
 
-		return apply_filters( 'woocommerce_email_styles', $styles );
+		// give the user a chance to filter the values
+		$styles = apply_filters( 'woocommerce_email_styles', $styles );
+
+		// escape all values
+		foreach( $styles as $key => $value ) {
+			$styles[$key] = wp_kses( $value, array() );
+		}
+
+		return $styles;
 	}
 
 	/**

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -189,6 +189,7 @@ class WC_Emails {
 
 		// everything else
 		$styles['width']             = 600;
+		$styles['border_radius']     = 6;
 
 		// give the user a chance to filter the values
 		$styles = apply_filters( 'woocommerce_email_styles', $styles );

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -173,23 +173,23 @@ class WC_Emails {
 	function get_styles() {
 
 		// colors
-		$styles['bg']                  = get_option( 'woocommerce_email_background_color' );
-		$styles['body_bg']             = get_option( 'woocommerce_email_body_background_color' );
-		$styles['base_color']          = get_option( 'woocommerce_email_base_color' );
-		$styles['base_text_color']     = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
-		$styles['text_color']          = get_option( 'woocommerce_email_text_color' );
-		$styles['footer_text_color']   = wc_hex_lighter( $styles['base_color'], 40 );
+		$styles['bg']                   = get_option( 'woocommerce_email_background_color' );
+		$styles['body_bg']              = get_option( 'woocommerce_email_body_background_color' );
+		$styles['base_color']           = get_option( 'woocommerce_email_base_color' );
+		$styles['base_text_color']      = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
+		$styles['text_color']           = get_option( 'woocommerce_email_text_color' );
+		$styles['footer_text_color']    = wc_hex_lighter( $styles['base_color'], 40 );
 
 		// fonts
-		$styles['base_text_size']      = 14;
-		$styles['header_text_size']    = 30;
-		$styles['header_text_weight']  = 'bold';
-		$styles['footer_text_size']    = 12;
-		$styles['font_family']         = 'Arial';
+		$styles['base_text_size']       = '14px';
+		$styles['header_text_size']     = '30px';
+		$styles['header_text_weight']   = 'bold';
+		$styles['footer_text_size']     = '12px';
+		$styles['font_family']          = 'Arial';
 
 		// everything else
-		$styles['width']             = 600;
-		$styles['border_radius']     = 6;
+		$styles['width']                = 600;
+		$styles['border_radius']        = '6px';
 
 		// give the user a chance to filter the values
 		$styles = apply_filters( 'woocommerce_email_styles', $styles );

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -172,12 +172,23 @@ class WC_Emails {
 	*/
 	function get_styles() {
 
-		$styles['bg']              = get_option( 'woocommerce_email_background_color' );
-		$styles['body_bg']         = get_option( 'woocommerce_email_body_background_color' );
-		$styles['base_color']      = get_option( 'woocommerce_email_base_color' );
-		$styles['base_text_color'] = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
-		$styles['text_color']      = get_option( 'woocommerce_email_text_color' );
-		$styles['width']           = 600;
+		// colors
+		$styles['bg']                  = get_option( 'woocommerce_email_background_color' );
+		$styles['body_bg']             = get_option( 'woocommerce_email_body_background_color' );
+		$styles['base_color']          = get_option( 'woocommerce_email_base_color' );
+		$styles['base_text_color']     = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
+		$styles['text_color']          = get_option( 'woocommerce_email_text_color' );
+		$styles['footer_text_color']   = wc_hex_lighter( $styles['base_color'], 40 );
+
+		// fonts
+		$styles['base_text_size']      = 14;
+		$styles['header_text_size']    = 30;
+		$styles['header_text_weight']  = 'bold';
+		$styles['footer_text_size']    = 12;
+		$styles['font_family']         = 'Arial';
+
+		// everything else
+		$styles['width']             = 600;
 
 		return apply_filters( 'woocommerce_email_styles', $styles );
 	}

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -173,29 +173,29 @@ class WC_Emails {
 	function get_styles() {
 
 		// colors
-		$styles['bg']                   = get_option( 'woocommerce_email_background_color' );
-		$styles['body_bg']              = get_option( 'woocommerce_email_body_background_color' );
-		$styles['base_color']           = get_option( 'woocommerce_email_base_color' );
-		$styles['base_text_color']      = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
-		$styles['text_color']           = get_option( 'woocommerce_email_text_color' );
-		$styles['footer_text_color']    = wc_hex_lighter( $styles['base_color'], 40 );
+		$styles['bg']                    = get_option( 'woocommerce_email_background_color' );
+		$styles['body_bg']               = get_option( 'woocommerce_email_body_background_color' );
+		$styles['base_color']            = get_option( 'woocommerce_email_base_color' );
+		$styles['base_text']['color']    = wc_light_or_dark( $styles['base_color'], '#202020', '#ffffff' );
+		$styles['text_color']            = get_option( 'woocommerce_email_text_color' );
+		$styles['footer_text']['color']  = wc_hex_lighter( $styles['base_color'], 40 );
 
 		// fonts
-		$styles['base_text_size']       = '14px';
-		$styles['header_text_size']     = '30px';
-		$styles['header_text_weight']   = 'bold';
-		$styles['footer_text_size']     = '12px';
-		$styles['font_family']          = 'Arial';
+		$styles['base_text']['size']     = '14px';
+		$styles['header_text']['size']   = '30px';
+		$styles['header_text']['weight'] = 'bold';
+		$styles['footer_text']['size']   = '12px';
+		$styles['font_family']           = 'Arial';
 
 		// box shadow
-		$styles['box_shadow']['offset'] = '0px 0px';
-		$styles['box_shadow']['blur']   = '0px';
-		$styles['box_shadow']['spread'] = '3px';
-		$styles['box_shadow']['color']  = 'rgba(0,0,0,0.025)';
+		$styles['box_shadow']['offset']  = '0px 0px';
+		$styles['box_shadow']['blur']    = '0px';
+		$styles['box_shadow']['spread']  = '3px';
+		$styles['box_shadow']['color']   = 'rgba(0,0,0,0.025)';
 
 		// everything else
-		$styles['width']                = 600;
-		$styles['border_radius']        = '6px';
+		$styles['width']                 = 600;
+		$styles['border_radius']         = '6px';
 
 		// give the user a chance to filter the values
 		$styles = apply_filters( 'woocommerce_email_styles', $styles );

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -18,7 +18,7 @@ $template_footer = "
 $credit = "
 	border:0;
 	color: " . $styles['footer_text_color'] . ";
-	font-family: Arial;
+	font-family: " . $styles['font_family'] . ";
 	font-size: " . $styles['footer_text_size'] . "px;
 	line-height:125%;
 	text-align:center;

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -43,7 +43,7 @@ $credit = "
                         	<tr>
                             	<td align="center" valign="top">
                                     <!-- Footer -->
-                                	<table border="0" cellpadding="10" cellspacing="0" width="600" id="template_footer" style="<?php echo $template_footer; ?>">
+                                	<table border="0" cellpadding="10" cellspacing="0" width="<?php echo $styles['width']; ?>" id="template_footer" style="<?php echo $template_footer; ?>">
                                     	<tr>
                                         	<td valign="top">
                                                 <table border="0" cellpadding="10" cellspacing="0" width="100%">

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -12,14 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 // For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline.
 $template_footer = "
 	border-top:0;
-	-webkit-border-radius:" . $styles['border_radius'] . "px;
+	-webkit-border-radius:" . $styles['border_radius'] . ";
 ";
 
 $credit = "
 	border:0;
 	color: " . $styles['footer_text_color'] . ";
 	font-family: " . $styles['font_family'] . ";
-	font-size: " . $styles['footer_text_size'] . "px;
+	font-size: " . $styles['footer_text_size'] . ";
 	line-height:125%;
 	text-align:center;
 ";

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -9,11 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-// Load colours
-$base = get_option( 'woocommerce_email_base_color' );
-
-$base_lighter_40 = wc_hex_lighter( $base, 40 );
-
 // For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline.
 $template_footer = "
 	border-top:0;
@@ -22,9 +17,9 @@ $template_footer = "
 
 $credit = "
 	border:0;
-	color: $base_lighter_40;
+	color: " . $styles['footer_text_color'] . ";
 	font-family: Arial;
-	font-size:12px;
+	font-size: " . $styles['footer_text_size'] . "px;
 	line-height:125%;
 	text-align:center;
 ";

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 // For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline.
 $template_footer = "
 	border-top:0;
-	-webkit-border-radius:6px;
+	-webkit-border-radius:" . $styles['border_radius'] . "px;
 ";
 
 $credit = "

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -17,9 +17,9 @@ $template_footer = "
 
 $credit = "
 	border:0;
-	color: " . $styles['footer_text_color'] . ";
+	color: " . $styles['footer_text']['color'] . ";
 	font-family: " . $styles['font_family'] . ";
-	font-size: " . $styles['footer_text_size'] . ";
+	font-size: " . $styles['footer_text']['size'] . ";
 	line-height:125%;
 	text-align:center;
 ";

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -25,20 +25,20 @@ $wrapper = "
 $template_container = "
 	-webkit-box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
 	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
-	-webkit-border-radius:6px !important;
-	border-radius:6px !important;
+	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
+	border-radius:" . $styles['border_radius'] . "px !important;
 	background-color: " . $styles['body_bg'] . ";
 	border: 1px solid $bg_darker_10;
-	-webkit-border-radius:6px !important;
-	border-radius:6px !important;
+	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
+	border-radius:" . $styles['border_radius'] . "px !important;
 ";
 $template_header = "
 	background-color: " . $styles['base_color'] .";
 	color: " . $styles['base_text_color'] . ";
-	-webkit-border-top-left-radius:6px !important;
-	-webkit-border-top-right-radius:6px !important;
-	border-top-left-radius:6px !important;
-	border-top-right-radius:6px !important;
+	-webkit-border-top-left-radius:" . $styles['border_radius'] . "px !important;
+	-webkit-border-top-right-radius:" . $styles['border_radius'] . "px !important;
+	border-top-left-radius:" . $styles['border_radius'] . "px !important;
+	border-top-right-radius:" . $styles['border_radius'] . "px !important;
 	border-bottom: 0;
 	font-family: " . $styles['font_family'] . ";
 	font-weight: " . $styles['header_text_weight'] . ";
@@ -47,8 +47,8 @@ $template_header = "
 ";
 $body_content = "
 	background-color: " . $styles['body_bg'] . ";
-	-webkit-border-radius:6px !important;
-	border-radius:6px !important;
+	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
+	border-radius:" . $styles['border_radius'] . "px !important;
 ";
 $body_content_inner = "
 	color: $text_lighter_20;

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -23,22 +23,22 @@ $wrapper = "
 	padding: 70px 0 70px 0;
 ";
 $template_container = "
-	-webkit-box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
-	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
-	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
-	border-radius:" . $styles['border_radius'] . "px !important;
+	-webkit-box-shadow:" . $styles['box_shadow']['offset'] . ' ' . $styles['box_shadow']['blur'] . ' ' . $styles['box_shadow']['spread'] . ' ' . $styles['box_shadow']['color'] . " !important;
+	box-shadow:" . $styles['box_shadow']['offset'] . ' ' . $styles['box_shadow']['blur'] . ' ' .  $styles['box_shadow']['spread'] . ' ' . $styles['box_shadow']['color'] . " !important;
+	-webkit-border-radius:" . $styles['border_radius'] . " !important;
+	border-radius:" . $styles['border_radius'] . " !important;
 	background-color: " . $styles['body_bg'] . ";
 	border: 1px solid " . $bg_darker_10 . ";
-	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
-	border-radius:" . $styles['border_radius'] . "px !important;
+	-webkit-border-radius:" . $styles['border_radius'] . " !important;
+	border-radius:" . $styles['border_radius'] . " !important;
 ";
 $template_header = "
 	background-color: " . $styles['base_color'] .";
 	color: " . $styles['base_text_color'] . ";
-	-webkit-border-top-left-radius:" . $styles['border_radius'] . "px !important;
-	-webkit-border-top-right-radius:" . $styles['border_radius'] . "px !important;
-	border-top-left-radius:" . $styles['border_radius'] . "px !important;
-	border-top-right-radius:" . $styles['border_radius'] . "px !important;
+	-webkit-border-top-left-radius:" . $styles['border_radius'] . " !important;
+	-webkit-border-top-right-radius:" . $styles['border_radius'] . " !important;
+	border-top-left-radius:" . $styles['border_radius'] . " !important;
+	border-top-right-radius:" . $styles['border_radius'] . " !important;
 	border-bottom: 0;
 	font-family: " . $styles['font_family'] . ";
 	font-weight: " . $styles['header_text_weight'] . ";
@@ -47,13 +47,13 @@ $template_header = "
 ";
 $body_content = "
 	background-color: " . $styles['body_bg'] . ";
-	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
-	border-radius:" . $styles['border_radius'] . "px !important;
+	-webkit-border-radius:" . $styles['border_radius'] . " !important;
+	border-radius:" . $styles['border_radius'] . " !important;
 ";
 $body_content_inner = "
 	color: " . $text_lighter_20 . ";
 	font-family: " . $styles['font_family'] . ";
-	font-size: " . $styles['base_text_size'] . "px;
+	font-size: " . $styles['base_text_size'] . ";
 	line-height:150%;
 	text-align:left;
 ";
@@ -64,7 +64,7 @@ $header_content_h1 = "
 	text-shadow: 0 1px 0 " . $base_lighter_20 . ";
 	display:block;
 	font-family: " . $styles['font_family'] . ";
-	font-size: " . $styles['header_text_size'] . "px;
+	font-size: " . $styles['header_text_size'] . ";
 	font-weight: " . $styles['header_text_weight'] . ";
 	text-align:left;
 	line-height: 150%;

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -28,7 +28,7 @@ $template_container = "
 	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
 	border-radius:" . $styles['border_radius'] . "px !important;
 	background-color: " . $styles['body_bg'] . ";
-	border: 1px solid $bg_darker_10;
+	border: 1px solid " . $bg_darker_10 . ";
 	-webkit-border-radius:" . $styles['border_radius'] . "px !important;
 	border-radius:" . $styles['border_radius'] . "px !important;
 ";
@@ -51,7 +51,7 @@ $body_content = "
 	border-radius:" . $styles['border_radius'] . "px !important;
 ";
 $body_content_inner = "
-	color: $text_lighter_20;
+	color: " . $text_lighter_20 . ";
 	font-family: " . $styles['font_family'] . ";
 	font-size: " . $styles['base_text_size'] . "px;
 	line-height:150%;
@@ -61,7 +61,7 @@ $header_content_h1 = "
 	color: " . $styles['base_text_color'] . ";
 	margin:0;
 	padding: 28px 24px;
-	text-shadow: 0 1px 0 $base_lighter_20;
+	text-shadow: 0 1px 0 " . $base_lighter_20 . ";
 	display:block;
 	font-family: " . $styles['font_family'] . ";
 	font-size: " . $styles['header_text_size'] . "px;

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -2,15 +2,15 @@
 /**
  * Email Header
  *
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     2.0.0
+ * @author  WooThemes
+ * @package WooCommerce/Templates/Emails
+ * @version 2.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 // Load colours
-$bg_darker_10 = wc_hex_darker( $styles['bg'], 10 );
+$bg_darker_10    = wc_hex_darker( $styles['bg'], 10 );
 $base_lighter_20 = wc_hex_lighter( $styles['base_color'], 20 );
 $text_lighter_20 = wc_hex_lighter( $styles['text_color'], 20 );
 

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -23,7 +23,6 @@ $wrapper = "
 	padding: 70px 0 70px 0;
 ";
 $template_container = "
-	-webkit-box-shadow:" . $styles['box_shadow']['offset'] . ' ' . $styles['box_shadow']['blur'] . ' ' . $styles['box_shadow']['spread'] . ' ' . $styles['box_shadow']['color'] . " !important;
 	box-shadow:" . $styles['box_shadow']['offset'] . ' ' . $styles['box_shadow']['blur'] . ' ' .  $styles['box_shadow']['spread'] . ' ' . $styles['box_shadow']['color'] . " !important;
 	-webkit-border-radius:" . $styles['border_radius'] . " !important;
 	border-radius:" . $styles['border_radius'] . " !important;

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -34,14 +34,14 @@ $template_container = "
 ";
 $template_header = "
 	background-color: " . $styles['base_color'] .";
-	color: " . $styles['base_text_color'] . ";
+	color: " . $styles['base_text']['color'] . ";
 	-webkit-border-top-left-radius:" . $styles['border_radius'] . " !important;
 	-webkit-border-top-right-radius:" . $styles['border_radius'] . " !important;
 	border-top-left-radius:" . $styles['border_radius'] . " !important;
 	border-top-right-radius:" . $styles['border_radius'] . " !important;
 	border-bottom: 0;
 	font-family: " . $styles['font_family'] . ";
-	font-weight: " . $styles['header_text_weight'] . ";
+	font-weight: " . $styles['header_text']['weight'] . ";
 	line-height:100%;
 	vertical-align:middle;
 ";
@@ -53,19 +53,19 @@ $body_content = "
 $body_content_inner = "
 	color: " . $text_lighter_20 . ";
 	font-family: " . $styles['font_family'] . ";
-	font-size: " . $styles['base_text_size'] . ";
+	font-size: " . $styles['base_text']['size'] . ";
 	line-height:150%;
 	text-align:left;
 ";
 $header_content_h1 = "
-	color: " . $styles['base_text_color'] . ";
+	color: " . $styles['base_text']['color'] . ";
 	margin:0;
 	padding: 28px 24px;
 	text-shadow: 0 1px 0 " . $base_lighter_20 . ";
 	display:block;
 	font-family: " . $styles['font_family'] . ";
-	font-size: " . $styles['header_text_size'] . ";
-	font-weight: " . $styles['header_text_weight'] . ";
+	font-size: " . $styles['header_text']['size'] . ";
+	font-weight: " . $styles['header_text']['weight'] . ";
 	text-align:left;
 	line-height: 150%;
 ";

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -88,11 +88,11 @@ $header_content_h1 = "
 	                			}
 	                		?>
 						</div>
-                    	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_container" style="<?php echo $template_container; ?>">
+                    	<table border="0" cellpadding="0" cellspacing="0" width="<?php echo $styles['width']; ?>" id="template_container" style="<?php echo $template_container; ?>">
                         	<tr>
                             	<td align="center" valign="top">
                                     <!-- Header -->
-                                	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_header" style="<?php echo $template_header; ?>" bgcolor="<?php echo $styles['base_color']; ?>">
+                                	<table border="0" cellpadding="0" cellspacing="0" width="<?php echo $styles['width']; ?>" id="template_header" style="<?php echo $template_header; ?>" bgcolor="<?php echo $styles['base_color']; ?>">
                                         <tr>
                                             <td>
                                             	<h1 style="<?php echo $header_content_h1; ?>"><?php echo $email_heading; ?></h1>
@@ -106,7 +106,7 @@ $header_content_h1 = "
                         	<tr>
                             	<td align="center" valign="top">
                                     <!-- Body -->
-                                	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_body">
+                                	<table border="0" cellpadding="0" cellspacing="0" width="<?php echo $styles['width']; ?>" id="template_body">
                                     	<tr>
                                             <td valign="top" style="<?php echo $body_content; ?>">
                                                 <!-- Content -->

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -10,19 +10,13 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 // Load colours
-$bg 		= get_option( 'woocommerce_email_background_color' );
-$body		= get_option( 'woocommerce_email_body_background_color' );
-$base 		= get_option( 'woocommerce_email_base_color' );
-$base_text 	= wc_light_or_dark( $base, '#202020', '#ffffff' );
-$text 		= get_option( 'woocommerce_email_text_color' );
-
-$bg_darker_10 = wc_hex_darker( $bg, 10 );
-$base_lighter_20 = wc_hex_lighter( $base, 20 );
-$text_lighter_20 = wc_hex_lighter( $text, 20 );
+$bg_darker_10 = wc_hex_darker( $styles['bg'], 10 );
+$base_lighter_20 = wc_hex_lighter( $styles['base_color'], 20 );
+$text_lighter_20 = wc_hex_lighter( $styles['text_color'], 20 );
 
 // For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline. !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
 $wrapper = "
-	background-color: " . esc_attr( $bg ) . ";
+	background-color: " . esc_attr( $styles['bg'] ) . ";
 	width:100%;
 	-webkit-text-size-adjust:none !important;
 	margin:0;
@@ -33,14 +27,14 @@ $template_container = "
 	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
 	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
-	background-color: " . esc_attr( $body ) . ";
+	background-color: " . esc_attr( $styles['body_bg'] ) . ";
 	border: 1px solid $bg_darker_10;
 	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 ";
 $template_header = "
-	background-color: " . esc_attr( $base ) .";
-	color: $base_text;
+	background-color: " . esc_attr( $styles['base_color'] ) .";
+	color: " . $styles['base_text_color'] . ";
 	-webkit-border-top-left-radius:6px !important;
 	-webkit-border-top-right-radius:6px !important;
 	border-top-left-radius:6px !important;
@@ -52,7 +46,7 @@ $template_header = "
 	vertical-align:middle;
 ";
 $body_content = "
-	background-color: " . esc_attr( $body ) . ";
+	background-color: " . esc_attr( $styles['body_bg'] ) . ";
 	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 ";
@@ -64,7 +58,7 @@ $body_content_inner = "
 	text-align:left;
 ";
 $header_content_h1 = "
-	color: " . esc_attr( $base_text ) . ";
+	color: " . esc_attr( $styles['base_text_color'] ) . ";
 	margin:0;
 	padding: 28px 24px;
 	text-shadow: 0 1px 0 $base_lighter_20;
@@ -98,7 +92,7 @@ $header_content_h1 = "
                         	<tr>
                             	<td align="center" valign="top">
                                     <!-- Header -->
-                                	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_header" style="<?php echo $template_header; ?>" bgcolor="<?php echo $base; ?>">
+                                	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_header" style="<?php echo $template_header; ?>" bgcolor="<?php echo $styles['base_color']; ?>">
                                         <tr>
                                             <td>
                                             	<h1 style="<?php echo $header_content_h1; ?>"><?php echo $email_heading; ?></h1>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -16,7 +16,7 @@ $text_lighter_20 = wc_hex_lighter( $styles['text_color'], 20 );
 
 // For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline. !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
 $wrapper = "
-	background-color: " . esc_attr( $styles['bg'] ) . ";
+	background-color: " . $styles['bg'] . ";
 	width:100%;
 	-webkit-text-size-adjust:none !important;
 	margin:0;
@@ -27,45 +27,45 @@ $template_container = "
 	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
 	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
-	background-color: " . esc_attr( $styles['body_bg'] ) . ";
+	background-color: " . $styles['body_bg'] . ";
 	border: 1px solid $bg_darker_10;
 	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 ";
 $template_header = "
-	background-color: " . esc_attr( $styles['base_color'] ) .";
+	background-color: " . $styles['base_color'] .";
 	color: " . $styles['base_text_color'] . ";
 	-webkit-border-top-left-radius:6px !important;
 	-webkit-border-top-right-radius:6px !important;
 	border-top-left-radius:6px !important;
 	border-top-right-radius:6px !important;
 	border-bottom: 0;
-	font-family:Arial;
-	font-weight:bold;
+	font-family: " . $styles['font_family'] . ";
+	font-weight: " . $styles['header_text_weight'] . ";
 	line-height:100%;
 	vertical-align:middle;
 ";
 $body_content = "
-	background-color: " . esc_attr( $styles['body_bg'] ) . ";
+	background-color: " . $styles['body_bg'] . ";
 	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 ";
 $body_content_inner = "
 	color: $text_lighter_20;
-	font-family:Arial;
-	font-size:14px;
+	font-family: " . $styles['font_family'] . ";
+	font-size: " . $styles['base_text_size'] . "px;
 	line-height:150%;
 	text-align:left;
 ";
 $header_content_h1 = "
-	color: " . esc_attr( $styles['base_text_color'] ) . ";
+	color: " . $styles['base_text_color'] . ";
 	margin:0;
 	padding: 28px 24px;
 	text-shadow: 0 1px 0 $base_lighter_20;
 	display:block;
-	font-family:Arial;
-	font-size:30px;
-	font-weight:bold;
+	font-family: " . $styles['font_family'] . ";
+	font-size: " . $styles['header_text_size'] . "px;
+	font-weight: " . $styles['header_text_weight'] . ";
 	text-align:left;
 	line-height: 150%;
 ";


### PR DESCRIPTION
Alright. This is the second attempt at adding filters to email templates. See issue #5692.

I've added an array of styles to `class-wc-emails.php` which are filterable. The styles include all sorts of things. font size, font family, all sorts of colors, email width, etc. These styles are then sent to `email-header.php` & `email-footer.php`.

The only style I didn't add in there was the drop shadow behind the email. Any thoughts on how to do that @jameskoster ? We could just filter a string like `0 0 0 3px rgba(0,0,0,0.025)` but maybe it's better to break it out into multiple items in the array? Ex. `$styles['box_shadow_color'], $styles['box_shadow_blur'], $styles['box_shadow_spread'], & $styles['box_shadow_offset']`  
