### PR TITLE
Set cookies when using AJAX add to cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -926,7 +926,7 @@ class WC_Cart {
 
 			}
 
-			if ( did_action( 'wp' ) ) {
+			if ( did_action( 'wp' ) || defined( 'DOING_AJAX' ) ) {
 				$this->set_cart_cookies( sizeof( $this->cart_contents ) > 0 );
 			}
 


### PR DESCRIPTION
This change ensures that cookies are set when non logged in user tries to add a product to cart using AJAX. Resolves #6244.
