### PR TITLE
Flat Rate shipping class calculations for $0

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -151,7 +151,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		$highest_class_cost     = 0;
 
 		foreach ( $found_shipping_classes as $shipping_class => $products ) {
-			$class_cost_string = $shipping_class ? $this->get_option( 'class_cost_' . $shipping_class, '' ) : $this->get_option( 'no_class_cost', '' );
+			$class_cost_string = $shipping_class ? $this->get_option( 'class_cost_' . $shipping_class ) : $this->get_option( 'no_class_cost' );
 
 			if ( $class_cost_string === '' ) {
 				continue;


### PR DESCRIPTION
Per https://github.com/woothemes/woocommerce/issues/9270

Removes the default get_option parameter that causes "0" to be mis-interpreted.
