### PR TITLE
Translation issue due hardcoded

### DIFF
--- a/templates/product-searchform.php
+++ b/templates/product-searchform.php
@@ -1,6 +1,6 @@
 <form role="search" method="get" class="woocommerce-product-search" action="<?php echo esc_url( home_url( '/'  ) ); ?>">
 	<label class="screen-reader-text" for="s"><?php _e( 'Search for:', 'woocommerce' ); ?></label>
-	<input type="search" class="search-field" placeholder="<?php echo esc_attr_x( 'Search Products&hellip;', 'placeholder', 'woocommerce' ); ?>" value="<?php echo get_search_query(); ?>" name="s" title="<?php echo esc_attr_x( 'Search for:', 'label', 'woocommerce' ); ?>" />
-	<input type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>" />
+	<input type="search" class="search-field" placeholder="<?php echo esc_attr_x( _e( 'Search Products', 'woocommerce' ).'&hellip;', 'placeholder', 'woocommerce' ); ?>" value="<?php echo get_search_query(); ?>" name="s" title="<?php echo esc_attr_x( _e( 'Search for:', 'woocommerce' ), 'label', 'woocommerce' ); ?>" />
+	<input type="submit" value="<?php echo esc_attr_x( _e( 'Search', 'woocommerce' ), 'submit button', 'woocommerce' ); ?>" />
 	<input type="hidden" name="post_type" value="product" />
 </form>


### PR DESCRIPTION
The change :
<?php echo esc_attr_x( 'Search Products&hellip;', 'placeholder', 'woocommerce' ); ?>
becomes : 
<?php echo esc_attr_x( _e( 'Search Products', 'woocommerce' ).'&hellip;', 'placeholder', 'woocommerce' ); ?>

Same for "Search":
'Search' should be _e( 'Search', 'woocommerce' )

And "Search for:"
_e( 'Search for:', 'woocommerce' )
