### PR TITLE
Add item meta to REST API orders response

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -177,6 +177,18 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$product = $order->get_product_from_item( $item );
 
+			$meta = new WC_Order_Item_Meta( $item['item_meta'], $product );
+
+			$item_meta = array();
+
+			foreach ( $meta->get_formatted() as $meta_key => $formatted_meta ) {
+				$item_meta[] = array(
+					'key' => $meta_key,
+					'label' => $formatted_meta['label'],
+					'value' => $formatted_meta['value'],
+				);
+			}
+
 			$order_data['line_items'][] = array(
 				'id'           => $item_id,
 				'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item ), 2 ),
@@ -189,6 +201,7 @@ class WC_API_Orders extends WC_API_Resource {
 				'name'         => $item['name'],
 				'product_id'   => ( isset( $product->variation_id ) ) ? $product->variation_id : $product->id,
 				'sku'          => is_object( $product ) ? $product->get_sku() : null,
+				'meta'         => $item_meta,
 			);
 		}
 

--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -5,7 +5,7 @@
  * A Simple class for managing order item meta so plugins add it in the correct format
  *
  * @class 		order_item_meta
- * @version		2.0.4
+ * @version		2.2
  * @package		WooCommerce/Classes
  * @author 		WooThemes
  */
@@ -18,8 +18,9 @@ class WC_Order_Item_Meta {
 	 * Constructor
 	 *
 	 * @access public
-	 * @param string $item_meta (default: '')
-	 * @return void
+	 * @param array $item_meta defaults to array()
+	 * @param \WC_Product $product defaults to null
+	 * @return \WC_Order_Item_Meta instance
 	 */
 	public function __construct( $item_meta = array(), $product = null ) {
 		$this->meta    = $item_meta;
@@ -37,72 +38,114 @@ class WC_Order_Item_Meta {
 	 */
 	public function display( $flat = false, $return = false, $hideprefix = '_' ) {
 
-		if ( ! empty( $this->meta ) ) {
+		$output = '';
+
+		$formatted_meta = $this->get_formatted( $hideprefix );
+
+		if ( ! empty( $formatted_meta ) ) {
 
 			$meta_list = array();
 
-			foreach ( $this->meta as $meta_key => $meta_values ) {
+			foreach ( $formatted_meta as $meta_key => $meta ) {
 
-				if ( empty( $meta_values ) || ( ! empty( $hideprefix ) && substr( $meta_key, 0, 1 ) == $hideprefix ) ) {
-					continue;
-				}
-
-				foreach( $meta_values as $meta_value ) {
-
-					// Skip serialised meta
-					if ( is_serialized( $meta_value ) ) {
-						continue;
-					}
-
-					$attribute_key = urldecode( str_replace( 'attribute_', '', $meta_key ) );
-
-					// If this is a term slug, get the term's nice name
-		            if ( taxonomy_exists( $attribute_key ) ) {
-		            	$term = get_term_by( 'slug', $meta_value, $attribute_key );
-
-		            	if ( ! is_wp_error( $term ) && is_object( $term ) && $term->name ) {
-		            		$meta_value = $term->name;
-		            	}
-
-		          	// If we have a product, and its not a term, try to find its non-sanitized name
-		            } elseif ( $this->product ) {
-						$product_attributes = $this->product->get_attributes();
-
-						if ( isset( $product_attributes[ $attribute_key ] ) ) {
-							$meta_key = wc_attribute_label( $product_attributes[ $attribute_key ]['name'] );
-						}
-		            }
-
-					if ( $flat ) {
-						$meta_list[] = wp_kses_post( wc_attribute_label( $attribute_key ) . ': ' . apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ) );
-					} else {
-						$meta_list[] = '
-							<dt class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( wc_attribute_label( $attribute_key ) ) . ':</dt>
-							<dd class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( wpautop( apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ) ) ) . '</dd>
+				if ( $flat ) {
+					$meta_list[] = wp_kses_post( $meta['label'] . ': ' . $meta['value'] );
+				} else {
+					$meta_list[] = '
+							<dt class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( $meta['label'] ) . ':</dt>
+							<dd class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( wpautop( $meta['value'] ) ) . '</dd>
 						';
-					}
 				}
 			}
 
-			if ( ! sizeof( $meta_list ) )
-				return '';
+			if ( ! empty( $meta_list ) ) {
 
-			$output = $flat ? '' : '<dl class="variation">';
-
-			if ( $flat )
-				$output .= implode( ", \n", $meta_list );
-			else
-				$output .= implode( '', $meta_list );
-
-			if ( ! $flat )
-				$output .= '</dl>';
-
-			if ( $return )
-				return $output;
-			else
-				echo $output;
+				if ( $flat ) {
+					$output .= implode( ", \n", $meta_list );
+				} else {
+					$output .= '<dl class="variation">' . implode( '', $meta_list ). '</dl>';
+				}
+			}
 		}
 
-		return '';
+		if ( $return ) {
+			return $output;
+		} else {
+			echo $output;
+		}
+	}
+
+
+	/**
+	 * Return an array of formatted item meta in format:
+	 *
+	 * array(
+	 *   $meta_key => array(
+	 *     'label' => $label,
+	 *     'value' => $value
+	 *   )
+	 * )
+	 *
+	 * e.g.
+	 *
+	 * array(
+	 *   'pa_size' => array(
+	 *     'label' => 'Size',
+	 *     'value' => 'Medium',
+	 *   )
+	 * )
+	 *
+	 * @since 2.2
+	 * @param string $hideprefix exclude meta when key is prefixed with this, defaults to `_`
+	 * @return array
+	 */
+	public function get_formatted( $hideprefix = '_' ) {
+
+		if ( empty( $this->meta ) ) {
+			return array();
+		}
+
+		$formatted_meta = array();
+
+		foreach ( (array) $this->meta as $meta_key => $meta_values ) {
+
+			if ( empty( $meta_values ) || ( ! empty( $hideprefix ) && substr( $meta_key, 0, 1 ) == $hideprefix ) ) {
+				continue;
+			}
+
+			foreach ( $meta_values as $meta_value ) {
+
+				// Skip serialised meta
+				if ( is_serialized( $meta_value ) ) {
+					continue;
+				}
+
+				$attribute_key = urldecode( str_replace( 'attribute_', '', $meta_key ) );
+
+				// If this is a term slug, get the term's nice name
+				if ( taxonomy_exists( $attribute_key ) ) {
+					$term = get_term_by( 'slug', $meta_value, $attribute_key );
+
+					if ( ! is_wp_error( $term ) && is_object( $term ) && $term->name ) {
+						$meta_value = $term->name;
+					}
+
+				// If we have a product, and its not a term, try to find its non-sanitized name
+				} elseif ( $this->product ) {
+					$product_attributes = $this->product->get_attributes();
+
+					if ( isset( $product_attributes[ $attribute_key ] ) ) {
+						$meta_key = wc_attribute_label( $product_attributes[ $attribute_key ]['name'] );
+					}
+				}
+
+				$formatted_meta[ $meta_key ] = array(
+					'label'     => wc_attribute_label( $attribute_key ),
+					'value'     => apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ),
+				);
+			}
+		}
+
+		return $formatted_meta;
 	}
 }


### PR DESCRIPTION
This fixes #5423 and introduces a new method to `WC_Order_Item_Meta` to make it easier for plugins/core to get formatted item meta in an array.
