### PR TITLE
Moves the loop product title into a function and creates a new action for it. Fixes #8601

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -507,6 +507,14 @@ if ( ! function_exists( 'woocommerce_product_loop_end' ) ) {
 			return ob_get_clean();
 	}
 }
+if (  ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
+	/**
+	 * Show the product title in the product loop. By default this is an H3
+	 */
+	function woocommerce_template_loop_product_title() {
+		wc_get_template( 'loop/title.php' );
+	}
+}
 if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 
 	/**

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -88,6 +88,7 @@ add_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 30 )
  */
 add_action( 'woocommerce_after_shop_loop_item', 'woocommerce_template_loop_add_to_cart', 10 );
 add_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail', 10 );
+add_action( 'woocommerce_shop_loop_item_title', 'woocommerce_template_loop_product_title', 10 );
 add_action( 'woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_price', 10 );
 add_action( 'woocommerce_after_shop_loop_item_title', 'woocommerce_template_loop_rating', 5 );
 

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -58,7 +58,15 @@ if ( 0 == $woocommerce_loop['loop'] % $woocommerce_loop['columns'] ) {
 			do_action( 'woocommerce_before_shop_loop_item_title' );
 		?>
 
-		<h3><?php the_title(); ?></h3>
+
+		<?php
+			/**
+			 * woocommerce_shop_loop_item_title hook
+			 *
+			 * @hooked woocommerce_template_loop_product_title - 10
+			 */
+			do_action( 'woocommerce_shop_loop_item_title' );
+		?>
 
 		<?php
 			/**

--- a/templates/loop/title.php
+++ b/templates/loop/title.php
@@ -4,7 +4,7 @@
  *
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 1.6.5
+ * @version 2.3.14
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/loop/title.php
+++ b/templates/loop/title.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Single Product title
+ *
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 1.6.5
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+<h3><?php the_title(); ?></h3>


### PR DESCRIPTION
After these changes, you can easily unhook and override the title, as described in #8601 
