### PR TITLE
ExtendedWC_AJAX::add_to_cart to be able to add variable products to cart

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -397,10 +397,12 @@ class WC_AJAX {
 
 		$product_id        = apply_filters( 'woocommerce_add_to_cart_product_id', absint( $_POST['product_id'] ) );
 		$quantity          = empty( $_POST['quantity'] ) ? 1 : wc_stock_amount( $_POST['quantity'] );
+		$variation_id      = isset($_POST['variation_id']) ? absint($_POST['variation_id']) : 0;
+		$variation         = isset($_POST['variation']) ? $_POST['variation'] : array();
 		$passed_validation = apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity );
 		$product_status    = get_post_status( $product_id );
 
-		if ( $passed_validation && WC()->cart->add_to_cart( $product_id, $quantity ) && 'publish' === $product_status ) {
+		if ( $passed_validation && WC()->cart->add_to_cart( $product_id, $quantity, $variation_id, $variation ) && 'publish' === $product_status ) {
 
 			do_action( 'woocommerce_ajax_added_to_cart', $product_id );
 


### PR DESCRIPTION
Hi, 
If the add_to_cart method is extended with these parameters you are able to use the woocommerce_add_to_cart action from the js-file to write your own custom ajax add to cart for variable products. The values default to the same parameter value as the WC_Cart->add_to_cart if they are not set.
