### PR TITLE
Add filter 'woocommerce_grouped_children_args'

### DIFF
--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Grouped products cannot be purchased - they are wrappers for other products.
  *
  * @class 		WC_Product_Grouped
- * @version		2.0.0
+ * @version		2.3.0
  * @package		WooCommerce/Classes/Products
  * @category	Class
  * @author 		WooThemes
@@ -62,7 +62,7 @@ class WC_Product_Grouped extends WC_Product {
 		        $this->total_stock = $this->stock;
 
 				if ( sizeof( $this->get_children() ) > 0 ) {
-					foreach ($this->get_children() as $child_id) {
+					foreach ( $this->get_children() as $child_id ) {
 						$stock = get_post_meta( $child_id, '_stock', true );
 
 						if ( $stock != '' ) {
@@ -91,7 +91,17 @@ class WC_Product_Grouped extends WC_Product {
 
         	if ( empty( $this->children ) ) {
 
-		        $this->children = get_posts( 'post_parent=' . $this->id . '&post_type=product&orderby=menu_order&order=ASC&fields=ids&post_status=publish&numberposts=-1' );
+        		$args = apply_filters( 'woocommerce_grouped_children_args', array(
+        			'post_parent' 	=> $this->id,
+        			'post_type'		=> 'product',
+        			'orderby'		=> 'menu_order',
+        			'order'			=> 'ASC',
+        			'fields'		=> 'ids',
+        			'post_status'	=> 'publish',
+        			'numberposts'	=> -1,
+        		) );
+
+		        $this->children = get_posts( $args );
 
 				set_transient( $transient_name, $this->children, YEAR_IN_SECONDS );
 			}
@@ -134,14 +144,16 @@ class WC_Product_Grouped extends WC_Product {
 
 			foreach ( $this->get_children() as $child_id ) {
 				$sale_price = get_post_meta( $child_id, '_sale_price', true );
-				if ( $sale_price !== "" && $sale_price >= 0 )
+				if ( $sale_price !== "" && $sale_price >= 0 ) {
 					return true;
+				}
 			}
 
 		} else {
 
-			if ( $this->sale_price && $this->sale_price == $this->price )
+			if ( $this->sale_price && $this->sale_price == $this->price ) {
 				return true;
+			}
 
 		}
 		return false;


### PR DESCRIPTION
Allows people to filter the grouped product children, like changing the
order that the children products are displayed in, etc.
![selfie-0](http://i.imgur.com/ml8pV98.png)
