### PR TITLE
fix string array conversion notice when passing array to get_image metho...

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -462,15 +462,29 @@ function wc_mail( $to, $subject, $message, $headers = "Content-Type: text/html\r
  *
  * Variable is filtered by woocommerce_get_image_size_{image_size}
  *
- * @param string $image_size
+ * @param mixed $image_size
  * @return array
  */
 function wc_get_image_size( $image_size ) {
-	if ( in_array( $image_size, array( 'shop_thumbnail', 'shop_catalog', 'shop_single' ) ) ) {
+	if ( is_array( $image_size ) ) {
+		$width  = isset( $image_size[0] ) ? $image_size[0] : '300';
+		$height = isset( $image_size[1] ) ? $image_size[1] : '300';
+		$crop   = isset( $image_size[2] ) ? $image_size[2] : 1;
+		
+		$size = array(
+			'width'  => $width,
+			'height' => $height,
+			'crop'   => $crop
+		);
+
+		$image_size = $width . '_' . $height;
+
+	} elseif ( in_array( $image_size, array( 'shop_thumbnail', 'shop_catalog', 'shop_single' ) ) ) {
 		$size           = get_option( $image_size . '_image_size', array() );
 		$size['width']  = isset( $size['width'] ) ? $size['width'] : '300';
 		$size['height'] = isset( $size['height'] ) ? $size['height'] : '300';
 		$size['crop']   = isset( $size['crop'] ) ? $size['crop'] : 0;
+
 	} else {
 		$size = array(
 			'width'  => '300',


### PR DESCRIPTION
...d

So the product method $product->get_image() is a wrapper for WP core function of get_the_post_thumbnail() and get_the_post_thumbnail() supports arbitrary size to be an array to be passed (width,height).  So normally this would work fine however if the product does not have an image set, it will fallback to calling wc_placeholder_img() which will cause string array conversion notice as the $size is expecting a string.

This change will make it aware and handle accordingly.
