### PR TITLE
Update archive-product.php

### DIFF
--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -31,15 +31,7 @@ get_header( 'shop' ); ?>
 
 		<?php endif; ?>
 
-		<?php
-			/**
-			 * woocommerce_archive_description hook
-			 * 
-			 * @hooked woocommerce_taxonomy_archive_description - 10
-			 * @hooked woocommerce_product_archive_description - 10
-			 */
-			do_action( 'woocommerce_archive_description' );
-		?>
+<?php echo term_description( '', get_query_var( 'taxonomy' ) ); ?>
 
 		<?php if ( have_posts() ) : ?>
 


### PR DESCRIPTION
By changing 
'<?php do_action( 'woocommerce_archive_description' ); ?>' 
to 
'<?php echo term_description( '', get_query_var( 'taxonomy' ) ); ?>'
we would get support for custom post taxonomies.

The archive page will still display the description of the regular tags and categories, but you will add support for the many custom taxonomies that people create. And support the "native" WordPress function.
