### PR TITLE
Remove Webkit Styles from Email Templates

### DIFF
--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -29,20 +29,15 @@ $wrapper = "
 	padding: 70px 0 70px 0;
 ";
 $template_container = "
-	-webkit-box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
 	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
-	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 	background-color: " . esc_attr( $body ) . ";
 	border: 1px solid $bg_darker_10;
-	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 ";
 $template_header = "
 	background-color: " . esc_attr( $base ) .";
 	color: $base_text;
-	-webkit-border-top-left-radius:6px !important;
-	-webkit-border-top-right-radius:6px !important;
 	border-top-left-radius:6px !important;
 	border-top-right-radius:6px !important;
 	border-bottom: 0;
@@ -53,7 +48,6 @@ $template_header = "
 ";
 $body_content = "
 	background-color: " . esc_attr( $body ) . ";
-	-webkit-border-radius:6px !important;
 	border-radius:6px !important;
 ";
 $body_content_inner = "


### PR DESCRIPTION
Neither `-webkit-box-shadow` & `-webkit-border-radius` have any meaning any more. Webkit browsers (Chrome & Safari) now use `box-shadow` & `border-radius` and have been for 4 versions. We should remove them to keep things clean and prevent off bugs.
- JavaScript that changes box-shadow might not change the -webkit-box-shadow (I just ran into this)
- If we end up using a CSS Inliner as discussed in #5692 it could create issues if some functionality uses -webkit- styles and other don't

Also they're fairly minor CSS rules. If someone does have an older browser and the corners in the email aren't rounded it isn't too big of a deal. :)

![border-radius-usage](https://cloud.githubusercontent.com/assets/1065372/3513596/48791686-06c4-11e4-80ff-7543d0d66c9c.png)

![box-shadow-usage](https://cloud.githubusercontent.com/assets/1065372/3513628/a479c188-06c4-11e4-8643-0efb68560bd0.png)

Sources: 
http://caniuse.com/border-radius
http://caniuse.com/css-boxshadow
http://www.w3schools.com/cssref/css3_pr_box-shadow.asp
http://www.w3schools.com/cssref/css3_pr_border-radius.asp
