### PR TITLE
[add_to_cart] - style attribute (#9693)

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -451,10 +451,16 @@ class WC_Shortcodes {
 		if ( ! $product ) {
 			return '';
 		}
+		
+		$style_attr = '';
+		
+		if( ! empty( $atts['style'] ) ) {
+			$style_attr = ' style="' . esc_attr( $atts['style'] ) . '"';	
+		}
 
 		ob_start();
 		?>
-		<p class="product woocommerce add_to_cart_inline <?php echo esc_attr( $atts['class'] ); ?>" style="<?php echo esc_attr( $atts['style'] ); ?>">
+		<p class="product woocommerce add_to_cart_inline <?php echo esc_attr( $atts['class'] ); ?>"<?php echo $style_attr; ?>>
 
 			<?php if ( 'true' == $atts['show_price'] ) : ?>
 				<?php echo $product->get_price_html(); ?>

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -454,7 +454,7 @@ class WC_Shortcodes {
 		
 		$style_attr = '';
 		
-		if( ! empty( $atts['style'] ) ) {
+		if ( ! empty( $atts['style'] ) ) {
 			$style_attr = ' style="' . esc_attr( $atts['style'] ) . '"';	
 		}
 


### PR DESCRIPTION
Added code which makes possible to remove the style attribute from the [add_to_cart] shortcode. Earlier there was an empty **style** attribute.

Related issue: https://github.com/woothemes/woocommerce/issues/9693
