### PR TITLE
Fixes issue with adding empty order item meta

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -227,16 +227,24 @@ function wc_save_order_items( $order_id, $items ) {
 
 	foreach ( $meta_keys as $id => $meta_key ) {
 		$meta_value = ( empty( $meta_values[ $id ] ) && ! is_numeric( $meta_values[ $id ] ) ) ? '' : $meta_values[ $id ];
-		$wpdb->update(
-			$wpdb->prefix . 'woocommerce_order_itemmeta',
-			array(
-				'meta_key'   => wp_unslash( $meta_key ),
-				'meta_value' => wp_unslash( $meta_value )
-			),
-			array( 'meta_id' => $id ),
-			array( '%s', '%s' ),
-			array( '%d' )
-		);
+
+		// Delele blank item meta entries
+		if ( mb_strlen( $meta_key ) == 0 && mb_strlen( $meta_value ) == 0 ) {
+			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_id = %d", $id ) );
+		}
+		else {
+
+			$wpdb->update(
+				$wpdb->prefix . 'woocommerce_order_itemmeta',
+				array(
+					'meta_key'   => wp_unslash( $meta_key ),
+					'meta_value' => wp_unslash( $meta_value )
+				),
+				array( 'meta_id' => $id ),
+				array( '%s', '%s' ),
+				array( '%d' )
+			);
+		}
 	}
 
 	// Shipping Rows

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -229,7 +229,7 @@ function wc_save_order_items( $order_id, $items ) {
 		$meta_value = ( empty( $meta_values[ $id ] ) && ! is_numeric( $meta_values[ $id ] ) ) ? '' : $meta_values[ $id ];
 
 		// Delele blank item meta entries
-		if ( mb_strlen( $meta_key ) == 0 && mb_strlen( $meta_value ) == 0 ) {
+		if ( $meta_key === '' && $meta_value === '' ) {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_id = %d", $id ) );
 		}
 		else {


### PR DESCRIPTION
The changes just check to make sure that either a meta key or meta
value has been entered before it saves. Otherwise it deletes the order
item meta row that has been added. The user must add something to the
order item meta row now or it won’t get saved.

Not sure if this is the cleanest way to fix this issue. I was expecting
to see the function wc_update_order_item_meta() but it is not used in
this case.

Fixes #8339
