### PR TITLE
fix for array_filter() expects parameter 1 to be array, boolean given

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -168,7 +168,7 @@ class WC_Admin_Duplicate_Product {
 		$this->duplicate_post_meta( $post->ID, $new_post_id );
 
 		// Copy the children (variations)
-		$exclude = array_filter( apply_filters( 'woocommerce_duplicate_product_exclude_children', false, $post ) );
+		$exclude = apply_filters( 'woocommerce_duplicate_product_exclude_children', false );
 
 		if ( ! $exclude && ( $children_products = get_children( 'post_parent=' . $post->ID . '&post_type=product_variation' ) ) ) {
 			foreach ( $children_products as $child ) {


### PR DESCRIPTION
array_filter() expects parameter 1 to be array, boolean given
/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-
product.php(171)

$exclude is evaluated as a boolean.
