### PR TITLE
Add filter to prevent admin order search from including custom fields

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1510,6 +1510,10 @@ class WC_Admin_Post_Types {
 			return;
 		}
 
+		if ( ! apply_filters( 'wc_shop_order_search_custom_fields', true, $wp ) ) {
+			return;
+		}
+
 		$search_fields = array_map( 'wc_clean', apply_filters( 'woocommerce_shop_order_search_fields', array(
 			'_order_key',
 			'_billing_company',


### PR DESCRIPTION
The `shop_order_search_custom_fields` adds post meta fields to be searched along with WordPress default fields for orders. This is great but is a huge performance issue for large stores. This PR adds a filter to short circuit that method.
