### PR TITLE
Improve docblock comments in WC_Report_Stock class

### DIFF
--- a/includes/admin/reports/class-wc-report-stock.php
+++ b/includes/admin/reports/class-wc-report-stock.php
@@ -18,10 +18,15 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
  */
 class WC_Report_Stock extends WP_List_Table {
 
+	/**
+	 * Max items.
+	 *
+	 * @var int
+	 */
 	protected $max_items;
 
 	/**
-	 * __construct function.
+	 * Constructor.
 	 */
 	public function __construct() {
 
@@ -41,6 +46,8 @@ class WC_Report_Stock extends WP_List_Table {
 
 	/**
 	 * Don't need this.
+	 *
+	 * @param string $position
 	 */
 	public function display_tablenav( $position ) {
 
@@ -61,10 +68,10 @@ class WC_Report_Stock extends WP_List_Table {
 	}
 
 	/**
-	 * column_default function.
+	 * Get column value.
 	 *
 	 * @param mixed $item
-	 * @param mixed $column_name
+	 * @param string $column_name
 	 */
 	public function column_default( $item, $column_name ) {
 		global $product;
@@ -147,7 +154,9 @@ class WC_Report_Stock extends WP_List_Table {
 	}
 
 	/**
-	 * get_columns function.
+	 * Get columns.
+	 *
+	 * @return array
 	 */
 	public function get_columns() {
 
@@ -163,7 +172,7 @@ class WC_Report_Stock extends WP_List_Table {
 	}
 
 	/**
-	 * prepare_items function.
+	 * Prepare customer list items.
 	 */
 	public function prepare_items() {
 


### PR DESCRIPTION
- Added comments to properties that don’t have any.
- Added comment to `__construct`, `column_default`, `get_columns` and
  `prepare_items` since it
  was `method function`
- Added missing param tags to `display_tablenav`
