### PR TITLE
integration with multilingual plugins

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -329,7 +329,12 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_option( $key, $empty_value = null ) {
-		return __( parent::get_option( $key, $empty_value ) );
+		$val = parent::get_option( $key, $empty_value );
+		if( defined('WP_ADMIN') && !defined('DOING_AJAX') ) {
+			return $val;
+		}else{
+			return __( $val );
+		}
 	}
 
 	/**


### PR DESCRIPTION
An administrator of a site needs to have raw option values to be able to set multilingual content for e-mail fields like '"From" Name', 'Email subject', 'Email heading', etc., and that is why an option need not to be translated on admin pages. Oppositely, when a customer at front-end presses whatever submit button, an email is sent via ajax call, and that email should go under the language chosen by customer during shopping, that is why all options need to be translated as they are under your current code.

I suggest to add an if-statement `if( defined('WP_ADMIN') && !defined('DOING_AJAX') )` to distinct whether to translate the value or not.

This allows our plugin [qTranslate-X](https://github.com/qTranslate-Team/qtranslate-x) to become fully integrated with WooCommerce, after adding a few more additonal filters. This is the only place which I cannot do with filters and hooks.

I do not see how it can affect other customers in a bad way, I can only see benefits. Please, let me know if I missed something. Thank you very much.
