### PR TITLE
#2906 - Set reviews count in tab to only count actual reviews

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1022,7 +1022,7 @@ if ( ! function_exists( 'woocommerce_default_product_tabs' ) ) {
 		// Reviews tab - shows comments
 		if ( comments_open() ) {
 			$tabs['reviews'] = array(
-				'title'    => sprintf( __( 'Reviews (%d)', 'woocommerce' ), apply_filters( 'woocommerce_product_reviews_count', $product->get_rating_count() ) ),
+				'title'    => sprintf( __( 'Reviews (%d)', 'woocommerce' ), $product->get_rating_count() ),
 				'priority' => 30,
 				'callback' => 'comments_template'
 			);

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1022,7 +1022,7 @@ if ( ! function_exists( 'woocommerce_default_product_tabs' ) ) {
 		// Reviews tab - shows comments
 		if ( comments_open() ) {
 			$tabs['reviews'] = array(
-				'title'    => sprintf( __( 'Reviews (%d)', 'woocommerce' ), get_comments_number( $post->ID ) ),
+				'title'    => sprintf( __( 'Reviews (%d)', 'woocommerce' ), apply_filters( 'woocommerce_product_reviews_count', $product->get_rating_count() ) ),
 				'priority' => 30,
 				'callback' => 'comments_template'
 			);


### PR DESCRIPTION
Nested comments on products shouldn’t be treated as reviews. This addresses that by
using `$product->get_rating_count()` to determine the correct number of
reviews, instead of get_comments_number.

It can be filtered using the new `woocommerce_product_reviews_count`
filter.
