### PR TITLE
[2.4] Variations script: Allow product variations data to be dynamically refreshed

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -29,6 +29,12 @@
 			return false;
 		} )
 
+		// Reload product variations data
+		.on( 'reload_product_variations', function() {
+			$product_variations = $form.data( 'product_variations' );
+			$use_ajax           = $product_variations === false;
+		} )
+
 		// Reset product data
 		.on( 'reset_data', function() {
 			var to_reset = {


### PR DESCRIPTION
Since WC 2.4, the `product_variations` data attribute that contains all variations data used by the script is retrieved and saved once in a `$product_variations` variable when the variations script is attached to to a `.variations_form` container.

In WC 2.3, the `product_variations` data attribute was retrieved every time the script ran, which allowed 3rd party scripts to creatively manipulate the `product_variations` object in order to dynamically add/remove variations, disable specific variation attributes, etc, in response to specific events.

To allow such scripts to keep working in WC 2.4, we can:
- either read the `product_variations` data every time the script is executed, as in WC 2.3, or
- introduce an event that can be fired to "reload" the `product_variations` data into the `$product_variations` script variable.

The proposed change is based on the latter approach, which is the faster one when the `product_variations` data doesn't need to be refreshed.
