### PR TITLE
Enable tooltip for woocommerce_wp_checkbox in metabox

### DIFF
--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -129,7 +129,15 @@ function woocommerce_wp_checkbox( $field ) {
 
 	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label><input type="checkbox" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['cbvalue'] ) . '" ' . checked( $field['value'], $field['cbvalue'], false ) . ' /> ';
 
-	if ( ! empty( $field['description'] ) ) echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+	if ( ! empty( $field['description'] ) ) {
+
+		if ( isset( $field['desc_tip'] ) && false !== $field['desc_tip'] ) {
+			echo '<img class="help_tip" data-tip="' . esc_attr( $field['description'] ) . '" src="' . esc_url( WC()->plugin_url() ) . '/assets/images/help.png" height="16" width="16" />';
+		} else {
+			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+		}
+
+	}
 
 	echo '</p>';
 }


### PR DESCRIPTION
Allow the use of the `desc_tip` value to add a tooltip to the checkbox field as allowed by other metabox fields.
