### PR TITLE
Mark session clean after commiting data

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -174,6 +174,8 @@ class WC_Session_Handler extends WC_Session {
 	    	} else {
 		    	update_option( $session_option, $this->_data );
 	    	}
+	    	// Mark session clean after saving
+	    	$this->_dirty = false;
 	    }
     }
 


### PR DESCRIPTION
If someone is calling save_data() manually in addition to WooCommerce calling it the data is saved twice regardless of any new data.

A plugin I am working on [WooCommerce Cart Stock Reducer](https://wordpress.org/plugins/woocommerce-cart-stock-reducer/) I need to force the session data to be saved when an item is added to the cart because I'm being crazy (stupid?) and searching the DB directly for specific items in the cart
