### PR TITLE
Adding CSS Inliner

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -116,6 +116,11 @@ class WC_Emails {
 		$this->emails['WC_Email_Customer_New_Account']      = include( 'emails/class-wc-email-customer-new-account.php' );
 
 		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );
+
+		// include css inliner
+		if ( ! class_exists( 'Emogrifier' ) ) {
+			include_once( 'libraries/class-emogrifier.php' );
+		}
 	}
 
 	/**

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -158,13 +158,8 @@ class WC_Email extends WC_Settings_API {
 		// For multipart messages
 		add_filter( 'phpmailer_init', array( $this, 'handle_multipart' ) );
 
-		// For default inline styles
-		add_filter( 'woocommerce_email_style_inline_tags',    array( $this, 'style_inline_tags' ) );
-		add_filter( 'woocommerce_email_style_inline_h1_tag',  array( $this, 'style_inline_h1_tag' ) );
-		add_filter( 'woocommerce_email_style_inline_h2_tag',  array( $this, 'style_inline_h2_tag' ) );
-		add_filter( 'woocommerce_email_style_inline_h3_tag',  array( $this, 'style_inline_h3_tag' ) );
-		add_filter( 'woocommerce_email_style_inline_a_tag',   array( $this, 'style_inline_a_tag' ) );
-		add_filter( 'woocommerce_email_style_inline_img_tag', array( $this, 'style_inline_img_tag' ) );
+		// Inline CSS styles for html emails
+		add_filter( 'woocommerce_mail_content', array( $this, 'style_inline' ), 10 );
 	}
 
 	/**
@@ -309,150 +304,10 @@ class WC_Email extends WC_Settings_API {
 		if ( $this->get_email_type() == 'plain' ) {
 			$email_content = preg_replace( $this->plain_search, $this->plain_replace, strip_tags( $this->get_content_plain() ) );
 		} else {
-			$email_content = $this->style_inline( $this->get_content_html() );
+			$email_content = $this->get_content_html();
 		}
 
 		return wordwrap( $email_content, 70 );
-	}
-
-	/**
-	 * style_inline_tags function.
-	 *
-	 * @param array $tags
-	 * @return array
-	 */
-	public function style_inline_tags( $tags ) {
-		return array_unique( array_merge( $tags, array( 'h1', 'h2', 'h3', 'a', 'img' ) ) );
-	}
-
-	/**
-	 * style_inline_h1_tag function.
-	 *
-	 * @param array $styles
-	 * @return array
-	 */
-	public function style_inline_h1_tag( $styles ) {
-
-		$styles['color']         = get_option( 'woocommerce_email_text_color' );
-		$styles['display']       = 'block';
-		$styles['font-family']   = 'Arial';
-		$styles['font-size']     = '34px';
-		$styles['font-weight']   = 'bold';
-		$styles['margin-top']    = '10px';
-		$styles['margin-right']  = '0';
-		$styles['margin-bottom'] = '10px';
-		$styles['margin-left']   = '0';
-		$styles['text-align']    = 'left';
-		$styles['line-height']   = '150%';
-
-		return $styles;
-	}
-
-	/**
-	 * style_inline_h2_tag function.
-	 *
-	 * @param array $styles
-	 * @return array
-	 */
-	public function style_inline_h2_tag( $styles ) {
-
-		$styles['color']         = get_option( 'woocommerce_email_text_color' );
-		$styles['display']       = 'block';
-		$styles['font-family']   = 'Arial';
-		$styles['font-size']     = '30px';
-		$styles['font-weight']   = 'bold';
-		$styles['margin-top']    = '10px';
-		$styles['margin-right']  = '0';
-		$styles['margin-bottom'] = '10px';
-		$styles['margin-left']   = '0';
-		$styles['text-align']    = 'left';
-		$styles['line-height']   = '150%';
-
-		return $styles;
-	}
-
-	/**
-	 * style_inline_h3_tag function.
-	 *
-	 * @param array $styles
-	 * @return array
-	 */
-	public function style_inline_h3_tag( $styles ) {
-
-		$styles['color']         = get_option( 'woocommerce_email_text_color' );
-		$styles['display']       = 'block';
-		$styles['font-family']   = 'Arial';
-		$styles['font-size']     = '26px';
-		$styles['font-weight']   = 'bold';
-		$styles['margin-top']    = '10px';
-		$styles['margin-right']  = '0';
-		$styles['margin-bottom'] = '10px';
-		$styles['margin-left']   = '0';
-		$styles['text-align']    = 'left';
-		$styles['line-height']   = '150%';
-
-		return $styles;
-	}
-
-	/**
-	 * @param array $styles
-	 * @return array
-	 */
-	public function style_inline_a_tag( $styles ) {
-
-		$styles['color']           = get_option( 'woocommerce_email_text_color' );
-		$styles['font-weight']     = 'normal';
-		$styles['text-decoration'] = 'underline';
-
-		return $styles;
-	}
-
-	/**
-	 * style_inline_img_tag function.
-	 *
-	 * @param array $styles
-	 * @return array
-	 */
-	public function style_inline_img_tag( $styles ) {
-
-		$styles['display']         = 'inline';
-		$styles['border']          = 'none';
-		$styles['font-size']       = '14px';
-		$styles['font-weight']     = 'bold';
-		$styles['height']          = 'auto';
-		$styles['line-height']     = '100%';
-		$styles['outline']         = 'none';
-		$styles['text-decoration'] = 'none';
-		$styles['text-transform']  = 'capitalize';
-
-		return $styles;
-	}
-
-	/**
-	 * get_style_inline_tags function.
-	 *
-	 * @return array
-	 */
-	public function get_style_inline_tags() {
-		return apply_filters( 'woocommerce_email_style_inline_tags', array() );
-	}
-
-	/**
-	 * get_style_inline_for_tag function.
-	 *
-	 * @param string $tag
-	 * @return string
-	 */
-	public function get_style_inline_for_tag( $tag ) {
-
-		$styles = apply_filters( 'woocommerce_email_style_inline_' . $tag . '_tag',  array() );
-		$css = array();
-
-		foreach( $styles as $property => $value ) {
-			$css[] = $property . ':' . $value;
-		}
-
-		return implode('; ', $css);
 	}
 
 	/**
@@ -463,26 +318,18 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function style_inline( $content ) {
 
-		if ( ! class_exists( 'DOMDocument' ) ) {
-			return $content;
+		// make sure we only inline CSS for html emails
+		if ( 'text/html' ==  $this->get_content_type() ) {
+
+			// get CSS styles
+			ob_start();
+			wc_get_template( 'emails/email-styles.php' );
+			$css = apply_filters( 'woocommerce_email_styles', ob_get_clean() );
+
+			// apply CSS styles inline for picky email clients
+			$emogrifier = new Emogrifier( $content, $css );
+			$content = $emogrifier->emogrify();
 		}
-
-		$dom = new DOMDocument();
-		libxml_use_internal_errors( true );
-		@$dom->loadHTML( $content );
-		libxml_clear_errors();
-
-		foreach( $this->get_style_inline_tags() as $tag ) {
-			$nodes = $dom->getElementsByTagName($tag);
-
-			foreach( $nodes as $node ) {
-				if ( ! $node->hasAttribute( 'style' ) ) {
-					$node->setAttribute( 'style', $this->get_style_inline_for_tag($tag) );
-				}
-			}
-		}
-
-		$content = $dom->saveHTML();
 
 		return $content;
 	}
@@ -534,6 +381,13 @@ class WC_Email extends WC_Settings_API {
 		add_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		add_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		add_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );
+
+		/**
+		 * Filter all WooCommerce mail content
+		 *
+		 * @hooked inline_styles - 10
+		*/
+		$message = apply_filters( 'woocommerce_mail_content', $message );
 
 		$return = wp_mail( $to, $subject, $message, $headers, $attachments );
 

