### PR TITLE
Improve wc_get_customer_available_downloads speed

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -388,10 +388,8 @@ function wc_get_customer_available_downloads( $customer_id ) {
 	$results = $wpdb->get_results( $wpdb->prepare( "
 		SELECT permissions.*
 		FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions as permissions
-		LEFT JOIN {$wpdb->posts} as posts ON permissions.order_id = posts.ID
 		WHERE user_id = %d
 		AND permissions.order_id > 0
-		AND posts.post_status IN ( '" . implode( "','", array_keys( wc_get_order_statuses() ) ) . "' )
 		AND
 			(
 				permissions.downloads_remaining > 0
@@ -414,6 +412,11 @@ function wc_get_customer_available_downloads( $customer_id ) {
 				// new order
 				$order    = wc_get_order( $result->order_id );
 				$_product = null;
+			}
+
+			// Make sure the order exists for this download
+			if ( ! $order ) {
+				continue;
 			}
 
 			// Downloads permitted?


### PR DESCRIPTION
Remove posts join from wc_get_customer_available_downloads, cuts query time in halve with large sites.

We can remove the post join and order status from the query as lateron in the function the status is also checked with is_download_permitted()

Added a check in to ensure the order exists before proceeding with all the checks.
