### PR TITLE
Fix missing fields in get_formatted_address

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -393,6 +393,21 @@ class WC_Countries {
 
 		$args = array_map( 'trim', $args );
 
+		$default = array (
+			'first_name' => '',
+			'last_name' => '',
+			'company' => '',
+			'address_1' => '',
+			'address_2' => '',
+			'city' => '',
+			'state' => '',
+			'postcode' => '',
+			'country' => ''
+		);
+		
+		// Add missing fields
+		$args = array_merge($default, $args);
+
 		extract( $args );
 
 		// Get all formats


### PR DESCRIPTION
Fixes missing fields in get_formatted_address in WC_Countries so it doesn't throw a notice about undefined variable when argument is missing.
