### PR TITLE
Target _blank to the Storefront read more button

### DIFF
--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -111,7 +111,7 @@ $theme 	= wp_get_theme();
 		</p>
 
 		<p>
-			<a href="<?php echo esc_url( 'http://www.woothemes.com/storefront/' ); ?>" target="_blank" class="button">Read all about it</a>
+			<a href="<?php echo esc_url( 'http://www.woothemes.com/storefront/' ); ?>" target="_blank" class="button"><?php _e( 'Read all about it', 'woocommerce' ) ?></a>
 			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php _e( 'Download &amp; install', 'woocommerce' ); ?></a>
 		</p>
 	</div>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -112,7 +112,7 @@ $theme 	= wp_get_theme();
 
 		<p>
 			<a href="<?php echo esc_url( 'http://www.woothemes.com/storefront/' ); ?>" target="_blank" class="button">Read all about it</a>
-			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php _e( 'Download & install', 'woocommerce' ); ?></a>
+			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php _e( 'Download &amp; install', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -111,7 +111,7 @@ $theme 	= wp_get_theme();
 		</p>
 
 		<p>
-			<a href="<?php echo esc_url( 'http://www.woothemes.com/storefront/' ); ?>" class="button">Read all about it</a>
+			<a href="<?php echo esc_url( 'http://www.woothemes.com/storefront/' ); ?>" target="_blank" class="button">Read all about it</a>
 			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php _e( 'Download & install', 'woocommerce' ); ?></a>
 		</p>
 	</div>


### PR DESCRIPTION
I think we should open the Storefront page from the Add-on (in the admin) into a new tab/window.

Added `target="_blank"`.
