### PR TITLE
Execute the 'order.updated' webhook when bulk editing and using the status action buttons (fixes #8116)

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1351,6 +1351,7 @@ class WC_Admin_Post_Types {
 		foreach ( $post_ids as $post_id ) {
 			$order = wc_get_order( $post_id );
 			$order->update_status( $new_status, __( 'Order status changed by bulk edit:', 'woocommerce' ) );
+			do_action( 'woocommerce_order_edit_status', $post_id, $new_status );
 			$changed++;
 		}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -465,6 +465,7 @@ class WC_AJAX {
 			if ( wc_is_order_status( 'wc-' . $status ) && $order_id ) {
 				$order = wc_get_order( $order_id );
 				$order->update_status( $status );
+				do_action( 'woocommerce_order_edit_status', $order_id, $status );
 			}
 		}
 

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -561,6 +561,7 @@ class WC_Webhook {
 			'order.updated' => array(
 				'woocommerce_process_shop_order_meta',
 				'woocommerce_api_edit_order',
+				'woocommerce_order_edit_status',
 			),
 			'order.deleted' => array(
 				'wp_trash_post',

--- a/includes/updates/woocommerce-update-2.4.php
+++ b/includes/updates/woocommerce-update-2.4.php
@@ -58,6 +58,18 @@ if ( ! empty( $apps_keys ) ) {
 	}
 }
 
+// Make sure order.update webhooks get the woocommerce_order_edit_status hook
+$order_update_webhooks = get_posts( array(
+	'posts_per_page' => -1,
+	'post_type'      => 'shop_webhook',
+	'meta_key'       => '_topic',
+	'meta_value'     => 'order.updated'
+) );
+foreach ( $order_update_webhooks as $order_update_webhook ) {
+	$webhook = new WC_Webhook( $order_update_webhook->ID );
+	$webhook->set_topic( 'order.updated' );
+}
+
 // Update fully refunded orders to ensure they have a refund line item so reports add up
 $refunded_orders = get_posts( array(
 	'posts_per_page' => -1,


### PR DESCRIPTION
Fixes #8116.

The `order.updated` webhook is not executed when changing the order status via the bulk edit tools or the action buttons.

This PR adds a new hook when the status gets updated, and adds that hook to the list of topics for `order.updated`. Since the list of topic hooks is only flushed when editing or creating a webhook, an upgrade routine is also added so that users upgrading to 2.4 will have the hook execute without having to go manually refresh all of their hooks.

**Testing Steps**:
- Create a webhook using the "Order Updated" topic (you can also existing webhook after running the upgrade routine)
- Go to /wp-admin/ > WooCommerce > Orders
- Bulk select some orders and change their status
- See that webhooks are fired by looking at the webhook logs
- Go to wp-admin > WooCommerce > Orders
- Mark an order as complete using the action button
- Note that a webhook is fired by looking at the webhook logs
