### PR TITLE
Remove current stock_status check to enforce saving meta for new products/variations

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -241,13 +241,9 @@ class WC_Product {
 	 */
 	public function check_stock_status() {
 		if ( ! $this->backorders_allowed() && $this->get_total_stock() <= get_option( 'woocommerce_notify_no_stock_amount' ) ) {
-			if ( $this->stock_status !== 'outofstock' ) {
-				$this->set_stock_status( 'outofstock' );
-			}
+			$this->set_stock_status( 'outofstock' );
 		} elseif ( $this->backorders_allowed() || $this->get_total_stock() > get_option( 'woocommerce_notify_no_stock_amount' ) ) {
-			if ( $this->stock_status !== 'instock' ) {
-				$this->set_stock_status( 'instock' );
-			}
+			$this->set_stock_status( 'instock' );
 		}
 	}
 


### PR DESCRIPTION
I would like to discuss the following issue:

Creation of a new variation with manage_stock=true and a positive stock amount will not set the stock_status meta on the variation level because the magical __get will always return „instock“ if the stock_status meta is not set.
This leads to strange behavior in price display and maybe other problems like unsynced products because subqueries like get_children are assuming this meta is set for all variations.

One fix would be to remove the stock_status check like I proposed in this pull request to enforce setting of the meta value. Another solution would be the override of the check_stock_status in the WC_Product_Variation class and just skip the check of the current stock_status there.

Example to reproduce the error via the v2 REST-API:

``` json
{
            "product": {
                "title": "API Testprodukt",
                "status": "publish",
                "type": "variable",
                "sku": "UNIQUESKU_",
                "attributes": [
                    {
                        "name": "Size",
                        "position": "0",
                        "visible": false,
                        "variation": true,
                        "options": [
                            "1",
                            "2",
                            "3"
                        ]
                    },
                ],
                "variations": [
                    {
                        "regular_price": "19.99",
                        "managing_stock": true,
                        "stock_quantity": 2,
                        "attributes": [
                            {
                                "name": "Size",
                                "option": "1"
                            }
                        ],
                    },
                    {
                        "regular_price": "10.00",
                        "managing_stock": true,
                        "stock_quantity": 0,
                        "attributes": [
                            {
                                "name": "Size",
                                "option": "2"
                            }
                        ],
                    }
                ]
            }
        }
```

You will see: the stock_status meta is not set in the first variation. In the second it is set because the stock amount is set to 0 and therefor the stock_status will be set and saved in the check_stock_status function.

The missing stock_status will then lead to incorrect outputs of e.g. WC_Product_Variable->get_children() and all functions that are using it.
