### PR TITLE
Add hooks after order line items in admin

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -87,6 +87,7 @@ if ( wc_tax_enabled() ) {
 
 				do_action( 'woocommerce_order_item_' . $item['type'] . '_html', $item_id, $item, $order );
 			}
+			do_action( 'woocommerce_admin_order_items_after_line_items', $order->id );
 		?>
 		</tbody>
 		<tbody id="order_shipping_line_items">
@@ -95,6 +96,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items_shipping as $item_id => $item ) {
 				include( 'html-order-shipping.php' );
 			}
+			do_action( 'woocommerce_admin_order_items_after_shipping', $order->id );
 		?>
 		</tbody>
 		<tbody id="order_fee_line_items">
@@ -102,6 +104,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items_fee as $item_id => $item ) {
 				include( 'html-order-fee.php' );
 			}
+			do_action( 'woocommerce_admin_order_items_after_fees', $order->id );
 		?>
 		</tbody>
 		<tbody id="order_refunds">
@@ -110,6 +113,7 @@ if ( wc_tax_enabled() ) {
 				foreach ( $refunds as $refund ) {
 					include( 'html-order-refund.php' );
 				}
+				do_action( 'woocommerce_admin_order_items_after_refunds', $order->id );
 			}
 		?>
 		</tbody>


### PR DESCRIPTION
@mikejolley As part of the split up PRs of #9739:

This PR is adding extra hooks in the order admin area. More spifically at the order lines such as shipping, fees, refunds, line items.

> MJ: Also for the ones around items in the backend, maybe you can explain a little of their purpose? I don't want to get locked into maintaining actions unnecessarily.

Here's a screenshot on how I will use them for a plugin:
![image](https://cloud.githubusercontent.com/assets/5774447/11681035/a2f540f4-9e5c-11e5-83af-28b278d15730.png)

Allowing one to add their own/custom lines (this is after the shipping, added the other hooks for consistency, but they're not required by me)

Thanks again :smile: 
