### PR TITLE
Add extra order/shipping related hooks

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -87,6 +87,7 @@ if ( wc_tax_enabled() ) {
 
 				do_action( 'woocommerce_order_item_' . $item['type'] . '_html', $item_id, $item, $order );
 			}
+			do_action( 'woocommerce_admin_order_items_after_line_items', $order->id );
 		?>
 		</tbody>
 		<tbody id="order_shipping_line_items">
@@ -95,6 +96,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items_shipping as $item_id => $item ) {
 				include( 'html-order-shipping.php' );
 			}
+			do_action( 'woocommerce_admin_order_items_after_shipping', $order->id );
 		?>
 		</tbody>
 		<tbody id="order_fee_line_items">
@@ -102,6 +104,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items_fee as $item_id => $item ) {
 				include( 'html-order-fee.php' );
 			}
+			do_action( 'woocommerce_admin_order_items_after_fees', $order->id );
 		?>
 		</tbody>
 		<tbody id="order_refunds">
@@ -111,6 +114,7 @@ if ( wc_tax_enabled() ) {
 					include( 'html-order-refund.php' );
 				}
 			}
+			do_action( 'woocommerce_admin_order_items_after_refunds', $order->id );
 		?>
 		</tbody>
 	</table>

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -40,14 +40,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php $method = current( $available_methods ); ?>
 			<?php echo wc_cart_totals_shipping_method_label( $method ); ?>
 			<input type="hidden" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" value="<?php echo esc_attr( $method->id ); ?>" class="shipping_method" />
+			<?php do_action( 'woocommerce_after_shipping_rate', $method, $index ); ?>
 
 		<?php elseif ( 'select' === get_option( 'woocommerce_shipping_method_format' ) ) : ?>
 
 			<select name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" class="shipping_method">
+				<?php $current_method = false; ?>
 				<?php foreach ( $available_methods as $method ) : ?>
+					<?php $current_method = ( $method->id == $chosen_method ) ? $method : $current_method; ?>
 					<option value="<?php echo esc_attr( $method->id ); ?>" <?php selected( $method->id, $chosen_method ); ?>><?php echo wc_cart_totals_shipping_method_label( $method ); ?></option>
 				<?php endforeach; ?>
 			</select>
+			<?php do_action( 'woocommerce_after_shipping_rate', $current_method, $index ); ?>
 
 		<?php else : ?>
 
@@ -56,6 +60,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<li>
 						<input type="radio" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>" value="<?php echo esc_attr( $method->id ); ?>" <?php checked( $method->id, $chosen_method ); ?> class="shipping_method" />
 						<label for="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>"><?php echo  wc_cart_totals_shipping_method_label( $method ); ?></label>
+						<?php do_action( 'woocommerce_after_shipping_rate', $method, $index ); ?>
 					</li>
 				<?php endforeach; ?>
 			</ul>


### PR DESCRIPTION
This PR will add multiple new hooks to the admin/front-end allowing 3rd party plugins to add stuff around shipping/fees/items etc

Some hooks are implemented for the sake of consistency. 

I'd love to see this in WC 2.5 for a plugin I'm bulding :smile: 
Thanks!
