### PR TITLE
ensure storage is writable when setting support flag. fixes #6755

### DIFF
--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -8,6 +8,9 @@ jQuery( function( $ ) {
 	/** Cart Handling */
 	try {
 		$supports_html5_storage = ( 'sessionStorage' in window && window.sessionStorage !== null );
+
+		window.sessionStorage.setItem( 'wc', 'test' );
+		window.sessionStorage.removeItem( 'wc' );
 	} catch( err ) {
 		$supports_html5_storage = false;
 	}


### PR DESCRIPTION
Check we can access storage by writing then removing a test value. This is similar to modernizr's check: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/localstorage.js#L41
