### PR TITLE
Retrieve reviewers avatar using the email

### DIFF
--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -20,7 +20,7 @@ $rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
 
 	<div id="comment-<?php comment_ID(); ?>" class="comment_container">
 
-		<?php echo get_avatar( $comment, apply_filters( 'woocommerce_review_gravatar_size', '60' ), '', get_comment_author() ); ?>
+		<?php echo get_avatar( $comment, apply_filters( 'woocommerce_review_gravatar_size', '60' ), '', get_comment_author_email( $comment->comment_ID ) ); ?>
 
 		<div class="comment-text">
 


### PR DESCRIPTION
Using the email will fix the wrong avatar issue occurring while creating manually the review from the admin panel.
