### PR TITLE
Fix breaking change in order item meta get_formatted_meta

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -110,7 +110,7 @@ class WC_Order_Item_Meta {
 		$formatted_meta = array();
 
 		foreach ( $this->item['item_meta_array'] as $meta_id => $meta ) {
-			if ( empty( $meta->value ) || is_serialized( $meta->value ) || ( ! empty( $hideprefix ) && substr( $meta->key, 0, 1 ) == $hideprefix ) ) {
+			if ( $meta->value == "" || is_serialized( $meta->value ) || ( ! empty( $hideprefix ) && substr( $meta->key, 0, 1 ) == $hideprefix ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
As we all know empty() becomes also TRUE for 0 values. For us this led to the problem that after 2.4 on an order with a free item or an order with a coupon that compensated 100% of the order value all hidden order item meta e.g.   "_line_subtotal“, "_line_total", "_line_subtotal_tax" and "_line_tax" also were removed from the rest response. But we relied on getting back 0 values.

What do you think about the fix to check agains emtpy string?

Another possibility imho is to check if hide prefix is empty and do the meta->value empty check only if hide prefix is active.
