### PR TITLE
fix taxes save issue when page is paginated

### DIFF
--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -167,8 +167,17 @@ class WC_Settings_Tax extends WC_Settings_Page {
 	 * Save tax rates
 	 */
 	public function save_tax_rates() {
+		global $wpdb;
+
 		$current_class = sanitize_title( $this->get_current_tax_class() );
-		$index         = 0;
+
+		// get the tax rate id of the first submited row
+		$first_tax_rate_id = key( $_POST['tax_rate_country'] );
+
+		// get the order position of the first tax rate id
+		$tax_rate_order = absint( $wpdb->get_var( $wpdb->prepare( "SELECT tax_rate_order FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %s", $first_tax_rate_id ) ) );
+		
+		$index = isset( $tax_rate_order ) ? $tax_rate_order : 0;
 
 		// Loop posted fields
 		foreach ( $_POST['tax_rate_country'] as $key => $value ) {


### PR DESCRIPTION
So if you have many taxes that spans multiple pages and you click on save changes on a paginated page, the order position will be jumbled up because the index is counting from zero for the first posted row.

This fix circumvents that by pulling the order position of the first posted row and increasing the count by 1 from there thus retaining the correct order positions of the tax rate.
