### PR TITLE
Add `WC_Abstract_Order::is_editable()` method and `'wc_order_is_editable'` filter

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2391,6 +2391,6 @@ abstract class WC_Abstract_Order {
 	 * @return bool
 	 */
 	public function is_editable() {
-		return in_array( $order->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold', 'auto-draft' ) ) );
+		return apply_filters( 'wc_order_is_editable', in_array( $this->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold', 'auto-draft' ) ) ), $this );
 	}
 }

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2383,4 +2383,14 @@ abstract class WC_Abstract_Order {
 			}
 		}
 	}
+
+	/**
+	 * Checks if an order can be edited, specifically for use on the Edit Order screen
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function is_editable() {
+		return in_array( $order->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold', 'auto-draft' ) ) );
+	}
 }

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2391,6 +2391,9 @@ abstract class WC_Abstract_Order {
 	 * @return bool
 	 */
 	public function is_editable() {
-		return apply_filters( 'wc_order_is_editable', in_array( $this->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold', 'auto-draft' ) ) ), $this );
+		if ( ! isset( $this->editable ) ) {
+			$this->editable = in_array( $this->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold', 'auto-draft' ) ) );
+		}
+		return apply_filters( 'wc_order_is_editable', $this->editable, $this );
 	}
 }

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -14,7 +14,7 @@ $line_items_fee      = $order->get_items( 'fee' );
 $line_items_shipping = $order->get_items( 'shipping' );
 
 // Check if order can be edited
-$can_be_edited = in_array( $order->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold', 'auto-draft' ) ) );
+$can_be_edited = $order->is_editable();
 
 if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 	$order_taxes         = $order->get_taxes();

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1005,7 +1005,7 @@ class WC_AJAX {
 		}
 
 		$item          = apply_filters( 'woocommerce_ajax_order_item', $item, $item_id );
-		$can_be_edited = in_array( $order->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold' ) ) );
+		$can_be_edited = $order->is_editable();
 
 		include( 'admin/meta-boxes/views/html-order-item.php' );
 
@@ -1023,7 +1023,7 @@ class WC_AJAX {
 		$order_id      = absint( $_POST['order_id'] );
 		$order         = wc_get_order( $order_id );
 		$order_taxes   = $order->get_taxes();
-		$can_be_edited = in_array( $order->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold' ) ) );
+		$can_be_edited = $order->is_editable();
 		$item          = array();
 
 		// Add new fee
@@ -1053,7 +1053,7 @@ class WC_AJAX {
 		$order            = wc_get_order( $order_id );
 		$order_taxes      = $order->get_taxes();
 		$shipping_methods = WC()->shipping() ? WC()->shipping->load_shipping_methods() : array();
-		$can_be_edited    = in_array( $order->get_status(), apply_filters( 'wc_order_can_be_edited', array( 'pending', 'on-hold' ) ) );
+		$can_be_edited    = $order->is_editable();
 		$item             = array();
 
 		// Add new shipping


### PR DESCRIPTION
When choosing whether to allow an order's properties to be edited from the Edit Order screen, WooCommerce checks the order's status.

This patch:
1. adds an `is_editable()` method to the `WC_Abstract_Order` class. This allows child classes to use custom logic beyond just checking status to determine if an order can be edited. It also centralises the logic making it easier to trace and change both from the outside (i.e. using the filter) and from the inside (i.e. using a child class).
2. adds a new `'wc_order_is_editable'` filter which filters whether an order can be edited or not (rather than just an array of statuses which can be edited as done with `'wc_order_can_be_edited'`). This provides more flexibility to extensions that may want to use other attributes of an order to determine if it can be edited or not. It is also called whenever the method is called rather than just when the `$editable` property is set to allow for different values in different contexts (e.g. allow editing in the `html-order-item.php` template but not the `html-order-shipping.php` template, at least, that would be the case if the `$can_be_edited` variable is replaced with calls to `$order->is_editable()` - see suggestion below)
3. passes the `WC_Abstract_Order` object to the `'wc_order_is_editable'` filter to provide easy access to the values of the order to which the filter relates, rather than requiring use of `global $post_id` or `$_POST['order_id']` as is required with the current `'wc_order_can_be_edited'` filter.

The change could go a couple of steps further too.
1. the `$can_be_edited` variable is pretty much redundant now as it could be replaced with calls to `$order->is_editable()`.
2. the `'wc_order_can_be_edited'` filter is pretty much redundant so it can probably be removed in favour of `'wc_order_is_editable'`, but I wanted to propose a patch that didn't break anything and leave the decision to break things up to you guys. :)
