### PR TITLE
Move TFOOT to after TBODY element throughout templates and classes

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -193,6 +193,17 @@ class WC_Meta_Box_Product_Data {
 									<th>&nbsp;</th>
 								</tr>
 							</thead>
+							<tbody>
+								<?php
+								$downloadable_files = get_post_meta( $post->ID, '_downloadable_files', true );
+
+								if ( $downloadable_files ) {
+									foreach ( $downloadable_files as $key => $file ) {
+										include( 'views/html-product-download.php' );
+									}
+								}
+								?>
+							</tbody>
 							<tfoot>
 								<tr>
 									<th colspan="5">
@@ -208,17 +219,6 @@ class WC_Meta_Box_Product_Data {
 									</th>
 								</tr>
 							</tfoot>
-							<tbody>
-								<?php
-								$downloadable_files = get_post_meta( $post->ID, '_downloadable_files', true );
-
-								if ( $downloadable_files ) {
-									foreach ( $downloadable_files as $key => $file ) {
-										include( 'views/html-product-download.php' );
-									}
-								}
-								?>
-							</tbody>
 						</table>
 					</div>
 					<?php

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -98,11 +98,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 		<div class="edit" style="display:none">
 			<table class="meta" cellspacing="0">
-				<tfoot>
-					<tr>
-						<td colspan="4"><button class="add_order_item_meta button"><?php _e( 'Add&nbsp;meta', 'woocommerce' ); ?></button></td>
-					</tr>
-				</tfoot>
 				<tbody class="meta_items">
 				<?php
 					if ( $metadata = $order->has_meta( $item_id )) {
@@ -142,6 +137,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 					}
 				?>
 				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="4"><button class="add_order_item_meta button"><?php _e( 'Add&nbsp;meta', 'woocommerce' ); ?></button></td>
+					</tr>
+				</tfoot>
 			</table>
 		</div>
 	</td>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -170,21 +170,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 												<th>&nbsp;</th>
 											</tr>
 										</thead>
-										<tfoot>
-											<tr>
-												<th colspan="4">
-													<a href="#" class="button insert" data-row="<?php
-														$file = array(
-															'file' => '',
-															'name' => ''
-														);
-														ob_start();
-														include( 'html-product-variation-download.php' );
-														echo esc_attr( ob_get_clean() );
-													?>"><?php _e( 'Add File', 'woocommerce' ); ?></a>
-												</th>
-											</tr>
-										</tfoot>
 										<tbody>
 											<?php
 											if ( $_downloadable_files ) {
@@ -200,6 +185,21 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 											}
 											?>
 										</tbody>
+										<tfoot>
+											<tr>
+												<th colspan="4">
+													<a href="#" class="button insert" data-row="<?php
+														$file = array(
+															'file' => '',
+															'name' => ''
+														);
+														ob_start();
+														include( 'html-product-variation-download.php' );
+														echo esc_attr( ob_get_clean() );
+													?>"><?php _e( 'Add File', 'woocommerce' ); ?></a>
+												</th>
+											</tr>
+										</tfoot>
 									</table>
 								</div>
 							</td>

--- a/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -120,14 +120,6 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 				</tr>
 			</thead>
 			<?php if ( $tax_rows ) : ?>
-				<tfoot>
-					<tr>
-						<th scope="row" colspan="3"><?php _e( 'Total', 'woocommerce' ); ?></th>
-						<th class="total_row"><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) ) ); ?></th>
-						<th class="total_row"><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></th>
-						<th class="total_row"><strong><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) + array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></strong></th>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php
 					$grouped_tax_tows = array();
@@ -162,6 +154,14 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 					}
 					?>
 				</tbody>
+				<tfoot>
+					<tr>
+						<th scope="row" colspan="3"><?php _e( 'Total', 'woocommerce' ); ?></th>
+						<th class="total_row"><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) ) ); ?></th>
+						<th class="total_row"><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></th>
+						<th class="total_row"><strong><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) + array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></strong></th>
+					</tr>
+				</tfoot>
 			<?php else : ?>
 				<tbody>
 					<tr>

--- a/includes/admin/reports/class-wc-report-taxes-by-date.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-date.php
@@ -118,16 +118,6 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 				$gross     = array_sum( wp_list_pluck( (array) $tax_rows, 'total_sales' ) ) - array_sum( wp_list_pluck( (array) $tax_rows, 'total_shipping' ) );
 				$total_tax = array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) + array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) );
 				?>
