### PR TITLE
Check if the endpoints array key is set and not empty.

### DIFF
--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -85,7 +85,7 @@ function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 		$permalink = get_permalink();
 
 	// Map endpoint to options
-	$endpoint = isset( WC()->query->query_vars[ $endpoint ] ) ? WC()->query->query_vars[ $endpoint ] : $endpoint;
+	$endpoint = !empty( WC()->query->query_vars[ $endpoint ] ) ? WC()->query->query_vars[ $endpoint ] : $endpoint;
 	$value    = ( 'edit-address' == $endpoint ) ? wc_edit_address_i18n( $value ) : $value;
 
 	if ( get_option( 'permalink_structure' ) ) {


### PR DESCRIPTION
For some reasons in a client's website, I've found that "order-pay" is set but is empty (even if in the backoffice the variable is written in the endpoint's form). So, it is better to check with !empty, doesn't it?
