### PR TITLE
Payment methods improvement in pay for order form

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -1902,7 +1902,7 @@ p.demo_store {
 				border-left-color: transparent;
 				border-top-color: transparent;
 				position: absolute;
-				top: -3px;
+				top: 1px;
 				left: 0;
 				margin: -1em 0 0 2em;
 			}

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -2,13 +2,13 @@
 /**
  * Pay for order form
  *
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     1.6.4
+ * @author   WooThemes
+ * @package  WooCommerce/Templates
+ * @version  2.4.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 ?>
@@ -52,13 +52,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<div id="payment">
 		<?php if ( $order->needs_payment() ) : ?>
-		<h3><?php _e( 'Payment', 'woocommerce' ); ?></h3>
 		<ul class="payment_methods methods">
 			<?php
 				if ( $available_gateways = WC()->payment_gateways->get_available_payment_gateways() ) {
 					// Chosen Method
-					if ( sizeof( $available_gateways ) )
+					if ( sizeof( $available_gateways ) ) {
 						current( $available_gateways )->set_current();
+					}
 
 					foreach ( $available_gateways as $gateway ) {
 						?>
@@ -94,6 +94,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<input type="hidden" name="woocommerce_pay" value="1" />
 		</div>
 
+		<div class="clear"></div>
 	</div>
 
 </form>


### PR DESCRIPTION
Before:
![capture](https://cloud.githubusercontent.com/assets/3774827/9641671/add5df28-51d7-11e5-8dc6-329fc2ce6130.PNG)

After:
![capture](https://cloud.githubusercontent.com/assets/3774827/9641735/ef988b7c-51d7-11e5-8c67-b8ac4ad62d29.PNG)

Changes:
- Deprecate the use of heading tag for form-pay checkout template, similar to checkout page.
- Fix - Margin for checkout page payment_box pseudo
