### PR TITLE
Fixed cropping function to respect option settings

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -407,7 +407,7 @@ function wc_get_image_size( $image_size ) {
 		$size           = get_option( $image_size . '_image_size', array() );
 		$size['width']  = isset( $size['width'] ) ? $size['width'] : '300';
 		$size['height'] = isset( $size['height'] ) ? $size['height'] : '300';
-		$size['crop']   = isset( $size['crop'] ) ? 1 : 0;
+		$size['crop']   = isset( $size['crop'] ) ? $size['crop'] : 0;
 	} else {
 		$size = array(
 			'width'  => '300',


### PR DESCRIPTION
I don’t think that it is the right way to set the cropping by checking if the ‚crop’ option is set because it could have been set to 0 in the options. In that case it would be cropped either way because isset would also return true.
