### PR TITLE
Add filters for From name/address to WC_Email (#9653)

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -435,8 +435,8 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_from_name() {
-		$from_name = wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name' ) ), ENT_QUOTES );
-		return apply_filters( 'woocommerce_email_from_name', $from_name, $this->id, $this->object );
+		$from_name = apply_filters( 'woocommerce_email_from_name', get_option( 'woocommerce_email_from_name' ), $this );
+		return wp_specialchars_decode( esc_html( $from_name ), ENT_QUOTES );
 	}
 
 	/**
@@ -444,8 +444,8 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_from_address() {
-		$from_address = return sanitize_email( get_option( 'woocommerce_email_from_address' ) );
-		return apply_filters( 'woocommerce_email_from_address', $from_address, $this->id, $this->object );
+		$from_address = apply_filters( 'woocommerce_email_from_address', get_option( 'woocommerce_email_from_address' ), $this );
+		return sanitize_email( $from_address );
 	}
 
 	/**

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -435,7 +435,8 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_from_name() {
-		return wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name' ) ), ENT_QUOTES );
+		$from_name = wp_specialchars_decode( esc_html( get_option( 'woocommerce_email_from_name' ) ), ENT_QUOTES );
+		return apply_filters( 'woocommerce_email_from_name', $from_name, $this->id, $this->object );
 	}
 
 	/**
@@ -443,7 +444,8 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_from_address() {
-		return sanitize_email( get_option( 'woocommerce_email_from_address' ) );
+		$from_address = return sanitize_email( get_option( 'woocommerce_email_from_address' ) );
+		return apply_filters( 'woocommerce_email_from_address', $from_address, $this->id, $this->object );
 	}
 
 	/**


### PR DESCRIPTION
- add woocommerce_email_from_name filter that accepts name and WC_Email (subclass) object
- add woocommerce_email_from_address filter that accepts address and WC_Email (subclass) object
- these allow return address info to be set conditionally, unlike wp_mail_from and wp_mail_from_name, which don’t pass any context to hooked functions
