### PR TITLE
Improve docblock comments in WC_Email_Customer_Invoice class

### DIFF
--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -19,7 +19,18 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice' ) ) :
  */
 class WC_Email_Customer_Invoice extends WC_Email {
 
+	/**
+	 * Strings to find in subjects/headings.
+	 *
+	 * @var array
+	 */
 	public $find;
+
+	/**
+	 * Strings to replace in subjects/headings.
+	 *
+	 * @var array
+	 */
 	public $replace;
 
 	/**
@@ -51,6 +62,8 @@ class WC_Email_Customer_Invoice extends WC_Email {
 
 	/**
 	 * Trigger.
+	 *
+	 * @param int|WC_Order $order
 	 */
 	function trigger( $order ) {
 
@@ -77,7 +90,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	}
 
 	/**
-	 * get_subject function.
+	 * Get email subject.
 	 *
 	 * @access public
 	 * @return string
@@ -91,7 +104,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	}
 
 	/**
-	 * get_heading function.
+	 * Get email heading.
 	 *
 	 * @access public
 	 * @return string
@@ -105,7 +118,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	}
 
 	/**
-	 * get_content_html function.
+	 * Get content html.
 	 *
 	 * @access public
 	 * @return string
@@ -121,7 +134,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	}
 
 	/**
-	 * get_content_plain function.
+	 * Get content plain.
 	 *
 	 * @access public
 	 * @return string


### PR DESCRIPTION
- Added comments to properties that don’t have any.
- Added comments to `get_subject`, `get_heading`, `get_content_html`
  and `get_content_plain`
- Added missing param tag to `trigger`
