### PR TITLE
Tweak the git ignorance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,14 @@ project.properties
 .buildpath
 .project
 .settings*
-sftp-config.json
 .idea
+
+# Deploy
+deploy.ini
+sftp-config.json
 
 # Grunt
 /node_modules/
-/deploy/
 
 # Sass
 .sass-cache/


### PR DESCRIPTION
@claudiosmweb Although Woo Team use Sublime SFTP package but we are in trouble
as we use 'deploy.ini' file which is the config file for PHPloy to deploy to sftp.

See: https://github.com/banago/PHPloy

Additionally, deploy dir is not need to ignore as there exist no grunt clean and copy task
Please, be happy to ignore deploy.ini file because everytime I do commit I have to exclude it and sometime I have to recreate it from the base xD
