### PR TITLE
Tweaks API list table User column

### DIFF
--- a/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -115,7 +115,7 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 			return '';
 		}
 
-		if ( current_user_can( 'edit_user' ) ) {
+		if ( current_user_can( 'edit_user', $user->ID ) ) {
 			return '<a href="' . esc_url( add_query_arg( array( 'user_id' => $user->ID ), admin_url( 'user-edit.php' ) ) ) . '">' . esc_html( $user->display_name ) . '</a>';
 		}
 

--- a/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -115,13 +115,11 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 			return '';
 		}
 
-		$user_name = ! empty( $user->data->display_name ) ? $user->data->display_name : $user->data->user_login;
-
 		if ( current_user_can( 'edit_user' ) ) {
-			return '<a href="' . esc_url( add_query_arg( array( 'user_id' => $user->ID ), admin_url( 'user-edit.php' ) ) ) . '">' . esc_html( $user_name ) . '</a>';
+			return '<a href="' . esc_url( add_query_arg( array( 'user_id' => $user->ID ), admin_url( 'user-edit.php' ) ) ) . '">' . esc_html( $user->display_name ) . '</a>';
 		}
 
-		return esc_html( $user_name );
+		return esc_html( $user->display_name );
 	}
 
 	/**


### PR DESCRIPTION
- No need to check for `display_name` as by default its `user_login`.
- Check if the user for API keys row is editable for specific user. Because currently shop manager can see edit profile link for admin users but can't edit ;)
