### PR TITLE
Add 'woocommerce_order_status_on-hold_to_processing', to $email_actions

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -394,6 +394,7 @@ final class WooCommerce {
 			'woocommerce_order_status_pending_to_on-hold',
 			'woocommerce_order_status_failed_to_processing',
 			'woocommerce_order_status_failed_to_completed',
+			'woocommerce_order_status_on-hold_to_processing',
 			'woocommerce_order_status_completed',
 			'woocommerce_new_customer_note',
 			'woocommerce_created_customer'


### PR DESCRIPTION
This addition would stop users from editing the core, as there is currently no eloquent way to edit the $email_actions array. Especially useful for creating email notifications for confirming payment (BACS).
