### PR TITLE
Template: remove unnecessary conditions

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -52,7 +52,11 @@ $get_checkout_url = apply_filters( 'woocommerce_get_checkout_url', WC()->cart->g
 
 	<?php endif; ?>
 
-	<?php do_action( 'woocommerce_checkout_order_review' ); ?>
+	<div id="order_review">
+
+		<?php do_action( 'woocommerce_checkout_order_review' ); ?>
+
+	</div>
 
 </form>
 

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -13,185 +13,181 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 
-<?php if ( ! $is_ajax ) : ?><div id="order_review"><?php endif; ?>
+<table class="shop_table">
+	<thead>
+		<tr>
+			<th class="product-name"><?php _e( 'Product', 'woocommerce' ); ?></th>
+			<th class="product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php
+			do_action( 'woocommerce_review_order_before_cart_contents' );
 
-	<table class="shop_table">
-		<thead>
-			<tr>
-				<th class="product-name"><?php _e( 'Product', 'woocommerce' ); ?></th>
-				<th class="product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
-			</tr>
-		</thead>
-		<tbody>
-			<?php
-				do_action( 'woocommerce_review_order_before_cart_contents' );
+			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+				$_product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					$_product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
-
-					if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
-						?>
-						<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
-							<td class="product-name">
-								<?php echo apply_filters( 'woocommerce_cart_item_name', $_product->get_title(), $cart_item, $cart_item_key ); ?>
-								<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times; %s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); ?>
-								<?php echo WC()->cart->get_item_data( $cart_item ); ?>
-							</td>
-							<td class="product-total">
-								<?php echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); ?>
-							</td>
-						</tr>
-						<?php
-					}
-				}
-
-				do_action( 'woocommerce_review_order_after_cart_contents' );
-			?>
-		</tbody>
-		<tfoot>
-
-			<tr class="cart-subtotal">
-				<th><?php _e( 'Cart Subtotal', 'woocommerce' ); ?></th>
-				<td><?php wc_cart_totals_subtotal_html(); ?></td>
-			</tr>
-
-			<?php foreach ( WC()->cart->get_coupons( 'cart' ) as $code => $coupon ) : ?>
-				<tr class="cart-discount coupon-<?php echo esc_attr( $code ); ?>">
-					<th><?php wc_cart_totals_coupon_label( $coupon ); ?></th>
-					<td><?php wc_cart_totals_coupon_html( $coupon ); ?></td>
-				</tr>
-			<?php endforeach; ?>
-
-			<?php if ( WC()->cart->needs_shipping() && WC()->cart->show_shipping() ) : ?>
-
-				<?php do_action( 'woocommerce_review_order_before_shipping' ); ?>
-
-				<?php wc_cart_totals_shipping_html(); ?>
-
-				<?php do_action( 'woocommerce_review_order_after_shipping' ); ?>
-
-			<?php endif; ?>
-
-			<?php foreach ( WC()->cart->get_fees() as $fee ) : ?>
-				<tr class="fee">
-					<th><?php echo esc_html( $fee->name ); ?></th>
-					<td><?php wc_cart_totals_fee_html( $fee ); ?></td>
-				</tr>
-			<?php endforeach; ?>
-
-			<?php if ( WC()->cart->tax_display_cart === 'excl' ) : ?>
-				<?php if ( get_option( 'woocommerce_tax_total_display' ) === 'itemized' ) : ?>
-					<?php foreach ( WC()->cart->get_tax_totals() as $code => $tax ) : ?>
-						<tr class="tax-rate tax-rate-<?php echo sanitize_title( $code ); ?>">
-							<th><?php echo esc_html( $tax->label ); ?></th>
-							<td><?php echo wp_kses_post( $tax->formatted_amount ); ?></td>
-						</tr>
-					<?php endforeach; ?>
-				<?php else : ?>
-					<tr class="tax-total">
-						<th><?php echo esc_html( WC()->countries->tax_or_vat() ); ?></th>
-						<td><?php echo wc_price( WC()->cart->get_taxes_total() ); ?></td>
+				if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+					?>
+					<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_cart_item_class', 'cart_item', $cart_item, $cart_item_key ) ); ?>">
+						<td class="product-name">
+							<?php echo apply_filters( 'woocommerce_cart_item_name', $_product->get_title(), $cart_item, $cart_item_key ); ?>
+							<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' <strong class="product-quantity">' . sprintf( '&times; %s', $cart_item['quantity'] ) . '</strong>', $cart_item, $cart_item_key ); ?>
+							<?php echo WC()->cart->get_item_data( $cart_item ); ?>
+						</td>
+						<td class="product-total">
+							<?php echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); ?>
+						</td>
 					</tr>
