### PR TITLE
Added new filter in WC_Shipping_Zone::get_shipping_methods()

### DIFF
--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -249,7 +249,7 @@ class WC_Shipping_Zone implements WC_Data {
 			}
 		}
 
-		return $methods;
+		return apply_filters( 'woocommerce_shipping_zone_shipping_methods', $methods, $raw_methods, $allowed_classes, $this );
 	}
 
 	/**


### PR DESCRIPTION
The filter will allow 3rd parties to process the INSTANCES of the shipping methods loaded for a zone.
## Why

**Until WC 2.5**, the `woocommerce_shipping_methods` filter could be invoked both when shipping methods were just listed (e.g. to find out which ones were configured) and when they were initialised. In fact, the array returned by that filter could contain either shipping methods' class names or instances (see [Fix - Handled case in which the list of method "classes" contains objects](https://github.com/aelia-co/woocommerce/commit/6d0f844d2b93ccb37ac357a4270f578e24b08e15). The filter could therefore be used to create instances of shipping methods before they were used for shipping calculations on the cart or checkout.  
This worked perfectly, because all it was needed to create an instance was calling `new Some_Method_Class()`. 

**WC 2.6 introduced radical changes in how the shipping methods are handled**. With the introduction of instance specific settings, the mechanism described above doesn't work anymore. Creating shipping method instance without passing an instance ID will returns a non-functional shipping method (no settings), and the filter `woocommerce_shipping_methods` doesn't provide any instance ID that could be used. 

To fix the issue, a new filter is required, to allow manipulating the shipping methods after they have been loaded. The best place seems to be `WC_Shipping_Zone::get_shipping_methods()`, as that loads the shipping methods taking into account instance specific settings. By hooking into this new filter, 3rd parties will be able to process shipping methods as they did before.
