### PR TITLE
Form field args and type filters

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1552,7 +1552,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		);
 
 		$args = wp_parse_args( $args, $defaults );
-		$args = apply_filters( 'woocommerce_form_field_args', $key, $args, $value );
+		$args = apply_filters( 'woocommerce_form_field_args', $args, $key, $value );
 
 		if ( ( ! empty( $args['clear'] ) ) ) {
 			$after = '<div class="clear"></div>';

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1811,10 +1811,12 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				break;
 			default :
 
-				$field = apply_filters( 'woocommerce_form_field_' . $args['type'], '', $key, $args, $value );
+				$field = '';
 
 				break;
 		}
+
+		$field = apply_filters( 'woocommerce_form_field_' . $args['type'], $field, $key, $args, $value );
 
 		if ( $args['return'] ) {
 			return $field;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1527,7 +1527,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 	 * Outputs a checkout/address form field.
 	 *
 	 * @subpackage	Forms
-	 * @param mixed $key
+	 * @param string $key
 	 * @param mixed $args
 	 * @param string $value (default: null)
 	 * @todo This function needs to be broken up in smaller pieces
@@ -1552,6 +1552,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		);
 
 		$args = wp_parse_args( $args, $defaults );
+		$args = apply_filters( 'woocommerce_form_field_args', $key, $args, $value );
 
 		if ( ( ! empty( $args['clear'] ) ) ) {
 			$after = '<div class="clear"></div>';


### PR DESCRIPTION
Allows hooking into form field args before any HTML. Also all form field types should be filtered, not only custom fields.
