### PR TITLE
Add payment complete update order date filter

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2383,11 +2383,13 @@ abstract class WC_Abstract_Order {
 				update_post_meta( $this->id, '_transaction_id', $transaction_id );
 			}
 
-			wp_update_post( array(
-				'ID'            => $this->id,
-				'post_date'     => current_time( 'mysql', 0 ),
-				'post_date_gmt' => current_time( 'mysql', 1 )
-			) );
+			if ( apply_filters( 'woocommerce_payment_complete_update_order_date', true, $this->id ) ) {
+				wp_update_post( array(
+					'ID'            => $this->id,
+					'post_date'     => current_time( 'mysql', 0 ),
+					'post_date_gmt' => current_time( 'mysql', 1 )
+				) );
+			}
 
 			// Payment is complete so reduce stock levels
 			if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', ! get_post_meta( $this->id, '_order_stock_reduced', true ), $this->id ) ) {


### PR DESCRIPTION
Adds a filter to prevent the order date from being updated to the time of payment.

We're manually raising some orders, sending out invoices and links to pay through PayPal, and the date is then updated to the time the customer pays. For tax reporting purposes though we're required to use the date the invoice was raised (which is the date the order was originally created) and not the date the payment was made, and this would allow us to do that.
