### PR TITLE
Added woocommerce_after_dashboard_status_widget

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -163,6 +163,8 @@ class WC_Admin_Dashboard {
 					<?php printf( _n( "<strong>%s product</strong> out of stock", "<strong>%s products</strong> out of stock", $outofstock_count, 'woocommerce' ), $outofstock_count ); ?>
 				</a>
 			</li>
+			
+			<?php do_action( 'woocommerce_after_dashboard_status_widget', $reports ); ?>
 		</ul>
 		<?php
 	}


### PR DESCRIPTION
Added the action `woocommerce_after_dashboard_status_widget` triggered after the out of stock box in the dashboard widget "WooCommerce Status".

Useful for 3rd-party developers.
