### PR TITLE
Add filters so permission checks can be overwritten

### DIFF
--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -725,19 +725,25 @@ class WC_API_Customers extends WC_API_Resource {
 			switch ( $context ) {
 
 				case 'read':
-					if ( ! current_user_can( 'list_users' ) ) {
+					$permission = current_user_can( 'list_users' );
+					$permission = apply_filters( 'woocommerce_api_validate_list_users_permission', $permission, $customer );
+					if ( ! $permission ) {
 						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), 401 );
 					}
 					break;
 
 				case 'edit':
-					if ( ! current_user_can( 'edit_users' ) ) {
+					$permission = current_user_can( 'edit_users' );
+					$permission = apply_filters( 'woocommerce_api_validate_edit_users_permission', $permission, $customer );
+					if ( ! $permission ) {
 						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), 401 );
 					}
 					break;
 
 				case 'delete':
-					if ( ! current_user_can( 'delete_users' ) ) {
+					$permission = current_user_can( 'delete_users' );
+					$permission = apply_filters( 'woocommerce_api_validate_delete_users_permission', $permission, $customer );
+					if ( ! $permission ) {
 						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), 401 );
 					}
 					break;


### PR DESCRIPTION
I would like to see this pull request added because:
- When I create a API key for a user with a "customer" role, he is not able to use the /products call because he needs to have permission to "read_private_posts".
- When a "customer" wants to edit his details trough /customers/<id> he is not allowed to because he cannot "edit_post".
- And the same thing for delete.

I have no problem making these validations myself, but I need those filters so I can make those changes.
