### PR TITLE
Fix settings for email classes

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -174,9 +174,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 		if ( $current_section ) {
 
-			foreach ( $email_templates as $email ) {
+			foreach ( $email_templates as $email_key => $email ) {
 
-				if ( strtolower( get_class( $email ) ) == $current_section ) {
+				if ( strtolower( $email_key ) == $current_section ) {
 					$email->admin_options();
 					break;
 				}

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -47,10 +47,10 @@ class WC_Settings_Emails extends WC_Settings_Page {
 		$mailer          = WC()->mailer();
 		$email_templates = $mailer->get_emails();
 
-		foreach ( $email_templates as $email_id => $email ) {
+		foreach ( $email_templates as $email_key => $email ) {
 			$title = empty( $email->title ) ? ucfirst( $email->id ) : ucfirst( $email->title );
 
-			$sections[ strtolower( $email_id ) ] = esc_html( $title );
+			$sections[ strtolower( $email_key ) ] = esc_html( $title );
 		}
 
 		return apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );


### PR DESCRIPTION
The `section` for email settings pages was recently changed in #8365 to be based on the key that was used when the email was registered rather than the email class.

This PR fixes the settings output for emails which was still using the class name as the key to with the current section.  If the email key was different than the lowercase string of the email class name, no fields would be output.  This had no effect on core email classes because both their class and key are the same.

Also, I renamed `$email_id` from the previous code to `$email_key` to not be confused with `$email->id` since they are different.
