### PR TITLE
removed false value for price_includes_tax and replace for public pro…

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -665,8 +665,8 @@ abstract class WC_Abstract_Order {
 					'tax_class' => $tax_class
 				) );
 
-				$line_subtotal_taxes = WC_Tax::calc_tax( $line_subtotal, $tax_rates, false );
-				$line_taxes          = WC_Tax::calc_tax( $line_total, $tax_rates, false );
+				$line_subtotal_taxes = WC_Tax::calc_tax( $line_subtotal, $tax_rates, $this->prices_include_tax );
+				$line_taxes          = WC_Tax::calc_tax( $line_total, $tax_rates, $this->prices_include_tax );
 				$line_subtotal_tax   = max( 0, array_sum( $line_subtotal_taxes ) );
 				$line_tax            = max( 0, array_sum( $line_taxes ) );
 				$tax_total           += $line_tax;


### PR DESCRIPTION
I ran into issues while calculating tax on products for multiple tax (VAT) regions.
I noticed the taxes where always calculated like the tax was NOT included in the prices, while configuring Woocommerce taxes to INCLUDE the tax while adding products.

I traced the issue down to these 2 rules and applied a proper fix (imo).

Cheers,

Mattijs
