### PR TITLE
Allow WC_Order to be constructed w/o Order ID

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -15,7 +15,7 @@ class WC_Order extends WC_Abstract_Order {
 	 *
 	 * @param int|WC_Order $order
 	 */
-	public function __construct( $order ) {
+	public function __construct( $order = '' ) {
 		$this->order_type = 'simple';
 
 		parent::__construct( $order );


### PR DESCRIPTION
This was allowed in WooCommerce 2.1 and some plugins rely on this behavior. Also, there seems to be no downside, as the parent class WC_Abstract_Order similarly doesn't require an Order ID at construction.
