### PR TITLE
#8037 [API] WC_API_Product::save_downloadable_files

### DIFF
--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1586,8 +1586,11 @@ class WC_API_Products extends WC_API_Resource {
 
 		// Grant permission to any newly added files on any existing orders for this product prior to saving
 		do_action( 'woocommerce_process_product_file_download_paths', $product_id, $variation_id, $files );
-
-		update_post_meta( $product_id, '_downloadable_files', $files );
+		
+		if ( $variation_id != 0 )	
+			update_post_meta( $variation_id, '_downloadable_files', $files );
+		else
+			update_post_meta( $product_id, '_downloadable_files', $files );
 	}
 
 	/**


### PR DESCRIPTION
Fixed  #8037 a Bug in save_downloadable_files.
REST API didn't save downloadable files for product variations. There was an error updating meta for variation product in save_downloadable_files 
