### PR TITLE
Round total_pages calculation up in the API keys list table.

### DIFF
--- a/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -188,7 +188,7 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 		$this->set_pagination_args( array(
 			'total_items' => $count,
 			'per_page'    => $per_page,
-			'total_pages' => $count / $per_page
+			'total_pages' => ceil( $count / $per_page )
 		) );
 	}
 }


### PR DESCRIPTION
Fixes #8283.

This PR addresses the issue outlined in #8283. It rounds the result up so we will always know the correct number of pages for items present.
