### PR TITLE
Removed unused global $woocommerce variable from the templates

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -9,8 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce;
-
 wc_print_notices();
 
 do_action( 'woocommerce_before_cart' ); ?>

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -9,7 +9,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $product, $woocommerce, $woocommerce_loop;
+global $product, $woocommerce_loop;
 
 $crosssells = WC()->cart->get_cross_sells();
 

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -10,8 +10,6 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
-
-global $woocommerce;
 ?>
 
 <?php do_action( 'woocommerce_before_mini_cart' ); ?>

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -9,8 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce;
-
 if ( get_option( 'woocommerce_enable_shipping_calc' ) === 'no' || ! WC()->cart->needs_shipping() )
 	return;
 ?>

--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -9,8 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce;
-
 wc_print_notices();
 
 do_action( 'woocommerce_before_checkout_form', $checkout );

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -9,8 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce;
-
 if ( ! WC()->cart->coupons_enabled() ) {
 	return;
 }

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -8,8 +8,6 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
-
-global $woocommerce;
 ?>
 <form id="order_review" method="post">
 

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -9,8 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce;
-
 if ( $order ) : ?>
 
 	<?php if ( $order->has_status( 'failed' ) ) : ?>

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -11,8 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-global $woocommerce;
-
 foreach ( $items as $item ) :
 	$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 	$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -11,8 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-global $woocommerce;
-
 foreach ( $items as $item ) :
 	$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 	$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -11,7 +11,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce, $wp_query;
+global $wp_query;
 
 if ( ! woocommerce_products_will_display() )
 	return;

--- a/templates/order/form-tracking.php
+++ b/templates/order/form-tracking.php
@@ -9,7 +9,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce, $post;
+global $post;
 ?>
 
 <form action="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" method="post" class="track_order">

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -9,8 +9,6 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce;
-
 $order = wc_get_order( $order_id );
 ?>
 <h2><?php _e( 'Order Details', 'woocommerce' ); ?></h2>

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -6,7 +6,7 @@
  * @package 	WooCommerce/Templates
  * @version     2.1.0
  */
-global $woocommerce, $product;
+global $product;
 
 if ( ! defined( 'ABSPATH' ) )
 	exit; // Exit if accessed directly

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -9,7 +9,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce, $product;
+global $product;
 
 if ( ! $product->is_purchasable() ) return;
 ?>

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -9,7 +9,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce, $product, $post;
+global $product, $post;
 ?>
 
 <?php do_action( 'woocommerce_before_add_to_cart_form' ); ?>

--- a/templates/single-product/tabs/description.php
+++ b/templates/single-product/tabs/description.php
@@ -9,7 +9,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-global $woocommerce, $post;
+global $post;
 
 $heading = esc_html( apply_filters( 'woocommerce_product_description_heading', __( 'Product Description', 'woocommerce' ) ) );
 ?>


### PR DESCRIPTION
The `WC()` function is in use since v2.1
