### PR TITLE
Update class-wc-coupon.php

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -111,7 +111,7 @@ class WC_Coupon {
 
 			$this->id                         = absint( $coupon_data['id'] );
 			$this->type                       = esc_html( $coupon_data['type'] );
-			$this->amount                     = esc_html( ($coupon_data['amount']?:$coupon_data['coupon_amount']) ) ;
+			$this->amount                     = esc_html( ($coupon_data['amount']?$coupon_data['amount']:$coupon_data['coupon_amount']) ) ;
 			$this->coupon_amount 		  = $this->amount;
 			$this->individual_use             = esc_html( $coupon_data['individual_use'] );
 			$this->product_ids                = is_array( $coupon_data['product_ids'] ) ? $coupon_data['product_ids'] : array();

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -111,7 +111,8 @@ class WC_Coupon {
 
 			$this->id                         = absint( $coupon_data['id'] );
 			$this->type                       = esc_html( $coupon_data['type'] );
-			$this->amount                     = esc_html( $coupon_data['amount'] );
+			$this->amount                     = esc_html( ($coupon_data['amount']?:$coupon_data['coupon_amount']) ) ;
+			$this->coupon_amount 		  = $this->amount;
 			$this->individual_use             = esc_html( $coupon_data['individual_use'] );
 			$this->product_ids                = is_array( $coupon_data['product_ids'] ) ? $coupon_data['product_ids'] : array();
 			$this->exclude_product_ids        = is_array( $coupon_data['exclude_product_ids'] ) ? $coupon_data['exclude_product_ids'] : array();


### PR DESCRIPTION
If you loaded custom coupon data using the  `'woocommerce_get_shop_coupon_data'` filter. Only `$coupon->amount` was set. While the 'normal' coupons loaded from the database get both `$coupon->coupon_amount` and `$coupon->amount` set.

This change also adds `$coupon->coupon_amount` for in code generated coupons and allows functions using the `'woocommerce_get_shop_coupon_data'` filter to use either `amount` or `coupon_amount`.
