### PR TITLE
current_user_can( 'delete_users' ) always returns false

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -360,7 +360,6 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 		case 'remove_user' :
 		case 'promote_user' :
 		case 'delete_user' :
-		case 'delete_users' :
 			if ( ! isset( $args[0] ) ) {
 				$caps[] = 'do_not_allow';
 			} elseif ( $args[0] === $user_id ) {


### PR DESCRIPTION
Having 'case: "delete_users" :' in this function always adds 'do_not_allow' as $args[0] is never set therefore current_user_can( 'delete_users' ) always returns false

This can be replicated by activating woocommerce and attempting to delete a user through wp admin.

This commit fixes the issue.
