### PR TITLE
Support gateway objects in the $load_gateways array

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -96,7 +96,7 @@ class WC_Payment_Gateways {
 
 		// Load gateways in order
 		foreach ( $load_gateways as $gateway ) {
-			$load_gateway = new $gateway();
+			$load_gateway = is_string( $gateway ) ? new $gateway() : $gateway;
 
 			if ( isset( $ordering[ $load_gateway->id ] ) && is_numeric( $ordering[ $load_gateway->id ] ) ) {
 				// Add in position


### PR DESCRIPTION
Rather than requiring $load_gateways to be the string class names of the payment gateways to load, support client code returning the actual gateway instance from the 'woocommerce_payment_gateways' filter.  This affords much more fine grained control over how, when, and how often, a payment gateway is instantiated
