### PR TITLE
Delete cached sessions when clearing expired sessions

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -238,6 +238,12 @@ class WC_Session_Handler extends WC_Session {
 			if ( ! empty( $expired_sessions ) ) {
 				$expired_sessions_chunked = array_chunk( $expired_sessions, 100 );
 				foreach ( $expired_sessions_chunked as $chunk ) {
+					// delete from object cache first, to avoid cached but deleted options
+					foreach ( $chunk as $option ) {
+						wp_cache_delete( $option, 'options' );
+					}
+
+					// delete from options table
 					$option_names = implode( "','", $chunk );
 					$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name IN ('$option_names')" );
 				}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -238,9 +238,11 @@ class WC_Session_Handler extends WC_Session {
 			if ( ! empty( $expired_sessions ) ) {
 				$expired_sessions_chunked = array_chunk( $expired_sessions, 100 );
 				foreach ( $expired_sessions_chunked as $chunk ) {
-					// delete from object cache first, to avoid cached but deleted options
-					foreach ( $chunk as $option ) {
-						wp_cache_delete( $option, 'options' );
+					if ( wp_using_ext_object_cache() ) {
+						// delete from object cache first, to avoid cached but deleted options
+						foreach ( $chunk as $option ) {
+							wp_cache_delete( $option, 'options' );
+						}
 					}
 
 					// delete from options table


### PR DESCRIPTION
Fixes #6907. When expired sessions are deleted from the `wp_options` table, they are first deleted from the object cache so that they can't hang around and prevent new sessions from being created.
