### PR TITLE
Allow devs to filter is_checkout()

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -113,7 +113,7 @@ if ( ! function_exists( 'is_checkout' ) ) {
 	 * @return bool
 	 */
 	function is_checkout() {
-		return is_page( wc_get_page_id( 'checkout' ) ) ? true : false;
+		return is_page( wc_get_page_id( 'checkout' ) ) || apply_filters( 'woocommerce_is_checkout', false ) ? true : false;
 	}
 }
 


### PR DESCRIPTION
Currently there is no easy way for devs to hook into `is_checkout()`.

Allowing devs to filter the result of `is_checkout()` is useful for extensions like WooCommerce One Page Checkout where the "checkout" may not be the default one used by WooCommerce core.

At the moment one has to resort to ugly hacks like the following or the creation of separate single use duplicate `is_checkout()` functions that replicate and modify the core functionality.

```
public static function is_checkout_hack( $page_id ) {
    global $wp;

    if ( 0 != self::$shortcode_page_id ) {

        $backtrace = debug_backtrace( false ); // Warned you it was a hack

        // allow devs to filter our list of functions
        $function_array = apply_filters( 'wcopc_is_checkout_override_function_names', array( 'wc_template_redirect', 'get_checkout_url' ) );

        // making sure we have an array
        if ( is_array( $function_array ) && ! in_array( $backtrace[4]['function'], $function_array ) ) {
            $page_id = self::$shortcode_page_id;
        }

    }

    return $page_id;

}

// Because there is no reliable way to filter is_checkout(), we need to do a page ID hack
add_filter( 'woocommerce_get_checkout_page_id', array( __CLASS__, 'is_checkout_hack' ) );
```

Even with the above, `is_checkout()` will only return true for "pages" because of its use of `is_page()` https://github.com/woothemes/woocommerce/blob/4785684b9204dd4d0937f28e130978c663c47a96/includes/wc-conditional-functions.php#L116 - which is another reason why adding a proper filter for devs to use would be beneficial.

If this seems reasonable it would be great to get this included in time for release with 2.3.
