### PR TITLE
Implement full basic authentication & query string auth without mixing the two (#8256)

### DIFF
--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -111,7 +111,8 @@ class WC_API_Authentication {
 	 * @since 2.4
 	 */
 	private function exit_with_unauthorized_headers() {
-		header( 'WWW-Authenticate: Basic realm="' . __( 'WooCommerce API', 'woocommerce' ) . '"' );
+		$auth_message = __( 'WooCommerce API. Use a consumer key in the username field and a consumer secret in the password field', 'woocommerce' );
+		header( 'WWW-Authenticate: Basic realm="' . $auth_message . '"' );
 		header( 'HTTP/1.0 401 Unauthorized' );
 		esc_html_e( 'A valid consumer key and secret must be provided to access this resource', 'woocommerce' );
 		exit;

--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -41,10 +41,6 @@ class WC_API_Authentication {
 			return new WP_User( 0 );
 		}
 
-		if ( '/reauth' === untrailingslashit( WC()->api->server->path ) ) {
-			$this->exit_with_unauthorized_headers();
-		}
-
 		try {
 			if ( is_ssl() ) {
 				$keys = $this->perform_ssl_authentication();
@@ -114,8 +110,7 @@ class WC_API_Authentication {
 		$auth_message = __( 'WooCommerce API. Use a consumer key in the username field and a consumer secret in the password field', 'woocommerce' );
 		header( 'WWW-Authenticate: Basic realm="' . $auth_message . '"' );
 		header( 'HTTP/1.0 401 Unauthorized' );
-		esc_html_e( 'A valid consumer key and secret must be provided to access this resource', 'woocommerce' );
-		exit;
+		throw new Exception( __( 'Consumer Secret is invalid', 'woocommerce' ), 401 );
 	}
 
 	/**

--- a/includes/api/v2/class-wc-api-authentication.php
+++ b/includes/api/v2/class-wc-api-authentication.php
@@ -1,0 +1,387 @@
+<?php
+/**
+ * WooCommerce API Authentication Class
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.1.0
+ * @version  2.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Authentication {
+
+	/**
+	 * Setup class
+	 *
+	 * @since 2.1
+	 * @return WC_API_Authentication
+	 */
+	public function __construct() {
+
+		// To disable authentication, hook into this filter at a later priority and return a valid WP_User
+		add_filter( 'woocommerce_api_check_authentication', array( $this, 'authenticate' ), 0 );
+	}
+
+	/**
+	 * Authenticate the request. The authentication method varies based on whether the request was made over SSL or not.
+	 *
+	 * @since 2.1
+	 * @param WP_User $user
+	 * @return null|WP_Error|WP_User
+	 */
+	public function authenticate( $user ) {
+
+		// Allow access to the index by default
+		if ( '/' === WC()->api->server->path ) {
+			return new WP_User( 0 );
+		}
+
+		try {
+
+			if ( is_ssl() ) {
+				$keys = $this->perform_ssl_authentication();
+			} else {
+				$keys = $this->perform_oauth_authentication();
+			}
+
+			// Check API key-specific permission
+			$this->check_api_key_permissions( $keys['permissions'] );
+
+			$user = $this->get_user_by_id( $keys['user_id'] );
+
+		} catch ( Exception $e ) {
+			$user = new WP_Error( 'woocommerce_api_authentication_error', $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+
+		return $user;
+	}
+
+	/**
+	 * SSL-encrypted requests are not subject to sniffing or man-in-the-middle
+	 * attacks, so the request can be authenticated by simply looking up the user
+	 * associated with the given consumer key and confirming the consumer secret
+	 * provided is valid
+	 *
+	 * @since 2.1
+	 * @return array
+	 * @throws Exception
+	 */
+	private function perform_ssl_authentication() {
+
+		$params = WC()->api->server->params['GET'];
+
+		// Get consumer key
+		if ( ! empty( $_SERVER['PHP_AUTH_USER'] ) ) {
+
+			// Should be in HTTP Auth header by default
+			$consumer_key = $_SERVER['PHP_AUTH_USER'];
+
+		} elseif ( ! empty( $params['consumer_key'] ) ) {
+
+			// Allow a query string parameter as a fallback
+			$consumer_key = $params['consumer_key'];
+
+		} else {
+
+			throw new Exception( __( 'Consumer Key is missing', 'woocommerce' ), 404 );
+		}
+
+		// Get consumer secret
+		if ( ! empty( $_SERVER['PHP_AUTH_PW'] ) ) {
+
+			// Should be in HTTP Auth header by default
+			$consumer_secret = $_SERVER['PHP_AUTH_PW'];
+
+		} elseif ( ! empty( $params['consumer_secret'] ) ) {
+
+			// Allow a query string parameter as a fallback
+			$consumer_secret = $params['consumer_secret'];
+
+		} else {
+
+			throw new Exception( __( 'Consumer Secret is missing', 'woocommerce' ), 404 );
+		}
+
+		$keys = $this->get_keys_by_consumer_key( $consumer_key );
+
+		if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], $consumer_secret ) ) {
+			throw new Exception( __( 'Consumer Secret is invalid', 'woocommerce' ), 401 );
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * Perform OAuth 1.0a "one-legged" (http://oauthbible.com/#oauth-10a-one-legged) authentication for non-SSL requests
+	 *
+	 * This is required so API credentials cannot be sniffed or intercepted when making API requests over plain HTTP
+	 *
+	 * This follows the spec for simple OAuth 1.0a authentication (RFC 5849) as closely as possible, with two exceptions:
+	 *
+	 * 1) There is no token associated with request/responses, only consumer keys/secrets are used
+	 *
+	 * 2) The OAuth parameters are included as part of the request query string instead of part of the Authorization header,
+	 *    This is because there is no cross-OS function within PHP to get the raw Authorization header
+	 *
+	 * @link http://tools.ietf.org/html/rfc5849 for the full spec
+	 * @since 2.1
+	 * @return array
+	 * @throws Exception
+	 */
+	private function perform_oauth_authentication() {
+
+		$params = WC()->api->server->params['GET'];
+
+		$param_names =  array( 'oauth_consumer_key', 'oauth_timestamp', 'oauth_nonce', 'oauth_signature', 'oauth_signature_method' );
+
+		// Check for required OAuth parameters
+		foreach ( $param_names as $param_name ) {
+
+			if ( empty( $params[ $param_name ] ) ) {
+				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce' ), $param_name ), 404 );
+			}
+		}
+
+		// Fetch WP user by consumer key
+		$keys = $this->get_keys_by_consumer_key( $params['oauth_consumer_key'] );
+
+		// Perform OAuth validation
+		$this->check_oauth_signature( $keys, $params );
+		$this->check_oauth_timestamp_and_nonce( $keys, $params['oauth_timestamp'], $params['oauth_nonce'] );
+
+		// Authentication successful, return user
+		return $keys;
+	}
+
+	/**
+	 * Return the keys for the given consumer key
+	 *
+	 * @since 2.4.0
+	 * @param string $consumer_key
+	 * @return array
+	 * @throws Exception
+	 */
+	private function get_keys_by_consumer_key( $consumer_key ) {
+		global $wpdb;
+
+		$consumer_key = wc_api_hash( sanitize_text_field( $consumer_key ) );
+
+		$keys = $wpdb->get_row( $wpdb->prepare( "
+			SELECT *
+			FROM {$wpdb->prefix}woocommerce_api_keys
+			WHERE consumer_key = '%s'
+		", $consumer_key ), ARRAY_A );
+
+		if ( empty( $keys ) ) {
+			throw new Exception( __( 'Consumer Key is invalid', 'woocommerce' ), 401 );
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * Get user by ID
+	 *
+	 * @since 2.4.0
+	 * @param int $user_id
+	 * @return WC_User
+	 */
+	private function get_user_by_id( $user_id ) {
+		$user = get_user_by( 'id', $user_id );
+
+		if ( ! $user ) {
+			throw new Exception( __( 'API user is invalid', 'woocommerce' ), 401 );
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Check if the consumer secret provided for the given user is valid
+	 *
+	 * @since 2.1
+	 * @param string $keys_consumer_secret
+	 * @param string $consumer_secret
+	 * @return bool
+	 */
+	private function is_consumer_secret_valid( $keys_consumer_secret, $consumer_secret ) {
+		return hash_equals( $keys_consumer_secret, $consumer_secret );
+	}
+
+	/**
+	 * Verify that the consumer-provided request signature matches our generated signature, this ensures the consumer
+	 * has a valid key/secret
+	 *
+	 * @param array $keys
+	 * @param array $params the request parameters
+	 * @throws Exception
+	 */
+	private function check_oauth_signature( $keys, $params ) {
+
+		$http_method = strtoupper( WC()->api->server->method );
+
+		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . WC()->api->server->path );
+
+		// Get the signature provided by the consumer and remove it from the parameters prior to checking the signature
+		$consumer_signature = rawurldecode( $params['oauth_signature'] );
+		unset( $params['oauth_signature'] );
+
+		// Remove filters and convert them from array to strings to void normalize issues
+		if ( isset( $params['filter'] ) ) {
+			$filters = $params['filter'];
+			unset( $params['filter'] );
+			foreach ( $filters as $filter => $filter_value ) {
+				$params['filter[' . $filter . ']'] = $filter_value;
+			}
+		}
+
+		// Normalize parameter key/values
+		$params = $this->normalize_parameters( $params );
+
+		// Sort parameters
+		if ( ! uksort( $params, 'strcmp' ) ) {
+			throw new Exception( __( 'Invalid Signature - failed to sort parameters', 'woocommerce' ), 401 );
+		}
+
+		// Form query string
+		$query_params = array();
+		foreach ( $params as $param_key => $param_value ) {
+
+			$query_params[] = $param_key . '%3D' . $param_value; // join with equals sign
+		}
+		$query_string = implode( '%26', $query_params ); // join with ampersand
+
+		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
+
+		if ( $params['oauth_signature_method'] !== 'HMAC-SHA1' && $params['oauth_signature_method'] !== 'HMAC-SHA256' ) {
+			throw new Exception( __( 'Invalid Signature - signature method is invalid', 'woocommerce' ), 401 );
+		}
+
+		$hash_algorithm = strtolower( str_replace( 'HMAC-', '', $params['oauth_signature_method'] ) );
+
+		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $keys['consumer_secret'], true ) );
+
+		if ( ! hash_equals( $signature, $consumer_signature ) ) {
+			throw new Exception( __( 'Invalid Signature - provided signature does not match', 'woocommerce' ), 401 );
+		}
+	}
+
+	/**
+	 * Normalize each parameter by assuming each parameter may have already been
+	 * encoded, so attempt to decode, and then re-encode according to RFC 3986
+	 *
+	 * Note both the key and value is normalized so a filter param like:
+	 *
+	 * 'filter[period]' => 'week'
+	 *
+	 * is encoded to:
+	 *
+	 * 'filter%5Bperiod%5D' => 'week'
+	 *
+	 * This conforms to the OAuth 1.0a spec which indicates the entire query string
+	 * should be URL encoded
+	 *
+	 * @since 2.1
+	 * @see rawurlencode()
+	 * @param array $parameters un-normalized pararmeters
+	 * @return array normalized parameters
+	 */
+	private function normalize_parameters( $parameters ) {
+
+		$normalized_parameters = array();
+
+		foreach ( $parameters as $key => $value ) {
+
+			// Percent symbols (%) must be double-encoded
+			$key   = str_replace( '%', '%25', rawurlencode( rawurldecode( $key ) ) );
+			$value = str_replace( '%', '%25', rawurlencode( rawurldecode( $value ) ) );
+
+			$normalized_parameters[ $key ] = $value;
+		}
+
+		return $normalized_parameters;
+	}
+
+	/**
+	 * Verify that the timestamp and nonce provided with the request are valid. This prevents replay attacks where
+	 * an attacker could attempt to re-send an intercepted request at a later time.
+	 *
+	 * - A timestamp is valid if it is within 15 minutes of now
+	 * - A nonce is valid if it has not been used within the last 15 minutes
+	 *
+	 * @param array $keys
+	 * @param int $timestamp the unix timestamp for when the request was made
+	 * @param string $nonce a unique (for the given user) 32 alphanumeric string, consumer-generated
+	 * @throws Exception
+	 */
+	private function check_oauth_timestamp_and_nonce( $keys, $timestamp, $nonce ) {
+		global $wpdb;
+
+		$valid_window = 15 * 60; // 15 minute window
+
+		if ( ( $timestamp < time() - $valid_window ) || ( $timestamp > time() + $valid_window ) ) {
+			throw new Exception( __( 'Invalid timestamp', 'woocommerce' ) );
+		}
+
+		$used_nonces = maybe_unserialize( $keys['nonces'] );
+
+		if ( empty( $used_nonces ) ) {
+			$used_nonces = array();
+		}
+
+		if ( in_array( $nonce, $used_nonces ) ) {
+			throw new Exception( __( 'Invalid nonce - nonce has already been used', 'woocommerce' ), 401 );
+		}
+
+		$used_nonces[ $timestamp ] = $nonce;
+
+		// Remove expired nonces
+		foreach ( $used_nonces as $nonce_timestamp => $nonce ) {
+			if ( $nonce_timestamp < ( time() - $valid_window ) ) {
+				unset( $used_nonces[ $nonce_timestamp ] );
+			}
+		}
+
+		$used_nonces = maybe_serialize( $used_nonces );
+
+		$wpdb->update(
+			$wpdb->prefix . 'woocommerce_api_keys',
+			array( 'nonces' => $used_nonces ),
+			array( 'key_id' => $keys['key_id'] ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Check that the API keys provided have the proper key-specific permissions to either read or write API resources
+	 *
+	 * @param string $key_permissions
+	 * @throws Exception if the permission check fails
+	 */
+	public function check_api_key_permissions( $key_permissions ) {
+		switch ( WC()->api->server->method ) {
+
+			case 'HEAD':
+			case 'GET':
+				if ( 'read' !== $key_permissions && 'read_write' !== $key_permissions ) {
+					throw new Exception( __( 'The API key provided does not have read permissions', 'woocommerce' ), 401 );
+				}
+				break;
+
+			case 'POST':
+			case 'PUT':
+			case 'PATCH':
+			case 'DELETE':
+				if ( 'write' !== $key_permissions && 'read_write' !== $key_permissions ) {
+					throw new Exception( __( 'The API key provided does not have write permissions', 'woocommerce' ), 401 );
+				}
+				break;
+		}
+	}
+}

--- a/includes/api/v2/class-wc-api-coupons.php
+++ b/includes/api/v2/class-wc-api-coupons.php
@@ -1,0 +1,572 @@
+<?php
+/**
+ * WooCommerce API Coupons Class
+ *
+ * Handles requests to the /coupons endpoint
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Coupons extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/coupons';
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * GET /coupons
+	 * GET /coupons/count
+	 * GET /coupons/<id>
+	 *
+	 * @since 2.1
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET/POST /coupons
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_coupons' ),     WC_API_Server::READABLE ),
+			array( array( $this, 'create_coupon' ),   WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET /coupons/count
+		$routes[ $this->base . '/count'] = array(
+			array( array( $this, 'get_coupons_count' ), WC_API_Server::READABLE ),
+		);
+
+		# GET/PUT/DELETE /coupons/<id>
+		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_coupon' ),    WC_API_Server::READABLE ),
+			array( array( $this, 'edit_coupon' ),   WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
+			array( array( $this, 'delete_coupon' ), WC_API_SERVER::DELETABLE ),
+		);
+
+		# GET /coupons/code/<code>, note that coupon codes can contain spaces, dashes and underscores
+		$routes[ $this->base . '/code/(?P<code>\w[\w\s\-]*)' ] = array(
+			array( array( $this, 'get_coupon_by_code' ), WC_API_Server::READABLE ),
+		);
+
+		# POST|PUT /coupons/bulk
+		$routes[ $this->base . '/bulk' ] = array(
+			array( array( $this, 'bulk' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get all coupons
+	 *
+	 * @since 2.1
+	 * @param string $fields
+	 * @param array $filter
+	 * @param int $page
+	 * @return array
+	 */
+	public function get_coupons( $fields = null, $filter = array(), $page = 1 ) {
+
+		$filter['page'] = $page;
+
+		$query = $this->query_coupons( $filter );
+
+		$coupons = array();
+
+		foreach ( $query->posts as $coupon_id ) {
+
+			if ( ! $this->is_readable( $coupon_id ) ) {
+				continue;
+			}
+
+			$coupons[] = current( $this->get_coupon( $coupon_id, $fields ) );
+		}
+
+		$this->server->add_pagination_headers( $query );
+
+		return array( 'coupons' => $coupons );
+	}
+
+	/**
+	 * Get the coupon for the given ID
+	 *
+	 * @since 2.1
+	 * @param int $id the coupon ID
+	 * @param string $fields fields to include in response
+	 * @return array|WP_Error
+	 */
+	public function get_coupon( $id, $fields = null ) {
+		global $wpdb;
+
+		try {
+
+			$id = $this->validate_request( $id, 'shop_coupon', 'read' );
+
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+
+			// get the coupon code
+			$code = $wpdb->get_var( $wpdb->prepare( "SELECT post_title FROM $wpdb->posts WHERE id = %s AND post_type = 'shop_coupon' AND post_status = 'publish'", $id ) );
+
+			if ( is_null( $code ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
+			}
+
+			$coupon      = new WC_Coupon( $code );
+			$coupon_post = get_post( $coupon->id );
+			$coupon_data = array(
+				'id'                           => $coupon->id,
+				'code'                         => $coupon->code,
+				'type'                         => $coupon->type,
+				'created_at'                   => $this->server->format_datetime( $coupon_post->post_date_gmt ),
+				'updated_at'                   => $this->server->format_datetime( $coupon_post->post_modified_gmt ),
+				'amount'                       => wc_format_decimal( $coupon->coupon_amount, 2 ),
+				'individual_use'               => ( 'yes' === $coupon->individual_use ),
+				'product_ids'                  => array_map( 'absint', (array) $coupon->product_ids ),
+				'exclude_product_ids'          => array_map( 'absint', (array) $coupon->exclude_product_ids ),
+				'usage_limit'                  => ( ! empty( $coupon->usage_limit ) ) ? $coupon->usage_limit : null,
+				'usage_limit_per_user'         => ( ! empty( $coupon->usage_limit_per_user ) ) ? $coupon->usage_limit_per_user : null,
+				'limit_usage_to_x_items'       => (int) $coupon->limit_usage_to_x_items,
+				'usage_count'                  => (int) $coupon->usage_count,
+				'expiry_date'                  => ( ! empty( $coupon->expiry_date ) ) ? $this->server->format_datetime( $coupon->expiry_date ) : null,
+				'enable_free_shipping'         => $coupon->enable_free_shipping(),
+				'product_category_ids'         => array_map( 'absint', (array) $coupon->product_categories ),
+				'exclude_product_category_ids' => array_map( 'absint', (array) $coupon->exclude_product_categories ),
+				'exclude_sale_items'           => $coupon->exclude_sale_items(),
+				'minimum_amount'               => wc_format_decimal( $coupon->minimum_amount, 2 ),
+				'maximum_amount'               => wc_format_decimal( $coupon->maximum_amount, 2 ),
+				'customer_emails'              => $coupon->customer_email,
+				'description'                  => $coupon_post->post_excerpt,
+			);
+
+			return array( 'coupon' => apply_filters( 'woocommerce_api_coupon_response', $coupon_data, $coupon, $fields, $this->server ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get the total number of coupons
+	 *
+	 * @since 2.1
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_coupons_count( $filter = array() ) {
+		try {
+			if ( ! current_user_can( 'read_private_shop_coupons' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce' ), 401 );
+			}
+
+			$query = $this->query_coupons( $filter );
+
+			return array( 'count' => (int) $query->found_posts );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get the coupon for the given code
+	 *
+	 * @since 2.1
+	 * @param string $code the coupon code
+	 * @param string $fields fields to include in response
+	 * @return int|WP_Error
+	 */
+	public function get_coupon_by_code( $code, $fields = null ) {
+		global $wpdb;
+
+		try {
+			$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish'", $code ) );
+
+			if ( is_null( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce' ), 404 );
+			}
+
+			return $this->get_coupon( $id, $fields );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Create a coupon
+	 *
+	 * @since 2.2
+	 * @param array $data
+	 * @return array
+	 */
+	public function create_coupon( $data ) {
+		global $wpdb;
+
+		try {
+			if ( ! isset( $data['coupon'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'coupon' ), 400 );
+			}
+
+			$data = $data['coupon'];
+
+			// Check user permission
+			if ( ! current_user_can( 'publish_shop_coupons' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_coupon', __( 'You do not have permission to create coupons', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_coupon_data', $data, $this );
+
+			// Check if coupon code is specified
+			if ( ! isset( $data['code'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_code', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'code' ), 400 );
+			}
+
+			$coupon_code = apply_filters( 'woocommerce_coupon_code', $data['code'] );
+
+			// Check for duplicate coupon codes
+			$coupon_found = $wpdb->get_var( $wpdb->prepare( "
+				SELECT $wpdb->posts.ID
+				FROM $wpdb->posts
+				WHERE $wpdb->posts.post_type = 'shop_coupon'
+				AND $wpdb->posts.post_status = 'publish'
+				AND $wpdb->posts.post_title = '%s'
+			 ", $coupon_code ) );
+
+			if ( $coupon_found ) {
+				throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), 400 );
+			}
+
+			$defaults = array(
+				'type'                         => 'fixed_cart',
+				'amount'                       => 0,
+				'individual_use'               => false,
+				'product_ids'                  => array(),
+				'exclude_product_ids'          => array(),
+				'usage_limit'                  => '',
+				'usage_limit_per_user'         => '',
+				'limit_usage_to_x_items'       => '',
+				'usage_count'                  => '',
+				'expiry_date'                  => '',
+				'enable_free_shipping'         => false,
+				'product_category_ids'         => array(),
+				'exclude_product_category_ids' => array(),
+				'exclude_sale_items'           => false,
+				'minimum_amount'               => '',
+				'maximum_amount'               => '',
+				'customer_emails'              => array(),
+				'description'                  => ''
+			);
+
+			$coupon_data = wp_parse_args( $data, $defaults );
+
+			// Validate coupon types
+			if ( ! in_array( wc_clean( $coupon_data['type'] ), array_keys( wc_get_coupon_types() ) ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
+			}
+
+			$new_coupon = array(
+				'post_title'   => $coupon_code,
+				'post_content' => '',
+				'post_status'  => 'publish',
+				'post_author'  => get_current_user_id(),
+				'post_type'    => 'shop_coupon',
+				'post_excerpt' => $coupon_data['description']
+	 		);
+
+			$id = wp_insert_post( $new_coupon, $wp_error = false );
+
+			if ( is_wp_error( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_coupon', $id->get_error_message(), 400 );
+			}
+
+			// Set coupon meta
+			update_post_meta( $id, 'discount_type', $coupon_data['type'] );
+			update_post_meta( $id, 'coupon_amount', wc_format_decimal( $coupon_data['amount'] ) );
+			update_post_meta( $id, 'individual_use', ( true === $coupon_data['individual_use'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'product_ids', implode( ',', array_filter( array_map( 'intval', $coupon_data['product_ids'] ) ) ) );
+			update_post_meta( $id, 'exclude_product_ids', implode( ',', array_filter( array_map( 'intval', $coupon_data['exclude_product_ids'] ) ) ) );
+			update_post_meta( $id, 'usage_limit', absint( $coupon_data['usage_limit'] ) );
+			update_post_meta( $id, 'usage_limit_per_user', absint( $coupon_data['usage_limit_per_user'] ) );
+			update_post_meta( $id, 'limit_usage_to_x_items', absint( $coupon_data['limit_usage_to_x_items'] ) );
+			update_post_meta( $id, 'usage_count', absint( $coupon_data['usage_count'] ) );
+			update_post_meta( $id, 'expiry_date', $this->get_coupon_expiry_date( wc_clean( $coupon_data['expiry_date'] ) ) );
+			update_post_meta( $id, 'free_shipping', ( true === $coupon_data['enable_free_shipping'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'product_categories', array_filter( array_map( 'intval', $coupon_data['product_category_ids'] ) ) );
+			update_post_meta( $id, 'exclude_product_categories', array_filter( array_map( 'intval', $coupon_data['exclude_product_category_ids'] ) ) );
+			update_post_meta( $id, 'exclude_sale_items', ( true === $coupon_data['exclude_sale_items'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'minimum_amount', wc_format_decimal( $coupon_data['minimum_amount'] ) );
+			update_post_meta( $id, 'maximum_amount', wc_format_decimal( $coupon_data['maximum_amount'] ) );
+			update_post_meta( $id, 'customer_email', array_filter( array_map( 'sanitize_email', $coupon_data['customer_emails'] ) ) );
+
+			do_action( 'woocommerce_api_create_coupon', $id, $data );
+
+			$this->server->send_status( 201 );
+
+			return $this->get_coupon( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit a coupon
+	 *
+	 * @since 2.2
+	 * @param int $id the coupon ID
+	 * @param array $data
+	 * @return array
+	 */
+	public function edit_coupon( $id, $data ) {
+
+		try {
+			if ( ! isset( $data['coupon'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'coupon' ), 400 );
+			}
+
+			$data = $data['coupon'];
+
+			$id = $this->validate_request( $id, 'shop_coupon', 'edit' );
+
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_coupon_data', $data, $id, $this );
+
+			if ( isset( $data['code'] ) ) {
+				global $wpdb;
+
+				$coupon_code = apply_filters( 'woocommerce_coupon_code', $data['code'] );
+
+				// Check for duplicate coupon codes
+				$coupon_found = $wpdb->get_var( $wpdb->prepare( "
+					SELECT $wpdb->posts.ID
+					FROM $wpdb->posts
+					WHERE $wpdb->posts.post_type = 'shop_coupon'
+					AND $wpdb->posts.post_status = 'publish'
+					AND $wpdb->posts.post_title = '%s'
+					AND $wpdb->posts.ID != %s
+				 ", $coupon_code, $id ) );
+
+				if ( $coupon_found ) {
+					throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), 400 );
+				}
+
+				$id = wp_update_post( array( 'ID' => intval( $id ), 'post_title' => $coupon_code, 'post_excerpt' => isset( $data['description'] ) ? $data['description'] : '' ) );
+				if ( 0 === $id ) {
+					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce' ), 400 );
+				}
+			}
+
+			if ( isset( $data['type'] ) ) {
+				// Validate coupon types
+				if ( ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_coupon_types() ) ) ) {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
+				}
+				update_post_meta( $id, 'discount_type', $data['type'] );
+			}
+
+			if ( isset( $data['amount'] ) ) {
+				update_post_meta( $id, 'coupon_amount', wc_format_decimal( $data['amount'] ) );
+			}
+
+			if ( isset( $data['individual_use'] ) ) {
+				update_post_meta( $id, 'individual_use', ( true === $data['individual_use'] ) ? 'yes' : 'no' );
+			}
+
+			if ( isset( $data['product_ids'] ) ) {
+				update_post_meta( $id, 'product_ids', implode( ',', array_filter( array_map( 'intval', $data['product_ids'] ) ) ) );
+			}
+
+			if ( isset( $data['exclude_product_ids'] ) ) {
+				update_post_meta( $id, 'exclude_product_ids', implode( ',', array_filter( array_map( 'intval', $data['exclude_product_ids'] ) ) ) );
+			}
+
+			if ( isset( $data['usage_limit'] ) ) {
+				update_post_meta( $id, 'usage_limit', absint( $data['usage_limit'] ) );
+			}
+
+			if ( isset( $data['usage_limit_per_user'] ) ) {
+				update_post_meta( $id, 'usage_limit_per_user', absint( $data['usage_limit_per_user'] ) );
+			}
+
+			if ( isset( $data['limit_usage_to_x_items'] ) ) {
+				update_post_meta( $id, 'limit_usage_to_x_items', absint( $data['limit_usage_to_x_items'] ) );
+			}
+
+			if ( isset( $data['usage_count'] ) ) {
+				update_post_meta( $id, 'usage_count', absint( $data['usage_count'] ) );
+			}
+
+			if ( isset( $data['expiry_date'] ) ) {
+				update_post_meta( $id, 'expiry_date', $this->get_coupon_expiry_date( wc_clean( $data['expiry_date'] ) ) );
+			}
+
+			if ( isset( $data['enable_free_shipping'] ) ) {
+				update_post_meta( $id, 'free_shipping', ( true === $data['enable_free_shipping'] ) ? 'yes' : 'no' );
+			}
+
+			if ( isset( $data['product_category_ids'] ) ) {
+				update_post_meta( $id, 'product_categories', array_filter( array_map( 'intval', $data['product_category_ids'] ) ) );
+			}
+
+			if ( isset( $data['exclude_product_category_ids'] ) ) {
+				update_post_meta( $id, 'exclude_product_categories', array_filter( array_map( 'intval', $data['exclude_product_category_ids'] ) ) );
+			}
+
+			if ( isset( $data['exclude_sale_items'] ) ) {
+				update_post_meta( $id, 'exclude_sale_items', ( true === $data['exclude_sale_items'] ) ? 'yes' : 'no' );
+			}
+
+			if ( isset( $data['minimum_amount'] ) ) {
+				update_post_meta( $id, 'minimum_amount', wc_format_decimal( $data['minimum_amount'] ) );
+			}
+
+			if ( isset( $data['maximum_amount'] ) ) {
+				update_post_meta( $id, 'maximum_amount', wc_format_decimal( $data['maximum_amount'] ) );
+			}
+
+			if ( isset( $data['customer_emails'] ) ) {
+				update_post_meta( $id, 'customer_email', array_filter( array_map( 'sanitize_email', $data['customer_emails'] ) ) );
+			}
+
+			do_action( 'woocommerce_api_edit_coupon', $id, $data );
+
+			return $this->get_coupon( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete a coupon
+	 *
+	 * @since  2.2
+	 * @param int $id the coupon ID
+	 * @param bool $force true to permanently delete coupon, false to move to trash
+	 * @return array
+	 */
+	public function delete_coupon( $id, $force = false ) {
+
+		$id = $this->validate_request( $id, 'shop_coupon', 'delete' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		do_action( 'woocommerce_api_delete_coupon', $id, $this );
+
+		return $this->delete( $id, 'shop_coupon', ( 'true' === $force ) );
+	}
+
+	/**
+	 * expiry_date format
+	 *
+	 * @since  2.3.0
+	 * @param  string $expiry_date
+	 * @return string
+	 */
+	protected function get_coupon_expiry_date( $expiry_date ) {
+		if ( '' != $expiry_date ) {
+			return date( 'Y-m-d', strtotime( $expiry_date ) );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Helper method to get coupon post objects
+	 *
+	 * @since 2.1
+	 * @param array $args request arguments for filtering query
+	 * @return WP_Query
+	 */
+	private function query_coupons( $args ) {
+
+		// set base query arguments
+		$query_args = array(
+			'fields'      => 'ids',
+			'post_type'   => 'shop_coupon',
+			'post_status' => 'publish',
+		);
+
+		$query_args = $this->merge_query_args( $query_args, $args );
+
+		return new WP_Query( $query_args );
+	}
+
+	/**
+	 * Bulk update or insert coupons
+	 * Accepts an array with coupons in the formats supported by
+	 * WC_API_Coupons->create_coupon() and WC_API_Coupons->edit_coupon()
+	 *
+	 * @since 2.4.0
+	 * @param array $data
+	 * @return array
+	 */
+	public function bulk( $data ) {
+
+		try {
+			if ( ! isset( $data['coupons'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupons_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'coupons' ), 400 );
+			}
+
+			$data  = $data['coupons'];
+			$limit = apply_filters( 'woocommerce_api_bulk_limit', 100, 'coupons' );
+
+			// Limit bulk operation
+			if ( count( $data ) > $limit ) {
+				throw new WC_API_Exception( 'woocommerce_api_coupons_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request', 'woocommerce' ), $limit ), 413 );
+			}
+
+			$coupons = array();
+
+			foreach ( $data as $_coupon ) {
+				$coupon_id = 0;
+
+				// Try to get the coupon ID
+				if ( isset( $_coupon['id'] ) ) {
+					$coupon_id = intval( $_coupon['id'] );
+				}
+
+				// Coupon exists / edit coupon
+				if ( $coupon_id ) {
+					$edit = $this->edit_coupon( $coupon_id, array( 'coupon' => $_coupon ) );
+
+					if ( is_wp_error( $edit ) ) {
+						$coupons[] = array(
+							'id'    => $coupon_id,
+							'error' => array( 'code' => $edit->get_error_code(), 'message' => $edit->get_error_message() )
+						);
+					} else {
+						$coupons[] = $edit['coupon'];
+					}
+				}
+
+				// Coupon don't exists / create coupon
+				else {
+					$new = $this->create_coupon( array( 'coupon' => $_coupon ) );
+
+					if ( is_wp_error( $new ) ) {
+						$coupons[] = array(
+							'id'    => $coupon_id,
+							'error' => array( 'code' => $new->get_error_code(), 'message' => $new->get_error_message() )
+						);
+					} else {
+						$coupons[] = $new['coupon'];
+					}
+				}
+			}
+
+			return array( 'coupons' => apply_filters( 'woocommerce_api_coupons_bulk_response', $coupons, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+}

--- a/includes/api/v2/class-wc-api-customers.php
+++ b/includes/api/v2/class-wc-api-customers.php
@@ -1,0 +1,845 @@
+<?php
+/**
+ * WooCommerce API Customers Class
+ *
+ * Handles requests to the /customers endpoint
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Customers extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/customers';
+
+	/** @var string $created_at_min for date filtering */
+	private $created_at_min = null;
+
+	/** @var string $created_at_max for date filtering */
+	private $created_at_max = null;
+
+	/**
+	 * Setup class, overridden to provide customer data to order response
+	 *
+	 * @since 2.1
+	 * @param WC_API_Server $server
+	 * @return WC_API_Customers
+	 */
+	public function __construct( WC_API_Server $server ) {
+
+		parent::__construct( $server );
+
+		// add customer data to order responses
+		add_filter( 'woocommerce_api_order_response', array( $this, 'add_customer_data' ), 10, 2 );
+
+		// modify WP_User_Query to support created_at date filtering
+		add_action( 'pre_user_query', array( $this, 'modify_user_query' ) );
+	}
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * GET /customers
+	 * GET /customers/count
+	 * GET /customers/<id>
+	 * GET /customers/<id>/orders
+	 *
+	 * @since 2.2
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET/POST /customers
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_customers' ),   WC_API_SERVER::READABLE ),
+			array( array( $this, 'create_customer' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET /customers/count
+		$routes[ $this->base . '/count'] = array(
+			array( array( $this, 'get_customers_count' ), WC_API_SERVER::READABLE ),
+		);
+
+		# GET/PUT/DELETE /customers/<id>
+		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_customer' ),    WC_API_SERVER::READABLE ),
+			array( array( $this, 'edit_customer' ),   WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
+			array( array( $this, 'delete_customer' ), WC_API_SERVER::DELETABLE ),
+		);
+
+		# GET /customers/email/<email>
+		$routes[ $this->base . '/email/(?P<email>.+)' ] = array(
+			array( array( $this, 'get_customer_by_email' ), WC_API_SERVER::READABLE ),
+		);
+
+		# GET /customers/<id>/orders
+		$routes[ $this->base . '/(?P<id>\d+)/orders' ] = array(
+			array( array( $this, 'get_customer_orders' ), WC_API_SERVER::READABLE ),
+		);
+
+		# GET /customers/<id>/downloads
+		$routes[ $this->base . '/(?P<id>\d+)/downloads' ] = array(
+			array( array( $this, 'get_customer_downloads' ), WC_API_SERVER::READABLE ),
+		);
+
+		# POST|PUT /customers/bulk
+		$routes[ $this->base . '/bulk' ] = array(
+			array( array( $this, 'bulk' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get all customers
+	 *
+	 * @since 2.1
+	 * @param array $fields
+	 * @param array $filter
+	 * @param int $page
+	 * @return array
+	 */
+	public function get_customers( $fields = null, $filter = array(), $page = 1 ) {
+
+		$filter['page'] = $page;
+
+		$query = $this->query_customers( $filter );
+
+		$customers = array();
+
+		foreach ( $query->get_results() as $user_id ) {
+
+			if ( ! $this->is_readable( $user_id ) ) {
+				continue;
+			}
+
+			$customers[] = current( $this->get_customer( $user_id, $fields ) );
+		}
+
+		$this->server->add_pagination_headers( $query );
+
+		return array( 'customers' => $customers );
+	}
+
+	/**
+	 * Get the customer for the given ID
+	 *
+	 * @since 2.1
+	 * @param int $id the customer ID
+	 * @param array $fields
+	 * @return array
+	 */
+	public function get_customer( $id, $fields = null ) {
+		global $wpdb;
+
+		$id = $this->validate_request( $id, 'customer', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$customer = new WP_User( $id );
+
+		// Get info about user's last order
+		$last_order = $wpdb->get_row( "SELECT id, post_date_gmt
+						FROM $wpdb->posts AS posts
+						LEFT JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
+						WHERE meta.meta_key = '_customer_user'
+						AND   meta.meta_value = {$customer->ID}
+						AND   posts.post_type = 'shop_order'
+						AND   posts.post_status IN ( '" . implode( "','", array_keys( wc_get_order_statuses() ) ) . "' )
+						ORDER BY posts.ID DESC
+					" );
+
+		$customer_data = array(
+			'id'               => $customer->ID,
+			'created_at'       => $this->server->format_datetime( $customer->user_registered ),
+			'email'            => $customer->user_email,
+			'first_name'       => $customer->first_name,
+			'last_name'        => $customer->last_name,
+			'username'         => $customer->user_login,
+			'role'             => $customer->roles[0],
+			'last_order_id'    => is_object( $last_order ) ? $last_order->id : null,
+			'last_order_date'  => is_object( $last_order ) ? $this->server->format_datetime( $last_order->post_date_gmt ) : null,
+			'orders_count'     => wc_get_customer_order_count( $customer->ID ),
+			'total_spent'      => wc_format_decimal( wc_get_customer_total_spent( $customer->ID ), 2 ),
+			'avatar_url'       => $this->get_avatar_url( $customer->customer_email ),
+			'billing_address'  => array(
+				'first_name' => $customer->billing_first_name,
+				'last_name'  => $customer->billing_last_name,
+				'company'    => $customer->billing_company,
+				'address_1'  => $customer->billing_address_1,
+				'address_2'  => $customer->billing_address_2,
+				'city'       => $customer->billing_city,
+				'state'      => $customer->billing_state,
+				'postcode'   => $customer->billing_postcode,
+				'country'    => $customer->billing_country,
+				'email'      => $customer->billing_email,
+				'phone'      => $customer->billing_phone,
+			),
+			'shipping_address' => array(
+				'first_name' => $customer->shipping_first_name,
+				'last_name'  => $customer->shipping_last_name,
+				'company'    => $customer->shipping_company,
+				'address_1'  => $customer->shipping_address_1,
+				'address_2'  => $customer->shipping_address_2,
+				'city'       => $customer->shipping_city,
+				'state'      => $customer->shipping_state,
+				'postcode'   => $customer->shipping_postcode,
+				'country'    => $customer->shipping_country,
+			),
+		);
+
+		return array( 'customer' => apply_filters( 'woocommerce_api_customer_response', $customer_data, $customer, $fields, $this->server ) );
+	}
+
+	/**
+	 * Get the customer for the given email
+	 *
+	 * @since 2.1
+	 * @param string $email the customer email
+	 * @param array $fields
+	 * @return array
+	 */
+	public function get_customer_by_email( $email, $fields = null ) {
+		try {
+			if ( is_email( $email ) ) {
+				$customer = get_user_by( 'email', $email );
+				if ( ! is_object( $customer ) ) {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer Email', 'woocommerce' ), 404 );
+				}
+			} else {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer Email', 'woocommerce' ), 404 );
+			}
+
+			return $this->get_customer( $customer->ID, $fields );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get the total number of customers
+	 *
+	 * @since 2.1
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_customers_count( $filter = array() ) {
+		try {
+			if ( ! current_user_can( 'list_users' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce' ), 401 );
+			}
+
+			$query = $this->query_customers( $filter );
+
+			return array( 'count' => count( $query->get_results() ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get customer billing address fields.
+	 *
+	 * @since  2.2
+	 * @return array
+	 */
+	protected function get_customer_billing_address() {
+		$billing_address = apply_filters( 'woocommerce_api_customer_billing_address', array(
+			'first_name',
+			'last_name',
+			'company',
+			'address_1',
+			'address_2',
+			'city',
+			'state',
+			'postcode',
+			'country',
+			'email',
+			'phone',
+		) );
+
+		return $billing_address;
+	}
+
+	/**
+	 * Get customer shipping address fields.
+	 *
+	 * @since  2.2
+	 * @return array
+	 */
+	protected function get_customer_shipping_address() {
+		$shipping_address = apply_filters( 'woocommerce_api_customer_shipping_address', array(
+			'first_name',
+			'last_name',
+			'company',
+			'address_1',
+			'address_2',
+			'city',
+			'state',
+			'postcode',
+			'country',
+		) );
+
+		return $shipping_address;
+	}
+
+	/**
+	 * Add/Update customer data.
+	 *
+	 * @since 2.2
+	 * @param int $id the customer ID
+	 * @param array $data
+	 * @return void
+	 */
+	protected function update_customer_data( $id, $data ) {
+		// Customer first name.
+		if ( isset( $data['first_name'] ) ) {
+			update_user_meta( $id, 'first_name', wc_clean( $data['first_name'] ) );
+		}
+
+		// Customer last name.
+		if ( isset( $data['last_name'] ) ) {
+			update_user_meta( $id, 'last_name', wc_clean( $data['last_name'] ) );
+		}
+
+		// Customer billing address.
+		if ( isset( $data['billing_address'] ) ) {
+			foreach ( $this->get_customer_billing_address() as $address ) {
+				if ( isset( $data['billing_address'][ $address ] ) ) {
+					update_user_meta( $id, 'billing_' . $address, wc_clean( $data['billing_address'][ $address ] ) );
+				}
+			}
+		}
+
+		// Customer shipping address.
+		if ( isset( $data['shipping_address'] ) ) {
+			foreach ( $this->get_customer_shipping_address() as $address ) {
+				if ( isset( $data['shipping_address'][ $address ] ) ) {
+					update_user_meta( $id, 'shipping_' . $address, wc_clean( $data['shipping_address'][ $address ] ) );
+				}
+			}
+		}
+
+		do_action( 'woocommerce_api_update_customer_data', $id, $data );
+	}
+
+	/**
+	 * Create a customer
+	 *
+	 * @since 2.2
+	 * @param array $data
+	 * @return array
+	 */
+	public function create_customer( $data ) {
+		try {
+			if ( ! isset( $data['customer'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'customer' ), 400 );
+			}
+
+			$data = $data['customer'];
+
+			// Checks with can create new users.
+			if ( ! current_user_can( 'create_users' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_customer_data', $data, $this );
+
+			// Checks with the email is missing.
+			if ( ! isset( $data['email'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_email', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'email' ), 400 );
+			}
+
+			// Sets the username.
+			$data['username'] = ! empty( $data['username'] ) ? $data['username'] : '';
+
+			// Sets the password.
+			$data['password'] = ! empty( $data['password'] ) ? $data['password'] : '';
+
+			// Attempts to create the new customer
+			$id = wc_create_new_customer( $data['email'], $data['username'], $data['password'] );
+
+			// Checks for an error in the customer creation.
+			if ( is_wp_error( $id ) ) {
+				throw new WC_API_Exception( $id->get_error_code(), $id->get_error_message(), 400 );
+			}
+
+			// Added customer data.
+			$this->update_customer_data( $id, $data );
+
+			do_action( 'woocommerce_api_create_customer', $id, $data );
+
+			$this->server->send_status( 201 );
+
+			return $this->get_customer( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit a customer
+	 *
+	 * @since 2.2
+	 * @param int $id the customer ID
+	 * @param array $data
+	 * @return array
+	 */
+	public function edit_customer( $id, $data ) {
+		try {
+			if ( ! isset( $data['customer'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'customer' ), 400 );
+			}
+
+			$data = $data['customer'];
+
+			// Validate the customer ID.
+			$id = $this->validate_request( $id, 'customer', 'edit' );
+
+			// Return the validate error.
+			if ( is_wp_error( $id ) ) {
+				throw new WC_API_Exception( $id->get_error_code(), $id->get_error_message(), 400 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_customer_data', $data, $this );
+
+			// Customer email.
+			if ( isset( $data['email'] ) ) {
+				wp_update_user( array( 'ID' => $id, 'user_email' => sanitize_email( $data['email'] ) ) );
+			}
+
+			// Customer password.
+			if ( isset( $data['password'] ) ) {
+				wp_update_user( array( 'ID' => $id, 'user_pass' => wc_clean( $data['password'] ) ) );
+			}
+
+			// Update customer data.
+			$this->update_customer_data( $id, $data );
+
+			do_action( 'woocommerce_api_edit_customer', $id, $data );
+
+			return $this->get_customer( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete a customer
+	 *
+	 * @since 2.2
+	 * @param int $id the customer ID
+	 * @return array
+	 */
+	public function delete_customer( $id ) {
+
+		// Validate the customer ID.
+		$id = $this->validate_request( $id, 'customer', 'delete' );
+
+		// Return the validate error.
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		do_action( 'woocommerce_api_delete_customer', $id, $this );
+
+		return $this->delete( $id, 'customer' );
+	}
+
+	/**
+	 * Get the orders for a customer
+	 *
+	 * @since 2.1
+	 * @param int $id the customer ID
+	 * @param string $fields fields to include in response
+	 * @return array
+	 */
+	public function get_customer_orders( $id, $fields = null ) {
+		global $wpdb;
+
+		$id = $this->validate_request( $id, 'customer', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$order_ids = $wpdb->get_col( $wpdb->prepare( "SELECT id
+						FROM $wpdb->posts AS posts
+						LEFT JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
+						WHERE meta.meta_key = '_customer_user'
+						AND   meta.meta_value = '%s'
+						AND   posts.post_type = 'shop_order'
+						AND   posts.post_status IN ( '" . implode( "','", array_keys( wc_get_order_statuses() ) ) . "' )
+					", $id ) );
+
+		if ( empty( $order_ids ) ) {
+			return array( 'orders' => array() );
+		}
+
+		$orders = array();
+
+		foreach ( $order_ids as $order_id ) {
+			$orders[] = current( WC()->api->WC_API_Orders->get_order( $order_id, $fields ) );
+		}
+
+		return array( 'orders' => apply_filters( 'woocommerce_api_customer_orders_response', $orders, $id, $fields, $order_ids, $this->server ) );
+	}
+
+	/**
+	 * Get the available downloads for a customer
+	 *
+	 * @since 2.2
+	 * @param int $id the customer ID
+	 * @param string $fields fields to include in response
+	 * @return array
+	 */
+	public function get_customer_downloads( $id, $fields = null ) {
+		$id = $this->validate_request( $id, 'customer', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$downloads  = array();
+		$_downloads = wc_get_customer_available_downloads( $id );
+
+		foreach ( $_downloads as $key => $download ) {
+			$downloads[ $key ] = $download;
+			$downloads[ $key ]['access_expires'] = $this->server->format_datetime( $downloads[ $key ]['access_expires'] );
+		}
+
+		return array( 'downloads' => apply_filters( 'woocommerce_api_customer_downloads_response', $downloads, $id, $fields, $this->server ) );
+	}
+
+	/**
+	 * Helper method to get customer user objects
+	 *
+	 * Note that WP_User_Query does not have built-in pagination so limit & offset are used to provide limited
+	 * pagination support
+	 *
+	 * The filter for role can only be a single role in a string.
+	 *
+	 * @since 2.3
+	 * @param array $args request arguments for filtering query
+	 * @return WP_User_Query
+	 */
+	private function query_customers( $args = array() ) {
+
+		// default users per page
+		$users_per_page = get_option( 'posts_per_page' );
+
+		// Set base query arguments
+		$query_args = array(
+			'fields'  => 'ID',
+			'role'    => 'customer',
+			'orderby' => 'registered',
+			'number'  => $users_per_page,
+		);
+
+		// Custom Role
+		if ( ! empty( $args['role'] ) ) {
+			$query_args['role'] = $args['role'];
+		}
+
+		// Search
+		if ( ! empty( $args['q'] ) ) {
+			$query_args['search'] = $args['q'];
+		}
+
+		// Limit number of users returned
+		if ( ! empty( $args['limit'] ) ) {
+			if ( $args['limit'] == -1 ) {
+				unset( $query_args['number'] );
+			} else {
+				$query_args['number'] = absint( $args['limit'] );
+				$users_per_page       = absint( $args['limit'] );
+			}
+		} else {
+			$args['limit'] = $query_args['number'];
+		}
+
+		// Page
+		$page = ( isset( $args['page'] ) ) ? absint( $args['page'] ) : 1;
+
+		// Offset
+		if ( ! empty( $args['offset'] ) ) {
+			$query_args['offset'] = absint( $args['offset'] );
+		} else {
+			$query_args['offset'] = $users_per_page * ( $page - 1 );
+		}
+
+		// Created date
+		if ( ! empty( $args['created_at_min'] ) ) {
+			$this->created_at_min = $this->server->parse_datetime( $args['created_at_min'] );
+		}
+
+		if ( ! empty( $args['created_at_max'] ) ) {
+			$this->created_at_max = $this->server->parse_datetime( $args['created_at_max'] );
+		}
+
+		// Order (ASC or DESC, ASC by default)
+		if ( ! empty( $args['order'] ) ) {
+			$query_args['order'] = $args['order'];
+		}
+
+		// Orderby
+		if ( ! empty( $args['orderby'] ) ) {
+			$query_args['orderby'] = $args['orderby'];
+
+			// Allow sorting by meta value
+			if ( ! empty( $args['orderby_meta_key'] ) ) {
+				$query_args['meta_key'] = $args['orderby_meta_key'];
+			}
+		}
+
+		$query = new WP_User_Query( $query_args );
+
+		// Helper members for pagination headers
+		$query->total_pages = ( $args['limit'] == -1 ) ? 1 : ceil( $query->get_total() / $users_per_page );
+		$query->page = $page;
+
+		return $query;
+	}
+
+	/**
+	 * Add customer data to orders
+	 *
+	 * @since 2.1
+	 * @param $order_data
+	 * @param $order
+	 * @return array
+	 */
+	public function add_customer_data( $order_data, $order ) {
+
+		if ( 0 == $order->customer_user ) {
+
+			// add customer data from order
+			$order_data['customer'] = array(
+				'id'               => 0,
+				'email'            => $order->billing_email,
+				'first_name'       => $order->billing_first_name,
+				'last_name'        => $order->billing_last_name,
+				'billing_address'  => array(
+					'first_name' => $order->billing_first_name,
+					'last_name'  => $order->billing_last_name,
+					'company'    => $order->billing_company,
+					'address_1'  => $order->billing_address_1,
+					'address_2'  => $order->billing_address_2,
+					'city'       => $order->billing_city,
+					'state'      => $order->billing_state,
+					'postcode'   => $order->billing_postcode,
+					'country'    => $order->billing_country,
+					'email'      => $order->billing_email,
+					'phone'      => $order->billing_phone,
+				),
+				'shipping_address' => array(
+					'first_name' => $order->shipping_first_name,
+					'last_name'  => $order->shipping_last_name,
+					'company'    => $order->shipping_company,
+					'address_1'  => $order->shipping_address_1,
+					'address_2'  => $order->shipping_address_2,
+					'city'       => $order->shipping_city,
+					'state'      => $order->shipping_state,
+					'postcode'   => $order->shipping_postcode,
+					'country'    => $order->shipping_country,
+				),
+			);
+
+		} else {
+
+			$order_data['customer'] = current( $this->get_customer( $order->customer_user ) );
+		}
+
+		return $order_data;
+	}
+
+	/**
+	 * Modify the WP_User_Query to support filtering on the date the customer was created
+	 *
+	 * @since 2.1
+	 * @param WP_User_Query $query
+	 */
+	public function modify_user_query( $query ) {
+
+		if ( $this->created_at_min ) {
+			$query->query_where .= sprintf( " AND user_registered >= STR_TO_DATE( '%s', '%%Y-%%m-%%d %%H:%%i:%%s' )", esc_sql( $this->created_at_min ) );
+		}
+
+		if ( $this->created_at_max ) {
+			$query->query_where .= sprintf( " AND user_registered <= STR_TO_DATE( '%s', '%%Y-%%m-%%d %%H:%%i:%%s' )", esc_sql( $this->created_at_max ) );
+		}
+	}
+
+	/**
+	 * Wrapper for @see get_avatar() which doesn't simply return
+	 * the URL so we need to pluck it from the HTML img tag
+	 *
+	 * Kudos to https://github.com/WP-API/WP-API for offering a better solution
+	 *
+	 * @since 2.1
+	 * @param string $email the customer's email
+	 * @return string the URL to the customer's avatar
+	 */
+	private function get_avatar_url( $email ) {
+		$avatar_html = get_avatar( $email );
+
+		// Get the URL of the avatar from the provided HTML
+		preg_match( '/src=["|\'](.+)[\&|"|\']/U', $avatar_html, $matches );
+
+		if ( isset( $matches[1] ) && ! empty( $matches[1] ) ) {
+			return esc_url_raw( $matches[1] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Validate the request by checking:
+	 *
+	 * 1) the ID is a valid integer
+	 * 2) the ID returns a valid WP_User
+	 * 3) the current user has the proper permissions
+	 *
+	 * @since 2.1
+	 * @see WC_API_Resource::validate_request()
+	 * @param integer $id the customer ID
+	 * @param string $type the request type, unused because this method overrides the parent class
+	 * @param string $context the context of the request, either `read`, `edit` or `delete`
+	 * @return int|WP_Error valid user ID or WP_Error if any of the checks fails
+	 */
+	protected function validate_request( $id, $type, $context ) {
+
+		try {
+			$id = absint( $id );
+
+			// validate ID
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce' ), 404 );
+			}
+
+			// non-existent IDs return a valid WP_User object with the user ID = 0
+			$customer = new WP_User( $id );
+
+			if ( 0 === $customer->ID ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce' ), 404 );
+			}
+
+			// validate permissions
+			switch ( $context ) {
+
+				case 'read':
+					if ( ! current_user_can( 'list_users' ) ) {
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), 401 );
+					}
+					break;
+
+				case 'edit':
+					if ( ! current_user_can( 'edit_users' ) ) {
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), 401 );
+					}
+					break;
+
+				case 'delete':
+					if ( ! current_user_can( 'delete_users' ) ) {
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), 401 );
+					}
+					break;
+			}
+
+			return $id;
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Check if the current user can read users
+	 *
+	 * @since 2.1
+	 * @see WC_API_Resource::is_readable()
+	 * @param int|WP_Post $post unused
+	 * @return bool true if the current user can read users, false otherwise
+	 */
+	protected function is_readable( $post ) {
+		return current_user_can( 'list_users' );
+	}
+
+	/**
+	 * Bulk update or insert customers
+	 * Accepts an array with customers in the formats supported by
+	 * WC_API_Customers->create_customer() and WC_API_Customers->edit_customer()
+	 *
+	 * @since 2.4.0
+	 * @param array $data
+	 * @return array
+	 */
+	public function bulk( $data ) {
+
+		try {
+			if ( ! isset( $data['customers'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_customers_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'customers' ), 400 );
+			}
+
+			$data  = $data['customers'];
+			$limit = apply_filters( 'woocommerce_api_bulk_limit', 100, 'customers' );
+
+			// Limit bulk operation
+			if ( count( $data ) > $limit ) {
+				throw new WC_API_Exception( 'woocommerce_api_customers_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request', 'woocommerce' ), $limit ), 413 );
+			}
+
+			$customers = array();
+
+			foreach ( $data as $_customer ) {
+				$customer_id = 0;
+
+				// Try to get the customer ID
+				if ( isset( $_customer['id'] ) ) {
+					$customer_id = intval( $_customer['id'] );
+				}
+
+				// Customer exists / edit customer
+				if ( $customer_id ) {
+					$edit = $this->edit_customer( $customer_id, array( 'customer' => $_customer ) );
+
+					if ( is_wp_error( $edit ) ) {
+						$customers[] = array(
+							'id'    => $customer_id,
+							'error' => array( 'code' => $edit->get_error_code(), 'message' => $edit->get_error_message() )
+						);
+					} else {
+						$customers[] = $edit['customer'];
+					}
+				}
+
+				// Customer don't exists / create customer
+				else {
+					$new = $this->create_customer( array( 'customer' => $_customer ) );
+
+					if ( is_wp_error( $new ) ) {
+						$customers[] = array(
+							'id'    => $customer_id,
+							'error' => array( 'code' => $new->get_error_code(), 'message' => $new->get_error_message() )
+						);
+					} else {
+						$customers[] = $new['customer'];
+					}
+				}
+			}
+
+			return array( 'customers' => apply_filters( 'woocommerce_api_customers_bulk_response', $customers, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+}

--- a/includes/api/v2/class-wc-api-exception.php
+++ b/includes/api/v2/class-wc-api-exception.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WooCommerce API Exception Class
+ *
+ * Extends Exception to provide additional data
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Exception extends Exception {
+
+	/** @var string sanitized error code */
+	protected $error_code;
+
+	/**
+	 * Setup exception, requires 3 params:
+	 *
+	 * error code - machine-readable, e.g. `woocommerce_invalid_product_id`
+	 * error message - friendly message, e.g. 'Product ID is invalid'
+	 * http status code - proper HTTP status code to respond with, e.g. 400
+	 *
+	 * @since 2.2
+	 * @param string $error_code
+	 * @param string $error_message user-friendly translated error message
+	 * @param int $http_status_code HTTP status code to respond with
+	 */
+	public function __construct( $error_code, $error_message, $http_status_code ) {
+		$this->error_code = $error_code;
+		parent::__construct( $error_message, $http_status_code );
+	}
+
+	/**
+	 * Returns the error code
+	 *
+	 * @since 2.2
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+}

--- a/includes/api/v2/class-wc-api-json-handler.php
+++ b/includes/api/v2/class-wc-api-json-handler.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WooCommerce API
+ *
+ * Handles parsing JSON request bodies and generating JSON responses
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_JSON_Handler implements WC_API_Handler {
+
+	/**
+	 * Get the content type for the response
+	 *
+	 * @since 2.1
+	 * @return string
+	 */
+	public function get_content_type() {
+
+		return sprintf( '%s; charset=%s', isset( $_GET['_jsonp'] ) ? 'application/javascript' : 'application/json', get_option( 'blog_charset' ) );
+	}
+
+	/**
+	 * Parse the raw request body entity
+	 *
+	 * @since 2.1
+	 * @param string $body the raw request body
+	 * @return array|mixed
+	 */
+	public function parse_body( $body ) {
+
+		return json_decode( $body, true );
+	}
+
+	/**
+	 * Generate a JSON response given an array of data
+	 *
+	 * @since 2.1
+	 * @param array $data the response data
+	 * @return string
+	 */
+	public function generate_response( $data ) {
+
+		if ( isset( $_GET['_jsonp'] ) ) {
+
+			// JSONP enabled by default
+			if ( ! apply_filters( 'woocommerce_api_jsonp_enabled', true ) ) {
+
+				WC()->api->server->send_status( 400 );
+
+				$data = array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce' ) ) );
+			}
+
+			// Check for invalid characters (only alphanumeric allowed)
+			if ( preg_match( '/\W/', $_GET['_jsonp'] ) ) {
+
+				WC()->api->server->send_status( 400 );
+
+				$data = array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce' ) ) );
+			}
+
+			// see http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/
+			WC()->api->server->header( 'X-Content-Type-Options', 'nosniff' );
+
+			// Prepend '/**/' to mitigate possible JSONP Flash attacks
+			return '/**/' . $_GET['_jsonp'] . '(' . json_encode( $data ) . ')';
+		}
+
+		return json_encode( $data );
+	}
+
+}

--- a/includes/api/v2/class-wc-api-orders.php
+++ b/includes/api/v2/class-wc-api-orders.php
@@ -1,0 +1,1843 @@
+<?php
+/**
+ * WooCommerce API Orders Class
+ *
+ * Handles requests to the /orders endpoint
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Orders extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/orders';
+
+	/** @var string $post_type the custom post type */
+	protected $post_type = 'shop_order';
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * GET|POST /orders
+	 * GET /orders/count
+	 * GET|PUT|DELETE /orders/<id>
+	 * GET /orders/<id>/notes
+	 *
+	 * @since 2.1
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET|POST /orders
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_orders' ),     WC_API_Server::READABLE ),
+			array( array( $this, 'create_order' ),   WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET /orders/count
+		$routes[ $this->base . '/count' ] = array(
+			array( array( $this, 'get_orders_count' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /orders/statuses
+		$routes[ $this->base . '/statuses' ] = array(
+			array( array( $this, 'get_order_statuses' ), WC_API_Server::READABLE ),
+		);
+
+		# GET|PUT|DELETE /orders/<id>
+		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_order' ),  WC_API_Server::READABLE ),
+			array( array( $this, 'edit_order' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order' ), WC_API_Server::DELETABLE ),
+		);
+
+		# GET|POST /orders/<id>/notes
+		$routes[ $this->base . '/(?P<order_id>\d+)/notes' ] = array(
+			array( array( $this, 'get_order_notes' ), WC_API_Server::READABLE ),
+			array( array( $this, 'create_order_note' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET|PUT|DELETE /orders/<order_id>/notes/<id>
+		$routes[ $this->base . '/(?P<order_id>\d+)/notes/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_order_note' ), WC_API_Server::READABLE ),
+			array( array( $this, 'edit_order_note' ), WC_API_SERVER::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order_note' ), WC_API_SERVER::DELETABLE ),
+		);
+
+		# GET|POST /orders/<order_id>/refunds
+		$routes[ $this->base . '/(?P<order_id>\d+)/refunds' ] = array(
+			array( array( $this, 'get_order_refunds' ), WC_API_Server::READABLE ),
+			array( array( $this, 'create_order_refund' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET|PUT|DELETE /orders/<order_id>/refunds/<id>
+		$routes[ $this->base . '/(?P<order_id>\d+)/refunds/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_order_refund' ), WC_API_Server::READABLE ),
+			array( array( $this, 'edit_order_refund' ), WC_API_SERVER::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order_refund' ), WC_API_SERVER::DELETABLE ),
+		);
+
+		# POST|PUT /orders/bulk
+		$routes[ $this->base . '/bulk' ] = array(
+			array( array( $this, 'bulk' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get all orders
+	 *
+	 * @since 2.1
+	 * @param string $fields
+	 * @param array $filter
+	 * @param string $status
+	 * @param int $page
+	 * @return array
+	 */
+	public function get_orders( $fields = null, $filter = array(), $status = null, $page = 1 ) {
+
+		if ( ! empty( $status ) ) {
+			$filter['status'] = $status;
+		}
+
+		$filter['page'] = $page;
+
+		$query = $this->query_orders( $filter );
+
+		$orders = array();
+
+		foreach ( $query->posts as $order_id ) {
+
+			if ( ! $this->is_readable( $order_id ) ) {
+				continue;
+			}
+
+			$orders[] = current( $this->get_order( $order_id, $fields, $filter ) );
+		}
+
+		$this->server->add_pagination_headers( $query );
+
+		return array( 'orders' => $orders );
+	}
+
+
+	/**
+	 * Get the order for the given ID
+	 *
+	 * @since 2.1
+	 * @param int $id the order ID
+	 * @param array $fields
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_order( $id, $fields = null, $filter = array() ) {
+
+		// ensure order ID is valid & user has permission to read
+		$id = $this->validate_request( $id, $this->post_type, 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		// Get the decimal precession
+		$dp         = ( isset( $filter['dp'] ) ? intval( $filter['dp'] ) : 2 );
+		$order      = wc_get_order( $id );
+		$order_post = get_post( $id );
+
+		$order_data = array(
+			'id'                        => $order->id,
+			'order_number'              => $order->get_order_number(),
+			'created_at'                => $this->server->format_datetime( $order_post->post_date_gmt ),
+			'updated_at'                => $this->server->format_datetime( $order_post->post_modified_gmt ),
+			'completed_at'              => $this->server->format_datetime( $order->completed_date, true ),
+			'status'                    => $order->get_status(),
+			'currency'                  => $order->get_order_currency(),
+			'total'                     => wc_format_decimal( $order->get_total(), $dp ),
+			'subtotal'                  => wc_format_decimal( $order->get_subtotal(), $dp ),
+			'total_line_items_quantity' => $order->get_item_count(),
+			'total_tax'                 => wc_format_decimal( $order->get_total_tax(), $dp ),
+			'total_shipping'            => wc_format_decimal( $order->get_total_shipping(), $dp ),
+			'cart_tax'                  => wc_format_decimal( $order->get_cart_tax(), $dp ),
+			'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), $dp ),
+			'total_discount'            => wc_format_decimal( $order->get_total_discount(), $dp ),
+			'shipping_methods'          => $order->get_shipping_method(),
+			'payment_details' => array(
+				'method_id'    => $order->payment_method,
+				'method_title' => $order->payment_method_title,
+				'paid'         => isset( $order->paid_date ),
+			),
+			'billing_address' => array(
+				'first_name' => $order->billing_first_name,
+				'last_name'  => $order->billing_last_name,
+				'company'    => $order->billing_company,
+				'address_1'  => $order->billing_address_1,
+				'address_2'  => $order->billing_address_2,
+				'city'       => $order->billing_city,
+				'state'      => $order->billing_state,
+				'postcode'   => $order->billing_postcode,
+				'country'    => $order->billing_country,
+				'email'      => $order->billing_email,
+				'phone'      => $order->billing_phone,
+			),
+			'shipping_address' => array(
+				'first_name' => $order->shipping_first_name,
+				'last_name'  => $order->shipping_last_name,
+				'company'    => $order->shipping_company,
+				'address_1'  => $order->shipping_address_1,
+				'address_2'  => $order->shipping_address_2,
+				'city'       => $order->shipping_city,
+				'state'      => $order->shipping_state,
+				'postcode'   => $order->shipping_postcode,
+				'country'    => $order->shipping_country,
+			),
+			'note'                      => $order->customer_note,
+			'customer_ip'               => $order->customer_ip_address,
+			'customer_user_agent'       => $order->customer_user_agent,
+			'customer_id'               => $order->get_user_id(),
+			'view_order_url'            => $order->get_view_order_url(),
+			'line_items'                => array(),
+			'shipping_lines'            => array(),
+			'tax_lines'                 => array(),
+			'fee_lines'                 => array(),
+			'coupon_lines'              => array(),
+		);
+
+		// add line items
+		foreach ( $order->get_items() as $item_id => $item ) {
+
+			$product     = $order->get_product_from_item( $item );
+			$product_id  = null;
+			$product_sku = null;
+
+			// Check if the product exists.
+			if ( is_object( $product ) ) {
+				$product_id  = ( isset( $product->variation_id ) ) ? $product->variation_id : $product->id;
+				$product_sku = $product->get_sku();
+			}
+
+			$meta = new WC_Order_Item_Meta( $item['item_meta'], $product );
+
+			$item_meta = array();
+
+			$hideprefix = ( isset( $filter['all_item_meta'] ) && $filter['all_item_meta'] === 'true' ) ? null : '_';
+
+			foreach ( $meta->get_formatted( $hideprefix ) as $meta_key => $formatted_meta ) {
+				$item_meta[] = array(
+					'key' => $meta_key,
+					'label' => $formatted_meta['label'],
+					'value' => $formatted_meta['value'],
+				);
+			}
+
+			$order_data['line_items'][] = array(
+				'id'           => $item_id,
+				'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item, false, false ), $dp ),
+				'subtotal_tax' => wc_format_decimal( $item['line_subtotal_tax'], $dp ),
+				'total'        => wc_format_decimal( $order->get_line_total( $item, false, false ), $dp ),
+				'total_tax'    => wc_format_decimal( $item['line_tax'], $dp ),
+				'price'        => wc_format_decimal( $order->get_item_total( $item, false, false ), $dp ),
+				'quantity'     => wc_stock_amount( $item['qty'] ),
+				'tax_class'    => ( ! empty( $item['tax_class'] ) ) ? $item['tax_class'] : null,
+				'name'         => $item['name'],
+				'product_id'   => $product_id,
+				'sku'          => $product_sku,
+				'meta'         => $item_meta,
+			);
+		}
+
+		// add shipping
+		foreach ( $order->get_shipping_methods() as $shipping_item_id => $shipping_item ) {
+
+			$order_data['shipping_lines'][] = array(
+				'id'           => $shipping_item_id,
+				'method_id'    => $shipping_item['method_id'],
+				'method_title' => $shipping_item['name'],
+				'total'        => wc_format_decimal( $shipping_item['cost'], $dp ),
+			);
+		}
+
+		// add taxes
+		foreach ( $order->get_tax_totals() as $tax_code => $tax ) {
+
+			$order_data['tax_lines'][] = array(
+				'id'       => $tax->id,
+				'rate_id'  => $tax->rate_id,
+				'code'     => $tax_code,
+				'title'    => $tax->label,
+				'total'    => wc_format_decimal( $tax->amount, $dp ),
+				'compound' => (bool) $tax->is_compound,
+			);
+		}
+
+		// add fees
+		foreach ( $order->get_fees() as $fee_item_id => $fee_item ) {
+
+			$order_data['fee_lines'][] = array(
+				'id'        => $fee_item_id,
+				'title'     => $fee_item['name'],
+				'tax_class' => ( ! empty( $fee_item['tax_class'] ) ) ? $fee_item['tax_class'] : null,
+				'total'     => wc_format_decimal( $order->get_line_total( $fee_item ), $dp ),
+				'total_tax' => wc_format_decimal( $order->get_line_tax( $fee_item ), $dp ),
+			);
+		}
+
+		// add coupons
+		foreach ( $order->get_items( 'coupon' ) as $coupon_item_id => $coupon_item ) {
+
+			$order_data['coupon_lines'][] = array(
+				'id'     => $coupon_item_id,
+				'code'   => $coupon_item['name'],
+				'amount' => wc_format_decimal( $coupon_item['discount_amount'], $dp ),
+			);
+		}
+
+		return array( 'order' => apply_filters( 'woocommerce_api_order_response', $order_data, $order, $fields, $this->server ) );
+	}
+
+	/**
+	 * Get the total number of orders
+	 *
+	 * @since 2.4
+	 * @param string $status
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_orders_count( $status = null, $filter = array() ) {
+
+		try {
+			if ( ! current_user_can( 'read_private_shop_orders' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce' ), 401 );
+			}
+
+			if ( ! empty( $status ) ) {
+
+				if ( $status == 'any' ) {
+
+					$order_statuses = array();
+
+					foreach ( wc_get_order_statuses() as $slug => $name ) {
+						$filter['status'] = str_replace( 'wc-', '', $slug );
+						$query = $this->query_orders( $filter );
+						$order_statuses[ str_replace( 'wc-', '', $slug ) ] = (int) $query->found_posts;
+					}
+
+					return array( 'count' => $order_statuses );
+
+				} else {
+					$filter['status'] = $status;
+				}
+			}
+
+			$query = $this->query_orders( $filter );
+
+			return array( 'count' => (int) $query->found_posts );
+
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get a list of valid order statuses
+	 *
+	 * Note this requires no specific permissions other than being an authenticated
+	 * API user. Order statuses (particularly custom statuses) could be considered
+	 * private information which is why it's not in the API index.
+	 *
+	 * @since 2.1
+	 * @return array
+	 */
+	public function get_order_statuses() {
+
+		$order_statuses = array();
+
+		foreach ( wc_get_order_statuses() as $slug => $name ) {
+			$order_statuses[ str_replace( 'wc-', '', $slug ) ] = $name;
+		}
+
+		return array( 'order_statuses' => apply_filters( 'woocommerce_api_order_statuses_response', $order_statuses, $this ) );
+	}
+
+	/**
+	 * Create an order
+	 *
+	 * @since 2.2
+	 * @param array $data raw order data
+	 * @return array
+	 */
+	public function create_order( $data ) {
+		global $wpdb;
+
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			if ( ! isset( $data['order'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order' ), 400 );
+			}
+
+			$data = $data['order'];
+
+			// permission check
+			if ( ! current_user_can( 'publish_shop_orders' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order', __( 'You do not have permission to create orders', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_order_data', $data, $this );
+
+			// default order args, note that status is checked for validity in wc_create_order()
+			$default_order_args = array(
+				'status'        => isset( $data['status'] ) ? $data['status'] : '',
+				'customer_note' => isset( $data['note'] ) ? $data['note'] : null,
+			);
+
+			// if creating order for existing customer
+			if ( ! empty( $data['customer_id'] ) ) {
+
+				// make sure customer exists
+				if ( false === get_user_by( 'id', $data['customer_id'] ) ) {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid', 'woocommerce' ), 400 );
+				}
+
+				$default_order_args['customer_id'] = $data['customer_id'];
+			}
+
+			// create the pending order
+			$order = $this->create_base_order( $default_order_args, $data );
+
+			if ( is_wp_error( $order ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order', sprintf( __( 'Cannot create order: %s', 'woocommerce' ), implode( ', ', $order->get_error_messages() ) ), 400 );
+			}
+
+			// billing/shipping addresses
+			$this->set_order_addresses( $order, $data );
+
+			$lines = array(
+				'line_item' => 'line_items',
+				'shipping'  => 'shipping_lines',
+				'fee'       => 'fee_lines',
+				'coupon'    => 'coupon_lines',
+			);
+
+			foreach ( $lines as $line_type => $line ) {
+
+				if ( isset( $data[ $line ] ) && is_array( $data[ $line ] ) ) {
+
+					$set_item = "set_{$line_type}";
+
+					foreach ( $data[ $line ] as $item ) {
+
+						$this->$set_item( $order, $item, 'create' );
+					}
+				}
+			}
+
+			// calculate totals and set them
+			$order->calculate_totals();
+
+			// payment method (and payment_complete() if `paid` == true)
+			if ( isset( $data['payment_details'] ) && is_array( $data['payment_details'] ) ) {
+
+				// method ID & title are required
+				if ( empty( $data['payment_details']['method_id'] ) || empty( $data['payment_details']['method_title'] ) ) {
+					throw new WC_API_Exception( 'woocommerce_invalid_payment_details', __( 'Payment method ID and title are required', 'woocommerce' ), 400 );
+				}
+
+				update_post_meta( $order->id, '_payment_method', $data['payment_details']['method_id'] );
+				update_post_meta( $order->id, '_payment_method_title', $data['payment_details']['method_title'] );
+
+				// mark as paid if set
+				if ( isset( $data['payment_details']['paid'] ) && true === $data['payment_details']['paid'] ) {
+					$order->payment_complete( isset( $data['payment_details']['transaction_id'] ) ? $data['payment_details']['transaction_id'] : '' );
+				}
+			}
+
+			// set order currency
+			if ( isset( $data['currency'] ) ) {
+
+				if ( ! array_key_exists( $data['currency'], get_woocommerce_currencies() ) ) {
+					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid', 'woocommerce'), 400 );
+				}
+
+				update_post_meta( $order->id, '_order_currency', $data['currency'] );
+			}
+
+			// set order number
+			if ( isset( $data['order_number'] ) ) {
+
+				update_post_meta( $order->id, '_order_number', $data['order_number'] );
+			}
+
+			// set order meta
+			if ( isset( $data['order_meta'] ) && is_array( $data['order_meta'] ) ) {
+				$this->set_order_meta( $order->id, $data['order_meta'] );
+			}
+
+			// HTTP 201 Created
+			$this->server->send_status( 201 );
+
+			wc_delete_shop_order_transients( $order->id );
+
+			do_action( 'woocommerce_api_create_order', $order->id, $data, $this );
+
+			$wpdb->query( 'COMMIT' );
+
+			return $this->get_order( $order->id );
+
+		} catch ( WC_API_Exception $e ) {
+
+			$wpdb->query( 'ROLLBACK' );
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Creates new WC_Order.
+	 *
+	 * Requires a separate function for classes that extend WC_API_Orders.
+	 *
+	 * @since 2.3
+	 * @param $args array
+	 * @return WC_Order
+	 */
+	protected function create_base_order( $args, $data ) {
+		return wc_create_order( $args );
+	}
+
+	/**
+	 * Edit an order
+	 *
+	 * @since 2.2
+	 * @param int $id the order ID
+	 * @param array $data
+	 * @return array
+	 */
+	public function edit_order( $id, $data ) {
+
+		try {
+			if ( ! isset( $data['order'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order' ), 400 );
+			}
+
+			$data = $data['order'];
+
+			$update_totals = false;
+
+			$id = $this->validate_request( $id, $this->post_type, 'edit' );
+
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+
+			$data  = apply_filters( 'woocommerce_api_edit_order_data', $data, $id, $this );
+			$order = wc_get_order( $id );
+
+			if ( empty( $order ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce' ), 400 );
+			}
+
+			$order_args = array( 'order_id' => $order->id );
+
+			// customer note
+			if ( isset( $data['note'] ) ) {
+				$order_args['customer_note'] = $data['note'];
+			}
+
+			// order status
+			if ( ! empty( $data['status'] ) ) {
+
+				$order->update_status( $data['status'], isset( $data['status_note'] ) ? $data['status_note'] : '' );
+			}
+
+			// customer ID
+			if ( isset( $data['customer_id'] ) && $data['customer_id'] != $order->get_user_id() ) {
+
+				// make sure customer exists
+				if ( false === get_user_by( 'id', $data['customer_id'] ) ) {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid', 'woocommerce' ), 400 );
+				}
+
+				update_post_meta( $order->id, '_customer_user', $data['customer_id'] );
+			}
+
+			// billing/shipping address
+			$this->set_order_addresses( $order, $data );
+
+			$lines = array(
+				'line_item' => 'line_items',
+				'shipping'  => 'shipping_lines',
+				'fee'       => 'fee_lines',
+				'coupon'    => 'coupon_lines',
+			);
+
+			foreach ( $lines as $line_type => $line ) {
+
+				if ( isset( $data[ $line ] ) && is_array( $data[ $line ] ) ) {
+
+					$update_totals = true;
+
+					foreach ( $data[ $line ] as $item ) {
+
+						// item ID is always required
+						if ( ! array_key_exists( 'id', $item ) ) {
+							throw new WC_API_Exception( 'woocommerce_invalid_item_id', __( 'Order item ID is required', 'woocommerce' ), 400 );
+						}
+
+						// create item
+						if ( is_null( $item['id'] ) ) {
+
+							$this->set_item( $order, $line_type, $item, 'create' );
+
+						} elseif ( $this->item_is_null( $item ) ) {
+
+							// delete item
+							wc_delete_order_item( $item['id'] );
+
+						} else {
+
+							// update item
+							$this->set_item( $order, $line_type, $item, 'update' );
+						}
+					}
+				}
+			}
+
+			// payment method (and payment_complete() if `paid` == true and order needs payment)
+			if ( isset( $data['payment_details'] ) && is_array( $data['payment_details'] ) ) {
+
+				// method ID
+				if ( isset( $data['payment_details']['method_id'] ) ) {
+					update_post_meta( $order->id, '_payment_method', $data['payment_details']['method_id'] );
+				}
+
+				// method title
+				if ( isset( $data['payment_details']['method_title'] ) ) {
+					update_post_meta( $order->id, '_payment_method_title', $data['payment_details']['method_title'] );
+				}
+
+				// mark as paid if set
+				if ( $order->needs_payment() && isset( $data['payment_details']['paid'] ) && true === $data['payment_details']['paid'] ) {
+					$order->payment_complete( isset( $data['payment_details']['transaction_id'] ) ? $data['payment_details']['transaction_id'] : '' );
+				}
+			}
+
+			// set order currency
+			if ( isset( $data['currency'] ) ) {
+
+				if ( ! array_key_exists( $data['currency'], get_woocommerce_currencies() ) ) {
+					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid', 'woocommerce' ), 400 );
+				}
+
+				update_post_meta( $order->id, '_order_currency', $data['currency'] );
+			}
+
+			// set order number
+			if ( isset( $data['order_number'] ) ) {
+
+				update_post_meta( $order->id, '_order_number', $data['order_number'] );
+			}
+
+			// if items have changed, recalculate order totals
+			if ( $update_totals ) {
+				$order->calculate_totals();
+			}
+
+			// update order meta
+			if ( isset( $data['order_meta'] ) && is_array( $data['order_meta'] ) ) {
+				$this->set_order_meta( $order->id, $data['order_meta'] );
+			}
+
+			// update the order post to set customer note/modified date
+			wc_update_order( $order_args );
+
+			wc_delete_shop_order_transients( $order->id );
+
+			do_action( 'woocommerce_api_edit_order', $order->id, $data, $this );
+
+			return $this->get_order( $id );
+
+		} catch ( WC_API_Exception $e ) {
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete an order
+	 *
+	 * @param int $id the order ID
+	 * @param bool $force true to permanently delete order, false to move to trash
+	 * @return array
+	 */
+	public function delete_order( $id, $force = false ) {
+
+		$id = $this->validate_request( $id, $this->post_type, 'delete' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		wc_delete_shop_order_transients( $id );
+
+		do_action( 'woocommerce_api_delete_order', $id, $this );
+
+		return $this->delete( $id, 'order',  ( 'true' === $force ) );
+	}
+
+	/**
+	 * Helper method to get order post objects
+	 *
+	 * @since 2.1
+	 * @param array $args request arguments for filtering query
+	 * @return WP_Query
+	 */
+	protected function query_orders( $args ) {
+
+		// set base query arguments
+		$query_args = array(
+			'fields'      => 'ids',
+			'post_type'   => $this->post_type,
+			'post_status' => array_keys( wc_get_order_statuses() )
+		);
+
+		// add status argument
+		if ( ! empty( $args['status'] ) ) {
+
+			$statuses                  = 'wc-' . str_replace( ',', ',wc-', $args['status'] );
+			$statuses                  = explode( ',', $statuses );
+			$query_args['post_status'] = $statuses;
+
+			unset( $args['status'] );
+
+		}
+
+		$query_args = $this->merge_query_args( $query_args, $args );
+
+		return new WP_Query( $query_args );
+	}
+
+	/**
+	 * Helper method to set/update the billing & shipping addresses for
+	 * an order
+	 *
+	 * @since 2.1
+	 * @param \WC_Order $order
+	 * @param array $data
+	 */
+	protected function set_order_addresses( $order, $data ) {
+
+		$address_fields = array(
+			'first_name',
+			'last_name',
+			'company',
+			'email',
+			'phone',
+			'address_1',
+			'address_2',
+			'city',
+			'state',
+			'postcode',
+			'country',
+		);
+
+		$billing_address = $shipping_address = array();
+
+		// billing address
+		if ( isset( $data['billing_address'] ) && is_array( $data['billing_address'] ) ) {
+
+			foreach ( $address_fields as $field ) {
+
+				if ( isset( $data['billing_address'][ $field ] ) ) {
+					$billing_address[ $field ] = wc_clean( $data['billing_address'][ $field ] );
+				}
+			}
+
+			unset( $address_fields['email'] );
+			unset( $address_fields['phone'] );
+		}
+
+		// shipping address
+		if ( isset( $data['shipping_address'] ) && is_array( $data['shipping_address'] ) ) {
+
+			foreach ( $address_fields as $field ) {
+
+				if ( isset( $data['shipping_address'][ $field ] ) ) {
+					$shipping_address[ $field ] = wc_clean( $data['shipping_address'][ $field ] );
+				}
+			}
+		}
+
+		$order->set_address( $billing_address, 'billing' );
+		$order->set_address( $shipping_address, 'shipping' );
+
+		// update user meta
+		if ( $order->get_user_id() ) {
+			foreach ( $billing_address as $key => $value ) {
+				update_user_meta( $order->get_user_id(), 'billing_' . $key, $value );
+			}
+			foreach ( $shipping_address as $key => $value ) {
+				update_user_meta( $order->get_user_id(), 'shipping_' . $key, $value );
+			}
+		}
+	}
+
+	/**
+	 * Helper method to add/update order meta, with two restrictions:
+	 *
+	 * 1) Only non-protected meta (no leading underscore) can be set
+	 * 2) Meta values must be scalar (int, string, bool)
+	 *
+	 * @since 2.2
+	 * @param int $order_id valid order ID
+	 * @param array $order_meta order meta in array( 'meta_key' => 'meta_value' ) format
+	 */
+	protected function set_order_meta( $order_id, $order_meta ) {
+
+		foreach ( $order_meta as $meta_key => $meta_value ) {
+
+			if ( is_string( $meta_key) && ! is_protected_meta( $meta_key ) && is_scalar( $meta_value ) ) {
+				update_post_meta( $order_id, $meta_key, $meta_value );
+			}
+		}
+	}
+
+	/**
+	 * Helper method to check if the resource ID associated with the provided item is null
+	 *
+	 * Items can be deleted by setting the resource ID to null
+	 *
+	 * @since 2.2
+	 * @param array $item item provided in the request body
+	 * @return bool true if the item resource ID is null, false otherwise
+	 */
+	protected function item_is_null( $item ) {
+
+		$keys = array( 'product_id', 'method_id', 'title', 'code' );
+
+		foreach ( $keys as $key ) {
+			if ( array_key_exists( $key, $item ) && is_null( $item[ $key ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Wrapper method to create/update order items
+	 *
+	 * When updating, the item ID provided is checked to ensure it is associated
+	 * with the order.
+	 *
+	 * @since 2.2
+	 * @param \WC_Order $order order
+	 * @param string $item_type
+	 * @param array $item item provided in the request body
+	 * @param string $action either 'create' or 'update'
+	 * @throws WC_API_Exception if item ID is not associated with order
+	 */
+	protected function set_item( $order, $item_type, $item, $action ) {
+		global $wpdb;
+
+		$set_method = "set_{$item_type}";
+
+		// verify provided line item ID is associated with order
+		if ( 'update' === $action ) {
+
+			$result = $wpdb->get_row(
+				$wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d AND order_id = %d",
+				absint( $item['id'] ),
+				absint( $order->id )
+			) );
+
+			if ( is_null( $result ) ) {
+				throw new WC_API_Exception( 'woocommerce_invalid_item_id', __( 'Order item ID provided is not associated with order', 'woocommerce' ), 400 );
+			}
+		}
+
+		$this->$set_method( $order, $item, $action );
+	}
+
+	/**
+	 * Create or update a line item
+	 *
+	 * @since 2.2
+	 * @param \WC_Order $order
+	 * @param array $item line item data
+	 * @param string $action 'create' to add line item or 'update' to update it
+	 * @throws WC_API_Exception invalid data, server error
+	 */
+	protected function set_line_item( $order, $item, $action ) {
+
+		$creating = ( 'create' === $action );
+
+		// product is always required
+		if ( ! isset( $item['product_id'] ) && ! isset( $item['sku'] ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID or SKU is required', 'woocommerce' ), 400 );
+		}
+
+		// when updating, ensure product ID provided matches
+		if ( 'update' === $action ) {
+
+			$item_product_id   = wc_get_order_item_meta( $item['id'], '_product_id' );
+			$item_variation_id = wc_get_order_item_meta( $item['id'], '_variation_id' );
+
+			if ( $item['product_id'] != $item_product_id && $item['product_id'] != $item_variation_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID provided does not match this line item', 'woocommerce' ), 400 );
+			}
+		}
+
+		if ( isset( $item['product_id'] ) ) {
+			$product_id = $item['product_id'];
+		} elseif ( isset( $item['sku'] ) ) {
+			$product_id = wc_get_product_id_by_sku( $item['sku'] );
+		}
+
+		// variations must each have a key & value
+		$variation_id = 0;
+		if ( isset( $item['variations'] ) && is_array( $item['variations'] ) ) {
+			foreach ( $item['variations'] as $key => $value ) {
+				if ( ! $key || ! $value ) {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_product_variation', __( 'The product variation is invalid', 'woocommerce' ), 400 );
+				}
+			}
+			$item_args['variation'] = $item['variations'];
+			$variation_id = $this->get_variation_id( wc_get_product( $product_id ), $item_args['variation'] );
+		}
+
+		$product = wc_get_product( $variation_id ? $variation_id : $product_id );
+
+		// must be a valid WC_Product
+		if ( ! is_object( $product ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product', __( 'Product is invalid', 'woocommerce' ), 400 );
+		}
+
+		// quantity must be positive float
+		if ( isset( $item['quantity'] ) && floatval( $item['quantity'] ) <= 0 ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity must be a positive float', 'woocommerce' ), 400 );
+		}
+
+		// quantity is required when creating
+		if ( $creating && ! isset( $item['quantity'] ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity is required', 'woocommerce' ), 400 );
+		}
+
+		$item_args = array();
+
+		// quantity
+		if ( isset( $item['quantity'] ) ) {
+			$item_args['qty'] = $item['quantity'];
+		}
+
+		// total
+		if ( isset( $item['total'] ) ) {
+			$item_args['totals']['total'] = floatval( $item['total'] );
+		}
+
+		// total tax
+		if ( isset( $item['total_tax'] ) ) {
+			$item_args['totals']['tax'] = floatval( $item['total_tax'] );
+		}
+
+		// subtotal
+		if ( isset( $item['subtotal'] ) ) {
+			$item_args['totals']['subtotal'] = floatval( $item['subtotal'] );
+		}
+
+		// subtotal tax
+		if ( isset( $item['subtotal_tax'] ) ) {
+			$item_args['totals']['subtotal_tax'] = floatval( $item['subtotal_tax'] );
+		}
+
+		if ( $creating ) {
+
+			$item_id = $order->add_product( $product, $item_args['qty'], $item_args );
+
+			if ( ! $item_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_create_line_item', __( 'Cannot create line item, try again', 'woocommerce' ), 500 );
+			}
+
+		} else {
+
+			$item_id = $order->update_product( $item['id'], $product, $item_args );
+
+			if ( ! $item_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_update_line_item', __( 'Cannot update line item, try again', 'woocommerce' ), 500 );
+			}
+		}
+	}
+
+	/**
+	 * Given a product ID & API provided variations, find the correct variation ID to use for calculation
+	 * We can't just trust input from the API to pass a variation_id manually, otherwise you could pass
+	 * the cheapest variation ID but provide other information so we have to look up the variation ID.
+	 * @param  int $product_id main product ID
+	 * @return int             returns an ID if a valid variation was found for this product
+	 */
+	function get_variation_id( $product, $variations = array() ) {
+		$variation_id = null;
+		$variations_normalized = array();
+
+		if ( $product->is_type( 'variable' ) && $product->has_child() ) {
+			if ( isset( $variations ) && is_array( $variations ) ) {
+				// start by normalizing the passed variations
+				foreach ( $variations as $key => $value ) {
+					$key = str_replace( 'attribute_', '', str_replace( 'pa_', '', $key ) ); // from get_attributes in class-wc-api-products.php
+					$variations_normalized[ $key ] = strtolower( $value );
+				}
+				// now search through each product child and see if our passed variations match anything
+				foreach ( $product->get_children() as $variation ) {
+					$meta = array();
+					foreach ( get_post_meta( $variation ) as $key => $value ) {
+						$value = $value[0];
+						$key = str_replace( 'attribute_', '', str_replace( 'pa_', '', $key ) );
+						$meta[ $key ] = strtolower( $value );
+					}
+					// if the variation array is a part of the $meta array, we found our match
+					if ( $this->array_contains( $variations_normalized, $meta ) ) {
+						$variation_id = $variation;
+						break;
+					}
+				}
+			}
+		}
+
+		return $variation_id;
+	}
+
+	/**
+	 * Utility function to see if the meta array contains data from variations
+	 */
+	protected function array_contains( $needles, $haystack ) {
+		foreach ( $needles as $key => $value ) {
+			if ( $haystack[ $key ] !== $value ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Create or update an order shipping method
+	 *
+	 * @since 2.2
+	 * @param \WC_Order $order
+	 * @param array $shipping item data
+	 * @param string $action 'create' to add shipping or 'update' to update it
+	 * @throws WC_API_Exception invalid data, server error
+	 */
+	protected function set_shipping( $order, $shipping, $action ) {
+
+		// total must be a positive float
+		if ( isset( $shipping['total'] ) && floatval( $shipping['total'] ) < 0 ) {
+			throw new WC_API_Exception( 'woocommerce_invalid_shipping_total', __( 'Shipping total must be a positive amount', 'woocommerce' ), 400 );
+		}
+
+		if ( 'create' === $action ) {
+
+			// method ID is required
+			if ( ! isset( $shipping['method_id'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_invalid_shipping_item', __( 'Shipping method ID is required', 'woocommerce' ), 400 );
+			}
+
+			$rate = new WC_Shipping_Rate( $shipping['method_id'], isset( $shipping['method_title'] ) ? $shipping['method_title'] : '', isset( $shipping['total'] ) ? floatval( $shipping['total'] ) : 0, array(), $shipping['method_id'] );
+
+			$shipping_id = $order->add_shipping( $rate );
+
+			if ( ! $shipping_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_create_shipping', __( 'Cannot create shipping method, try again', 'woocommerce' ), 500 );
+			}
+
+		} else {
+
+			$shipping_args = array();
+
+			if ( isset( $shipping['method_id'] ) ) {
+				$shipping_args['method_id'] = $shipping['method_id'];
+			}
+
+			if ( isset( $shipping['method_title'] ) ) {
+				$shipping_args['method_title'] = $shipping['method_title'];
+			}
+
+			if ( isset( $shipping['total'] ) ) {
+				$shipping_args['cost'] = floatval( $shipping['total'] );
+			}
+
+			$shipping_id = $order->update_shipping( $shipping['id'], $shipping_args );
+
+			if ( ! $shipping_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again', 'woocommerce' ), 500 );
+			}
+		}
+	}
+
+	/**
+	 * Create or update an order fee
+	 *
+	 * @since 2.2
+	 * @param \WC_Order $order
+	 * @param array $fee item data
+	 * @param string $action 'create' to add fee or 'update' to update it
+	 * @throws WC_API_Exception invalid data, server error
+	 */
+	protected function set_fee( $order, $fee, $action ) {
+
+		if ( 'create' === $action ) {
+
+			// fee title is required
+			if ( ! isset( $fee['title'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee title is required', 'woocommerce' ), 400 );
+			}
+
+			$order_fee            = new stdClass();
+			$order_fee->id        = sanitize_title( $fee['title'] );
+			$order_fee->name      = $fee['title'];
+			$order_fee->amount    = isset( $fee['total'] ) ? floatval( $fee['total'] ) : 0;
+			$order_fee->taxable   = false;
+			$order_fee->tax       = 0;
+			$order_fee->tax_data  = array();
+			$order_fee->tax_class = '';
+
+			// if taxable, tax class and total are required
+			if ( isset( $fee['taxable'] ) && $fee['taxable'] ) {
+
+				if ( ! isset( $fee['tax_class'] ) ) {
+					throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee tax class is required when fee is taxable', 'woocommerce' ), 400 );
+				}
+
+				$order_fee->taxable   = true;
+				$order_fee->tax_class = $fee['tax_class'];
+
+				if ( isset( $fee['total_tax'] ) ) {
+					$order_fee->tax = isset( $fee['total_tax'] ) ? wc_format_refund_total( $fee['total_tax'] ) : 0;
+				}
+
+				if ( isset( $fee['tax_data'] ) ) {
+					$order_fee->tax      = wc_format_refund_total( array_sum( $fee['tax_data'] ) );
+					$order_fee->tax_data = array_map( 'wc_format_refund_total', $fee['tax_data'] );
+				}
+			}
+
+			$fee_id = $order->add_fee( $order_fee );
+
+			if ( ! $fee_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_create_fee', __( 'Cannot create fee, try again', 'woocommerce' ), 500 );
+			}
+
+		} else {
+
+			$fee_args = array();
+
+			if ( isset( $fee['title'] ) ) {
+				$fee_args['name'] = $fee['title'];
+			}
+
+			if ( isset( $fee['tax_class'] ) ) {
+				$fee_args['tax_class'] = $fee['tax_class'];
+			}
+
+			if ( isset( $fee['total'] ) ) {
+				$fee_args['line_total'] = floatval( $fee['total'] );
+			}
+
+			if ( isset( $fee['total_tax'] ) ) {
+				$fee_args['line_tax'] = floatval( $fee['total_tax'] );
+			}
+
+			$fee_id = $order->update_fee( $fee['id'], $fee_args );
+
+			if ( ! $fee_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again', 'woocommerce' ), 500 );
+			}
+		}
+	}
+
+	/**
+	 * Create or update an order coupon
+	 *
+	 * @since 2.2
+	 * @param \WC_Order $order
+	 * @param array $coupon item data
+	 * @param string $action 'create' to add coupon or 'update' to update it
+	 * @throws WC_API_Exception invalid data, server error
+	 */
+	protected function set_coupon( $order, $coupon, $action ) {
+
+		// coupon amount must be positive float
+		if ( isset( $coupon['amount'] ) && floatval( $coupon['amount'] ) < 0 ) {
+			throw new WC_API_Exception( 'woocommerce_invalid_coupon_total', __( 'Coupon discount total must be a positive amount', 'woocommerce' ), 400 );
+		}
+
+		if ( 'create' === $action ) {
+
+			// coupon code is required
+			if ( empty( $coupon['code'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_invalid_coupon_coupon', __( 'Coupon code is required', 'woocommerce' ), 400 );
+			}
+
+			$coupon_id = $order->add_coupon( $coupon['code'], isset( $coupon['amount'] ) ? floatval( $coupon['amount'] ) : 0 );
+
+			if ( ! $coupon_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_create_order_coupon', __( 'Cannot create coupon, try again', 'woocommerce' ), 500 );
+			}
+
+		} else {
+
+			$coupon_args = array();
+
+			if ( isset( $coupon['code'] ) ) {
+				$coupon_args['code'] = $coupon['code'];
+			}
+
+			if ( isset( $coupon['amount'] ) ) {
+				$coupon_args['discount_amount'] = floatval( $coupon['amount'] );
+			}
+
+			$coupon_id = $order->update_coupon( $coupon['id'], $coupon_args );
+
+			if ( ! $coupon_id ) {
+				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again', 'woocommerce' ), 500 );
+			}
+		}
+	}
+
+	/**
+	 * Get the admin order notes for an order
+	 *
+	 * @since 2.1
+	 * @param string $order_id order ID
+	 * @param string|null $fields fields to include in response
+	 * @return array
+	 */
+	public function get_order_notes( $order_id, $fields = null ) {
+
+		// ensure ID is valid order ID
+		$order_id = $this->validate_request( $order_id, $this->post_type, 'read' );
+
+		if ( is_wp_error( $order_id ) ) {
+			return $order_id;
+		}
+
+		$args = array(
+			'post_id' => $order_id,
+			'approve' => 'approve',
+			'type'    => 'order_note'
+		);
+
+		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+
+		$notes = get_comments( $args );
+
+		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+
+		$order_notes = array();
+
+		foreach ( $notes as $note ) {
+
+			$order_notes[] = current( $this->get_order_note( $order_id, $note->comment_ID, $fields ) );
+		}
+
+		return array( 'order_notes' => apply_filters( 'woocommerce_api_order_notes_response', $order_notes, $order_id, $fields, $notes, $this->server ) );
+	}
+
+	/**
+	 * Get an order note for the given order ID and ID
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string $id order note ID
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_order_note( $order_id, $id, $fields = null ) {
+		try {
+			// Validate order ID
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'read' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+			}
+
+			$note = get_comment( $id );
+
+			if ( is_null( $note ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			$order_note = array(
+				'id'            => $note->comment_ID,
+				'created_at'    => $this->server->format_datetime( $note->comment_date_gmt ),
+				'note'          => $note->comment_content,
+				'customer_note' => get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ? true : false,
+			);
+
+			return array( 'order_note' => apply_filters( 'woocommerce_api_order_note_response', $order_note, $id, $fields, $note, $order_id, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Create a new order note for the given order
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param array $data raw request data
+	 * @return WP_Error|array error or created note response data
+	 */
+	public function create_order_note( $order_id, $data ) {
+		try {
+			if ( ! isset( $data['order_note'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order_note' ), 400 );
+			}
+
+			$data = $data['order_note'];
+
+			// permission check
+			if ( ! current_user_can( 'publish_shop_orders' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_note', __( 'You do not have permission to create order notes', 'woocommerce' ), 401 );
+			}
+
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'edit' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			$order = wc_get_order( $order_id );
+
+			$data = apply_filters( 'woocommerce_api_create_order_note_data', $data, $order_id, $this );
+
+			// note content is required
+			if ( ! isset( $data['note'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note', __( 'Order note is required', 'woocommerce' ), 400 );
+			}
+
+			$is_customer_note = ( isset( $data['customer_note'] ) && true === $data['customer_note'] );
+
+			// create the note
+			$note_id = $order->add_order_note( $data['note'], $is_customer_note );
+
+			if ( ! $note_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again', 'woocommerce' ), 500 );
+			}
+
+			// HTTP 201 Created
+			$this->server->send_status( 201 );
+
+			do_action( 'woocommerce_api_create_order_note', $note_id, $order_id, $this );
+
+			return $this->get_order_note( $order->id, $note_id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit the order note
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string $id note ID
+	 * @param array $data parsed request data
+	 * @return WP_Error|array error or edited note response data
+	 */
+	public function edit_order_note( $order_id, $id, $data ) {
+		try {
+			if ( ! isset( $data['order_note'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order_note' ), 400 );
+			}
+
+			$data = $data['order_note'];
+
+			// Validate order ID
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'edit' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			$order = wc_get_order( $order_id );
+
+			// Validate note ID
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+			}
+
+			// Ensure note ID is valid
+			$note = get_comment( $id );
+
+			if ( is_null( $note ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			// Ensure note ID is associated with given order
+			if ( $note->comment_post_ID != $order->id ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce' ), 400 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_order_note_data', $data, $note->comment_ID, $order->id, $this );
+
+			// Note content
+			if ( isset( $data['note'] ) ) {
+
+				wp_update_comment(
+					array(
+						'comment_ID'      => $note->comment_ID,
+						'comment_content' => $data['note'],
+					)
+				);
+			}
+
+			// Customer note
+			if ( isset( $data['customer_note'] ) ) {
+
+				update_comment_meta( $note->comment_ID, 'is_customer_note', true === $data['customer_note'] ? 1 : 0 );
+			}
+
+			do_action( 'woocommerce_api_edit_order_note', $note->comment_ID, $order->id, $this );
+
+			return $this->get_order_note( $order->id, $note->comment_ID );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete order note
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string $id note ID
+	 * @return WP_Error|array error or deleted message
+	 */
+	public function delete_order_note( $order_id, $id ) {
+		try {
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'delete' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			// Validate note ID
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+			}
+
+			// Ensure note ID is valid
+			$note = get_comment( $id );
+
+			if ( is_null( $note ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			// Ensure note ID is associated with given order
+			if ( $note->comment_post_ID != $order_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce' ), 400 );
+			}
+
+			// Force delete since trashed order notes could not be managed through comments list table
+			$result = wp_delete_comment( $note->comment_ID, true );
+
+			if ( ! $result ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce' ), 500 );
+			}
+
+			do_action( 'woocommerce_api_delete_order_note', $note->comment_ID, $order_id, $this );
+
+			return array( 'message' => __( 'Permanently deleted order note', 'woocommerce' ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get the order refunds for an order
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string|null $fields fields to include in response
+	 * @return array
+	 */
+	public function get_order_refunds( $order_id, $fields = null ) {
+
+		// Ensure ID is valid order ID
+		$order_id = $this->validate_request( $order_id, $this->post_type, 'read' );
+
+		if ( is_wp_error( $order_id ) ) {
+			return $order_id;
+		}
+
+		$refund_items = get_posts(
+			array(
+				'post_type'      => 'shop_order_refund',
+				'post_parent'    => $order_id,
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+				'fields'         => 'ids'
+			)
+		);
+		$order_refunds = array();
+
+		foreach ( $refund_items as $refund_id ) {
+			$order_refunds[] = current( $this->get_order_refund( $order_id, $refund_id, $fields ) );
+		}
+
+		return array( 'order_refunds' => apply_filters( 'woocommerce_api_order_refunds_response', $order_refunds, $order_id, $fields, $refund_items, $this ) );
+	}
+
+	/**
+	 * Get an order refund for the given order ID and ID
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_order_refund( $order_id, $id, $fields = null ) {
+		try {
+			// Validate order ID
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'read' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID', 'woocommerce' ), 400 );
+			}
+
+			$order  = wc_get_order( $id );
+			$refund = wc_get_order( $id );
+
+			if ( ! $refund ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			$line_items = array();
+
+			// Add line items
+			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
+
+				$product   = $order->get_product_from_item( $item );
+				$meta      = new WC_Order_Item_Meta( $item['item_meta'], $product );
+				$item_meta = array();
+
+				foreach ( $meta->get_formatted() as $meta_key => $formatted_meta ) {
+					$item_meta[] = array(
+						'key' => $meta_key,
+						'label' => $formatted_meta['label'],
+						'value' => $formatted_meta['value'],
+					);
+				}
+
+				$line_items[] = array(
+					'id'           => $item_id,
+					'subtotal'     => wc_format_decimal( $order->get_line_subtotal( $item ), 2 ),
+					'subtotal_tax' => wc_format_decimal( $item['line_subtotal_tax'], 2 ),
+					'total'        => wc_format_decimal( $order->get_line_total( $item ), 2 ),
+					'total_tax'    => wc_format_decimal( $order->get_line_tax( $item ), 2 ),
+					'price'        => wc_format_decimal( $order->get_item_total( $item ), 2 ),
+					'quantity'     => (int) $item['qty'],
+					'tax_class'    => ( ! empty( $item['tax_class'] ) ) ? $item['tax_class'] : null,
+					'name'         => $item['name'],
+					'product_id'   => ( isset( $product->variation_id ) ) ? $product->variation_id : $product->id,
+					'sku'          => is_object( $product ) ? $product->get_sku() : null,
+					'meta'         => $item_meta,
+				);
+			}
+
+			$order_refund = array(
+				'id'         => $refund->id,
+				'created_at' => $this->server->format_datetime( $refund->date ),
+				'amount'     => wc_format_decimal( $refund->get_refund_amount(), 2 ),
+				'reason'     => $refund->get_refund_reason(),
+				'line_items' => $line_items
+			);
+
+			return array( 'order_refund' => apply_filters( 'woocommerce_api_order_refund_response', $order_refund, $id, $fields, $refund, $order_id, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Create a new order refund for the given order
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param array $data raw request data
+	 * @param bool $api_refund do refund using a payment gateway API
+	 * @return WP_Error|array error or created refund response data
+	 */
+	public function create_order_refund( $order_id, $data, $api_refund = true ) {
+		try {
+			if ( ! isset( $data['order_refund'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order_refund' ), 400 );
+			}
+
+			$data = $data['order_refund'];
+
+			// Permission check
+			if ( ! current_user_can( 'publish_shop_orders' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_refund', __( 'You do not have permission to create order refunds', 'woocommerce' ), 401 );
+			}
+
+			$order_id = absint( $order_id );
+
+			if ( empty( $order_id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce' ), 400 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_order_refund_data', $data, $order_id, $this );
+
+			// Refund amount is required
+			if ( ! isset( $data['amount'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount is required', 'woocommerce' ), 400 );
+			} elseif ( 0 > $data['amount'] ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount must be positive', 'woocommerce' ), 400 );
+			}
+
+			$data['order_id']  = $order_id;
+			$data['refund_id'] = 0;
+
+			// Create the refund
+			$refund = wc_create_refund( $data );
+
+			if ( ! $refund ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_refund', __( 'Cannot create order refund, please try again', 'woocommerce' ), 500 );
+			}
+
+			// Refund via API
+			if ( $api_refund ) {
+				if ( WC()->payment_gateways() ) {
+					$payment_gateways = WC()->payment_gateways->payment_gateways();
+				}
+
+				$order = wc_get_order( $order_id );
+
+				if ( isset( $payment_gateways[ $order->payment_method ] ) && $payment_gateways[ $order->payment_method ]->supports( 'refunds' ) ) {
+					$result = $payment_gateways[ $order->payment_method ]->process_refund( $order_id, $refund->get_refund_amount(), $refund->get_refund_reason() );
+
+					if ( is_wp_error( $result ) ) {
+						return $result;
+					} elseif ( ! $result ) {
+						throw new WC_API_Exception( 'woocommerce_api_create_order_refund_api_failed', __( 'An error occurred while attempting to create the refund using the payment gateway API', 'woocommerce' ), 500 );
+					}
+				}
+			}
+
+			// HTTP 201 Created
+			$this->server->send_status( 201 );
+
+			do_action( 'woocommerce_api_create_order_refund', $refund->id, $order_id, $this );
+
+			return $this->get_order_refund( $order_id, $refund->id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit an order refund
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string $id refund ID
+	 * @param array $data parsed request data
+	 * @return WP_Error|array error or edited refund response data
+	 */
+	public function edit_order_refund( $order_id, $id, $data ) {
+		try {
+			if ( ! isset( $data['order_refund'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order_refund' ), 400 );
+			}
+
+			$data = $data['order_refund'];
+
+			// Validate order ID
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'edit' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			// Validate refund ID
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID', 'woocommerce' ), 400 );
+			}
+
+			// Ensure order ID is valid
+			$refund = get_post( $id );
+
+			if ( ! $refund ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			// Ensure refund ID is associated with given order
+			if ( $refund->post_parent != $order_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order', 'woocommerce' ), 400 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_order_refund_data', $data, $refund->ID, $order_id, $this );
+
+			// Update reason
+			if ( isset( $data['reason'] ) ) {
+				$updated_refund = wp_update_post( array( 'ID' => $refund->ID, 'post_excerpt' => $data['reason'] ) );
+
+				if ( is_wp_error( $updated_refund ) ) {
+					return $updated_refund;
+				}
+			}
+
+			// Update refund amount
+			if ( isset( $data['amount'] ) && 0 < $data['amount'] ) {
+				update_post_meta( $refund->ID, '_refund_amount', wc_format_decimal( $data['amount'] ) );
+			}
+
+			do_action( 'woocommerce_api_edit_order_refund', $refund->ID, $order_id, $this );
+
+			return $this->get_order_refund( $order_id, $refund->ID );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete order refund
+	 *
+	 * @since 2.2
+	 * @param string $order_id order ID
+	 * @param string $id refund ID
+	 * @return WP_Error|array error or deleted message
+	 */
+	public function delete_order_refund( $order_id, $id ) {
+		try {
+			$order_id = $this->validate_request( $order_id, $this->post_type, 'delete' );
+
+			if ( is_wp_error( $order_id ) ) {
+				return $order_id;
+			}
+
+			// Validate refund ID
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID', 'woocommerce' ), 400 );
+			}
+
+			// Ensure refund ID is valid
+			$refund = get_post( $id );
+
+			if ( ! $refund ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			// Ensure refund ID is associated with given order
+			if ( $refund->post_parent != $order_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order', 'woocommerce' ), 400 );
+			}
+
+			wc_delete_shop_order_transients( $order_id );
+
+			do_action( 'woocommerce_api_delete_order_refund', $refund->ID, $order_id, $this );
+
+			return $this->delete( $refund->ID, 'refund', true );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Bulk update or insert orders
+	 * Accepts an array with orders in the formats supported by
+	 * WC_API_Orders->create_order() and WC_API_Orders->edit_order()
+	 *
+	 * @since 2.4.0
+	 * @param array $data
+	 * @return array
+	 */
+	public function bulk( $data ) {
+
+		try {
+			if ( ! isset( $data['orders'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_orders_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'orders' ), 400 );
+			}
+
+			$data  = $data['orders'];
+			$limit = apply_filters( 'woocommerce_api_bulk_limit', 100, 'orders' );
+
+			// Limit bulk operation
+			if ( count( $data ) > $limit ) {
+				throw new WC_API_Exception( 'woocommerce_api_orders_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request', 'woocommerce' ), $limit ), 413 );
+			}
+
+			$orders = array();
+
+			foreach ( $data as $_order ) {
+				$order_id = 0;
+
+				// Try to get the order ID
+				if ( isset( $_order['id'] ) ) {
+					$order_id = intval( $_order['id'] );
+				}
+
+				// Order exists / edit order
+				if ( $order_id ) {
+					$edit = $this->edit_order( $order_id, array( 'order' => $_order ) );
+
+					if ( is_wp_error( $edit ) ) {
+						$orders[] = array(
+							'id'    => $order_id,
+							'error' => array( 'code' => $edit->get_error_code(), 'message' => $edit->get_error_message() )
+						);
+					} else {
+						$orders[] = $edit['order'];
+					}
+				}
+
+				// Order don't exists / create order
+				else {
+					$new = $this->create_order( array( 'order' => $_order ) );
+
+					if ( is_wp_error( $new ) ) {
+						$orders[] = array(
+							'id'    => $order_id,
+							'error' => array( 'code' => $new->get_error_code(), 'message' => $new->get_error_message() )
+						);
+					} else {
+						$orders[] = $new['order'];
+					}
+				}
+			}
+
+			return array( 'orders' => apply_filters( 'woocommerce_api_orders_bulk_response', $orders, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+}

--- a/includes/api/v2/class-wc-api-products.php
+++ b/includes/api/v2/class-wc-api-products.php
@@ -1,0 +1,2418 @@
+<?php
+/**
+ * WooCommerce API Products Class
+ *
+ * Handles requests to the /products endpoint
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Products extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/products';
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * GET/POST /products
+	 * GET /products/count
+	 * GET/PUT/DELETE /products/<id>
+	 * GET /products/<id>/reviews
+	 *
+	 * @since 2.1
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET/POST /products
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_products' ), WC_API_Server::READABLE ),
+			array( array( $this, 'create_product' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET /products/count
+		$routes[ $this->base . '/count'] = array(
+			array( array( $this, 'get_products_count' ), WC_API_Server::READABLE ),
+		);
+
+		# GET/PUT/DELETE /products/<id>
+		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_product' ), WC_API_Server::READABLE ),
+			array( array( $this, 'edit_product' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_product' ), WC_API_Server::DELETABLE ),
+		);
+
+		# GET /products/<id>/reviews
+		$routes[ $this->base . '/(?P<id>\d+)/reviews' ] = array(
+			array( array( $this, 'get_product_reviews' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /products/<id>/orders
+		$routes[ $this->base . '/(?P<id>\d+)/orders' ] = array(
+			array( array( $this, 'get_product_orders' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /products/categories
+		$routes[ $this->base . '/categories' ] = array(
+			array( array( $this, 'get_product_categories' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /products/categories/<id>
+		$routes[ $this->base . '/categories/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_product_category' ), WC_API_Server::READABLE ),
+		);
+
+		# GET/POST /products/attributes
+		$routes[ $this->base . '/attributes' ] = array(
+			array( array( $this, 'get_product_attributes' ), WC_API_Server::READABLE ),
+			array( array( $this, 'create_product_attribute' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET/PUT/DELETE /attributes/<id>
+		$routes[ $this->base . '/attributes/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_product_attribute' ), WC_API_Server::READABLE ),
+			array( array( $this, 'edit_product_attribute' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_product_attribute' ), WC_API_Server::DELETABLE ),
+		);
+
+		# GET /products/sku/<product sku>
+		$routes[ $this->base . '/sku/(?P<sku>\w[\w\s\-]*)' ] = array(
+			array( array( $this, 'get_product_by_sku' ), WC_API_Server::READABLE ),
+		);
+
+		# POST|PUT /products/bulk
+		$routes[ $this->base . '/bulk' ] = array(
+			array( array( $this, 'bulk' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get all products
+	 *
+	 * @since 2.1
+	 * @param string $fields
+	 * @param string $type
+	 * @param array $filter
+	 * @param int $page
+	 * @return array
+	 */
+	public function get_products( $fields = null, $type = null, $filter = array(), $page = 1 ) {
+
+		if ( ! empty( $type ) ) {
+			$filter['type'] = $type;
+		}
+
+		$filter['page'] = $page;
+
+		$query = $this->query_products( $filter );
+
+		$products = array();
+
+		foreach ( $query->posts as $product_id ) {
+
+			if ( ! $this->is_readable( $product_id ) ) {
+				continue;
+			}
+
+			$products[] = current( $this->get_product( $product_id, $fields ) );
+		}
+
+		$this->server->add_pagination_headers( $query );
+
+		return array( 'products' => $products );
+	}
+
+	/**
+	 * Get the product for the given ID
+	 *
+	 * @since 2.1
+	 * @param int $id the product ID
+	 * @param string $fields
+	 * @return array
+	 */
+	public function get_product( $id, $fields = null ) {
+
+		$id = $this->validate_request( $id, 'product', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$product = wc_get_product( $id );
+
+		// add data that applies to every product type
+		$product_data = $this->get_product_data( $product );
+
+		// add variations to variable products
+		if ( $product->is_type( 'variable' ) && $product->has_child() ) {
+
+			$product_data['variations'] = $this->get_variation_data( $product );
+		}
+
+		// add the parent product data to an individual variation
+		if ( $product->is_type( 'variation' ) ) {
+
+			$product_data['parent'] = $this->get_product_data( $product->parent );
+		}
+
+		return array( 'product' => apply_filters( 'woocommerce_api_product_response', $product_data, $product, $fields, $this->server ) );
+	}
+
+	/**
+	 * Get the total number of products
+	 *
+	 * @since 2.1
+	 * @param string $type
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_products_count( $type = null, $filter = array() ) {
+		try {
+			if ( ! current_user_can( 'read_private_products' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce' ), 401 );
+			}
+
+			if ( ! empty( $type ) ) {
+				$filter['type'] = $type;
+			}
+
+			$query = $this->query_products( $filter );
+
+			return array( 'count' => (int) $query->found_posts );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Create a new product
+	 *
+	 * @since 2.2
+	 * @param array $data posted data
+	 * @return array
+	 */
+	public function create_product( $data ) {
+		$id = 0;
+
+		try {
+			if ( ! isset( $data['product'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product' ), 400 );
+			}
+
+			$data = $data['product'];
+
+			// Check permissions
+			if ( ! current_user_can( 'publish_products' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product', __( 'You do not have permission to create products', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_product_data', $data, $this );
+
+			// Check if product title is specified
+			if ( ! isset( $data['title'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_title', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'title' ), 400 );
+			}
+
+			// Check product type
+			if ( ! isset( $data['type'] ) ) {
+				$data['type'] = 'simple';
+			}
+
+			// Set visible visibility when not sent
+			if ( ! isset( $data['catalog_visibility'] ) ) {
+				$data['catalog_visibility'] = 'visible';
+			}
+
+			// Validate the product type
+			if ( ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
+			}
+
+			// Enable description html tags.
+			$post_content = isset( $data['description'] ) ? wc_clean( $data['description'] ) : '';
+			if ( $post_content && isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) {
+
+				$post_content = $data['description'];
+			}
+
+			// Enable short description html tags.
+			$post_excerpt = isset( $data['short_description'] ) ? wc_clean( $data['short_description'] ) : '';
+			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) {
+				$post_excerpt = $data['short_description'];
+			}
+
+			$new_product = array(
+				'post_title'   => wc_clean( $data['title'] ),
+				'post_status'  => ( isset( $data['status'] ) ? wc_clean( $data['status'] ) : 'publish' ),
+				'post_type'    => 'product',
+				'post_excerpt' => ( isset( $data['short_description'] ) ? $post_excerpt : '' ),
+				'post_content' => ( isset( $data['description'] ) ? $post_content : '' ),
+				'post_author'  => get_current_user_id(),
+			);
+
+			// Attempts to create the new product
+			$id = wp_insert_post( $new_product, true );
+
+			// Checks for an error in the product creation
+			if ( is_wp_error( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_product', $id->get_error_message(), 400 );
+			}
+
+			// Check for featured/gallery images, upload it and set it
+			if ( isset( $data['images'] ) ) {
+				$this->save_product_images( $id, $data['images'] );
+			}
+
+			// Save product meta fields
+			$this->save_product_meta( $id, $data );
+
+			// Save variations
+			if ( isset( $data['type'] ) && 'variable' == $data['type'] && isset( $data['variations'] ) && is_array( $data['variations'] ) ) {
+				$this->save_variations( $id, $data );
+			}
+
+			do_action( 'woocommerce_api_create_product', $id, $data );
+
+			// Clear cache/transients
+			wc_delete_product_transients( $id );
+
+			$this->server->send_status( 201 );
+
+			return $this->get_product( $id );
+		} catch ( WC_API_Exception $e ) {
+			// Remove the product when fails
+			$this->clear_product( $id );
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit a product
+	 *
+	 * @since 2.2
+	 * @param int $id the product ID
+	 * @param array $data
+	 * @return array
+	 */
+	public function edit_product( $id, $data ) {
+		try {
+			if ( ! isset( $data['product'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product' ), 400 );
+			}
+
+			$data = $data['product'];
+
+			$id = $this->validate_request( $id, 'product', 'edit' );
+
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_product_data', $data, $this );
+
+			// Product title.
+			if ( isset( $data['title'] ) ) {
+				wp_update_post( array( 'ID' => $id, 'post_title' => wc_clean( $data['title'] ) ) );
+			}
+
+			// Product name (slug).
+			if ( isset( $data['name'] ) ) {
+				wp_update_post( array( 'ID' => $id, 'post_name' => sanitize_title( $data['name'] ) ) );
+			}
+
+			// Product status.
+			if ( isset( $data['status'] ) ) {
+				wp_update_post( array( 'ID' => $id, 'post_status' => wc_clean( $data['status'] ) ) );
+			}
+
+			// Product short description.
+			if ( isset( $data['short_description'] ) ) {
+				// Enable short description html tags.
+				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
+
+				wp_update_post( array( 'ID' => $id, 'post_excerpt' => $post_excerpt ) );
+			}
+
+			// Product description.
+			if ( isset( $data['description'] ) ) {
+				// Enable description html tags.
+				$post_content = ( isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
+
+				wp_update_post( array( 'ID' => $id, 'post_content' => $post_content ) );
+			}
+
+			// Validate the product type
+			if ( isset( $data['type'] ) && ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
+			}
+
+			// Check for featured/gallery images, upload it and set it
+			if ( isset( $data['images'] ) ) {
+				$this->save_product_images( $id, $data['images'] );
+			}
+
+			// Save product meta fields
+			$this->save_product_meta( $id, $data );
+
+			// Save variations
+			if ( isset( $data['type'] ) && 'variable' == $data['type'] && isset( $data['variations'] ) && is_array( $data['variations'] ) ) {
+				$this->save_variations( $id, $data );
+			}
+
+			do_action( 'woocommerce_api_edit_product', $id, $data );
+
+			// Clear cache/transients
+			wc_delete_product_transients( $id );
+
+			return $this->get_product( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete a product
+	 *
+	 * @since 2.2
+	 * @param int $id the product ID
+	 * @param bool $force true to permanently delete order, false to move to trash
+	 * @return array
+	 */
+	public function delete_product( $id, $force = false ) {
+
+		$id = $this->validate_request( $id, 'product', 'delete' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		do_action( 'woocommerce_api_delete_product', $id, $this );
+
+		return $this->delete( $id, 'product', ( 'true' === $force ) );
+	}
+
+	/**
+	 * Get the reviews for a product
+	 *
+	 * @since 2.1
+	 * @param int $id the product ID to get reviews for
+	 * @param string $fields fields to include in response
+	 * @return array
+	 */
+	public function get_product_reviews( $id, $fields = null ) {
+
+		$id = $this->validate_request( $id, 'product', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$comments = get_approved_comments( $id );
+		$reviews  = array();
+
+		foreach ( $comments as $comment ) {
+
+			$reviews[] = array(
+				'id'             => intval( $comment->comment_ID ),
+				'created_at'     => $this->server->format_datetime( $comment->comment_date_gmt ),
+				'review'         => $comment->comment_content,
+				'rating'         => get_comment_meta( $comment->comment_ID, 'rating', true ),
+				'reviewer_name'  => $comment->comment_author,
+				'reviewer_email' => $comment->comment_author_email,
+				'verified'       => (bool) wc_customer_bought_product( $comment->comment_author_email, $comment->user_id, $id ),
+			);
+		}
+
+		return array( 'product_reviews' => apply_filters( 'woocommerce_api_product_reviews_response', $reviews, $id, $fields, $comments, $this->server ) );
+	}
+
+	/**
+	 * Get the orders for a product
+	 *
+	 * @since 2.4.0
+	 * @param int $id the product ID to get orders for
+	 * @param string fields  fields to retrieve
+	 * @param string $filter filters to include in response
+	 * @param string $status the order status to retrieve
+	 * @param $page  $page   page to retrieve
+	 * @return array
+	 */
+	public function get_product_orders( $id, $fields = null, $filter = array(), $status = null, $page = 1 ) {
+		global $wpdb;
+
+		$id = $this->validate_request( $id, 'product', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$order_ids = $wpdb->get_col( $wpdb->prepare( "
+			SELECT order_id
+			FROM {$wpdb->prefix}woocommerce_order_items
+			WHERE order_item_id IN ( SELECT order_item_id FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_key = '_product_id' AND meta_value = %d )
+			AND order_item_type = 'line_item'
+		 ", $id ) );
+
+		if ( empty( $order_ids ) ) {
+			return array( 'orders' => array() );
+		}
+
+		$filter = array_merge( $filter, array(
+			'in' => implode( ',', $order_ids )
+		) );
+
+		$orders = WC()->api->WC_API_Orders->get_orders( $fields, $filter, $status, $page );
+
+		return array( 'orders' => apply_filters( 'woocommerce_api_product_orders_response', $orders['orders'], $id, $filter, $fields, $this->server ) );
+	}
+
+	/**
+	 * Get a listing of product categories
+	 *
+	 * @since 2.2
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_product_categories( $fields = null ) {
+		try {
+			// Permissions check
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce' ), 401 );
+			}
+
+			$product_categories = array();
+
+			$terms = get_terms( 'product_cat', array( 'hide_empty' => false, 'fields' => 'ids' ) );
+
+			foreach ( $terms as $term_id ) {
+				$product_categories[] = current( $this->get_product_category( $term_id, $fields ) );
+			}
+
+			return array( 'product_categories' => apply_filters( 'woocommerce_api_product_categories_response', $product_categories, $terms, $fields, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get the product category for the given ID
+	 *
+	 * @since 2.2
+	 * @param string $id product category term ID
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_product_category( $id, $fields = null ) {
+		try {
+			$id = absint( $id );
+
+			// Validate ID
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'Invalid product category ID', 'woocommerce' ), 400 );
+			}
+
+			// Permissions check
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce' ), 401 );
+			}
+
+			$term = get_term( $id, 'product_cat' );
+
+			if ( is_wp_error( $term ) || is_null( $term ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'A product category with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			$term_id = intval( $term->term_id );
+
+			// Get category display type
+			$display_type = get_woocommerce_term_meta( $term_id, 'display_type' );
+
+			// Get category image
+			$image = '';
+			if ( $image_id = get_woocommerce_term_meta( $term_id, 'thumbnail_id' ) ) {
+				$image = wp_get_attachment_url( $image_id );
+			}
+
+			$product_category = array(
+				'id'          => $term_id,
+				'name'        => $term->name,
+				'slug'        => $term->slug,
+				'parent'      => $term->parent,
+				'description' => $term->description,
+				'display'     => $display_type ? $display_type : 'default',
+				'image'       => $image ? esc_url( $image ) : '',
+				'count'       => intval( $term->count )
+			);
+
+			return array( 'product_category' => apply_filters( 'woocommerce_api_product_category_response', $product_category, $id, $fields, $term, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Helper method to get product post objects
+	 *
+	 * @since 2.1
+	 * @param array $args request arguments for filtering query
+	 * @return WP_Query
+	 */
+	private function query_products( $args ) {
+
+		// Set base query arguments
+		$query_args = array(
+			'fields'      => 'ids',
+			'post_type'   => 'product',
+			'post_status' => 'publish',
+			'meta_query'  => array(),
+		);
+
+		if ( ! empty( $args['type'] ) ) {
+
+			$types = explode( ',', $args['type'] );
+
+			$query_args['tax_query'] = array(
+				array(
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => $types,
+				),
+			);
+
+			unset( $args['type'] );
+		}
+
+		// Filter products by category
+		if ( ! empty( $args['category'] ) ) {
+			$query_args['product_cat'] = $args['category'];
+		}
+
+		// Filter by specific sku
+		if ( ! empty( $args['sku'] ) ) {
+			if ( ! is_array( $query_args['meta_query'] ) ) {
+				$query_args['meta_query'] = array();
+			}
+
+			$query_args['meta_query'][] = array(
+				'key'     => '_sku',
+				'value'   => $args['sku'],
+				'compare' => '='
+			);
+		}
+
+		$query_args = $this->merge_query_args( $query_args, $args );
+
+		return new WP_Query( $query_args );
+	}
+
+	/**
+	 * Get standard product data that applies to every product type
+	 *
+	 * @since 2.1
+	 * @param WC_Product $product
+	 * @return WC_Product
+	 */
+	private function get_product_data( $product ) {
+		$prices_precision = wc_get_price_decimals();
+
+		return array(
+			'title'              => $product->get_title(),
+			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->id,
+			'created_at'         => $this->server->format_datetime( $product->get_post_data()->post_date_gmt ),
+			'updated_at'         => $this->server->format_datetime( $product->get_post_data()->post_modified_gmt ),
+			'type'               => $product->product_type,
+			'status'             => $product->get_post_data()->post_status,
+			'downloadable'       => $product->is_downloadable(),
+			'virtual'            => $product->is_virtual(),
+			'permalink'          => $product->get_permalink(),
+			'sku'                => $product->get_sku(),
+			'price'              => wc_format_decimal( $product->get_price(), $prices_precision ),
+			'regular_price'      => wc_format_decimal( $product->get_regular_price(), $prices_precision ),
+			'sale_price'         => $product->get_sale_price() ? wc_format_decimal( $product->get_sale_price(), $prices_precision ) : null,
+			'price_html'         => $product->get_price_html(),
+			'taxable'            => $product->is_taxable(),
+			'tax_status'         => $product->get_tax_status(),
+			'tax_class'          => $product->get_tax_class(),
+			'managing_stock'     => $product->managing_stock(),
+			'stock_quantity'     => (int) $product->get_stock_quantity(),
+			'in_stock'           => $product->is_in_stock(),
+			'backorders_allowed' => $product->backorders_allowed(),
+			'backordered'        => $product->is_on_backorder(),
+			'sold_individually'  => $product->is_sold_individually(),
+			'purchaseable'       => $product->is_purchasable(),
+			'featured'           => $product->is_featured(),
+			'visible'            => $product->is_visible(),
+			'catalog_visibility' => $product->visibility,
+			'on_sale'            => $product->is_on_sale(),
+			'product_url'        => $product->is_type( 'external' ) ? $product->get_product_url() : '',
+			'button_text'        => $product->is_type( 'external' ) ? $product->get_button_text() : '',
+			'weight'             => $product->get_weight() ? wc_format_decimal( $product->get_weight(), 2 ) : null,
+			'dimensions'         => array(
+				'length' => $product->length,
+				'width'  => $product->width,
+				'height' => $product->height,
+				'unit'   => get_option( 'woocommerce_dimension_unit' ),
+			),
+			'shipping_required'  => $product->needs_shipping(),
+			'shipping_taxable'   => $product->is_shipping_taxable(),
+			'shipping_class'     => $product->get_shipping_class(),
+			'shipping_class_id'  => ( 0 !== $product->get_shipping_class_id() ) ? $product->get_shipping_class_id() : null,
+			'description'        => wpautop( do_shortcode( $product->get_post_data()->post_content ) ),
+			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_post_data()->post_excerpt ),
+			'reviews_allowed'    => ( 'open' === $product->get_post_data()->comment_status ),
+			'average_rating'     => wc_format_decimal( $product->get_average_rating(), 2 ),
+			'rating_count'       => (int) $product->get_rating_count(),
+			'related_ids'        => array_map( 'absint', array_values( $product->get_related() ) ),
+			'upsell_ids'         => array_map( 'absint', $product->get_upsells() ),
+			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sells() ),
+			'parent_id'          => $product->post->post_parent,
+			'categories'         => wp_get_post_terms( $product->id, 'product_cat', array( 'fields' => 'names' ) ),
+			'tags'               => wp_get_post_terms( $product->id, 'product_tag', array( 'fields' => 'names' ) ),
+			'images'             => $this->get_images( $product ),
+			'featured_src'       => wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->id ) ),
+			'attributes'         => $this->get_attributes( $product ),
+			'downloads'          => $this->get_downloads( $product ),
+			'download_limit'     => (int) $product->download_limit,
+			'download_expiry'    => (int) $product->download_expiry,
+			'download_type'      => $product->download_type,
+			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->purchase_note ) ) ),
+			'total_sales'        => metadata_exists( 'post', $product->id, 'total_sales' ) ? (int) get_post_meta( $product->id, 'total_sales', true ) : 0,
+			'variations'         => array(),
+			'parent'             => array(),
+		);
+	}
+
+	/**
+	 * Get an individual variation's data
+	 *
+	 * @since 2.1
+	 * @param WC_Product $product
+	 * @return array
+	 */
+	private function get_variation_data( $product ) {
+		$prices_precision = wc_get_price_decimals();
+		$variations       = array();
+
+		foreach ( $product->get_children() as $child_id ) {
+
+			$variation = $product->get_child( $child_id );
+
+			if ( ! $variation->exists() ) {
+				continue;
+			}
+
+			$variations[] = array(
+					'id'                => $variation->get_variation_id(),
+					'created_at'        => $this->server->format_datetime( $variation->get_post_data()->post_date_gmt ),
+					'updated_at'        => $this->server->format_datetime( $variation->get_post_data()->post_modified_gmt ),
+					'downloadable'      => $variation->is_downloadable(),
+					'virtual'           => $variation->is_virtual(),
+					'permalink'         => $variation->get_permalink(),
+					'sku'               => $variation->get_sku(),
+					'price'             => wc_format_decimal( $variation->get_price(), $prices_precision ),
+					'regular_price'     => wc_format_decimal( $variation->get_regular_price(), $prices_precision ),
+					'sale_price'        => $variation->get_sale_price() ? wc_format_decimal( $variation->get_sale_price(), $prices_precision ) : null,
+					'taxable'           => $variation->is_taxable(),
+					'tax_status'        => $variation->get_tax_status(),
+					'tax_class'         => $variation->get_tax_class(),
+					'managing_stock'    => $variation->managing_stock(),
+					'stock_quantity'    => (int) $variation->get_stock_quantity(),
+					'in_stock'          => $variation->is_in_stock(),
+					'backordered'       => $variation->is_on_backorder(),
+					'purchaseable'      => $variation->is_purchasable(),
+					'visible'           => $variation->variation_is_visible(),
+					'on_sale'           => $variation->is_on_sale(),
+					'weight'            => $variation->get_weight() ? wc_format_decimal( $variation->get_weight(), 2 ) : null,
+					'dimensions'        => array(
+						'length' => $variation->length,
+						'width'  => $variation->width,
+						'height' => $variation->height,
+						'unit'   => get_option( 'woocommerce_dimension_unit' ),
+					),
+					'shipping_class'    => $variation->get_shipping_class(),
+					'shipping_class_id' => ( 0 !== $variation->get_shipping_class_id() ) ? $variation->get_shipping_class_id() : null,
+					'image'             => $this->get_images( $variation ),
+					'attributes'        => $this->get_attributes( $variation ),
+					'downloads'         => $this->get_downloads( $variation ),
+					'download_limit'    => (int) $product->download_limit,
+					'download_expiry'   => (int) $product->download_expiry,
+			);
+		}
+
+		return $variations;
+	}
+
+	/**
+	 * Save product meta
+	 *
+	 * @since 2.2
+	 * @param int $product_id
+	 * @param array $data
+	 * @return bool
+	 */
+	protected function save_product_meta( $product_id, $data ) {
+		global $wpdb;
+
+		// Product Type
+		$product_type = null;
+		if ( isset( $data['type'] ) ) {
+			$product_type = wc_clean( $data['type'] );
+			wp_set_object_terms( $product_id, $product_type, 'product_type' );
+		} else {
+			$_product_type = get_the_terms( $product_id, 'product_type' );
+			if ( is_array( $_product_type ) ) {
+				$_product_type = current( $_product_type );
+				$product_type  = $_product_type->slug;
+			}
+		}
+
+		// Virtual
+		if ( isset( $data['virtual'] ) ) {
+			update_post_meta( $product_id, '_virtual', ( true === $data['virtual'] ) ? 'yes' : 'no' );
+		}
+
+		// Tax status
+		if ( isset( $data['tax_status'] ) ) {
+			update_post_meta( $product_id, '_tax_status', wc_clean( $data['tax_status'] ) );
+		}
+
+		// Tax Class
+		if ( isset( $data['tax_class'] ) ) {
+			update_post_meta( $product_id, '_tax_class', wc_clean( $data['tax_class'] ) );
+		}
+
+		// Catalog Visibility
+		if ( isset( $data['catalog_visibility'] ) ) {
+			update_post_meta( $product_id, '_visibility', wc_clean( $data['catalog_visibility'] ) );
+		}
+
+		// Purchase Note
+		if ( isset( $data['purchase_note'] ) ) {
+			update_post_meta( $product_id, '_purchase_note', wc_clean( $data['purchase_note'] ) );
+		}
+
+		// Featured Product
+		if ( isset( $data['featured'] ) ) {
+			update_post_meta( $product_id, '_featured', ( true === $data['featured'] ) ? 'yes' : 'no' );
+		}
+
+		// Shipping data
+		$this->save_product_shipping_data( $product_id, $data );
+
+		// SKU
+		if ( isset( $data['sku'] ) ) {
+			$sku     = get_post_meta( $product_id, '_sku', true );
+			$new_sku = wc_clean( $data['sku'] );
+
+			if ( '' == $new_sku ) {
+				update_post_meta( $product_id, '_sku', '' );
+			} elseif ( $new_sku !== $sku ) {
+				if ( ! empty( $new_sku ) ) {
+					$unique_sku = wc_product_has_unique_sku( $product_id, $new_sku );
+					if ( ! $unique_sku ) {
+						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product', 'woocommerce' ), 400 );
+					} else {
+						update_post_meta( $product_id, '_sku', $new_sku );
+					}
+				} else {
+					update_post_meta( $product_id, '_sku', '' );
+				}
+			}
+		}
+
+		// Attributes
+		if ( isset( $data['attributes'] ) ) {
+			$attributes = array();
+
+			foreach ( $data['attributes'] as $attribute ) {
+				$is_taxonomy    = 0;
+				$taxonomy       = 0;
+
+				if ( ! isset( $attribute['name'] ) ) {
+					continue;
+				}
+
+				$attribute_slug = sanitize_title( $attribute['name'] );
+
+				if ( isset( $attribute['slug'] ) ) {
+					$taxonomy       = $this->get_attribute_taxonomy_by_slug( $attribute['slug'] );
+					$attribute_slug = sanitize_title( $attribute['slug'] );
+				}
+
+				if ( $taxonomy ) {
+					$is_taxonomy = 1;
+				}
+
+				if ( $is_taxonomy ) {
+
+					if ( isset( $attribute['options'] ) ) {
+						// Select based attributes - Format values (posted values are slugs)
+						if ( is_array( $attribute['options'] ) ) {
+							$values = array_map( 'sanitize_title', $attribute['options'] );
+
+						// Text based attributes - Posted values are term names - don't change to slugs
+						} else {
+							$values = array_map( 'stripslashes', array_map( 'strip_tags', explode( WC_DELIMITER, $attribute['options'] ) ) );
+						}
+
+						$values = array_filter( $values, 'strlen' );
+					} else {
+						$values = array();
+					}
+
+					// Update post terms
+					if ( taxonomy_exists( $taxonomy ) ) {
+						wp_set_object_terms( $product_id, $values, $taxonomy );
+					}
+
+					if ( $values ) {
+						// Add attribute to array, but don't set values
+						$attributes[ $taxonomy ] = array(
+							'name'         => $taxonomy,
+							'value'        => '',
+							'position'     => isset( $attribute['position'] ) ? absint( $attribute['position'] ) : 0,
+							'is_visible'   => ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0,
+							'is_variation' => ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0,
+							'is_taxonomy'  => $is_taxonomy
+						);
+					}
+
+				} elseif ( isset( $attribute['options'] ) ) {
+					// Array based
+					if ( is_array( $attribute['options'] ) ) {
+						$values = implode( ' ' . WC_DELIMITER . ' ', array_map( 'wc_clean', $attribute['options'] ) );
+
+					// Text based, separate by pipe
+					} else {
+						$values = implode( ' ' . WC_DELIMITER . ' ', array_map( 'wc_clean', explode( WC_DELIMITER, $attribute['options'] ) ) );
+					}
+
+					// Custom attribute - Add attribute to array and set the values
+					$attributes[ $attribute_slug ] = array(
+						'name'         => wc_clean( $attribute['name'] ),
+						'value'        => $values,
+						'position'     => isset( $attribute['position'] ) ? absint( $attribute['position'] ) : 0,
+						'is_visible'   => ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0,
+						'is_variation' => ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0,
+						'is_taxonomy'  => $is_taxonomy
+					);
+				}
+			}
+
+			if ( ! function_exists( 'attributes_cmp' ) ) {
+				function attributes_cmp( $a, $b ) {
+					if ( $a['position'] == $b['position'] ) {
+						return 0;
+					}
+
+					return ( $a['position'] < $b['position'] ) ? -1 : 1;
+				}
+			}
+			uasort( $attributes, 'attributes_cmp' );
+
+			update_post_meta( $product_id, '_product_attributes', $attributes );
+		}
+
+		// Sales and prices
+		if ( in_array( $product_type, array( 'variable', 'grouped' ) ) ) {
+
+			// Variable and grouped products have no prices
+			update_post_meta( $product_id, '_regular_price', '' );
+			update_post_meta( $product_id, '_sale_price', '' );
+			update_post_meta( $product_id, '_sale_price_dates_from', '' );
+			update_post_meta( $product_id, '_sale_price_dates_to', '' );
+			update_post_meta( $product_id, '_price', '' );
+
+		} else {
+
+			// Regular Price
+			if ( isset( $data['regular_price'] ) ) {
+				$regular_price = ( '' === $data['regular_price'] ) ? '' : wc_format_decimal( $data['regular_price'] );
+				update_post_meta( $product_id, '_regular_price', $regular_price );
+			} else {
+				$regular_price = get_post_meta( $product_id, '_regular_price', true );
+			}
+
+			// Sale Price
+			if ( isset( $data['sale_price'] ) ) {
+				$sale_price = ( '' === $data['sale_price'] ) ? '' : wc_format_decimal( $data['sale_price'] );
+				update_post_meta( $product_id, '_sale_price', $sale_price );
+			} else {
+				$sale_price = get_post_meta( $product_id, '_sale_price', true );
+			}
+
+			$date_from = isset( $data['sale_price_dates_from'] ) ? strtotime( $data['sale_price_dates_from'] ) : get_post_meta( $product_id, '_sale_price_dates_from', true );
+			$date_to   = isset( $data['sale_price_dates_to'] ) ? strtotime( $data['sale_price_dates_to'] ) : get_post_meta( $product_id, '_sale_price_dates_to', true );
+
+			// Dates
+			if ( $date_from ) {
+				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
+			} else {
+				update_post_meta( $product_id, '_sale_price_dates_from', '' );
+			}
+
+			if ( $date_to ) {
+				update_post_meta( $product_id, '_sale_price_dates_to', $date_to );
+			} else {
+				update_post_meta( $product_id, '_sale_price_dates_to', '' );
+			}
+
+			if ( $date_to && ! $date_from ) {
+				$date_from = strtotime( 'NOW', current_time( 'timestamp' ) );
+				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
+			}
+
+			// Update price if on sale
+			if ( '' !== $sale_price && '' == $date_to && '' == $date_from ) {
+				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
+			} else {
+				update_post_meta( $product_id, '_price', $regular_price );
+			}
+
+			if ( '' !== $sale_price && $date_from && $date_from <= strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
+			}
+
+			if ( $date_to && $date_to < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+				update_post_meta( $product_id, '_price', $regular_price );
+				update_post_meta( $product_id, '_sale_price_dates_from', '' );
+				update_post_meta( $product_id, '_sale_price_dates_to', '' );
+			}
+		}
+
+		// Product parent ID for groups
+		if ( isset( $data['parent_id'] ) ) {
+			wp_update_post( array( 'ID' => $product_id, 'post_parent' => absint( $data['parent_id'] ) ) );
+		}
+
+		// Update parent if grouped so price sorting works and stays in sync with the cheapest child
+		$_product = wc_get_product( $product_id );
+		if ( $_product->post->post_parent > 0 || $product_type == 'grouped' ) {
+
+			$clear_parent_ids = array();
+
+			if ( $_product->post->post_parent > 0 ) {
+				$clear_parent_ids[] = $_product->post->post_parent;
+			}
+
+			if ( $product_type == 'grouped' ) {
+				$clear_parent_ids[] = $product_id;
+			}
+
+			if ( $clear_parent_ids ) {
+				foreach ( $clear_parent_ids as $clear_id ) {
+
+					$children_by_price = get_posts( array(
+						'post_parent'    => $clear_id,
+						'orderby'        => 'meta_value_num',
+						'order'          => 'asc',
+						'meta_key'       => '_price',
+						'posts_per_page' => 1,
+						'post_type'      => 'product',
+						'fields'         => 'ids'
+					) );
+
+					if ( $children_by_price ) {
+						foreach ( $children_by_price as $child ) {
+							$child_price = get_post_meta( $child, '_price', true );
+							update_post_meta( $clear_id, '_price', $child_price );
+						}
+					}
+				}
+			}
+		}
+
+		// Sold Individually
+		if ( isset( $data['sold_individually'] ) ) {
+			update_post_meta( $product_id, '_sold_individually', ( true === $data['sold_individually'] ) ? 'yes' : '' );
+		}
+
+		// Stock status
+		if ( isset( $data['in_stock'] ) ) {
+			$stock_status = ( true === $data['in_stock'] ) ? 'instock' : 'outofstock';
+		} else {
+			$stock_status = get_post_meta( $product_id, '_stock_status', true );
+
+			if ( '' === $stock_status ) {
+				$stock_status = 'instock';
+			}
+		}
+
+		// Stock Data
+		if ( 'yes' == get_option( 'woocommerce_manage_stock' ) ) {
+			// Manage stock
+			if ( isset( $data['managing_stock'] ) ) {
+				$managing_stock = ( true === $data['managing_stock'] ) ? 'yes' : 'no';
+				update_post_meta( $product_id, '_manage_stock', $managing_stock );
+			} else {
+				$managing_stock = get_post_meta( $product_id, '_manage_stock', true );
+			}
+
+			// Backorders
+			if ( isset( $data['backorders'] ) ) {
+				if ( 'notify' == $data['backorders'] ) {
+					$backorders = 'notify';
+				} else {
+					$backorders = ( true === $data['backorders'] ) ? 'yes' : 'no';
+				}
+
+				update_post_meta( $product_id, '_backorders', $backorders );
+			} else {
+				$backorders = get_post_meta( $product_id, '_backorders', true );
+			}
+
+			if ( 'grouped' == $product_type ) {
+
+				update_post_meta( $product_id, '_manage_stock', 'no' );
+				update_post_meta( $product_id, '_backorders', 'no' );
+				update_post_meta( $product_id, '_stock', '' );
+
+				wc_update_product_stock_status( $product_id, $stock_status );
+
+			} elseif ( 'external' == $product_type ) {
+
+				update_post_meta( $product_id, '_manage_stock', 'no' );
+				update_post_meta( $product_id, '_backorders', 'no' );
+				update_post_meta( $product_id, '_stock', '' );
+
+				wc_update_product_stock_status( $product_id, 'instock' );
+
+			} elseif ( 'yes' == $managing_stock ) {
+				update_post_meta( $product_id, '_backorders', $backorders );
+
+				wc_update_product_stock_status( $product_id, $stock_status );
+
+				// Stock quantity
+				if ( isset( $data['stock_quantity'] ) ) {
+					wc_update_product_stock( $product_id, intval( $data['stock_quantity'] ) );
+				}
+			} else {
+
+				// Don't manage stock
+				update_post_meta( $product_id, '_manage_stock', 'no' );
+				update_post_meta( $product_id, '_backorders', $backorders );
+				update_post_meta( $product_id, '_stock', '' );
+
+				wc_update_product_stock_status( $product_id, $stock_status );
+			}
+
+		} else {
+			wc_update_product_stock_status( $product_id, $stock_status );
+		}
+
+		// Upsells
+		if ( isset( $data['upsell_ids'] ) ) {
+			$upsells = array();
+			$ids     = $data['upsell_ids'];
+
+			if ( ! empty( $ids ) ) {
+				foreach ( $ids as $id ) {
+					if ( $id && $id > 0 ) {
+						$upsells[] = $id;
+					}
+				}
+
+				update_post_meta( $product_id, '_upsell_ids', $upsells );
+			} else {
+				delete_post_meta( $product_id, '_upsell_ids' );
+			}
+		}
+
+		// Cross sells
+		if ( isset( $data['cross_sell_ids'] ) ) {
+			$crosssells = array();
+			$ids        = $data['cross_sell_ids'];
+
+			if ( ! empty( $ids ) ) {
+				foreach ( $ids as $id ) {
+					if ( $id && $id > 0 ) {
+						$crosssells[] = $id;
+					}
+				}
+
+				update_post_meta( $product_id, '_crosssell_ids', $crosssells );
+			} else {
+				delete_post_meta( $product_id, '_crosssell_ids' );
+			}
+		}
+
+		// Product categories
+		if ( isset( $data['categories'] ) && is_array( $data['categories'] ) ) {
+			$term_ids = array_unique( array_map( 'intval', $data['categories'] ) );
+			wp_set_object_terms( $product_id, $term_ids, 'product_cat' );
+		}
+
+		// Product tags
+		if ( isset( $data['tags'] ) && is_array( $data['tags'] ) ) {
+			$term_ids = array_unique( array_map( 'intval', $data['tags'] ) );
+			wp_set_object_terms( $product_id, $term_ids, 'product_tag' );
+		}
+
+		// Downloadable
+		if ( isset( $data['downloadable'] ) ) {
+			$is_downloadable = ( true === $data['downloadable'] ) ? 'yes' : 'no';
+			update_post_meta( $product_id, '_downloadable', $is_downloadable );
+		} else {
+			$is_downloadable = get_post_meta( $product_id, '_downloadable', true );
+		}
+
+		// Downloadable options
+		if ( 'yes' == $is_downloadable ) {
+
+			// Downloadable files
+			if ( isset( $data['downloads'] ) && is_array( $data['downloads'] ) ) {
+				$this->save_downloadable_files( $product_id, $data['downloads'] );
+			}
+
+			// Download limit
+			if ( isset( $data['download_limit'] ) ) {
+				update_post_meta( $product_id, '_download_limit', ( '' === $data['download_limit'] ) ? '' : absint( $data['download_limit'] ) );
+			}
+
+			// Download expiry
+			if ( isset( $data['download_expiry'] ) ) {
+				update_post_meta( $product_id, '_download_expiry', ( '' === $data['download_expiry'] ) ? '' : absint( $data['download_expiry'] ) );
+			}
+
+			// Download type
+			if ( isset( $data['download_type'] ) ) {
+				update_post_meta( $product_id, '_download_type', wc_clean( $data['download_type'] ) );
+			}
+		}
+
+		// Product url
+		if ( $product_type == 'external' ) {
+			if ( isset( $data['product_url'] ) ) {
+				update_post_meta( $product_id, '_product_url', wc_clean( $data['product_url'] ) );
+			}
+
+			if ( isset( $data['button_text'] ) ) {
+				update_post_meta( $product_id, '_button_text', wc_clean( $data['button_text'] ) );
+			}
+		}
+
+		// Reviews allowed
+		if ( isset( $data['reviews_allowed'] ) ) {
+			$reviews_allowed = ( true === $data['reviews_allowed'] ) ? 'open' : 'closed';
+
+			$wpdb->update( $wpdb->posts, array( 'comment_status' => $reviews_allowed ), array( 'ID' => $product_id ) );
+		}
+
+		// Do action for product type
+		do_action( 'woocommerce_api_process_product_meta_' . $product_type, $product_id, $data );
+
+		return true;
+	}
+
+	/**
+	 * Save variations
+	 *
+	 * @since 2.2
+	 * @param int $id
+	 * @param array $data
+	 * @return bool
+	 */
+	protected function save_variations( $id, $data ) {
+		global $wpdb;
+
+		$variations = $data['variations'];
+		$attributes = (array) maybe_unserialize( get_post_meta( $id, '_product_attributes', true ) );
+
+		foreach ( $variations as $menu_order => $variation ) {
+			$variation_id = isset( $variation['id'] ) ? absint( $variation['id'] ) : 0;
+
+			// Generate a useful post title
+			$variation_post_title = sprintf( __( 'Variation #%s of %s', 'woocommerce' ), $variation_id, esc_html( get_the_title( $id ) ) );
+
+			// Update or Add post
+			if ( ! $variation_id ) {
+				$post_status = ( isset( $variation['visible'] ) && false === $variation['visible'] ) ? 'private' : 'publish';
+
+				$new_variation = array(
+					'post_title'   => $variation_post_title,
+					'post_content' => '',
+					'post_status'  => $post_status,
+					'post_author'  => get_current_user_id(),
+					'post_parent'  => $id,
+					'post_type'    => 'product_variation',
+					'menu_order'   => $menu_order
+				);
+
+				$variation_id = wp_insert_post( $new_variation );
+
+				do_action( 'woocommerce_create_product_variation', $variation_id );
+			} else {
+				$update_variation = array( 'post_title' => $variation_post_title, 'menu_order' => $menu_order );
+				if ( isset( $variation['visible'] ) ) {
+					$post_status = ( false === $variation['visible'] ) ? 'private' : 'publish';
+					$update_variation['post_status'] = $post_status;
+				}
+
+				$wpdb->update( $wpdb->posts, $update_variation, array( 'ID' => $variation_id ) );
+
+				do_action( 'woocommerce_update_product_variation', $variation_id );
+			}
+
+			// Stop with we don't have a variation ID
+			if ( is_wp_error( $variation_id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_save_product_variation', $variation_id->get_error_message(), 400 );
+			}
+
+			// SKU
+			if ( isset( $variation['sku'] ) ) {
+				$sku     = get_post_meta( $variation_id, '_sku', true );
+				$new_sku = wc_clean( $variation['sku'] );
+
+				if ( '' == $new_sku ) {
+					update_post_meta( $variation_id, '_sku', '' );
+				} elseif ( $new_sku !== $sku ) {
+					if ( ! empty( $new_sku ) ) {
+						$unique_sku = wc_product_has_unique_sku( $variation_id, $new_sku );
+						if ( ! $unique_sku ) {
+							throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product', 'woocommerce' ), 400 );
+						} else {
+							update_post_meta( $variation_id, '_sku', $new_sku );
+						}
+					} else {
+						update_post_meta( $variation_id, '_sku', '' );
+					}
+				}
+			}
+
+			// Thumbnail
+			if ( isset( $variation['image'] ) && is_array( $variation['image'] ) ) {
+				$image = current( $variation['image'] );
+				if ( $image && is_array( $image ) ) {
+					if ( isset( $image['position'] ) && isset( $image['src'] ) && $image['position'] == 0 ) {
+						$upload = $this->upload_product_image( wc_clean( $image['src'] ) );
+						if ( is_wp_error( $upload ) ) {
+							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );
+						}
+						$attachment_id = $this->set_product_image_as_attachment( $upload, $id );
+						update_post_meta( $variation_id, '_thumbnail_id', $attachment_id );
+					}
+				} else {
+					delete_post_meta( $variation_id, '_thumbnail_id' );
+				}
+			}
+
+			// Virtual variation
+			if ( isset( $variation['virtual'] ) ) {
+				$is_virtual = ( true === $variation['virtual'] ) ? 'yes' : 'no';
+				update_post_meta( $variation_id, '_virtual', $is_virtual );
+			}
+
+			// Downloadable variation
+			if ( isset( $variation['downloadable'] ) ) {
+				$is_downloadable = ( true === $variation['downloadable'] ) ? 'yes' : 'no';
+				update_post_meta( $variation_id, '_downloadable', $is_downloadable );
+			} else {
+				$is_downloadable = get_post_meta( $variation_id, '_downloadable', true );
+			}
+
+			// Shipping data
+			$this->save_product_shipping_data( $variation_id, $variation );
+
+			// Stock handling
+			if ( isset( $variation['managing_stock'] ) ) {
+				$managing_stock = ( true === $variation['managing_stock'] ) ? 'yes' : 'no';
+				update_post_meta( $variation_id, '_manage_stock', $managing_stock );
+			} else {
+				$managing_stock = get_post_meta( $variation_id, '_manage_stock', true );
+			}
+
+			// Only update stock status to user setting if changed by the user, but do so before looking at stock levels at variation level
+			if ( isset( $variation['in_stock'] ) ) {
+				$stock_status = ( true === $variation['in_stock'] ) ? 'instock' : 'outofstock';
+				wc_update_product_stock_status( $variation_id, $stock_status );
+			}
+
+			if ( 'yes' === $managing_stock ) {
+				if ( isset( $variation['backorders'] ) ) {
+					if ( 'notify' == $variation['backorders'] ) {
+						$backorders = 'notify';
+					} else {
+						$backorders = ( true === $variation['backorders'] ) ? 'yes' : 'no';
+					}
+				} else {
+					$backorders = 'no';
+				}
+
+				update_post_meta( $variation_id, '_backorders', $backorders );
+
+				if ( isset( $variation['stock_quantity'] ) ) {
+					wc_update_product_stock( $variation_id, wc_stock_amount( $variation['stock_quantity'] ) );
+				}
+			} else {
+				delete_post_meta( $variation_id, '_backorders' );
+				delete_post_meta( $variation_id, '_stock' );
+			}
+
+			// Regular Price
+			if ( isset( $variation['regular_price'] ) ) {
+				$regular_price = ( '' === $variation['regular_price'] ) ? '' : wc_format_decimal( $variation['regular_price'] );
+				update_post_meta( $variation_id, '_regular_price', $regular_price );
+			} else {
+				$regular_price = get_post_meta( $variation_id, '_regular_price', true );
+			}
+
+			// Sale Price
+			if ( isset( $variation['sale_price'] ) ) {
+				$sale_price = ( '' === $variation['sale_price'] ) ? '' : wc_format_decimal( $variation['sale_price'] );
+				update_post_meta( $variation_id, '_sale_price', $sale_price );
+			} else {
+				$sale_price = get_post_meta( $variation_id, '_sale_price', true );
+			}
+
+			$date_from = isset( $variation['sale_price_dates_from'] ) ? strtotime( $variation['sale_price_dates_from'] ) : get_post_meta( $variation_id, '_sale_price_dates_from', true );
+			$date_to   = isset( $variation['sale_price_dates_to'] ) ? strtotime( $variation['sale_price_dates_to'] ) : get_post_meta( $variation_id, '_sale_price_dates_to', true );
+
+			// Save Dates
+			if ( $date_from ) {
+				update_post_meta( $variation_id, '_sale_price_dates_from', $date_from );
+			} else {
+				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
+			}
+
+			if ( $date_to ) {
+				update_post_meta( $variation_id, '_sale_price_dates_to', $date_to );
+			} else {
+				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
+			}
+
+			if ( $date_to && ! $date_from ) {
+				update_post_meta( $variation_id, '_sale_price_dates_from', strtotime( 'NOW', current_time( 'timestamp' ) ) );
+			}
+
+			// Update price if on sale
+			if ( '' != $sale_price && '' == $date_to && '' == $date_from ) {
+				update_post_meta( $variation_id, '_price', $sale_price );
+			} else {
+				update_post_meta( $variation_id, '_price', $regular_price );
+			}
+
+			if ( '' != $sale_price && $date_from && $date_from < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+				update_post_meta( $variation_id, '_price', $sale_price );
+			}
+
+			if ( $date_to && $date_to < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+				update_post_meta( $variation_id, '_price', $regular_price );
+				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
+				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
+			}
+
+			// Tax class
+			if ( isset( $variation['tax_class'] ) ) {
+				if ( $variation['tax_class'] !== 'parent' ) {
+					update_post_meta( $variation_id, '_tax_class', wc_clean( $variation['tax_class'] ) );
+				} else {
+					delete_post_meta( $variation_id, '_tax_class' );
+				}
+			}
+
+			// Downloads
+			if ( 'yes' == $is_downloadable ) {
+				// Downloadable files
+				if ( isset( $variation['downloads'] ) && is_array( $variation['downloads'] ) ) {
+					$this->save_downloadable_files( $id, $variation['downloads'], $variation_id );
+				}
+
+				// Download limit
+				if ( isset( $variation['download_limit'] ) ) {
+					$download_limit = absint( $variation['download_limit'] );
+					update_post_meta( $variation_id, '_download_limit', ( ! $download_limit ) ? '' : $download_limit );
+				}
+
+				// Download expiry
+				if ( isset( $variation['download_expiry'] ) ) {
+					$download_expiry = absint( $variation['download_expiry'] );
+					update_post_meta( $variation_id, '_download_expiry', ( ! $download_expiry ) ? '' : $download_expiry );
+				}
+			} else {
+				update_post_meta( $variation_id, '_download_limit', '' );
+				update_post_meta( $variation_id, '_download_expiry', '' );
+				update_post_meta( $variation_id, '_downloadable_files', '' );
+			}
+
+			// Update taxonomies
+			if ( isset( $variation['attributes'] ) ) {
+				$updated_attribute_keys = array();
+
+				foreach ( $variation['attributes'] as $attribute_key => $attribute ) {
+					if ( ! isset( $attribute['name'] ) ) {
+						continue;
+					}
+
+					$taxonomy   = sanitize_title( $attribute['name'] );
+					$_attribute = array();
+
+					if ( isset( $attribute['slug'] ) ) {
+						$taxonomy = $this->get_attribute_taxonomy_by_slug( $attribute['slug'] );
+					}
+
+					if ( isset( $attributes[ $taxonomy ] ) ) {
+						$_attribute = $attributes[ $taxonomy ];
+					}
+
+					if ( isset( $_attribute['is_variation'] ) && $_attribute['is_variation'] ) {
+						$attribute_key   = 'attribute_' . sanitize_title( $_attribute['name'] );
+						$attribute_value = isset( $attribute['option'] ) ? sanitize_title( stripslashes( $attribute['option'] ) ) : '';
+						$updated_attribute_keys[] = $attribute_key;
+
+						update_post_meta( $variation_id, $attribute_key, $attribute_value );
+					}
+				}
+
+				// Remove old taxonomies attributes so data is kept up to date - first get attribute key names
+				$delete_attribute_keys = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key LIKE 'attribute_%%' AND meta_key NOT IN ( '" . implode( "','", $updated_attribute_keys ) . "' ) AND post_id = %d;", $variation_id ) );
+
+				foreach ( $delete_attribute_keys as $key ) {
+					delete_post_meta( $variation_id, $key );
+				}
+			}
+
+			do_action( 'woocommerce_api_save_product_variation', $variation_id, $menu_order, $variation );
+		}
+
+		// Update parent if variable so price sorting works and stays in sync with the cheapest child
+		WC_Product_Variable::sync( $id );
+
+		// Update default attributes options setting
+		if ( isset( $data['default_attribute'] ) ) {
+			$data['default_attributes'] = $data['default_attribute'];
+		}
+
+		if ( isset( $data['default_attributes'] ) && is_array( $data['default_attributes'] ) ) {
+			$default_attributes = array();
+
+			foreach ( $data['default_attributes'] as $default_attr_key => $default_attr ) {
+				if ( ! isset( $default_attr['name'] ) ) {
+					continue;
+				}
+
+				$taxonomy = sanitize_title( $default_attr['name'] );
+
+				if ( isset( $default_attr['slug'] ) ) {
+					$taxonomy = $this->get_attribute_taxonomy_by_slug( $default_attr['slug'] );
+				}
+
+				if ( isset( $attributes[ $taxonomy ] ) ) {
+					$_attribute = $attributes[ $taxonomy ];
+
+					if ( $_attribute['is_variation'] ) {
+						// Don't use wc_clean as it destroys sanitized characters
+						if ( isset( $default_attr['option'] ) ) {
+							$value = sanitize_title( trim( stripslashes( $default_attr['option'] ) ) );
+						} else {
+							$value = '';
+						}
+
+						if ( $value ) {
+							$default_attributes[ $taxonomy ] = $value;
+						}
+					}
+				}
+			}
+
+			update_post_meta( $id, '_default_attributes', $default_attributes );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Save product shipping data
+	 *
+	 * @since 2.2
+	 * @param int $id
+	 * @param array $data
+	 * @return void
+	 */
+	private function save_product_shipping_data( $id, $data ) {
+		if ( isset( $data['weight'] ) ) {
+			update_post_meta( $id, '_weight', ( '' === $data['weight'] ) ? '' : wc_format_decimal( $data['weight'] ) );
+		}
+
+		// Product dimensions
+		if ( isset( $data['dimensions'] ) ) {
+			// Height
+			if ( isset( $data['dimensions']['height'] ) ) {
+				update_post_meta( $id, '_height', ( '' === $data['dimensions']['height'] ) ? '' : wc_format_decimal( $data['dimensions']['height'] ) );
+			}
+
+			// Width
+			if ( isset( $data['dimensions']['width'] ) ) {
+				update_post_meta( $id, '_width', ( '' === $data['dimensions']['width'] ) ? '' : wc_format_decimal($data['dimensions']['width'] ) );
+			}
+
+			// Length
+			if ( isset( $data['dimensions']['length'] ) ) {
+				update_post_meta( $id, '_length', ( '' === $data['dimensions']['length'] ) ? '' : wc_format_decimal( $data['dimensions']['length'] ) );
+			}
+		}
+
+		// Virtual
+		if ( isset( $data['virtual'] ) ) {
+			$virtual = ( true === $data['virtual'] ) ? 'yes' : 'no';
+
+			if ( 'yes' == $virtual ) {
+				update_post_meta( $id, '_weight', '' );
+				update_post_meta( $id, '_length', '' );
+				update_post_meta( $id, '_width', '' );
+				update_post_meta( $id, '_height', '' );
+			}
+		}
+
+		// Shipping class
+		if ( isset( $data['shipping_class'] ) ) {
+			wp_set_object_terms( $id, wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
+		}
+	}
+
+	/**
+	 * Save downloadable files
+	 *
+	 * @since 2.2
+	 * @param int $product_id
+	 * @param array $downloads
+	 * @param int $variation_id
+	 * @return void
+	 */
+	private function save_downloadable_files( $product_id, $downloads, $variation_id = 0 ) {
+		$files = array();
+
+		// File paths will be stored in an array keyed off md5(file path)
+		foreach ( $downloads as $key => $file ) {
+			if ( isset( $file['url'] ) ) {
+				$file['file'] = $file['url'];
+			}
+
+			if ( ! isset( $file['file'] ) ) {
+				continue;
+			}
+
+			$file_name = isset( $file['name'] ) ? wc_clean( $file['name'] ) : '';
+
+			if ( 0 === strpos( $file['file'], 'http' ) ) {
+				$file_url = esc_url_raw( $file['file'] );
+			} else {
+				$file_url = wc_clean( $file['file'] );
+			}
+
+			$files[ md5( $file_url ) ] = array(
+				'name' => $file_name,
+				'file' => $file_url
+			);
+		}
+
+		// Grant permission to any newly added files on any existing orders for this product prior to saving
+		do_action( 'woocommerce_process_product_file_download_paths', $product_id, $variation_id, $files );
+
+		$id = ( 0 === $variation_id ) ? $product_id : $variation_id;
+		update_post_meta( $id, '_downloadable_files', $files );
+	}
+
+	/**
+	 * Get attribute taxonomy by slug.
+	 *
+	 * @since 2.2
+	 * @param string $slug
+	 * @return string|null
+	 */
+	private function get_attribute_taxonomy_by_slug( $slug ) {
+		$taxonomy = null;
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+
+		foreach ( $attribute_taxonomies as $key => $tax ) {
+			if ( $slug == $tax->attribute_name ) {
+				$taxonomy = 'pa_' . $tax->attribute_name;
+
+				break;
+			}
+		}
+
+		return $taxonomy;
+	}
+
+	/**
+	 * Get the images for a product or product variation
+	 *
+	 * @since 2.1
+	 * @param WC_Product|WC_Product_Variation $product
+	 * @return array
+	 */
+	private function get_images( $product ) {
+
+		$images = $attachment_ids = array();
+
+		if ( $product->is_type( 'variation' ) ) {
+
+			if ( has_post_thumbnail( $product->get_variation_id() ) ) {
+
+				// Add variation image if set
+				$attachment_ids[] = get_post_thumbnail_id( $product->get_variation_id() );
+
+			} elseif ( has_post_thumbnail( $product->id ) ) {
+
+				// Otherwise use the parent product featured image if set
+				$attachment_ids[] = get_post_thumbnail_id( $product->id );
+			}
+
+		} else {
+
+			// Add featured image
+			if ( has_post_thumbnail( $product->id ) ) {
+				$attachment_ids[] = get_post_thumbnail_id( $product->id );
+			}
+
+			// Add gallery images
+			$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_attachment_ids() );
+		}
+
+		// Build image data
+		foreach ( $attachment_ids as $position => $attachment_id ) {
+
+			$attachment_post = get_post( $attachment_id );
+
+			if ( is_null( $attachment_post ) ) {
+				continue;
+			}
+
+			$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+
+			if ( ! is_array( $attachment ) ) {
+				continue;
+			}
+
+			$images[] = array(
+				'id'         => (int) $attachment_id,
+				'created_at' => $this->server->format_datetime( $attachment_post->post_date_gmt ),
+				'updated_at' => $this->server->format_datetime( $attachment_post->post_modified_gmt ),
+				'src'        => current( $attachment ),
+				'title'      => get_the_title( $attachment_id ),
+				'alt'        => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+				'position'   => (int) $position,
+			);
+		}
+
+		// Set a placeholder image if the product has no images set
+		if ( empty( $images ) ) {
+
+			$images[] = array(
+				'id'         => 0,
+				'created_at' => $this->server->format_datetime( time() ), // Default to now
+				'updated_at' => $this->server->format_datetime( time() ),
+				'src'        => wc_placeholder_img_src(),
+				'title'      => __( 'Placeholder', 'woocommerce' ),
+				'alt'        => __( 'Placeholder', 'woocommerce' ),
+				'position'   => 0,
+			);
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Save product images
+	 *
+	 * @since 2.2
+	 * @param array $images
+	 * @param int $id
+	 */
+	protected function save_product_images( $id, $images ) {
+		if ( is_array( $images ) ) {
+			$gallery = array();
+
+			foreach ( $images as $image ) {
+				if ( isset( $image['position'] ) && $image['position'] == 0 ) {
+					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
+
+					if ( 0 === $attachment_id && isset( $image['src'] ) ) {
+						$upload = $this->upload_product_image( esc_url_raw( $image['src'] ) );
+
+						if ( is_wp_error( $upload ) ) {
+							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );
+						}
+
+						$attachment_id = $this->set_product_image_as_attachment( $upload, $id );
+					}
+
+					set_post_thumbnail( $id, $attachment_id );
+				} else {
+					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
+
+					if ( 0 === $attachment_id && isset( $image['src'] ) ) {
+						$upload = $this->upload_product_image( esc_url_raw( $image['src'] ) );
+
+						if ( is_wp_error( $upload ) ) {
+							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );
+						}
+
+						$gallery[] = $this->set_product_image_as_attachment( $upload, $id );
+					} else {
+						$gallery[] = $attachment_id;
+					}
+				}
+			}
+
+			if ( ! empty( $gallery ) ) {
+				update_post_meta( $id, '_product_image_gallery', implode( ',', $gallery ) );
+			}
+		} else {
+			delete_post_thumbnail( $id );
+			update_post_meta( $id, '_product_image_gallery', '' );
+		}
+	}
+
+	/**
+	 * Upload image from URL
+	 *
+	 * @since 2.2
+	 * @param string $image_url
+	 * @return int|WP_Error attachment id
+	 */
+	public function upload_product_image( $image_url ) {
+		$file_name 		= basename( current( explode( '?', $image_url ) ) );
+		$wp_filetype 	= wp_check_filetype( $file_name, null );
+		$parsed_url 	= @parse_url( $image_url );
+
+		// Check parsed URL
+		if ( ! $parsed_url || ! is_array( $parsed_url ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_image', sprintf( __( 'Invalid URL %s', 'woocommerce' ), $image_url ), 400 );
+		}
+
+		// Ensure url is valid
+		$image_url = str_replace( ' ', '%20', $image_url );
+
+		// Get the file
+		$response = wp_safe_remote_get( $image_url, array(
+			'timeout' => 10
+		) );
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_remote_product_image', sprintf( __( 'Error getting remote image %s', 'woocommerce' ), $image_url ), 400 );
+		}
+
+		// Ensure we have a file name and type
+		if ( ! $wp_filetype['type'] ) {
+			$headers = wp_remote_retrieve_headers( $response );
+			if ( isset( $headers['content-disposition'] ) && strstr( $headers['content-disposition'], 'filename=' ) ) {
+				$disposition = end( explode( 'filename=', $headers['content-disposition'] ) );
+				$disposition = sanitize_file_name( $disposition );
+				$file_name   = $disposition;
+			} elseif ( isset( $headers['content-type'] ) && strstr( $headers['content-type'], 'image/' ) ) {
+				$file_name = 'image.' . str_replace( 'image/', '', $headers['content-type'] );
+			}
+			unset( $headers );
+		}
+
+		// Upload the file
+		$upload = wp_upload_bits( $file_name, '', wp_remote_retrieve_body( $response ) );
+
+		if ( $upload['error'] ) {
+			throw new WC_API_Exception( 'woocommerce_api_product_image_upload_error', $upload['error'], 400 );
+		}
+
+		// Get filesize
+		$filesize = filesize( $upload['file'] );
+
+		if ( 0 == $filesize ) {
+			@unlink( $upload['file'] );
+			unset( $upload );
+			throw new WC_API_Exception( 'woocommerce_api_product_image_upload_file_error', __( 'Zero size file downloaded', 'woocommerce' ), 400 );
+		}
+
+		unset( $response );
+
+		return $upload;
+	}
+
+	/**
+	 * Get product image as attachment
+	 *
+	 * @since 2.2
+	 * @param integer $upload
+	 * @param int $id
+	 * @return int
+	 */
+	protected function set_product_image_as_attachment( $upload, $id ) {
+		$info    = wp_check_filetype( $upload['file'] );
+		$title   = '';
+		$content = '';
+
+		if ( $image_meta = @wp_read_image_metadata( $upload['file'] ) ) {
+			if ( trim( $image_meta['title'] ) && ! is_numeric( sanitize_title( $image_meta['title'] ) ) ) {
+				$title = $image_meta['title'];
+			}
+			if ( trim( $image_meta['caption'] ) ) {
+				$content = $image_meta['caption'];
+			}
+		}
+
+		$attachment = array(
+			'post_mime_type' => $info['type'],
+			'guid'           => $upload['url'],
+			'post_parent'    => $id,
+			'post_title'     => $title,
+			'post_content'   => $content
+		);
+
+		$attachment_id = wp_insert_attachment( $attachment, $upload['file'], $id );
+		if ( ! is_wp_error( $attachment_id ) ) {
+			wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $upload['file'] ) );
+		}
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Get the attributes for a product or product variation
+	 *
+	 * @since 2.1
+	 * @param WC_Product|WC_Product_Variation $product
+	 * @return array
+	 */
+	private function get_attributes( $product ) {
+
+		$attributes = array();
+
+		if ( $product->is_type( 'variation' ) ) {
+
+			// variation attributes
+			foreach ( $product->get_variation_attributes() as $attribute_name => $attribute ) {
+
+				// taxonomy-based attributes are prefixed with `pa_`, otherwise simply `attribute_`
+				$attributes[] = array(
+					'name'   => wc_attribute_label( str_replace( 'attribute_', '', $attribute_name ) ),
+					'slug'   => str_replace( 'attribute_', '', str_replace( 'pa_', '', $attribute_name ) ),
+					'option' => $attribute,
+				);
+			}
+
+		} else {
+
+			foreach ( $product->get_attributes() as $attribute ) {
+
+				// taxonomy-based attributes are comma-separated, others are pipe (|) separated
+				if ( $attribute['is_taxonomy'] ) {
+					$options = explode( ',', $product->get_attribute( $attribute['name'] ) );
+				} else {
+					$options = explode( '|', $product->get_attribute( $attribute['name'] ) );
+				}
+
+				$attributes[] = array(
+					'name'      => wc_attribute_label( $attribute['name'] ),
+					'slug'      => str_replace( 'pa_', '', $attribute['name'] ),
+					'position'  => (int) $attribute['position'],
+					'visible'   => (bool) $attribute['is_visible'],
+					'variation' => (bool) $attribute['is_variation'],
+					'options'   => array_map( 'trim', $options ),
+				);
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Get the downloads for a product or product variation
+	 *
+	 * @since 2.1
+	 * @param WC_Product|WC_Product_Variation $product
+	 * @return array
+	 */
+	private function get_downloads( $product ) {
+
+		$downloads = array();
+
+		if ( $product->is_downloadable() ) {
+
+			foreach ( $product->get_files() as $file_id => $file ) {
+
+				$downloads[] = array(
+					'id'   => $file_id, // do not cast as int as this is a hash
+					'name' => $file['name'],
+					'file' => $file['file'],
+				);
+			}
+		}
+
+		return $downloads;
+	}
+
+	/**
+	 * Get a listing of product attributes
+	 *
+	 * @since 2.4.0
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_product_attributes( $fields = null ) {
+		try {
+			// Permissions check
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce' ), 401 );
+			}
+
+			$product_attributes   = array();
+			$attribute_taxonomies = wc_get_attribute_taxonomies();
+
+			foreach ( $attribute_taxonomies as $attribute ) {
+				$product_attributes[] = array(
+					'id'           => intval( $attribute->attribute_id ),
+					'name'         => $attribute->attribute_label,
+					'slug'         => wc_attribute_taxonomy_name( $attribute->attribute_name ),
+					'type'         => $attribute->attribute_type,
+					'order_by'     => $attribute->attribute_orderby,
+					'has_archives' => (bool) $attribute->attribute_public
+				);
+			}
+
+			return array( 'product_attributes' => apply_filters( 'woocommerce_api_product_attributes_response', $product_attributes, $attribute_taxonomies, $fields, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get the product attribute for the given ID
+	 *
+	 * @since 2.4.0
+	 * @param string $id product attribute term ID
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_product_attribute( $id, $fields = null ) {
+		global $wpdb;
+
+		try {
+			$id = absint( $id );
+
+			// Validate ID
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'Invalid product attribute ID', 'woocommerce' ), 400 );
+			}
+
+			// Permissions check
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product attributes', 'woocommerce' ), 401 );
+			}
+
+			$attribute = $wpdb->get_row( $wpdb->prepare( "
+				SELECT *
+				FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
+				WHERE attribute_id = %d
+			 ", $id ) );
+
+			if ( is_wp_error( $attribute ) || is_null( $attribute ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			$product_attribute = array(
+				'id'           => intval( $attribute->attribute_id ),
+				'name'         => $attribute->attribute_label,
+				'slug'         => wc_attribute_taxonomy_name( $attribute->attribute_name ),
+				'type'         => $attribute->attribute_type,
+				'order_by'     => $attribute->attribute_orderby,
+				'has_archives' => (bool) $attribute->attribute_public
+			);
+
+			return array( 'product_attribute' => apply_filters( 'woocommerce_api_product_attribute_response', $product_attribute, $id, $fields, $attribute, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Validate attribute data.
+	 *
+	 * @since  2.4.0
+	 * @param  string $name
+	 * @param  string $slug
+	 * @param  string $type
+	 * @param  string $order_by
+	 * @param  bool   $new_data
+	 * @return bool
+	 */
+	protected function validate_attribute_data( $name, $slug, $type, $order_by, $new_data = true ) {
+		if ( empty( $name ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
+		}
+
+		if ( strlen( $slug ) >= 28 ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), 400 );
+		} else if ( wc_check_if_attribute_name_is_reserved( $slug ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), $slug ), 400 );
+		} else if ( $new_data && taxonomy_exists( wc_attribute_taxonomy_name( $slug ) ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_already_exists', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), $slug ), 400 );
+		}
+
+		// Validate the attribute type
+		if ( ! in_array( wc_clean( $type ), array_keys( wc_get_attribute_types() ) ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_type', sprintf( __( 'Invalid product attribute type - the product attribute type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_attribute_types() ) ) ), 400 );
+		}
+
+		// Validate the attribute order by
+		if ( ! in_array( wc_clean( $order_by ), array( 'menu_order', 'name', 'name_num', 'id' ) ) ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_order_by', sprintf( __( 'Invalid product attribute order_by type - the product attribute order_by type must be any of these: %s', 'woocommerce' ), implode( ', ', array( 'menu_order', 'name', 'name_num', 'id' ) ) ), 400 );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create a new product attribute
+	 *
+	 * @since 2.4.0
+	 * @param array $data posted data
+	 * @return array
+	 */
+	public function create_product_attribute( $data ) {
+		global $wpdb;
+
+		try {
+			if ( ! isset( $data['product_attribute'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_attribute' ), 400 );
+			}
+
+			$data = $data['product_attribute'];
+
+			// Check permissions
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_product_attribute_data', $data, $this );
+
+			if ( ! isset( $data['name'] ) ) {
+				$data['name'] = '';
+			}
+
+			// Set the attribute slug
+			if ( ! isset( $data['slug'] ) ) {
+				$data['slug'] = wc_sanitize_taxonomy_name( stripslashes( $data['name'] ) );
+			} else {
+				$data['slug'] = preg_replace( '/^pa\_/', '', wc_sanitize_taxonomy_name( stripslashes( $data['slug'] ) ) );
+			}
+
+			// Set attribute type when not sent
+			if ( ! isset( $data['type'] ) ) {
+				$data['type'] = 'select';
+			}
+
+			// Set order by when not sent
+			if ( ! isset( $data['order_by'] ) ) {
+				$data['order_by'] = 'menu_order';
+			}
+
+			// Validate the attribute data
+			$this->validate_attribute_data( $data['name'], $data['slug'], $data['type'], $data['order_by'], true );
+
+			$insert = $wpdb->insert(
+				$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+				array(
+					'attribute_label'   => $data['name'],
+					'attribute_name'    => $data['slug'],
+					'attribute_type'    => $data['type'],
+					'attribute_orderby' => $data['order_by'],
+					'attribute_public'  => isset( $data['has_archives'] ) && true === $data['has_archives'] ? 1 : 0
+				),
+				array( '%s', '%s', '%s', '%s', '%d' )
+			);
+
+			// Checks for an error in the product creation
+			if ( is_wp_error( $insert ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_product_attribute', $insert->get_error_message(), 400 );
+			}
+
+			$id = $wpdb->insert_id;
+
+			do_action( 'woocommerce_api_create_product_attribute', $id, $data );
+
+			// Clear transients
+			delete_transient( 'wc_attribute_taxonomies' );
+
+			$this->server->send_status( 201 );
+
+			return $this->get_product_attribute( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit a product attribute
+	 *
+	 * @since 2.4.0
+	 * @param int $id the attribute ID
+	 * @param array $data
+	 * @return array
+	 */
+	public function edit_product_attribute( $id, $data ) {
+		global $wpdb;
+
+		try {
+			if ( ! isset( $data['product_attribute'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_attribute' ), 400 );
+			}
+
+			$id   = absint( $id );
+			$data = $data['product_attribute'];
+
+			// Check permissions
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce' ), 401 );
+			}
+
+			$data      = apply_filters( 'woocommerce_api_edit_product_attribute_data', $data, $this );
+			$attribute = $this->get_product_attribute( $id );
+
+			if ( is_wp_error( $attribute ) ) {
+				return $attribute;
+			}
+
+			$attribute_name     = isset( $data['name'] ) ? $data['name'] : $attribute['product_attribute']['name'];
+			$attribute_type     = isset( $data['type'] ) ? $data['type'] : $attribute['product_attribute']['type'];
+			$attribute_order_by = isset( $data['order_by'] ) ? $data['order_by'] : $attribute['product_attribute']['order_by'];
+
+			if ( isset( $data['slug'] ) ) {
+				$attribute_slug = wc_sanitize_taxonomy_name( stripslashes( $data['slug'] ) );
+			} else {
+				$attribute_slug = $attribute['product_attribute']['slug'];
+			}
+			$attribute_slug = preg_replace( '/^pa\_/', '', $attribute_slug );
+
+			if ( isset( $data['has_archives'] ) ) {
+				$attribute_public = true === $data['has_archives'] ? 1 : 0;
+			} else {
+				$attribute_public = $attribute['product_attribute']['has_archives'];
+			}
+
+			// Validate the attribute data
+			$this->validate_attribute_data( $attribute_name, $attribute_slug, $attribute_type, $attribute_order_by, false );
+
+			$update = $wpdb->update(
+				$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+				array(
+					'attribute_label'   => $attribute_name,
+					'attribute_name'    => $attribute_slug,
+					'attribute_type'    => $attribute_type,
+					'attribute_orderby' => $attribute_order_by,
+					'attribute_public'  => $attribute_public
+				),
+				array( 'attribute_id' => $id ),
+				array( '%s', '%s', '%s', '%s', '%d' ),
+				array( '%d' )
+			);
+
+			// Checks for an error in the product creation
+			if ( false === $update ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_attribute', __( 'Could not edit the attribute', 'woocommerce' ), 400 );
+			}
+
+			do_action( 'woocommerce_api_edit_product_attribute', $id, $data );
+
+			// Clear transients
+			delete_transient( 'wc_attribute_taxonomies' );
+
+			return $this->get_product_attribute( $id );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete a product attribute
+	 *
+	 * @since  2.4.0
+	 * @param  int $id the product attribute ID
+	 * @return array
+	 */
+	public function delete_product_attribute( $id ) {
+		global $wpdb;
+
+		try {
+			// Check permissions
+			if ( ! current_user_can( 'manage_product_terms' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute', __( 'You do not have permission to delete product attributes', 'woocommerce' ), 401 );
+			}
+
+			$id = absint( $id );
+
+			$attribute_name = $wpdb->get_var( $wpdb->prepare( "
+				SELECT attribute_name
+				FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
+				WHERE attribute_id = %d
+			 ", $id ) );
+
+			if ( is_null( $attribute_name ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+			}
+
+			$deleted = $wpdb->delete(
+				$wpdb->prefix . 'woocommerce_attribute_taxonomies',
+				array( 'attribute_id' => $id ),
+				array( '%d' )
+			);
+
+			if ( false === $deleted ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute', __( 'Could not delete the attribute', 'woocommerce' ), 401 );
+			}
+
+			$taxonomy = wc_attribute_taxonomy_name( $attribute_name );
+
+			if ( taxonomy_exists( $taxonomy ) ) {
+				$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
+				foreach ( $terms as $term ) {
+					wp_delete_term( $term->term_id, $taxonomy );
+				}
+			}
+
+			do_action( 'woocommerce_attribute_deleted', $id, $attribute_name, $taxonomy );
+			do_action( 'woocommerce_api_delete_product_attribute', $id, $this );
+
+			// Clear transients
+			delete_transient( 'wc_attribute_taxonomies' );
+
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Get product by SKU
+	 *
+	 * @deprecated 2.4.0
+	 *
+	 * @since  2.3.0
+	 * @param  int    $sku the product SKU
+	 * @param  string $fields
+	 * @return array
+	 */
+	public function get_product_by_sku( $sku, $fields = null ) {
+		try {
+			$id = wc_get_product_id_by_sku( $sku );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_sku', __( 'Invalid product SKU', 'woocommerce' ), 404 );
+			}
+
+			return $this->get_product( $id, $fields );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Clear product
+	 */
+	protected function clear_product( $product_id ) {
+		if ( 0 >= $product_id ) {
+			return;
+		}
+
+		// Delete product attachments
+		$attachments = get_children( array(
+			'post_parent' => $product_id,
+			'post_status' => 'any',
+			'post_type'   => 'attachment',
+		) );
+
+		foreach ( (array) $attachments as $attachment ) {
+			wp_delete_attachment( $attachment->ID, true );
+		}
+
+		// Delete product
+		wp_delete_post( $product_id, true );
+	}
+
+	/**
+	 * Bulk update or insert products
+	 * Accepts an array with products in the formats supported by
+	 * WC_API_Products->create_product() and WC_API_Products->edit_product()
+	 *
+	 * @since 2.4.0
+	 * @param array $data
+	 * @return array
+	 */
+	public function bulk( $data ) {
+
+		try {
+			if ( ! isset( $data['products'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_products_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'products' ), 400 );
+			}
+
+			$data  = $data['products'];
+			$limit = apply_filters( 'woocommerce_api_bulk_limit', 100, 'products' );
+
+			// Limit bulk operation
+			if ( count( $data ) > $limit ) {
+				throw new WC_API_Exception( 'woocommerce_api_products_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request', 'woocommerce' ), $limit ), 413 );
+			}
+
+			$products = array();
+
+			foreach ( $data as $_product ) {
+				$product_id  = 0;
+				$product_sku = '';
+
+				// Try to get the product ID
+				if ( isset( $_product['id'] ) ) {
+					$product_id = intval( $_product['id'] );
+				}
+
+				if ( ! $product_id && isset( $_product['sku'] ) ) {
+					$product_sku = wc_clean( $_product['sku'] );
+					$product_id  = wc_get_product_id_by_sku( $product_sku );
+				}
+
+				// Product exists / edit product
+				if ( $product_id ) {
+					$edit = $this->edit_product( $product_id, array( 'product' => $_product ) );
+
+					if ( is_wp_error( $edit ) ) {
+						$products[] = array(
+							'id'    => $product_id,
+							'sku'   => $product_sku,
+							'error' => array( 'code' => $edit->get_error_code(), 'message' => $edit->get_error_message() )
+						);
+					} else {
+						$products[] = $edit['product'];
+					}
+				}
+
+				// Product don't exists / create product
+				else {
+					$new = $this->create_product( array( 'product' => $_product ) );
+
+					if ( is_wp_error( $new ) ) {
+						$products[] = array(
+							'id'    => $product_id,
+							'sku'   => $product_sku,
+							'error' => array( 'code' => $new->get_error_code(), 'message' => $new->get_error_message() )
+						);
+					} else {
+						$products[] = $new['product'];
+					}
+				}
+			}
+
+			return array( 'products' => apply_filters( 'woocommerce_api_products_bulk_response', $products, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+}

--- a/includes/api/v2/class-wc-api-reports.php
+++ b/includes/api/v2/class-wc-api-reports.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * WooCommerce API Reports Class
+ *
+ * Handles requests to the /reports endpoint
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Reports extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/reports';
+
+	/** @var WC_Admin_Report instance */
+	private $report;
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * GET /reports
+	 * GET /reports/sales
+	 *
+	 * @since 2.1
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET /reports
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_reports' ),     WC_API_Server::READABLE ),
+		);
+
+		# GET /reports/sales
+		$routes[ $this->base . '/sales'] = array(
+			array( array( $this, 'get_sales_report' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /reports/sales/top_sellers
+		$routes[ $this->base . '/sales/top_sellers' ] = array(
+			array( array( $this, 'get_top_sellers_report' ), WC_API_Server::READABLE ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get a simple listing of available reports
+	 *
+	 * @since 2.1
+	 * @return array
+	 */
+	public function get_reports() {
+		return array( 'reports' => array( 'sales', 'sales/top_sellers' ) );
+	}
+
+	/**
+	 * Get the sales report
+	 *
+	 * @since 2.1
+	 * @param string $fields fields to include in response
+	 * @param array $filter date filtering
+	 * @return array
+	 */
+	public function get_sales_report( $fields = null, $filter = array() ) {
+
+		// check user permissions
+		$check = $this->validate_request();
+
+		// check for WP_Error
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		// set date filtering
+		$this->setup_report( $filter );
+
+		// new customers
+		$users_query = new WP_User_Query(
+			array(
+				'fields' => array( 'user_registered' ),
+				'role'   => 'customer',
+			)
+		);
+
+		$customers = $users_query->get_results();
+
+		foreach ( $customers as $key => $customer ) {
+			if ( strtotime( $customer->user_registered ) < $this->report->start_date || strtotime( $customer->user_registered ) > $this->report->end_date ) {
+				unset( $customers[ $key ] );
+			}
+		}
+
+		$total_customers = count( $customers );
+		$report_data     = $this->report->get_report_data();
+		$period_totals   = array();
+
+		// setup period totals by ensuring each period in the interval has data
+		for ( $i = 0; $i <= $this->report->chart_interval; $i ++ ) {
+
+			switch ( $this->report->chart_groupby ) {
+				case 'day' :
+					$time = date( 'Y-m-d', strtotime( "+{$i} DAY", $this->report->start_date ) );
+					break;
+				default :
+					$time = date( 'Y-m', strtotime( "+{$i} MONTH", $this->report->start_date ) );
+					break;
+			}
+
+			// set the customer signups for each period
+			$customer_count = 0;
+			foreach ( $customers as $customer ) {
+				if ( date( ( 'day' == $this->report->chart_groupby ) ? 'Y-m-d' : 'Y-m', strtotime( $customer->user_registered ) ) == $time ) {
+					$customer_count++;
+				}
+ 			}
+
+			$period_totals[ $time ] = array(
+				'sales'     => wc_format_decimal( 0.00, 2 ),
+				'orders'    => 0,
+				'items'     => 0,
+				'tax'       => wc_format_decimal( 0.00, 2 ),
+				'shipping'  => wc_format_decimal( 0.00, 2 ),
+				'discount'  => wc_format_decimal( 0.00, 2 ),
+				'customers' => $customer_count,
+			);
+		}
+
+		// add total sales, total order count, total tax and total shipping for each period
+		foreach ( $report_data->orders as $order ) {
+			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $order->post_date ) ) : date( 'Y-m', strtotime( $order->post_date ) );
+
+			if ( ! isset( $period_totals[ $time ] ) ) {
+				continue;
+			}
+
+			$period_totals[ $time ]['sales']    = wc_format_decimal( $order->total_sales, 2 );
+			$period_totals[ $time ]['tax']      = wc_format_decimal( $order->total_tax + $order->total_shipping_tax, 2 );
+			$period_totals[ $time ]['shipping'] = wc_format_decimal( $order->total_shipping, 2 );
+		}
+
+		foreach ( $report_data->order_counts as $order ) {
+			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $order->post_date ) ) : date( 'Y-m', strtotime( $order->post_date ) );
+
+			if ( ! isset( $period_totals[ $time ] ) ) {
+				continue;
+			}
+
+			$period_totals[ $time ]['orders']   = (int) $order->count;
+		}
+
+		// add total order items for each period
+		foreach ( $report_data->order_items as $order_item ) {
+			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $order_item->post_date ) ) : date( 'Y-m', strtotime( $order_item->post_date ) );
+
+			if ( ! isset( $period_totals[ $time ] ) ) {
+				continue;
+			}
+
+			$period_totals[ $time ]['items'] = (int) $order_item->order_item_count;
+		}
+
+		// add total discount for each period
+		foreach ( $report_data->coupons as $discount ) {
+			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $discount->post_date ) ) : date( 'Y-m', strtotime( $discount->post_date ) );
+
+			if ( ! isset( $period_totals[ $time ] ) ) {
+				continue;
+			}
+
+			$period_totals[ $time ]['discount'] = wc_format_decimal( $discount->discount_amount, 2 );
+		}
+
+		$sales_data  = array(
+			'total_sales'       => $report_data->total_sales,
+			'net_sales'         => $report_data->net_sales,
+			'average_sales'     => $report_data->average_sales,
+			'total_orders'      => $report_data->total_orders,
+			'total_items'       => $report_data->total_items,
+			'total_tax'         => wc_format_decimal( $report_data->total_tax + $report_data->total_shipping_tax, 2 ),
+			'total_shipping'    => $report_data->total_shipping,
+			'total_refunds'     => $report_data->total_refunds,
+			'total_discount'    => $report_data->total_coupons,
+			'totals_grouped_by' => $this->report->chart_groupby,
+			'totals'            => $period_totals,
+			'total_customers'   => $total_customers,
+		);
+
+		return array( 'sales' => apply_filters( 'woocommerce_api_report_response', $sales_data, $this->report, $fields, $this->server ) );
+	}
+
+	/**
+	 * Get the top sellers report
+	 *
+	 * @since 2.1
+	 * @param string $fields fields to include in response
+	 * @param array $filter date filtering
+	 * @return array
+	 */
+	public function get_top_sellers_report( $fields = null, $filter = array() ) {
+
+		// check user permissions
+		$check = $this->validate_request();
+
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		// set date filtering
+		$this->setup_report( $filter );
+
+		$top_sellers = $this->report->get_order_report_data( array(
+			'data' => array(
+				'_product_id' => array(
+					'type'            => 'order_item_meta',
+					'order_item_type' => 'line_item',
+					'function'        => '',
+					'name'            => 'product_id'
+				),
+				'_qty' => array(
+					'type'            => 'order_item_meta',
+					'order_item_type' => 'line_item',
+					'function'        => 'SUM',
+					'name'            => 'order_item_qty'
+				)
+			),
+			'order_by'     => 'order_item_qty DESC',
+			'group_by'     => 'product_id',
+			'limit'        => isset( $filter['limit'] ) ? absint( $filter['limit'] ) : 12,
+			'query_type'   => 'get_results',
+			'filter_range' => true,
+		) );
+
+		$top_sellers_data = array();
+
+		foreach ( $top_sellers as $top_seller ) {
+
+			$product = wc_get_product( $top_seller->product_id );
+
+			if ( $product ) {
+				$top_sellers_data[] = array(
+					'title'      => $product->get_title(),
+					'product_id' => $top_seller->product_id,
+					'quantity'   => $top_seller->order_item_qty,
+				);
+			}
+		}
+
+		return array( 'top_sellers' => apply_filters( 'woocommerce_api_report_response', $top_sellers_data, $this->report, $fields, $this->server ) );
+	}
+
+	/**
+	 * Setup the report object and parse any date filtering
+	 *
+	 * @since 2.1
+	 * @param array $filter date filtering
+	 */
+	private function setup_report( $filter ) {
+
+		include_once( WC()->plugin_path() . '/includes/admin/reports/class-wc-admin-report.php' );
+		include_once( WC()->plugin_path() . '/includes/admin/reports/class-wc-report-sales-by-date.php' );
+
+		$this->report = new WC_Report_Sales_By_Date();
+
+		if ( empty( $filter['period'] ) ) {
+
+			// custom date range
+			$filter['period'] = 'custom';
+
+			if ( ! empty( $filter['date_min'] ) || ! empty( $filter['date_max'] ) ) {
+
+				// overwrite _GET to make use of WC_Admin_Report::calculate_current_range() for custom date ranges
+				$_GET['start_date'] = $this->server->parse_datetime( $filter['date_min'] );
+				$_GET['end_date'] = isset( $filter['date_max'] ) ? $this->server->parse_datetime( $filter['date_max'] ) : null;
+
+			} else {
+
+				// default custom range to today
+				$_GET['start_date'] = $_GET['end_date'] = date( 'Y-m-d', current_time( 'timestamp' ) );
+			}
+
+		} else {
+
+			// ensure period is valid
+			if ( ! in_array( $filter['period'], array( 'week', 'month', 'last_month', 'year' ) ) ) {
+				$filter['period'] = 'week';
+			}
+
+			// TODO: change WC_Admin_Report class to use "week" instead, as it's more consistent with other periods
+			// allow "week" for period instead of "7day"
+			if ( 'week' === $filter['period'] ) {
+				$filter['period'] = '7day';
+			}
+		}
+
+		$this->report->calculate_current_range( $filter['period'] );
+	}
+
+	/**
+	 * Verify that the current user has permission to view reports
+	 *
+	 * @since 2.1
+	 * @see WC_API_Resource::validate_request()
+	 * @param null $id unused
+	 * @param null $type unused
+	 * @param null $context unused
+	 * @return bool true if the request is valid and should be processed, false otherwise
+	 */
+	protected function validate_request( $id = null, $type = null, $context = null ) {
+
+		if ( ! current_user_can( 'view_woocommerce_reports' ) ) {
+
+			return new WP_Error( 'woocommerce_api_user_cannot_read_report', __( 'You do not have permission to read this report', 'woocommerce' ), array( 'status' => 401 ) );
+
+		} else {
+
+			return true;
+		}
+	}
+}

--- a/includes/api/v2/class-wc-api-resource.php
+++ b/includes/api/v2/class-wc-api-resource.php
@@ -1,0 +1,458 @@
+<?php
+/**
+ * WooCommerce API Resource class
+ *
+ * Provides shared functionality for resource-specific API classes
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Resource {
+
+	/** @var WC_API_Server the API server */
+	protected $server;
+
+	/** @var string sub-classes override this to set a resource-specific base route */
+	protected $base;
+
+	/**
+	 * Setup class
+	 *
+	 * @since 2.1
+	 * @param WC_API_Server $server
+	 * @return WC_API_Resource
+	 */
+	public function __construct( WC_API_Server $server ) {
+
+		$this->server = $server;
+
+		// automatically register routes for sub-classes
+		add_filter( 'woocommerce_api_endpoints', array( $this, 'register_routes' ) );
+
+		// maybe add meta to top-level resource responses
+		foreach ( array( 'order', 'coupon', 'customer', 'product', 'report' ) as $resource ) {
+			add_filter( "woocommerce_api_{$resource}_response", array( $this, 'maybe_add_meta' ), 15, 2 );
+		}
+
+		$response_names = array( 'order', 'coupon', 'customer', 'product', 'report',
+			'customer_orders', 'customer_downloads', 'order_note', 'order_refund',
+			'product_reviews', 'product_category'
+		);
+
+		foreach ( $response_names as $name ) {
+
+			/* remove fields from responses when requests specify certain fields
+			 * note these are hooked at a later priority so data added via
+			 * filters (e.g. customer data to the order response) still has the
+			 * fields filtered properly
+			 */
+			add_filter( "woocommerce_api_{$name}_response", array( $this, 'filter_response_fields' ), 20, 3 );
+		}
+	}
+
+	/**
+	 * Validate the request by checking:
+	 *
+	 * 1) the ID is a valid integer
+	 * 2) the ID returns a valid post object and matches the provided post type
+	 * 3) the current user has the proper permissions to read/edit/delete the post
+	 *
+	 * @since 2.1
+	 * @param string|int $id the post ID
+	 * @param string $type the post type, either `shop_order`, `shop_coupon`, or `product`
+	 * @param string $context the context of the request, either `read`, `edit` or `delete`
+	 * @return int|WP_Error valid post ID or WP_Error if any of the checks fails
+	 */
+	protected function validate_request( $id, $type, $context ) {
+
+		if ( 'shop_order' === $type || 'shop_coupon' === $type || 'shop_webhook' === $type ) {
+			$resource_name = str_replace( 'shop_', '', $type );
+		} else {
+			$resource_name = $type;
+		}
+
+		$id = absint( $id );
+
+		// Validate ID
+		if ( empty( $id ) ) {
+			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+		}
+
+		// Only custom post types have per-post type/permission checks
+		if ( 'customer' !== $type ) {
+
+			$post = get_post( $id );
+
+			if ( null === $post ) {
+				return new WP_Error( "woocommerce_api_no_{$resource_name}_found", sprintf( __( 'No %s found with the ID equal to %s', 'woocommerce' ), $resource_name, $id ), array( 'status' => 404 ) );
+			}
+
+			// For checking permissions, product variations are the same as the product post type
+			$post_type = ( 'product_variation' === $post->post_type ) ? 'product' : $post->post_type;
+
+			// Validate post type
+			if ( $type !== $post_type ) {
+				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce' ), $resource_name ), array( 'status' => 404 ) );
+			}
+
+			// Validate permissions
+			switch ( $context ) {
+
+				case 'read':
+					if ( ! $this->is_readable( $post ) )
+						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					break;
+
+				case 'edit':
+					if ( ! $this->is_editable( $post ) )
+						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					break;
+
+				case 'delete':
+					if ( ! $this->is_deletable( $post ) )
+						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					break;
+			}
+		}
+
+		return $id;
+	}
+
+	/**
+	 * Add common request arguments to argument list before WP_Query is run
+	 *
+	 * @since 2.1
+	 * @param array $base_args required arguments for the query (e.g. `post_type`, etc)
+	 * @param array $request_args arguments provided in the request
+	 * @return array
+	 */
+	protected function merge_query_args( $base_args, $request_args ) {
+
+		$args = array();
+
+		// date
+		if ( ! empty( $request_args['created_at_min'] ) || ! empty( $request_args['created_at_max'] ) || ! empty( $request_args['updated_at_min'] ) || ! empty( $request_args['updated_at_max'] ) ) {
+
+			$args['date_query'] = array();
+
+			// resources created after specified date
+			if ( ! empty( $request_args['created_at_min'] ) ) {
+				$args['date_query'][] = array( 'column' => 'post_date_gmt', 'after' => $this->server->parse_datetime( $request_args['created_at_min'] ), 'inclusive' => true );
+			}
+
+			// resources created before specified date
+			if ( ! empty( $request_args['created_at_max'] ) ) {
+				$args['date_query'][] = array( 'column' => 'post_date_gmt', 'before' => $this->server->parse_datetime( $request_args['created_at_max'] ), 'inclusive' => true );
+			}
+
+			// resources updated after specified date
+			if ( ! empty( $request_args['updated_at_min'] ) ) {
+				$args['date_query'][] = array( 'column' => 'post_modified_gmt', 'after' => $this->server->parse_datetime( $request_args['updated_at_min'] ), 'inclusive' => true );
+			}
+
+			// resources updated before specified date
+			if ( ! empty( $request_args['updated_at_max'] ) ) {
+				$args['date_query'][] = array( 'column' => 'post_modified_gmt', 'before' => $this->server->parse_datetime( $request_args['updated_at_max'] ), 'inclusive' => true );
+			}
+		}
+
+		// search
+		if ( ! empty( $request_args['q'] ) ) {
+			$args['s'] = $request_args['q'];
+		}
+
+		// resources per response
+		if ( ! empty( $request_args['limit'] ) ) {
+			$args['posts_per_page'] = $request_args['limit'];
+		}
+
+		// resource offset
+		if ( ! empty( $request_args['offset'] ) ) {
+			$args['offset'] = $request_args['offset'];
+		}
+
+		// order (ASC or DESC, ASC by default)
+		if ( ! empty( $request_args['order'] ) ) {
+			$args['order'] = $request_args['order'];
+		}
+
+		// orderby
+		if ( ! empty( $request_args['orderby'] ) ) {
+			$args['orderby'] = $request_args['orderby'];
+
+			// allow sorting by meta value
+			if ( ! empty( $request_args['orderby_meta_key'] ) ) {
+				$args['meta_key'] = $request_args['orderby_meta_key'];
+			}
+		}
+
+		// allow post status change
+		if ( ! empty( $request_args['post_status'] ) ) {
+			$args['post_status'] = $request_args['post_status'];
+			unset( $request_args['post_status'] );
+		}
+
+		// filter by a list of post id
+		if ( ! empty( $request_args['in'] ) ) {
+			$args['post__in'] = explode( ',', $request_args['in'] );
+			unset( $request_args['in'] );
+		}
+
+
+		// resource page
+		$args['paged'] = ( isset( $request_args['page'] ) ) ? absint( $request_args['page'] ) : 1;
+
+		$args = apply_filters( 'woocommerce_api_query_args', $args, $request_args );
+
+		return array_merge( $base_args, $args );
+	}
+
+	/**
+	 * Add meta to resources when requested by the client. Meta is added as a top-level
+	 * `<resource_name>_meta` attribute (e.g. `order_meta`) as a list of key/value pairs
+	 *
+	 * @since 2.1
+	 * @param array $data the resource data
+	 * @param object $resource the resource object (e.g WC_Order)
+	 * @return mixed
+	 */
+	public function maybe_add_meta( $data, $resource ) {
+
+		if ( isset( $this->server->params['GET']['filter']['meta'] ) && 'true' === $this->server->params['GET']['filter']['meta'] && is_object( $resource ) ) {
+
+			// don't attempt to add meta more than once
+			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) )
+				return $data;
+
+			// define the top-level property name for the meta
+			switch ( get_class( $resource ) ) {
+
+				case 'WC_Order':
+					$meta_name = 'order_meta';
+					break;
+
+				case 'WC_Coupon':
+					$meta_name = 'coupon_meta';
+					break;
+
+				case 'WP_User':
+					$meta_name = 'customer_meta';
+					break;
+
+				default:
+					$meta_name = 'product_meta';
+					break;
+			}
+
+			if ( is_a( $resource, 'WP_User' ) ) {
+
+				// customer meta
+				$meta = (array) get_user_meta( $resource->ID );
+
+			} elseif ( is_a( $resource, 'WC_Product_Variation' ) ) {
+
+				// product variation meta
+				$meta = (array) get_post_meta( $resource->get_variation_id() );
+
+			} else {
+
+				// coupon/order/product meta
+				$meta = (array) get_post_meta( $resource->id );
+			}
+
+			foreach( $meta as $meta_key => $meta_value ) {
+
+				// don't add hidden meta by default
+				if ( ! is_protected_meta( $meta_key ) ) {
+					$data[ $meta_name ][ $meta_key ] = maybe_unserialize( $meta_value[0] );
+				}
+			}
+
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Restrict the fields included in the response if the request specified certain only certain fields should be returned
+	 *
+	 * @since 2.1
+	 * @param array $data the response data
+	 * @param object $resource the object that provided the response data, e.g. WC_Coupon or WC_Order
+	 * @param array|string the requested list of fields to include in the response
+	 * @return array response data
+	 */
+	public function filter_response_fields( $data, $resource, $fields ) {
+
+		if ( ! is_array( $data ) || empty( $fields ) ) {
+			return $data;
+		}
+
+		$fields = explode( ',', $fields );
+		$sub_fields = array();
+
+		// get sub fields
+		foreach ( $fields as $field ) {
+
+			if ( false !== strpos( $field, '.' ) ) {
+
+				list( $name, $value ) = explode( '.', $field );
+
+				$sub_fields[ $name ] = $value;
+			}
+		}
+
+		// iterate through top-level fields
+		foreach ( $data as $data_field => $data_value ) {
+
+			// if a field has sub-fields and the top-level field has sub-fields to filter
+			if ( is_array( $data_value ) && in_array( $data_field, array_keys( $sub_fields ) ) ) {
+
+				// iterate through each sub-field
+				foreach ( $data_value as $sub_field => $sub_field_value ) {
+
+					// remove non-matching sub-fields
+					if ( ! in_array( $sub_field, $sub_fields ) ) {
+						unset( $data[ $data_field ][ $sub_field ] );
+					}
+				}
+
+			} else {
+
+				// remove non-matching top-level fields
+				if ( ! in_array( $data_field, $fields ) ) {
+					unset( $data[ $data_field ] );
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Delete a given resource
+	 *
+	 * @since 2.1
+	 * @param int $id the resource ID
+	 * @param string $type the resource post type, or `customer`
+	 * @param bool $force true to permanently delete resource, false to move to trash (not supported for `customer`)
+	 * @return array|WP_Error
+	 */
+	protected function delete( $id, $type, $force = false ) {
+
+		if ( 'shop_order' === $type || 'shop_coupon' === $type ) {
+			$resource_name = str_replace( 'shop_', '', $type );
+		} else {
+			$resource_name = $type;
+		}
+
+		if ( 'customer' === $type ) {
+
+			$result = wp_delete_user( $id );
+
+			if ( $result )
+				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce' ) );
+			else
+				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce' ), array( 'status' => 500 ) );
+
+		} else {
+
+			// delete order/coupon/product/webhook
+
+			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
+
+			if ( ! $result )
+				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), $resource_name ), array( 'status' => 500 ) );
+
+			if ( $force ) {
+				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), $resource_name ) );
+
+			} else {
+
+				$this->server->send_status( '202' );
+
+				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), $resource_name ) );
+			}
+		}
+	}
+
+
+	/**
+	 * Checks if the given post is readable by the current user
+	 *
+	 * @since 2.1
+	 * @see WC_API_Resource::check_permission()
+	 * @param WP_Post|int $post
+	 * @return bool
+	 */
+	protected function is_readable( $post ) {
+
+		return $this->check_permission( $post, 'read' );
+	}
+
+	/**
+	 * Checks if the given post is editable by the current user
+	 *
+	 * @since 2.1
+	 * @see WC_API_Resource::check_permission()
+	 * @param WP_Post|int $post
+	 * @return bool
+	 */
+	protected function is_editable( $post ) {
+
+		return $this->check_permission( $post, 'edit' );
+
+	}
+
+	/**
+	 * Checks if the given post is deletable by the current user
+	 *
+	 * @since 2.1
+	 * @see WC_API_Resource::check_permission()
+	 * @param WP_Post|int $post
+	 * @return bool
+	 */
+	protected function is_deletable( $post ) {
+
+		return $this->check_permission( $post, 'delete' );
+	}
+
+	/**
+	 * Checks the permissions for the current user given a post and context
+	 *
+	 * @since 2.1
+	 * @param WP_Post|int $post
+	 * @param string $context the type of permission to check, either `read`, `write`, or `delete`
+	 * @return bool true if the current user has the permissions to perform the context on the post
+	 */
+	private function check_permission( $post, $context ) {
+
+		if ( ! is_a( $post, 'WP_Post' ) ) {
+			$post = get_post( $post );
+		}
+
+		if ( is_null( $post ) ) {
+			return false;
+		}
+
+		$post_type = get_post_type_object( $post->post_type );
+
+		if ( 'read' === $context ) {
+			return ( 'revision' !== $post->post_type && current_user_can( $post_type->cap->read_private_posts, $post->ID ) );
+		} elseif ( 'edit' === $context ) {
+			return current_user_can( $post_type->cap->edit_post, $post->ID );
+		} elseif ( 'delete' === $context ) {
+			return current_user_can( $post_type->cap->delete_post, $post->ID );
+		} else {
+			return false;
+		}
+	}
+
+}

--- a/includes/api/v2/class-wc-api-server.php
+++ b/includes/api/v2/class-wc-api-server.php
@@ -1,0 +1,750 @@
+<?php
+/**
+ * WooCommerce API
+ *
+ * Handles REST API requests
+ *
+ * This class and related code (JSON response handler, resource classes) are based on WP-API v0.6 (https://github.com/WP-API/WP-API)
+ * Many thanks to Ryan McCue and any other contributors!
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+require_once ABSPATH . 'wp-admin/includes/admin.php';
+
+class WC_API_Server {
+
+	const METHOD_GET    = 1;
+	const METHOD_POST   = 2;
+	const METHOD_PUT    = 4;
+	const METHOD_PATCH  = 8;
+	const METHOD_DELETE = 16;
+
+	const READABLE   = 1;  // GET
+	const CREATABLE  = 2;  // POST
+	const EDITABLE   = 14; // POST | PUT | PATCH
+	const DELETABLE  = 16; // DELETE
+	const ALLMETHODS = 31; // GET | POST | PUT | PATCH | DELETE
+
+	/**
+	 * Does the endpoint accept a raw request body?
+	 */
+	const ACCEPT_RAW_DATA = 64;
+
+	/** Does the endpoint accept a request body? (either JSON or XML) */
+	const ACCEPT_DATA = 128;
+
+	/**
+	 * Should we hide this endpoint from the index?
+	 */
+	const HIDDEN_ENDPOINT = 256;
+
+	/**
+	 * Map of HTTP verbs to constants
+	 * @var array
+	 */
+	public static $method_map = array(
+		'HEAD'   => self::METHOD_GET,
+		'GET'    => self::METHOD_GET,
+		'POST'   => self::METHOD_POST,
+		'PUT'    => self::METHOD_PUT,
+		'PATCH'  => self::METHOD_PATCH,
+		'DELETE' => self::METHOD_DELETE,
+	);
+
+	/**
+	 * Requested path (relative to the API root, wp-json.php)
+	 *
+	 * @var string
+	 */
+	public $path = '';
+
+	/**
+	 * Requested method (GET/HEAD/POST/PUT/PATCH/DELETE)
+	 *
+	 * @var string
+	 */
+	public $method = 'HEAD';
+
+	/**
+	 * Request parameters
+	 *
+	 * This acts as an abstraction of the superglobals
+	 * (GET => $_GET, POST => $_POST)
+	 *
+	 * @var array
+	 */
+	public $params = array( 'GET' => array(), 'POST' => array() );
+
+	/**
+	 * Request headers
+	 *
+	 * @var array
+	 */
+	public $headers = array();
+
+	/**
+	 * Request files (matches $_FILES)
+	 *
+	 * @var array
+	 */
+	public $files = array();
+
+	/**
+	 * Request/Response handler, either JSON by default
+	 * or XML if requested by client
+	 *
+	 * @var WC_API_Handler
+	 */
+	public $handler;
+
+
+	/**
+	 * Setup class and set request/response handler
+	 *
+	 * @since 2.1
+	 * @param $path
+	 * @return WC_API_Server
+	 */
+	public function __construct( $path ) {
+
+		if ( empty( $path ) ) {
+			if ( isset( $_SERVER['PATH_INFO'] ) ) {
+				$path = $_SERVER['PATH_INFO'];
+			} else {
+				$path = '/';
+			}
+		}
+
+		$this->path           = $path;
+		$this->method         = $_SERVER['REQUEST_METHOD'];
+		$this->params['GET']  = $_GET;
+		$this->params['POST'] = $_POST;
+		$this->headers        = $this->get_headers( $_SERVER );
+		$this->files          = $_FILES;
+
+		// Compatibility for clients that can't use PUT/PATCH/DELETE
+		if ( isset( $_GET['_method'] ) ) {
+			$this->method = strtoupper( $_GET['_method'] );
+		}
+
+		// load response handler
+		$handler_class = apply_filters( 'woocommerce_api_default_response_handler', 'WC_API_JSON_Handler', $this->path, $this );
+
+		$this->handler = new $handler_class();
+	}
+
+	/**
+	 * Check authentication for the request
+	 *
+	 * @since 2.1
+	 * @return WP_User|WP_Error WP_User object indicates successful login, WP_Error indicates unsuccessful login
+	 */
+	public function check_authentication() {
+
+		// allow plugins to remove default authentication or add their own authentication
+		$user = apply_filters( 'woocommerce_api_check_authentication', null, $this );
+
+		// API requests run under the context of the authenticated user
+		if ( is_a( $user, 'WP_User' ) ) {
+			wp_set_current_user( $user->ID );
+		}
+
+		// WP_Errors are handled in serve_request()
+		elseif ( ! is_wp_error( $user ) ) {
+			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce' ), array( 'code' => 500 ) );
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Convert an error to an array
+	 *
+	 * This iterates over all error codes and messages to change it into a flat
+	 * array. This enables simpler client behaviour, as it is represented as a
+	 * list in JSON rather than an object/map
+	 *
+	 * @since 2.1
+	 * @param WP_Error $error
+	 * @return array List of associative arrays with code and message keys
+	 */
+	protected function error_to_array( $error ) {
+		$errors = array();
+		foreach ( (array) $error->errors as $code => $messages ) {
+			foreach ( (array) $messages as $message ) {
+				$errors[] = array( 'code' => $code, 'message' => $message );
+			}
+		}
+
+		return array( 'errors' => $errors );
+	}
+
+	/**
+	 * Handle serving an API request
+	 *
+	 * Matches the current server URI to a route and runs the first matching
+	 * callback then outputs a JSON representation of the returned value.
+	 *
+	 * @since 2.1
+	 * @uses WC_API_Server::dispatch()
+	 */
+	public function serve_request() {
+
+		do_action( 'woocommerce_api_server_before_serve', $this );
+
+		$this->header( 'Content-Type', $this->handler->get_content_type(), true );
+
+		// the API is enabled by default
+		if ( ! apply_filters( 'woocommerce_api_enabled', true, $this ) || ( 'no' === get_option( 'woocommerce_api_enabled' ) ) ) {
+
+			$this->send_status( 404 );
+
+			echo $this->handler->generate_response( array( 'errors' => array( 'code' => 'woocommerce_api_disabled', 'message' => 'The WooCommerce API is disabled on this site' ) ) );
+
+			return;
+		}
+
+		$result = $this->check_authentication();
+
+		// if authorization check was successful, dispatch the request
+		if ( ! is_wp_error( $result ) ) {
+			$result = $this->dispatch();
+		}
+
+		// handle any dispatch errors
+		if ( is_wp_error( $result ) ) {
+			$data = $result->get_error_data();
+			if ( is_array( $data ) && isset( $data['status'] ) ) {
+				$this->send_status( $data['status'] );
+			}
+
+			$result = $this->error_to_array( $result );
+		}
+
+		// This is a filter rather than an action, since this is designed to be
+		// re-entrant if needed
+		$served = apply_filters( 'woocommerce_api_serve_request', false, $result, $this );
+
+		if ( ! $served ) {
+
+			if ( 'HEAD' === $this->method ) {
+				return;
+			}
+
+			echo $this->handler->generate_response( $result );
+		}
+	}
+
+	/**
+	 * Retrieve the route map
+	 *
+	 * The route map is an associative array with path regexes as the keys. The
+	 * value is an indexed array with the callback function/method as the first
+	 * item, and a bitmask of HTTP methods as the second item (see the class
+	 * constants).
+	 *
+	 * Each route can be mapped to more than one callback by using an array of
+	 * the indexed arrays. This allows mapping e.g. GET requests to one callback
+	 * and POST requests to another.
+	 *
+	 * Note that the path regexes (array keys) must have @ escaped, as this is
+	 * used as the delimiter with preg_match()
+	 *
+	 * @since 2.1
+	 * @return array `'/path/regex' => array( $callback, $bitmask )` or `'/path/regex' => array( array( $callback, $bitmask ), ...)`
+	 */
+	public function get_routes() {
+
+		// index added by default
+		$endpoints = array(
+
+			'/' => array( array( $this, 'get_index' ), self::READABLE ),
+		);
+
+		$endpoints = apply_filters( 'woocommerce_api_endpoints', $endpoints );
+
+		// Normalise the endpoints
+		foreach ( $endpoints as $route => &$handlers ) {
+			if ( count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
+				$handlers = array( $handlers );
+			}
+		}
+
+		return $endpoints;
+	}
+
+	/**
+	 * Match the request to a callback and call it
+	 *
+	 * @since 2.1
+	 * @return mixed The value returned by the callback, or a WP_Error instance
+	 */
+	public function dispatch() {
+
+		switch ( $this->method ) {
+
+			case 'HEAD' :
+			case 'GET' :
+				$method = self::METHOD_GET;
+				break;
+
+			case 'POST' :
+				$method = self::METHOD_POST;
+				break;
+
+			case 'PUT' :
+				$method = self::METHOD_PUT;
+				break;
+
+			case 'PATCH' :
+				$method = self::METHOD_PATCH;
+				break;
+
+			case 'DELETE' :
+				$method = self::METHOD_DELETE;
+				break;
+
+			default :
+				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		foreach ( $this->get_routes() as $route => $handlers ) {
+			foreach ( $handlers as $handler ) {
+				$callback  = $handler[0];
+				$supported = isset( $handler[1] ) ? $handler[1] : self::METHOD_GET;
+
+				if ( ! ( $supported & $method ) ) {
+					continue;
+				}
+
+				$match = preg_match( '@^' . $route . '$@i', urldecode( $this->path ), $args );
+
+				if ( ! $match ) {
+					continue;
+				}
+
+				if ( ! is_callable( $callback ) ) {
+					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce' ), array( 'status' => 500 ) );
+				}
+
+				$args = array_merge( $args, $this->params['GET'] );
+				if ( $method & self::METHOD_POST ) {
+					$args = array_merge( $args, $this->params['POST'] );
+				}
+				if ( $supported & self::ACCEPT_DATA ) {
+					$data = $this->handler->parse_body( $this->get_raw_data() );
+					$args = array_merge( $args, array( 'data' => $data ) );
+				} elseif ( $supported & self::ACCEPT_RAW_DATA ) {
+					$data = $this->get_raw_data();
+					$args = array_merge( $args, array( 'data' => $data ) );
+				}
+
+				$args['_method']  = $method;
+				$args['_route']   = $route;
+				$args['_path']    = $this->path;
+				$args['_headers'] = $this->headers;
+				$args['_files']   = $this->files;
+
+				$args = apply_filters( 'woocommerce_api_dispatch_args', $args, $callback );
+
+				// Allow plugins to halt the request via this filter
+				if ( is_wp_error( $args ) ) {
+					return $args;
+				}
+
+				$params = $this->sort_callback_params( $callback, $args );
+				if ( is_wp_error( $params ) ) {
+					return $params;
+				}
+
+				return call_user_func_array( $callback, $params );
+			}
+		}
+
+		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce' ), array( 'status' => 404 ) );
+	}
+
+	/**
+	 * urldecode deep.
+	 *
+	 * @since  2.2
+	 * @param  string/array $value Data to decode with urldecode.
+	 * @return string/array        Decoded data.
+	 */
+	protected function urldecode_deep( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( array( $this, 'urldecode_deep' ), $value );
+		} else {
+			return urldecode( $value );
+		}
+	}
+
+	/**
+	 * Sort parameters by order specified in method declaration
+	 *
+	 * Takes a callback and a list of available params, then filters and sorts
+	 * by the parameters the method actually needs, using the Reflection API
+	 *
+	 * @since 2.2
+	 * @param callable|array $callback the endpoint callback
+	 * @param array $provided the provided request parameters
+	 * @return array
+	 */
+	protected function sort_callback_params( $callback, $provided ) {
+		if ( is_array( $callback ) ) {
+			$ref_func = new ReflectionMethod( $callback[0], $callback[1] );
+		} else {
+			$ref_func = new ReflectionFunction( $callback );
+		}
+
+		$wanted = $ref_func->getParameters();
+		$ordered_parameters = array();
+
+		foreach ( $wanted as $param ) {
+			if ( isset( $provided[ $param->getName() ] ) ) {
+				// We have this parameters in the list to choose from
+				if ( 'data' == $param->getName() ) {
+					$ordered_parameters[] = $provided[ $param->getName() ];
+					continue;
+				}
+
+				$ordered_parameters[] = $this->urldecode_deep( $provided[ $param->getName() ] );
+			} elseif ( $param->isDefaultValueAvailable() ) {
+				// We don't have this parameter, but it's optional
+				$ordered_parameters[] = $param->getDefaultValue();
+			} else {
+				// We don't have this parameter and it wasn't optional, abort!
+				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param->getName() ), array( 'status' => 400 ) );
+			}
+		}
+
+		return $ordered_parameters;
+	}
+
+	/**
+	 * Get the site index.
+	 *
+	 * This endpoint describes the capabilities of the site.
+	 *
+	 * @since 2.3
+	 * @return array Index entity
+	 */
+	public function get_index() {
+
+		// General site data
+		$available = array( 'store' => array(
+			'name'        => get_option( 'blogname' ),
+			'description' => get_option( 'blogdescription' ),
+			'URL'         => get_option( 'siteurl' ),
+			'wc_version'  => WC()->version,
+			'routes'      => array(),
+			'meta'        => array(
+				'timezone'           => wc_timezone_string(),
+				'currency'           => get_woocommerce_currency(),
+				'currency_format'    => get_woocommerce_currency_symbol(),
+				'currency_position'  => get_option( 'woocommerce_currency_pos' ),
+				'thousand_separator' => get_option( 'woocommerce_price_decimal_sep' ),
+				'decimal_separator'  => get_option( 'woocommerce_price_thousand_sep' ),
+				'price_num_decimals' => wc_get_price_decimals(),
+				'tax_included'       => wc_prices_include_tax(),
+				'weight_unit'        => get_option( 'woocommerce_weight_unit' ),
+				'dimension_unit'     => get_option( 'woocommerce_dimension_unit' ),
+				'ssl_enabled'        => ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ),
+				'permalinks_enabled' => ( '' !== get_option( 'permalink_structure' ) ),
+				'generate_password'  => ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) ),
+				'links'              => array(
+					'help' => 'http://woothemes.github.io/woocommerce-rest-api-docs/',
+				),
+			),
+		) );
+
+		// Find the available routes
+		foreach ( $this->get_routes() as $route => $callbacks ) {
+			$data = array();
+
+			$route = preg_replace( '#\(\?P(<\w+?>).*?\)#', '$1', $route );
+
+			foreach ( self::$method_map as $name => $bitmask ) {
+				foreach ( $callbacks as $callback ) {
+					// Skip to the next route if any callback is hidden
+					if ( $callback[1] & self::HIDDEN_ENDPOINT ) {
+						continue 3;
+					}
+
+					if ( $callback[1] & $bitmask ) {
+						$data['supports'][] = $name;
+					}
+
+					if ( $callback[1] & self::ACCEPT_DATA ) {
+						$data['accepts_data'] = true;
+					}
+
+					// For non-variable routes, generate links
+					if ( strpos( $route, '<' ) === false ) {
+						$data['meta'] = array(
+							'self' => get_woocommerce_api_url( $route ),
+						);
+					}
+				}
+			}
+
+			$available['store']['routes'][ $route ] = apply_filters( 'woocommerce_api_endpoints_description', $data );
+		}
+
+		return apply_filters( 'woocommerce_api_index', $available );
+	}
+
+	/**
+	 * Send a HTTP status code
+	 *
+	 * @since 2.1
+	 * @param int $code HTTP status
+	 */
+	public function send_status( $code ) {
+		status_header( $code );
+	}
+
+	/**
+	 * Send a HTTP header
+	 *
+	 * @since 2.1
+	 * @param string $key Header key
+	 * @param string $value Header value
+	 * @param boolean $replace Should we replace the existing header?
+	 */
+	public function header( $key, $value, $replace = true ) {
+		header( sprintf( '%s: %s', $key, $value ), $replace );
+	}
+
+	/**
+	 * Send a Link header
+	 *
+	 * @internal The $rel parameter is first, as this looks nicer when sending multiple
+	 *
+	 * @link http://tools.ietf.org/html/rfc5988
+	 * @link http://www.iana.org/assignments/link-relations/link-relations.xml
+	 *
+	 * @since 2.1
+	 * @param string $rel Link relation. Either a registered type, or an absolute URL
+	 * @param string $link Target IRI for the link
+	 * @param array $other Other parameters to send, as an associative array
+	 */
+	public function link_header( $rel, $link, $other = array() ) {
+
+		$header = sprintf( '<%s>; rel="%s"', $link, esc_attr( $rel ) );
+
+		foreach ( $other as $key => $value ) {
+
+			if ( 'title' == $key ) {
+
+				$value = '"' . $value . '"';
+			}
+
+			$header .= '; ' . $key . '=' . $value;
+		}
+
+		$this->header( 'Link', $header, false );
+	}
+
+	/**
+	 * Send pagination headers for resources
+	 *
+	 * @since 2.1
+	 * @param WP_Query|WP_User_Query $query
+	 */
+	public function add_pagination_headers( $query ) {
+
+		// WP_User_Query
+		if ( is_a( $query, 'WP_User_Query' ) ) {
+
+			$single      = count( $query->get_results() ) == 1;
+			$total       = $query->get_total();
+
+			if( $query->get( 'number' ) > 0 ) {
+				$page = ( $query->get( 'offset' ) / $query->get( 'number' ) ) + 1;
+				$total_pages = ceil( $total / $query->get( 'number' ) );
+			} else {
+				$page = 1;
+				$total_pages = 1;
+			}
+
+		// WP_Query
+		} else {
+
+			$page        = $query->get( 'paged' );
+			$single      = $query->is_single();
+			$total       = $query->found_posts;
+			$total_pages = $query->max_num_pages;
+		}
+
+		if ( ! $page ) {
+			$page = 1;
+		}
+
+		$next_page = absint( $page ) + 1;
+
+		if ( ! $single ) {
+
+			// first/prev
+			if ( $page > 1 ) {
+				$this->link_header( 'first', $this->get_paginated_url( 1 ) );
+				$this->link_header( 'prev', $this->get_paginated_url( $page -1 ) );
+			}
+
+			// next
+			if ( $next_page <= $total_pages ) {
+				$this->link_header( 'next', $this->get_paginated_url( $next_page ) );
+			}
+
+			// last
+			if ( $page != $total_pages ) {
+				$this->link_header( 'last', $this->get_paginated_url( $total_pages ) );
+			}
+		}
+
+		$this->header( 'X-WC-Total', $total );
+		$this->header( 'X-WC-TotalPages', $total_pages );
+
+		do_action( 'woocommerce_api_pagination_headers', $this, $query );
+	}
+
+	/**
+	 * Returns the request URL with the page query parameter set to the specified page
+	 *
+	 * @since 2.1
+	 * @param int $page
+	 * @return string
+	 */
+	private function get_paginated_url( $page ) {
+
+		// remove existing page query param
+		$request = remove_query_arg( 'page' );
+
+		// add provided page query param
+		$request = urldecode( add_query_arg( 'page', $page, $request ) );
+
+		// get the home host
+		$host = parse_url( get_home_url(), PHP_URL_HOST );
+
+		return set_url_scheme( "http://{$host}{$request}" );
+	}
+
+	/**
+	 * Retrieve the raw request entity (body)
+	 *
+	 * @since 2.1
+	 * @return string
+	 */
+	public function get_raw_data() {
+		global $HTTP_RAW_POST_DATA;
+
+		// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
+		// but we can do it ourself.
+		if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
+			$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
+		}
+
+		return $HTTP_RAW_POST_DATA;
+	}
+
+	/**
+	 * Parse an RFC3339 datetime into a MySQl datetime
+	 *
+	 * Invalid dates default to unix epoch
+	 *
+	 * @since 2.1
+	 * @param string $datetime RFC3339 datetime
+	 * @return string MySQl datetime (YYYY-MM-DD HH:MM:SS)
+	 */
+	public function parse_datetime( $datetime ) {
+
+		// Strip millisecond precision (a full stop followed by one or more digits)
+		if ( strpos( $datetime, '.' ) !== false ) {
+			$datetime = preg_replace( '/\.\d+/', '', $datetime );
+		}
+
+		// default timezone to UTC
+		$datetime = preg_replace( '/[+-]\d+:+\d+$/', '+00:00', $datetime );
+
+		try {
+
+			$datetime = new DateTime( $datetime, new DateTimeZone( 'UTC' ) );
+
+		} catch ( Exception $e ) {
+
+			$datetime = new DateTime( '@0' );
+
+		}
+
+		return $datetime->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Format a unix timestamp or MySQL datetime into an RFC3339 datetime
+	 *
+	 * @since 2.1
+	 * @param int|string $timestamp unix timestamp or MySQL datetime
+	 * @param bool $convert_to_utc
+	 * @return string RFC3339 datetime
+	 */
+	public function format_datetime( $timestamp, $convert_to_utc = false ) {
+
+		if ( $convert_to_utc ) {
+			$timezone = new DateTimeZone( wc_timezone_string() );
+		} else {
+			$timezone = new DateTimeZone( 'UTC' );
+		}
+
+		try {
+
+			if ( is_numeric( $timestamp ) ) {
+				$date = new DateTime( "@{$timestamp}" );
+			} else {
+				$date = new DateTime( $timestamp, $timezone );
+			}
+
+			// convert to UTC by adjusting the time based on the offset of the site's timezone
+			if ( $convert_to_utc ) {
+				$date->modify( -1 * $date->getOffset() . ' seconds' );
+			}
+
+		} catch ( Exception $e ) {
+
+			$date = new DateTime( '@0' );
+		}
+
+		return $date->format( 'Y-m-d\TH:i:s\Z' );
+	}
+
+	/**
+	 * Extract headers from a PHP-style $_SERVER array
+	 *
+	 * @since 2.1
+	 * @param array $server Associative array similar to $_SERVER
+	 * @return array Headers extracted from the input
+	 */
+	public function get_headers($server) {
+		$headers = array();
+		// CONTENT_* headers are not prefixed with HTTP_
+		$additional = array('CONTENT_LENGTH' => true, 'CONTENT_MD5' => true, 'CONTENT_TYPE' => true);
+
+		foreach ($server as $key => $value) {
+			if ( strpos( $key, 'HTTP_' ) === 0) {
+				$headers[ substr( $key, 5 ) ] = $value;
+			} elseif ( isset( $additional[ $key ] ) ) {
+				$headers[ $key ] = $value;
+			}
+		}
+
+		return $headers;
+	}
+
+}

--- a/includes/api/v2/class-wc-api-webhooks.php
+++ b/includes/api/v2/class-wc-api-webhooks.php
@@ -1,0 +1,462 @@
+<?php
+/**
+ * WooCommerce API Webhooks class
+ *
+ * Handles requests to the /webhooks endpoint
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WC_API_Webhooks extends WC_API_Resource {
+
+	/** @var string $base the route base */
+	protected $base = '/webhooks';
+
+	/**
+	 * Register the routes for this class
+	 *
+	 * @since 2.2
+	 * @param array $routes
+	 * @return array
+	 */
+	public function register_routes( $routes ) {
+
+		# GET|POST /webhooks
+		$routes[ $this->base ] = array(
+			array( array( $this, 'get_webhooks' ),     WC_API_Server::READABLE ),
+			array( array( $this, 'create_webhook' ),   WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+		);
+
+		# GET /webhooks/count
+		$routes[ $this->base . '/count'] = array(
+			array( array( $this, 'get_webhooks_count' ), WC_API_Server::READABLE ),
+		);
+
+		# GET|PUT|DELETE /webhooks/<id>
+		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_webhook' ),  WC_API_Server::READABLE ),
+			array( array( $this, 'edit_webhook' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_webhook' ), WC_API_Server::DELETABLE ),
+		);
+
+		# GET /webhooks/<id>/deliveries
+		$routes[ $this->base . '/(?P<webhook_id>\d+)/deliveries' ] = array(
+			array( array( $this, 'get_webhook_deliveries' ), WC_API_Server::READABLE ),
+		);
+
+		# GET /webhooks/<webhook_id>/deliveries/<id>
+		$routes[ $this->base . '/(?P<webhook_id>\d+)/deliveries/(?P<id>\d+)' ] = array(
+			array( array( $this, 'get_webhook_delivery' ), WC_API_Server::READABLE ),
+		);
+
+		return $routes;
+	}
+
+	/**
+	 * Get all webhooks
+	 *
+	 * @since 2.2
+	 * @param array $fields
+	 * @param array $filter
+	 * @param int $page
+	 * @return array
+	 */
+	public function get_webhooks( $fields = null, $filter = array(), $status = null, $page = 1 ) {
+
+		if ( ! empty( $status ) ) {
+			$filter['status'] = $status;
+		}
+
+		$filter['page'] = $page;
+
+		$query = $this->query_webhooks( $filter );
+
+		$webhooks = array();
+
+		foreach ( $query->posts as $webhook_id ) {
+
+			if ( ! $this->is_readable( $webhook_id ) ) {
+				continue;
+			}
+
+			$webhooks[] = current( $this->get_webhook( $webhook_id, $fields ) );
+		}
+
+		$this->server->add_pagination_headers( $query );
+
+		return array( 'webhooks' => $webhooks );
+	}
+
+	/**
+	 * Get the webhook for the given ID
+	 *
+	 * @since 2.2
+	 * @param int $id webhook ID
+	 * @param array $fields
+	 * @return array
+	 */
+	public function get_webhook( $id, $fields = null ) {
+
+		// ensure webhook ID is valid & user has permission to read
+		$id = $this->validate_request( $id, 'shop_webhook', 'read' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		$webhook = new WC_Webhook( $id );
+
+		$webhook_data = array(
+			'id'           => $webhook->id,
+			'name'         => $webhook->get_name(),
+			'status'       => $webhook->get_status(),
+			'topic'        => $webhook->get_topic(),
+			'resource'     => $webhook->get_resource(),
+			'event'        => $webhook->get_event(),
+			'hooks'        => $webhook->get_hooks(),
+			'delivery_url' => $webhook->get_delivery_url(),
+			'created_at'   => $this->server->format_datetime( $webhook->get_post_data()->post_date_gmt ),
+			'updated_at'   => $this->server->format_datetime( $webhook->get_post_data()->post_modified_gmt ),
+		);
+
+		return array( 'webhook' => apply_filters( 'woocommerce_api_webhook_response', $webhook_data, $webhook, $fields, $this ) );
+	}
+
+	/**
+	 * Get the total number of webhooks
+	 *
+	 * @since 2.2
+	 * @param string $status
+	 * @param array $filter
+	 * @return array
+	 */
+	public function get_webhooks_count( $status = null, $filter = array() ) {
+		try {
+			if ( ! current_user_can( 'read_private_shop_webhooks' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_webhooks_count', __( 'You do not have permission to read the webhooks count', 'woocommerce' ), 401 );
+			}
+
+			if ( ! empty( $status ) ) {
+				$filter['status'] = $status;
+			}
+
+			$query = $this->query_webhooks( $filter );
+
+			return array( 'count' => (int) $query->found_posts );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Create an webhook
+	 *
+	 * @since 2.2
+	 * @param array $data parsed webhook data
+	 * @return array
+	 */
+	public function create_webhook( $data ) {
+
+		try {
+			if ( ! isset( $data['webhook'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'webhook' ), 400 );
+			}
+
+			$data = $data['webhook'];
+
+			// permission check
+			if ( ! current_user_can( 'publish_shop_webhooks' ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_webhooks', __( 'You do not have permission to create webhooks', 'woocommerce' ), 401 );
+			}
+
+			$data = apply_filters( 'woocommerce_api_create_webhook_data', $data, $this );
+
+			// validate topic
+			if ( empty( $data['topic'] ) || ! wc_is_webhook_valid_topic( strtolower( $data['topic'] ) ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic is required and must be valid', 'woocommerce' ), 400 );
+			}
+
+			// validate delivery URL
+			if ( empty( $data['delivery_url'] ) || ! wc_is_valid_url( $data['delivery_url'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+			}
+
+			$webhook_data = apply_filters( 'woocommerce_new_webhook_data', array(
+				'post_type'     => 'shop_webhook',
+				'post_status'   => 'publish',
+				'ping_status'   => 'closed',
+				'post_author'   => get_current_user_id(),
+				'post_password' => strlen( ( $password = uniqid( 'webhook_' ) ) ) > 20 ? substr( $password, 0, 20 ) : $password,
+				'post_title'    => ! empty( $data['name'] ) ? $data['name'] : sprintf( __( 'Webhook created on %s', 'woocommerce' ), strftime( _x( '%b %d, %Y @ %I:%M %p', 'Webhook created on date parsed by strftime', 'woocommerce' ) ) ),
+			), $data, $this );
+
+			$webhook_id = wp_insert_post( $webhook_data );
+
+			if ( is_wp_error( $webhook_id ) || ! $webhook_id ) {
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_webhook', sprintf( __( 'Cannot create webhook: %s', 'woocommerce' ), is_wp_error( $webhook_id ) ? implode( ', ', $webhook_id->get_error_messages() ) : '0' ), 500 );
+			}
+
+			$webhook = new WC_Webhook( $webhook_id );
+
+			// set topic, delivery URL, and optional secret
+			$webhook->set_topic( $data['topic'] );
+			$webhook->set_delivery_url( $data['delivery_url'] );
+
+			// set secret if provided, defaults to API users consumer secret
+			$webhook->set_secret( ! empty( $data['secret'] ) ? $data['secret'] : get_user_meta( get_current_user_id(), 'woocommerce_api_consumer_secret', true ) );
+
+			// send ping
+			$webhook->deliver_ping();
+
+			// HTTP 201 Created
+			$this->server->send_status( 201 );
+
+			do_action( 'woocommerce_api_create_webhook', $webhook->id, $this );
+
+			delete_transient( 'woocommerce_webhook_ids' );
+
+			return $this->get_webhook( $webhook->id );
+
+		} catch ( WC_API_Exception $e ) {
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Edit a webhook
+	 *
+	 * @since 2.2
+	 * @param int $id webhook ID
+	 * @param array $data parsed webhook data
+	 * @return array
+	 */
+	public function edit_webhook( $id, $data ) {
+
+		try {
+			if ( ! isset( $data['webhook'] ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'webhook' ), 400 );
+			}
+
+			$data = $data['webhook'];
+
+			$id = $this->validate_request( $id, 'shop_webhook', 'edit' );
+
+			if ( is_wp_error( $id ) ) {
+				return $id;
+			}
+
+			$data = apply_filters( 'woocommerce_api_edit_webhook_data', $data, $id, $this );
+
+			$webhook = new WC_Webhook( $id );
+
+			// update topic
+			if ( ! empty( $data['topic'] ) ) {
+
+				if ( wc_is_webhook_valid_topic( strtolower( $data['topic'] ) ) ) {
+
+					$webhook->set_topic( $data['topic'] );
+
+				} else {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic must be valid', 'woocommerce' ), 400 );
+				}
+			}
+
+			// update delivery URL
+			if ( ! empty( $data['delivery_url'] ) ) {
+				if ( wc_is_valid_url( $data['delivery_url'] ) ) {
+
+					$webhook->set_delivery_url( $data['delivery_url'] );
+
+				} else {
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+				}
+			}
+
+			// update secret
+			if ( ! empty( $data['secret'] ) ) {
+				$webhook->set_secret( $data['secret'] );
+			}
+
+			// update status
+			if ( ! empty( $data['status'] ) ) {
+				$webhook->update_status( $data['status'] );
+			}
+
+			// update user ID
+			$webhook_data = array(
+				'ID'          => $webhook->id,
+				'post_author' => get_current_user_id()
+			);
+
+			// update name
+			if ( ! empty( $data['name'] ) ) {
+				$webhook_data['post_title'] = $data['name'];
+			}
+
+			// update post
+			wp_update_post( $webhook_data );
+
+			do_action( 'woocommerce_api_edit_webhook', $webhook->id, $this );
+
+			delete_transient( 'woocommerce_webhook_ids' );
+
+			return $this->get_webhook( $id );
+
+		} catch ( WC_API_Exception $e ) {
+
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete a webhook
+	 *
+	 * @since 2.2
+	 * @param int $id webhook ID
+	 * @return array
+	 */
+	public function delete_webhook( $id ) {
+
+		$id = $this->validate_request( $id, 'shop_webhook', 'delete' );
+
+		if ( is_wp_error( $id ) ) {
+			return $id;
+		}
+
+		do_action( 'woocommerce_api_delete_webhook', $id, $this );
+
+		delete_transient( 'woocommerce_webhook_ids' );
+
+		// no way to manage trashed webhooks at the moment, so force delete
+		return $this->delete( $id, 'webhook', true );
+	}
+
+	/**
+	 * Helper method to get webhook post objects
+	 *
+	 * @since 2.2
+	 * @param array $args request arguments for filtering query
+	 * @return WP_Query
+	 */
+	private function query_webhooks( $args ) {
+
+		// Set base query arguments
+		$query_args = array(
+			'fields'      => 'ids',
+			'post_type'   => 'shop_webhook',
+		);
+
+		// Add status argument
+		if ( ! empty( $args['status'] ) ) {
+
+			switch ( $args['status'] ) {
+				case 'active':
+					$query_args['post_status'] = 'publish';
+					break;
+				case 'paused':
+					$query_args['post_status'] = 'draft';
+					break;
+				case 'disabled':
+					$query_args['post_status'] = 'pending';
+					break;
+				default:
+					$query_args['post_status'] = 'publish';
+			}
+			unset( $args['status'] );
+		}
+
+		$query_args = $this->merge_query_args( $query_args, $args );
+
+		return new WP_Query( $query_args );
+	}
+
+	/**
+	 * Get deliveries for a webhook
+	 *
+	 * @since 2.2
+	 * @param string $webhook_id webhook ID
+	 * @param string|null $fields fields to include in response
+	 * @return array
+	 */
+	public function get_webhook_deliveries( $webhook_id, $fields = null ) {
+
+		// Ensure ID is valid webhook ID
+		$webhook_id = $this->validate_request( $webhook_id, 'shop_webhook', 'read' );
+
+		if ( is_wp_error( $webhook_id ) ) {
+			return $webhook_id;
+		}
+
+		$webhook       = new WC_Webhook( $webhook_id );
+		$logs          = $webhook->get_delivery_logs();
+		$delivery_logs = array();
+
+		foreach ( $logs as $log ) {
+
+			// Add timestamp
+			$log['created_at'] = $this->server->format_datetime( $log['comment']->comment_date_gmt );
+
+			// Remove comment object
+			unset( $log['comment'] );
+
+			$delivery_logs[] = $log;
+		}
+
+		return array( 'webhook_deliveries' => $delivery_logs );
+	}
+
+	/**
+	 * Get the delivery log for the given webhook ID and delivery ID
+	 *
+	 * @since 2.2
+	 * @param string $webhook_id webhook ID
+	 * @param string $id delivery log ID
+	 * @param string|null $fields fields to limit response to
+	 * @return array
+	 */
+	public function get_webhook_delivery( $webhook_id, $id, $fields = null ) {
+		try {
+			// Validate webhook ID
+			$webhook_id = $this->validate_request( $webhook_id, 'shop_webhook', 'read' );
+
+			if ( is_wp_error( $webhook_id ) ) {
+				return $webhook_id;
+			}
+
+			$id = absint( $id );
+
+			if ( empty( $id ) ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID', 'woocommerce' ), 404 );
+			}
+
+			$webhook = new WC_Webhook( $webhook_id );
+
+			$log = $webhook->get_delivery_log( $id );
+
+			if ( ! $log ) {
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery', 'woocommerce' ), 400 );
+			}
+
+			$delivery_log = $log;
+
+			// Add timestamp
+			$delivery_log['created_at'] = $this->server->format_datetime( $log['comment']->comment_date_gmt );
+
+			// Remove comment object
+			unset( $delivery_log['comment'] );
+
+			return array( 'webhook_delivery' => apply_filters( 'woocommerce_api_webhook_delivery_response', $delivery_log, $id, $fields, $log, $webhook_id, $this ) );
+		} catch ( WC_API_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+}

--- a/includes/api/v2/interface-wc-api-handler.php
+++ b/includes/api/v2/interface-wc-api-handler.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * WooCommerce API
+ *
+ * Defines an interface that API request/response handlers should implement
+ *
+ * @author      WooThemes
+ * @category    API
+ * @package     WooCommerce/API
+ * @since       2.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+interface WC_API_Handler {
+
+	/**
+	 * Get the content type for the response
+	 *
+	 * This should return the proper HTTP content-type for the response
+	 *
+	 * @since 2.1
+	 * @return string
+	 */
+	public function get_content_type();
+
+	/**
+	 * Parse the raw request body entity into an array
+	 *
+	 * @since 2.1
+	 * @param string $data
+	 * @return array
+	 */
+	public function parse_body( $data );
+
+	/**
+	 * Generate a response from an array of data
+	 *
+	 * @since 2.1
+	 * @param array $data
+	 * @return string
+	 */
+	public function generate_response( $data );
+
+}

--- a/tests/unit-tests/util/core-functions.php
+++ b/tests/unit-tests/util/core-functions.php
@@ -107,10 +107,10 @@ class Core_Functions extends \WC_Unit_Test_Case {
 		$base_uri = get_home_url();
 
 		// base uri
-		$this->assertEquals( "$base_uri/wc-api/v2/", get_woocommerce_api_url( null ) );
+		$this->assertEquals( "$base_uri/wc-api/v3/", get_woocommerce_api_url( null ) );
 
 		// path
-		$this->assertEquals( "$base_uri/wc-api/v2/orders", get_woocommerce_api_url( 'orders' ) );
+		$this->assertEquals( "$base_uri/wc-api/v3/orders", get_woocommerce_api_url( 'orders' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8256.

This PR does a number of things:
- Versions the REST API into v3 so we can make some larger auth changes. v2 and v1 routes will still work ([mentioned here](https://github.com/woothemes/woocommerce/issues/8256#issuecomment-107682873))
- Fixes basic auth so that it conforms to the Basic auth spec (returns correct headers, etc) instead of the weird hybrid approach present in current versions (and documented more [here and in the rest of the thread](https://github.com/woothemes/woocommerce/issues/8256#issuecomment-107380883))
- Continues to support query string auth, but does so without basic auth getting in the way or the two messing with each other

**Testing Steps**:
- Generate a consumer key and secret if you don't have them already
- Visit /wc-api/v3/products in your browser over https
- See that you are prompted with a basic http auth dialog
- Type in a bogus username/password and see that you get an error echoed to the screen (not a json error)
- Try again and this time provide your correct credentials
- See that the products json is returned
- Visit /wc-api/v3/orders and see that your auth is retained
- Add ?consumer_key=&consumer_secret= to the URL, and fill in your key and secret
- See that you still get a response
- Change consumer_secret to a bogus secret and see a JSON error returned
- Remove the query strings and see that basic auth still works
