### PR TITLE
Set cookie for non logged when add to cart ajax

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -975,7 +975,7 @@ class WC_Cart {
 
 			}
 
-			if ( did_action( 'wp' ) ) {
+			if ( did_action( 'wp' ) || defined( 'DOING_AJAX' ) ) {
 				$this->set_cart_cookies( sizeof( $this->cart_contents ) > 0 );
 			}
 


### PR DESCRIPTION
http://stackoverflow.com/questions/27168479/woocommerce-cant-add-to-cart-as-a-guest-using-quick-order-one-page-shop/
