### PR TITLE
Typos conditonal_includes -> conditional_includes

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -23,7 +23,7 @@ class WC_Admin {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'includes' ) );
-		add_action( 'current_screen', array( $this, 'conditonal_includes' ) );
+		add_action( 'current_screen', array( $this, 'conditional_includes' ) );
 		add_action( 'admin_init', array( $this, 'prevent_admin_access' ) );
 		add_action( 'admin_init', array( $this, 'preview_emails' ) );
 		add_action( 'admin_footer', 'wc_print_js', 25 );
@@ -66,7 +66,7 @@ class WC_Admin {
 	/**
 	 * Include admin files conditionally
 	 */
-	public function conditonal_includes() {
+	public function conditional_includes() {
 
 		$screen = get_current_screen();
 


### PR DESCRIPTION
I believe you meant 'conditional' - I don't think it's referenced elsewhere so it should be safe to rename
