### PR TITLE
Add support for option attributes

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2072,6 +2072,10 @@ img.help_tip {
 			width: 100%;
 		}
 
+		label.radio {
+			display: block;
+		}
+
 		img.help_tip {
 			padding: 0;
 			margin: -4px 0 0 5px;

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -622,9 +622,99 @@ abstract class WC_Settings_API {
 					<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
 					<select class="select <?php echo esc_attr( $data['class'] ); ?>" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?>>
 						<?php foreach ( (array) $data['options'] as $option_key => $option_value ) : ?>
-							<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $option_key, esc_attr( $this->get_option( $key ) ) ); ?>><?php echo esc_attr( $option_value ); ?></option>
+							<?php
+								$option_atts = array();
+								$custom_option_attributes = array();
+
+								if ( is_array( $option_value ) ) {
+									$option_atts = $option_value;
+
+									if ( isset( $option_atts['value'] ) ) {
+										$option_value = $option_atts['value'];
+										unset( $option_atts['value'] );
+									} else {
+										$option_value = '';
+									}
+								}
+
+								if ( ! empty( $option_atts ) ) {
+
+									foreach ( $option_atts as $attribute => $attribute_value ){
+										$custom_option_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+									}
+								}
+							?>
+							<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $option_key, esc_attr( $this->get_option( $key ) ) ); ?> <?php echo implode( ' ', $custom_option_attributes ); ?>><?php echo esc_attr( $option_value ); ?></option>
 						<?php endforeach; ?>
 					</select>
