### PR TITLE
Add a back button on the email notification management screens

### DIFF
--- a/includes/admin/settings/views/html-admin-page-shipping-zones-instance.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zones-instance.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<h2><?php echo esc_html( $shipping_method->get_method_title() ); ?> <small class="wc-admin-breadcrumb"><a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . absint( $zone->get_zone_id() ) ) ); ?>" title="<?php echo esc_attr( __( 'Return to Shipping Methods', 'woocommerce' ) . ' (' . $zone->get_zone_name() . ')' ); ?>">&#x21a9;</a></small></h2>
+<h2><?php echo esc_html( $shipping_method->get_method_title() ); ?> <?php wc_back_link( __( 'Return to Shipping Methods', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . absint( $zone->get_zone_id() ) ) ); ?></h2>
 <?php $shipping_method->admin_options(); ?>
 <p class="submit"><input type="submit" class="button button-primary" name="save_method" value="<?php _e( 'Save changes', 'woocommerce' ); ?>" /></p>
 <?php wp_nonce_field( 'woocommerce_save_method', 'woocommerce_save_method_nonce' ); ?>

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -704,7 +704,8 @@ class WC_Email extends WC_Settings_API {
 		// Do admin actions.
 		$this->admin_actions();
 		?>
-		<h2><?php echo esc_html( $this->get_title() ); ?></h2>
+		<h2><?php echo esc_html( $this->get_title() ); ?> <?php wc_back_link( __( 'Return to Emails', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=email' ) ); ?></h2>
+
 		<?php echo wpautop( wp_kses_post( $this->get_description() ) ); ?>
 
 		<?php

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -935,3 +935,13 @@ function woocommerce_register_shipping_method( $shipping_method ) {
 function wc_get_shipping_zone( $package ) {
 	return WC_Shipping_Zones::get_zone_matching_package( $package );
 }
+
+/**
+ * Outputs a "back" link so admin screens can easily jump back a page.
+
+ * @param  string $label Title of the page to return to
+ * @param  string $url   URL of the page to return to
+ */
+function wc_back_link( $label, $url ) {
+	echo '<small class="wc-admin-breadcrumb"><a href="' . esc_url( $url ) . '" title="' . esc_attr( $label ) . '">&#x21a9;</a></small>';
+}


### PR DESCRIPTION
Fixes #10317.

Adds the back button seen on some screens like shipping zones so you can easily get back to the main listing page. Adds a new function to generate these so they can all easily be updated.
