### PR TITLE
move post_class out of template and into display filter

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -318,6 +318,36 @@ function wc_product_post_class( $classes, $class = '', $post_id = '' ) {
 	return $classes;
 }
 
+function wc_product_post_display_class( $classes, $class = '', $post_id = '' ) {
+	if ( ! $post_id || 'product' !== get_post_type( $post_id ) ) {
+		return $classes;
+	}
+
+	$product = wc_get_product( $post_id );
+
+	// Ensure visibility
+	if ( ! $product || ! $product->is_visible() ) {
+		return;
+	}
+
+	$woocommerce_loop['loop'] = $wp_query->current_post;
+	$woocommerce_loop['columns'] = apply_filters( 'loop_shop_columns', 4 );
+
+	// Increase loop count
+	$woocommerce_loop['loop']++;
+
+	if ( 0 == ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] || 1 == $woocommerce_loop['columns'] ) {
+		$classes[] = 'first';
+	}
+
+	if ( 0 == $woocommerce_loop['loop'] % $woocommerce_loop['columns'] ) {
+		$classes[] = 'last';
+	}
+
+	return $classes;
+
+}
+
 /** Template pages ********************************************************/
 
 if ( ! function_exists( 'woocommerce_content' ) ) {

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 add_filter( 'body_class', 'wc_body_class' );
 add_filter( 'post_class', 'wc_product_post_class', 20, 3 );
+add_filter( 'post_class', 'wc_product_post_display_class', 25, 3 );
 
 /**
  * WP Header

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -11,38 +11,8 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
-}
-
-global $product, $woocommerce_loop;
-
-// Store loop count we're currently on
-if ( empty( $woocommerce_loop['loop'] ) ) {
-	$woocommerce_loop['loop'] = 0;
-}
-
-// Store column count for displaying the grid
-if ( empty( $woocommerce_loop['columns'] ) ) {
-	$woocommerce_loop['columns'] = apply_filters( 'loop_shop_columns', 4 );
-}
-
-// Ensure visibility
-if ( ! $product || ! $product->is_visible() ) {
-	return;
-}
-
-// Increase loop count
-$woocommerce_loop['loop']++;
-
-// Extra post classes
-$classes = array();
-if ( 0 == ( $woocommerce_loop['loop'] - 1 ) % $woocommerce_loop['columns'] || 1 == $woocommerce_loop['columns'] ) {
-	$classes[] = 'first';
-}
-if ( 0 == $woocommerce_loop['loop'] % $woocommerce_loop['columns'] ) {
-	$classes[] = 'last';
-}
-?>
-<li <?php post_class( $classes ); ?>>
+} ?>
+<li <?php post_class(); ?>>
 
 	<?php do_action( 'woocommerce_before_shop_loop_item' ); ?>
 


### PR DESCRIPTION
PR for related issue: #9024

I moved the 'first' and 'last' layout classes out of the theme template and into a display class function. I chose to keep the loop display classes out of the wc_product_post_class filter, as those classes are functional and probably have a lot of theme dependencies. The wc_product_post_display_class filter is more specific to the woocommerce-layout CSS so a developer can remove the filter without hurting anything.
