### PR TITLE
Construct copy of instance of shipping method and pass instance id to it

### DIFF
--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -231,7 +231,7 @@ class WC_Shipping_Zone implements WC_Data {
 				// as classes. If the "class" is an instance, just use it. If not,
 				// create an instance.
 				if ( is_object( $class_name ) ) {
-					$methods[ $raw_method->instance_id ] = $class_name;
+					$methods[ $raw_method->instance_id ] = new $class_name( $raw_method->instance_id );
 				} else {
 					// If the class is not an object, it should be a string. It's better
 					// to double check, to be sure (a class must be a string, anything)

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -231,7 +231,8 @@ class WC_Shipping_Zone implements WC_Data {
 				// as classes. If the "class" is an instance, just use it. If not,
 				// create an instance.
 				if ( is_object( $class_name ) ) {
-					$methods[ $raw_method->instance_id ] = new $class_name( $raw_method->instance_id );
+					$class_name_of_instance = get_class( $class_name );
+					$methods[ $raw_method->instance_id ] = new $class_name_of_instance( $raw_method->instance_id );
 				} else {
 					// If the class is not an object, it should be a string. It's better
 					// to double check, to be sure (a class must be a string, anything)

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -93,6 +93,9 @@ class WC_Shipping_Zones {
 
 		if ( in_array( $raw_shipping_method->method_id, array_keys( $allowed_classes ) ) ) {
 			$class_name = $allowed_classes[ $raw_shipping_method->method_id ];
+			if ( is_object( $class_name ) ) {
+				$class_name = get_class( $class_name );
+			}
 			return new $class_name( $raw_shipping_method->instance_id );
 		}
 		return false;


### PR DESCRIPTION
In `includes/class-wc-shipping-zone.php` `get_shipping_methods`, if we are working with an instance of a shipping method when populating the `$methods` array for a given zone, the instance will be added without its `instance_id` set.  This will cause only a single method to display when editing a shipping zone even if multiple instances of the method were added to the zone.  It will also cause the edit URL to be malformed for that method as it will have an empty instance_id query parameter.

The trick is to follow the same pattern as `WC_Shipping_Zones::get_shipping_method` and `new` the object while passing an `instance_id` to the constructor.  This PR does that.

To test, use a shipping method that adds an instance of itself (instead of a classname) in the woocommerce_shipping_methods filter, ensure that you can add multiple instances of the same shipping method to a zone, that all the instances are displayed when editing the zone, and that hovering over the link for a given method shows a non empty instance_id in the link URL.

cc @mikejolley @daigo75 
