### PR TITLE
Fixed attribute check for less notices

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1343,7 +1343,7 @@ class WC_Product {
 
 			$attribute = isset( $attributes[ $attr ] ) ? $attributes[ $attr ] : $attributes[ 'pa_' . $attr ];
 
-			if ( $attribute['is_taxonomy'] ) {
+			if ( isset( $attribute['is_taxonomy'] ) && $attribute['is_taxonomy'] ) {
 
 				return implode( ', ', wc_get_product_terms( $this->id, $attribute['name'], array( 'fields' => 'names' ) ) );
 


### PR DESCRIPTION
Today I was fetching products via the REST API 2.0 and got the notice "PHP Notice:  Undefined index: is_taxonomy"

This PR should fix that.
