### PR TITLE
Improve docblock comments in WC_Auth class

### DIFF
--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -20,6 +20,8 @@ class WC_Auth {
 
 	/**
 	 * Version.
+	 *
+	 * @var int
 	 */
 	const VERSION = 1;
 
@@ -44,7 +46,7 @@ class WC_Auth {
 	 *
 	 * @since  2.4.0
 	 *
-	 * @param  $vars
+	 * @param  array $vars
 	 *
 	 * @return string[]
 	 */


### PR DESCRIPTION
- Added missing var tag to `VERSION` const
- Added missing param type to `add_query_vars`
