### PR TITLE
[2.4] Variation descriptions flickering fix

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -520,12 +520,17 @@
 	$.fn.wc_variations_description_update = function( variation_description ) {
 		var $form                   = this;
 		var $variations_description = $form.find( '.woocommerce-variation-description' );
+		var $single_variation_wrap  = $form.find( '.single_variation_wrap' );
 
 		if ( $variations_description.length === 0 ) {
 			if ( variation_description ) {
 				// add transparent border to allow correct height measurement when children have top/bottom margins
-				$form.find( '.single_variation_wrap' ).prepend( $( '<div class="woocommerce-variation-description" style="border:1px solid transparent;">' + variation_description + '</div>' ).hide() );
-				$form.find( '.woocommerce-variation-description' ).slideDown( 200 );
+				$single_variation_wrap.prepend( $( '<div class="woocommerce-variation-description" style="border:1px solid transparent;">' + variation_description + '</div>' ).hide() );
+				if ( $single_variation_wrap.is( ':visible' ) ) {
+					$form.find( '.woocommerce-variation-description' ).slideDown( 200 );
+				} else {
+					$form.find( '.woocommerce-variation-description' ).show();
+				}
 			}
 		} else {
 			var load_height    = $variations_description.outerHeight( true );


### PR DESCRIPTION
@claudiosmweb 

In the 2.4 variations script a flicker in the variation descriptions animation can be seen when the parent container `single_variation_wrap` is slid down at the same time as the variation descriptions container is animated.

To reproduce, load a variable product with no attribute selected (`single_variation_wrap` hidden), and select an attribute that corresponds to a variation with a description set.

http://cl.ly/0c1f2E1o3v2v

After the "fix":

http://cl.ly/2u283E1i1F3g

It's a minor thing, especially since 2.5 gets rid of these animations due to the use of `wp.template` (wish there was a way to keep them).
