### PR TITLE
Simplify: require SSL only on checkout

### DIFF
--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -163,7 +163,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway {
 			return false;
 		}
 
-		if ( 'standard' == $this->mode && ! is_ssl() && 'yes' != $this->sandbox ) {
+		if ( 'standard' == $this->mode && 'yes' != $this->sandbox  && ( ( is_checkout() && ! is_ssl() ) || ( 'no' == get_option( 'woocommerce_force_ssl_checkout' ) && ! class_exists( 'WordPressHTTPS' ) ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
This patch refactors the `WC_Gateway_Simplify_Commerce::is_available()` logic to require SSL only on the checkout page. On any other page, it instead requires SSL checkout be enabled or `WordPressHTTPS` to exist (similar to the admin notice about the extension).

This is to make sure that extensions, like Subscriptions, can call `WC()->payment_gateways->get_available_payment_gateways()` outside of the checkout page and get a list of available gateways that includes Simplify.
