### PR TITLE
Make variations script re-usable

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -70,7 +70,7 @@
 			.on( 'change', '.variations select', function( event ) {
 
 				$variation_form = $( this ).closest( '.variations_form' );
-				$variation_form.find( 'input[name=variation_id]' ).val( '' ).change();
+				$variation_form.find( 'input.variation_id' ).val( '' ).change();
 
 				$variation_form
 					.trigger( 'woocommerce_variation_select_change' )
@@ -91,7 +91,7 @@
 
 				$variation_form
 					.trigger( 'woocommerce_variation_select_focusin' )
-					.trigger( 'check_variations', [ $( this ).attr( 'name' ), true ] );
+					.trigger( 'check_variations', [ $( this ).data( 'attribute_name' ), true ] );
 
 			} )
 
@@ -112,10 +112,10 @@
 						any_set = true;
 					}
 
-					if ( exclude && $( this ).attr( 'name' ) === exclude ) {
+					if ( exclude && $( this ).data( 'attribute_name' ) === exclude ) {
 
 						all_set = false;
-						current_settings[$( this ).attr( 'name' )] = '';
+						current_settings[$( this ).data( 'attribute_name' )] = '';
 
 					} else {
 
@@ -123,7 +123,7 @@
 						value = $( this ).val();
 
 						// Add to settings array
-						current_settings[ $( this ).attr( 'name' ) ] = value;
+						current_settings[ $( this ).data( 'attribute_name' ) ] = value;
 					}
 
 				});
@@ -149,7 +149,7 @@
 
 						// Found - set ID
 						$variation_form
-							.find( 'input[name=variation_id]' )
+							.find( 'input.variation_id' )
 							.val( variation.variation_id )
 							.change();
 
@@ -249,7 +249,7 @@
 					current_attr_select.find( 'option:gt(0)' ).removeAttr( 'disabled' );
 
 					// Get name
-					var current_attr_name = current_attr_select.attr( 'name' );
+					var current_attr_name = current_attr_select.data( 'attribute_name' );
 
 					// Loop through variations
 					for ( var num in variations ) {
@@ -404,17 +404,17 @@
 				}
 
 				if ( variation.min_qty )
-					$single_variation_wrap.find( 'input[name=quantity]' ).attr( 'min', variation.min_qty ).val( variation.min_qty );
+					$single_variation_wrap.find( 'quantity input.qty' ).attr( 'min', variation.min_qty ).val( variation.min_qty );
 				else
-					$single_variation_wrap.find( 'input[name=quantity]' ).removeAttr( 'min' );
+					$single_variation_wrap.find( 'quantity input.qty' ).removeAttr( 'min' );
 
 				if ( variation.max_qty )
-					$single_variation_wrap.find( 'input[name=quantity]' ).attr( 'max', variation.max_qty );
+					$single_variation_wrap.find( 'quantity input.qty' ).attr( 'max', variation.max_qty );
 				else
-					$single_variation_wrap.find( 'input[name=quantity]' ).removeAttr( 'max' );
+					$single_variation_wrap.find( 'quantity input.qty' ).removeAttr( 'max' );
 
 				if ( variation.is_sold_individually === 'yes' ) {
-					$single_variation_wrap.find( 'input[name=quantity]' ).val( '1' );
+					$single_variation_wrap.find( 'quantity input.qty' ).val( '1' );
 					$single_variation_wrap.find( '.quantity' ).hide();
 				}
 

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -70,7 +70,11 @@
 			.on( 'change', '.variations select', function( event ) {
 
 				$variation_form = $( this ).closest( '.variations_form' );
-				$variation_form.find( 'input.variation_id' ).val( '' ).change();
+
+				if ( $variation_form.find( 'input.variation_id' ).length > 0 )
+					$variation_form.find( 'input.variation_id' ).val( '' ).change();
+				else
+					$variation_form.find( 'input[name=variation_id]' ).val( '' ).change();
 
 				$variation_form
 					.trigger( 'woocommerce_variation_select_change' )
@@ -89,9 +93,15 @@
 
 				$variation_form = $( this ).closest( '.variations_form' );
 
+				// Get attribute name from data-attribute_name, or from input name if it doesn't exist
+				if ( typeof( $( this ).data( 'attribute_name' ) ) != 'undefined' )
+					attribute_name = $( this ).data( 'attribute_name' );
+				else
+					attribute_name = $( this ).attr( 'name' );
+
 				$variation_form
 					.trigger( 'woocommerce_variation_select_focusin' )
-					.trigger( 'check_variations', [ $( this ).data( 'attribute_name' ), true ] );
+					.trigger( 'check_variations', [ attribute_name, true ] );
 
 			} )
 
