### PR TITLE
Allow custom CSS classes to be specified for [product] shortcode

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -461,8 +461,14 @@ class WC_Shortcodes {
 		<?php endif;
 
 		wp_reset_postdata();
+		
+		$css_class = 'woocommerce';
 
-		return '<div class="woocommerce">' . ob_get_clean() . '</div>';
+		if ( isset( $atts['css_class'] ) ) {
+
+			$css_class .= ' ' .  $atts['css_class'];
+		}
+		return '<div class="' . $css_class . '">' . ob_get_clean() . '</div>';
 	}
 
 	/**


### PR DESCRIPTION
This change allows custom CSS classes to be added to the output generated by the [product] shortcode. This is useful, for instance, when embedding a product into a regular post as an advertisement. With custom CSS classes, you can style it to be left or right aligned, floating, etc.
