### PR TITLE
Tweaks admin notices view pages

### DIFF
--- a/assets/css/activation.scss
+++ b/assets/css/activation.scss
@@ -42,7 +42,6 @@ p.woocommerce-actions,
 	a.skip,
 	a.docs {
 		opacity: 0.5;
-		text-decoration: none !important;
 
 		&:hover, &:focus {
 			opacity: 1;

--- a/includes/admin/views/html-notice-frontend-colors.php
+++ b/includes/admin/views/html-notice-frontend-colors.php
@@ -18,5 +18,5 @@ if ( current_user_can( 'install_plugins' ) ) {
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>The Frontend Style options are deprecated</strong> &#8211; If you want to continue editing the colors of your store we recommended that you install the replacement WooCommerce Colors plugin from WordPress.org.', 'woocommerce' ); ?></p>
-	<p class="submit"><a href="<?php echo esc_url( $url ); ?>" class="button-primary"><?php _e( 'Install the new WooCommerce Colors plugin', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'frontend_colors' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
+	<p class="submit"><a href="<?php echo esc_url( $url ); ?>" class="button-primary"><?php _e( 'Install the new WooCommerce Colors plugin', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'frontend_colors' ) ); ?>"><?php _e( 'Hide This Notice', 'woocommerce' ); ?></a></p>
 </div>

--- a/includes/admin/views/html-notice-frontend-colors.php
+++ b/includes/admin/views/html-notice-frontend-colors.php
@@ -4,7 +4,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 $plugin_slug = 'woocommerce-colors';
@@ -14,10 +14,9 @@ if ( current_user_can( 'install_plugins' ) ) {
 } else {
 	$url = 'http://wordpress.org/plugins/' . $plugin_slug;
 }
-?>
 
+?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>The Frontend Style options are deprecated</strong> &#8211; If you want to continue editing the colors of your store we recommended that you install the replacement WooCommerce Colors plugin from WordPress.org.', 'woocommerce' ); ?></p>
-
-	<p class="submit"><a href="<?php echo esc_url( $url ); ?>" class="wc-update-now button-primary"><?php _e( 'Install the new WooCommerce Colors plugin', 'woocommerce' ); ?></a> <a class="skip button" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'frontend_colors' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
+	<p class="submit"><a href="<?php echo esc_url( $url ); ?>" class="button-primary"><?php _e( 'Install the new WooCommerce Colors plugin', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'frontend_colors' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
 </div>

--- a/includes/admin/views/html-notice-install.php
+++ b/includes/admin/views/html-notice-install.php
@@ -10,5 +10,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>Welcome to WooCommerce</strong> &#8211; You\'re almost ready to start selling :)', 'woocommerce' ); ?></p>
-	<p class="submit"><a href="<?php echo esc_url( add_query_arg( 'install_woocommerce_pages', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="button-primary"><?php _e( 'Install WooCommerce Pages', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'install' ) ); ?>"><?php _e( 'Skip setup', 'woocommerce' ); ?></a></p>
+	<p class="submit"><a href="<?php echo esc_url( add_query_arg( 'install_woocommerce_pages', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="button-primary"><?php _e( 'Install WooCommerce Pages', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'install' ) ); ?>"><?php _e( 'Skip Setup', 'woocommerce' ); ?></a></p>
 </div>

--- a/includes/admin/views/html-notice-install.php
+++ b/includes/admin/views/html-notice-install.php
@@ -4,12 +4,11 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 ?>
-
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>Welcome to WooCommerce</strong> &#8211; You\'re almost ready to start selling :)', 'woocommerce' ); ?></p>
-	<p class="submit"><a href="<?php echo esc_url( add_query_arg( 'install_woocommerce_pages', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="button-primary"><?php _e( 'Install WooCommerce Pages', 'woocommerce' ); ?></a> <a class="skip button" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'install' ) ); ?>"><?php _e( 'Skip setup', 'woocommerce' ); ?></a></p>
+	<p class="submit"><a href="<?php echo esc_url( add_query_arg( 'install_woocommerce_pages', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="button-primary"><?php _e( 'Install WooCommerce Pages', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'install' ) ); ?>"><?php _e( 'Skip setup', 'woocommerce' ); ?></a></p>
 </div>

--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -4,12 +4,11 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 ?>
-
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>Your theme has bundled outdated copies of WooCommerce template files.</strong> If you notice an issue on your site, this could be the reason. Please contact your theme developer for further assistance. You can review the System Status report for full details or <a href="http://docs.woothemes.com/document/template-structure/" target="_blank">learn more about WooCommerce Template Structure here</a>.', 'woocommerce' ); ?></p>
-	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>"><?php _e( 'System Status', 'woocommerce' ); ?></a> <a class="skip button-primary" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'template_files' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
+	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>"><?php _e( 'System Status', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'template_files' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
 </div>

--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -10,5 +10,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>Your theme has bundled outdated copies of WooCommerce template files.</strong> If you notice an issue on your site, this could be the reason. Please contact your theme developer for further assistance. You can review the System Status report for full details or <a href="http://docs.woothemes.com/document/template-structure/" target="_blank">learn more about WooCommerce Template Structure here</a>.', 'woocommerce' ); ?></p>
-	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>"><?php _e( 'System Status', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'template_files' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a></p>
+	<p class="submit"><a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>"><?php _e( 'System Status', 'woocommerce' ); ?></a> <a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'template_files' ) ); ?>"><?php _e( 'Hide This Notice', 'woocommerce' ); ?></a></p>
 </div>

--- a/includes/admin/views/html-notice-theme-support.php
+++ b/includes/admin/views/html-notice-theme-support.php
@@ -4,16 +4,15 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 ?>
-
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php printf( __( '<strong>Your theme does not declare WooCommerce support</strong> &#8211; Please read our integration guide or check out our %sStorefront%s theme which is totally free to download and designed specifically for use with WooCommerce :)', 'woocommerce' ), '<a href="' . esc_url( admin_url( 'theme-install.php?theme=storefront' ) ) . '">', '</a>' ); ?></p>
 	<p class="submit">
 		<a href="http://www.woothemes.com/storefront/?utm_source=wpadmin&utm_medium=notice&utm_campaign=Storefront" class="button-primary" target="_blank"><?php _e( 'Find out more about Storefront', 'woocommerce' ); ?></a>
-		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button" target="_blank"><?php _e( 'Theme integration guide', 'woocommerce' ); ?></a>
-		<a class="skip button" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'theme_support' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a>
+		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'Theme integration guide', 'woocommerce' ); ?></a>
+		<a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'theme_support' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-theme-support.php
+++ b/includes/admin/views/html-notice-theme-support.php
@@ -13,6 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p class="submit">
 		<a href="http://www.woothemes.com/storefront/?utm_source=wpadmin&utm_medium=notice&utm_campaign=Storefront" class="button-primary" target="_blank"><?php _e( 'Find out more about Storefront', 'woocommerce' ); ?></a>
 		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'Theme integration guide', 'woocommerce' ); ?></a>
-		<a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'theme_support' ) ); ?>"><?php _e( 'Hide this notice', 'woocommerce' ); ?></a>
+		<a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'theme_support' ) ); ?>"><?php _e( 'Hide This Notice', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-theme-support.php
+++ b/includes/admin/views/html-notice-theme-support.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p><?php printf( __( '<strong>Your theme does not declare WooCommerce support</strong> &#8211; Please read our integration guide or check out our %sStorefront%s theme which is totally free to download and designed specifically for use with WooCommerce :)', 'woocommerce' ), '<a href="' . esc_url( admin_url( 'theme-install.php?theme=storefront' ) ) . '">', '</a>' ); ?></p>
 	<p class="submit">
 		<a href="http://www.woothemes.com/storefront/?utm_source=wpadmin&utm_medium=notice&utm_campaign=Storefront" class="button-primary" target="_blank"><?php _e( 'Find out more about Storefront', 'woocommerce' ); ?></a>
