### PR TITLE
Load page-templates/$slug.php when attempting to find templates

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -153,9 +153,9 @@ function wc_get_template_part( $slug, $name = '' ) {
 		$template = WC()->plugin_path() . "/templates/{$slug}-{$name}.php";
 	}
 
-	// If template file doesn't exist, look in yourtheme/slug.php and yourtheme/woocommerce/slug.php
+	// If template file doesn't exist, look in yourtheme/slug.php, yourtheme/woocommerce/slug.php, and template-parts/slug.php
 	if ( ! $template && ! WC_TEMPLATE_DEBUG_MODE ) {
-		$template = locate_template( array( "{$slug}.php", WC()->template_path() . "{$slug}.php" ) );
+		$template = locate_template( array( "{$slug}.php", WC()->template_path() . "{$slug}.php", "template-parts/{$slug}.php" ) );
 	}
 
 	// Allow 3rd party plugin filter template file from their plugin.


### PR DESCRIPTION
`wc_get_template_part` attempts to find the correct template based on a few different locations. An example usage of this is WC Photography which tries to look for `content-photography.php` in a few diffent locations and eventually falls back to `content.php`. WC looks for `content.php` in the main theme folder and a woocommerce folder. Twenty Sixteen (and any child themes or themes that are forked from it) are storing content.php in a `page-templates` folder. We should add that path to the array so we can load the correct template..otherwise any plugin trying to load a fallback file (like photography) will fail to find a suitable template.
