### PR TITLE
New order post type param: exclude_from_order_webhook

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -139,6 +139,7 @@ class WC_Webhook {
 		}
 
 		$current_action = current_action();
+		$resource       = get_post( absint( $arg ) );
 
 		// only deliver deleted event for coupons, orders, and products
 		if ( 'delete_post' == $current_action && ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product' ) ) ) {
@@ -155,12 +156,14 @@ class WC_Webhook {
 				return false;
 			}
 
+		// check if the custom order type has chosen to exclude order webhooks from triggering along with its own webhooks.
+		} elseif ( 'order' == $this->get_resource() && ! in_array( $resource->post_type, wc_get_order_types( 'order-webhooks' ) ) ) {
+			return false;
+
 		} elseif ( 0 === strpos( $current_action, 'woocommerce_process_shop' ) ) {
 
 			// the `woocommerce_process_shop_*` hook fires for both updates
 			// and creation so check the post creation date to determine the actual event
-			$resource = get_post( absint( $arg ) );
-
 			// a resource is considered created when the hook is executed within 10 seconds of the post creation date
 			$resource_created = ( ( time() - 10 ) <= strtotime( $resource->post_date_gmt ) );
 

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -141,6 +141,13 @@ function wc_get_order_types( $for = '' ) {
 				}
 			}
 		break;
+		case 'order-webhooks' :
+			foreach ( $wc_order_types as $type => $args ) {
+				if ( ! $args['exclude_from_order_webhooks'] ) {
+					$order_types[] = $type;
+				}
+			}
+		break;
 		default :
 			$order_types = array_keys( $wc_order_types );
 		break;
@@ -208,6 +215,7 @@ function wc_register_order_type( $type, $args = array() ) {
 		'add_order_meta_boxes'             => true,
 		'exclude_from_order_count'         => false,
 		'exclude_from_order_views'         => false,
+		'exclude_from_order_webhooks'      => false,
 		'exclude_from_order_reports'       => false,
 		'exclude_from_order_sales_reports' => false,
 		'class_name'                       => 'WC_Order'


### PR DESCRIPTION
Allows others that are using custom order types to choose whether webhooks for WC Orders should also be triggered.
Going for more of a CPT approach rather than adding more hooks and filters to `WC_Webhooks::should_deliver()`.

Feel free to suggest a better solution and obviously, feedback welcomed :)

---

The main reason for the PR is to avoid `order.created` and `order.updated` webhooks being triggered when updating a subscription via the Edit Subscription Page - fix also helps future Custom Order Types.
