### PR TITLE
[WP 4.4] Enhancing Product Embeds

### DIFF
--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Embed Controller
- *
  * Embed Class which handles any WooCommerce Products that are embedded on this site or another site
  *
  * @class 		WC_Embed
@@ -55,7 +53,7 @@ class WC_Embed {
 	}
 
 	/**
-	 * Init email classes.
+	 * Init embed class.
 	 */
 	public static function init() {
 
@@ -146,7 +144,7 @@ class WC_Embed {
     }
 
     /**
-     * Returns whether or not comments are open Since we don't want the comment icon to show up we're going to return false.
+     * Returns whether or not comments are open - since we don't want the comment icon to show up we're going to return false.
      *
      * @return bool
      */

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -15,43 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Embed {
 
-	/** @var WC_Embed The single instance of the class */
-	protected static $_instance = null;
-
-	/**
-	 * Main WC_Embed Instance.
-	 *
-	 * Ensures only one instance of WC_Embed is loaded or can be loaded.
-	 *
-	 * @since 2.5
-	 * @static
-	 * @return WC_Embed Main instance
-	 */
-	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
-		}
-		return self::$_instance;
-	}
-
-	/**
-	 * Cloning is forbidden.
-	 *
-	 * @since 2.5
-	 */
-	public function __clone() {
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'woocommerce' ), '2.1' );
-	}
-
-	/**
-	 * Unserializing instances of this class is forbidden.
-	 *
-	 * @since 2.5
-	 */
-	public function __wakeup() {
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'woocommerce' ), '2.1' );
-	}
-
 	/**
 	 * Init embed class.
 	 */

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -1,0 +1,162 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Embed Controller
+ *
+ * Embed Class which handles any WooCommerce Products that are embedded on this site or another site
+ *
+ * @class 		WC_Embed
+ * @version		2.5.0
+ * @package		WooCommerce/Classes/Embed
+ * @category	Class
+ * @author 		WooThemes
+ */
+class WC_Embed {
+
+	/** @var WC_Embed The single instance of the class */
+	protected static $_instance = null;
+
+	/**
+	 * Main WC_Embed Instance.
+	 *
+	 * Ensures only one instance of WC_Embed is loaded or can be loaded.
+	 *
+	 * @since 2.5
+	 * @static
+	 * @return WC_Embed Main instance
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Cloning is forbidden.
+	 *
+	 * @since 2.5
+	 */
+	public function __clone() {
+		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'woocommerce' ), '2.1' );
+	}
+
+	/**
+	 * Unserializing instances of this class is forbidden.
+	 *
+	 * @since 2.5
+	 */
+	public function __wakeup() {
+		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'woocommerce' ), '2.1' );
+	}
+
+	/**
+	 * Init email classes.
+	 */
+	public static function init() {
+
+        // filter all of the content that's going to be embedded
+        add_filter( 'the_title', array( 'WC_Embed', 'the_title' ), 10 );
+        add_filter( 'the_excerpt_embed', array( 'WC_Embed', 'the_excerpt' ), 10 );
+
+        // make sure no comments display. Doesn't make sense for products
+        add_filter( 'get_comments_number', array( 'WC_Embed', 'get_comments_number' ), 10);
+        add_filter( 'comments_open', array( 'WC_Embed', 'comments_open' ), 10 );
+
+	}
+
+    /**
+     * Create the title for embedded products - we want to add the price to it
+     *
+     * @return string
+     */
+    public static function the_title( $title ) {
+        // make sure we're only affecting embedded products
+        if ( WC_Embed::is_embedded_product() ) {
+
+            // get product
+            $_pf = new WC_Product_Factory();
+            $_product = $_pf->get_product( get_the_ID() );
+
+            // add the price
+            $title = $title . '<span class="price" style="float: right;">' . $_product->get_price_html() . '</span>';
+        }
+        return $title;
+    }
+
+    /**
+     * Check if this is an embedded product - to make sure we don't mess up regular posts
+     *
+     * @return bool
+     */
+    public static function is_embedded_product() {
+        if ( function_exists( 'is_embed' ) && is_embed() && is_product() ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Create the excerpt for embedded products - we want to add the buy button to it
+     *
+     * @return string
+     */
+    public static function the_excerpt( $excerpt ) {
+        //  make sure we're only affecting embedded products
+        if ( WC_Embed::is_embedded_product() ) {
+
+            // get product
+            $_pf = new WC_Product_Factory();
+            $_product = $_pf->get_product( get_the_ID() );
+
+            // add the exerpt
+            $excerpt = wpautop( $excerpt );
+
+            // add the button
+            $excerpt .= WC_Embed::product_button();
+        }
+        return $excerpt;
+    }
+
+    /**
+     * Create the button to go to the product page for embedded products.
+     *
+     * @return string
+     */
+    public static function product_button( ) {
+        $button = '<a href="%s" class="wp-embed-more">%s &rarr;</a>';
+        return sprintf( $button, get_the_permalink(), __( 'View The Product', 'woocommerce' ) );
+    }
+
+    /**
+     * Returns number of comments for embedded products. Since we don't want the comment icon to show up we're going to return 0.
+     *
+     * @return string
+     */
+    public static function get_comments_number( $comments ) {
+        //  make sure we're only affecting embedded products
+        if ( WC_Embed::is_embedded_product() ) {
+            return 0;
+        }
+        return $comments;
+    }
+
+    /**
+     * Returns whether or not comments are open Since we don't want the comment icon to show up we're going to return false.
+     *
+     * @return bool
+     */
+    public static function comments_open( $comments_open ) {
+        //  make sure we're only affecting embedded products
+        if ( WC_Embed::is_embedded_product() ) {
+            return false;
+        }
+        return $comments_open;
+    }
+}
+
+WC_Embed::init();

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -75,10 +75,6 @@ class WC_Embed {
         //  make sure we're only affecting embedded products
         if ( WC_Embed::is_embedded_product() ) {
 
-            // get product
-            $_pf = new WC_Product_Factory();
-            $_product = $_pf->get_product( get_the_ID() );
-
             // add the exerpt
             $excerpt = wpautop( $excerpt );
 

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Embed Class which handles any WooCommerce Products that are embedded on this site or another site
  *
  * @class 		WC_Embed
- * @version		2.5.0
+ * @version		2.5
  * @package		WooCommerce/Classes/Embed
  * @category	Class
  * @author 		WooThemes
@@ -17,6 +17,8 @@ class WC_Embed {
 
 	/**
 	 * Init embed class.
+     *
+     * @since 2.5
 	 */
 	public static function init() {
 
@@ -34,6 +36,7 @@ class WC_Embed {
      * Create the title for embedded products - we want to add the price to it
      *
      * @return string
+     * @since 2.5
      */
     public static function the_title( $title ) {
         // make sure we're only affecting embedded products
@@ -53,6 +56,7 @@ class WC_Embed {
      * Check if this is an embedded product - to make sure we don't mess up regular posts
      *
      * @return bool
+     * @since 2.5
      */
     public static function is_embedded_product() {
         if ( function_exists( 'is_embed' ) && is_embed() && is_product() ) {
@@ -65,6 +69,7 @@ class WC_Embed {
      * Create the excerpt for embedded products - we want to add the buy button to it
      *
      * @return string
+     * @since 2.5
      */
     public static function the_excerpt( $excerpt ) {
         //  make sure we're only affecting embedded products
@@ -87,6 +92,7 @@ class WC_Embed {
      * Create the button to go to the product page for embedded products.
      *
      * @return string
+     * @since 2.5
      */
     public static function product_button( ) {
         $button = '<a href="%s" class="wp-embed-more">%s &rarr;</a>';
@@ -97,6 +103,7 @@ class WC_Embed {
      * Returns number of comments for embedded products. Since we don't want the comment icon to show up we're going to return 0.
      *
      * @return string
+     * @since 2.5
      */
     public static function get_comments_number( $comments ) {
         //  make sure we're only affecting embedded products
@@ -110,6 +117,7 @@ class WC_Embed {
      * Returns whether or not comments are open - since we don't want the comment icon to show up we're going to return false.
      *
      * @return bool
+     * @since 2.5
      */
     public static function comments_open( $comments_open ) {
         //  make sure we're only affecting embedded products

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -7,11 +7,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Embed Class which handles any WooCommerce Products that are embedded on this site or another site
  *
- * @class 		WC_Embed
- * @version		2.5
- * @package		WooCommerce/Classes/Embed
- * @category	Class
- * @author 		WooThemes
+ * @class       WC_Embed
+ * @version     2.5
+ * @package     WooCommerce/Classes/Embed
+ * @category    Class
+ * @author      WooThemes
  */
 class WC_Embed {
 
@@ -27,8 +27,10 @@ class WC_Embed {
         add_filter( 'the_excerpt_embed', array( 'WC_Embed', 'the_excerpt' ), 10 );
 
         // make sure no comments display. Doesn't make sense for products
-        add_filter( 'get_comments_number', array( 'WC_Embed', 'get_comments_number' ), 10);
-        add_filter( 'comments_open', array( 'WC_Embed', 'comments_open' ), 10 );
+        remove_action( 'embed_content_meta', 'print_embed_comments_button' );
+
+        // in the comments place let's display the product rating
+        add_action( 'embed_content_meta', array( 'WC_Embed', 'get_ratings' ), 5 );
 
 	}
 
@@ -96,32 +98,27 @@ class WC_Embed {
     }
 
     /**
-     * Returns number of comments for embedded products. Since we don't want the comment icon to show up we're going to return 0.
+     * Prints the markup for the rating stars
      *
      * @return string
      * @since 2.5
      */
-    public static function get_comments_number( $comments ) {
+    public static function get_ratings( $comments ) {
         //  make sure we're only affecting embedded products
         if ( WC_Embed::is_embedded_product() ) {
-            return 0;
+            ?>
+            <div style="display:inline-block;">
+                <?php
+                // get product
+                $_pf = new WC_Product_Factory();
+                $_product = $_pf->get_product( get_the_ID() );
+                echo $_product->get_rating_html();
+                ?>
+            </div>
+            <?php
         }
-        return $comments;
     }
 
-    /**
-     * Returns whether or not comments are open - since we don't want the comment icon to show up we're going to return false.
-     *
-     * @return bool
-     * @since 2.5
-     */
-    public static function comments_open( $comments_open ) {
-        //  make sure we're only affecting embedded products
-        if ( WC_Embed::is_embedded_product() ) {
-            return false;
-        }
-        return $comments_open;
-    }
 }
 
 WC_Embed::init();

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -266,6 +266,7 @@ final class WooCommerce {
 		include_once( 'includes/class-wc-customer.php' );                       // Customer class
 		include_once( 'includes/class-wc-shortcodes.php' );                     // Shortcodes class
 		include_once( 'includes/class-wc-https.php' );                          // https Helper
+		include_once( 'includes/class-wc-embed.php' );                          // Embeds
 	}
 
 	/**


### PR DESCRIPTION
With WordPress 4.4 [WordPress has become an oEmbed provider](https://make.wordpress.org/core/tag/feature-oembed/). That means that any oEmbed consumer can embed posts from WordPress sites. And this doesn't just work for posts. It works for any custom post type including WooCommerce products.

Regular posts look like this:

![post-embed](https://cloud.githubusercontent.com/assets/1065372/11412205/f12024f4-9396-11e5-80e8-1b46a27f128b.jpg)

And products look just like that which is a bit disappointing. I've used some of the filters available to customize how products look. This includes:
- Removing the comment icon
- Adding the product price to the top right
- Adding an additional `View The Product ->` link to make sure it's obvious that you can click on this and see more information about the product.

![product-embed](https://cloud.githubusercontent.com/assets/1065372/11412238/7ebbd006-9397-11e5-96f3-61b6be8c557f.jpg)
### Lots More

There's a _lot_ more we can do with this. I'd like to add an add-to-cart button. That would be pretty awesome but there are lots of variables like variable products. Which variation should be added to the cart? The cheapest / the most expensive? Or should we also include the variation drop down selector in the embed? _Lots_ of great questions that we should answer in time.

**I'd like to include this basic functionality now in time for WordPress 4.4 (due December 8th).**

Before we do all the things let's see how people use this and add more features after people start using this functionality. :)
### A Note on CSS

After a talk with @jameskoster we decided to inline the CSS. The embed doesn't use `wp_head` so we'd have to duplicate styles. So we are using a link for the `View The Product` link (which was originally going to be a button) and just floated the product price to the right hand side.

As we add more functionality we should definitely consider adding a stylesheet. It's a waste to include one for one or two lines of CSS.

FWIW here's how you can add your own CSS:

``` php
/**
 * Include styles for embedded products
 */
public static function embed_head ( ) {
    wp_enqueue_style( 'woocommerce-embed', WC()->plugin_url() . '/assets/css/embed.css' );
}
```
