### PR TITLE
DRY status actions, support custom status handling

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -608,7 +608,7 @@ class WC_Admin_Post_Types {
 
 						if ( $the_order->has_status( array( 'pending', 'on-hold' ) ) ) {
 							$actions['processing'] = array(
-								'url' 		=> wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_processing&order_id=' . $post->ID ), 'woocommerce-mark-order-processing' ),
+								'url' 		=> wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_status&status=processing&order_id=' . $post->ID ), 'woocommerce-mark-order-status' ),
 								'name' 		=> __( 'Processing', 'woocommerce' ),
 								'action' 	=> "processing"
 							);
@@ -616,7 +616,7 @@ class WC_Admin_Post_Types {
 
 						if ( $the_order->has_status( array( 'pending', 'on-hold', 'processing' ) ) ) {
 							$actions['complete'] = array(
-								'url' 		=> wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_complete&order_id=' . $post->ID ), 'woocommerce-mark-order-complete' ),
+								'url' 		=> wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_status&status=completed&order_id=' . $post->ID ), 'woocommerce-mark-order-status' ),
 								'name' 		=> __( 'Complete', 'woocommerce' ),
 								'action' 	=> "complete"
 							);


### PR DESCRIPTION
DRY up order status bulk actions and AJAX actions. Provides also support for custom order status handling. 

NB! Changes the AJAX action name for marking an order with a status: instead of using named actions like `mark_order_processing`, it uses a generic name: `mark_order_status`. This means that whoever calls this AJAX action needs to supply the status via URL query params, like `?action=mark_order_status&status=completed`.
I'm fairly sure it does not break anything in core, but I can't speak for extensions that might possibly use these named actions. If you think this might be a problem, I can add named actions for `completed` and `processing` for 100% backwards compatibility.

What follows is a longer reasoning behind this PR:
There are some built-in bulk actions and single-order actions regarding order statuses. These are: Mark complete, Mark processing, Mark on-hold. While implementing a few custom order statuses I noticed that core does some code duplication here and there. I realized some of it could be refactored to be DRYer and also, provide a few hooks so that custom order statuses could be registered for both bulk an AJAX actions.

First of all, these methods are practically identical: https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-ajax.php#L344-L392
These could be refactored into a single method that gets the status from request params, and possibly validates it against `wc_get_order_statuses()`. This would automatically enable marking orders with any status via AJAX without having to duplicate any code. Core would still only provide action buttons for processing and complete, of course.

Second, we can refactor [this](https://github.com/woothemes/woocommerce/blob/master/includes/admin/class-wc-admin-post-types.php#L1203-L1244), so that, again, it would work for other order statuses as well.
