### PR TITLE
Fixed underlined links in wc-connect box

### DIFF
--- a/assets/css/activation.scss
+++ b/assets/css/activation.scss
@@ -49,6 +49,7 @@ p.woocommerce-actions,
 	a.skip,
 	a.docs {
 		opacity: 0.5;
+		text-decoration: none !important;
 
 		&:hover, &:focus {
 			opacity: 1;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -136,6 +136,7 @@
 	a.skip,
 	a.docs {
 		opacity: 0.5;
+		text-decoration: none !important;
 	}
 
 	.twitter-share-button {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -136,7 +136,6 @@
 	a.skip,
 	a.docs {
 		opacity: 0.5;
-		text-decoration: none !important;
 	}
 
 	.twitter-share-button {


### PR DESCRIPTION
Fixes the following display:

![](http://cld.wthms.co/17NxU+)

by removing the underline.
