### PR TITLE
Expiry date along with download details

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -462,6 +462,7 @@ function wc_get_customer_available_downloads( $customer_id ) {
 				'order_id'            => $order->id,
 				'order_key'           => $order->order_key,
 				'downloads_remaining' => $result->downloads_remaining,
+				'access_expires' 	  => $result->access_expires,
 				'file'                => $download_file
 			);
 


### PR DESCRIPTION
For a downloadable file, expiry date is also an important detail. It'll be useful for 3rd party plugin, if this details is also passed along with download details.
