### PR TITLE
Ignore /logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 
 # Unit tests
 /tmp
+
+# Logs
+/logs


### PR DESCRIPTION
Because sometimes logs appear and we don't want them to be checked in, do we?
