### PR TITLE
#10072

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -99,6 +99,8 @@ class WC_Payment_Gateways {
 		$ordering  = (array) get_option( 'woocommerce_gateway_order' );
 		$order_end = 999;
 
+		WC()->shipping()->load_shipping_methods();
+
 		// Load gateways in order
 		foreach ( $load_gateways as $gateway ) {
 			$load_gateway = is_string( $gateway ) ? new $gateway() : $gateway;

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -52,7 +52,7 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
     	$shipping_methods = array();
 
     	if ( is_admin() )
-	    	foreach ( WC()->shipping()->load_shipping_methods() as $method ) {
+	    	foreach ( WC()->shipping()->get_shipping_methods() as $method ) {
 		    	$shipping_methods[ $method->id ] = $method->get_title();
 	    	}
 


### PR DESCRIPTION
My fix is to load shippings before Gateways are initialized so they are not tied to gateways. In practice it means that they are loaded few lines sooner.
