### PR TITLE
Check for edit_post cap if the post type is revision

### DIFF
--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -442,17 +442,19 @@ class WC_API_Resource {
 
 		$post_type = get_post_type_object( $post->post_type );
 
-		if ( 'read' === $context )
-			return current_user_can( $post_type->cap->read_private_posts, $post->ID );
+		if ( 'read' === $context ) {
+			if ( ( 'revision' !== $post->post_type && current_user_can( $post_type->cap->read_private_posts, $post->ID ) ) || ( 'revision' === $post->post_type && current_user_can( $post_type->cap->edit_post, $post->ID ) ) ) {
+				return true;
+			}
 
-		elseif ( 'edit' === $context )
-			return current_user_can( $post_type->cap->edit_post, $post->ID );
-
-		elseif ( 'delete' === $context )
-			return current_user_can( $post_type->cap->delete_post, $post->ID );
-
-		else
 			return false;
+		} elseif ( 'edit' === $context ) {
+			return current_user_can( $post_type->cap->edit_post, $post->ID );
+		} elseif ( 'delete' === $context ) {
+			return current_user_can( $post_type->cap->delete_post, $post->ID );
+		} else {
+			return false;
+		}
 	}
 
 }

--- a/includes/api/class-wc-api-resource.php
+++ b/includes/api/class-wc-api-resource.php
@@ -434,20 +434,18 @@ class WC_API_Resource {
 	 */
 	private function check_permission( $post, $context ) {
 
-		if ( ! is_a( $post, 'WP_Post' ) )
+		if ( ! is_a( $post, 'WP_Post' ) ) {
 			$post = get_post( $post );
+		}
 
-		if ( is_null( $post ) )
+		if ( is_null( $post ) ) {
 			return false;
+		}
 
 		$post_type = get_post_type_object( $post->post_type );
 
 		if ( 'read' === $context ) {
-			if ( ( 'revision' !== $post->post_type && current_user_can( $post_type->cap->read_private_posts, $post->ID ) ) || ( 'revision' === $post->post_type && current_user_can( $post_type->cap->edit_post, $post->ID ) ) ) {
-				return true;
-			}
-
-			return false;
+			return ( 'revision' !== $post->post_type && current_user_can( $post_type->cap->read_private_posts, $post->ID ) );
 		} elseif ( 'edit' === $context ) {
 			return current_user_can( $post_type->cap->edit_post, $post->ID );
 		} elseif ( 'delete' === $context ) {


### PR DESCRIPTION
PR is related to security update of WP REST API: https://make.wordpress.org/core/2015/04/09/wp-rest-api-critical-security-release/

As far as I can see this patch isn't as critical to us as it's to e.g. the WP REST API because we're already checking on the capability `read_private_posts`.  This is an Editor+ roles capability and these roles are allowed to view all revisions already by default.

This PR makes sure all access to revisions is disallowed.
