### PR TITLE
Change the default value of an experimental feature to false

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1185,7 +1185,7 @@ class WC_Cart {
  					 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
  					 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
  					 */
-					if ( $item_tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
+					if ( $item_tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', false ) ) {
 
 						// Work out a new base price without the shop's base tax
 						$taxes                 = WC_Tax::calc_tax( $line_price, $base_tax_rates, true, true );


### PR DESCRIPTION
Because if something is experimental and use at own risk, it probably shouldn't be turned on by default.

With included pricing, we pass the price of the subscription with the tax (for the shipping country, which DOES have a tax rate) included. The function following this line would try to strip away the tax included there, but the base does not have any, so it removes 0 from the price. And then, because it's still shipping to a country which has tax, the price is essentially double taxed.
