### PR TITLE
[2.3] Add order_item_visible_filter

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -14,59 +14,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 foreach ( $items as $item_id => $item ) :
 	$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 	$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );
-	?>
-	<tr>
-		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee; word-wrap:break-word;"><?php
 
-			// Show title/image etc
-			if ( $show_image ) {
-				echo apply_filters( 'woocommerce_order_item_thumbnail', '<img src="' . ( $_product->get_image_id() ? current( wp_get_attachment_image_src( $_product->get_image_id(), 'thumbnail') ) : wc_placeholder_img_src() ) .'" alt="' . __( 'Product Image', 'woocommerce' ) . '" height="' . esc_attr( $image_size[1] ) . '" width="' . esc_attr( $image_size[0] ) . '" style="vertical-align:middle; margin-right: 10px;" />', $item );
-			}
+	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+		?>
+		<tr>
+			<td style="text-align:left; vertical-align:middle; border: 1px solid #eee; word-wrap:break-word;"><?php
 
-			// Product name
-			echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
-
-			// SKU
-			if ( $show_sku && is_object( $_product ) && $_product->get_sku() ) {
-				echo ' (#' . $_product->get_sku() . ')';
-			}
-
-			// allow other plugins to add additional product information here
-			do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
-
-			// Variation
-			if ( $item_meta->meta ) {
-				echo '<br/><small>' . nl2br( $item_meta->display( true, true, '_', "\n" ) ) . '</small>';
-			}
-
-			// File URLs
-			if ( $show_download_links && is_object( $_product ) && $_product->exists() && $_product->is_downloadable() ) {
-
-				$download_files = $order->get_item_downloads( $item );
-				$i              = 0;
-
-				foreach ( $download_files as $download_id => $file ) {
-					$i++;
-
-					if ( count( $download_files ) > 1 ) {
-						$prefix = sprintf( __( 'Download %d', 'woocommerce' ), $i );
-					} elseif ( $i == 1 ) {
-						$prefix = __( 'Download', 'woocommerce' );
-					}
-
-					echo '<br/><small>' . $prefix . ': <a href="' . esc_url( $file['download_url'] ) . '" target="_blank">' . esc_html( $file['name'] ) . '</a></small>';
+				// Show title/image etc
+				if ( $show_image ) {
+					echo apply_filters( 'woocommerce_order_item_thumbnail', '<img src="' . ( $_product->get_image_id() ? current( wp_get_attachment_image_src( $_product->get_image_id(), 'thumbnail') ) : wc_placeholder_img_src() ) .'" alt="' . __( 'Product Image', 'woocommerce' ) . '" height="' . esc_attr( $image_size[1] ) . '" width="' . esc_attr( $image_size[0] ) . '" style="vertical-align:middle; margin-right: 10px;" />', $item );
 				}
-			}
 
-			// allow other plugins to add additional product information here
-			do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+				// Product name
+				echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
 
-		?></td>
-		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $item['qty'] ;?></td>
-		<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
-	</tr>
+				// SKU
+				if ( $show_sku && is_object( $_product ) && $_product->get_sku() ) {
+					echo ' (#' . $_product->get_sku() . ')';
+				}
 
-	<?php if ( $show_purchase_note && is_object( $_product ) && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) : ?>
+				// allow other plugins to add additional product information here
+				do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+
+				// Variation
+				if ( $item_meta->meta ) {
+					echo '<br/><small>' . nl2br( $item_meta->display( true, true, '_', "\n" ) ) . '</small>';
+				}
+
+				// File URLs
+				if ( $show_download_links && is_object( $_product ) && $_product->exists() && $_product->is_downloadable() ) {
+
+					$download_files = $order->get_item_downloads( $item );
+					$i              = 0;
+
+					foreach ( $download_files as $download_id => $file ) {
+						$i++;
+
+						if ( count( $download_files ) > 1 ) {
+							$prefix = sprintf( __( 'Download %d', 'woocommerce' ), $i );
+						} elseif ( $i == 1 ) {
+							$prefix = __( 'Download', 'woocommerce' );
+						}
+
+						echo '<br/><small>' . $prefix . ': <a href="' . esc_url( $file['download_url'] ) . '" target="_blank">' . esc_html( $file['name'] ) . '</a></small>';
+					}
+				}
+
+				// allow other plugins to add additional product information here
+				do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+
+			?></td>
+			<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $item['qty'] ;?></td>
+			<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
+		</tr>
+		<?php
+	}
+
+	if ( $show_purchase_note && is_object( $_product ) && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) : ?>
 		<tr>
 			<td colspan="3" style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo wpautop( do_shortcode( wp_kses_post( $purchase_note ) ) ); ?></td>
 		</tr>

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -15,46 +15,50 @@ foreach ( $items as $item_id => $item ) :
 	$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 	$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );
 
-	// Title
-	echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
+	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 
-	// SKU
-	if ( $show_sku && $_product->get_sku() ) {
-		echo ' (#' . $_product->get_sku() . ')';
-	}
+		// Title
+		echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
 
