### PR TITLE
Init added variables if product doesnt have featured image.

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -566,7 +566,7 @@ class WC_Product_Variable extends WC_Product {
 			$image_srcset    = wp_get_attachment_image_srcset( $attachment_id, 'shop_single' );
 			$image_sizes     = wp_get_attachment_image_sizes( $attachment_id, 'shop_single' );
 		} else {
-			$image = $image_link = $image_title = $image_alt = '';
+			$image = $image_link = $image_title = $image_alt = $image_srcset = $image_sizes = '';
 		}
 
 		$availability      = $variation->get_availability();


### PR DESCRIPTION
Still related to #9624. Should fix the notices reported by @roykho in https://github.com/woothemes/woocommerce/commit/105105db0635b621e05966d8cdea9b757d130549.
