### PR TITLE
Capitalizing the Update Translation Button

### DIFF
--- a/includes/admin/views/html-notice-translation-upgrade.php
+++ b/includes/admin/views/html-notice-translation-upgrade.php
@@ -20,7 +20,7 @@ if ( isset( $_GET['action'] ) && 'hide_translation_upgrade' == $_GET['action'] )
 		<?php if ( is_multisite() ) : ?>
 			<a href="<?php echo wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ); ?>" class="button-primary"><?php _e( 'Update Translation', 'woocommerce' ); ?></a>
 		<?php else : ?>
-			<a href="<?php echo wp_nonce_url( add_query_arg( array( 'action' => 'do-translation-upgrade' ), admin_url( 'update-core.php' ) ), 'upgrade-translations' ); ?>" class="button-primary"><?php _e( 'Update translation', 'woocommerce' ); ?></a>
+			<a href="<?php echo wp_nonce_url( add_query_arg( array( 'action' => 'do-translation-upgrade' ), admin_url( 'update-core.php' ) ), 'upgrade-translations' ); ?>" class="button-primary"><?php _e( 'Update Translation', 'woocommerce' ); ?></a>
 			<a href="<?php echo wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ); ?>" class="button-primary"><?php _e( 'Force Update Translation', 'woocommerce' ); ?></a>
 		<?php endif; ?>
 		<a href="<?php echo wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=hide_translation_upgrade' ), 'debug_action' ); ?>" class="button"><?php _e( 'Hide This Message', 'woocommerce' ); ?></a>


### PR DESCRIPTION
The `Update translation` is the only button without uppercase letters. The rest of the buttons have them.

![update-translation](https://cloud.githubusercontent.com/assets/1065372/4412796/ec7d0bea-44fc-11e4-9c31-29d7233c8c93.png)
