### PR TITLE
Allow adding custom 'action buttons' in order item metabox

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -224,9 +224,13 @@ if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 		<?php if ( ( $order->get_total() - $order->get_total_refunded() ) > 0 ) : ?>
 			<button type="button" class="button refund-items"><?php _e( 'Refund', 'woocommerce' ); ?></button>
 		<?php endif; ?>
+		<?php
+			// allow adding custom buttons
+			do_action( 'woocommerce_order_item_add_action_buttons', $order );
+		?>
 		<?php if ( $order->is_editable() ) : ?>
-		<button type="button" class="button button-primary calculate-tax-action"><?php _e( 'Calculate Taxes', 'woocommerce' ); ?></button>
-		<button type="button" class="button button-primary calculate-action"><?php _e( 'Calculate Total', 'woocommerce' ); ?></button>
+			<button type="button" class="button button-primary calculate-tax-action"><?php _e( 'Calculate Taxes', 'woocommerce' ); ?></button>
+			<button type="button" class="button button-primary calculate-action"><?php _e( 'Calculate Total', 'woocommerce' ); ?></button>
 		<?php endif; ?>
 	</p>
 </div>


### PR DESCRIPTION
Similar to #6305 only we are adding 'action buttons' instead of the 'add line buttons'. These buttons would site before the blue 'calculate' buttons, but after the grey 'add line item(s)', 'add tax' and 'add refund' buttons. In my use case I am adding a 'add coupon' button, so that an admin can apply a coupon to an order, for proper reporting. I am sure there are other use cases though. I figure here is the best location, since we can add blue or grey buttons at this location. Also, I corrected the indention problem in on the blue buttons, so that they match indention of the greys.
