### PR TITLE
Allow WC_Product_Variation children to extend meta

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -38,7 +38,7 @@ class WC_Product_Variation extends WC_Product {
 	public $variation_has_downloadable_files = true;
 
 	/** @private array Data which is only at variation level - no inheritance plus their default values if left blank. */
-	private $variation_level_meta_data = array(
+	protected $variation_level_meta_data = array(
 		'downloadable'          => 'no',
 		'virtual'               => 'no',
 		'manage_stock'          => 'no',
@@ -53,7 +53,7 @@ class WC_Product_Variation extends WC_Product {
 	);
 
 	/** @private array Data which can be at variation level, otherwise fallback to parent if not set. */
-	private $variation_inherited_meta_data = array(
+	protected $variation_inherited_meta_data = array(
 		'tax_class'  => '',
 		'backorders' => 'no',
 		'sku'        => '',


### PR DESCRIPTION
When SHA: 50a0577b81 introduced `$variation_level_meta_data` and `$variation_inherited_meta_data`, it set their access to `private`.

Child classes of `WC_Product_Variation` should be able to extend these properties to allow them to take advantage of the `__isset()` and __get()`methods and they don't have to duplicate the`WC_Product_Variation->variation_level_meta_data`and`WC_Product_Variation->variation_inherited_meta_data` values.

Related to #6065.
