### PR TITLE
Adding hook woocommerce_admin_js

### DIFF
--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -264,6 +264,8 @@ class WC_Admin_Assets {
 		if ( is_rtl() ) {
 			wp_enqueue_script( 'chosen-rtl', WC()->plugin_url() . '/assets/js/chosen/chosen-rtl' . $suffix . '.js', array( 'jquery' ), WC_VERSION, true );
 		}
+
+		do_action( 'woocommerce_admin_js' );
 	}
 
 	/**


### PR DESCRIPTION
Add new hook in admin js area.  `woocommerce_admin_css` hook already exists so cloning the name from there.
