### PR TITLE
Allow support for variable in backbone modal template in extensions

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -406,7 +406,7 @@ jQuery( function ( $ ) {
 
 		add_item: function() {
 			$( this ).WCBackboneModal({
-				template: '#wc-modal-add-products'
+				template: 'wc-modal-add-products'
 			});
 
 			return false;
@@ -448,7 +448,7 @@ jQuery( function ( $ ) {
 
 		add_tax: function() {
 			$( this ).WCBackboneModal({
-				template: '#wc-modal-add-tax'
+				template: 'wc-modal-add-tax'
 			});
 			return false;
 		},
@@ -1001,13 +1001,13 @@ jQuery( function ( $ ) {
 		backbone: {
 
 			init: function( e, target ) {
-				if ( '#wc-modal-add-products' === target ) {
+				if ( 'wc-modal-add-products' === target ) {
 					$( document.body ).trigger( 'wc-enhanced-select-init' );
 				}
 			},
 
 			response: function( e, target, data ) {
-				if ( '#wc-modal-add-tax' === target ) {
+				if ( 'wc-modal-add-tax' === target ) {
 					var rate_id = data.add_order_tax;
 					var manual_rate_id = '';
 
@@ -1017,7 +1017,7 @@ jQuery( function ( $ ) {
 
 					wc_meta_boxes_order_items.backbone.add_tax( rate_id, manual_rate_id );
 				}
-				if ( '#wc-modal-add-products' === target ) {
+				if ( 'wc-modal-add-products' === target ) {
 					wc_meta_boxes_order_items.backbone.add_item( data.add_order_items );
 				}
 			},

--- a/assets/js/admin/order-backbone-modal.js
+++ b/assets/js/admin/order-backbone-modal.js
@@ -59,7 +59,9 @@
 			this.render();
 		},
 		render: function() {
-			this.$el.attr( 'tabindex' , '0' ).append( $( this._target ).html() );
+			var template = wp.template( this._target );
+
+			this.$el.attr( 'tabindex' , '0' ).append( template );
 
 			$( document.body ).css({
 				'overflow': 'hidden'

--- a/assets/js/admin/order-backbone-modal.js
+++ b/assets/js/admin/order-backbone-modal.js
@@ -25,7 +25,8 @@
 
 		if ( settings.template ) {
 			new $.WCBackboneModal.View({
-				target: settings.template
+				target: settings.template,
+				string: settings.variable
 			});
 		}
 	};
@@ -36,7 +37,8 @@
 	 * @type {object}
 	 */
 	$.WCBackboneModal.defaultOptions = {
-		template: ''
+		template: '',
+		variable: {}
 	};
 
 	/**
@@ -48,6 +50,7 @@
 		tagName: 'div',
 		id: 'wc-backbone-modal-dialog',
 		_target: undefined,
+		_string: undefined,
 		events: {
 			'click .modal-close': 'closeButton',
 			'click #btn-ok':      'addButton',
@@ -55,13 +58,16 @@
 		},
 		initialize: function( data ) {
 			this._target = data.target;
+			this._string = data.string;
 			_.bindAll( this, 'render' );
 			this.render();
 		},
 		render: function() {
 			var template = wp.template( this._target );
 
-			this.$el.attr( 'tabindex' , '0' ).append( template );
+			this.$el.attr( 'tabindex' , '0' ).append(
+				template( this._string )
+			);
 
 			$( document.body ).css({
 				'overflow': 'hidden'

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -197,7 +197,7 @@ class WC_Admin_Assets {
 		}
 		if ( in_array( str_replace( 'edit-', '', $screen->id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
 			wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes' ), WC_VERSION );
-			wp_enqueue_script( 'wc-admin-order-meta-boxes-modal', WC()->plugin_url() . '/assets/js/admin/order-backbone-modal' . $suffix . '.js', array( 'underscore', 'backbone', 'wc-admin-order-meta-boxes' ), WC_VERSION );
+			wp_enqueue_script( 'wc-admin-order-meta-boxes-modal', WC()->plugin_url() . '/assets/js/admin/order-backbone-modal' . $suffix . '.js', array( 'underscore', 'backbone', 'wp-util', 'wc-admin-order-meta-boxes' ), WC_VERSION );
 
 			$params = array(
 				'countries'              => json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -306,7 +306,7 @@ if ( wc_tax_enabled() ) {
 </div>
 <?php endif; ?>
 
-<script type="text/template" id="wc-modal-add-products">
+<script type="text/template" id="tmpl-wc-modal-add-products">
 	<div class="wc-backbone-modal">
 		<div class="wc-backbone-modal-content">
 			<section class="wc-backbone-modal-main" role="main">
@@ -332,7 +332,7 @@ if ( wc_tax_enabled() ) {
 	<div class="wc-backbone-modal-backdrop modal-close"></div>
 </script>
 
-<script type="text/template" id="wc-modal-add-tax">
+<script type="text/template" id="tmpl-wc-modal-add-tax">
 	<div class="wc-backbone-modal">
 		<div class="wc-backbone-modal-content">
 			<section class="wc-backbone-modal-main" role="main">


### PR DESCRIPTION
Load the WooCommerce Modal plugin with some variable set:

``` js
$( this ).WCBackboneModal({
    template: 'wc-modal-variable-extension-demo',
    variable: {
        class: 'wc-extension-demo',
        title: woocommerce_extension_demo.i18n_example_title,
        message: woocommerce_extension_demo.i18n_example_message
    }
});
```

Finally pretty fun to use `{{data.escaped}}` or `{{{data.unescaped}}}` style template tags. One other thing to note that is we can make use of some light logic inside `<# //Logic #>` style tags too.

``` html
<script type="text/template" id="tmpl-wc-modal-extension-demo">
    <div class="wc-backbone-modal">
        <div class="wc-backbone-modal-content">
            <section class="wc-backbone-modal-main" role="main">
                <header class="wc-backbone-modal-header">
                    <h1>{{ data.title }}</h1>
                    <button class="modal-close modal-close-link dashicons dashicons-no-alt">
                        <span class="screen-reader-text">Close modal panel</span>
                    </button>
                </header>
                <article>
                    <div class="{{ data.class }}">
                        {{{ data.message }}}
                    </div>
                </article>
                <footer>
                    <div class="inner">
                        <button id="btn-ok" class="button button-primary button-large"><?php _e( 'Ok', 'woocommerce-extension' ); ?></button>
                    </div>
                </footer>
            </section>
        </div>
    </div>
    <div class="wc-backbone-modal-backdrop modal-close"></div>
</script>
```
