### PR TITLE
Make edit account details nonce unique to customer.

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -330,7 +330,9 @@ class WC_Checkout {
 	 * @return void
 	 */
 	public function process_checkout() {
-		wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-process_checkout' );
+		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-process_checkout' ) ) {
+			return;
+		}
 
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) )
 			define( 'WOOCOMMERCE_CHECKOUT', true );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -44,11 +44,9 @@ class WC_Form_Handler {
 			return;
 		}
 
-		if ( empty( $_POST[ 'action' ] ) || ( 'edit_address' !== $_POST[ 'action' ] ) || empty( $_POST['_wpnonce'] ) ) {
+		if ( empty( $_POST[ 'action' ] ) || ( 'edit_address' !== $_POST[ 'action' ] ) || empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-edit_address' ) ) {
 			return;
 		}
-
-		wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-edit_address' );
 
 		$user_id = get_current_user_id();
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -856,8 +856,6 @@ class WC_Form_Handler {
 	 * Process the registration form.
 	 */
 	public static function process_registration() {
-		print_r( $_POST );
-		//die( 'Before' );
 		if ( ! empty( $_POST['register'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-register' ) ) {
 			die( 'Passed' );
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -857,7 +857,6 @@ class WC_Form_Handler {
 	 */
 	public static function process_registration() {
 		if ( ! empty( $_POST['register'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-register' ) ) {
-			die( 'Passed' );
 
 			if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) ) {
 				$_username = $_POST['username'];

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -729,9 +729,7 @@ class WC_Form_Handler {
 	 * Process the login form.
 	 */
 	public static function process_login() {
-		if ( ! empty( $_POST['login'] ) && ! empty( $_POST['_wpnonce'] ) ) {
-
-			wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-login' );
+		if ( ! empty( $_POST['login'] ) && ! empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-login' ) ) {
 
 			try {
 				$creds  = array();

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -44,7 +44,11 @@ class WC_Form_Handler {
 			return;
 		}
 
-		if ( empty( $_POST[ 'action' ] ) || ( 'edit_address' !== $_POST[ 'action' ] ) || empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-edit_address' ) ) {
+		if ( empty( $_POST[ 'action' ] ) || ( 'edit_address' !== $_POST[ 'action' ] ) || empty( $_POST['_wpnonce'] ) ) {
+			return;
+		}
+
+		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-edit_address' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -141,11 +141,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		if ( empty( $_POST[ 'action' ] ) || ( 'save_account_details' !== $_POST[ 'action' ] ) || empty( $_POST['_wpnonce'] ) ) {
-			return;
-		}
-
-		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'save_account_details' ) ) {
+		if ( empty( $_POST[ 'action' ] ) || ( 'save_account_details' !== $_POST[ 'action' ] ) || empty( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'save_account_details' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -147,7 +147,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-save_account_details' );
+		wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-save_account_details_' . (int) get_current_user_id() );
 
 		$update       = true;
 		$errors       = new WP_Error();

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -803,14 +803,13 @@ class WC_Form_Handler {
 		}
 
 		// process lost password form
-		if ( isset( $_POST['user_login'] ) && isset( $_POST['_wpnonce'] ) ) {
-			wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-lost_password' );
+		if ( isset( $_POST['user_login'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'lost_password' ) ) {
 
 			WC_Shortcode_My_Account::retrieve_password();
 		}
 
 		// process reset password form
-		if ( isset( $_POST['password_1'] ) && isset( $_POST['password_2'] ) && isset( $_POST['reset_key'] ) && isset( $_POST['reset_login'] ) && isset( $_POST['_wpnonce'] ) ) {
+		if ( isset( $_POST['password_1'] ) && isset( $_POST['password_2'] ) && isset( $_POST['reset_key'] ) && isset( $_POST['reset_login'] ) && isset( $_POST['_wpnonce'] ) &&  wp_verify_nonce( $_POST['_wpnonce'], 'reset_password' ) ) {
 
 			// verify reset key again
 			$user = WC_Shortcode_My_Account::check_password_reset_key( $_POST['reset_key'], $_POST['reset_login'] );
@@ -820,8 +819,6 @@ class WC_Form_Handler {
 				// save these values into the form again in case of errors
 				$args['key']   = wc_clean( $_POST['reset_key'] );
 				$args['login'] = wc_clean( $_POST['reset_login'] );
-
-				wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-reset_password' );
 
 				if ( empty( $_POST['password_1'] ) || empty( $_POST['password_2'] ) ) {
 					wc_add_notice( __( 'Please enter your password.', 'woocommerce' ), 'error' );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -856,7 +856,10 @@ class WC_Form_Handler {
 	 * Process the registration form.
 	 */
 	public static function process_registration() {
-		if ( ! empty( $_POST['register'] ) && wp_verify_nonce( $_POST['register'], 'register' ) ) {
+		print_r( $_POST );
+		//die( 'Before' );
+		if ( ! empty( $_POST['register'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-register' ) ) {
+			die( 'Passed' );
 
 			if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) ) {
 				$_username = $_POST['username'];

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -147,7 +147,9 @@ class WC_Form_Handler {
 			return;
 		}
 
-		wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-save_account_details_' . (int) get_current_user_id() );
+		if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'save_account_details' ) ) {
+			return;
+		}
 
 		$update       = true;
 		$errors       = new WP_Error();

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -856,9 +856,7 @@ class WC_Form_Handler {
 	 * Process the registration form.
 	 */
 	public static function process_registration() {
-		if ( ! empty( $_POST['register'] ) ) {
-
-			wp_verify_nonce( $_POST['register'], 'woocommerce-register' );
+		if ( ! empty( $_POST['register'] ) && wp_verify_nonce( $_POST['register'], 'register' ) ) {
 
 			if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) ) {
 				$_username = $_POST['username'];

--- a/includes/shortcodes/class-wc-shortcode-order-tracking.php
+++ b/includes/shortcodes/class-wc-shortcode-order-tracking.php
@@ -42,9 +42,7 @@ class WC_Shortcode_Order_Tracking {
 
 		global $post;
 
-		if ( ! empty( $_REQUEST['orderid'] ) ) {
-
-			wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-order_tracking' );
+		if ( ! empty( $_REQUEST['orderid'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-order_tracking' ) ) {
 
 			$order_id 		= empty( $_REQUEST['orderid'] ) ? 0 : esc_attr( $_REQUEST['orderid'] );
 			$order_email	= empty( $_REQUEST['order_email'] ) ? '' : esc_attr( $_REQUEST['order_email']) ;

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -52,11 +52,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php do_action( 'woocommerce_edit_account_form' ); ?>
 
 	<p>
-		<?php wp_nonce_field( 'save_account_details' ); ?>
+		<?php wp_nonce_field( 'save_account_details_' . (int) get_current_user_id() ); ?>
 		<input type="submit" class="button" name="save_account_details" value="<?php _e( 'Save changes', 'woocommerce' ); ?>" />
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 
-	<?php do_action( 'woocommerce_edit_account_form_end_' . (int) get_current_user_id() ); ?>
+	<?php do_action( 'woocommerce_edit_account_form_end' ); ?>
 	
 </form>

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -57,6 +57,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 
-	<?php do_action( 'woocommerce_edit_account_form_end' ); ?>
+	<?php do_action( 'woocommerce_edit_account_form_end_' . (int) get_current_user_id() ); ?>
 	
 </form>

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php do_action( 'woocommerce_edit_account_form' ); ?>
 
 	<p>
-		<?php wp_nonce_field( 'save_account_details_' . (int) get_current_user_id() ); ?>
+		<?php wp_nonce_field( 'save_account_details' ); ?>
 		<input type="submit" class="button" name="save_account_details" value="<?php _e( 'Save changes', 'woocommerce' ); ?>" />
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -98,7 +98,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php do_action( 'register_form' ); ?>
 
 			<p class="form-row">
-				<?php wp_nonce_field( 'woocommerce-register', 'register' ); ?>
+				<?php wp_nonce_field( 'woocommerce-register' ); ?>
 				<input type="submit" class="button" name="register" value="<?php _e( 'Register', 'woocommerce' ); ?>" />
 			</p>
 

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     2.1.0
+ * @version     2.2.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Nonces should be more unique, in the case unique to the customer as you could possibly setup a remote form with the generic 'save_account_details' nonce that when a customer submits it can update their email to something else and allow that person to reset the password.

Adding in the user ID make it more unique to that user so the nonce will fail if it was taken from another user edit details form.
