### PR TITLE
Show the right 'no shipping availalbe' message when a country doesn't…

### DIFF
--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<?php endif; ?>
 
-		<?php elseif ( ! WC()->customer->get_shipping_state() || ! WC()->customer->get_shipping_postcode() ) : ?>
+		<?php elseif ( ( ! empty( WC()->countries->get_states( WC()->customer->get_shipping_country() ) ) && ! WC()->customer->get_shipping_state() ) || ! WC()->customer->get_shipping_postcode() ) : ?>
 
 			<?php if ( is_cart() && get_option( 'woocommerce_enable_shipping_calc' ) === 'yes' ) : ?>
 


### PR DESCRIPTION
… have states.

Countries without states were showing the message `Please fill in your details to see available shipping methods.` while everything was filled out correctly. 
Other countries with states showed `There are no shipping methods available. Please double check your address, or contact us if you need any help.` when everything was filled out correctly (and not rates are available).

This pulls things straight and shows the correct 'no shipping available' message for those countries without states.

Old:
![image](https://cloud.githubusercontent.com/assets/5774447/9323030/2d0c1090-457c-11e5-84ce-335dadf585db.png)

New:
![image](https://cloud.githubusercontent.com/assets/5774447/9323028/19bbf2a8-457c-11e5-9ab9-cd4e3c28f07e.png)
(note the 'country' in the screenshots)
