### PR TITLE
Coupon usage count can become negative

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -266,7 +266,7 @@ class WC_Coupon {
 	 * @param string $used_by Either user ID or billing email
 	 */
 	public function dcr_usage_count( $used_by = '' ) {
-		if ( $this->id ) {
+		if ( $this->id && $this->usage_count > 0 ) {
 			global $wpdb;
 			$this->usage_count--;
 			update_post_meta( $this->id, 'usage_count', $this->usage_count );


### PR DESCRIPTION
This commit fixes issue #9086 by checking if the usage count is greater than zero before the usage count of the coupon is decreased.
