### PR TITLE
Add variable $order to action 'woocommerce_order_item_' . $item['type'] . '_html'

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -85,7 +85,7 @@ if ( wc_tax_enabled() ) {
 
 				include( 'html-order-item.php' );
 
-				do_action( 'woocommerce_order_item_' . $item['type'] . '_html', $item_id, $item );
+				do_action( 'woocommerce_order_item_' . $item['type'] . '_html', $item_id, $item, $order );
 			}
 		?>
 		</tbody>


### PR DESCRIPTION
This comes in handy when you want change the line_items loop.
In my case I wanted to have a single line for each order item (per quantity) so I could edit the order and change the product for individual items. Would be appreciated if this could be merged.
