### PR TITLE
Reinstate default value for $items

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1126,6 +1126,7 @@ abstract class WC_Abstract_Order {
 			$type = array( $type );
 		}
 
+		$items          = array();
 		$get_items_sql  = $wpdb->prepare( "SELECT order_item_id, order_item_name, order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d ", $this->id );
 		$get_items_sql .= "AND order_item_type IN ( '" . implode( "','", array_map( 'esc_sql', $type ) ) . "' ) ORDER BY order_item_id;";
 		$line_items     = $wpdb->get_results( $get_items_sql );


### PR DESCRIPTION
The default value for `$items` was (accidentally?) removed with SHA: 877e39064

That causes a `PHP Notice:  Undefined variable: items` when attempting to get line items of a type that does not exist on the order, like coupons.
