### PR TITLE
Handle user deletion

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -593,20 +593,4 @@ function wc_get_customer_order_count( $user_id ) {
 
 	return absint( $count );
 }
-
-/**
- * Update orders to belong to a different customer
- *
- * Note that if $new_user_id is NULL, $wpdb will enter it as a 0
- * The effect of this is that the order becomes a guest order
- *
- * @param  int $old_user_id
- * @param  int $new_user_id
- */
-function wc_reassign_customer_orders( $old_user_id, $new_user_id ) {			
-	global $wpdb;
-	$wpdb->query( $wpdb->prepare("UPDATE {$wpdb->postmeta} SET meta_value=%d WHERE meta_key='_customer_user' and meta_value=%d", $new_user_id, $old_user_id ) );
-	wc_update_new_customer_past_orders($new_user_id);
-}
-add_action('deleted_user','wc_reassign_customer_orders',10,2);
 	

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -187,10 +187,10 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 /**
  * Get orders (by customer) and change the customer
  *
- * @param  int $old_user_id
- * @param  int $new_user_id
+ * @param  int $old_customer_id
+ * @param  int $customer_id
  */
-function wc_reassign_customer_orders( $old_user_id, $new_user_id ) {
+function wc_reassign_customer_orders( $old_customer_id, $customer_id ) {
 
 	$customer_orders = get_posts( array(
 		'numberposts' => -1,
@@ -200,7 +200,7 @@ function wc_reassign_customer_orders( $old_user_id, $new_user_id ) {
 		'meta_query' => array(
 			array(
 				'key'     => '_customer_user',
-				'value'   => $old_user_id
+				'value'   => $old_customer_id
 			)
 		),
 	) );
@@ -210,9 +210,9 @@ function wc_reassign_customer_orders( $old_user_id, $new_user_id ) {
 
 	if ( $customer_orders ) {
 		foreach ( $customer_orders as $order_id ) {
-			update_post_meta( $order_id, '_customer_user', $new_user_id );
+			update_post_meta( $order_id, '_customer_user', $customer_id );
 
-			do_action( 'woocommerce_reassign_customer_order', $order_id, $old_user_id, $new_user_id );
+			do_action( 'woocommerce_reassign_customer_order', $order_id, $old_customer_id, $customer_id );
 
 			if ( get_post_status( $order_id ) === 'wc-completed' ) {
 				$complete++;
@@ -223,9 +223,9 @@ function wc_reassign_customer_orders( $old_user_id, $new_user_id ) {
 	}
 
 	if ( $complete ) {
-		update_user_meta( $new_user_id, 'paying_customer', 1 );
-		wc_get_customer_total_spent( $new_user_id, TRUE );
-		wc_get_customer_order_count( $new_user_id, TRUE );
+		update_user_meta( $customer_id, 'paying_customer', 1 );
+		wc_get_customer_total_spent( $customer_id, TRUE );
+		wc_get_customer_order_count( $customer_id, TRUE );
 	}
 
 	return $linked;

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -585,4 +585,3 @@ function wc_get_customer_order_count( $user_id, $force_update = FALSE ) {
 
 	return absint( $count );
 }
-	

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -185,7 +185,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 }
 
 /**
- * Get orders (by customer) and change the customer
+ * Get orders (belonging to an old customer) and change to an existing customer
  *
  * @param  int $old_customer_id
  * @param  int $customer_id

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -177,12 +177,8 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 
 	if ( $complete ) {
 		update_user_meta( $customer_id, 'paying_customer', 1 );
-		
-		delete_user_meta( $customer_id, '_money_spent' );
-		wc_get_customer_total_spent( $customer_id );
-		
-		delete_user_meta( $customer_id, '_order_count' );
-		wc_get_customer_order_count( $customer_id );
+		wc_get_customer_total_spent( $new_user_id, TRUE );
+		wc_get_customer_order_count( $new_user_id, TRUE );
 	}
 
 	return $linked;
@@ -228,12 +224,8 @@ function wc_reassign_customer_orders( $old_user_id, $new_user_id ) {
 
 	if ( $complete ) {
 		update_user_meta( $new_user_id, 'paying_customer', 1 );
-		
-		delete_user_meta( $new_user_id, '_money_spent' );
-		wc_get_customer_total_spent( $new_user_id );
-		
-		delete_user_meta( $new_user_id, '_order_count' );
-		wc_get_customer_order_count( $new_user_id );
+		wc_get_customer_total_spent( $new_user_id, TRUE );
+		wc_get_customer_order_count( $new_user_id, TRUE );
 	}
 
 	return $linked;
@@ -545,8 +537,8 @@ function wc_get_customer_available_downloads( $customer_id ) {
  * @param  int $user_id
  * @return string
  */
-function wc_get_customer_total_spent( $user_id ) {
-	if ( ! $spent = get_user_meta( $user_id, '_money_spent', true ) ) {
+function wc_get_customer_total_spent( $user_id, $force_update = FALSE ) {
+	if ( $force_update || ! $spent = get_user_meta( $user_id, '_money_spent', true ) ) {
 		global $wpdb;
 
 		$spent = $wpdb->get_var( "SELECT SUM(meta2.meta_value)
@@ -573,8 +565,8 @@ function wc_get_customer_total_spent( $user_id ) {
  * @param  int $user_id
  * @return int
  */
-function wc_get_customer_order_count( $user_id ) {
-	if ( ! $count = get_user_meta( $user_id, '_order_count', true ) ) {
+function wc_get_customer_order_count( $user_id, $force_update = FALSE ) {
+	if ( $force_update || ! $count = get_user_meta( $user_id, '_order_count', true ) ) {
 		global $wpdb;
 
 		$count = $wpdb->get_var( "SELECT COUNT(*)


### PR DESCRIPTION
possible solution to #9166 

 introduces the `wc_reassign_customer_orders` function and hooks it to the wordpress `deleted_user` action which fires after a user has been successfully deleted.

the function is mostly a copy of `wc_update_new_customer_past_orders` which reassigns orders from user id 0 (guest order) to a new user id. This new function does the opposite - takes orders already assigned to a user id and reassigns them to user id of 0 (guest order) or another user.

choosing to assign to a new user is accomplished by selecting who to reassign to when you delete the user from wordpress. if you choose not to reassign, orders will be assigned an id of 0 (guest order)

also while i'm here... i updated the `wc_reassign_customer_orders` function to actually update `_money_spent` and `_order_count` usermeta fields now instead of just blanking them out to be updated at a later time. Blanking them out to let them be updated later was an okay idea except they only get updated when the function `wc_get_customer_order_count` and `wc_get_customer_total_spent` are called, and some plugins don't use those functions and instead access those usermeta fields directly. Now those plugins wont have 0'd out data when `wc_reassign_customer_orders` is used on a customer
