### PR TITLE
Fixed reordering products table cells

### DIFF
--- a/assets/js/admin/product-ordering.js
+++ b/assets/js/admin/product-ordering.js
@@ -3,53 +3,70 @@
  *
  * Modified - products have no children (non hierarchical)
  */
-jQuery('table.widefat tbody th, table.widefat tbody td').css('cursor','move');
+( function( $ ){
+$( document ).ready(function(){
+	$('table.widefat tbody th, table.widefat tbody td').css('cursor','move');
 
-jQuery("table.widefat tbody").sortable({
-	items: 'tr:not(.inline-edit-row)',
-	cursor: 'move',
-	axis: 'y',
-	containment: 'table.widefat',
-	scrollSensitivity: 40,
-	helper: function(e, ui) {
-		ui.children().each(function() { jQuery(this).width(jQuery(this).width()); });
-		return ui;
-	},
-	start: function(event, ui) {
-		if ( ! ui.item.hasClass('alternate') ) ui.item.css( 'background-color', '#ffffff' );
-		ui.item.children('td,th').css('border-bottom-width','0');
-		ui.item.css( 'outline', '1px solid #dfdfdf' );
-	},
-	stop: function(event, ui) {
-		ui.item.removeAttr('style');
-		ui.item.children('td,th').css('border-bottom-width','1px');
-	},
-	update: function(event, ui) {
-		jQuery('table.widefat tbody th, table.widefat tbody td').css('cursor','default');
-		jQuery("table.widefat tbody").sortable('disable');
+	$("table.widefat tbody").sortable({
+		items: 'tr:not(.inline-edit-row)',
+		cursor: 'move',
+		axis: 'y',
+		containment: 'table.widefat',
+		scrollSensitivity: 40,
+		helper: function(event, ui) {
+			ui.each(function() { $(this).width($(this).width()); });
+			return ui;
+		},
+		start: function(event, ui) {
+			ui.placeholder.children().each(function(){
+				var $original = ui.item.children().eq( ui.placeholder.children().index(this) ),
+					$this = $( this );
 
-		var postid = ui.item.find('.check-column input').val();	// this post id
-		var postparent = ui.item.find('.post_parent').html(); 	// post parent
+				$.each( $original[0].attributes, function( k, attr ){
+					$this.attr( attr.name, attr.value );
+				} );
+			});
+			if ( ! ui.item.hasClass('alternate') ) {
+				ui.item.css( 'background-color', '#ffffff' );
+			}
+			ui.item.children('td,th').css('border-bottom-width','0');
+			ui.item.css( 'outline', '1px solid #dfdfdf' );
+		},
+		stop: function(event, ui) {
+			ui.item.removeAttr('style');
+			ui.item.children('td,th').css('border-bottom-width','1px');
+		},
+		update: function(event, ui) {
+			$('table.widefat tbody th, table.widefat tbody td').css('cursor','default');
+			$("table.widefat tbody").sortable('disable');
 
-		var prevpostid = ui.item.prev().find('.check-column input').val();
-		var nextpostid = ui.item.next().find('.check-column input').val();
+			var postid = ui.item.find('.check-column input').val();	// this post id
+			var postparent = ui.item.find('.post_parent').html(); // post parent
 
-		// show spinner
-		ui.item.find('.check-column input').hide().after('<img alt="processing" src="images/wpspin_light.gif" class="waiting" style="margin-left: 6px;" />');
+			var prevpostid = ui.item.prev().find('.check-column input').val();
+			var nextpostid = ui.item.next().find('.check-column input').val();
 
-		// go do the sorting stuff via ajax
-		jQuery.post( ajaxurl, { action: 'woocommerce_product_ordering', id: postid, previd: prevpostid, nextid: nextpostid }, function(response){
-			jQuery.each(response, function(key,value) { jQuery('#inline_'+key+' .menu_order').html(value); });
-			ui.item.find('.check-column input').show().siblings('img').remove();
-			jQuery('table.widefat tbody th, table.widefat tbody td').css('cursor','move');
-			jQuery("table.widefat tbody").sortable('enable');
-		});
+			// show spinner
+			ui.item.find('.check-column input').hide().after('<img alt="processing" src="images/wpspin_light.gif" class="waiting" style="margin-left: 6px;" />');
 
-		// fix cell colors
-		jQuery( 'table.widefat tbody tr' ).each(function(){
-			var i = jQuery('table.widefat tbody tr').index(this);
-			if ( i%2 == 0 ) jQuery(this).addClass('alternate');
-			else jQuery(this).removeClass('alternate');
-		});
-	}
+			// go do the sorting stuff via ajax
+			$.post( ajaxurl, { action: 'woocommerce_product_ordering', id: postid, previd: prevpostid, nextid: nextpostid }, function(response){
+				$.each(response, function(key,value) { $('#inline_'+key+' .menu_order').html(value); });
+				ui.item.find('.check-column input').show().siblings('img').remove();
+				$('table.widefat tbody th, table.widefat tbody td').css('cursor','move');
+				$("table.widefat tbody").sortable('enable');
+			});
+
+			// fix cell colors
+			$( 'table.widefat tbody tr' ).each(function(){
+				var i = $('table.widefat tbody tr').index(this);
+				if ( i%2 === 0 ){
+					$(this).addClass('alternate');
+				} else {
+					$(this).removeClass('alternate');
+				}
+			});
+		}
+	});
 });
+}( jQuery ) );


### PR DESCRIPTION
@robertdall reported a bug on #5956 about the reordering of the products. The problem was not happening when you sorted it, but on all cases.

So what was really happening was that all the `tr` elements from the `ui.placeholder` would go messy because  they were not respecting the `ui.item` (original row) attributes, like `style` or `class`, and that might cause problems of them been Hidden (the current bug), or even different widths because of the classes.

**Note:** I've done a bit of rewriting on the JS to follow @claudiosmweb ideas on `.jshintrc` from WP.
