### PR TITLE
WC_Product __get should check for False instead of empty

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -128,7 +128,7 @@ class WC_Product {
 
 		}
 
-		if ( ! empty( $value ) ) {
+		if ( false !== $value ) {
 			$this->$key = $value;
 		}
 


### PR DESCRIPTION
WC_Product __get should check for False instead of empty. Now the value does not get saved to the property if it is:

"" (an empty string)
0 (0 as an integer)
0.0 (0 as a float)
"0" (0 as a string)
NULL
FALSE
array() (an empty array)
$var; (a variable declared, but without a value)

This results in unnecessary executions of get_post_meta. E.g. in the case of WooCommerce Bookings getting the 'qty' property resulted in about 10 000 unnecessary executions of wp_cache_get through get_post_meta.

This comparison would make more sense than empty, because $value comes from get_post_meta that returns FALSE when the value has not been stored and something else than FALSE when the meta exists.
