### PR TITLE
[2.4] Filter to enable deprecated addon rates

### DIFF
--- a/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -100,7 +100,7 @@ if ( WC()->shipping->get_shipping_classes() ) {
 	);
 }
 
-if ( $this->get_option( 'options', false ) ) {
+if ( apply_filers( 'woocommerce_enable_deprecated_additional_flat_rates', $this->get_option( 'options', false ) ) ) {
 	$settings[ 'additional_rates' ] = array(
 		'title'			=> __( 'Additional Rates', 'woocommerce' ),
 		'type'			=> 'title',

--- a/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -100,7 +100,7 @@ if ( WC()->shipping->get_shipping_classes() ) {
 	);
 }
 
-if ( apply_filers( 'woocommerce_enable_deprecated_additional_flat_rates', $this->get_option( 'options', false ) ) ) {
+if ( apply_filters( 'woocommerce_enable_deprecated_additional_flat_rates', $this->get_option( 'options', false ) ) ) {
 	$settings[ 'additional_rates' ] = array(
 		'title'			=> __( 'Additional Rates', 'woocommerce' ),
 		'type'			=> 'title',


### PR DESCRIPTION
Add-on flat rates have been deprecated in 2.4 in order to pave the way for https://github.com/woothemes/woocommerce/issues/8294

Currently, back-compat is provided by displaying the associated settings to users that already utilize Add-on rates. See https://github.com/woothemes/woocommerce/blob/master/includes/shipping/flat-rate/includes/settings-flat-rate.php#L103

So far so good.

However, if a 3rd party / one of our own extensions provides functionality that relies on add-on / instance-based flat rates, it is necessary that the functionality will remain intact all the way to the 2.5 release. This will be possible:
- in core, by migrating add-on flat rates to instance-based flat rates
- in extensions, by migrating settings that referenced the old add-on rates to reference the new instance-based rates

So what's currently missing to complete the picture is a filter that will make it easy for plugins/extensions to re-enable the dropped "additional flat rate" options box until the 2.5 release, when all the migratiion work will happen.

One alternative is to hook into `option_woocommerce_flat_rate_settings` and manually add content to the `options` field -- if it's empty. That's not really elegant though, since dummy content, such as an empty space, will cover the placeholder text.
