### PR TITLE
Pass term object to get_term_link()

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -558,7 +558,7 @@ function woocommerce_template_loop_product_link_close() {
  * Insert the opening anchor tag for categories in the loop.
  */
 function woocommerce_template_loop_category_link_open( $category ) {
-	echo '<a href="' . get_term_link( $category->slug, 'product_cat' ) . '">';
+	echo '<a href="' . get_term_link( $category, 'product_cat' ) . '">';
 }
 /**
  * Insert the opening anchor tag for categories in the loop.


### PR DESCRIPTION
Passing the term object to get_term_link() instead of just the slug is slightly more efficient and robust, and it fixes a compatibiltity issue with Ceceppa Multilingua support for Woocommerce.
