### PR TITLE
Allow category loop classes to be filtered - see #7923

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -269,6 +269,21 @@ function wc_product_post_class( $classes, $class = '', $post_id = '' ) {
 	return $classes;
 }
 
+/**
+ * Adds extra category classes
+ *
+ * @since 2.4.0
+ * @param array $classes
+ * @return void
+ */
+function wc_category_class( $classes = array() ) {
+
+	if ( $classes = apply_filters( 'wc_category_loop_class', $classes ) ) {
+		echo 'class="' . join( ' ', $classes ) . '"';
+	}
+
+}
+
 /** Template pages ********************************************************/
 
 if ( ! function_exists( 'woocommerce_content' ) ) {

--- a/templates/content-product_cat.php
+++ b/templates/content-product_cat.php
@@ -25,13 +25,16 @@ if ( empty( $woocommerce_loop['columns'] ) )
 
 // Increase loop count
 $woocommerce_loop['loop']++;
+
+// Extra category classes
+$classes = array( 'product-category', 'product' );
+if ( ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] == 0 || $woocommerce_loop['columns'] == 1 )
+	$classes[] = 'first';
+if ( $woocommerce_loop['loop'] % $woocommerce_loop['columns'] == 0 )
+	$classes[] = 'last';
 ?>
-<li class="product-category product<?php
-    if ( ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] == 0 || $woocommerce_loop['columns'] == 1 )
-        echo ' first';
-	if ( $woocommerce_loop['loop'] % $woocommerce_loop['columns'] == 0 )
-		echo ' last';
-	?>">
+
+<li <?php wc_category_class( $classes );?>>
 
 	<?php do_action( 'woocommerce_before_subcategory', $category ); ?>
 


### PR DESCRIPTION
Created the function `wc_category_class()` which works in a similar way to `post_class()`, joining the provided classes into a HTML class list.

The filter `wc_category_loop_class` allows filtering of these classes before they are applied.

Classes are collated and passed into `wc_category_class()` within the template `content-product_cat.php`, rather than being outputted directly as is currently performed.

This means the simple act of adding a layout defining class (or similar) can be achieved without putting the template in the theme folder.

All template based class calculations (working out column position) could be moved back into the `wc_category_class()` function; it would clean up the template significantly but I wasn’t sure if that was a step too far.
