### PR TITLE
Fix possible fatal error on the order admin page

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -23,7 +23,11 @@ class WC_Meta_Box_Order_Items {
 	 * Output the metabox
 	 */
 	public static function output( $post ) {
-		global $thepostid, $theorder;
+		global $post, $thepostid, $theorder;
+
+		if ( ! is_int( $thepostid ) ) {
+			$thepostid = $post->ID;
+		}
 
 		if ( ! is_object( $theorder ) ) {
 			$theorder = wc_get_order( $thepostid );


### PR DESCRIPTION
On a customer site i was having a fatal error becasuse `$theorder` and `$thepostid` were both `NULL`.

This fixes. We use the same code on other admin functions.
