### PR TITLE
[2.3] Restore $theorder

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -23,6 +23,12 @@ class WC_Meta_Box_Order_Actions {
 	 * Output the metabox
 	 */
 	public static function output( $post ) {
+		global $theorder;
+
+		if ( ! is_object( $theorder ) ) {
+			$theorder = wc_get_order( $post->ID );
+		}
+
 		$order_type_object = get_post_type_object( $post->post_type );
 		?>
 		<ul class="order_actions submitbox">


### PR DESCRIPTION
SHA: 74ba11c1895fe7 removed instantiation of `$theorder` global in `WC_Meta_Box_Order_Actions::output()` as it was mistaken for unused code. However, some callbacks attached to hooks in that function (like `'woocommerce_order_actions'` or `'woocommerce_resend_order_emails_available'`) rely on that global to determine if actions should be displayed for certain orders.
