### PR TITLE
Update class-wc-comments.php

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -270,7 +270,7 @@ class WC_Comments {
 				}
 			}
 
-			$stats['total_comments'] = $total;
+			$stats['all'] = $total;
 			foreach ( $approved as $key ) {
 				if ( empty( $stats[ $key ] ) ) {
 					$stats[ $key ] = 0;


### PR DESCRIPTION
Updating `'total_comments'` to `'all'` on line 273

\wp-admin\includes\class-wp-list-table.php is looking for 'all' not 'total_comments'. This makes the if statement `if ( !isset( $num_comments->$status ) )` line 253 of class-wp-list-table.php true and therefore `$num_comments->$status = 10;`

What this means is that when viewing the dashboard's activity widget, the number of All comments will always be 10.

I'm changing the index to `'all'` to resolve that issue.
