### PR TITLE
Geolocation: strip whitespace when obtaining external IP

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -76,7 +76,7 @@ class WC_Geolocation {
 				$response         = wp_remote_get( $service_endpoint, array( 'timeout' => 2 ) );
 
 				if ( ! is_wp_error( $response ) && $response['body'] ) {
-					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', trim( $response['body'] ), $service_name );
+					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', wc_clean( $response['body'] ), $service_name );
 					break;
 				}
 			}

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -76,7 +76,7 @@ class WC_Geolocation {
 				$response         = wp_remote_get( $service_endpoint, array( 'timeout' => 2 ) );
 
 				if ( ! is_wp_error( $response ) && $response['body'] ) {
-					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', $response['body'], $service_name );
+					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', trim( $response['body'] ), $service_name );
 					break;
 				}
 			}


### PR DESCRIPTION
The "ip.appspot" service returns an IP address plus a  new line character in its response.

An example response from "ip.appspot" is:

`123.123.123.123\n`

This fix strips whitespace from the response before proceeding.

Other IP Lookup APIs don't seem to include a newline in the response, which means the trim() should be harmless in those cases.
