### PR TITLE
Add $hideprefix param to WC_Order_Item_Meta::get_formatted_legacy()

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -139,7 +139,7 @@ class WC_Order_Item_Meta {
 	 * Handles @deprecated args
 	 * @return array
 	 */
-	public function get_formatted_legacy() {
+	public function get_formatted_legacy( $hideprefix = '_' ) {
 		_deprecated_function( 'get_formatted_legacy', '2.4', 'Item Meta Data is being called with legacy arguments' );
 
 		$formatted_meta = array();


### PR DESCRIPTION
To honour the `$hideprefix` value when dealing with legacy item meta data. Currently, all item meta is being displayed, whether it is prefixed with the `$hideprefix` or not.
