### PR TITLE
Check specifically for Post IDs in WC Query verbose rules fix

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -212,7 +212,7 @@ class WC_Query {
 		}
 
 		// Fix for verbose page rules
-		if ( $GLOBALS['wp_rewrite']->use_verbose_page_rules && isset( $q->queried_object_id ) && $q->queried_object_id === wc_get_page_id('shop') ) {
+		if ( $GLOBALS['wp_rewrite']->use_verbose_page_rules && isset( $q->queried_object->ID ) && $q->queried_object->ID === wc_get_page_id('shop') ) {
 			$q->set( 'post_type', 'product' );
 			$q->set( 'page', '' );
 			$q->set( 'pagename', '' );


### PR DESCRIPTION
Talk about an edge case. I recently ran into a situation where a term ID happened to be the same as the post ID for the shop page. Since, the code currently doesn't check which type of object is being queried, it set the `post_type` to product and applied the general WooCommerce query filter to a non-product related query (causing the query to incorrectly return no results).

Since, the `WP_Query::queried_object_id` property can reference either a post ID or a term ID. This small tweak ensures that we are checking for posts only.
