### PR TITLE
Missing argument on `woocommerce_product_is_on_sale` grouped product filter

### DIFF
--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -127,6 +127,7 @@ class WC_Product_Grouped extends WC_Product {
 	 */
 	public function is_on_sale() {
 		$is_on_sale = false;
+
 		if ( $this->has_child() ) {
 
 			foreach ( $this->get_children() as $child_id ) {
@@ -143,7 +144,8 @@ class WC_Product_Grouped extends WC_Product {
 			}
 
 		}
-		return apply_filters( 'woocommerce_product_is_on_sale', $is_on_sale );
+
+		return apply_filters( 'woocommerce_product_is_on_sale', $is_on_sale, $this );
 	}
 
 


### PR DESCRIPTION
Avoids a “missing argument” warning when using this filter with 2 arguments. The remaining `woocommerce_product_is_on_sale` filters have both arguments
