### PR TITLE
Add tests for localStorage

### DIFF
--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -8,10 +8,13 @@ jQuery( function( $ ) {
 
 	/* Storage Handling */
 	var $supports_html5_storage;
+
 	try {
 		$supports_html5_storage = ( 'sessionStorage' in window && window.sessionStorage !== null );
 		window.sessionStorage.setItem( 'wc', 'test' );
 		window.sessionStorage.removeItem( 'wc' );
+		window.localStorage.setItem( 'wc', 'test' );
+		window.localStorage.removeItem( 'wc' );
 	} catch( err ) {
 		$supports_html5_storage = false;
 	}


### PR DESCRIPTION
Some spiders will not error out on sessions storage, but will throw an exception on localstorage. For example, my site has been hit with the following almost on an hourly basis:

```
TypeError: Cannot call method 'setItem' of null
1
File https://maureentaylor.com/app/plugins/woocommerce/assets/js/frontend/cart-fragments.min.js line 1 in [anonymous]
```
