### PR TITLE
Prevent warning

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -30,7 +30,7 @@ function wc_get_product_terms( $product_id, $taxonomy, $args = array() ) {
 		return array();
 	}
 
-	if ( empty( $args['orderby'] ) && taxonomy_is_product_attribute( $taxonomy ) ) {
+	if ( ( ! isset( $args['orderby'] ) || empty( $args['orderby'] ) ) && taxonomy_is_product_attribute( $taxonomy ) ) {
 		$args['orderby'] = wc_attribute_orderby( $taxonomy );
 	}
 


### PR DESCRIPTION
Prevents `Warning: illegal string offset 'orderby' in /wp-content/plugins/woocommerce/includes/wc-term-functions.php on line 34`

ref 393615-zd-woothemes
