### PR TITLE
Use generic `ajax_add_to_cart` class for adding items in the loop to …

### DIFF
--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -12,7 +12,7 @@ jQuery( function( $ ) {
 		// AJAX add to cart request
 		var $thisbutton = $( this );
 
-		if ( $thisbutton.is( '.product_type_simple' ) ) {
+		if ( $thisbutton.is( '.ajax_add_to_cart' ) ) {
 
 			if ( ! $thisbutton.attr( 'data-product_id' ) ) {
 				return true;

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -751,6 +751,17 @@ class WC_Product {
 	}
 
 	/**
+	 * Returns whether or not the product can be added to the cart via ajax
+	 *
+	 * @since 2.4.9
+	 * @return bool
+	 */
+	public function supports_ajax_add_to_cart() {
+		return apply_filters( 'woocommerce_product_supports_ajax_add_to_cart', $this->is_type( 'simple' ), $this );
+	}
+
+
+	/**
 	 * Set a products price dynamically.
 	 *
 	 * @param float $price Price to set.

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -12,7 +12,7 @@
  * @see 	    http://docs.woothemes.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     2.1.0
+ * @version     2.4.9
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,12 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $product;
 
 echo apply_filters( 'woocommerce_loop_add_to_cart_link',
-	sprintf( '<a href="%s" rel="nofollow" data-product_id="%s" data-product_sku="%s" data-quantity="%s" class="button %s product_type_%s">%s</a>',
+	sprintf( '<a href="%s" rel="nofollow" data-product_id="%s" data-product_sku="%s" data-quantity="%s" class="button %s %s product_type_%s">%s</a>',
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( $product->id ),
 		esc_attr( $product->get_sku() ),
 		esc_attr( isset( $quantity ) ? $quantity : 1 ),
 		$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
+		$product->supports_ajax_add_to_cart() ? 'ajax_add_to_cart' : '',
 		esc_attr( $product->product_type ),
 		esc_html( $product->add_to_cart_text() )
 	),


### PR DESCRIPTION
…the cart via ajax.

What this will do is allow other product types (such as Subscriptions and sometimes Bundles) to add their product types to the cart via ajax without needing to submit the page and redirect the user back to the loop page which is what Subscriptions is doing [here](https://github.com/Prospress/woocommerce-subscriptions/blob/master/woocommerce-subscriptions.php#L673-L687).

For Name Your Price, it would allow me to stop modifying the product type in the loop (same with Add-ons which is where I copied this approach from) so as to prevent the ajax add to cart action. 

The main benefit to NYP is when it is used in conjunction with Subs. 
https://github.com/Prospress/woocommerce-subscriptions/issues/166

the summary of that issue is that when "add to cart" is clicked on a single product page, the page reloads normally and NYP shows the values that were just entered for the price in the NYP input. But since Subs has to redirect itself back to this page, the `$_POST` array is cleared and NYP can't show the entered values. 

@thenbrent 
