### PR TITLE
cast $meta_values as array

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -47,7 +47,7 @@ class WC_Order_Item_Meta {
 					continue;
 				}
 
-				foreach( $meta_values as $meta_value ) {
+				foreach( (array) $meta_values as $meta_value ) {
 
 					// Skip serialised meta
 					if ( is_serialized( $meta_value ) ) {


### PR DESCRIPTION
I was trying to pass a variation's attributes to the `display()` method of `WC_Order_Item_Meta` and was getting invalid foreach statements on line 50:

```
foreach( $meta_values as $meta_value ) {
```

I guess the actual meta has an array, but the attribute's $meta_values were a string.
