### PR TITLE
Tweaks JSHint for cart and cart fragments

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
 		"_": false,
 		"Backbone": false,
 		"jQuery": false,
+		"JSON": false,
 		"wp": false
 	}
 }

--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -1,3 +1,4 @@
+/* global wc_cart_fragments_params */
 jQuery( function( $ ) {
 
 	// wc_cart_fragments_params is required to continue, ensure the object exists
@@ -5,7 +6,8 @@ jQuery( function( $ ) {
 		return false;
 	}
 
-	/** Cart Handling */
+	/* Storage Handling */
+	var $supports_html5_storage;
 	try {
 		$supports_html5_storage = ( 'sessionStorage' in window && window.sessionStorage !== null );
 
@@ -15,7 +17,7 @@ jQuery( function( $ ) {
 		$supports_html5_storage = false;
 	}
 
-	$fragment_refresh = {
+	var $fragment_refresh = {
 		url: wc_cart_fragments_params.wc_ajax_url + 'get_refreshed_fragments',
 		type: 'POST',
 		success: function( data ) {
@@ -35,6 +37,7 @@ jQuery( function( $ ) {
 		}
 	};
 
+	/* Cart Handling */
 	if ( $supports_html5_storage ) {
 
 		$( document.body ).bind( 'added_to_cart', function( event, fragments, cart_hash ) {
@@ -55,14 +58,13 @@ jQuery( function( $ ) {
 				cookie_hash = '';
 			}
 
-			if ( wc_fragments && wc_fragments['div.widget_shopping_cart_content'] && cart_hash == cookie_hash ) {
+			if ( wc_fragments && wc_fragments['div.widget_shopping_cart_content'] && cart_hash === cookie_hash ) {
 
 				$.each( wc_fragments, function( key, value ) {
 					$( key ).replaceWith(value);
 				});
 
 				$( document.body ).trigger( 'wc_fragments_loaded' );
-
 			} else {
 				throw 'No fragment';
 			}
@@ -75,7 +77,7 @@ jQuery( function( $ ) {
 		$.ajax( $fragment_refresh );
 	}
 
-	/* Cart hiding */
+	/* Cart Hiding */
 	if ( $.cookie( 'woocommerce_items_in_cart' ) > 0 ) {
 		$( '.hide_cart_widget_if_empty' ).closest( '.widget_shopping_cart' ).show();
 	} else {
@@ -84,6 +86,5 @@ jQuery( function( $ ) {
 
 	$( document.body ).bind( 'adding_to_cart', function() {
 		$( '.hide_cart_widget_if_empty' ).closest( '.widget_shopping_cart' ).show();
-	} );
-
+	});
 });

--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -1,3 +1,4 @@
+/* global wc_cart_params */
 jQuery( function( $ ) {
 
 	// wc_cart_params is required to continue, ensure the object exists
@@ -8,15 +9,13 @@ jQuery( function( $ ) {
 	// Shipping calculator
 	$( document ).on( 'click', '.shipping-calculator-button', function() {
 		$( '.shipping-calculator-form' ).slideToggle( 'slow' );
-
 		return false;
 	}).on( 'change', 'select.shipping_method, input[name^=shipping_method]', function() {
-
 		var shipping_methods = [];
 
-		$( 'select.shipping_method, input[name^=shipping_method][type=radio]:checked, input[name^=shipping_method][type=hidden]' ).each( function( index, input ) {
+		$( 'select.shipping_method, input[name^=shipping_method][type=radio]:checked, input[name^=shipping_method][type=hidden]' ).each( function() {
 			shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();
-		} );
+		});
 
 		$( 'div.cart_totals' ).block({
 			message: null,
@@ -32,13 +31,10 @@ jQuery( function( $ ) {
 		};
 
 		$.post( wc_cart_params.wc_ajax_url + 'update_shipping_method', data, function( response ) {
-
 			$( 'div.cart_totals' ).replaceWith( response );
 			$( document.body ).trigger( 'updated_shipping_method' );
-
 		});
 	});
 
 	$( '.shipping-calculator-form' ).hide();
-
 });


### PR DESCRIPTION
Added JSON to globals ignore in `.jshintrc` which avoids some JSON errors for `JSON.stringify` used in `cart-fragments.js`. See: [Changeset 31679](https://core.trac.wordpress.org/changeset/31649)
