### PR TITLE
Fix image alt attribute

### DIFF
--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -2,9 +2,9 @@
 /**
  * Single Product Image
  *
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     2.0.14
+ * @author      WooThemes
+ * @package     WooCommerce/Templates
+ * @version     2.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,13 +19,16 @@ global $post, $woocommerce, $product;
 	<?php
 		if ( has_post_thumbnail() ) {
 
-			$image_title 	= esc_attr( get_the_title( get_post_thumbnail_id() ) );
-			$image_caption 	= get_post( get_post_thumbnail_id() )->post_excerpt;
-			$image_link  	= wp_get_attachment_url( get_post_thumbnail_id() );
-			$image       	= get_the_post_thumbnail( $post->ID, apply_filters( 'single_product_large_thumbnail_size', 'shop_single' ), array(
-				'title'	=> $image_title,
-				'alt'	=> $image_title
-				) );
+			$thumbnail_id   = get_post_thumbnail_id();
+			$image_title    = esc_attr( get_the_title( $thumbnail_id ) );
+			$image_alt      = esc_attr( get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true ) );
+			$image_alt      = ! empty( $image_alt ) ? $image_alt : $image_title;
+			$image_caption  = get_post( $thumbnail_id )->post_excerpt;
+			$image_link     = wp_get_attachment_url( $thumbnail_id );
+			$image          = get_the_post_thumbnail( $post->ID, apply_filters( 'single_product_large_thumbnail_size', 'shop_single' ), array(
+				'title' => $image_title,
+				'alt'   => $image_alt
+			) );
 
 			$attachment_count = count( $product->get_gallery_attachment_ids() );
 


### PR DESCRIPTION
Until now the feature product image used the title even for the `alt` attribute.

Now the title is a fallback only if the alt is empty.
