### PR TITLE
Extra Order Items Modals

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -361,3 +361,5 @@ if ( 'yes' == get_option( 'woocommerce_calc_taxes' ) ) {
 	</div>
 	<div class="wc-backbone-modal-backdrop">&nbsp;</div>
 </script>
+
+<?php do_action( 'woocommerce_order_items_extra_modals', $order ) ?>


### PR DESCRIPTION
There should be a clean way to add our own order items metabox modals. Currently I either have to take over the entire template (which is difficult in itself, and a conversation for another time), or use a filter that puts the modal in a sub-optimal location. It would be cleaner if we could group the modals together in the same location, like this.

Thanks,
loushou

p.s. - this may also be bunched with the conversation in #6306, and if that is the case, just link them, and let me know.
