### PR TITLE
Display notice when accessing deprecated WC_Cart->discount_total

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1313,7 +1313,7 @@ class WC_Cart {
 				// Allow plugins to hook and alter totals before final total is calculated
 				do_action( 'woocommerce_calculate_totals', $this );
 
-				// Grand Total - Discounted product prices, discounted tax, shipping cost + tax, and any discounts to be added after tax (e.g. store credit)
+				// Grand Total - Discounted product prices, discounted tax, shipping cost + tax
 				$this->total = max( 0, apply_filters( 'woocommerce_calculated_total', round( $this->cart_contents_total + $this->tax_total + $this->shipping_tax_total + $this->shipping_total + $this->fee_total, $this->dp ), $this ) );
 
 			} else {

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -61,9 +61,6 @@ class WC_Cart {
 	/** @var float Discounted tax amount. Used predominantly for displaying tax inclusive prices correctly */
 	public $discount_cart_tax;
 
-	/** @var @deprecated 2.3 No longer used - used to be after tax discount. */
-	public $discount_total = 0;
-
 	/** @var float Total for additional fees. */
 	public $fee_total;
 
@@ -124,6 +121,9 @@ class WC_Cart {
 				_deprecated_argument( 'WC_Cart->tax', '2.3', 'Use WC_Tax:: directly' );
 				$this->tax = new WC_Tax();
 				return $this->tax;
+			case 'discount_total':
+				_deprecated_argument( 'WC_Cart->discount_total', '2.3', 'After tax coupons are no longer supported. For more information see: http://develop.woothemes.com/woocommerce/2014/12/upcoming-coupon-changes-in-woocommerce-2-3/' );
+				return 0;
 		}
 	}
 


### PR DESCRIPTION
When accessing the `WC()->cart->discount_total` property directly, display a notice and then return `0` (rather than just retuning `0`) to get the information in front of developers that are not tuned into the [develop blog](http://develop.woothemes.com/woocommerce/2014/12/upcoming-coupon-changes-in-woocommerce-2-3/).

Example notice: 

```
PHP Notice:  WC_Cart->discount_total was called with an argument that is <strong>deprecated</strong> since version 2.3! After tax coupons are no longer supported. For more information see: http://develop.woothemes.com/woocommerce/2014/12/upcoming-coupon-changes-in-woocommerce-2-3/ in /wp-includes/functions.php on line 3318
```

Related to #6830.
