### PR TITLE
trigger an action if an item is dropped from the cart session

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -230,6 +230,7 @@ class WC_Cart {
 							// Flag to indicate the stored cart should be update
 							$update_cart_session = true;
 							wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $_product->get_title() ), 'error' );
+							do_action( 'woocommerce_cart_item_removed_from_session', $_product, $values );
 
 						} else {
 


### PR DESCRIPTION
For parent/container types of products like Mix and Match and Bundles... if the parent container suddenly becomes non-purchasable then it is not added to the cart session array in `get_cart_from_session()`. This leaves its child/bundled elements orphaned. 

Without it, we'll have to loop through the cart items again on `do_action( 'woocommerce_cart_loaded_from_session', $this );` and re-set the session.... which would be a lot less efficient. 
