### PR TITLE
Weight/dimension conversions

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -46,11 +46,14 @@ function wc_get_filename_from_url( $file_url ) {
  *
  * @param mixed $dim
  * @param mixed $to_unit 'in', 'm', 'cm', 'm'
+ * @param mixed $from_unit (optional) 'in', 'm', 'cm', 'm'
  * @return float
  */
-function wc_get_dimension( $dim, $to_unit ) {
+function wc_get_dimension( $dim, $to_unit, $from_unit = null ) {
 
-	$from_unit 	= strtolower( get_option( 'woocommerce_dimension_unit' ) );
+	if ( empty( $from_unit ) ) {
+		$from_unit = strtolower( get_option( 'woocommerce_dimension_unit' ) );
+	}
 	$to_unit	= strtolower( $to_unit );
 
 	// Unify all units to cm first
@@ -97,11 +100,14 @@ function wc_get_dimension( $dim, $to_unit ) {
  *
  * @param mixed $weight
  * @param mixed $to_unit 'g', 'kg', 'lbs'
+ * @param mixed $from_unit (optional) 'g', 'kg', 'lbs'
  * @return float
  */
-function wc_get_weight( $weight, $to_unit ) {
+function wc_get_weight( $weight, $to_unit, $from_unit = null ) {
 
-	$from_unit 	= strtolower( get_option('woocommerce_weight_unit') );
+	if ( empty( $from_unit ) ) {
+		$from_unit = strtolower( get_option( 'woocommerce_weight_unit' ) );
+	}
 	$to_unit	= strtolower( $to_unit );
 
 	//Unify all units to kg first

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -95,10 +95,17 @@ class Functions extends \WC_Unit_Test_Case {
 			array( 0, wc_get_dimension( -10, 'mm' ) ),
 		);
 
+		$custom = array(
+			array( 25.4, wc_get_dimension( 10, 'cm', 'in' ) ),
+			array( 914.4, wc_get_dimension( 10, 'cm', 'yd' ) ),
+			array( 393.7, wc_get_dimension( 10, 'in', 'm' ) ),
+			array( 0.010936133, wc_get_dimension( 10, 'yd', 'mm' ) )
+		);
+
 		// restore default
 		update_option( 'woocommerce_dimension_unit', $default_unit );
 
-		return array_merge( $cm, $in, $m, $mm, $yd, $n );
+		return array_merge( $cm, $in, $m, $mm, $yd, $n, $custom );
 
 	}
 
@@ -151,6 +158,12 @@ class Functions extends \WC_Unit_Test_Case {
 		$this->assertEquals( 283.495, wc_get_weight( 10, 'g' ) );
 		$this->assertEquals( 0.6249987469, wc_get_weight( 10, 'lbs' ) );
 		$this->assertEquals( 10, wc_get_weight( 10, 'oz' ) );
+
+		// custom from unit
+		$this->assertEquals( 0.283495, wc_get_weight( 10, 'kg', 'oz' ) );
+		$this->assertEquals( 0.01, wc_get_weight( 10, 'kg', 'g' ) );
+		$this->assertEquals( 4.53592, wc_get_weight( 10, 'kg', 'lbs' ) );
+		$this->assertEquals( 10, wc_get_weight( 10, 'kg', 'kg' ) );
 
 		// negative
 		$this->assertEquals( 0, wc_get_weight( -10, 'g' ) );


### PR DESCRIPTION
Add a third optional parameter to the weight and dimension normalization
functions in order to be able to specify a specific "from unit" instead
of using the site option. This allows arbitrary conversions between
different units of measure; which is particularly useful for extensions
that need to perform arbitrary unit conversions (e.g. shipping extension
that specifies custom box formats).

Also includes tests.

Tagged this for 2.6 but would be awesome if it sneaked into 2.5.
