### PR TITLE
Added Related Products heading text filter

### DIFF
--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -39,7 +39,7 @@ if ( $products->have_posts() ) : ?>
 
 	<div class="related products">
 
-		<h2><?php _e( 'Related Products', 'woocommerce' ); ?></h2>
+		<h2><?php echo apply_filters( 'woocommerce_related_products_heading', __( 'Related Products', 'woocommerce' ) ); ?></h2>
 
 		<?php woocommerce_product_loop_start(); ?>
 


### PR DESCRIPTION
Added woocommerce_related_products_heading filter to templates/single-product/related.php

Closes #8596.
