### PR TITLE
Filter the array which determines what classes are applied to an order note

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -44,7 +44,8 @@ class WC_Meta_Box_Order_Notes {
 			foreach( $notes as $note ) {
 
 				$note_classes = get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ? array( 'customer-note', 'note' ) : array( 'note' );
-
+				$note_classes = apply_filters('woocommerce_order_notes_note_classes',$note_classes,$note);
+				
 				?>
 				<li rel="<?php echo absint( $note->comment_ID ) ; ?>" class="<?php echo implode( ' ', $note_classes ); ?>">
 					<div class="note_content">

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -44,10 +44,10 @@ class WC_Meta_Box_Order_Notes {
 			foreach( $notes as $note ) {
 
 				$note_classes = get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ? array( 'customer-note', 'note' ) : array( 'note' );
-				$note_classes = apply_filters('woocommerce_order_notes_note_classes',$note_classes,$note);
+				$note_classes = apply_filters( 'woocommerce_order_note_class', $note_classes, $note );
 				
 				?>
-				<li rel="<?php echo absint( $note->comment_ID ) ; ?>" class="<?php echo implode( ' ', $note_classes ); ?>">
+				<li rel="<?php echo absint( $note->comment_ID ) ; ?>" class="<?php echo esc_attr( implode( ' ', $note_classes ) ); ?>">
 					<div class="note_content">
 						<?php echo wpautop( wptexturize( wp_kses_post( $note->comment_content ) ) ); ?>
 					</div>


### PR DESCRIPTION
Allows plugins to hook into the order notes meta box

Useful to highlight notes with different colors based on the comment meta

Example: I have a plugin which allows custom meta to be added to comments (a drop down box below the order note entry box allows a note to be assigned as a task to another user) and with this hook I will be able to add classes to the order note for better CSS styling
