### PR TITLE
Ignorance for logs files excluded.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,3 @@ Thumbs.db
 sftp-config.json
 /deploy/
 /wc-apidocs/
-
-# Ignore all log files except for .htaccess
-/logs/*
-!/logs/.htaccess


### PR DESCRIPTION
`WC_LOG_DIR` is different from `/logs` and this directory is not created anymore in this root directory...better do remove logs from ignorance.
