### PR TITLE
Define a margin for the input.qty

### DIFF
--- a/assets/css/woocommerce.less
+++ b/assets/css/woocommerce.less
@@ -676,6 +676,7 @@ p.demo_store {
 			height: 28px;
 			float:left;
 			padding: 0;
+			margin: 0;
 			text-align: center;
 			border: 1px solid darken( @secondary, 20 );
 			border-right: 0;


### PR DESCRIPTION
- This is needed, as it seems on at least Safari/Chrome it would push the -
  button down outside of the text field
- Tested on OS X Mavericks
