### PR TITLE
Rollback WCAPI create_order if exception is thrown after wc_create_order

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -356,8 +356,11 @@ class WC_API_Orders extends WC_API_Resource {
 	 * @return array
 	 */
 	public function create_order( $data ) {
+		global $wpdb;
 
 		$data = isset( $data['order'] ) ? $data['order'] : array();
+
+		$wpdb->query( 'START TRANSACTION' );
 
 		try {
 
@@ -463,9 +466,13 @@ class WC_API_Orders extends WC_API_Resource {
 
 			do_action( 'woocommerce_api_create_order', $order->id, $data, $this );
 
+			$wpdb->query( 'COMMIT' );
+
 			return $this->get_order( $order->id );
 
 		} catch ( WC_API_Exception $e ) {
+
+			$wpdb->query( 'ROLLBACK' );
 
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}


### PR DESCRIPTION
Hey Team,
When you use `WC_API_Orders::create_order()` to create an order and specify a `method_id` for the payment details and without a `method_title`, you receive a WP_Error as the
response but a pending order of $0 is still created.

As you can see, this commit just uses `$wpdb->query( 'COMMIT' );` and `$wpdb->query( 'ROLLBACK' );` to fix this issue.

Matt
