### PR TITLE
check for file exists after wc_get_template filter

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -190,6 +190,8 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 	// Allow 3rd party plugin filter template file from their plugin
 	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
 
+	if ( ! file_exists( $located ) ) return;
+
 	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located, $args );
 
 	include( $located );


### PR DESCRIPTION
This is very handy to filter specific template via custom filters and do not show it or do own handling of template in custom filter.

For example you can create your own templates in php directly like this:

```
add_filter("wc_get_template", function($located, $template_name, $args, $template_path, $default_path)
{
    if($template_name == "global/quantity-input.php") {

        echo '<input type="number">';

        return null;
    }

    return $located;
}, 10, 5);
```

Similar to wc_get_template_part func.
