### PR TITLE
Have wp_insert_post return WP_Error when creating our coupon in the REST API

### DIFF
--- a/includes/api/class-wc-api-coupons.php
+++ b/includes/api/class-wc-api-coupons.php
@@ -279,7 +279,7 @@ class WC_API_Coupons extends WC_API_Resource {
 				'post_excerpt' => $coupon_data['description']
 	 		);
 
-			$id = wp_insert_post( $new_coupon, $wp_error = false );
+			$id = wp_insert_post( $new_coupon, true );
 
 			if ( is_wp_error( $id ) ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_create_coupon', $id->get_error_message(), 400 );

--- a/includes/api/v2/class-wc-api-coupons.php
+++ b/includes/api/v2/class-wc-api-coupons.php
@@ -279,7 +279,7 @@ class WC_API_Coupons extends WC_API_Resource {
 				'post_excerpt' => $coupon_data['description']
 	 		);
 
-			$id = wp_insert_post( $new_coupon, $wp_error = false );
+			$id = wp_insert_post( $new_coupon, true );
 
 			if ( is_wp_error( $id ) ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_create_coupon', $id->get_error_message(), 400 );


### PR DESCRIPTION
Found a bug when I was looking at the REST API code. When code is switched to use CRUD this wouldn't be a problem, but we should fix it in the meantime.

The calls to `wp_insert_post` in the Coupon REST API are setting `wp_error` to false. Our error checking right below (`is_wp_error`) will never work since an ID of `0` will get returned instead. 

All the other endpoints that use `wp_insert_post` do it correctly.
