### PR TITLE
Fix 5.2 func_args issue

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -84,7 +84,8 @@ class WC_Emails {
 	 */
 	public static function send_transactional_email() {
 		self::instance();
-		do_action_ref_array( current_filter() . '_notification', func_get_args() );
+		$args = func_get_args();
+		do_action_ref_array( current_filter() . '_notification', $args );
 	}
 
 	/**


### PR DESCRIPTION
This does look like a 5.2 issue. Similar:
- http://elinorhurst.blogspot.com/2008/09/php-fatal-error-funcgetargs-cant-be.html
- https://github.com/drush-ops/drush/issues/356
- https://forge.typo3.org/issues/62409

This seems to be the same fix we have used throughout WC.

Closes #7270 
