### PR TITLE
Switch the ajax json_search_* functions to check for the read_product capability

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1711,7 +1711,7 @@ class WC_AJAX {
 
 		check_ajax_referer( 'search-products', 'security' );
 
-		if ( ! current_user_can( 'edit_products' ) ) {
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			die(-1);
 		}
 
@@ -1863,7 +1863,7 @@ class WC_AJAX {
 
 		check_ajax_referer( 'search-products', 'security' );
 
-		if ( ! current_user_can( 'edit_products' ) ) {
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			die(-1);
 		}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1711,10 +1711,6 @@ class WC_AJAX {
 
 		check_ajax_referer( 'search-products', 'security' );
 
-		if ( ! current_user_can( 'edit_shop_orders' ) ) {
-			die(-1);
-		}
-
 		$term = (string) wc_clean( stripslashes( $_GET['term'] ) );
 
 		if ( empty( $term ) ) {
@@ -1788,6 +1784,10 @@ class WC_AJAX {
 		if ( ! empty( $posts ) ) {
 			foreach ( $posts as $post ) {
 				$product = wc_get_product( $post );
+
+				if ( ! current_user_can( 'read_product', $post ) ) {
+					continue;
+				}
 
 				$found_products[ $post ] = rawurldecode( $product->get_formatted_name() );
 			}
@@ -1863,10 +1863,6 @@ class WC_AJAX {
 
 		check_ajax_referer( 'search-products', 'security' );
 
-		if ( ! current_user_can( 'edit_shop_orders' ) ) {
-			die(-1);
-		}
-
 		$term = (string) wc_clean( stripslashes( $_GET['term'] ) );
 
 		$args = array(
@@ -1890,6 +1886,11 @@ class WC_AJAX {
 		if ( ! empty( $posts ) ) {
 			foreach ( $posts as $post ) {
 				$product = wc_get_product( $post->ID );
+
+				if ( ! current_user_can( 'read_product', $post->ID ) ) {
+					continue;
+				}
+
 				$found_products[ $post->ID ] = $product->get_formatted_name();
 			}
 		}


### PR DESCRIPTION
Both `json_search_products` and `json_search_downloadable_products_and_variations` are checking the `edit_products` capability check.

`read_product` make more sense and allows users to still search for products in the order form without managing them.

Fixes #8321
