### PR TITLE
Fix coupon rounding based on old definition: taxes round half down, net round half up

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1282,7 +1282,7 @@ abstract class WC_Abstract_Order {
 			$tax_totals[ $code ]->is_compound       = $tax[ 'compound' ];
 			$tax_totals[ $code ]->label             = isset( $tax[ 'label' ] ) ? $tax[ 'label' ] : $tax[ 'name' ];
 			$tax_totals[ $code ]->amount           += $tax[ 'tax_amount' ] + $tax[ 'shipping_tax_amount' ];
-			$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax_total( $tax_totals[ $code ]->amount ), array('currency' => $this->get_order_currency()) );
+			$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax( $tax_totals[ $code ]->amount ), array('currency' => $this->get_order_currency()) );
 		}
 
 		return apply_filters( 'woocommerce_order_tax_totals', $tax_totals, $this );
@@ -1432,7 +1432,7 @@ abstract class WC_Abstract_Order {
 	 * @return float
 	 */
 	public function get_total_tax() {
-		return apply_filters( 'woocommerce_order_amount_total_tax', wc_round_tax_total( $this->get_cart_tax() + $this->get_shipping_tax() ), $this );
+		return apply_filters( 'woocommerce_order_amount_total_tax', wc_round_tax( $this->get_cart_tax() + $this->get_shipping_tax() ), $this );
 	}
 
 	/**
@@ -1560,7 +1560,7 @@ abstract class WC_Abstract_Order {
 	public function get_item_tax( $item, $round = true ) {
 
 		$price = $item['line_tax'] / max( 1, $item['qty'] );
-		$price = $round ? wc_round_tax_total( $price ) : $price;
+		$price = $round ? wc_round_tax( $price ) : $price;
 
 		return apply_filters( 'woocommerce_order_amount_item_tax', $price, $item, $round, $this );
 	}
@@ -1572,7 +1572,7 @@ abstract class WC_Abstract_Order {
 	 * @return float
 	 */
 	public function get_line_tax( $item ) {
-		return apply_filters( 'woocommerce_order_amount_line_tax', wc_round_tax_total( $item['line_tax'] ), $item, $this );
+		return apply_filters( 'woocommerce_order_amount_line_tax', wc_round_tax( $item['line_tax'] ), $item, $this );
 	}
 
 	/** End Total Getters *******************************************************/

--- a/includes/admin/meta-boxes/views/html-order-fee.php
+++ b/includes/admin/meta-boxes/views/html-order-fee.php
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<td class="line_cost" width="1%">
 		<div class="view">
 			<?php
-				echo ( isset( $item['line_total'] ) ) ? wc_price( wc_round_tax_total( $item['line_total'] ) ) : '';
+				echo ( isset( $item['line_total'] ) ) ? wc_price( wc_round_tax( $item['line_total'] ) ) : '';
 
 				if ( $refunded = $order->get_total_refunded_for_item( $item_id, 'fee' ) ) {
 					echo '<small class="refunded">-' . wc_price( $refunded ) . '</small>';
@@ -61,7 +61,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<td class="line_tax" width="1%">
 						<div class="view">
 							<?php
-								echo ( '' != $tax_item_total ) ? wc_price( wc_round_tax_total( $tax_item_total ) ) : '&ndash;';
+								echo ( '' != $tax_item_total ) ? wc_price( wc_round_tax( $tax_item_total ) ) : '&ndash;';
 
 								if ( $refunded = $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'fee' ) ) {
 									echo '<small class="refunded">-' . wc_price( $refunded ) . '</small>';

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -228,10 +228,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<?php
 								if ( '' != $tax_item_total ) {
 									if ( isset( $tax_item_subtotal ) && $tax_item_subtotal != $tax_item_total ) {
-										echo '<del>' . wc_price( wc_round_tax_total( $tax_item_subtotal ), array( 'currency' => $order->get_order_currency() ) ) . '</del> ';
+										echo '<del>' . wc_price( wc_round_tax( $tax_item_subtotal ), array( 'currency' => $order->get_order_currency() ) ) . '</del> ';
 									}
 
-									echo wc_price( wc_round_tax_total( $tax_item_total ), array( 'currency' => $order->get_order_currency() ) );
+									echo wc_price( wc_round_tax( $tax_item_total ), array( 'currency' => $order->get_order_currency() ) );
 								} else {
 									echo '&ndash;';
 								}

--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -58,7 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<td class="line_cost" width="1%">
 		<div class="view">
 			<?php
-				echo ( isset( $item['cost'] ) ) ? wc_price( wc_round_tax_total( $item['cost'] ), array( 'currency' => $order->get_order_currency() ) ) : '';
+				echo ( isset( $item['cost'] ) ) ? wc_price( wc_round_tax( $item['cost'] ), array( 'currency' => $order->get_order_currency() ) ) : '';
 
 				if ( $refunded = $order->get_total_refunded_for_item( $item_id, 'shipping' ) ) {
 					echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_order_currency() ) ) . '</small>';
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<td class="line_tax" width="1%">
 						<div class="view">
 							<?php
-								echo ( '' != $tax_item_total ) ? wc_price( wc_round_tax_total( $tax_item_total ), array( 'currency' => $order->get_order_currency() ) ) : '&ndash;';
+								echo ( '' != $tax_item_total ) ? wc_price( wc_round_tax( $tax_item_total ), array( 'currency' => $order->get_order_currency() ) ) : '&ndash;';
 
 								if ( $refunded = $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'shipping' ) ) {
 									echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_order_currency() ) ) . '</small>';

