### PR TITLE
Set user agent for wp_safe_remote_get

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -242,7 +242,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$posting['wp_remote_get']['name'] = __( 'Remote Get', 'woocommerce');
 			$posting['wp_remote_get']['help'] = '<a href="#" class="help_tip" data-tip="' . esc_attr__( 'WooCommerce plugins may use this method of communication when checking for plugin updates.', 'woocommerce' ) . '">[?]</a>';
 
-			$response = wp_safe_remote_get( 'http://www.woothemes.com/wc-api/product-key-api?request=ping&network=' . ( is_multisite() ? '1' : '0' ) );
+			$response = wp_safe_remote_get( 'http://www.woothemes.com/wc-api/product-key-api?request=ping&network=' . ( is_multisite() ? '1' : '0' ), array(
+				'user-agent' => 'WooCommerce/' . WC()->version
+			) );
 
 			if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 ) {
 				$posting['wp_remote_get']['success'] = true;


### PR DESCRIPTION
For some server this may be required.
I had a user who was having issues with the `wp_remote_get` and WooThemes.com was returning a 403.

As soon as i setted the user agent everything went through smootly.

cc @kloon (needs an update for the WooThemes Helper?)
