### PR TITLE
Add attributes do_action in products settings

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -591,6 +591,7 @@ class WC_Meta_Box_Product_Data {
 
 					<button type="button" class="button save_attributes"><?php _e( 'Save attributes', 'woocommerce' ); ?></button>
 				</p>
+				<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 			</div>
 			<div id="linked_product_data" class="panel woocommerce_options_panel">
 


### PR DESCRIPTION
Adds do_action('woocommerce_product_options_attributes') in the product settings in the administration.
