### PR TITLE
Fix notice when invalid order id / email used

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-order-tracking.php
+++ b/includes/shortcodes/class-wc-shortcode-order-tracking.php
@@ -7,7 +7,7 @@
  * @author 		WooThemes
  * @category 	Shortcodes
  * @package 	WooCommerce/Shortcodes/Order_Tracking
- * @version     2.0.0
+ * @version     2.3.0
  */
 class WC_Shortcode_Order_Tracking {
 
@@ -58,7 +58,7 @@ class WC_Shortcode_Order_Tracking {
 
 				$order = wc_get_order( apply_filters( 'woocommerce_shortcode_order_tracking_order_id', $order_id ) );
 
-				if ( $order->id && $order_email ) {
+				if ( $order && $order->id && $order_email ) {
 
 					if ( strtolower( $order->billing_email ) == strtolower( $order_email ) ) {
 						do_action( 'woocommerce_track_order', $order->id );
@@ -71,7 +71,7 @@ class WC_Shortcode_Order_Tracking {
 
 				} else {
 
-					echo '<p class="woocommerce-error">' . sprintf( __( 'Sorry, we could not find that order id in our database.', 'woocommerce' ), get_permalink($post->ID ) ) . '</p>';
+					echo '<p class="woocommerce-error">' . sprintf( __( 'Sorry, we could not find that order ID in our database.', 'woocommerce' ), get_permalink($post->ID ) ) . '</p>';
 
 				}
 


### PR DESCRIPTION
We also need to check if the $order object exists. Closes #7302
