### PR TITLE
wc_get_customer_default_location not always filtered

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -711,21 +711,27 @@ function wc_get_customer_default_location() {
 		case 'geolocation_ajax' :
 		case 'geolocation' :
 			$location = WC_Geolocation::geolocate_ip();
-
-			// Base fallback.
-			if ( empty( $location['country'] ) ) {
-				$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', get_option( 'woocommerce_default_country' ) ) );
+			if ( ! empty( $location['country'] ) ) {
+				// We have a geolocated location. Convert it to a string so it can be passed
+				// through the filter in the same way as other results.
+				if ( empty( $location['state'] ) ) {
+					$location = $location['country'];
+				} else {
+					$location = implode( ':', $location );
+				}
+			} else {
+				// Base fallback.
+				$location = get_option( 'woocommerce_default_country' );
 			}
 		break;
 		case 'base' :
-			$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', get_option( 'woocommerce_default_country' ) ) );
+			$location = get_option( 'woocommerce_default_country' );
 		break;
 		default :
-			$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', '' ) );
+			$location = '';
 		break;
 	}
-
-	return $location;
+	return wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', $location ) );
 }
 
 // This function can be removed when WP 3.9.2 or greater is required.


### PR DESCRIPTION
The inline docs suggest that the output of wc_get_customer_default_location is filtered. Indeed for 4 out of 6 of the possible routes through the function - that's the case.

If geolocation isn't in use, or isn't successful, then the location string (E.g. "GB", or "US:AL" if there is a state) will be passed through the filter woocommerce_customer_default_location. The results of this filter are then passed through wc_format_country_state_string to turn them into an array of country and state, e.g.

```
Array
(
    [country] => GB
    [state] => 
)

```

However - geolocation is required, and happens successfully, this results in an array directly, and the results are _not_ passed through the filter woocommerce_customer_default_location. 

Since the geolocation already returns an array of country/state, and not a string, we can't directly pass this through a filter (since consumers of that filter will expect a country:state string, so the options are:
1. Introduce a _new_ filter that only applies to this case (Seems complicated, and a bit yacky)
2. Convert from the geolocated array back to a string, then pass through the filter, before converting the filter results back into the desired array.

This PR implements the second approach.
