### PR TITLE
Fix Unknown column '_customer_user' notice when deleting a user

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -542,7 +542,7 @@ function wc_get_customer_order_count( $user_id ) {
 function wc_reset_order_customer_id_on_deleted_user( $user_id ) {
 	global $wpdb;
 
-	$wpdb->update( $wpdb->postmeta, array( '_customer_user' => 0 ), array( '_customer_user' => $user_id ) );
+	$wpdb->update( $wpdb->postmeta, array( 'meta_value' => 0 ), array( 'meta_key' => '_customer_user', 'meta_value' => $user_id ) );
 }
 
 add_action( 'deleted_user', 'wc_reset_order_customer_id_on_deleted_user' );


### PR DESCRIPTION
When deleting a user, the following notice is being logged: `WordPress database error Unknown column '_customer_user' in 'where clause'`.

This is because the `$wpdb->update()` call introduced with SHA: aa86069e56808 was using the `_customer_user` meta key as the column name.

This fixes that.

This also ensures the `_customer_user` meta value on orders is set to a guest user (`0`) when deleting a user instead of remaining as the non-existent user's ID (which is what SHA: aa86069e56808 was originally introduced to fix for #9166).
