### PR TITLE
Settings API: add optional "select all"/"select none" buttons to multiselect fields

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -666,6 +666,7 @@ abstract class WC_Settings_API {
 			'desc_tip'          => false,
 			'description'       => '',
 			'custom_attributes' => array(),
+			'allbuttons'        => false,
 			'options'           => array()
 		);
 
@@ -688,6 +689,9 @@ abstract class WC_Settings_API {
 						<?php endforeach; ?>
 					</select>
 					<?php echo $this->get_description_html( $data ); ?>
+					<?php if ( $data['allbuttons'] ) : ?>
+						<br/><a class="select_all button" href="#"><?php _e( 'Select all', 'woocommerce' ); ?></a> <a class="select_none button" href="#"><?php _e( 'Select none', 'woocommerce' ); ?></a>
+					<?php endif; ?>
 				</fieldset>
 			</td>
 		</tr>


### PR DESCRIPTION
Add optional "select all"/"select none" buttons to multiselect fields, similarly to what already exists for the country field, triggered by an `allbuttons` data param.

This enhancement was inspired by seeing some WC extensions doing this by overwriting the `generate_multiselect_html` function, just to add this. Seems unnecessary as we could just support it in core.

![screenshot from 2016-01-14 22-06-03](https://cloud.githubusercontent.com/assets/260253/12346729/fbc36280-bb0b-11e5-859c-4ee010194e87.png)