+					<?php echo $this->get_description_html( $data ); ?>
+				</fieldset>
+			</td>
+		</tr>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Generate Radio HTML.
+	 *
+	 * @param mixed $key
+	 * @param mixed $data
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function generate_radio_html( $key, $data ) {
+
+		$field    = $this->plugin_id . $this->id . '_' . $key;
+		$defaults = array(
+			'title'             => '',
+			'class'             => '',
+			'css'               => '',
+			'placeholder'       => '',
+			'type'              => 'radio',
+			'desc_tip'          => false,
+			'description'       => '',
+			'options'           => array()
+		);
+
+		$data = wp_parse_args( $data, $defaults );
+
+		ob_start();
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $field . '_' . current( array_keys( $data['options'] ) ) ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
+				<?php echo $this->get_tooltip_html( $data ); ?>
+			</th>
+			<td class="forminp">
+				<fieldset>
+					<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
+					<?php foreach ( (array) $data['options'] as $option_key => $option_value ) : ?>
+						<?php
+							$option_atts = array();
+							$custom_option_attributes = array();
+
+							if ( is_array( $option_value ) ) {
+								$option_atts = $option_value;
+
+								if ( isset( $option_atts['value'] ) ) {
+									$option_value = $option_atts['value'];
+									unset( $option_atts['value'] );
+								} else {
+									$option_value = '';
+								}
+							}
+
+							if ( ! empty( $option_atts ) ) {
+
+								foreach ( $option_atts as $attribute => $attribute_value ){
+									$custom_option_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+								}
+							}
+						?>
+						<label class="radio"><input type="radio" class="radio <?php echo esc_attr( $data['class'] ); ?>" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field . '_' . $option_key ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" value="<?php echo esc_attr( $option_key ); ?>" <?php checked( $option_key, esc_attr( $this->get_option( $key ) ) ); ?> <?php echo implode( ' ', $custom_option_attributes ); ?>><?php echo esc_attr( $option_value ); ?></label>
+					<?php endforeach; ?>
 					<?php echo $this->get_description_html( $data ); ?>
 				</fieldset>
 			</td>

--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -195,7 +195,32 @@ function woocommerce_wp_select( $field ) {
 	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label><select id="' . esc_attr( $field['id'] ) . '" name="' . esc_attr( $field['name'] ) . '" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" ' . implode( ' ', $custom_attributes ) . '>';
 
 	foreach ( $field['options'] as $key => $value ) {
-		echo '<option value="' . esc_attr( $key ) . '" ' . selected( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
+
+		// Determine value and custom option attributes
+		$atts = array();
+
+		if ( is_array( $value ) ) {
+			$atts = $value;
+
+			if ( isset( $atts['value'] ) ) {
+				$value = $atts['value'];
+				unset( $atts['value'] );
+			} else {
+				$value = '';
+			}
+		}
+
+		// Custom option attribute handling
+		$custom_option_attributes = array();
+
+		if ( ! empty( $atts ) ) {
+
+			foreach ( $atts as $attribute => $attribute_value ){
+				$custom_option_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+			}
+		}
+
+		echo '<option value="' . esc_attr( $key ) . '" ' . selected( esc_attr( $field['value'] ), esc_attr( $key ), false ) . ' ' . implode( ' ', $custom_option_attributes ) . '>' . esc_html( $value ) . '</option>';
 	}
 
 	echo '</select> ';
@@ -230,6 +255,30 @@ function woocommerce_wp_radio( $field ) {
 
 	foreach ( $field['options'] as $key => $value ) {
 
+		// Determine value and custom option attributes
+		$atts = array();
+
+		if ( is_array( $value ) ) {
+			$atts = $value;
+
+			if ( isset( $atts['value'] ) ) {
+				$value = $atts['value'];
+				unset( $atts['value'] );
+			} else {
+				$value = '';
+			}
+		}
+
+		// Custom option attribute handling
+		$custom_option_attributes = array();
+
+		if ( ! empty( $atts ) ) {
+
+			foreach ( $atts as $attribute => $attribute_value ){
+				$custom_option_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+			}
+		}
+
 		echo '<li><label><input
 				name="' . esc_attr( $field['name'] ) . '"
 				value="' . esc_attr( $key ) . '"
@@ -237,6 +286,7 @@ function woocommerce_wp_radio( $field ) {
 				class="' . esc_attr( $field['class'] ) . '"
 				style="' . esc_attr( $field['style'] ) . '"
 				' . checked( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '
+				' . implode( ' ', $custom_option_attributes ) . '
 				/> ' . esc_html( $value ) . '</label>
 		</li>';
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1906,7 +1906,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $args['id'] ) . '_field">';
 
 				if ( $args['label'] ) {
-					$field .= '<label for="' . esc_attr( current( array_keys( $args['options'] ) ) ) . '" class="' . esc_attr( implode( ' ', $args['label_class'] ) ) .'">' . $args['label']. $required  . '</label>';
+					$field .= '<label for="' . esc_attr( $args['id'] . '_' . current( array_keys( $args['options'] ) ) ) . '" class="' . esc_attr( implode( ' ', $args['label_class'] ) ) .'">' . $args['label']. $required  . '</label>';
 				}
 
 				if ( ! empty( $args['options'] ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1850,6 +1850,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				if ( ! empty( $args['options'] ) ) {
 					foreach ( $args['options'] as $option_key => $option_text ) {
+
 						if ( "" === $option_key ) {
 							// If we have a blank option, select2 needs a placeholder
 							if ( empty( $args['placeholder'] ) ) {
@@ -1857,7 +1858,29 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 							}
 							$custom_attributes[] = 'data-allow_clear="true"';
 						}
-						$options .= '<option value="' . esc_attr( $option_key ) . '" '. selected( $value, $option_key, false ) . '>' . esc_attr( $option_text ) .'</option>';
+
+						$option_atts = array();
+						$custom_option_attributes = array();
+
+						if ( is_array( $option_text ) ) {
+							$option_atts = $option_text;
+
+							if ( isset( $option_atts['value'] ) ) {
+								$option_text = $option_atts['value'];
+								unset( $option_atts['value'] );
+							} else {
+								$option_text = '';
+							}
+						}
+
+						if ( ! empty( $option_atts ) ) {
+
+							foreach ( $option_atts as $attribute => $attribute_value ){
+								$custom_option_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+							}
+						}
+
+						$options .= '<option value="' . esc_attr( $option_key ) . '" '. selected( $value, $option_key, false ) . ' ' . implode( ' ', $custom_option_attributes ) . '>' . esc_attr( $option_text ) .'</option>';
 					}
 
 					$field = '<p class="form-row ' . esc_attr( implode( ' ', $args['class'] ) ) .'" id="' . esc_attr( $args['id'] ) . '_field">';
@@ -1888,7 +1911,29 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				if ( ! empty( $args['options'] ) ) {
 					foreach ( $args['options'] as $option_key => $option_text ) {
-						$field .= '<input type="radio" class="input-radio ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" value="' . esc_attr( $option_key ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_key ) . '"' . checked( $value, $option_key, false ) . ' />';
+
+						$option_atts = array();
+						$custom_option_attributes = array();
+
+						if ( is_array( $option_text ) ) {
+							$option_atts = $option_text;
+
+							if ( isset( $option_atts['value'] ) ) {
+								$option_text = $option_atts['value'];
+								unset( $option_atts['value'] );
+							} else {
+								$option_text = '';
+							}
+						}
+
+						if ( ! empty( $option_atts ) ) {
+
+							foreach ( $option_atts as $attribute => $attribute_value ){
+								$custom_option_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+							}
+						}
+
+						$field .= '<input type="radio" class="input-radio ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" value="' . esc_attr( $option_key ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_key ) . '"' . checked( $value, $option_key, false ) . ' ' . implode( ' ', $custom_option_attributes ) . '/>';
 						$field .= '<label for="' . esc_attr( $args['id'] ) . '_' . esc_attr( $option_key ) . '" class="radio ' . implode( ' ', $args['label_class'] ) .'">' . $option_text . '</label>';
 					}
 				}


### PR DESCRIPTION
This PR adds a few small, but useful things:
- Support for custom option attributes for `select` and `radio` type fields
- Support for `radio` type field in WC Settings API
- Fixes `radio` label `for` attribute in `woocommerce_form_field`

The biggest change, of course, is the custom option attributes. Basically it's like `custom_attributes`, but for each single option. This allows doing stuff like:

``` php
woocommerce_form_field( 'my_field', array(
  'type' => 'select',
  'options' => array(
    'one' => 'One',
    'two' => array( 'disabled' => true, 'value' => 'Two' ),
    'three' => 'Three' 
));
```

The "syntax" is exactly the same for each `woocommerce_form_field`, `woocommerce_wp_select/radio` and WC Settings API.

The main reasoning is that not options are always created equal. Some options may need to be disabled, and allowing the use of custom attributes lets developers to assign custom data (for example, `data-...` attributes) to each option, which opens up many possibilities for doing custom stuff with the controls.
