### PR TITLE
Take product variation into account when creating orders from the API (fixes #7951)

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -902,7 +902,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$product_id = wc_get_product_id_by_sku( $item['sku'] );
 		}
 
-		$variation_id = $this->get_variation_id( $product_id, $item );
+		$variation_id = $this->get_variation_id( $product_id, $item['variations'] );
 		$product = wc_get_product( $variation_id ? $variation_id : $product_id );
 
 		// must be a valid WC_Product
@@ -982,17 +982,17 @@ class WC_API_Orders extends WC_API_Resource {
 	 * @param  int $product_id main product ID
 	 * @return int             returns an ID if a valid variation was found for this product
 	 */
-	function get_variation_id( $product_id, $item ) {
-		$variations = array();
-		$product = wc_get_product( $item['product_id'] );
+	function get_variation_id( $product_id, $variations ) {
+		$product = wc_get_product( $product_id );
 		$variation_id = null;
+		$variations_normalized = array();
 
-		if ( $product->is_type( 'variable') && $product->has_child() ) {
-			if ( isset( $item['variations'] ) && is_array( $item['variations'] ) ) {
+		if ( $product->is_type( 'variable' ) && $product->has_child() ) {
+			if ( isset( $variations ) && is_array( $variations ) ) {
 				// start by normalizing the passed variations
-				foreach ( $item['variations'] as $key => $value ) {
-					$key = str_replace( 'attribute_', '', str_replace( 'pa_', '', $key ) );
-					$variations[ $key ] = strtolower( $value );
+				foreach ( $variations as $key => $value ) {
+					$key = str_replace( 'attribute_', '', str_replace( 'pa_', '', $key ) ); // from get_attributes in class-wc-api-products.php
+					$variations_normalized[ $key ] = strtolower( $value );
 				}
 				// now search through each product child and see if our passed variations match anything
 				foreach ( $product->get_children() as $variation ) {
@@ -1003,7 +1003,7 @@ class WC_API_Orders extends WC_API_Resource {
 						$meta[ $key ] = strtolower( $value );
 					}
 					// if the variation array is a part of the $meta array, we found our match
-					if ( $this->array_contains( $variations, $meta ) ) {
+					if ( $this->array_contains( $variations_normalized, $meta ) ) {
 						$variation_id = $variation;
 						break;
 					}

--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -902,7 +902,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$product_id = wc_get_product_id_by_sku( $item['sku'] );
 		}
 
-		$variation_id = $this->get_variation_id( $product_id, $item['variations'] );
+		$variation_id = $this->get_variation_id( wc_get_product( $product_id ), $item['variations'] );
 		$product = wc_get_product( $variation_id ? $variation_id : $product_id );
 
 		// must be a valid WC_Product
@@ -982,8 +982,7 @@ class WC_API_Orders extends WC_API_Resource {
 	 * @param  int $product_id main product ID
 	 * @return int             returns an ID if a valid variation was found for this product
 	 */
-	function get_variation_id( $product_id, $variations ) {
-		$product = wc_get_product( $product_id );
+	function get_variation_id( $product, $variations = array() ) {
 		$variation_id = null;
 		$variations_normalized = array();
 

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -77,9 +77,9 @@ class WC_Helper_Product {
 		// Price related meta
 		update_post_meta( $product_id, '_price', '10' );
 		update_post_meta( $product_id, '_min_variation_price', '10' );
-		update_post_meta( $product_id, '_max_variation_price', '10' );
+		update_post_meta( $product_id, '_max_variation_price', '15' );
 		update_post_meta( $product_id, '_min_variation_regular_price', '10' );
-		update_post_meta( $product_id, '_max_variation_regular_price', '10' );
+		update_post_meta( $product_id, '_max_variation_regular_price', '15' );
 
 		// General meta
 		update_post_meta( $product_id, '_sku', 'DUMMY SKU' );
@@ -135,6 +135,31 @@ class WC_Helper_Product {
 
 		// Add the variation meta to the main product
 		update_post_meta( $product_id, '_min_price_variation_id', $variation_id );
+
+		// Create the variation
+		$variation_id = wp_insert_post( array(
+			'post_title'  => 'Variation #' . ( $product_id + 2 ) . ' of Dummy Product',
+			'post_type'   => 'product_variation',
+			'post_parent' => $product_id,
+			'post_status' => 'publish'
+		) );
+
+		// Price related meta
+		update_post_meta( $variation_id, '_price', '15' );
+		update_post_meta( $variation_id, '_regular_price', '15' );
+
+		// General meta
+		update_post_meta( $variation_id, '_sku', 'DUMMY SKU VARIABLE SMALL' );
+		update_post_meta( $variation_id, '_manage_stock', 'no' );
+		update_post_meta( $variation_id, '_downloadable', 'no' );
+		update_post_meta( $variation_id, '_virtual', 'taxable' );
+		update_post_meta( $variation_id, '_stock_status', 'instock' );
+
+		// Attribute meta
+		update_post_meta( $variation_id, 'attribute_pa_size', 'large' );
+
+		// Add the variation meta to the main product
+
 		update_post_meta( $product_id, '_max_price_variation_id', $variation_id );
 
 		return new WC_Product_Variable( $product_id );

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WooCommerce\Tests\API;
+
+/**
+ * Class Functions
+ * @package WooCommerce\Tests\API
+ * @since 2.4
+ */
+class Orders extends \WC_API_Unit_Test_Case {
+
+	/**
+	 * Test test_wc_api_order_get_variation_id_returns_correct_id
+	 *
+	 * @since 2.4
+	 */
+	public function test_wc_api_order_get_variation_id_returns_correct_id() {
+		parent::setUp();
+		$product    = \WC_Helper_Product::create_variation_product();
+		$orders_api = WC()->api->WC_API_Orders;
+
+		$variation_id = $orders_api->get_variation_id( $product, array( 'size' => 'small' ) );
+		$this->assertSame( ( $product->id + 1 ), $variation_id );
+
+		$variation_id = $orders_api->get_variation_id( $product, array( 'size' => 'large' ) );
+		$this->assertSame( ( $product->id + 2 ), $variation_id );
+	}
+
+
+}


### PR DESCRIPTION
Fixes #7951.

The orders API does not take into account variation details (specifically things like price) when creating an order. This is because the correct product/id is not getting passed into the eventual `add_product` call.

The only way I could think of to get around this was to take the variation information that gets passed by the API (like size or chocolate as seen in #7951) and try to figure out the correct `variation_id` and load that as the product in `set_line_item`.

Put another way:
- API passes main parent product_id (per example in #7951)
- API passes variation data like size
- In `set_line_item`, while loading product data, check against all possible variations. If the data passed matches a variation, grab that ID
- Set that ID as the product in `add_product` so all the correct information (like price) is passed

This seems to fix the issue. If no variation data is passed, the default product price/setting is used.

I'm open to other suggestions if this doesn't make sense -- but we have to load the ID manually either way. Even if we an API dev pass the ID in with information like size, we would still need to do some checking to make sure that the attribute data matches with the variation (other wise you could request a 3XL tshirt but pass in the variation ID of a cheaper shirt). This also seems nicer since it doesn't require the dev to know yet another ID and existing API calls will work correctly.

**Testing Steps**:

I created a new test for this. `phpunit --filter=test_wc_api_order_get_variation_id_returns_correct_id`.
