### PR TITLE
Fix the tax_rate_locations location_type_code index to fit within 1000 bytes (#8367)

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -430,7 +430,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_tax_rate_locations (
   PRIMARY KEY  (location_id),
   KEY tax_rate_id (tax_rate_id),
   KEY location_type (location_type),
-  KEY location_type_code (location_type,location_code)
+  KEY location_type_code (location_type(40),location_code(90))
 ) $collate;
 		";
 	}


### PR DESCRIPTION
Fixes #8367 

Our `location_type_code` index is too large when using utf8. Since multiple bytes are stored per character, a long index (255 varchar + 40 varchar) can easily reach a limit of 1000 bytes per key.

This was leading to a MySQL error on install:
`WordPress database error Specified key was too long; max key length is 1000 bytes for query`

The solution to this is to only index the prefix of `location_code`. 90 characters of `location_code` in the index should be more than enough to perform quick lookups.

I was able to reproduce the missing table in #8367. Once I dropped the tables and reinstalled with this PR, the table was successfully created. I also created a new standard shipping rate and it was applied during checkout.
