### PR TITLE
Update class-wc-shortcodes.php

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -575,8 +575,6 @@ class WC_Shortcodes {
 			'meta_query'          => WC()->query->get_meta_query()
 		);
 
-		ob_start();
-
 		add_filter( 'posts_clauses', array( __CLASS__, 'order_by_rating_post_clauses' ) );
 
 		$return = self::product_loop( $query_args, $atts, 'top_rated_products' );


### PR DESCRIPTION
`ob_start` is used which is not required. Fixes #8956 
