### PR TITLE
Breaks shortcodes with javascript in

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -491,7 +491,7 @@ if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 		if ( is_post_type_archive( 'product' ) && get_query_var( 'paged' ) == 0 ) {
 			$shop_page   = get_post( wc_get_page_id( 'shop' ) );
 			if ( $shop_page ) {
-				$description = wpautop( do_shortcode( $shop_page->post_content ) );
+				$description = apply_filters( 'the_content', $shop_page->post_content );
 				if ( $description ) {
 					echo '<div class="page-description">' . $description . '</div>';
 				}


### PR DESCRIPTION
calling wpautop on do_shortcode content wraps javascript content etc in
<p> tags, this breaks things, I found the issue because it broke
rev_slider as inserted by visual compose by shortcode. You could swap
the order, and run do_shortcode on the wpautop'd content, but why not
just do it the proper way with apply_filters('the_content',$content);
