### PR TITLE
options.include is now supported for makepot task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -142,8 +142,8 @@ module.exports = function( grunt ) {
 			admin: {
 				options: {
 					potFilename: 'woocommerce-admin.pot',
-					exclude: [
-						'^(?!includes\/admin).*'
+					include: [
+						'includes/admin/.*'
 					],
 					processPot: function ( pot ) {
 						pot.headers['project-id-version'] += ' Admin';

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-checktextdomain": "^0.1.1",
-    "grunt-wp-i18n": "^0.4.6",
+    "grunt-wp-i18n": "^0.4.7",
     "grunt-contrib-jshint": "^0.10.0"
   },
   "engines": {


### PR DESCRIPTION
@claudiosmweb `grunt-wp-i18n` has now support for `options.include`.
