### PR TITLE
Grunt jshint changeset

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
 		"_": false,
 		"Backbone": false,
 		"jQuery": false,
+		"JSON": false,
 		"wp": false
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-shell": "^1.1.2",
-    "grunt-wp-i18n": "^0.5.1",
+    "grunt-wp-i18n": "^0.5.2",
     "node-bourbon": "^4.2.1-beta1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
   "main": "Gruntfile.js",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-checktextdomain": "^0.1.1",
+    "grunt-checktextdomain": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-cssmin": "^0.12.2",
-    "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-sass": "^0.9.2",
-    "grunt-contrib-uglify": "^0.8.0",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-shell": "^1.1.2",
-    "grunt-wp-i18n": "^0.5.0",
+    "grunt-wp-i18n": "^0.5.1",
     "node-bourbon": "^4.2.1-beta1"
   },
   "engines": {


### PR DESCRIPTION
[Changeset 31679](https://core.trac.wordpress.org/changeset/31649) has added JSON to globals ignore in .jshintrc which avoids some JSON errors on `frontend/cart-fragments.js`. Additionally, `npm-check-updates` has updated some other packages too.
