### PR TITLE
WC_AJAX::calc_line_taxes - Provide a filter after tax calculations are done

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1672,6 +1672,8 @@ class WC_AJAX {
 			$items['order_taxes'][ $tax_id ] = absint( $tax_item['rate_id'] );
 		}
 
+		$items = apply_filters( 'woocommerce_ajax_after_calc_line_taxes', $items, $order_id, $country, $_POST );
+
 		// Save order items
 		wc_save_order_items( $order_id, $items );
 


### PR DESCRIPTION
As discussed in #9313, it is currently not possible to set completely custom taxes on backend orders. This is because the default tax calculation is hardcoded right after the filter `woocommerce_ajax_calc_line_taxes` has run, leaving developers with no further options to adjust taxes.

Please see the referenced issue for more information about use-cases (TL;DR: It's needed by German Law)

It has been suggested to add another filter right before the order is re-saved (and after tax calculation is done), so this is the according PR.
