### PR TITLE
New 'listtype' variable for $woocommerce_loop and consistent filters for upsell and cross-sell queries

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -84,9 +84,10 @@ class WC_Shortcodes {
 	private static function product_loop( $query_args, $atts, $loop_name ) {
 		global $woocommerce_loop;
 
-		$products                    = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $query_args, $atts, $loop_name ) );
-		$columns                     = absint( $atts['columns'] );
-		$woocommerce_loop['columns'] = $columns;
+		$products                     = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $query_args, $atts, $loop_name ) );
+		$columns                      = absint( $atts['columns'] );
+		$woocommerce_loop['columns']  = $columns;
+		$woocommerce_loop['listtype'] = $loopname;
 
 		ob_start();
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -112,7 +112,7 @@ if ( ! function_exists( 'woocommerce_reset_loop' ) ) {
 	function woocommerce_reset_loop() {
 		global $woocommerce_loop;
 		// Reset loop/columns globals when starting a new loop
-		$woocommerce_loop['loop'] = $woocommerce_loop['columns'] = '';
+		$woocommerce_loop['loop'] = $woocommerce_loop['columns'] = $woocommerce_loop['listtype'] = '';
 	}
 }
 add_filter( 'loop_end', 'woocommerce_reset_loop' );

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -41,6 +41,8 @@ $products = new WP_Query( $args );
 
 $woocommerce_loop['columns'] = apply_filters( 'woocommerce_cross_sells_columns', $columns );
 
+$woocommerce_loop['listtype'] = 'cross-sells';
+
 if ( $products->have_posts() ) : ?>
 
 	<div class="cross-sells">

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -27,7 +27,7 @@ if ( 0 === sizeof( $crosssells ) ) return;
 
 $meta_query = WC()->query->get_meta_query();
 
-$args = array(
+$args = apply_filters( 'woocommerce_cross_sells_products_args', array(
 	'post_type'           => 'product',
 	'ignore_sticky_posts' => 1,
 	'no_found_rows'       => 1,
@@ -35,7 +35,7 @@ $args = array(
 	'orderby'             => $orderby,
 	'post__in'            => $crosssells,
 	'meta_query'          => $meta_query
-);
+));
 
 $products = new WP_Query( $args );
 

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -31,6 +31,11 @@ if ( empty( $woocommerce_loop['columns'] ) ) {
 	$woocommerce_loop['columns'] = apply_filters( 'loop_shop_columns', 4 );
 }
 
+// Store list type so that plugin authors and theme developers can see where the product is being shown
+if ( empty ( $woocommerce_loop['listtype'] ) ) {
+	$woocommerce_loop['listtype'] = 'general';
+}
+
 // Ensure visibility
 if ( ! $product || ! $product->is_visible() ) {
 	return;

--- a/templates/content-product_cat.php
+++ b/templates/content-product_cat.php
@@ -31,6 +31,11 @@ if ( empty( $woocommerce_loop['columns'] ) ) {
 	$woocommerce_loop['columns'] = apply_filters( 'loop_shop_columns', 4 );
 }
 
+// Store list type so that plugin authors and theme developers can see where the product is being shown
+if ( empty ( $woocommerce_loop['listtype'] ) ) {
+	$woocommerce_loop['listtype'] = 'general';
+}
+
 // Increase loop count
 $woocommerce_loop['loop'] ++;
 ?>

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -43,6 +43,8 @@ $products = new WP_Query( $args );
 
 $woocommerce_loop['columns'] = $columns;
 
+$woocommerce_loop['listtype'] = 'related';
+
 if ( $products->have_posts() ) : ?>
 
 	<div class="related products">

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -29,7 +29,7 @@ if ( sizeof( $upsells ) === 0 ) {
 
 $meta_query = WC()->query->get_meta_query();
 
-$args = array(
+$args = apply_filters( 'woocommerce_upsell_products_args', array(
 	'post_type'           => 'product',
 	'ignore_sticky_posts' => 1,
 	'no_found_rows'       => 1,

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -44,6 +44,8 @@ $products = new WP_Query( $args );
 
 $woocommerce_loop['columns'] = $columns;
 
+$woocommerce_loop['listtype'] = 'upsells';
+
 if ( $products->have_posts() ) : ?>
 
 	<div class="upsells products">

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -38,7 +38,7 @@ $args = apply_filters( 'woocommerce_upsell_products_args', array(
 	'post__in'            => $upsells,
 	'post__not_in'        => array( $product->id ),
 	'meta_query'          => $meta_query
-);
+) );
 
 $products = new WP_Query( $args );
 


### PR DESCRIPTION
I am the developer of the plugin "DuracellTomi's Google Tag Manager for WordPress". While extending the implementation of the Google Analytics Enhanced Ecommerce tracking in my plugin, I found some opportunity to make the code better.

**Inconsistent WP filters**

There are some inconsistencies in the code:
- related products template uses a WP filter for the whole WP query args
- up-sells template does not have any WP filter for WP query args
- cross-sells template only apply a WP filter for the posts_per_page arg

I modified the codes to use a WP filter for each template for the whole WP query args array.

**New variable for the loop**

I added a new variable to the $woocommerce_loop array so that during product code generation I and other plugin authors can "see" in the code which type of product list is being generated: general product category, related products, upsells, etc.
I think this will be useful for other plugin authors and theme developers as well.
