### PR TITLE
Catch exceptions in Simplify Commerce

### DIFF
--- a/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
@@ -280,20 +280,37 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 			return new WP_Error( 'simplify_error', __( 'Customer not found', 'woocommerce' ) );
 		}
 
-		// Charge the customer
-		$payment = Simplify_Payment::createPayment( array(
-			'amount'              => $amount * 100, // In cents
-			'customer'            => $customer_id,
-			'description'         => trim( substr( $subscription_name, 0, 1024 ) ),
-			'currency'            => strtoupper( get_woocommerce_currency() ),
-			'reference'           => $order->id,
-			'card.addressCity'    => $order->billing_city,
-			'card.addressCountry' => $order->billing_country,
-			'card.addressLine1'   => $order->billing_address_1,
-			'card.addressLine2'   => $order->billing_address_2,
-			'card.addressState'   => $order->billing_state,
-			'card.addressZip'     => $order->billing_postcode
-		) );
+		try {
+			// Charge the customer
+			$payment = Simplify_Payment::createPayment( array(
+				'amount'              => $amount * 100, // In cents
+				'customer'            => $customer_id,
+				'description'         => trim( substr( $subscription_name, 0, 1024 ) ),
+				'currency'            => strtoupper( get_woocommerce_currency() ),
+				'reference'           => $order->id,
+				'card.addressCity'    => $order->billing_city,
+				'card.addressCountry' => $order->billing_country,
+				'card.addressLine1'   => $order->billing_address_1,
+				'card.addressLine2'   => $order->billing_address_2,
+				'card.addressState'   => $order->billing_state,
+				'card.addressZip'     => $order->billing_postcode
+			) );
+
+		} catch ( Exception $e ) {
+
+			$error_message = $e->getMessage();
+
+			if ( $e instanceof Simplify_BadRequestException && $e->hasFieldErrors() && $e->getFieldErrors() ) {
+				$error_message = '';
+				foreach ( $e->getFieldErrors() as $error ) {
+					$error_message .= ' ' . $error->getFieldName() . ': "' . $error->getMessage() . '" (' . $error->getErrorCode() . ')';
+				}
+			}
+
+			$order->add_order_note( sprintf( __( 'Simplify payment error: %s', 'woocommerce' ), $error_message ) );
+
+			return new WP_Error( 'simplify_payment_declined', $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
 
 		if ( 'APPROVED' == $payment->paymentStatus ) {
 			// Payment complete

--- a/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
@@ -62,7 +62,7 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 	 * @return bool
 	 */
 	protected function order_contains_subscription( $order_id ) {
-		return class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Order::order_contains_subscription( $order_id );
+		return class_exists( 'WC_Subscriptions_Order' ) && ( WC_Subscriptions_Order::order_contains_subscription( $order_id ) || WC_Subscriptions_Renewal_Order::is_renewal( $order_id ) );
 	}
 
 	/**


### PR DESCRIPTION
Failed subscription renewal payments don't work at all with Simplify as the payment method at the moment because `Simplify_Payment::createPayment()` throws an exception for failed payments that is never caught.

This PR fixes that by catching the exception in `WC_Addons_Gateway_Simplify_Commerce::process_subscription_payment()` and then passing a `WP_Error` object back to 
 `WC_Addons_Gateway_Simplify_Commerce::scheduled_subscription_payment()` so that it will call `WC_Subscriptions_Manager::process_subscription_payment_failure_on_order()` to have Subscriptions process the failure (where as previously, the entire script would terminate half way through `WC_Addons_Gateway_Simplify_Commerce::process_subscription_payment()` when the exception was thrown).

This PR also adds SHA: 028cea41d3e4d9da33072d5c0dac19890f4c24e7 to make sure that when a customer logs in [to complete payment on the failed renewal order](http://docs.woothemes.com/document/subscriptions/customers-view/#section-3), that the new customer ID is used for future recurring payment, instead of the old customer ID.

To test, follow the instructions [in the Subscriptions Payment Gateway Integration guide](http://docs.woothemes.com/document/subscriptions/develop/payment-gateway-integration/#section-6).
