### PR TITLE
Improved Shop Page Display option

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -118,7 +118,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'type'     => 'select',
 					'options'  => array(
 						''              => __( 'Show products', 'woocommerce' ),
-						'subcategories' => __( 'Show subcategories', 'woocommerce' ),
+						'subcategories' => __( 'Show categories &amp; subcategories', 'woocommerce' ),
 						'both'          => __( 'Show both', 'woocommerce' ),
 					),
 					'desc_tip' =>  true,


### PR DESCRIPTION
I tweaked the text of the second option in Shop Page Display because i guess it confuse users that only read "Show subcategories". What about main categories?

I'd like to change also "Show both" to "Show all". What do you think?
