### PR TITLE
EditorConfig - Matches multiple files with brace expansion notation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,20 +15,10 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
-trim_trailing_whitespace = false
-indent_style = space
-indent_size = 2
-
 [*.txt]
 trim_trailing_whitespace = false
 
-[*.json]
-insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.yml]
-insert_final_newline = false
+[*.{md,json,yml}]
+trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
@claudiosmweb Using `[{*.md,*.json,*.yml}]` doesn't work very well but `[*.{md,json,yml}]` works great. I am using VIM and Sublime Text. See this: http://editorconfig.org/#example-file
