### PR TITLE
Add filter to set which product types can have their "simple prices" updated by bulk edit

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1264,7 +1264,16 @@ class WC_Admin_Post_Types {
 		}
 
 		// Handle price - remove dates and set to lowest
-		if ( $product->is_type( 'simple' ) || $product->is_type( 'external' ) ) {
+		$change_price_product_types = apply_filters( 'woocommerce_bulk_edit_save_price_product_types', array( 'simple', 'external' ) );
+		$can_product_type_change_price = false;
+		foreach ( $change_price_product_types as $product_type ) {
+			if ( $product->is_type( $product_type ) ) {
+				$can_product_type_change_price = true;
+				break;
+			}
+		}
+
+		if ( $can_product_type_change_price ) {
 
 			$price_changed = false;
 


### PR DESCRIPTION
If you try to bulk edit prices on product types like 'photography' who store their price like simple products (in `_regular_price`), nothing happens. This is because the bulk update code is limited to `simple` and `external` only.

Some extensions like subscriptions ship their own code - which is essentially just a copy and paste. If we had a simple filter for product types like this, our extensions could enable price bulk edit with something very simple (anonymous function used for example -- extensions would have to be BC compat):

```
add_filter( 'woocommerce_bulk_edit_save_price_product_types', function( $types ) {
    $types[] = 'photography';
    return $types;
} );
```

This would be a quick fix for photography and we could remove 100+ lines of code from subscriptions with the filter - or at least use the filter for newer versions of WC.
