### PR TITLE
End function requires variable to prevent strict standards errors

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -958,10 +958,11 @@ class WC_Countries {
 		$address_fields = array();
 
 		foreach ( $fields as $key => $value ) {
+			$keys = array_keys( $fields );
 			$address_fields[ $type . $key ] = $value;
 
 			// Add email and phone after company or last
-			if ( $type == 'billing_' && ( 'company' === $key || ( ! array_key_exists( 'company', $fields ) && $key === end( array_keys( $fields ) ) ) ) ) {
+			if ( $type == 'billing_' && ( 'company' === $key || ( ! array_key_exists( 'company', $fields ) && $key === end( $keys ) ) ) ) {
 				$address_fields['billing_email'] = array(
 					'label'		=> __( 'Email Address', 'woocommerce' ),
 					'required'	=> true,


### PR DESCRIPTION
Just a temporary variable that is only used to pass an actual variable to the PHP end function (as that takes a reference as argument). This prevents strict standard errors, as discussed in [this comment](https://github.com/woothemes/woocommerce/pull/3721#issuecomment-162285457).
