### PR TITLE
Allow custom CSS classes to be specified for [product] shortcode

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -466,7 +466,14 @@ class WC_Shortcodes {
 
 		wp_reset_postdata();
 
-		return '<div class="woocommerce">' . ob_get_clean() . '</div>';
+		$css_class = 'woocommerce';
+
+		if ( isset( $atts['class'] ) ) {
+
+			$css_class .= ' ' . $atts['class'];
+		}
+
+		return '<div class="' . esc_attr( $css_class ) . '">' . ob_get_clean() . '</div>';
 	}
 
 	/**


### PR DESCRIPTION
This change allows custom CSS classes to be added to the output generated by the [product] shortcode. This is useful, for instance, when embedding a product into a regular post as an advertisement. With custom CSS classes, you can style it to be left or right aligned, floating, etc.
