### PR TITLE
Improve display of multiword product attributes

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -59,7 +59,7 @@ function wc_attribute_label( $name ) {
 			$label = ucfirst( $name );
 		}
 	} else {
-		$label = $name;
+		$label = ucwords( str_replace( '-', ' ', $name ) );
 	}
 
 	return apply_filters( 'woocommerce_attribute_label', $label, $name );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -297,6 +297,8 @@ function wc_get_formatted_variation( $variation, $flat = false ) {
 				$term = get_term_by( 'slug', $value, esc_attr( str_replace( 'attribute_', '', $name ) ) );
 				if ( ! is_wp_error( $term ) && $term->name )
 					$value = $term->name;
+			} else {
+				$value = ucwords( str_replace( '-', ' ', $value ) );
 			}
 
 			if ( $flat ) {


### PR DESCRIPTION
Instead of displaying a variation's custom product attributes like this: `attribute-name: attribute-value`. Display it like this: `Attribute Name: Attribute Value`.

This affects only custom product attributes set on the product, not those set in WooCommerce.

For example, the "Custom Attribute" on this product: https://cloudup.com/cxWabMgdNQ8 is currently displayed like this https://cloudup.com/cAZd6zB7TMA

With this pull request, it is displayed like this: https://cloudup.com/cVKtI6nhFTc

There will likely be unintended consequences in blindly replacing dashes with spaces and uppercasing all words, but I couldn't see a way to neatly match a variation's custom attributes against the original  names/value strings set on the variable product's attributes.
