### PR TITLE
Custom order type tweaks

### DIFF
--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -106,11 +106,12 @@ class WC_Admin_Meta_Boxes {
 
 		// Orders
 		foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
-			add_meta_box( 'woocommerce-order-data', __( 'Order Data', 'woocommerce' ), 'WC_Meta_Box_Order_Data::output', $type, 'normal', 'high' );
-			add_meta_box( 'woocommerce-order-items', __( 'Order Items', 'woocommerce' ), 'WC_Meta_Box_Order_Items::output', $type, 'normal', 'high' );
-			add_meta_box( 'woocommerce-order-notes', __( 'Order Notes', 'woocommerce' ), 'WC_Meta_Box_Order_Notes::output', $type, 'side', 'default' );
+			$order_type_object = get_post_type_object( $type );
+			add_meta_box( 'woocommerce-order-data', sprintf( __( '%s Data', 'woocommerce' ), $order_type_object->labels->singular_name ), 'WC_Meta_Box_Order_Data::output', $type, 'normal', 'high' );
+			add_meta_box( 'woocommerce-order-items', sprintf( __( '%s Items', 'woocommerce' ), $order_type_object->labels->singular_name ), 'WC_Meta_Box_Order_Items::output', $type, 'normal', 'high' );
+			add_meta_box( 'woocommerce-order-notes', sprintf( __( '%s Notes', 'woocommerce' ), $order_type_object->labels->singular_name ), 'WC_Meta_Box_Order_Notes::output', $type, 'side', 'default' );
 			add_meta_box( 'woocommerce-order-downloads', __( 'Downloadable Product Permissions', 'woocommerce' ) . ' <span class="tips" data-tip="' . __( 'Note: Permissions for order items will automatically be granted when the order status changes to processing/completed.', 'woocommerce' ) . '">[?]</span>', 'WC_Meta_Box_Order_Downloads::output', $type, 'normal', 'default' );
-			add_meta_box( 'woocommerce-order-actions', __( 'Order Actions', 'woocommerce' ), 'WC_Meta_Box_Order_Actions::output', $type, 'side', 'high' );
+			add_meta_box( 'woocommerce-order-actions', sprintf( __( '%s Actions', 'woocommerce' ), $order_type_object->labels->singular_name ), 'WC_Meta_Box_Order_Actions::output', $type, 'side', 'high' );
 		}
 
 		// Coupons

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1527,7 +1527,7 @@ class WC_Admin_Post_Types {
 				$vars['meta_value'] = wc_clean( $_GET['coupon_type'] );
 			}
 
