### PR TITLE
Added action hook into product_category shortcode

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -182,6 +182,8 @@ class WC_Shortcodes {
 
 			<?php woocommerce_product_loop_end(); ?>
 
+			<?php do_action( 'woocommerce_product_category_shortcode_after_loop' ); ?>
+
 		<?php endif;
 
 		woocommerce_reset_loop();


### PR DESCRIPTION
Hi team, please take a look on this simple action hook definition. A reason behind it is to have same feature as for `woocommerce_after_shop_loop` hook.
