### PR TITLE
Catch Emogrifier Exceptions

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -393,9 +393,18 @@ class WC_Email extends WC_Settings_API {
 			wc_get_template( 'emails/email-styles.php' );
 			$css = apply_filters( 'woocommerce_email_styles', ob_get_clean() );
 
-			// apply CSS styles inline for picky email clients
-			$emogrifier = new Emogrifier( $content, $css );
-			$content = $emogrifier->emogrify();
+			try {
+
+				// apply CSS styles inline for picky email clients
+				$emogrifier = new Emogrifier( $content, $css );
+				$content = $emogrifier->emogrify();
+
+			} catch ( Exception $e ) {
+
+				$logger = new WC_Logger();
+
+				$logger->add( 'emogrifier', $e->getMessage() );
+			}
 		}
 
 		return $content;


### PR DESCRIPTION
Emogrifier throws various exceptions for invalid input, etc. that currently are not caught anywhere, causing fatal errors or unexpected behaviors in other plugins. This commit fixes that by catching all exceptions and logging them.

Reference: [ZD Ticket 265961](https://woothemes.zendesk.com/agent/tickets/265961)
