### PR TITLE
Fix bugs in variable sale price (display)

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -273,7 +273,7 @@ class WC_Product_Variable extends WC_Product {
 				}
 
 				// If we are getting prices for display, we need to account for taxes
-				if ( $display && ( $variation = $this->get_child( $variation_id ) ) ) {
+				if ( $display && $variation ) {
 					$price         = $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $price ) : $variation->get_price_excluding_tax( 1, $price );
 					$regular_price = $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $regular_price ) : $variation->get_price_excluding_tax( 1, $regular_price );
 					$sale_price    = $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $sale_price ) : $variation->get_price_excluding_tax( 1, $sale_price );

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -201,7 +201,7 @@ class WC_Product_Variable extends WC_Product {
 	public function is_on_sale() {
 		$is_on_sale = false;
 		$prices     = $this->get_variation_prices();
-		if ( $prices['regular_price'] !== $prices['sale_price'] ) {
+		if ( $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price'] ) {
 			$is_on_sale = true;
 		}
 		return apply_filters( 'woocommerce_product_is_on_sale', $is_on_sale, $this );
@@ -262,7 +262,11 @@ class WC_Product_Variable extends WC_Product {
 			$tax_display_mode  = get_option( 'woocommerce_tax_display_shop' );
 
 			foreach ( $this->get_children( true ) as $variation_id ) {
-				$variation     = $this->get_child( $variation_id );
+
+				if ( ! $variation = $this->get_child( $variation_id ) ) {
+					continue;
+				}
+
 				$price         = $variation->get_price();
 				$regular_price = $variation->get_regular_price();
 				$sale_price    = $variation->get_sale_price();

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -201,7 +201,7 @@ class WC_Product_Variable extends WC_Product {
 	public function is_on_sale() {
 		$is_on_sale = false;
 		$prices     = $this->get_variation_prices();
-		if ( $prices['regular_price'] !== $prices['price'] ) {
+		if ( $prices['regular_price'] !== $prices['sale_price'] ) {
 			$is_on_sale = true;
 		}
 		return apply_filters( 'woocommerce_product_is_on_sale', $is_on_sale, $this );
@@ -262,9 +262,10 @@ class WC_Product_Variable extends WC_Product {
 			$tax_display_mode  = get_option( 'woocommerce_tax_display_shop' );
 
 			foreach ( $this->get_children( true ) as $variation_id ) {
-				$price         = get_post_meta( $variation_id, '_price', true );
-				$regular_price = get_post_meta( $variation_id, '_regular_price', true );
-				$sale_price    = get_post_meta( $variation_id, '_sale_price', true );
+				$variation     = $this->get_child( $variation_id );
+				$price         = $variation->get_price();
+				$regular_price = $variation->get_regular_price();
+				$sale_price    = $variation->get_sale_price();
 
 				// If sale price does not equal price, the product is not yet on sale
 				if ( $price != $sale_price ) {


### PR DESCRIPTION
Hey guys,

I noticed some bugs in the variable products - pricing area.
- When one modifies the price via the `woocommerce_get_price` filter it wasn't picked up by the displaying price on the product/archive pages, but was when in the cart.
- the `is_on_sale()` returned true even when the product isn't actually in sale (again, when one modified the `woocommerce_get_price` filter it recognised it as a sale while it doesn't do that with other product types. 

This pulls that straight.
