### PR TITLE
Verify order was found

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -277,7 +277,7 @@ function wc_customer_has_capability( $allcaps, $caps, $args ) {
 				$user_id = $args[1];
 				$order   = wc_get_order( $args[2] );
 
-				if ( $user_id == $order->user_id ) {
+				if ( $order && $user_id == $order->user_id ) {
 					$allcaps['view_order'] = true;
 				}
 			break;


### PR DESCRIPTION
Verify the order was found before evaluating the user_id on the $order object. Would previously throw a notice if attempting to view an invalid order number.
