### PR TITLE
Added Nepal States (districts)

### DIFF
--- a/i18n/states/NP.php
+++ b/i18n/states/NP.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Nepal states (Districts)
+ *
+ * @author      WooThemes
+ * @category    i18n
+ * @package     WooCommerce/i18n
+ * @version     2.2.3
+ */
+global $states;
+
+$states['NP'] = array(
+
+	// Mechi
+	'ILL' => __( 'Illam', 'woocommerce' ),
+	'JHA' => __( 'Jhapa', 'woocommerce' ),
+	'PAN' => __( 'Panchthar', 'woocommerce' ),
+	'TAP' => __( 'Taplejung', 'woocommerce' ),
+
+	// Koshi
+	'BHO' => __( 'Bhojpur', 'woocommerce' ),
+	'DKA' => __( 'Dhankuta', 'woocommerce' ),
+	'MOR' => __( 'Morang', 'woocommerce' ),
+	'SUN' => __( 'Sunsari', 'woocommerce' ),
+	'SAN' => __( 'Sankhuwa', 'woocommerce' ),
+	'TER' => __( 'Terhathum', 'woocommerce' ),
+
+	// Sagarmatha
+	'KHO' => __( 'Khotang', 'woocommerce' ),
+	'OKH' => __( 'Okhaldhunga', 'woocommerce' ),
+	'SAP' => __( 'Saptari', 'woocommerce' ),
+	'SIR' => __( 'Siraha', 'woocommerce' ),
+	'SOL' => __( 'Solukhumbu', 'woocommerce' ),
+	'UDA' => __( 'Udayapur', 'woocommerce' ),
+
+	// Janakpur
+	'DHA' => __( 'Dhanusa', 'woocommerce' ),
+	'DLK' => __( 'Dolakha', 'woocommerce' ),
+	'MOH' => __( 'Mohottari', 'woocommerce' ),
+	'RAM' => __( 'Ramechha', 'woocommerce' ),
+	'SAR' => __( 'Sarlahi', 'woocommerce' ),
+	'SIN' => __( 'Sindhuli', 'woocommerce' ),
+
+	// Bagmati
+	'BHA' => __( 'Bhaktapur', 'woocommerce' ),
+	'DHD' => __( 'Dhading', 'woocommerce' ),
+	'KTM' => __( 'Kathmandu', 'woocommerce' ),
+	'KAV' => __( 'Kavrepalanchowk', 'woocommerce' ),
+	'LAL' => __( 'Lalitpur', 'woocommerce' ),
+	'NUW' => __( 'Nuwakot', 'woocommerce' ),
+	'RAS' => __( 'Rasuwa', 'woocommerce' ),
+	'SPC' => __( 'Sindhupalchowk', 'woocommerce' ),
+
+	// Narayani
+	'BAR' => __( 'Bara', 'woocommerce' ),
+	'CHI' => __( 'Chitwan', 'woocommerce' ),
+	'MAK' => __( 'Makwanpur', 'woocommerce' ),
+	'PAR' => __( 'Parsa', 'woocommerce' ),
+	'RAU' => __( 'Rautahat', 'woocommerce' ),
+
+	// Gandaki
+	'GOR' => __( 'Gorkha', 'woocommerce' ),
+	'KAS' => __( 'Kaski', 'woocommerce' ),
+	'LAM' => __( 'Lamjung', 'woocommerce' ),
+	'MAN' => __( 'Manang', 'woocommerce' ),
+	'SYN' => __( 'Syangja', 'woocommerce' ),
+	'TAN' => __( 'Tanahun', 'woocommerce' ),
+
+	// Dhawalagiri
+	'BAG' => __( 'Baglung', 'woocommerce' ),
+	'PBT' => __( 'Parbat', 'woocommerce' ),
+	'MUS' => __( 'Mustang', 'woocommerce' ),
+	'MYG' => __( 'Myagdi', 'woocommerce' ),
+
+	// Lumbini
+	'AGR' => __( 'Agrghakanchi', 'woocommerce' ),
+	'GUL' => __( 'Gulmi', 'woocommerce' ),
+	'KAP' => __( 'Kapilbastu', 'woocommerce' ),
+	'NAW' => __( 'Nawalparasi', 'woocommerce' ),
+	'PAL' => __( 'Palpa', 'woocommerce' ),
+	'RUP' => __( 'Rupandehi', 'woocommerce' ),
+
+	// Rapti
+	'DAN' => __( 'Dang', 'woocommerce' ),
+	'PYU' => __( 'Pyuthan', 'woocommerce' ),
+	'ROL' => __( 'Rolpa', 'woocommerce' ),
+	'RUK' => __( 'Rukum', 'woocommerce' ),
+	'SAL' => __( 'Salyan', 'woocommerce' ),
+
+	// Bheri
+	'BAN' => __( 'Banke', 'woocommerce' ),
+	'BDA' => __( 'Bardiya', 'woocommerce' ),
+	'DAI' => __( 'Dailekh', 'woocommerce' ),
+	'JAJ' => __( 'Jajarkot', 'woocommerce' ),
+	'SUR' => __( 'Surkhet', 'woocommerce' ),
+
+	// Karnali
+	'DOL' => __( 'Dolpa', 'woocommerce' ),
+	'HUM' => __( 'Humla', 'woocommerce' ),
+	'JUM' => __( 'Jumla', 'woocommerce' ),
+	'KAL' => __( 'Kalikot', 'woocommerce' ),
+	'MUG' => __( 'Mugu', 'woocommerce' ),
+
+	// Seti
+	'ACH' => __( 'Achham', 'woocommerce' ),
+	'BJH' => __( 'Bajhang', 'woocommerce' ),
+	'BJU' => __( 'Bajura', 'woocommerce' ),
+	'DOT' => __( 'Doti', 'woocommerce' ),
+	'KAI' => __( 'Kailali', 'woocommerce' ),
+
+	// Mahakali
+	'BAI' => __( 'Baitadi', 'woocommerce' ),
+	'DAD' => __( 'Dadeldhura', 'woocommerce' ),
+	'DAR' => __( 'Darchula', 'woocommerce' ),
+	'KAN' => __( 'Kanchanpur', 'woocommerce' )
+);


### PR DESCRIPTION
Nepal has 75 districts and being a Nepali citizen I have fulfill my responsibility for Adding all of them for WooCommerce. Since they are necessary for Local eCommerce in Nepal.

Be Noted that all Inline comments inside array of `$states['NP']` are the zone name for easier. In Nepal there are 14 zones where 75 districts are located.
