### PR TITLE
Add permissions in scope filter

### DIFF
--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -115,7 +115,7 @@ class WC_Auth {
 				$permissions[] = __( 'View and manage products', 'woocommerce' );
 			break;
 		}
-		return $permissions;
+		return apply_filters( 'woocommerce_api_permissions_in_scope', $permissions, $scope );
 	}
 
 	/**


### PR DESCRIPTION
Allow extensions to display the permissions that API keys will provide for their objects, in addition to the permissions for core WC objects.

For example, Subscriptions 2.0 adds endpoints for creating, reading, updating and deleting subscriptions. With this filter, Subscriptions can use code similar to below to make sure the Visual API page lists "subscriptions" as one of the objects that can be viewed/managed, e.g. https://cloudup.com/cSoqdG7lAF0

```
wcs_get_permissions_in_scope( $permissions, $scope ) {

    switch ( $scope )  {
        case 'read' :
            $permissions[] = __( 'View subscriptions', 'woocommerce-subscriptions' );
        break;
        case 'write' :
            $permissions[] = __( 'Create subscriptions', 'woocommerce-subscriptions' );
        break;
        case 'read_write' :
            $permissions[] = __( 'View and manage subscriptions', 'woocommerce-subscriptions' );
        break;
    }

    return $permissions;
}
add_filter( 'woocommerce_api_permissions_in_scope', 'wcs_get_permissions_in_scope', 10, 2 );
```
