### PR TITLE
Passed $args to dynamic class that inherits WC_Abstract_Order is never used

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -18,10 +18,9 @@ class WC_Order_Factory {
 	 *
 	 * @access public
 	 * @param bool $the_order (default: false)
-	 * @param array $args (default: array())
 	 * @return WC_Order
 	 */
-	public function get_order( $the_order = false, $args = array() ) {
+	public function get_order( $the_order = false ) {
 		global $post;
 
 		if ( false === $the_order ) {
@@ -50,6 +49,6 @@ class WC_Order_Factory {
 			$classname = 'WC_Order';
 		}
 
-		return new $classname( $the_order, $args );
+		return new $classname( $the_order );
 	}
 }

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -35,11 +35,10 @@ function wc_get_order_statuses() {
  * Main function for returning orders, uses the WC_Order_Factory class.
  *
  * @param mixed $the_order Post object or post ID of the order.
- * @param array $args (default: array()) Contains all arguments to be used to get this order.
  * @return WC_Order
  */
-function wc_get_order( $the_order = false, $args = array() ) {
-	return WC()->order_factory->get_order( $the_order, $args );
+function wc_get_order( $the_order = false ) {
+	return WC()->order_factory->get_order( $the_order );
 }
 
 /**


### PR DESCRIPTION
Therefor the $args in the function and method in factory class seems unnecessary.
