### PR TITLE
Add greater flexibility to the admin order send email action

### DIFF
--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -37,6 +37,7 @@ class WC_Email_Cancelled_Order extends WC_Email {
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_pending_to_cancelled_notification', array( $this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ) );
+		add_action( 'woocommerce_order_action_send_cancelled_order', array( $this, 'trigger' ) );
 
 		// Call parent constructor
 		parent::__construct();

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -36,6 +36,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_completed_notification', array( $this, 'trigger' ) );
+		add_action( 'woocommerce_order_action_send_customer_completed_order', array( $this, 'trigger' ) );
 
 		// Other settings
 		$this->heading_downloadable = $this->get_option( 'heading_downloadable', __( 'Your order is complete - download your files', 'woocommerce' ) );

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -40,6 +40,9 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		$this->subject_paid   = __( 'Your {site_title} order from {order_date}', 'woocommerce');
 		$this->heading_paid   = __( 'Order {order_number} details', 'woocommerce');
 
+		// Triggers for this email
+		add_action( 'woocommerce_order_action_send_customer_invoice', array( $this, 'trigger' ) );
+
 		// Call parent constructor
 		parent::__construct();
 

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -37,6 +37,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_pending_to_processing_notification', array( $this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $this, 'trigger' ) );
+		add_action( 'woocommerce_order_action_send_customer_processing_order', array( $this, 'trigger' ) );
 
 		// Call parent constructor
 		parent::__construct();

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order' ) ) :
  * @extends  WC_Email
  */
 class WC_Email_Customer_Refunded_Order extends WC_Email {
-	
+
 	public $refund;
 	public $partial_refund;
 
@@ -31,6 +31,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 		// Triggers for this email
 		add_action( 'woocommerce_order_fully_refunded_notification', array( $this, 'trigger_full' ), 10, 2 );
 		add_action( 'woocommerce_order_partially_refunded_notification', array( $this, 'trigger_partial' ), 10, 2 );
+		add_action( 'woocommerce_order_action_send_customer_refunded_order', array( $this, 'trigger' ), 10, 3 );
 
 		// Call parent constuctor
 		parent::__construct();

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -41,6 +41,7 @@ class WC_Email_New_Order extends WC_Email {
 		add_action( 'woocommerce_order_status_failed_to_processing_notification', array( $this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_failed_to_completed_notification', array( $this, 'trigger' ) );
 		add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $this, 'trigger' ) );
+		add_action( 'woocommerce_order_action_send_new_order', array( $this, 'trigger' ) );
 
 		// Call parent constructor
 		parent::__construct();


### PR DESCRIPTION
Hey!

This PR should add greater flexibility to the admin order actions for emails.
Before this PR it was not possible to:
- Unhook email sends
- Change the mail that is going out when manually sending a mail via the action (goes in the same group as the point above)
- Add your own email to the `Resend order emails` drop down group (without registering a official WC email)

Via this PR one could add a new email to that list via either:
1) Registering a email
2) Adding it via `woocommerce_resend_order_emails_available` with just a email title
     2.a) Adding it via `woocommerce_resend_order_emails_available` with a `id => title`

Should be fully backwards compatible.
