### PR TITLE
Prevent negative refund amounts (#8346)

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2065,7 +2065,7 @@ class WC_AJAX {
 			$order_items = $order->get_items();
 			$max_refund  = wc_format_decimal( $order->get_total() - $order->get_total_refunded() );
 
-			if ( ! $refund_amount || $max_refund < $refund_amount ) {
+			if ( ! $refund_amount || $max_refund < $refund_amount || 0 > $refund_amount ) {
 				throw new exception( __( 'Invalid refund amount', 'woocommerce' ) );
 			}
 

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -612,6 +612,11 @@ function wc_create_refund( $args = array() ) {
 	$args        = wp_parse_args( $args, $default_args );
 	$refund_data = array();
 
+	// prevent negative refunds
+	if ( 0 > $args['amount'] ) {
+		$args['amount'] = 0;
+	}
+
 	if ( $args['refund_id'] > 0 ) {
 		$updating          = true;
 		$refund_data['ID'] = $args['refund_id'];


### PR DESCRIPTION
Fixes #8346

This PR prevents negative refunds (and zeros them out if necessary). It will show an error in /wp-admin/ if a user tries to enter a negative value so they can correct the mistake. The API already has a check for negative values so no change is needed there.

**Testing Steps**:
- Find a completed order under WooCommerce > Orders
- Click the order number to edit
- Scroll down to the gray refund button and click it
- Enter a negative amount and hit the blue refund button
- See error message
