### PR TITLE
Introduce woocommerce_recorded_sales action hook

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2381,6 +2381,13 @@ abstract class WC_Abstract_Order {
 		}
 
 		update_post_meta( $this->id, '_recorded_sales', 'yes' );
+
+		/**
+		 * Called when sales for an order are recorded
+		 *
+		 * @param int $order_id order id
+		 */
+		do_action( 'woocommerce_recorded_sales', $this->id );
 	}
 
 


### PR DESCRIPTION
Sometimes it's useful to react to when sales are recorded for an order. This PR adds a new action hook that is called whenever that happens.

Another thing worth considering is storing the date-time when the sales were recorded. This way, it would be possible to retroactively find out when sales were recorded. I'm not sure what kind of approach would be better: storing a date instead of the current `yes` or storing it in a different meta key, like `_sales_recorded_at`. 

Feedback welcome!
