### PR TITLE
Password protected posts are not hidden from catalog by default anymore, visibility can be set via the 'Catalog visibility' option.

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -240,8 +240,6 @@ class WC_Query {
 		    add_filter( 'wp', array( $this, 'remove_posts_where' ) );
 		}
 
-		add_filter( 'posts_where', array( $this, 'exclude_protected_products' ) );
-
 		// We're on a shop page so queue the woocommerce_get_products_in_view function
 		add_action( 'wp', array( $this, 'get_products_in_view' ), 2);
 
@@ -268,18 +266,6 @@ class WC_Query {
 		    "post_title LIKE $1) OR (post_excerpt LIKE $1", $where );
 
 		return $where;
-	}
-
-	/**
-	 * Prevent password protected products appearing in the loops
-	 *
-	 * @param  string $where
-	 * @return string
-	 */
-	public function exclude_protected_products( $where ) {
-		global $wpdb;
-		$where .= " AND {$wpdb->posts}.post_password = ''";
-    	return $where;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Tweak - Load archive-product.php for other product taxonomies.
 * Tweak - Disable image size settings if filters are being used.
 * Tweak - Hide the shipping address when local pickup is used.
+* Tweak - Password protected posts are not hidden from catalog by default anymore, visibility can be set via the 'Catalog visibility' option.
 * Dev - API Version 2 with push support.
 * Dev - API: Lookup customers by email endpoint.
 * Dev - API: Allow ordering on the resource level.


### PR DESCRIPTION
Password protected posts are not hidden from catalog by default anymore, visibility can be set via the 'Catalog visibility' option.

Fixes #6168
