### PR TITLE
[2.3] Generate unique transient for modified/filtered variation prices

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -266,11 +266,9 @@ class WC_Product_Variable extends WC_Product {
 		foreach ( $wp_filter as $key => $val ) {
 			if ( false !== strpos( $key, 'woocommerce_variation_price_in_transient' ) ) {
 				$variation_price_filters[ 'price' ][] = $val;
-			}
-			if ( false !== strpos( $key, 'woocommerce_variation_regular_price_in_transient' ) ) {
+			} elseif ( false !== strpos( $key, 'woocommerce_variation_regular_price_in_transient' ) ) {
 				$variation_price_filters[ 'regular_price' ][] = $val;
-			}
-			if ( false !== strpos( $key, 'woocommerce_variation_sale_price_in_transient' ) ) {
+			} elseif ( false !== strpos( $key, 'woocommerce_variation_sale_price_in_transient' ) ) {
 				$variation_price_filters[ 'sale_price' ][] = $val;
 			}
 		}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -272,20 +272,20 @@ class WC_Product_Variable extends WC_Product {
 
 			foreach ( $this->get_children( true ) as $variation_id ) {
 				if ( $variation = $this->get_child( $variation_id ) ) {
-					$price         = $variation->get_price();
-					$regular_price = $variation->get_regular_price();
-					$sale_price    = $variation->get_sale_price();
+					$price         = $variation->price;
+					$regular_price = $variation->regular_price;
+					$sale_price    = $variation->sale_price;
 
 					// If sale price does not equal price, the product is not yet on sale
-					if ( ! $variation->is_on_sale() ) {
+					if ( $sale_price === $regular_price || $sale_price !== $price ) {
 						$sale_price = $regular_price;
 					}
 
 					// If we are getting prices for display, we need to account for taxes
 					if ( $display ) {
-						$price         = $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $price ) : $variation->get_price_excluding_tax( 1, $price );
-						$regular_price = $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $regular_price ) : $variation->get_price_excluding_tax( 1, $regular_price );
-						$sale_price    = $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $sale_price ) : $variation->get_price_excluding_tax( 1, $sale_price );
+						$price         = $price !== '' ? ( $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $price ) : $variation->get_price_excluding_tax( 1, $price ) ) : '';
+						$regular_price = $regular_price !== '' ? ( $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $regular_price ) : $variation->get_price_excluding_tax( 1, $regular_price ) ) : '';
+						$sale_price    = $sale_price !== '' ? ( $tax_display_mode == 'incl' ? $variation->get_price_including_tax( 1, $sale_price ) : $variation->get_price_excluding_tax( 1, $sale_price ) ) : '';
 					}
 
 					$prices[ $variation_id ]         = $price;


### PR DESCRIPTION
https://github.com/woothemes/woocommerce/pull/8753 went under my radar, so apologies for joining the discussion late. @JeroenSormani @mikejolley 

The purpose of this transient is to provide data consistent with the price meta. Allowing prices to be filtered while generating transients can mess with the cached data very easily:

Any code should be able to trigger `get_variation_prices()` without having to know whether price filters exist or not, and whether transients will be generated or not.

The logic at this point should not contain any filters that may change the result (transient content).

Price calculations incl/excl tax (`$display===true`) already allow taxes to be filtered, which is as far as we should be allowed to go here (taxes are taken into account in the generated hash, still not 100% fool proof due to how filters work).
