### PR TITLE
Added new `wc_paypal_standard_refund_before` action

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -278,9 +278,23 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		WC_Gateway_Paypal_Refund::$api_password  = $this->get_option( 'api_password' );
 		WC_Gateway_Paypal_Refund::$api_signature = $this->get_option( 'api_signature' );
 
-		do_action('wc_paypal_standard_refund_before', $order, $amount, $reason, $this);
+		// Allow 3rd parties to modify the arguments. By passing the refund class,
+		// we can allow them to override it entirely, if needed
+		$refund_args = apply_filters('wc_paypal_standard_refund_args', array(
+			'order' => $order,
+			'amount' => $amount,
+			'reason' => $reason,
+			'refund_class' => WC_Gateway_Paypal_Refund
+		), $this);
 
-		$result = WC_Gateway_Paypal_Refund::refund_order( $order, $amount, $reason, $this->testmode );
+		// Failsafe check - If the filter remove the refund class from the arguments,
+		// use the default one
+		$refund_class = !empty($refund_args['refund_class']) ? $refund_args['refund_class'] : WC_Gateway_Paypal_Refund;
+
+		$result = $refund_class::refund_order( $refund_args['order'],
+																					 $refund_args['amount'],
+																					 $refund_args['reason'],
+																					 $this->testmode );
 
 		if ( is_wp_error( $result ) ) {
 			$this->log( 'Refund Failed: ' . $result->get_error_message() );

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -278,6 +278,8 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		WC_Gateway_Paypal_Refund::$api_password  = $this->get_option( 'api_password' );
 		WC_Gateway_Paypal_Refund::$api_signature = $this->get_option( 'api_signature' );
 
+		do_action('wc_paypal_standard_refund_before', $order, $amount, $reason, $this);
+
 		$result = WC_Gateway_Paypal_Refund::refund_order( $order, $amount, $reason, $this->testmode );
 
 		if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
The action will allow to intercept a refund just before it's placed, and to alter the parameters, if required. Without such action, the only way to alter the behaviour of the refunds is to copy/paste and modify the code from `WC_Gateway_Paypal::process_refund()` method, which is a sub-optimal approach.

**Note**
The action name is hypothetical, it can be changed to follow current WooCommerce standards.
