### PR TITLE
fixes a case were there are orphaned variations and trying to call th…

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -358,7 +358,7 @@ class WC_Product_Variation extends WC_Product {
 	public function managing_stock() {
 		if ( 'yes' === get_option( 'woocommerce_manage_stock', 'yes' ) ) {
 			if ( 'no' === $this->manage_stock ) {
-				if ( $this->parent->managing_stock() ) {
+				if ( $this->parent && $this->parent->managing_stock() ) {
 					return 'parent';
 				}
 			} else {


### PR DESCRIPTION
…e parent that doesn't exist

This fixes a fatal error on a use case where you have orphaned variations and trying to call the parent's managing stock method when parent doesn't exist.  Fixes an issue with Bulk Stock Management plugin. https://github.com/woothemes/woocommerce-bulk-stock-management/issues/6
