### PR TITLE
Prevent PHP notice

### DIFF
--- a/includes/class-wc-geo-ip.php
+++ b/includes/class-wc-geo-ip.php
@@ -1604,7 +1604,7 @@ class WC_Geo_IP {
 	 */
 	public function geoip_country_code_by_addr_v6( $addr ) {
 		$country_id = $this->geoip_country_id_by_addr_v6( $addr );
-		if ( $country_id !== false ) {
+		if ( $country_id !== false && isset( $this->GEOIP_COUNTRY_CODES[ $country_id ]  ) ) {
 			return $this->GEOIP_COUNTRY_CODES[ $country_id ];
 		}
 


### PR DESCRIPTION
Prevents this PHP notice (on my localhost/testing setup):

PHP Notice:  Undefined offset: -16776960 in wp
-content/plugins/woocommerce/includes/class-wc-geo-ip.php on line 1608

Note that the geoip_country_code_by_addr() method, a few lines further down, already makes a similar check to this one which is being added for IPv6.
