### PR TITLE
Update html-order-refund.php - missing extra TD element

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -23,7 +23,7 @@ $who_refunded = new WP_User( $refund->post->post_author );
 		<?php endif; ?>
 		<input type="hidden" class="order_refund_id" name="order_refund_id[]" value="<?php echo esc_attr( $refund->id ); ?>" />
 	</td>
-
+        <td></td>
 	<td class="quantity" width="1%">&nbsp;</td>
 
 	<td class="line_cost" width="1%">


### PR DESCRIPTION
Missing extra TD element after "name" and before "quantity". On html-order-item.php, this element is created using <?php do_action( 'woocommerce_admin_order_item_values', $_product, $item, absint( $item_id ) ); ?>. Since this element is missing, it produces a offsized TR for the refund line item. Another option would be to colspan the name TD to 2.
