### PR TITLE
Fix variation attributes check

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -605,7 +605,7 @@ class WC_Meta_Box_Product_Data {
 
 		if ( $attributes ) {
 			foreach ( $attributes as $attribute ) {
-				if ( isset( $attribute['is_variation'] ) ) {
+				if ( $attribute['is_variation'] === 1 ) {
 					$variation_attribute_found = true;
 					break;
 				}


### PR DESCRIPTION
`$attribute['is_variation']` returns an integer. 0 if not checked, 1 if checked. So it is always set once the attribute has been created.

Per https://github.com/woothemes/woocommerce/issues/8954
