### PR TITLE
Fix issues with our OAuth implementation, including nonconformance to spec (#7928)

### DIFF
--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -227,7 +227,7 @@ class WC_API_Authentication {
 		$server_path = WC()->api->server->path;
 
 		// if the requested URL has a trailingslash, make sure our base URL does as well
-		if ( wp_endswith( $_SERVER['REDIRECT_URL'], '/' ) ) {
+		if ( '/' === substr( $_SERVER['REDIRECT_URL'], -1 ) ) {
 			$server_path .= '/';
 		}
 

--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -225,7 +225,14 @@ class WC_API_Authentication {
 
 		$http_method = strtoupper( WC()->api->server->method );
 
-		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . WC()->api->server->path );
+		$server_path = WC()->api->server->path;
+
+		// if the requested URL has a trailingslash, make sure our base URL does as well
+		if ( wp_endswith( $_SERVER['REDIRECT_URL'], '/' ) ) {
+			$server_path .= '/';
+		}
+
+		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . $server_path );
 
 		// Get the signature provided by the consumer and remove it from the parameters prior to checking the signature
 		$consumer_signature = rawurldecode( $params['oauth_signature'] );

--- a/includes/api/class-wc-api-authentication.php
+++ b/includes/api/class-wc-api-authentication.php
@@ -264,7 +264,8 @@ class WC_API_Authentication {
 
 		$hash_algorithm = strtolower( str_replace( 'HMAC-', '', $params['oauth_signature_method'] ) );
 
-		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $keys['consumer_secret'], true ) );
+		$secret = $keys['consumer_secret'] . '&';
+		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $secret, true ) );
 
 		if ( ! hash_equals( $signature, $consumer_signature ) ) {
 			throw new Exception( __( 'Invalid Signature - provided signature does not match', 'woocommerce' ), 401 );


### PR DESCRIPTION
Fixes #7928

There are a few issues with our OAuth implementation. We couldn't fix them before without potentially breaking existing clients that use WooCommerce. However, since we are versioning the API for our basic auth fixes (#8406), we can now go back and fix the issues for v3. This brings our OAuth implementation inline with the spec and compatible with other OAuth libraries.

I specifically tested WooCommerce with https://github.com/guzzle/oauth-subscriber, but any standard library should be a good test case if they do things correctly. In short, the requests failed before my changes, but now they pass with this PR. I offer some testing steps below if you want to try what I did.

The three issues addressed by this PR:
- Missing `&` after the `consumer_secret`. The spec says that we need to include a trailing `&` **even** if there is no token secret. Some OAuth clients are lenient about this, so it wasn't a problem everywhere, but for other ones that follow the spec (like Guzzle) it broke the implementation.
- Trailing slash issue. If you made an API request to `/wc-api/v#/orders` the request would work because WooCommerce assumed the request should have no trailing slash. If you make a request to `/wc-api/v#/orders/` the request would fail, because the signature wouldn't match. Guzzle (and other libraries) calculate the signature with the slash and WooCommerce calculated it without.
- Parameter/query string calculation. We were doing some weird stuff with the query strings. Like converting nested parameters (`filter[limit]=50`) to a string. Signatures wouldn't match since we would be comparing the wrong query strings. We can also simplify the code a bit here and use `http_build_query` to help build the query and encode things properly.

https://github.com/woothemes/woocommerce-rest-api-docs would also need updated, but this can be addressed in a separate PR.

These changes are against the "current" version of the API. So once #8406 is merged, they will only effect v3. If this is merged first, they will effect v2 until both PRs are landed.

cc @maxrice @claudiosmweb 

If you wish to test on your own using Guzzle..
**Testing Steps:**

Install composer (if it is not already present on your system)

Create a composer.json file with the following

```
{
    "name": "Guzzle WooCommerce OAuth Test",
    "require": {
        "guzzlehttp/oauth-subscriber": "0.1.*"
    }
}
```

Run `composer install` or `php composer.phar install` if running locally

Create a script with the following

```
<?php

require 'vendor/autoload.php';

use GuzzleHttp\Client;
use GuzzleHttp\Subscriber\Oauth\Oauth1;

$client = new Client( ['base_url' => 'http://'] );

$oauth = new Oauth1( [
    'consumer_key'    => '',
    'consumer_secret' => '',
    'request_method' => 'query'
] );

$client->getEmitter()->attach($oauth);

// Set the "auth" request option to "oauth" to sign using oauth
$res = $client->get( 'orders/', ['auth' => 'oauth'] );

print_r( $res );
```

Fill in the `consumer_key`, `consumer_secret`, and `base_url` fields.

Load your test script.

If you see `Uncaught exception 'GuzzleHttp\Exception\ClientException'` and a 401 in your error logs, then the request failed. This is what you should expect before this PR applied. After the PR is applied, `$res` should contain a valid object.
