### PR TITLE
Correct order status for checking downloads

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -91,7 +91,7 @@ class WC_Download_Handler {
 			if ( $order_id ) {
 				$order = get_order( $order_id );
 
-				if ( ! $order->is_download_permitted() || $order->post_status != 'publish' ) {
+				if ( ! $order->is_download_permitted() || $order->post_status != 'wc-completed' ) {
 					wp_die( __( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( home_url() ) . '" class="wc-forward">' . __( 'Go to homepage', 'woocommerce' ) . '</a>', '', array( 'response' => 404 ) );
 				}
 			}


### PR DESCRIPTION
Download validation routine still checks against `publish` post_status of the order post. This PR changes that to the `wc-completed` new post status.

Closes #5795
