### PR TITLE
Allow extensions to hijack i18n_product_type_alert

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -91,10 +91,6 @@ jQuery( function( $ ){
 		// Get value
 		var select_val = $( this ).val();
 
-		if ( 'variable' !== select_val && 0 < $( '#variable_product_options input[name^=variable_sku]' ).length ) {
-			window.alert( woocommerce_admin_meta_boxes.i18n_product_type_alert );
-		}
-
 		if ( 'variable' === select_val ) {
 			$( 'input#_manage_stock' ).change();
 			$( 'input#_downloadable' ).prop( 'checked', false );
@@ -114,6 +110,12 @@ jQuery( function( $ ){
 		$( 'body' ).trigger( 'woocommerce-product-type-change', select_val, $( this ) );
 
 	}).change();
+
+	$( 'body' ).on( 'woocommerce-product-type-change', function( e, select_val ) {
+		if ( 'variable' !== select_val && 0 < $( '#variable_product_options input[name^=variable_sku]' ).length && $( 'body' ).triggerHandler( 'woocommerce-display-product-type-alert', select_val ) !== false ) {
+			window.alert( woocommerce_admin_meta_boxes.i18n_product_type_alert );
+		}
+	});
 
 	$('input#_downloadable, input#_virtual').change(function(){
 		show_and_hide_panels();


### PR DESCRIPTION
This allows extensions to remove or hijack the display of the product type alert introduced with SHA: 519de5be59684.

A product may have variations, but not be explicitly `'variable'`. For example, a variable subscription.

At the moment, the product type error will be displayed every time the page loads for any product that has variations but is not core's variable product.

I thought WooCommerce could allow extensions to hijack the warning by using `triggerHandler()`. Specifically, replacing:

```
if ( 'variable' !== select_val && 0 < $( '#variable_product_options input[name^=variable_sku]' ).length ) {
```

With: 

```
if ( 'variable' !== select_val && 0 < $( '#variable_product_options input[name^=variable_sku]' ).length && $( 'body' ).triggerHandler( 'woocommerce-display-product-type-alert' ) !== false ) {
```

However, the `$( 'select#product-type' )` change event is triggered when the script is loaded. That's a good thing, but for this circumstance, it means any script trying to attach itself to 
`'woocommerce-display-product-type-alert'` to turn off the alert needs to be loaded _before_ the `'wc-admin-meta-boxes'` script (i.e. `meta-boxes-product.js`). This doesn't make sense for most scripts because they probably depend on the WC script.

So to make it work, I moved the alert logic outside of the default `change` handler and attached it to the custom `'woocommerce-product-type-change'` event.

This allows extensions to hijack the alert for their product types with code like: 

```
    $( 'body' ).on( 'woocommerce-display-product-type-alert', function(e, select_val) {
        if (select_val=='variable-subscription') {
            return false;
        }
    });
```

It also has the added benefit of allowing the alert to be removed completely with `.off()`.
