### PR TITLE
Unset cart item only after action has ran

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -974,10 +974,10 @@ class WC_Cart {
 				$remove = $this->cart_contents[ $cart_item_key ];
 				$this->removed_cart_contents[ $cart_item_key ] = $remove;
 
-				unset( $this->cart_contents[ $cart_item_key ] );
-
 				do_action( 'woocommerce_cart_item_removed', $cart_item_key, $this );
-
+				
+				unset( $this->cart_contents[ $cart_item_key ] );
+				
 				$this->calculate_totals();
 
 				return true;


### PR DESCRIPTION
The cart item should only be unset after the woocommerce_cart_item_removed has ran (as $cart_item_key) is needed to make the action work.

This is especially apparent for the WooCommerce Kissmetric plugin - whereby removal via cart when quantity is set to 0 works and tracks events & properties (using $cart_item_key) but removal via remove_cart_item fails to track due to $cart_item_key being useless after unset.
