### PR TITLE
Port 'woocommerce_get_children' filter from 2.2-bleeding

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -166,7 +166,7 @@ class WC_Product_Variable extends WC_Product {
 			$children = $this->children;
 		}
 
-		return $children;
+		return apply_filters( 'woocommerce_get_children', $children, $this );
 	}
 
 	/**


### PR DESCRIPTION
@mikejolley Thought it might help to have this in the master branch, too. Just in case we forget about it later on.