-				<?php endif; ?>
-			<?php endif; ?>
-
-			<?php foreach ( WC()->cart->get_coupons( 'order' ) as $code => $coupon ) : ?>
-				<tr class="order-discount coupon-<?php echo esc_attr( $code ); ?>">
-					<th><?php wc_cart_totals_coupon_label( $coupon ); ?></th>
-					<td><?php wc_cart_totals_coupon_html( $coupon ); ?></td>
-				</tr>
-			<?php endforeach; ?>
-
-			<?php do_action( 'woocommerce_review_order_before_order_total' ); ?>
-
-			<tr class="order-total">
-				<th><?php _e( 'Order Total', 'woocommerce' ); ?></th>
-				<td><?php wc_cart_totals_order_total_html(); ?></td>
-			</tr>
-
-			<?php do_action( 'woocommerce_review_order_after_order_total' ); ?>
-
-		</tfoot>
-	</table>
-
-	<?php do_action( 'woocommerce_review_order_before_payment' ); ?>
-
-	<div id="payment">
-		<?php if ( WC()->cart->needs_payment() ) : ?>
-		<ul class="payment_methods methods">
-			<?php
-				$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-				if ( ! empty( $available_gateways ) ) {
-
-					// Chosen Method
-					if ( isset( WC()->session->chosen_payment_method ) && isset( $available_gateways[ WC()->session->chosen_payment_method ] ) ) {
-						$available_gateways[ WC()->session->chosen_payment_method ]->set_current();
-					} elseif ( isset( $available_gateways[ get_option( 'woocommerce_default_gateway' ) ] ) ) {
-						$available_gateways[ get_option( 'woocommerce_default_gateway' ) ]->set_current();
-					} else {
-						current( $available_gateways )->set_current();
-					}
-
-					foreach ( $available_gateways as $gateway ) {
-						?>
-						<li class="payment_method_<?php echo $gateway->id; ?>">
-							<input id="payment_method_<?php echo $gateway->id; ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
-							<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo $gateway->get_title(); ?> <?php echo $gateway->get_icon(); ?></label>
-							<?php
-								if ( $gateway->has_fields() || $gateway->get_description() ) :
-									echo '<div class="payment_box payment_method_' . $gateway->id . '" ' . ( $gateway->chosen ? '' : 'style="display:none;"' ) . '>';
-									$gateway->payment_fields();
-									echo '</div>';
-								endif;
-							?>
-						</li>
-						<?php
-					}
-				} else {
-
-					if ( ! WC()->customer->get_country() )
-						$no_gateways_message = __( 'Please fill in your details above to see available payment methods.', 'woocommerce' );
-					else
-						$no_gateways_message = __( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' );
-
-					echo '<p>' . apply_filters( 'woocommerce_no_available_payment_methods_message', $no_gateways_message ) . '</p>';
-
+					<?php
 				}
-			?>
-		</ul>
+			}
+
+			do_action( 'woocommerce_review_order_after_cart_contents' );
+		?>
+	</tbody>
+	<tfoot>
+
+		<tr class="cart-subtotal">
+			<th><?php _e( 'Cart Subtotal', 'woocommerce' ); ?></th>
+			<td><?php wc_cart_totals_subtotal_html(); ?></td>
+		</tr>
+
+		<?php foreach ( WC()->cart->get_coupons( 'cart' ) as $code => $coupon ) : ?>
+			<tr class="cart-discount coupon-<?php echo esc_attr( $code ); ?>">
+				<th><?php wc_cart_totals_coupon_label( $coupon ); ?></th>
+				<td><?php wc_cart_totals_coupon_html( $coupon ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+
+		<?php if ( WC()->cart->needs_shipping() && WC()->cart->show_shipping() ) : ?>
+
+			<?php do_action( 'woocommerce_review_order_before_shipping' ); ?>
+
+			<?php wc_cart_totals_shipping_html(); ?>
+
+			<?php do_action( 'woocommerce_review_order_after_shipping' ); ?>
+
 		<?php endif; ?>
 
-		<div class="form-row place-order">
+		<?php foreach ( WC()->cart->get_fees() as $fee ) : ?>
+			<tr class="fee">
+				<th><?php echo esc_html( $fee->name ); ?></th>
+				<td><?php wc_cart_totals_fee_html( $fee ); ?></td>
+			</tr>
+		<?php endforeach; ?>
 
-			<noscript><?php _e( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the <em>Update Totals</em> button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'woocommerce' ); ?><br/><input type="submit" class="button alt" name="woocommerce_checkout_update_totals" value="<?php _e( 'Update totals', 'woocommerce' ); ?>" /></noscript>
+		<?php if ( WC()->cart->tax_display_cart === 'excl' ) : ?>
+			<?php if ( get_option( 'woocommerce_tax_total_display' ) === 'itemized' ) : ?>
+				<?php foreach ( WC()->cart->get_tax_totals() as $code => $tax ) : ?>
+					<tr class="tax-rate tax-rate-<?php echo sanitize_title( $code ); ?>">
+						<th><?php echo esc_html( $tax->label ); ?></th>
+						<td><?php echo wp_kses_post( $tax->formatted_amount ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+			<?php else : ?>
+				<tr class="tax-total">
+					<th><?php echo esc_html( WC()->countries->tax_or_vat() ); ?></th>
+					<td><?php echo wc_price( WC()->cart->get_taxes_total() ); ?></td>
+				</tr>
+			<?php endif; ?>
+		<?php endif; ?>
 
-			<?php wp_nonce_field( 'woocommerce-process_checkout' ); ?>
+		<?php foreach ( WC()->cart->get_coupons( 'order' ) as $code => $coupon ) : ?>
+			<tr class="order-discount coupon-<?php echo esc_attr( $code ); ?>">
+				<th><?php wc_cart_totals_coupon_label( $coupon ); ?></th>
+				<td><?php wc_cart_totals_coupon_html( $coupon ); ?></td>
+			</tr>
+		<?php endforeach; ?>
 
-			<?php do_action( 'woocommerce_review_order_before_submit' ); ?>
+		<?php do_action( 'woocommerce_review_order_before_order_total' ); ?>
 
-			<?php
-			$order_button_text = apply_filters( 'woocommerce_order_button_text', __( 'Place order', 'woocommerce' ) );
+		<tr class="order-total">
+			<th><?php _e( 'Order Total', 'woocommerce' ); ?></th>
+			<td><?php wc_cart_totals_order_total_html(); ?></td>
+		</tr>
 
-			echo apply_filters( 'woocommerce_order_button_html', '<input type="submit" class="button alt" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '" />' );
+		<?php do_action( 'woocommerce_review_order_after_order_total' ); ?>
+
+	</tfoot>
+</table>
+
+<?php do_action( 'woocommerce_review_order_before_payment' ); ?>
+
+<div id="payment">
+	<?php if ( WC()->cart->needs_payment() ) : ?>
+	<ul class="payment_methods methods">
+		<?php
+			$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+			if ( ! empty( $available_gateways ) ) {
+
+				// Chosen Method
+				if ( isset( WC()->session->chosen_payment_method ) && isset( $available_gateways[ WC()->session->chosen_payment_method ] ) ) {
+					$available_gateways[ WC()->session->chosen_payment_method ]->set_current();
+				} elseif ( isset( $available_gateways[ get_option( 'woocommerce_default_gateway' ) ] ) ) {
+					$available_gateways[ get_option( 'woocommerce_default_gateway' ) ]->set_current();
+				} else {
+					current( $available_gateways )->set_current();
+				}
+
+				foreach ( $available_gateways as $gateway ) {
+					?>
+					<li class="payment_method_<?php echo $gateway->id; ?>">
+						<input id="payment_method_<?php echo $gateway->id; ?>" type="radio" class="input-radio" name="payment_method" value="<?php echo esc_attr( $gateway->id ); ?>" <?php checked( $gateway->chosen, true ); ?> data-order_button_text="<?php echo esc_attr( $gateway->order_button_text ); ?>" />
+						<label for="payment_method_<?php echo $gateway->id; ?>"><?php echo $gateway->get_title(); ?> <?php echo $gateway->get_icon(); ?></label>
+						<?php
+							if ( $gateway->has_fields() || $gateway->get_description() ) :
+								echo '<div class="payment_box payment_method_' . $gateway->id . '" ' . ( $gateway->chosen ? '' : 'style="display:none;"' ) . '>';
+								$gateway->payment_fields();
+								echo '</div>';
+							endif;
+						?>
+					</li>
+					<?php
+				}
+			} else {
+
+				if ( ! WC()->customer->get_country() )
+					$no_gateways_message = __( 'Please fill in your details above to see available payment methods.', 'woocommerce' );
+				else
+					$no_gateways_message = __( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' );
+
+				echo '<p>' . apply_filters( 'woocommerce_no_available_payment_methods_message', $no_gateways_message ) . '</p>';
+
+			}
+		?>
+	</ul>
+	<?php endif; ?>
+
+	<div class="form-row place-order">
+
+		<noscript><?php _e( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the <em>Update Totals</em> button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'woocommerce' ); ?><br/><input type="submit" class="button alt" name="woocommerce_checkout_update_totals" value="<?php _e( 'Update totals', 'woocommerce' ); ?>" /></noscript>
+
+		<?php wp_nonce_field( 'woocommerce-process_checkout' ); ?>
+
+		<?php do_action( 'woocommerce_review_order_before_submit' ); ?>
+
+		<?php
+		$order_button_text = apply_filters( 'woocommerce_order_button_text', __( 'Place order', 'woocommerce' ) );
+
+		echo apply_filters( 'woocommerce_order_button_html', '<input type="submit" class="button alt" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '" />' );
+		?>
+
+		<?php if ( wc_get_page_id( 'terms' ) > 0 && apply_filters( 'woocommerce_checkout_show_terms', true ) ) {
+			$terms_is_checked = apply_filters( 'woocommerce_terms_is_checked_default', isset( $_POST['terms'] ) );
 			?>
+			<p class="form-row terms">
+				<label for="terms" class="checkbox"><?php printf( __( 'I&rsquo;ve read and accept the <a href="%s" target="_blank">terms &amp; conditions</a>', 'woocommerce' ), esc_url( get_permalink( wc_get_page_id( 'terms' ) ) ) ); ?></label>
+				<input type="checkbox" class="input-checkbox" name="terms" <?php checked( $terms_is_checked, true ); ?> id="terms" />
+			</p>
+		<?php } ?>
 
-			<?php if ( wc_get_page_id( 'terms' ) > 0 && apply_filters( 'woocommerce_checkout_show_terms', true ) ) {
-				$terms_is_checked = apply_filters( 'woocommerce_terms_is_checked_default', isset( $_POST['terms'] ) );
-				?>
-				<p class="form-row terms">
-					<label for="terms" class="checkbox"><?php printf( __( 'I&rsquo;ve read and accept the <a href="%s" target="_blank">terms &amp; conditions</a>', 'woocommerce' ), esc_url( get_permalink( wc_get_page_id( 'terms' ) ) ) ); ?></label>
-					<input type="checkbox" class="input-checkbox" name="terms" <?php checked( $terms_is_checked, true ); ?> id="terms" />
-				</p>
-			<?php } ?>
-
-			<?php do_action( 'woocommerce_review_order_after_submit' ); ?>
-
-		</div>
-
-		<div class="clear"></div>
+		<?php do_action( 'woocommerce_review_order_after_submit' ); ?>
 
 	</div>
 
-	<?php do_action( 'woocommerce_review_order_after_payment' ); ?>
+	<div class="clear"></div>
 
-<?php if ( ! $is_ajax ) : ?></div><?php endif; ?>
+</div>
+
+<?php do_action( 'woocommerce_review_order_after_payment' ); ?>


### PR DESCRIPTION
Sry for the new PR, I again removed the old fork because of merge conflicts (now I should be able to handle with git _gg_)...

The "is_ajax" conditions in the template file review-order.php are not necessary.
To move the html element to the form-checkout.php should also do the job.

PS: before you refer to #5910, please read also my comment below:
https://github.com/woothemes/woocommerce/pull/5910#issuecomment-50788660

Thanks :)
