### PR TITLE
Flat Rate Calculation - min_fee

### DIFF
--- a/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$cost_desc = __( 'Enter a cost (excl. tax) or sum, e.g. <code>10 * [qty]</code>.', 'woocommerce' ) . '<br/>' . __( 'Supports the following placeholders: <code>[qty]</code> = number of items, <code>[cost]</code> = cost of items, <code>[fee percent="10" min="20"]</code> = Percentage based fee.', 'woocommerce' );
+$cost_desc = __( 'Enter a cost (excl. tax) or sum, e.g. <code>10 * [qty]</code>.', 'woocommerce' ) . '<br/>' . __( 'Supports the following placeholders: <code>[qty]</code> = number of items, <code>[cost]</code> = cost of items, <code>[fee percent="10" min_fee="20"]</code> = Percentage based fee.', 'woocommerce' );
 
 /**
  * Settings for flat rate shipping


### PR DESCRIPTION
The correct shortcode term to use is `min_fee`: https://github.com/woothemes/woocommerce/blob/master/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php#L94
