### PR TITLE
Define DOING_AJAX early

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -21,6 +21,7 @@ class WC_AJAX {
 	 * Hook in ajax handlers
 	 */
 	public static function init() {
+		add_action( 'init', array( __CLASS__, 'define_ajax'), 0 );
 		add_action( 'template_redirect', array( __CLASS__, 'do_wc_ajax'), 0 );
 		self::add_ajax_events();
 	}
@@ -35,6 +36,21 @@ class WC_AJAX {
 	}
 
 	/**
+	 * Set AJAX defines.
+	 */
+	public static function define_ajax() {
+
+		if ( ! empty( $_GET['wc-ajax'] ) ) {
+			if ( ! defined( 'DOING_AJAX' ) ) {
+				define( 'DOING_AJAX', true );
+			}
+			if ( ! defined( 'WC_DOING_AJAX' ) ) {
+				define( 'WC_DOING_AJAX', true );
+			}
+		}
+	}
+
+	/**
 	 * Check for WC Ajax request and fire action
 	 */
 	public static function do_wc_ajax() {
@@ -45,12 +61,6 @@ class WC_AJAX {
 		}
 
 		if ( $action = $wp_query->get( 'wc-ajax' ) ) {
-			if ( ! defined( 'DOING_AJAX' ) ) {
-				define( 'DOING_AJAX', true );
-			}
-			if ( ! defined( 'WC_DOING_AJAX' ) ) {
-				define( 'WC_DOING_AJAX', true );
-			}
 			do_action( 'wc_ajax_' . sanitize_text_field( $action ) );
 			die();
 		}


### PR DESCRIPTION
Hey Guys,

This PR is to make sure the DOING_AJAX is defined at a earlier stage. Originally its hooking into `template_redirect` which is a fairly 'late' hook for this purpose.

Defining the constants earlier is important for plugins hooking into e.g. `init`, as they can then do a check to see if its a AJAX request, when its defined at `template_redirect` its already too late for many plugins. Plus the ajax request does a `die` so no one would be able to use the `DOING_AJAX` except when hooking into the `wc_ajax_*`.

What was happening with me;
- Was adding `wc_add_notice()` at the init hook.
- When adding a product to cart extra `wc_add_notice()` calls were made
- Resulting in extra notices \* add-to-carts.

Hope this makes sense and that I'm not totally wrong, had a long day.
