### PR TITLE
[2.4] Text-based attribute defaults saved in v2.3- don't work in v2.4

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -643,7 +643,8 @@ class WC_Meta_Box_Product_Data {
 									$options = wc_get_text_attributes( $attribute['value'] );
 
 									foreach ( $options as $option ) {
-										echo '<option ' . selected( $variation_selected_value, $option, false ) . ' value="' . esc_attr( $option ) . '">' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) )  . '</option>';
+										$selected = sanitize_title( $variation_selected_value ) === $variation_selected_value ? selected( sanitize_title( $variation_selected_value ), sanitize_title( $option ), false ) : selected( $variation_selected_value, $option, false );
+										echo '<option ' . $selected . ' value="' . esc_attr( $option ) . '">' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) )  . '</option>';
 									}
 
 								}

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -45,7 +45,8 @@ extract( $variation_data );
 					$options = wc_get_text_attributes( $attribute['value'] );
 
 					foreach ( $options as $option ) {
-						echo '<option ' . selected( $variation_selected_value, $option, false ) . ' value="' . esc_attr( $option ) . '">' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) ) . '</option>';
+						$selected = sanitize_title( $variation_selected_value ) === $variation_selected_value ? selected( sanitize_title( $variation_selected_value ), sanitize_title( $option ), false ) : selected( $variation_selected_value, $option, false );
+						echo '<option ' . $selected . ' value="' . esc_attr( $option ) . '">' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) ) . '</option>';
 					}
 
 				}

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -53,7 +53,8 @@ global $product, $post;
 
 									} else {
 										foreach ( $options as $option ) {
-											echo '<option value="' . esc_attr( $option ) . '" ' . selected( $selected_value, $option, false ) . '>' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) ) . '</option>';
+											$selected = sanitize_title( $selected_value ) === $selected_value ? selected( sanitize_title( $selected_value ), sanitize_title( $option ), false ) : selected( $selected_value, $option, false );
+											echo '<option value="' . esc_attr( $option ) . '" ' . $selected . '>' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) ) . '</option>';
 										}
 									}
 								}


### PR DESCRIPTION
See https://github.com/woothemes/woocommerce/commit/89f7e15052e1e593be46324952a01182a6248b50

To reproduce the issue in the admin + front-end: 
- save a few text-based attributes in 2.3 
- create a variable product with these attributes, and 
- update to 2.4

Result: The saved default attributes no longer work.
