### PR TITLE
Incorrectly nested p tag within ul

### DIFF
--- a/templates/checkout/payment.php
+++ b/templates/checkout/payment.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					$no_gateways_message = __( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' );
 				}
 
-				echo '<p>' . apply_filters( 'woocommerce_no_available_payment_methods_message', $no_gateways_message ) . '</p>';
+				echo '<li>' . apply_filters( 'woocommerce_no_available_payment_methods_message', $no_gateways_message ) . '</li>';
 			}
 		?>
 	</ul>


### PR DESCRIPTION
Nesting a `p` element within a `ul` html element results in incorrect/invalid html structure and causes output like http://cl.ly/image/342u3v0l3J22 (example using stock storefront + subscriptions).

Changing it to use `li` results in something nicer: http://cl.ly/image/2H3H2Z451W0e
