### PR TITLE
Moved deprecated action inside IF

### DIFF
--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -60,9 +60,9 @@ class WC_Admin_Assets {
 		/**
 		 * @deprecated 2.3
 		 */
-		do_action( 'woocommerce_admin_css' );
 
 		if ( has_action( 'woocommerce_admin_css' ) ) {
+			do_action( 'woocommerce_admin_css' );
 			_deprecated_function( 'The woocommerce_admin_css action', '2.3', 'admin_enqueue_scripts' );
 		}
 	}


### PR DESCRIPTION
Moved do action of 'woocommerce_admin_css' to avoid possible add action from debug plugin as "Debug Bar" and "Debug Bar Slow Actions"

See screen: http://d.pr/i/1fYX1/7ZiItezr
