### PR TITLE
Added bool param for email order items hooks

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2012,6 +2012,7 @@ abstract class WC_Abstract_Order {
 			'show_purchase_note'  => $this->is_paid() && ! $args['sent_to_admin'],
 			'show_image'          => $args['show_image'],
 			'image_size'          => $args['image_size'],
+			'plain_text'          => $args['plain_text'],
 			'sent_to_admin'       => $args['sent_to_admin']
 		) );
 

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -43,7 +43,7 @@ foreach ( $items as $item_id => $item ) :
 				}
 
 				// allow other plugins to add additional product information here
-				do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+				do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
 
 				// Variation
 				if ( ! empty( $item_meta->meta ) ) {
@@ -56,7 +56,7 @@ foreach ( $items as $item_id => $item ) :
 				}
 
 				// allow other plugins to add additional product information here
-				do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+				do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 
 			?></td>
 			<td class="td" style="text-align:left; vertical-align:middle; border: 1px solid #eee; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;"><?php echo apply_filters( 'woocommerce_email_order_item_quantity', $item['qty'], $item ); ?></td>

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -35,7 +35,7 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		// allow other plugins to add additional product information here
-		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
 
 		// Variation
 		echo ( $item_meta_content = $item_meta->display( true, true ) ) ? "\n" . $item_meta_content : '';
@@ -65,7 +65,7 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		// allow other plugins to add additional product information here
-		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woothemes/woocommerce/issues/10513 by adding a boolean `$plain_text` parameter to the hooks.
