### PR TITLE
maximum ammount for coupon functionality added

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -84,6 +84,9 @@ class WC_Meta_Box_Coupon_Data {
 				// minimum spend
 				woocommerce_wp_text_input( array( 'id' => 'minimum_amount', 'label' => __( 'Minimum spend', 'woocommerce' ), 'placeholder' => __( 'No minimum', 'woocommerce' ), 'description' => __( 'This field allows you to set the minimum subtotal needed to use the coupon.', 'woocommerce' ), 'data_type' => 'price', 'desc_tip' => true ) );
 
+				// minimum spend
+				woocommerce_wp_text_input( array( 'id' => 'maximum_amount', 'label' => __( 'Maximum spend', 'woocommerce' ), 'placeholder' => __( 'No maximum', 'woocommerce' ), 'description' => __( 'This field allows you to set the maximum subtotal needed to use the coupon.', 'woocommerce' ), 'data_type' => 'price', 'desc_tip' => true ) );
+
 				// Individual use
 				woocommerce_wp_checkbox( array( 'id' => 'individual_use', 'label' => __( 'Individual use only', 'woocommerce' ), 'description' => __( 'Check this box if the coupon cannot be used in conjunction with other coupons.', 'woocommerce' ) ) );
 
@@ -243,6 +246,7 @@ class WC_Meta_Box_Coupon_Data {
 		$free_shipping          = isset( $_POST['free_shipping'] ) ? 'yes' : 'no';
 		$exclude_sale_items     = isset( $_POST['exclude_sale_items'] ) ? 'yes' : 'no';
 		$minimum_amount         = wc_format_decimal( $_POST['minimum_amount'] );
+		$maximum_amount         = wc_format_decimal( $_POST['maximum_amount'] );
 		$customer_email         = array_filter( array_map( 'trim', explode( ',', wc_clean( $_POST['customer_email'] ) ) ) );
 
 		if ( isset( $_POST['product_ids'] ) ) {
@@ -276,6 +280,7 @@ class WC_Meta_Box_Coupon_Data {
 		update_post_meta( $post_id, 'product_categories', $product_categories );
 		update_post_meta( $post_id, 'exclude_product_categories', $exclude_product_categories );
 		update_post_meta( $post_id, 'minimum_amount', $minimum_amount );
+		update_post_meta( $post_id, 'maximum_amount', $maximum_amount );
 		update_post_meta( $post_id, 'customer_email', $customer_email );
 
 		do_action( 'woocommerce_coupon_options_save', $post_id );

--- a/includes/api/class-wc-api-coupons.php
+++ b/includes/api/class-wc-api-coupons.php
@@ -137,6 +137,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			'exclude_product_category_ids' => array_map( 'absint', (array) $coupon->exclude_product_categories ),
 			'exclude_sale_items'           => $coupon->exclude_sale_items(),
 			'minimum_amount'               => wc_format_decimal( $coupon->minimum_amount, 2 ),
+			'maximum_amount'               => wc_format_decimal( $coupon->maximum_amount, 2 ),
 			'customer_emails'              => $coupon->customer_email,
 			'description'                  => $coupon_post->post_excerpt,
 		);
@@ -234,6 +235,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			'exclude_product_categories' => array(),
 			'exclude_sale_items' => 'no',
 			'minimum_amount' => '',
+			'maximum_amount' => '',
 			'customer_email' => array(),
 		);
 
@@ -275,6 +277,7 @@ class WC_API_Coupons extends WC_API_Resource {
 		update_post_meta( $id, 'exclude_product_categories', array_filter( array_map( 'intval', $coupon_data['exclude_product_categories'] ) ) );
 		update_post_meta( $id, 'exclude_sale_items', wc_clean( $coupon_data['exclude_sale_items'] ) );
 		update_post_meta( $id, 'minimum_amount', wc_format_decimal( $coupon_data['minimum_amount'] ) );
+		update_post_meta( $id, 'maximum_amount', wc_format_decimal( $coupon_data['maximum_amount'] ) );
 		update_post_meta( $id, 'customer_email', array_filter( array_map( 'sanitize_email', $coupon_data['customer_email'] ) ) );
 
 		do_action( 'woocommerce_api_create_coupon', $id, $data );
@@ -391,6 +394,10 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		if ( isset( $data['minimum_amount'] ) ) {
 			update_post_meta( $id, 'minimum_amount', wc_format_decimal( $data['minimum_amount'] ) );
+		}
+
+		if ( isset( $data['maximum_amount'] ) ) {
+			update_post_meta( $id, 'maximum_amount', wc_format_decimal( $data['maximum_amount'] ) );
 		}
 
 		if ( isset( $data['customer_email'] ) ) {

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -24,6 +24,7 @@ class WC_Coupon {
 	const E_WC_COUPON_NOT_APPLICABLE                 = 109;
 	const E_WC_COUPON_NOT_VALID_SALE_ITEMS           = 110;
 	const E_WC_COUPON_PLEASE_ENTER                   = 111;
+	const E_WC_COUPON_MAX_SPEND_LIMIT_MET        		 = 112;
 	const WC_COUPON_SUCCESS                          = 200;
 	const WC_COUPON_REMOVED                          = 201;
 
@@ -81,6 +82,9 @@ class WC_Coupon {
 	/** @public string Minimum cart amount. */
 	public $minimum_amount;
 
+	/** @public string Maximum cart amount. */
+	public $maximum_amount;
+
 	/** @public string Coupon owner's email. */
 	public $customer_email;
 
@@ -127,6 +131,7 @@ class WC_Coupon {
 			$this->exclude_product_categories = is_array( $coupon_data['exclude_product_categories'] ) ? $coupon_data['exclude_product_categories'] : array();
 			$this->exclude_sale_items         = esc_html( $coupon_data['exclude_sale_items'] );
 			$this->minimum_amount             = esc_html( $coupon_data['minimum_amount'] );
+			$this->maximum_amount             = esc_html( $coupon_data['maximum_amount'] );
 			$this->customer_email             = esc_html( $coupon_data['customer_email'] );
 
 		} else {
@@ -162,6 +167,7 @@ class WC_Coupon {
 				'exclude_product_categories' => array(),
 				'exclude_sale_items'         => 'no',
 				'minimum_amount'             => '',
+				'maximum_amount'             => '',
 				'customer_email'             => array()
 			);
 
@@ -315,6 +321,14 @@ class WC_Coupon {
 				if ( $this->minimum_amount > WC()->cart->subtotal ) {
 					$valid = false;
 					$error_code = self::E_WC_COUPON_MIN_SPEND_LIMIT_NOT_MET;
+				}
+			}
+
+			// Maximum spend
+			if ( $this->maximum_amount > 0 ) {
+				if ( $this->maximum_amount < WC()->cart->subtotal ) {
+					$valid = false;
+					$error_code = self::E_WC_COUPON_MAX_SPEND_LIMIT_MET;
 				}
 			}
 
@@ -641,6 +655,9 @@ class WC_Coupon {
 			break;
 			case self::E_WC_COUPON_MIN_SPEND_LIMIT_NOT_MET:
 				$err = sprintf( __( 'The minimum spend for this coupon is %s.', 'woocommerce' ), wc_price( $this->minimum_amount ) );
+			break;
+			case self::E_WC_COUPON_MAX_SPEND_LIMIT_MET:
+				$err = sprintf( __( 'The maximum spend for this coupon is %s.', 'woocommerce' ), wc_price( $this->minimum_amount ) );
 			break;
 			case self::E_WC_COUPON_NOT_APPLICABLE:
 				$err = __( 'Sorry, this coupon is not applicable to your cart contents.', 'woocommerce' );


### PR DESCRIPTION
I had a couple of clients request this feature so I rolled it into the core.  

Basically the clients wanted to cap the amount they were willing to discount.

If a customer had a coupon for 30% off.  They didn't want them to be able to use it if the total cart/item was over $200.   (thus caping the discount at $60 for a 30% off coupon of this setting).  etc.

I pretty much cloned the style/usage of the minimum spend functionality changing only the logic in class-wp-coupon.php to be LESS than the amount checked.  

I've seen a good number of folks requesting this on forums and my two clients currently.   Figured it'd be useful.

Any and all feedback welcome!
