### PR TITLE
Save product type before saving variations

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -434,10 +434,11 @@ jQuery( function( $ ) {
 			if ( 0 < need_update.length ) {
 				wc_meta_boxes_product_variations_ajax.block();
 
-				data            = wc_meta_boxes_product_variations_ajax.get_variations_fields( need_update );
-				data.action     = 'woocommerce_save_variations';
-				data.security   = woocommerce_admin_meta_boxes_variations.save_variations_nonce;
-				data.product_id = woocommerce_admin_meta_boxes_variations.post_id;
+				data                 = wc_meta_boxes_product_variations_ajax.get_variations_fields( need_update );
+				data.action          = 'woocommerce_save_variations';
+				data.security        = woocommerce_admin_meta_boxes_variations.save_variations_nonce;
+				data.product_id      = woocommerce_admin_meta_boxes_variations.post_id;
+				data['product-type'] = $( '#product-type' ).val();
 
 				$.ajax({
 					url: woocommerce_admin_meta_boxes_variations.ajax_url,

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2557,7 +2557,16 @@ class WC_AJAX {
 		// Remove previous meta box errors
 		WC_Admin_Meta_Boxes::$meta_box_errors = array();
 
-		$product_id = absint( $_POST['product_id'] );
+		$product_id   = absint( $_POST['product_id'] );
+		$product_type = empty( $_POST['product-type'] ) ? 'simple' : sanitize_title( stripslashes( $_POST['product-type'] ) );
+
+		$product_type_terms = wp_get_object_terms( $product_id, 'product_type' );
+
+		// If the product type hasn't been set or it has changed, update it before saving variations
+		if ( empty( $product_type_terms ) || $product_type !== sanitize_title( current( $product_type_terms )->name ) ) {
+			wp_set_object_terms( $product_id, $product_type, 'product_type' );
+		}
+
 		WC_Meta_Box_Product_Data::save_variations( $product_id, get_post( $product_id ) );
 
 		do_action( 'woocommerce_ajax_save_product_variations', $product_id );


### PR DESCRIPTION
WooCommerce prior to WC 2.4 saved the product type before any variations were saved because `WC_Meta_Box_Product_Data::save_variations()` was called by `WC_Meta_Box_Product_Data::save()`. However, in WC 2.4 the variations are saved independently of other data about the containing variable product, including product type. Because the product type hasn't been saved yet, extensions that need to save their own variation level meta data can't know when saving variations if the product is of the type they want to act on. They also can't check `$_POST` to find out when saving variations, because 'product-type' isn't passed to that as it's variable level meta data, not variation level meta data.

This patch passes the product type along with the variation level meta data when saving variations. It then uses that to save the product type if the variable product has not yet been saved (and therefore the product type has never been stored, which means calling `get_product()` would instantiate a `'simple'` product, as that is the default product type). This can lead to fatal errors if callbacks expect the product type to be variable and attempt to call methods that only exist on those product types, like `variable_product_sync()`.

It will also update the product type if it was previously saved but has since changed. This prevents fatal errors like that mentioned above but caused by switching from one product type, like a simple product, to another, like a variable product.
