### PR TITLE
Add get_stock_quantity filter

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -177,7 +177,7 @@ class WC_Product {
 	 * @return int
 	 */
 	public function get_stock_quantity() {
-		return $this->managing_stock() ? wc_stock_amount( $this->stock ) : '';
+		return apply_filters( 'woocommerce_get_stock_quantity', $this->managing_stock() ? wc_stock_amount( $this->stock ) : '', $this );
 	}
 
 	/**


### PR DESCRIPTION
Add a filter to the `$product->get_stock_quantity()` method.

I'm currently building a plugin where I need to modify the total stock quantity. I can also imagine some other plugins for inventory management like POS integrations or something similar that might have use for this.
