### PR TITLE
Bug: Price slider price_slider_updated declared incorrectly

### DIFF
--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -42,7 +42,7 @@ jQuery( function( $ ) {
 
 		}
 
-		$( 'body' ).trigger( 'price_slider_updated', min, max );
+		$( 'body' ).trigger( 'price_slider_updated', [ min, max ] );
 	});
 
 	$( '.price_slider' ).slider({


### PR DESCRIPTION
As per jQuery documentation for the trigger() method, the second parameter must be an array or a simple object.
With the current code, in the boud function the max parameter will always be "undefined"
