### PR TITLE
Fix missing downloads

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -402,11 +402,12 @@ function wc_get_customer_available_downloads( $customer_id ) {
 				OR
 				permissions.access_expires >= %s
 			)
-		GROUP BY permissions.download_id
 		ORDER BY permissions.order_id, permissions.product_id, permissions.permission_id;
 		", $customer_id, date( 'Y-m-d', current_time( 'timestamp' ) ) ) );
 
 	if ( $results ) {
+		
+		$looped_downloads = array();
 		foreach ( $results as $result ) {
 			if ( ! $order || $order->id != $result->order_id ) {
 				// new order
@@ -438,6 +439,13 @@ function wc_get_customer_available_downloads( $customer_id ) {
 			}
 
 			$download_file = $_product->get_file( $result->download_id );
+			
+			// Check if the file has been already added to the downloads list
+			if ( in_array( $download_file, $looped_downloads ) ) {
+				continue;
+			}
+
+			array_push( $looped_downloads, $download_file );
 
 			// Download name will be 'Product Name' for products with a single downloadable file, and 'Product Name - File X' for products with multiple files
 			$download_name = apply_filters(


### PR DESCRIPTION
We can't use the `GROUP BY` in the query.
The issue is that if you refund an order which is downloadable, and then the customer order again the same product, he will have access to that file, but it will not show in his account page because it's grouped by download ID.

This fix the issue, and still shows only once the downloadable file if it has been purchased multiple times.
