### PR TITLE
Added Address Format for India

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -379,6 +379,7 @@ class WC_Countries {
 				'FR' => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city_upper}\n{country}",
 				'HK' => "{company}\n{first_name} {last_name_upper}\n{address_1}\n{address_2}\n{city_upper}\n{state_upper}\n{country}",
 				'HU' => "{name}\n{company}\n{city}\n{address_1}\n{address_2}\n{postcode}\n{country}",
+				'IN' => "{company}\n{name}\n{address_1}\n{address_2}\n{city} - {postcode}\n{state}, {country}",
 				'IS' => $postcode_before_city,
 				'IT' => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode}\n{city}\n{state_upper}\n{country}",
 				'JP' => "{postcode}\n{state}{city}{address_1}\n{address_2}\n{company}\n{last_name} {first_name}\n {country}",


### PR DESCRIPTION
In India the Postcode is at the city level, thus updated the file in accordance with the Indian Standard of Address Formatting.
@ line # 382: Hyphenated Postcode to the City Name & State then Country.

_REF:_ 
1. I am an Indian Citizen myself
2. http://en.wikipedia.org/wiki/Address_(geography)#India
3. http://www.addressdoctor.com/en/countries-data/address-formats.html#fbid=Bv4FMyXjoPh
4. http://www.bitboost.com/ref/international-address-formats/india/
