### PR TITLE
Swap .change for .on method in country-select.js

### DIFF
--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -82,7 +82,7 @@ jQuery( function( $ ) {
 	var states_json = wc_country_select_params.countries.replace( /&quot;/g, '"' ),
 		states = $.parseJSON( states_json );
 
-	$( 'select.country_to_state, input.country_to_state' ).change( function() {
+	$( 'body' ).on( 'change', 'select.country_to_state, input.country_to_state', function() {
 
 		var country = $( this ).val(),
 			$statebox = $( this ).closest( 'div' ).find( '#billing_state, #shipping_state, #calc_shipping_state' ),


### PR DESCRIPTION
Removed .change method for .on( 'change') so that if this field is ever replaced via ajax then the country select still works as expected
