### PR TITLE
Force to use bash for generating docs using grunt on windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -225,7 +225,7 @@ module.exports = function( grunt ) {
 			},
 			apigen: {
 				command: [
-					'apigen generate',
+					'bash -c "apigen generate"',
 					'cd apigen',
 					'php hook-docs.php'
 				].join( '&&' )


### PR DESCRIPTION
Node internally uses cmd on Windows, not bash. We have to do `bash -c "apigen generate"` to force use of bash. Hard life for Windows users :P
