### PR TITLE
Better Documentation: Period Endings

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -20,11 +20,11 @@ if ( ! empty( $status_options['uninstall_data'] ) ) {
 
 	global $wpdb;
 
-	// Roles + caps
+	// Roles + caps.
 	include_once( 'includes/class-wc-install.php' );
 	WC_Install::remove_roles();
 
-	// Pages
+	// Pages.
 	wp_trash_post( get_option( 'woocommerce_shop_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_cart_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_checkout_page_id' ) );
@@ -34,7 +34,7 @@ if ( ! empty( $status_options['uninstall_data'] ) ) {
 	wp_trash_post( get_option( 'woocommerce_change_password_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_logout_page_id' ) );
 
-	// Tables
+	// Tables.
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_api_keys" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_attribute_taxonomies" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_downloadable_product_permissions" );
@@ -42,10 +42,10 @@ if ( ! empty( $status_options['uninstall_data'] ) ) {
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_tax_rates" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_tax_rate_locations" );
 
-	// Delete options
+	// Delete options.
 	$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE 'woocommerce\_%';");
 
-	// Delete posts + data
+	// Delete posts + data.
 	$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'product', 'product_variation', 'shop_coupon', 'shop_order', 'shop_order_refund' );" );
 	$wpdb->query( "DELETE meta FROM {$wpdb->postmeta} meta LEFT JOIN {$wpdb->posts} posts ON posts.ID = meta.post_id WHERE posts.ID IS NULL;" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_items" );


### PR DESCRIPTION
As per the [PHP documentation standards in the core handbook](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/), this commit helps make the documentation better
- Single line comments endings with periods.
