### PR TITLE
Correct Geographical Ordering

### DIFF
--- a/i18n/states/NZ.php
+++ b/i18n/states/NZ.php
@@ -15,6 +15,7 @@ $states['NZ'] = array(
 	'WA' => __( 'Waikato', 'woocommerce' ),
 	'BP' => __( 'Bay of Plenty', 'woocommerce' ),
 	'TK' => __( 'Taranaki', 'woocommerce' ),
+	'GI' => __( 'Gisborne', 'woocommerce' ),
 	'HB' => __( 'Hawke&rsquo;s Bay', 'woocommerce' ),
 	'MW' => __( 'Manawatu-Wanganui', 'woocommerce' ),
 	'WE' => __( 'Wellington', 'woocommerce' ),
@@ -25,6 +26,5 @@ $states['NZ'] = array(
 	'CT' => __( 'Canterbury', 'woocommerce' ),
 	'OT' => __( 'Otago', 'woocommerce' ),
 	'SL' => __( 'Southland', 'woocommerce'),
-	'GI' => __( 'Gisborne', 'woocommerce' ),
 );
 


### PR DESCRIPTION
This changes the order of the listings so that they are in geographical order, according to https://woothemes.zendesk.com/agent/tickets/277081
