### PR TITLE
Use wc_stock_amount for ajax response in variation admin

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -805,6 +805,7 @@ class WC_AJAX {
 			$variation_data['image']          = $variation_data['_thumbnail_id'] ? wp_get_attachment_thumb_url( $variation_data['_thumbnail_id'] ) : '';
 			$variation_data['shipping_class'] = $shipping_classes && ! is_wp_error( $shipping_classes ) ? current( $shipping_classes )->term_id : '';
 			$variation_data['menu_order']     = $variation->menu_order;
+			$variation_data['_stock']         = wc_stock_amount( $variation_data['_stock'] );
 
 			// Get tax classes
 			$tax_classes           = WC_Tax::get_tax_classes();


### PR DESCRIPTION
My previous already merged pull request of old WC 2.3 didn’t get applied in the new
2.4 AJAX method for the variation admin. So let’s apply it again ;) (old
pull request see #8304)
