### PR TITLE
Run URLs through esc_url_raw instead of wc_clean in the Products API (#8335)

### DIFF
--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1603,7 +1603,12 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			$file_name = isset( $file['name'] ) ? wc_clean( $file['name'] ) : '';
-			$file_url  = esc_url_raw( $file['file'] );
+
+			if ( 0 === strpos( $file['file'], 'http' ) ) {
+				$file_url = esc_url_raw( $file['file'] );
+			} else {
+				$file_url = wc_clean( $file['file'] );
+			}
 
 			$files[ md5( $file_url ) ] = array(
 				'name' => $file_name,

--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1603,7 +1603,7 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			$file_name = isset( $file['name'] ) ? wc_clean( $file['name'] ) : '';
-			$file_url  = wc_clean( $file['file'] );
+			$file_url  = esc_url_raw( $file['file'] );
 
 			$files[ md5( $file_url ) ] = array(
 				'name' => $file_name,
@@ -1734,7 +1734,7 @@ class WC_API_Products extends WC_API_Resource {
 					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
 					if ( 0 === $attachment_id && isset( $image['src'] ) ) {
-						$upload = $this->upload_product_image( wc_clean( $image['src'] ) );
+						$upload = $this->upload_product_image( esc_url_raw( $image['src'] ) );
 
 						if ( is_wp_error( $upload ) ) {
 							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );
@@ -1748,7 +1748,7 @@ class WC_API_Products extends WC_API_Resource {
 					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
 					if ( 0 === $attachment_id && isset( $image['src'] ) ) {
-						$upload = $this->upload_product_image( wc_clean( $image['src'] ) );
+						$upload = $this->upload_product_image( esc_url_raw( $image['src'] ) );
 
 						if ( is_wp_error( $upload ) ) {
 							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );


### PR DESCRIPTION
Fixes #8335.

Downloadable files (and images) are ran through `wc_clean` which can strip some valid URL characters like URL encoded entities. So if a download URL uses entities, it will get incorrectly stored in the database.

This PR replaces those calls with `esc_url_raw` which will still sanitize the URLs, but in the right context.

**Testing Steps**:
Make an API request with a payload similar to

`{"title":"Website PSD","regular_price":"19","type":"simple","downloadable":true,"virtual":true,"sold_individually":true,"reviews_allowed":true,"short_description":"A sliced PSD.","downloads":[{"name":"PSD","file":"http:\/\/theredlist.fr\/media\/database\/architecture\/history\/architecture-maure\/espagne\/grande-mosquee-de-cordoue\/002_grande-mosquee-de-cordoue_theredlist.jpg&signature=402930932%3D%3D"}]}`

(file URL from the reporting issue).

Verify that the response contains the URL as intended

`[file] => http://theredlist.fr/media/database/architecture/history/architecture-maure/espagne/grande-mosquee-de-cordoue/002_grande-mosquee-de-cordoue_theredlist.jpg&signature=402930932%3D%3D`
