### PR TITLE
Allow getting rating count for a specific rating value

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -975,20 +975,20 @@ class WC_Product {
 	/**
 	 * get_rating_count function.
 	 *
-	 * @param  int $rating Optional. Rating number to get the count for. By default
-	 *                               returns the count for all ratings.
+	 * @param  int $value Optional. Rating value to get the count for. By default
+	 *                              returns the count of all rating values.
 	 * @return int
 	 */
-	public function get_rating_count( $rating = null ) {
+	public function get_rating_count( $value = null ) {
 
-		$rating = intval( $rating );
-		$rating_suffix = $rating ? '_' . $rating : '';
+		$value = intval( $value );
+		$value_suffix = $value ? '_' . $value : '';
 
-		if ( false === ( $count = get_transient( 'wc_rating_count_' . $this->id . $rating_suffix ) ) ) {
+		if ( false === ( $count = get_transient( 'wc_rating_count_' . $this->id . $value_suffix ) ) ) {
 
 			global $wpdb;
 
-			$where_meta_value = $rating ? $wpdb->prepare( " AND meta_value = %d", $rating ) : " AND meta_value > 0";
+			$where_meta_value = $value ? $wpdb->prepare( " AND meta_value = %d", $value ) : " AND meta_value > 0";
 
 			$count = $wpdb->get_var( $wpdb->prepare("
 				SELECT COUNT(meta_value) FROM $wpdb->commentmeta
@@ -998,7 +998,7 @@ class WC_Product {
 				AND comment_approved = '1'
 			", $this->id ) . $where_meta_value );
 
-			set_transient( 'wc_rating_count_' . $this->id . $rating_suffix, $count, YEAR_IN_SECONDS );
+			set_transient( 'wc_rating_count_' . $this->id . $value_suffix, $count, YEAR_IN_SECONDS );
 		}
 
 		return $count;

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -975,13 +975,20 @@ class WC_Product {
 	/**
 	 * get_rating_count function.
 	 *
+	 * @param  int $rating Optional. Rating number to get the count for. By default
+	 *                               returns the count for all ratings.
 	 * @return int
 	 */
-	public function get_rating_count() {
+	public function get_rating_count( $rating = null ) {
 
-		if ( false === ( $count = get_transient( 'wc_rating_count_' . $this->id ) ) ) {
+		$rating = intval( $rating );
+		$rating_suffix = $rating ? '_' . $rating : '';
+
+		if ( false === ( $count = get_transient( 'wc_rating_count_' . $this->id . $rating_suffix ) ) ) {
 
 			global $wpdb;
+
+			$where_meta_value = $rating ? $wpdb->prepare( " AND meta_value = %d", $rating ) : " AND meta_value > 0";
 
 			$count = $wpdb->get_var( $wpdb->prepare("
 				SELECT COUNT(meta_value) FROM $wpdb->commentmeta
@@ -989,10 +996,9 @@ class WC_Product {
 				WHERE meta_key = 'rating'
 				AND comment_post_ID = %d
 				AND comment_approved = '1'
-				AND meta_value > 0
-			", $this->id ) );
+			", $this->id ) . $where_meta_value );
 
-			set_transient( 'wc_rating_count_' . $this->id, $count, YEAR_IN_SECONDS );
+			set_transient( 'wc_rating_count_' . $this->id . $rating_suffix, $count, YEAR_IN_SECONDS );
 		}
 
 		return $count;

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -211,8 +211,14 @@ class WC_Comments {
 	 * @param mixed $post_id
 	 */
 	public static function clear_transients( $post_id ) {
-		delete_transient( 'wc_average_rating_' . absint( $post_id ) );
-		delete_transient( 'wc_rating_count_' . absint( $post_id ) );
+		$post_id = absint( $post_id );
+		delete_transient( 'wc_average_rating_' . $post_id );
+		delete_transient( 'wc_rating_count_' . $post_id );
+		delete_transient( 'wc_rating_count_' . $post_id . '_1' );
+		delete_transient( 'wc_rating_count_' . $post_id . '_2' );
+		delete_transient( 'wc_rating_count_' . $post_id . '_3' );
+		delete_transient( 'wc_rating_count_' . $post_id . '_4' );
+		delete_transient( 'wc_rating_count_' . $post_id . '_5' );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds an optional param to the `get_rating_count` method of `WC_Product` class. This allows getting the rating count for a specific rating number. Useful if you want to determine how the review ratings break down - how many n-star reviews a product has gotten etc.

Completely backwards-compatible, since it's only adding an optional param.

``` php
$product->get_rating_count( 2 ); // Will return the number of 2-star ratings on this product
```
