### PR TITLE
#6026 - Introduction of Sort Code 'locale' for BACS

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -732,16 +732,16 @@ class WC_Countries {
 	                    'label'         => __( 'Province', 'woocommerce' ),
 	                )
             	),
-            	'IE' => array(
+				'IE' => array(
 					'sortcode'	=> array(
 						'label'			=> __( 'Sort Code', 'woocommerce' ),
 					),
-            	),
-            	'IN' => array(
+ 				),
+				'IN' => array(
 					'sortcode'	=> array(
 						'label'			=> __( 'IFSC', 'woocommerce' ),
 					),
-            	),
+				),
 				'IS' => array(
 					'postcode_before_city' => true,
 					'state'		=> array(

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -606,10 +606,7 @@ class WC_Countries {
 					),
 					'state'		=> array(
 						'label' 		=> __( 'State', 'woocommerce' ),
-					),
-					'sortcode'	=> array(
-						'label'			=> __( 'BSB', 'woocommerce' ),
-					),
+					)
 				),
 				'BD' => array(
 					'postcode' => array(
@@ -646,10 +643,7 @@ class WC_Countries {
 				'CA' => array(
 					'state'	=> array(
 						'label'			=> __( 'Province', 'woocommerce' ),
-					),
-					'sortcode'	=> array(
-						'label'			=> __( 'Bank Transit Number', 'woocommerce' ),
-					),
+					)
 				),
 				'CH' => array(
                     'postcode_before_city' => true,
@@ -732,16 +726,6 @@ class WC_Countries {
 	                    'label'         => __( 'Province', 'woocommerce' ),
 	                )
             	),
-				'IE' => array(
-					'sortcode'	=> array(
-						'label'			=> __( 'Sort Code', 'woocommerce' ),
-					),
- 				),
-				'IN' => array(
-					'sortcode'	=> array(
-						'label'			=> __( 'IFSC', 'woocommerce' ),
-					),
-				),
 				'IS' => array(
 					'postcode_before_city' => true,
 					'state'		=> array(
@@ -759,10 +743,7 @@ class WC_Countries {
 					'state'		=> array(
 						'required' => true,
 						'label'    => __( 'Province', 'woocommerce' ),
-					),
-					'sortcode'	=> array(
-						'label'		=> __( 'Branch Sort', 'woocommerce' ),
-					),
+					)
 				),
 				'JP' => array(
 					'state'		=> array(
@@ -784,10 +765,7 @@ class WC_Countries {
 				'NZ' => array(
 					'state'		=> array(
 						'required' => false
-					),
-					'sortcode'	=> array(
-						'label'		=> __( 'Bank Code', 'woocommerce' ),
-					),
+					)
 				),
 				'NO' => array(
 					'postcode_before_city' => true,
@@ -850,10 +828,7 @@ class WC_Countries {
 					'postcode_before_city' => true,
 					'state'	=> array(
 						'required' => false
-					),
-					'sortcode'	=> array(
-						'label'			=> __( 'Bank Code', 'woocommerce' ),
-					),
+					)
 				),
 				'TR' => array(
 					'postcode_before_city' => true,
@@ -867,10 +842,7 @@ class WC_Countries {
 					),
 					'state'		=> array(
 						'label' 		=> __( 'State', 'woocommerce' ),
-					),
-					'sortcode'	=> array(
-						'label'			=> __( 'Routing Number', 'woocommerce' ),
-					),
+					)
 				),
 				'GB' => array(
 					'postcode'	=> array(
@@ -879,10 +851,7 @@ class WC_Countries {
 					'state'		=> array(
 						'label' 		=> __( 'County', 'woocommerce' ),
 						'required' 		=> false
-					),
-					'sortcode'	=> array(
-						'label'			=> __( 'Sort Code', 'woocommerce' ),
-					),
+					)
 				),
 				'VN' => array(
 					'state'		=> array(
@@ -906,10 +875,7 @@ class WC_Countries {
 				'ZA' => array(
 					'state'	=> array(
 						'label'			=> __( 'Province', 'woocommerce' ),
-					),
-					'sortcode'	=> array(
-						'label'		=> __( 'Branch Code', 'woocommerce' ),
-					),
+					)
 				),
 				'ZW' => array(
 					'postcode' => array(
@@ -926,9 +892,8 @@ class WC_Countries {
 			$this->locale['default'] = apply_filters('woocommerce_get_country_locale_default', $this->get_default_address_fields() );
 
 			// Filter default AND shop base locales to allow overides via a single function. These will be used when changing countries on the checkout
-			if ( ! isset( $this->locale[ $this->get_base_country() ] ) ) {
+			if ( ! isset( $this->locale[ $this->get_base_country() ] ) )
 				$this->locale[ $this->get_base_country() ] = $this->locale['default'];
-			}
 
 			$this->locale['default'] 					= apply_filters( 'woocommerce_get_country_locale_base', $this->locale['default'] );
 			$this->locale[ $this->get_base_country() ] 	= apply_filters( 'woocommerce_get_country_locale_base', $this->locale[ $this->get_base_country() ] );

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -606,7 +606,10 @@ class WC_Countries {
 					),
 					'state'		=> array(
 						'label' 		=> __( 'State', 'woocommerce' ),
-					)
+					),
+					'sortcode'	=> array(
+						'label'			=> __( 'BSB', 'woocommerce' ),
+					),
 				),
 				'BD' => array(
 					'postcode' => array(
@@ -643,7 +646,10 @@ class WC_Countries {
 				'CA' => array(
 					'state'	=> array(
 						'label'			=> __( 'Province', 'woocommerce' ),
-					)
+					),
+					'sortcode'	=> array(
+						'label'			=> __( 'Bank Transit Number', 'woocommerce' ),
+					),
 				),
 				'CH' => array(
                     'postcode_before_city' => true,
@@ -726,6 +732,16 @@ class WC_Countries {
 	                    'label'         => __( 'Province', 'woocommerce' ),
 	                )
             	),
+            	'IE' => array(
+					'sortcode'	=> array(
+						'label'			=> __( 'Sort Code', 'woocommerce' ),
+					),
+            	),
+            	'IN' => array(
+					'sortcode'	=> array(
+						'label'			=> __( 'IFSC', 'woocommerce' ),
+					),
+            	),
 				'IS' => array(
 					'postcode_before_city' => true,
 					'state'		=> array(
@@ -743,7 +759,10 @@ class WC_Countries {
 					'state'		=> array(
 						'required' => true,
 						'label'    => __( 'Province', 'woocommerce' ),
-					)
+					),
+					'sortcode'	=> array(
+						'label'		=> __( 'Branch Sort', 'woocommerce' ),
+					),
 				),
 				'JP' => array(
 					'state'		=> array(
@@ -765,7 +784,10 @@ class WC_Countries {
 				'NZ' => array(
 					'state'		=> array(
 						'required' => false
-					)
+					),
+					'sortcode'	=> array(
+						'label'		=> __( 'Bank Code', 'woocommerce' ),
+					),
 				),
 				'NO' => array(
 					'postcode_before_city' => true,
@@ -828,7 +850,10 @@ class WC_Countries {
 					'postcode_before_city' => true,
 					'state'	=> array(
 						'required' => false
-					)
+					),
+					'sortcode'	=> array(
+						'label'			=> __( 'Bank Code', 'woocommerce' ),
+					),
 				),
 				'TR' => array(
 					'postcode_before_city' => true,
@@ -842,7 +867,10 @@ class WC_Countries {
 					),
 					'state'		=> array(
 						'label' 		=> __( 'State', 'woocommerce' ),
-					)
+					),
+					'sortcode'	=> array(
+						'label'			=> __( 'Routing Number', 'woocommerce' ),
+					),
 				),
 				'GB' => array(
 					'postcode'	=> array(
@@ -851,7 +879,10 @@ class WC_Countries {
 					'state'		=> array(
 						'label' 		=> __( 'County', 'woocommerce' ),
 						'required' 		=> false
-					)
+					),
+					'sortcode'	=> array(
+						'label'			=> __( 'Sort Code', 'woocommerce' ),
+					),
 				),
 				'VN' => array(
 					'state'		=> array(
@@ -875,7 +906,10 @@ class WC_Countries {
 				'ZA' => array(
 					'state'	=> array(
 						'label'			=> __( 'Province', 'woocommerce' ),
-					)
+					),
+					'sortcode'	=> array(
+						'label'		=> __( 'Branch Code', 'woocommerce' ),
+					),
 				),
 				'ZW' => array(
 					'postcode' => array(
@@ -892,8 +926,9 @@ class WC_Countries {
 			$this->locale['default'] = apply_filters('woocommerce_get_country_locale_default', $this->get_default_address_fields() );
 
 			// Filter default AND shop base locales to allow overides via a single function. These will be used when changing countries on the checkout
-			if ( ! isset( $this->locale[ $this->get_base_country() ] ) )
+			if ( ! isset( $this->locale[ $this->get_base_country() ] ) ) {
 				$this->locale[ $this->get_base_country() ] = $this->locale['default'];
+			}
 
 			$this->locale['default'] 					= apply_filters( 'woocommerce_get_country_locale_base', $this->locale['default'] );
 			$this->locale[ $this->get_base_country() ] 	= apply_filters( 'woocommerce_get_country_locale_base', $this->locale[ $this->get_base_country() ] );

--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -357,7 +357,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 
 		if ( ! $this->locale ) {
 
-			// Locale information to be used
+			// Locale information to be used - only those that are not 'Sort Code'
 			$this->locale = apply_filters( 'woocommerce_get_bacs_locale', array(
 				'AU' => array(
 					'sortcode'	=> array(
@@ -369,16 +369,6 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 						'label'		=> __( 'Bank Transit Number', 'woocommerce' ),
 					),
 				),
-				'GB' => array(
-					'sortcode'	=> array(
-						'label'		=> __( 'Sort Code', 'woocommerce' ),
-					),
-				),
-				'IE' => array(
-					'sortcode'	=> array(
-						'label'		=> __( 'Sort Code', 'woocommerce' ),
-					),
- 				),
 				'IN' => array(
 					'sortcode'	=> array(
 						'label'		=> __( 'IFSC', 'woocommerce' ),

--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -102,6 +102,13 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 	 */
 	public function generate_account_details_html() {
 		ob_start();
+
+		$country 	= WC()->countries->get_base_country();
+		$locale		= WC()->countries->get_country_locale();
+
+		$sortcode_label = $locale[$country]['sortcode']['label'];
+		$sortcode = $sortcode_label ? $sortcode_label : __( 'Sort Code', 'woocommerce' );
+
 		?>
 		<tr valign="top">
 			<th scope="row" class="titledesc"><?php _e( 'Account Details', 'woocommerce' ); ?>:</th>
@@ -113,7 +120,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 							<th><?php _e( 'Account Name', 'woocommerce' ); ?></th>
 							<th><?php _e( 'Account Number', 'woocommerce' ); ?></th>
 							<th><?php _e( 'Bank Name', 'woocommerce' ); ?></th>
-							<th><?php _e( 'Sort Code', 'woocommerce' ); ?></th>
+							<th><?php echo $sortcode; ?></th>
 							<th><?php _e( 'IBAN', 'woocommerce' ); ?></th>
 							<th><?php _e( 'BIC / Swift', 'woocommerce' ); ?></th>
 						</tr>
@@ -240,12 +247,26 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 			return;
 		}
 
+		// Get order and store in $order
+		$order 		= wc_get_order( $order_id );
+
+		// Get the order country and country $locale
+		$country 	= $order->billing_country;
+		$locale		= WC()->countries->get_country_locale();
+		
+		// Get sortcode label in the $locale array
+		$sortcode_label = $locale[$country]['sortcode']['label'];
+		
+		// If a sortcode label exists uses it, if not use Sort Code
+		$sortcode = $sortcode_label ? $sortcode_label : __( 'Sort Code', 'woocommerce' );
+
 		echo '<h2>' . __( 'Our Bank Details', 'woocommerce' ) . '</h2>' . PHP_EOL;
 
 		$bacs_accounts = apply_filters( 'woocommerce_bacs_accounts', $this->account_details );
 
 		if ( ! empty( $bacs_accounts ) ) {
 			foreach ( $bacs_accounts as $bacs_account ) {
+
 				$bacs_account = (object) $bacs_account;
 
 				if ( $bacs_account->account_name || $bacs_account->bank_name ) {
@@ -261,7 +282,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 						'value' => $bacs_account->account_number
 					),
 					'sort_code'     => array(
-						'label' => __( 'Sort Code', 'woocommerce' ),
+						'label' => $sortcode,
 						'value' => $bacs_account->sort_code
 					),
 					'iban'          => array(


### PR DESCRIPTION
In the admin, it will use the store’s base country to determine the
term for ‘Sort Code’.

In the front-end, it will use the customer’s billing country to
determine the term for ‘Sort Code’.

In all cases, if a locale does not have a sortcode label set, it will
use ‘Sort Code’.

**Locales have been added for:**
- AU
- CA
- IE
- IN
- IT
- NZ
- SE
- US
- GB
- ZA

But may need adjusting based on user feedback.

This closes #6026 
