### PR TITLE
Track & return when a customer was last updated

### DIFF
--- a/includes/api/class-wc-api-customers.php
+++ b/includes/api/class-wc-api-customers.php
@@ -162,6 +162,7 @@ class WC_API_Customers extends WC_API_Resource {
 		$customer_data = array(
 			'id'               => $customer->ID,
 			'created_at'       => $this->server->format_datetime( $customer->user_registered ),
+			'last_update'      => $this->server->format_datetime( get_user_meta( $customer->ID, 'last_update', true ) ),
 			'email'            => $customer->user_email,
 			'first_name'       => $customer->first_name,
 			'last_name'        => $customer->last_name,

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -605,10 +605,21 @@ add_action( 'profile_update', 'wc_update_profile_last_update_time', 10, 2 );
  * @param  string $_meta_value Value of the meta that was changed
  */
 function wc_meta_update_last_update_time( $meta_id, $user_id, $meta_key, $_meta_value ) {
-	if ( 'last_update' === $meta_key ) {
-		return;
+	$keys_to_track = apply_filters( 'woocommerce_user_last_update_fields', array( 'first_name', 'last_name' ) );
+	$update_time   = false;
+	if ( in_array( $meta_key, $keys_to_track ) ) {
+		$update_time = true;
 	}
-	wc_set_user_last_update_time( $user_id );
+	if ( 'billing_' === substr( $meta_key, 0, 8 ) ) {
+		$update_time = true;
+	}
+	if ( 'shipping_' === substr( $meta_key, 0, 9 ) ) {
+		$update_time = true;
+	}
+
+	if ( $update_time ) {
+		wc_set_user_last_update_time( $user_id );
+	}
 }
 
 add_action( "update_user_meta", 'wc_meta_update_last_update_time', 10, 4 );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -583,7 +583,7 @@ function wc_disable_author_archives_for_customers() {
 add_action( 'template_redirect', 'wc_disable_author_archives_for_customers' );
 
 /**
- * Hooks into the `profile_update` hook to set the user last updated timestamp
+ * Hooks into the `profile_update` hook to set the user last updated timestamp.
  *
  * @since 2.6
  * @param  int   $user_id    The user that was updated
@@ -596,7 +596,7 @@ function wc_update_profile_last_update_time( $user_id, $old ) {
 add_action( 'profile_update', 'wc_update_profile_last_update_time', 10, 2 );
 
 /**
- * Hooks into the update user meta function to set the user last updated timestamp
+ * Hooks into the update user meta function to set the user last updated timestamp.
  *
  * @since  2.6
  * @param  int    $meta_id     ID of the meta object that was changed
@@ -622,10 +622,10 @@ function wc_meta_update_last_update_time( $meta_id, $user_id, $meta_key, $_meta_
 	}
 }
 
-add_action( "update_user_meta", 'wc_meta_update_last_update_time', 10, 4 );
+add_action( 'update_user_meta', 'wc_meta_update_last_update_time', 10, 4 );
 
 /**
- * Sets a user's "last update" time to the current timestamp
+ * Sets a user's "last update" time to the current timestamp.
  *
  * @since  2.6
  * @param  int $user_id The user to set a timestamp for

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -581,3 +581,44 @@ function wc_disable_author_archives_for_customers() {
 }
 
 add_action( 'template_redirect', 'wc_disable_author_archives_for_customers' );
+
+/**
+ * Hooks into the `profile_update` hook to set the user last updated timestamp
+ *
+ * @since 2.6
+ * @param  int   $user_id    The user that was updated
+ * @param  array $old        The profile fields pre-change
+ */
+function wc_update_profile_last_update_time( $user_id, $old ) {
+	wc_set_user_last_update_time( $user_id );
+}
+
+add_action( 'profile_update', 'wc_update_profile_last_update_time', 10, 2 );
+
+/**
+ * Hooks into the update user meta function to set the user last updated timestamp
+ *
+ * @since  2.6
+ * @param  int    $meta_id     ID of the meta object that was changed
+ * @param  int    $user_id     The user that was updated
+ * @param  string $meta_key    Name of the meta key that was changed
+ * @param  string $_meta_value Value of the meta that was changed
+ */
+function wc_meta_update_last_update_time( $meta_id, $user_id, $meta_key, $_meta_value ) {
+	if ( 'last_update' === $meta_key ) {
+		return;
+	}
+	wc_set_user_last_update_time( $user_id );
+}
+
+add_action( "update_user_meta", 'wc_meta_update_last_update_time', 10, 4 );
+
+/**
+ * Sets a user's "last update" time to the current timestamp
+ *
+ * @since  2.6
+ * @param  int $user_id The user to set a timestamp for
+ */
+function wc_set_user_last_update_time( $user_id ) {
+	update_user_meta( $user_id, 'last_update', time() );
+}


### PR DESCRIPTION
Closes #10306.

I took a stab at #10306. Since there is no concept of a "user last updated" time like there is for post types/orders/etc we would have to track when a user last updated their profile - this is my proposal on how to do that. Luckily hooks make that easy for us.
