### PR TITLE
Add null date check for download permissions

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -401,6 +401,8 @@ function wc_get_customer_available_downloads( $customer_id ) {
 				permissions.access_expires IS NULL
 				OR
 				permissions.access_expires >= %s
+				OR
+				permissions.access_expires = '0000-00-00 00:00:00'
 			)
 		ORDER BY permissions.order_id, permissions.product_id, permissions.permission_id;
 		", $customer_id, date( 'Y-m-d', current_time( 'timestamp' ) ) ) );


### PR DESCRIPTION
Fixes #7861
- implements check if `access_expiry` is 0 epoch

Sadly there's no way to circumvent WordPress's sanitization without using raw query in `WC_Meta_Box_Order_Downloads::save`, but it's a lot easier to check for 0 epoch.
