### PR TITLE
Fix invalid orderby key name for orderby pricing closes #9584

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -563,7 +563,7 @@ class WC_Query {
 				$args['order']    = $order == 'ASC' ? 'ASC' : 'DESC';
 			break;
 			case 'price' :
-				$args['orderby']  = "meta_value_num {$wpdb->posts}.ID";
+				$args['orderby']  = "meta_value_num ID";
 				$args['order']    = $order == 'DESC' ? 'DESC' : 'ASC';
 				$args['meta_key'] = '_price';
 			break;


### PR DESCRIPTION
This is for price ordering on catalog page.  If pricing is all different, it appears to work as first order is by meta_value_num.  But if you have two products with same price and the second product was added later, there is a chance the later added product comes before the first product which means it is not sorted by ID ASC.

This commit fixes that by using valid orderby argument.
