### PR TITLE
Makepot now Supports PoEdit Header

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,6 +124,7 @@ module.exports = function( grunt ) {
 				type: 'wp-plugin',
 				domainPath: 'i18n/languages',
 				potHeaders: {
+					poedit: true,
 					'report-msgid-bugs-to': 'https://github.com/woothemes/woocommerce/issues',
 					'language-team': 'LANGUAGE <EMAIL@ADDRESS>'
 				}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,6 @@ module.exports = function( grunt ) {
 				type: 'wp-plugin',
 				domainPath: 'i18n/languages',
 				potHeaders: {
-					poedit: true,
 					'report-msgid-bugs-to': 'https://github.com/woothemes/woocommerce/issues',
 					'language-team': 'LANGUAGE <EMAIL@ADDRESS>'
 				}

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   "main": "Gruntfile.js",
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-uglify": "~0.5.1",
-    "grunt-contrib-less": "~0.11.4",
-    "grunt-contrib-cssmin": "~0.10.0",
-    "grunt-shell": "~0.7.0",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-clean": "~0.6.0",
     "grunt-checktextdomain": "^0.1.1",
-    "grunt-wp-i18n": "^0.4.7",
-    "grunt-contrib-jshint": "^0.10.0"
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-less": "~0.11.4",
+    "grunt-contrib-uglify": "~0.5.1",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-shell": "^1.1.1",
+    "grunt-wp-i18n": "^0.4.8"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
**Hip Hip Hurray! for WooCommerce and PoEdit**
- Added Support for PoEdit Headers and Updated Npm `devDepedencies`

``` js
{
    'language': 'en',
    'plural-forms': 'nplurals=2; plural=(n != 1);',
    'x-poedit-country': 'United States',
    'x-poedit-sourcecharset': 'UTF-8',
    'x-poedit-keywordslist': '__;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;_n_noop:1,2;_c;_nc:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;',
    'x-poedit-basepath': '../',
    'x-poedit-searchpath-0': '.',
    'x-poedit-bookmarks': '',
    'x-textdomain-support': 'yes'
}
```
