### PR TITLE
Added cancelled order admin email

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -41,7 +41,7 @@ class WC_Meta_Box_Order_Actions {
 					<optgroup label="<?php _e( 'Resend order emails', 'woocommerce' ); ?>">
 						<?php
 						$mailer           = WC()->mailer();
-						$available_emails = apply_filters( 'woocommerce_resend_order_emails_available', array( 'new_order', 'customer_processing_order', 'customer_completed_order', 'customer_invoice' ) );
+						$available_emails = apply_filters( 'woocommerce_resend_order_emails_available', array( 'new_order', 'cancelled_order', 'customer_processing_order', 'customer_completed_order', 'customer_invoice' ) );
 						$mails            = $mailer->get_emails();
 
 						if ( ! empty( $mails ) ) {

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -106,6 +106,7 @@ class WC_Emails {
 		include_once( 'emails/class-wc-email.php' );
 
 		$this->emails['WC_Email_New_Order']                 = include( 'emails/class-wc-email-new-order.php' );
+		$this->emails['WC_Email_Cancelled_Order']           = include( 'emails/class-wc-email-cancelled-order.php' );
 		$this->emails['WC_Email_Customer_Processing_Order'] = include( 'emails/class-wc-email-customer-processing-order.php' );
 		$this->emails['WC_Email_Customer_Completed_Order']  = include( 'emails/class-wc-email-customer-completed-order.php' );
 		$this->emails['WC_Email_Customer_Invoice']          = include( 'emails/class-wc-email-customer-invoice.php' );

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -1,0 +1,161 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'WC_Email_Cancelled_Order' ) ) :
+
+/**
+ * Cancelled Order Email
+ *
+ * An email sent to the admin when a new order is received/paid for.
+ *
+ * @class       WC_Email_Cancelled_Order
+ * @version     2.2.7
+ * @package     WooCommerce/Classes/Emails
+ * @author      WooThemes
+ * @extends     WC_Email
+ */
+class WC_Email_Cancelled_Order extends WC_Email {
+
+    /**
+     * Constructor
+     */
+    function __construct() {
+
+        $this->id               = 'cancelled_order';
+        $this->title            = __( 'Cancelled order', 'woocommerce' );
+        $this->description      = __( 'Cancelled order emails are sent when an order has been marked to cancelled from pending or on hold.', 'woocommerce' );
+
+        $this->heading          = __( 'Cancelled order', 'woocommerce' );
+        $this->subject          = __( '[{site_title}] Cancelled order ({order_number})', 'woocommerce' );
+
+        $this->template_html    = 'emails/admin-cancelled-order.php';
+        $this->template_plain   = 'emails/plain/admin-cancelled-order.php';
+
+        // Triggers for this email
+        add_action( 'woocommerce_order_status_pending_to_cancelled_notification', array( $this, 'trigger' ) );
+        add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ) );
+
+        // Call parent constructor
+        parent::__construct();
+
+        // Other settings
+        $this->recipient = $this->get_option( 'recipient' );
+
+        if ( ! $this->recipient )
+            $this->recipient = get_option( 'admin_email' );
+    }
+
+    /**
+     * trigger function.
+     *
+     * @access public
+     * @return void
+     */
+    function trigger( $order_id ) {
+
+        if ( $order_id ) {
+            $this->object       = wc_get_order( $order_id );
+
+            $this->find['order-number']    = '{order_number}';
+
+            $this->replace['order-number'] = $this->object->get_order_number();
+        }
+
+        if ( ! $this->is_enabled() || ! $this->get_recipient() ) {
+            return;
+        }
+
+        $this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+    }
+
+    /**
+     * get_content_html function.
+     *
+     * @access public
+     * @return string
+     */
+    function get_content_html() {
+        ob_start();
+        wc_get_template( $this->template_html, array(
+            'order'         => $this->object,
+            'email_heading' => $this->get_heading(),
+            'sent_to_admin' => true,
+            'plain_text'    => false
+        ) );
+        return ob_get_clean();
+    }
+
+    /**
+     * get_content_plain function.
+     *
+     * @access public
+     * @return string
+     */
+    function get_content_plain() {
+        ob_start();
+        wc_get_template( $this->template_plain, array(
+            'order'         => $this->object,
+            'email_heading' => $this->get_heading(),
+            'sent_to_admin' => true,
+            'plain_text'    => true
+        ) );
+        return ob_get_clean();
+    }
+
+    /**
+     * Initialise Settings Form Fields
+     *
+     * @access public
+     * @return void
+     */
+    function init_form_fields() {
+        $this->form_fields = array(
+            'enabled' => array(
+                'title'         => __( 'Enable/Disable', 'woocommerce' ),
+                'type'          => 'checkbox',
+                'label'         => __( 'Enable this email notification', 'woocommerce' ),
+                'default'       => 'yes'
+            ),
+            'recipient' => array(
+                'title'         => __( 'Recipient(s)', 'woocommerce' ),
+                'type'          => 'text',
+                'description'   => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to <code>%s</code>.', 'woocommerce' ), esc_attr( get_option('admin_email') ) ),
+                'placeholder'   => '',
+                'default'       => ''
+            ),
+            'subject' => array(
+                'title'         => __( 'Subject', 'woocommerce' ),
+                'type'          => 'text',
+                'description'   => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'woocommerce' ), $this->subject ),
+                'placeholder'   => '',
+                'default'       => ''
+            ),
+            'heading' => array(
+                'title'         => __( 'Email Heading', 'woocommerce' ),
+                'type'          => 'text',
+                'description'   => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'woocommerce' ), $this->heading ),
+                'placeholder'   => '',
+                'default'       => ''
+            ),
+            'email_type' => array(
+                'title'         => __( 'Email type', 'woocommerce' ),
+                'type'          => 'select',
+                'description'   => __( 'Choose which format of email to send.', 'woocommerce' ),
+                'default'       => 'html',
+                'class'         => 'email_type',
+                'options'       => array(
+                    'plain'         => __( 'Plain text', 'woocommerce' ),
+                    'html'          => __( 'HTML', 'woocommerce' ),
+                    'multipart'     => __( 'Multipart', 'woocommerce' ),
+                )
+            )
+        );
+    }
+}
+
+endif;
+
+return new WC_Email_Cancelled_Order();

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Admin cancelled order email
+ *
+ * @author      WooThemes
+ * @package     WooCommerce/Templates/Emails
+ * @version     2.0.0
+ */
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
+
+<?php do_action( 'woocommerce_email_header', $email_heading ); ?>
+
+<p><?php printf( __( 'The order #%d from %s has been cancelled. The order was as follow:', 'woocommerce' ), $order->id, $order->billing_first_name . ' ' . $order->billing_last_name ); ?></p>
+
+<?php do_action( 'woocommerce_email_before_order_table', $order, true, false ); ?>
+
+<h2><a href="<?php echo admin_url( 'post.php?post=' . $order->id . '&action=edit' ); ?>"><?php printf( __( 'Order: %s', 'woocommerce'), $order->get_order_number() ); ?></a> (<?php printf( '<time datetime="%s">%s</time>', date_i18n( 'c', strtotime( $order->order_date ) ), date_i18n( wc_date_format(), strtotime( $order->order_date ) ) ); ?>)</h2>
+
+<table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
+	<thead>
+		<tr>
+			<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Product', 'woocommerce' ); ?></th>
+			<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Quantity', 'woocommerce' ); ?></th>
+			<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php _e( 'Price', 'woocommerce' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php echo $order->email_order_items_table( false, true ); ?>
+	</tbody>
+	<tfoot>
+		<?php
+			if ( $totals = $order->get_order_item_totals() ) {
+				$i = 0;
+				foreach ( $totals as $total ) {
+					$i++;
+					?><tr>
+						<th scope="row" colspan="2" style="text-align:left; border: 1px solid #eee; <?php if ( $i == 1 ) echo 'border-top-width: 4px;'; ?>"><?php echo $total['label']; ?></th>
+						<td style="text-align:left; border: 1px solid #eee; <?php if ( $i == 1 ) echo 'border-top-width: 4px;'; ?>"><?php echo $total['value']; ?></td>
+					</tr><?php
+				}
+			}
+		?>
+	</tfoot>
+</table>
+
+<?php do_action( 'woocommerce_email_after_order_table', $order, true, false ); ?>
+
+<?php do_action( 'woocommerce_email_order_meta', $order, true, false ); ?>
+
+<h2><?php _e( 'Customer details', 'woocommerce' ); ?></h2>
+
+<?php if ( $order->billing_email ) : ?>
+	<p><strong><?php _e( 'Email:', 'woocommerce' ); ?></strong> <?php echo $order->billing_email; ?></p>
+<?php endif; ?>
+<?php if ( $order->billing_phone ) : ?>
+	<p><strong><?php _e( 'Tel:', 'woocommerce' ); ?></strong> <?php echo $order->billing_phone; ?></p>
+<?php endif; ?>
+
+<?php wc_get_template( 'emails/email-addresses.php', array( 'order' => $order ) ); ?>
+
+<?php do_action( 'woocommerce_email_footer' ); ?>

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Admin cancelled order email (plain text)
+ *
+ * @author      WooThemes
+ * @package     WooCommerce/Templates/Emails/Plain
+ * @version     2.0.0
+ */
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+echo $email_heading . "\n\n";
+
+echo srintf( __( 'The order #%d from %s has been cancelled. The order was as follow:', 'woocommerce' ), $order->id, $order->billing_first_name . ' ' . $order->billing_last_name ) . "\n\n";
+
+echo "****************************************************\n\n";
+
+do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text );
+
+echo sprintf( __( 'Order number: %s', 'woocommerce'), $order->get_order_number() ) . "\n";
+echo sprintf( __( 'Order link: %s', 'woocommerce'), admin_url( 'post.php?post=' . $order->id . '&action=edit' ) ) . "\n";
+echo sprintf( __( 'Order date: %s', 'woocommerce'), date_i18n( __( 'jS F Y', 'woocommerce' ), strtotime( $order->order_date ) ) ) . "\n";
+
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text );
+
+echo "\n" . $order->email_order_items_table( false, true, '', '', '', true );
+
+echo "----------\n\n";
+
+if ( $totals = $order->get_order_item_totals() ) {
+    foreach ( $totals as $total ) {
+        echo $total['label'] . "\t " . $total['value'] . "\n";
+    }
+}
+
+echo "\n****************************************************\n\n";
+
+do_action( 'woocommerce_email_after_order_table', $order, $sent_to_admin, $plain_text );
+
+echo __( 'Customer details', 'woocommerce' ) . "\n";
+
+if ( $order->billing_email )
+    echo __( 'Email:', 'woocommerce' ); echo $order->billing_email . "\n";
+
+if ( $order->billing_phone )
+    echo __( 'Tel:', 'woocommerce' ); ?> <?php echo $order->billing_phone . "\n";
+
+wc_get_template( 'emails/plain/email-addresses.php', array( 'order' => $order ) );
+
+echo "\n****************************************************\n\n";
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -391,10 +391,12 @@ final class WooCommerce {
 			'woocommerce_product_on_backorder',
 			'woocommerce_order_status_pending_to_processing',
 			'woocommerce_order_status_pending_to_completed',
+			'woocommerce_order_status_pending_to_cancelled',
 			'woocommerce_order_status_pending_to_on-hold',
 			'woocommerce_order_status_failed_to_processing',
 			'woocommerce_order_status_failed_to_completed',
 			'woocommerce_order_status_on-hold_to_processing',
+			'woocommerce_order_status_on-hold_to_cancelled',
 			'woocommerce_order_status_completed',
 			'woocommerce_new_customer_note',
 			'woocommerce_created_customer'


### PR DESCRIPTION
Added the cancelled order admin email notification. Useful when an order has been cancelled automatically because the customer does not pay for it.

It's triggered when the order status changes from

on-hold -> cancelled
pending -> cancelled

i was not sure if i should add it also when the status changes from failed. What do you think @mikejolley ?