-	// allow other plugins to add additional product information here
-	do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
-
-	// Variation
-	echo $item_meta->meta ? "\n" . $item_meta->display( true, true ) : '';
-
-	// Quantity
-	echo "\n" . sprintf( __( 'Quantity: %s', 'woocommerce' ), $item['qty'] );
-
-	// Cost
-	echo "\n" . sprintf( __( 'Cost: %s', 'woocommerce' ), $order->get_formatted_line_subtotal( $item ) );
-
-	// Download URLs
-	if ( $show_download_links && $_product->exists() && $_product->is_downloadable() ) {
-		$download_files = $order->get_item_downloads( $item );
-		$i              = 0;
-
-		foreach ( $download_files as $download_id => $file ) {
-			$i++;
-
-			if ( count( $download_files ) > 1 ) {
-				$prefix = sprintf( __( 'Download %d', 'woocommerce' ), $i );
-			} elseif ( $i == 1 ) {
-				$prefix = __( 'Download', 'woocommerce' );
-			}
-
-			echo "\n" . $prefix . '(' . esc_html( $file['name'] ) . '): ' . esc_url( $file['download_url'] );
+		// SKU
+		if ( $show_sku && $_product->get_sku() ) {
+			echo ' (#' . $_product->get_sku() . ')';
 		}
-	}
 
-	// allow other plugins to add additional product information here
-	do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+		// allow other plugins to add additional product information here
+		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+
+		// Variation
+		echo $item_meta->meta ? "\n" . $item_meta->display( true, true ) : '';
+
+		// Quantity
+		echo "\n" . sprintf( __( 'Quantity: %s', 'woocommerce' ), $item['qty'] );
+
+		// Cost
+		echo "\n" . sprintf( __( 'Cost: %s', 'woocommerce' ), $order->get_formatted_line_subtotal( $item ) );
+
+		// Download URLs
+		if ( $show_download_links && $_product->exists() && $_product->is_downloadable() ) {
+			$download_files = $order->get_item_downloads( $item );
+			$i              = 0;
+
+			foreach ( $download_files as $download_id => $file ) {
+				$i++;
+
+				if ( count( $download_files ) > 1 ) {
+					$prefix = sprintf( __( 'Download %d', 'woocommerce' ), $i );
+				} elseif ( $i == 1 ) {
+					$prefix = __( 'Download', 'woocommerce' );
+				}
+
+				echo "\n" . $prefix . '(' . esc_html( $file['name'] ) . '): ' . esc_url( $file['download_url'] );
+			}
+		}
+
+		// allow other plugins to add additional product information here
+		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+
+	}
 
 	// Note
 	if ( $show_purchase_note && $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) {

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -30,46 +30,48 @@ $order = wc_get_order( $order_id );
 				$_product     = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 				$item_meta    = new WC_Order_Item_Meta( $item['item_meta'], $_product );
 
-				?>
-				<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
-					<td class="product-name">
-						<?php
-							if ( $_product && ! $_product->is_visible() )
-								echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
-							else
-								echo apply_filters( 'woocommerce_order_item_name', sprintf( '<a href="%s">%s</a>', get_permalink( $item['product_id'] ), $item['name'] ), $item );
+				if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+					?>
+					<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
+						<td class="product-name">
+							<?php
+								if ( $_product && ! $_product->is_visible() )
+									echo apply_filters( 'woocommerce_order_item_name', $item['name'], $item );
+								else
+									echo apply_filters( 'woocommerce_order_item_name', sprintf( '<a href="%s">%s</a>', get_permalink( $item['product_id'] ), $item['name'] ), $item );
 
-							echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
+								echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item['qty'] ) . '</strong>', $item );
 
-							// allow other plugins to add additional product information here
-							do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+								// allow other plugins to add additional product information here
+								do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
 
-							$item_meta->display();
+								$item_meta->display();
 
-							if ( $_product && $_product->exists() && $_product->is_downloadable() && $order->is_download_permitted() ) {
+								if ( $_product && $_product->exists() && $_product->is_downloadable() && $order->is_download_permitted() ) {
 
-								$download_files = $order->get_item_downloads( $item );
-								$i              = 0;
-								$links          = array();
+									$download_files = $order->get_item_downloads( $item );
+									$i              = 0;
+									$links          = array();
 
-								foreach ( $download_files as $download_id => $file ) {
-									$i++;
+									foreach ( $download_files as $download_id => $file ) {
+										$i++;
 
-									$links[] = '<small><a href="' . esc_url( $file['download_url'] ) . '">' . sprintf( __( 'Download file%s', 'woocommerce' ), ( count( $download_files ) > 1 ? ' ' . $i . ': ' : ': ' ) ) . esc_html( $file['name'] ) . '</a></small>';
+										$links[] = '<small><a href="' . esc_url( $file['download_url'] ) . '">' . sprintf( __( 'Download file%s', 'woocommerce' ), ( count( $download_files ) > 1 ? ' ' . $i . ': ' : ': ' ) ) . esc_html( $file['name'] ) . '</a></small>';
+									}
+
+									echo '<br/>' . implode( '<br/>', $links );
 								}
 
-								echo '<br/>' . implode( '<br/>', $links );
-							}
-
-							// allow other plugins to add additional product information here
-							do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
-						?>
-					</td>
-					<td class="product-total">
-						<?php echo $order->get_formatted_line_subtotal( $item ); ?>
-					</td>
-				</tr>
-				<?php
+								// allow other plugins to add additional product information here
+								do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+							?>
+						</td>
+						<td class="product-total">
+							<?php echo $order->get_formatted_line_subtotal( $item ); ?>
+						</td>
+					</tr>
+					<?php
+				}
 
 				if ( $order->has_status( array( 'completed', 'processing' ) ) && ( $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) ) {
 					?>


### PR DESCRIPTION
Added to complement the existing 'cart_item_visible' filter.

Necessary for cases such as https://woothemes.zendesk.com/agent/tickets/239102 , where an item must be added to an order but remain invisible to the customer.
