### PR TITLE
Use real checkout fields for getting value

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -765,18 +765,22 @@ class WC_Checkout {
 			}
 
 			// Get the billing_ and shipping_ address fields
-			$address_fields = array_merge( WC()->countries->get_address_fields(), WC()->countries->get_address_fields( '', 'shipping_' ) );
+			if ( isset( $this->checkout_fields['shipping'] ) && isset( $this->checkout_fields['billing'] ) ) {
 
-			if ( is_user_logged_in() && array_key_exists( $input, $address_fields ) ) {
-				$current_user = wp_get_current_user();
+				$address_fields = array_merge( $this->checkout_fields['billing'], $this->checkout_fields['shipping'] );
 
-				if ( $meta = get_user_meta( $current_user->ID, $input, true ) ) {
-					return $meta;
+				if ( is_user_logged_in() && is_array( $address_fields ) && array_key_exists( $input, $address_fields ) ) {
+					$current_user = wp_get_current_user();
+
+					if ( $meta = get_user_meta( $current_user->ID, $input, true ) ) {
+						return $meta;
+					}
+
+					if ( $input == 'billing_email' ) {
+						return $current_user->user_email;
+					}
 				}
 
-				if ( $input == 'billing_email' ) {
-					return $current_user->user_email;
-				}
 			}
 
 			switch ( $input ) {


### PR DESCRIPTION
This proposed change is to ensure that the real (/ all) checkout fields are used when the data in the DB is searched.

Previously using [WC()->countries->get_address_fields()](https://github.com/woothemes/woocommerce/blob/3dba3378c2c4a96fd84d8349f0ac0a0aaa209037/includes/class-wc-checkout.php#L100-L101) which doesn't go through the [woocommerce_checkout_fields](https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-checkout.php#L130) filter which can be used to modify checkout fields. 

That resulted in cases where custom fields not having the saved value from the database, this PR fixes that.

Let me know the thoughts :smile: 
