### PR TITLE
Remove URL parameter check on dropdown

### DIFF
--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -207,14 +207,8 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			wc_enqueue_js( "
 				jQuery( '.dropdown_product_cat' ).change( function() {
 					if ( jQuery(this).val() != '' ) {
-						var this_page = '';
 						var home_url  = '" . esc_js( home_url( '/' ) ) . "';
-						if ( home_url.indexOf( '?' ) > 0 ) {
-							this_page = home_url + '&product_cat=' + jQuery(this).val();
-						} else {
-							this_page = home_url + '?product_cat=' + jQuery(this).val();
-						}
-						location.href = this_page;
+						location.href = home_url + '?product_cat=' + jQuery(this).val();
 					}
 				});
 			" );


### PR DESCRIPTION
Checking whether the URL contains an ampersand isn't actually required since switching categories will always take you the category URL without any paging or filter parameters.

There was a bug in that when using a Product Categories Widget as a dropdown and a filter is applied, and I switch to another category the forwarding `location.href` is set as `home_url + '&product_cat=' + jQuery(this).val();` (note the ampersand), which results in a 404.

This is happening because the current URL is being checked for a `?` which returns true. I initially added an additional check for `home_url.indexOf( 'filter_types' )` as well, but then realised the check isn't required at all.

I've tried to go through all widget usage scenarios. Have a good think though since there may be something I haven't thought of.