--- a/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -134,8 +134,8 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 			}
 
 			$tax_rows[ $key ]->tax_rate            = $tax_row->tax_rate;
-			$tax_rows[ $key ]->tax_amount          += wc_round_tax_total( $tax_row->tax_amount );
-			$tax_rows[ $key ]->shipping_tax_amount += wc_round_tax_total( $tax_row->shipping_tax_amount );
+			$tax_rows[ $key ]->tax_amount          += wc_round_tax( $tax_row->tax_amount );
+			$tax_rows[ $key ]->shipping_tax_amount += wc_round_tax( $tax_row->shipping_tax_amount );
 		}
 		?>
 		<table class="widefat">
@@ -170,9 +170,9 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 				<tfoot>
 					<tr>
 						<th scope="row" colspan="3"><?php _e( 'Total', 'woocommerce' ); ?></th>
-						<th class="total_row"><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) ) ); ?></th>
-						<th class="total_row"><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></th>
-						<th class="total_row"><strong><?php echo wc_price( wc_round_tax_total( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) + array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></strong></th>
+						<th class="total_row"><?php echo wc_price( wc_round_tax( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) ) ); ?></th>
+						<th class="total_row"><?php echo wc_price( wc_round_tax( array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></th>
+						<th class="total_row"><strong><?php echo wc_price( wc_round_tax( array_sum( wp_list_pluck( (array) $tax_rows, 'tax_amount' ) ) + array_sum( wp_list_pluck( (array) $tax_rows, 'shipping_tax_amount' ) ) ) ); ?></strong></th>
 					</tr>
 				</tfoot>
 			<?php else : ?>

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1770,7 +1770,7 @@ class WC_Cart {
 				$discount_amount += $this->get_coupon_discount_tax_amount( $code );
 			}
 
-			return wc_cart_round_discount( $discount_amount, $this->dp );
+			return round( $discount_amount, WC_ROUNDING_PRECISION );
 		}
 
 		/**
@@ -1780,7 +1780,7 @@ class WC_Cart {
 		 * @return float discount amount
 		 */
 		public function get_coupon_discount_tax_amount( $code ) {
-			return wc_cart_round_discount( isset( $this->coupon_discount_tax_amounts[ $code ] ) ? $this->coupon_discount_tax_amounts[ $code ] : 0, $this->dp );
+			return wc_round_tax( isset( $this->coupon_discount_tax_amounts[ $code ] ) ? $this->coupon_discount_tax_amounts[ $code ] : 0, WC_ROUNDING_PRECISION );
 		}
 
 		/**
@@ -2180,7 +2180,7 @@ class WC_Cart {
 		 * @return float
 		 */
 		public function get_cart_discount_total() {
-			return wc_cart_round_discount( $this->discount_cart, $this->dp );
+			return round( $this->discount_cart, WC_ROUNDING_PRECISION );
 		}
 
 		/**
@@ -2189,7 +2189,7 @@ class WC_Cart {
 		 * @return float
 		 */
 		public function get_cart_discount_tax_total() {
-			return wc_cart_round_discount( $this->discount_cart_tax, $this->dp );
+			return wc_round_tax( $this->discount_cart_tax, WC_ROUNDING_PRECISION );
 		}
 
 		/**

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -753,8 +753,8 @@ class WC_Cart {
 					$tax_totals[ $code ]->tax_rate_id       = $key;
 					$tax_totals[ $code ]->is_compound       = WC_Tax::is_compound( $key );
 					$tax_totals[ $code ]->label             = WC_Tax::get_rate_label( $key );
-					$tax_totals[ $code ]->amount           += wc_round_tax_total( $tax );
-					$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax_total( $tax_totals[ $code ]->amount ) );
+					$tax_totals[ $code ]->amount           += wc_round_tax( $tax );
+					$tax_totals[ $code ]->formatted_amount  = wc_price( wc_round_tax( $tax_totals[ $code ]->amount ) );
 				}
 			}
 
@@ -2128,7 +2128,7 @@ class WC_Cart {
 		 * @return string formatted price
 		 */
 		public function get_cart_tax() {
-			$cart_total_tax = wc_round_tax_total( $this->tax_total + $this->shipping_tax_total );
+			$cart_total_tax = wc_round_tax( $this->tax_total + $this->shipping_tax_total );
 
 			return apply_filters( 'woocommerce_get_cart_tax', $cart_total_tax ? wc_price( $cart_total_tax ) : '' );
 		}
@@ -2169,7 +2169,7 @@ class WC_Cart {
 				$total += $tax;
 			}
 			if ( $display ) {
-				$total = wc_round_tax_total( $total );
+				$total = wc_round_tax( $total );
 			}
 			return apply_filters( 'woocommerce_cart_taxes_total', $total, $compound, $display, $this );
 		}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -257,7 +257,7 @@ class WC_Order extends WC_Abstract_Order {
 				}
 			}
 		}
