### PR TITLE
Empty fee tax_class problem in WC_API_Orders

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -1127,7 +1127,7 @@ class WC_API_Orders extends WC_API_Resource {
 			// if taxable, tax class and total are required
 			if ( isset( $fee['taxable'] ) && $fee['taxable'] ) {
 
-				if ( ! isset( $fee['tax_class'] ) ) {
+				if ( !array_key_exists('tax_class', $fee) ) {
 					throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee tax class is required when fee is taxable', 'woocommerce' ), 400 );
 				}
 


### PR DESCRIPTION
If tax_class is empty (this is the default value of tax_class), 'Fee tax class is required when fee is taxable' exception is thrown by Orders API.

In `set_fee` function 'Fee tax class is required when fee is taxable' exception is thrown if `$fee['tax_class']` is not set, e.g. it has an empty (null or '') value:
`if ( ! isset( $fee['tax_class'] ) )` //this is the original condition

The problem is that empty value (null or '') is the default tax class, so it is valid. Because of this condition we can get an unnecessary error. This problem can be fixes if the API would check that tax_class key exists in $fee array, but does not evaluate if the value is empty or not:
`if ( !array_key_exists('tax_class', $fee) )`
