### PR TITLE
Arrays should be checked for emptiness explicitly!

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -226,7 +226,7 @@ class WC_Tax {
 		$rates_transient_key = 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $country, $state, $city, implode( ',', $valid_postcodes ), $tax_class ) );
 		$matched_tax_rates   = get_transient( $rates_transient_key );
 
-		if ( false === $matched_tax_rates ) {
+		if ( empty($matched_tax_rates) ) {
 			$matched_tax_rates = self::get_matched_tax_rates( $country, $state, $postcode, $city, $tax_class, $valid_postcodes );
 			set_transient( $rates_transient_key, $matched_tax_rates, WEEK_IN_SECONDS );
 		}


### PR DESCRIPTION
Using the `===` operator in php causes an explicit comparison of types and values of operands (`$a === $b`  Identical   `TRUE` if `$a` is equal to `$b`, and they are of the same type from http://php.net/manual/en/language.operators.comparison.php). 

One could have used `==`, but never `===` in this case.

The usage of `===` caused a very nasty and hard to track down bug, where after transients were cleared, the condition in ln 229 was never true, thus never re-querying the tax rate table, and thus never resetting the transient, causing a zero tax to be displayed in the cart page.
