### PR TITLE
Sass bourbon

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function( grunt ) {
 			compile: {
 				options: {
 					sourcemap: 'none',
-					loadPath: require( 'node-bourbon' ).includePaths
+					loadPath: require( 'sass-bourbon' ).includePaths
 				},
 				files: [{
 					expand: true,

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-sass": "^0.8.1",
-    "grunt-contrib-uglify": "^0.5.1",
+    "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-shell": "^1.1.1",
-    "grunt-wp-i18n": "^0.4.8",
-    "node-bourbon": "^1.2.3"
+    "grunt-wp-i18n": "^0.4.9",
+    "sass-bourbon": "^4.0.2"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
Since WooCommerce is using Ruby Version of Sass via `grunt-contrib-sass` we are not forced to use [Bourbon 3.2.x](https://github.com/thoughtbot/bourbon#requirements) which node-bourbon is completely based. [sass-bourbon](https://github.com/axisthemes/sass-bourbon) is based upon the latest updates via bourbon :)

This Fixes #6709 :) 
