### PR TITLE
Check for a valid product ID/SKU in the add_to_cart shortcodes

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -446,9 +446,9 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$product = wc_setup_product_data( $product_data );
-
-		if ( ! $product ) {
+		if ( is_object( $product_data ) ) {
+			$product = wc_setup_product_data( $product_data );
+		} else {
 			return '';
 		}
 
@@ -490,6 +490,12 @@ class WC_Shortcodes {
 		} elseif ( isset( $atts['sku'] ) ) {
 			$product_id   = wc_get_product_id_by_sku( $atts['sku'] );
 			$product_data = get_post( $product_id );
+		} else {
+			return '';
+		}
+
+		if ( is_object( $product_data ) ) {
+			$product = wc_setup_product_data( $product_data );
 		} else {
 			return '';
 		}


### PR DESCRIPTION
If the `[add_to_cart]` or `[add_to_cart_url]` shortcodes are used on the product page with an invalid ID, then a fatal error will be caused: http://cld.wthms.co/10pIe/2QneeebG

This patch makes sure `$product_data` is an object first before running `wc_setup_product_data()`.
