### PR TITLE
Improve the color picker preview visibility by moving the preview to its own element (#8355)

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2218,6 +2218,12 @@ img.help_tip {
 			}
 		}
 
+		.colorpickpreview {
+			padding: 8px;
+			margin-right: 10px;
+			border: 1px solid #000000;
+		}
+
 		.image_width_settings {
 			vertical-align: middle;
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2219,9 +2219,14 @@ img.help_tip {
 		}
 
 		.colorpickpreview {
-			padding: 8px;
-			margin-right: 10px;
-			border: 1px solid #000000;
+			padding: 3px;
+			padding-left: 20px;
+			border: 1px solid #ddd;
+			border-right: 0;
+		}
+
+		.colorpick {
+			border-left: 0;
 		}
 
 		.image_width_settings {

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -13,12 +13,10 @@ jQuery( window ).load( function() {
 	// Color picker
 	jQuery( '.colorpick' ).iris({
 		change: function( event, ui ) {
-			jQuery( this ).css({ backgroundColor: ui.color.toString() });
+			jQuery( this ).parent().find( '.colorpickpreview' ).css({ backgroundColor: ui.color.toString() });
 		},
 		hide: true,
 		border: true
-	}).each( function() {
-		jQuery( this ).css({ backgroundColor: jQuery( this ).val() });
 	}).click( function() {
 		jQuery( '.iris-picker' ).hide();
 		jQuery( this ).closest( '.color_box, td' ).find( '.iris-picker' ).show();

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -296,6 +296,11 @@ class WC_Admin_Settings {
 							<?php echo $tooltip_html; ?>
 						</th>
 						<td class="forminp forminp-<?php echo sanitize_title( $value['type'] ) ?>">
+							<?php
+							if ( 'color' == $value['type'] ) {
+								echo '<span class="colorpickpreview" style="background: ' . esc_attr( $option_value ) . ';"></span>';
+							}
+							?>
 							<input
 								name="<?php echo esc_attr( $value['id'] ); ?>"
 								id="<?php echo esc_attr( $value['id'] ); ?>"


### PR DESCRIPTION
Fixes #8355.

This PR goes from

![Current WooCommerce color settings](https://cldup.com/ngQ8eduUh5-3000x3000.png)

to

![Proposed WooCommerce color settings](https://cldup.com/twR98eAHV9-3000x3000.png)

Moving the preview out of the input and into its own preview box makes it easier to see and change the current hex code since the background of the input box won't be changing.
