### PR TITLE
Remove all calls to get_page(), as it was deprecated on WordPress 3.5.0

### DIFF
--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -99,7 +99,7 @@ class WC_Admin_Permalink_Settings {
 
 		// Get shop page
 		$shop_page_id 	= wc_get_page_id( 'shop' );
-		$base_slug 		= ( $shop_page_id > 0 && get_page( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
+		$base_slug 		= ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
 		$product_base 	= _x( 'product', 'default-slug', 'woocommerce' );
 
 		$structures = array(
@@ -199,7 +199,7 @@ class WC_Admin_Permalink_Settings {
 
 			// Shop base may require verbose page rules if nesting pages
 			$shop_page_id   = wc_get_page_id( 'shop' );
-			$shop_permalink = ( $shop_page_id > 0 && get_page( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
+			$shop_permalink = ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
 			if ( $shop_page_id && trim( $permalinks['product_base'], '/' ) === $shop_permalink ) {
 				$permalinks['use_verbose_page_rules'] = true;
 			}

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -191,7 +191,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 			// Get shop page
 			$shop_page_id = wc_get_page_id('shop');
 
-			$base_slug = ($shop_page_id > 0 && get_page( $shop_page_id )) ? get_page_uri( $shop_page_id ) : 'shop';
+			$base_slug = ($shop_page_id > 0 && get_post( $shop_page_id )) ? get_page_uri( $shop_page_id ) : 'shop';
 
 			$woocommerce_prepend_shop_page_to_products_warning = '';
 

--- a/includes/gateways/mijireh/class-wc-gateway-mijireh.php
+++ b/includes/gateways/mijireh/class-wc-gateway-mijireh.php
@@ -299,7 +299,7 @@ class WC_Gateway_Mijireh extends WC_Payment_Gateway {
     public static function page_slurp() {
     	self::init_mijireh();
 
-		$page 	= get_page( absint( $_POST['page_id'] ) );
+		$page 	= get_post( absint( $_POST['page_id'] ) );
 		$url 	= get_permalink( $page->ID );
 		$job_id = $url;
 		if ( wp_update_post( array( 'ID' => $page->ID, 'post_status' => 'publish' ) ) ) {

--- a/includes/updates/woocommerce-update-2.0.php
+++ b/includes/updates/woocommerce-update-2.0.php
@@ -40,7 +40,7 @@ $shop_page_id 	= wc_get_page_id( 'shop' );
 
 if ( empty( $permalinks ) && $shop_page_id > 0 ) {
 
-	$base_slug 		= $shop_page_id > 0 && get_page( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
+	$base_slug 		= $shop_page_id > 0 && get_post( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
 
 	$category_base 	= get_option('woocommerce_prepend_shop_page_to_urls') == "yes" ? trailingslashit( $base_slug ) : '';
 	$category_slug 	= get_option('woocommerce_product_category_slug') ? get_option('woocommerce_product_category_slug') : _x( 'product-category', 'slug', 'woocommerce' );


### PR DESCRIPTION
On #6467 @tivnet removed one call to `get_page` because it was deprecated, I simply did a replace of the remaining ones.
