### PR TITLE
Execute `woocommerce_order_action_{$action}` only once

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -128,8 +128,9 @@ class WC_Meta_Box_Order_Actions {
 
 			} else {
 
-				do_action( 'woocommerce_order_action_' . sanitize_title( $action ), $order );
-
+				if ( ! did_action( 'woocommerce_order_action_' . sanitize_title( $action ) ) ) {
+					do_action( 'woocommerce_order_action_' . sanitize_title( $action ), $order );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Prevents a “Maximum function nesting level reached” fatal error in certain cases.

Since this ends up running on `'save_post'`, updating something like the order status while hooked onto to `woocommerce_order_action_{$action}` causes a fun recursion :)

I'm not 100% sure if this change will have other implications I have not thought of so feel free to close without merging. I ran into it while testing a code snippet for Customer/Order CSV Export, so I can always adjust that code snippet to only run the first time. 
