### PR TITLE
Bugfix: The old regex rule selects more then the unknown/unhandled entit...

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -162,7 +162,7 @@ class WC_Email extends WC_Settings_API {
 		'/&(pound|#163);/i',                             // Pound sign
 		'/&(euro|#8364);/i',                             // Euro sign
 		'/&#36;/',                                       // Dollar sign
-		'/&[^&;]+;/i',                                   // Unknown/unhandled entities
+		'/&[^&\s;]+;/i',                                 // Unknown/unhandled entities
 		'/[ ]{2,}/'                                      // Runs of spaces, post-handling
 	);
 


### PR DESCRIPTION
Bugfix: The old regex rule selects more then the unknown/unhandled entities. Plain-text emails are missing content because the text is stripped out. #8012 

Example: Lorem & ipsum dolor sit amet; consectetur adipiscing elit.
