### PR TITLE
[WC-CLI] Allow multidimensional arrays to be created properly

### DIFF
--- a/includes/cli/class-wc-cli-command.php
+++ b/includes/cli/class-wc-cli-command.php
@@ -367,7 +367,7 @@ class WC_CLI_Command extends WP_CLI_Command {
 				foreach ( $subarray as $sub_key => $sub_value ) {
 					$sub_key = $this->get_normalized_array_key( $sub_key );
 					if ( ! empty( $unflatten[ $first_key ][ $sub_key ] ) ) {
-						$unflatten[ $first_key ][ $sub_key ] = array_merge( $unflatten[ $first_key ][ $sub_key ], $sub_value );
+						$unflatten[ $first_key ][ $sub_key ] = array_merge_recursive( $unflatten[ $first_key ][ $sub_key ], $sub_value );
 					} else {
 						$unflatten[ $first_key ][ $sub_key ] = $sub_value;
 					}


### PR DESCRIPTION
The issue:

I'm creating a variable products via WC CLI with 2 attributes, color and size. The attribute color has 2 terms, the attribute size has 3 terms.

I'd use a command like this:

```
wp wc product create --title="Variable Product Test" --type=variable
    --attributes.0.name="Color" --attributes.0.visible=yes --attributes.0.variation=yes --attributes.0.options="Black|Blue"
    --attributes.1.name="Size" --attributes.1.visible=yes --attributes.1.variation=yes --attributes.1.options="Small|Medium"

    --variations.0.attributes.color="Black" --variations.0.attributes.size="Small" --variations.0.regular_price=20
    --variations.1.attributes.color="Black" --variations.1.attributes.size="Medium" --variations.1.regular_price=20
    --variations.2.attributes.color="Black" --variations.2.attributes.size="Large" --variations.2.regular_price=20
    --variations.3.attributes.color="Blue" --variations.3.attributes.size="Small" --variations.3.regular_price=20
    --variations.4.attributes.color="Blue" --variations.4.attributes.size="Medium" --variations.4.regular_price=20
    --variations.5.attributes.color="Blue" --variations.5.attributes.size="Large" --variations.5.regular_price=20
```

With the current code, only the last attribute defined in a variation is stored, because the index is the same (`0` for the first variation), so the code merges the two array wrongly.

With the new code, the arrays are merged recursively, so all the attributes are stored properly when creating variations.
