### PR TITLE
Instroducing WC_Session::delete

### DIFF
--- a/includes/abstracts/abstract-wc-session.php
+++ b/includes/abstracts/abstract-wc-session.php
@@ -55,7 +55,7 @@ abstract class WC_Session {
 	 * @param mixed $key
 	 */
 	public function __unset( $key ) {
-		$this->delete( $key );
+		$this->unset( $key );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-session.php
+++ b/includes/abstracts/abstract-wc-session.php
@@ -55,10 +55,7 @@ abstract class WC_Session {
 	 * @param mixed $key
 	 */
 	public function __unset( $key ) {
-		if ( isset( $this->_data[ $key ] ) ) {
-			unset( $this->_data[ $key ] );
-			$this->_dirty = true;
-		}
+		$this->delete( $key );
 	}
 
 	/**
@@ -82,6 +79,18 @@ abstract class WC_Session {
 	public function set( $key, $value ) {
 		if ( $value !== $this->get( $key ) ) {
 			$this->_data[ sanitize_key( $key ) ] = maybe_serialize( $value );
+			$this->_dirty = true;
+		}
+	}
+
+	/**
+	 * Delete a session variable
+	 *
+	 * @param string $key
+	 */
+	public function delete( $key ) {
+		if ( isset( $this->_data[ $key ] ) ) {
+			unset( $this->_data[ $key ] );
 			$this->_dirty = true;
 		}
 	}

--- a/includes/abstracts/abstract-wc-session.php
+++ b/includes/abstracts/abstract-wc-session.php
@@ -88,7 +88,7 @@ abstract class WC_Session {
 	 *
 	 * @param string $key
 	 */
-	public function delete( $key ) {
+	public function unset( $key ) {
 		if ( isset( $this->_data[ $key ] ) ) {
 			unset( $this->_data[ $key ] );
 			$this->_dirty = true;


### PR DESCRIPTION
Introducing `WC()->session->delete ($key )` to delete sessions data without the need to use the magic method `__unset` which now falls back to this method.
