### PR TITLE
Assert log line format and its log message instead of log line equality.

### DIFF
--- a/tests/unit-tests/util/log.php
+++ b/tests/unit-tests/util/log.php
@@ -21,7 +21,8 @@ class Log extends \WC_Unit_Test_Case {
 
 		$log->add( 'unit-tests', 'this is a message' );
 
-		$this->assertEquals( date( 'm-d-Y @ H:i:s' ) . ' - this is a message' . PHP_EOL, $this->read_content( 'unit-tests' ) );
+		$this->assertStringMatchesFormat( '%d-%d-%d @ %d:%d:%d - %s', $this->read_content( 'unit-tests' ) );
+		$this->assertStringEndsWith( ' - this is a message' . PHP_EOL, $this->read_content( 'unit-tests' ) );
 	}
 
 	/**


### PR DESCRIPTION
Timestamp is not reliable to assert during the test.

Fixes #9110.
