### PR TITLE
need to pass the $cart item too. #7358 part 2

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -230,7 +230,7 @@ class WC_Cart {
 							// Flag to indicate the stored cart should be update
 							$update_cart_session = true;
 							wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $_product->get_title() ), 'error' );
-							do_action( 'woocommerce_cart_item_removed_from_session', $_product, $values );
+							do_action( 'woocommerce_cart_item_removed_from_session', $key, $values, $this );
 
 						} else {
 


### PR DESCRIPTION
Sorry @mikejolley. You were so fast getting #7358 merged in, I didn't realized that I would need the $cart object along too. I've also changed the `$_product` to `$key` as I think that is more similar to how `woocommerce_cart_item_removed()` works. 
