### PR TITLE
Postponed call to woocommerce_shipping_methods filter

### DIFF
--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -226,8 +226,24 @@ class WC_Shipping_Zone implements WC_Data {
 		foreach ( $raw_methods as $raw_method ) {
 			if ( in_array( $raw_method->method_id, array_keys( $allowed_classes ) ) ) {
 				$class_name = $allowed_classes[ $raw_method->method_id ];
-				if ( class_exists( $class_name ) ) {
-					$methods[ $raw_method->instance_id ]               = new $class_name( $raw_method->instance_id );
+
+				// The returned array may contain instances of shipping methods, as well
+				// as classes. If the "class" is an instance, just use it. If not,
+				// create an instance.
+				if( is_object( $class_name ) ) {
+					$methods[ $raw_method->instance_id ] = $class_name;
+				}
+				else {
+					// If the class is not an object, it should be a string. It's better
+					// to double check, to be sure (a class must be a string, anything)
+					// else would be useless
+					if( is_string( $class_name ) && class_exists( $class_name ) ) {
+						$methods[ $raw_method->instance_id ] = new $class_name( $raw_method->instance_id );
+					}
+				}
+
+				// Let's make sure that we have an instance before setting its attributes
+				if ( is_object( $methods[ $raw_method->instance_id ] ) ) {
 					$methods[ $raw_method->instance_id ]->method_order = absint( $raw_method->method_order );
 					$methods[ $raw_method->instance_id ]->has_settings = $methods[ $raw_method->instance_id ]->has_settings();
 				}

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -118,9 +118,7 @@ class WC_Shipping {
 			}
 		}
 
-		$shipping_methods = apply_filters( 'woocommerce_shipping_methods', $shipping_methods );
-
-		return $shipping_methods;
+		return apply_filters( 'woocommerce_shipping_methods', $shipping_methods );
 	}
 
 	/**

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -102,11 +102,11 @@ class WC_Shipping {
 	 */
 	public function get_shipping_method_class_names() {
 		// Unique Method ID => Method Class name
-		$shipping_methods = apply_filters( 'woocommerce_shipping_methods', array(
+		$shipping_methods = array(
 			'flat_rate'     => 'WC_Shipping_Flat_Rate',
 			'free_shipping' => 'WC_Shipping_Free_Shipping',
 			'local_pickup'  => 'WC_Shipping_Local_Pickup',
-		) );
+		);
 
 		// For backwards compatibility with 2.5.x we load any ENABLED legacy shipping methods here
 		$maybe_load_legacy_methods = array( 'flat_rate', 'free_shipping', 'international_delivery', 'local_delivery', 'local_pickup' );
@@ -117,6 +117,8 @@ class WC_Shipping {
 				$shipping_methods[ 'legacy_' . $method ] = 'WC_Shipping_Legacy_' . $method;
 			}
 		}
+
+		$shipping_methods = apply_filters( 'woocommerce_shipping_methods', $shipping_methods );
 
 		return $shipping_methods;
 	}


### PR DESCRIPTION
The filter should be called after adding all shipping methods, to provide a complete set of data to consumers that hook into it.
