### PR TITLE
Small fixes: attachment page & get_category_parents() 

### DIFF
--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -44,7 +44,7 @@ if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_f
 		if ( 0 != $this_category->parent ) {
 			$parent_category = get_category( $this_category->parent );
 			if ( ( $parents = get_category_parents( $parent_category, TRUE, $after . $delimiter . $before ) ) && ! is_wp_error( $parents ) ) {
-				echo $before . substr( $parents, 0, strlen($parents) - strlen($after . $delimiter . $before) ) . $after . $delimiter;
+				echo $before . substr( $parents, 0, strlen( $parents ) - strlen( $after . $delimiter . $before ) ) . $after . $delimiter;
 			}
 		}
 
@@ -145,7 +145,7 @@ if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_f
 
 			$cat = current( get_the_category() );
 			if ( ( $parents = get_category_parents( $cat, TRUE, $after . $delimiter . $before ) ) && ! is_wp_error( $parents ) ) {
-				echo $before . substr( $parents, 0, strlen($parents) - strlen($after . $delimiter . $before) ) . $after . $delimiter;
+				echo $before . substr( $parents, 0, strlen( $parents ) - strlen( $after . $delimiter . $before ) ) . $after . $delimiter;
 			}
 			echo $before . get_the_title() . $after;
 
@@ -168,7 +168,7 @@ if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_f
 		$parent = get_post( $post->post_parent );
 		$cat = current( get_the_category( $parent->ID ) );
 		if ( ( $parents = get_category_parents( $cat, TRUE, $after . $delimiter . $before ) ) && ! is_wp_error( $parents ) ) {
-			echo $before . substr( $parents, 0, strlen($parents) - strlen($after . $delimiter . $before) ) . $after . $delimiter;
+			echo $before . substr( $parents, 0, strlen( $parents ) - strlen( $after . $delimiter . $before ) ) . $after . $delimiter;
 		}
 		echo $before . '<a href="' . get_permalink( $parent ) . '">' . $parent->post_title . '</a>' . $after . $delimiter;
 		echo $before . get_the_title() . $after;

--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -44,7 +44,7 @@ if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_f
 		if ( 0 != $this_category->parent ) {
 			$parent_category = get_category( $this_category->parent );
 			if ( ( $parents = get_category_parents( $parent_category, TRUE, $after . $delimiter . $before ) ) && ! is_wp_error( $parents ) ) {
-				echo $before . rtrim( $parents, $after . $delimiter . $before ) . $after . $delimiter;
+				echo $before . substr( $parents, 0, strlen($parents) - strlen($after . $delimiter . $before) ) . $after . $delimiter;
 			}
 		}
 
@@ -145,7 +145,7 @@ if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_f
 
 			$cat = current( get_the_category() );
 			if ( ( $parents = get_category_parents( $cat, TRUE, $after . $delimiter . $before ) ) && ! is_wp_error( $parents ) ) {
-				echo $before . rtrim( $parents, $after . $delimiter . $before ) . $after . $delimiter;
+				echo $before . substr( $parents, 0, strlen($parents) - strlen($after . $delimiter . $before) ) . $after . $delimiter;
 			}
 			echo $before . get_the_title() . $after;
 
@@ -166,10 +166,9 @@ if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_f
 	} elseif ( is_attachment() ) {
 
 		$parent = get_post( $post->post_parent );
-		$cat = get_the_category( $parent->ID );
-		$cat = $cat[0];
+		$cat = current( get_the_category( $parent->ID ) );
 		if ( ( $parents = get_category_parents( $cat, TRUE, $after . $delimiter . $before ) ) && ! is_wp_error( $parents ) ) {
-			echo $before . rtrim( $parents, $after . $delimiter . $before ) . $after . $delimiter;
+			echo $before . substr( $parents, 0, strlen($parents) - strlen($after . $delimiter . $before) ) . $after . $delimiter;
 		}
 		echo $before . '<a href="' . get_permalink( $parent ) . '">' . $parent->post_title . '</a>' . $after . $delimiter;
 		echo $before . get_the_title() . $after;


### PR DESCRIPTION
- Now the attachment page shouldn't print errors anymore
- The `rtrim()` function need to be replaced with `substr()` or
  something like `preg_replace(\' . preg_quote( $after . $delimiter .
  $before, '/' ) . '\z\', '', $parents);` (I recommend the one in my
  commit, because the `preg_quote()` function don't escape everything
  per default.
  The reason why we should replace the current solution is, that
  `rtrim()` removes the last string more than once time. For example:
  `rtrim('>>>1>>>', '>')` outputs the following: `>>>1`. This can
  result into conflicts, if you're using a tag (for example:
  `<li></li>`) as `$before` and `$after`. So the `rtrim()`
  also removes the `>` from the `</a>` tag of the `$parents`
  variable. This results in html structure problems.
