### PR TITLE
[2.3] Fix WC_Order::payment_complete() on back-end

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2141,7 +2141,9 @@ abstract class WC_Abstract_Order {
 
 		do_action( 'woocommerce_pre_payment_complete', $this->id );
 
-		WC()->session->set( 'order_awaiting_payment', false );
+		if ( null !== WC()->session ) {
+			WC()->session->set( 'order_awaiting_payment', false );
+		}
 
 		$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment_complete', array( 'on-hold', 'pending', 'failed', 'cancelled' ), $this );
 


### PR DESCRIPTION
SHA: c038001eab changed `WC_Abstract_Order::payment_complete()` to use `WC()->session->set( 'order_awaiting_payment' )` instead of `WC()->session->order_awaiting_payment`, but `WC()->session` is only
set on front-end requests, meaning any extension that tries to complete payment on an order from the back-end would cause a fatal error.
