### PR TITLE
Adds a woocommerce_add_to_cart_sold_individually_quantity filter

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -817,8 +817,9 @@ class WC_Cart {
 				return false;
 
 			// Force quantity to 1 if sold individually
-			if ( $product_data->is_sold_individually() )
-				$quantity = 1;
+			if ( $product_data->is_sold_individually() ) {
+				$quantity = apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', 1, $product_id, $variation_id, $cart_item_data );
+			}
 
 			// Check product is_purchasable
 			if ( ! $product_data->is_purchasable() ) {

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -818,7 +818,7 @@ class WC_Cart {
 
 			// Force quantity to 1 if sold individually
 			if ( $product_data->is_sold_individually() ) {
-				$quantity = apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', 1, $product_id, $variation_id, $cart_item_data );
+				$quantity = apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', 1, $quantity, $product_id, $variation_id, $cart_item_data );
 			}
 
 			// Check product is_purchasable


### PR DESCRIPTION
Additional control over the quantity added when a product is "sold individually"

A bit of an oddball filter, I'll admit, but needed by Measurement Price Calculator in order to support pricing products that have managed inventory and are sold individually, and potentially by other plugins that heavily modify the product price/quantity :smile: 
