### PR TITLE
Update cart.php - Added $cart_item to woocommerce_cart_item_quantity

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -94,7 +94,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 								), $_product, false );
 							}
 
-							echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key );
+							echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item );
 						?>
 					</td>
 


### PR DESCRIPTION
In the `woocommerce_cart_item_quantity` filter the `$cart_item_key` is useless without the `$cart_item`, which is included in all the other relevant filters in this file. NB. Added here as last argument so not to break existing code.