-				<tfoot>
-					<tr>
-						<th scope="row"><?php _e( 'Totals', 'woocommerce' ); ?></th>
-						<th class="total_row"><?php echo array_sum( wp_list_pluck( (array) $tax_rows, 'total_orders' ) ); ?></th>
-						<th class="total_row"><?php echo wc_price( $gross ); ?></th>
-						<th class="total_row"><?php echo wc_price( array_sum( wp_list_pluck( (array) $tax_rows, 'total_shipping' ) ) ); ?></th>
-						<th class="total_row"><?php echo wc_price( $total_tax ); ?></th>
-						<th class="total_row"><?php echo wc_price( $gross - $total_tax ); ?></th>
-					</tr>
-				</tfoot>
 				<tbody>
 					<?php
 					foreach ( $tax_rows as $tax_row ) {
@@ -151,6 +141,16 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 					}
 					?>
 				</tbody>
+				<tfoot>
+					<tr>
+						<th scope="row"><?php _e( 'Totals', 'woocommerce' ); ?></th>
+						<th class="total_row"><?php echo array_sum( wp_list_pluck( (array) $tax_rows, 'total_orders' ) ); ?></th>
+						<th class="total_row"><?php echo wc_price( $gross ); ?></th>
+						<th class="total_row"><?php echo wc_price( array_sum( wp_list_pluck( (array) $tax_rows, 'total_shipping' ) ) ); ?></th>
+						<th class="total_row"><?php echo wc_price( $total_tax ); ?></th>
+						<th class="total_row"><?php echo wc_price( $gross - $total_tax ); ?></th>
+					</tr>
+				</tfoot>
 			<?php else : ?>
 				<tbody>
 					<tr>

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -201,15 +201,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 							<th class="settings">&nbsp;</th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<th width="1%" class="default">
-								<input type="radio" name="default_shipping_method" value="" <?php checked( $default_shipping_method, '' ); ?> />
-							</th>
-							<th><?php _e( 'Automatic', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'The cheapest available shipping method will be selected by default.', 'woocommerce' ); ?>">[?]</a></th>
-							<th colspan="3"><span class="description"><?php _e( 'Drag and drop the above shipping methods to control their display order.', 'woocommerce' ); ?></span></th>
-						</tr>
-					</tfoot>
 					<tbody>
 				    	<?php
 				    	foreach ( WC()->shipping->load_shipping_methods() as $key => $method ) {
@@ -243,6 +234,15 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				    	}
 				    	?>
 					</tbody>
