### PR TITLE
[2.3] Allow extensions to add support for the remove/restore cart item functionality

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -948,6 +948,8 @@ class WC_Cart {
 
 				unset( $this->cart_contents[ $cart_item_key ] );
 
+				do_action( 'woocommerce_cart_item_removed', $cart_item_key, $this );
+
 				$this->calculate_totals();
 
 				return true;
@@ -968,6 +970,8 @@ class WC_Cart {
 				$this->cart_contents[ $cart_item_key ] = $restore;
 
 				unset( $this->removed_cart_contents[ $cart_item_key ] );
+
+				do_action( 'woocommerce_cart_item_restored', $cart_item_key, $this );
 
 				$this->calculate_totals();
 


### PR DESCRIPTION
Extensions affected include Bundles, Composites, MnM, Force Sells -- basically all extensions where a cart item groups/manages one or more "child" cart items, usually by keeping the `quantity` cart item field between the "parent" and the "children" in sync and establishing cart item key links between the "parent" and its "children".

The issue: When the "parent" is removed and sent to `$cart->removed_cart_contents`, the children are orphaned. 

Proposed solution: Use action hooks to allow moving the children between `$cart->cart_contents` and `$cart->removed_cart_contents`when the parent is moved. The ideal location for these hooks is before calling `calculate_totals()`.

All affected extensions must be updated in time for WC 2.3. @helgatheviking @mikejolley 
