### PR TITLE
Added an option to disable password strength meter

### DIFF
--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -153,6 +153,14 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'      => false
 			),
 
+			array(
+				'desc'          => __( 'Disable password strength meter', 'woocommerce' ),
+				'id'            => 'woocommerce_disable_password_strength_meter',
+				'default'       => 'no',
+				'type'          => 'checkbox',
+				'autoload'      => false
+			),
+
 			array( 'type' => 'sectionend', 'id' => 'account_registration_options'),
 
 		) );

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -185,8 +185,10 @@ class WC_Frontend_Scripts {
 
 			// Password strength meter.
 			// Load in checkout, account login and edit account page.
-			if ( ( 'no' === get_option( 'woocommerce_registration_generate_password' ) && ! is_user_logged_in() ) || is_edit_account_page() ) {
-				self::enqueue_script( 'wc-password-strength-meter' );
+			if ( 'yes' !== get_option('woocommerce_disable_password_strength_meter') ) {
+				if ( ( 'no' === get_option( 'woocommerce_registration_generate_password' ) && ! is_user_logged_in() ) || is_edit_account_page() ) {
+					self::enqueue_script( 'wc-password-strength-meter' );
+				}
 			}
 		}
 		if ( is_checkout() ) {


### PR DESCRIPTION
Implementation related to issue #10201 about an option in settings/account to disable the new password strength meter introduced in woocommerce 2.5.

I've decided to nest two if statement in class-wc-frontend-scripts.php to keep the code more readable.
