### PR TITLE
Fix duplicate key errors during db upgrade/install

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -367,8 +367,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
   session_key char(32) NOT NULL,
   session_value longtext NOT NULL,
   session_expiry bigint(20) NOT NULL,
-  UNIQUE KEY  session_id (session_id),
-  PRIMARY KEY  session_key (session_key)
+  UNIQUE KEY session_id (session_id),
+  PRIMARY KEY  (session_key)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_api_keys (
   key_id bigint(20) NOT NULL auto_increment,


### PR DESCRIPTION
Running phpunit tests currently outputs the following errors/warnings:

```
WordPress database error Duplicate key name 'session_id' for query ALTER TABLE wptests_woocommerce_sessions ADD UNIQUE KEY  session_id (session_id) made by PHPUnit_TextUI_Command::main, PHPUnit_TextUI_Command->run, PHPUnit_TextUI_Command->handleArguments, PHPUnit_TextUI_Command->handleBootstrap, PHPUnit_Util_Fileloader::checkAndLoad, PHPUnit_Util_Fileloader::load, include_once('/srv/www/woocommerce/htdocs/wp-content/plugins/woocommerce/tests/bootstrap.php'), WC_Unit_Tests_Bootstrap::instance, WC_Unit_Tests_Bootstrap->__construct, require_once('/srv/www/wordpress-develop/tests/phpunit/includes/bootstrap.php'), require_once('wp-settings.php'), do_action('setup_theme'), call_user_func_array, WC_Unit_Tests_Bootstrap->install_wc, WC_Install::install, WC_Install::create_tables, dbDelta
WordPress database error Multiple primary key defined for query ALTER TABLE wptests_woocommerce_sessions ADD PRIMARY KEY  session_key (session_key) made by PHPUnit_TextUI_Command::main, PHPUnit_TextUI_Command->run, PHPUnit_TextUI_Command->handleArguments, PHPUnit_TextUI_Command->handleBootstrap, PHPUnit_Util_Fileloader::checkAndLoad, PHPUnit_Util_Fileloader::load, include_once('/srv/www/woocommerce/htdocs/wp-content/plugins/woocommerce/tests/bootstrap.php'), WC_Unit_Tests_Bootstrap::instance, WC_Unit_Tests_Bootstrap->__construct, require_once('/srv/www/wordpress-develop/tests/phpunit/includes/bootstrap.php'), require_once('wp-settings.php'), do_action('setup_theme'), call_user_func_array, WC_Unit_Tests_Bootstrap->install_wc, WC_Install::install, WC_Install::create_tables, dbDelta

WordPress database error Duplicate key name 'session_id' for query ALTER TABLE wptests_woocommerce_sessions ADD UNIQUE KEY  session_id (session_id) made by PHPUnit_TextUI_Command::main, PHPUnit_TextUI_Command->run, PHPUnit_TextUI_TestRunner->doRun, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestCase->run, PHPUnit_Framework_TestResult->run, PHPUnit_Framework_TestCase->runBare, PHPUnit_Framework_TestCase->runTest, ReflectionMethod->invokeArgs, WooCommerce\Tests\Util\WC_Tests_Install->test_check_version, WC_Install::check_version, WC_Install::install, WC_Install::create_tables, dbDelta
WordPress database error Multiple primary key defined for query ALTER TABLE wptests_woocommerce_sessions ADD PRIMARY KEY  session_key (session_key) made by PHPUnit_TextUI_Command::main, PHPUnit_TextUI_Command->run, PHPUnit_TextUI_TestRunner->doRun, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestCase->run, PHPUnit_Framework_TestResult->run, PHPUnit_Framework_TestCase->runBare, PHPUnit_Framework_TestCase->runTest, ReflectionMethod->invokeArgs, WooCommerce\Tests\Util\WC_Tests_Install->test_check_version, WC_Install::check_version, WC_Install::install, WC_Install::create_tables, dbDelta
.WordPress database error Duplicate key name 'session_id' for query ALTER TABLE wptests_woocommerce_sessions ADD UNIQUE KEY  session_id (session_id) made by PHPUnit_TextUI_Command::main, PHPUnit_TextUI_Command->run, PHPUnit_TextUI_TestRunner->doRun, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestCase->run, PHPUnit_Framework_TestResult->run, PHPUnit_Framework_TestCase->runBare, PHPUnit_Framework_TestCase->runTest, ReflectionMethod->invokeArgs, WooCommerce\Tests\Util\WC_Tests_Install->test_install, WC_Install::install, WC_Install::create_tables, dbDelta
WordPress database error Multiple primary key defined for query ALTER TABLE wptests_woocommerce_sessions ADD PRIMARY KEY  session_key (session_key) made by PHPUnit_TextUI_Command::main, PHPUnit_TextUI_Command->run, PHPUnit_TextUI_TestRunner->doRun, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestSuite->run, PHPUnit_Framework_TestCase->run, PHPUnit_Framework_TestResult->run, PHPUnit_Framework_TestCase->runBare, PHPUnit_Framework_TestCase->runTest, ReflectionMethod->invokeArgs, WooCommerce\Tests\Util\WC_Tests_Install->test_install, WC_Install::install, WC_Install::create_tables, dbDelta
```

dbDelta requires very specific syntax (as per http://codex.wordpress.org/Creating_Tables_with_Plugins).

This change slightly alters the spacing and syntax for the creation of the `woocommerce_sessions` database table.
