### PR TITLE
Using post_status of 'any' causes a conflict with the WP Invoice Plugin ...

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -141,7 +141,7 @@ class WC_Product_Variable extends WC_Product {
 					'orderby'     => 'menu_order',
 					'order'       => 'ASC',
 					'fields'      => 'ids',
-					'post_status' => 'any',
+					'post_status' => 'publish',
 					'numberposts' => -1
 		        );
 


### PR DESCRIPTION
When the WooCommerce Variable Subscriptions Plugin is installed and it calls this function to display the respective drop down list on the front end it filters this functions output to remove anything with a post_status of "trash" - and I think some others. But when the WP Invoice Plugin, by Usability Dynamics, is installed this functionality breaks preventing the users from adding products to their cart. So while this is caused by WP Invoice, it seems the "any" status is just too broad a status since only Published items show on the front end anyway, so this Pull Request changes that status to "published". We've not seen any adverse affects throughout WooComemrce but if this cannot be accepted for any reason we'd appreciate an explanation. Thank you!!
