### PR TITLE
Fixed variable product pricing reference

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -316,7 +316,7 @@ class WC_Product_Variable extends WC_Product {
 
 			if ( $price !== $saleprice ) {
 				$price = apply_filters( 'woocommerce_variable_sale_price_html', $this->get_price_html_from_to( $saleprice, $price ) . $this->get_price_suffix(), $this );
-			} elseif ( $price == 0 ) {
+			} elseif ( $price === 0 ) {
 				$price = __( 'Free!', 'woocommerce' );
 				$price = apply_filters( 'woocommerce_variable_free_price_html', $price, $this );
 			} else {


### PR DESCRIPTION
Fix to issue #7130

'==' as comparator for string to int will always return true. ''===" allows  comparison of type as well.
