### PR TITLE
get_formatted_name() produces cryptic output for variations

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -652,67 +652,70 @@ class WC_Product_Variation extends WC_Product {
 		$description    = array();
 		$return         = '';
 
-		if ( ! $flat ) {
-			$return = '<dl class="variation">';
-		}
+		if ( is_array( $variation_data ) ) {
 
-		foreach ( $attributes as $attribute ) {
-
-			// Only deal with attributes that are variations
-			if ( ! $attribute[ 'is_variation' ] ) {
-				continue;
+			if ( ! $flat ) {
+				$return = '<dl class="variation">';
 			}
 
-			$variation_selected_value = isset( $variation_data[ 'attribute_' . sanitize_title( $attribute[ 'name' ] ) ] ) ? $variation_data[ 'attribute_' . sanitize_title( $attribute[ 'name' ] ) ] : '';
-			$description_name         = esc_html( wc_attribute_label( $attribute[ 'name' ] ) );
-			$description_value        = __( 'Any', 'woocommerce' );
+			foreach ( $attributes as $attribute ) {
 
-			// Get terms for attribute taxonomy or value if its a custom attribute
-			if ( $attribute[ 'is_taxonomy' ] ) {
+				// Only deal with attributes that are variations
+				if ( ! $attribute[ 'is_variation' ] ) {
+					continue;
+				}
 
-				$post_terms = wp_get_post_terms( $this->id, $attribute[ 'name' ] );
+				$variation_selected_value = isset( $variation_data[ 'attribute_' . sanitize_title( $attribute[ 'name' ] ) ] ) ? $variation_data[ 'attribute_' . sanitize_title( $attribute[ 'name' ] ) ] : '';
+				$description_name         = esc_html( wc_attribute_label( $attribute[ 'name' ] ) );
+				$description_value        = __( 'Any', 'woocommerce' );
 
-				foreach ( $post_terms as $term ) {
-					if ( $variation_selected_value === $term->slug ) {
-						$description_value = apply_filters( 'woocommerce_variation_option_name', esc_html( $term->name ) );
+				// Get terms for attribute taxonomy or value if its a custom attribute
+				if ( $attribute[ 'is_taxonomy' ] ) {
+
+					$post_terms = wp_get_post_terms( $this->id, $attribute[ 'name' ] );
+
+					foreach ( $post_terms as $term ) {
+						if ( $variation_selected_value === $term->slug ) {
+							$description_value = apply_filters( 'woocommerce_variation_option_name', esc_html( $term->name ) );
+						}
+					}
+
+				} else {
+
+					$options = wc_get_text_attributes( $attribute[ 'value' ] );
+
+					foreach ( $options as $option ) {
+
+						if ( sanitize_title( $variation_selected_value ) === $variation_selected_value ) {
+							if ( $variation_selected_value !== sanitize_title( $option ) ) {
+								continue;
+							}
+						} else {
+							if ( $variation_selected_value !== $option ) {
+								continue;
+							}
+						}
+
+						$description_value = esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) );
 					}
 				}
 
-			} else {
-
-				$options = wc_get_text_attributes( $attribute[ 'value' ] );
-
-				foreach ( $options as $option ) {
-
-					if ( sanitize_title( $variation_selected_value ) === $variation_selected_value ) {
-						if ( $variation_selected_value !== sanitize_title( $option ) ) {
-							continue;
-						}
-					} else {
-						if ( $variation_selected_value !== $option ) {
-							continue;
-						}
-					}
-
-					$description_value = esc_html( apply_filters( 'woocommerce_variation_option_name', $option ) );
+				if ( $flat ) {
+					$description[] = $description_name . ': ' . rawurldecode( $description_value );
+				} else {
+					$description[] = '<dt>' . $description_name . ':</dt><dd>' . rawurldecode( $description_value ) . '</dd>';
 				}
 			}
 
 			if ( $flat ) {
-				$description[] = $description_name . ': ' . rawurldecode( $description_value );
+				$return .= implode( ', ', $description );
 			} else {
-				$description[] = '<dt>' . $description_name . ':</dt><dd>' . rawurldecode( $description_value ) . '</dd>';
+				$return .= implode( '', $description );
 			}
-		}
 
-		if ( $flat ) {
-			$return .= implode( ', ', $description );
-		} else {
-			$return .= implode( '', $description );
-		}
-
-		if ( ! $flat ) {
-			$return .= '</dl>';
+			if ( ! $flat ) {
+				$return .= '</dl>';
+			}
 		}
 
 		return $return;


### PR DESCRIPTION
**Problem 1**

WC core seems to lack a suitable method for formatting variation attributes easily & reliably:

`wc_get_formatted_variation()` produces some mildly annoying results (text-based attribute names) when called with `$variation->get_variation_attributes()` as its arg, since it cannot possibly convert sanitized attribute names back to how they were originally entered.

Ideally, it would be suitable to have such a method in the `WC_Product_Variation` class, to display a formatted variation attributes string/markup reliably.

**Problem 2**

`get_formatted_name()` is in dire need of such a method, since its current output is quite cryptic. This is, for example, a selector for products and variations with ajax-powered search -- the returned results look like this:

![Example of the issue](http://f.cl.ly/items/0Y1g1N2A2a3j47393v3K/Image%202015-08-13%20at%201.11.18%20PM.png)

**Proposal**

Introduce a `get_formatted_variation_attributes()` method in `WC_Product_Variation`, which can be reused by `get_formatted_name()` to display a more user-friendly variation name with a proper attributes description.

Example after the change:

![Example after proposed solution](http://f.cl.ly/items/3L3W3x0B063S1u3V3V2u/Image%202015-08-13%20at%201.23.59%20PM.png)
