### PR TITLE
WP Test suite installation updated to support via environment vars

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,7 +30,7 @@ class WC_Unit_Tests_Bootstrap {
 
 		$this->tests_dir    = dirname( __FILE__ );
 		$this->plugin_dir   = dirname( $this->tests_dir );
-		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : $this->plugin_dir . '/tmp/wordpress-tests-lib';
+		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
 
 		// load test function so tests_add_filter() is available
 		require_once( $this->wp_tests_dir . '/includes/functions.php' );


### PR DESCRIPTION
- Either use `curl` or `wget` to download.
- If WordPress core directory exists, skip.
- Set up testing suite if it doesn't yet exist.
- Set up `wp-test-config.php` if it doesn't yet exist.
- Allow environment vars `WP_TESTS_DIR` & `WP_CORE_DIR`
- Fix - conditional binary operator expected in `msygit` because of `=~`, #7952

CC @claudiosmweb all these changes were adapted from wp-cli, `install-wp-test.sh` bash file :P
