### PR TITLE
Update class-wc-report-taxes-by-code.php

### DIFF
--- a/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -124,7 +124,6 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 			'filter_range'        => true,
 			'order_types'         => array_merge( wc_get_order_types( 'sales-reports' ), array( 'shop_order_refund' ) ),
 			'order_status'        => array( 'completed', 'processing', 'on-hold' ),
-			'parent_order_status' => array( 'completed', 'processing', 'on-hold' ) // Partial refunds inside refunded orders should be ignored
 		) );
 
 		// Merge


### PR DESCRIPTION
Hello Team!
I have problem with empty report section, but it should not be empty. After some investigations I found that this parameter in query builder is blocking all query.

`'parent_order_status' => array( 'completed', 'processing', 'on-hold' ) // Partial refunds inside`refunded`orders should be ignored`

Because in result SQL we get 

```
LEFT JOIN wp_posts AS parent ON posts.post_parent = parent.ID 
            WHERE   posts.post_type     IN ( 'shop_order','shop_order_refund' )
             AND parent.post_status IN ( 'wc-completed','wc-processing','wc-on-hold')  
```

But as I know most orders do not have any parents. And with this query part all orders without parent record are ignored, I think it is incorrect behaviour.
