### PR TITLE
#8186 memory exhausted problem fix

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1430,7 +1430,7 @@ class WC_Admin_Post_Types {
 		$post_ids = array_unique( array_merge(
 			$wpdb->get_col(
 				$wpdb->prepare( "
-					SELECT p1.post_id
+					SELECT DISTINCT p1.post_id
 					FROM {$wpdb->postmeta} p1
 					INNER JOIN {$wpdb->postmeta} p2 ON p1.post_id = p2.post_id
 					WHERE


### PR DESCRIPTION
While searching through approx 400 orders, I got fatal error memory exhausted. Using query monitor I detected that query that runs for filtering making around 16 000 results which with 256mb memory limit kills page. I have tracked down the query in code and just added "DISTINCT" in to query which worked like a charm.
