### PR TITLE
Fix warnings thrown about $menu_order being a boolean

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -35,7 +35,7 @@ class WC_Admin_Menus {
 
 		add_action( 'admin_head', array( $this, 'menu_highlight' ) );
 		add_action( 'admin_head', array( $this, 'menu_order_count' ) );
-		add_filter( 'menu_order', array( $this, 'menu_order' ) );
+		add_filter( 'menu_order', array( $this, 'menu_order' ), 1 );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 
 		// Add endpoints custom URLs in Appearance > Menus > Pages


### PR DESCRIPTION
I've seen the following warnings thrown on two different sites when `define('WP_DEBUG_DISPLAY', true);` and `display_errors = 1` are set.

I'm seeing the same errors on sites with the following setups:
- WordPress 4.3.1 / WC 2.4.10
- WordPress 4.4 / WC 2.4.12

```
Warning: array_search() expects parameter 2 to be array, boolean given in wp-content/plugins/woocommerce/includes/admin/class-wc-admin-menus.php on line 169

Warning: array_search() expects parameter 2 to be array, boolean given in wp-content/plugins/woocommerce/includes/admin/class-wc-admin-menus.php on line 172

Warning: Invalid argument supplied for foreach() in wp-content/plugins/woocommerce/includes/admin/class-wc-admin-menus.php on line 175
```

The reason I even saw these errors though is they started showing up in our Wordpress admin.  Looks like we didn't have `@ini_set('display_errors', 0);` in our `wp-config.php` file, so it started throwing problems.
