### PR TITLE
Added woocommerce_get_dimensions filter

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1437,10 +1437,9 @@ class WC_Product {
 			if ( ! empty( $this->dimensions ) ) {
 				$this->dimensions .= ' ' . get_option( 'woocommerce_dimension_unit' );
 			}
-
 		}
 
-		return $this->dimensions;
+		return apply_filters( 'woocommerce_get_dimensions', $this->dimensions, $this->length, $this->width, $this->height, get_option( 'woocommerce_dimension_unit' ) );
 	}
 
 	/**


### PR DESCRIPTION
Proposed solution for #7617

Added the filter `woocommerce_get_dimensions` with all the dimension parameters to allow a different format.
