### PR TITLE
Flat Rate Shipping Method now showing when it shouldn't (cost_per_order = $0)

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -97,7 +97,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		if ( method_exists( $this, $this->type . '_shipping' ) ) {
 			$costs = call_user_func( array( $this, $this->type . '_shipping' ), $package );
 
-			if ( ! is_null( $costs ) || $cost_per_order > 0 ) {
+			if ( $costs > 0 || $cost_per_order > 0 ) {
 				if ( is_array( $costs ) ) {
 					$costs['order'] = $cost_per_order;
 				} else {
@@ -329,7 +329,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		if ( $matched ) {
 			return $cost + $fee;
 		} else {
-			return null;
+			return 0;
 		}
 	}
 
@@ -372,7 +372,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		if ( $matched ) {
 			return $costs;
 		} else {
-			return null;
+			return 0;
 		}
 	}
 

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -97,7 +97,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		if ( method_exists( $this, $this->type . '_shipping' ) ) {
 			$costs = call_user_func( array( $this, $this->type . '_shipping' ), $package );
 
-			if ( ! is_null( $costs ) || $costs > 0 ) {
+			if ( ! is_null( $costs ) || $cost_per_order > 0 ) {
 				if ( is_array( $costs ) ) {
 					$costs['order'] = $cost_per_order;
 				} else {
@@ -329,7 +329,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		if ( $matched ) {
 			return $cost + $fee;
 		} else {
-			return 0;
+			return null;
 		}
 	}
 
@@ -372,7 +372,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		if ( $matched ) {
 			return $costs;
 		} else {
-			return 0;
+			return null;
 		}
 	}
 


### PR DESCRIPTION
New bug introduced in woocommerce 2.3.8. Flat Rate now shows when it shouldn't when cost_per_order is set to nothing or $0. Flat Rate now shows when it shouldn't even when the class doesn't match because the class_shipping() returns 0 instead of null like it use to.
