### PR TITLE
Result count for languages with multiple plurals

### DIFF
--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -38,9 +38,9 @@ if ( ! woocommerce_products_will_display() )
 	if ( 1 === $total ) {
 		_e( 'Showing the single result', 'woocommerce' );
 	} elseif ( $total <= $per_page || -1 === $per_page ) {
-		printf( __( 'Showing all %d results', 'woocommerce' ), $total );
+		printf( _n( 'Showing the single result', 'Showing all %d results', $total, 'woocommerce' ), $total );
 	} else {
-		printf( _x( 'Showing %1$d&ndash;%2$d of %3$d results', '%1$d = first, %2$d = last, %3$d = total', 'woocommerce' ), $first, $last, $total );
+		printf( _nx( 'Showing the single result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, '%1$d = first, %2$d = last, %3$d = total', 'woocommerce' ), $first, $last, $total );
 	}
 	?>
 </p>


### PR DESCRIPTION
There are languages with two or more plural forms.

For example in Romanian plural forms can be defined like this:
`Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);`

 `_n()` and `_nx()` can handle all those special cases for results count texts.

This fix will not add any extra strings in the i18n package, just allows for better translations.
