### PR TITLE
Remove the DEFAULT SORTING option from orderby.php

### DIFF
--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -18,7 +18,7 @@ if ( 1 == $wp_query->found_posts || ! woocommerce_products_will_display() )
 	<select name="orderby" class="orderby">
 		<?php
 			$catalog_orderby = apply_filters( 'woocommerce_catalog_orderby', array(
-				'menu_order' => __( 'Default sorting', 'woocommerce' ),
+				//'menu_order' => __( 'Default sorting', 'woocommerce' ), THIS SHOULD BE REMOVED/DEACTIVATED AS IT'S REDUNDANT & CONFUSING IN SOME INSTANCES
 				'popularity' => __( 'Sort by popularity', 'woocommerce' ),
 				'rating'     => __( 'Sort by average rating', 'woocommerce' ),
 				'date'       => __( 'Sort by newness', 'woocommerce' ),


### PR DESCRIPTION
The DEFAULT SORTING option being listed on the shop pages with is a bit redundant - the page loads with the default and the default is listed amongst all the choices.  Having 'DEFAULT SORTING' as it's own option tends to be a bit confusing.  Potentially adding (default) alongside the actual default option's name could be an alternative, but I suspect that once someone has decided to sort a page the way they want it sorted, that they don't often care what the default is.
