### PR TITLE
Pass cart item values to is_valid_for_product method in WC_Coupon

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1741,7 +1741,7 @@ class WC_Cart {
 					$coupon = new WC_Coupon( $code );
 
 					if ( $coupon->apply_before_tax() && $coupon->is_valid() ) {
-						if ( $coupon->is_valid_for_product( $values['data'] ) || $coupon->is_valid_for_cart() ) {
+						if ( $coupon->is_valid_for_product( $values['data'], $values ) || $coupon->is_valid_for_cart() ) {
 
 							$discount_amount       = $coupon->get_discount_amount( $price, $values, $single = true );
 							$price                 = max( $price - $discount_amount, 0 );

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -474,7 +474,7 @@ class WC_Coupon {
 	 * @param  WC_Product  $product
 	 * @return boolean
 	 */
-	public function is_valid_for_product( $product, $values ) {
+	public function is_valid_for_product( $product, $values = array() ) {
 		if ( $this->type != 'fixed_product' && $this->type != 'percent_product' )
 			return apply_filters( 'woocommerce_coupon_is_valid_for_product', false, $product, $this, $values );
 

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -474,9 +474,9 @@ class WC_Coupon {
 	 * @param  WC_Product  $product
 	 * @return boolean
 	 */
-	public function is_valid_for_product( $product ) {
+	public function is_valid_for_product( $product, $values ) {
 		if ( $this->type != 'fixed_product' && $this->type != 'percent_product' )
-			return apply_filters( 'woocommerce_coupon_is_valid_for_product', false, $product, $this );
+			return apply_filters( 'woocommerce_coupon_is_valid_for_product', false, $product, $this, $values );
 
 		$valid        = false;
 		$product_cats = wp_get_post_terms( $product->id, 'product_cat', array( "fields" => "ids" ) );
@@ -516,7 +516,7 @@ class WC_Coupon {
 				$valid = false;
 		}
 
-		return apply_filters( 'woocommerce_coupon_is_valid_for_product', $valid, $product, $this );
+		return apply_filters( 'woocommerce_coupon_is_valid_for_product', $valid, $product, $this, $values );
 	}
 
 	/**


### PR DESCRIPTION
This is simply so third party plugins can determine if a cart item is valid for a discount based on custom item attributes.

This is done in a backward compatible manner so it shouldn't affect compatibility with plugins that already hook into this filter.
