### PR TITLE
Update html-variation-admin.php - issue #8017

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -182,7 +182,7 @@ extract( $variation_data );
 						<option value="parent" <?php selected( is_null( $_tax_class ), true ); ?>><?php _e( 'Same as parent', 'woocommerce' ); ?></option>
 						<?php
 						foreach ( $parent_data['tax_class_options'] as $key => $value )
-							echo '<option value="' . esc_attr( $key ) . '" ' . selected( $key === $_tax_class, true, false ) . '>' . esc_html( $value ) . '</option>';
+							echo '<option value="' . esc_attr( $key ) . '" ' . selected( $key === $_tax_class && $_tax_class != NULL , true, false ) . '>' . esc_html( $value ) . '</option>';
 					?></select>
 					<?php endif; ?>
 				</p>


### PR DESCRIPTION
When first creating a product, the $key === $_tax_class condition is true, because both $parent_data['tax_class_options'] value and $_tax_class are NULL. That leads to the "Standard" tax class being selected, instead of the "Same as parent" one.

An extra check needs to be added, for $_tax_class not being NULL.
