### PR TITLE
Added woocommerce_unique_skus filter. Allows non-unique variation skus.

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -974,8 +974,8 @@ class WC_Meta_Box_Product_Data {
 
 				if ( ! $unique_sku ) {
 					// set woocommerce_unique_skus filter true to require unique variation skus and false to allow non-unique variation skus.
-					$unique_skus = apply_filters( 'woocommerce_unique_skus' , true);
-					if( $unique_skus == true ){
+					$unique_skus = apply_filters( 'woocommerce_unique_skus' , true );
+					if ( $unique_skus == true ) {
 						WC_Admin_Meta_Boxes::add_error( __( 'Variation SKU must be unique.', 'woocommerce' ) );
 					} else {
 						WC_Admin_Meta_Boxes::add_error( __( 'Warning: You added a non-unique Variation SKU.', 'woocommerce' ) );

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -973,7 +973,14 @@ class WC_Meta_Box_Product_Data {
 				$unique_sku = wc_product_has_unique_sku( $post_id, $new_sku );
 
 				if ( ! $unique_sku ) {
-					WC_Admin_Meta_Boxes::add_error( __( 'Product SKU must be unique.', 'woocommerce' ) );
+					// set woocommerce_unique_skus filter true to require unique variation skus and false to allow non-unique variation skus.
+					$unique_skus = apply_filters( 'woocommerce_unique_skus' , true);
+					if( $unique_skus == true ){
+						WC_Admin_Meta_Boxes::add_error( __( 'Variation SKU must be unique.', 'woocommerce' ) );
+					} else {
+						WC_Admin_Meta_Boxes::add_error( __( 'Warning: You added a non-unique Variation SKU.', 'woocommerce' ) );
+						update_post_meta( $variation_id, '_sku', $new_sku );
+					}
 				} else {
 					update_post_meta( $post_id, '_sku', $new_sku );
 				}


### PR DESCRIPTION
Some stores require the ability to allow non-unique skus for specific
variations. This filter allows the store to set the filter to false and
allow non-unique skus.
