### PR TITLE
Fixed loading of variation prices. Fixes #9224

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -264,10 +264,6 @@ class WC_Product_Variable extends WC_Product {
 	public function get_variation_prices( $display = false ) {
 		global $wp_filter;
 
-		if ( ! empty( $this->prices_array ) ) {
-			return $this->prices_array;
-		}
-
 		/**
 		 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
 		 * Max transient length is 45, -10 for get_transient_version.


### PR DESCRIPTION
## Bug descriptions

The original method loaded the variation prices once, then stored them in a property of the product instance. Any subsequent calls to WC_Product_Variable::get_variation_prices() would get the stored prices, regardless of the value of the $display argument.
## Quick fix

Removed the caching against the property object. Since WC 2.4.7, there is already a caching mechanism to improve performance, therefore storing prices in a property might not bring a significant improvement.
## Alternative fix

If the extra caching is needed, instead of using a single "prices_array" property, use two properties (or a multi-dimensional array) to store both prices for display and non-display purposes. This would require more work and more testing, it could be implemented after the quick fix has been released.
