### PR TITLE
Introduce 'woocommerce_email_order_item_quantity' filter

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -64,7 +64,7 @@ foreach ( $items as $item_id => $item ) :
 				do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
 
 			?></td>
-			<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $item['qty'] ;?></td>
+			<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo apply_filters( 'woocommerce_email_order_item_quantity', $item['qty'], $item ); ?></td>
 			<td style="text-align:left; vertical-align:middle; border: 1px solid #eee;"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
 		</tr>
 		<?php

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -32,7 +32,7 @@ foreach ( $items as $item_id => $item ) :
 		echo ( $item_meta_content = $item_meta->display( true, true ) ) ? "\n" . $item_meta_content : '';
 
 		// Quantity
-		echo "\n" . sprintf( __( 'Quantity: %s', 'woocommerce' ), $item['qty'] );
+		echo "\n" . sprintf( __( 'Quantity: %s', 'woocommerce' ), apply_filters( 'woocommerce_email_order_item_quantity', $item['qty'], $item ) );
 
 		// Cost
 		echo "\n" . sprintf( __( 'Cost: %s', 'woocommerce' ), $order->get_formatted_line_subtotal( $item ) );


### PR DESCRIPTION
We currently have `woocommerce_order_item_quantity_html` in the `order-details.php` template.
Here I've just added its equivalent in the `email-order-items.php` templates.

Note that I have used a different filter name since the quantity filtered by `woocommerce_order_item_quantity_html` includes some markup (`woocommerce_order_item_quantity` is already in use).
