### PR TITLE
Run woocommerce_package_rates filter on cached shipping rates

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -372,7 +372,7 @@ class WC_Shipping {
 
 		} else {
 
-			$package['rates'] = $stored_rates;
+			$package['rates'] = apply_filters( 'woocommerce_package_rates', $stored_rates, $package );
 
 		}
 


### PR DESCRIPTION
After lots of frustrating attempts at customizing the list of shipping rates returned to customers, I realized that cached shipping rates aren't being run through the very useful woocommerce_package_rates filter.

Would it make sense to run those rates through the filter as well? I think doing so would result in a more consistent, less confusing experience for developers. In [this Gist](https://gist.github.com/ChromeOrange/6617327), for example, users are surprised by the fact that the filter isn't running (but they don't realize that the shipping packages have been cached).

Thanks for considering!
