### PR TITLE
Add handling for custom product fields when manually adding order items

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -4454,6 +4454,23 @@ table.bar_chart {
 			padding: 10px 0 0;
 			text-align: center;
 		}
+
+		h2 {
+			font-size: 16px;
+			font-weight: 700;
+		}
+
+		h3 {
+			font-size: 14px;
+		}
+
+		.order-item-field {
+			margin: auto 1em;
+		}
+
+		.order-item-field-select_variation {
+			min-height: 70px;
+		}
 	}
 
 	footer {

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1013,14 +1013,13 @@ jQuery( function ( $ ) {
 					if ( item.has_fields ) {
 
 						if ( $( '#wc-backbone-modal-dialog' ).length === 0 ) {
-							wc_meta_boxes_order_items.backbone.modal = $( '.woocommerce_order_items' ).WCBackboneModal( {
+							wc_meta_boxes_order_items.backbone.modal = $( '#woocommerce-order-items' ).WCBackboneModal( {
 								template: 'wc-modal-configure-product-fields',
 								variable: { title: item.title, fields_html: item.fields_html }
 							} );
 						}
 					} else {
 						wc_meta_boxes_order_items.backbone.add_configured_item( item.id, false );
-						wc_meta_boxes_order_items.backbone.configure_items();
 					}
 				}
 
@@ -1045,10 +1044,17 @@ jQuery( function ( $ ) {
 
 				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 					if ( response.result === 'success' && response.html ) {
-						$( 'table.woocommerce_order_items tbody#order_line_items' ).append( response.html );
+
 						if ( $( '#wc-backbone-modal-dialog' ).length > 0 ) {
 							$( '#wc-backbone-modal-dialog button.modal-close' ).trigger( 'click' );
 						}
+
+						$( '#woocommerce-order-items' ).find( '.inside' ).empty();
+						$( '#woocommerce-order-items' ).find( '.inside' ).append( response.html );
+
+						wc_meta_boxes_order.init_tiptip();
+						wc_meta_boxes_order_items.stupidtable.init();
+
 					} else {
 						if ( response.messages ) {
 							window.alert( response.messages.join( '\n\n' ) );
@@ -1058,7 +1064,6 @@ jQuery( function ( $ ) {
 							}
 						}
 					}
-					wc_meta_boxes_order.init_tiptip();
 					wc_meta_boxes_order_items.unblock();
 					wc_meta_boxes_order_items.backbone.configure_items();
 				} );

--- a/assets/js/admin/order-backbone-modal.js
+++ b/assets/js/admin/order-backbone-modal.js
@@ -52,10 +52,12 @@
 		_target: undefined,
 		_string: undefined,
 		events: {
-			'click .modal-close': 'closeButton',
-			'click #btn-ok':      'addButton',
-			'touchstart #btn-ok': 'addButton',
-			'keydown':            'keyboardActions'
+			'click .modal-close':       'closeButton',
+			'click #btn-ok':            'addButton',
+			'click #btn-validate':      'validateButton',
+			'touchstart #btn-ok':       'addButton',
+			'touchstart #btn-validate': 'validateButton',
+			'keydown':                  'keyboardActions'
 		},
 		initialize: function( data ) {
 			this._target = data.target;
@@ -115,6 +117,9 @@
 		addButton: function( e ) {
 			$( document.body ).trigger( 'wc_backbone_modal_response', [ this._target, this.getFormData() ] );
 			this.closeButton( e );
+		},
+		validateButton: function( e ) {
+			$( document.body ).trigger( 'wc_backbone_modal_response', [ this._target, this.getFormData() ] );
 		},
 		getFormData: function() {
 			var data = {};

--- a/includes/admin/meta-boxes/views/html-order-item-fields-variable.php
+++ b/includes/admin/meta-boxes/views/html-order-item-fields-variable.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Shows configuration fields for new order items.
+ *
+ * @var array $fields Fields for display
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+foreach ( $item_fields as $field ) {
+	?>
+	<h3><?php echo esc_html( $field['description'] ); ?></h3>
+	<input type="hidden" name="add_order_item" value="<?php echo $_product->id; ?>"/>
+	<div class="order-item-field-<?php echo esc_attr( $field['id'] ); ?>">
+		<?php do_action( 'woocommerce_get_order_item_' . $field['id'] . '_fields', $_product, $order_id ); ?>
+	</div>
+	<?php
+}

--- a/includes/admin/meta-boxes/views/html-order-item-fields.php
+++ b/includes/admin/meta-boxes/views/html-order-item-fields.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Shows configuration fields for new order items.
+ *
+ * @var array $fields Fields for display
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+foreach ( $item_fields as $field ) {
+	?>
+	<h2><?php echo esc_html( $field['field_title'] ); ?></h2>
+	<input type="hidden" name="add_order_item" value="<?php echo $_product->id; ?>"/>
+	<div class="order-item-field order-item-field-<?php echo esc_attr( $field['field_id'] ); ?>">
+		<?php echo $field['field_html']; ?>
+	</div>
+	<?php
+}

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -330,6 +330,32 @@ if ( wc_tax_enabled() ) {
 	<div class="wc-backbone-modal-backdrop modal-close"></div>
 </script>
 
+<script type="text/template" id="tmpl-wc-modal-configure-product-fields">
+	<div class="wc-backbone-modal">
+		<div class="wc-backbone-modal-content">
+			<section class="wc-backbone-modal-main" role="main">
+				<header class="wc-backbone-modal-header">
+					<h1><?php _e( 'Configure product:', 'woocommerce' ); ?> {{{ data.title }}}</h1>
+					<button class="modal-close modal-close-link dashicons dashicons-no-alt">
+						<span class="screen-reader-text">Close modal panel</span>
+					</button>
+				</header>
+				<article>
+					<form action="" method="post">
+						{{{ data.fields_html }}}
+					</form>
+				</article>
+				<footer>
+					<div class="inner">
+						<button id="btn-validate" class="button button-primary button-large"><?php _e( 'Done', 'woocommerce' ); ?></button>
+					</div>
+				</footer>
+			</section>
+		</div>
+	</div>
+	<div class="wc-backbone-modal-backdrop modal-close"></div>
+</script>
+
 <script type="text/template" id="tmpl-wc-modal-add-tax">
 	<div class="wc-backbone-modal">
 		<div class="wc-backbone-modal-content">

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -111,6 +111,7 @@ class WC_AJAX {
 			'grant_access_to_download'                         => false,
 			'get_customer_details'                             => false,
 			'add_order_item'                                   => false,
+			'get_order_items_fields'                           => false,
 			'add_order_fee'                                    => false,
 			'add_order_shipping'                               => false,
 			'add_order_tax'                                    => false,
@@ -1109,6 +1110,75 @@ class WC_AJAX {
 	}
 
 	/**
+	 * Get order item configuration fields via ajax.
+	 */
+	public static function get_order_items_fields() {
+		check_ajax_referer( 'order-item', 'security' );
+
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			die(-1);
+		}
+
+		$items_to_add = array_map( 'absint', $_POST['items_to_add'] );
+		$order_id     = absint( $_POST['order_id'] );
+		$fields       = array();
+
+		foreach ( $items_to_add as $item_to_add ) {
+
+			$post = get_post( $item_to_add );
+
+			if ( ! $post || ( 'product' !== $post->post_type && 'product_variation' !== $post->post_type ) ) {
+				die();
+			}
+
+			$_product         = wc_get_product( $post->ID );
+			$item_fields      = array();
+			$item_fields_html = '';
+
+			if ( $_product->is_type( 'variable' ) ) {
+				$item_fields[] = array(
+					'field_id'    => 'select_variation',
+					'field_title' => __( 'Select a variation', 'woocommerce' ),
+					'field_html'  => self::get_order_item_select_variation_fields( $_product, $order_id ),
+				);
+			}
+
+			$item_fields = apply_filters( 'woocommerce_ajax_get_order_item_fields', $item_fields, $_product, $order_id );
+
+			if ( ! empty( $item_fields ) ) {
+				ob_start();
+				include( 'admin/meta-boxes/views/html-order-item-fields.php' );
+				$item_fields_html = ob_get_clean();
+			}
+
+			$fields[] = array(
+				'id'          => $item_to_add,
+				'title'       => $_product->get_title(),
+				'has_fields'  => ! empty( $item_fields_html ),
+				'fields_html' => $item_fields_html
+			);
+		}
+
+		wp_send_json( $fields );
+	}
+
+	/**
+	 * Variable order item configuration fields.
+	 *
+	 * @param  WC_Product_Variable $product   the variable order item currently being added into the order
+	 * @param  int                 $order_id  the order id
+	 * @return string
+	 */
+	public static function get_order_item_select_variation_fields( $product, $order_id ) {
+		ob_start();
+		?>
+		<p><?php _e( '&hellip;or continue to add the parent product to this order.', 'woocommerce' ); ?></p>
+		<input type="hidden" id="add_item_id" name="add_order_item_variation" class="wc-product-search" data-allow_clear="true" data-placeholder="<?php esc_attr_e( 'Search for a variation&hellip;', 'woocommerce' ); ?>" data-multiple="false" data-include="<?php echo implode( ',', $product->get_children() ); ?>" />
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
 	 * Add order item via ajax.
 	 */
 	public static function add_order_item() {
@@ -1120,6 +1190,11 @@ class WC_AJAX {
 
 		$item_to_add = sanitize_text_field( $_POST['item_to_add'] );
 		$order_id    = absint( $_POST['order_id'] );
+		$data        = array();
+
+		if ( ! empty( $_POST['data'] ) ) {
+			parse_str( $_POST['data'], $data );
+		}
 
 		// Find the item
 		if ( ! is_numeric( $item_to_add ) ) {
@@ -1132,65 +1207,86 @@ class WC_AJAX {
 			die();
 		}
 
-		$_product    = wc_get_product( $post->ID );
-		$order       = wc_get_order( $order_id );
-		$order_taxes = $order->get_taxes();
-		$class       = 'new_row';
+		$_product = wc_get_product( $post->ID );
 
-		// Set values
-		$item = array();
-
-		$item['product_id']        = $_product->id;
-		$item['variation_id']      = isset( $_product->variation_id ) ? $_product->variation_id : '';
-		$item['variation_data']    = $item['variation_id'] ? $_product->get_variation_attributes() : '';
-		$item['name']              = $_product->get_title();
-		$item['tax_class']         = $_product->get_tax_class();
-		$item['qty']               = 1;
-		$item['line_subtotal']     = wc_format_decimal( $_product->get_price_excluding_tax() );
-		$item['line_subtotal_tax'] = '';
-		$item['line_total']        = wc_format_decimal( $_product->get_price_excluding_tax() );
-		$item['line_tax']          = '';
-		$item['type']              = 'line_item';
-
-		// Add line item
-		$item_id = wc_add_order_item( $order_id, array(
-			'order_item_name' 		=> $item['name'],
-			'order_item_type' 		=> 'line_item'
-		) );
-
-		// Add line item meta
-		if ( $item_id ) {
-			wc_add_order_item_meta( $item_id, '_qty', $item['qty'] );
-			wc_add_order_item_meta( $item_id, '_tax_class', $item['tax_class'] );
-			wc_add_order_item_meta( $item_id, '_product_id', $item['product_id'] );
-			wc_add_order_item_meta( $item_id, '_variation_id', $item['variation_id'] );
-			wc_add_order_item_meta( $item_id, '_line_subtotal', $item['line_subtotal'] );
-			wc_add_order_item_meta( $item_id, '_line_subtotal_tax', $item['line_subtotal_tax'] );
-			wc_add_order_item_meta( $item_id, '_line_total', $item['line_total'] );
-			wc_add_order_item_meta( $item_id, '_line_tax', $item['line_tax'] );
-
-			// Since 2.2
-			wc_add_order_item_meta( $item_id, '_line_tax_data', array( 'total' => array(), 'subtotal' => array() ) );
-
-			// Store variation data in meta
-			if ( $item['variation_data'] && is_array( $item['variation_data'] ) ) {
-				foreach ( $item['variation_data'] as $key => $value ) {
-					wc_add_order_item_meta( $item_id, str_replace( 'attribute_', '', $key ), $value );
-				}
+		if ( $_product->is_type( 'variable' ) && ! empty( $data[ 'add_order_item_variation' ] ) ) {
+			$variation_to_add = absint( $data[ 'add_order_item_variation' ] );
+			$variation        = $_product->get_child( $variation_to_add );
+			if ( $variation ) {
+				$_product = $variation;
 			}
-
-			do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item );
 		}
 
-		$item['item_meta']       = $order->get_item_meta( $item_id );
-		$item['item_meta_array'] = $order->get_item_meta_array( $item_id );
-		$item                    = $order->expand_item_meta( $item );
-		$item                    = apply_filters( 'woocommerce_ajax_order_item', $item, $item_id );
+		$order    = wc_get_order( $order_id );
+		$messages = apply_filters( 'woocommerce_ajax_add_order_item_validation_messages', array(), $_product, $order, $item_to_add, $data );
 
-		include( 'admin/meta-boxes/views/html-order-item.php' );
+		if ( empty( $messages ) ) {
 
-		// Quit out
-		die();
+			$order_taxes = $order->get_taxes();
+			$class       = 'new_row';
+
+			// Set values
+			$item = array();
+
+			$item['product_id']        = $_product->id;
+			$item['variation_id']      = isset( $_product->variation_id ) ? $_product->variation_id : '';
+			$item['variation_data']    = $item['variation_id'] ? $_product->get_variation_attributes() : '';
+			$item['name']              = $_product->get_title();
+			$item['tax_class']         = $_product->get_tax_class();
+			$item['qty']               = 1;
+			$item['line_subtotal']     = wc_format_decimal( $_product->get_price_excluding_tax() );
+			$item['line_subtotal_tax'] = '';
+			$item['line_total']        = wc_format_decimal( $_product->get_price_excluding_tax() );
+			$item['line_tax']          = '';
+			$item['type']              = 'line_item';
+
+			// Add line item
+			$item_id = wc_add_order_item( $order_id, array(
+				'order_item_name' => $item['name'],
+				'order_item_type' => 'line_item'
+			) );
+
+			// Add line item meta
+			if ( $item_id ) {
+				wc_add_order_item_meta( $item_id, '_qty', $item['qty'] );
+				wc_add_order_item_meta( $item_id, '_tax_class', $item['tax_class'] );
+				wc_add_order_item_meta( $item_id, '_product_id', $item['product_id'] );
+				wc_add_order_item_meta( $item_id, '_variation_id', $item['variation_id'] );
+				wc_add_order_item_meta( $item_id, '_line_subtotal', $item['line_subtotal'] );
+				wc_add_order_item_meta( $item_id, '_line_subtotal_tax', $item['line_subtotal_tax'] );
+				wc_add_order_item_meta( $item_id, '_line_total', $item['line_total'] );
+				wc_add_order_item_meta( $item_id, '_line_tax', $item['line_tax'] );
+
+				// Since 2.2
+				wc_add_order_item_meta( $item_id, '_line_tax_data', array( 'total' => array(), 'subtotal' => array() ) );
+
+				// Store variation data in meta
+				if ( $item['variation_data'] && is_array( $item['variation_data'] ) ) {
+					foreach ( $item['variation_data'] as $key => $value ) {
+						wc_add_order_item_meta( $item_id, str_replace( 'attribute_', '', $key ), $value );
+					}
+				}
+
+				do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item, $order, $data );
+			}
+
+			$item['item_meta']       = $order->get_item_meta( $item_id );
+			$item['item_meta_array'] = $order->get_item_meta_array( $item_id );
+			$item                    = $order->expand_item_meta( $item );
+			$item                    = apply_filters( 'woocommerce_ajax_order_item', $item, $item_id, $order, $data );
+
+			ob_start();
+			include( 'admin/meta-boxes/views/html-order-item.php' );
+			$order_item_html = ob_get_clean();
+		}
+
+		$data = array(
+			'result'   => empty( $messages ) ? 'success' : 'failure',
+			'html'     => empty( $messages ) ? $order_item_html : '',
+			'messages' => $messages,
+		);
+
+		wp_send_json( $data );
 	}
 
 	/**

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1270,19 +1270,17 @@ class WC_AJAX {
 				do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item, $order, $data );
 			}
 
-			$item['item_meta']       = $order->get_item_meta( $item_id );
-			$item['item_meta_array'] = $order->get_item_meta_array( $item_id );
-			$item                    = $order->expand_item_meta( $item );
-			$item                    = apply_filters( 'woocommerce_ajax_order_item', $item, $item_id, $order, $data );
+			$order    = wc_get_order( $order_id );
+			$data     = get_post_meta( $order_id );
 
 			ob_start();
-			include( 'admin/meta-boxes/views/html-order-item.php' );
-			$order_item_html = ob_get_clean();
+			include( 'admin/meta-boxes/views/html-order-items.php' );
+			$order_items_html = ob_get_clean();
 		}
 
 		$data = array(
 			'result'   => empty( $messages ) ? 'success' : 'failure',
-			'html'     => empty( $messages ) ? $order_item_html : '',
+			'html'     => empty( $messages ) ? $order_items_html : '',
 			'messages' => $messages,
 		);
 


### PR DESCRIPTION
From https://trello.com/c/UlW3M1Ha/69-configurable-product-fileds-in-orders-backend - 

**Problem Description**

Currently, the core doesn't provide an infrastructure for configuring products when adding a product manually into an order. All we can do is add a single line item - no form/fields can be added to trigger extension-specific actions such as adding custom order meta or adding extra line items / fees linked to the initially-added product. I've seen some shop managers going around this issue/limitation by creating an order in the front end, and then assigning the right customer to it.

This affects the core and many extensions -- variable products, composites, add-ons, bundles, and even bookings and subscriptions to name a few.

Possible applications:
- Select Add-ons when manually adding a product to an order ( see working example at https://github.com/woothemes/woocommerce-product-addons/commit/80f46c4d1255643212ad51db6997d537638ddef4 )
- When adding a Bundle/Composite, choose product contents/options and then add all necessary line-items to the order along with the necessary order-meta relationships.
- Show bookings fields and create the corresponding booking when manually adding a booking product to an order.
- ...

**Proposed WC release target**

WC 2.6

**Notes on the Implementation**

The submitted code includes a new ajax handler, `get_order_items_fields`, which is used to return optional order item fields for the selected products. Plugins/extensions may hook into the `woocommerce_ajax_get_order_item_fields` filter to add their own product fields into the `$item_fields` array of each product.

The `backbone.add_items` function in `meta-boxes-order` script has been modified to submit a `get_order_items_fields` request when attempting to add a set of products to the order. On receiving the field contents, `configure_items` is used to display a new modal that contains the returned product fields, based on a new `tmpl-wc-modal-configure-product-fields` template in `html-order-items.php`. 

`configure_items` works with one product at a time: 
- If a product has fields to configure, the new modal pops up to collect user input, which is submitted using a `woocommerce_add_order_item` request on hitting the **Done** button.
- If a product has no fields to configure, `add_configured_item` is called to actually add the product to the order by sending a `woocommerce_add_order_item` request.

In both cases, the submitted data is validated (ref: `woocommerce_ajax_add_order_item_validation_messages` filter in the `add_order_item()` ajax handler) and the response determines whether `configure_items` will be called to add the remaining products in the order.

**Example**

http://cl.ly/1r0o3v1J3U0Y

**Notes**
1. Every time a product is added to the order, the `add_order_item` handler re-submits the entire order contents and the entire table is refreshed. The reason for this change is that extensions/plugins may add multiple line items in response to a request to add a single line item, possibly by hooking into the `woocommerce_ajax_add_order_item_meta` action.
2. I have tried to make minimal changes to the existing `meta-boxes-order` script, which might benefit from a code review.
3. In the submitted code, when a variable product is chosen, the user can optionally search for a variation. This could be replaced by prompting the user to select variation attributes, and then resolve those to the corresponding variation product.
4. `grunt css` before testing.
