### PR TITLE
Fixed incompatibility with PHP 5.4 and earlier

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -451,7 +451,8 @@ abstract class WC_Abstract_Order {
 		wc_add_order_item_meta( $item_id, 'taxes', $taxes );
 
 		// Store meta
-		if ( ! empty( $shipping_rate->get_meta_data() ) ) {
+		$shipping_meta = $shipping_rate->get_meta_data();
+		if ( ! empty( $shipping_meta ) ) {
 			foreach ( $shipping_rate->get_meta_data() as $key => $value ) {
 				wc_add_order_item_meta( $item_id, $key, $value );
 			}


### PR DESCRIPTION
It's not possible to pass the result of a function call to the `empty()` function in PHP 5.4 and earlier. Although they are fairly old versions, it's safe to assume that hosting providers won't update PHP to 5.5 for a while, therefore backward compatibility should be maintained.
