### PR TITLE
Encode variation data

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -172,7 +172,8 @@ class WC_Product_Variation extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_url() {
-		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg( 'added-to-cart', add_query_arg( array_merge( array( 'variation_id' => $this->variation_id, 'add-to-cart' => $this->id ), $this->variation_data ) ) ) : get_permalink( $this->id );
+		$variation_data = array_map( 'urlencode', $this->variation_data );
+		$url            = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg( 'added-to-cart', add_query_arg( array_merge( array( 'variation_id' => $this->variation_id, 'add-to-cart' => $this->id ), $variation_data ) ) ) : get_permalink( $this->id );
 
 		return apply_filters( 'woocommerce_product_add_to_cart_url', $url, $this );
 	}


### PR DESCRIPTION
Variation data (attribute values) in the URL returned by `WC_Product_Variation::add_to_cart_url()` should be properly encoded to get them working by using the method in a custom code.

You can check the difference by trying to add to the cart a variation via its URL.
Be sure to use an attribute with a `#` in its value.

You should get an URL like:

`domain.com/product/ship-your-idea-2/?variation_id=2487&add-to-cart=40&attribute_pa_color=black&attribute_size=Test+#1`

Instead of the correct one

`domain.com/product/ship-your-idea-2/?variation_id=2487&add-to-cart=40&attribute_pa_color=black&attribute_size=Test+%231`
