### PR TITLE
Check so `product_base` exists before using it

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -100,7 +100,7 @@ class WC_Breadcrumb {
 		$shop_page    = get_post( $shop_page_id );
 
 		// If permalinks contain the shop page in the URI prepend the breadcrumb with shop
-		if ( $shop_page_id && $shop_page && strstr( $permalinks['product_base'], '/' . $shop_page->post_name ) && get_option( 'page_on_front' ) != $shop_page_id ) {
+		if ( $shop_page_id && $shop_page && isset( $permalinks['product_base'] ) && strstr( $permalinks['product_base'], '/' . $shop_page->post_name ) && get_option( 'page_on_front' ) != $shop_page_id ) {
 			$this->add_crumb( get_the_title( $shop_page ), get_permalink( $shop_page ) );
 		}
 	}


### PR DESCRIPTION
`product_base` index in `$permalinks` array in `prepend_shop_page` method don't always exists for a new WooCommerce site, doing a isset check before will solve `Notice: Undefined index: product_base` error.
