### PR TITLE
Wrong per_page attribute

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -779,7 +779,7 @@ class WC_Shortcodes {
 	 */
 	public static function related_products( $atts ) {
 		$atts = shortcode_atts( array(
-			'posts_per_page' => '4',
+			'per_page' => '4',
 			'columns'        => '4',
 			'orderby'        => 'rand'
 		), $atts );


### PR DESCRIPTION
The shortcode `[related_products]` was the only one using `posts_per_page` instead of `per_page` for the number of products to show.
