### PR TITLE
Fix webhook status not changed after save with active object-cache

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -675,6 +675,7 @@ class WC_Webhook {
 		}
 
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $post_status ), array( 'ID' => $this->id ) );
+		clean_post_cache( $this->id );
 	}
 
 	/**


### PR DESCRIPTION
If object cache is used the sebhook status will be shown false.
