### PR TITLE
Add $the_order to woocommerce_order_class filter

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -41,7 +41,7 @@ class WC_Order_Factory {
 		}
 
 		// Filter classname so that the class can be overridden if extended.
-		$classname = apply_filters( 'woocommerce_order_class', $classname, $post_type, $order_id );
+		$classname = apply_filters( 'woocommerce_order_class', $classname, $post_type, $order_id, $the_order );
 
 		if ( ! class_exists( $classname ) ) {
 			$classname = 'WC_Order';


### PR DESCRIPTION
My be developer using another class to wrap the order. and in this case, the value of $classname allway is false. Send $the_order to filter is the solution.
