### PR TITLE
Cannot remove shipping class at quick edit

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -977,7 +977,9 @@ class WC_Admin_Post_Types {
 		}
 
 		if ( ! empty( $_REQUEST['_shipping_class'] ) ) {
-			wp_set_object_terms( $post_id, wc_clean( $_REQUEST['_shipping_class'] ), 'product_shipping_class' );
+			$shipping_class = '_no_shipping_class' == $_REQUEST['_shipping_class'] ? '' : wc_clean( $_REQUEST['_shipping_class'] );
+
+			wp_set_object_terms( $post_id, $shipping_class, 'product_shipping_class' );
 		}
 
 		if ( isset( $_REQUEST['_visibility'] ) ) {

--- a/includes/admin/views/html-quick-edit-product.php
+++ b/includes/admin/views/html-quick-edit-product.php
@@ -121,7 +121,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<span class="title"><?php _e( 'Shipping class', 'woocommerce' ); ?></span>
 			<span class="input-text-wrap">
 				<select class="shipping_class" name="_shipping_class">
-					<option value=""><?php _e( 'No shipping class', 'woocommerce' ); ?></option>
+					<option value="_no_shipping_class"><?php _e( 'No shipping class', 'woocommerce' ); ?></option>
 				<?php
 					foreach ( $shipping_class as $key => $value ) {
 						echo '<option value="' . esc_attr( $value->slug ) . '">'. $value->name .'</option>';


### PR DESCRIPTION
Since quick edit send empty value for shipping class, the value cannot pass the check `! empty( $REQUEST['_shipping_class'] )` and then it will never be persisted to the database.

The check has been replaced with the one from bulk edit.
