### PR TITLE
Add `woocommerce_outdated_template_notice` filter

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -214,6 +214,8 @@ class WC_Admin_Notices {
 			}
 		}
 
+		$outdated = apply_filters( 'woocommerce_outdated_template_notice', $outdated, $core_templates );
+
 		if ( $outdated ) {
 			include( 'views/html-notice-template-check.php' );
 		} else {


### PR DESCRIPTION
This PR adds a new filter to WooCommerce that allows users to suppress the 'outdated template files' notification.

I run automated integration tests across two development stages to ensure themes don't break, but it's a pain to need to edit every theme file to let WooCommerce know things are up to date.

This filter allows me (and other similarly-prepared users) to suppress this notice, keeping my clients from having minor panic attacks.

It could also be used for some more advanced things, such as suppressing the error message while still notifying the developer. A quickly hacked-together example:

``` php
add_filter( 'woocommerce_outdated_template_notice', function( $outdated ) {
    // If template files are outdated, notify the site admin
    if ( $outdated === true ) {
        $sent = wp_mail(
            sanitize_email( get_option( 'admin_email' ) ),
            sprintf( __( 'Outdated WooCommerce templates at %s', 'mysite' ), esc_url( home_url() ) ),
            __( 'Uh-oh, looks like some of the WooCommerce template files are outdated.', 'mysite' )
        );

        // If the email doesn't send properly, let's show the message to be safe
        if ( $sent === true ) {
            return false;
        } else {
            return $outdated;
        }
    }

    return $outdated;
} );
```
