### PR TITLE
Replace bool checks with 'yes'

### DIFF
--- a/includes/cli/class-wc-cli-product.php
+++ b/includes/cli/class-wc-cli-product.php
@@ -168,13 +168,13 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Enable description html tags.
 			$post_content = isset( $data['description'] ) ? wc_clean( $data['description'] ) : '';
-			if ( $post_content && isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) {
+			if ( $post_content && isset( $data['enable_html_description'] ) && 'yes' === $data['enable_html_description'] ) {
 				$post_content = $data['description'];
 			}
 
 			// Enable short description html tags.
 			$post_excerpt = isset( $data['short_description'] ) ? wc_clean( $data['short_description'] ) : '';
-			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) {
+			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && 'yes' === $data['enable_html_short_description'] ) {
 				$post_excerpt = $data['short_description'];
 			}
 
@@ -623,7 +623,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			// Product short description.
 			if ( isset( $data['short_description'] ) ) {
 				// Enable short description html tags.
-				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
+				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && 'yes' === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
 
 				wp_update_post( array( 'ID' => $id, 'post_excerpt' => $post_excerpt ) );
 			}
@@ -631,7 +631,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			// Product description.
 			if ( isset( $data['description'] ) ) {
 				// Enable description html tags.
-				$post_content = ( isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
+				$post_content = ( isset( $data['enable_html_description'] ) && 'yes' === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
 
 				wp_update_post( array( 'ID' => $id, 'post_content' => $post_content ) );
 			}
@@ -1081,7 +1081,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			update_post_meta( $product_id, '_virtual', ( true === $data['virtual'] ) ? 'yes' : 'no' );
+			update_post_meta( $product_id, '_virtual', ( 'yes' === $data['virtual'] ) ? 'yes' : 'no' );
 		}
 
 		// Tax status
@@ -1106,7 +1106,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Featured Product
 		if ( isset( $data['featured'] ) ) {
-			update_post_meta( $product_id, '_featured', ( true === $data['featured'] ) ? 'yes' : 'no' );
+			update_post_meta( $product_id, '_featured', ( 'yes' === $data['featured'] ) ? 'yes' : 'no' );
 		}
 
 		// Shipping data
@@ -1336,12 +1336,12 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Sold Individually
 		if ( isset( $data['sold_individually'] ) ) {
-			update_post_meta( $product_id, '_sold_individually', ( true === $data['sold_individually'] ) ? 'yes' : '' );
+			update_post_meta( $product_id, '_sold_individually', ( 'yes' === $data['sold_individually'] ) ? 'yes' : '' );
 		}
 
 		// Stock status
 		if ( isset( $data['in_stock'] ) ) {
-			$stock_status = ( true === $data['in_stock'] ) ? 'instock' : 'outofstock';
+			$stock_status = ( 'yes' === $data['in_stock'] ) ? 'instock' : 'outofstock';
 		} else {
 			$stock_status = get_post_meta( $product_id, '_stock_status', true );
 
@@ -1354,7 +1354,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 		if ( 'yes' == get_option( 'woocommerce_manage_stock' ) ) {
 			// Manage stock
 			if ( isset( $data['managing_stock'] ) ) {
-				$managing_stock = ( true === $data['managing_stock'] ) ? 'yes' : 'no';
+				$managing_stock = ( 'yes' === $data['managing_stock'] ) ? 'yes' : 'no';
 				update_post_meta( $product_id, '_manage_stock', $managing_stock );
 			} else {
 				$managing_stock = get_post_meta( $product_id, '_manage_stock', true );
@@ -1365,7 +1365,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 				if ( 'notify' == $data['backorders'] ) {
 					$backorders = 'notify';
 				} else {
-					$backorders = ( true === $data['backorders'] ) ? 'yes' : 'no';
+					$backorders = ( 'yes' === $data['backorders'] ) ? 'yes' : 'no';
 				}
 
 				update_post_meta( $product_id, '_backorders', $backorders );
@@ -1462,7 +1462,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Downloadable
 		if ( isset( $data['downloadable'] ) ) {
-			$is_downloadable = ( true === $data['downloadable'] ) ? 'yes' : 'no';
+			$is_downloadable = ( 'yes' === $data['downloadable'] ) ? 'yes' : 'no';
 			update_post_meta( $product_id, '_downloadable', $is_downloadable );
 		} else {
 			$is_downloadable = get_post_meta( $product_id, '_downloadable', true );
@@ -1505,7 +1505,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Reviews allowed
 		if ( isset( $data['reviews_allowed'] ) ) {
-			$reviews_allowed = ( true === $data['reviews_allowed'] ) ? 'open' : 'closed';
+			$reviews_allowed = ( 'yes' === $data['reviews_allowed'] ) ? 'open' : 'closed';
 
 			$wpdb->update( $wpdb->posts, array( 'comment_status' => $reviews_allowed ), array( 'ID' => $product_id ) );
 		}
@@ -1611,13 +1611,13 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Virtual variation
 			if ( isset( $variation['virtual'] ) ) {
-				$is_virtual = ( true === $variation['virtual'] ) ? 'yes' : 'no';
+				$is_virtual = ( 'yes' === $variation['virtual'] ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_virtual', $is_virtual );
 			}
 
 			// Downloadable variation
 			if ( isset( $variation['downloadable'] ) ) {
-				$is_downloadable = ( true === $variation['downloadable'] ) ? 'yes' : 'no';
+				$is_downloadable = ( 'yes' === $variation['downloadable'] ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_downloadable', $is_downloadable );
 			} else {
 				$is_downloadable = get_post_meta( $variation_id, '_downloadable', true );
@@ -1628,7 +1628,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Stock handling
 			if ( isset( $variation['managing_stock'] ) ) {
-				$managing_stock = ( true === $variation['managing_stock'] ) ? 'yes' : 'no';
+				$managing_stock = ( 'yes' === $variation['managing_stock'] ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_manage_stock', $managing_stock );
 			} else {
 				$managing_stock = get_post_meta( $variation_id, '_manage_stock', true );
@@ -1636,7 +1636,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Only update stock status to user setting if changed by the user, but do so before looking at stock levels at variation level
 			if ( isset( $variation['in_stock'] ) ) {
-				$stock_status = ( true === $variation['in_stock'] ) ? 'instock' : 'outofstock';
+				$stock_status = ( 'yes' === $variation['in_stock'] ) ? 'instock' : 'outofstock';
 				wc_update_product_stock_status( $variation_id, $stock_status );
 			}
 
@@ -1645,7 +1645,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 					if ( 'notify' == $variation['backorders'] ) {
 						$backorders = 'notify';
 					} else {
-						$backorders = ( true === $variation['backorders'] ) ? 'yes' : 'no';
+						$backorders = ( 'yes' === $variation['backorders'] ) ? 'yes' : 'no';
 					}
 				} else {
 					$backorders = 'no';
@@ -1918,7 +1918,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			$virtual = ( true === $data['virtual'] ) ? 'yes' : 'no';
+			$virtual = ( 'yes' === $data['virtual'] ) ? 'yes' : 'no';
 
 			if ( 'yes' == $virtual ) {
 				update_post_meta( $id, '_weight', '' );


### PR DESCRIPTION
With WC CLI it is impossible to turn on options like "Managing stock" or "Virtual" because the code checks the value in the command-line with a boolean true, which is impossible to get because values in the command-line are always strings.

I replaced `true` with `yes` for all these options.
