### PR TITLE
WC CLI can't turn on checkboxes

### DIFF
--- a/includes/cli/class-wc-cli-command.php
+++ b/includes/cli/class-wc-cli-command.php
@@ -394,4 +394,15 @@ class WC_CLI_Command extends WP_CLI_Command {
 		}
 		return $key;
 	}
+
+	/**
+	 * Check if the value is equal to 'yes', 'true' or '1'
+	 *
+	 * @since 2.5.4
+	 * @param  string $value
+	 * @return boolean
+	 */
+	protected function is_true( $value ) {
+		return ( 'yes' === $value || 'true' === $value || '1' === $value ) ? true : false;
+	}
 }

--- a/includes/cli/class-wc-cli-coupon.php
+++ b/includes/cli/class-wc-cli-coupon.php
@@ -124,7 +124,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			// Set coupon meta
 			update_post_meta( $id, 'discount_type', $coupon_data['type'] );
 			update_post_meta( $id, 'coupon_amount', wc_format_decimal( $coupon_data['amount'] ) );
-			update_post_meta( $id, 'individual_use', ( true === $coupon_data['individual_use'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'individual_use', ( 'yes' === $coupon_data['individual_use'] ) ? 'yes' : 'no' );
 			update_post_meta( $id, 'product_ids', implode( ',', array_filter( array_map( 'intval', $coupon_data['product_ids'] ) ) ) );
 			update_post_meta( $id, 'exclude_product_ids', implode( ',', array_filter( array_map( 'intval', $coupon_data['exclude_product_ids'] ) ) ) );
 			update_post_meta( $id, 'usage_limit', absint( $coupon_data['usage_limit'] ) );
@@ -132,10 +132,10 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			update_post_meta( $id, 'limit_usage_to_x_items', absint( $coupon_data['limit_usage_to_x_items'] ) );
 			update_post_meta( $id, 'usage_count', absint( $coupon_data['usage_count'] ) );
 			update_post_meta( $id, 'expiry_date', $this->get_coupon_expiry_date( wc_clean( $coupon_data['expiry_date'] ) ) );
-			update_post_meta( $id, 'free_shipping', ( true === $coupon_data['enable_free_shipping'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'free_shipping', ( 'yes' === $coupon_data['enable_free_shipping'] ) ? 'yes' : 'no' );
 			update_post_meta( $id, 'product_categories', array_filter( array_map( 'intval', $coupon_data['product_category_ids'] ) ) );
 			update_post_meta( $id, 'exclude_product_categories', array_filter( array_map( 'intval', $coupon_data['exclude_product_category_ids'] ) ) );
-			update_post_meta( $id, 'exclude_sale_items', ( true === $coupon_data['exclude_sale_items'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'exclude_sale_items', ( 'yes' === $coupon_data['exclude_sale_items'] ) ? 'yes' : 'no' );
 			update_post_meta( $id, 'minimum_amount', wc_format_decimal( $coupon_data['minimum_amount'] ) );
 			update_post_meta( $id, 'maximum_amount', wc_format_decimal( $coupon_data['maximum_amount'] ) );
 			update_post_meta( $id, 'customer_email', array_filter( array_map( 'sanitize_email', $coupon_data['customer_emails'] ) ) );
@@ -472,7 +472,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			}
 
 			if ( isset( $data['individual_use'] ) ) {
-				update_post_meta( $id, 'individual_use', ( true === $data['individual_use'] ) ? 'yes' : 'no' );
+				update_post_meta( $id, 'individual_use', ( 'yes' === $data['individual_use'] ) ? 'yes' : 'no' );
 			}
 
 			if ( isset( $data['product_ids'] ) ) {
@@ -504,7 +504,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			}
 
 			if ( isset( $data['enable_free_shipping'] ) ) {
-				update_post_meta( $id, 'free_shipping', ( true === $data['enable_free_shipping'] ) ? 'yes' : 'no' );
+				update_post_meta( $id, 'free_shipping', ( 'yes' === $data['enable_free_shipping'] ) ? 'yes' : 'no' );
 			}
 
 			if ( isset( $data['product_category_ids'] ) ) {
@@ -516,7 +516,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			}
 
 			if ( isset( $data['exclude_sale_items'] ) ) {
-				update_post_meta( $id, 'exclude_sale_items', ( true === $data['exclude_sale_items'] ) ? 'yes' : 'no' );
+				update_post_meta( $id, 'exclude_sale_items', ( 'yes' === $data['exclude_sale_items'] ) ? 'yes' : 'no' );
 			}
 
 			if ( isset( $data['minimum_amount'] ) ) {

--- a/includes/cli/class-wc-cli-coupon.php
+++ b/includes/cli/class-wc-cli-coupon.php
@@ -124,7 +124,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			// Set coupon meta
 			update_post_meta( $id, 'discount_type', $coupon_data['type'] );
 			update_post_meta( $id, 'coupon_amount', wc_format_decimal( $coupon_data['amount'] ) );
-			update_post_meta( $id, 'individual_use', ( 'yes' === $coupon_data['individual_use'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'individual_use', ( $this->is_true( $coupon_data['individual_use'] ) ) ? 'yes' : 'no' );
 			update_post_meta( $id, 'product_ids', implode( ',', array_filter( array_map( 'intval', $coupon_data['product_ids'] ) ) ) );
 			update_post_meta( $id, 'exclude_product_ids', implode( ',', array_filter( array_map( 'intval', $coupon_data['exclude_product_ids'] ) ) ) );
 			update_post_meta( $id, 'usage_limit', absint( $coupon_data['usage_limit'] ) );
@@ -132,10 +132,10 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			update_post_meta( $id, 'limit_usage_to_x_items', absint( $coupon_data['limit_usage_to_x_items'] ) );
 			update_post_meta( $id, 'usage_count', absint( $coupon_data['usage_count'] ) );
 			update_post_meta( $id, 'expiry_date', $this->get_coupon_expiry_date( wc_clean( $coupon_data['expiry_date'] ) ) );
-			update_post_meta( $id, 'free_shipping', ( 'yes' === $coupon_data['enable_free_shipping'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'free_shipping', ( $this->is_true( $coupon_data['enable_free_shipping'] ) ) ? 'yes' : 'no' );
 			update_post_meta( $id, 'product_categories', array_filter( array_map( 'intval', $coupon_data['product_category_ids'] ) ) );
 			update_post_meta( $id, 'exclude_product_categories', array_filter( array_map( 'intval', $coupon_data['exclude_product_category_ids'] ) ) );
-			update_post_meta( $id, 'exclude_sale_items', ( 'yes' === $coupon_data['exclude_sale_items'] ) ? 'yes' : 'no' );
+			update_post_meta( $id, 'exclude_sale_items', ( $this->is_true( $coupon_data['exclude_sale_items'] ) ) ? 'yes' : 'no' );
 			update_post_meta( $id, 'minimum_amount', wc_format_decimal( $coupon_data['minimum_amount'] ) );
 			update_post_meta( $id, 'maximum_amount', wc_format_decimal( $coupon_data['maximum_amount'] ) );
 			update_post_meta( $id, 'customer_email', array_filter( array_map( 'sanitize_email', $coupon_data['customer_emails'] ) ) );
@@ -472,7 +472,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			}
 
 			if ( isset( $data['individual_use'] ) ) {
-				update_post_meta( $id, 'individual_use', ( 'yes' === $data['individual_use'] ) ? 'yes' : 'no' );
+				update_post_meta( $id, 'individual_use', ( $this->is_true( $data['individual_use'] ) ) ? 'yes' : 'no' );
 			}
 
 			if ( isset( $data['product_ids'] ) ) {
@@ -504,7 +504,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			}
 
 			if ( isset( $data['enable_free_shipping'] ) ) {
-				update_post_meta( $id, 'free_shipping', ( 'yes' === $data['enable_free_shipping'] ) ? 'yes' : 'no' );
+				update_post_meta( $id, 'free_shipping', ( $this->is_true( $data['enable_free_shipping'] ) ) ? 'yes' : 'no' );
 			}
 
 			if ( isset( $data['product_category_ids'] ) ) {
@@ -516,7 +516,7 @@ class WC_CLI_Coupon extends WC_CLI_Command {
 			}
 
 			if ( isset( $data['exclude_sale_items'] ) ) {
-				update_post_meta( $id, 'exclude_sale_items', ( 'yes' === $data['exclude_sale_items'] ) ? 'yes' : 'no' );
+				update_post_meta( $id, 'exclude_sale_items', ( $this->is_true( $data['exclude_sale_items'] ) ) ? 'yes' : 'no' );
 			}
 
 			if ( isset( $data['minimum_amount'] ) ) {

--- a/includes/cli/class-wc-cli-order.php
+++ b/includes/cli/class-wc-cli-order.php
@@ -155,7 +155,7 @@ class WC_CLI_Order extends WC_CLI_Command {
 				update_post_meta( $order->id, '_payment_method_title', $data['payment_details']['method_title'] );
 
 				// Mark as paid if set.
-				if ( isset( $data['payment_details']['paid'] ) && true === $data['payment_details']['paid'] ) {
+				if ( isset( $data['payment_details']['paid'] ) && 'yes' === $data['payment_details']['paid'] ) {
 					$order->payment_complete( isset( $data['payment_details']['transaction_id'] ) ? $data['payment_details']['transaction_id'] : '' );
 				}
 			}
@@ -509,7 +509,7 @@ class WC_CLI_Order extends WC_CLI_Command {
 				}
 
 				// mark as paid if set
-				if ( $order->needs_payment() && isset( $data['payment_details']['paid'] ) && true === $data['payment_details']['paid'] ) {
+				if ( $order->needs_payment() && isset( $data['payment_details']['paid'] ) && 'yes' === $data['payment_details']['paid'] ) {
 					$order->payment_complete( isset( $data['payment_details']['transaction_id'] ) ? $data['payment_details']['transaction_id'] : '' );
 				}
 			}

--- a/includes/cli/class-wc-cli-order.php
+++ b/includes/cli/class-wc-cli-order.php
@@ -155,7 +155,7 @@ class WC_CLI_Order extends WC_CLI_Command {
 				update_post_meta( $order->id, '_payment_method_title', $data['payment_details']['method_title'] );
 
 				// Mark as paid if set.
-				if ( isset( $data['payment_details']['paid'] ) && 'yes' === $data['payment_details']['paid'] ) {
+				if ( isset( $data['payment_details']['paid'] ) && $this->is_true( $data['payment_details']['paid'] ) ) {
 					$order->payment_complete( isset( $data['payment_details']['transaction_id'] ) ? $data['payment_details']['transaction_id'] : '' );
 				}
 			}
@@ -509,7 +509,7 @@ class WC_CLI_Order extends WC_CLI_Command {
 				}
 
 				// mark as paid if set
-				if ( $order->needs_payment() && isset( $data['payment_details']['paid'] ) && 'yes' === $data['payment_details']['paid'] ) {
+				if ( $order->needs_payment() && isset( $data['payment_details']['paid'] ) && $this->is_true( $data['payment_details']['paid'] ) ) {
 					$order->payment_complete( isset( $data['payment_details']['transaction_id'] ) ? $data['payment_details']['transaction_id'] : '' );
 				}
 			}

--- a/includes/cli/class-wc-cli-product.php
+++ b/includes/cli/class-wc-cli-product.php
@@ -168,13 +168,13 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Enable description html tags.
 			$post_content = isset( $data['description'] ) ? wc_clean( $data['description'] ) : '';
-			if ( $post_content && isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) {
+			if ( $post_content && isset( $data['enable_html_description'] ) && 'yes' === $data['enable_html_description'] ) {
 				$post_content = $data['description'];
 			}
 
 			// Enable short description html tags.
 			$post_excerpt = isset( $data['short_description'] ) ? wc_clean( $data['short_description'] ) : '';
-			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) {
+			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && 'yes' === $data['enable_html_short_description'] ) {
 				$post_excerpt = $data['short_description'];
 			}
 
@@ -623,7 +623,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			// Product short description.
 			if ( isset( $data['short_description'] ) ) {
 				// Enable short description html tags.
-				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
+				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && 'yes' === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
 
 				wp_update_post( array( 'ID' => $id, 'post_excerpt' => $post_excerpt ) );
 			}
@@ -631,7 +631,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			// Product description.
 			if ( isset( $data['description'] ) ) {
 				// Enable description html tags.
-				$post_content = ( isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
+				$post_content = ( isset( $data['enable_html_description'] ) && 'yes' === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
 
 				wp_update_post( array( 'ID' => $id, 'post_content' => $post_content ) );
 			}
@@ -1081,7 +1081,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			update_post_meta( $product_id, '_virtual', ( true === $data['virtual'] ) ? 'yes' : 'no' );
+			update_post_meta( $product_id, '_virtual', ( 'yes' === $data['virtual'] ) ? 'yes' : 'no' );
 		}
 
 		// Tax status
@@ -1106,7 +1106,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Featured Product
 		if ( isset( $data['featured'] ) ) {
-			update_post_meta( $product_id, '_featured', ( true === $data['featured'] ) ? 'yes' : 'no' );
+			update_post_meta( $product_id, '_featured', ( 'yes' === $data['featured'] ) ? 'yes' : 'no' );
 		}
 
 		// Shipping data
@@ -1336,12 +1336,12 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Sold Individually
 		if ( isset( $data['sold_individually'] ) ) {
-			update_post_meta( $product_id, '_sold_individually', ( true === $data['sold_individually'] ) ? 'yes' : '' );
+			update_post_meta( $product_id, '_sold_individually', ( 'yes' === $data['sold_individually'] ) ? 'yes' : '' );
 		}
 
 		// Stock status
 		if ( isset( $data['in_stock'] ) ) {
-			$stock_status = ( true === $data['in_stock'] ) ? 'instock' : 'outofstock';
+			$stock_status = ( 'yes' === $data['in_stock'] ) ? 'instock' : 'outofstock';
 		} else {
 			$stock_status = get_post_meta( $product_id, '_stock_status', true );
 
@@ -1354,7 +1354,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 		if ( 'yes' == get_option( 'woocommerce_manage_stock' ) ) {
 			// Manage stock
 			if ( isset( $data['managing_stock'] ) ) {
-				$managing_stock = ( true === $data['managing_stock'] ) ? 'yes' : 'no';
+				$managing_stock = ( 'yes' === $data['managing_stock'] ) ? 'yes' : 'no';
 				update_post_meta( $product_id, '_manage_stock', $managing_stock );
 			} else {
 				$managing_stock = get_post_meta( $product_id, '_manage_stock', true );
@@ -1365,7 +1365,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 				if ( 'notify' == $data['backorders'] ) {
 					$backorders = 'notify';
 				} else {
-					$backorders = ( true === $data['backorders'] ) ? 'yes' : 'no';
+					$backorders = ( 'yes' === $data['backorders'] ) ? 'yes' : 'no';
 				}
 
 				update_post_meta( $product_id, '_backorders', $backorders );
@@ -1462,7 +1462,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Downloadable
 		if ( isset( $data['downloadable'] ) ) {
-			$is_downloadable = ( true === $data['downloadable'] ) ? 'yes' : 'no';
+			$is_downloadable = ( 'yes' === $data['downloadable'] ) ? 'yes' : 'no';
 			update_post_meta( $product_id, '_downloadable', $is_downloadable );
 		} else {
 			$is_downloadable = get_post_meta( $product_id, '_downloadable', true );
@@ -1505,7 +1505,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Reviews allowed
 		if ( isset( $data['reviews_allowed'] ) ) {
-			$reviews_allowed = ( true === $data['reviews_allowed'] ) ? 'open' : 'closed';
+			$reviews_allowed = ( 'yes' === $data['reviews_allowed'] ) ? 'open' : 'closed';
 
 			$wpdb->update( $wpdb->posts, array( 'comment_status' => $reviews_allowed ), array( 'ID' => $product_id ) );
 		}
@@ -1611,13 +1611,13 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Virtual variation
 			if ( isset( $variation['virtual'] ) ) {
-				$is_virtual = ( true === $variation['virtual'] ) ? 'yes' : 'no';
+				$is_virtual = ( 'yes' === $variation['virtual'] ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_virtual', $is_virtual );
 			}
 
 			// Downloadable variation
 			if ( isset( $variation['downloadable'] ) ) {
-				$is_downloadable = ( true === $variation['downloadable'] ) ? 'yes' : 'no';
+				$is_downloadable = ( 'yes' === $variation['downloadable'] ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_downloadable', $is_downloadable );
 			} else {
 				$is_downloadable = get_post_meta( $variation_id, '_downloadable', true );
@@ -1628,7 +1628,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Stock handling
 			if ( isset( $variation['managing_stock'] ) ) {
-				$managing_stock = ( true === $variation['managing_stock'] ) ? 'yes' : 'no';
+				$managing_stock = ( 'yes' === $variation['managing_stock'] ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_manage_stock', $managing_stock );
 			} else {
 				$managing_stock = get_post_meta( $variation_id, '_manage_stock', true );
@@ -1636,7 +1636,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Only update stock status to user setting if changed by the user, but do so before looking at stock levels at variation level
 			if ( isset( $variation['in_stock'] ) ) {
-				$stock_status = ( true === $variation['in_stock'] ) ? 'instock' : 'outofstock';
+				$stock_status = ( 'yes' === $variation['in_stock'] ) ? 'instock' : 'outofstock';
 				wc_update_product_stock_status( $variation_id, $stock_status );
 			}
 
@@ -1645,7 +1645,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 					if ( 'notify' == $variation['backorders'] ) {
 						$backorders = 'notify';
 					} else {
-						$backorders = ( true === $variation['backorders'] ) ? 'yes' : 'no';
+						$backorders = ( 'yes' === $variation['backorders'] ) ? 'yes' : 'no';
 					}
 				} else {
 					$backorders = 'no';
@@ -1918,7 +1918,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			$virtual = ( true === $data['virtual'] ) ? 'yes' : 'no';
+			$virtual = ( 'yes' === $data['virtual'] ) ? 'yes' : 'no';
 
 			if ( 'yes' == $virtual ) {
 				update_post_meta( $id, '_weight', '' );

--- a/includes/cli/class-wc-cli-product.php
+++ b/includes/cli/class-wc-cli-product.php
@@ -168,13 +168,13 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Enable description html tags.
 			$post_content = isset( $data['description'] ) ? wc_clean( $data['description'] ) : '';
-			if ( $post_content && isset( $data['enable_html_description'] ) && 'yes' === $data['enable_html_description'] ) {
+			if ( $post_content && isset( $data['enable_html_description'] ) && $this->is_true( $data['enable_html_description'] ) ) {
 				$post_content = $data['description'];
 			}
 
 			// Enable short description html tags.
 			$post_excerpt = isset( $data['short_description'] ) ? wc_clean( $data['short_description'] ) : '';
-			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && 'yes' === $data['enable_html_short_description'] ) {
+			if ( $post_excerpt && isset( $data['enable_html_short_description'] ) && $this->is_true( $data['enable_html_short_description'] ) ) {
 				$post_excerpt = $data['short_description'];
 			}
 
@@ -623,7 +623,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			// Product short description.
 			if ( isset( $data['short_description'] ) ) {
 				// Enable short description html tags.
-				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && 'yes' === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
+				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && $this->is_true( $data['enable_html_short_description'] ) ) ? $data['short_description'] : wc_clean( $data['short_description'] );
 
 				wp_update_post( array( 'ID' => $id, 'post_excerpt' => $post_excerpt ) );
 			}
@@ -631,7 +631,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			// Product description.
 			if ( isset( $data['description'] ) ) {
 				// Enable description html tags.
-				$post_content = ( isset( $data['enable_html_description'] ) && 'yes' === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
+				$post_content = ( isset( $data['enable_html_description'] ) && $this->is_true( $data['enable_html_description'] ) ) ? $data['description'] : wc_clean( $data['description'] );
 
 				wp_update_post( array( 'ID' => $id, 'post_content' => $post_content ) );
 			}
@@ -1081,7 +1081,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			update_post_meta( $product_id, '_virtual', ( 'yes' === $data['virtual'] ) ? 'yes' : 'no' );
+			update_post_meta( $product_id, '_virtual', ( $this->is_true( $data['virtual'] ) ) ? 'yes' : 'no' );
 		}
 
 		// Tax status
@@ -1106,7 +1106,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Featured Product
 		if ( isset( $data['featured'] ) ) {
-			update_post_meta( $product_id, '_featured', ( 'yes' === $data['featured'] ) ? 'yes' : 'no' );
+			update_post_meta( $product_id, '_featured', ( $this->is_true( $data['featured'] ) ) ? 'yes' : 'no' );
 		}
 
 		// Shipping data
@@ -1336,12 +1336,12 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Sold Individually
 		if ( isset( $data['sold_individually'] ) ) {
-			update_post_meta( $product_id, '_sold_individually', ( 'yes' === $data['sold_individually'] ) ? 'yes' : '' );
+			update_post_meta( $product_id, '_sold_individually', ( $this->is_true( $data['sold_individually'] ) ) ? 'yes' : '' );
 		}
 
 		// Stock status
 		if ( isset( $data['in_stock'] ) ) {
-			$stock_status = ( 'yes' === $data['in_stock'] ) ? 'instock' : 'outofstock';
+			$stock_status = ( $this->is_true( $data['in_stock'] ) ) ? 'instock' : 'outofstock';
 		} else {
 			$stock_status = get_post_meta( $product_id, '_stock_status', true );
 
@@ -1354,7 +1354,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 		if ( 'yes' == get_option( 'woocommerce_manage_stock' ) ) {
 			// Manage stock
 			if ( isset( $data['managing_stock'] ) ) {
-				$managing_stock = ( 'yes' === $data['managing_stock'] ) ? 'yes' : 'no';
+				$managing_stock = ( $this->is_true( $data['managing_stock'] ) ) ? 'yes' : 'no';
 				update_post_meta( $product_id, '_manage_stock', $managing_stock );
 			} else {
 				$managing_stock = get_post_meta( $product_id, '_manage_stock', true );
@@ -1365,7 +1365,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 				if ( 'notify' == $data['backorders'] ) {
 					$backorders = 'notify';
 				} else {
-					$backorders = ( 'yes' === $data['backorders'] ) ? 'yes' : 'no';
+					$backorders = ( $this->is_true( $data['backorders'] ) ) ? 'yes' : 'no';
 				}
 
 				update_post_meta( $product_id, '_backorders', $backorders );
@@ -1462,7 +1462,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Downloadable
 		if ( isset( $data['downloadable'] ) ) {
-			$is_downloadable = ( 'yes' === $data['downloadable'] ) ? 'yes' : 'no';
+			$is_downloadable = ( $this->is_true( $data['downloadable'] ) ) ? 'yes' : 'no';
 			update_post_meta( $product_id, '_downloadable', $is_downloadable );
 		} else {
 			$is_downloadable = get_post_meta( $product_id, '_downloadable', true );
@@ -1505,7 +1505,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Reviews allowed
 		if ( isset( $data['reviews_allowed'] ) ) {
-			$reviews_allowed = ( 'yes' === $data['reviews_allowed'] ) ? 'open' : 'closed';
+			$reviews_allowed = ( $this->is_true( $data['reviews_allowed'] ) ) ? 'open' : 'closed';
 
 			$wpdb->update( $wpdb->posts, array( 'comment_status' => $reviews_allowed ), array( 'ID' => $product_id ) );
 		}
@@ -1611,13 +1611,13 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Virtual variation
 			if ( isset( $variation['virtual'] ) ) {
-				$is_virtual = ( 'yes' === $variation['virtual'] ) ? 'yes' : 'no';
+				$is_virtual = ( $this->is_true( $variation['virtual'] ) ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_virtual', $is_virtual );
 			}
 
 			// Downloadable variation
 			if ( isset( $variation['downloadable'] ) ) {
-				$is_downloadable = ( 'yes' === $variation['downloadable'] ) ? 'yes' : 'no';
+				$is_downloadable = ( $this->is_true( $variation['downloadable'] ) ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_downloadable', $is_downloadable );
 			} else {
 				$is_downloadable = get_post_meta( $variation_id, '_downloadable', true );
@@ -1628,7 +1628,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Stock handling
 			if ( isset( $variation['managing_stock'] ) ) {
-				$managing_stock = ( 'yes' === $variation['managing_stock'] ) ? 'yes' : 'no';
+				$managing_stock = ( $this->is_true( $variation['managing_stock'] ) ) ? 'yes' : 'no';
 				update_post_meta( $variation_id, '_manage_stock', $managing_stock );
 			} else {
 				$managing_stock = get_post_meta( $variation_id, '_manage_stock', true );
@@ -1636,7 +1636,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 			// Only update stock status to user setting if changed by the user, but do so before looking at stock levels at variation level
 			if ( isset( $variation['in_stock'] ) ) {
-				$stock_status = ( 'yes' === $variation['in_stock'] ) ? 'instock' : 'outofstock';
+				$stock_status = ( $this->is_true( $variation['in_stock'] ) ) ? 'instock' : 'outofstock';
 				wc_update_product_stock_status( $variation_id, $stock_status );
 			}
 
@@ -1645,7 +1645,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 					if ( 'notify' == $variation['backorders'] ) {
 						$backorders = 'notify';
 					} else {
-						$backorders = ( 'yes' === $variation['backorders'] ) ? 'yes' : 'no';
+						$backorders = ( $this->is_true( $variation['backorders'] ) ) ? 'yes' : 'no';
 					}
 				} else {
 					$backorders = 'no';
@@ -1918,7 +1918,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			$virtual = ( 'yes' === $data['virtual'] ) ? 'yes' : 'no';
+			$virtual = ( $this->is_true( $data['virtual'] ) ) ? 'yes' : 'no';
 
 			if ( 'yes' == $virtual ) {
 				update_post_meta( $id, '_weight', '' );


### PR DESCRIPTION
WC CLI can't turn on options like "Managing Stock?" on products or "Exclude items on sale" for coupons because it checks for the value sent by the command-line with a strict `true` value. Since the command-line can't send boolean values, but only strings, they can't be turned on.

Changing `true ===` with `'yes' ===`.
