### PR TITLE
Adds a filter when returning a product's schema

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -582,7 +582,7 @@ if ( ! function_exists( 'woocommerce_get_product_schema' ) ) {
 			}
 		}
 
-		return 'http://schema.org/' . $schema;
+		return apply_filters( 'woocommerce_product_schema', 'http://schema.org/' . $schema, $schema, $product );
 	}
 }
 


### PR DESCRIPTION
I am working on a store which has a number of books as such I was looking to override the Schema URL, as adding an `author` itemprop is invalid within a Product type.

I appreciate you can do function overriding here to customise it but I thought a filter might be more flexible going forward.
