### PR TITLE
Standardise case of various strings

### DIFF
--- a/includes/admin/views/html-quick-edit-product.php
+++ b/includes/admin/views/html-quick-edit-product.php
@@ -32,14 +32,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<label>
 				<span class="title"><?php _e( 'Price', 'woocommerce' ); ?></span>
 				<span class="input-text-wrap">
-					<input type="text" name="_regular_price" class="text regular_price" placeholder="<?php _e( 'Regular price', 'woocommerce' ); ?>" value="">
+					<input type="text" name="_regular_price" class="text regular_price" placeholder="<?php _e( 'Regular Price', 'woocommerce' ); ?>" value="">
 				</span>
 			</label>
 			<br class="clear" />
 			<label>
 				<span class="title"><?php _e( 'Sale', 'woocommerce' ); ?></span>
 				<span class="input-text-wrap">
-					<input type="text" name="_sale_price" class="text sale_price" placeholder="<?php _e( 'Sale price', 'woocommerce' ); ?>" value="">
+					<input type="text" name="_sale_price" class="text sale_price" placeholder="<?php _e( 'Sale Price', 'woocommerce' ); ?>" value="">
 				</span>
 			</label>
 			<br class="clear" />

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -412,7 +412,7 @@ class WC_Post_types {
 	 */
 	public static function register_post_status() {
 		register_post_status( 'wc-pending', array(
-			'label'                     => _x( 'Pending payment', 'Order status', 'woocommerce' ),
+			'label'                     => _x( 'Pending Payment', 'Order status', 'woocommerce' ),
 			'public'                    => false,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,
@@ -428,7 +428,7 @@ class WC_Post_types {
 			'label_count'               => _n_noop( 'Processing <span class="count">(%s)</span>', 'Processing <span class="count">(%s)</span>', 'woocommerce' )
 		) );
 		register_post_status( 'wc-on-hold', array(
-			'label'                     => _x( 'On hold', 'Order status', 'woocommerce' ),
+			'label'                     => _x( 'On Hold', 'Order status', 'woocommerce' ),
 			'public'                    => false,
 			'exclude_from_search'       => false,
 			'show_in_admin_all_list'    => true,

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -134,7 +134,7 @@ class WC_Email_Cancelled_Order extends WC_Email {
 				'default'       => ''
 			),
 			'heading' => array(
-				'title'         => __( 'Email Heading', 'woocommerce' ),
+				'title'         => __( 'Email heading', 'woocommerce' ),
 				'type'          => 'text',
 				'description'   => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'woocommerce' ), $this->heading ),
 				'placeholder'   => '',

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -155,7 +155,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 				'default'       => ''
 			),
 			'heading' => array(
-				'title'         => __( 'Email Heading', 'woocommerce' ),
+				'title'         => __( 'Email heading', 'woocommerce' ),
 				'type'          => 'text',
 				'description'   => sprintf( __( 'Defaults to <code>%s</code>', 'woocommerce' ), $this->heading ),
 				'placeholder'   => '',
@@ -169,7 +169,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 				'default'       => ''
 			),
 			'heading_downloadable' => array(
-				'title'         => __( 'Email Heading (downloadable)', 'woocommerce' ),
+				'title'         => __( 'Email heading (downloadable)', 'woocommerce' ),
 				'type'          => 'text',
 				'description'   => sprintf( __( 'Defaults to <code>%s</code>', 'woocommerce' ), $this->heading_downloadable ),
 				'placeholder'   => '',

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -149,7 +149,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 				'default'     => ''
 			),
 			'heading' => array(
-				'title'       => __( 'Email Heading', 'woocommerce' ),
+				'title'       => __( 'Email heading', 'woocommerce' ),
 				'type'        => 'text',
 				'description' => sprintf( __( 'Defaults to <code>%s</code>', 'woocommerce' ), $this->heading ),
 				'placeholder' => '',

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -140,7 +140,7 @@ class WC_Email_New_Order extends WC_Email {
 				'default'       => ''
 			),
 			'heading' => array(
-				'title'         => __( 'Email Heading', 'woocommerce' ),
+				'title'         => __( 'Email heading', 'woocommerce' ),
 				'type'          => 'text',
 				'description'   => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'woocommerce' ), $this->heading ),
 				'placeholder'   => '',


### PR DESCRIPTION
Standardises a few string translations that had different cases when the same strings were used in different places in the code [Note: The "other" uses of these strings aren't shown in the PR - grep is your friend - or let me know if you need more info]
