### PR TITLE
Fixed Post ID Error when using in ajax

### DIFF
--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -12,6 +12,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Checks and returns a valid post id
+ * @param int $thepostid
+ * @param Object $post
+ */
+function _woocomerce_get_post_id_input($thepostid = null ,$post = null){
+    $return_id = 0;
+    if( $post === null && $thepostid === null ) {
+        $return_id = 0;
+    } else if( isset( $post->id ) ){
+        $return_id = $post->id;
+    } else if( isset( $thepostid ) ){
+        $return_id = $thepostid;
+    }
+    return $return_id;
+}
+
+/**
  * Output a text input box.
  *
  * @param array $field
@@ -19,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function woocommerce_wp_text_input( $field ) {
 	global $thepostid, $post;
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$thepostid              = _woocomerce_get_post_id_input($thepostid,$post);
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
@@ -82,7 +99,7 @@ function woocommerce_wp_text_input( $field ) {
 function woocommerce_wp_hidden_input( $field ) {
 	global $thepostid, $post;
 
-	$thepostid = empty( $thepostid ) ? $post->ID : $thepostid;
+	$thepostid  = _woocomerce_get_post_id_input($thepostid,$post);
 	$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
 	$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
 
@@ -97,7 +114,7 @@ function woocommerce_wp_hidden_input( $field ) {
 function woocommerce_wp_textarea_input( $field ) {
 	global $thepostid, $post;
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$thepostid              = _woocomerce_get_post_id_input($thepostid,$post);
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
@@ -135,7 +152,7 @@ function woocommerce_wp_textarea_input( $field ) {
 function woocommerce_wp_checkbox( $field ) {
 	global $thepostid, $post;
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$thepostid              = _woocomerce_get_post_id_input($thepostid,$post);
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
@@ -175,7 +192,7 @@ function woocommerce_wp_checkbox( $field ) {
 function woocommerce_wp_select( $field ) {
 	global $thepostid, $post;
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$thepostid              = _woocomerce_get_post_id_input($thepostid,$post);
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
@@ -219,7 +236,7 @@ function woocommerce_wp_select( $field ) {
 function woocommerce_wp_radio( $field ) {
 	global $thepostid, $post;
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$thepostid              = _woocomerce_get_post_id_input($thepostid,$post);
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
 	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
 	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';


### PR DESCRIPTION
When using the below functions in ajax request in was getting a notice that no post_id available. 
`woocommerce_wp_text_input`
`woocommerce_wp_hidden_input`
`woocommerce_wp_textarea_input`
`woocommerce_wp_checkbox`
`woocommerce_wp_select`
`woocommerce_wp_radio`

For more info refer #8507
