### PR TITLE
Don't try add new download permissions if order has been deleted

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -2203,7 +2203,7 @@ class WC_Admin_Post_Types {
 			foreach ( $existing_permissions as $existing_permission ) {
 				$order = wc_get_order( $existing_permission->order_id );
 
-				if ( $order->id ) {
+				if ( ! empty( $order->id ) ) {
 					// Remove permissions
 					if ( ! empty( $removed_download_ids ) ) {
 						foreach ( $removed_download_ids as $download_id ) {


### PR DESCRIPTION
Hey hey,

If an order that had a downloadable product was deleted, and then you add a new download file to that product, `process_product_file_download_paths()` will still try add new permissions to an order that doesn't exist.

```
PHP Notice:  Trying to get property of non-object in /wp-content/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php on line 2208
```
