### PR TITLE
[2.3] Reduce number of woocommerce_update_order_review requests

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -161,7 +161,17 @@ jQuery( function( $ ) {
 				$parent.removeClass( 'woocommerce-invalid woocommerce-invalid-required-field' ).addClass( 'woocommerce-validated' );
 			}
 		},
-	    update_checkout: function() {
+		queued_update_checkout: false,
+		update_checkout: function() {
+			if ( ! wc_checkout_form.queued_update_checkout ) {
+				wc_checkout_form.queued_update_checkout = true;
+				setTimeout( wc_checkout_form.update_checkout_task, '20' );
+			}
+		},
+	    update_checkout_task: function() {
+
+	    	wc_checkout_form.queued_update_checkout = false;
+
 	    	if ( wc_checkout_form.xhr ) {
 				wc_checkout_form.xhr.abort();
 			}


### PR DESCRIPTION
@mikejolley Couldn't help but notice the number of chained requests for `woocommerce_update_order_review` while debugging my own code. Sometimes 4, 5 or 6 in a row. 

Looking at `checkout.js`, it seems that requests are aborted to keep things going smoothly on the client side, but isn't there any additional measure we could take to avoid loading the server?

Here's a quick hack, just introducing a tiny delay and dropping all in-between calls.
