### PR TITLE
Allow filter for breadcrumb terms

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -144,7 +144,7 @@ class WC_Breadcrumb {
 		if ( 'product' === get_post_type( $post ) ) {
 			$this->prepend_shop_page();
 			if ( $terms = wc_get_product_terms( $post->ID, 'product_cat', array( 'orderby' => 'parent', 'order' => 'DESC' ) ) ) {
-				$main_term = $terms[0];
+				$main_term = apply_filters('wc_breadcrumb_terms', $terms[0], $terms);
 				$this->term_ancestors( $main_term->term_id, 'product_cat' );
 				$this->add_crumb( $main_term->name, get_term_link( $main_term ) );
 			}

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -144,7 +144,7 @@ class WC_Breadcrumb {
 		if ( 'product' === get_post_type( $post ) ) {
 			$this->prepend_shop_page();
 			if ( $terms = wc_get_product_terms( $post->ID, 'product_cat', array( 'orderby' => 'parent', 'order' => 'DESC' ) ) ) {
-				$main_term = apply_filters('wc_breadcrumb_terms', $terms[0], $terms);
+				$main_term = apply_filters('woocommerce_breadcrumb_main_term', $terms[0], $terms);
 				$this->term_ancestors( $main_term->term_id, 'product_cat' );
 				$this->add_crumb( $main_term->name, get_term_link( $main_term ) );
 			}


### PR DESCRIPTION
In some cases we may want to specify a primary term for breadcrumbs. This change would allow that to be done via a filter.
