### PR TITLE
replace get_bloginfo('name') with get_bloginfo('name', 'display')

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -75,7 +75,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				'id'       => 'woocommerce_email_from_name',
 				'type'     => 'text',
 				'css'      => 'min-width:300px;',
-				'default'  => esc_attr(get_bloginfo('title')),
+				'default'  => esc_attr(get_bloginfo('title', 'display')),
 				'autoload' => false
 			),
 
@@ -112,7 +112,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				'id'       => 'woocommerce_email_footer_text',
 				'css'      => 'width:100%; height: 75px;',
 				'type'     => 'textarea',
-				'default'  => get_bloginfo('title') . ' - ' . __( 'Powered by WooCommerce', 'woocommerce' ),
+				'default'  => get_bloginfo('title', 'display') . ' - ' . __( 'Powered by WooCommerce', 'woocommerce' ),
 				'autoload' => false
 			),
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -335,7 +335,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_option( $key, $empty_value = null ) {
-		return apply_filters( 'woocommerce_email_get_option', __( parent::get_option( $key, $empty_value ) ), $this );
+		return apply_filters( 'woocommerce_email_get_option', __( parent::get_option( $key, $empty_value ) ), $this, $key, $empty_value );
 	}
 
 	/**

--- a/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
@@ -268,7 +268,7 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 	public function process_subscription_payment( $order = '', $amount = 0 ) {
 		$order_items       = $order->get_items();
 		$order_item        = array_shift( $order_items );
-		$subscription_name = sprintf( __( '%s - Subscription for "%s"', 'woocommerce' ), esc_html( get_bloginfo( 'name' ) ), $order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ), $order->get_order_number() );
+		$subscription_name = sprintf( __( '%s - Subscription for "%s"', 'woocommerce' ), esc_html( get_bloginfo( 'name', 'display' ) ), $order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ), $order->get_order_number() );
 
 		if ( $amount * 100 < 50 ) {
 			return new WP_Error( 'simplify_error', __( 'Sorry, the minimum allowed order total is 0.50 to use this payment method.', 'woocommerce' ) );
@@ -371,7 +371,7 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 		try {
 			$order_items    = $order->get_items();
 			$order_item     = array_shift( $order_items );
-			$pre_order_name = sprintf( __( '%s - Pre-order for "%s"', 'woocommerce' ), esc_html( get_bloginfo( 'name' ) ), $order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ), $order->get_order_number() );
+			$pre_order_name = sprintf( __( '%s - Pre-order for "%s"', 'woocommerce' ), esc_html( get_bloginfo( 'name', 'display' ) ), $order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ), $order->get_order_number() );
 
 			$customer_id = get_post_meta( $order->id, '_simplify_customer_id', true );
 

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -326,7 +326,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 			$payment = Simplify_Payment::createPayment( array(
 				'amount'              => $order->order_total * 100, // In cents
 				'token'               => $cart_token,
-				'description'         => sprintf( __( '%s - Order #%s', 'woocommerce' ), esc_html( get_bloginfo( 'name' ) ), $order->get_order_number() ),
+				'description'         => sprintf( __( '%s - Order #%s', 'woocommerce' ), esc_html( get_bloginfo( 'name', 'display' ) ), $order->get_order_number() ),
 				'currency'            => strtoupper( get_woocommerce_currency() ),
 				'reference'           => $order->id,
 				'card.addressCity'    => $order->billing_city,
@@ -408,7 +408,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 			'sc-key'       => $this->public_key,
 			'amount'       => $order->order_total * 100,
 			'reference'    => $order->id,
-			'name'         => esc_html( get_bloginfo( 'name' ) ),
+			'name'         => esc_html( get_bloginfo( 'name', 'display' ) ),
 			'description'  => sprintf( __( 'Order #%s', 'woocommerce' ), $order->get_order_number() ),
 			'receipt'      => 'false',
 			'color'        => $this->modal_color,

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php if ( $order->has_status( 'pending' ) ) : ?>
 
-	<p><?php printf( __( 'An order has been created for you on %s. To pay for this order please use the following link: %s', 'woocommerce' ), get_bloginfo( 'name' ), '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . __( 'pay', 'woocommerce' ) . '</a>' ); ?></p>
+	<p><?php printf( __( 'An order has been created for you on %s. To pay for this order please use the following link: %s', 'woocommerce' ), get_bloginfo( 'name', 'display' ), '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . __( 'pay', 'woocommerce' ) . '</a>' ); ?></p>
 
 <?php endif; ?>
 

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title><?php echo get_bloginfo( 'name' ); ?></title>
+        <title><?php echo get_bloginfo( 'name', 'display' ); ?></title>
 	</head>
     <body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
     	<div id="wrapper">
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<div id="template_header_image">
 	                		<?php
 	                			if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
-	                				echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name' ) . '" /></p>';
+	                				echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
 	                			}
 	                		?>
 						</div>

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo $email_heading . "\n\n";
 
 if ( $order->has_status( 'pending' ) )
-	echo sprintf( __( 'An order has been created for you on %s. To pay for this order please use the following link: %s', 'woocommerce' ), get_bloginfo( 'name' ), $order->get_checkout_payment_url() ) . "\n\n";
+	echo sprintf( __( 'An order has been created for you on %s. To pay for this order please use the following link: %s', 'woocommerce' ), get_bloginfo( 'name', 'display' ), $order->get_checkout_payment_url() ) . "\n\n";
 
 echo "****************************************************\n\n";
 


### PR DESCRIPTION
Hi Claudio, here is another possible improvement. WP made default second argument in `get_bloginfo` to be 'raw', while all the places I changed in this pull request are meant for the display purpose, and therefore the second argument should be 'display' instead of 'raw'. I hope this will not kill any kids, since for the majority of the sites the two values, 'raw' and 'display', are the same. Even if they are different, then the value for 'display' is preferable to be used. Do you see any potential problems with this change?

Thanks a lot.

P.S. First argument 'title', which you see in a couple of places, is equivalent to 'name'.
