### PR TITLE
Add priority support to shipping rates

### DIFF
--- a/includes/class-wc-shipping-rate.php
+++ b/includes/class-wc-shipping-rate.php
@@ -32,6 +32,9 @@ class WC_Shipping_Rate {
 	/** @var string Label for the rate. */
 	public $method_id = '';
 
+	/** @var int Default rate priority. */
+	public $priority  = 1;
+
 	/**
 	 * Constructor.
 	 *
@@ -40,13 +43,15 @@ class WC_Shipping_Rate {
 	 * @param float $cost
 	 * @param array $taxes
 	 * @param string $method_id
+	 * @param int $priority
 	 */
-	public function __construct( $id, $label, $cost, $taxes, $method_id ) {
+	public function __construct( $id, $label, $cost, $taxes, $method_id, $priority = 1 ) {
 		$this->id 			= $id;
 		$this->label 		= $label;
 		$this->cost 		= $cost;
 		$this->taxes 		= $taxes ? $taxes : array();
 		$this->method_id 	= $method_id;
+		$this->priority		= $priority;
 	}
 
 	/**
@@ -69,5 +74,23 @@ class WC_Shipping_Rate {
 	 */
 	public function get_label() {
 		return apply_filters( 'woocommerce_shipping_rate_label', $this->label );
+	}
+
+	/**
+	 * Get priority.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return int Shipping rate priority.
+	 */
+	public function get_priority() {
+
+		// BC - Check for priority in settings when it has the default value.
+		if ( 1 == $this->priority ) {
+			$selection_priority = get_option( 'woocommerce_shipping_method_selection_priority', array() );
+			$this->priority = isset( $selection_priority[ $this->id ] ) ? absint( $selection_priority[ $this->id ] ) : 1;
+		}
+
+		return apply_filters( 'woocommerce_shipping_rate_priority', (int) $this->priority );
 	}
 }

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -217,7 +217,6 @@ class WC_Shipping {
 	 * @return string
 	 */
 	private function get_default_method( $available_methods, $current_chosen_method = false ) {
-		$selection_priority = get_option( 'woocommerce_shipping_method_selection_priority', array() );
 
 		if ( ! empty( $available_methods ) ) {
 
@@ -234,8 +233,8 @@ class WC_Shipping {
 			$prioritized_methods = array();
 
 			foreach ( $available_methods as $method_key => $method ) {
-				// Some IDs contain : if they have multiple rates so use $method->method_id
-				$priority  = isset( $selection_priority[ $method->method_id ] ) ? absint( $selection_priority[ $method->method_id ] ): 1;
+
+				$priority  = $method->get_priority();
 
 				if ( empty( $prioritized_methods[ $priority ] ) ) {
 					$prioritized_methods[ $priority ] = array();


### PR DESCRIPTION
Before 2.4.7 it was possible in _a_ way to setup priorities for shipping rates (and not only shipping methods). 
I believe this commit unintentionally removed that support: https://github.com/woothemes/woocommerce/commit/705fbef31aeb86b2b716cdf78860e007ed5ead9c

This pull request adds support for shipping rate priorities in a different way, I think its prettier, but if needed, we can also add support for the shipping rate priorities through a hook.

With this it will be possible to add a priority though the `new WC_Shipping_Rate( $id, $label, $cost, $taxes, $method_id, $priority )`

If this gets accepted, I will also submit another PR for the core shipping rates to appropriately use the new argument.
