### PR TITLE
Filterable mini cart item class for consistency with cart/order templates

### DIFF
--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					$thumbnail     = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
 					$product_price = apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key );
 					?>
-					<li>
+					<li class="<?php echo esc_attr( apply_filters( 'woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key ) ); ?>">
 						<?php echo apply_filters( 'woocommerce_cart_item_remove_link', sprintf( '<a href="%s" class="remove" title="%s">&times;</a>', esc_url( WC()->cart->get_remove_url( $cart_item_key ) ), __( 'Remove this item', 'woocommerce' ) ), $cart_item_key ); ?>
 						<?php if ( ! $_product->is_visible() ) : ?>
 							<?php echo str_replace( array( 'http:', 'https:' ), '', $thumbnail ) . $product_name . '&nbsp;'; ?>


### PR DESCRIPTION
All these filters are used by extensions for styling purposes, for instance to differentiate between parent/child cart/order items.

Note that in `cart.php`, the filter is named `woocommerce_cart_item_class`.

I went with a different class/filter name here since the mini cart template has different styling requirements (see `woocommerce_order_item_class`). Also to avoid breaking any custom css that references the `cart.php` template elements.
