### PR TITLE
Improve, fix, WC_Payment_Gateway::get_transaction_url()

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -78,15 +78,19 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 
 	/**
 	 * Get a link to the transaction on the 3rd party gateway size (if applicable)
-	 * @param  string $transaction_id
-	 * @return string
+	 *
+	 * @param  WC_Order $order the order object
+	 * @return string transaction URL, or empty string
 	 */
-	public function get_transaction_url( $transaction_id ) {
+	public function get_transaction_url( $order ) {
 		$return_url = '';
+		$transaction_id = $order->get_transaction_id();
+
 		if ( ! empty( $this->view_transaction_url ) && ! empty( $transaction_id ) ) {
 			$return_url = sprintf( $this->view_transaction_url, $transaction_id );
 		}
-		return apply_filters( 'woocommerce_get_transaction_url', $return_url, $transaction_id, $this );
+
+		return apply_filters( 'woocommerce_get_transaction_url', $return_url, $order, $this );
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -163,7 +163,7 @@ class WC_Meta_Box_Order_Data {
 						printf( __( 'Payment via %s', 'woocommerce' ), ( isset( $payment_gateways[ $payment_method ] ) ? esc_html( $payment_gateways[ $payment_method ]->get_title() ) : esc_html( $payment_method ) ) );
 
 						if ( $transaction_id = $order->get_transaction_id() ) {
-								if ( isset( $payment_gateways[ $payment_method ] ) && ( $url = $payment_gateways[ $payment_method ]->get_transaction_url( $transaction_id ) ) ) {
+								if ( isset( $payment_gateways[ $payment_method ] ) && ( $url = $payment_gateways[ $payment_method ]->get_transaction_url( $order ) ) ) {
 								echo ' (<a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $transaction_id ) . '</a>)';
 							} else {
 								echo ' (' . esc_html( $transaction_id ) . ')';

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -1045,21 +1045,18 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	/**
 	 * Get the transaction URL.
 	 *
-	 * @param  string $transaction_id
+	 * @param  WC_Order $order
 	 *
 	 * @return string
 	 */
-	public function get_transaction_url( $transaction_id ) {
-		$return_url = '';
+	public function get_transaction_url( $order ) {
 
-		if ( empty( $transaction_id ) ) {
-			if ( 'yes' == $this->testmode ) {
-				$return_url = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_view-a-trans&id=%s';
-			} else {
-				$return_url = 'https://www.paypal.com/cgi-bin/webscr?cmd=_view-a-trans&id=%s';
-			}
+		if ( 'yes' == $this->testmode ) {
+			$this->view_transaction_url = 'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_view-a-trans&id=%s';
+		} else {
+			$this->view_transaction_url = 'https://www.paypal.com/cgi-bin/webscr?cmd=_view-a-trans&id=%s';
 		}
 
-		return apply_filters( 'woocommerce_get_transaction_url', $return_url, $transaction_id, $this );
+		return parent::get_transaction_url( $order );
 	}
 }


### PR DESCRIPTION
- Make the new get_transaction_url() method a bit more flexible/convenient by passing in the full order object rather than transaction_id
- Fix bug with core PayPal gateway get_transaction_url() override
