### PR TITLE
Add autocomplete support to fields in checkout process

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -490,55 +490,64 @@ class WC_Countries {
 	public function get_default_address_fields() {
 		$fields = array(
 			'first_name' => array(
-				'label'    => __( 'First Name', 'woocommerce' ),
-				'required' => true,
-				'class'    => array( 'form-row-first' ),
+				'label'        => __( 'First Name', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-first' ),
+				'autocomplete' => 'given-name',
 			),
 			'last_name' => array(
-				'label'    => __( 'Last Name', 'woocommerce' ),
-				'required' => true,
-				'class'    => array( 'form-row-last' ),
-				'clear'    => true
+				'label'        => __( 'Last Name', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-last' ),
+				'clear'        => true,
+				'autocomplete' => 'family-name',
 			),
 			'company' => array(
-				'label' => __( 'Company Name', 'woocommerce' ),
-				'class' => array( 'form-row-wide' ),
+				'label'        => __( 'Company Name', 'woocommerce' ),
+				'class'        => array( 'form-row-wide' ),
+				'autocomplete' => 'organization',
 			),
 			'country' => array(
-				'type'     => 'country',
-				'label'    => __( 'Country', 'woocommerce' ),
-				'required' => true,
-				'class'    => array( 'form-row-wide', 'address-field', 'update_totals_on_change' ),
+				'type'         => 'country',
+				'label'        => __( 'Country', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-wide', 'address-field', 'update_totals_on_change' ),
+				'autocomplete' => 'country',
 			),
 			'address_1' => array(
-				'label'       => __( 'Address', 'woocommerce' ),
-				'placeholder' => _x( 'Street address', 'placeholder', 'woocommerce' ),
-				'required'    => true,
-				'class'       => array( 'form-row-wide', 'address-field' )
+				'label'        => __( 'Address', 'woocommerce' ),
+				'placeholder'  => _x( 'Street address', 'placeholder', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-wide', 'address-field' ),
+				'autocomplete' => 'address-line1',
 			),
 			'address_2' => array(
-				'placeholder' => _x( 'Apartment, suite, unit etc. (optional)', 'placeholder', 'woocommerce' ),
-				'class'       => array( 'form-row-wide', 'address-field' ),
-				'required'    => false
+				'placeholder'  => _x( 'Apartment, suite, unit etc. (optional)', 'placeholder', 'woocommerce' ),
+				'class'        => array( 'form-row-wide', 'address-field' ),
+				'required'     => false,
+				'autocomplete' => 'address-line2',
 			),
 			'city' => array(
-				'label'       => __( 'Town / City', 'woocommerce' ),
-				'required'    => true,
-				'class'       => array( 'form-row-wide', 'address-field' )
+				'label'        => __( 'Town / City', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-wide', 'address-field' ),
+				'autocomplete' => 'address-level2',
 			),
 			'state' => array(
-				'type'        => 'state',
-				'label'       => __( 'State / County', 'woocommerce' ),
-				'required'    => true,
-				'class'       => array( 'form-row-first', 'address-field' ),
-				'validate'    => array( 'state' )
+				'type'         => 'state',
+				'label'        => __( 'State / County', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-first', 'address-field' ),
+				'validate'     => array( 'state' ),
+				'autocomplete' => 'address-level1',
 			),
 			'postcode' => array(
-				'label'       => __( 'Postcode / ZIP', 'woocommerce' ),
-				'required'    => true,
-				'class'       => array( 'form-row-last', 'address-field' ),
-				'clear'       => true,
-				'validate'    => array( 'postcode' )
+				'label'        => __( 'Postcode / ZIP', 'woocommerce' ),
+				'required'     => true,
+				'class'        => array( 'form-row-last', 'address-field' ),
+				'clear'        => true,
+				'validate'     => array( 'postcode' ),
+				'autocomplete' => 'postal-code',
 			),
 		);
 
@@ -939,19 +948,21 @@ class WC_Countries {
 			// Add email and phone after company or last
 			if ( $type == 'billing_' && ( 'company' === $key || ( ! array_key_exists( 'company', $fields ) && $key === end( $keys ) ) ) ) {
 				$address_fields['billing_email'] = array(
-					'label'		=> __( 'Email Address', 'woocommerce' ),
-					'required'	=> true,
-					'type'		=> 'email',
-					'class'		=> array( 'form-row-first' ),
-					'validate'	=> array( 'email' ),
+					'label'        => __( 'Email Address', 'woocommerce' ),
+					'required'     => true,
+					'type'         => 'email',
+					'class'        => array( 'form-row-first' ),
+					'validate'     => array( 'email' ),
+					'autocomplete' => 'email',
 				);
 				$address_fields['billing_phone'] = array(
-					'label'    	=> __( 'Phone', 'woocommerce' ),
-					'required' 	=> true,
-					'type'		=> 'tel',
-					'class'    	=> array( 'form-row-last' ),
-					'clear'    	=> true,
-					'validate' 	=> array( 'phone' ),
+					'label'        => __( 'Phone', 'woocommerce' ),
+					'required'     => true,
+					'type'         => 'tel',
+					'class'        => array( 'form-row-last' ),
+					'clear'        => true,
+					'validate'     => array( 'phone' ),
+					'autocomplete' => 'tel',
 				);
 			}
 		}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1694,6 +1694,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			'placeholder'       => '',
 			'maxlength'         => false,
 			'required'          => false,
+			'autocomplete'      => false,
 			'id'                => $key,
 			'class'             => array(),
 			'label_class'       => array(),
@@ -1716,6 +1717,8 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		}
 
 		$args['maxlength'] = ( $args['maxlength'] ) ? 'maxlength="' . absint( $args['maxlength'] ) . '"' : '';
+
+		$args['autocomplete'] = ( $args['autocomplete'] ) ? 'autocomplete="' . esc_attr( $args['autocomplete'] ) . '"' : '';
 
 		if ( is_string( $args['label_class'] ) ) {
 			$args['label_class'] = array( $args['label_class'] );
@@ -1757,7 +1760,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				} else {
 
-					$field = '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="country_to_state country_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" ' . implode( ' ', $custom_attributes ) . '>'
+					$field = '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" ' . $args['autocomplete'] . ' class="country_to_state country_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" ' . implode( ' ', $custom_attributes ) . '>'
 							. '<option value="">'.__( 'Select a country&hellip;', 'woocommerce' ) .'</option>';
 
 					foreach ( $countries as $ckey => $cvalue ) {
@@ -1786,7 +1789,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				} elseif ( is_array( $states ) ) {
 
-					$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="state_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" ' . implode( ' ', $custom_attributes ) . ' data-placeholder="' . esc_attr( $args['placeholder'] ) . '">
+					$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="state_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" ' . implode( ' ', $custom_attributes ) . ' data-placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['autocomplete'] . '>
 						<option value="">'.__( 'Select a state&hellip;', 'woocommerce' ) .'</option>';
 
 					foreach ( $states as $ckey => $cvalue ) {
@@ -1797,14 +1800,14 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				} else {
 
-					$field .= '<input type="text" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" value="' . esc_attr( $value ) . '"  placeholder="' . esc_attr( $args['placeholder'] ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+					$field .= '<input type="text" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" value="' . esc_attr( $value ) . '"  placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['autocomplete'] . ' name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 
 				}
 
 				break;
 			case 'textarea' :
 
-				$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['maxlength'] . ' ' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>';
+				$field .= '<textarea name="' . esc_attr( $key ) . '" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['maxlength'] . ' ' . $args['autocomplete'] . ' ' . ( empty( $args['custom_attributes']['rows'] ) ? ' rows="2"' : '' ) . ( empty( $args['custom_attributes']['cols'] ) ? ' cols="5"' : '' ) . implode( ' ', $custom_attributes ) . '>'. esc_textarea( $value  ) .'</textarea>';
 
 				break;
 			case 'checkbox' :
@@ -1820,7 +1823,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			case 'tel' :
 			case 'number' :
 
-				$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['maxlength'] . ' value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+				$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) .'" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['maxlength'] . ' ' . $args['autocomplete'] . ' value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 
 				break;
 			case 'select' :
@@ -1839,7 +1842,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 						$options .= '<option value="' . esc_attr( $option_key ) . '" '. selected( $value, $option_key, false ) . '>' . esc_attr( $option_text ) .'</option>';
 					}
 
-					$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="select '. esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . ' data-placeholder="' . esc_attr( $args['placeholder'] ) . '">
+					$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="select '. esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . ' data-placeholder="' . esc_attr( $args['placeholder'] ) . '" ' . $args['autocomplete'] . '>
 							' . $options . '
 						</select>';
 				}


### PR DESCRIPTION
This pull request adds first class support for the [`autocomplete` attribute](https://html.spec.whatwg.org/multipage/forms.html#autofill) to fields using the `woocommerce_form_field` function. This allows the browsers to automatically fill in a large number of fields, significantly decreasing the amount of time it takes for users to complete the checkout process.

The following fields in the checkout process have been given autocomplete attributes:
- First name
- Last name
- Company name
- County
- Address line 1 (Street name)
- Address line 2 (Apartment, suite, unit etc.)
- City
- State / Country
- Postcode / ZIP
- Email address
- Phone number

For more information on why it is important to support autocomplete see: [Help users checkout faster with Autofill](https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill).
For a complete overview of the `autocomplete` attribute see the [WHATWGHTML specification](https://html.spec.whatwg.org/multipage/forms.html#autofill).
