### PR TITLE
filters for custom order item information on oi display tables

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -31,6 +31,14 @@ foreach ( $items as $item ) :
 				echo ' (#' . $_product->get_sku() . ')';
 			}
 
+			// allow other plugins to add additional product information here
+			do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+
+			// Variation
+			if ( $item_meta->meta ) {
+				echo '<br/><small>' . nl2br( $item_meta->display( true, true ) ) . '</small>';
+			}
+
 			// File URLs
 			if ( $show_download_links && is_object( $_product ) && $_product->exists() && $_product->is_downloadable() ) {
 
@@ -51,12 +59,7 @@ foreach ( $items as $item ) :
 			}
 
 			// allow other plugins to add additional product information here
-			do_action( 'woocommerce_order_item_display_custom', $item_id, $item, $order );
-
-			// Variation
-			if ( $item_meta->meta ) {
-				echo '<br/><small>' . nl2br( $item_meta->display( true, true ) ) . '</small>';
-			}
+			do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
 
 		?></td>
 		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $item['qty'] ;?></td>

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -50,6 +50,9 @@ foreach ( $items as $item ) :
 				}
 			}
 
+			// allow other plugins to add additional product information here
+			do_action( 'woocommerce_order_item_display_custom', $item_id, $item, $order );
+
 			// Variation
 			if ( $item_meta->meta ) {
 				echo '<br/><small>' . nl2br( $item_meta->display( true, true ) ) . '</small>';

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -39,7 +39,7 @@ $order = wc_get_order( $order_id );
 							echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
 
 							// allow other plugins to add additional product information here
-							do_action( 'woocommerce_order_item_display_custom', $item_id, $item, $order );
+							do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
 
 							$item_meta->display();
 
@@ -57,6 +57,9 @@ $order = wc_get_order( $order_id );
 
 								echo '<br/>' . implode( '<br/>', $links );
 							}
+
+							// allow other plugins to add additional product information here
+							do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
 						?>
 					</td>
 					<td class="product-total">

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -23,7 +23,7 @@ $order = wc_get_order( $order_id );
 		<?php
 		if ( sizeof( $order->get_items() ) > 0 ) {
 
-			foreach( $order->get_items() as $item ) {
+			foreach( $order->get_items() as $item_id => $item ) {
 				$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 				$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );
 
@@ -37,6 +37,9 @@ $order = wc_get_order( $order_id );
 								echo apply_filters( 'woocommerce_order_item_name', sprintf( '<a href="%s">%s</a>', get_permalink( $item['product_id'] ), $item['name'] ), $item );
 
 							echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
+
+							// allow other plugins to add additional product information here
+							do_action( 'woocommerce_order_item_display_custom', $item_id, $item, $order );
 
 							$item_meta->display();
 


### PR DESCRIPTION
Subset of #6291 . Allows plugins to add additional order item information, above the order item meta printout, on the order confirmation screen order item table and on the order email order item table. (think additional 'link' to an order item asset, like a printable ticket, or some other custom, distinguishing feature of the order item that does not live in the order item meta)
