### PR TITLE
Add Australian checkout locale

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -592,6 +592,17 @@ class WC_Countries {
 						'required' => false
 					)
 				),
+				'AU' => array(
+					'city'	=> array(
+						'label' 		=> __( 'Suburb', 'woocommerce' ),
+					),
+					'postcode'	=> array(
+						'label' 		=> __( 'Postcode', 'woocommerce' ),
+					),
+					'state'		=> array(
+						'label' 		=> __( 'State', 'woocommerce' ),
+					)
+				),
 				'BD' => array(
 					'postcode' => array(
 						'required' => false


### PR DESCRIPTION
Customises checkout labels for Australian address terminology:

Town / City -> Suburb
State / Country -> State
Postcode / Zip -> Postcode

This matches the terminology used on the Australia Post website: http://auspost.com.au/apps/postage-calculator.html
