### PR TITLE
Prevent duplicate key name 'location_type_code' MySQL error

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -319,6 +319,12 @@ class WC_Install {
 			}
 		}
 
+		if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}woocommerce_tax_rate_locations';" ) ) {
+			if ( $wpdb->get_var( "SHOW INDEX FROM `{$wpdb->prefix}woocommerce_tax_rate_locations` WHERE Key_name LIKE 'location_type_code';" ) ) {
+				$wpdb->query( "DROP INDEX `location_type_code` ON {$wpdb->prefix}woocommerce_tax_rate_locations;" );
+			}
+		}
+
 		dbDelta( self::get_schema() );
 	}
 


### PR DESCRIPTION
It looks like the upgrade routine has been throwing a database error when dbDelta encounters the key length change. This is because dbDelta sees a difference and tries to create the key. But it already exists. The solution is to drop the current key and create the new one. This is since #8373 was merged.

The easiest way to see this is by running `phpunit`. I've seen the error both locally and on the CI tests.

There is some similar code above it - it looks like we've ran into that issue before: https://github.com/woothemes/woocommerce/commit/744732db7a663cfed176a0358109a9f3f3acb8ff
