### PR TITLE
[2.4] Trigger do_variation_action + '_ajax_data'

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -666,6 +666,7 @@ jQuery( function( $ ) {
 					break;
 				default :
 					$( 'select.variation_actions' ).trigger( do_variation_action );
+					data = $( 'select.variation_actions' ).triggerHandler( do_variation_action + '_ajax_data', data );
 					break;
 			}
 


### PR DESCRIPTION
To allow extensions which add their own variation bulk actions to pass data back to WooCommerce core's handler so that only one ajax call is necessary for updating the data (the extension can then hook to `'woocommerce_bulk_edit_variations'` to process that data server side).

Previously, a duplicate ajax call would be required as `trigger()` does not allow callbacks to pass data back, so the existing `$( 'select.variation_actions' ).trigger( do_variation_action )` could only be used to pass the data to the server itself rather than having WooCommerce do it.

It's necessary to trigger a new handler (i.e. `triggerHandler( do_variation_action + '_ajax_data', data )`) instead of just replacing the existing `trigger( do_variation_action )` with `triggerHandler( do_variation_action, data )` to maintain backward compatibility. Specifically, `trigger()` bubbles up the DOM, where as `triggerHandler()` doesn't. That means existing extensions may have been handling `do_variation_action` on elements other than `'select.variation_actions'` (like `body`) and that JS would break if we just updating the existing handler.
