### PR TITLE
remove attribute label formatting and allow users to decide the formatti...

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -59,14 +59,13 @@ function wc_attribute_label( $name, $product = '' ) {
 		$label = $wpdb->get_var( $wpdb->prepare( "SELECT attribute_label FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name = %s;", $name ) );
 
 		if ( ! $label ) {
-			$label = ucfirst( $name );
+			$label = $name;
 		}
 	} elseif ( $product && ( $attributes = $product->get_attributes() ) && isset( $attributes[ sanitize_title( $name ) ]['name'] ) ) {
 		// Attempt to get label from product, as entered by the user
 		$label = $attributes[ sanitize_title( $name ) ]['name'];
 	} else {
-		// Just format as best as we can
-		$label = ucwords( str_replace( '-', ' ', $name ) );
+		$label = str_replace( '-', ' ', $name );
 	}
 
 	return apply_filters( 'woocommerce_attribute_label', $label, $name, $product );


### PR DESCRIPTION
...ng

Currently attribute labels are being forced formatted.  For example if I enter the attribute name to be all lowercase, I want it to show all lower case.

This change let's the user decide what formatting they want instead of it being applied automatically.
