### PR TITLE
Refund deleted hook parameter fix

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2159,10 +2159,11 @@ class WC_AJAX {
 		$refund_id = absint( $_POST['refund_id'] );
 
 		if ( $refund_id && 'shop_order_refund' === get_post_type( $refund_id ) ) {
-			wc_delete_shop_order_transients( wp_get_post_parent_id( $refund_id ) );
+			$order_id = wp_get_post_parent_id( $refund_id );
+			wc_delete_shop_order_transients( $order_id );
 			wp_delete_post( $refund_id );
 
-			do_action( 'woocommerce_refund_deleted', $refund_id );
+			do_action( 'woocommerce_refund_deleted', $order_id );
 		}
 
 		die();

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2163,7 +2163,7 @@ class WC_AJAX {
 			wc_delete_shop_order_transients( $order_id );
 			wp_delete_post( $refund_id );
 
-			do_action( 'woocommerce_refund_deleted', $order_id );
+			do_action( 'woocommerce_refund_deleted', $refund_id, $order_id );
 		}
 
 		die();


### PR DESCRIPTION
This hook parameter dose not trigger in action due to delete that post. This should set '$order_id' as parameter
