### PR TITLE
Fix Payment Token 'set default' methods.

### DIFF
--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -202,6 +202,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			update_metadata( 'payment_token', $this->get_id(), $meta_key, $meta_value );
 		}
 
+		// Make sure all other tokens are not set to default
+		if ( $this->is_default() && $this->get_user_id() > 0 ) {
+			WC_Payment_Tokens::set_users_default( $this->get_user_id(), $this->get_id() );
+		}
+
 		do_action( 'woocommerce_payment_token_updated', $this->get_id() );
 		return true;
 	}
@@ -217,10 +222,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 
 		global $wpdb;
-
 		// Are there any other tokens? If not, set this token as default
-		if ( ! $this->is_default() && is_user_logged_in() ) {
-			$default_token = WC_Payment_Tokens::get_customer_default_token( get_current_user_id() );
+		if ( ! $this->is_default() && $this->get_user_id() > 0 ) {
+			$default_token = WC_Payment_Tokens::get_customer_default_token( $this->get_user_id() );
 			if ( is_null( $default_token ) ) {
 				$this->set_default( true );
 			}
@@ -230,6 +234,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$this->id = $token_id = $wpdb->insert_id;
 		foreach ( $this->meta as $meta_key => $meta_value ) {
 			add_metadata( 'payment_token', $token_id, $meta_key, $meta_value, true );
+		}
+
+		// Make sure all other tokens are not set to default
+		if ( $this->is_default() && $this->get_user_id() > 0 ) {
+			WC_Payment_Tokens::set_users_default( $this->get_user_id(), $token_id );
 		}
 
 		do_action( 'woocommerce_payment_token_created', $token_id );

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -169,14 +169,24 @@ class WC_Payment_Tokens {
 	 * @param int $token_id The ID of the token that should be default
 	 */
 	public static function set_users_default( $user_id, $token_id ) {
+		global $wpdb; // DB queries so we avoid an infintie loop (update & create use this function)
 		$users_tokens = self::get_customer_tokens( $user_id );
 		foreach ( $users_tokens as $token ) {
 			if ( $token_id === $token->get_id() ) {
 				$token->set_default( true );
+				$wpdb->update(
+					$wpdb->prefix . 'woocommerce_payment_tokens',
+					array( 'is_default' => 1 ),
+					array( 'token_id' => $token->get_id(),
+				) );
 			} else {
 				$token->set_default( false );
+				$wpdb->update(
+					$wpdb->prefix . 'woocommerce_payment_tokens',
+					array( 'is_default' => 0 ),
+					array( 'token_id' => $token->get_id(),
+				) );
 			}
-			$token->update();
 		}
 	}
 

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -169,7 +169,7 @@ class WC_Payment_Tokens {
 	 * @param int $token_id The ID of the token that should be default
 	 */
 	public static function set_users_default( $user_id, $token_id ) {
-		global $wpdb; // DB queries so we avoid an infintie loop (update & create use this function)
+		global $wpdb; // DB queries so we avoid an  infinite loop (update & create use this function)
 		$users_tokens = self::get_customer_tokens( $user_id );
 		foreach ( $users_tokens as $token ) {
 			if ( $token_id === $token->get_id() ) {

--- a/tests/framework/helpers/class-wc-helper-payment-token.php
+++ b/tests/framework/helpers/class-wc-helper-payment-token.php
@@ -12,13 +12,16 @@ class WC_Helper_Payment_Token {
 	 * @since 2.6
 	 * @return WC_Payment_Token_CC object
 	 */
-	public static function create_cc_token() {
+	public static function create_cc_token( $user_id = '' ) {
 		$token = new WC_Payment_Token_CC();
 		$token->set_last4( 1234 );
 		$token->set_expiry_month( '08' );
 		$token->set_expiry_year( '2016' );
 		$token->set_card_type( 'visa' );
 		$token->set_token( time() );
+		if ( ! empty ( $user_id ) ) {
+			$token->set_user_id( $user_id );
+		}
 		$token->save();
 		return $token;
 	}

--- a/tests/framework/helpers/class-wc-helper-payment-token.php
+++ b/tests/framework/helpers/class-wc-helper-payment-token.php
@@ -19,7 +19,7 @@ class WC_Helper_Payment_Token {
 		$token->set_expiry_year( '2016' );
 		$token->set_card_type( 'visa' );
 		$token->set_token( time() );
-		if ( ! empty ( $user_id ) ) {
+		if ( ! empty( $user_id ) ) {
 			$token->set_user_id( $user_id );
 		}
 		$token->save();
@@ -56,4 +56,3 @@ class WC_Helper_Payment_Token {
 	}
 
 }
-

--- a/tests/unit-tests/payment-tokens/payment-tokens.php
+++ b/tests/unit-tests/payment-tokens/payment-tokens.php
@@ -7,6 +7,12 @@ namespace WooCommerce\Tests\Payment_Tokens;
  */
 class Payment_Tokens extends \WC_Unit_Test_Case {
 
+	public function setUp() {
+		parent::setUp();
+		$this->user_id = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $this->user_id );
+	}
+
 	/**
 	 * Test getting tokens associated with an order.
 	 * @since 2.6.0
@@ -27,17 +33,17 @@ class Payment_Tokens extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_get_customer_tokens_no_gateway() {
-		$this->assertEmpty( \WC_Payment_Tokens::get_customer_tokens( 1 ) );
+		$this->assertEmpty( \WC_Payment_Tokens::get_customer_tokens( $this->user_id ) );
 
 		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token->set_user_id( $this->user_id );
 		$token->save();
 
 		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token->set_user_id( $this->user_id );
 		$token->save();
 
-		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( 1 ) );
+		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( $this->user_id ) );
 	}
 
 	/**
@@ -45,22 +51,22 @@ class Payment_Tokens extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_get_customer_tokens_with_gateway() {
-		$this->assertEmpty( \WC_Payment_Tokens::get_customer_tokens( 1 ) );
+		$this->assertEmpty( \WC_Payment_Tokens::get_customer_tokens( $this->user_id ) );
 
 		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token->set_user_id( $this->user_id );
 		$token->set_gateway_id( 'simplify_commerce' );
 		$token->save();
 
 		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token->set_user_id( $this->user_id );
 		$token->set_gateway_id( 'paypal' );
 		$token->save();
 
-		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( 1 ) );
-		$this->assertCount( 1, \WC_Payment_Tokens::get_customer_tokens( 1, 'simplify_commerce' ) );
+		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( $this->user_id ) );
+		$this->assertCount( 1, \WC_Payment_Tokens::get_customer_tokens( $this->user_id, 'simplify_commerce' ) );
 
-		foreach ( \WC_Payment_Tokens::get_customer_tokens( 1, 'simplify_commerce' ) as $simplify_token ) {
+		foreach ( \WC_Payment_Tokens::get_customer_tokens( $this->user_id, 'simplify_commerce' ) as $simplify_token ) {
 			$this->assertEquals( 'simplify_commerce', $simplify_token->get_gateway_id() );
 		}
 	}
@@ -71,41 +77,42 @@ class Payment_Tokens extends \WC_Unit_Test_Case {
 	 */
 	function test_wc_get_customer_default_token() {
 		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token->set_user_id( $this->user_id );
 		$token->set_gateway_id( 'simplify_commerce' );
 		$token->save();
 
 		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token->set_user_id( $this->user_id );
 		$token->set_default( true );
 		$token->set_gateway_id( 'paypal' );
 		$token->save();
 
-		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( 1 ) );
+		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( $this->user_id ) );
 
-		$default_token = \WC_Payment_Tokens::get_customer_default_token( 1 );
+		$default_token = \WC_Payment_Tokens::get_customer_default_token( $this->user_id );
 		$this->assertEquals( 'paypal', $default_token->get_gateway_id() );
 	}
 
 	/**
-	 * Test getting a customers default token, when there is no default token.
+	 * Test getting a customers default token, when there no token is expictly set.
+	 * This should be the "first created".
+	 * @see WC_Payment_Token::create()
+	 * @group failing
 	 * @since 2.6.0
 	 */
-	function test_wc_get_customer_default_token_returns_null_when_no_default_token() {
-		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+	function test_wc_get_customer_default_token_returns_first_created_when_no_default_token_set() {
+		$token = \WC_Helper_Payment_Token::create_cc_token( $this->user_id );
 		$token->set_gateway_id( 'simplify_commerce' );
 		$token->save();
 
-		$token = \WC_Helper_Payment_Token::create_cc_token();
-		$token->set_user_id( 1 );
+		$token = \WC_Helper_Payment_Token::create_cc_token( $this->user_id );
 		$token->set_gateway_id( 'paypal' );
 		$token->save();
 
-		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( 1 ) );
+		$this->assertCount( 2, \WC_Payment_Tokens::get_customer_tokens( $this->user_id ) );
 
-		$default_token = \WC_Payment_Tokens::get_customer_default_token( 1 );
-		$this->assertNull( $default_token );
+		$default_token = \WC_Payment_Tokens::get_customer_default_token( $this->user_id );
+		$this->assertEquals( 'simplify_commerce', $default_token->get_gateway_id() );
 	}
 
 	/**
@@ -148,26 +155,24 @@ class Payment_Tokens extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_set_users_default() {
-		$token = \WC_Helper_Payment_Token::create_cc_token();
+		$token = \WC_Helper_Payment_Token::create_cc_token( $this->user_id );
 		$token_id = $token->get_id();
-		$token->set_user_id( 1 );
 		$token->save();
 
-		$token2 = \WC_Helper_Payment_Token::create_cc_token();
+		$token2 = \WC_Helper_Payment_Token::create_cc_token( $this->user_id );
 		$token_id_2 = $token2->get_id();
-		$token2->set_user_id( 1 );
 		$token2->save();
 
-		$this->assertFalse( $token->is_default() );
+		$this->assertTrue( $token->is_default() ); // first created is default
 		$this->assertFalse( $token2->is_default() );
 
-		\WC_Payment_Tokens::set_users_default( 1, $token_id_2 );
+		\WC_Payment_Tokens::set_users_default( $this->user_id, $token_id_2 );
 		$token->read( $token_id );
 		$token2->read( $token_id_2 );
 		$this->assertFalse( $token->is_default() );
 		$this->assertTrue( $token2->is_default() );
 
-		\WC_Payment_Tokens::set_users_default( 1, $token_id );
+		\WC_Payment_Tokens::set_users_default( $this->user_id, $token_id );
 		$token->read( $token_id );
 		$token2->read( $token_id_2 );
 		$this->assertTrue( $token->is_default() );


### PR DESCRIPTION
@claudiosmweb pointed out some broken payment token tests on WP 4.0. This lead to some fixes/things I noticed (which was semi-broken on other versions as well):
- Makes sure we are using the user ID of the payment token, and not the current user.
- Also makes sure to properly unset other tokens when a new one is set as default.
- Finally, we make sure that a user is always set in our payment token tests (which was broken in some WP versions which alerted us to some broken tests).
