### PR TITLE
Correct unavailable condition

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -120,7 +120,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	public function is_available() {
 		$is_available = ( 'yes' === $this->enabled ) ? true : false;
 
-		if ( WC()->cart && 0 < $this->get_order_total() && $this->max_amount >= $this->get_order_total() ) {
+		if ( WC()->cart && 0 < $this->get_order_total() && 0 < $this->max_amount && $this->max_amount < $this->get_order_total() ) {
 			$is_available = false;
 		}
 


### PR DESCRIPTION
The payment method should be unavailable when order total exceeds max_amount if max amount is greater than 0.
