### PR TITLE
Better ajax checking

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -206,7 +206,7 @@ if ( ! function_exists( 'is_ajax' ) ) {
 	 * @return bool
 	 */
 	function is_ajax() {
-		return defined( 'DOING_AJAX' );
+		return defined( 'DOING_AJAX' ) || ( isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] )  === 'xmlhttprequest' );
 	}
 }
 


### PR DESCRIPTION
Not all ajax calls to WordPress are using `admin-ajax.php`, e.g. the theme customizer preview invoke an ajax call the the home url. Consider if your admin is protected by https and when you invoke an ajax call to the home url AND you have the `unforce_https_template_redirect` enabled, it will redirect to the non-https version of the home url, and break the theme preview feature.

So, by fixing `is_ajax` function and it will make the `WC_HTTPS::unforce_https_template_redirect` work properly.
