### PR TITLE
Added hook woocommerce_product_options_stock_fields

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -126,7 +126,7 @@ extract( $variation_data );
 							?>
 						</select>
 					</p>
-			<?php do_action( 'woocommerce_product_options_stock_fields' ); ?>
+			<?php do_action( 'woocommerce_product_variation_options_stock_fields' ); ?>
 				</div>
 			<?php endif; ?>
 

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -126,6 +126,7 @@ extract( $variation_data );
 							?>
 						</select>
 					</p>
+			<?php do_action( 'woocommerce_product_options_stock_fields' ); ?>
 				</div>
 			<?php endif; ?>
 


### PR DESCRIPTION
Added hook woocommerce_product_options_stock_fields available for single products so variations can use it too.
https://github.com/woothemes/woocommerce/blob/master/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
