### PR TITLE
Move exit to main download method.

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -187,6 +187,8 @@ class WC_Download_Handler {
 
 		// Trigger download via one of the methods
 		do_action( 'woocommerce_download_file_' . $file_download_method, $file_path, $filename );
+
+		exit;
 	}
 
 	/**
@@ -196,7 +198,6 @@ class WC_Download_Handler {
 	 */
 	public static function download_file_redirect( $file_path, $filename = '' ) {
 		header( 'Location: ' . $file_path );
-		exit;
 	}
 
 	/**
@@ -252,16 +253,13 @@ class WC_Download_Handler {
 		if ( function_exists( 'apache_get_modules' ) && in_array( 'mod_xsendfile', apache_get_modules() ) ) {
 			self::download_headers( $file_path, $filename );
 			header( "X-Sendfile: $file_path" );
-			exit;
 		} elseif ( stristr( getenv( 'SERVER_SOFTWARE' ), 'lighttpd' ) ) {
 			self::download_headers( $file_path, $filename );
 			header( "X-Lighttpd-Sendfile: $file_path" );
-			exit;
 		} elseif ( stristr( getenv( 'SERVER_SOFTWARE' ), 'nginx' ) || stristr( getenv( 'SERVER_SOFTWARE' ), 'cherokee' ) ) {
 			self::download_headers( $file_path, $filename );
 			$xsendfile_path = trim( preg_replace( '`^' . str_replace( '\\', '/', getcwd() ) . '`', '', $file_path ), '/' );
 			header( "X-Accel-Redirect: /$xsendfile_path" );
-			exit;
 		}
 
 		// Fallback
@@ -287,8 +285,6 @@ class WC_Download_Handler {
 				self::download_error( __( 'File not found', 'woocommerce' ) );
 			}
 		}
-
-		exit;
 	}
 
 	/**

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -198,6 +198,7 @@ class WC_Download_Handler {
 	 */
 	public static function download_file_redirect( $file_path, $filename = '' ) {
 		header( 'Location: ' . $file_path );
+		exit;
 	}
 
 	/**
@@ -253,13 +254,16 @@ class WC_Download_Handler {
 		if ( function_exists( 'apache_get_modules' ) && in_array( 'mod_xsendfile', apache_get_modules() ) ) {
 			self::download_headers( $file_path, $filename );
 			header( "X-Sendfile: $file_path" );
+			exit;
 		} elseif ( stristr( getenv( 'SERVER_SOFTWARE' ), 'lighttpd' ) ) {
 			self::download_headers( $file_path, $filename );
 			header( "X-Lighttpd-Sendfile: $file_path" );
+			exit;
 		} elseif ( stristr( getenv( 'SERVER_SOFTWARE' ), 'nginx' ) || stristr( getenv( 'SERVER_SOFTWARE' ), 'cherokee' ) ) {
 			self::download_headers( $file_path, $filename );
 			$xsendfile_path = trim( preg_replace( '`^' . str_replace( '\\', '/', getcwd() ) . '`', '', $file_path ), '/' );
 			header( "X-Accel-Redirect: /$xsendfile_path" );
+			exit;
 		}
 
 		// Fallback


### PR DESCRIPTION
Usefull for when you have to call a download method from within a plugin and then execute code afterwards.
