### PR TITLE
Introduce woocommerce_order_full_refunded_status filter

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2211,7 +2211,7 @@ class WC_AJAX {
 			}
 
 			if ( $refund_amount == $max_refund ) {
-				$order->update_status( 'refunded' );
+				$order->update_status( apply_filters( 'woocommerce_order_fully_refunded_status', 'refunded', $order_id, $refund->id ) );
 				$response_data['status'] = 'fully_refunded';
 			}
 


### PR DESCRIPTION
In certain situations it’s undesirable to automatically change the order status for an order that has been fully refunded to `refunded`. For example, an order processed with a credit card whose charge has been authorized but not yet captured is typically voided, not refunded since no funds have actually been transferred. In that case, it’s ideal to allow gateways to change the status to `cancelled` instead.
