### PR TITLE
Added args category to some shortcodes

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -2,11 +2,11 @@
 /**
  * WC_Shortcodes class.
  *
- * @class 		WC_Shortcodes
- * @version		2.1.0
- * @package		WooCommerce/Classes
- * @category	Class
- * @author 		WooThemes
+ * @class       WC_Shortcodes
+ * @version     2.1.0
+ * @package     WooCommerce/Classes
+ * @category    Class
+ * @author      WooThemes
  */
 class WC_Shortcodes {
 
@@ -172,22 +172,16 @@ class WC_Shortcodes {
 		$ordering_args = WC()->query->get_catalog_ordering_args( $atts['orderby'], $atts['order'] );
 		$meta_query    = WC()->query->get_meta_query();
 		$query_args    = array(
-			'post_type'				=> 'product',
-			'post_status' 			=> 'publish',
-			'ignore_sticky_posts'	=> 1,
-			'orderby' 				=> $ordering_args['orderby'],
-			'order' 				=> $ordering_args['order'],
-			'posts_per_page' 		=> $atts['per_page'],
-			'meta_query' 			=> $meta_query,
-			'tax_query' 			=> array(
-				array(
-					'taxonomy' 		=> 'product_cat',
-					'terms' 		=> array_map( 'sanitize_title', explode( ',', $atts['category'] ) ),
-					'field' 		=> 'slug',
-					'operator' 		=> $atts['operator']
-				)
-			)
+			'post_type'             => 'product',
+			'post_status'           => 'publish',
+			'ignore_sticky_posts'   => 1,
+			'orderby'               => $ordering_args['orderby'],
+			'order'                 => $ordering_args['order'],
+			'posts_per_page'        => $atts['per_page'],
+			'meta_query'            => $meta_query
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		if ( isset( $ordering_args['meta_key'] ) ) {
 			$query_args['meta_key'] = $ordering_args['meta_key'];
@@ -291,10 +285,12 @@ class WC_Shortcodes {
 	 */
 	public static function recent_products( $atts ) {
 		$atts = shortcode_atts( array(
-			'per_page' 	=> '12',
-			'columns' 	=> '4',
-			'orderby' 	=> 'date',
-			'order' 	=> 'desc'
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'date',
+			'order'    => 'desc',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$query_args = array(
@@ -306,6 +302,8 @@ class WC_Shortcodes {
 			'order'               => $atts['order'],
 			'meta_query'          => WC()->query->get_meta_query()
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		return self::product_loop( $query_args, $atts, 'recent_products' );
 	}
@@ -373,9 +371,9 @@ class WC_Shortcodes {
 
 		if ( isset( $atts['sku'] ) ) {
 			$args['meta_query'][] = array(
-				'key' 		=> '_sku',
-				'value' 	=> $atts['sku'],
-				'compare' 	=> '='
+				'key'       => '_sku',
+				'value'     => $atts['sku'],
+				'compare'   => '='
 			);
 		}
 
@@ -513,14 +511,14 @@ class WC_Shortcodes {
 		), $atts );
 
 		$query_args = array(
-			'posts_per_page'	=> $atts['per_page'],
-			'orderby' 			=> $atts['orderby'],
-			'order' 			=> $atts['order'],
-			'no_found_rows' 	=> 1,
-			'post_status' 		=> 'publish',
-			'post_type' 		=> 'product',
-			'meta_query' 		=> WC()->query->get_meta_query(),
-			'post__in'			=> array_merge( array( 0 ), wc_get_product_ids_on_sale() )
+			'posts_per_page' => $atts['per_page'],
+			'orderby'        => $atts['orderby'],
+			'order'          => $atts['order'],
+			'no_found_rows'  => 1,
+			'post_status'    => 'publish',
+			'post_type'      => 'product',
+			'meta_query'     => WC()->query->get_meta_query(),
+			'post__in'       => array_merge( array( 0 ), wc_get_product_ids_on_sale() )
 		);
 
 		return self::product_loop( $query_args, $atts, 'sale_products' );
@@ -535,7 +533,9 @@ class WC_Shortcodes {
 	public static function best_selling_products( $atts ) {
 		$atts = shortcode_atts( array(
 			'per_page' => '12',
-			'columns'  => '4'
+			'columns'  => '4',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$query_args = array(
@@ -547,6 +547,8 @@ class WC_Shortcodes {
 			'orderby'             => 'meta_value_num',
 			'meta_query'          => WC()->query->get_meta_query()
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		return self::product_loop( $query_args, $atts, 'best_selling_products' );
 	}
@@ -562,7 +564,9 @@ class WC_Shortcodes {
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
-			'order'    => 'asc'
+			'order'    => 'asc',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$query_args = array(
@@ -574,6 +578,8 @@ class WC_Shortcodes {
 			'posts_per_page'      => $atts['per_page'],
 			'meta_query'          => WC()->query->get_meta_query()
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		ob_start();
 
@@ -597,7 +603,9 @@ class WC_Shortcodes {
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'date',
-			'order'    => 'desc'
+			'order'    => 'desc',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$meta_query   = WC()->query->get_meta_query();
@@ -615,6 +623,8 @@ class WC_Shortcodes {
 			'order'               => $atts['order'],
 			'meta_query'          => $meta_query
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		return self::product_loop( $query_args, $atts, 'featured_products' );
 	}
@@ -791,5 +801,29 @@ class WC_Shortcodes {
 		woocommerce_related_products( $atts );
 
 		return ob_get_clean();
+	}
+
+	/**
+	 * Adds a tax_query index to the query to filter by category.
+	 *
+	 * @param array $args
+	 * @param string $category
+	 * @param string $operator
+	 * @return array;
+	 * @access private
+	 */
+	private static function _maybe_add_category_args( $args, $category, $operator ) {
+		if ( ! empty( $category ) ) {
+			$args['tax_query'] = array(
+				array(
+					'taxonomy' => 'product_cat',
+					'terms'    => array_map( 'sanitize_title', explode( ',', $category ) ),
+					'field'    => 'slug',
+					'operator' => $operator
+				)
+			);
+		}
+
+		return $args;
 	}
 }

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -2,11 +2,11 @@
 /**
  * WC_Shortcodes class.
  *
- * @class 		WC_Shortcodes
- * @version		2.1.0
- * @package		WooCommerce/Classes
- * @category	Class
- * @author 		WooThemes
+ * @class       WC_Shortcodes
+ * @version     2.1.0
+ * @package     WooCommerce/Classes
+ * @category    Class
+ * @author      WooThemes
  */
 class WC_Shortcodes {
 
@@ -172,22 +172,16 @@ class WC_Shortcodes {
 		$ordering_args = WC()->query->get_catalog_ordering_args( $atts['orderby'], $atts['order'] );
 		$meta_query    = WC()->query->get_meta_query();
 		$query_args    = array(
-			'post_type'				=> 'product',
-			'post_status' 			=> 'publish',
-			'ignore_sticky_posts'	=> 1,
-			'orderby' 				=> $ordering_args['orderby'],
-			'order' 				=> $ordering_args['order'],
-			'posts_per_page' 		=> $atts['per_page'],
-			'meta_query' 			=> $meta_query,
-			'tax_query' 			=> array(
-				array(
-					'taxonomy' 		=> 'product_cat',
-					'terms' 		=> array_map( 'sanitize_title', explode( ',', $atts['category'] ) ),
-					'field' 		=> 'slug',
-					'operator' 		=> $atts['operator']
-				)
-			)
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => $ordering_args['orderby'],
+			'order'               => $ordering_args['order'],
+			'posts_per_page'      => $atts['per_page'],
+			'meta_query'          => $meta_query
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		if ( isset( $ordering_args['meta_key'] ) ) {
 			$query_args['meta_key'] = $ordering_args['meta_key'];
@@ -291,10 +285,12 @@ class WC_Shortcodes {
 	 */
 	public static function recent_products( $atts ) {
 		$atts = shortcode_atts( array(
-			'per_page' 	=> '12',
-			'columns' 	=> '4',
-			'orderby' 	=> 'date',
-			'order' 	=> 'desc'
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'date',
+			'order'    => 'desc',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$query_args = array(
@@ -306,6 +302,8 @@ class WC_Shortcodes {
 			'order'               => $atts['order'],
 			'meta_query'          => WC()->query->get_meta_query()
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		return self::product_loop( $query_args, $atts, 'recent_products' );
 	}
@@ -373,9 +371,9 @@ class WC_Shortcodes {
 
 		if ( isset( $atts['sku'] ) ) {
 			$args['meta_query'][] = array(
-				'key' 		=> '_sku',
-				'value' 	=> $atts['sku'],
-				'compare' 	=> '='
+				'key'     => '_sku',
+				'value'   => $atts['sku'],
+				'compare' => '='
 			);
 		}
 
@@ -513,14 +511,14 @@ class WC_Shortcodes {
 		), $atts );
 
 		$query_args = array(
-			'posts_per_page'	=> $atts['per_page'],
-			'orderby' 			=> $atts['orderby'],
-			'order' 			=> $atts['order'],
-			'no_found_rows' 	=> 1,
-			'post_status' 		=> 'publish',
-			'post_type' 		=> 'product',
-			'meta_query' 		=> WC()->query->get_meta_query(),
-			'post__in'			=> array_merge( array( 0 ), wc_get_product_ids_on_sale() )
+			'posts_per_page' => $atts['per_page'],
+			'orderby'        => $atts['orderby'],
+			'order'          => $atts['order'],
+			'no_found_rows'  => 1,
+			'post_status'    => 'publish',
+			'post_type'      => 'product',
+			'meta_query'     => WC()->query->get_meta_query(),
+			'post__in'       => array_merge( array( 0 ), wc_get_product_ids_on_sale() )
 		);
 
 		return self::product_loop( $query_args, $atts, 'sale_products' );
@@ -535,7 +533,9 @@ class WC_Shortcodes {
 	public static function best_selling_products( $atts ) {
 		$atts = shortcode_atts( array(
 			'per_page' => '12',
-			'columns'  => '4'
+			'columns'  => '4',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$query_args = array(
@@ -547,6 +547,8 @@ class WC_Shortcodes {
 			'orderby'             => 'meta_value_num',
 			'meta_query'          => WC()->query->get_meta_query()
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		return self::product_loop( $query_args, $atts, 'best_selling_products' );
 	}
@@ -562,7 +564,9 @@ class WC_Shortcodes {
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
-			'order'    => 'asc'
+			'order'    => 'asc',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$query_args = array(
@@ -574,6 +578,10 @@ class WC_Shortcodes {
 			'posts_per_page'      => $atts['per_page'],
 			'meta_query'          => WC()->query->get_meta_query()
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
+
+		ob_start();
 
 		add_filter( 'posts_clauses', array( __CLASS__, 'order_by_rating_post_clauses' ) );
 
@@ -595,7 +603,9 @@ class WC_Shortcodes {
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'date',
-			'order'    => 'desc'
+			'order'    => 'desc',
+			'category' => '',  // Slugs
+			'operator' => 'IN' // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $atts );
 
 		$meta_query   = WC()->query->get_meta_query();
@@ -613,6 +623,8 @@ class WC_Shortcodes {
 			'order'               => $atts['order'],
 			'meta_query'          => $meta_query
 		);
+
+		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
 
 		return self::product_loop( $query_args, $atts, 'featured_products' );
 	}
@@ -789,5 +801,29 @@ class WC_Shortcodes {
 		woocommerce_related_products( $atts );
 
 		return ob_get_clean();
+	}
+
+	/**
+	 * Adds a tax_query index to the query to filter by category.
+	 *
+	 * @param array $args
+	 * @param string $category
+	 * @param string $operator
+	 * @return array;
+	 * @access private
+	 */
+	private static function _maybe_add_category_args( $args, $category, $operator ) {
+		if ( ! empty( $category ) ) {
+			$args['tax_query'] = array(
+				array(
+					'taxonomy' => 'product_cat',
+					'terms'    => array_map( 'sanitize_title', explode( ',', $category ) ),
+					'field'    => 'slug',
+					'operator' => $operator
+				)
+			);
+		}
+
+		return $args;
 	}
 }

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -86,7 +86,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 	 */
 	public function admin_options() {
 		?>
-		<h3><?php _e( 'Simplify Commerce by Mastercard', 'woocommerce' ); ?></h3>
+		<h3><?php _e( 'Simplify Commerce by MasterCard', 'woocommerce' ); ?></h3>
 
 		<?php if ( empty( $this->public_key ) ) : ?>
 			<div class="simplify-commerce-banner updated">
@@ -197,7 +197,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 				'title'       => __( 'Description', 'woocommerce' ),
 				'type'        => 'text',
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce' ),
-				'default'     => 'Pay with your credit card via Simplify Commerce by Mastercard.',
+				'default'     => 'Pay with your credit card via Simplify Commerce by MasterCard.',
 				'desc_tip'    => true
 			),
 			'mode' => array(
@@ -542,7 +542,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 	 */
 	public function get_icon() {
 		$icon  = '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/visa.png' ) . '" alt="Visa" />';
-		$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/mastercard.png' ) . '" alt="Mastercard" />';
+		$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/mastercard.png' ) . '" alt="MasterCard" />';
 		$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/discover.png' ) . '" alt="Discover" />';
 		$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/amex.png' ) . '" alt="Amex" />';
 		$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/jcb.png' ) . '" alt="JCB" />';


### PR DESCRIPTION
I added the arguments `category` and `operator` to the following shortcodes:
- [recent_products]
- [featured_products]
- [best_selling_products]
- [top_rated_products]

It's managed with a private static function to avoid to repeat always the same code.
Also i fixed some style issues, like indentation and spaces.
