### PR TITLE
Only print checkout notices when not reloading the checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -669,14 +669,19 @@ class WC_Checkout {
 		// If we reached this point then there were errors
 		if ( is_ajax() ) {
 
-			ob_start();
-			wc_print_notices();
-			$messages = ob_get_clean();
+			// only print notices if not reloading the checkout, otherwise they're lost in the page reload
+			if ( ! isset( WC()->session->reload_checkout ) ) {
+
+				ob_start();
+				wc_print_notices();
+				$messages = ob_get_clean();
+			}
+
 
 			echo '<!--WC_START-->' . json_encode(
 				array(
 					'result'	=> 'failure',
-					'messages' 	=> $messages,
+					'messages' 	=> isset( $messages ) ? $messages : '',
 					'refresh' 	=> isset( WC()->session->refresh_totals ) ? 'true' : 'false',
 					'reload'    => isset( WC()->session->reload_checkout ) ? 'true' : 'false'
 				)


### PR DESCRIPTION
Any notices that are added during checkout are immediately lost when the checkout is forced to reload. This commit fixes that by only printing the notices if the checkout is not being reloaded, otherwise they’re printed on the page reload and properly displayed to the user.

reference [ZD ticket #193873](https://woothemes.zendesk.com/agent/#/tickets/193873)
