### PR TITLE
Update Simplify Commerce for Subscriptions v2.0

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -75,7 +75,11 @@ class WC_Payment_Gateways {
 
 		if ( 'US' === WC()->countries->get_base_country() ) {
 			if ( class_exists( 'WC_Subscriptions_Order' ) || class_exists( 'WC_Pre_Orders_Order' ) ) {
-				$load_gateways[] = 'WC_Addons_Gateway_Simplify_Commerce';
+				if ( ! function_exists( 'wcs_create_renewal_order' ) ) { // Subscriptions < 2.0
+					$load_gateways[] = 'WC_Addons_Gateway_Simplify_Commerce_Deprecated';
+				} else {
+					$load_gateways[] = 'WC_Addons_Gateway_Simplify_Commerce';
+				}
 			} else {
 				$load_gateways[] = 'WC_Gateway_Simplify_Commerce';
 			}

--- a/includes/gateways/simplify-commerce-deprecated/class-wc-addons-gateway-simplify-commerce-deprecated.php
+++ b/includes/gateways/simplify-commerce-deprecated/class-wc-addons-gateway-simplify-commerce-deprecated.php
@@ -1,0 +1,25 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Simplify Commerce Gateway for Subscriptions < 2.0
+ *
+ * @class 		WC_Addons_Gateway_Simplify_Commerce_Deprecated
+ * @extends		WC_Addons_Gateway_Simplify_Commerce
+ * @since       2.4.0
+ * @version		1.0.0
+ * @package		WooCommerce/Classes/Payment
+ * @author 		WooThemes
+ */
+class WC_Addons_Gateway_Simplify_Commerce_Deprecated extends WC_Addons_Gateway_Simplify_Commerce {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		parent::__construct();
+	}
+}

--- a/includes/gateways/simplify-commerce-deprecated/class-wc-addons-gateway-simplify-commerce-deprecated.php
+++ b/includes/gateways/simplify-commerce-deprecated/class-wc-addons-gateway-simplify-commerce-deprecated.php
@@ -149,4 +149,14 @@ class WC_Addons_Gateway_Simplify_Commerce_Deprecated extends WC_Addons_Gateway_S
 
 		return $order_meta_query;
 	}
+
+	/**
+	 * Check if order contains subscriptions.
+	 *
+	 * @param  int $order_id
+	 * @return bool
+	 */
+	protected function order_contains_subscription( $order_id ) {
+		return class_exists( 'WC_Subscriptions_Order' ) && ( WC_Subscriptions_Order::order_contains_subscription( $order_id ) || WC_Subscriptions_Renewal_Order::is_renewal( $order_id ) );
+	}
 }

