### PR TITLE
Fix cart icon alignment on welcome page

### DIFF
--- a/includes/admin/class-wc-admin-welcome.php
+++ b/includes/admin/class-wc-admin-welcome.php
@@ -143,7 +143,7 @@ class WC_Admin_Welcome {
 			.about-wrap div.icon {
 				width: 0 !important;
 				padding: 0;
-				margin: 0;
+				margin: 20px 0 !important;
 			}
 			.about-wrap .feature-rest div.icon:before {
 				font-family: WooCommerce !important;


### PR DESCRIPTION
Adds a 20px margin-top to fix cart icon alignment

![cart icon](http://cld.wthms.co/1jPCn+)
