### PR TITLE
Restored wc<2.4 behavior of order item meta keys

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -232,7 +232,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			foreach ( $meta->get_formatted( $hideprefix ) as $meta_key => $formatted_meta ) {
 				$item_meta[] = array(
-					'key' => $meta_key,
+					'key'   => $formatted_meta['key'],
 					'label' => $formatted_meta['label'],
 					'value' => $formatted_meta['value'],
 				);

--- a/includes/api/v2/class-wc-api-orders.php
+++ b/includes/api/v2/class-wc-api-orders.php
@@ -232,7 +232,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			foreach ( $meta->get_formatted( $hideprefix ) as $meta_key => $formatted_meta ) {
 				$item_meta[] = array(
-					'key' => $meta_key,
+					'key'   => $formatted_meta['key'],
 					'label' => $formatted_meta['label'],
 					'value' => $formatted_meta['value'],
 				);


### PR DESCRIPTION
The previous version of woocommerce showed the machine readable names
in item_meta['key’] especially for the custom variation attributes but
after 2.4 it shows only meta ids in the key.

This commit reverts the behavior to the prior 2.4 behavior.
