### PR TITLE
Deprecate PHP4 constructor usage in widgets. 

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -55,7 +55,7 @@ abstract class WC_Widget extends WP_Widget {
 			'description' => $this->widget_description
 		);
 
-		$this->WP_Widget( $this->widget_id, $this->widget_name, $widget_ops );
+		parent::__construct( $this->widget_id, $this->widget_name, $widget_ops );
 
 		add_action( 'save_post', array( $this, 'flush_widget_cache' ) );
 		add_action( 'deleted_post', array( $this, 'flush_widget_cache' ) );


### PR DESCRIPTION
This is deprecated in upcoming PHP versions.
