### PR TITLE
always save a 0 price if none entered #6739

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1034,7 +1034,8 @@ class WC_Meta_Box_Product_Data {
 
 		// Update post meta
 		if ( isset( $_POST['_regular_price'] ) ) {
-			update_post_meta( $post_id, '_regular_price', ( $_POST['_regular_price'] === '' ) ? '' : wc_format_decimal( $_POST['_regular_price'] ) );
+			$price = trim( $_POST['_regular_price'] ) === '' ? 0 : $_POST['_regular_price'];
+			update_post_meta( $post_id, '_regular_price', $price );
 		}
 
 		if ( isset( $_POST['_sale_price'] ) ) {


### PR DESCRIPTION
Originally, I had a message in there, but then I remembered that user's with Name Your Price enabled won't even see the regular price input, so a message about a zero price would be very confusing. 
