### PR TITLE
Introduce `woocommerce_product_is_on_sale` filter

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -660,7 +660,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	public function is_on_sale() {
-		return ( $this->get_sale_price() != $this->get_regular_price() && $this->get_sale_price() == $this->get_price() );
+		return apply_filters( 'woocommerce_product_is_on_sale', ( $this->get_sale_price() != $this->get_regular_price() && $this->get_sale_price() == $this->get_price() ), $this );
 	}
 
 	/**


### PR DESCRIPTION
This filter is useful for extensions like Measurement Price Calculator
which alter the product price quite a bit, but would still like the
sale badge to appear :)

Current workaround is to use three filters ( `woocommerce_get_price`,
`woocommerce_get_regular_price`, and `woocommerce_get_sale_price` )
which most extension may be using already, but not all need/want to
alter these prices.
