### PR TITLE
new filter for plugins to add extra custom billing fields in order metabox

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -284,6 +284,9 @@ class WC_Meta_Box_Order_Data {
 
 							woocommerce_wp_text_input( array( 'id' => '_transaction_id', 'label' => __( 'Transaction ID', 'woocommerce' ) ) );
 
+							// allow other plugins to add their own extra billing fields at the bottom of the field list
+							do_action( 'woocommerce_admin_order_data_billing_address_fields', $order );
+
 							echo '</div>';
 
 							do_action( 'woocommerce_admin_order_data_after_billing_address', $order );


### PR DESCRIPTION
Subset of #6291 . Allows for plugins to add their own editable billing information, that does not fit into the current method of display, at the bottom of the billing information list.