-		return wc_round_tax_total( $total ) * -1;
+		return wc_round_tax( $total ) * -1;
 	}
 
 	/**

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -287,18 +287,3 @@ function wc_cart_totals_shipping_method_label( $method ) {
 
 	return apply_filters( 'woocommerce_cart_shipping_method_full_label', $label, $method );
 }
-
-/**
- * Round discount
- *
- * @param  float $value
- * @param  int $precision
- * @return float
- */
-function wc_cart_round_discount( $value, $precision ) {
-	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
-		return round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE );
-	} else {
-		return round( $value, $precision );
-	}
-}

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -291,7 +291,7 @@ function woocommerce_trim_zeros( $price ) {
  * @deprecated
  */
 function woocommerce_round_tax_total( $tax ) {
-	return wc_round_tax_total( $tax );
+	return wc_round_tax( $tax );
 }
 /**
  * @deprecated

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -151,8 +151,11 @@ function wc_trim_zeros( $price ) {
  * @param mixed $tax
  * @return double
  */
-function wc_round_tax_total( $tax ) {
-	$dp = wc_get_price_decimals();
+function wc_round_tax( $tax, $dp = false ) {
+
+	if ( !$dp ) {
+		$dp = wc_get_price_decimals();
+	}
 
 	// @codeCoverageIgnoreStart
 	if ( version_compare( phpversion(), '5.3', '<' ) ) {

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -180,9 +180,9 @@ class Functions extends \WC_Unit_Test_Case {
 	 */
 	public function test_wc_round_tax_total() {
 
-		$this->assertEquals( 1.25, wc_round_tax_total( 1.246 ) );
-		$this->assertEquals( 20, wc_round_tax_total( 19.9997 ) );
-		$this->assertEquals( 19.99, wc_round_tax_total( 19.99 ) );
+		$this->assertEquals( 1.25, wc_round_tax( 1.246 ) );
+		$this->assertEquals( 20, wc_round_tax( 19.9997 ) );
+		$this->assertEquals( 19.99, wc_round_tax( 19.99 ) );
 	}
 
 	/**

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -160,7 +160,6 @@ final class WooCommerce {
 		$this->define( 'WC_VERSION', $this->version );
 		$this->define( 'WOOCOMMERCE_VERSION', $this->version );
 		$this->define( 'WC_ROUNDING_PRECISION', 4 );
-		$this->define( 'WC_DISCOUNT_ROUNDING_MODE', 2 );
 		$this->define( 'WC_TAX_ROUNDING_MODE', 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1 );
 		$this->define( 'WC_DELIMITER', '|' );
 		$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );


### PR DESCRIPTION
Hi everybody,

After PR #9256 regarding the precission of the coupon line and discount amounts an taxes I stumbled upon another inconsistency: the rounding of nets and taxes in the cart.

Normally there was a rounding definition set up by you: net prices round half up and taxes round half down. But not here - With the discounts/coupons you introduced a round half down for discount/coupon net AND discount/coupon tax.

I think we should fix that or is there a reason for this behaviour.

I also refactored the old round_tax function for reusabillty and removed the introduced round_discount function and constant.
