### PR TITLE
Implement shipping packages filters to allow multiple origins

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -249,7 +249,7 @@ class WC_Shipping {
 		 * but before Woocommerce does anything with them. A good example of usage is to merge the shipping methods for multiple
 		 * packages for marketplaces.
 		 *
-		 * @since 2.5.6
+		 * @since 2.6.0
 		 *
 		 * @param array $packages The array of packages after shipping costs are calculated.
 		 */

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -237,16 +237,23 @@ class WC_Shipping {
 			return;
 		}
 
-		// Allow packages to be reorganized before calculate the shipping
-		$packages = apply_filters( 'woocommerce_shipping_packages_before_calculate', $packages );
-
 		// Calculate costs for passed packages
 		foreach ( $packages as $package_key => $package ) {
 			$this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package );
 		}
 
-		// Allow packages to be reorganized after calculate the shipping
-		$this->packages = apply_filters( 'woocommerce_shipping_packages_after_calculate', $this->packages );
+		/**
+		 * Allow packages to be reorganized after calculate the shipping.
+		 *
+		 * This filter can be used to apply some extra manipulation after the shipping costs are calculated for the packages
+		 * but before Woocommerce does anything with them. A good example of usage is to merge the shipping methods for multiple
+		 * packages for marketplaces.
+		 *
+		 * @since 2.5.6
+		 *
+		 * @param array $packages The array of packages after shipping costs are calculated.
+		 */
+		$this->packages = apply_filters( 'woocommerce_shipping_packages', $this->packages );
 
 		if ( ! is_array( $this->packages ) || empty( $this->packages ) ) {
 			return;

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -237,9 +237,19 @@ class WC_Shipping {
 			return;
 		}
 
+		// Allow packages to be reorganized before calculate the shipping
+		$packages = apply_filters( 'woocommerce_shipping_packages_before_calculate', $packages );
+
 		// Calculate costs for passed packages
 		foreach ( $packages as $package_key => $package ) {
-			$this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package );
+			 $this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package );
+		}
+
+		// Allow packages to be reorganized after calculate the shipping
+		$this->packages = apply_filters( 'woocommerce_shipping_packages_after_calculate', $this->packages );
+
+		if ( ! is_array( $this->packages ) || empty( $this->packages ) ) {
+			return;
 		}
 
 		// Get all chosen methods

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -242,7 +242,7 @@ class WC_Shipping {
 
 		// Calculate costs for passed packages
 		foreach ( $packages as $package_key => $package ) {
-			 $this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package );
+			$this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package );
 		}
 
 		// Allow packages to be reorganized after calculate the shipping


### PR DESCRIPTION
One of the main problems I've been facing with some of the stores I manage is the ability to use existing shipping method plugins but allowing them to calculate the shipping cost from more than one origin.

I can list a few use cases where this is needed:
1. A marketplace that should group the packages in packages based on the seller of the product
2. A store that have more than one warehouse/deposit and send different products from different places

I know I can get close to a solution to the problem if I use the `woocommerce_cart_shipping_packages` filter, but I can't make it work the way most of the customers want. This filter allows me to split a package in multiple packages, but I have no way to merge the packages again, summing the shipping costs to display a single shipping method selection in the cart.

I am suggesting adding two filters, one right before calculate the shipping of packages and one after. This way, custom code can split the packages the way it wants and merge them again as required based on each store rules.

My problem is not resolved with only this change in the core, but I am also working to combine my customers solutions in a single plugin that will define a standard way of passing the origin of a package. This extra plugin will add a default store shipping origin (postcode, city, state and country fields in the shipping tab) and add the origin to each package. I am planning to make use of a custom feature called "package-origin", so that people can make their plugins compatible with my solution.

This will make it easy to customize (or the developer can easily rewrite their shipping method plugins) to check if there is an origin set in the package and use that OR fallback to their default way of getting the shipping origin.

Since this is a very simple change that should have no impact I am creating this Pull Request to avoid having to maintain a forked version of the Woocommerce because of only 2 filters.
