### PR TITLE
Improve docblock comments in WC_Report_Sales_By_Date class

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -1,4 +1,9 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
 /**
  * WC_Report_Sales_By_Date
  *
@@ -9,12 +14,23 @@
  */
 class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
+	/**
+	 * Chart colours.
+	 *
+	 * @var array
+	 */
 	public $chart_colours = array();
+
+	/**
+	 * The report data.
+	 *
+	 * @var stdClass
+	 */
 	private $report_data;
 
 	/**
 	 * Get report data.
-	 * @return array
+	 * @return stdClass
 	 */
 	public function get_report_data() {
 		if ( empty( $this->report_data ) ) {


### PR DESCRIPTION
- Added comments to properties that don’t have any.
- Fixed return tag value for `get_report_data`
