### PR TITLE
Remove repeated code_rating & duplication

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,8 +21,8 @@ checks:
     require_php_tag_first: false
 
 tools:
+  php_code_sniffer:
+      config:
+          standard: "WordPress"
   external_code_coverage:
     timeout: 600
-    php_code_sniffer:
-        config:
-            standard: "WordPress"

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,8 +13,6 @@ checks:
   php:
     code_rating: true
     duplication: true
-    code_rating: true
-    duplication: true
     psr2_switch_declaration: false
     psr2_control_structure_declaration: false
     psr2_class_declaration: false


### PR DESCRIPTION
Fix duplication in `.scrutinizer.yml` + Seperated `php_code_sniffer` & `external_code_coverage` as they are different tools xD
