### PR TITLE
Webhooks Implementation

### DIFF
--- a/includes/api/class-wc-api-coupons.php
+++ b/includes/api/class-wc-api-coupons.php
@@ -138,6 +138,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			'exclude_sale_items'           => $coupon->exclude_sale_items(),
 			'minimum_amount'               => wc_format_decimal( $coupon->minimum_amount, 2 ),
 			'customer_emails'              => $coupon->customer_email,
+			'description'                  => $coupon_post->post_excerpt,
 		);
 
 		return array( 'coupon' => apply_filters( 'woocommerce_api_coupon_response', $coupon_data, $coupon, $fields, $this->server ) );

--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -59,7 +59,7 @@ class WC_API_Resource {
 	 */
 	protected function validate_request( $id, $type, $context ) {
 
-		if ( 'shop_order' === $type || 'shop_coupon' === $type )
+		if ( 'shop_order' === $type || 'shop_coupon' === $type || 'shop_webhook' === $type )
 			$resource_name = str_replace( 'shop_', '', $type );
 		else
 			$resource_name = $type;
@@ -333,7 +333,7 @@ class WC_API_Resource {
 
 		} else {
 
-			// delete order/coupon/product
+			// delete order/coupon/product/webhook
 
 			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 

--- a/includes/api/class-wc-api-webhooks.php
+++ b/includes/api/class-wc-api-webhooks.php
@@ -1,0 +1,501 @@
+<?php
+/**
+ * WooCommerce API Webhooks class
+ *
+ * Handles requests to the /webhooks endpoint
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+class WC_API_Webhooks extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/webhooks';
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * @since 2.2
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET|POST /webhooks
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_webhooks' ),     WC_API_Server::READABLE ),
+			array( array( $this, 'create_webhook' ),   WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET /webhooks/count
+		$routes[ $this->base . '/count'] = array(
+			array( array( $this, 'get_webhooks_count' ), WC_API_Server::READABLE ),
+		);
+
+		# GET|PUT|DELETE /webhooks/<id>
+		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_webhook' ),  WC_API_Server::READABLE ),
+			array( array( $this, 'edit_webhook' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_webhook' ), WC_API_Server::DELETABLE ),
+		);
+
+		# GET /webhooks/<id>/deliveries
+		$routes[ $this->base . '/(?P<webhook_id>\d+)/deliveries' ] = array(
+			array( array( $this, 'get_webhook_deliveries' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /webhooks/<webhook_id>/deliveries/<id>
+		$routes[ $this->base . '/(?P<webhook_id>\d+)/deliveries/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_webhook_delivery' ), WC_API_Server::READABLE ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get all webhooks
+	 *
+	 * @since 2.2
+	 * @param string $fields
+	 * @param array $filter
+	 * @param int $page
+	 * @return array
+	 */
+	public function get_webhooks( $fields = null, $filter = array(), $status = null, $page = 1 ) {
+
+		if ( ! empty( $status ) ) {
+			$filter['status'] = $status;
+		}
+
+		$filter['page'] = $page;
+
+		$query = $this->query_webhooks( $filter );
+
+		$webhooks = array();
+
+		foreach( $query->posts as $webhook_id ) {
+
+			if ( ! $this->is_readable( $webhook_id ) ) {
+				continue;
+			}
+
+			$webhooks[] = current( $this->get_webhook( $webhook_id, $fields ) );
+		}
+
+		$this->server->add_pagination_headers( $query );
+
+		return array( 'webhooks' => $webhooks );
+	}
+
+	/**
+	 * Get the webhook for the given ID
+	 *
+	 * @since 2.2
+	 * @param int $id webhook ID
+	 * @param array $fields
+	 * @return array
+	 */
+	public function get_webhook( $id, $fields = null ) {
+
+		// ensure webhook ID is valid & user has permission to read
+		$id = $this->validate_request( $id, 'shop_webhook', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$webhook = new WC_Webhook( $id );
+
+		$webhook_data = array(
+			'id'           => $webhook->id,
+			'name'         => $webhook->get_name(),
+			'status'       => $webhook->get_status(),
+			'topic'        => $webhook->get_topic(),
+			'resource'     => $webhook->get_resource(),
+			'event'        => $webhook->get_event(),
+			'hooks'        => $webhook->get_hooks(),
+			'delivery_url' => $webhook->get_delivery_url(),
+			'created_at'   => $this->server->format_datetime( $webhook->get_post_data()->post_date_gmt ),
+			'updated_at'   => $this->server->format_datetime( $webhook->get_post_data()->post_modified_gmt ),
+		);
+
+		return array( 'webhook' => apply_filters( 'woocommerce_api_webhook_response', $webhook_data, $webhook, $fields, $this ) );
+	}
+
+	/**
+	 * Get the total number of webhooks
+	 *
+	 * @since 2.2
+	 * @param string $status
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_webhooks_count( $status = null, $filter = array() ) {
+
+		if ( ! empty( $status ) ) {
+			$filter['status'] = $status;
+		}
+
+		$query = $this->query_webhooks( $filter );
+
+		if ( ! current_user_can( 'read_private_shop_webhooks' ) ) {
+			return new WP_Error( 'woocommerce_api_user_cannot_read_webhooks_count', __( 'You do not have permission to read the webhooks count', 'woocommerce' ), array( 'status' => 401 ) );
+		}
+
+		return array( 'count' => (int) $query->found_posts );
+	}
+
+	/**
+	 * Create an webhook
+	 *
+	 * @since 2.2
+	 * @param array $data parsed webhook data
+	 * @return array
+	 */
+	public function create_webhook( $data ) {
+
+		$data = isset( $data['webhook'] ) ? $data['webhook'] : array();
+
+		try {
+
+			// permission check
+			if ( ! current_user_can( 'publish_shop_webhooks' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_webhooks', __( 'You do not have permission to create webhooks', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_webhook_data', $data, $this );
+
+			// validate topic
+			if ( empty( $data['topic'] ) || ! $this->is_valid_topic( strtolower( $data['topic'] ) ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic is required and must be valid', 'woocommerce' ), 400 );
+			}
+
+			// validate delivery URL
+			if ( empty( $data['delivery_url'] ) || ! $this->is_valid_url( $data['delivery_url'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+			}
+
+			$webhook_data = apply_filters( 'woocommerce_new_webhook_data', array(
+				'post_type'     => 'shop_webhook',
+				'post_status'   => 'publish',
+				'ping_status'   => 'closed',
+				'post_author'   => get_current_user_id(),
+				'post_password' => uniqid( 'webhook_' ),
+				'post_title'    => ! empty( $data['name'] ) ? $data['name'] : sprintf( __( 'Webhook created on %s', 'woocommerce' ), strftime( _x( '%b %d, %Y @ %I:%M %p', 'Webhook created on date parsed by strftime', 'woocommerce' ) ) ),
+			), $data, $this );
+
+			$webhook_id = wp_insert_post( $webhook_data );
+
+			if ( is_wp_error( $webhook_id ) || ! $webhook_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_webhook', sprintf( __( 'Cannot create webhook: %s', 'woocommerce' ), is_wp_error( $webhook_id ) ? implode( ', ', $webhook_id->get_error_messages() ) : '0' ), 500 );
+			}
+
+			$webhook = new WC_Webhook( $webhook_id );
+
+			// set topic, delivery URL, and optional secret
+			$webhook->set_topic( $data['topic'] );
+			$webhook->set_delivery_url( $data['delivery_url'] );
+
+			// set secret if provided, defaults to API users consumer secret
+			$webhook->set_secret( ! empty( $data['secret'] ) ? $data['secret'] : get_user_meta( get_current_user_id(), 'woocommerce_api_consumer_secret', true ) );
+
+			// send ping
+			$webhook->deliver_ping();
+
+			// HTTP 201 Created
+			$this->server->send_status( 201 );
+
+			do_action( 'woocommerce_api_create_webhook', $webhook->id, $this );
+
+			return $this->get_webhook( $webhook->id );
+
+		} catch ( WC_API_Exception $e ) {
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit a webhook
+	 *
+	 * @since 2.2
+	 * @param int $id webhook ID
+	 * @param array $data parsed webhook data
+	 * @return array
+	 */
+	public function edit_webhook( $id, $data ) {
+
+		$data = isset( $data['webhook'] ) ? $data['webhook'] : array();
+
+		try {
+
+			$id = $this->validate_request( $id, 'shop_webhook', 'edit' );
+
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_webhook_data', $data, $id, $this );
+
+			$webhook = new WC_Webhook( $id );
+
+			// update topic
+			if ( ! empty( $data['topic'] ) ) {
+
+				if ( $this->is_valid_topic( strtolower( $data['topic'] ) ) ) {
+
+					$webhook->set_topic( $data['topic'] );
+
+				} else {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic must be valid', 'woocommerce' ), 400 );
+				}
+			}
+
+			// update delivery URL
+			if ( ! empty( $data['delivery_url'] ) ) {
+				if ( $this->is_valid_url( $data['delivery_url'] ) ) {
+
+					$webhook->set_delivery_url( $data['delivery_url'] );
+
+				} else {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+				}
+			}
+
+			// update secret
+			if ( ! empty( $data['secret'] ) ) {
+				$webhook->set_secret( $data['secret'] );
+			}
+
+			// update status
+			if ( ! empty( $data['status'] ) ) {
+				$webhook->update_status( $data['status'] );
+			}
+
+			// update user ID
+			$webhook_data = array(
+				'ID'          => $webhook->id,
+				'post_author' => get_current_user_id()
+			);
+
+			// update name
+			if ( ! empty( $data['name'] ) ) {
+				$webhook_data['post_title'] = $data['name'];
+			}
+
+			// update post
+			wp_update_post( $webhook_data );
+
+			do_action( 'woocommerce_api_edit_webhook', $webhook->id, $this );
+
+			return $this->get_webhook( $id );
+
+		} catch ( WC_API_Exception $e ) {
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+
+	/**
+	 * Check if the given topic is a valid webhook topic, a topic is valid if:
+	 *
+	 * + starts with `action.woocommerce_` or `action.wc_`
+	 * + it has a valid resource & event
+	 *
+	 * @since 2.2
+	 * @param string $topic webhook topic
+	 * @return bool true if valid, false otherwise
+	 */
+	private function is_valid_topic( $topic ) {
+
+		// custom topics are prefixed with woocommerce_ or wc_ are valid
+		if ( 0 === strpos( $topic, 'action.woocommerce_' ) || 0 === strpos( $topic, 'action.wc_' ) ) {
+			return true;
+		}
+
+		list( $resource, $event ) = explode( '.', $topic );
+
+		if ( ! isset( $resource ) || ! isset( $event ) ) {
+			return false;
+		}
+
+		$valid_resources = apply_filters( 'woocommerce_valid_webhook_resources', array( 'coupon', 'customer', 'order', 'product' ) );
+		$valid_events    = apply_filters( 'woocommerce_valid_webhook_events', array( 'created', 'updated', 'deleted' ) );
+
+		if ( in_array( $resource, $valid_resources ) && in_array( $event, $valid_events ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Simple check for validating a URL, it must start with http:// or https://
+	 * and pass FILTER_VALIDATE_URL validation
+	 *
+	 * @since 2.2
+	 * @param string $url delivery URL for the webhook
+	 * @return bool true if valid, false otherwise
+	 */
+	private function is_valid_url( $url ) {
+
+		// must start with http:// or https://
+		if ( 0 !== strpos( $url, 'http://' ) && 0 !== strpos( $url, 'https://' ) ) {
+			return false;
+		}
+
+		// must pass validation
+		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Delete a webhook
+	 *
+	 * @since 2.2
+	 * @param int $id webhook ID
+	 * @return array
+	 */
+	public function delete_webhook( $id ) {
+
+		$id = $this->validate_request( $id, 'shop_webhook', 'delete' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		do_action( 'woocommerce_api_delete_webhook', $id, $this );
+
+		// no way to manage trashed webhooks at the moment, so force delete
+		return $this->delete( $id, 'webhook', true );
+	}
+
+	/**
+	 * Helper method to get webhook post objects
+	 *
+	 * @since 2.2
+	 * @param array $args request arguments for filtering query
+	 * @return WP_Query
+	 */
+	private function query_webhooks( $args ) {
+
+		// set base query arguments
+		$query_args = array(
+			'fields'      => 'ids',
+			'post_type'   => 'shop_webhook',
+		);
+
+		// add status argument
+		if ( ! empty( $args['status'] ) ) {
+
+			switch ( $args['status'] ) {
+				case 'active':
+					$query_args['post_status'] = 'publish';
+					break;
+				case 'paused':
+					$query_args['post_status'] = 'draft';
+					break;
+				case 'disabled':
+					$query_args['post_status'] = 'pending';
+					break;
+				default:
+					$query_args['post_status'] = 'publish';
+			}
+			unset( $args['status'] );
+		}
+
+		$query_args = $this->merge_query_args( $query_args, $args );
+
+		return new WP_Query( $query_args );
+	}
+
+	/**
+	 * Get deliveries for a webhook
+	 *
+	 * @since 2.2
+	 * @param string $webhook_id webhook ID
+	 * @param string|null $fields fields to include in response
+	 * @return array
+	 */
+	public function get_webhook_deliveries( $webhook_id, $fields = null ) {
+
+		// ensure ID is valid webhook ID
+		$webhook_id = $this->validate_request( $webhook_id, 'shop_webhook', 'read' );
+
+		if ( is_wp_error( $webhook_id ) ) {
+			return $webhook_id;
+		}
+
+		$webhook = new WC_Webhook( $webhook_id );
+
+		$logs = $webhook->get_delivery_logs();
+
+		$delivery_logs = array();
+
+		foreach ( $logs as $log ) {
+
+			// add timestamp
+			$log['created_at'] = $this->server->format_datetime( $log['comment']->comment_date_gmt );
+
+			// remove comment object
+			unset( $log['comment'] );
+
+			$delivery_logs[] = $log;
+		}
+
+		return array( 'webhook_deliveries' => $delivery_logs );
+	}
+
+	/**
+	 * Get the delivery log for the given webhook ID and delivery ID
+	 *
+	 * @since 2.2
+	 * @param string $webhook_id webhook ID
+	 * @param string $id delivery log ID
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_webhook_delivery( $webhook_id, $id, $fields = null ) {
+
+		// validate webhook ID
+		$webhook_id = $this->validate_request( $webhook_id, 'shop_webhook', 'read' );
+
+		if ( is_wp_error( $webhook_id ) ) {
+			return $webhook_id;
+		}
+
+		$id = absint( $id );
+
+		if ( empty( $id ) ) {
+			return new WP_Error( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$webhook = new WC_Webhook( $webhook_id );
+
+		$log = $webhook->get_delivery_log( $id );
+
+		if ( ! $log ) {
+			return new WP_Error( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$delivery_log = $log;
+
+		// add timestamp
+		$delivery_log['created_at'] = $this->server->format_datetime( $log['comment']->comment_date_gmt );
+
+		// remove comment object
+		unset( $delivery_log['comment'] );
+
+		return array( 'webhook_delivery' => apply_filters( 'woocommerce_api_webhook_delivery_response', $delivery_log, $id, $fields, $log, $webhook_id, $this ) );
+	}
+
+}

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -129,7 +129,7 @@ class WC_API {
 	 *
 	 * @since 2.1
 	 */
-	private function includes() {
+	public function includes() {
 
 		// API server / response handlers
 		include_once( 'api/class-wc-api-exception.php' );
@@ -147,6 +147,7 @@ class WC_API {
 		include_once( 'api/class-wc-api-coupons.php' );
 		include_once( 'api/class-wc-api-customers.php' );
 		include_once( 'api/class-wc-api-reports.php' );
+		include_once( 'api/class-wc-api-webhooks.php' );
 
 		// allow plugins to load other response handlers or resource classes
 		do_action( 'woocommerce_api_loaded' );
@@ -167,6 +168,7 @@ class WC_API {
 				'WC_API_Products',
 				'WC_API_Coupons',
 				'WC_API_Reports',
+				'WC_API_Webhooks',
 			)
 		);
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -520,7 +520,7 @@ class WC_Install {
 			'view_woocommerce_reports'
 		);
 
-		$capability_types = array( 'product', 'shop_order', 'shop_coupon' );
+		$capability_types = array( 'product', 'shop_order', 'shop_coupon', 'shop_webhook' );
 
 		foreach ( $capability_types as $capability_type ) {
 

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -367,6 +367,27 @@ class WC_Post_types {
 				)
 			);
 		}
+
+		register_post_type( 'shop_webhook',
+			apply_filters( 'woocommerce_register_post_type_shop_webhook',
+				array(
+					'label' => __( 'Webhooks', 'woocommerce' ),
+					'public'              => false,
+					'show_ui'             => false,
+					'capability_type'     => 'shop_webhook',
+					'map_meta_cap'        => true,
+					'publicly_queryable'  => false,
+					'exclude_from_search' => true,
+					'show_in_menu'        => false,
+					'hierarchical'        => false,
+					'rewrite'             => false,
+					'query_var'           => false,
+					'supports'            => false,
+					'show_in_nav_menus'   => false,
+					'show_in_admin_bar'   => false,
+				)
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -1,0 +1,785 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+/**
+ * WooCommerce Webhook class
+ *
+ * This class handles storing and retrieving webhook data from the associated
+ * `shop_webhook` custom post type, as well as delivery logs from the `webhook_delivery`
+ * comment type.
+ *
+ * Webhooks are enqueued to their associated actions, delivered, and logged.
+ *
+ * @author      WooThemes
+ * @category    Webhooks
+ * @package     WooCommerce/Webhooks
+ * @since       2.2
+ */
+class WC_Webhook {
+
+	/** @var int webhook ID (post ID) */
+	public $id;
+
+	/**
+	 * Setup webhook & load post data
+	 *
+	 * @since 2.2
+	 * @param string|int $id
+	 * @return \WC_Webhook
+	 */
+	public function __construct( $id ) {
+
+		$id = absint( $id );
+
+		if ( ! $id ) {
+			return;
+		}
+
+		$this->id = $id;
+		$this->post_data = get_post( $id );
+	}
+
+
+	/**
+	 * Magic isset as a wrapper around metadata_exists()
+	 *
+	 * @since 2.2
+	 * @param string $key
+	 * @return bool true if $key isset, false otherwise
+	 */
+	public function __isset( $key ) {
+		if ( ! $this->id ) {
+			return false;
+		}
+		return metadata_exists( 'post', $this->id, '_' . $key );
+	}
+
+
+	/**
+	 * Magic get, wraps get_post_meta() for all keys except $status
+	 *
+	 * @since 2.2
+	 * @param string $key
+	 * @return mixed|null|void value
+	 */
+	public function __get( $key ) {
+
+		$value = null;
+
+		if ( 'status' === $key ) {
+			$value = $this->get_status();
+		} else {
+			$value = get_post_meta( $this->id, '_' . $key, true );
+		}
+
+		return $value;
+	}
+
+
+	/**
+	 * Enqueue the hooks associated with the webhook
+	 *
+	 * @since 2.2
+	 */
+	public function enqueue() {
+
+		foreach ( $this->get_hooks() as $hook ) {
+			add_action( $hook, array( $this, 'process' ) );
+		}
+	}
+
+
+	/**
+	 * Process the webhook for delivery by verifying the it should be delivered
+	 * and scheduling the delivery (in the background by default, or immediately)
+	 *
+	 * @since 2.2
+	 * @param mixed $arg the first argument provided from the associated hooks
+	 */
+	public function process( $arg ) {
+
+		// verify that webhook should be processed for delivery
+		if ( ! $this->should_deliver( $arg ) ) {
+			return;
+		}
+
+		// webhooks are processed in the background by default
+		// so as to avoid delays or failures in delivery from affecting the
+		// user who triggered it
+		if ( apply_filters( 'woocommerce_webhook_deliver_async', true, $this ) ) {
+
+			// deliver in background
+			wp_schedule_single_event( time(), 'woocommerce_deliver_webhook_async', array( $this->id, is_scalar( $arg ) ? $arg : 0 ) );
+
+		} else {
+
+			// deliver immediately
+			$this->deliver( $arg );
+		}
+	}
+
+	/**
+	 * Helper to check if the webhook should be delivered, as some hooks
+	 * (like `wp_trash_post`) will fire for every post type, not just ours.
+	 *
+	 * @since 2.2
+	 * @param mixed $arg first hook argument
+	 * @return bool true if webhook should be delivered, false otherwise
+	 */
+	private function should_deliver( $arg ) {
+
+		// only active webhooks can be delivered
+		if ( 'active' != $this->get_status() ) {
+			return false;
+		}
+
+		$current_action = current_action();
+
+		// only deliver deleted event for coupons, orders, and products
+		if ( 'delete_post' == $current_action && ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product' ) ) ) {
+
+			return false;
+
+		} elseif ( 'delete_user' == $current_action ) {
+
+
+			$user = get_userdata( absint( $arg ) );
+
+			// only deliver deleted customer event for users with customer role
+			if ( ! $user || ! in_array( 'customer', (array) $user->roles ) ) {
+				return false;
+			}
+
+		} elseif ( 0 === strpos( $current_action, 'woocommerce_process_shop' ) ) {
+
+			// the `woocommerce_process_shop_*` hook fires for both updates
+			// and creation so check the post creation date to determine the actual event
+			$resource = get_post( absint( $arg ) );
+
+			// a resource is considered created when the hook is executed within 10 seconds of the post creation date
+			$resource_created = ( ( time() - 10 ) <= strtotime( $resource->post_date_gmt ) );
+
+			if ( 'created' == $this->get_event() && ! $resource_created ) {
+				return false;
+			} elseif ( 'updated' == $this->get_event() && $resource_created ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Deliver the webhook payload using wp_remote_request()
+	 *
+	 * @since 2.2
+	 * @param mixed $arg first hook argument
+	 */
+	public function deliver( $arg ) {
+
+		$payload = $this->build_payload( $arg );
+
+		// setup request args
+		$http_args = array(
+			'method'      => 'POST',
+			'timeout'     => MINUTE_IN_SECONDS,
+			'redirection' => 0,
+			'httpversion' => '1.0',
+			'sslverify'   => false,
+			'blocking'    => true,
+			'user-agent'  => sprintf( 'WooCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),
+			'body'        => trim( json_encode( $payload ) ),
+			'headers'     => array( 'Content-Type' => 'application/json' ),
+			'cookies'     => array(),
+		);
+
+		$http_args = apply_filters( 'woocommerce_webhook_http_args', $http_args, $arg, $this->id );
+
+		// add custom headers
+		$http_args['headers']['X-WC-Webhook-Topic']       = $this->get_topic();
+		$http_args['headers']['X-WC-Webhook-Resource']    = $this->get_resource();
+		$http_args['headers']['X-WC-Webhook-Event']       = $this->get_event();
+		$http_args['headers']['X-WC-Webhook-Signature']   = $this->generate_signature( $http_args['body'] );
+		$http_args['headers']['X-WC-Webhook-ID']          = $this->id;
+		$http_args['headers']['X-WC-Webhook-Delivery-ID'] = $delivery_id = $this->get_new_delivery_id();
+
+		$start_time = microtime( true );
+
+		// webhook away!
+		$response = wp_remote_request( $this->get_delivery_url(), $http_args );
+
+		$duration = round( microtime( true ) - $start_time, 5 );
+
+		$this->log_delivery( $delivery_id, $http_args, $response, $duration );
+
+		do_action( 'woocommerce_webhook_delivery', $http_args, $response, $duration, $arg, $this->id );
+	}
+
+
+	/**
+	 * Build the payload data for the webhook
+	 *
+	 * @since 2.2
+	 * @param mixed $resource_id first hook argument, typically the resource ID
+	 * @return mixed payload data
+	 */
+	private function build_payload( $resource_id ) {
+
+		// build the payload with the same user context as the user who created
+		// the webhook -- this avoids permission errors as background processing
+		// runs with no user context
+		$current_user = get_current_user_id();
+		wp_set_current_user( $this->get_user_id() );
+
+		$resource = $this->get_resource();
+		$event    = $this->get_event();
+
+		// if a resource has been deleted, just include the ID
+		if ( 'deleted' == $event ) {
+
+			$payload = array(
+				'id' => $resource_id,
+			);
+
+		} else {
+
+			// include & load API classes
+			WC()->api->includes();
+			WC()->api->register_resources( new WC_API_Server( '/' ) );
+
+			switch( $resource ) {
+
+				case 'coupon':
+					$payload = WC()->api->WC_API_Coupons->get_coupon( $resource_id );
+					break;
+
+				case 'customer':
+					$payload = WC()->api->WC_API_Customers->get_customer( $resource_id );
+					break;
+
+				case 'order':
+					$payload = WC()->api->WC_API_Orders->get_order( $resource_id );
+					break;
+
+				case 'product':
+					$payload = WC()->api->WC_API_Products->get_product( $resource_id );
+					break;
+
+				// custom topics include the first hook argument
+				case 'action':
+					$payload = array(
+						'action' => current( $this->get_hooks() ),
+						'arg'    => $resource_id,
+					);
+					break;
+
+				default:
+					$payload = array();
+			}
+		}
+
+		// restore the current user
+		wp_set_current_user( $current_user );
+
+		return apply_filters( 'woocommerce_webhook_payload', $payload, $resource, $resource_id, $this->id );
+	}
+
+
+	/**
+	 * Generate a base64-encoded HMAC-SHA256 signature of the payload body so the
+	 * recipient can verify the authenticity of the webhook. Note that the signature
+	 * is calculated after the body has already been encoded (JSON by default)
+	 *
+	 * @since 2.2
+	 * @param string $payload payload data to hash
+	 * @return string hash
+	 */
+	public function generate_signature( $payload ) {
+
+		$hash_algo = apply_filters( 'woocommerce_webhook_hash_algorithm', 'sha256', $payload, $this->id );
+
+		return base64_encode( hash_hmac( $hash_algo, $payload, $this->get_secret(), true ) );
+	}
+
+
+	/**
+	 * Create a new comment for log the delivery request/response and
+	 * return the ID for inclusion in the webhook request
+	 *
+	 * @since 2.2
+	 * @return int delivery (comment) ID
+	 */
+	public function get_new_delivery_id() {
+
+		$comment_data = apply_filters( 'woocommerce_new_webhook_delivery_data', array(
+			'comment_author'       => __( 'WooCommerce', 'woocommerce' ),
+			'comment_author_email' => sanitize_email( sprintf( '%s@%s', strtolower( __( 'WooCommerce', 'woocommerce' ) ), isset( $_SERVER['HTTP_HOST'] ) ? str_replace( 'www.', '', $_SERVER['HTTP_HOST'] ) : 'noreply.com' ) ),
+			'comment_post_ID'      => $this->id,
+			'comment_agent'        => 'WooCommerce Hookshot',
+			'comment_type'         => 'webhook_delivery',
+			'comment_parent'       => 0,
+			'comment_approved'     => 1,
+		), $this->id );
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		return $comment_id;
+	}
+
+
+	/**
+	 * Log the delivery request/response
+	 *
+	 * @since 2.2
+	 * @param int $delivery_id previously created comment ID
+	 * @param array $request request data
+	 * @param array $response response data
+	 * @param float $duration request duration
+	 */
+	public function log_delivery( $delivery_id, $request, $response, $duration ) {
+
+		// save request data
+		add_comment_meta( $delivery_id, '_request_method', $request['method'] );
+		add_comment_meta( $delivery_id, '_request_headers', array_merge( (array) $request['user-agent'], $request['headers'] ) );
+		add_comment_meta( $delivery_id, '_request_body', $request['body'] );
+
+		// parse response
+		if ( is_wp_error( $response ) ) {
+			$response_code    = $response->get_error_code();
+			$response_message = $response->get_error_message();
+			$response_headers = $response_body = array();
+
+		} else {
+			$response_code    = wp_remote_retrieve_response_code( $response );
+			$response_message = wp_remote_retrieve_response_message( $response );
+			$response_headers = wp_remote_retrieve_headers( $response );
+			$response_body    = wp_remote_retrieve_body( $response );
+		}
+
+		// save response data
+		add_comment_meta( $delivery_id, '_response_code', $response_code );
+		add_comment_meta( $delivery_id, '_response_message', $response_message );
+		add_comment_meta( $delivery_id, '_response_headers', $response_headers );
+		add_comment_meta( $delivery_id, '_response_body', $response_body );
+
+		// save duration
+		add_comment_meta( $delivery_id, '_duration', $duration );
+
+		// set a summary for quick display
+		$args = array(
+			'comment_ID' => $delivery_id,
+			'comment_content' => sprintf( 'HTTP %s %s: %s', $response_code, $response_message, $response_body ),
+		);
+
+		wp_update_comment( $args );
+
+		// track failures
+		if ( intval( $response_code ) >= 200 && intval( $response_code ) < 300 ) {
+			delete_post_meta( $this->id, '_failure_count' );
+		} else {
+			$this->failed_delivery();
+		}
+
+		// keep the 25 most recent delivery logs
+		$log = wp_count_comments( $this->id );
+		if ( $log->total_comments > apply_filters( 'woocommerce_max_webhook_delivery_logs', 25 ) ) {
+			global $wpdb;
+
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->comments} WHERE comment_post_ID = %d ORDER BY comment_date_gmt ASC LIMIT 1",
+					$this->id
+				)
+			);
+		}
+	}
+
+	/**
+	 * Track consecutive delivery failures and automatically disable the webhook
+	 * if more than 5 consecutive failures occur. A failure is defined as a
+	 * non-2xx response
+	 *
+	 * @since 2.2
+	 */
+	private function failed_delivery() {
+
+		$failures = $this->get_failure_count();
+
+		if ( $failures > apply_filters( 'woocommerce_max_webhook_delivery_failures', 5 ) ) {
+
+			$this->update_status( 'disabled' );
+
+		} else {
+
+			update_post_meta( $this->id, '_failure_count', ++$failures );
+		}
+	}
+
+
+	/**
+	 * Get the delivery logs for this webhook
+	 *
+	 * @since 2.2
+	 * @return array
+	 */
+	public function get_delivery_logs() {
+
+		$args = array(
+			'post_id' => $this->id,
+			'status'  => 'approve',
+			'type'    => 'webhook_delivery',
+		);
+
+		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_webhook_comments' ), 10, 1 );
+
+		$logs = get_comments( $args );
+
+		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_webhook_comments' ), 10, 1 );
+
+		$delivery_logs = array();
+
+		foreach ( $logs as $log ) {
+
+			$log = $this->get_delivery_log( $log->comment_ID );
+
+			$delivery_logs[] = ( ! empty( $log )  ? $log : array() );
+		}
+
+		return $delivery_logs;
+	}
+
+
+	/**
+	 * Get the delivery log specified by the ID. The delivery log includes:
+	 *
+	 * + duration
+	 * + summary
+	 * + request method/url
+	 * + request headers/body
+	 * + response code/message/headers/body
+	 *
+	 * @since 2.2
+	 * @param int $delivery_id
+	 * @return bool|array false if invalid delivery ID, array of log data otherwise
+	 */
+	public function get_delivery_log( $delivery_id ) {
+
+		$log = get_comment( $delivery_id );
+
+		// valid comment and ensure delivery log belongs to this webhook
+		if ( is_null( $log ) || $log->comment_post_ID != $this->id ) {
+			return false;
+		}
+
+		$delivery_log = array(
+			'id'               => intval( $delivery_id ),
+			'duration'         => get_comment_meta( $delivery_id, '_duration', true ),
+			'summary'          => $log->comment_content,
+			'request_method'   => get_comment_meta( $delivery_id, '_request_method', true ),
+			'request_url'      => $this->get_delivery_url(),
+			'request_headers'  => get_comment_meta( $delivery_id, '_request_headers', true ),
+			'request_body'     => get_comment_meta( $delivery_id, '_request_body', true ),
+			'response_code'    => get_comment_meta( $delivery_id, '_response_code', true ),
+			'response_message' => get_comment_meta( $delivery_id, '_response_message', true ),
+			'response_headers' => get_comment_meta( $delivery_id, '_response_headers', true ),
+			'response_body'    => get_comment_meta( $delivery_id, '_response_body', true ),
+			'comment'          => $log,
+		);
+
+		return apply_filters( 'woocommerce_webhook_delivery_log', $delivery_log, $delivery_id, $this->id );
+	}
+
+	/**
+	 * Set the webhook topic and associated hooks. The topic resource & event
+	 * are also saved separately.
+	 *
+	 * @since 2.2
+	 * @param string $topic
+	 */
+	public function set_topic( $topic ) {
+
+		$topic = strtolower( $topic );
+
+		list( $resource, $event ) = explode( '.', $topic );
+
+		update_post_meta( $this->id, '_topic', $topic );
+		update_post_meta( $this->id, '_resource', $resource );
+		update_post_meta( $this->id, '_event', $event );
+
+		// custom topics are mapped to a single hook
+		if ( 'action' === $resource ) {
+
+			update_post_meta( $this->id, '_hooks', array( $event ) );
+
+		} else {
+
+			// API topics have multiple hooks
+			update_post_meta( $this->id, '_hooks', $this->get_topic_hooks( $topic ) );
+		}
+	}
+
+	/**
+	 * Get the associated hook names for a topic
+	 *
+	 * @since 2.2
+	 * @param string $topic
+	 * @return array hook names
+	 */
+	private function get_topic_hooks( $topic ) {
+
+		$topic_hooks = array(
+			'coupon.created' => array(
+				'woocommerce_process_shop_coupon_meta',
+				'woocommerce_api_create_coupon',
+			),
+			'coupon.updated' => array(
+				'woocommerce_process_shop_coupon_meta',
+				'woocommerce_api_edit_coupon',
+			),
+			'coupon.deleted' => array(
+				'wp_trash_post',
+			),
+			'customer.created' => array(
+				'woocommerce_created_customer',
+			),
+			'customer.updated' => array(
+				'profile_update',
+				'woocommerce_api_edit_customer',
+			),
+			'customer.deleted' => array(
+				'delete_user',
+			),
+			'order.created'    => array(
+				'woocommerce_checkout_order_processed',
+				'woocommerce_process_shop_order_meta',
+				'woocommerce_api_create_order',
+			),
+			'order.updated' => array(
+				'woocommerce_process_shop_order_meta',
+				'woocommerce_api_edit_order',
+			),
+			'order.deleted' => array(
+				'wp_trash_post',
+			),
+			'product.created' => array(
+				'woocommerce_process_product_meta',
+				'woocommerce_api_create_product',
+			),
+			'product.updated' => array(
+				'woocommerce_process_product_meta',
+				'woocommerce_api_edit_product',
+			),
+			'product.deleted' => array(
+				'wp_trash_post',
+			),
+		);
+
+		$topic_hooks = apply_filters( 'woocommerce_webhook_topic_hooks', $topic_hooks, $this );
+
+		return isset( $topic_hooks[ $topic ] ) ? $topic_hooks[ $topic ] : array();
+	}
+
+	/**
+	 * Send a test ping to the delivery URL, sent when the webhook is first created
+	 *
+	 * @since 2.2
+	 */
+	public function deliver_ping() {
+
+		$args = array(
+			'user-agent' => sprintf( 'WooCommerce/%s Hookshot (WordPress/%s)', WC_VERSION, $GLOBALS['wp_version'] ),
+			'body' => "webhook_id={$this->id}",
+		);
+
+		wp_remote_post( $this->get_delivery_url(), $args );
+	}
+
+	/**
+	 * Get the webhook status:
+	 *
+	 * + `active` - delivers payload
+	 * + `paused` - does not deliver payload, paused by admin
+	 * + `disabled` - does not delivery payload, paused automatically due to
+	 * consecutive failures
+	 *
+	 * @since 2.2
+	 * @return string status
+	 */
+	public function get_status() {
+
+		switch ( $this->get_post_data()->post_status ) {
+
+			case 'publish':
+				$status = 'active';
+				break;
+
+			case 'draft':
+				$status = 'paused';
+				break;
+
+			case 'pending':
+				$status = 'disabled';
+				break;
+
+			default:
+				$status = 'paused';
+		}
+
+		return apply_filters( 'woocommerce_webhook_status', $status, $this->id );
+	}
+
+	/**
+	 * Update the webhook status, see get_status() for valid statuses
+	 *
+	 * @since 2.2
+	 * @param $status
+	 */
+	public function update_status( $status ) {
+
+		switch ( $status ) {
+
+			case 'active':
+				$post_status = 'publish';
+				break;
+
+			case 'paused':
+				$post_status = 'draft';
+				break;
+
+			case 'disabled':
+				$post_status = 'pending';
+				break;
+
+			default:
+				$post_status = 'draft';
+		}
+
+		wp_update_post( array( 'ID' => $this->id, 'post_status' => $post_status ) );
+	}
+
+	/**
+	 * Set the delivery URL
+	 *
+	 * @since 2.2
+	 * @param string $url
+	 */
+	public function set_delivery_url( $url ) {
+
+		update_post_meta( $this->id, '_delivery_url', esc_url_raw( $url, array( 'http', 'https' ) ) );
+	}
+
+	/**
+	 * Get the delivery URL
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function get_delivery_url() {
+
+		return apply_filters( 'woocommerce_webhook_delivery_url', $this->delivery_url, $this->id );
+	}
+
+	/**
+	 * Set the secret used for generating the HMAC-SHA256 signature
+	 *
+	 * @since 2.2
+	 * @param string $secret
+	 */
+	public function set_secret( $secret ) {
+
+		update_post_meta( $this->id, '_secret', $secret );
+	}
+
+	/**
+	 * Get the secret used for generating the HMAC-SHA256 signature
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function get_secret() {
+		return apply_filters( 'woocommerce_webhook_secret', $this->secret, $this->id );
+	}
+
+	/**
+	 * Get the friendly name for the webhook
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function get_name() {
+		return apply_filters( 'woocommece_webhook_name', $this->get_post_data()->post_title, $this->id );
+	}
+
+	/**
+	 * Get the webhook topic, e.g. `order.created`
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function get_topic() {
+		return apply_filters( 'woocommerce_webhook_topic', $this->topic, $this->id );
+	}
+
+	/**
+	 * Get the hook names for the webhook
+	 *
+	 * @since 2.2
+	 * @return array hook names
+	 */
+	public function get_hooks() {
+		return apply_filters( 'woocommerce_webhook_hooks', $this->hooks, $this->id );
+	}
+
+	/**
+	 * Get the resource for the webhook, e.g. `order`
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function get_resource() {
+		return apply_filters( 'woocommerce_webhook_resource', $this->resource, $this->id );
+	}
+
+	/**
+	 * Get the event for the webhook, e.g. `created`
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function get_event() {
+		return apply_filters( 'woocommerce_webhook_event', $this->event, $this->id );
+	}
+
+	/**
+	 * Get the failure count
+	 *
+	 * @since 2.2
+	 * @return int
+	 */
+	public function get_failure_count() {
+		return intval( $this->failure_count );
+	}
+
+	/**
+	 * Get the user ID for this webhook
+	 *
+	 * @since 2.2
+	 * @return int|string user ID
+	 */
+	public function get_user_id() {
+		return $this->get_post_data()->post_author;
+	}
+
+	/**
+	 * Get the post data for the webhook
+	 *
+	 * @since 2.2
+	 * @return null|WP_Post
+	 */
+	public function get_post_data() {
+		return $this->post_data;
+	}
+
+}

--- a/includes/updates/woocommerce-update-2.2.php
+++ b/includes/updates/woocommerce-update-2.2.php
@@ -30,7 +30,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-pending'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'pending%';
@@ -42,7 +42,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-processing'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'processing%';
@@ -54,7 +54,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-on-hold'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'on-hold%';
@@ -66,7 +66,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-completed'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'completed%';
@@ -78,7 +78,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-cancelled'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'cancelled%';
@@ -90,7 +90,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-refunded'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'refunded%';
@@ -102,7 +102,7 @@ $wpdb->query( "
 	LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
 	LEFT JOIN {$wpdb->terms} AS term USING( term_id )
 	SET posts.post_status = 'wc-failed'
-	WHERE posts.post_type = 'shop_order' 
+	WHERE posts.post_type = 'shop_order'
 	AND posts.post_status = 'publish'
 	AND tax.taxonomy = 'shop_order_status'
 	AND	term.slug LIKE 'failed%';
@@ -122,4 +122,43 @@ $update_variations = $wpdb->get_col( "
 
 foreach ( $update_variations as $variation_id ) {
 	add_post_meta( $variation_id, '_manage_stock', 'yes', true );
+}
+
+// add webhook capabilities to shop_manager/administrator role
+global $wp_roles;
+
+if ( class_exists( 'WP_Roles' ) ) {
+	if ( ! isset( $wp_roles ) ) {
+		$wp_roles = new WP_Roles();
+	}
+}
+
+if ( is_object( $wp_roles ) ) {
+	$webhook_capabilities = array(
+		// post type
+		'edit_shop_webhook',
+		'read_shop_webhook',
+		'delete_shop_webhook',
+		'edit_shop_webhooks',
+		'edit_others_shop_webhooks',
+		'publish_shop_webhooks',
+		'read_private_shop_webhooks',
+		'delete_shop_webhooks',
+		'delete_private_shop_webhooks',
+		'delete_published_shop_webhooks',
+		'delete_others_shop_webhooks',
+		'edit_private_shop_webhooks',
+		'edit_published_shop_webhooks',
+
+		// terms
+		'manage_shop_webhook_terms',
+		'edit_shop_webhook_terms',
+		'delete_shop_webhook_terms',
+		'assign_shop_webhook_terms'
+	);
+
+	foreach ( $webhook_capabilities as $cap ) {
+		$wp_roles->add_cap( 'shop_manager', $cap );
+		$wp_roles->add_cap( 'administrator', $cap );
+	}
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -617,3 +617,19 @@ add_filter( 'wp_count_comments', 'wc_remove_order_notes_from_wp_count_comments',
 function wc_get_core_supported_themes() {
 	return array( 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' );
 }
+
+/**
+ * Wrapper function to execute the `woocommerce_deliver_webhook_async` cron
+ * hook, see WC_Webhook::process()
+ *
+ * @since 2.2
+ * @param int $webhook_id webhook ID to deliver
+ * @param mixed $arg hook argument
+ */
+function wc_deliver_webhook_async( $webhook_id, $arg ) {
+
+	$webhook = new WC_Webhook( $webhook_id );
+
+	$webhook->deliver( $arg );
+}
+add_action( 'woocommerce_deliver_webhook_async', 'wc_deliver_webhook_async', 10, 2 );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -402,6 +402,9 @@ final class WooCommerce {
 			add_action( $action, array( $this, 'send_transactional_email' ), 10, 10 );
 		}
 
+		// webhooks
+		$this->load_webhooks();
+
 		// Init action
 		do_action( 'woocommerce_init' );
 	}
@@ -439,7 +442,7 @@ final class WooCommerce {
 
 		// Post thumbnail support
 		if ( ! current_theme_supports( 'post-thumbnails' ) ) {
-			add_theme_support( 'post-thumbnails' );	
+			add_theme_support( 'post-thumbnails' );
 		}
 		add_post_type_support( 'product', 'thumbnail' );
 
@@ -545,6 +548,30 @@ final class WooCommerce {
 		$this->mailer();
 		$args = func_get_args();
 		do_action_ref_array( current_filter() . '_notification', $args );
+	}
+
+	/**
+	 * Load & enqueue active webhooks
+	 *
+	 * @since 2.2
+	 */
+	public function load_webhooks() {
+
+		$args = array(
+			'fields'      => 'ids',
+			'post_type'   => 'shop_webhook',
+			'post_status' => 'publish',
+		);
+
+		$query = new WP_Query( $args );
+
+		if ( ! empty( $query->posts ) ) {
+
+			foreach ( $query->posts as $id ) {
+				$webhook = new WC_Webhook( $id );
+				$webhook->enqueue();
+			}
+		}
 	}
 
 	/** Load Instances on demand **********************************************/


### PR DESCRIPTION
This PR introduces a `shop_webhook` custom post type and associated `WC_Webhook` class, along with a REST API endpoint for creating/reading/updating/deleting webhooks. This still needs more testing but it's ready for the beta :smile: 
## Summary

The `WC_Webhook` class manages all data storage/retrieval from the custom post type, as well as enqueuing a webhook's actions and processing/delivering/logging the webhook. On `woocommerce_init`, active webhooks are loaded and their associated hooks are added.

Each webhook has:
- status: active (delivers payload), paused (delivery paused by admin), disabled (delivery paused by failure)
- topic: determines which resource events the webhook is triggered for
- delivery URL: URL where the payload is delivered, must be HTTP or HTTPS
- secret: an optional secret key that is used to generate a HMAC-SHA256 hash of the request body so the receiver can verify authenticity of the webhook
- hooks: an array of hook names that are added and bound to the webhook for processing
## Topics

The topic is a combination resource (e.g. order) and event (e.g. created) and maps to one or more hook names (e.g. `woocommerce_checkout_order_processed`). Webhooks can be created using the topic name and the appropriate hooks are automatically added.

Core topics are:
- `coupon.created, coupon.updated, coupon.deleted`
- `customer.created, customer.updated, customer.deleted`
- `order.created, order.updated, order.deleted`
- `product.created, product.updated, product.deleted`

Custom topics can also be used which map to a single hook name, so for example you could add a webhook with topic `action.woocommerce_add_to_cart` that is triggered on that event. Custom topics pass the first hook argument to the payload, so in this example the `cart_item_key` would be included in the payload.
## Delivery/Payload

Delivery is done using `wp_remote_post()` and processed in the background by default using wp-cron. A few custom headers are added to the request to help the receiver process the webhook:
- `X-WC-Webhook-Topic` - e.g. `order.updated`
- `X-WC-Webhook-Resource` - e.g. `order`
- `X-WC-Webhook-Event` - e.g. `updated`
- `X-WC-Webhook-Signature` - a base64 encoded HMAC-SHA256 hash of the payload
- `X-WC-Webhook-ID` - webhook's post ID
- `X-WC-Delivery-ID` - delivery log ID (a comment)

The payload is JSON encoded and for API resources (coupons,customers,orders,products), the response is exactly the same as if requested via the REST API. 
## Logging

Requests/responses are logged as comments on the webhook custom post type. Each delivery log includes:
- Request duration
- Request URL, method, headers, and body
- Response Code, message, headers, and body

Only the 25 most recent delivery logs are kept in order to reduce comment table bloat.

After 5 consecutive failed deliveries (as defined by a non HTTP 2xx response code), the webhook is disabled and must be edited via the REST API to re-enable.

Delivery logs can be fetched through the REST API or in code using `WC_Webhook::get_delivery_logs()`
## REST API Endpoints
- `GET /webhooks` - get all webhooks
- `GET /webhooks/count` - get a count of webhooks
- `GET /webhooks/#{id}` - get a webhook by ID
- `POST /webhooks/` - create a new webhook
- `PUT /webhooks/#{id}` - update a webhook
- `DELETE /webhooks/#{id}` - delete a webhook
- `GET /webhooks/#{webhook_id}/deliveries` - get delivery logs for the given webhook
- `GET /webhooks/#{webhook_id}/deliveries/#{id}` - get a delivery log by ID for the given webhook

`topic` and `delivery_url` are required when creating or updating a webhook. `secret` defaults to the API user's consumer secret key if not provided.

After successfully creating a new webhook, a ping is sent to the delivery URL containing the newly-created webhook's ID.

Closes #5564
