### PR TITLE
Resolve blank shipping information bug. Fixes #8235

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -406,7 +406,7 @@ class WC_Checkout {
 			foreach ( $this->checkout_fields as $fieldset_key => $fieldset ) {
 
 				// Skip shipping if not needed
-				if ( $fieldset_key == 'shipping' && ( $this->posted['ship_to_different_address'] == false || ! WC()->cart->needs_shipping() ) ) {
+				if ( $fieldset_key == 'shipping' && ( $this->posted['ship_to_different_address'] == false || ! WC()->cart->needs_shipping_address() ) ) {
 					$skipped_shipping = true;
 					continue;
 				}


### PR DESCRIPTION
Setting the 'woocommerce_cart_needs_shipping' filter to true means the shipping fields can be shown for virtual products. Whether to check shipping details should be based on whether they're shown and not whether the cart needs shipping.
