### PR TITLE
Adding Check in System Status for Private WooCommerce Pages

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -528,6 +528,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				if ( ! $page_id ) {
 					echo '<mark class="error">' . __( 'Page not set', 'woocommerce' ) . '</mark>';
 					$error = true;
+				} else if ( get_post_status ( $page_id ) != 'publish' ) { // make sure the page isn't private or a draft
+					echo '<mark class="error">' . sprintf( __( 'Page visibility should be <a href="%s" target="_blank">public</a>', 'woocommerce' ), 'https://codex.wordpress.org/Content_Visibility' ) . '</mark>';
+					$error = true;
 				} else {
 
 					// Shortcode check

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -528,7 +528,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				if ( ! $page_id ) {
 					echo '<mark class="error">' . __( 'Page not set', 'woocommerce' ) . '</mark>';
 					$error = true;
-				} else if ( get_post_status ( $page_id ) != 'publish' ) { // make sure the page isn't private or a draft
+				} else if ( get_post_status( $page_id ) !== 'publish' ) {
 					echo '<mark class="error">' . sprintf( __( 'Page visibility should be <a href="%s" target="_blank">public</a>', 'woocommerce' ), 'https://codex.wordpress.org/Content_Visibility' ) . '</mark>';
 					$error = true;
 				} else {

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -529,7 +529,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					echo '<mark class="error">' . __( 'Page not set', 'woocommerce' ) . '</mark>';
 					$error = true;
 				} else if ( get_post_status( $page_id ) !== 'publish' ) {
-					echo '<mark class="error">' . sprintf( __( 'Page visibility should be <a href="%s" target="_blank">public</a>', 'woocommerce' ), 'https://codex.wordpress.org/Content_Visibility' ) . '</mark>';
+					echo '<mark class="error">' . sprintf( __( 'Page visibility should be %spublic%s', 'woocommerce' ), '<a href="https://codex.wordpress.org/Content_Visibility" target="_blank">', '</a>' ) . '</mark>';
 					$error = true;
 				} else {
 


### PR DESCRIPTION
Sometimes users will accidentally set their important WooCommerce pages (like the checkout page) to `private`. This can cause numerous problems including not letting logged out users checkout. In fact the checkout page 404s not giving the user a chance to even login. A 404 is definitely not a good user experience.

This PR adds an additional check to the system status giving the user a clue that something is wrong with a link to the [WordPress documentation](https://codex.wordpress.org/Content_Visibility) to change this on their own.

![woocommerce_status_ _patrick_s_baller_test_site_ _wordpress](https://cloud.githubusercontent.com/assets/1065372/13117792/98fc749e-d55e-11e5-8d00-cc378339ea6f.jpg)
- Happier store owners (being able to solve their own problem)
- Happier customers (being able to checkout)
- Happier support (fewer tickets / easier to diagnose tickets)

Can we include this in 2.5.3 since it will be a while before 2.6 comes out?
