### PR TITLE
Various filters and minor tweaks to order metaboxes

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -170,7 +170,7 @@ class WC_Meta_Box_Order_Data {
 								echo ' (' . esc_html( $transaction_id ) . ')';
 							}
 						}
-						echo '. ';
+						echo '. ' ;
 					}
 
 					if ( $ip_address = get_post_meta( $post->ID, '_customer_ip_address', true ) ) {
@@ -239,7 +239,7 @@ class WC_Meta_Box_Order_Data {
 
 							// Display form
 							echo '<div class="edit_address"><p><button class="button load_customer_billing">' . __( 'Load billing address', 'woocommerce' ) . '</button></p>';
-
+ 
 							foreach ( self::$billing_fields as $key => $field ) {
 								if ( ! isset( $field['type'] ) ) {
 									$field['type'] = 'text';
@@ -247,10 +247,12 @@ class WC_Meta_Box_Order_Data {
 
 								switch ( $field['type'] ) {
 									case 'select' :
-										woocommerce_wp_select( array( 'id' => '_billing_' . $key, 'label' => $field['label'], 'options' => $field['options'] ) );
+										// allow for setting a default value programaticaly, and draw the selectbox
+										woocommerce_wp_select( array( 'id' => '_billing_' . $key, 'label' => $field['label'], 'options' => $field['options'], 'value' => isset( $field['value'] ) ? $field['value'] : '' ) );
 									break;
 									default :
-										woocommerce_wp_text_input( array( 'id' => '_billing_' . $key, 'label' => $field['label'] ) );
+										// allow for setting a default value programaticaly, and draw the textbox
+										woocommerce_wp_text_input( array( 'id' => '_billing_' . $key, 'label' => $field['label'], 'value' => isset( $field['value'] ) ? $field['value'] : '' ) );
 									break;
 								}
 							}
@@ -277,12 +279,15 @@ class WC_Meta_Box_Order_Data {
 										} else {
 											echo '<option value="other">' . __( 'Other', 'woocommerce' ) . '</option>';
 										}
-									?>
+									?> 
 								</select>
 							</p>
 							<?php
 
 							woocommerce_wp_text_input( array( 'id' => '_transaction_id', 'label' => __( 'Transaction ID', 'woocommerce' ) ) );
+
+							// allow other plugins to add their own extra billing fields at the bottom of the field list
+							do_action( 'woocommerce_admin_order_data_billing_address_fields', $order );
 
 							echo '</div>';
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -170,7 +170,7 @@ class WC_Meta_Box_Order_Data {
 								echo ' (' . esc_html( $transaction_id ) . ')';
 							}
 						}
-						echo '. ' ;
+						echo '. ';
 					}
 
 					if ( $ip_address = get_post_meta( $post->ID, '_customer_ip_address', true ) ) {
@@ -239,7 +239,6 @@ class WC_Meta_Box_Order_Data {
 
 							// Display form
 							echo '<div class="edit_address"><p><button class="button load_customer_billing">' . __( 'Load billing address', 'woocommerce' ) . '</button></p>';
- 
 							foreach ( self::$billing_fields as $key => $field ) {
 								if ( ! isset( $field['type'] ) ) {
 									$field['type'] = 'text';
@@ -279,7 +278,7 @@ class WC_Meta_Box_Order_Data {
 										} else {
 											echo '<option value="other">' . __( 'Other', 'woocommerce' ) . '</option>';
 										}
-									?> 
+									?>
 								</select>
 							</p>
 							<?php

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -239,6 +239,7 @@ class WC_Meta_Box_Order_Data {
 
 							// Display form
 							echo '<div class="edit_address"><p><button class="button load_customer_billing">' . __( 'Load billing address', 'woocommerce' ) . '</button></p>';
+
 							foreach ( self::$billing_fields as $key => $field ) {
 								if ( ! isset( $field['type'] ) ) {
 									$field['type'] = 'text';

--- a/includes/admin/meta-boxes/views/html-order-fee.php
+++ b/includes/admin/meta-boxes/views/html-order-fee.php
@@ -75,7 +75,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		endif;
 	?>
 
-	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /* add columns at the end of the values list */ ?>
 
 	<td class="wc-order-edit-line-item">
 		<?php if ( $order->is_editable() ) : ?>

--- a/includes/admin/meta-boxes/views/html-order-fee.php
+++ b/includes/admin/meta-boxes/views/html-order-fee.php
@@ -75,6 +75,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		endif;
 	?>
 
+	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+
 	<td class="wc-order-edit-line-item">
 		<?php if ( $order->is_editable() ) : ?>
 			<div class="wc-order-edit-line-item-actions">

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -48,7 +48,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php do_action('woocommerce_before_order_itemmeta', $item_id, $item, $_product) ?>
 
 		<div class="view">
-			<?php do_action('woocommerce_before_view_order_itemmeta', $item_id, $item, $_product) /*@@@@LOUSHOU - filter for customizing meta */ ?>
+			<?php do_action('woocommerce_before_view_order_itemmeta', $item_id, $item, $_product) /* filter for customizing meta */ ?>
 			<?php
 				global $wpdb;
 
@@ -98,10 +98,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 					echo '</table>';
 				}
 			?>
-			<?php do_action('woocommerce_after_view_order_itemmeta', $item_id, $item, $_product) /*@@@@LOUSHOU - filter for customizing meta */ ?>
+			<?php do_action('woocommerce_after_view_order_itemmeta', $item_id, $item, $_product) /* filter for customizing meta */ ?>
 		</div>
 		<div class="edit" style="display: none;">
-			<?php do_action('woocommerce_before_edit_order_itemmeta', $item_id, $item, $_product, $order) /*@@@@LOUSHOU - filter for customizing meta */ ?>
+			<?php do_action('woocommerce_before_edit_order_itemmeta', $item_id, $item, $_product, $order) /* filter for customizing meta */ ?>
 			<table class="meta" cellspacing="0">
 				<tbody class="meta_items">
 				<?php
@@ -148,7 +148,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</tr>
 				</tfoot>
 			</table>
-			<?php do_action('woocommerce_after_edit_order_itemmeta', $item_id, $item, $_product, $order) /*@@@@LOUSHOU - filter for customizing meta */ ?>
+			<?php do_action('woocommerce_after_edit_order_itemmeta', $item_id, $item, $_product, $order) /* filter for customizing meta */ ?>
 		</div>
 	</td>
 
@@ -250,7 +250,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		endif;
 	?>
 
-	<?php do_action( 'woocommerce_admin_after_order_item_values', $_product, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+	<?php do_action( 'woocommerce_admin_after_order_item_values', $_product, $item, absint( $item_id ) ); /* add columns at the end of the values list */ ?>
 
 	<td class="wc-order-edit-line-item">
 		<?php if ( $order->is_editable() ) : ?>

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -45,7 +45,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="hidden" class="order_item_id" name="order_item_id[]" value="<?php echo esc_attr( $item_id ); ?>" />
 		<input type="hidden" name="order_item_tax_class[<?php echo absint( $item_id ); ?>]" value="<?php echo isset( $item['tax_class'] ) ? esc_attr( $item['tax_class'] ) : ''; ?>" />
 
+		<?php do_action('woocommerce_before_order_itemmeta', $item_id, $item, $_product) ?>
+
 		<div class="view">
+			<?php do_action('woocommerce_before_view_order_itemmeta', $item_id, $item, $_product) /*@@@@LOUSHOU - filter for customizing meta */ ?>
 			<?php
 				global $wpdb;
 
@@ -95,8 +98,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 					echo '</table>';
 				}
 			?>
+			<?php do_action('woocommerce_after_view_order_itemmeta', $item_id, $item, $_product) /*@@@@LOUSHOU - filter for customizing meta */ ?>
 		</div>
 		<div class="edit" style="display: none;">
+			<?php do_action('woocommerce_before_edit_order_itemmeta', $item_id, $item, $_product, $order) /*@@@@LOUSHOU - filter for customizing meta */ ?>
 			<table class="meta" cellspacing="0">
 				<tbody class="meta_items">
 				<?php
@@ -143,6 +148,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</tr>
 				</tfoot>
 			</table>
+			<?php do_action('woocommerce_after_edit_order_itemmeta', $item_id, $item, $_product, $order) /*@@@@LOUSHOU - filter for customizing meta */ ?>
 		</div>
 	</td>
 
@@ -243,6 +249,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			endforeach;
 		endif;
 	?>
+
+	<?php do_action( 'woocommerce_admin_after_order_item_values', $_product, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
 
 	<td class="wc-order-edit-line-item">
 		<?php if ( $order->is_editable() ) : ?>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -235,9 +235,8 @@ if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 	<button type="button" class="button cancel-action"><?php _e( 'Cancel', 'woocommerce' ); ?></button>
 	<button type="button" class="button button-primary save-action"><?php _e( 'Save', 'woocommerce' ); ?></button>
 	<?php
-		//@@@@LOUSHOU - allow adding custom buttons
-		$data = get_post_meta( $order->id );
-		do_action('woocommerce_order_item_add_line_buttons', $order, $data, $line_items);
+		// allow adding custom buttons
+		do_action('woocommerce_order_item_add_line_buttons', $order, $line_items);
 	?>
 </div>
 <?php if ( ( $order->get_total() - $order->get_total_refunded() ) > 0 ) : ?>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -74,7 +74,7 @@ if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 					endif;
 				?>
 
-				<?php do_action( 'woocommerce_admin_after_order_item_headers' ); /*@@@@LOUSHOU - allow addition of columns to the end of the list */ ?>
+				<?php do_action( 'woocommerce_admin_after_order_item_headers' ); /* allow addition of columns to the end of the list */ ?>
 				<th class="wc-order-edit-line-item" width="1%">&nbsp;</th>
 			</tr>
 		</thead>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -74,6 +74,7 @@ if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 					endif;
 				?>
 
+				<?php do_action( 'woocommerce_admin_after_order_item_headers' ); /*@@@@LOUSHOU - allow addition of columns to the end of the list */ ?>
 				<th class="wc-order-edit-line-item" width="1%">&nbsp;</th>
 			</tr>
 		</thead>
@@ -233,6 +234,11 @@ if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 	<button type="button" class="button add-order-shipping"><?php _e( 'Add shipping cost', 'woocommerce' ); ?></button>
 	<button type="button" class="button cancel-action"><?php _e( 'Cancel', 'woocommerce' ); ?></button>
 	<button type="button" class="button button-primary save-action"><?php _e( 'Save', 'woocommerce' ); ?></button>
+	<?php
+		//@@@@LOUSHOU - allow adding custom buttons
+		$data = get_post_meta( $order->id );
+		do_action('woocommerce_order_item_add_line_buttons', $order, $data, $line_items);
+	?>
 </div>
 <?php if ( ( $order->get_total() - $order->get_total_refunded() ) > 0 ) : ?>
 <div class="wc-order-data-row wc-order-refund-items" style="display: none;">

--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -36,7 +36,7 @@ $who_refunded = new WP_User( $refund->post->post_author );
 
 	<?php endfor; endif; ?>
 
-	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /* add columns at the end of the values list */ ?>
 
 	<td class="wc-order-edit-line-item">
 		<div class="wc-order-edit-line-item-actions">

--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -36,6 +36,8 @@ $who_refunded = new WP_User( $refund->post->post_author );
 
 	<?php endfor; endif; ?>
 
+	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+
 	<td class="wc-order-edit-line-item">
 		<div class="wc-order-edit-line-item-actions">
 			<a class="delete_refund" href="#"></a>

--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -100,6 +100,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		endif;
 	?>
 
+	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+
 	<td class="wc-order-edit-line-item">
 		<?php if ( $order->is_editable() ) : ?>
 			<div class="wc-order-edit-line-item-actions">

--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -100,7 +100,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		endif;
 	?>
 
-	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /*@@@@LOUSHOU - add columns at the end of the values list */ ?>
+	<?php do_action( 'woocommerce_admin_after_order_item_values', null, $item, absint( $item_id ) ); /* add columns at the end of the values list */ ?>
 
 	<td class="wc-order-edit-line-item">
 		<?php if ( $order->is_editable() ) : ?>

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -50,6 +50,9 @@ foreach ( $items as $item ) :
 				}
 			}
 
+			// allow other plugins to add additional product information here
+			do_action( 'woocommerce_order_item_custom', $item_id, $item, $order );
+
 			// Variation
 			if ( $item_meta->meta ) {
 				echo '<br/><small>' . nl2br( $item_meta->display( true, true ) ) . '</small>';

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -23,7 +23,7 @@ $order = wc_get_order( $order_id );
 		<?php
 		if ( sizeof( $order->get_items() ) > 0 ) {
 
-			foreach( $order->get_items() as $item ) {
+			foreach( $order->get_items() as $item_id => $item ) {
 				$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 				$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );
 
@@ -37,6 +37,9 @@ $order = wc_get_order( $order_id );
 								echo apply_filters( 'woocommerce_order_item_name', sprintf( '<a href="%s">%s</a>', get_permalink( $item['product_id'] ), $item['name'] ), $item );
 
 							echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
+
+							// allow other plugins to add additional product information here
+							do_action( 'woocommerce_order_item_custom', $item_id, $item, $order );
 
 							$item_meta->display();
 


### PR DESCRIPTION
These are all universal filters that can be used to modify the output of the order metaboxes in the admin, without degrading existing functionality or structure. see https://github.com/woothemes/woocommerce/issues/6291 for a fuller explanation
