### PR TITLE
Makes the "Try Storefront" button more contextual

### DIFF
--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -25,24 +25,33 @@ class WC_Admin_Addons {
 		$text = __( 'View more about Storefront', 'woocommerce' );
 		$template = get_option( 'template' );
 		$stylesheet = get_option( 'stylesheet' );
+		$utm_content = 'hasstorefront';
 
 		// If we're using Storefront with a child theme.
 		if ( 'storefront' == $template && 'storefront' != $stylesheet ) {
 			$url = 'http:///www.woothemes.com/product-category/themes/storefront-child-theme-themes/';
 			$text = __( 'View more Storefront child themes', 'woocommerce' );
+			$utm_content = 'hasstorefrontchildtheme';
 		}
 
 		// If we're using Storefront without a child theme.
 		if ( 'storefront' == $template && 'storefront' == $stylesheet ) {
 			$url = 'http:///www.woothemes.com/product-category/themes/storefront-child-theme-themes/';
 			$text = __( 'Need a fresh look? Try Storefront child themes', 'woocommerce' );
+			$utm_content = 'nostorefrontchildtheme';
 		}
 
 		// If we're not using Storefront at all.
 		if ( 'storefront' != $template && 'storefront' != $stylesheet ) {
 			$url = 'http://www.woothemes.com/storefront/';
 			$text = __( 'Need a theme? Try Storefront', 'woocommerce' );
+			$utm_content = 'nostorefront';
 		}
+
+		$url = add_query_arg( 'utm_source', 'product', $url );
+		$url = add_query_arg( 'utm_medium', 'upsell', $url );
+		$url = add_query_arg( 'utm_campaign', 'wcaddons', $url );
+		$url = add_query_arg( 'utm_content', $utm_content, $url );
 
 		echo '<a href="' . esc_url( $url ) . '" class="add-new-h2">' . esc_html( $text ) . '</a>' . "\n";
 	}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -18,6 +18,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Admin_Addons {
 
 	/**
+	 * Handles the outputting of a contextually aware Storefront link (points to child themes if Storefront is already active).
+	 */
+	public static function output_storefront_button() {
+		$url = '';
+		$text = '';
+		$template = get_option( 'template' );
+		$stylesheet = get_option( 'stylesheet' );
+
+		// If we're using Storefront with a child theme.
+		if ( 'storefront' == $template && 'storefront' != $stylesheet ) {
+			$url = 'http:///www.woothemes.com/product-category/themes/storefront-child-theme-themes/';
+			$text = __( 'View more Storefront child themes', 'woocommerce' );
+		}
+
+		// If we're using Storefront without a child theme.
+		if ( 'storefront' == $template && 'storefront' == $stylesheet ) {
+			$url = 'http:///www.woothemes.com/product-category/themes/storefront-child-theme-themes/';
+			$text = __( 'Need a fresh look? Try Storefront child themes', 'woocommerce' );
+		}
+
+		// If we're not using Storefront at all.
+		if ( 'storefront' != $template && 'storefront' != $stylesheet ) {
+			$url = 'http://www.woothemes.com/storefront/';
+			$text = __( 'Need a theme? Try Storefront', 'woocommerce' );
+		}
+
+		if ( '' != $url && '' != $text ) {
+			echo '<a href="' . esc_url( $url ) . '" class="add-new-h2">' . esc_html( $text ) . '</a>' . "\n";
+		}
+	}
+
+	/**
 	 * Handles output of the reports page in admin.
 	 */
 	public static function output() {

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -21,8 +21,8 @@ class WC_Admin_Addons {
 	 * Handles the outputting of a contextually aware Storefront link (points to child themes if Storefront is already active).
 	 */
 	public static function output_storefront_button() {
-		$url = '';
-		$text = '';
+		$url = 'http://www.woothemes.com/storefront/';
+		$text = __( 'View more about Storefront', 'woocommerce' );
 		$template = get_option( 'template' );
 		$stylesheet = get_option( 'stylesheet' );
 
@@ -44,9 +44,7 @@ class WC_Admin_Addons {
 			$text = __( 'Need a theme? Try Storefront', 'woocommerce' );
 		}
 
-		if ( '' != $url && '' != $text ) {
-			echo '<a href="' . esc_url( $url ) . '" class="add-new-h2">' . esc_html( $text ) . '</a>' . "\n";
-		}
+		echo '<a href="' . esc_url( $url ) . '" class="add-new-h2">' . esc_html( $text ) . '</a>' . "\n";
 	}
 
 	/**

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -19,7 +19,7 @@ $theme 	= wp_get_theme();
 	<h2>
 		<?php _e( 'WooCommerce Add-ons/Extensions', 'woocommerce' ); ?>
 		<a href="http://www.woothemes.com/product-category/woocommerce-extensions/" class="add-new-h2"><?php _e( 'Browse all extensions', 'woocommerce' ); ?></a>
-		<?php WC_Admin_Addons::output_storefront_button( $theme ); ?>
+		<?php WC_Admin_Addons::output_storefront_button(); ?>
 	</h2>
 	<?php if ( $addons ) : ?>
 		<ul class="subsubsub">

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -19,7 +19,7 @@ $theme 	= wp_get_theme();
 	<h2>
 		<?php _e( 'WooCommerce Add-ons/Extensions', 'woocommerce' ); ?>
 		<a href="http://www.woothemes.com/product-category/woocommerce-extensions/" class="add-new-h2"><?php _e( 'Browse all extensions', 'woocommerce' ); ?></a>
-		<a href="http://www.woothemes.com/storefront/" class="add-new-h2"><?php _e( 'Need a theme? Try Storefront', 'woocommerce' ); ?></a>
+		<?php WC_Admin_Addons::output_storefront_button( $theme ); ?>
 	</h2>
 	<?php if ( $addons ) : ?>
 		<ul class="subsubsub">


### PR DESCRIPTION
On the "Addons" screen, the "Need a theme? Try Storefront" button could be more contextual.

This pull adds the following adjustments, based on context:

If the current active theme is `storefront`, and the current active stylesheet (child theme) is also `storefront`, adjust the button text to "Need a fresh look? Try Storefront child themes".

If the current active theme is `storefront`, and the current active stylesheet (child theme) is a different child theme (whether made by Woo or custom made), adjust the button text to "View more Storefront child themes".

Both of the above button changes also direct the store owner to the Storefront Child Themes listing on WooThemes.com.

If the current active theme or child theme isn't `storefront`, display the button text as "Need a theme? Try Storefront".

One adjustment (coming shortly after opening this pull request) is handling a case where Storefront is already in use, with or without a child theme. I'll add logic to adjust the button to be a "View more about Storefront", to encourage existing Storefront users to view new Storefront extensions, child themes, etc.

cc @mikejolley @warrendholmes 
