### PR TITLE
Added shipping class instance to woocommerce_evaluate_shipping_cost_args

### DIFF
--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -68,7 +68,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		include_once( 'includes/class-wc-eval-math.php' );
 
 		// Allow 3rd parties to process shipping cost arguments
-		$args           = apply_filters( 'woocommerce_evaluate_shipping_cost_args', $args, $sum );
+		$args           = apply_filters( 'woocommerce_evaluate_shipping_cost_args', $args, $sum, $this );
 		$locale         = localeconv();
 		$decimals       = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
 		$this->fee_cost = $args['cost'];


### PR DESCRIPTION
Improvement over [PR 10054](https://github.com/woothemes/woocommerce/pull/10054)

The instance is going to be useful if any 3rd party needs to read any other property of the shipping class, which might not have been passed through the `$args` variable.
