### PR TITLE
Don't use translated key for name in bulk action checkbox

### DIFF
--- a/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -52,7 +52,7 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $key ) {
-		return sprintf( '<input type="checkbox" name="%1$s[]" value="%2$s" />', $this->_args['singular'], $key['key_id'] );
+		return sprintf( '<input type="checkbox" name="%1$s[]" value="%2$s" />', "key", $key['key_id'] );
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -52,7 +52,7 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $key ) {
-		return sprintf( '<input type="checkbox" name="%1$s[]" value="%2$s" />', "key", $key['key_id'] );
+		return sprintf( '<input type="checkbox" name="key[]" value="%1$s" />', $key['key_id'] );
 	}
 
 	/**


### PR DESCRIPTION
Otherwise the translation will break the code in
https://github.com/woothemes/woocommerce/blob/master/includes/admin/class-wc-admin-api-keys.php#L122

We shouldn’t use the translated string here in my opinion.

See also issue #9019
