### PR TITLE
[2.5] Add action hooks before/after processing payment

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -640,7 +640,12 @@ class WC_Checkout {
 					WC()->session->order_awaiting_payment = $order_id;
 
 					// Process Payment
+
+					do_action( 'woocommerce_before_process_payment', $order_id );
+
 					$result = $available_gateways[ $this->posted['payment_method'] ]->process_payment( $order_id );
+
+					do_action( 'woocommerce_after_process_payment', $order_id, $result );
 
 					// Redirect to success/confirmation/payment page
 					if ( isset( $result['result'] ) && 'success' === $result['result'] ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -322,7 +322,11 @@ class WC_Form_Handler {
 					// Process
 					if ( wc_notice_count( 'error' ) == 0 ) {
 
+						do_action( 'woocommerce_before_process_payment', $order_id );
+
 						$result = $available_gateways[ $payment_method ]->process_payment( $order_id );
+
+						do_action( 'woocommerce_after_process_payment', $order_id, $result );
 
 						// Redirect to success/confirmation/payment page
 						if ( 'success' === $result['result'] ) {


### PR DESCRIPTION
A minor addition - hopefully in time for the 2.5 release.

Added action hooks before/after `process_payment()` is triggered. The goal here is to be able to filter order content, for instance to safely add a `woocommerce_order_get_items` filter in order to tweak line items before submitting a request for processing payment.

Example use cases: 
- Allow submitting a single line item for Bundles/Composites/Grouped products when processing payment (after merging totals/taxes of children into the parent and adding any necessary meta).
- Allow hiding specific order items from the payment gateway (for instance with 0.0 value), or merging totals of "invisible" line items (added for administrative purposes) into the totals of an assumed "parent" fee or product.
