### PR TITLE
Apigen Neon file Editorconfig Configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,9 @@ indent_size = 2
 [*.txt]
 trim_trailing_whitespace = false
 
+[*.neon]
+trim_trailing_whitespace = false
+
 [*.json]
 insert_final_newline = false
 indent_style = space


### PR DESCRIPTION
Trailing whitespace for `*.neon` file should be trimmed ;)
