### PR TITLE
use term slug instead of term name for product type

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1360,7 +1360,7 @@ class WC_Admin_Post_Types {
 		$output .= '<option value="">' . __( 'Show all product types', 'woocommerce' ) . '</option>';
 
 		foreach ( $terms as $term ) {
-			$output .= '<option value="' . sanitize_title( $term->name ) . '" ';
+			$output .= '<option value="' . sanitize_title( $term->slug ) . '" ';
 
 			if ( isset( $wp_query->query['product_type'] ) ) {
 				$output .= selected( $term->slug, $wp_query->query['product_type'], false );
@@ -1368,7 +1368,7 @@ class WC_Admin_Post_Types {
 
 			$output .= '>';
 
-			switch ( $term->name ) {
+			switch ( $term->slug ) {
 				case 'grouped' :
 					$output .= __( 'Grouped product', 'woocommerce' );
 					break;

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -30,7 +30,7 @@ class WC_Meta_Box_Product_Data {
 		$thepostid = $post->ID;
 
 		if ( $terms = wp_get_object_terms( $post->ID, 'product_type' ) ) {
-			$product_type = sanitize_title( current( $terms )->name );
+			$product_type = sanitize_title( current( $terms )->slug );
 		} else {
 			$product_type = apply_filters( 'default_product_type', 'simple' );
 		}

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -45,7 +45,7 @@ class WC_Product_Factory {
 				$product_type = 'variation';
 			} else {
 				$terms        = get_the_terms( $product_id, 'product_type' );
-				$product_type = ! empty( $terms ) && isset( current( $terms )->name ) ? sanitize_title( current( $terms )->name ) : 'simple';
+				$product_type = ! empty( $terms ) && isset( current( $terms )->slug ) ? sanitize_title( current( $terms )->slug ) : 'simple';
 			}
 
 			// Create a WC coding standards compliant class name e.g. WC_Product_Type_Class instead of WC_Product_type-class


### PR DESCRIPTION
For the default product types there isn't much difference, but for extended product types the slug and the term name could/should be different. Mostly they should be different so that they can be referred to by their slugs for programming reasons but then displayed on the front end by a name that might make more sense to users.

For example the product type filtering `select` element on the edit.php screen uses the term object name for the select option values. 

The default product types are defined in the switch statement, but new types end up with potentially unreadable options. The Composite product type shows up here as "bto". The new product type I am working on is called "Mix and Match" but the slug is "mnm". 

And then if they are different, there are a few places where the admin side should use the slug.. such as the product type value in the product metabox and the $product_type in the edit.php product type column. 
