### PR TITLE
Add order to woocommerce_get_return_url filter

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -102,7 +102,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			$return_url = str_replace( 'http:', 'https:', $return_url );
 		}
 
-		return apply_filters( 'woocommerce_get_return_url', $return_url );
+		return apply_filters( 'woocommerce_get_return_url', $return_url, $order );
 	}
 
 	/**


### PR DESCRIPTION
I think it will be useful to have order_id there.
