### PR TITLE
[2.3] Trigger a JS event after an attribute is added

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -299,6 +299,8 @@ jQuery( function( $ ){
 			$('body').trigger( 'wc-enhanced-select-init' );
 			attribute_row_indexes();
 			$wrapper.unblock();
+
+			$('body').trigger( 'woocommerce_added_attribute' );
 		});
 
 		if ( attribute ) {


### PR DESCRIPTION
Trigger a new `'woocommerce_added_attribute'` event when adding an attribute on the **Edit Product** screen for a variable product (or extensions of a variable product, like a variable subscription).

This allows extensions to update the UI based on the attribute once it has been successfully added. Previously, click events on the `button.add_attribute` element could be used (i.e. `$('button.add_attribute').on('click', callback)` because the attribute's HTML was [inserted almost immediately](https://github.com/woothemes/woocommerce/blob/2.2/assets/js/admin/meta-boxes-product.js#L287:L321), but now that it is dynamically loaded via Ajax, that event occurs too early.
