### PR TITLE
Add possibility to remove product taxonomy and meta while duplicating products

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -168,8 +168,9 @@ class WC_Admin_Duplicate_Product {
 		$this->duplicate_post_meta( $post->ID, $new_post_id );
 
 		// Copy the children (variations)
-		if ( $children_products = get_children( 'post_parent=' . $post->ID . '&post_type=product_variation' )
-              && apply_filters( 'woocommerce_duplicate_product_variations', TRUE ) ) {
+		if( apply_filters( 'woocommerce_duplicate_product_variations', TRUE ) ) {
+
+			$children_products = get_children( 'post_parent=' . $post->ID . '&post_type=product_variation' );
 
 			if ( $children_products ) {
 

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -168,7 +168,8 @@ class WC_Admin_Duplicate_Product {
 		$this->duplicate_post_meta( $post->ID, $new_post_id );
 
 		// Copy the children (variations)
-		if ( $children_products = get_children( 'post_parent='.$post->ID.'&post_type=product_variation' ) ) {
+		if ( $children_products = get_children( 'post_parent=' . $post->ID . '&post_type=product_variation' )
+              && apply_filters( 'woocommerce_duplicate_product_variations', TRUE ) ) {
 
 			if ( $children_products ) {
 


### PR DESCRIPTION
For our team our workflow requires to filter out product taxonomies and product meta data while we create duplicates.

So I added two filters to "blacklist" taxonomies and/or meta data while creating duplicates of products because I thought this feature could also be useful for other teams.
