### PR TITLE
Add new filters around order meta (#8353)

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -79,6 +79,8 @@ class WC_Order_Item_Meta {
 			}
 		}
 
+		$output = apply_filters( 'woocommerce_order_items_meta_display', $output, $this );
+
 		if ( $return ) {
 			return $output;
 		} else {
@@ -129,7 +131,7 @@ class WC_Order_Item_Meta {
 			);
 		}
 
-		return $formatted_meta;
+		return apply_filters( 'woocommerce_order_items_meta_get_formatted', $formatted_meta, $this );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8353

Wrote up a quick PR to handle the filter request in #8353 since its an easy one :). Added one enabling filtering of the `$formatted_meta` array, and another on the generated HTML itself.
