### PR TITLE
Adding filter to email settings description text (#8509)

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -246,6 +246,25 @@ abstract class WC_Settings_API {
 	}
 
 	/**
+	 * Generate text description for the email settings tabs
+	 *
+	 * Filter applied to easily adjust description text
+	 * 
+	 * @param  string $description current description text
+	 * @return string the text for the modified settings description
+	 */
+	public function generate_email_settings_text_description( $description ) {
+
+		if ( ! empty( $description ) ) {
+			wpautop( $description );
+		} else {
+			$description = '';
+		}
+
+		return apply_filters( 'woocommerce_settings_api_description_text_' . $this->id, $description );
+	}
+
+	/**
 	 * Get HTML for tooltips
 	 *
 	 * @param  array $data

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -246,25 +246,6 @@ abstract class WC_Settings_API {
 	}
 
 	/**
-	 * Generate text description for the email settings tabs
-	 *
-	 * Filter applied to easily adjust description text
-	 * 
-	 * @param  string $description current description text
-	 * @return string the text for the modified settings description
-	 */
-	public function generate_email_settings_text_description( $description ) {
-
-		if ( ! empty( $description ) ) {
-			wpautop( $description );
-		} else {
-			$description = '';
-		}
-
-		return apply_filters( 'woocommerce_settings_api_description_text_' . $this->id, $description );
-	}
-
-	/**
 	 * Get HTML for tooltips
 	 *
 	 * @param  array $data

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -696,6 +696,24 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
+	 * Generate text description for the email settings tabs
+	 *
+	 * Filter applied to easily adjust description text
+	 * 
+	 * @return string the text for the modified settings description
+	 */
+	public function generate_settings_text_description() {
+
+		if ( ! empty( $this->description ) ) {
+			$description = wpautop( $this->description );
+		} else {
+			$description = '';
+		}
+
+		return apply_filters( 'woocommerce_email_settings_description_text_' . $this->id, $description );
+	}
+
+	/**
 	 * Admin Options
 	 *
 	 * Setup the email settings screen.
@@ -710,7 +728,7 @@ class WC_Email extends WC_Settings_API {
 		?>
 		<h3><?php echo ( ! empty( $this->title ) ) ? $this->title : __( 'Settings','woocommerce' ) ; ?></h3>
 
-		<?php echo $this->generate_email_settings_text_description( $this->description ); ?>
+		<?php echo $this->generate_settings_text_description(); ?>
 
 		<?php
 			/**

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -710,7 +710,7 @@ class WC_Email extends WC_Settings_API {
 		?>
 		<h3><?php echo ( ! empty( $this->title ) ) ? $this->title : __( 'Settings','woocommerce' ) ; ?></h3>
 
-		<?php echo ( ! empty( $this->description ) ) ? wpautop( $this->description ) : ''; ?>
+		<?php echo $this->generate_email_settings_text_description( $this->description ); ?>
 
 		<?php
 			/**


### PR DESCRIPTION
Added a filter to the description text within email settings enabling the user to adjust the description per type of email being sent out if required.

We have developed an extension to Woocommerce (Woocommerce Waitlist) that would benefit from this as we are sending out emails to customers at times not mentioned in the default description.

Screenshot with the filter applied:
![wc-settings](https://cloud.githubusercontent.com/assets/6690398/8501061/e7f27b80-2199-11e5-8c15-181d6e6b0217.png)

The adjustment makes it easy to filter the text to properly notify users of when the mailouts will occur if you change them.
