### PR TITLE
Filters added to $base_price

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1008,8 +1008,8 @@ class WC_Cart {
 				$this->cart_contents_count  += $values['quantity'];
 
 				// Prices
-				$base_price = $_product->get_price();
-				$line_price = $_product->get_price() * $values['quantity'];
+				$base_price = apply_filters( 'woocommerce_base_price', $_product->get_price(), $values, $cart_item_key);
+				$line_price = $base_price * $values['quantity'];
 
 				$line_subtotal = 0;
 				$line_subtotal_tax = 0;
@@ -1106,8 +1106,8 @@ class WC_Cart {
 				$_product = $values['data'];
 
 				// Prices
-				$base_price = $_product->get_price();
-				$line_price = $_product->get_price() * $values['quantity'];
+				$base_price = apply_filters( 'woocommerce_base_price', $_product->get_price(), $values, $cart_item_key);
+				$line_price = $base_price * $values['quantity'];
 
 				// Tax data
 				$taxes = array();

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1008,7 +1008,7 @@ class WC_Cart {
 				$this->cart_contents_count  += $values['quantity'];
 
 				// Prices
-				$base_price = apply_filters( 'woocommerce_base_price', $_product->get_price(), $values, $cart_item_key);
+				$base_price = apply_filters( 'woocommerce_cart_totals_base_price', $_product->get_price(), $values, $cart_item_key);
 				$line_price = $base_price * $values['quantity'];
 
 				$line_subtotal = 0;
@@ -1106,7 +1106,7 @@ class WC_Cart {
 				$_product = $values['data'];
 
 				// Prices
-				$base_price = apply_filters( 'woocommerce_base_price', $_product->get_price(), $values, $cart_item_key);
+				$base_price = apply_filters( 'woocommerce_cart_totals_base_price', $_product->get_price(), $values, $cart_item_key);
 				$line_price = $base_price * $values['quantity'];
 
 				// Tax data


### PR DESCRIPTION
It would be great to have opportunity to change $base_price through filters if product price depends on the quantity, for example.
Say, if I ordered {x} units, then the base_price will be 5$. But if I ordered more than {y}, then it will be 3$.

The add_filter function might look like:

``` php
add_filter( 'woocommerce_cart_totals_base_price', 'my_base_price', 10, 2);
function my_base_price($price, $cart_item) {
    $product_id   = $cart_item['product_id'];
    // x < y
    $product_more_than_x = get_post_meta( $product_id, '_woo_more_than_x', true );
    $product_more_than_y = get_post_meta( $product_id, '_woo_more_than_y', true );

    if ($cart_item['quantity'] >= $product_more_than_y) {
        return get_post_meta( $product_id, '_woo_big_price', true );
    } elseif ($cart_item['quantity'] >= $product_more_than_x) {
        return get_post_meta( $product_id, '_woo_medium_price', true );
    } else {
        return $price;   
    }
}
```
