### PR TITLE
Add support for minimum amount a payment gateway supports

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -79,6 +79,12 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	public $max_amount = 0;
 
 	/**
+	 * Minimum transaction amount, zero does not define a minimum.
+	 * @var int
+	 */
+	public $min_amount = 0;
+
+	/**
 	 * Optional URL to view a transaction.
 	 * @var string
 	 */
@@ -156,6 +162,10 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		$is_available = ( 'yes' === $this->enabled ) ? true : false;
 
 		if ( WC()->cart && 0 < $this->get_order_total() && 0 < $this->max_amount && $this->max_amount < $this->get_order_total() ) {
+			$is_available = false;
+		}
+
+		if ( WC()->cart && 0 < $this->get_order_total() && 0 < $this->min_amount && $this->min_amount > $this->get_order_total() ) {
 			$is_available = false;
 		}
 


### PR DESCRIPTION
We, as a payment service provider, need this because we don't support payments lower than the transaction costs. It seems to be a very common use case and as a maximum amount is already supported, it's only a small fix.
