### PR TITLE
Added the filter for the ajax cart_hash

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -96,7 +96,7 @@ class WC_AJAX {
 					'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>'
 				)
 			),
-			'cart_hash' => WC()->cart->get_cart() ? md5( json_encode( WC()->cart->get_cart() ) ) : ''
+			'cart_hash' => apply_filters( 'add_to_cart_cart_hash', WC()->cart->get_cart() ? md5( json_encode( WC()->cart->get_cart() ) ) : '', WC()->cart->get_cart() )
 		);
 
 		wp_send_json( $data );


### PR DESCRIPTION
When I use the custom page fragments with WPML and the cart is empty (empty array), the page fragment gets loaded from the JS sessionStorage. If the user is switching the languages and the page fragment is containing the i18n string (for example 'CART' or 'No products in the cart') the wrong i18n version of the string stays in the user's cache.

This filter will enable the theme/plugin authors to implement their own cache busting hashes if needed, even if the cart is empty.

Thank you for including this minor change in the next version of the WooCommerce! :)
