### PR TITLE
[2.5] Filter when purchase note is showed

### DIFF
--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -4,7 +4,7 @@
  *
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 2.4.0
+ * @version 2.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -35,7 +35,7 @@ if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 		<?php echo $order->get_formatted_line_subtotal( $item ); ?>
 	</td>
 </tr>
-<?php if ( $order->has_status( array( 'completed', 'processing' ) ) && ( $purchase_note = get_post_meta( $product->id, '_purchase_note', true ) ) ) : ?>
+<?php if ( $show_purchase_note && $purchase_note ) : ?>
 <tr class="product-purchase-note">
 	<td colspan="3"><?php echo wpautop( do_shortcode( wp_kses_post( $purchase_note ) ) ); ?></td>
 </tr>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -4,7 +4,7 @@
  *
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 2.4.0
+ * @version 2.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $order = wc_get_order( $order_id );
+
+$show_purchase_note = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
 ?>
 <h2><?php _e( 'Order Details', 'woocommerce' ); ?></h2>
 <table class="shop_table order_details">
@@ -24,11 +26,16 @@ $order = wc_get_order( $order_id );
 	<tbody>
 		<?php
 			foreach( $order->get_items() as $item_id => $item ) {
+				$product = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
+				$purchase_note = get_post_meta( $product->id, '_purchase_note', true );
+
 				wc_get_template( 'order/order-details-item.php', array(
-					'order'   => $order,
-					'item_id' => $item_id,
-					'item'    => $item,
-					'product' => apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item )
+					'order'					=> $order,
+					'item_id'				=> $item_id,
+					'item'					=> $item,
+					'show_purchase_note'	=> $show_purchase_note,
+					'purchase_note'			=> $purchase_note,
+					'product'				=> $product,
 				) );
 			}
 		?>


### PR DESCRIPTION
@mikejolley @claudiosmweb RE convo in https://github.com/woothemes/woocommerce/pull/8975 -- new PR for WooCommerce 2.5 (due to template changes)

adds `woocommerce_purchase_note_order_statuses` filter and pulls purchase note logic up from `/order/order-details-item.php`
