### PR TITLE
get_rating_html: Return a "not-rated" DIV instead of empty string

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1031,10 +1031,11 @@ class WC_Product {
 
 			$rating_html .= '</div>';
 
-			return $rating_html;
+		} else {
+			$rating_html = '<div class="star-rating not-rated"></div>';
 		}
 
-		return '';
+		return $rating_html;
 	}
 
 


### PR DESCRIPTION
This will make the `li.product` same height.
In CSS, the `.non-rated` can be set to any color, opacity or visibility, (see the screenshot).

Alternatively, you can make a filter on the $rating_html.

Thank you!

![wc-rating-fix](https://cloud.githubusercontent.com/assets/1696330/5059810/b47f494e-6cfa-11e4-932b-5a53fcc80094.png)
