### PR TITLE
Update abstract-wc-order.php

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -684,13 +684,16 @@ abstract class WC_Abstract_Order {
 
 		// Now calculate shipping tax
 		$matched_tax_rates = array();
-		$tax_rates         = WC_Tax::find_rates( array(
-			'country'   => $country,
-			'state'     => $state,
-			'postcode'  => $postcode,
-			'city'      => $city,
-			'tax_class' => ''
-		) );
+		$shipping_methods = $this->get_shipping_methods();
+		if ( ! empty( $shipping_methods ) ) {
+			$tax_rates         = WC_Tax::find_rates( array(
+				'country'   => $country,
+				'state'     => $state,
+				'postcode'  => $postcode,
+				'city'      => $city,
+				'tax_class' => ''
+			) );
+		}
 
 		if ( ! empty( $tax_rates ) ) {
 			foreach ( $tax_rates as $key => $rate ) {

--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -466,8 +466,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 					foreach ( $data[ $line ] as $item ) {
 
-						$new_item_id = $this->$set_item( $order, $item, 'create' );
-						do_action( 'woocommerce_api_create_order_item', $item, $new_item_id, $this, $data );
+						$this->$set_item( $order, $item, 'create' );
 					}
 				}
 			}
@@ -805,9 +804,6 @@ class WC_API_Orders extends WC_API_Resource {
 				update_user_meta( $order->get_user_id(), 'shipping_' . $key, $value );
 			}
 		}
-		
-		do_action( 'woocommerce_api_set_order_addresses', $order, $data, $address_fields );
-		
 	}
 
 	/**
@@ -884,9 +880,7 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 		}
 
-		$item_id = $this->$set_method( $order, $item, $action );
-		
-		return $item_id;
+		$this->$set_method( $order, $item, $action );
 	}
 
 	/**
@@ -978,8 +972,6 @@ class WC_API_Orders extends WC_API_Resource {
 		if ( isset( $item['subtotal_tax'] ) ) {
 			$item_args['totals']['subtotal_tax'] = floatval( $item['subtotal_tax'] );
 		}
-		
-		$item_args = apply_filters( 'woocommerce_api_set_line_item', $item_args, $order, $item, $action );
 
 		if ( $creating ) {
 
@@ -997,9 +989,6 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_line_item', __( 'Cannot update line item, try again', 'woocommerce' ), 500 );
 			}
 		}
-		
-		return $item_id;
-		
 	}
 
 	/**
@@ -1106,8 +1095,6 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again', 'woocommerce' ), 500 );
 			}
 		}
-		
-		return $shipping_id;
 	}
 
 	/**
@@ -1189,8 +1176,6 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again', 'woocommerce' ), 500 );
 			}
 		}
-		
-		return $fee_id;
 	}
 
 	/**
@@ -1240,8 +1225,6 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again', 'woocommerce' ), 500 );
 			}
 		}
-		
-		return $coupon_id;
 	}
 
 	/**

--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -466,7 +466,8 @@ class WC_API_Orders extends WC_API_Resource {
 
 					foreach ( $data[ $line ] as $item ) {
 
-						$this->$set_item( $order, $item, 'create' );
+						$new_item_id = $this->$set_item( $order, $item, 'create' );
+						do_action( 'woocommerce_api_create_order_item', $item, $new_item_id, $this, $data );
 					}
 				}
 			}
@@ -804,6 +805,9 @@ class WC_API_Orders extends WC_API_Resource {
 				update_user_meta( $order->get_user_id(), 'shipping_' . $key, $value );
 			}
 		}
+		
+		do_action( 'woocommerce_api_set_order_addresses', $order, $data, $address_fields );
+		
 	}
 
 	/**
@@ -880,7 +884,9 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 		}
 
-		$this->$set_method( $order, $item, $action );
+		$item_id = $this->$set_method( $order, $item, $action );
+		
+		return $item_id;
 	}
 
 	/**
@@ -972,6 +978,8 @@ class WC_API_Orders extends WC_API_Resource {
 		if ( isset( $item['subtotal_tax'] ) ) {
 			$item_args['totals']['subtotal_tax'] = floatval( $item['subtotal_tax'] );
 		}
+		
+		$item_args = apply_filters( 'woocommerce_api_set_line_item', $item_args, $order, $item, $action );
 
 		if ( $creating ) {
 
@@ -989,6 +997,9 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_line_item', __( 'Cannot update line item, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $item_id;
+		
 	}
 
 	/**
@@ -1095,6 +1106,8 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $shipping_id;
 	}
 
 	/**
@@ -1176,6 +1189,8 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $fee_id;
 	}
 
 	/**
@@ -1225,6 +1240,8 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $coupon_id;
 	}
 
 	/**


### PR DESCRIPTION
If the order has no shipping line, an unnecessary shipping tax line is generated using Orders API.

If the order has no shipping line, there should not be generated this unnecessary shipping tax line with 0 value. It happens if different tax class is set for shipping than the tax class of the actual product line items of the order, and the order has not got any shipping line.
The aim of this fix is to have the same tax calculation behavior if an order is created using the GUI (front end or back end), and the API.

![wc_shipping_tax_api_problem](https://cloud.githubusercontent.com/assets/16391244/11964518/9809a51c-a8ee-11e5-9587-45e024498f93.png)

This new condition prevents to create the unnecessary tax line if there are no shipping methods of the order:

```
// Now calculate shipping tax
$matched_tax_rates = array();
$shipping_methods = $this->get_shipping_methods();
if ( ! empty( $shipping_methods ) ) {
    ......
}
```

It is similar to the existing solution in calc_line_taxes() in WC_AJAX class (this similarity ensures the similar tax calculation of API and GUI):

```
// Get shipping taxes
if ( isset( $items['shipping_method_id'] ) ) {
    .....
}
```
