### PR TITLE
Optimize variable price hash generation

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -283,9 +283,9 @@ class WC_Product_Variable extends WC_Product {
 			$price_hash = array( false );
 		}
 
-		foreach ( $wp_filter as $key => $val ) {
-			if ( in_array( $key, array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' ) ) ) {
-				$price_hash[ $key ] = $val;
+		foreach ( array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' ) as $filter_name ) {
+			if ( ! empty( $wp_filter[ $filter_name ] ) ) {
+				$hash[ $filter_name ] = $wp_filter[ $filter_name ];
 			}
 		}
 


### PR DESCRIPTION
The current code loops through every defined hook in the WordPress environment. This way seems quite a bit more efficient and should produce identical results as far as I can see.
