### PR TITLE
Do not stop hide_variation, and show_variation from bubbling

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -38,7 +38,6 @@
 		// When the variation is hidden
 		.on( 'hide_variation', function() {
 			$form.find( '.single_add_to_cart_button' ).attr( 'disabled', 'disabled' ).attr( 'title', wc_add_to_cart_variation_params.i18n_make_a_selection_text );
-			return false;
 		} )
 
 		// When the variation is revealed
@@ -48,7 +47,6 @@
 			} else {
 				$form.find( '.single_add_to_cart_button' ).attr( 'disabled', 'disabled' ).attr( 'title', wc_add_to_cart_variation_params.i18n_unavailable_text );
 			}
-			return false;
 		} )
 
 		// Reload product variations data

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -32,7 +32,6 @@
 		.on( 'click', '.reset_variations', function() {
 			$form.find( '.variations select' ).val( '' ).change();
 			$form.trigger( 'reset_data' );
-			return false;
 		} )
 
 		// When the variation is hidden


### PR DESCRIPTION
Currently add-to-cart-variation.js returns false from its events attached to show_variation and hide_variation and reset_variations.

This stops other plugins using those triggers reliably. 
