### PR TITLE
Allow `meta_is_product_attribute()` variable product types to be filterable.

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -271,7 +271,7 @@ if ( ! function_exists( 'meta_is_product_attribute' ) ) {
 	function meta_is_product_attribute( $name, $value, $product_id ) {
 		$product = wc_get_product( $product_id );
 
-		if ( $product->product_type != 'variable' ) {
+		if ( ! in_array( $product->product_type, apply_filters( 'meta_is_product_attribute_product_types', array( 'variable' ) ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
..so that custom variable product types (like variable subscriptions) also get their custom attribute variation data attached to the new order correctly.

Related to https://github.com/woothemes/woocommerce/issues/7601
