### PR TITLE
Prevent notices if variation_id isn't set

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -18,9 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				echo '<strong>' . __( 'Product ID:', 'woocommerce' ) . '</strong> ' . absint( $item['product_id'] );
 
-				if ( $item['variation_id'] && 'product_variation' === get_post_type( $item['variation_id'] ) ) {
+				if ( ! empty( $item['variation_id'] ) && 'product_variation' === get_post_type( $item['variation_id'] ) ) {
 					echo '<br/><strong>' . __( 'Variation ID:', 'woocommerce' ) . '</strong> ' . absint( $item['variation_id'] );
-				} elseif ( $item['variation_id'] ) {
+				} elseif ( ! empty( $item['variation_id'] ) ) {
 					echo '<br/><strong>' . __( 'Variation ID:', 'woocommerce' ) . '</strong> ' . absint( $item['variation_id'] ) . ' (' . __( 'No longer exists', 'woocommerce' ) . ')';
 				}
 


### PR DESCRIPTION
It's a minor thing, but I have ran into circumstances where the `$item` array doesn't have the `variation_id` key set (namely after importing data using another plugin). This tweak checks for the `variation_id` without throwing a notice if the array key doesn't exist.
