### PR TITLE
Adds the URL that PayPal IPN needs to be set to on PayPal settings page

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -31,7 +31,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$this->has_fields         = false;
 		$this->order_button_text  = __( 'Proceed to PayPal', 'woocommerce' );
 		$this->method_title       = __( 'PayPal', 'woocommerce' );
-		$this->method_description = sprintf( __( 'PayPal standard sends customers to PayPal to enter their payment information. PayPal IPN requires fsockopen/cURL support to update order statuses after payment. Check the %ssystem status%s page for more details.', 'woocommerce' ), '<a href="' . admin_url( 'admin.php?page=wc-status' ) . '">', '</a>' );
+		$this->method_description = sprintf( __( 'PayPal standard sends customers to PayPal to enter their payment information. PayPal IPN requires fsockopen/cURL support to update order statuses after payment. Check the %ssystem status%s page for more details. Your IPN callback URL is: %s.', 'woocommerce' ), '<a href="' . admin_url( 'admin.php?page=wc-status' ) . '">', '</a>', '<code>' . esc_url( home_url( '/?wc-api=WC_Gateway_Paypal' ) ) . '</code>' );
 		$this->supports           = array(
 			'products',
 			'refunds'


### PR DESCRIPTION
The reason is we're seeing a number of tickets where customers are
searching for what the IPN url should be, and even when they find the
PayPal Standard documentation, they need to substitute www.example.com
to their own domain. This is an easier copy-paste way to achieve the
same thing.
