### PR TITLE
Checkout - createaccount value check

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -347,7 +347,7 @@ class WC_Checkout {
 
 		// Checkout fields (not defined in checkout_fields)
 		$this->posted['terms']                     = isset( $_POST['terms'] ) ? 1 : 0;
-		$this->posted['createaccount']             = isset( $_POST['createaccount'] ) ? 1 : 0;
+		$this->posted['createaccount']             = isset( $_POST['createaccount'] ) && ! empty( $_POST['createaccount'] ) ? 1 : 0;
 		$this->posted['payment_method']            = isset( $_POST['payment_method'] ) ? stripslashes( $_POST['payment_method'] ) : '';
 		$this->posted['shipping_method']           = isset( $_POST['shipping_method'] ) ? $_POST['shipping_method'] : '';
 		$this->posted['ship_to_different_address'] = isset( $_POST['ship_to_different_address'] ) ? true : false;


### PR DESCRIPTION
There should also be a check of the value, because otherwise a radiobutton-style is not possible.

In my theme I changed the "createaccount" checkbox in the checkout to radio buttons. First radio button is "Checkout as guest", the other "Create an account".
See the html structure:

```
<label for="createaccount-guest" class="radio-inline">
    <input class="input-radio" id="createaccount-guest" <?php checked( ( true !== $checkout->get_value( 'createaccount' ) && ( true !== apply_filters( 'woocommerce_create_account_default_checked', false ) ) ), true) ?> type="radio" name="createaccount" value="" /> <?php _e( 'Checkout as Guest', $ethemez->domain ); ?>
</label>
<label for="createaccount" class="radio-inline">
    <input class="input-radio" id="createaccount" <?php checked( ( true === $checkout->get_value( 'createaccount' ) || ( true === apply_filters( 'woocommerce_create_account_default_checked', false ) ) ), true) ?> type="radio" name="createaccount" value="1" /> <?php _e( 'Create an Account', $ethemez->domain ); ?>
</label>
```

The problem is, that the isset() request is not enough, because if you check "createaccount-guest", the request still returns true and so it's like you selected "createaccount".

With my pr it's possible to use also radio buttons instead of the checkbox. Radioboxes are needed, if you create for example a step-by-step checkout (more user friendly). But I'm sure that there are also theme developers which want to use radioboxes instead of checkboxes on their one-page checkout.

Thanks :)
