### PR TITLE
Improve docblock comments in WC_Email_New_Order class

### DIFF
--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -48,6 +48,8 @@ class WC_Email_New_Order extends WC_Email {
 
 	/**
 	 * Trigger.
+	 *
+	 * @param int $order_id
 	 */
 	public function trigger( $order_id ) {
 		if ( $order_id ) {
@@ -66,7 +68,7 @@ class WC_Email_New_Order extends WC_Email {
 	}
 
 	/**
-	 * get_content_html function.
+	 * Get content html.
 	 *
 	 * @access public
 	 * @return string
@@ -82,7 +84,7 @@ class WC_Email_New_Order extends WC_Email {
 	}
 
 	/**
-	 * get_content_plain function.
+	 * Get content plain.
 	 *
 	 * @access public
 	 * @return string


### PR DESCRIPTION
- Added comments to `get_content_plain` and `get_content_html`
- Added missing param tag to `trigger`
