### PR TITLE
Update class-wc-webhook.php customer.created webhook to be triggered with 'user_register' action

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -546,6 +546,7 @@ class WC_Webhook {
 			'customer.created' => array(
 				'user_register',
 				'woocommerce_created_customer',
+				'woocommerce_api_create_customer'
 			),
 			'customer.updated' => array(
 				'profile_update',

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -544,6 +544,7 @@ class WC_Webhook {
 				'wp_trash_post',
 			),
 			'customer.created' => array(
+				'user_register',
 				'woocommerce_created_customer',
 			),
 			'customer.updated' => array(


### PR DESCRIPTION
Hi,

I just added the action **user_register** to trigger the **customer.created** webhook, so it will trigger both when the customer is created on the shop area or in the admin area.

Also by looking at the code i saw that normally all the webhooks actions are also triggered by api calls, except, again, for the **customer.created** one, there shouldn't be another line like **woocommerce_api_create_customer** ? If that's the case let me know that I will add in this PR.
