### PR TITLE
added tooltip hint to expiration date field and CVV code field

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -1487,6 +1487,85 @@ p.demo_store {
 		}
 	}
 
+	/* Tooltips */
+	.tips {
+		cursor: help;
+		text-decoration: none;
+	}
+
+	/* TipTip CSS - Version 1.2 (custom) */
+	#tiptip_holder {
+		display: none;
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: 99999;
+	}
+	#tiptip_holder {
+		&.tip_top {
+			padding-bottom: 5px;
+
+			#tiptip_arrow_inner {
+				margin-top: -7px;
+				margin-left: -6px;
+				border-top-color: #464646;
+			}
+		}
+		&.tip_bottom {
+			padding-top: 5px;
+
+			#tiptip_arrow_inner {
+				margin-top: -5px;
+				margin-left: -6px;
+				border-bottom-color: #464646;
+			}
+		}
+		&.tip_right {
+			padding-left: 5px;
+
+			#tiptip_arrow_inner {
+				margin-top: -6px;
+				margin-left: -5px;
+				border-right-color: #464646;
+			}
+		}
+		&.tip_left {
+			padding-right: 5px;
+
+			#tiptip_arrow_inner {
+				margin-top: -6px;
+				margin-left: -7px;
+				border-left-color: #464646;
+			}
+		}
+	}
+	#tiptip_content {
+		font-size: 11px;
+		color: #fff;
+		padding: .5em .5em;
+		background:#464646;
+		-webkit-border-radius: 3px;
+		-moz-border-radius: 3px;
+		border-radius: 3px;
+		-webkit-box-shadow: 1px 1px 3px rgba(0,0,0,0.10);
+		-moz-box-shadow: 1px 1px 3px rgba(0,0,0,0.10);
+		box-shadow: 1px 1px 3px rgba(0,0,0,0.10);
+		text-align: center;
+		max-width: 150px;
+		code {
+			background: #888;
+			padding: 1px;
+		}
+	}
+	#tiptip_arrow, #tiptip_arrow_inner {
+		position: absolute;
+		border-color: transparent;
+		border-style: solid;
+		border-width: 6px;
+		height: 0;
+		width: 0;
+	}
+
 	/* Payment box - appears on checkout and page page */
 	#payment {
 		background: $secondary;

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -154,6 +154,14 @@ jQuery( function( $ ) {
 		} else {
 			$( '#place_order' ).val( $( '#place_order' ).data( 'value' ) );
 		}
+
+		// run tip tip
+		$( '.tips' ).tipTip({
+			'attribute': 'data-tip',
+			'fadeIn': 50,
+			'fadeOut': 50,
+			'delay': 200
+		});
 	})
 
 	// Trigger initial click

--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -276,11 +276,11 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 				<input id="' . esc_attr( $this->id ) . '-card-number" class="input-text wc-credit-card-form-card-number" type="text" maxlength="20" autocomplete="off" placeholder="•••• •••• •••• ••••" name="' . ( $args['fields_have_names'] ? $this->id . '-card-number' : '' ) . '" />
 			</p>',
 			'card-expiry-field' => '<p class="form-row form-row-first">
-				<label for="' . esc_attr( $this->id ) . '-card-expiry">' . __( 'Expiry (MM/YY)', 'woocommerce' ) . ' <span class="required">*</span></label>
+				<label for="' . esc_attr( $this->id ) . '-card-expiry">' . __( 'Expiry (MM/YY)', 'woocommerce' ) . ' <span class="tips" data-tip="' . __( 'Enter the credit card expiration date stated on your card.', 'woocommerce' ) . '">[?]</span> <span class="required">*</span></label>
 				<input id="' . esc_attr( $this->id ) . '-card-expiry" class="input-text wc-credit-card-form-card-expiry" type="text" autocomplete="off" placeholder="' . __( 'MM / YY', 'woocommerce' ) . '" name="' . ( $args['fields_have_names'] ? $this->id . '-card-expiry' : '' ) . '" />
 			</p>',
 			'card-cvc-field' => '<p class="form-row form-row-last">
-				<label for="' . esc_attr( $this->id ) . '-card-cvc">' . __( 'Card Code', 'woocommerce' ) . ' <span class="required">*</span></label>
+				<label for="' . esc_attr( $this->id ) . '-card-cvc">' . __( 'Card Code', 'woocommerce' ) . ' <span class="tips" data-tip="' . __( 'Enter the 3 digit security code from the back of the card.  For AMEX, it is the 4 digit in the front.', 'woocommerce' ) . '">[?]</span> <span class="required">*</span></label>
 				<input id="' . esc_attr( $this->id ) . '-card-cvc" class="input-text wc-credit-card-form-card-cvc" type="text" autocomplete="off" placeholder="' . __( 'CVC', 'woocommerce' ) . '" name="' . ( $args['fields_have_names'] ? $this->id . '-card-cvc' : '' ) . '" />
 			</p>'
 		);

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -122,6 +122,7 @@ class WC_Frontend_Scripts {
 		self::register_script( 'wc-single-product', $frontend_script_path . 'single-product' . $suffix . '.js' );
 		self::register_script( 'wc-country-select', $frontend_script_path . 'country-select' . $suffix . '.js' );
 		self::register_script( 'wc-address-i18n', $frontend_script_path . 'address-i18n' . $suffix . '.js' );
+		self::register_script( 'jquery-tiptip', $assets_path . 'js/jquery-tiptip/jquery.tipTip' . $suffix . '.js', array( 'jquery' ), '1.3' );
 
 		// Register frontend scripts conditionally
 		if ( $ajax_cart_en ) {
@@ -135,7 +136,7 @@ class WC_Frontend_Scripts {
 			wp_enqueue_style( 'woocommerce_chosen_styles', $assets_path . 'css/chosen.css' );
 		}
 		if ( is_checkout() ) {
-			self::enqueue_script( 'wc-checkout', $frontend_script_path . 'checkout' . $suffix . '.js', array( 'jquery', 'woocommerce', 'wc-country-select', 'wc-address-i18n' ) );
+			self::enqueue_script( 'wc-checkout', $frontend_script_path . 'checkout' . $suffix . '.js', array( 'jquery', 'woocommerce', 'wc-country-select', 'wc-address-i18n', 'jquery-tiptip' ) );
 		}
 		if ( is_add_payment_method_page() ) {
 			self::enqueue_script( 'wc-add-payment-method', $frontend_script_path . 'add-payment-method' . $suffix . '.js', array( 'jquery', 'woocommerce' ) );


### PR DESCRIPTION
Occasionally I am still getting support tickets asking if we could add some sort of hint/description for the credit card fields especially the CVV/card code field as some customers still don't know what that is.  

So this commit adds jQuery tiptip to checkout and added the hint text to the expiration and CVV code fields.  Be sure to compile the woocommerce sass file to see it in affect.
