### PR TITLE
Improve docblock comments in WC_Email class

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -220,7 +220,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * handle_multipart function.
+	 * Handle multipart mail.
 	 *
 	 * @param PHPMailer $mailer
 	 * @return PHPMailer
@@ -234,7 +234,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * format_string function.
+	 * Format email string.
 	 *
 	 * @param mixed $string
 	 * @return string
@@ -244,7 +244,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_subject function.
+	 * Get email subject.
 	 *
 	 * @return string
 	 */
@@ -253,7 +253,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_heading function.
+	 * Get email heading.
 	 *
 	 * @return string
 	 */
@@ -273,7 +273,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_headers function.
+	 * Get email headers.
 	 *
 	 * @return string
 	 */
@@ -282,7 +282,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_attachments function.
+	 * Get email attachments.
 	 *
 	 * @return string|array
 	 */
@@ -300,7 +300,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_content_type function.
+	 * Get email content type.
 	 *
 	 * @return string
 	 */
@@ -368,7 +368,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_blogname function.
+	 * Get WordPress blog name.
 	 *
 	 * @return string
 	 */
@@ -377,7 +377,7 @@ class WC_Email extends WC_Settings_API {
 	}
 
 	/**
-	 * get_content function.
+	 * Get email content.
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
- Added comments to `handle_multipart`, `format_string`, `get_subject`,
  `get_heading`, `get_headers`, `get_attachments`, `get_content_type`,
  `get_blogname` and `get_content`
