### PR TITLE
Fix coupon rounding precision to equalize two code paths

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1770,7 +1770,7 @@ class WC_Cart {
 				$discount_amount += $this->get_coupon_discount_tax_amount( $code );
 			}
 
-			return wc_cart_round_discount( $discount_amount, $this->dp );
+			return wc_cart_round_discount( $discount_amount, WC_ROUNDING_PRECISION );
 		}
 
 		/**
@@ -1780,7 +1780,7 @@ class WC_Cart {
 		 * @return float discount amount
 		 */
 		public function get_coupon_discount_tax_amount( $code ) {
-			return wc_cart_round_discount( isset( $this->coupon_discount_tax_amounts[ $code ] ) ? $this->coupon_discount_tax_amounts[ $code ] : 0, $this->dp );
+			return wc_cart_round_discount( isset( $this->coupon_discount_tax_amounts[ $code ] ) ? $this->coupon_discount_tax_amounts[ $code ] : 0, WC_ROUNDING_PRECISION );
 		}
 
 		/**
@@ -2180,7 +2180,7 @@ class WC_Cart {
 		 * @return float
 		 */
 		public function get_cart_discount_total() {
-			return wc_cart_round_discount( $this->discount_cart, $this->dp );
+			return wc_cart_round_discount( $this->discount_cart, WC_ROUNDING_PRECISION );
 		}
 
 		/**
@@ -2189,7 +2189,7 @@ class WC_Cart {
 		 * @return float
 		 */
 		public function get_cart_discount_tax_total() {
-			return wc_cart_round_discount( $this->discount_cart_tax, $this->dp );
+			return wc_cart_round_discount( $this->discount_cart_tax, WC_ROUNDING_PRECISION );
 		}
 
 		/**

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -160,8 +160,8 @@ final class WooCommerce {
 		$this->define( 'WC_VERSION', $this->version );
 		$this->define( 'WOOCOMMERCE_VERSION', $this->version );
 		$this->define( 'WC_ROUNDING_PRECISION', 4 );
-		$this->define( 'WC_DISCOUNT_ROUNDING_MODE', 2 );
-		$this->define( 'WC_TAX_ROUNDING_MODE', 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1 );
+		$this->define( 'WC_DISCOUNT_ROUNDING_MODE', 2 ); // PHP_ROUND_HALF_DOWN
+		$this->define( 'WC_TAX_ROUNDING_MODE', 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1 ); // PHP_ROUND_HALF_DOWN : PHP_ROUND_HALF_UP
 		$this->define( 'WC_DELIMITER', '|' );
 		$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
 	}


### PR DESCRIPTION
Hi everybody,

at the moment we try to bind a third party software on woocommerce via the REST API. Everything works quite well exept some small precision issues:

1) The cart discount sums are calculated with a two decimals precision on checkout but if you save the order in the admin backend it gets a four decimal precision.
2) Because of the two decimals precision in the line items the sum of the coupon lines don't match anymore.

In my opinion and for the sake of third party systems which have to calculate sums because of the woocommerce data I would suggest to push the decimal precision for all coupon sums and coupon lines to 4 decimals.
