### PR TITLE
Update class-wc-post-types.php

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -156,6 +156,9 @@ class WC_Post_types {
 		$wc_product_attributes = array();
 
 		if ( $attribute_taxonomies = wc_get_attribute_taxonomies() ) {
+			
+			/* This for each slows Woocommerce down because of making all taxonomys. I've got a webshop with 33,000 products and a lot of attributes, with a server load time of 6 seconds. I've recodes this area to only make taxonomys when needed. Like when viewing the Attribute page or a category. */
+			
 			foreach ( $attribute_taxonomies as $tax ) {
 				if ( $name = wc_attribute_taxonomy_name( $tax->attribute_name ) ) {
 


### PR DESCRIPTION
This for each slows Woocommerce down because of making all taxonomys. I've got a webshop with 33,000 products and thousands of attributes, with a server load time of 6 seconds. I've recodes this area to only load taxonomys when needed. Like when viewing the Attribute page or a category. Woocommerce is perfect for webshops, only bug is this thing. http://koophetzelf.nl. 

My code ain't good at the moment, but it works better than the existing one.

Problems: validating when the taxonomy needs to be created and how to info goes to the post types creation.

![schermafbeelding 2014-09-10 om 23 29 18](https://cloud.githubusercontent.com/assets/5340923/4225826/918884ca-3931-11e4-9d07-d917320753ff.png)
