### PR TITLE
add_to_cart() return $cart_item_key

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -794,7 +794,7 @@ class WC_Cart {
 		 * @param int $variation_id
 		 * @param array $variation attribute values
 		 * @param array $cart_item_data extra cart item data we want to pass into the item
-		 * @return bool
+		 * @return string $cart_item_key
 		 */
 		public function add_to_cart( $product_id, $quantity = 1, $variation_id = '', $variation = '', $cart_item_data = array() ) {
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -927,7 +927,7 @@ class WC_Cart {
 
 			$this->calculate_totals();
 
-			return true;
+			return $cart_item_key;
 		}
 
 		/**


### PR DESCRIPTION
make the `add_to_cart()` method return `$cart_item_key` instead of `true`. This will be helpful for product types that are a container for other product types... I'm working on a "pack/case" for mixing and matching products are various quantities. For example if I manually call `add_to_cart()` I'd like to save the newly added item's cart key as cart data for the parent item.

In a cursory look, I don't see any conditional checks in core that test the result of `add_to_cart()` but if there are they should still work as expected unless they're checking for a boolean type. 
