### PR TITLE
Stop using the frontend display setting for tax rounding in the API (#8328)

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -241,9 +241,9 @@ class WC_API_Orders extends WC_API_Resource {
 			$order_data['line_items'][] = array(
 				'id'           => $item_id,
 				'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item, false, false ), $dp ),
-				'subtotal_tax' => wc_format_decimal( wc_round_tax_total( $item['line_subtotal_tax'] ), $dp ),
+				'subtotal_tax' => wc_format_decimal( $item['line_subtotal_tax'], $dp ),
 				'total'        => wc_format_decimal( $order->get_line_total( $item, false, false ), $dp ),
-				'total_tax'    => wc_format_decimal( $order->get_line_tax( $item ), $dp ),
+				'total_tax'    => wc_format_decimal( $item['line_tax'], $dp ),
 				'price'        => wc_format_decimal( $order->get_item_total( $item, false, false ), $dp ),
 				'quantity'     => wc_stock_amount( $item['qty'] ),
 				'tax_class'    => ( ! empty( $item['tax_class'] ) ) ? $item['tax_class'] : null,


### PR DESCRIPTION
@claudiosmweb regarding #8328 (and https://github.com/woothemes/woocommerce/commit/1475b9000cec41493462c32c0817385d24fe183c#diff-39c9aa2e37fd880e94e92e2ab96378eaR239)

`wc_round_tax_total` was added around subtotal tax, and the `total_tax` line makes a call to get_line_tax which in turn also calls `wc_round_tax_total`. 

`wc_round_tax_total` uses the decimal function for front end display, so things get rounded to 0. I'm guessing this wasn't intentional and this PR fixes #8328. I was wondering if this works, or if there was another reason for that change. Thanks!
