### PR TITLE
fix BadMethodCallException

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -481,7 +481,9 @@ class WC_Meta_Box_Product_Data {
 
 					foreach ( $product_ids as $product_id ) {
 						$product = wc_get_product( $product_id );
-						$json_ids[ $product_id ] = wp_kses_post( $product->get_formatted_name() );
+						if ( is_object( $product ) ) {
+							$json_ids[ $product_id ] = wp_kses_post( $product->get_formatted_name() );
+						}
 					}
 
 					echo esc_attr( json_encode( $json_ids ) );
@@ -494,7 +496,9 @@ class WC_Meta_Box_Product_Data {
 
 					foreach ( $product_ids as $product_id ) {
 						$product = wc_get_product( $product_id );
-						$json_ids[ $product_id ] = wp_kses_post( $product->get_formatted_name() );
+						if ( is_object( $product ) ) {
+							$json_ids[ $product_id ] = wp_kses_post( $product->get_formatted_name() );
+						}
 					}
 
 					echo esc_attr( json_encode( $json_ids ) );


### PR DESCRIPTION
receiving lines like this in the php error log:

Fatal error: Uncaught exception 'BadMethodCallException' with message 'Call to a member function get_formatted_name() on a non-object (boolean)' in /var/www/example.com/htdocs/wp-content/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php:484\nStack trace:\n#0 /var/www/example.com/htdocs/wp-admin/includes/template.php(1044): WC_Meta_Box_Product_Data::output()\n#1 /var/www/example.com/htdocs/wp-admin/edit-form-advanced.php(600): do_meta_boxes()\n#2 /var/www/example.com/htdocs/wp-admin/post.php(209): include()\n#3 {main}

The error resulted in a WSOD when trying to edit some products.

See also #7518 
