### PR TITLE
Add filter for registration auth cookie #6707

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -903,7 +903,9 @@ class WC_Form_Handler {
 				return;
 			}
 
-			wc_set_customer_auth_cookie( $new_customer );
+			if ( apply_filters( 'woocommerce_registration_auth_new_customer', true, $new_customer ) ) {
+				wc_set_customer_auth_cookie( $new_customer );
+			}
 
 			// Redirect
 			if ( wp_get_referer() ) {


### PR DESCRIPTION
I guess this makes sense in some cases. The user said:

> In combination with the option for WooCommerce to generate and send the registration password, this helps create an effective email verification loopback, a popular requested feature.

Thoughts?
