### PR TITLE
Use wc_cart_totals_taxes_total_html()

### DIFF
--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -86,7 +86,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php else : ?>
 				<tr class="tax-total">
 					<th><?php echo esc_html( WC()->countries->tax_or_vat() ); ?></th>
-					<td><?php echo wc_price( WC()->cart->get_taxes_total() ); ?></td>
+					<td><?php wc_cart_totals_taxes_total_html(); ?></td>
 				</tr>
 			<?php endif; ?>
 		<?php endif; ?>


### PR DESCRIPTION
The `order-review.php` template was printing the tax total directly, which meant extensions could not filter the tax total. This patch updates the `order-review.php` template to use the `wc_cart_totals_taxes_total_html()` function, which applies the 'woocommerce_cart_totals_taxes_total_html' filter.

This is the same way the [`cart-totals.php` template displays the tax total](https://github.com/woothemes/woocommerce/blob/ee1263db9c0c5cdc7ccb29a51abfd9d5bed15cda/templates/cart/cart-totals.php#L70).
