### PR TITLE
API: Backorders string needs identical comparison due to boolean values

### DIFF
--- a/includes/api/class-wc-api-products.php
+++ b/includes/api/class-wc-api-products.php
@@ -1545,7 +1545,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Backorders.
 			if ( isset( $data['backorders'] ) ) {
-				if ( 'notify' == $data['backorders'] ) {
+				if ( 'notify' === $data['backorders'] ) {
 					$backorders = 'notify';
 				} else {
 					$backorders = ( true === $data['backorders'] ) ? 'yes' : 'no';


### PR DESCRIPTION
Backorders may have mixed value, true/false or 'notify'. String comparison needs identical check due to boolean values. Without this, true value (Allow backorders) can not be set via API.
