### PR TITLE
Removed redundant strtolower()

### DIFF
--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -40,7 +40,7 @@ class WC_Autoloader {
 	 * @return string
 	 */
 	private function get_file_name_from_class( $class ) {
-		return 'class-' . str_replace( '_', '-', strtolower( $class ) ) . '.php';
+		return 'class-' . str_replace( '_', '-', $class ) . '.php';
 	}
 
 	/**


### PR DESCRIPTION
Removed the redundant strtolower on line 43 in the private function get_file_name_from_class() which is only called from line 66 using a $class variable that is just strtolower()ed on line 65
