### PR TITLE
Skip coupon notices if there's no message

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -659,7 +659,7 @@ class WC_Coupon {
 	 */
 	public function add_coupon_message( $msg_code ) {
 
-		$msg = $this->get_coupon_error( $msg_code );
+		$msg = $msg_code < 200 ? $this->get_coupon_error( $msg_code ) : $this->get_coupon_message( $msg_code );
 
 		if ( ! $msg ) {
 			return;

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -656,13 +656,19 @@ class WC_Coupon {
 	 * displays the message/error.
 	 *
 	 * @param int $msg_code Message/error code.
-	 * @return void
 	 */
 	public function add_coupon_message( $msg_code ) {
+
+		$msg = $this->get_coupon_error( $msg_code );
+
+		if ( ! $msg ) {
+			return;
+		}
+
 		if ( $msg_code < 200 ) {
-			wc_add_notice( $this->get_coupon_error( $msg_code ), 'error' );
+			wc_add_notice( $msg, 'error' );
 		} else {
-			wc_add_notice( $this->get_coupon_message( $msg_code ) );
+			wc_add_notice( $msg );
 		}
 	}
 


### PR DESCRIPTION
Handy for defining programmatic coupons to apply cart discounts, when you wouldn't necessarily want to have a notice displayed
