### PR TITLE
Hide the "View Mode" option on the "Screen Options" tab for products, orders, and coupons.

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -29,6 +29,7 @@ class WC_Admin {
 		add_action( 'admin_init', array( $this, 'admin_redirects' ) );
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
+		add_filter( 'view_mode_post_types', array( $this, 'remove_post_types_from_view_mode' ) );
 	}
 
 	/**
@@ -207,6 +208,20 @@ class WC_Admin {
 		}
 
 		return $footer_text;
+	}
+
+	/**
+	 * Removes products, orders, and coupons from the list of post types that support "View Mode" switching.
+	 * View mode is seen on posts where you can switch between list or excerpt. Our post types don't support
+	 * it, so we want to hide the useless UI from the screen options tab.
+	 *
+	 * @since 2.6
+	 * @param  array $post_types Array of post types supporting view mode
+	 * @return array             Array of post types supporting view mode, without products, orders, and coupons
+	 */
+	public function remove_post_types_from_view_mode( $post_types ) {
+		unset( $post_types['product'], $post_types['shop_order'], $post_types['shop_coupon'] );
+		return $post_types;
 	}
 
 }


### PR DESCRIPTION
Fixes #10373.

A "view mode" option

![screen shot 2016-02-17 at 9 03 25 am](https://cloud.githubusercontent.com/assets/689165/13156425/45000e08-d637-11e5-8687-261877afa2b2.png)

was showing up on products, orders, and coupon listing screens. None of these support other views, so we should hide them.
