### PR TITLE
Eliminated duplicate price save code in api v2 and api v3

### DIFF
--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1438,14 +1438,14 @@ class WC_API_Products extends WC_API_Resource {
 				$date_from = $data['sale_price_dates_from'];
 			} else {
 				$date_from = get_post_meta( $product_id, '_sale_price_dates_from', true );
-				$date_from = date( 'Y-m-d', $date_from );
+				$date_from = ( '' === $date_from ) ? '' : date( 'Y-m-d', $date_from );
 			}
 
 			if ( isset( $data['sale_price_dates_to'] ) ) {
 				$date_to = $data['sale_price_dates_to'];
 			} else {
-				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', TRUE );
-				$date_to = date( 'Y-m-d', $date_to );
+				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', true );
+				$date_to = ( '' === $date_to ) ? '' : date( 'Y-m-d', $date_to );
 			}
 
 			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
@@ -1849,14 +1849,14 @@ class WC_API_Products extends WC_API_Resource {
 				$date_from = $variation['sale_price_dates_from'];
 			} else {
 				$date_from = get_post_meta( $variation_id, '_sale_price_dates_from', true );
-				$date_from = date( 'Y-m-d', $date_from );
+				$date_from = ( '' === $date_from ) ? '' : date( 'Y-m-d', $date_from );
 			}
 
 			if ( isset( $variation['sale_price_dates_to'] ) ) {
 				$date_to = $variation['sale_price_dates_to'];
 			} else {
 				$date_to = get_post_meta( $variation_id, '_sale_price_dates_to', true );
-				$date_to = date( 'Y-m-d', $date_to );
+				$date_to = ( '' === $date_to ) ? '' : date( 'Y-m-d', $date_to );
 			}
 
 			_wc_save_product_price( $variation_id, $regular_price, $sale_price, $date_from, $date_to );

--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1420,59 +1420,25 @@ class WC_API_Products extends WC_API_Resource {
 
 		} else {
 
-			// Regular Price.
+			// Regular Price
 			if ( isset( $data['regular_price'] ) ) {
-				$regular_price = ( '' === $data['regular_price'] ) ? '' : wc_format_decimal( $data['regular_price'] );
-				update_post_meta( $product_id, '_regular_price', $regular_price );
+				$regular_price = ( '' === $data['regular_price'] ) ? '' : $data['regular_price'];
 			} else {
 				$regular_price = get_post_meta( $product_id, '_regular_price', true );
 			}
 
-			// Sale Price.
+			// Sale Price
 			if ( isset( $data['sale_price'] ) ) {
-				$sale_price = ( '' === $data['sale_price'] ) ? '' : wc_format_decimal( $data['sale_price'] );
-				update_post_meta( $product_id, '_sale_price', $sale_price );
+				$sale_price = ( '' === $data['sale_price'] ) ? '' : $data['sale_price'];
 			} else {
 				$sale_price = get_post_meta( $product_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $data['sale_price_dates_from'] ) ? strtotime( $data['sale_price_dates_from'] ) : get_post_meta( $product_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $data['sale_price_dates_to'] ) ? strtotime( $data['sale_price_dates_to'] ) : get_post_meta( $product_id, '_sale_price_dates_to', true );
+			$date_from = isset( $data['sale_price_dates_from'] ) ? $data['sale_price_dates_from'] : get_post_meta( $product_id, '_sale_price_dates_from', true );
+			$date_to   = isset( $data['sale_price_dates_to'] ) ? $data['sale_price_dates_to'] : get_post_meta( $product_id, '_sale_price_dates_to', true );
 
-			// Dates
-			if ( $date_from ) {
-				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
-			} else {
-				update_post_meta( $product_id, '_sale_price_dates_from', '' );
-			}
+			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
 
-			if ( $date_to ) {
-				update_post_meta( $product_id, '_sale_price_dates_to', $date_to );
-			} else {
-				update_post_meta( $product_id, '_sale_price_dates_to', '' );
-			}
-
-			if ( $date_to && ! $date_from ) {
-				$date_from = strtotime( 'NOW', current_time( 'timestamp' ) );
-				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
-			}
-
-			// Update price if on sale.
-			if ( '' !== $sale_price && '' == $date_to && '' == $date_from ) {
-				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
-			} else {
-				update_post_meta( $product_id, '_price', $regular_price );
-			}
-
-			if ( '' !== $sale_price && $date_from && $date_from <= strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
-			}
-
-			if ( $date_to && $date_to < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $product_id, '_price', $regular_price );
-				update_post_meta( $product_id, '_sale_price_dates_from', '' );
-				update_post_meta( $product_id, '_sale_price_dates_to', '' );
-			}
 		}
 
 		// Product parent ID for groups.
