### PR TITLE
Update class-wc-admin-settings.php

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -690,6 +690,7 @@ class WC_Admin_Settings {
 					$value = array_filter( array_map( 'wc_clean', (array) $raw_value ) );
 					break;
 				case 'image_width' :
+					$value = array();
 					if ( isset( $raw_value['width'] ) ) {
 						$value['width']  = wc_clean( $raw_value['width'] );
 						$value['height'] = wc_clean( $raw_value['height'] );


### PR DESCRIPTION
Reset the $value to array when processing image_width.  Strange bug if the value is a string and the array is not explicitly created.
