### PR TITLE
Adds a unit test for wc_format_country_state_string().

### DIFF
--- a/tests/unit-tests/util/core-functions.php
+++ b/tests/unit-tests/util/core-functions.php
@@ -159,7 +159,10 @@ class Core_Functions extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_format_country_state_string() {
+		// Test with correct values.
 		$this->assertEquals( array( 'country' => 'US', 'state' => 'CA' ), wc_format_country_state_string( 'US:CA' ) );
+		// Test what happens when we pass an incorrect value.
+		$this->assertEquals( array( 'country' => 'US-CA', 'state' => '' ), wc_format_country_state_string( 'US-CA' ) );
 	}
 
 }

--- a/tests/unit-tests/util/core-functions.php
+++ b/tests/unit-tests/util/core-functions.php
@@ -153,5 +153,14 @@ class Core_Functions extends \WC_Unit_Test_Case {
 		$this->assertEquals( '', $default['state'] );
 	}
 
+	/**
+	 * Test wc_format_country_state_string().
+	 *
+	 * @since 2.6.0
+	 */
+	public function test_wc_format_country_state_string() {
+		$this->assertEquals( array( 'country' => 'US', 'state' => 'CA' ), wc_format_country_state_string( 'US:CA' ) );
+	}
+
 }
 


### PR DESCRIPTION
As part of ramping up on writing unit tests and increasing our test coverage, I've created a small test for the `wc_format_country_state_string()` function.

@claudiosmweb @mikejolley - I'd love y'all's review on this test when you have a moment, please.
