### PR TITLE
Fixed issue with category widget JS

### DIFF
--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -208,11 +208,10 @@ class WC_Widget_Product_Categories extends WC_Widget {
 				jQuery( '.dropdown_product_cat' ).change( function() {
 					if ( jQuery(this).val() != '' ) {
 						var this_page = location.href.toString();
-						var home_url  = '" . esc_js( home_url( '/' ) ) . "';
 						if ( this_page.indexOf( '?' ) > 0 ) {
-							this_page = home_url + '&product_cat=' + jQuery(this).val();
+							this_page += '&product_cat=' + jQuery(this).val();
 						} else {
-							this_page = home_url + '?product_cat=' + jQuery(this).val();
+							this_page += '?product_cat=' + jQuery(this).val();
 						}
 						location.href = this_page;
 					}


### PR DESCRIPTION
There was an issue where the category picker would redirect to http://site.com/&product_cat=CAT when a query string was present in the current URL. This could easily be rectified by not using the 'home_url' variable to build the new URL, not really sure why this was being used?
