### PR TITLE
Decode HTML entities in titles of linked products

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -480,7 +480,7 @@ class WC_Meta_Box_Product_Data {
 
 					foreach ( $product_ids as $product_id ) {
 						$product = wc_get_product( $product_id );
-						$json_ids[ $product_id ] = wp_kses_post( $product->get_formatted_name() );
+						$json_ids[ $product_id ] = wp_kses_post( html_entity_decode( $product->get_formatted_name() ) );
 					}
 
 					echo esc_attr( json_encode( $json_ids ) );
@@ -493,7 +493,7 @@ class WC_Meta_Box_Product_Data {
 
 					foreach ( $product_ids as $product_id ) {
 						$product = wc_get_product( $product_id );
-						$json_ids[ $product_id ] = wp_kses_post( $product->get_formatted_name() );
+						$json_ids[ $product_id ] = wp_kses_post( html_entity_decode( $product->get_formatted_name() ) );
 					}
 
 					echo esc_attr( json_encode( $json_ids ) );


### PR DESCRIPTION
Without this change, I was getting errors on the Edit Product page when adding linked products that had html entities ("&quot;" in particular) in their titles.

Perhaps there is a better way to fix this -- by using sanitize_title() instead of wp_kses_post() but I've tested this patch and it solves the problem for me.
