### PR TITLE
Filter for PayPal Gateway Text

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -27,10 +27,10 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$this->id                   = 'paypal';
 		$this->icon                 = apply_filters( 'woocommerce_paypal_icon', WC()->plugin_url() . '/assets/images/icons/paypal.png' );
 		$this->has_fields           = false;
-		$this->order_button_text    = __( 'Proceed to PayPal', 'woocommerce' );
+		$this->order_button_text    = apply_filters( 'woocommerce_paypal_proceed_text', __( 'Proceed to PayPal', 'woocommerce' ) );
 		$this->liveurl              = 'https://www.paypal.com/cgi-bin/webscr';
 		$this->testurl              = 'https://www.sandbox.paypal.com/cgi-bin/webscr';
-		$this->method_title         = __( 'PayPal', 'woocommerce' );
+		$this->method_title         = apply_filters( 'woocommerce_paypal_title_text', __( 'PayPal', 'woocommerce' ) );
 		$this->method_description   = __( 'PayPal standard works by sending the user to PayPal to enter their payment information.', 'woocommerce' );
 		$this->notify_url           = WC()->api_request_url( 'WC_Gateway_Paypal' );
 		$this->supports 			= array(


### PR DESCRIPTION
For the strings:
- Proceed to PayPal
- PayPal

These can easily be changed with localization but it's common that users want to change them so having filters will make it a lot easier.
