### PR TITLE
Add `woocommerce_admin_order_item_thumbnail` filter in admin

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					echo '<br/>' . wc_get_formatted_variation( $_product->variation_data, true );
 				}
 
-			?>"><?php echo $_product->get_image( 'shop_thumbnail', array( 'title' => '' ) ); ?></a>
+			?>"><?php echo apply_filters( 'woocommerce_admin_order_item_thumbnail', $_product->get_image( 'shop_thumbnail', array( 'title' => '' ) ), $item_id, $item ); ?></a>
 		<?php else : ?>
 			<?php echo wc_placeholder_img( 'shop_thumbnail' ); ?>
 		<?php endif; ?>


### PR DESCRIPTION
When viewing the order items in in `html-order-item.php` the thumbnails cannot be fitlered. In the case of customizable products, the shop may want to display a custom thumbnail in the order overview.

The `woocommerce_order_item_thumbnail` filter already exists in [`email-order-items.php`](https://github.com/woothemes/woocommerce/blob/master/templates/emails/email-order-items.php#L25).  Potentially you could reuse the same filter, but that might also have some side effects on people who weren't expecting it, so I went with a unique filter name. 
