### PR TITLE
Fixing typo with get_error_message being referenced as a property

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -259,7 +259,7 @@ class WC_Shortcode_My_Account {
 
 		} elseif ( is_wp_error( $allow ) ) {
 
-			wc_add_notice( $allow->get_error_message, 'error' );
+			wc_add_notice( $allow->get_error_message(), 'error' );
 
 			return false;
 		}


### PR DESCRIPTION
In class-wc-shortcode-my-account.php, the get_error_message method is being called as a property. This PR adds the two parentheses to call it as a method.
