### PR TITLE
Disable autosave for all Edit Order screens 

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1701,7 +1701,7 @@ class WC_Admin_Post_Types {
 	public function disable_autosave(){
 	    global $post;
 
-	    if ( $post && get_post_type( $post->ID ) === 'shop_order' ) {
+	    if ( $post && in_array( get_post_type( $post->ID ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
 	        wp_dequeue_script( 'autosave' );
 	    }
 	}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1699,11 +1699,11 @@ class WC_Admin_Post_Types {
 	 * @return void
 	 */
 	public function disable_autosave(){
-	    global $post;
+		global $post;
 
-	    if ( $post && in_array( get_post_type( $post->ID ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
-	        wp_dequeue_script( 'autosave' );
-	    }
+		if ( $post && in_array( get_post_type( $post->ID ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
+			wp_dequeue_script( 'autosave' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
At the moment, the `'autosave'` script is only dequeued for the `'shop_order'` post type.

It makes sense to dequeue it for any order/post type that is using the order meta boxes.