@@ -1856,56 +1822,22 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Regular Price
 			if ( isset( $variation['regular_price'] ) ) {
-				$regular_price = ( '' === $variation['regular_price'] ) ? '' : wc_format_decimal( $variation['regular_price'] );
-				update_post_meta( $variation_id, '_regular_price', $regular_price );
+				$regular_price = ( '' === $variation['regular_price'] ) ? '' : $variation['regular_price'];
 			} else {
 				$regular_price = get_post_meta( $variation_id, '_regular_price', true );
 			}
 
 			// Sale Price
 			if ( isset( $variation['sale_price'] ) ) {
-				$sale_price = ( '' === $variation['sale_price'] ) ? '' : wc_format_decimal( $variation['sale_price'] );
-				update_post_meta( $variation_id, '_sale_price', $sale_price );
+				$sale_price = ( '' === $variation['sale_price'] ) ? '' : $variation['sale_price'];
 			} else {
 				$sale_price = get_post_meta( $variation_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $variation['sale_price_dates_from'] ) ? strtotime( $variation['sale_price_dates_from'] ) : get_post_meta( $variation_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $variation['sale_price_dates_to'] ) ? strtotime( $variation['sale_price_dates_to'] ) : get_post_meta( $variation_id, '_sale_price_dates_to', true );
+			$date_from = isset( $variation['sale_price_dates_from'] ) ? $variation['sale_price_dates_from'] : get_post_meta( $variation_id, '_sale_price_dates_from', true );
+			$date_to   = isset( $variation['sale_price_dates_to'] ) ? $variation['sale_price_dates_to'] : get_post_meta( $variation_id, '_sale_price_dates_to', true );
 
-			// Save Dates
-			if ( $date_from ) {
-				update_post_meta( $variation_id, '_sale_price_dates_from', $date_from );
-			} else {
-				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
-			}
-
-			if ( $date_to ) {
-				update_post_meta( $variation_id, '_sale_price_dates_to', $date_to );
-			} else {
-				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
-			}
-
-			if ( $date_to && ! $date_from ) {
-				update_post_meta( $variation_id, '_sale_price_dates_from', strtotime( 'NOW', current_time( 'timestamp' ) ) );
-			}
-
-			// Update price if on sale
-			if ( '' != $sale_price && '' == $date_to && '' == $date_from ) {
-				update_post_meta( $variation_id, '_price', $sale_price );
-			} else {
-				update_post_meta( $variation_id, '_price', $regular_price );
-			}
-
-			if ( '' != $sale_price && $date_from && $date_from < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $variation_id, '_price', $sale_price );
-			}
-
-			if ( $date_to && $date_to < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $variation_id, '_price', $regular_price );
-				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
-				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
-			}
+			_wc_save_product_price( $variation_id, $regular_price, $sale_price, $date_from, $date_to );
 
 			// Tax class
 			if ( isset( $variation['tax_class'] ) ) {

--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1434,8 +1434,19 @@ class WC_API_Products extends WC_API_Resource {
 				$sale_price = get_post_meta( $product_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $data['sale_price_dates_from'] ) ? $data['sale_price_dates_from'] : get_post_meta( $product_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $data['sale_price_dates_to'] ) ? $data['sale_price_dates_to'] : get_post_meta( $product_id, '_sale_price_dates_to', true );
+			if ( isset( $data['sale_price_dates_from'] ) ) {
+				$date_from = $data['sale_price_dates_from'];
+			} else {
+				$date_from = get_post_meta( $product_id, '_sale_price_dates_from', true );
+				$date_from = date( 'Y-m-d', $date_from );
+			}
+
+			if ( isset( $data['sale_price_dates_to'] ) ) {
+				$date_to = $data['sale_price_dates_to'];
+			} else {
+				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', TRUE );
+				$date_to = date( 'Y-m-d', $date_to );
+			}
 
 			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
 
@@ -1834,8 +1845,19 @@ class WC_API_Products extends WC_API_Resource {
 				$sale_price = get_post_meta( $variation_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $variation['sale_price_dates_from'] ) ? $variation['sale_price_dates_from'] : get_post_meta( $variation_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $variation['sale_price_dates_to'] ) ? $variation['sale_price_dates_to'] : get_post_meta( $variation_id, '_sale_price_dates_to', true );
+			if ( isset( $variation['sale_price_dates_from'] ) ) {
+				$date_from = $variation['sale_price_dates_from'];
+			} else {
+				$date_from = get_post_meta( $variation_id, '_sale_price_dates_from', true );
+				$date_from = date( 'Y-m-d', $date_from );
+			}
+
+			if ( isset( $variation['sale_price_dates_to'] ) ) {
+				$date_to = $variation['sale_price_dates_to'];
+			} else {
+				$date_to = get_post_meta( $variation_id, '_sale_price_dates_to', true );
+				$date_to = date( 'Y-m-d', $date_to );
+			}
 
 			_wc_save_product_price( $variation_id, $regular_price, $sale_price, $date_from, $date_to );
 

--- a/includes/api/v2/class-wc-api-products.php
+++ b/includes/api/v2/class-wc-api-products.php
@@ -977,8 +977,19 @@ class WC_API_Products extends WC_API_Resource {
 				$sale_price = get_post_meta( $product_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $data['sale_price_dates_from'] ) ? $data['sale_price_dates_from'] : get_post_meta( $product_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $data['sale_price_dates_to'] ) ? $data['sale_price_dates_to'] : get_post_meta( $product_id, '_sale_price_dates_to', true );
+			if ( isset( $data['sale_price_dates_from'] ) ) {
+				$date_from = $data['sale_price_dates_from'];
+			} else {
+				$date_from = get_post_meta( $product_id, '_sale_price_dates_from', true );
+				$date_from = date( 'Y-m-d', $date_from );
+			}
+
+			if ( isset( $data['sale_price_dates_to'] ) ) {
+				$date_to = $data['sale_price_dates_to'];
+			} else {
+				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', TRUE );
+				$date_to = date( 'Y-m-d', $date_to );
+			}
 
 			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
 
@@ -1367,8 +1378,19 @@ class WC_API_Products extends WC_API_Resource {
 				$sale_price = get_post_meta( $variation_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $variation['sale_price_dates_from'] ) ? $variation['sale_price_dates_from'] : get_post_meta( $variation_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $variation['sale_price_dates_to'] ) ? $variation['sale_price_dates_to'] : get_post_meta( $variation_id, '_sale_price_dates_to', true );
+			if ( isset( $variation['sale_price_dates_from'] ) ) {
+				$date_from = $variation['sale_price_dates_from'];
+			} else {
+				$date_from = get_post_meta( $variation_id, '_sale_price_dates_from', true );
+				$date_from = date( 'Y-m-d', $date_from );
+			}
+
+			if ( isset( $variation['sale_price_dates_to'] ) ) {
+				$date_to = $variation['sale_price_dates_to'];
+			} else {
+				$date_to = get_post_meta( $variation_id, '_sale_price_dates_to', true );
+				$date_to = date( 'Y-m-d', $date_to );
+			}
 
 			_wc_save_product_price( $variation_id, $regular_price, $sale_price, $date_from, $date_to );
 

--- a/includes/api/v2/class-wc-api-products.php
+++ b/includes/api/v2/class-wc-api-products.php
@@ -965,57 +965,23 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Regular Price
 			if ( isset( $data['regular_price'] ) ) {
-				$regular_price = ( '' === $data['regular_price'] ) ? '' : wc_format_decimal( $data['regular_price'] );
-				update_post_meta( $product_id, '_regular_price', $regular_price );
+				$regular_price = ( '' === $data['regular_price'] ) ? '' : $data['regular_price'];
 			} else {
 				$regular_price = get_post_meta( $product_id, '_regular_price', true );
 			}
 
 			// Sale Price
 			if ( isset( $data['sale_price'] ) ) {
-				$sale_price = ( '' === $data['sale_price'] ) ? '' : wc_format_decimal( $data['sale_price'] );
-				update_post_meta( $product_id, '_sale_price', $sale_price );
+				$sale_price = ( '' === $data['sale_price'] ) ? '' : $data['sale_price'];
 			} else {
 				$sale_price = get_post_meta( $product_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $data['sale_price_dates_from'] ) ? strtotime( $data['sale_price_dates_from'] ) : get_post_meta( $product_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $data['sale_price_dates_to'] ) ? strtotime( $data['sale_price_dates_to'] ) : get_post_meta( $product_id, '_sale_price_dates_to', true );
+			$date_from = isset( $data['sale_price_dates_from'] ) ? $data['sale_price_dates_from'] : get_post_meta( $product_id, '_sale_price_dates_from', true );
+			$date_to   = isset( $data['sale_price_dates_to'] ) ? $data['sale_price_dates_to'] : get_post_meta( $product_id, '_sale_price_dates_to', true );
 
-			// Dates
-			if ( $date_from ) {
-				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
-			} else {
-				update_post_meta( $product_id, '_sale_price_dates_from', '' );
-			}
+			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
 
-			if ( $date_to ) {
-				update_post_meta( $product_id, '_sale_price_dates_to', $date_to );
-			} else {
-				update_post_meta( $product_id, '_sale_price_dates_to', '' );
-			}
-
-			if ( $date_to && ! $date_from ) {
-				$date_from = strtotime( 'NOW', current_time( 'timestamp' ) );
-				update_post_meta( $product_id, '_sale_price_dates_from', $date_from );
-			}
-
-			// Update price if on sale
-			if ( '' !== $sale_price && '' == $date_to && '' == $date_from ) {
-				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
-			} else {
-				update_post_meta( $product_id, '_price', $regular_price );
-			}
-
-			if ( '' !== $sale_price && $date_from && $date_from <= strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $product_id, '_price', wc_format_decimal( $sale_price ) );
-			}
-
-			if ( $date_to && $date_to < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $product_id, '_price', $regular_price );
-				update_post_meta( $product_id, '_sale_price_dates_from', '' );
-				update_post_meta( $product_id, '_sale_price_dates_to', '' );
-			}
 		}
 
 		// Product parent ID for groups
@@ -1389,56 +1355,22 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Regular Price
 			if ( isset( $variation['regular_price'] ) ) {
-				$regular_price = ( '' === $variation['regular_price'] ) ? '' : wc_format_decimal( $variation['regular_price'] );
-				update_post_meta( $variation_id, '_regular_price', $regular_price );
+				$regular_price = ( '' === $variation['regular_price'] ) ? '' : $variation['regular_price'];
 			} else {
 				$regular_price = get_post_meta( $variation_id, '_regular_price', true );
 			}
 
 			// Sale Price
 			if ( isset( $variation['sale_price'] ) ) {
-				$sale_price = ( '' === $variation['sale_price'] ) ? '' : wc_format_decimal( $variation['sale_price'] );
-				update_post_meta( $variation_id, '_sale_price', $sale_price );
+				$sale_price = ( '' === $variation['sale_price'] ) ? '' : $variation['sale_price'];
 			} else {
 				$sale_price = get_post_meta( $variation_id, '_sale_price', true );
 			}
 
-			$date_from = isset( $variation['sale_price_dates_from'] ) ? strtotime( $variation['sale_price_dates_from'] ) : get_post_meta( $variation_id, '_sale_price_dates_from', true );
-			$date_to   = isset( $variation['sale_price_dates_to'] ) ? strtotime( $variation['sale_price_dates_to'] ) : get_post_meta( $variation_id, '_sale_price_dates_to', true );
+			$date_from = isset( $variation['sale_price_dates_from'] ) ? $variation['sale_price_dates_from'] : get_post_meta( $variation_id, '_sale_price_dates_from', true );
+			$date_to   = isset( $variation['sale_price_dates_to'] ) ? $variation['sale_price_dates_to'] : get_post_meta( $variation_id, '_sale_price_dates_to', true );
 
-			// Save Dates
-			if ( $date_from ) {
-				update_post_meta( $variation_id, '_sale_price_dates_from', $date_from );
-			} else {
-				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
-			}
-
-			if ( $date_to ) {
-				update_post_meta( $variation_id, '_sale_price_dates_to', $date_to );
-			} else {
-				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
-			}
-
-			if ( $date_to && ! $date_from ) {
-				update_post_meta( $variation_id, '_sale_price_dates_from', strtotime( 'NOW', current_time( 'timestamp' ) ) );
-			}
-
-			// Update price if on sale
-			if ( '' != $sale_price && '' == $date_to && '' == $date_from ) {
-				update_post_meta( $variation_id, '_price', $sale_price );
-			} else {
-				update_post_meta( $variation_id, '_price', $regular_price );
-			}
-
-			if ( '' != $sale_price && $date_from && $date_from < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $variation_id, '_price', $sale_price );
-			}
-
-			if ( $date_to && $date_to < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
-				update_post_meta( $variation_id, '_price', $regular_price );
-				update_post_meta( $variation_id, '_sale_price_dates_from', '' );
-				update_post_meta( $variation_id, '_sale_price_dates_to', '' );
-			}
+			_wc_save_product_price( $variation_id, $regular_price, $sale_price, $date_from, $date_to );
 
 			// Tax class
 			if ( isset( $variation['tax_class'] ) ) {

--- a/includes/api/v2/class-wc-api-products.php
+++ b/includes/api/v2/class-wc-api-products.php
@@ -981,14 +981,14 @@ class WC_API_Products extends WC_API_Resource {
 				$date_from = $data['sale_price_dates_from'];
 			} else {
 				$date_from = get_post_meta( $product_id, '_sale_price_dates_from', true );
-				$date_from = date( 'Y-m-d', $date_from );
+				$date_from = ( '' === $date_from ) ? '' : date( 'Y-m-d', $date_from );
 			}
 
 			if ( isset( $data['sale_price_dates_to'] ) ) {
 				$date_to = $data['sale_price_dates_to'];
 			} else {
-				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', TRUE );
-				$date_to = date( 'Y-m-d', $date_to );
+				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', true );
+				$date_to = ( '' === $date_to ) ? '' : date( 'Y-m-d', $date_to );
 			}
 
 			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
@@ -1382,14 +1382,14 @@ class WC_API_Products extends WC_API_Resource {
 				$date_from = $variation['sale_price_dates_from'];
 			} else {
 				$date_from = get_post_meta( $variation_id, '_sale_price_dates_from', true );
-				$date_from = date( 'Y-m-d', $date_from );
+				$date_from = ( '' === $date_from ) ? '' : date( 'Y-m-d', $date_from );
 			}
 
 			if ( isset( $variation['sale_price_dates_to'] ) ) {
 				$date_to = $variation['sale_price_dates_to'];
 			} else {
 				$date_to = get_post_meta( $variation_id, '_sale_price_dates_to', true );
-				$date_to = date( 'Y-m-d', $date_to );
+				$date_to = ( '' === $date_to ) ? '' : date( 'Y-m-d', $date_to );
 			}
 
 			_wc_save_product_price( $variation_id, $regular_price, $sale_price, $date_from, $date_to );


### PR DESCRIPTION
DRY: I think we shouldn’t coyp&paste too much code from core into the api so I eliminated the duplicate code and made use of the already existing _wc_save_product_price function for products and variations.
