### PR TITLE
Pass current variation to woocommerce_hide_invisible_variations filter

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -441,7 +441,7 @@ class WC_Product_Variable extends WC_Product {
 			}
 
 			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price)
-			if ( apply_filters( 'woocommerce_hide_invisible_variations', false, $this->id ) && ! $variation->variation_is_visible() ) {
+			if ( apply_filters( 'woocommerce_hide_invisible_variations', false, $this->id, $variation ) && ! $variation->variation_is_visible() ) {
 				continue;
 			}
 


### PR DESCRIPTION
Sometimes it may be necessary to control the `woocommerce_hide_invisible_variations` boolean per variation. A valid use case would be if you do not want to hide variations with no prices, but would like to hide some variations that are not visible for other reasons (plugin filtering variation_is_visible).
In this case, it would help if the current variation was passed to the filter.

This would help hiding variations that are not visible to public/guests and may contain sensitive information (prices, etc), that you don't want to be visible even in the DOM.
