### PR TITLE
filter instead of hard-coded __()

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -329,7 +329,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_option( $key, $empty_value = null ) {
-		return __( parent::get_option( $key, $empty_value ) );
+		return apply_filters( 'woocommerce_email_get_option', parent::get_option( $key, $empty_value ), $this );
 	}
 
 	/**


### PR DESCRIPTION
Having a filter here, instead of hard-coded `__()` will  allow other plugins to customize this place according to their needs, instead of finding a workaround to cancel the effect of unwanted hard-coded `__()`. Besides, the majority of woocommerce users do not need a customization in this place at all, so an empty filter would produce the least impact in terms of performance.

No need to mention, that I do not insist on a specific name of filter, it can be anything according to your standards. However, I would not suggest to make it dependent on `$this->id`, but instead to pass `$this` argument into the filter, to provide ability to fork inside filter implementation depending on `$this->id` or any other value, if needed.

Thank you very much.