+					<tfoot>
+						<tr>
+							<th width="1%" class="default">
+								<input type="radio" name="default_shipping_method" value="" <?php checked( $default_shipping_method, '' ); ?> />
+							</th>
+							<th><?php _e( 'Automatic', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'The cheapest available shipping method will be selected by default.', 'woocommerce' ); ?>">[?]</a></th>
+							<th colspan="3"><span class="description"><?php _e( 'Drag and drop the above shipping methods to control their display order.', 'woocommerce' ); ?></span></th>
+						</tr>
+					</tfoot>
 				</table>
 			</td>
 		</tr>

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -267,30 +267,6 @@ class WC_Settings_Tax extends WC_Settings_Page {
 
 				</tr>
 			</thead>
-			<tfoot>
-				<tr>
-					<th colspan="10">
-						<a href="#" class="button plus insert"><?php _e( 'Insert row', 'woocommerce' ); ?></a>
-						<a href="#" class="button minus remove_tax_rates"><?php _e( 'Remove selected row(s)', 'woocommerce' ); ?></a>
-
-						<div class="pagination">
-							<?php
-								echo str_replace( 'page-numbers', 'page-numbers button', paginate_links( array(
-									'base'      => add_query_arg( 'p', '%#%' ),
-									'type'      => 'plain',
-									'prev_text' => '&laquo;',
-									'next_text' => '&raquo;',
-									'total'     => ceil( absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(tax_rate_id) FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_class = %s;", sanitize_title( $current_class ) ) ) ) / $limit ),
-									'current'   => $page
-								) ) );
-							?>
-						</div>
-
-						<a href="#" download="tax_rates.csv" class="button export"><?php _e( 'Export CSV', 'woocommerce' ); ?></a>
-						<a href="<?php echo admin_url( 'admin.php?import=woocommerce_tax_rate_csv' ); ?>" class="button import"><?php _e( 'Import CSV', 'woocommerce' ); ?></a>
-					</th>
-				</tr>
-			</tfoot>
 			<tbody id="rates">
 				<?php
 					$rates = $wpdb->get_results( $wpdb->prepare(
@@ -356,6 +332,30 @@ class WC_Settings_Tax extends WC_Settings_Page {
 					}
 				?>
 			</tbody>
+			<tfoot>
+				<tr>
+					<th colspan="10">
+						<a href="#" class="button plus insert"><?php _e( 'Insert row', 'woocommerce' ); ?></a>
+						<a href="#" class="button minus remove_tax_rates"><?php _e( 'Remove selected row(s)', 'woocommerce' ); ?></a>
+
+						<div class="pagination">
+							<?php
+								echo str_replace( 'page-numbers', 'page-numbers button', paginate_links( array(
+									'base'      => add_query_arg( 'p', '%#%' ),
+									'type'      => 'plain',
+									'prev_text' => '&laquo;',
+									'next_text' => '&raquo;',
+									'total'     => ceil( absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(tax_rate_id) FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_class = %s;", sanitize_title( $current_class ) ) ) ) / $limit ),
+									'current'   => $page
+								) ) );
+							?>
+						</div>
+
+						<a href="#" download="tax_rates.csv" class="button export"><?php _e( 'Export CSV', 'woocommerce' ); ?></a>
+						<a href="<?php echo admin_url( 'admin.php?import=woocommerce_tax_rate_csv' ); ?>" class="button import"><?php _e( 'Import CSV', 'woocommerce' ); ?></a>
+					</th>
+				</tr>
+			</tfoot>
 		</table>
 		<script type="text/javascript">
 			jQuery( function() {

--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -116,11 +116,6 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 			            	<th><?php _e( 'BIC / Swift', 'woocommerce' ); ?></th>
 		    			</tr>
 		    		</thead>
-		    		<tfoot>
-		    			<tr>
-		    				<th colspan="7"><a href="#" class="add button"><?php _e( '+ Add Account', 'woocommerce' ); ?></a> <a href="#" class="remove_rows button"><?php _e( 'Remove selected account(s)', 'woocommerce' ); ?></a></th>
-		    			</tr>
-		    		</tfoot>
 		    		<tbody class="accounts">
 		            	<?php
 		            	$i = -1;
@@ -141,6 +136,11 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 		            	}
 		            	?>
 		        	</tbody>
+		    		<tfoot>
+		    			<tr>
+		    				<th colspan="7"><a href="#" class="add button"><?php _e( '+ Add Account', 'woocommerce' ); ?></a> <a href="#" class="remove_rows button"><?php _e( 'Remove selected account(s)', 'woocommerce' ); ?></a></th>
+		    			</tr>
+		    		</tfoot>
 		        </table>
 		       	<script type="text/javascript">
 					jQuery(function() {

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -549,11 +549,6 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 							<th><?php _e( 'Handling Fee', 'woocommerce' ); ?> <a class="tips" data-tip="<?php _e( 'Fee excluding tax. Enter an amount, e.g. 2.50, or a percentage, e.g. 5%.', 'woocommerce' ); ?>">[?]</a></th>
 						</tr>
 					</thead>
-					<tfoot>
-						<tr>
-							<th colspan="4"><a href="#" class="add button"><?php _e( 'Add Cost', 'woocommerce' ); ?></a> <a href="#" class="remove button"><?php _e( 'Delete selected costs', 'woocommerce' ); ?></a></th>
-						</tr>
-					</tfoot>
 					<tbody class="flat_rates">
 						<tr>
 							<td></td>
@@ -589,6 +584,11 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 						}
 						?>
 					</tbody>
+					<tfoot>
+						<tr>
+							<th colspan="4"><a href="#" class="add button"><?php _e( 'Add Cost', 'woocommerce' ); ?></a> <a href="#" class="remove button"><?php _e( 'Delete selected costs', 'woocommerce' ); ?></a></th>
+						</tr>
+					</tfoot>
 				</table>
 			   	<script type="text/javascript">
 					jQuery(function() {

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -21,18 +21,6 @@ global $woocommerce;
 				<th class="product-total"><?php _e( 'Totals', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
-		<tfoot>
-		<?php
-			if ( $totals = $order->get_order_item_totals() ) foreach ( $totals as $total ) :
-				?>
-				<tr>
-					<th scope="row" colspan="2"><?php echo $total['label']; ?></th>
-					<td class="product-total"><?php echo $total['value']; ?></td>
-				</tr>
-				<?php
-			endforeach;
-		?>
-		</tfoot>
 		<tbody>
 			<?php
 			if ( sizeof( $order->get_items() ) > 0 ) :
@@ -47,6 +35,18 @@ global $woocommerce;
 			endif;
 			?>
 		</tbody>
+		<tfoot>
+		<?php
+			if ( $totals = $order->get_order_item_totals() ) foreach ( $totals as $total ) :
+				?>
+				<tr>
+					<th scope="row" colspan="2"><?php echo $total['label']; ?></th>
+					<td class="product-total"><?php echo $total['value']; ?></td>
+				</tr>
+				<?php
+			endforeach;
+		?>
+		</tfoot>
 	</table>
 
 	<div id="payment">

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -19,6 +19,32 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 				<th class="product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
+		<tbody>
+			<?php
+				do_action( 'woocommerce_review_order_before_cart_contents' );
+
+				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+					$_product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+
+					if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+						?>
+						<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
+							<td class="product-name">
+								<?php echo apply_filters( 'woocommerce_cart_item_name', $_product->get_title(), $cart_item, $cart_item_key ); ?>
+								<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times; %s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); ?>
+								<?php echo WC()->cart->get_item_data( $cart_item ); ?>
+							</td>
+							<td class="product-total">
+								<?php echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); ?>
+							</td>
+						</tr>
+						<?php
+					}
+				}
+
+				do_action( 'woocommerce_review_order_after_cart_contents' );
+			?>
+		</tbody>
 		<tfoot>
 
 			<tr class="cart-subtotal">
@@ -83,32 +109,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 			<?php do_action( 'woocommerce_review_order_after_order_total' ); ?>
 
 		</tfoot>
-		<tbody>
-			<?php
-				do_action( 'woocommerce_review_order_before_cart_contents' );
-
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					$_product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
-
-					if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
-						?>
-						<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
-							<td class="product-name">
-								<?php echo apply_filters( 'woocommerce_cart_item_name', $_product->get_title(), $cart_item, $cart_item_key ); ?>
-								<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times; %s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); ?>
-								<?php echo WC()->cart->get_item_data( $cart_item ); ?>
-							</td>
-							<td class="product-total">
-								<?php echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); ?>
-							</td>
-						</tr>
-						<?php
-					}
-				}
-
-				do_action( 'woocommerce_review_order_after_cart_contents' );
-			?>
-		</tbody>
 	</table>
 
 	<?php do_action( 'woocommerce_review_order_before_payment' ); ?>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -21,18 +21,6 @@ $order = get_order( $order_id );
 			<th class="product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
 		</tr>
 	</thead>
-	<tfoot>
-	<?php
-		if ( $totals = $order->get_order_item_totals() ) foreach ( $totals as $total ) :
-			?>
-			<tr>
-				<th scope="row"><?php echo $total['label']; ?></th>
-				<td><?php echo $total['value']; ?></td>
-			</tr>
-			<?php
-		endforeach;
-	?>
-	</tfoot>
 	<tbody>
 		<?php
 		if ( sizeof( $order->get_items() ) > 0 ) {
@@ -89,6 +77,18 @@ $order = get_order( $order_id );
 		do_action( 'woocommerce_order_items_table', $order );
 		?>
 	</tbody>
+	<tfoot>
+	<?php
+		if ( $totals = $order->get_order_item_totals() ) foreach ( $totals as $total ) :
+			?>
+			<tr>
+				<th scope="row"><?php echo $total['label']; ?></th>
+				<td><?php echo $total['value']; ?></td>
+			</tr>
+			<?php
+		endforeach;
+	?>
+	</tfoot>
 </table>
 
 <?php do_action( 'woocommerce_order_details_after_order_table', $order ); ?>


### PR DESCRIPTION
> ### [WHATWG HTML5: 4.9.7 The `tfoot` element](http://www.whatwg.org/specs/web-apps/current-work/multipage/tabular-data.html#the-tfoot-element)
> 
> Contexts in which this element can be used:
> - As a child of a table element [...] before any `tbody` and `tr` elements [...]
> - As a child of a table element, **after** any [...] `tbody`, and `tr` elements [...]
