### PR TITLE
Corrected the docblock descriptions for two "send email" classes

### DIFF
--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order' ) ) :
 /**
  * Cancelled Order Email
  *
- * An email sent to the admin when a new order is received/paid for.
+ * An email sent to the admin when an order is cancelled.
  *
  * @class       WC_Email_Cancelled_Order
  * @version     2.2.7

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -9,7 +9,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order' ) ) :
 /**
  * Customer Processing Order Email
  *
- * An email sent to the admin when a new order is received/paid for.
+ * An email sent to the customer when a new order is received/paid for.
  *
  * @class 		WC_Email_Customer_Processing_Order
  * @version		2.0.0


### PR DESCRIPTION
Two "send email" classes have an incorrect description in the docbock of the purpose of the class.
