### PR TITLE
Escape HTML entities in coupon description

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -2067,7 +2067,7 @@ class WC_Admin_Post_Types {
 	public function edit_form_after_title( $post ) {
 		if ( 'shop_coupon' === $post->post_type ) {
 			?>
-			<textarea id="woocommerce-coupon-description" name="excerpt" cols="5" rows="2" placeholder="<?php esc_attr_e( 'Description (optional)', 'woocommerce' ); ?>"><?php echo esc_textarea( $post->post_excerpt ); ?></textarea>
+			<textarea id="woocommerce-coupon-description" name="excerpt" cols="5" rows="2" placeholder="<?php esc_attr_e( 'Description (optional)', 'woocommerce' ); ?>"><?php esc_html_e( $post->post_excerpt ); ?></textarea>
 			<?php
 		}
 	}


### PR DESCRIPTION
Fix: Escape HTML entities during output of coupon description on admin page

Fix for issue #9273 
