### PR TITLE
Make sure sale prices are properly applied when no from date is set and today is used as default (#8357)

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1120,7 +1120,7 @@ class WC_Meta_Box_Product_Data {
 				update_post_meta( $post_id, '_price', ( $_POST['_regular_price'] === '' ) ? '' : wc_format_decimal( $_POST['_regular_price'] ) );
 			}
 
-			if ( '' !== $_POST['_sale_price'] && $date_from && strtotime( $date_from ) < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+			if ( '' !== $_POST['_sale_price'] && $date_from && strtotime( $date_from ) <= strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
 				update_post_meta( $post_id, '_price', wc_format_decimal( $_POST['_sale_price'] ) );
 			}
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1109,7 +1109,8 @@ class WC_Meta_Box_Product_Data {
 			}
 
 			if ( $date_to && ! $date_from ) {
-				update_post_meta( $post_id, '_sale_price_dates_from', strtotime( 'NOW', current_time( 'timestamp' ) ) );
+				$date_from = date( 'Y-m-d' );
+				update_post_meta( $post_id, '_sale_price_dates_from', strtotime( $date_from ) );
 			}
 
 			// Update price if on sale

--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -970,7 +970,8 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			if ( $date_to && ! $date_from ) {
-				update_post_meta( $product_id, '_sale_price_dates_from', strtotime( 'NOW', current_time( 'timestamp' ) ) );
+				$date_from = strtotime( 'NOW', current_time( 'timestamp' ) );
+				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
 			}
 
 			// Update price if on sale
@@ -980,7 +981,7 @@ class WC_API_Products extends WC_API_Resource {
 				update_post_meta( $product_id, '_price', $regular_price );
 			}
 
-			if ( '' !== $sale_price && $date_from && $date_from < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+			if ( '' !== $sale_price && $date_from && $date_from <= strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
 				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
 			}
 


### PR DESCRIPTION
Fixes #8357

There was already some logic in the REST API and admin backend functions to default to "today" if no from date was set for a sale. However, a check a few lines down to actual set the sale price would fail because a variable (`$date_from`) would be empty. This PR makes sure `$date_from` is set in the case of using today as default so that the check will succeed when it should.

**Testing Steps:**
- Go to a product's edit screen
- Set a sale price
- Click schedule
- Leave from blank
- Set to for a week out
- Save your product
- After admin refresh, see today's date
- Go to front end and see sale is applied
- To test the API, pass `'sale_price_dates_to' => 'YYYY-MM-DD'` and a `sale_price` but omit a from date. When you get back the response, you should see the sale reflected (`price_html` is a good indicator for that)
