### PR TITLE
Fix network activated plugins not showing up in system status report.

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -322,7 +322,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$active_plugins = (array) get_option( 'active_plugins', array() );
 
 		if ( is_multisite() ) {
-			$active_plugins = array_merge( $active_plugins, get_site_option( 'active_sitewide_plugins', array() ) );
+			$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+			$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
 		}
 
 		foreach ( $active_plugins as $plugin ) {


### PR DESCRIPTION
The array returned by `get_site_option( 'active_sitewide_plugins' )` has plugin file as array's key while array returned by `get_option( 'active_plugins' )` has plugin file as array's value.

Fixes #8721
