### PR TITLE
Order tests

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -25,6 +25,8 @@ class WC_Order_Factory {
 			$the_order = $post;
 		} elseif ( is_numeric( $the_order ) ) {
 			$the_order = get_post( $the_order );
+		} elseif ( $the_order instanceof WC_Order ) {
+			$the_order = get_post( $the_order->id );
 		}
 
 		if ( ! $the_order || ! is_object( $the_order ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -101,6 +101,7 @@ class WC_Unit_Tests_Bootstrap {
 		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-fee.php' );
 		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-shipping.php' );
 		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-customer.php' );
+		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-order.php' );
 	}
 
 	/**

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -52,7 +52,7 @@ class WC_Helper_Order {
 		$order 					= wc_create_order( $order_data );
 
 		// Add order products
-		$item_id = $order->add_product( $product, 1 );
+		$item_id = $order->add_product( $product, 4 );
 
 		// Set billing address
 		$billing_address = array(
@@ -85,7 +85,7 @@ class WC_Helper_Order {
 		$order->set_total( 0, 'cart_discount_tax' );
 		$order->set_total( 0, 'tax' );
 		$order->set_total( 0, 'shipping_tax' );
-		$order->set_total( 45, 'total' );
+		$order->set_total( 40, 'total' ); // 4 x $10 simple helper product
 
 		return new WC_Order( $order->id );
 	}

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -23,7 +23,6 @@ class WC_Helper_Order {
 
 		WC_Helper_Shipping::delete_simple_flat_rate();
 
-
 		// Delete the order post
 		wp_delete_post( $order_id, true );
 	}
@@ -45,7 +44,7 @@ class WC_Helper_Order {
 			'status'        => 'pending',
 			'customer_id'   => 1,
 			'customer_note' => '',
-			'total' 		=> '',
+			'total'         => '',
 		);
 
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception
@@ -56,20 +55,19 @@ class WC_Helper_Order {
 
 		// Set billing address
 		$billing_address = array(
-			'country' 		=> 'US',
-			'first_name'	=> 'Jeroen',
-			'last_name' 	=> 'Sormani',
-			'company' 		=> 'WooCompany',
-			'address_1' 	=> 'WooAddress',
-			'address_2' 	=> '',
-			'postcode' 		=> '123456',
-			'city' 			=> 'WooCity',
-			'state' 		=> 'NY',
-			'email' 		=> 'admin@example.org',
-			'phone' 		=> '555-32123',
+			'country'    => 'US',
+			'first_name' => 'Jeroen',
+			'last_name'  => 'Sormani',
+			'company'    => 'WooCompany',
+			'address_1'  => 'WooAddress',
+			'address_2'  => '',
+			'postcode'   => '123456',
+			'city'       => 'WooCity',
+			'state'      => 'NY',
+			'email'      => 'admin@example.org',
+			'phone'      => '555-32123',
 		);
 		$order->set_address( $billing_address, 'billing' );
-
 
 		// Add shipping costs
 		$shipping_taxes = WC_Tax::calc_shipping_tax( '10', WC_Tax::get_shipping_tax_rates() );

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Class WC_Helper_Order
+ *
+ * This helper class should ONLY be used for unit tests!
+ */
+class WC_Helper_Order {
+
+	/**
+	 * Delete a product.
+	 *
+	 * @param int $order_id ID of the order to delete.
+	 */
+	public static function delete_order( $order_id ) {
+
+		$order = new WC_Order( $order_id );
+
+		// Delete all products in the order
+		foreach ( $order->get_items() as $item ) :
+			WC_Helper_Product::delete_product( $item['product_id'] );
+		endforeach;
+
+		WC_Helper_Shipping::delete_simple_flat_rate();
+
+
+		// Delete the order post
+		wp_delete_post( $order_id, true );
+	}
+
+	/**
+	 * Create a order.
+	 *
+	 * @since 2.4
+	 *
+	 * @return WC_Order Order object.
+	 */
+	public static function create_order() {
+
+		// Create product
+		$product = WC_Helper_Product::create_simple_product();
+		WC_Helper_Shipping::create_simple_flat_rate();
+
+		$order_data = array(
+			'status'        => 'pending',
+			'customer_id'   => 1,
+			'customer_note' => '',
+			'total' 		=> '',
+		);
+
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception
+		$order 					= wc_create_order( $order_data );
+
+		// Add order products
+		$item_id = $order->add_product( $product, 1 );
+
+		// Set billing address
+		$billing_address = array(
+			'country' 		=> 'US',
+			'first_name'	=> 'Jeroen',
+			'last_name' 	=> 'Sormani',
+			'company' 		=> 'WooCompany',
+			'address_1' 	=> 'WooAddress',
+			'address_2' 	=> '',
+			'postcode' 		=> '123456',
+			'city' 			=> 'WooCity',
+			'state' 		=> 'NY',
+			'email' 		=> 'admin@example.org',
+			'phone' 		=> '555-32123',
+		);
+		$order->set_address( $billing_address, 'billing' );
+
+
+		// Add shipping costs
+		$shipping_taxes = WC_Tax::calc_shipping_tax( '10', WC_Tax::get_shipping_tax_rates() );
+		$order->add_shipping( new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', $shipping_taxes, 'flat_rate' ) );
+
+		// Set payment gateway
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$order->set_payment_method( $payment_gateways['bacs'] );
+
+		// Set totals
+		$order->set_total( 10, 'shipping' );
+		$order->set_total( 0, 'cart_discount' );
+		$order->set_total( 0, 'cart_discount_tax' );
+		$order->set_total( 0, 'tax' );
+		$order->set_total( 0, 'shipping_tax' );
+		$order->set_total( 45, 'total' );
+
+		return new WC_Order( $order->id );
+	}
+}

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -68,4 +68,34 @@ class Functions extends \WC_Unit_Test_Case {
 
 		update_option( 'woocommerce_ship_to_destination', $default );
 	}
+
+	/**
+	 * Test wc_get_order()
+	 *
+	 * @since 2.4.0
+	 * @group test
+	 */
+	public function test_wc_get_order() {
+
+		$order = \WC_Helper_Order::create_order();
+
+		// Assert that $order is a WC_Order object
+		$this->assertInstanceOf( 'WC_Order', $order );
+
+		// Assert that wc_get_order() accepts a WC_Order object
+		$this->assertInstanceOf( 'WC_Order', wc_get_order( $order ) );
+
+		// Assert that wc_get_order() accepts a order post id.
+		$this->assertInstanceOf( 'WC_Order', wc_get_order( $order->id ) );
+
+		// Assert that a non-shop_order post returns false
+		$post = $this->factory->post->create_and_get( array( 'post_type' => 'post' ) );
+		$this->assertFalse( wc_get_order( $post->ID ) );
+
+		// Assert the return when $the_order args is false
+		$this->assertFalse( wc_get_order( false ) );
+
+		// Assert the return when $the_order args is a random (incorrect) id.
+		$this->assertFalse( wc_get_order( 123456 ) );
+	}
 }


### PR DESCRIPTION
This PR does a couple of things;
1. Most importantly, fixing a small newly introduced bug related to issue https://github.com/woothemes/woocommerce/issues/8180 and Commit https://github.com/woothemes/woocommerce/commit/79a5c2e98ddd783c8945420db9c1488f821e6c8e

This caused one of my unit tests to fail, after researching it, it turned out that `wc_get_order()` no longer accepted `WC_Order` objects as a arg, which it did before.
1. Add a `WC_Order_Helper` class
2. Add unit tests for the `wc_get_order()` function to make sure everything works

Let me know your thoughts :smile: 

Jeroen Sormani
