### PR TITLE
Payment heading tag removed in pay for order form

### DIFF
--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -2,13 +2,13 @@
 /**
  * Pay for order form
  *
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     1.6.4
+ * @author   WooThemes
+ * @package  WooCommerce/Templates
+ * @version  2.4.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 ?>
@@ -52,13 +52,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<div id="payment">
 		<?php if ( $order->needs_payment() ) : ?>
-		<h3><?php _e( 'Payment', 'woocommerce' ); ?></h3>
 		<ul class="payment_methods methods">
 			<?php
 				if ( $available_gateways = WC()->payment_gateways->get_available_payment_gateways() ) {
 					// Chosen Method
-					if ( sizeof( $available_gateways ) )
+					if ( sizeof( $available_gateways ) ) {
 						current( $available_gateways )->set_current();
+					}
 
 					foreach ( $available_gateways as $gateway ) {
 						?>
@@ -94,6 +94,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<input type="hidden" name="woocommerce_pay" value="1" />
 		</div>
 
+		<div class="clear"></div>
 	</div>
 
 </form>


### PR DESCRIPTION
- If we cancel the transaction then we will see this message:
  ![capture](https://cloud.githubusercontent.com/assets/3774827/9660372/0c1363ec-5275-11e5-866f-f0276f7ff57a.PNG)
- And if we click "Pay" again then we received the Pay for order form:
  ![capture-1](https://cloud.githubusercontent.com/assets/3774827/9660422/441cc530-5275-11e5-9ad4-f53de1e41334.PNG)

@mikejolley this was to hide that "Payment" heading tag and make similar to checkout page :)
