### PR TITLE
Added: Action hooks for terms

### DIFF
--- a/templates/checkout/terms.php
+++ b/templates/checkout/terms.php
@@ -11,9 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( wc_get_page_id( 'terms' ) > 0 && apply_filters( 'woocommerce_checkout_show_terms', true ) ) : ?>
+
+	<?php do_action( 'woocommerce_review_order_before_terms' ); ?>
+
     <p class="form-row terms wc-terms-and-conditions">
 		<input type="checkbox" class="input-checkbox" name="terms" <?php checked( apply_filters( 'woocommerce_terms_is_checked_default', isset( $_POST['terms'] ) ), true ); ?> id="terms" />
         <label for="terms" class="checkbox"><?php printf( __( 'I&rsquo;ve read and accept the <a href="%s" target="_blank">terms &amp; conditions</a>', 'woocommerce' ), esc_url( wc_get_page_permalink( 'terms' ) ) ); ?> <span class="required">*</span></label>
         <input type="hidden" name="terms-field" value="1" />
     </p>
+
+	<?php do_action( 'woocommerce_review_order_after_terms' ); ?>
+
 <?php endif; ?>


### PR DESCRIPTION
- `<?php do_action( 'woocommerce_review_order_before_terms' ); ?>`
- `<?php do_action( 'woocommerce_review_order_after_terms' ); ?>`
