### PR TITLE
Customer-details to use wc_get_template views

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -341,24 +341,9 @@ class WC_Emails {
 			$heading = apply_filters( 'woocommerce_email_custom_details_header', $heading, $sent_to_admin, $order );
 
 			if ( $plain_text ) {
-
-				echo strtoupper( $heading ) . "\n\n";
-
-				foreach ( $fields as $field ) {
-					if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) {
-						echo $field['label'] . ': ' . $field['value'] . "\n";
-					}
-				}
-
+				wc_get_template( 'emails/plain/email-customer-details.php', array( 'order' => $order, 'heading' => $heading ) );
 			} else {
-
-				echo '<h2>' . $heading . '</h2>';
-
-				foreach ( $fields as $field ) {
-					if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) {
-						echo '<p><strong>' . $field['label'] . ':</strong> <span class="text">' . $field['value'] . '</span></p>';
-					}
-				}
+				wc_get_template( 'emails/email-customer-details.php', array( 'order' => $order, 'heading' => $heading ) );
 			}
 
 		}

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -1,0 +1,6 @@
+<h2><?php echo $heading; ?></h2>
+<?php foreach ( $fields as $field ) : ?>
+<?php if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) : ?>
+<p><strong><?php echo $field['label']; ?></strong><?php echo $field['value']; ?></p>
+<?php endif;?>
+<?php endforeach; ?>

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Login Form
+ * Admin customer details template part
  *
  * @author 		WooThemes
  * @package 	WooCommerce/Templates

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -1,6 +1,25 @@
+<?php
+/**
+ * Login Form
+ *
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates
+ * @version     2.3.13
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+
 <h2><?php echo $heading; ?></h2>
-<?php foreach ( $fields as $field ) : ?>
-<?php if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) : ?>
+
+<?php
+foreach ( $fields as $field ) :
+	if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) : ?>
+
 <p><strong><?php echo $field['label']; ?></strong><?php echo $field['value']; ?></p>
-<?php endif;?>
-<?php endforeach; ?>
+
+<?php endif;
+endforeach; ?>

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -1,0 +1,7 @@
+<?php echo strtoupper( $heading ); ?> 
+
+<?php foreach ( $fields as $field ) : ?>
+<?php if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) : ?>
+<?php echo $field['label']; ?>: <?php echo $field['value']; ?> 
+<?php endif; ?>
+<?php endforeach; ?>

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -1,7 +1,23 @@
-<?php echo strtoupper( $heading ); ?> 
+<?php
+/**
+ * Admin new order email (plain text)
+ *
+ * @author		WooThemes
+ * @package 	WooCommerce/Templates/Emails/Plain
+ * @version 	2.3.13
+ */
 
-<?php foreach ( $fields as $field ) : ?>
-<?php if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) : ?>
-<?php echo $field['label']; ?>: <?php echo $field['value']; ?> 
-<?php endif; ?>
-<?php endforeach; ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+echo strtoupper( $heading ) . "\n\n";
+
+foreach ( $fields as $field ) {
+	
+	if ( isset( $field['label'] ) && isset( $field['value'] ) && $field['value'] ) {
+		
+		echo $field['label']. ' : ' . $field['value'] . "\n";
+		
+	}
+}

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Admin new order email (plain text)
+ * Admin customer details template part (plain text)
  *
  * @author		WooThemes
  * @package 	WooCommerce/Templates/Emails/Plain


### PR DESCRIPTION
Modification to take the output out of `WC_Emails` in `class-wc-emails.php`, and use in a more consistent `wc_get_template` views
- Modified `WC_Emails` Class to remove output for customer-details
- Created plain-text view / template part
- Created HTML view / template part
