### PR TITLE
User full name validation filter hook and  the other two hooks.

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -173,7 +173,9 @@ class WC_Form_Handler {
 		// Prevent emails being displayed, or leave alone.
 		$user->display_name = is_email( $current_user->display_name ) ? $user->first_name : $current_user->display_name;
 
-		if ( empty( $account_first_name ) || empty( $account_last_name ) ) {
+        $is_invalid_user_full_name = apply_filters( 'woocommerce_is_invalid_user_full_name', ( empty( $account_first_name ) || empty( $account_last_name ) ) ? true : false, $account_first_name, $account_last_name );
+
+		if ( $is_invalid_user_full_name ) {
 			wc_add_notice( __( 'Please enter your name.', 'woocommerce' ), 'error' );
 		}
 

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -23,17 +23,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<label for="account_first_name"><?php _e( 'First name', 'woocommerce' ); ?> <span class="required">*</span></label>
 		<input type="text" class="input-text" name="account_first_name" id="account_first_name" value="<?php echo esc_attr( $user->first_name ); ?>" />
 	</p>
+<?php 
+
+	$is_last_name_required = apply_filters( 'woocommerce_is_last_name_required', true );
+	if( $is_last_name_required ):
+ ?>
 	<p class="form-row form-row-last">
 		<label for="account_last_name"><?php _e( 'Last name', 'woocommerce' ); ?> <span class="required">*</span></label>
 		<input type="text" class="input-text" name="account_last_name" id="account_last_name" value="<?php echo esc_attr( $user->last_name ); ?>" />
 	</p>
 	<div class="clear"></div>
-
+<?php endif; ?>
 	<p class="form-row form-row-wide">
 		<label for="account_email"><?php _e( 'Email address', 'woocommerce' ); ?> <span class="required">*</span></label>
 		<input type="email" class="input-text" name="account_email" id="account_email" value="<?php echo esc_attr( $user->user_email ); ?>" />
 	</p>
-
+<?php do_action( 'woocommerce_after_my_account_user_info' ); ?>
 	<fieldset>
 		<legend><?php _e( 'Password Change', 'woocommerce' ); ?></legend>
 


### PR DESCRIPTION
@mikejolley
1. adding a filter hook (`woocommerce_is_invalid_user_full_name`) into `/includes/class-wc-form-handler.php` to handle the user full name validation;
2. adding a filter hook (`woocommerce_is_last_name_required`)  into `/templates/myaccount/form-edit-account.php`;
3. adding an action hook (`woocommerce_after_my_account_user_info`)   into `/templates/myaccount/form-edit-account.php`.
