### PR TITLE
Avoid notices if file does not exist

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -266,6 +266,11 @@ class WC_Admin_Status {
 	 * @return string
 	 */
 	public static function get_file_version( $file ) {
+		// Avoid notices if file does not exist
+		if ( ! file_exists( $file ) ) {
+			return '';
+		}
+
 		// We don't need to write to the file, so just open for reading.
 		$fp = fopen( $file, 'r' );
 


### PR DESCRIPTION
1. I've got notices on files
   my-theme/woocommerce/single-product\add-to-cart\bundle.php, 
   my-theme/woocommerce/single-product\bundled-item-image.php, 
   my-theme/woocommerce/single-product\bundled-item-title.php
   which are Template Overrides (WooCommerce Product Bundles)
   and do not exist in the WC plugin.
2. There should be a more elegant way, because this is just to shut up notices. No version comparison performed.
