### PR TITLE
Seperate variation description field from shipping div container

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -242,7 +242,8 @@ extract( $variation_data );
 						do_action( 'woocommerce_product_options_tax', $loop, $variation_data, $variation );
 					?>
 				<?php endif; ?>
-
+			</div>
+			<div>
 				<p class="form-row form-row-full">
 					<label><?php _e( 'Variation Description:', 'woocommerce' ); ?></label>
 					<textarea name="variable_description[<?php echo $loop; ?>]" rows="3" style="width:100%;"><?php echo isset( $variation_data['_variation_description'] ) ? esc_textarea( $variation_data['_variation_description'] ) : ''; ?></textarea>


### PR DESCRIPTION
Currently the variation description field is within the same DIV container as the shipping class/tax class and sometimes we want to hide the container for those which in turns hides the variation description field as well.

So to make this easier to manipulate, putting variation description in its own DIV container would be better.
