### PR TITLE
Do not escape redirect url in form handler

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -772,11 +772,11 @@ class WC_Form_Handler {
 				} else {
 
 					if ( ! empty( $_POST['redirect'] ) ) {
-						$redirect = esc_url( $_POST['redirect'] );
+						$redirect = $_POST['redirect'];
 					} elseif ( wp_get_referer() ) {
-						$redirect = esc_url( wp_get_referer() );
+						$redirect = wp_get_referer();
 					} else {
-						$redirect = esc_url( get_permalink( wc_get_page_id( 'myaccount' ) ) );
+						$redirect = get_permalink( wc_get_page_id( 'myaccount' ) );
 					}
 
 					// Feedback


### PR DESCRIPTION
Escaping the redirect URL in WC Form Handler serves no purpose as escaping is required when outputting the URL in HTML. WordPress itself does also not escape the redirect URL in it's own login handler (wp-login.php).

Escaping the URL also causes issues when the URL contains query vars, for example: `http://example.com/?foo=bar&baz=bux` becomes `http://example.com/?foo=bar&#038;baz=bux` - which breaks the redirect, as wp_redirect does not convert HTML entities back to ampersands.

Feel free to offer alternative solutions.
