### PR TITLE
Remove null parents from the featured IDs array

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -180,7 +180,7 @@ function wc_get_featured_product_ids() {
 	) );
 
 	$product_ids          = array_keys( $featured );
-	$parent_ids           = array_values( $featured );
+	$parent_ids           = array_values( array_filter( $featured ) );
 	$featured_product_ids = array_unique( array_merge( $product_ids, $parent_ids ) );
 
 	set_transient( 'wc_featured_products', $featured_product_ids, DAY_IN_SECONDS * 30 );


### PR DESCRIPTION
`wc_get_featured_product_ids()` returns the list of IDs which are featured, including their parents.
If the product does not have a parent it has value `0` and it's added into the array anyway.

It's only one value because then there's `array_unique` but i don't see why we should have it.
