### PR TITLE
Fix bug product with variations

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -78,7 +78,7 @@ function wc_get_product_terms( $product_id, $taxonomy, $args = array() ) {
 			// Set args for get_terms
 			$args['menu_order'] = isset( $args['order'] ) ? $args['order'] : 'ASC';
 			$args['hide_empty'] = isset( $args['hide_empty'] ) ? $args['hide_empty'] : 0;
-			$args['fields']     = isset( $args['fields'] ) ? $args['fields'] : 'names';
+			$args['fields']     = isset( $args['fields'] ) ? $args['fields'] : 'all';
 
 			// Ensure slugs is valid for get_terms - slugs isn't supported
 			$args['fields']     = $args['fields'] === 'slugs' ? 'id=>slug' : $args['fields'];


### PR DESCRIPTION
Fix bug with product and variations, see screen: http://d.pr/i/14NL2/3uBBcGaF

I don't know if there is some specific reason, but the wc_get_product_terms function return list with only names and not the object (this if there isn't any "fields" specified in arguments of function), as expected by variable.php template at line 45. I think it's a mistake.
