### PR TITLE
Don't redirect on prevent admin access for Ajax requests

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -87,6 +87,9 @@ class WC_Admin {
 	 * Prevent any user who cannot 'edit_posts' (subscribers, customers etc) from accessing admin
 	 */
 	public function prevent_admin_access() {
+		if ( defined('DOING_AJAX') && DOING_AJAX ) {
+			return;
+		}
 
 		$prevent_access = false;
 


### PR DESCRIPTION
Of course, you can put the `DOING_AJAX` conditional around applying your filter for `woocommerce_prevent_admin_access`, but since you never want to redirect Ajax requests for this method, I think the method itself should check for Ajax requests.
