### PR TITLE
URL-decode variation names

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -145,7 +145,7 @@ class WC_Product_Variation extends WC_Product {
 				if ( ! strstr( $name, 'attribute_' ) ) {
 					continue;
 				}
-				$this->variation_data[ $name ] = sanitize_title( $value[0] );
+				$this->variation_data[ $name ] = rawurldecode( sanitize_title( $value[0] ) );
 			}
 			return $this->variation_data;
 


### PR DESCRIPTION
Without this change, the names of variation products that were not in English (not ASCII) were displayed garbled (in percent encoding) in the modal product-search window when adding products to an order on the admin page.
