### PR TITLE
Check for non-existing attribute ID

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -255,6 +255,10 @@ class WC_Admin_Attributes {
 
 		$attribute_to_edit = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies WHERE attribute_id = '$edit'" );
 
+		if ( ! $attribute_to_edit ) {
+			wp_die( __( 'Error: non-existing attribute ID.', 'woocommerce' ) );
+		}
+
 		$att_type    = $attribute_to_edit->attribute_type;
 		$att_label   = $attribute_to_edit->attribute_label;
 		$att_name    = $attribute_to_edit->attribute_name;


### PR DESCRIPTION
If get_row returns `null`, should not continue. Avoid "not an object" errors on the following lines, and potential data corruption after submitting form with non-existing ID.
