### PR TITLE
Fix checkout result notice

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -643,7 +643,7 @@ class WC_Checkout {
 					$result = $available_gateways[ $this->posted['payment_method'] ]->process_payment( $order_id );
 
 					// Redirect to success/confirmation/payment page
-					if ( 'success' === $result['result'] ) {
+					if ( isset( $result['result'] ) && 'success' === $result['result'] ) {
 
 						$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
 


### PR DESCRIPTION
If a payment gateway doesn't always return an array with a result element, you'll see an undefined index notice: `PHP Notice:  Undefined index: result in /woocommerce/includes/class-wc-checkout.php on line 646`. I never saw this in 2.4 or earlier, so it may have been introduced in the strict check changes [here](https://github.com/woothemes/woocommerce/commit/ef98a2d79cdb317b29b77843d7773ff8e38845a5#diff-1144db956b12f18d5935fdc3989109b3).

At any rate, this commit prevents that notice and is preferable over forcing gateways to always return a specific array because there's no specific handling for a non-`success` result and the abstract `process_payment()` method already [returns a blank array by default](https://github.com/woothemes/woocommerce/blob/2.5.0-beta-2/includes/abstracts/abstract-wc-payment-gateway.php#L228).
