### PR TITLE
Improve docblock comments in WC_Email_Customer_Note class

### DIFF
--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -19,6 +19,11 @@ if ( ! class_exists( 'WC_Email_Customer_Note' ) ) :
  */
 class WC_Email_Customer_Note extends WC_Email {
 
+	/**
+	 * Customer note.
+	 *
+	 * @var string
+	 */
 	public $customer_note;
 
 	/**
@@ -46,6 +51,8 @@ class WC_Email_Customer_Note extends WC_Email {
 
 	/**
 	 * Trigger.
+	 *
+	 * @param array $args
 	 */
 	function trigger( $args ) {
 
@@ -82,7 +89,7 @@ class WC_Email_Customer_Note extends WC_Email {
 	}
 
 	/**
-	 * get_content_html function.
+	 * Get content html.
 	 *
 	 * @access public
 	 * @return string
@@ -99,7 +106,7 @@ class WC_Email_Customer_Note extends WC_Email {
 	}
 
 	/**
-	 * get_content_plain function.
+	 * Get content plain.
 	 *
 	 * @access public
 	 * @return string


### PR DESCRIPTION
- Added comments to properties that don’t have any.
- Added comments to `get_content_plain` and `get_content_html`
- Added missing param tag to `trigger`
