### PR TITLE
Update wc-template-functions.php

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1710,6 +1710,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		$args = apply_filters( 'woocommerce_form_field_args', $args, $key, $value );
 
 		if ( $args['required'] ) {
+			$args['class'] = array();
 			$args['class'][] = 'validate-required';
 			$required = ' <abbr class="required" title="' . esc_attr__( 'required', 'woocommerce'  ) . '">*</abbr>';
 		} else {


### PR DESCRIPTION
`$args['class']` does not exist in the array.

**Fatal error: [] operator not supported for strings.**

Defining the array, fixes the checkout page. 

![Error on checkout page](https://dl.dropboxusercontent.com/u/12445484/Screen%20Shot%202016-01-27%20at%204.56.14%20PM.png)
