### PR TITLE
Add a line break after every download file link (fixes #8327)

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -56,7 +56,7 @@ foreach ( $items as $item_id => $item ) :
 							$prefix = __( 'Download', 'woocommerce' );
 						}
 
-						echo '<br/><small>' . $prefix . ': <a href="' . esc_url( $file['download_url'] ) . '" target="_blank">' . esc_html( $file['name'] ) . '</a></small>';
+						echo '<br/><small>' . $prefix . ': <a href="' . esc_url( $file['download_url'] ) . '" target="_blank">' . esc_html( $file['name'] ) . '</a></small>' . "\n";
 					}
 				}
 


### PR DESCRIPTION
Props [robertstaddon](https://github.com/robertstaddon). Fixes #8327.

All of the download URLs are outputted on the same line which can cause some email clients to break their links (as seen in #8327). This simple PR adds a line break after each link.
