### PR TITLE
Add an action hook to wc_update_new_customer_past_orders

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -164,6 +164,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 	if ( $customer_orders ) {
 		foreach ( $customer_orders as $order_id ) {
 			update_post_meta( $order_id, '_customer_user', $customer->ID );
+			do_action('woocommerce_order_linked_to_customer',$customer,$order_id);
 
 			if ( get_post_status( $order_id ) === 'wc-completed' ) {
 				$complete ++;

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -164,7 +164,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 	if ( $customer_orders ) {
 		foreach ( $customer_orders as $order_id ) {
 			update_post_meta( $order_id, '_customer_user', $customer->ID );
-			do_action('woocommerce_order_linked_to_customer',$customer,$order_id);
+			do_action('woocommerce_order_linked_to_customer',$order_id,$customer);
 
 			if ( get_post_status( $order_id ) === 'wc-completed' ) {
 				$complete ++;

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -164,7 +164,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 	if ( $customer_orders ) {
 		foreach ( $customer_orders as $order_id ) {
 			update_post_meta( $order_id, '_customer_user', $customer->ID );
-			do_action('woocommerce_order_linked_to_customer',$order_id,$customer);
+			do_action( 'woocommerce_update_new_customer_past_order', $order_id, $customer );
 
 			if ( get_post_status( $order_id ) === 'wc-completed' ) {
 				$complete ++;


### PR DESCRIPTION
This allows plugins to hook into `wc_update_new_customer_past_orders` and do an action using the `$order_id` and the `$customer` object

One example use case:
Our store favors documenting as much as possible in the order notes section. I have written a small feature which will add an order note to the order when the customer's new account is linked. I need to hook to this function to make that possible.
