### PR TITLE
[2.3] Fix bug introduced in #8365

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -203,7 +203,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			if ( in_array( $current_section, array_map( 'sanitize_title', array_keys( $wc_emails->get_emails() ) ) ) ) {
 				foreach ( $wc_emails->get_emails() as $email_id => $email ) {
 					if ( $current_section === sanitize_title( $email_id ) ) {
-						do_action( 'woocommerce_update_options_' . $this->id . '_' . $email_id );
+						do_action( 'woocommerce_update_options_' . $this->id . '_' . $email->id );
 					}
 				}
 			} else {


### PR DESCRIPTION
The silly change I made to line 206 in  #8365 removes the ability to save settings for WC core emails :smile_cat: This PR fixes that
