### PR TITLE
Returns attribute slugs when linking all variations to fix #6979

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -697,7 +697,7 @@ class WC_AJAX {
 			$attribute_field_name = 'attribute_' . sanitize_title( $attribute['name'] );
 
 			if ( $attribute['is_taxonomy'] ) {
-				$options = wc_get_product_terms( $post_id, $attribute['name'], array( 'fields' => 'names' ) );
+				$options = wc_get_product_terms( $post_id, $attribute['name'], array( 'fields' => 'slugs' ) );
 			} else {
 				$options = explode( WC_DELIMITER, $attribute['value'] );
 			}


### PR DESCRIPTION
This effectively undoes a change made in https://github.com/woothemes/woocommerce/commit/fe432980216e00f0a9a1ca256166d1159dc0435b which breaks the Link All Variations action.
