### PR TITLE
Fixes: Fatal error on my-account/view-order/### for non-existing orde…

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -109,6 +109,12 @@ class WC_Shortcode_My_Account {
 			return;
 		}
 
+		if ( ! $order ) {
+			status_header( 404 );
+			echo '<div class="woocommerce-error">' . __( 'Order not found.', 'woocommerce' ) . ' <a href="' . wc_get_page_permalink( 'myaccount' ).'" class="wc-forward">'. __( 'My Account', 'woocommerce' ) .'</a>' . '</div>';
+			return;
+		}
+
 		// Backwards compatibility
 		$status       = new stdClass();
 		$status->name = wc_get_order_status_name( $order->get_status() );


### PR DESCRIPTION
…r numbers. #9829 

Adds fix for error reported.  If there is no order number returned, it will return a status code of 404, display an error message wrapped in the 'woocommerce-error' class, and then return within the function so it does not try to get run methods or get variables from a non-existing order object.
