### PR TITLE
Reenabling translation of service description

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -44,6 +44,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		// Define user set variables
 		$this->title          = $this->get_option( 'title' );
 		$this->description    = $this->get_option( 'description' );
+		if (empty($this->description)){
+			$this->description    = __( "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.", 'woocommerce' );
+		}
 		$this->testmode       = 'yes' === $this->get_option( 'testmode', 'no' );
 		$this->debug          = 'yes' === $this->get_option( 'debug', 'no' );
 		$this->email          = $this->get_option( 'email' );


### PR DESCRIPTION
At some point it seems like we got the option to change the extended service description for Paypal in the User Backend. With setting that option the possibility to translate the description properly was gone. 
The small change checks whether the user has set a custom description in the backend (Woocommerce Settings -> Checkout -> Paypal) and uses it, but if not falls back to the provided translation files.
