### PR TITLE
Rest 1.0/2.0 Customers - Fix missing output of pagination headers

### DIFF
--- a/includes/api/class-wc-api-server.php
+++ b/includes/api/class-wc-api-server.php
@@ -553,7 +553,7 @@ class WC_API_Server {
 		if ( is_a( $query, 'WP_User_Query' ) ) {
 
 			$page        = $query->page;
-			$single      = count( $query->get_results() ) > 1;
+			$single      = count( $query->get_results() ) == 1;
 			$total       = $query->get_total();
 			$total_pages = $query->total_pages;
 

--- a/includes/api/v1/class-wc-api-server.php
+++ b/includes/api/v1/class-wc-api-server.php
@@ -537,7 +537,7 @@ class WC_API_Server {
 		if ( is_a( $query, 'WP_User_Query' ) ) {
 
 			$page        = $query->page;
-			$single      = count( $query->get_results() ) > 1;
+			$single      = count( $query->get_results() ) == 1;
 			$total       = $query->get_total();
 			$total_pages = $query->total_pages;
 


### PR DESCRIPTION
Today I had to use the pagination headers of the customer endpoint but they didn't exist because of a wrong condition for the calculation of $single so I fixed that.
