### PR TITLE
Trim leading plus sign and "1" digit from US/CA phone numbers

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -103,6 +103,7 @@ class WC_Gateway_Paypal_Request {
 	protected function get_phone_number_args( $order ) {
 		if ( in_array( $order->billing_country, array( 'US','CA' ) ) ) {
 			$phone_number = str_replace( array( '(', '-', ' ', ')', '.' ), '', $order->billing_phone );
+			$phone_number = ltrim( $phone_number, '+1' );
 			$phone_args   = array(
 				'night_phone_a' => substr( $phone_number, 0, 3 ),
 				'night_phone_b' => substr( $phone_number, 3, 3 ),


### PR DESCRIPTION
Fixes #9156.
