### PR TITLE
fix to send billing address when send shipping details is unchecked

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -354,8 +354,6 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			$paypal_args['state']			= $this->get_paypal_state( $order->shipping_country, $order->shipping_state );
 			$paypal_args['country']			= $order->shipping_country;
 			$paypal_args['zip']				= $order->shipping_postcode;
-		} else {
-			$paypal_args['no_shipping'] = 1;
 		}
 
 		// Try to send line items, or default to sending the order as a whole


### PR DESCRIPTION
Currently this option here http://cld.wthms.co/ifnw is suppose to be a toggle between either sending the billing address to PayPal by default or when checked, will send the shipping address to PayPal instead as described in the description.  However it is not working due to the else clause.  This patch removes the else clause allowing the billing to be sent by default.

Before the patch -> http://cld.wthms.co/Lmb9

After the patch -> http://cld.wthms.co/byUb
