### PR TITLE
Api orders and abstract order hooks

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -721,6 +721,8 @@ abstract class WC_Abstract_Order {
 		foreach ( array_keys( $taxes + $shipping_taxes ) as $tax_rate_id ) {
 			$this->add_tax( $tax_rate_id, isset( $taxes[ $tax_rate_id ] ) ? $taxes[ $tax_rate_id ] : 0, isset( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] : 0 );
 		}
+		
+		do_action( 'woocommerce_order_calculate_taxes', $this ); 
 
 		return true;
 	}
@@ -822,7 +824,7 @@ abstract class WC_Abstract_Order {
 		// line items
 		foreach ( $this->get_items() as $item ) {
 			$cart_subtotal     += wc_format_decimal( isset( $item['line_subtotal'] ) ? $item['line_subtotal'] : 0 );
-			$cart_total        += wc_format_decimal( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
+	 	 			$cart_total        += wc_format_decimal( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
 			$cart_subtotal_tax += wc_format_decimal( isset( $item['line_subtotal_tax'] ) ? $item['line_subtotal_tax'] : 0 );
 			$cart_total_tax    += wc_format_decimal( isset( $item['line_tax'] ) ? $item['line_tax'] : 0 );
 		}
@@ -839,6 +841,8 @@ abstract class WC_Abstract_Order {
 		$grand_total = round( $cart_total + $fee_total + $this->get_total_shipping() + $this->get_cart_tax() + $this->get_shipping_tax(), wc_get_price_decimals() );
 
 		$this->set_total( $grand_total, 'total' );
+		
+		apply_filters( 'woocommerce_order_calculate_totals', $grand_total, $this, $and_taxes );
 
 		return $grand_total;
 	}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -824,7 +824,7 @@ abstract class WC_Abstract_Order {
 		// line items
 		foreach ( $this->get_items() as $item ) {
 			$cart_subtotal     += wc_format_decimal( isset( $item['line_subtotal'] ) ? $item['line_subtotal'] : 0 );
-	 	 			$cart_total        += wc_format_decimal( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
+	 	 	$cart_total        += wc_format_decimal( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
 			$cart_subtotal_tax += wc_format_decimal( isset( $item['line_subtotal_tax'] ) ? $item['line_subtotal_tax'] : 0 );
 			$cart_total_tax    += wc_format_decimal( isset( $item['line_tax'] ) ? $item['line_tax'] : 0 );
 		}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -824,7 +824,7 @@ abstract class WC_Abstract_Order {
 		// line items
 		foreach ( $this->get_items() as $item ) {
 			$cart_subtotal     += wc_format_decimal( isset( $item['line_subtotal'] ) ? $item['line_subtotal'] : 0 );
-	 	 	$cart_total        += wc_format_decimal( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
+			$cart_total        += wc_format_decimal( isset( $item['line_total'] ) ? $item['line_total'] : 0 );
 			$cart_subtotal_tax += wc_format_decimal( isset( $item['line_subtotal_tax'] ) ? $item['line_subtotal_tax'] : 0 );
 			$cart_total_tax    += wc_format_decimal( isset( $item['line_tax'] ) ? $item['line_tax'] : 0 );
 		}

--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -466,7 +466,8 @@ class WC_API_Orders extends WC_API_Resource {
 
 					foreach ( $data[ $line ] as $item ) {
 
-						$this->$set_item( $order, $item, 'create' );
+						$item_id = $this->$set_item( $order, $item, 'create' );
+						do_action( 'woocommerce_api_create_order_item', $item, $item_id, $this, $data ); 
 					}
 				}
 			}
@@ -804,6 +805,9 @@ class WC_API_Orders extends WC_API_Resource {
 				update_user_meta( $order->get_user_id(), 'shipping_' . $key, $value );
 			}
 		}
+		
+		do_action( 'woocommerce_api_set_order_addresses', $order, $data, $address_fields );
+		
 	}
 
 	/**
@@ -880,7 +884,9 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 		}
 
-		$this->$set_method( $order, $item, $action );
+		$item_id = $this->$set_method( $order, $item, $action );
+		
+		return $item_id;
 	}
 
 	/**
@@ -939,7 +945,7 @@ class WC_API_Orders extends WC_API_Resource {
 		}
 
 		// quantity must be positive float
-		if ( isset( $item['quantity'] ) && floatval( $item['quantity'] ) <= 0 ) {
+		if ( isset( $item['quantity'] ) && floatval( $item['quantity'] ) <= 0 && apply_filters( 'woocommerce_api_is_check_positive_float_amount' , true, 'line_item', $order, $action ) ) {
 			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity must be a positive float', 'woocommerce' ), 400 );
 		}
 
@@ -972,6 +978,8 @@ class WC_API_Orders extends WC_API_Resource {
 		if ( isset( $item['subtotal_tax'] ) ) {
 			$item_args['totals']['subtotal_tax'] = floatval( $item['subtotal_tax'] );
 		}
+		
+		$item_args = apply_filters( 'woocommerce_api_set_line_item', $item_args, $order, $item, $action ); 
 
 		if ( $creating ) {
 
@@ -989,6 +997,8 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_line_item', __( 'Cannot update line item, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $item_id;
 	}
 
 	/**
@@ -1054,7 +1064,7 @@ class WC_API_Orders extends WC_API_Resource {
 	protected function set_shipping( $order, $shipping, $action ) {
 
 		// total must be a positive float
-		if ( isset( $shipping['total'] ) && floatval( $shipping['total'] ) < 0 ) {
+		if ( isset( $shipping['total'] ) && floatval( $shipping['total'] ) < 0 && apply_filters( 'woocommerce_api_is_check_positive_float_amount' , true, 'shipping', $order, $action ) ) {
 			throw new WC_API_Exception( 'woocommerce_invalid_shipping_total', __( 'Shipping total must be a positive amount', 'woocommerce' ), 400 );
 		}
 
@@ -1095,6 +1105,9 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $shipping_id;
+		
 	}
 
 	/**
@@ -1176,6 +1189,8 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $fee_id;
 	}
 
 	/**
@@ -1190,7 +1205,7 @@ class WC_API_Orders extends WC_API_Resource {
 	protected function set_coupon( $order, $coupon, $action ) {
 
 		// coupon amount must be positive float
-		if ( isset( $coupon['amount'] ) && floatval( $coupon['amount'] ) < 0 ) {
+		if ( isset( $coupon['amount'] ) && floatval( $coupon['amount'] ) < 0 && apply_filters( 'woocommerce_api_is_check_positive_float_amount' , true, 'coupon', $order, $action ) ) {
 			throw new WC_API_Exception( 'woocommerce_invalid_coupon_total', __( 'Coupon discount total must be a positive amount', 'woocommerce' ), 400 );
 		}
 
@@ -1225,6 +1240,9 @@ class WC_API_Orders extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again', 'woocommerce' ), 500 );
 			}
 		}
+		
+		return $coupon_id;
+		
 	}
 
 	/**

--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -276,6 +276,7 @@ class WC_API_Orders extends WC_API_Resource {
 				'method_id'    => $shipping_item['method_id'],
 				'method_title' => $shipping_item['name'],
 				'total'        => wc_format_decimal( $shipping_item['cost'], $dp ),
+				'taxes'        => $shipping_item['taxes'],
 			);
 		}
 


### PR DESCRIPTION
In order to use order API to create custom orders, some new hooks are needed for us. Get shipping taxes using get_order function of the API would also be great.

New hooks in WC_API_Orders:
- `woocommerce_api_create_order_item` - do custom actions after set an item
- `woocommerce_api_set_order_addresses` - do custom actions after set addresses
- `woocommerce_api_set_line_item` - modify item_args before add the item
- `woocommerce_api_is_check_positive_float_amount` - (true / false) enable or disable checking if amount is a positive flow (e.g. in case of a cancel type of invoice negative amount is needed). This filter is applied for line_item, shipping and coupon. (We have tested that it is possible to handle negative amounts in other parts of WC without any problem, using some existing filters and actions. It is very important for us in some business cases).

New return values needed for the functions below. These are important to use the generated item ID-s as parameters of the new hooks:
- set_item(..) function - `return $item_id;`
- set_line_item(..) function - `return $item_id;`
- set_shipping(..) function - `return $shipping_id;`
- set_fee(..) function - `return $fee_id;`
- set_coupon(..) function - `return $coupon_id;`

Get shipping taxes:

Taxes array contains very useful data about shipping line taxes. We need to get it using get_order function of Orders API.
In get_order function, $order_data['shipping_lines'][] array is completed with taxes:
`'taxes'        => $shipping_item['taxes'],`

New hooks in WC_Abstract_Order:
Orders API calls calculate_totals() and it calls calculate_taxes function. The following hooks would also be very useful for us:
- `woocommerce_order_calculate_totals` - do custom action after calculate totals, and change return value if needed
- `woocommerce_order_calculate_taxes` - do custom action after calculate taxes

Thanks in advance.
