### PR TITLE
fix redirect loop problem if cart page and checkout page have the same url

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -27,7 +27,7 @@ function wc_template_redirect() {
 	}
 
 	// When on the checkout with an empty cart, redirect to cart page
-	elseif ( is_page( wc_get_page_id( 'checkout' ) ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) ) {
+	elseif ( is_page( wc_get_page_id( 'checkout' ) ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] )  && wc_get_page_permalink('cart') !== wc_get_page_permalink('checkout') ) {
 		wp_redirect( wc_get_page_permalink( 'cart' ) );
 		exit;
 	}


### PR DESCRIPTION
Hello

In one project for my client i had a trouble with pasting checkout shortcode to cart page and accordingly change checkout page option to cart page in woocommerce admin option. If checkout page and cart page have the same url like - /cart then if cart is empty i have a infinite redirect loop. 

I find only this way to fix this situation.  

Thanks! 
