### PR TITLE
Wrong coupons amount

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -254,7 +254,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		$this->report_data->total_shipping        = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_shipping' ) ), 2 );
 		$this->report_data->total_shipping_tax    = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_shipping_tax' ) ), 2 );
 		$this->report_data->total_refunds         = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->partial_refunds, 'total_refund' ) ) + array_sum( wp_list_pluck( $this->report_data->full_refunds, 'total_refund' ) ), 2 );
-		$this->report_data->total_coupons         = number_format( array_sum( wp_list_pluck( $this->report_data->coupons, 'discount_amount' ) ), 2 );
+		$this->report_data->total_coupons         = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->coupons, 'discount_amount' ) ), 2 );
 		$this->report_data->total_orders          = absint( array_sum( wp_list_pluck( $this->report_data->order_counts, 'count' ) ) );
 		$this->report_data->total_partial_refunds = array_sum( wp_list_pluck( $this->report_data->partial_refunds, 'order_item_count' ) ) * -1;
 		$this->report_data->total_item_refunds    = array_sum( wp_list_pluck( $this->report_data->refunded_order_items, 'order_item_count' ) ) * -1;


### PR DESCRIPTION
The total value of the coupons for a given period is not correct if the value is $1000 or more.

This is caused by the `class-wc-report-sales-by-date.ph`p file on line 256, which is currently using `number_format()`.

When the value is 1000+ the `array_sum()` function is returning "1,000" which is then truncated to "$1". The other totals use the `wc_decimal_format()` function, and when the coupon calculation is changed to use this is well it is displayed correctly.

Thanks to Justin for reporting it in the ticket #289485
