### PR TITLE
Strip slashes in the attribute value

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -47,7 +47,7 @@ extract( $variation_data );
 
 					foreach ( $options as $option ) {
 						$selected = sanitize_title( $variation_selected_value ) === $variation_selected_value ? selected( $variation_selected_value, sanitize_title( $option ), false ) : selected( $variation_selected_value, $option, false );
-						echo '<option ' . $selected . ' value="' . esc_attr( $option ) . '">' . esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) ) . '</option>';
+						echo '<option ' . $selected . ' value="' . esc_attr( $option ) . '">' . esc_html( apply_filters( 'woocommerce_variation_option_name', stripslashes( $option ) ) ) . '</option>';
 					}
 
 				}


### PR DESCRIPTION
In the admin, if you have an attribute with values including quotes (like `Men's`) the selection dropdown does not strip the slash.

Fixed in this PR.

This is how it shows without the fix

![](http://cld.wthms.co/1cdmR/2TmVIYFc+)

check the second dropdown for each variation
