### PR TITLE
Automatically creates clickable links in item metas

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1075,7 +1075,7 @@ abstract class WC_Abstract_Order {
 					if ( '_' === substr( $name, 0, 1 ) ) {
 						$items[ $item->order_item_id ][ substr( $name, 1 ) ] = $value[0];
 					} elseif ( ! in_array( $name, $reserved_item_meta_keys ) ) {
-						$items[ $item->order_item_id ][ $name ] = $value[0];
+						$items[ $item->order_item_id ][ $name ] = make_clickable( $value[0] );
 					}
 				}
 			}

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -94,7 +94,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							$meta['meta_value'] = ( isset( $term->name ) ) ? $term->name : $meta['meta_value'];
 						}
 
-						echo '<tr><th>' . wp_kses_post( urldecode( $meta['meta_key'] ) ) . ':</th><td>' . wp_kses_post( wpautop( urldecode( $meta['meta_value'] ) ) ) . '</td></tr>';
+						echo '<tr><th>' . wp_kses_post( urldecode( $meta['meta_key'] ) ) . ':</th><td>' . wp_kses_post( wpautop( make_clickable( $meta['meta_value'] ) ) ) . '</td></tr>';
 					}
 					echo '</table>';
 				}

--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -54,7 +54,7 @@ class WC_Order_Item_Meta {
 				} else {
 					$meta_list[] = '
 							<dt class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( $meta['label'] ) . ':</dt>
-							<dd class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( wpautop( $meta['value'] ) ) . '</dd>
+							<dd class="variation-' . sanitize_html_class( sanitize_text_field( $meta_key ) ) . '">' . wp_kses_post( wpautop( make_clickable( $meta['value'] ) ) ) . '</dd>
 						';
 				}
 			}


### PR DESCRIPTION
This commit fix the issue #6555 and add the feature of automatic clickable links for item metas in Product Add-ons https://github.com/woothemes/woocommerce-product-addons/issues/24

This handle the products table in the emails, the order products list and the order received page.