@@ -106,16 +116,23 @@
 
 				$variation_form.find( '.variations select' ).each( function() {
 
+					// Get attribute name from data-attribute_name, or from input name if it doesn't exist
+					if ( typeof( $( this ).data( 'attribute_name' ) ) != 'undefined' )
+						attribute_name = $( this ).data( 'attribute_name' );
+					else
+						attribute_name = $( this ).attr( 'name' );
+
+
 					if ( $( this ).val().length === 0 ) {
 						all_set = false;
 					} else {
 						any_set = true;
 					}
 
-					if ( exclude && $( this ).data( 'attribute_name' ) === exclude ) {
+					if ( exclude && attribute_name === exclude ) {
 
 						all_set = false;
-						current_settings[$( this ).data( 'attribute_name' )] = '';
+						current_settings[ attribute_name ] = '';
 
 					} else {
 
@@ -123,7 +140,7 @@
 						value = $( this ).val();
 
 						// Add to settings array
-						current_settings[ $( this ).data( 'attribute_name' ) ] = value;
+						current_settings[ attribute_name ] = value;
 					}
 
 				});
@@ -148,8 +165,15 @@
 					if ( variation ) {
 
 						// Found - set ID
-						$variation_form
-							.find( 'input.variation_id' )
+
+						// Get variation input by class, or by input name if class doesn't exist
+						if ( $variation_form.find( 'input.variation_id' ).length > 0 )
+							$variation_input = $variation_form.find( 'input.variation_id' );
+						else
+							$variation_input = $variation_form.find( 'input[name=variation_id]' );
+
+						// Set ID
+						$variation_input
 							.val( variation.variation_id )
 							.change();
 
@@ -248,8 +272,11 @@
 					current_attr_select.find( 'option:gt(0)' ).removeClass( 'enabled' );
 					current_attr_select.find( 'option:gt(0)' ).removeAttr( 'disabled' );
 
-					// Get name
-					var current_attr_name = current_attr_select.data( 'attribute_name' );
+					// Get name from data-attribute_name, or from input name if it doesn't exist
+					if ( typeof( current_attr_select.data( 'attribute_name' ) ) != 'undefined' )
+						current_attr_name = current_attr_select.data( 'attribute_name' );
+					else
+						current_attr_name = current_attr_select.attr( 'name' );
 
 					// Loop through variations
 					for ( var num in variations ) {

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -431,17 +431,17 @@
 				}
 
 				if ( variation.min_qty )
-					$single_variation_wrap.find( 'quantity input.qty' ).attr( 'min', variation.min_qty ).val( variation.min_qty );
+					$single_variation_wrap.find( '.quantity input.qty' ).attr( 'min', variation.min_qty ).val( variation.min_qty );
 				else
-					$single_variation_wrap.find( 'quantity input.qty' ).removeAttr( 'min' );
+					$single_variation_wrap.find( '.quantity input.qty' ).removeAttr( 'min' );
 
 				if ( variation.max_qty )
-					$single_variation_wrap.find( 'quantity input.qty' ).attr( 'max', variation.max_qty );
+					$single_variation_wrap.find( '.quantity input.qty' ).attr( 'max', variation.max_qty );
 				else
-					$single_variation_wrap.find( 'quantity input.qty' ).removeAttr( 'max' );
+					$single_variation_wrap.find( '.quantity input.qty' ).removeAttr( 'max' );
 
 				if ( variation.is_sold_individually === 'yes' ) {
-					$single_variation_wrap.find( 'quantity input.qty' ).val( '1' );
+					$single_variation_wrap.find( '.quantity input.qty' ).val( '1' );
 					$single_variation_wrap.find( '.quantity' ).hide();
 				}
 

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -24,7 +24,7 @@ global $product, $post;
 				<?php $loop = 0; foreach ( $attributes as $name => $options ) : $loop++; ?>
 					<tr>
 						<td class="label"><label for="<?php echo sanitize_title($name); ?>"><?php echo wc_attribute_label( $name ); ?></label></td>
-						<td class="value"><select id="<?php echo esc_attr( sanitize_title( $name ) ); ?>" name="attribute_<?php echo sanitize_title( $name ); ?>">
+						<td class="value"><select id="<?php echo esc_attr( sanitize_title( $name ) ); ?>" name="attribute_<?php echo sanitize_title( $name ); ?>" data-attribute_name="attribute_<?php echo sanitize_title( $name ); ?>">
 							<option value=""><?php echo __( 'Choose an option', 'woocommerce' ) ?>&hellip;</option>
 							<?php
 								if ( is_array( $options ) ) {
@@ -94,7 +94,7 @@ global $product, $post;
 
 			<input type="hidden" name="add-to-cart" value="<?php echo $product->id; ?>" />
 			<input type="hidden" name="product_id" value="<?php echo esc_attr( $post->ID ); ?>" />
-			<input type="hidden" name="variation_id" value="" />
+			<input type="hidden" name="variation_id" class="variation_id" value="" />
 
 			<?php do_action( 'woocommerce_after_single_variation' ); ?>
 		</div>


### PR DESCRIPTION
At the moment, the variations script is partially re-usable since it can be dynamically attached to a DOM element. To make the variations script 100% re-usable on dynamically loaded (and possibly multiple) `variations_form` elements, all references to input names must be removed, since those inputs may have different (unique) names when submitting data for multiple variable products inside the same `form`.

Therefore,
- the variation_id input field must be referenced by class
- quantity input fields must be referenced by class
- attribute names must be referenced by class or -- probably better, as done -- a data attribute.
