### PR TITLE
[API] validate customers request

### DIFF
--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -725,22 +725,34 @@ class WC_API_Customers extends WC_API_Resource {
 			switch ( $context ) {
 
 				case 'read':
-					if ( ! current_user_can( 'list_users' ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), 401 );
-					}
-					break;
-
-				case 'edit':
-					if ( ! current_user_can( 'edit_users' ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), 401 );
-					}
-					break;
-
-				case 'delete':
-					if ( ! current_user_can( 'delete_users' ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), 401 );
-					}
-					break;
+ -					if ( ! current_user_can( 'list_users' ) ) {
+ +					$permission = current_user_can( 'list_users' );
+ +					$permission = apply_filters( 'woocommerce_api_validate_list_users_permission', $permission, $customer, $context );
+ +					if ( ! $permission )
+  						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), 401 );
+ -					}
+ +					
+  					break;
+  
+  				case 'edit':
+ -					if ( ! current_user_can( 'edit_users' ) ) {
+ +					$permission = current_user_can( 'edit_users' );
+ +					$permission = apply_filters( 'woocommerce_api_validate_edit_users_permission', $permission, $customer, $context );
+ +					if ( ! $permission )
+  						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), 401 );
+ -					}
+ +					
+  					break;
+  
+  				case 'delete':
+ -					if ( ! current_user_can( 'delete_users' ) ) {
+ +					$permission = current_user_can( 'delete_users' );
+ +					$permission = apply_filters( 'woocommerce_api_validate_delete_users_permission', $permission, $customer, $context );
+ +					if ( ! $permission )
+  						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), 401 );
+ -					}
+ +					
+  					break;
 			}
 
 			return $id;


### PR DESCRIPTION
First of all thank you for woothemes@ebdbe5d

My final request is to add a similar filter to the validate_request function in the WC_API_Customers class.

The reason for this filter is that when an user with "customer" role tries to access the route: PUT /customers/ID he doesn't have the permission to "edit_users". Same goes for reading and deleting. With this filter I can make my own validation.
Recently the "woocommerce_api_check_permission" filter was added, so it would make sense to add these filters too, because its the same validation except its user and not post related.
