### PR TITLE
Admin Order Header lacks Variable for context

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -50,7 +50,7 @@ if ( wc_tax_enabled() ) {
 				<th><input type="checkbox" class="check-column" /></th>
 				<th class="item sortable" colspan="2" data-sort="string-ins"><?php _e( 'Item', 'woocommerce' ); ?></th>
 
-				<?php do_action( 'woocommerce_admin_order_item_headers' ); ?>
+				<?php do_action( 'woocommerce_admin_order_item_headers', $order ); ?>
 
 				<th class="item_cost sortable" data-sort="float"><?php _e( 'Cost', 'woocommerce' ); ?></th>
 				<th class="quantity sortable" data-sort="int"><?php _e( 'Qty', 'woocommerce' ); ?></th>


### PR DESCRIPTION
On `woocommerce_admin_order_item_values` there are some variables that allow the user to do some contextualization on which columns should be displayed on not.

So I think it's reasonable to have some variables to allow the user to do the same on the header, by passing `$order` as a variable on `woocommerce_admin_order_item_headers`
