### PR TITLE
Multiple notices  broke my local woocommerce setup after an update.

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -962,6 +962,7 @@ class WC_Countries {
 			$address_fields[ $type . $key ] = $value;
 
 			// Add email and phone after company or last
+			$keys = array_keys( $fields );
 			if ( $type == 'billing_' && ( 'company' === $key || ( ! array_key_exists( 'company', $fields ) && $key === end( $keys ) ) ) ) {
 				$address_fields['billing_email'] = array(
 					'label'		=> __( 'Email Address', 'woocommerce' ),


### PR DESCRIPTION
I found this issue after I recently updated woocommerce. I was getting the following error :

Strict Standards: Only variables should be passed by reference in /Sites/staging/wp-content/plugins/woocommerce/includes/class-wc-countries.php on line 966

I have changed the code a little bit to prevent this particular notice.
