### PR TITLE
[fixes #8349] Ajax/Redirect needed add_to_cart_redirect filter

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -244,7 +244,7 @@ class WC_Frontend_Scripts {
 					'ajax_url'                => WC()->ajax_url(),
 					'wc_ajax_url'             => WC_AJAX::get_endpoint(),
 					'i18n_view_cart'          => esc_attr__( 'View Cart', 'woocommerce' ),
-					'cart_url'                => wc_get_page_permalink( 'cart' ),
+					'cart_url'                => ($redirect_url = apply_filters( 'woocommerce_add_to_cart_redirect', false )) ? $redirect_url : WC()->cart->get_cart_url(),
 					'is_cart'                 => is_cart(),
 					'cart_redirect_after_add' => get_option( 'woocommerce_cart_redirect_after_add' )
 				);


### PR DESCRIPTION
The 'cart_url' param is hard-coded as the "Cart" page url. This causes redirection to the "Cart" page, regardless of whether the user has overridden this option with the filter 'woocommerce_add_to_cart_redirect'.
It should obviously have the woocommerce_add_to_cart_redirect filter applied to it.
