### PR TITLE
Checks if payment needed before displaying coupon form

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1328,7 +1328,9 @@ if ( ! function_exists( 'woocommerce_checkout_coupon_form' ) ) {
 	 * @subpackage	Checkout
 	 */
 	function woocommerce_checkout_coupon_form() {
-		wc_get_template( 'checkout/form-coupon.php', array( 'checkout' => WC()->checkout() ) );
+		if ( WC()->cart->needs_payment() ) {
+			wc_get_template( 'checkout/form-coupon.php', array( 'checkout' => WC()->checkout() ) );
+		}
 	}
 }
 


### PR DESCRIPTION
Not sure if I’m missing something, so feel free to boot this.

I can’t think of a reason to show the coupon form at checkout if we
know the cart total is already 0, as there’s nothing to discount — no
order total or shipping charges.
