### PR TITLE
[2.3] Fix session expired notice on checkout

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -235,7 +235,7 @@ jQuery( function( $ ) {
 				url:		wc_checkout_params.ajax_url,
 				data:		data,
 				success:	function( data ) {
-					// Always update the fragements
+					// Always update the fragments
 					if ( data && data.fragments ) {
 						$.each( data.fragments, function ( key, value ) {
 							$( key ).replaceWith( value );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -187,7 +187,7 @@ class WC_AJAX {
 		if ( 0 == sizeof( WC()->cart->get_cart() ) ) {
 			$data = array(
 				'fragments' => apply_filters( 'woocommerce_update_order_review_fragments', array(
-					'.woocommerce-checkout' => '<div class="woocommerce-error">' . __( 'Sorry, your session has expired.', 'woocommerce' ) . ' <a href="' . home_url() . '" class="wc-backward">' . __( 'Return to homepage', 'woocommerce' ) . '</a></div>'
+					'form.woocommerce-checkout' => '<div class="woocommerce-error">' . __( 'Sorry, your session has expired.', 'woocommerce' ) . ' <a href="' . home_url() . '" class="wc-backward">' . __( 'Return to homepage', 'woocommerce' ) . '</a></div>'
 				) )
 			);
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -292,7 +292,7 @@ class WC_AJAX {
 		woocommerce_order_review();
 		$woocommerce_order_review = ob_get_clean();
 
-		// Get checkout payment fragement
+		// Get checkout payment fragment
 		ob_start();
 		woocommerce_checkout_payment();
 		$woocommerce_checkout_payment = ob_get_clean();


### PR DESCRIPTION
When the checkout page is refreshed via ajax and the cart has been emptied, WooCommerce is supposed to display a "_Sorry, your session has expired_" notice like this: https://cloudup.com/cIHCIHwiNeG

However, the [new fragments system](https://github.com/woothemes/woocommerce/commit/2e398a3a791ceb62efe2eeaefc646e08eb7fe5cc#diff-133db5662c51f5686d87611121a05a3bL256) uses the generic selector `.woocommerce-checkout`, but that class is also applied to the `body` of the checkout page (because of [`wc_body_class()`](https://github.com/woothemes/woocommerce/blob/56d40dcf5527a43636dcf747b6456e50a0d31bf1/includes/wc-template-functions.php#L180)). 

Because of that, the entire body is replaced with the `<div class="woocommerce-error">` element instead of just the checkout form giving something one step up from a White Screen of Death: https://cloudup.com/iWBM1n_KjUJ

SHA: 60a161aa93264a031f9a61733f49131496292425 fixes that.