--- a/includes/gateways/simplify-commerce-deprecated/class-wc-addons-gateway-simplify-commerce-deprecated.php
+++ b/includes/gateways/simplify-commerce-deprecated/class-wc-addons-gateway-simplify-commerce-deprecated.php
@@ -21,5 +21,114 @@ class WC_Addons_Gateway_Simplify_Commerce_Deprecated extends WC_Addons_Gateway_S
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		if ( class_exists( 'WC_Subscriptions_Order' ) ) {
+			add_action( 'scheduled_subscription_payment_' . $this->id, array( $this, 'process_scheduled_subscription_payment' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Store the customer and card IDs on the order and subscriptions in the order
+	 *
+	 * @param int $order_id
+	 * @param string $customer_id
+	 * @return array
+	 */
+	protected function save_subscription_meta( $order_id, $customer_id ) {
+		update_post_meta( $order_id, '_simplify_customer_id', wc_clean( $customer_id ) );
+	}
+
+	/**
+	 * process_subscription_payment function.
+	 *
+	 * @param WC_order $order
+	 * @param integer $amount (default: 0)
+	 * @uses  Simplify_BadRequestException
+	 * @return bool|WP_Error
+	 */
+	public function process_subscription_payment( $order, $amount = 0 ) {
+		if ( 0 == $amount ) {
+			// Payment complete
+			$order->payment_complete();
+
+			return true;
+		}
+
+		if ( $amount * 100 < 50 ) {
+			return new WP_Error( 'simplify_error', __( 'Sorry, the minimum allowed order total is 0.50 to use this payment method.', 'woocommerce' ) );
+		}
+
+		$order_items       = $order->get_items();
+		$order_item        = array_shift( $order_items );
+		$subscription_name = sprintf( __( '%s - Subscription for "%s"', 'woocommerce' ), esc_html( get_bloginfo( 'name', 'display' ) ), $order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ), $order->get_order_number() );
+
+		$customer_id = get_post_meta( $order->id, '_simplify_customer_id', true );
+
+		if ( ! $customer_id ) {
+			return new WP_Error( 'simplify_error', __( 'Customer not found', 'woocommerce' ) );
+		}
+
+		try {
+			// Charge the customer
+			$payment = Simplify_Payment::createPayment( array(
+				'amount'              => $amount * 100, // In cents
+				'customer'            => $customer_id,
+				'description'         => trim( substr( $subscription_name, 0, 1024 ) ),
+				'currency'            => strtoupper( get_woocommerce_currency() ),
+				'reference'           => $order->id,
+				'card.addressCity'    => $order->billing_city,
+				'card.addressCountry' => $order->billing_country,
+				'card.addressLine1'   => $order->billing_address_1,
+				'card.addressLine2'   => $order->billing_address_2,
+				'card.addressState'   => $order->billing_state,
+				'card.addressZip'     => $order->billing_postcode
+			) );
+
+		} catch ( Exception $e ) {
+
+			$error_message = $e->getMessage();
+
+			if ( $e instanceof Simplify_BadRequestException && $e->hasFieldErrors() && $e->getFieldErrors() ) {
+				$error_message = '';
+				foreach ( $e->getFieldErrors() as $error ) {
+					$error_message .= ' ' . $error->getFieldName() . ': "' . $error->getMessage() . '" (' . $error->getErrorCode() . ')';
+				}
+			}
+
+			$order->add_order_note( sprintf( __( 'Simplify payment error: %s', 'woocommerce' ), $error_message ) );
+
+			return new WP_Error( 'simplify_payment_declined', $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+
+		if ( 'APPROVED' == $payment->paymentStatus ) {
+			// Payment complete
+			$order->payment_complete( $payment->id );
+
+			// Add order note
+			$order->add_order_note( sprintf( __( 'Simplify payment approved (ID: %s, Auth Code: %s)', 'woocommerce' ), $payment->id, $payment->authCode ) );
+
+			return true;
+		} else {
+			$order->add_order_note( __( 'Simplify payment declined', 'woocommerce' ) );
+
+			return new WP_Error( 'simplify_payment_declined', __( 'Payment was declined - please try another card.', 'woocommerce' ) );
+		}
+	}
+
+	/**
+	 * process_scheduled_subscription_payment function.
+	 *
+	 * @param float $amount_to_charge The amount to charge.
+	 * @param WC_Order $order The WC_Order object of the order which the subscription was purchased in.
+	 * @param int $product_id The ID of the subscription product for which this payment relates.
+	 */
+	public function process_scheduled_subscription_payment( $amount_to_charge, $order, $product_id ) {
+		$result = $this->process_subscription_payment( $order, $amount_to_charge );
+
+		if ( is_wp_error( $result ) ) {
+			WC_Subscriptions_Manager::process_subscription_payment_failure_on_order( $order, $product_id );
+		} else {
+			WC_Subscriptions_Manager::process_subscription_payments_on_order( $order );
+		}
 	}
 }

--- a/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
@@ -65,7 +65,7 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 	 * @return bool
 	 */
 	protected function order_contains_subscription( $order_id ) {
-		return class_exists( 'WC_Subscriptions_Order' ) && ( WC_Subscriptions_Order::order_contains_subscription( $order_id ) || WC_Subscriptions_Renewal_Order::is_renewal( $order_id ) );
+		return function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) );
 	}
 
 	/**

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -31,7 +31,8 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 			'subscription_reactivation',
 			'subscription_suspension',
 			'subscription_amount_changes',
-			'subscription_payment_method_change',
+			'subscription_payment_method_change', // Subscriptions 1.n compatibility
+			'subscription_payment_method_change_customer',
 			'subscription_payment_method_change_admin',
 			'subscription_date_changes',
 			'default_credit_card_form',

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -35,6 +35,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 			'subscription_payment_method_change_customer',
 			'subscription_payment_method_change_admin',
 			'subscription_date_changes',
+			'multiple_subscriptions',
 			'default_credit_card_form',
 			'refunds',
 			'pre-orders'

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -32,6 +32,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 			'subscription_suspension',
 			'subscription_amount_changes',
 			'subscription_payment_method_change',
+			'subscription_payment_method_change_admin',
 			'subscription_date_changes',
 			'default_credit_card_form',
 			'refunds',


### PR DESCRIPTION
This is a proposed patch for updating Simplify Commerce to support the upcoming WooCommerce Subscriptions v2.0 release. If we can get this patch into WooCommerce v2.4 rather than a point release (i.e. v2.4.3), it will be easier to explain the minimum version required. However, I appreciate it's a fairly large change to introduce so late in the WC 2.4 beta cycle.
### Overview of Changes

Subscriptions v2.0 will be mostly backward compatible so few of these patches are required, but v2.0 is also introducing a number of architectural improvements and new features. This pull request takes advantage of those.

Most notably, it:
1. adds support for the new _Multiple Subscriptions_ feature, with SHA: ff458f907018cee63ae
2. adds support for the new _Admin Change Payment Method_ feature to allow store manager to manually set Simplify Commerce as the recurring payment method for a subscription, with SHA: 6c16ecadc52
3. updates how renewal payments are processed to take advantage of the renewal order now being generated before payment is processed instead of afterwards. This allows Simplify to record the payment's transaction ID on the renewal order, and pass the renewal order's ID to the Simplify gateway in the description to help store managers link up payments with renewal orders (previously, the original subscription's order ID would be used for all payments).

It also updates Simplify's support of the the [change payment method](http://docs.woothemes.com/document/subscriptions/customers-view/#section-5) process to be compatible with v2.0 (with SHA: b8f902df782f94d8cf5).
### Issues with Patch

The architecture of the patch is a bit hacky IMHO. But without bigger changes, that is unavoidable.

Ideally, Subscriptions would be responsible for handing Simplify Commerce's support for Subscriptions features, in much the same way Subscriptions is responsible for PayPal's support of its features. This would prevent WooCommerce having a deprecated class for backward compatibility and also mean when there is a bug in the Subscriptions support of Simplify, only a new version of Subscriptions needs to be release, not a new version of WooCommerce (although, fortunately, this is a very rare occurrence).

However, because Simplify uses a single class for `Addons` compatibility, there is currently no way to do that without also making Subscriptions responsible for Simplify Commerce's support of Pre-Orders. Which is the greater of the two evils and why this patch keeps Subscriptions support in core.
### Tests ran with Subscriptions v1.5 and v2.0

The patch has been thoroughly tested with both Subscriptions v1.5 and v2.0 to ensure the following work when using Simplify as the payment method:
- [x] pay for order with a simple product
- [x] pay for order with a simple subscription product
- [x] pay for order with a simple subscription product synchronised to a day in the future
- [x] pay for order with a simple subscription product with a sign-up fee
- [x] pay for order with a simple product and simple subscription product
- [x] test an automatic renewal with a working card
- [x] test an automatic renewal with a working card for subscription synchronised to a day in the future
- [x] test an automatic renewal with a failing card
- [x] complete manual payment process on failed renewal  (includes checking customer ID is updated correctly and testing automatic renewal after changing the payment method)
- [x] test “Change Payment Method” process on a subscription (includes checking customer ID is updated correctly and testing automatic renewal after changing the payment method)
