### PR TITLE
[2.5] Allow ajax product searches from known ids + introduce search results limit

### DIFF
--- a/assets/js/admin/wc-enhanced-select.js
+++ b/assets/js/admin/wc-enhanced-select.js
@@ -95,7 +95,9 @@ jQuery( function( $ ) {
 								term:     term,
 								action:   $( this ).data( 'action' ) || 'woocommerce_json_search_products_and_variations',
 								security: wc_enhanced_select_params.search_products_nonce,
-								exclude:  $( this ).data( 'exclude' )
+								exclude:  $( this ).data( 'exclude' ),
+								include:  $( this ).data( 'include' ),
+								limit:    $( this ).data( 'limit' )
 				            };
 				        },
 				        results: function( data ) {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1749,8 +1749,7 @@ class WC_AJAX {
 
 		check_ajax_referer( 'search-products', 'security' );
 
-		$term    = (string) wc_clean( stripslashes( $_GET['term'] ) );
-		$exclude = array();
+		$term = (string) wc_clean( stripslashes( $_GET['term'] ) );
 
 		if ( empty( $term ) ) {
 			die();
@@ -1789,6 +1788,14 @@ class WC_AJAX {
 
 		if ( ! empty( $_GET['exclude'] ) ) {
 			$query .= " AND posts.ID NOT IN (" . implode( ',', array_map( 'intval', explode( ',', $_GET['exclude'] ) ) ) . ")";
+		}
+
+		if ( ! empty( $_GET['include'] ) ) {
+			$query .= " AND posts.ID IN (" . implode( ',', array_map( 'intval', explode( ',', $_GET['include'] ) ) ) . ")";
+		}
+
+		if ( ! empty( $_GET['limit'] ) ) {
+			$query .= " LIMIT " . intval( $_GET['limit'] );
 		}
 
 		$posts          = array_unique( $wpdb->get_col( $query ) );


### PR DESCRIPTION
Makes it possible to search from a pre-defined set of known ids without returning all results, avoiding an excessive amount of product instantiations with large result sets.

Instead of looking for (and sending) a `limit` field with the request, It might be a better idea to simply hardcode a query limit value, perhaps 1000, to speed things up (could be filterable, too).

Too many returned results and the user will make a more specific search anyway :)

Apologies for bringing this late in the dev cycle, may as well review it for WC 2.6.
