### PR TITLE
Variations UI improvements for out-of-stock variations + "greying out" ability for variation attributes.

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -243,7 +243,10 @@
 
 					current_attr_select.find( 'option:gt(0)' ).remove();
 					current_attr_select.append( current_attr_select.data( 'attribute_options' ) );
-					current_attr_select.find( 'option:gt(0)' ).removeClass( 'active' );
+					current_attr_select.find( 'option:gt(0)' ).removeClass( 'attached' );
+
+					current_attr_select.find( 'option:gt(0)' ).removeClass( 'enabled' );
+					current_attr_select.find( 'option:gt(0)' ).removeAttr( 'disabled' );
 
 					// Get name
 					var current_attr_name = current_attr_select.attr( 'name' );
@@ -256,10 +259,17 @@
 							var attributes = variations[ num ].attributes;
 
 							for ( var attr_name in attributes ) {
+
 								if ( attributes.hasOwnProperty( attr_name ) ) {
+
 									var attr_val = attributes[ attr_name ];
 
 									if ( attr_name == current_attr_name ) {
+
+										if ( variations[ num ].variation_is_active )
+											variation_active = 'enabled';
+										else
+											variation_active = '';
 
 										if ( attr_val ) {
 
@@ -271,11 +281,11 @@
 											attr_val = attr_val.replace( /"/g, "\\\"" );
 
 											// Compare the meerkat
-											current_attr_select.find( 'option[value="' + attr_val + '"]' ).addClass( 'active' );
+											current_attr_select.find( 'option[value="' + attr_val + '"]' ).addClass( 'attached ' + variation_active );
 
 										} else {
 
-											current_attr_select.find( 'option:gt(0)' ).addClass( 'active' );
+											current_attr_select.find( 'option:gt(0)' ).addClass( 'attached ' + variation_active );
 
 										}
 									}
@@ -284,8 +294,11 @@
 						}
 					}
 
-					// Detach inactive
-					current_attr_select.find( 'option:gt(0):not(.active)' ).remove();
+					// Detach unattached
+					current_attr_select.find( 'option:gt(0):not(.attached)' ).remove();
+
+					// Grey out disabled
+					current_attr_select.find( 'option:gt(0):not(.enabled)' ).attr( 'disabled', 'disabled' );
 
 				});
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -429,10 +429,16 @@ class WC_Product_Variable extends WC_Product {
 
 			$variation = $this->get_child( $child_id );
 
+			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked
 			if ( empty( $variation->variation_id ) || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
 				continue;
 			}
-				
+
+			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price)
+			if ( apply_filters( 'woocommerce_hide_invisible_variations', false, $this->id ) && ! $variation->variation_is_visible() ) {
+				continue;
+			}
+
 			$variation_attributes = $variation->get_variation_attributes();
 			$availability         = $variation->get_availability();
 			$availability_html    = empty( $availability['availability'] ) ? '' : '<p class="stock ' . esc_attr( $availability['class'] ) . '">' . wp_kses_post( $availability['availability'] ) . '</p>';
@@ -456,6 +462,7 @@ class WC_Product_Variable extends WC_Product {
 			$available_variations[] = apply_filters( 'woocommerce_available_variation', array(
 				'variation_id'         => $child_id,
 				'variation_is_visible' => $variation->variation_is_visible(),
+				'variation_is_active'  => $variation->variation_is_active(),
 				'is_purchasable'       => $variation->is_purchasable(),
 				'attributes'           => $variation_attributes,
 				'image_src'            => $image,
@@ -519,7 +526,7 @@ class WC_Product_Variable extends WC_Product {
 		) );
 
 		$stock_status = 'outofstock';
-		
+
 		foreach ( $children as $child_id ) {
 			$child_stock_status = get_post_meta( $child_id, '_stock_status', true );
 			$child_stock_status = $child_stock_status ? $child_stock_status : 'instock';
@@ -616,7 +623,7 @@ class WC_Product_Variable extends WC_Product {
 			// The VARIABLE PRODUCT price should equal the min price of any type
 			update_post_meta( $product_id, '_price', $min_price );
 			delete_transient( 'wc_products_onsale' );
-			
+
 			do_action( 'woocommerce_variable_product_sync', $product_id, $children );
 		}
 	}

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -212,11 +212,6 @@ class WC_Product_Variation extends WC_Product {
 			$visible = false;
 		}
 
-		// Out of stock visibility
-		elseif ( get_option('woocommerce_hide_out_of_stock_items') == 'yes' && ! $this->is_in_stock() ) {
-			$visible = false;
-		}
-
 		// Price not set
 		elseif ( $this->get_price() === "" ) {
 			$visible = false;

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -188,7 +188,7 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
-	 * Get the add to cart button text
+	 * Get the add to cart button text.
 	 *
 	 * @access public
 	 * @return string
@@ -200,7 +200,9 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
-	 * Checks if this particular variation is visible (variations with no price, or out of stock, can be hidden)
+	 * Checks if this particular variation is visible. Invisible variations are enabled and can be selected, but no price / stock info is displayed.
+	 * Instead, a suitable 'unavailable' message is displayed.
+	 * Invisible by default: Disabled variations and variations with an empty price.
 	 *
 	 * @return bool
 	 */
@@ -221,7 +223,19 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
+	 * Controls whether this particular variation will appear greyed-out (inactive) or not (active).
+	 * Used by extensions to make incompatible variations appear greyed-out, etc.
+	 * Other possible uses: prevent out-of-stock variations from being selected.
+	 *
+	 * @return bool
+	 */
+	public function variation_is_active() {
+		return apply_filters( 'woocommerce_variation_is_active', true, $this->variation_id, $this->id );
+	}
+
+	/**
 	 * Returns false if the product cannot be bought.
+	 * Override abstract method so that: i) Disabled variations are not be purchasable by admins. ii) Enabled variations are not purchasable if the parent product is not purchasable.
 	 *
 	 * @access public
 	 * @return bool


### PR DESCRIPTION
1) Handling of out-of-stock variations.

As @jameskoster pointed out in #5661 if the 'Hide out of stock products' option is enabled and a variation is out of stock, the variation should be hidden. This works correctly already.

However, if the 'Hide out of stock products' option is not enabled, out-of-stock variations should be selectable, in order to view variation information such as price. Currently, this doesn't work correctly, because `variation_is_visible()` returns false when a variation is out-of-stock. This results in a i18n_unavailable_text message without any further info shown. 

This fix allows out-of-stock variations to be selected and displayed with a regular 'out-of-stock' availability status.

2) Handling of "non-visible" variations.

After fixing (1) the i18n_unavailable_text message is shown _only_ when a variation is disabled, or when it has an empty price.

It should be possible to modify this default behaviour and hide disabled variations and variations with an empty price completely. Here, a filter is proposed (`woocommerce_hide_invisible_variations`) which can be used to prevent such variations from being added to the `available_variations` array, in the same way that out-of-stock variations are left out when 'Hide out of stock products' is enabled.

3) Ability to grey-out attributes for certain variations.

In some cases it might be desirable to optionally "grey-out" certain variation attributes. Some people may want to use this in order to "grey-out" out-of-stock variations. This can have more applications - such as filtering-out variations based on compatibility (Composite Products).

Here, `variation_is_active` is introduced to control the "greying-out" behaviour of the variations script. The method output can be filtered to grey-out "out-of-stock" variations etc.

4) Future work.

Refactor the variations script and possibly include the ability to add context-sensitive information into variation attribute options, such as stock information, pricing info, etc.
