### PR TITLE
WC Metabox classes don't get toggled when box added via js

### DIFF
--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -27,7 +27,7 @@ jQuery( function ( $ ) {
 		}
 	});
 
-	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox h3', function( event ) {
+	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox > h3', function( event ) {
 		$( this ).parent( '.wc-metabox' ).toggleClass( 'closed' ).toggleClass( 'open' );
 	});
 

--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -27,10 +27,8 @@ jQuery( function ( $ ) {
 		}
 	});
 
-	$( function() {
-		$( '.wc-metabox > h3' ).click( function() {
-			$( this ).parent( '.wc-metabox' ).toggleClass( 'closed' ).toggleClass( 'open' );
-		});
+	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox h3', function( event ) {
+		$( this ).parent( '.wc-metabox' ).toggleClass( 'closed' ).toggleClass( 'open' );
 	});
 
 	// Tabbed Panels


### PR DESCRIPTION
Minor detail.

Affects all wc metaboxes since the handler is attached to the `h3` tag of existing elements only:

http://cl.ly/3f0h3i1W1U0i

Therefore, when a metabox gets added via js this doesn't work.

I have moved the handler to `'.wc-metaboxes-wrapper'` and unwrapped the block (not sure why it's wrapped into a function at that point?).
