### PR TITLE
Add Unit Testing Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,25 @@
-/nbproject/private/
-/node_modules/
+# Editors
 project.xml
 project.properties
-.DS_Store
-Thumbs.db
+/nbproject/private/
 .buildpath
 .project
 .settings*
 sftp-config.json
-/deploy/
-/wc-apidocs/
 .idea
+
+# Grunt
+/node_modules/
+/deploy/
+
+# OS X metadata
+.DS_Store
+
+# Windows junk
+Thumbs.db
+
+# ApiGen
+/wc-apidocs/
+
+# Unit tests
+/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+
+matrix:
+  include:
+    - php: '5.5'
+      env: WP_VERSION=latest WP_MULTISITE=1
+    - php: '5.4'
+      env: WP_VERSION=3.8 WP_MULTISITE=0
+    - php: '5.3'
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: '5.3'
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    - php: '5.2'
+      env: WP_VERSION=latest WP_MULTISITE=0
+
+before_script:
+    - bash tests/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION
+
+script: phpunit

--- a/includes/api/class-wc-api-webhooks.php
+++ b/includes/api/class-wc-api-webhooks.php
@@ -319,7 +319,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 			return true;
 		}
 
-		list( $resource, $event ) = explode( '.', $topic );
+		@list( $resource, $event ) = explode( '.', $topic );
 
 		if ( ! isset( $resource ) || ! isset( $event ) ) {
 			return false;
@@ -476,7 +476,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 		$id = absint( $id );
 
 		if ( empty( $id ) ) {
-			return new WP_Error( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID', 'woocommerce' ), array( 'status' => 400 ) );
+			return new WP_Error( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$webhook = new WC_Webhook( $webhook_id );

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	verbose="true"
+	>
+	<testsuites>
+		<testsuite name="WooCommerce Test Suite">
+			<directory suffix=".php">./tests/unit-tests</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<blacklist>
+			<directory suffix=".php">./apigen/</directory>
+			<directory suffix=".php">./i18n/</directory>
+			<directory suffix=".php">./templates/</directory>
+			<directory suffix=".php">./tests/</directory>
+			<directory suffix=".php">./tmp/</directory>
+		</blacklist>
+	</filter>
+	<logging>
+		<log type="coverage-html" target="./tmp/coverage" charset="UTF-8" />
+	</logging>
+</phpunit>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,41 @@
+# WooCommerce Unit Tests
+
+## Initial Setup
+
+1) Install [PHPUnit](http://phpunit.de/) by following their [installation guide](https://phpunit.de/getting-started.html). If you've installed it correctly, this should display the version:
+
+    $ phpunit --version
+
+2) Install WordPress and the WP Unit Test lib using the `install-wp-tests.sh` script. Change to the plugin root directory and type:
+
+    $ tests/install-wp-tests.sh <db-name> <db-user> <db-password> [db-host]
+
+Sample usage:
+
+    $ tests/install-wp-tests.sh woocommerce_tests root root
+
+**Important**: The `<db-name>` database will be created if it doesn't exist and all data will be removed during testing.
+
+## Running Tests
+
+Simply change to the plugin root directory and type:
+
+    $ phpunit
+
+The tests will execute and you'll be presented with a summary. Code coverage documentation is automatically generated as HTML in the `tmp/coverage` directory.
+
+You can run specific tests by providing the path and filename to the test class:
+
+    $ phpunit tests/unit-tests/api/webhooks
+
+A text code coverage summary can be displayed using the `--coverage-text` option:
+
+    $ phpunit --coverage-text
+
+## Writing Tests
+
+TODO
+
+## Automated Tests
+
+Tests are automatically run with Travis-CI for each commit and pull request.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,14 +10,13 @@ class WC_Unit_Tests_Bootstrap {
 	protected static $instance = null;
 
 	/** @var string directory where wordpress-tests-lib is installed */
-	protected $wp_tests_dir;
+	public $wp_tests_dir;
 
 	/** @var string testing directory */
-	protected $tests_dir;
+	public $tests_dir;
 
 	/** @var string plugin directory */
-	protected $plugin_dir;
-
+	public $plugin_dir;
 
 	/**
 	 * Setup the unit testing environment
@@ -33,36 +32,50 @@ class WC_Unit_Tests_Bootstrap {
 		$this->plugin_dir   = dirname( $this->tests_dir );
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : $this->plugin_dir . '/tmp/wordpress-tests-lib';
 
+		// load test function so tests_add_filter() is available
+		require_once( $this->wp_tests_dir . '/includes/functions.php' );
+
+		// load WC
+		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
+
+		// install WC
+		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
+
 		// load the WP testing environment
 		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );
 
-		$this->install_wc();
-
-		activate_plugin( 'woocommerce/woocommerce.php' );
-
+		// load WC testing framework
 		$this->includes();
 	}
 
+	/**
+	 * Load WooCommerce
+	 *
+	 * @since 2.2
+	 */
+	public function load_wc() {
+		require_once( $this->plugin_dir . '/woocommerce.php' );
+	}
 
 	/**
-	 * Install WooCommerce after the test environment has loaded, but prior
-	 * to activating the plugin
+	 * Install WooCommerce after the test environment and WC have been loaded
 	 *
 	 * @since 2.2
 	 */
 	public function install_wc() {
 
-		echo 'Installing WooCommerce...' . PHP_EOL;
-
-		require_once( $this->plugin_dir . '/woocommerce.php' );
+		// clean existing install first
+		define( 'WP_UNINSTALL_PLUGIN', true );
+		include( $this->plugin_dir . '/uninstall.php' );
 
 		$installer = include( $this->plugin_dir . '/includes/class-wc-install.php' );
 		$installer->install();
 
-		$GLOBALS['current_user'] = new WP_User(1);
-		$GLOBALS['current_user']->set_role('administrator');
-	}
+		// reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374
+		$GLOBALS['wp_roles']->reinit();
 
+		echo "Installing WooCommerce..." . PHP_EOL;
+	}
 
 	/**
 	 * Load WC-specific test cases and factories
@@ -75,7 +88,6 @@ class WC_Unit_Tests_Bootstrap {
 		require_once( $this->tests_dir . '/framework/class-wc-unit-test-case.php' );
 		require_once( $this->tests_dir . '/framework/class-wc-api-unit-test-case.php' );
 	}
-
 
 	/**
 	 * Get the single class instance

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WooCommerce Unit Tests Bootstrap
+ *
+ * @since 2.2
+ */
+class WC_Unit_Tests_Bootstrap {
+
+	/** @var \WC_Unit_Tests_Bootstrap instance */
+	protected static $instance = null;
+
+	/** @var string directory where wordpress-tests-lib is installed */
+	protected $wp_tests_dir;
+
+	/** @var string testing directory */
+	protected $tests_dir;
+
+	/** @var string plugin directory */
+	protected $plugin_dir;
+
+
+	/**
+	 * Setup the unit testing environment
+	 *
+	 * @since 2.2
+	 */
+	public function __construct() {
+
+		ini_set( 'display_errors','on' );
+		error_reporting( E_ALL );
+
+		$this->tests_dir    = dirname( __FILE__ );
+		$this->plugin_dir   = dirname( $this->tests_dir );
+		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : $this->plugin_dir . '/tmp/wordpress-tests-lib';
+
+		// load the WP testing environment
+		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );
+
+		$this->install_wc();
+
+		activate_plugin( 'woocommerce/woocommerce.php' );
+
+		$this->includes();
+	}
+
+
+	/**
+	 * Install WooCommerce after the test environment has loaded, but prior
+	 * to activating the plugin
+	 *
+	 * @since 2.2
+	 */
+	public function install_wc() {
+
+		echo 'Installing WooCommerce...' . PHP_EOL;
+
+		require_once( $this->plugin_dir . '/woocommerce.php' );
+
+		$installer = include( $this->plugin_dir . '/includes/class-wc-install.php' );
+		$installer->install();
+
+		$GLOBALS['current_user'] = new WP_User(1);
+		$GLOBALS['current_user']->set_role('administrator');
+	}
+
+
+	/**
+	 * Load WC-specific test cases and factories
+	 *
+	 * @since 2.2
+	 */
+	public function includes() {
+
+		require_once( $this->tests_dir . '/framework/wc-unit-test-factory.php' );
+		require_once( $this->tests_dir . '/framework/class-wc-unit-test-case.php' );
+		require_once( $this->tests_dir . '/framework/class-wc-api-unit-test-case.php' );
+	}
+
+
+	/**
+	 * Get the single class instance
+	 *
+	 * @since 2.2
+	 * @return WC_Unit_Tests_Bootstrap
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+}
+
+WC_Unit_Tests_Bootstrap::instance();

--- a/tests/framework/class-wc-api-unit-test-case.php
+++ b/tests/framework/class-wc-api-unit-test-case.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WC API Unit Test Case
+ *
+ * Provides REST API specific setup/tear down/assert methods, along with some helper
+ * functions
+ *
+ * @since 2.2
+ */
+class WC_API_Unit_Test_Case extends WC_Unit_Test_Case {
+
+	/**
+	 * Setup the test case case
+	 *
+	 * @since 2.2
+	 * @see WC_Unit_Test_Case::setUp()
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		// load API classes
+		WC()->api->includes();
+
+		// set user
+		$this->user = $this->factory->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->user->ID );
+
+		// this isn't used, but it causes a warning unless set
+		$_SERVER['REQUEST_METHOD'] = null;
+
+		// mock the API server to prevent headers from being sent
+		$this->mock_server = $this->getMock( 'WC_API_Server', array ('header' ), array( '/' ) );
+
+		WC()->api->register_resources( $this->mock_server );
+	}
+
+	/**
+	 * Assert the given response is an API error with a specific code and status
+	 *
+	 * @since 2.2
+	 * @param string $code error code, e.g. `woocommerce_api_user_cannot_read_orders_count`
+	 * @param int|null $status HTTP status code associated with error, e.g. 400
+	 * @param WP_Error $response
+	 * @param string $message optional message to render when assertion fails
+	 */
+	public function assertHasAPIError( $code, $status = null, $response, $message = '' ) {
+
+		$this->assertWPError( $response, $message );
+
+		// code
+		$this->assertEquals( $code, $response->get_error_code(), $message );
+
+		// status
+		$data = $response->get_error_data();
+
+		$this->assertArrayHasKey( 'status', $data, $message );
+		$this->assertEquals( $status, $data['status'], $message );
+	}
+
+
+	/**
+	 * Disable the given capability for the current user, used for testing
+	 * permission checking
+	 *
+	 * @since 2.2
+	 * @param string $capability, e.g. `read_private_shop_orders`
+	 */
+	protected function disable_capability( $capability ) {
+
+		$user = wp_get_current_user();
+		$user->add_cap( $capability, false );
+
+		// flush capabilities, see https://core.trac.wordpress.org/ticket/28374
+		$user->get_role_caps();
+		$user->update_user_level_from_caps();
+	}
+
+}

--- a/tests/framework/class-wc-api-unit-test-case.php
+++ b/tests/framework/class-wc-api-unit-test-case.php
@@ -23,8 +23,8 @@ class WC_API_Unit_Test_Case extends WC_Unit_Test_Case {
 		WC()->api->includes();
 
 		// set user
-		$this->user = $this->factory->user->create_and_get( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $this->user->ID );
+		$this->user_id = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $this->user_id );
 
 		// this isn't used, but it causes a warning unless set
 		$_SERVER['REQUEST_METHOD'] = null;

--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * WC Unit Test Case
+ *
+ * Provides WooCommerce-specific setup/tear down/assert methods, custom factories,
+ * and helper functions
+ *
+ * @since 2.2
+ */
+class WC_Unit_Test_Case extends WP_UnitTestCase {
+
+	/** @var \WC_Unit_Test_Factory instance */
+	protected $factory;
+
+	/**
+	 * Setup test case
+	 *
+	 * @since 2.2
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		// add custom factories
+		$this->factory = new WC_Unit_Test_Factory();
+	}
+
+	/**
+	 * Asserts thing is not WP_Error
+	 *
+	 * @since 2.2
+	 * @param mixed $actual
+	 * @param string $message
+	 */
+	public function assertNotWPError( $actual, $message = '' ) {
+		$this->assertNotInstanceOf( 'WP_Error', $actual, $message );
+	}
+
+}

--- a/tests/framework/wc-unit-test-factory.php
+++ b/tests/framework/wc-unit-test-factory.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * WC Unit Test Factory
+ *
+ * Provides WooCommerce-specific factories
+ *
+ * @since 2.2
+ */
+class WC_Unit_Test_Factory extends WP_UnitTest_Factory {
+
+	/** @var \WC_Unit_Test_Factory_For_Webhook_Delivery */
+	public $webhook_delivery;
+
+	/**
+	 * Setup factories
+	 */
+	public function __construct() {
+
+		parent::__construct();
+
+		$this->webhook_delivery = new WC_Unit_Test_Factory_For_Webhook_Delivery( $this );
+	}
+}
+
+/**
+ * Webhook Delivery Test Factory
+ *
+ * @since 2.2
+ */
+class WC_Unit_Test_Factory_For_Webhook_Delivery extends WP_UnitTest_Factory_For_Comment {
+
+	/**
+	 * Setup factory
+	 *
+	 * @since 2.2
+	 * @param null $factory
+	 */
+	public function __construct( $factory = null ) {
+
+		parent::__construct( $factory );
+
+		// set defaults
+		$this->default_generation_definitions = array(
+			'comment_author'       => __( 'WooCommerce', 'woocommerce' ),
+			'comment_author_email' => 'woocommerce@noreply.com',
+			'comment_agent'        => 'WooCommerce Hookshot',
+			'comment_type'         => 'webhook_delivery',
+			'comment_parent'       => 0,
+			'comment_approved'     => 1,
+			'comment_content'      => 'HTTP 200: OK',
+		);
+	}
+
+	/**
+	 * Create a mock webhook delivery
+	 *
+	 * @since 2.2
+	 * @see WP_UnitTest_Factory_For_comment::create_object()
+	 * @param array $args
+	 * @return int webhook delivery (comment) ID
+	 */
+	public function create_object( $args ) {
+
+		$id = parent::create_object( $args );
+
+		$comment_meta_args = array(
+			'_request_method'    => 'POST',
+			'_request_headers'   => array( 'User-Agent', 'WooCommerce Hookshot' ),
+			'_request_body'      => "webhook_id={$id}",
+			'_response_code'     => 200,
+			'_response_messaage' => 'OK',
+			'_response_headers'  => array( 'server' => 'nginx' ),
+			'_response_body'     => 'OK',
+			'_duration'          => '0.47976',
+		);
+
+		foreach ( $comment_meta_args as $key => $value ) {
+			update_comment_meta( $id, $key, $value );
+		}
+
+		return $id;
+	}
+
+}

--- a/tests/install-wp-tests.sh
+++ b/tests/install-wp-tests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# see https://github.com/wp-cli/wp-cli/blob/master/templates/install-wp-tests.sh
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+# TODO: allow environment vars for WP_TESTS_DIR & WP_CORE_DIR
+WP_TESTS_DIR="${PWD}/tmp/wordpress-tests-lib"
+WP_CORE_DIR="${PWD}/tmp/wordpress/"
+
+
+set -ex
+
+install_wp() {
+	mkdir -p $WP_CORE_DIR
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	curl http://wordpress.org/${ARCHIVE_NAME}.tar.gz --output /tmp/wordpress.tar.gz --silent
+
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	curl https://raw.github.com/markoheijnen/wp-mysqli/master/db.php --output $WP_CORE_DIR/wp-content/db.php --silent
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite
+	mkdir -p $WP_TESTS_DIR
+	cd $WP_TESTS_DIR
+	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+
+	curl http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php --output wp-tests-config.php --silent
+
+	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
+	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
+	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
+	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
+	sed $ioption "s|localhost|${DB_HOST}|" wp-tests-config.php
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/tests/unit-tests/api/webhooks.php
+++ b/tests/unit-tests/api/webhooks.php
@@ -1,0 +1,524 @@
+<?php
+
+/**
+ * Test the WC API /webhooks endpoint
+ *
+ * @since 2.2
+ */
+class WC_Tests_Webhooks extends WC_API_Unit_Test_Case {
+
+	/** @var \WC_API_Webhooks instance */
+	protected $endpoint;
+
+	/** @var \WC_Webhook instance */
+	protected $webhook;
+
+	/** @var int webhook delivery (comment) ID */
+	protected $webhook_delivery_id;
+
+	/**
+	 * Setup test webhook data
+	 *
+	 * @see WC_API_UnitTestCase::setup()
+	 * @since 2.2
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->endpoint = WC()->api->WC_API_Webhooks;
+
+		$post_args = array(
+			'post_type'     => 'shop_webhook',
+			'post_status'   => 'publish',
+			'post_title' => rand_str(),
+		);
+
+		$post_id = $this->factory->post->create( $post_args );
+
+		$meta_args = array(
+			'_topic'        => 'coupon.created',
+			'_resource'     => 'coupon',
+			'_event'        => 'created',
+			'_hooks'        => array(
+				'woocommerce_process_shop_coupon_meta',
+				'woocommerce_api_create_coupon',
+			),
+			'_delivery_url' => rand_str(),
+		);
+
+		foreach ( $meta_args as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// mock webhook
+		$this->webhook = new WC_Webhook( $post_id );
+
+		// mock webhook delivery
+		$this->webhook_delivery_id = $this->factory->webhook_delivery->create( array( 'comment_post_ID' => $this->webhook->id ) );
+	}
+
+
+	/**
+	 * Test route registration
+	 *
+	 * @since 2.2
+	 */
+	public function test_register_routes() {
+
+		$routes = $this->endpoint->register_routes( array() );
+
+		$this->assertArrayHasKey( '/webhooks', $routes );
+		$this->assertArrayHasKey( '/webhooks/count', $routes );
+		$this->assertArrayHasKey( '/webhooks/(?P<id>\d+)', $routes );
+		$this->assertArrayHasKey( '/webhooks/(?P<webhook_id>\d+)/deliveries', $routes );
+		$this->assertArrayHasKey( '/webhooks/(?P<webhook_id>\d+)/deliveries/(?P<id>\d+)', $routes );
+	}
+
+	/**
+	 * Test GET /webhooks/{id}
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhook() {
+
+		// invalid ID
+		$response = $this->endpoint->get_webhook( 0 );
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_id', 404, $response );
+
+		// valid request
+		$response = $this->endpoint->get_webhook( $this->webhook->id );
+
+		$this->assertNotWPError( $response );
+		$this->assertArrayHasKey( 'webhook', $response );
+
+		$this->check_get_webhook_response( $response['webhook'], $this->webhook );
+	}
+
+	/**
+	 * Test GET /webhooks/{id} without valid permissions
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhook_without_permission() {
+
+		$this->disable_capability( 'read_private_shop_webhooks' );
+
+		$response = $this->endpoint->get_webhook( $this->webhook->id );
+
+		$this->assertHasAPIError( 'woocommerce_api_user_cannot_read_webhook', 401, $response );
+	}
+
+	/**
+	 * Test GET /webhooks
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhooks() {
+
+		// valid request
+		$response = $this->endpoint->get_webhooks( null, null, 'active' );
+
+		$this->assertNotWPError( $response );
+		$this->assertArrayHasKey( 'webhooks', $response );
+		$this->assertCount( 1, $response['webhooks'] );
+
+		$this->check_get_webhook_response( $response['webhooks'][0], $this->webhook );
+	}
+
+	/**
+	 * Test GET /webhooks without valid permissions
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhooks_without_permission() {
+
+		$this->disable_capability( 'read_private_shop_webhooks' );
+
+		$response = $this->endpoint->get_webhooks();
+
+		$this->assertArrayHasKey( 'webhooks', $response );
+		$this->assertEmpty( $response['webhooks'] );
+	}
+
+	/**
+	 * Test GET /webhooks/count
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhooks_count() {
+
+		// paused status
+		$response = $this->endpoint->get_webhooks_count( 'paused' );
+		$this->assertArrayHasKey( 'count', $response );
+		$this->assertEquals( 0, $response['count'] );
+
+		// disabled status
+		$response = $this->endpoint->get_webhooks_count( 'disabled' );
+		$this->assertArrayHasKey( 'count', $response );
+		$this->assertEquals( 0, $response['count'] );
+
+		// an invalid status defaults to 'active'
+		$response = $this->endpoint->get_webhooks_count( 'bogus' );
+		$this->assertArrayHasKey( 'count', $response );
+		$this->assertEquals( 1, $response['count'] );
+
+		// valid request
+		$response = $this->endpoint->get_webhooks_count();
+		$this->assertArrayHasKey( 'count', $response );
+		$this->assertEquals( 1, $response['count'] );
+	}
+
+	/**
+	 * Test GET /webhooks/count without valid permissions
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhooks_count_without_permission() {
+
+		// invalid permissions
+		$this->disable_capability( 'read_private_shop_webhooks' );
+
+		$response = $this->endpoint->get_webhooks_count();
+
+		$this->assertHasAPIError( 'woocommerce_api_user_cannot_read_webhooks_count', 401, $response );
+	}
+
+	/**
+	 * Test POST /webhooks
+	 *
+	 * @since 2.2
+	 */
+	public function test_create_webhook() {
+
+		$response = $this->endpoint->create_webhook( $this->get_defaults() );
+
+		$this->check_create_webhook_response( $response );
+	}
+
+	/**
+	 * Test POST /webhooks without valid permissions
+	 *
+	 * @since 2.2
+	 */
+	public function test_create_webhook_without_permission() {
+
+		$this->disable_capability( 'publish_shop_webhooks' );
+
+		$response = $this->endpoint->create_webhook( $this->get_defaults() );
+
+		$this->assertHasAPIError( 'woocommerce_api_user_cannot_create_webhooks', 401, $response );
+	}
+
+	/**
+	 * Test POST /webhooks with custom topic
+	 *
+	 * @since 2.2
+	 */
+	public function test_create_webhook_custom_topic() {
+
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'topic' => 'action.woocommerce_cart_updated' ) ) );
+
+		$this->check_edit_webhook_response( $response );
+	}
+
+	/**
+	 * Test an invalid or empty topic for POST /webhooks
+	 *
+	 * @since 2.2
+	 */
+	public function test_create_webhook_invalid_topic() {
+
+		// empty
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'topic' => null ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_topic', 400, $response );
+
+		// invalid - missing event
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'topic' => 'invalid' ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_topic', 400, $response );
+
+		// invalid
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'topic' => 'invalid.topic' ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_topic', 400, $response );
+	}
+
+	/**
+	 * Test an invalid or empty delivery for POST /webhooks
+	 *
+	 * @since 2.2
+	 */
+	public function test_create_webhook_invalid_delivery_url() {
+
+		// empty
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'delivery_url' => null ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_delivery_url', 400, $response );
+
+		// invalid - scheme must be HTTP or HTTPS
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'delivery_url' => 'foo://bar' ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_delivery_url', 400, $response );
+
+		// invalid - must be valid URL
+		$response = $this->endpoint->create_webhook( $this->get_defaults( array( 'delivery_url' => 'https://foobar!' ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_delivery_url', 400, $response );
+	}
+
+	/**
+	 * Test wp_insert_post() failure for POST /webhooks
+	 *
+	 * @since 2.2
+	 */
+	public function test_create_webhook_insert_post_failure() {
+
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$response = $this->endpoint->create_webhook( $this->get_defaults() );
+
+		$this->assertHasAPIError( 'woocommerce_api_cannot_create_webhook', 500, $response );
+	}
+
+	/**
+	 * Test PUT /webhooks/{id}
+	 *
+	 * @since 2.2
+	 */
+	public function test_edit_webhook() {
+
+		// invalid ID
+		$response = $this->endpoint->edit_webhook( 0, $this->get_defaults() );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_id', 404, $response );
+
+		$args = array(
+			'secret' => rand_str(),
+			'status' => 'paused',
+		);
+
+		// valid request
+		$response = $this->endpoint->edit_webhook( $this->webhook->id, $this->get_defaults( $args ) );
+
+		$this->check_edit_webhook_response( $response );
+	}
+
+	/**
+	 * Test PUT /webhooks/{id} without valid permissions
+	 *
+	 * @since 2.2
+	 */
+	public function test_edit_webhook_without_permission() {
+
+		$this->disable_capability( 'edit_published_shop_webhooks' );
+
+		$response = $this->endpoint->edit_webhook( $this->webhook->id, $this->get_defaults() );
+
+		$this->assertHasAPIError( 'woocommerce_api_user_cannot_edit_webhook', 401, $response );
+	}
+
+	/**
+	 * Test PUT /webhooks/{id} with updated topic
+	 *
+	 * @since 2.2
+	 */
+	public function test_edit_webhook_change_topic() {
+
+		// invalid topic
+		$response = $this->endpoint->edit_webhook( $this->webhook->id, $this->get_defaults( array( 'topic' => 'invalid.topic' ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_topic', 400, $response );
+
+		// valid request
+		$response = $this->endpoint->edit_webhook( $this->webhook->id, $this->get_defaults( array( 'topic' => 'order.updated' ) ) );
+
+		$this->check_edit_webhook_response( $response );
+	}
+
+	/**
+	 * Test PUT /webhooks/{id} with updated delivery URL
+	 *
+	 * @since 2.2
+	 */
+	public function test_edit_webhook_change_delivery_url() {
+
+		// invalid delivery URL
+		$response = $this->endpoint->edit_webhook( $this->webhook->id, $this->get_defaults( array( 'delivery_url' => 'foo://bar' ) ) );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_delivery_url', 400, $response );
+
+		// valid request
+		$response = $this->endpoint->edit_webhook( $this->webhook->id, $this->get_defaults( array( 'delivery_url' => 'http://www.skyverge.com' ) ) );
+
+		$this->check_edit_webhook_response( $response );
+	}
+
+	/**
+	 * Test DELETE /webhooks/{id}
+	 *
+	 * @since 2.2
+	 */
+	public function test_delete_webhook() {
+
+		// invalid ID
+		$response = $this->endpoint->delete_webhook( 0 );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_id', 404, $response );
+
+		// valid request
+		$response = $this->endpoint->delete_webhook( $this->webhook->id );
+		$this->assertArrayHasKey( 'message', $response );
+		$this->assertEquals( 'Permanently deleted webhook', $response['message'] );
+	}
+
+
+	/**
+	 * Test GET /webhooks/{id}/deliveries
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhook_deliveries() {
+
+		// invalid ID
+		$response = $this->endpoint->get_webhook_deliveries( 0 );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_id', '404', $response );
+
+		// valid request
+		$response = $this->endpoint->get_webhook_deliveries( $this->webhook->id );
+
+		$this->assertNotWPError( $response );
+		$this->assertArrayHasKey( 'webhook_deliveries', $response );
+		$this->assertCount( 1, $response['webhook_deliveries'] );
+
+		$this->check_get_webhook_delivery_response( $response['webhook_deliveries'][0], $this->webhook->get_delivery_log( $response['webhook_deliveries'][0]['id'] ) );
+	}
+
+
+	/**
+	 * Test GET /webhooks/{id}/deliveries/{id}
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhook_delivery() {
+
+		$response = $this->endpoint->get_webhook_delivery( $this->webhook->id, $this->webhook_delivery_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertArrayHasKey( 'webhook_delivery', $response );
+		$this->assertNotEmpty( $response['webhook_delivery'] );
+
+		$this->check_get_webhook_delivery_response( $response['webhook_delivery'], $this->webhook->get_delivery_log( $response['webhook_delivery']['id'] ) );
+	}
+
+	/**
+	 * Test GET /webhooks/{id}/deliveries/{id} with invalid webhook & delivery IDs
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_webhook_delivery_invalid_ids() {
+
+		// invalid webhook ID
+		$response = $this->endpoint->get_webhook_delivery( 0, 0 );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_id', 404, $response );
+
+		// invalid delivery ID
+		$response = $this->endpoint->get_webhook_delivery( $this->webhook->id, 0 );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_delivery_id', 404, $response );
+
+		$post_id = $this->factory->post->create();
+		$mock_comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
+
+		// invalid delivery (valid comment, but not the correct type)
+		$response = $this->endpoint->get_webhook_delivery( $this->webhook->id, $mock_comment_id );
+
+		$this->assertHasAPIError( 'woocommerce_api_invalid_webhook_delivery_id', 400, $response );
+	}
+
+	/**
+	 * Get default arguments for creating/editing a webhook
+	 *
+	 * @since 2.2
+	 * @param array $args
+	 * @return array
+	 */
+	protected function get_defaults( $args = array() ) {
+
+		$defaults = array(
+			'name'         => rand_str(),
+			'topic'        => 'coupon.created',
+			'delivery_url' => 'http://example.org',
+		);
+
+		return array( 'webhook' => wp_parse_args( $args, $defaults ) );
+	}
+
+	/**
+	 * Ensure a valid response when creating a webhook
+	 * @since 2.2
+	 * @param $response
+	 */
+	protected function check_create_webhook_response( $response )  {
+
+		$this->assertNotWPError( $response );
+		$this->assertArrayHasKey( 'webhook', $response );
+
+		$this->check_get_webhook_response( $response['webhook'], new WC_Webhook( $response['webhook']['id'] ) );
+	}
+
+	/**
+	 * Ensure a valid response after editing a webhook
+	 *
+	 * @since 2.2
+	 * @param $response
+	 */
+	protected function check_edit_webhook_response( $response ) {
+
+		$this->assertNotWPError( $response );
+		$this->assertArrayHasKey( 'webhook', $response );
+
+		$this->check_get_webhook_response( $response['webhook'], new WC_Webhook( $response['webhook']['id'] ) );
+	}
+
+	/**
+	 * Ensure valid webhook data response
+	 *
+	 * @since 2.2
+	 * @param array $response
+	 * @param WC_Webhook $webhook
+	 */
+	protected function check_get_webhook_response( $response, $webhook ) {
+
+		$this->assertEquals( $webhook->id, $response['id'] );
+		$this->assertEquals( $webhook->get_name(), $response['name'] );
+		$this->assertEquals( $webhook->get_status() , $response['status'] );
+		$this->assertEquals( $webhook->get_topic(), $response['topic'] );
+		$this->assertEquals( $webhook->get_resource(), $response['resource'] );
+		$this->assertEquals( $webhook->get_event(), $response['event'] );
+		$this->assertEquals( $webhook->get_hooks(), $response['hooks'] );
+		$this->assertEquals( $webhook->get_delivery_url(), $response['delivery_url'] );
+		$this->assertArrayHasKey( 'created_at', $response );
+		$this->assertArrayHasKey( 'updated_at', $response );
+	}
+
+	/**
+	 * Ensure valid webhook delivery response
+	 *
+	 * @since 2.2
+	 * @param array $response
+	 * @param array $delivery
+	 */
+	protected function check_get_webhook_delivery_response( $response, $delivery ) {
+
+		// normalize data
+		unset( $response['created_at'] );
+		unset( $delivery['comment'] );
+
+		$this->assertEquals( $delivery, $response );
+	}
+
+}

--- a/tests/unit-tests/core-functions.php
+++ b/tests/unit-tests/core-functions.php
@@ -1,13 +1,27 @@
 <?php
 
-class WC_Tests_Core_Functions extends WP_UnitTestCase {
+/**
+ * Test WooCommerce core functions
+ *
+ * @since 2.2
+ */
+class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 
-
+	/**
+	 * Test get_woocommerce_currency()
+	 *
+	 * @since 2.2
+	 */
 	public function test_get_woocommerce_currency() {
 
 		$this->assertEquals( 'GBP', get_woocommerce_currency() );
 	}
 
+	/**
+	 * Test get_woocommerce_currencies()
+	 *
+	 * @since 2.2
+	 */
 	public function test_get_woocommerce_currencies() {
 
 		$expected_currencies = array(
@@ -33,7 +47,7 @@ class WC_Tests_Core_Functions extends WP_UnitTestCase {
 			'NPR' => __( 'Nepali Rupee', 'woocommerce' ),
 			'ILS' => __( 'Israeli Shekel', 'woocommerce' ),
 			'JPY' => __( 'Japanese Yen', 'woocommerce' ),
-			'KIP'	=> __( 'Lao Kip', 'woocommerce' ),
+			'KIP' => __( 'Lao Kip', 'woocommerce' ),
 			'KRW' => __( 'South Korean Won', 'woocommerce' ),
 			'MYR' => __( 'Malaysian Ringgits', 'woocommerce' ),
 			'MXN' => __( 'Mexican Peso', 'woocommerce' ),
@@ -61,29 +75,50 @@ class WC_Tests_Core_Functions extends WP_UnitTestCase {
 		$this->assertEquals( $expected_currencies, get_woocommerce_currencies() );
 	}
 
+	/**
+	 * Test get_woocommerce_currency_symbol()
+	 *
+	 * @since 2.2
+	 */
 	public function test_get_woocommerce_currency_symbol() {
 
+		// default currency
 		$this->assertEquals( '&pound;', get_woocommerce_currency_symbol() );
+
+		// given specific currency
 		$this->assertEquals( '&#36;', get_woocommerce_currency_symbol( 'USD' ) );
+
+		// each case
+		foreach ( array_keys( get_woocommerce_currencies() ) as $currency_code ) {
+			$this->assertInternalType( 'string', get_woocommerce_currency_symbol( $currency_code ) );
+		}
 	}
 
-	public function test_get_v2_woocommerce_api_url() {
+	/**
+	 * Test get_woocommerce_api_url()
+	 *
+	 * @since 2.2
+	 */
+	public function test_get_woocommerce_api_url() {
 
-		$this->assertEquals( 'http://example.org/wc-api/v2/', get_woocommerce_api_url( '' ) );
+		// base uri
+		$this->assertEquals( 'http://example.org/wc-api/v2/', get_woocommerce_api_url( null ) );
+
+		// path
+		$this->assertEquals( 'http://example.org/wc-api/v2/orders', get_woocommerce_api_url( 'orders' ) );
 	}
 
-	public function test_get_v1_woocommerce_api_url() {
-
-		define( 'WC_API_REQUEST_VERSION', 1 );
-
-		$this->assertEquals( 'http://example.org/wc-api/v1/', get_woocommerce_api_url( '' ) );
-	}
-
+	/**
+	 * Test wc_get_core_supported_themes()
+	 *
+	 * @since 2.2
+	 */
 	public function test_wc_get_core_supported_themes() {
 
 		$expected_themes = array( 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' );
 
 		$this->assertEquals( $expected_themes, wc_get_core_supported_themes() );
 	}
+
 }
 

--- a/tests/unit-tests/woocommerce.php
+++ b/tests/unit-tests/woocommerce.php
@@ -1,0 +1,89 @@
+<?php
+
+class WC_Tests_Core_Functions extends WP_UnitTestCase {
+
+
+	public function test_get_woocommerce_currency() {
+
+		$this->assertEquals( 'GBP', get_woocommerce_currency() );
+	}
+
+	public function test_get_woocommerce_currencies() {
+
+		$expected_currencies = array(
+			'AED' => __( 'United Arab Emirates Dirham', 'woocommerce' ),
+			'AUD' => __( 'Australian Dollars', 'woocommerce' ),
+			'BDT' => __( 'Bangladeshi Taka', 'woocommerce' ),
+			'BRL' => __( 'Brazilian Real', 'woocommerce' ),
+			'BGN' => __( 'Bulgarian Lev', 'woocommerce' ),
+			'CAD' => __( 'Canadian Dollars', 'woocommerce' ),
+			'CLP' => __( 'Chilean Peso', 'woocommerce' ),
+			'CNY' => __( 'Chinese Yuan', 'woocommerce' ),
+			'COP' => __( 'Colombian Peso', 'woocommerce' ),
+			'CZK' => __( 'Czech Koruna', 'woocommerce' ),
+			'DKK' => __( 'Danish Krone', 'woocommerce' ),
+			'DOP' => __( 'Dominican Peso', 'woocommerce' ),
+			'EUR' => __( 'Euros', 'woocommerce' ),
+			'HKD' => __( 'Hong Kong Dollar', 'woocommerce' ),
+			'HRK' => __( 'Croatia kuna', 'woocommerce' ),
+			'HUF' => __( 'Hungarian Forint', 'woocommerce' ),
+			'ISK' => __( 'Icelandic krona', 'woocommerce' ),
+			'IDR' => __( 'Indonesia Rupiah', 'woocommerce' ),
+			'INR' => __( 'Indian Rupee', 'woocommerce' ),
+			'NPR' => __( 'Nepali Rupee', 'woocommerce' ),
+			'ILS' => __( 'Israeli Shekel', 'woocommerce' ),
+			'JPY' => __( 'Japanese Yen', 'woocommerce' ),
+			'KIP'	=> __( 'Lao Kip', 'woocommerce' ),
+			'KRW' => __( 'South Korean Won', 'woocommerce' ),
+			'MYR' => __( 'Malaysian Ringgits', 'woocommerce' ),
+			'MXN' => __( 'Mexican Peso', 'woocommerce' ),
+			'NGN' => __( 'Nigerian Naira', 'woocommerce' ),
+			'NOK' => __( 'Norwegian Krone', 'woocommerce' ),
+			'NZD' => __( 'New Zealand Dollar', 'woocommerce' ),
+			'PYG' => __( 'Paraguayan Guaraní', 'woocommerce' ),
+			'PHP' => __( 'Philippine Pesos', 'woocommerce' ),
+			'PLN' => __( 'Polish Zloty', 'woocommerce' ),
+			'GBP' => __( 'Pounds Sterling', 'woocommerce' ),
+			'RON' => __( 'Romanian Leu', 'woocommerce' ),
+			'RUB' => __( 'Russian Ruble', 'woocommerce' ),
+			'SGD' => __( 'Singapore Dollar', 'woocommerce' ),
+			'ZAR' => __( 'South African rand', 'woocommerce' ),
+			'SEK' => __( 'Swedish Krona', 'woocommerce' ),
+			'CHF' => __( 'Swiss Franc', 'woocommerce' ),
+			'TWD' => __( 'Taiwan New Dollars', 'woocommerce' ),
+			'THB' => __( 'Thai Baht', 'woocommerce' ),
+			'TRY' => __( 'Turkish Lira', 'woocommerce' ),
+			'USD' => __( 'US Dollars', 'woocommerce' ),
+			'VND' => __( 'Vietnamese Dong', 'woocommerce' ),
+			'EGP' => __( 'Egyptian Pound', 'woocommerce' ),
+		);
+
+		$this->assertEquals( $expected_currencies, get_woocommerce_currencies() );
+	}
+
+	public function test_get_woocommerce_currency_symbol() {
+
+		$this->assertEquals( '&pound;', get_woocommerce_currency_symbol() );
+		$this->assertEquals( '&#36;', get_woocommerce_currency_symbol( 'USD' ) );
+	}
+
+	public function test_get_v2_woocommerce_api_url() {
+
+		$this->assertEquals( 'http://example.org/wc-api/v2/', get_woocommerce_api_url( '' ) );
+	}
+
+	public function test_get_v1_woocommerce_api_url() {
+
+		define( 'WC_API_REQUEST_VERSION', 1 );
+
+		$this->assertEquals( 'http://example.org/wc-api/v1/', get_woocommerce_api_url( '' ) );
+	}
+
+	public function test_wc_get_core_supported_themes() {
+
+		$expected_themes = array( 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' );
+
+		$this->assertEquals( $expected_themes, wc_get_core_supported_themes() );
+	}
+}
+

--- a/tests/unit-tests/woocommerce.php
+++ b/tests/unit-tests/woocommerce.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Test WooCommerce class
+ *
+ * @since 2.2
+ */
+class WC_Tests_WooCommerce extends WC_Unit_Test_Case {
+
+	/** @var \WooCommerce instance */
+	protected $wc;
+
+	/**
+	 * Setup test
+	 *
+	 * @since 2.2
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->wc = WC();
+	}
+
+	/**
+	 * Test WC has static instance
+	 *
+	 * @since 2.2
+	 */
+	public function test_wc_instance() {
+
+		$this->assertClassHasStaticAttribute( '_instance', 'WooCommerce' );
+	}
+
+	public function test_constructor() {
+
+	}
+
+	/**
+	 * Test that all WC constants are set
+	 *
+	 * @since 2.2
+	 */
+	public function test_constants() {
+
+		$this->assertEquals( str_replace( 'tests/unit-tests/', '', plugin_dir_path( __FILE__ ) ) . 'woocommerce.php', WC_PLUGIN_FILE );
+
+		$this->assertEquals( $this->wc->version, WC_VERSION );
+		$this->assertEquals( WC_VERSION, WOOCOMMERCE_VERSION );
+		$this->assertEquals( 4, WC_ROUNDING_PRECISION );
+		$this->assertContains( WC_TAX_ROUNDING_MODE, array ( 2, 1 ) );
+		$this->assertEquals( '|', WC_DELIMITER );
+		$this->assertEquals( dirname( ABSPATH ) . '/wc-logs/', WC_LOG_DIR );
+	}
+
+	/**
+	 * Test class instance
+	 *
+	 * @since 2.2
+	 */
+	public function test_wc_class_instances() {
+
+		$this->wc->init();
+
+		$this->assertInstanceOf( 'WC_Product_Factory', $this->wc->product_factory );
+		$this->assertInstanceOf( 'WC_Order_Factory', $this->wc->order_factory );
+		$this->assertInstanceOf( 'WC_Countries', $this->wc->countries );
+		$this->assertInstanceOf( 'WC_Session_Handler', $this->wc->session );
+		$this->assertInstanceOf( 'WC_Cart', $this->wc->cart );
+		$this->assertInstanceOf( 'WC_Customer', $this->wc->customer );
+	}
+}
+


### PR DESCRIPTION
These commits add a basic unit testing framework for WC using PHPUnit and the WP Unit Tests library, along with automated testing via travis-ci. I've added completed tests for the webhooks REST API endpoint as a reference implementation for other tests to follow. There's a basic readme with steps to install and run the tests [here](https://github.com/maxrice/woocommerce/blob/feature-3176-unit-tests/tests/README.md).

The phpunit.xml config is set to automatically generate an HTML test coverage report like:

![screen shot 2014-09-01 at 4 16 22 pm](https://cloud.githubusercontent.com/assets/1579862/4111902/6a77a9fa-3216-11e4-9923-3d97b14a7a9e.png)

Now we just need everyone to start writing tests :smile_cat: 

@mikejolley I don't have admin permissions for the WC repository so you'll need to log into travis-ci.org and connect the repository to have automated builds.

Closes #3176 
