### PR TITLE
Remember the user's quantity selection if a validation error occurs

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -38,7 +38,12 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 							<?php else : ?>
 								<?php
 									$quantites_required = true;
-									woocommerce_quantity_input( array( 'input_name' => 'quantity[' . $product_id . ']', 'input_value' => '0', 'min_value' => apply_filters( 'woocommerce_quantity_input_min', 0, $product ), 'max_value' => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product ) ) );
+									woocommerce_quantity_input( array(
+										'input_name'  => 'quantity[' . $product_id . ']',
+										'input_value' => ( isset( $_POST['quantity'][$product_id] ) ? $_POST['quantity'][$product_id] : 0 ),
+										'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
+										'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product )
+									) );
 								?>
 							<?php endif; ?>
 						</td>

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -40,7 +40,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 									$quantites_required = true;
 									woocommerce_quantity_input( array(
 										'input_name'  => 'quantity[' . $product_id . ']',
-										'input_value' => ( isset( $_POST['quantity'][$product_id] ) ? $_POST['quantity'][$product_id] : 0 ),
+										'input_value' => ( isset( $_POST['quantity'][$product_id] ) ? wc_stock_amount( $_POST['quantity'][$product_id] ) : 0 ),
 										'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
 										'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product )
 									) );

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -39,7 +39,7 @@ if ( ! $product->is_purchasable() ) {
 	 			woocommerce_quantity_input( array(
 	 				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 1, $product ),
 	 				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product ),
-	 				'input_value' => ( isset( $_POST['quantity'] ) ? $_POST['quantity'] : 1 )
+	 				'input_value' => ( isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : 1 )
 	 			) );
 	 		}
 	 	?>

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -35,11 +35,13 @@ if ( ! $product->is_purchasable() ) {
 	 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
 	 	<?php
-	 		if ( ! $product->is_sold_individually() )
+	 		if ( ! $product->is_sold_individually() ) {
 	 			woocommerce_quantity_input( array(
-	 				'min_value' => apply_filters( 'woocommerce_quantity_input_min', 1, $product ),
-	 				'max_value' => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product )
+	 				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 1, $product ),
+	 				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->backorders_allowed() ? '' : $product->get_stock_quantity(), $product ),
+	 				'input_value' => ( isset( $_POST['quantity'] ) ? $_POST['quantity'] : 1 )
 	 			) );
+	 		}
 	 	?>
 
 	 	<input type="hidden" name="add-to-cart" value="<?php echo esc_attr( $product->id ); ?>" />

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -77,7 +77,7 @@ global $product, $post;
 
 			<div class="variations_button">
 				<?php woocommerce_quantity_input( array(
-					'input_value' => ( isset( $_POST['quantity'] ) ? $_POST['quantity'] : 1 )
+					'input_value' => ( isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : 1 )
 				) ); ?>
 				<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 			</div>

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -76,7 +76,9 @@ global $product, $post;
 			<div class="single_variation"></div>
 
 			<div class="variations_button">
-				<?php woocommerce_quantity_input(); ?>
+				<?php woocommerce_quantity_input( array(
+					'input_value' => ( isset( $_POST['quantity'] ) ? $_POST['quantity'] : 1 )
+				) ); ?>
 				<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 			</div>
 


### PR DESCRIPTION
While I was working with the addons plugin, I noticed that the quantity resets itself if a validation error occurs. Say I select "5" of an item, and then leave a required field blank. I will get an error at the top, and my quantity will be 0 for grouped products, and 1 for other types. Since I explicitly selected 5, my selection should be retained so all I have to do is fill in the required field and hit enter.

This PR sets the default to the users selection if there is one, otherwise the default is 0 for grouped products and 1 for others (same defaults from before).
