### PR TITLE
Include link to order in PayPal refund email, for convenience

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -257,7 +257,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 		$order->update_status( 'on-hold', sprintf( __( 'Payment %s via IPN.', 'woocommerce' ), wc_clean( $posted['payment_status'] ) ) );
 
 		$this->send_ipn_email_notification(
-			sprintf( __( 'Payment for order #%s reversed', 'woocommerce' ), $order->get_order_number() ),
+			sprintf( __( 'Payment for order %s refunded/reversed', 'woocommerce' ), '<a class="link" href="' . admin_url( 'post.php?post=' . $order->id . '&action=edit' ).'">#' . $order->get_order_number() . '</a>' ),
 			sprintf( __( 'Order #%s has been marked on-hold due to a reversal - PayPal reason code: %s', 'woocommerce' ), $order->get_order_number(), wc_clean( $posted['reason_code'] ) )
 		);
 	}


### PR DESCRIPTION
Includes a link to the relevant order in the PayPal refund email, so that the shop owner doesn't have to manually bring up the dashboard, search the for order, and click through.
