### PR TITLE
Register shop_order post statuses earlier

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -26,7 +26,7 @@ class WC_Post_types {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 5 );
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
-		add_action( 'init', array( __CLASS__, 'register_post_status' ), 10 );
+		add_action( 'init', array( __CLASS__, 'register_post_status' ), 9 );
 		add_action( 'init', array( __CLASS__, 'support_jetpack_omnisearch' ) );
 	}
 


### PR DESCRIPTION
Registering the post statuses on `init` with a priority of 10 is too
late for some uses. Particularly if you are using `WP_Query` on `init`,
WP core will not add the `post_status` where clause if the custom post
statuses are not registered yet.

I ran into this issue on a site using `ALTERNATE_WP_CRON` which runs
`wp_cron()` on `init` with a default priority of `10`. It appears that
this may fix #7408 as well.
