### PR TITLE
Removing References to the Community Forum

### DIFF
--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -52,11 +52,11 @@ class WC_Admin_Help {
 			'title'     => __( 'Support', 'woocommerce' ),
 			'content'   =>
 
-				'<p>' . sprintf( __( 'After %sreading the documentation%s, for further assistance you can use our %scommunity forum%s if you get stuck. For help with premium add-ons from WooThemes, or if you are a WooThemes customer, you can %suse our helpdesk%s.', 'woocommerce' ), '<a href="http://docs.woothemes.com/documentation/plugins/woocommerce/">', '</a>', '<a href="https://support.woothemes.com/hc/communities/public/topics">', '</a>', '<a href="http://support.woothemes.com">', '</a>' ) . '</p>' .
+				'<p>' . sprintf( __( 'After %sreading the documentation%s, for further assistance you can use the %sWordPress.org support forum%s. For help with premium add-ons from WooThemes, or if you are a WooThemes customer, you can %suse our helpdesk%s.', 'woocommerce' ), '<a href="http://docs.woothemes.com/documentation/plugins/woocommerce/">', '</a>', '<a href="https://wordpress.org/support/plugin/woocommerce">', '</a>', '<a href="http://support.woothemes.com">', '</a>' ) . '</p>' .
 
 				'<p>' . __( 'Before asking for help we recommend checking the status page to identify any problems with your configuration.', 'woocommerce' ) . '</p>' .
 
-				'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System Status', 'woocommerce' ) . '</a> <a href="' . 'https://support.woothemes.com/hc/communities/public/topics' . '" class="button">' . __( 'WooThemes Community Support', 'woocommerce' ) . '</a> <a href="' . 'http://support.woothemes.com' . '" class="button">' . __( 'WooThemes Customer Support', 'woocommerce' ) . '</a></p>'
+				'<p><a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button button-primary">' . __( 'System Status', 'woocommerce' ) . '</a> <a href="' . 'https://wordpress.org/support/plugin/woocommerce' . '" class="button">' . __( 'WordPress.org Support Forum', 'woocommerce' ) . '</a> <a href="' . 'http://support.woothemes.com' . '" class="button">' . __( 'WooThemes Customer Support', 'woocommerce' ) . '</a></p>'
 
 		) );
 


### PR DESCRIPTION
The [WooThemes Community Forum](https://support.woothemes.com/hc/communities/public/topics) only allows browsing. It doesn't allow users to post questions. For that reason we should remove any references of it and instead point people to the WordPress.org support forum where they'll actually be able to ask a question.

You can see it here in the help tab on a WooCommerce page:

![screen shot 2015-06-09 at 13 45 14](https://cloud.githubusercontent.com/assets/1065372/8068159/68553266-0eaf-11e5-9104-232c89b59ce7.png)
