### PR TITLE
Better to use Time Constants since WordPress 3.5

### DIFF
--- a/includes/admin/class-wc-admin-welcome.php
+++ b/includes/admin/class-wc-admin-welcome.php
@@ -415,7 +415,7 @@ class WC_Admin_Welcome {
 			return array();
 		}
 
-		set_transient( 'woocommerce_contributors', $contributors, 3600 );
+		set_transient( 'woocommerce_contributors', $contributors, HOUR_IN_SECONDS );
 
 		return $contributors;
 	}


### PR DESCRIPTION
@mikejolly Reference this link http://codex.wordpress.org/Transients_API#Using_Time_Constants