-		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'Theme integration guide', 'woocommerce' ); ?></a>
+		<a href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woothemes.com/document/third-party-custom-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'Theme Integration Guide', 'woocommerce' ); ?></a>
 		<a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'theme_support' ) ); ?>"><?php _e( 'Hide This Notice', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-tracking.php
+++ b/includes/admin/views/html-notice-tracking.php
@@ -5,11 +5,12 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
 ?>
 <div id="message" class="updated woocommerce-message woocommerce-tracker">
 	<p><?php printf( __( 'Want to help make WooCommerce even more awesome? Allow WooThemes to collect non-sensitive diagnostic data and usage information, and get %s discount on your next WooThemes purchase. %sFind out more%s.', 'woocommerce' ), '20%', '<a href="http://www.woothemes.com/woocommerce/usage-tracking/" target="_blank">', '</a>' ); ?></p>
 	<p class="submit">
 		<a class="button-primary" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc_tracker_optin', 'true' ), 'wc_tracker_optin', 'wc_tracker_nonce' ) ); ?>"><?php _e( 'Allow', 'woocommerce' ); ?></a>
-		<a class="skip button" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'tracking' ) ); ?>"><?php _e( 'No, do not bother me again', 'woocommerce' ); ?></a>
+		<a class="button-secondary skip" href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'tracking' ) ); ?>"><?php _e( 'No, do not bother me again', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-translation-upgrade.php
+++ b/includes/admin/views/html-notice-translation-upgrade.php
@@ -4,10 +4,10 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
-?>
 
