### PR TITLE
Removing Blank Line in wc-template-functions.php

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * WooCommerce Template


### PR DESCRIPTION
Blank lines before PHP probably don't do us any good. And this is possibly related to #7829 .
