### PR TITLE
Fix backward compatibility for $tax intance variable of WC_Cart.

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -99,9 +99,6 @@ class WC_Cart {
 	/** @var array An array of fees. */
 	public $fees                  = array();
 
-	/** @var WC_Tax Stores tax class objected, @deprecated */
-	public $tax;
-
 	/** @var boolean Prices inc tax */
 	public $prices_include_tax;
 


### PR DESCRIPTION
It seems that the intended mechanism for providing access to the deprecated `$tax` instance variable is through the magic `__get()` function however commit 0300ce2768e17aba2d7747743344ec3afb26b009 has re-introduced the instance variable which takes precedence over `__get()`. As `$tax` isn't initialised anywhere outside of `__get()` that results in `$tax` being NULL.

Any attempts of invoking methods on  `$tax` result in a PHP fatal error.

This commit restores access to `$tax` by removing explicit declaration and thus letting it fall back onto `__get()`.

PS. Initial commit introducing deprecation warning seems to be 3c82331a8b9dfc709b9d834bd4f225fce6028e43
