### PR TITLE
[2.4] System Report: Template version check path incorrect

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -678,7 +678,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					}
 
 					if ( ! empty( $theme_file ) ) {
-						$core_version  = WC_Admin_Status::get_file_version( $template_path . $file ); error_log( $core_version  );
+						$core_version  = WC_Admin_Status::get_file_version( $template_path . $file );
 						$theme_version = WC_Admin_Status::get_file_version( $theme_file );
 
 						if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -661,11 +661,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$outdated_templates = false;
 
 			foreach ( $template_paths as $plugin_name => $template_path ) {
-				$scanned_files[ $plugin_name ] = WC_Admin_Status::scan_template_files( $template_path );
-			}
 
-			foreach ( $scanned_files as $plugin_name => $files ) {
-				foreach ( $files as $file ) {
+				$scanned_files = WC_Admin_Status::scan_template_files( $template_path );
+
+				foreach ( $scanned_files as $file ) {
 					if ( file_exists( get_stylesheet_directory() . '/' . $file ) ) {
 						$theme_file = get_stylesheet_directory() . '/' . $file;
 					} elseif ( file_exists( get_stylesheet_directory() . '/woocommerce/' . $file ) ) {
@@ -679,7 +678,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					}
 
 					if ( ! empty( $theme_file ) ) {
-						$core_version  = WC_Admin_Status::get_file_version( $template_path . $file );
+						$core_version  = WC_Admin_Status::get_file_version( $template_path . $file ); error_log( $core_version  );
 						$theme_version = WC_Admin_Status::get_file_version( $theme_file );
 
 						if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -679,7 +679,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					}
 
 					if ( ! empty( $theme_file ) ) {
-						$core_version  = WC_Admin_Status::get_file_version( WC()->plugin_path() . '/templates/' . $file );
+						$core_version  = WC_Admin_Status::get_file_version( $template_path . $file );
 						$theme_version = WC_Admin_Status::get_file_version( $theme_file );
 
 						if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {


### PR DESCRIPTION
When checking template files in paths added via `woocommerce_template_overrides_scan_paths`, the correct path that contains the original template file is the one specified in the filter.

Currently, the version check doesn't work correctly for files in custom paths added via `woocommerce_template_overrides_scan_paths`.

Fixed logic in #9236 
