### PR TITLE
Checking $_POST['_wpnonce'] before using it; several typos fixed

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -638,7 +638,7 @@ class WC_Cart {
 				// Get the checkout URL
 				$checkout_url = get_permalink( $checkout_page_id );
 
-				// Force SLL if needed
+				// Force SSL if needed
 				if ( is_ssl() || 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ) {
 					$checkout_url = str_replace( 'http:', 'https:', $checkout_url );
 				}

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -856,7 +856,7 @@ class WC_Form_Handler {
 	 * Process the registration form.
 	 */
 	public static function process_registration() {
-		if ( ! empty( $_POST['register'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-register' ) ) {
+		if ( ! empty( $_POST['register'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-register' ) ) {
 
 			if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) ) {
 				$_username = $_POST['username'];

--- a/tests/unit-tests/cart.php
+++ b/tests/unit-tests/cart.php
@@ -21,7 +21,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 			// Get the permalink
 			$checkout_url = get_permalink( $checkout_page_id );
 
-			// Force SLL if needed
+			// Force SSL if needed
 			if ( is_ssl() || 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ) {
 				$checkout_url = str_replace( 'http:', 'https:', $checkout_url );
 			}
@@ -43,7 +43,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		// Get the original setting
 		$o_setting = get_option( 'woocommerce_force_ssl_checkout' );
 
-		// Force SLL checkout
+		// Force SSL checkout
 		update_option( 'woocommerce_force_ssl_checkout', 'no' );
 
 		$this->assertEquals( $this->get_checkout_url(), WC()->cart->get_checkout_url() );
@@ -63,7 +63,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		// Get the original setting
 		$o_setting = get_option( 'woocommerce_force_ssl_checkout' );
 
-		// Force SLL checkout
+		// Force SSL checkout
 		update_option( 'woocommerce_force_ssl_checkout', 'yes' );
 
 		$this->assertEquals( $this->get_checkout_url(), WC()->cart->get_checkout_url() );


### PR DESCRIPTION
Checking $_POST['_wpnonce'] before using it in WC_Form_Handler::process_registration().
Not having this check was triggering an `E_NOTICE`.
