### PR TITLE
Improve order total formatting

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -183,13 +183,7 @@ if ( wc_tax_enabled() ) {
 		<tr>
 			<td class="label"><?php _e( 'Order Total', 'woocommerce' ); ?>:</td>
 			<td class="total">
-				<div class="view"><?php
-					if ( $order->get_total_refunded() > 0 ) {
-						echo '<del>' . strip_tags( $order->get_formatted_order_total() ) . '</del> <ins>' . wc_price( $order->get_total() - $order->get_total_refunded(), array( 'currency' => $order->get_order_currency() ) ) . '</ins>';
-					} else {
-						echo esc_html( strip_tags( $order->get_formatted_order_total() ) );
-					}
-				?></div>
+				<div class="view"><?php echo $order->get_formatted_order_total(); ?></div>
 				<div class="edit" style="display: none;">
 					<input type="text" class="wc_input_price" id="_order_total" name="_order_total" placeholder="<?php echo wc_format_localized_price( 0 ); ?>" value="<?php echo ( isset( $data['_order_total'][0] ) ) ? esc_attr( wc_format_localized_price( $data['_order_total'][0] ) ) : ''; ?>" />
 					<div class="clear"></div>


### PR DESCRIPTION
#9047

The function get_formatted_order_total already provides formatted HTML with indication of a prior refund. No need to do that logic and formatting again.
