### PR TITLE
Improve docblock comments in WC_Report_Out_Of_Stock class

### DIFF
--- a/includes/admin/reports/class-wc-report-out-of-stock.php
+++ b/includes/admin/reports/class-wc-report-out-of-stock.php
@@ -27,6 +27,9 @@ class WC_Report_Out_Of_Stock extends WC_Report_Stock {
 
 	/**
 	 * Get Products matching stock criteria.
+	 *
+	 * @param int $current_page
+	 * @param int $per_page
 	 */
 	public function get_items( $current_page, $per_page ) {
 		global $wpdb;


### PR DESCRIPTION
- Added missing param tags to `get_items`
