### PR TITLE
Fixed jumping to top of product edit page on deleting product gallery image

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -43,7 +43,7 @@ class WC_Meta_Box_Product_Images {
 							echo '<li class="image" data-attachment_id="' . esc_attr( $attachment_id ) . '">
 								' . wp_get_attachment_image( $attachment_id, 'thumbnail' ) . '
 								<ul class="actions">
-									<li><a href="#" class="delete tips" data-tip="' . __( 'Delete image', 'woocommerce' ) . '">' . __( 'Delete', 'woocommerce' ) . '</a></li>
+									<li><a href="javascript:void(0)" class="delete tips" data-tip="' . __( 'Delete image', 'woocommerce' ) . '">' . __( 'Delete', 'woocommerce' ) . '</a></li>
 								</ul>
 							</li>';
 						}


### PR DESCRIPTION
Clicking on the delete-Button of a product gallery image led to jump to
the top of the page

now used best practice javascript:void(0) instead of # for href
see also http://stackoverflow.com/a/138233/4371742
