### PR TITLE
New filter for Shipping Tax

### DIFF
--- a/includes/class-wc-shipping-rate.php
+++ b/includes/class-wc-shipping-rate.php
@@ -52,6 +52,6 @@ class WC_Shipping_Rate {
 		if ( $this->taxes && sizeof( $this->taxes ) > 0 && ! WC()->customer->is_vat_exempt() ) {
 			$taxes = array_sum( $this->taxes );
 		}
-		return $taxes;
+		return apply_filters( 'woocommerce_get_shipping_tax', $taxes, $this );
 	}
 }


### PR DESCRIPTION
Legislation in some European countries (Germany, Austria, possibly others) requires for taxes applied to shipping costs to be calculated on a percentage basis from the number of products in your cart and their tax rates.

In order to make WooCommerce legally compliant in those countries via extension we’d need this filter to set a new shipping tax.

If a more in-depth description of what that calculation formula looks like should be of interest, we’ll be glad to share the details, but be ye warned—it’s madness.
