### PR TITLE
Improve docblock comments in WC_Email_Customer_Processing_Order class

### DIFF
--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -42,6 +42,8 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 
 	/**
 	 * Trigger.
+	 *
+	 * @param int $order_id
 	 */
 	function trigger( $order_id ) {
 
@@ -64,7 +66,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	}
 
 	/**
-	 * get_content_html function.
+	 * Get content html.
 	 *
 	 * @access public
 	 * @return string
@@ -80,7 +82,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	}
 
 	/**
-	 * get_content_plain function.
+	 * Get content plain.
 	 *
 	 * @access public
 	 * @return string


### PR DESCRIPTION
- Added comments to `get_content_plain` and `get_content_html`
- Added missing param tag to `trigger`
