### PR TITLE
Fix deprecated notice for WP_User->id usage

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -244,7 +244,7 @@ class WC_Shortcode_My_Account {
 			return false;
 		}
 
-		if ( is_multisite() && ! is_user_member_of_blog( $user_data->id, get_current_blog_id() ) ) {
+		if ( is_multisite() && ! is_user_member_of_blog( $user_data->ID, get_current_blog_id() ) ) {
 			wc_add_notice( __( 'Invalid username or e-mail.', 'woocommerce' ), 'error' );
 			return false;
 		}


### PR DESCRIPTION
Fix E_USER_NOTICE WP_User->id was called with an argument that is deprecated since version 2.1! Use WP_User->ID instead
