### PR TITLE
Re-add all filters of widget on change of category

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -142,8 +142,8 @@ function wc_product_dropdown_categories( $args = array(), $deprecated_hierarchic
 		return;
 	}
 
-	$output  = "<select name='product_cat' id='dropdown_product_cat'>";
 	$output .= '<option value="" ' .  selected( $current_product_cat, '', false ) . '>' . __( 'Select a category', 'woocommerce' ) . '</option>';
+	$output  = "<select name='product_cat' class='dropdown_product_cat'>";
 	$output .= wc_walk_category_dropdown_tree( $terms, 0, $args );
 	if ( $args['show_uncategorized'] ) {
 		$output .= '<option value="0" ' . selected( $current_product_cat, '0', false ) . '>' . __( 'Uncategorized', 'woocommerce' ) . '</option>';

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -142,8 +142,8 @@ function wc_product_dropdown_categories( $args = array(), $deprecated_hierarchic
 		return;
 	}
 
-	$output .= '<option value="" ' .  selected( $current_product_cat, '', false ) . '>' . __( 'Select a category', 'woocommerce' ) . '</option>';
 	$output  = "<select name='product_cat' class='dropdown_product_cat'>";
+	$output .= '<option value="" ' .  selected( $current_product_cat, '', false ) . '>' . __( 'Select a category', 'woocommerce' ) . '</option>';
 	$output .= wc_walk_category_dropdown_tree( $terms, 0, $args );
 	if ( $args['show_uncategorized'] ) {
 		$output .= '<option value="0" ' . selected( $current_product_cat, '0', false ) . '>' . __( 'Uncategorized', 'woocommerce' ) . '</option>';

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -204,7 +204,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 				var product_cat_dropdown = document.getElementById("dropdown_product_cat");
 				function onProductCatChange() {
 					if ( product_cat_dropdown.options[product_cat_dropdown.selectedIndex].value !=='' ) {
-						location.href = "<?php echo home_url(); ?>/?product_cat="+product_cat_dropdown.options[product_cat_dropdown.selectedIndex].value;
+						location.href = "<?php echo home_url(); ?>/?product_cat="+product_cat_dropdown.options[product_cat_dropdown.selectedIndex].value+"&"+location.search.substring(1);
 					}
 				}
 				product_cat_dropdown.onchange = onProductCatChange;

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -200,15 +200,9 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			wc_product_dropdown_categories( apply_filters( 'woocommerce_product_categories_widget_dropdown_args', $dropdown_args ) );
 			?>
 			<script type='text/javascript'>
-			/* <![CDATA[ */
-				var product_cat_dropdown = document.getElementById("dropdown_product_cat");
-				function onProductCatChange() {
-					if ( product_cat_dropdown.options[product_cat_dropdown.selectedIndex].value !=='' ) {
-						location.href = "<?php echo home_url(); ?>/?product_cat="+product_cat_dropdown.options[product_cat_dropdown.selectedIndex].value+"&"+location.search.substring(1);
-					}
-				}
-				product_cat_dropdown.onchange = onProductCatChange;
-			/* ]]> */
+        jQuery('.dropdown_product_cat').change(function() {
+          location.href = "<?php echo home_url(); ?>/?product_cat="+jQuery(this).val()+"&"+location.search.substring(1);
+        });
 			</script>
 			<?php
 


### PR DESCRIPTION
At the moment all filters that were applied via the layered nav filter
widget are lost on changing the category with the product category
widget.

I just append all query strings to the end of the new location so that the filters are preserved while changing the category. 
