### PR TITLE
Fix searching for SKUs with spaces (#8395)

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1768,7 +1768,7 @@ class WC_Admin_Post_Types {
 		$search_ids = array_filter( array_map( 'absint', $search_ids ) );
 
 		if ( sizeof( $search_ids ) > 0 ) {
-			$where = str_replace( ')))', ") OR ({$wpdb->posts}.ID IN (" . implode( ',', $search_ids ) . "))))", $where );
+			$where = str_replace( 'AND (((', "AND ( ({$wpdb->posts}.ID IN (" . implode( ',', $search_ids ) . ")) OR ((", $where );
 		}
 
 		return $where;


### PR DESCRIPTION
As seen in #8395, products that have an SKU with spaces are not properly found when searching on /wp-admin/ > Products.

This PR takes the recommendation from the issue (with a slight spacing/coding style fix) to move the post ID WHERE clause out so it properly finds results.

Fixes #8395

**Testing Steps:**
- Create a product and give it a SKU with spaces (ex: 215 29)
- Go to /wp-admin/ > products
- Search for 215 29
- See your product
