### PR TITLE
Add hook e.g. for woocommerce german market (variable.php)

### DIFF
--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -75,6 +75,8 @@ global $product, $post;
 
 			<div class="single_variation"></div>
 
+			<?php do_action( 'woocommerce_before_variations_button' ); ?>
+
 			<div class="variations_button">
 				<?php woocommerce_quantity_input( array(
 					'input_value' => ( isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : 1 )


### PR DESCRIPTION
A hook like that is needed to add german staff before the variations button. Without this hook customers need to customize the /single-product/add-to-cart/variable.php template file.
