### PR TITLE
Notices Fix and Collisions

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -29,7 +29,7 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * Reset notices for themes when switched or a new version of WC is installed
+	 * Reset notices for themes when switched or a new version of WC is installed.
 	 */
 	public function reset_admin_notices() {
 		update_option( 'woocommerce_admin_notices', array( 'template_files', 'theme_support' ) );
@@ -60,18 +60,18 @@ class WC_Admin_Notices {
 			$template = get_option( 'template' );
 
 			if ( ! in_array( $template, wc_get_core_supported_themes() ) ) {
-				wp_enqueue_style( 'woocommerce-activation', plugins_url(  '/assets/css/activation.css', WC_PLUGIN_FILE ) );
-				add_action( 'admin_notices', array( $this, 'theme_check_notice' ) );
+				wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/styles/activation.css', array(), WC_VERSION );
+				add_action( 'admin_notices', array( $this, 'theme_support_notice' ) );
 			}
 		}
 
 		if ( in_array( 'template_files', $notices ) ) {
-			wp_enqueue_style( 'woocommerce-activation', plugins_url(  '/assets/css/activation.css', WC_PLUGIN_FILE ) );
+			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/styles/activation.css', array(), WC_VERSION );
 			add_action( 'admin_notices', array( $this, 'template_file_check_notice' ) );
 		}
 
 		if ( in_array( 'translation_upgrade', $notices ) ) {
-			wp_enqueue_style( 'woocommerce-activation', plugins_url(  '/assets/css/activation.css', WC_PLUGIN_FILE ) );
+			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/styles/activation.css', array(), WC_VERSION );
 			add_action( 'admin_notices', array( $this, 'translation_upgrade_notice' ) );
 		}
 
@@ -81,29 +81,29 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * Show the install notices
+	 * Show the install notices.
 	 */
 	public function install_notice() {
-		// If we need to update, include a message with the update button
+		// If we need to update, include a message with the update button.
 		if ( get_option( '_wc_needs_update' ) == 1 ) {
 			include( 'views/html-notice-update.php' );
 		}
 
-		// If we have just installed, show a message with the install pages button
+		// If we have just installed, show a message with the install pages button.
 		elseif ( get_option( '_wc_needs_pages' ) == 1 ) {
 			include( 'views/html-notice-install.php' );
 		}
 	}
 
 	/**
-	 * Show the Theme Check notice
+	 * Show the Theme Support notice.
 	 */
-	public function theme_check_notice() {
+	public function theme_support_notice() {
 		include( 'views/html-notice-theme-support.php' );
 	}
 
 	/**
-	 * Show the translation upgrade notice
+	 * Show the Translation Upgrade notice.
 	 */
 	public function translation_upgrade_notice() {
 		$screen = get_current_screen();
@@ -114,7 +114,7 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * Show a notice highlighting bad template files
+	 * Show a notice highlighting bad template files.
 	 */
 	public function template_file_check_notice() {
 		if ( isset( $_GET['page'] ) && 'wc-status' == $_GET['page'] ) {

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -40,7 +40,7 @@ class WC_Admin_Notices {
 	 */
 	public function add_notices() {
 		if ( get_option( '_wc_needs_update' ) == 1 || get_option( '_wc_needs_pages' ) == 1 ) {
-			wp_enqueue_style( 'woocommerce-activation', plugins_url(  '/assets/css/activation.css', WC_PLUGIN_FILE ) );
+			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/css/activation.css', array(), WC_VERSION );
 			add_action( 'admin_notices', array( $this, 'install_notice' ) );
 		}
 
@@ -60,18 +60,18 @@ class WC_Admin_Notices {
 			$template = get_option( 'template' );
 
 			if ( ! in_array( $template, wc_get_core_supported_themes() ) ) {
-				wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/styles/activation.css', array(), WC_VERSION );
+				wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/css/activation.css', array(), WC_VERSION );
 				add_action( 'admin_notices', array( $this, 'theme_support_notice' ) );
 			}
 		}
 
 		if ( in_array( 'template_files', $notices ) ) {
-			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/styles/activation.css', array(), WC_VERSION );
+			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/css/activation.css', array(), WC_VERSION );
 			add_action( 'admin_notices', array( $this, 'template_file_check_notice' ) );
 		}
 
 		if ( in_array( 'translation_upgrade', $notices ) ) {
-			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/styles/activation.css', array(), WC_VERSION );
+			wp_enqueue_style( 'woocommerce-activation', WC()->plugin_url() . '/assets/css/activation.css', array(), WC_VERSION );
 			add_action( 'admin_notices', array( $this, 'translation_upgrade_notice' ) );
 		}
 

--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -11,5 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>Your theme has bundled outdated copies of WooCommerce template files</strong> &#8211; if you encounter functionality issues on the frontend this could be the reason. Ensure you update or remove them (in general we recommend only bundling the template files you actually need to customize). See the system report for full details.', 'woocommerce' ); ?></p>
-	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>"><?php _e( 'System Status', 'woocommerce' ); ?></a> <a class="skip button-primary" href="<?php echo esc_url( add_query_arg( 'hide_template_files_notice', 'true' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
+	<p class="submit">
+		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>"><?php _e( 'System Status', 'woocommerce' ); ?></a>
+		<a class="skip button-primary" href="<?php echo esc_url( add_query_arg( 'hide_template_files_notice', 'true' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a>
+	</p>
 </div>

--- a/includes/admin/views/html-notice-theme-support.php
+++ b/includes/admin/views/html-notice-theme-support.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div id="message" class="updated woocommerce-message wc-connect">
-	<p><?php printf( __( '<strong>Your theme does not declare WooCommerce support</strong> &#8211; Please read our integration guide or check out our %s Storefront %s theme which is totally free to download and designed specifically for use with WooCommerce :)', 'woocommerce' ), '<a href="' . esc_url( admin_url( 'theme-install.php?theme=highwind' ) ) . '">', '</a>' ); ?></p>
+	<p><?php printf( __( '<strong>Your theme does not declare WooCommerce support</strong> &#8211; Please read our integration guide or check out our %sStorefront%s theme which is totally free to download and designed specifically for use with WooCommerce :)', 'woocommerce' ), '<a href="' . esc_url( admin_url( 'theme-install.php?theme=highwind' ) ) . '">', '</a>' ); ?></p>
 	<p class="submit">
 		<a href="http://woothemes.com/storefront" class="button-primary" target="_blank"><?php _e( 'Find out more about Storefront', 'woocommerce' ); ?></a>
 		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button"><?php _e( 'Theme integration guide', 'woocommerce' ); ?></a>

--- a/includes/admin/views/html-notice-theme-support.php
+++ b/includes/admin/views/html-notice-theme-support.php
@@ -10,9 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div id="message" class="updated woocommerce-message wc-connect">
-	<p><?php echo sprintf( __( '<strong>Your theme does not declare WooCommerce support</strong> &#8211; Please read our integration guide or check out our %sStorefront%s theme which is totally free to download and designed specifically for use with WooCommerce :)', 'woocommerce' ), '<a href="' . esc_url( admin_url( 'theme-install.php?theme=highwind">' ) ) . '', '</a>' ); ?></p>
+	<p><?php printf( __( '<strong>Your theme does not declare WooCommerce support</strong> &#8211; Please read our integration guide or check out our %s Storefront %s theme which is totally free to download and designed specifically for use with WooCommerce :)', 'woocommerce' ), '<a href="' . esc_url( admin_url( 'theme-install.php?theme=highwind' ) ) . '">', '</a>' ); ?></p>
 	<p class="submit">
 		<a href="http://woothemes.com/storefront" class="button-primary" target="_blank"><?php _e( 'Find out more about Storefront', 'woocommerce' ); ?></a>
 		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button"><?php _e( 'Theme integration guide', 'woocommerce' ); ?></a>
-		<a class="skip button" href="<?php echo esc_url( add_query_arg( 'hide_theme_support_notice', 'true' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
+		<a class="skip button" href="<?php echo esc_url( add_query_arg( 'hide_theme_support_notice', 'true' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a>
+	</p>
 </div>

--- a/includes/admin/views/html-notice-translation-upgrade.php
+++ b/includes/admin/views/html-notice-translation-upgrade.php
@@ -23,6 +23,6 @@ if ( isset( $_GET['action'] ) && 'hide_translation_upgrade' == $_GET['action'] )
 			<a href="<?php echo wp_nonce_url( add_query_arg( array( 'action' => 'do-translation-upgrade' ), admin_url( 'update-core.php' ) ), 'upgrade-translations' ); ?>" class="button-primary"><?php _e( 'Update Translation', 'woocommerce' ); ?></a>
 			<a href="<?php echo wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ); ?>" class="button-primary"><?php _e( 'Force Update Translation', 'woocommerce' ); ?></a>
 		<?php endif; ?>
-		<a href="<?php echo wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=hide_translation_upgrade' ), 'debug_action' ); ?>" class="button"><?php _e( 'Hide This Message', 'woocommerce' ); ?></a>
+		<a href="<?php echo wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=hide_translation_upgrade' ), 'debug_action' ); ?>" class="button-secondary"><?php _e( 'Hide This Message', 'woocommerce' ); ?></a>
 	</p>
 </div>


### PR DESCRIPTION
**Features:**
- [x] Use of `WC()->plugin_url() . '/assets/css/activation.css'`
- [x] Fix the notice message after the Storefront was hooked there. It was some closing tag issues.
- [x] Instead of `sprintf()` utilized the `printf()` as it directly prints the message and no need to use `echo`
- [ ] Collision with other theme or plugin query args `hide_theme_support_notice` , `hide_translation_upgrade` & `hide_template_files_notice` in the query so why not use them with woocommerce short prefix wc. i.e  `hide_wc_theme_support_notice`
- [x] Button secondary used so that text-decoration underlined is fixed to none :)
