### PR TITLE
Update to fix #5911

### DIFF
--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -54,7 +54,7 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 		foreach ( $ancestors as $ancestor ) {
 			$ancestor = get_term( $ancestor, 'product_cat' );
 
-			echo $before .  '<a href="' . get_term_link( $ancestor->slug, 'product_cat' ) . '">' . esc_html( $ancestor->name ) . '</a>' . $after . $delimiter;
+			echo $before .  '<a href="' . get_term_link( $ancestor ) . '">' . esc_html( $ancestor->name ) . '</a>' . $after . $delimiter;
 		}
 
 		echo $before . esc_html( $current_term->name ) . $after;
@@ -108,7 +108,7 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 
 			echo $prepend;
 
-			if ( $terms = get_the_terms( $post->ID, 'product_cat' ) ) {
+			if ( $terms = wc_get_product_terms( $post->ID, 'product_cat' ) ) {
 				$terms     = array_values( $terms );
 				$main_term = $terms[0];
 				$ancestors = get_ancestors( $main_term->term_id, 'product_cat' );
@@ -118,11 +118,11 @@ if ( ( ! is_home() && ! is_front_page() && ! ( is_post_type_archive() && get_opt
 					$ancestor = get_term( $ancestor, 'product_cat' );
 
 					if ( ! is_wp_error( $ancestor ) && $ancestor ) {
-						echo $before . '<a href="' . get_term_link( $ancestor->slug, 'product_cat' ) . '">' . $ancestor->name . '</a>' . $after . $delimiter;
+						echo $before . '<a href="' . get_term_link( $ancestor ) . '">' . $ancestor->name . '</a>' . $after . $delimiter;
 					}
 				}
 
-				echo $before . '<a href="' . get_term_link( $main_term->slug, 'product_cat' ) . '">' . $main_term->name . '</a>' . $after . $delimiter;
+				echo $before . '<a href="' . get_term_link( $main_term ) . '">' . $main_term->name . '</a>' . $after . $delimiter;
 
 			}
 


### PR DESCRIPTION
Missed get_term calls still with slug, reverted to wc_get_product_terms (get_the_terms, whilst great for performance, bypasses all the special sorting implemented by the former).
