### PR TITLE
WooCommerce Opt-In Tracker

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -145,7 +145,7 @@ class WC_Admin_Status {
 					update_option( 'woocommerce_allow_tracking', false );
 					update_option( 'woocommerce_hide_tracking_notice', false );
 
-					echo '<div class="updated"><p>' . __( 'Usage tracking settings reseted successfully!', 'woocommerce' ) . '</p></div>';
+					echo '<div class="updated"><p>' . __( 'Usage tracking settings successfully reset.', 'woocommerce' ) . '</p></div>';
 				break;
 				default :
 					$action = esc_attr( $_GET['action'] );

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -141,6 +141,12 @@ class WC_Admin_Status {
 
 					echo '<div class="updated"><p>' . __( 'Translation update message hidden successfully!', 'woocommerce' ) . '</p></div>';
 				break;
+				case 'reset_tracking' :
+					update_option( 'woocommerce_allow_tracking', false );
+					update_option( 'woocommerce_hide_tracking_notice', false );
+
+					echo '<div class="updated"><p>' . __( 'Usage tracking settings reseted successfully!', 'woocommerce' ) . '</p></div>';
+				break;
 				default :
 					$action = esc_attr( $_GET['action'] );
 					if ( isset( $tools[ $action ]['callback'] ) ) {
@@ -230,6 +236,11 @@ class WC_Admin_Status {
 				'name'    => __( 'Delete all WooCommerce tax rates', 'woocommerce' ),
 				'button'  => __( 'Delete ALL tax rates', 'woocommerce' ),
 				'desc'    => __( '<strong class="red">Note:</strong> This option will delete ALL of your tax rates, use with caution.', 'woocommerce' ),
+			),
+			'reset_tracking' => array(
+				'name'    => __( 'Reset Usage Tracking Settings', 'woocommerce' ),
+				'button'  => __( 'Reset usage tracking settings', 'woocommerce' ),
+				'desc'    => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
 			)
 		);
 

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -104,6 +104,9 @@ class WC_Tracker {
 		$data['email'] = apply_filters( 'woocommerce_tracker_admin_email', get_option( 'admin_email' ) );
 		$data['theme'] = $this->get_theme_info();
 
+		// WordPress Data
+		$data['wp'] = $this->get_wordpress_data();
+
 		// Plugin info
 		$all_plugins = $this->get_all_plugins();
 		$data['active_plugins']   = $all_plugins['active_plugins'];
@@ -147,6 +150,23 @@ class WC_Tracker {
 		$theme_wc_support = ( ! current_theme_supports( 'woocommerce' ) && ! in_array( $active_theme->template, wc_get_core_supported_themes() ) ) ? 'No' : 'Yes';
 
 		return array( 'name' => $theme_name, 'version' => $theme_version, 'child_theme' => $theme_child_theme, 'wc_support' => $theme_wc_support );
+	}
+
+	/**
+	 * Get WordPress related data.
+	 * @return array
+	 */
+	public function get_wordpress_data() {
+		$wp_data = array();
+
+		$memory = wc_let_to_num( WP_MEMORY_LIMIT );
+		$wp_data['memory_limit'] = size_format( $memory );
+		$wp_data['debug_mode'] = ( defined('WP_DEBUG') && WP_DEBUG ) ? 'Yes' : 'No';
+		$wp_data['locale'] = get_locale();
+		$wp_data['version'] = bloginfo( 'version' );
+		$wp_data['multisite'] = is_multisite() ? 'Yes' : 'No';
+
+		return $wp_data;
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -330,24 +330,24 @@ class WC_Tracker {
 	 * @return array
 	 */
 	public function get_all_woocommerce_options_values() {
-		global $wpdb;
-
-		$alloptions_db = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE %s",
-				'woocommerce_%'
-			)
+		return array(
+			'currency'								=> get_woocommerce_currency(),
+			'base_location'							=> WC()->countries->get_base_country(),
+			'selling_locations'						=> WC()->countries->get_allowed_countries(),
+			'api_enabled'							=> get_option( 'woocommerce_api_enabled' ),
+			'weight_unit'							=> get_option( 'woocommerce_weight_unit' ),
+			'dimension_unit'						=> get_option( 'woocommerce_dimension_unit' ),
+			'download_method'						=> get_option( 'woocommerce_file_download_method' ),
+			'download_require_login'				=> get_option( 'woocommerce_downloads_require_login' ),
+			'calc_taxes'							=> get_option( 'woocommerce_calc_taxes' ),
+			'coupons_enabled'						=> get_option( 'woocommerce_enable_coupons' ),
+			'guest_checkout'						=> get_option( 'woocommerce_enable_guest_checkout'),
+			'secure_checkout'						=> get_option( 'woocommerce_force_ssl_checkout' ),
+			'enable_signup_and_login_from_checkout'	=> get_option( 'woocommerce_enable_signup_and_login_from_checkout' ),
+			'enable_myaccount_registration'			=> get_option( 'woocommerce_enable_myaccount_registration' ),
+			'registration_generate_username'		=> get_option( 'woocommerce_registration_generate_username' ),
+			'registration_generate_password'		=> get_option( 'woocommerce_registration_generate_password' ),
 		);
-
-		$alloptions = array();
-		foreach ( (array) $alloptions_db as $o ) {
-			// We dont want to keep track of serialized data, ie. payment gateway/shipping method settings
-			if ( ! is_serialized( $o->option_value ) ) {
-				$alloptions[ $o->option_name ] = $o->option_value;
-			}
-		}
-
-		return $alloptions;
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -70,7 +70,7 @@ class WC_Tracker {
 
 		// General site info
 		$data['url']   = home_url();
-		$data['email'] = apply_filters( 'woocommerce_tracker_admin_email', get_bloginfo( 'admin_email' ) );
+		$data['email'] = apply_filters( 'woocommerce_tracker_admin_email', get_option( 'admin_email' ) );
 		$data['theme'] = $this->get_theme_info();
 
 		// Plugin info

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -121,7 +121,7 @@ class WC_Tracker {
 		$data['shipping_methods'] = $this->get_active_shipping_methods();
 
 		// Get all WooCommerce options info
-		$data['general'] = $this->get_all_woocommerce_options_values();
+		$data['settings'] = $this->get_all_woocommerce_options_values();
 
 		// Template overrides
 		$data['template_overrides'] = $this->get_all_template_overrides();

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -404,7 +404,7 @@ class WC_Tracker {
 		}
 
 		echo '<div id="message" class="updated woocommerce-message wc-connect">';
-		echo '<p>' . __( 'Allow WooCommerce usage tracking? Send non sensitive WooCommerce usage data to WooThemes and get 20% discount on your next WooThemes purchase.', 'woocommerce' ) . '</p>';
+		echo '<p>' . __( 'Want to help make WooCommerce even more awesome? Allow WooThemes to collect non-sensitive diagnostic data and usage information, and get 20% discount on your next WooThemes purchase.', 'woocommerce' ) . '</p>';
 		echo '<p class="submit"><a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-in' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="button-primary">' . __( 'Allow', 'woocommerce' ) . '</a>';
 		echo '&nbsp;<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-out' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="skip button-primary">' . __( 'No, don\'t bother me again', 'woocommerce' ) . '</a></p>';
 		echo '</div>';

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -166,7 +166,7 @@ class WC_Tracker {
 		$wp_data['memory_limit'] = size_format( $memory );
 		$wp_data['debug_mode'] = ( defined('WP_DEBUG') && WP_DEBUG ) ? 'Yes' : 'No';
 		$wp_data['locale'] = get_locale();
-		$wp_data['version'] = bloginfo( 'version' );
+		$wp_data['version'] = get_bloginfo( 'version' );
 		$wp_data['multisite'] = is_multisite() ? 'Yes' : 'No';
 
 		return $wp_data;

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -138,7 +138,7 @@ class WC_Tracker {
 			$theme_name = $theme_data->Name;
 			$theme_version = $theme_data->Version;
 		}
-		return array( array( 'name' => $theme_name, 'version' => $theme_version ) );
+		return array( 'name' => $theme_name, 'version' => $theme_version );
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -49,7 +49,7 @@ class WC_Tracker {
 
 	/**
 	 * Decide whether to send tracking data or not
-	 * @param  boolean $check_last_send
+	 * @param  boolean $override
 	 * @return void
 	 */
 	public function send_tracking_data( $override = false ) {

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -74,7 +74,7 @@ class WC_Tracker {
 				'redirection' => 5,
 				'httpversion' => '1.0',
 				'blocking' => true,
-				'headers' => array( 'user-agent' => 'WooCommerce/' . WC_VERSION . '; ' . esc_url( home_url( '/' ) ) ),
+				'headers' => array( 'user-agent' => 'WooCommerceTracker/' . md5( esc_url( home_url( '/' ) ) ) . ';' ),
 				'body' => json_encode( $params ),
 				'cookies' => array()
 			)

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * WooCommerce Tracker
+ *
+ * The WooCommerce tracker class adds functionality to track WooCommerce usage based on if the customer opted in.
+ * No personal infomation is tracked, only setting, general product and order counts and admin email for discount code.
+ *
+ * @class 		WC_Tracker
+ * @version		2.3.0
+ * @package		WooCommerce/Classes
+ * @category	Class
+ * @author 		WooThemes
+ */
+class WC_Tracker {
+
+	/**
+	 * URL to the WooThemes Tracker API endpoint
+	 * @var string
+	 */
+	public $api_url = 'http://woothemes.com/wc-api/tracker/';
+
+	/**
+	 * Constructor
+	 * @return void
+	 */
+	public function __construct() {
+		add_action( 'wp', array( $this, 'add_tracking_event_to_cron_schedule' ) );
+		add_action( 'wc_tracker_send_event', array( $this, 'send_tracking_data' ) );
+	}
+
+	/**
+	 * Schedule daily cron to check if tracking data must be sent
+	 * @return void
+	 */
+	public function add_tracking_event_to_cron_schedule () {
+		if ( ! wp_next_scheduled( 'wc_tracker_send_event' ) ) {
+			wp_schedule_event( time(), apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'wc_tracker_send_event' );
+		}
+	}
+
+	/**
+	 * Decide whether to send tracking data or not
+	 * @param  boolean $check_last_send
+	 * @return void
+	 */
+	public function send_tracking_data( $check_last_send = true ) {
+		// Send a maximum of once per week by default.
+		if ( apply_filters( 'woocommerce_tracker_check_last_send', $check_last_send ) ) {
+			$last_send = $this->get_last_send_time();
+			if ( $last_send && $last_send > apply_filters( 'woocommerce_tracker_last_send_interval', strtotime( '-1 week' ) ) ) {
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Get the last time tracking data was sent
+	 * @return int|bool
+	 */
+	public function get_last_send_time() {
+		return apply_filters( 'woocommerce_tracker_last_send_time', get_option( 'woocommerce_tracker_last_send', false ) );
+	}
+
+	/**
+	 * Get all the tracking data
+	 * @return array
+	 */
+	public function get_tracking_data() {
+		$data = array();
+
+		// General site info
+		$data['url']   = home_url();
+		$data['email'] = apply_filters( 'woocommerce_tracker_admin_email', get_bloginfo( 'admin_email' ) );
+		$data['theme'] = $this->get_theme_info();
+
+		// Plugin info
+		$all_plugins = $this->get_all_plugins();
+		$data['active_plugins']   = $all_plugins['active_plugins'];
+		$data['inactive_plugins'] = $all_plugins['inactive_plugins'];
+
+		// Store count info
+		$data['users']    = $this->get_user_counts();
+		$data['products'] = $this->get_product_counts();
+		$data['orders']   = $this->get_order_counts();
+
+		// Payment gateway info
+		$data['gateways'] = $this->get_active_payment_gateways();
+
+		// Shipping method info
+		$data['shipping_methods'] = $this->get_active_shipping_methods();
+
+		// Get all WooCommerce options info
+		$data['general'] = $this->get_all_woocommerce_options_values();
+
+		// Template overrides
+		$data['template_overrides'] = $this->get_all_template_overrides();
+	}
+
+	/**
+	 * Get the current theme info, theme name and version
+	 * @return array
+	 */
+	public function get_theme_info() {
+		if ( get_bloginfo( 'version' ) < '3.4' ) {
+			$theme_data = get_theme_data( get_stylesheet_directory() . '/style.css' );
+			$theme_name = $theme_data['Name'];
+			$theme_version = $theme_data['Version'];
+		} else {
+			$theme_data = wp_get_theme();
+			$theme_name = $theme_data->Name;
+			$theme_version = $theme_data->Version;
+		}
+		return array( array( 'name' => $theme_name, 'version' => $theme_version ) );
+	}
+
+	/**
+	 * Get all plugins grouped into activated or not
+	 * @return array
+	 */
+	public function get_all_plugins() {
+		// Ensure get_plugins function is loaded
+		if( ! function_exists( 'get_plugins' ) ) {
+			include ABSPATH . '/wp-admin/includes/plugin.php';
+		}
+
+		$plugins        	 = get_plugins();
+		$active_plugins_keys = get_option( 'active_plugins', array() );
+		$active_plugins 	 = array();
+
+		foreach ( $plugins as $k => $v ) {
+			// Take care of formatting the data how we want it.
+			$formatted = array();
+			$formatted['name'] = strip_tags( $v['Name'] );
+			if ( isset( $v['Version'] ) ) {
+				$formatted['version'] = strip_tags( $v['Version'] );
+			}
+			if ( isset( $v['Author'] ) ) {
+				$formatted['author'] = strip_tags( $v['Author'] );
+			}
+			if ( isset( $v['Network'] ) ) {
+				$formatted['network'] = strip_tags( $v['Network'] );
+			}
+			if ( isset( $v['PluginURI'] ) ) {
+				$formatted['plugin_uri'] = strip_tags( $v['PluginURI'] );
+			}
+			if ( in_array( $k, $active_plugins_keys ) ) {
+				// Remove active plugins from list so we can show active and inactive separately
+				unset( $plugins[$k] );
+				$active_plugins[$k] = $formatted;
+			} else {
+				$plugins[$k] = $formatted;
+			}
+		}
+
+		return array( 'active_plugins' => $active_plugins, 'inactive_plugins' => $plugins );
+	}
+
+	/**
+	 * Get user totals based on user role
+	 * @return array
+	 */
+	public function get_user_counts() {
+		$user_count = array();
+		$user_count_data = count_users();
+		$user_count['total'] = $user_count_data['total_users'];
+
+		// Get user count based on user role
+		foreach ( $user_count_data['avail_roles'] as $role => $count ) {
+			$user_count[ $role ] = $count;
+		}
+
+		return $user_count;
+	}
+
+	/**
+	 * Get product totals based on product type
+	 * @return array
+	 */
+	public function get_product_counts() {
+		$product_count = array();
+		$product_count_data = wp_count_posts( 'product' );
+		$product_count['total'] = $product_count_data->publish;
+
+		$product_statuses = get_terms( 'product_type', array( 'hide_empty' => 0 ) );
+		foreach ( $product_statuses as $product_status ) {
+			$product_count[ $product_status->name ] = $product_status->count;
+		}
+		return $product_count;
+	}
+
+	/**
+	 * Get order counts based on order status
+	 * @return array
+	 */
+	public function get_order_counts() {
+		$order_count = array();
+		$order_count_data = wp_count_posts( 'shop_order' );
+
+		foreach ( wc_get_order_statuses() as $status_slug => $status_name ) {
+			$order_count[ $status_slug ] = $order_count_data->{ $status_slug };
+		}
+		return $order_count;
+	}
+
+	/**
+	 * Get a list of all active payment gateways
+	 * @return void
+	 */
+	public function get_active_payment_gateways() {
+		$active_gateways = array();
+		$gateways = WC()->payment_gateways->payment_gateways();
+		foreach ( $gateways as $id => $gateway ) {
+			if ( isset( $gateway->enabled ) && $gateway->enabled == 'yes' ) {
+				$active_gateways[ $id ] = array( 'title' => $gateway->title, 'supports' => $gateway->supports );
+			}
+		}
+		return $active_gateways;
+	}
+
+	/**
+	 * Get a list of all active shipping methods
+	 * @return void
+	 */
+	public function get_active_shipping_methods() {
+		$active_methods = array();
+		$shipping_methods = WC()->shipping->get_shipping_methods();
+		foreach ( $shipping_methods as $id => $shipping_method ) {
+			if ( isset( $shipping_method->enabled ) && $shipping_method->enabled == 'yes' ) {
+				$active_methods[ $id ] = array( 'title' => $shipping_method->title, 'tax_status' => $shipping_method->tax_status );
+			}
+		}
+		return $active_methods;
+	}
+
+	/**
+	 * Get all options starting with woocommerce_ prefix
+	 * @return array
+	 */
+	public function get_all_woocommerce_options_values() {
+		global $wpdb;
+
+		$alloptions_db = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE %s",
+				'woocommerce_%'
+			)
+		);
+
+		$alloptions = array();
+		foreach ( (array) $alloptions_db as $o ) {
+			// We dont want to keep track of serialized data
+			if ( ! is_serialized( $o->option_value ) ) {
+				$alloptions[ $o->option_name ] = $o->option_value;
+			}
+		}
+
+		return $alloptions;
+	}
+
+	/**
+	 * Look for any template override and return filenames
+	 * @return array
+	 */
+	public function get_all_template_overrides() {
+		$override_data = array();
+		$template_paths = apply_filters( 'woocommerce_template_overrides_scan_paths', array( 'WooCommerce' => WC()->plugin_path() . '/templates/' ) );
+		$scanned_files  = array();
+		$found_files    = array();
+		$status         = require_once( WC()->plugin_path() . '/includes/admin/class-wc-admin-status.php' );
+
+		foreach ( $template_paths as $plugin_name => $template_path ) {
+			$scanned_files[ $plugin_name ] = WC_Admin_Status::scan_template_files( $template_path );
+		}
+
+		foreach ( $scanned_files as $plugin_name => $files ) {
+			foreach ( $files as $file ) {
+				if ( file_exists( get_stylesheet_directory() . '/' . $file ) ) {
+					$theme_file = get_stylesheet_directory() . '/' . $file;
+				} elseif ( file_exists( get_stylesheet_directory() . '/woocommerce/' . $file ) ) {
+					$theme_file = get_stylesheet_directory() . '/woocommerce/' . $file;
+				} elseif ( file_exists( get_template_directory() . '/' . $file ) ) {
+					$theme_file = get_template_directory() . '/' . $file;
+				} elseif( file_exists( get_template_directory() . '/woocommerce/' . $file ) ) {
+					$theme_file = get_template_directory() . '/woocommerce/' . $file;
+				} else {
+					$theme_file = false;
+				}
+				if ( $theme_file ) {
+					$override_data[] = basename( $theme_file );
+				}
+			}
+		}
+		return $override_data;
+	}
+}

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -24,7 +24,7 @@ class WC_Tracker {
 	 * URL to the WooThemes Tracker API endpoint
 	 * @var string
 	 */
-	public $api_url = 'http://tracking.woocommerce.com/wc-api/tracker/';
+	public $api_url = 'https://tracking.woocommerce.com/v1/';
 
 	/**
 	 * Constructor

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -150,7 +150,7 @@ class WC_Tracker {
 			$theme_version = $theme_data->Version;
 		}
 		$theme_child_theme = is_child_theme() ? 'Yes' : 'No';
-		$theme_wc_support = ( ! current_theme_supports( 'woocommerce' ) && ! in_array( $active_theme->template, wc_get_core_supported_themes() ) ) ? 'No' : 'Yes';
+		$theme_wc_support = ( ! current_theme_supports( 'woocommerce' ) && ! in_array( $theme_data->template, wc_get_core_supported_themes() ) ) ? 'No' : 'Yes';
 
 		return array( 'name' => $theme_name, 'version' => $theme_version, 'child_theme' => $theme_child_theme, 'wc_support' => $theme_wc_support );
 	}

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -297,7 +297,7 @@ class WC_Tracker {
 
 	/**
 	 * Get a list of all active payment gateways
-	 * @return void
+	 * @return array
 	 */
 	public function get_active_payment_gateways() {
 		$active_gateways = array();
@@ -312,7 +312,7 @@ class WC_Tracker {
 
 	/**
 	 * Get a list of all active shipping methods
-	 * @return void
+	 * @return array
 	 */
 	public function get_active_shipping_methods() {
 		$active_methods = array();

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -63,7 +63,7 @@ class WC_Tracker {
 
 		$params = $this->get_tracking_data();
 
-		$response = wp_remote_post( esc_url( $this->api_url ), array(
+		$response = wp_remote_post( esc_url( apply_filters( 'woocommerce_tracker_api_url', $this->api_url ) ), array(
 				'method' => 'POST',
 				'timeout' => 45,
 				'redirection' => 5,
@@ -121,7 +121,7 @@ class WC_Tracker {
 		// Template overrides
 		$data['template_overrides'] = $this->get_all_template_overrides();
 
-		return $data;
+		return apply_filters( 'woocommerce_tracker_data', $data );
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -355,7 +355,7 @@ class WC_Tracker {
 	 * @return array
 	 */
 	public function get_all_template_overrides() {
-		$override_data = array();
+		$override_data  = array();
 		$template_paths = apply_filters( 'woocommerce_template_overrides_scan_paths', array( 'WooCommerce' => WC()->plugin_path() . '/templates/' ) );
 		$scanned_files  = array();
 		$found_files    = array();

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -404,7 +404,7 @@ class WC_Tracker {
 		}
 
 		echo '<div id="message" class="updated woocommerce-message wc-connect">';
-		echo '<p>' . __( 'Want to help make WooCommerce even more awesome? Allow WooThemes to collect non-sensitive diagnostic data and usage information, and get 20% discount on your next WooThemes purchase.', 'woocommerce' ) . '</p>';
+		echo '<p>' . __( 'Want to help make WooCommerce even more awesome? Allow WooThemes to collect non-sensitive diagnostic data and usage information, and get 20% discount on your next WooThemes purchase. <a href="http://docs.woothemes.com/document/woocommerce-usage-tracking/">Find out more</a>.', 'woocommerce' ) . '</p>';
 		echo '<p class="submit"><a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-in' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="button-primary">' . __( 'Allow', 'woocommerce' ) . '</a>';
 		echo '&nbsp;<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-out' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="skip button-primary">' . __( 'No, don\'t bother me again', 'woocommerce' ) . '</a></p>';
 		echo '</div>';

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -143,7 +143,10 @@ class WC_Tracker {
 			$theme_name = $theme_data->Name;
 			$theme_version = $theme_data->Version;
 		}
-		return array( 'name' => $theme_name, 'version' => $theme_version );
+		$theme_child_theme = is_child_theme() ? 'Yes' : 'No';
+		$theme_wc_support = ( ! current_theme_supports( 'woocommerce' ) && ! in_array( $active_theme->template, wc_get_core_supported_themes() ) ) ? 'No' : 'Yes';
+
+		return array( 'name' => $theme_name, 'version' => $theme_version, 'child_theme' => $theme_child_theme, 'wc_support' => $theme_wc_support );
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -52,9 +52,14 @@ class WC_Tracker {
 	 * @param  boolean $check_last_send
 	 * @return void
 	 */
-	public function send_tracking_data( $check_last_send = true ) {
-		// Send a maximum of once per week by default.
-		if ( apply_filters( 'woocommerce_tracker_check_last_send', $check_last_send ) ) {
+	public function send_tracking_data( $override = false ) {
+		if ( ! apply_filters( 'woocommerce_tracker_send_override', $override ) ) {
+			// User must opt in to send
+			if ( ! get_option( 'woocommerce_allow_tracking' ) ) {
+				return;
+			}
+
+			// Send a maximum of once per week by default.
 			$last_send = $this->get_last_send_time();
 			if ( $last_send && $last_send > apply_filters( 'woocommerce_tracker_last_send_interval', strtotime( '-1 week' ) ) ) {
 				return;
@@ -361,7 +366,7 @@ class WC_Tracker {
 		if ( 'opt-in' == $_GET['wc_tracker'] ) {
 			update_option( 'woocommerce_allow_tracking', true );
 			update_option( 'woocommerce_hide_tracking_notice', true );
-			$this->send_tracking_data( false );
+			$this->send_tracking_data( true );
 		} elseif ( 'opt-out' == $_GET['wc_tracker'] ) {
 			update_option( 'woocommerce_allow_tracking', false );
 			update_option( 'woocommerce_hide_tracking_notice', true );

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -104,8 +104,11 @@ class WC_Tracker {
 		$data['email'] = apply_filters( 'woocommerce_tracker_admin_email', get_option( 'admin_email' ) );
 		$data['theme'] = $this->get_theme_info();
 
-		// WordPress Data
-		$data['wp'] = $this->get_wordpress_data();
+		// WordPress Info
+		$data['wp'] = $this->get_wordpress_info();
+
+		// Server Info
+		$data['server'] = $this->get_server_info();
 
 		// Plugin info
 		$all_plugins = $this->get_all_plugins();
@@ -156,7 +159,7 @@ class WC_Tracker {
 	 * Get WordPress related data.
 	 * @return array
 	 */
-	public function get_wordpress_data() {
+	public function get_wordpress_info() {
 		$wp_data = array();
 
 		$memory = wc_let_to_num( WP_MEMORY_LIMIT );
@@ -167,6 +170,40 @@ class WC_Tracker {
 		$wp_data['multisite'] = is_multisite() ? 'Yes' : 'No';
 
 		return $wp_data;
+	}
+
+	/**
+	 * Get server related info
+	 * @return array
+	 */
+	public function get_server_info() {
+		$server_data = array();
+
+		if ( isset( $_SERVER['SERVER_SOFTWARE'] ) && ! empty( $_SERVER['SERVER_SOFTWARE'] ) ) {
+			$server_data['software'] = $_SERVER['SERVER_SOFTWARE'];
+		}
+
+		if ( function_exists( 'phpversion' ) ) {
+			$server_data['php_version'] = phpversion();
+		}
+
+		if ( function_exists( 'ini_get' ) ) {
+			$server_data['php_post_max_size'] = size_format( wc_let_to_num( ini_get( 'post_max_size' ) ) );
+			$server_data['php_time_limt'] = ini_get( 'max_execution_time' );
+			$server_data['php_max_input_vars'] = ini_get( 'max_input_vars' );
+			$server_data['php_suhosin'] = extension_loaded( 'suhosin' ) ? 'Yes' : 'No';
+		}
+
+		global $wpdb;
+		$server_data['mysql_version'] = $wpdb->db_version();
+
+		$server_data['php_max_upload_size'] = size_format( wp_max_upload_size() );
+		$server_data['php_default_timezone'] = date_default_timezone_get();
+		$server_data['php_soap'] = class_exists( 'SoapClient' ) ? 'Yes' : 'No';
+		$server_data['php_fsockopen'] = function_exists( 'fsockopen' ) ? 'Yes' : 'No';
+		$server_data['php_curl'] = function_exists( 'curl_init' ) ? 'Yes' : 'No';
+
+		return $server_data;
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -24,7 +24,7 @@ class WC_Tracker {
 	 * URL to the WooThemes Tracker API endpoint
 	 * @var string
 	 */
-	public $api_url = 'http://woothemes.com/wc-api/tracker/';
+	public $api_url = 'http://tracking.woocommerce.com/wc-api/tracker/';
 
 	/**
 	 * Constructor

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -3,7 +3,7 @@
  * WooCommerce Tracker
  *
  * The WooCommerce tracker class adds functionality to track WooCommerce usage based on if the customer opted in.
- * No personal infomation is tracked, only setting, general product and order counts and admin email for discount code.
+ * No personal infomation is tracked, only general WooCommerce settings, general product, order and user counts and admin email for discount code.
  *
  * @class 		WC_Tracker
  * @version		2.3.0
@@ -11,6 +11,13 @@
  * @category	Class
  * @author 		WooThemes
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( 'WC_Tracker' ) ) :
+
 class WC_Tracker {
 
 	/**
@@ -250,7 +257,7 @@ class WC_Tracker {
 
 		$alloptions = array();
 		foreach ( (array) $alloptions_db as $o ) {
-			// We dont want to keep track of serialized data
+			// We dont want to keep track of serialized data, ie. payment gateway/shipping method settings
 			if ( ! is_serialized( $o->option_value ) ) {
 				$alloptions[ $o->option_name ] = $o->option_value;
 			}
@@ -312,11 +319,11 @@ class WC_Tracker {
 			return;
 		}
 
-		echo '<div class="updated"></p>';
-		echo  __( 'Allow WooCommerce usage tracking? Send non sensitive WooCommerce usage data to WooThemes and get 20% discount on your next WooThemes purchase.', 'woocommerce' );
-		echo '&nbsp;<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-in' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="button-secondary">' . __( 'Allow', 'woocommerce' ) . '</a>';
-		echo '&nbsp;<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-out' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="button-secondary">' . __( 'No, don\'t bother me again', 'woocommerce' ) . '</a>';
-		echo '</p></div>';
+		echo '<div id="message" class="updated woocommerce-message wc-connect">';
+		echo '<p>' . __( 'Allow WooCommerce usage tracking? Send non sensitive WooCommerce usage data to WooThemes and get 20% discount on your next WooThemes purchase.', 'woocommerce' ) . '</p>';
+		echo '<p class="submit"><a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-in' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="button-primary">' . __( 'Allow', 'woocommerce' ) . '</a>';
+		echo '&nbsp;<a href="' . esc_url( wp_nonce_url( add_query_arg( 'wc_tracker', 'opt-out' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ) . '" class="skip button-primary">' . __( 'No, don\'t bother me again', 'woocommerce' ) . '</a></p>';
+		echo '</div>';
 	}
 
 	/**
@@ -342,3 +349,7 @@ class WC_Tracker {
 		}
 	}
 }
+
+endif;
+
+return new WC_Tracker;

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -60,6 +60,23 @@ class WC_Tracker {
 				return;
 			}
 		}
+
+		$params = $this->get_tracking_data();
+
+		$response = wp_remote_post( esc_url( $this->api_url ), array(
+				'method' => 'POST',
+				'timeout' => 45,
+				'redirection' => 5,
+				'httpversion' => '1.0',
+				'blocking' => true,
+				'headers' => array( 'user-agent' => 'WooCommerce/' . WC_VERSION . '; ' . esc_url( home_url( '/' ) ) ),
+				'body' => json_encode( $params ),
+				'cookies' => array()
+			)
+		);
+		if ( ! is_wp_error( $response ) && '200' == wp_remote_retrieve_response_code( $response ) ) {
+			update_option( 'woocommerce_tracker_last_send', time() );
+		}
 	}
 
 	/**
@@ -103,6 +120,8 @@ class WC_Tracker {
 
 		// Template overrides
 		$data['template_overrides'] = $this->get_all_template_overrides();
+
+		return $data;
 	}
 
 	/**

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -233,6 +233,7 @@ final class WooCommerce {
 		include_once( 'includes/class-wc-integrations.php' );                   // Loads integrations
 		include_once( 'includes/class-wc-cache-helper.php' );                   // Cache Helper
 		include_once( 'includes/class-wc-language-pack-upgrader.php' );         // Download/update languages
+		include_once( 'includes/class-wc-tracker.php' );						// Usage Tracker
 	}
 
 	/**


### PR DESCRIPTION
How this will work is upon installation of WC 2.3 and up the admin will be prompted with a banner asking them wether they want to opt-in to sending non sensitive data to WooThemes
![Opt-in message](http://cld.wthms.co/wZPY+)

If they select to opt-in it makes an immediate call to the WooThemes API endpoint, and then issues the user with a one-time discount coupon via email. The email is sent to the WordPress admin email as defined in the WordPress general settings, the discount can only be used with that email address.

After the initial call, it will make another call every 7 days with updated data.

@BFTrick can you check if you are happy with the general WooCommerce settings we track? Perhaps some settings we are missing and want to add?

To sum it up we keep track of the following data on each call the the API:
- Admin Email - only used for sending the coupon
- Site URL
- Theme Name
- Theme Version
- If child theme is used
- If theme declares WC support
- WP Version
- WP Memory Limit
- WP Debug Mode
- WP Locale
- If WP multisite
- Server Software
- PHP Version
- PHP Limits, ie max post size, time, input vars and if suhosin is installed
- PHP Modules, check if curl, fsockopen and soap is activated on server
- List of active plugins
- List of inactive plugins
- User counts
- Product counts
- Order counts
- Active payment gateways and what they support, ie subscriptions, pre-orders
- Active shipping methods
- Template overrides
- General WC settings, ie currency, base location, weight unit, dimension unit, download method etc.

@mikejolley @claudiosmweb Please leave this pull request open until everyone is happy and I give the go ahead to merge :smiley:

Feel free to make recommendations where you guys see fit.
