### PR TITLE
Add price suffix filters [Issue: #8713]

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -937,17 +937,17 @@ class WC_Product {
 		$display_price         = $this->get_display_price();
 		$display_regular_price = $this->get_display_price( $this->get_regular_price() );
 
+		$display_suffix = apply_filters( 'woocommerce_price_suffix', $this->get_price_suffix(), $this );
+
 		if ( $this->get_price() > 0 ) {
 
 			if ( $this->is_on_sale() && $this->get_regular_price() ) {
-
-				$price .= $this->get_price_html_from_to( $display_regular_price, $display_price ) . $this->get_price_suffix();
+				$price .= $this->get_price_html_from_to( $display_regular_price, $display_price ) . $display_suffix;
 
 				$price = apply_filters( 'woocommerce_sale_price_html', $price, $this );
 
 			} else {
-
-				$price .= wc_price( $display_price ) . $this->get_price_suffix();
+				$price .= wc_price( $display_price ) . $display_suffix;
 
 				$price = apply_filters( 'woocommerce_price_html', $price, $this );
 

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -193,7 +193,7 @@ class WC_Product_Grouped extends WC_Product {
 				$display_price = sprintf( _x( '%1$s&ndash;%2$s', 'Price range: from-to', 'woocommerce' ), $from, $to );
 			}
 
-			$price .= $display_price . $this->get_price_suffix();
+			$price .= $display_price . apply_filters( 'woocommerce_grouped_price_suffix', $this->get_price_suffix(), $this );
 
 			$price = apply_filters( 'woocommerce_grouped_price_html', $price, $this );
 		} else {

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -324,7 +324,8 @@ class WC_Product_Variable extends WC_Product {
 			} elseif ( $is_free ) {
 				$price = apply_filters( 'woocommerce_variable_free_price_html', __( 'Free!', 'woocommerce' ), $this );
 			} else {
-				$price = apply_filters( 'woocommerce_variable_price_html', $price . $this->get_price_suffix(), $this );
+				$suffix = apply_filters( 'woocommerce_variable_price_suffix', $this->get_price_suffix(), $this );
+				$price = apply_filters( 'woocommerce_variable_price_html', $price . $suffix, $this );
 			}
 		}
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -303,7 +303,7 @@ class WC_Product_Variation extends WC_Product {
 			if ( $this->is_on_sale() ) {
 				$price = apply_filters( 'woocommerce_variation_sale_price_html', '<del>' . wc_price( $display_regular_price ) . '</del> <ins>' . wc_price( $display_sale_price ) . '</ins>' . $this->get_price_suffix(), $this );
 			} elseif ( $this->get_price() > 0 ) {
-				$price = apply_filters( 'woocommerce_variation_price_html', wc_price( $display_price ) . $display_suffix(), $this );
+				$price = apply_filters( 'woocommerce_variation_price_html', wc_price( $display_price ) . $display_suffix, $this );
 			} else {
 				$price = apply_filters( 'woocommerce_variation_free_price_html', __( 'Free!', 'woocommerce' ), $this );
 			}

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -297,11 +297,13 @@ class WC_Product_Variation extends WC_Product {
 		$display_regular_price = $this->get_display_price( $this->get_regular_price() );
 		$display_sale_price    = $this->get_display_price( $this->get_sale_price() );
 
+		$display_suffix = apply_filters( 'woocommerce_variation_price_suffix', $this->get_price_suffix(), $this );
+
 		if ( $this->get_price() !== '' ) {
 			if ( $this->is_on_sale() ) {
 				$price = apply_filters( 'woocommerce_variation_sale_price_html', '<del>' . wc_price( $display_regular_price ) . '</del> <ins>' . wc_price( $display_sale_price ) . '</ins>' . $this->get_price_suffix(), $this );
 			} elseif ( $this->get_price() > 0 ) {
-				$price = apply_filters( 'woocommerce_variation_price_html', wc_price( $display_price ) . $this->get_price_suffix(), $this );
+				$price = apply_filters( 'woocommerce_variation_price_html', wc_price( $display_price ) . $display_suffix(), $this );
 			} else {
 				$price = apply_filters( 'woocommerce_variation_free_price_html', __( 'Free!', 'woocommerce' ), $this );
 			}


### PR DESCRIPTION
New filters to be used when modifying the product price suffix

'woocommerce_price_suffix'
'woocommerce_grouped_price_suffix'
'woocommerce_variable_price_suffix'
'woocommerce_variation_price_suffix'

Resolves woothemes/woocommerce#8713
