### PR TITLE
Added a filter for disabling automatic redirect to the setup wizard

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -100,7 +100,7 @@ class WC_Admin {
 
 		delete_transient( '_wc_activation_redirect' );
 
-		if ( ( ! empty( $_GET['page'] ) && in_array( $_GET['page'], array( 'wc-setup' ) ) ) || is_network_admin() || isset( $_GET['activate-multi'] ) || ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ( ! empty( $_GET['page'] ) && in_array( $_GET['page'], array( 'wc-setup' ) ) ) || is_network_admin() || isset( $_GET['activate-multi'] ) || ! current_user_can( 'manage_woocommerce' ) || apply_filters( 'woocommerce_prevent_automatic_wizard_redirect', false ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Added a filter for disabling automatic redirect to the setup wizard, after plugin activation.

This would enable theme authors to have a better flow for setting up the theme, where the WooCommerce setup comes at the end.

The `woocommerce_enable_setup_wizard` filter is too strong and also disables the setup wizard itself. with this code, we can only disable the forced redirect after the plugin activation, but the users can still use the nice setup wizard, by clicking on the button in the notice...

Take care.
