### PR TITLE
update template version numbers to 2.3.0. closes #8176

### DIFF
--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -4,7 +4,7 @@
  *
  * @author WooThemes
  * @package WooCommerce/Templates/Emails/HTML
- * @version 2.0.0
+ * @version 2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails
- * @version     1.6.4
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails
- * @version     1.6.4
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails
- * @version     1.6.4
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -4,7 +4,7 @@
  *
  * @author		WooThemes
  * @package 	WooCommerce/Templates/Emails/Plain
- * @version 	2.0.0
+ * @version 	2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -4,7 +4,7 @@
  *
  * @author		WooThemes
  * @package		WooCommerce/Templates/Emails/Plain
- * @version		2.0.0
+ * @version		2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails/Plain
- * @version     2.0.0
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -4,7 +4,7 @@
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails/Plain
- * @version     2.2.0
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
`woocommerce_email_customer_details` was added to email templates in 2.3.0 so some of template version numbers need to be updated so that core can detect when these templates are out of date
