### PR TITLE
Added new woocommerce_evaluate_shipping_cost filter

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -70,6 +70,9 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		$locale   = localeconv();
 		$decimals = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
 
+		// Allow 3rd parties to process shipping cost arguments
+		$args = apply_filters( 'woocommerce_evaluate_shipping_cost', $args, $sum, $decimals );
+
 		$this->fee_cost = $args['cost'];
 
 		// Expand shortcodes


### PR DESCRIPTION
## Summary

The filter will allow 3rd parties to pre-process the arguments used to evaluate a shipping cost formula, before they are used for calculations.
## Why

The formulas used for shipping calculation work only if shop's base currency and the cart currency are the same. This is not always the case, as in a multi-currency environment the two currencies may be different. The result is that, if a formula contains a reference to the cart, the shipping cost are calculated incorrectly.
## Example
- Base currency: USD
- Cart amount: 200 EUR
- Formula: 100 + [cost] \* 0.1

Calculation result (incorrect)
100 USD + (200 EUR \* 0.1) = 120 (assumed to be USD, which converted to EUR, become 110.22 EUR)

Correct calculation: 100 + [(200 EUR to USD -> 217.76) \* 0.1] = 121.77 USD. After conversion, it becomes 112.86 EUR, which is correct.
## Solution

The filter will allow multi-currency solutions to normalise the elements that are used for the calculation of fees (e.g. the cart total), so that, when the calculation occurs, all elements are in the same currency.
