### PR TITLE
Add a filter for get_weight

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -705,7 +705,7 @@ class WC_Product {
 	 * @return string
 	 */
 	public function get_weight() {
-		return ( $this->weight ) ? $this->weight : '';
+		return ( apply_filters( 'woocommerce_get_weight', $this->weight, $this ); ) ? apply_filters( 'woocommerce_get_weight', $this->weight, $this ); : '';
 	}
 
 	/**


### PR DESCRIPTION
apply_filters( 'woocommerce_get_weight', $this->weight, $this );

Photography is a new product type which is great for using with product add-ons for selling framed pictures 

If shipping is based on weight then different frames require changing the product weight.

I know that product addons also require a change :-)
