### PR TITLE
Typo in checkout.js

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -434,7 +434,7 @@ jQuery( function( $ ) {
 			return false;
 	    },
 	    remove_coupon: function( e ) {
-	    	e.preDefault();
+	    	e.preventDefault();
 
 			var container = $( this ).parents( '.woocommerce-checkout-review-order' ),
 				coupon    = $( this ).data( 'coupon' );


### PR DESCRIPTION
Fixes an "Uncaught TypeError: undefined is not a function" when removing coupons during checkout.
