### PR TITLE
add variation class method which tests if all the attributes are set

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -277,23 +277,23 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
-	 * Check if all variation attributes are defined
+	 * Check if all variation's attributes are set
 	 *
 	 * @return boolean
 	 */
-	public function is_all_defined() {
+	public function has_all_attributes_set() {
 
-		$defined = true;
+		$set = true;
 		
 		// undefined attributes have null strings as array values
 		foreach( $this->get_variation_attributes() as $att ){
 			if( ! $att ){
-				$defined = false;
+				$set = false;
 				break;
 			}
 		}
 
-		return $defined;
+		return $set;
 
 	}
 	

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -277,6 +277,27 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
+	 * Check if all variation attributes are defined
+	 *
+	 * @return boolean
+	 */
+	public function is_all_defined() {
+
+		$defined = true;
+		
+		// undefined attributes have null strings as array values
+		foreach( $this->get_variation_attributes() as $att ){
+			if( ! $att ){
+				$defined = false;
+				break;
+			}
+		}
+
+		return $defined;
+
+	}
+	
+	/**
 	 * Get variation price HTML. Prices are not inherited from parents.
 	 *
 	 * @return string containing the formatted price


### PR DESCRIPTION
In Mix and Match, I want to make sure that people can't put partially defined variations in the container. ie: Variation 99: T-Shirt Size=Large, Color=Any. So I wrote this method to loop through the attributes and make sure they are all defined. 

I wasn't sure if it belonged in core or not... guess that depends on whether you think it might be useful to other extensions. 
