### PR TITLE
Check for file exists after wc_get_template filter

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -181,7 +181,7 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 	}
 
 	$located = wc_locate_template( $template_name, $template_path, $default_path );
-	
+
 	if ( ! file_exists( $located ) ) {
 		_doing_it_wrong( __FUNCTION__, sprintf( '<code>%s</code> does not exist.', $located ), '2.1' );
 		return;

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -182,13 +182,13 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 
 	$located = wc_locate_template( $template_name, $template_path, $default_path );
 
+	// Allow 3rd party plugin filter template file from their plugin
+	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
+	
 	if ( ! file_exists( $located ) ) {
 		_doing_it_wrong( __FUNCTION__, sprintf( '<code>%s</code> does not exist.', $located ), '2.1' );
 		return;
 	}
-
-	// Allow 3rd party plugin filter template file from their plugin
-	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
 
 	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located, $args );
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -181,15 +181,17 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 	}
 
 	$located = wc_locate_template( $template_name, $template_path, $default_path );
-
-	// Allow 3rd party plugin filter template file from their plugin
-	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
 	
 	if ( ! file_exists( $located ) ) {
 		_doing_it_wrong( __FUNCTION__, sprintf( '<code>%s</code> does not exist.', $located ), '2.1' );
 		return;
 	}
 
+	// Allow 3rd party plugin filter template file from their plugin
+	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
+	
+	if ( ! file_exists( $located ) ) return;
+	
 	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located, $args );
 
 	include( $located );


### PR DESCRIPTION
This is very handy to filter specific template via custom filters and do not show it or do own handling of template in custom filter.

For example you can create your own templates in php directly like this:

```
add_filter("wc_get_template", function($located, $template_name, $args, $template_path, $default_path)
{
    if($template_name == "global/quantity-input.php") {

        echo '<input type="number">';

        return null;
    }

    return $located;
}, 10, 5);
```

Similar to wc_get_template_part func.
