### PR TITLE
Refund reason

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -208,9 +208,10 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * 
 	 * @param  int $order_id
 	 * @param  float $amount
+	 * @param  string $reason
 	 * @return  bool|wp_error True or false based on success, or a WP_Error object
 	 */
-	public function process_refund( $order_id, $amount = null ) {
+	public function process_refund( $order_id, $amount = null, $reason = '' ) {
 		return false;
 	}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1859,7 +1859,7 @@ class WC_AJAX {
 					$payment_gateways = WC()->payment_gateways->payment_gateways();
 				}
 				if ( isset( $payment_gateways[ $order->payment_method ] ) && $payment_gateways[ $order->payment_method ]->supports( 'refunds' ) ) {
-					$result = $payment_gateways[ $order->payment_method ]->process_refund( $order_id, $refund_amount );
+					$result = $payment_gateways[ $order->payment_method ]->process_refund( $order_id, $refund_amount, $refund_reason );
 
 					if ( is_wp_error( $result ) ) {
 						throw new exception( $result->get_error_message() );

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -565,9 +565,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * Process a refund if supported
 	 * @param  int $order_id
 	 * @param  float $amount
+	 * @param  string $reason
 	 * @return  bool|wp_error True or false based on success, or a WP_Error object
 	 */
-	public function process_refund( $order_id, $amount = null ) {
+	public function process_refund( $order_id, $amount = null, $reason = '' ) {
 		$order = get_order( $order_id );
 
 		if ( ! $order || ! $order->get_transaction_id() || ! $this->api_username || ! $this->api_password || ! $this->api_password ) {


### PR DESCRIPTION
Some payment gateways accept a reason string that is viewable within their portal/dashboard etc. This change passes the refund reason to the gateway's process_refund() method allowing them to use it if required.

Other gateways would need updating, as would the post here if this is accepted:

http://develop.woothemes.com/woocommerce/2014/08/wc-2-2-payment-gateways-adding-refund-support-and-transaction-ids/?utm_source=rss&utm_medium=rss&utm_campaign=wc-2-2-payment-gateways-adding-refund-support-and-transaction-ids
