### PR TITLE
Added DocBlock to woocommerce_after_shop_loop_item

### DIFF
--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -67,6 +67,15 @@ if ( 0 == $woocommerce_loop['loop'] % $woocommerce_loop['columns'] )
 
 	</a>
 
-	<?php do_action( 'woocommerce_after_shop_loop_item' ); ?>
+	<?php
+
+		/**
+		 * woocommerce_after_shop_loop_item hook
+		 *
+		 * @hooked woocommerce_template_loop_add_to_cart - 10
+		 */
+		do_action( 'woocommerce_after_shop_loop_item' ); 
+
+	?>
 
 </li>


### PR DESCRIPTION
Noticed that the woocommerce_after_shop_loop_item was lacking a DocBlock, detailing the hooks attached to it. Added it :)
