### PR TITLE
[2.3] Do not set WC_Product property when calling __get()

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -91,30 +91,34 @@ class WC_Product {
 	 * @return mixed
 	 */
 	public function __get( $key ) {
-		$this->$key = get_post_meta( $this->id, '_' . $key, true );
+		$value = get_post_meta( $this->id, '_' . $key, true );
 
 		// Get values or default if not set
 		if ( in_array( $key, array( 'downloadable', 'virtual', 'backorders', 'manage_stock', 'featured', 'sold_individually' ) ) ) {
-			$this->$key = $this->$key ? $this->$key : 'no';
+			$value = $value ? $value : 'no';
 
 		} elseif ( in_array( $key, array( 'product_attributes', 'crosssell_ids', 'upsell_ids' ) ) ) {
-			$this->$key = $this->$key ? $this->$key : array();
+			$value = $value ? $value : array();
 
 		} elseif ( 'visibility' === $key ) {
-			$this->$key = $this->$key ? $this->$key : 'hidden';
+			$value = $value ? $value : 'hidden';
 
 		} elseif ( 'stock' === $key ) {
-			$this->$key = $this->$key ? $this->$key : 0;
+			$value = $value ? $value : 0;
 
 		} elseif ( 'stock_status' === $key ) {
-			$this->$key = $this->$key ? $this->$key : 'instock';
+			$value = $value ? $value : 'instock';
 
 		} elseif ( 'tax_status' === $key ) {
-			$this->$key = $this->$key ? $this->$key : 'taxable';
+			$value = $value ? $value : 'taxable';
 
 		}
 
-		return $this->$key;
+		if ( ! empty( $value ) ) {
+			$this->$key = $value;
+		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
SHA: 100b95a tweaked the `__get()` magic method in `WC_Product` to:
- only call `get_post_meta()` once; and
- set `$this->$key` to save the overhead of calling `__get()` every
  time that property needs to be accessed.

However, in the process, it also set an empty value (`''`) - the default return value of `get_post_meta()` - for every single key that is passed to `__get()` on the product object. Any calls to `isset()` after attempting to get that value would return `true`, even if `metadata_exists()` for that property would return `false` (and no value is set in memory).

A quick test case:

```
function eg_test_isset_magic() {
    if ( ! is_admin() && ! defined( 'DOING_AJAX' ) && ! defined( 'DOING_CRON' ) ) {
        foreach ( WC()->cart->get_cart() as $cart_item ) {
            error_log( 'For ' . $cart_item['product_id'] . ' isset( $cart_item[data]->gobbledygook )     = ' . var_export( isset( $cart_item['data']->gobbledygook ), true ) );
            error_log( 'For ' . $cart_item['product_id'] . ' $cart_item[data]->gobbledygook              = ' . var_export( $cart_item['data']->gobbledygook, true ) );
            error_log( 'For ' . $cart_item['product_id'] . ' NOW isset( $cart_item[data]->gobbledygook ) = ' . var_export( isset( $cart_item['data']->gobbledygook ), true ) );
        }
    }
}
add_action( 'wp_loaded', 'eg_test_isset_magic', 100 );
```

With the existing code on a product with ID `53` this will result in the following:

```
[23-Jan-2015 23:05:26 UTC] For 53 isset( $cart_item[data]->gobbledygook )     = false
[23-Jan-2015 23:05:26 UTC] For 53 $cart_item[data]->gobbledygook              = ''
[23-Jan-2015 23:05:26 UTC] For 53 NOW isset( $cart_item[data]->gobbledygook ) = true
```

Note the changing value of `isset()` check.

With this patch applied, it will (correctly) result in:

```
[23-Jan-2015 23:05:26 UTC] For 53 isset( $cart_item[data]->gobbledygook )     = false
[23-Jan-2015 23:05:26 UTC] For 53 $cart_item[data]->gobbledygook              = ''
[23-Jan-2015 23:05:26 UTC] For 53 NOW isset( $cart_item[data]->gobbledygook ) = false
```