--- a/includes/libraries/class-emogrifier.php
+++ b/includes/libraries/class-emogrifier.php
@@ -1,0 +1,803 @@
+<?php
+/**
+ * This class provides functions for converting CSS styles into inline style attributes in your HTML code.
+ *
+ * For more information, please see the README.md file.
+ *
+ * @author Cameron Brooks
+ * @author Jaime Prado
+ * @author Roman Ožana <ozana@omdesign.cz>
+ */
+class Emogrifier {
+    /**
+     * @var string
+     */
+    const ENCODING = 'UTF-8';
+
+    /**
+     * @var integer
+     */
+    const CACHE_KEY_CSS = 0;
+
+    /**
+     * @var integer
+     */
+    const CACHE_KEY_SELECTOR = 1;
+
+    /**
+     * @var integer
+     */
+    const CACHE_KEY_XPATH = 2;
+
+    /**
+     * @var integer
+     */
+    const CACHE_KEY_CSS_DECLARATION_BLOCK = 3;
+
+    /**
+     * for calculating nth-of-type and nth-child selectors
+     *
+     * @var integer
+     */
+    const INDEX = 0;
+
+    /**
+     * for calculating nth-of-type and nth-child selectors
+     *
+     * @var integer
+     */
+    const MULTIPLIER = 1;
+
+    /**
+     * @var string
+     */
+    const ID_ATTRIBUTE_MATCHER = '/(\\w+)?\\#([\\w\\-]+)/';
+
+    /**
+     * @var string
+     */
+    const CLASS_ATTRIBUTE_MATCHER = '/(\\w+|[\\*\\]])?((\\.[\\w\\-]+)+)/';
+
+    /**
+     * @var string
+     */
+    private $html = '';
+
+    /**
+     * @var string
+     */
+    private $css = '';
+
+    /**
+     * @var array<string>
+     */
+    private $unprocessableHtmlTags = array('wbr');
+
+    /**
+     * @var array<array>
+     */
+    private $caches = array(
+        self::CACHE_KEY_CSS => array(),
+        self::CACHE_KEY_SELECTOR => array(),
+        self::CACHE_KEY_XPATH => array(),
+        self::CACHE_KEY_CSS_DECLARATION_BLOCK => array(),
+    );
+
+    /**
+     * the visited nodes with the XPath paths as array keys
+     *
+     * @var array<\DOMNode>
+     */
+    private $visitedNodes = array();
+
+    /**
+     * the styles to apply to the nodes with the XPath paths as array keys for the outer array and the attribute names/values
+     * as key/value pairs for the inner array
+     *
+     * @var array<array><string>
+     */
+    private $styleAttributesForNodes = array();
+
+    /**
+     * This attribute applies to the case where you want to preserve your original text encoding.
+     *
+     * By default, emogrifier translates your text into HTML entities for two reasons:
+     *
+     * 1. Because of client incompatibilities, it is better practice to send out HTML entities rather than unicode over email.
+     *
+     * 2. It translates any illegal XML characters that DOMDocument cannot work with.
+     *
+     * If you would like to preserve your original encoding, set this attribute to TRUE.
+     *
+     * @var boolean
+     */
+    public $preserveEncoding = FALSE;
+
+    /**
+     * The constructor.
+     *
+     * @param string $html the HTML to emogrify, must be UTF-8-encoded
+     * @param string $css the CSS to merge, must be UTF-8-encoded
+     */
+    public function __construct($html = '', $css = '') {
+        $this->setHtml($html);
+        $this->setCss($css);
+    }
+
+    /**
+     * The destructor.
+     */
+    public function __destruct() {
+        $this->purgeVisitedNodes();
+    }
+
+    /**
+     * Sets the HTML to emogrify.
+     *
+     * @param string $html the HTML to emogrify, must be UTF-8-encoded
+     *
+     * @return void
+     */
+    public function setHtml($html = '') {
+        $this->html = $html;
+    }
+
+    /**
+     * Sets the CSS to merge with the HTML.
+     *
+     * @param string $css the CSS to merge, must be UTF-8-encoded
+     *
+     * @return void
+     */
+    public function setCss($css = '') {
+        $this->css = $css;
+    }
+
+    /**
+     * Clears all caches.
+     *
+     * @return void
+     */
+    private function clearAllCaches() {
+        $this->clearCache(self::CACHE_KEY_CSS);
+        $this->clearCache(self::CACHE_KEY_SELECTOR);
+        $this->clearCache(self::CACHE_KEY_XPATH);
+        $this->clearCache(self::CACHE_KEY_CSS_DECLARATION_BLOCK);
+    }
+
+    /**
+     * Clears a single cache by key.
+     *
+     * @param integer $key the cache key, must be CACHE_KEY_CSS, CACHE_KEY_SELECTOR, CACHE_KEY_XPATH or CACHE_KEY_CSS_DECLARATION_BLOCK
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function clearCache($key) {
+        $allowedCacheKeys = array(self::CACHE_KEY_CSS, self::CACHE_KEY_SELECTOR, self::CACHE_KEY_XPATH, self::CACHE_KEY_CSS_DECLARATION_BLOCK);
+        if (!in_array($key, $allowedCacheKeys, TRUE)) {
+            throw new \InvalidArgumentException('Invalid cache key: ' . $key, 1391822035);
+        }
+
+        $this->caches[$key] = array();
+    }
+
+    /**
+     * Purges the visited nodes.
+     *
+     * @return void
+     */
+    private function purgeVisitedNodes() {
+        $this->visitedNodes = array();
+        $this->styleAttributesForNodes = array();
+    }
+
+    /**
+     * Marks a tag for removal.
+     *
+     * There are some HTML tags that DOMDocument cannot process, and it will throw an error if it encounters them.
+     * In particular, DOMDocument will complain if you try to use HTML5 tags in an XHTML document.
+     *
+     * Note: The tags will not be removed if they have any content.
+     *
+     * @param string $tagName the tag name, e.g., "p"
+     *
+     * @return void
+     */
+    public function addUnprocessableHtmlTag($tagName) {
+        $this->unprocessableHtmlTags[] = $tagName;
+    }
+
+    /**
+     * Drops a tag from the removal list.
+     *
+     * @param string $tagName the tag name, e.g., "p"
+     *
+     * @return void
+     */
+    public function removeUnprocessableHtmlTag($tagName) {
+        $key = array_search($tagName, $this->unprocessableHtmlTags, TRUE);
+        if ($key !== FALSE) {
+            unset($this->unprocessableHtmlTags[$key]);
+        }
+    }
+
+    /**
+     * Applies the CSS you submit to the HTML you submit.
+     *
+     * This method places the CSS inline.
+     *
+     * @return string
+     *
+     * @throws \BadMethodCallException
+     */
+    public function emogrify() {
+        if ($this->html === '') {
+            throw new \BadMethodCallException('Please set some HTML first before calling emogrify.', 1390393096);
+        }
+
+        $xmlDocument = $this->createXmlDocument();
+        $xpath = new \DOMXPath($xmlDocument);
+        $this->clearAllCaches();
+
+        // before be begin processing the CSS file, parse the document and normalize all existing CSS attributes (changes 'DISPLAY: none' to 'display: none');
+        // we wouldn't have to do this if DOMXPath supported XPath 2.0.
+        // also store a reference of nodes with existing inline styles so we don't overwrite them
+        $this->purgeVisitedNodes();
+
+        $nodesWithStyleAttributes = $xpath->query('//*[@style]');
+        if ($nodesWithStyleAttributes !== FALSE) {
+            /** @var $nodeWithStyleAttribute \DOMNode */
+            foreach ($nodesWithStyleAttributes as $node) {
+                $normalizedOriginalStyle = preg_replace_callback(
+                    '/[A-z\\-]+(?=\\:)/S',
+                    function (array $m) {
+                        return strtolower($m[0]);
+                    },
+                    $node->getAttribute('style')
+                );
+
+                // in order to not overwrite existing style attributes in the HTML, we have to save the original HTML styles
+                $nodePath = $node->getNodePath();
+                if (!isset($this->styleAttributesForNodes[$nodePath])) {
+                    $this->styleAttributesForNodes[$nodePath] = $this->parseCssDeclarationBlock($normalizedOriginalStyle);
+                    $this->visitedNodes[$nodePath] = $node;
+                }
+
+                $node->setAttribute('style', $normalizedOriginalStyle);
+            }
+        }
+
+        // grab any existing style blocks from the html and append them to the existing CSS
+        // (these blocks should be appended so as to have precedence over conflicting styles in the existing CSS)
+        $allCss = $this->css;
+
+        $allCss .= $this->getCssFromAllStyleNodes($xpath);
+
+        $cssParts = $this->splitCssAndMediaQuery($allCss);
+
+        $cssKey = md5($cssParts['css']);
+        if (!isset($this->caches[self::CACHE_KEY_CSS][$cssKey])) {
+            // process the CSS file for selectors and definitions
+            preg_match_all('/(?:^|[\\s^{}]*)([^{]+){([^}]*)}/mis', $cssParts['css'], $matches, PREG_SET_ORDER);
+
+            $allSelectors = array();
+            foreach ($matches as $key => $selectorString) {
+                // if there is a blank definition, skip
+                if (!strlen(trim($selectorString[2]))) {
+                    continue;
+                }
+
+                // else split by commas and duplicate attributes so we can sort by selector precedence
+                $selectors = explode(',', $selectorString[1]);
+                foreach ($selectors as $selector) {
+                    // don't process pseudo-elements and behavioral (dynamic) pseudo-classes; ONLY allow structural pseudo-classes
+                    if (strpos($selector, ':') !== FALSE && !preg_match('/:\\S+\\-(child|type)\\(/i', $selector)) {
+                        continue;
+                    }
+
+                    $allSelectors[] = array('selector' => trim($selector),
+                                             'attributes' => trim($selectorString[2]),
+                                             // keep track of where it appears in the file, since order is important
+                                             'line' => $key,
+                    );
+                }
+            }
+
+            // now sort the selectors by precedence
+            usort($allSelectors, array($this,'sortBySelectorPrecedence'));
+
+            $this->caches[self::CACHE_KEY_CSS][$cssKey] = $allSelectors;
+        }
+
+        foreach ($this->caches[self::CACHE_KEY_CSS][$cssKey] as $value) {
+            // query the body for the xpath selector
+            $nodesMatchingCssSelectors = $xpath->query($this->translateCssToXpath($value['selector']));
+
+            /** @var $node \DOMNode */
+            foreach ($nodesMatchingCssSelectors as $node) {
+                // if it has a style attribute, get it, process it, and append (overwrite) new stuff
+                if ($node->hasAttribute('style')) {
+                    // break it up into an associative array
+                    $oldStyleDeclarations = $this->parseCssDeclarationBlock($node->getAttribute('style'));
+                } else {
+                    $oldStyleDeclarations = array();
+                }
+                $newStyleDeclarations = $this->parseCssDeclarationBlock($value['attributes']);
+                $node->setAttribute('style', $this->generateStyleStringFromDeclarationsArrays($oldStyleDeclarations, $newStyleDeclarations));
+            }
+        }
+
+        // now iterate through the nodes that contained inline styles in the original HTML
+        foreach ($this->styleAttributesForNodes as $nodePath => $styleAttributesForNode) {
+            $node = $this->visitedNodes[$nodePath];
+            $currentStyleAttributes = $this->parseCssDeclarationBlock($node->getAttribute('style'));
+            $node->setAttribute('style', $this->generateStyleStringFromDeclarationsArrays($currentStyleAttributes, $styleAttributesForNode));
+        }
+
+        // This removes styles from your email that contain display:none.
+        // We need to look for display:none, but we need to do a case-insensitive search. Since DOMDocument only supports XPath 1.0,
+        // lower-case() isn't available to us. We've thus far only set attributes to lowercase, not attribute values. Consequently, we need
+        // to translate() the letters that would be in 'NONE' ("NOE") to lowercase.
+        $nodesWithStyleDisplayNone = $xpath->query('//*[contains(translate(translate(@style," ",""),"NOE","noe"),"display:none")]');
+        // The checks on parentNode and is_callable below ensure that if we've deleted the parent node,
+        // we don't try to call removeChild on a nonexistent child node
+        if ($nodesWithStyleDisplayNone->length > 0) {
+            /** @var $node \DOMNode */
+            foreach ($nodesWithStyleDisplayNone as $node) {
+                if ($node->parentNode && is_callable(array($node->parentNode,'removeChild'))) {
+                    $node->parentNode->removeChild($node);
+                }
+            }
+        }
+
+        $this->copyCssWithMediaToStyleNode($cssParts, $xmlDocument);
+
+        if ($this->preserveEncoding) {
+            return mb_convert_encoding($xmlDocument->saveHTML(), self::ENCODING, 'HTML-ENTITIES');
+        } else {
+            return $xmlDocument->saveHTML();
+        }
+    }
+
+
+    /**
+     * This method merges old or existing name/value array with new name/value array
+     * and then generates a string of the combined style suitable for placing inline.
+     * This becomes the single point for CSS string generation allowing for consistent
+     * CSS output no matter where the CSS originally came from.
+     * @param array $oldStyles
+     * @param array $newStyles
+     * @return string
+     */
+    private function generateStyleStringFromDeclarationsArrays(array $oldStyles, array $newStyles) {
+        $combinedStyles = array_merge($oldStyles, $newStyles);
+        $style = '';
+        foreach ($combinedStyles as $attributeName => $attributeValue) {
+            $style .= (strtolower(trim($attributeName)) . ': ' . trim($attributeValue) . '; ');
+        }
+        return trim($style);
+    }
+
+
+    /**
+     * Copies the media part from CSS array parts to $xmlDocument.
+     *
+     * @param array $cssParts
+     * @param \DOMDocument $xmlDocument
+     * @return void
+     */
+    public function copyCssWithMediaToStyleNode(array $cssParts, \DOMDocument $xmlDocument) {
+        if (isset($cssParts['media']) && $cssParts['media'] !== '') {
+            $this->addStyleElementToDocument($xmlDocument, $cssParts['media']);
+        }
+    }
+
+    /**
+     * Returns CSS content.
+     *
+     * @param \DOMXPath $xpath
+     * @return string
+     */
+    private function getCssFromAllStyleNodes(\DOMXPath $xpath) {
+        $styleNodes = $xpath->query('//style');
+
+        if ($styleNodes === FALSE) {
+            return '';
+        }
+
+        $css = '';
+        /** @var $styleNode \DOMNode */
+        foreach ($styleNodes as $styleNode) {
+            $css .= "\n\n" . $styleNode->nodeValue;
+            $styleNode->parentNode->removeChild($styleNode);
+        }
+
+        return $css;
+    }
+
+    /**
+     * Adds a style element with $css to $document.
+     *
+     * @param \DOMDocument $document
+     * @param string $css
+     * @return void
+     */
+    private function addStyleElementToDocument(\DOMDocument $document, $css) {
+        $styleElement = $document->createElement('style', $css);
+        $styleAttribute = $document->createAttribute('type');
+        $styleAttribute->value = 'text/css';
+        $styleElement->appendChild($styleAttribute);
+
+        $head = $this->getOrCreateHeadElement($document);
+        $head->appendChild($styleElement);
+    }
+
+    /**
+     * Returns the existing or creates a new head element in $document.
+     *
+     * @param \DOMDocument $document
+     * @return \DOMNode the head element
+     */
+    private function getOrCreateHeadElement(\DOMDocument $document) {
+        $head = $document->getElementsByTagName('head')->item(0);
+
+        if ($head === NULL) {
+            $head = $document->createElement('head');
+            $html = $document->getElementsByTagName('html')->item(0);
+            $html->insertBefore($head, $document->getElementsByTagName('body')->item(0));
+        }
+
+        return $head;
+    }
+
+    /**
+     * Splits input CSS code to an array where:
+     *
+     * - key "css" will be contains clean CSS code
+     * - key "media" will be contains all valuable media queries
+     *
+     * Example:
+     *
+     * The CSS code
+     *
+     *   "@import "file.css"; h1 { color:red; } @media { h1 {}} @media tv { h1 {}}"
+     *
+     * will be parsed into the following array:
+     *
+     *   "css" => "h1 { color:red; }"
+     *   "media" => "@media { h1 {}}"
+     *
+     * @param string $css
+     * @return array
+     */
+    private function splitCssAndMediaQuery($css) {
+        $media = '';
+
+        $css = preg_replace_callback(
+            '#@media\\s+(?:only\\s)?(?:[\\s{\(]|screen|all)\\s?[^{]+{.*}\\s*}\\s*#misU',
+            function($matches) use (&$media) {
+                $media .= $matches[0];
+            }, $css
+        );
+
+        // filter the CSS
+        $search = array(
+            // get rid of css comment code
+            '/\\/\\*.*\\*\\//sU',
+            // strip out any import directives
+            '/^\\s*@import\\s[^;]+;/misU',
+            // strip remains media enclosures
+            '/^\\s*@media\\s[^{]+{(.*)}\\s*}\\s/misU',
+        );
+
+        $replace = array(
+            '',
+            '',
+            '',
+        );
+
+        // clean CSS before output
+        $css = preg_replace($search, $replace, $css);
+
+        return array('css' => $css, 'media' => $media);
+    }
+
+    /**
+     * Creates a DOMDocument instance with the current HTML.
+     *
+     * @return \DOMDocument
+     */
+    private function createXmlDocument() {
+        $xmlDocument = new \DOMDocument;
+        $xmlDocument->encoding = self::ENCODING;
+        $xmlDocument->strictErrorChecking = FALSE;
+        $xmlDocument->formatOutput = TRUE;
+        $libXmlState = libxml_use_internal_errors(TRUE);
+        $xmlDocument->loadHTML($this->getUnifiedHtml());
+        libxml_clear_errors();
+        libxml_use_internal_errors($libXmlState);
+        $xmlDocument->normalizeDocument();
+
+        return $xmlDocument;
+    }
+
+    /**
+     * Returns the HTML with the non-ASCII characters converts into HTML entities and the unprocessable HTML tags removed.
+     *
+     * @return string the unified HTML
+     *
+     * @throws \BadMethodCallException
+     */
+    private function getUnifiedHtml() {
+        if (!empty($this->unprocessableHtmlTags)) {
+            $unprocessableHtmlTags = implode('|', $this->unprocessableHtmlTags);
+            $bodyWithoutUnprocessableTags = preg_replace('/<\\/?(' . $unprocessableHtmlTags . ')[^>]*>/i', '', $this->html);
+        } else {
+            $bodyWithoutUnprocessableTags = $this->html;
+        }
+
+        return mb_convert_encoding($bodyWithoutUnprocessableTags, 'HTML-ENTITIES', self::ENCODING);
+    }
+
+    /**
+     * @param array $a
+     * @param array $b
+     *
+     * @return integer
+     */
+    private function sortBySelectorPrecedence(array $a, array $b) {
+        $precedenceA = $this->getCssSelectorPrecedence($a['selector']);
+        $precedenceB = $this->getCssSelectorPrecedence($b['selector']);
+
+        // We want these sorted in ascending order so selectors with lesser precedence get processed first and
+        // selectors with greater precedence get sorted last.
+        // The parenthesis around the -1 are necessary to avoid a PHP_CodeSniffer warning about missing spaces around
+        // arithmetic operators.
+        // @see http://forge.typo3.org/issues/55605
+        $precedenceForEquals = ($a['line'] < $b['line'] ? (-1) : 1);
+        $precedenceForNotEquals = ($precedenceA < $precedenceB ? (-1) : 1);
+        return ($precedenceA === $precedenceB) ? $precedenceForEquals : $precedenceForNotEquals;
+    }
+
+    /**
+     * @param string $selector
+     *
+     * @return integer
+     */
+    private function getCssSelectorPrecedence($selector) {
+        $selectorKey = md5($selector);
+        if (!isset($this->caches[self::CACHE_KEY_SELECTOR][$selectorKey])) {
+            $precedence = 0;
+            $value = 100;
+            // ids: worth 100, classes: worth 10, elements: worth 1
+            $search = array('\\#','\\.','');
+
+            foreach ($search as $s) {
+                if (trim($selector == '')) {
+                    break;
+                }
+                $number = 0;
+                $selector = preg_replace('/' . $s . '\\w+/', '', $selector, -1, $number);
+                $precedence += ($value * $number);
+                $value /= 10;
+            }
+            $this->caches[self::CACHE_KEY_SELECTOR][$selectorKey] = $precedence;
+        }
+
+        return $this->caches[self::CACHE_KEY_SELECTOR][$selectorKey];
+    }
+
+    /**
+     * Right now, we support all CSS 1 selectors and most CSS2/3 selectors.
+     *
+     * @see http://plasmasturm.org/log/444/
+     *
+     * @param string $paramCssSelector
+     *
+     * @return string
+     */
+    private function translateCssToXpath($paramCssSelector) {
+        $cssSelector = ' ' . $paramCssSelector . ' ';
+        $cssSelector = preg_replace_callback('/\s+\w+\s+/',
+            function(array $matches) {
+                return strtolower($matches[0]);
+            },
+            $cssSelector
+        );
+        $cssSelector = trim($cssSelector);
+        $xpathKey = md5($cssSelector);
+        if (!isset($this->caches[self::CACHE_KEY_XPATH][$xpathKey])) {
+            // returns an Xpath selector
+            $search = array(
+                // Matches any element that is a child of parent.
+                '/\\s+>\\s+/',
+                // Matches any element that is an adjacent sibling.
+                '/\\s+\\+\\s+/',
+                // Matches any element that is a descendant of an parent element element.
+                '/\\s+/',
+                // first-child pseudo-selector
+                '/([^\\/]+):first-child/i',
+                // last-child pseudo-selector
+                '/([^\\/]+):last-child/i',
+                // Matches attribute only selector
+                '/^\\[(\\w+)\\]/',
+                // Matches element with attribute
+                '/(\\w)\\[(\\w+)\\]/',
+                // Matches element with EXACT attribute
+                '/(\\w)\\[(\\w+)\\=[\'"]?(\\w+)[\'"]?\\]/',
+            );
+            $replace = array(
+                '/',
+                '/following-sibling::*[1]/self::',
+                '//',
+                '*[1]/self::\\1',
+                '*[last()]/self::\\1',
+                '*[@\\1]',
+                '\\1[@\\2]',
+                '\\1[@\\2="\\3"]',
+            );
+
+            $cssSelector = '//' . preg_replace($search, $replace, $cssSelector);
+
+            $cssSelector = preg_replace_callback(self::ID_ATTRIBUTE_MATCHER, array($this, 'matchIdAttributes'), $cssSelector);
+            $cssSelector = preg_replace_callback(self::CLASS_ATTRIBUTE_MATCHER, array($this, 'matchClassAttributes'), $cssSelector);
+
+            // Advanced selectors are going to require a bit more advanced emogrification.
+            // When we required PHP 5.3, we could do this with closures.
+            $cssSelector = preg_replace_callback(
+                '/([^\\/]+):nth-child\\(\s*(odd|even|[+\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
+                array($this, 'translateNthChild'), $cssSelector
+            );
+            $cssSelector = preg_replace_callback(
+                '/([^\\/]+):nth-of-type\\(\s*(odd|even|[+\-]?\\d|[+\\-]?\\d?n(\\s*[+\\-]\\s*\\d)?)\\s*\\)/i',
+                array($this, 'translateNthOfType'), $cssSelector
+            );
+
+            $this->caches[self::CACHE_KEY_SELECTOR][$xpathKey] = $cssSelector;
+        }
+        return $this->caches[self::CACHE_KEY_SELECTOR][$xpathKey];
+    }
+
+    /**
+     * @param array $match
+     *
+     * @return string
+     */
+    private function matchIdAttributes(array $match) {
+        return (strlen($match[1]) ? $match[1] : '*') . '[@id="' . $match[2] . '"]';
+    }
+
+    /**
+     * @param array $match
+     *
+     * @return string
+     */
+    private function matchClassAttributes(array $match) {
+        return (strlen($match[1]) ? $match[1] : '*') . '[contains(concat(" ",@class," "),concat(" ","' .
+            implode(
+                '"," "))][contains(concat(" ",@class," "),concat(" ","',
+                explode('.', substr($match[2], 1))
+            ) . '"," "))]';
+    }
+
+    /**
+     * @param array $match
+     *
+     * @return string
+     */
+    private function translateNthChild(array $match) {
+        $result = $this->parseNth($match);
+
+        if (isset($result[self::MULTIPLIER])) {
+            if ($result[self::MULTIPLIER] < 0) {
+                $result[self::MULTIPLIER] = abs($result[self::MULTIPLIER]);
+                return sprintf('*[(last() - position()) mod %u = %u]/self::%s', $result[self::MULTIPLIER], $result[self::INDEX], $match[1]);
+            } else {
+                return sprintf('*[position() mod %u = %u]/self::%s', $result[self::MULTIPLIER], $result[self::INDEX], $match[1]);
+            }
+        } else {
+            return sprintf('*[%u]/self::%s', $result[self::INDEX], $match[1]);
+        }
+    }
+
+    /**
+     * @param array $match
+     *
+     * @return string
+     */
+    private function translateNthOfType(array $match) {
+        $result = $this->parseNth($match);
+
+        if (isset($result[self::MULTIPLIER])) {
+            if ($result[self::MULTIPLIER] < 0) {
+                $result[self::MULTIPLIER] = abs($result[self::MULTIPLIER]);
+                return sprintf('%s[(last() - position()) mod %u = %u]', $match[1], $result[self::MULTIPLIER], $result[self::INDEX]);
+            } else {
+                return sprintf('%s[position() mod %u = %u]', $match[1], $result[self::MULTIPLIER], $result[self::INDEX]);
+            }
+        } else {
+            return sprintf('%s[%u]', $match[1], $result[self::INDEX]);
+        }
+    }
+
+    /**
+     * @param array $match
+     *
+     * @return array
+     */
+    private function parseNth(array $match) {
+        if (in_array(strtolower($match[2]), array('even','odd'))) {
+            $index = strtolower($match[2]) == 'even' ? 0 : 1;
+            return array(self::MULTIPLIER => 2, self::INDEX => $index);
+        } elseif (stripos($match[2], 'n') === FALSE) {
+            // if there is a multiplier
+            $index = intval(str_replace(' ', '', $match[2]));
+            return array(self::INDEX => $index);
+        } else {
+            if (isset($match[3])) {
+                $multipleTerm = str_replace($match[3], '', $match[2]);
+                $index = intval(str_replace(' ', '', $match[3]));
+            } else {
+                $multipleTerm = $match[2];
+                $index = 0;
+            }
+
+            $multiplier = str_ireplace('n', '', $multipleTerm);
+
+            if (!strlen($multiplier)) {
+                $multiplier = 1;
+            } elseif ($multiplier == 0) {
+                return array(self::INDEX => $index);
+            } else {
+                $multiplier = intval($multiplier);
+            }
+
+            while ($index < 0) {
+                $index += abs($multiplier);
+            }
+
+            return array(self::MULTIPLIER => $multiplier, self::INDEX => $index);
+        }
+    }
+
+    /**
+     * Parses a CSS declaration block into property name/value pairs.
+     *
+     * Example:
+     *
+     * The declaration block
+     *
+     *   "color: #000; font-weight: bold;"
+     *
+     * will be parsed into the following array:
+     *
+     *   "color" => "#000"
+     *   "font-weight" => "bold"
+     *
+     * @param string $cssDeclarationBlock the CSS declaration block without the curly braces, may be empty
+     *
+     * @return array the CSS declarations with the property names as array keys and the property values as array values
+     */
+    private function parseCssDeclarationBlock($cssDeclarationBlock) {
+        if (isset($this->caches[self::CACHE_KEY_CSS_DECLARATION_BLOCK][$cssDeclarationBlock])) {
+            return $this->caches[self::CACHE_KEY_CSS_DECLARATION_BLOCK][$cssDeclarationBlock];
+        }
+
+        $properties = array();
+        $declarations = explode(';', $cssDeclarationBlock);
+        foreach ($declarations as $declaration) {
+            $matches = array();
+            if (!preg_match('/ *([A-Za-z\\-]+) *: *([^;]+) */', $declaration, $matches)) {
+                continue;
+            }
+            $propertyName = strtolower($matches[1]);
+            $propertyValue = $matches[2];
+            $properties[$propertyName] = $propertyValue;
+        }
+        $this->caches[self::CACHE_KEY_CSS_DECLARATION_BLOCK][$cssDeclarationBlock] = $properties;
+
+        return $properties;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,8 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 
 = 2.3.0 =
 * Refactor - Removed deprecated methods from WC_Frontend_Scripts and rewrote script registration and localization to run once.
+* Refactor - Routing all email functionality through one send() method.
+* Refactor - Replaced existing email css inliner with Emogrifier
 * Fix - When 'hide out of stock products' is disabled, out of stock variations / attributes are now visible.
 * Tweak - Double the default product image dimensions.
 * Tweak - Added refunds to Sales by Date report.

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -11,17 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-// Load colours
-$bg 		= get_option( 'woocommerce_email_background_color' );
-$body		= get_option( 'woocommerce_email_body_background_color' );
-$base 		= get_option( 'woocommerce_email_base_color' );
-$base_text 	= wc_light_or_dark( $base, '#202020', '#ffffff' );
-$text 		= get_option( 'woocommerce_email_text_color' );
-
-$bg_darker_10 = wc_hex_darker( $bg, 10 );
-$base_lighter_20 = wc_hex_lighter( $base, 20 );
-$text_lighter_20 = wc_hex_lighter( $text, 20 );
-
 ?>
 <!DOCTYPE html>
 <html>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -22,55 +22,6 @@ $bg_darker_10 = wc_hex_darker( $bg, 10 );
 $base_lighter_20 = wc_hex_lighter( $base, 20 );
 $text_lighter_20 = wc_hex_lighter( $text, 20 );
 
-// For gmail compatibility, including CSS styles in head/body are stripped out therefore styles need to be inline. These variables contain rules which are added to the template inline. !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
-$wrapper = "
-	background-color: " . esc_attr( $bg ) . ";
-	width:100%;
-	-webkit-text-size-adjust:none !important;
-	margin:0;
-	padding: 70px 0 70px 0;
-";
-$template_container = "
-	box-shadow:0 0 0 3px rgba(0,0,0,0.025) !important;
-	border-radius:6px !important;
-	background-color: " . esc_attr( $body ) . ";
-	border: 1px solid $bg_darker_10;
-	border-radius:6px !important;
-";
-$template_header = "
-	background-color: " . esc_attr( $base ) .";
-	color: $base_text;
-	border-top-left-radius:6px !important;
-	border-top-right-radius:6px !important;
-	border-bottom: 0;
-	font-family:Arial;
-	font-weight:bold;
-	line-height:100%;
-	vertical-align:middle;
-";
-$body_content = "
-	background-color: " . esc_attr( $body ) . ";
-	border-radius:6px !important;
-";
-$body_content_inner = "
-	color: $text_lighter_20;
-	font-family:Arial;
-	font-size:14px;
-	line-height:150%;
-	text-align:left;
-";
-$header_content_h1 = "
-	color: " . esc_attr( $base_text ) . ";
-	margin:0;
-	padding: 28px 24px;
-	text-shadow: 0 1px 0 $base_lighter_20;
-	display:block;
-	font-family:Arial;
-	font-size:30px;
-	font-weight:bold;
-	text-align:left;
-	line-height: 150%;
-";
 ?>
 <!DOCTYPE html>
 <html>
@@ -79,7 +30,7 @@ $header_content_h1 = "
         <title><?php echo get_bloginfo( 'name' ); ?></title>
 	</head>
     <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
-    	<div style="<?php echo $wrapper; ?>">
+    	<div id="wrapper">
         	<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
             	<tr>
                 	<td align="center" valign="top">
@@ -90,15 +41,14 @@ $header_content_h1 = "
 	                			}
 	                		?>
 						</div>
-                    	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_container" style="<?php echo $template_container; ?>">
+                    	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_container">
                         	<tr>
                             	<td align="center" valign="top">
                                     <!-- Header -->
-                                	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_header" style="<?php echo $template_header; ?>" bgcolor="<?php echo $base; ?>">
+                                	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_header" bgcolor="<?php echo $base; ?>">
                                         <tr>
                                             <td>
-                                            	<h1 style="<?php echo $header_content_h1; ?>"><?php echo $email_heading; ?></h1>
-
+                                            	<h1><?php echo $email_heading; ?></h1>
                                             </td>
                                         </tr>
                                     </table>
@@ -110,9 +60,9 @@ $header_content_h1 = "
                                     <!-- Body -->
                                 	<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_body">
                                     	<tr>
-                                            <td valign="top" style="<?php echo $body_content; ?>">
+                                            <td valign="top" id="body_content">
                                                 <!-- Content -->
                                                 <table border="0" cellpadding="20" cellspacing="0" width="100%">
                                                     <tr>
                                                         <td valign="top">
-                                                            <div style="<?php echo $body_content_inner; ?>">
+                                                            <div id="body_content_inner">

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails
- * @version     2.0.0
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Email Styles
+ *
+ * @author  WooThemes
+ * @package WooCommerce/Templates/Emails
+ * @version 2.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+// Load colours
+$bg              = get_option( 'woocommerce_email_background_color' );
+$body            = get_option( 'woocommerce_email_body_background_color' );
+$base            = get_option( 'woocommerce_email_base_color' );
+$base_text       = wc_light_or_dark( $base, '#202020', '#ffffff' );
+$text            = get_option( 'woocommerce_email_text_color' );
+
+$bg_darker_10    = wc_hex_darker( $bg, 10 );
+$base_lighter_20 = wc_hex_lighter( $base, 20 );
+$text_lighter_20 = wc_hex_lighter( $text, 20 );
+
+// !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
+?>
+#wrapper {
+    background-color: <?php echo esc_attr( $bg ); ?>;
+    margin: 0;
+    padding: 70px 0 70px 0;
+    -webkit-text-size-adjust: none !important;
+    width: 100%;
+}
+#template_container {
+    box-shadow: 0 0 0 3px rgba(0,0,0,0.025) !important;
+    border-radius: 6px !important;
+    background-color: <?php echo esc_attr( $body ); ?>;
+    border: 1px solid $bg_darker_10;
+    border-radius: 6px !important;
+}
+#template_header {
+    background-color: <?php echo esc_attr( $base ); ?>;
+    color: <?php echo $base_text; ?>;
+    border-top-left-radius:6px !important;
+    border-top-right-radius:6px !important;
+    border-bottom: 0;
+    font-family:Arial;
+    font-weight:bold;
+    line-height:100%;
+    vertical-align:middle;
+}
+#template_header h1 {
+    color: <?php echo $base_text; ?>;
+}
+#body_content {
+    background-color: <?php echo esc_attr( $body ); ?>;
+    border-radius:6px !important;
+}
+#body_content_inner {
+    color: <?php echo $text_lighter_20;?>;
+    font-family:Arial;
+    font-size:14px;
+    line-height:150%;
+    text-align:left;
+}
+h1 {
+    color: <?php echo esc_attr( $base ); ?>;
+    display: block;
+    font-family: Arial;
+    font-size: 30px;
+    font-weight: bold;
+    line-height: 150%;
+    margin: 10px 0;
+    padding: 28px 24px;
+    text-align: left;
+    text-shadow: 0 1px 0 <?php echo $base_lighter_20; ?>;
+}
+h2 {
+    color: <?php echo esc_attr( $base ); ?>;
+    display: block;
+    font-family: Arial;
+    font-size: 30px;
+    font-weight: bold;
+    line-height: 150%;
+    margin: 10px 0;
+    text-align: left;
+}
+h3 {
+    color: <?php echo esc_attr( $base ); ?>;
+    display: block;
+    font-family: Arial;
+    font-size: 26px;
+    font-weight: bold;
+    line-height: 150%;
+    margin: 10px 0;
+    text-align: left;
+}
+a {
+    color: <?php echo esc_attr( $base ); ?>;
+    font-weight: normal;
+    text-decoration: underline;
+}
+img {
+    border: non;
+    display: inline;
+    font-size: 14px;
+    font-weight: bold;
+    height: auto;
+    line-height: 100%;
+    outline: none;
+    text-decoration: none;
+    text-transform: capitalize;
+}
+<?php


