### PR TITLE
Fixing a small typo

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -50,7 +50,7 @@ abstract class WC_Abstract_Order {
 	}
 
 	/**
-	 * Init/load the order object. Called from the contructor.
+	 * Init/load the order object. Called from the constructor.
 	 *
 	 * @param  string|int|WP_POST|WC_Order $order Order to init
 	 */


### PR DESCRIPTION
Fixing a small typo in the documentation of `WC_Abstract_Order`
