### PR TITLE
Add related option to product widget 

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -144,6 +144,28 @@ function wc_get_product_ids_on_sale() {
 }
 
 /**
+ * Function that returns an array containing the IDs of the products that are related.
+ *
+ * @since 2.0
+ * @access public
+ * @return array
+ * Mohamed Mahrous m.mahrous.94@gmail.com
+ */
+function wc_get_product_related($number) {
+	global $product;
+
+	if ( empty( $product ) || ! $product->exists() ) {
+		return;
+	}
+
+	$related = $product->get_related( $number );
+
+	if ( sizeof( $related ) == 0 ) return;
+
+	return $related;
+}
+
+/**
  * Function that returns an array containing the IDs of the featured products.
  *
  * @since 2.1

--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -45,6 +45,8 @@ class WC_Widget_Products extends WC_Widget {
 					''         => __( 'All Products', 'woocommerce' ),
 					'featured' => __( 'Featured Products', 'woocommerce' ),
 					'onsale'   => __( 'On-sale Products', 'woocommerce' ),
+					'related'   => __( 'Related Products', 'woocommerce' )
+
 				)
 			),
 			'orderby' => array(
@@ -131,6 +133,10 @@ class WC_Widget_Products extends WC_Widget {
 				$product_ids_on_sale    = wc_get_product_ids_on_sale();
 				$product_ids_on_sale[]  = 0;
 				$query_args['post__in'] = $product_ids_on_sale;
+				break;
+			case 'related' :
+				$related = wc_get_product_related($number);
+				$query_args['post__in'] = $related;
 				break;
 		}
 


### PR DESCRIPTION
I have added patch to add related option in product widget, so it will get the related product to single product which you view it base on categorize.
![screen shot 2015-03-26 at 12 56 22 pm](https://cloud.githubusercontent.com/assets/5109309/6844854/8c6e9b2a-d3b7-11e4-8769-9ee1c5c382d7.png)
