### PR TITLE
Bump modified date of variations on update

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1324,7 +1324,7 @@ class WC_Meta_Box_Product_Data {
 
 				} else {
 
-					$modified_date = current_time( 'timestamp' );
+					$modified_date = date_i18n( 'Y-m-d H:i:s', current_time( 'timestamp' ) );
 
 					$wpdb->update( $wpdb->posts, array(
 							'post_status'       => $post_status,

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1528,6 +1528,9 @@ class WC_Meta_Box_Product_Data {
 					delete_post_meta( $variation_id, $key );
 				}
 
+				$modified_date = current_time( 'timestamp' );
+				$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->posts SET post_date = %s, post_date_gmt = %s WHERE ID = %s", $modified_date, get_gmt_from_date( $modified_date ), $variation_id ) );
+
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );
 			}
 		}

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1324,7 +1324,15 @@ class WC_Meta_Box_Product_Data {
 
 				} else {
 
-					$wpdb->update( $wpdb->posts, array( 'post_status' => $post_status, 'post_title' => $variation_post_title, 'menu_order' => $variable_menu_order[ $i ] ), array( 'ID' => $variation_id ) );
+					$modified_date = current_time( 'timestamp' );
+
+					$wpdb->update( $wpdb->posts, array(
+							'post_status'       => $post_status,
+							'post_title'        => $variation_post_title,
+							'menu_order'        => $variable_menu_order[ $i ],
+							'post_modified'     => $modified_date,
+							'post_modified_gmt' => get_gmt_from_date( $modified_date )
+					), array( 'ID' => $variation_id ) );
 
 					clean_post_cache( $variation_id );
 
@@ -1527,9 +1535,6 @@ class WC_Meta_Box_Product_Data {
 				foreach ( $delete_attribute_keys as $key ) {
 					delete_post_meta( $variation_id, $key );
 				}
-
-				$modified_date = current_time( 'timestamp' );
-				$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->posts SET post_date = %s, post_date_gmt = %s WHERE ID = %s", $modified_date, get_gmt_from_date( $modified_date ), $variation_id ) );
 
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );
 			}


### PR DESCRIPTION
Added a update for the modified date after changing data of a variation e.g. by using the ajax endpoint in the new admin variation ui.

Otherwise the modified date would only be updated if the product is saved by clicking on the „Save Product“ button.
