### PR TITLE
Improve phpdoc comments in WC_Tax_Rate_Importer class

### DIFF
--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -17,9 +17,32 @@ if ( ! class_exists( 'WP_Importer' ) ) {
  */
 class WC_Tax_Rate_Importer extends WP_Importer {
 
+	/**
+	 * The current file id.
+	 *
+	 * @var int
+	 */
 	public $id;
+
+	/**
+	 * The current file url.
+	 *
+	 * @var string
+	 */
 	public $file_url;
+
+	/**
+	 * The current import page.
+	 *
+	 * @var string
+	 */
 	public $import_page;
+
+	/**
+	 * The current delimiter.
+	 *
+	 * @var string
+	 */
 	public $delimiter;
 
 	/**
@@ -84,7 +107,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	}
 
 	/**
-	 * format_data_from_csv function.
+	 * UTF-8 encode the data if `$enc` value isn't UTF-8.
 	 *
 	 * @param mixed $data
 	 * @param string $enc
@@ -95,7 +118,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	}
 
 	/**
-	 * import function.
+	 * Import the file if it exists and is valid.
 	 *
 	 * @param mixed $file
 	 */
@@ -186,7 +209,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	}
 
 	/**
-	 * header function.
+	 * Output header html.
 	 */
 	public function header() {
 		echo '<div class="wrap"><div class="icon32 icon32-woocommerce-importer" id="icon-woocommerce"><br></div>';
@@ -194,14 +217,14 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	}
 
 	/**
-	 * footer function.
+	 * Output footer html.
 	 */
 	public function footer() {
 		echo '</div>';
 	}
 
 	/**
-	 * greet function.
+	 * Output information about the uploading process.
 	 */
 	public function greet() {
 


### PR DESCRIPTION
- Added comments to missing properties (I hope I understand the code correctly).
- Added comments to `format_data_from_csv`, `import`, `header`, `footer` and `greet` since they had comments like `method function`.

Is `format_data_from_csv` method and `$import_page` property used somewhere? Couldn't find any use of the code in the project or in `WP_Import` class. If the code isn't used by anything, can it be removed?
