### PR TITLE
Improve docblock comments WC_Comments

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -213,6 +213,8 @@ class WC_Comments {
 
 	/**
 	 * Modify recipient of review email.
+	 * @param array $emails
+	 * @param int $comment_id
 	 * @return array
 	 */
 	public static function comment_moderation_recipients( $emails, $comment_id ) {


### PR DESCRIPTION
- Added missing param tags to `comment_moderation_recipients`
