### PR TITLE
Ensure $wp->request has a trailing slash to avoid pagination issues.

### DIFF
--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -158,7 +158,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		if ( '' == get_option( 'permalink_structure' ) ) {
 			$form_action = remove_query_arg( array( 'page', 'paged' ), add_query_arg( $wp->query_string, '', home_url( $wp->request ) ) );
 		} else {
-			$form_action = preg_replace( '%\/page/[0-9]+%', '', home_url( $wp->request ) );
+			$form_action = preg_replace( '%\/page/[0-9]+%', '', home_url( trailingslashit( $wp->request ) ) );
 		}
 
 		echo '<form method="get" action="' . esc_url( $form_action ) . '">


### PR DESCRIPTION
$wp->request does not have a trailing slash which results in the price filter widget form action url to be set without a trailing slash, this if fine if you are on page one as it will load http://domain.com/shop?min_price=0&max_price=249 but it messes up the pagination so page 2 url will be http://domain.com/shoppage/2/?min_price=0&max_price=249 causing a 404.

This is not an issue if you dont use permalinks only when permalinks is active, this patch makes sure there is always a trailing slash present in the form action url to avoid the pagination issues.
