### PR TITLE
Inform plugins of 'save_order_items'

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -393,4 +393,7 @@ function wc_save_order_items( $order_id, $items ) {
 
 	// Set the currency
 	add_post_meta( $order_id, '_order_currency', get_woocommerce_currency(), true );
+
+	// inform other plugins that the items have been saved
+	do_action( 'woocommerce_save_order_items', $order_id, $items );
 }

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -395,5 +395,5 @@ function wc_save_order_items( $order_id, $items ) {
 	add_post_meta( $order_id, '_order_currency', get_woocommerce_currency(), true );
 
 	// inform other plugins that the items have been saved
-	do_action( 'woocommerce_save_order_items', $order_id, $items );
+	do_action( 'woocommerce_saved_order_items', $order_id, $items );
 }


### PR DESCRIPTION
The `wc_save_order_items()` needs to let us know it saved those items. It is only called in two places, one by the 'save_order_items' ajax call and the other by the order item metabox save function. Neither of those places inform us that the items were saved either.

Currently, there is no way to hook in on the ajax call path, after the core ajax function does it's magic, since the ajax function exits at the end. That means you cannot modify any meta that would be changed by the core ajax function, since it would be overwritten. There is a method to hook in after the order item metabox save, but it is suboptimal, because the `woocommerce_process_shop_order_meta` priority orders could have been changed, and you may still wind up after the save function runs.

Adding this filter will open up the ability to know the order items were saved in the admin, from both call paths, without any strange workarounds or takeovers.
