### PR TITLE
Reintroduced filter woocommerce_available_shipping_methods

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -384,7 +384,7 @@ class WC_Shipping {
 	 * @return array
 	 */
 	public  function get_packages() {
-		return $this->packages;
+		return apply_filters( 'woocommerce_available_shipping_methods', $this->packages );
 	}
 
 


### PR DESCRIPTION
The filter was removed in an update, should we include it again?

Plugins and custom codes may break because of the missing filter.
