### PR TITLE
Attribute values consistency

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -999,7 +999,7 @@ class WC_Meta_Box_Product_Data {
 
 						// Select based attributes - Format values (posted values are slugs)
 						if ( is_array( $attribute_values[ $i ] ) ) {
-							$values = array_map( 'sanitize_title', $attribute_values[ $i ] );
+							$values = array_map( 'wc_clean', $attribute_values[ $i ] );
 
 						// Text based attributes - Posted values are term names - don't change to slugs
 						} else {


### PR DESCRIPTION
Before this PR WooCommerce was using `sanitize_title` to sanitize text based attributes (if defined in Attributes), but `wc_clean` for custom attributes.

This caused inconsistency. For example using the value `-1~0bar` it was saved correctly if custom attribute, but saved as `~10bar` if the attribute was defined in Products > Attributes.
