### PR TITLE
Add hooks after shipping rate display

### DIFF
--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -40,14 +40,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php $method = current( $available_methods ); ?>
 			<?php echo wc_cart_totals_shipping_method_label( $method ); ?>
 			<input type="hidden" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" value="<?php echo esc_attr( $method->id ); ?>" class="shipping_method" />
+			<?php do_action( 'woocommerce_after_shipping_rate', $method, $index ); ?>
 
 		<?php elseif ( 'select' === get_option( 'woocommerce_shipping_method_format' ) ) : ?>
 
 			<select name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>" class="shipping_method">
+				<?php $current_method = false; ?>
 				<?php foreach ( $available_methods as $method ) : ?>
+					<?php $current_method = ( $method->id == $chosen_method ) ? $method : $current_method; ?>
 					<option value="<?php echo esc_attr( $method->id ); ?>" <?php selected( $method->id, $chosen_method ); ?>><?php echo wc_cart_totals_shipping_method_label( $method ); ?></option>
 				<?php endforeach; ?>
 			</select>
+			<?php do_action( 'woocommerce_after_shipping_rate', $method, $index ); ?>
 
 		<?php else : ?>
 
@@ -57,6 +61,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<input type="radio" name="shipping_method[<?php echo $index; ?>]" data-index="<?php echo $index; ?>" id="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>" value="<?php echo esc_attr( $method->id ); ?>" <?php checked( $method->id, $chosen_method ); ?> class="shipping_method" />
 						<label for="shipping_method_<?php echo $index; ?>_<?php echo sanitize_title( $method->id ); ?>"><?php echo  wc_cart_totals_shipping_method_label( $method ); ?></label>
 					</li>
+					<?php do_action( 'woocommerce_after_shipping_rate', $method, $index ); ?>
 				<?php endforeach; ?>
 			</ul>
 


### PR DESCRIPTION
@mikejolley thanks for your feedback in #9739

Split the PR up in two seprate ones, one for the shipping template, and the other #9798 for the admin area.

> MJ: Having an action based on something which can change doesn't seem logical?
> Something generic after output of the selects/radios would be more acceptable - you can get chosen method from the session if needed.
> In case the hook is after all the shipping rates, the chosen from session would work, but when they're after each separate shipping rate (which is the case for the radio buttons - not for a single / drop down shipping option) it won't work.

Here's the plugin/use-case where I'm using these hooks for: 
![image](https://cloud.githubusercontent.com/assets/5774447/11680803/f5fdd4c0-9e5a-11e5-85f1-bf237ad8adfa.png)

Hope that gives some clarification on how it can be used. Thats the reason why it 'needs' to have the `$method` argument and its placed after each shipping rate. 

I've had multiple requests from users for something like a description at a shipping rate. 

Thanks :smile: 
