### PR TITLE
[2.3] Fix: Handling of zero min/max input qty attributes in scripts

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -433,12 +433,12 @@
 					$variation_form.find( '.single_variation' ).html( '<p>' + wc_add_to_cart_variation_params.i18n_unavailable_text + '</p>' );
 				}
 
-				if ( variation.min_qty )
+				if ( variation.min_qty !== '' )
 					$single_variation_wrap.find( '.quantity input.qty' ).attr( 'min', variation.min_qty ).val( variation.min_qty );
 				else
 					$single_variation_wrap.find( '.quantity input.qty' ).removeAttr( 'min' );
 
-				if ( variation.max_qty )
+				if ( variation.max_qty !== '' )
 					$single_variation_wrap.find( '.quantity input.qty' ).attr( 'max', variation.max_qty );
 				else
 					$single_variation_wrap.find( '.quantity input.qty' ).removeAttr( 'max' );

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -9,7 +9,7 @@ jQuery( function( $ ) {
 	$( 'input.qty:not(.product-quantity input.qty)' ).each( function() {
 		var min = parseFloat( $( this ).attr( 'min' ) );
 
-		if ( min && min > 0 && parseFloat( $( this ).val() ) < min ) {
+		if ( min >= 0 && parseFloat( $( this ).val() ) < min ) {
 			$( this ).val( min );
 		}
 	});


### PR DESCRIPTION
Currently, the add-to-cart-variation script removes min/max qty attributes when `variation.min_qty` or `variation.max_qty` is `0`. When that happens, negative qty values may be entered.

Similarly, zero min qty values are not handled correctly when initializing qty inputs in `woocommerce.js`.

Please consider any possible implications of these changes in other edge cases.
- the `woocommerce.js` change shouldn't have any adverse effects when the min/max attributes are undefined or empty.
- the `add-to-cart-variation.js` fix could be improved.

ref - https://woothemes.zendesk.com/agent/tickets/267057
