### PR TITLE
[CSS] word-wrap for woocommerce notices

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -89,6 +89,7 @@ p.demo_store {
 		list-style: none outside !important;
 		@include clearfix();
 		width: auto;
+		word-wrap: break-word;
 
 		&:before {
 			font-family: "WooCommerce";


### PR DESCRIPTION
Useful in particular when debugging plugin like USPS, Fedex etc where .woocommerce-notice is used to display a hug amount of inline content.
