### PR TITLE
Add orderby filtering to REST API resource endpoints

### DIFF
--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -539,6 +539,10 @@ class WC_API_Customers extends WC_API_Resource {
 			$this->created_at_max = $this->server->parse_datetime( $args['created_at_max'] );
 		}
 
+		// order (ASC or DESC, ASC by default)
+		if ( ! empty( $args['order'] ) ) {
+			$query_args['order'] = $args['order'];
+		}
 		$query = new WP_User_Query( $query_args );
 
 		// helper members for pagination headers

--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -549,7 +549,7 @@ class WC_API_Customers extends WC_API_Resource {
 			$query_args['orderby'] = $args['orderby'];
 
 			// allow sorting by meta value
-			if ( 'meta_value' === $query_args['orderby'] && ! empty( $args['orderby_meta_key'] ) ) {
+			if ( ! empty( $args['orderby_meta_key'] ) ) {
 				$query_args['meta_key'] = $args['orderby_meta_key'];
 			}
 		}

--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -543,6 +543,17 @@ class WC_API_Customers extends WC_API_Resource {
 		if ( ! empty( $args['order'] ) ) {
 			$query_args['order'] = $args['order'];
 		}
+
+		// orderby
+		if ( ! empty( $args['orderby'] ) ) {
+			$query_args['orderby'] = $args['orderby'];
+
+			// allow sorting by meta value
+			if ( 'meta_value' === $query_args['orderby'] && ! empty( $args['orderby_meta_key'] ) ) {
+				$query_args['meta_key'] = $args['orderby_meta_key'];
+			}
+		}
+
 		$query = new WP_User_Query( $query_args );
 
 		// helper members for pagination headers

--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -168,7 +168,7 @@ class WC_API_Resource {
 			$args['orderby'] = $request_args['orderby'];
 
 			// allow sorting by meta value
-			if ( 'meta_value' === $args['orderby'] && ! empty( $request_args['orderby_meta_key'] ) ) {
+			if ( ! empty( $request_args['orderby_meta_key'] ) ) {
 				$args['meta_key'] = $request_args['orderby_meta_key'];
 			}
 		}

--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -158,10 +158,19 @@ class WC_API_Resource {
 			$args['offset'] = $request_args['offset'];
 		}
 
-		// allow order change (ASC or DESC)
+		// order (ASC or DESC, ASC by default)
 		if ( ! empty( $request_args['order'] ) ) {
 			$args['order'] = $request_args['order'];
-			unset( $request_args['order'] );
+		}
+
+		// orderby
+		if ( ! empty( $request_args['orderby'] ) ) {
+			$args['orderby'] = $request_args['orderby'];
+
+			// allow sorting by meta value
+			if ( 'meta_value' === $args['orderby'] && ! empty( $request_args['orderby_meta_key'] ) ) {
+				$args['meta_key'] = $request_args['orderby_meta_key'];
+			}
 		}
 
 		// allow post status change

--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -123,33 +123,40 @@ class WC_API_Resource {
 			$args['date_query'] = array();
 
 			// resources created after specified date
-			if ( ! empty( $request_args['created_at_min'] ) )
+			if ( ! empty( $request_args['created_at_min'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_date_gmt', 'after' => $this->server->parse_datetime( $request_args['created_at_min'] ), 'inclusive' => true );
+			}
 
 			// resources created before specified date
-			if ( ! empty( $request_args['created_at_max'] ) )
+			if ( ! empty( $request_args['created_at_max'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_date_gmt', 'before' => $this->server->parse_datetime( $request_args['created_at_max'] ), 'inclusive' => true );
+			}
 
 			// resources updated after specified date
-			if ( ! empty( $request_args['updated_at_min'] ) )
+			if ( ! empty( $request_args['updated_at_min'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_modified_gmt', 'after' => $this->server->parse_datetime( $request_args['updated_at_min'] ), 'inclusive' => true );
+			}
 
 			// resources updated before specified date
-			if ( ! empty( $request_args['updated_at_max'] ) )
+			if ( ! empty( $request_args['updated_at_max'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_modified_gmt', 'before' => $this->server->parse_datetime( $request_args['updated_at_max'] ), 'inclusive' => true );
+			}
 		}
 
 		// search
-		if ( ! empty( $request_args['q'] ) )
+		if ( ! empty( $request_args['q'] ) ) {
 			$args['s'] = $request_args['q'];
+		}
 
 		// resources per response
-		if ( ! empty( $request_args['limit'] ) )
+		if ( ! empty( $request_args['limit'] ) ) {
 			$args['posts_per_page'] = $request_args['limit'];
+		}
 
 		// resource offset
-		if ( ! empty( $request_args['offset'] ) )
+		if ( ! empty( $request_args['offset'] ) ) {
 			$args['offset'] = $request_args['offset'];
+		}
 
 		// allow order change (ASC or DESC)
 		if ( ! empty( $request_args['order'] ) ) {


### PR DESCRIPTION
These commits add orderby filtering to the REST API resource endpoints:
- `order` filtering to GET /customers
- `orderby` filtering to all resource endpoints, as supported by WP. For coupons, orders, and products this means [WP_Query orderby params](http://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters) and for customers this means [WP_User_Query orderby params](http://codex.wordpress.org/Class_Reference/WP_User_Query#Order_.26_Orderby_Parameters)
- `meta_value`/`meta_value_num` orderby parameters are supported by an additional filter param, `filter[orderby_meta_key]`

Closes #5720
