### PR TITLE
Avoid making multiple get_default_* calls

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -373,7 +373,7 @@ class WC_Customer {
 		}
 
 		if ( empty( $this->_data['shipping_country'] ) ) {
-			$this->_data['shipping_country'] = $this->get_default_country();
+			$this->_data['shipping_country'] = $this->_data['country'];
 		}
 
 		if ( empty( $this->_data['state'] ) ) {
@@ -381,7 +381,7 @@ class WC_Customer {
 		}
 
 		if ( empty( $this->_data['shipping_state'] ) ) {
-			$this->_data['shipping_state'] = $this->get_default_state();
+			$this->_data['shipping_state'] = $this->_data['state'];
 		}
 	}
 


### PR DESCRIPTION
On the WC_Customer class when it sets default data it makes multiple calls to get_default_country and get_default_state in a row, rather then making multiple calls which in turn can result in multiple API calls on a single pageload to get customer locations remotely, reuse the last call.