### PR DESCRIPTION
Now that we only have one `send()` method I added a CSS inliner which takes all CSS styles and adds them inline the appropriate elements. This is necessary since many email clients (like Gmail) ignore regular CSS styles in the head. Ref: #6358 

A summary of what I did:
1. I added the [Emogrifier](https://github.com/jjriv/emogrifier) CSS inliner (MIT license).
2. I ripped out the CSS styles in `includes/emails/class-wc-email.php` & `templates/emails/email-header.php`, combined them, and put them in `templates/emails/email-styles.php` which can be overridden like any other WooCommerce template.
3. I setup Emogrifier to inline the CSS styles in the `style_inline` method.
4. I added two filters `woocommerce_email_styles` & `woocommerce_mail_content`
## Moving Forward

Now that we have this infrastructure a plugin or theme can add styles to a WooCommerce email using the `woocommerce_email_styles` filter. And they can do so writing regular css. I created an [example plugin](https://gist.github.com/BFTrick/01cc414ee56ce93715ec) which turns all paragraph text red.

One other fun fact. I added a filter called `woocommerce_mail_content` in the `send()` method so now anyone can easily customize any WooCommerce email.

And the email with customized CSS in gmail:

![your_wc_core_order_receipt_from_october_8__2014_-_patrick_r_woothemes_com_-_woothemes_mail](https://cloud.githubusercontent.com/assets/1065372/4567823/c8bea8ac-4f34-11e4-9991-43d9854774b7.jpg)
