### PR TITLE
Removed ucwords and ucfirst in attribute labels

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -58,10 +58,10 @@ function wc_attribute_label( $name ) {
 		$label = $wpdb->get_var( $wpdb->prepare( "SELECT attribute_label FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name = %s;", $name ) );
 
 		if ( ! $label ) {
-			$label = ucfirst( $name );
+			$label = $name;
 		}
 	} else {
-		$label = ucwords( str_replace( '-', ' ', $name ) );
+		$label = str_replace( '-', ' ', $name ) );
 	}
 
 	return apply_filters( 'woocommerce_attribute_label', $label, $name );

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -61,7 +61,7 @@ function wc_attribute_label( $name ) {
 			$label = $name;
 		}
 	} else {
-		$label = str_replace( '-', ' ', $name ) );
+		$label = str_replace( '-', ' ', $name );
 	}
 
 	return apply_filters( 'woocommerce_attribute_label', $label, $name );


### PR DESCRIPTION
Is there any particular reason to `ucfirst` and `ucwords` the attribute lables?

If not, it would be better to not change them but leave the as the admin writes.
