### PR TITLE
Replace get_product_url with add_to_cart_url

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -883,13 +883,14 @@ if ( ! function_exists( 'woocommerce_external_add_to_cart' ) ) {
 	function woocommerce_external_add_to_cart() {
 		global $product;
 
-		if ( ! $product->get_product_url() )
+		if ( ! $product->add_to_cart_url() ) {
 			return;
+		}
 
 		wc_get_template( 'single-product/add-to-cart/external.php', array(
-				'product_url' => $product->get_product_url(),
-				'button_text' => $product->single_add_to_cart_text()
-			) );
+			'product_url' => $product->add_to_cart_url(),
+			'button_text' => $product->single_add_to_cart_text()
+		) );
 	}
 }
 


### PR DESCRIPTION
It make sense to use `add_to_cart_url()` instead of `get_product_url` for the Add to Cart button in external products since the first one is filterable.

Thanks to Dan for reporting!
