### PR TITLE
[2.5] Search-products: failing to load results when orphaned variation posts in the result set

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1809,6 +1809,10 @@ class WC_AJAX {
 					continue;
 				}
 
+				if ( ! $product || ( $product->is_type( 'variation' ) && empty( $product->parent ) ) ) {
+					continue;
+				}
+
 				$found_products[ $post ] = rawurldecode( $product->get_formatted_name() );
 			}
 		}


### PR DESCRIPTION
Resolves a "PHP Fatal error:  Call to a member function get_attributes() on a non-object" error when the result set during a product-search includes orphaned variations.
