### PR TITLE
WC CLI does not allow to bulk delete orders

### DIFF
--- a/includes/cli/class-wc-cli-order.php
+++ b/includes/cli/class-wc-cli-order.php
@@ -209,7 +209,7 @@ class WC_CLI_Order extends WC_CLI_Command {
 	public function delete( $args, $assoc_args ) {
 		$exit_code = 0;
 		foreach ( $args as $id ) {
-			$order = wc_get_order( $args[0] );
+			$order = wc_get_order( $id );
 			if ( ! $order ) {
 				WP_CLI::warning( "Invalid order ID $id" );
 				continue;


### PR DESCRIPTION
The argument used to get the order was always the first ID returned (`$args[0]`).

So when trying to bulk delete orders with a command like:

``` cmd
wp wc order delete $(wp wc order list --format=ids)
```

It was deleting only the first, and then returning an "Invalid order ID" error even if the ID in the error message was correct.

Ref: https://wordpress.org/support/topic/bulk-delete-orders-via-cli
