### PR TITLE
[2.3] Email settings save tweak

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -202,9 +202,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			$wc_emails = WC_Emails::instance();
 
 			if ( in_array( $current_section, array_map( 'sanitize_title', array_keys( $wc_emails->get_emails() ) ) ) ) {
-				foreach ( $wc_emails->get_emails() as $email ) {
-					if ( $current_section === sanitize_title( get_class( $email ) ) ) {
-						do_action( 'woocommerce_update_options_' . $this->id . '_' . $email->id );
+				foreach ( $wc_emails->get_emails() as $email_id => $email ) {
+					if ( $current_section === sanitize_title( $email_id ) ) {
+						do_action( 'woocommerce_update_options_' . $this->id . '_' . $email_id );
 					}
 				}
 			} else {


### PR DESCRIPTION
Allows emails to use a single common class as is done in Order Status
Manager
