### PR TITLE
[2.2] Introduce 'woocommerce_get_children' filter

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -166,7 +166,7 @@ class WC_Product_Variable extends WC_Product {
 			$children = $this->children;
 		}
 
-		return $children;
+		return apply_filters( 'woocommerce_get_children', $children, $this );
 	}
 
 	/**


### PR DESCRIPTION
The filter can be used to skip loading certain variations already from the stage of fetching their ids.

This is particularly useful for optimizing the performance of variable products with many variations when some of them need to be excluded. As an example, `WC_Product_Variable::get_available_variations` by default loads all children, which is particularly costly performance-wise if only a subset of the children must be active.
