### PR TITLE
Ability to modify $query_args for query_products

### DIFF
--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -508,6 +508,8 @@ class WC_API_Products extends WC_API_Resource {
 		if ( ! empty( $args['category'] ) ) {
 			$query_args['product_cat'] = $args['category'];
 		}
+		
+		$query_args = apply_filters( 'woocommerce_api_query_products_args', $query_args, $args );
 
 		$query_args = $this->merge_query_args( $query_args, $args );
 


### PR DESCRIPTION
This will allow to use custom filters with get_products endpoint and customize $query_args based on them. 

In my case, I need to filter products by custom metadata of author who created the product. It wasn't possible before. With addition of this filter I can check all the incoming filter parameters and modify $query_args appropriately. Here is a short example:

API call:
`https://woocommerce.example.com/wc-api/v2/products?filter[zip]=10025`

Custom hook:

``` php
add_filter( 'woocommerce_api_query_products_args', 'example_filter_products' , 10, 2);
function example_filter_products( $query_args, $filter ) {
    if ( ! empty( $filter['zip'] ) ) {
        $user = reset( 
            get_users(
                array(
                    'meta_key' => 'zip',
                    'meta_value' => $filter['zip'],
                    'number' => 1,
                    'count_total' => false
                )
            )
        );
        if ( ! empty( $user ) ) {
            $query_args['author'] = $user->id;
        }
        unset( $filter['zip'] );
    }
    return $query_args;
}
```
