### PR TITLE
Introduce WC_Product::get_id() method

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -167,6 +167,17 @@ class WC_Product {
 	}
 
 	/**
+	 * Return the product ID
+	 *
+	 * @since 2.5.0
+	 * @return int product (post) ID
+	 */
+	public function get_id() {
+
+		return $this->id;
+	}
+
+	/**
 	 * get_gallery_attachment_ids function.
 	 *
 	 * @return array

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -148,6 +148,17 @@ class WC_Product_Variation extends WC_Product {
 	}
 
 	/**
+	 * Return the variation ID
+	 *
+	 * @since 2.5.0
+	 * @return int variation (post) ID
+	 */
+	public function get_id() {
+
+		return $this->variation_id;
+	}
+
+	/**
 	 * Returns whether or not the product post exists.
 	 *
 	 * @return bool


### PR DESCRIPTION
This is a small quality of life improvement to introduce the `get_id()` method for `WC_Product`. We have a ton of this sort of code in our extensions:

``` php
// get the product id
$product_id = $product->is_type( 'variation' ) ? $product->variation_id : $product->id;
```

which would be neatly replaced by a single `$product_id = $product->get_id()` without needing to be concerned about the product type. It also has the small (future) benefit of encouraging external code to use the accessor method instead of the member variable directly :rocket: 