+?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php printf( __( '<strong>WooCommerce Translation Available</strong> &#8211; Install or update your <code>%s</code> translation to version <code>%s</code>.', 'woocommerce' ), get_locale(), WC_VERSION ); ?></p>
 
@@ -16,8 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ) ); ?>" class="button-primary"><?php _e( 'Update Translation', 'woocommerce' ); ?></a>
 		<?php else : ?>
 			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'do-translation-upgrade' ), admin_url( 'update-core.php' ) ), 'upgrade-translations' ) ); ?>" class="button-primary"><?php _e( 'Update Translation', 'woocommerce' ); ?></a>
-			<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ) ); ?>" class="button-primary"><?php _e( 'Force Update Translation', 'woocommerce' ); ?></a>
+			<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ) ); ?>" class="button-secondary"><?php _e( 'Force Update Translation', 'woocommerce' ); ?></a>
 		<?php endif; ?>
-		<a href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'translation_upgrade' ) ); ?>" class="button"><?php _e( 'Hide This Message', 'woocommerce' ); ?></a>
+		<a href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'translation_upgrade' ) ); ?>" class="button-secondary skip"><?php _e( 'Hide This Message', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-translation-upgrade.php
+++ b/includes/admin/views/html-notice-translation-upgrade.php
@@ -18,6 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'do-translation-upgrade' ), admin_url( 'update-core.php' ) ), 'upgrade-translations' ) ); ?>" class="button-primary"><?php _e( 'Update Translation', 'woocommerce' ); ?></a>
 			<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=translation_upgrade' ), 'debug_action' ) ); ?>" class="button-secondary"><?php _e( 'Force Update Translation', 'woocommerce' ); ?></a>
 		<?php endif; ?>
-		<a href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'translation_upgrade' ) ); ?>" class="button-secondary skip"><?php _e( 'Hide This Message', 'woocommerce' ); ?></a>
+		<a href="<?php echo esc_url( add_query_arg( 'wc-hide-notice', 'translation_upgrade' ) ); ?>" class="button-secondary skip"><?php _e( 'Hide This Notice', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-update.php
+++ b/includes/admin/views/html-notice-update.php
@@ -4,11 +4,10 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 ?>
-
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p><?php _e( '<strong>WooCommerce Data Update Required</strong> &#8211; We just need to update your install to the latest version', 'woocommerce' ); ?></p>
 	<p class="submit"><a href="<?php echo esc_url( add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="wc-update-now button-primary"><?php _e( 'Run the updater', 'woocommerce' ); ?></a></p>


### PR DESCRIPTION
Some button with css class `button skip` till has underlined link so to fix this applied `button-secondary` & `button-secondary skip` css class rules as of PR #7643 . Additionally, applied Hide This Notice for skip buttons if message is suitable xD
