### PR TITLE
Update the help text to mention that we expect already encoded URLs

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -190,7 +190,7 @@ class WC_Meta_Box_Product_Data {
 								<tr>
 									<th class="sort">&nbsp;</th>
 									<th><?php _e( 'Name', 'woocommerce' ); ?> <span class="tips" data-tip="<?php _e( 'This is the name of the download shown to the customer.', 'woocommerce' ); ?>">[?]</span></th>
-									<th colspan="2"><?php _e( 'File URL', 'woocommerce' ); ?> <span class="tips" data-tip="<?php _e( 'This is the URL or absolute path to the file which customers will get access to.', 'woocommerce' ); ?>">[?]</span></th>
+									<th colspan="2"><?php _e( 'File URL', 'woocommerce' ); ?> <span class="tips" data-tip="<?php _e( 'This is the URL or absolute path to the file which customers will get access to. URLs entered here should already be encoded.', 'woocommerce' ); ?>">[?]</span></th>
 									<th>&nbsp;</th>
 								</tr>
 							</thead>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -200,7 +200,7 @@ extract( $variation_data );
 						<thead>
 							<div>
 								<th><?php _e( 'Name', 'woocommerce' ); ?> <span class="tips" data-tip="<?php _e( 'This is the name of the download shown to the customer.', 'woocommerce' ); ?>">[?]</span></th>
-								<th colspan="2"><?php _e( 'File URL', 'woocommerce' ); ?> <span class="tips" data-tip="<?php _e( 'This is the URL or absolute path to the file which customers will get access to.', 'woocommerce' ); ?>">[?]</span></th>
+								<th colspan="2"><?php _e( 'File URL', 'woocommerce' ); ?> <span class="tips" data-tip="<?php _e( 'This is the URL or absolute path to the file which customers will get access to. URLs entered here should already be encoded.', 'woocommerce' ); ?>">[?]</span></th>
 								<th>&nbsp;</th>
 							</div>
 						</thead>


### PR DESCRIPTION
See #7442 

This small PR adds some extra information to the download URL help text to let users know that URLs should already be encoded (because we don't double encode).
