### PR TITLE
Add better phpdoc comments and missing param and return value

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -163,7 +163,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	}
 
 	/**
-	 * has_fields function.
+	 * Check if the gateway has fields on the checkout.
 	 *
 	 * @return bool
 	 */
@@ -190,7 +190,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	}
 
 	/**
-	 * get_icon function.
+	 * Return the gateway's icon.
 	 *
 	 * @return string
 	 */
@@ -247,6 +247,8 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * Validate frontend fields.
 	 *
 	 * Validate payment fields on the frontend.
+	 *
+	 * @return bool
 	 */
 	public function validate_fields() { return true; }
 
@@ -283,6 +285,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * Core credit card form which gateways can used if needed.
 	 *
 	 * @param  array $args
+	 * @param  array $fields
 	 */
 	public function credit_card_form( $args = array(), $fields = array() ) {
 


### PR DESCRIPTION
- Added better phpdoc comment to `has_fields` and `get_icon` since they had comments like `method function` and that isn't useful.
- Added return tag to `validate_fields` since it didn't have any but returned a bool.
- Added second param tag to `credit_card_form` since it has two parameters but only one param tag.