-		} elseif ( 'shop_order' === $typenow ) {
+		} elseif ( in_array( $typenow, wc_get_order_types( 'order-meta-boxes' ) ) ) {
 
 			// Filter the orders by the posted customer.
 			if ( isset( $_GET['_customer_user'] ) && $_GET['_customer_user'] > 0 ) {

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1768,7 +1768,7 @@ class WC_Admin_Post_Types {
 
 			$post_type = get_post_type( $id );
 
-			if ( 'shop_order' == $post_type ) {
+			if ( in_array( $post_type, wc_get_order_types( 'order-count' ) ) ) {
 
 				// Delete count - meta doesn't work on trashed posts
 				$user_id = get_post_meta( $id, '_customer_user', true );
@@ -1804,7 +1804,7 @@ class WC_Admin_Post_Types {
 
 			$post_type = get_post_type( $id );
 
-			if ( 'shop_order' == $post_type ) {
+			if ( in_array( $post_type, wc_get_order_types( 'order-count' ) ) ) {
 
 				// Delete count - meta doesn't work on trashed posts
 				$user_id = get_post_meta( $id, '_customer_user', true );
@@ -1835,7 +1835,7 @@ class WC_Admin_Post_Types {
 	public function delete_order_items( $postid ) {
 		global $wpdb;
 
-		if ( get_post_type( $postid ) == 'shop_order' ) {
+		if ( in_array( get_post_type( $postid ), wc_get_order_types() ) ) {
 			do_action( 'woocommerce_delete_order_items', $postid );
 
 			$wpdb->query( "

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1340,18 +1340,12 @@ class WC_Admin_Post_Types {
 	public function restrict_manage_posts() {
 		global $typenow, $wp_query;
 
-		switch ( $typenow ) {
-			case 'product' :
-				$this->product_filters();
-				break;
-			case 'shop_coupon' :
-				$this->shop_coupon_filters();
-				break;
-			case 'shop_order' :
-				$this->shop_order_filters();
-				break;
-			default :
-				break;
+		if ( in_array( $typenow, wc_get_order_types( 'order-meta-boxes' ) ) ) {
+			$this->shop_order_filters();
+		} elseif ( 'product' == $typenow ) {
+			$this->product_filters();
+		} elseif( 'shop_coupon' == $typenow ) {
+			$this->shop_coupon_filters();
 		}
 	}
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1924,7 +1924,7 @@ class WC_Admin_Post_Types {
 	function change_insert_into_post( $strings ) {
 		global $post_type;
 
-		if ( in_array( $post_type, array( 'product', 'shop_order', 'shop_coupon' ) ) ) {
+		if ( in_array( $post_type, array( 'product', 'shop_coupon' ) ) || in_array( $post_type, wc_get_order_types() ) ) {
 			$obj = get_post_type_object( $post_type );
 
 			$strings['insertIntoPost']     = sprintf( __( 'Insert into %s', 'woocommerce' ), $obj->labels->singular_name );

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -30,6 +30,7 @@ class WC_Meta_Box_Order_Actions {
 		}
 
 		$order = $theorder;
+		$order_type_object = get_post_type_object( $post->post_type );
 		?>
 		<ul class="order_actions submitbox">
 
@@ -78,7 +79,7 @@ class WC_Meta_Box_Order_Actions {
 					}
 				?></div>
 
-				<input type="submit" class="button save_order button-primary tips" name="save" value="<?php _e( 'Save Order', 'woocommerce' ); ?>" data-tip="<?php _e( 'Save/update the order', 'woocommerce' ); ?>" />
+				<input type="submit" class="button save_order button-primary tips" name="save" value="<?php printf( __( 'Save %s', 'woocommerce' ), $order_type_object->labels->singular_name ); ?>" data-tip="<?php printf( __( 'Save/update the %s', 'woocommerce' ), $order_type_object->labels->singular_name ); ?>" />
 			</li>
 
 			<?php do_action( 'woocommerce_order_actions_end', $post->ID ); ?>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -24,14 +24,14 @@ class WC_Meta_Box_Order_Data {
 	 *
 	 * @var array
 	 */
-	private static $billing_fields = array();
+	protected static $billing_fields = array();
 
 	/**
 	 * Shipping fields
 	 *
 	 * @var array
 	 */
-	private static $shipping_fields = array();
+	protected static $shipping_fields = array();
 
 	/**
 	 * Init billing and shipping fields we display + save

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -58,7 +58,7 @@ class WC_Meta_Box_Order_Notes {
 			}
 
 		} else {
-			echo '<li>' . __( 'There are no notes for this order yet.', 'woocommerce' ) . '</li>';
+			echo '<li>' . __( 'There are no notes yet.', 'woocommerce' ) . '</li>';
 		}
 
 		echo '</ul>';

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1083,7 +1083,7 @@ class WC_AJAX {
 
 		$order_id = absint( $_POST['order_id'] );
 		$rate_id  = absint( $_POST['rate_id'] );
-		$order    = new WC_Order( $order_id );
+		$order    = wc_get_order( $order_id );
 		$data     = get_post_meta( $order_id );
 
 		// Add new tax
@@ -1129,7 +1129,7 @@ class WC_AJAX {
 		wc_delete_order_item( $rate_id );
 
 		// Return HTML items
-		$order = new WC_Order( $order_id );
+		$order = wc_get_order( $order_id );
 		$data  = get_post_meta( $order_id );
 		include( 'admin/meta-boxes/views/html-order-items.php' );
 
@@ -1399,7 +1399,7 @@ class WC_AJAX {
 		wc_save_order_items( $order_id, $items );
 
 		// Return HTML items
-		$order = new WC_Order( $order_id );
+		$order = wc_get_order( $order_id );
 		$data  = get_post_meta( $order_id );
 		include( 'admin/meta-boxes/views/html-order-items.php' );
 
@@ -1423,7 +1423,7 @@ class WC_AJAX {
 			wc_save_order_items( $order_id, $items );
 
 			// Return HTML items
-			$order = new WC_Order( $order_id );
+			$order = wc_get_order( $order_id );
 			$data  = get_post_meta( $order_id );
 			include( 'admin/meta-boxes/views/html-order-items.php' );
 		}
@@ -1439,7 +1439,7 @@ class WC_AJAX {
 
 		// Return HTML items
 		$order_id = absint( $_POST['order_id'] );
-		$order    = new WC_Order( $order_id );
+		$order    = wc_get_order( $order_id );
 		$data     = get_post_meta( $order_id );
 		include( 'admin/meta-boxes/views/html-order-items.php' );
 


### PR DESCRIPTION
A few tweaks for the custom order types API.

Mostly semantic (i.e. displaying the order type's name instead of a hardcoded **Order** string).

It does include a couple of important logic changes though, like deleting order items and item meta data when deleting an instance of a custom order type and updating order counts when trashing/untrashing an instance of a custom order type that requests being included in those (SHA: 47e8ca0d93783152cbaa56e5a55e870066b82f1b). SHA: 3b917737ebc23289a4dd also ensures that meta boxes receive an instance of the custom order type rather than forcing it to `WC_Order`.

I've made the PR to the `2.2` branch so they go out with the next minor version, but let me know if you'd prefer it to go to `master` and I'll make another PR. The only issue then is that store managers will need WC 2.3 to use Subscriptions 2.0.
