### PR TITLE
Shipping calculation results no longer bleed over

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -267,13 +267,13 @@ class WC_Shipping {
 	 * @param array $packages multi-dimensional array of cart items to calc shipping for
 	 */
 	public function calculate_shipping( $packages = array() ) {
-		if ( ! $this->enabled || empty( $packages ) ) {
-			return;
-		}
-
 		$this->shipping_total = null;
 		$this->shipping_taxes = array();
 		$this->packages       = array();
+
+		if ( ! $this->enabled || empty( $packages ) ) {
+			return;
+		}
 
 		// Calculate costs for passed packages
 		$package_keys 		= array_keys( $packages );


### PR DESCRIPTION
Fixes #9404

Before we decide whether to just return from shipping calculation or
actually calculate it, let's null the values.

Reason for this and not `reset` is because reset also wiped the chosen
shipping method, which might have unintended consequences.

Please test this extensively. You know WooCommerce a lot better than I
do, and I'd like to avoid side effects.
