### PR TITLE
Fixed problem with bulk action ajax data trigger after saving attributes

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -753,7 +753,7 @@ jQuery( function( $ ) {
 					break;
 				default :
 					$( 'select.variation_actions' ).trigger( do_variation_action );
-					data = $( 'select.variation_actions' ).triggerHandler( do_variation_action + '_ajax_data', data );
+					data = $( document.body ).triggerHandler( do_variation_action + '_ajax_data', data );
 					break;
 			}
 


### PR DESCRIPTION
Use document.body as more convenient dom node to register ajax_data event listeners.

I think the original idea of the usage of ajax_data trigger was to create a custom event listener like

``` js
$("select.variation_actions“).on("my_action_ajax_data“ … )
```

The problem with registering the event handlers directly to the select: After saving attributes my registered event listener was detached because of some javascript triggered after saving the attributes?! Maybe I'm wrong here but that are my observations so far.

Because we are using triggerHandler here it was also not possible to register an event listener on a parent because triggerHandler events don’t bubble up the dom.

So lets just use document.body here as dom node for registering all ajax_data action event listeners.

What do you think about this issue?

You can reproduce the problem by doing the following:
1) Register an own bulk action
2) Register an own event handler on the bulk action ajax data event
3) Use the bulk action on the variations tab -> event is handled perfectly
4) Go to attributes tab + change + save some attributes
5) Go back to variations tab, rerun the bulk action -> nothing happens anymore… :(
