### PR TITLE
New WC_Data class with meta methods for CRUD

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 *
 * Implemented by classes using the same CRUD(s) pattern.
 *
-* @version  2.7.0
+* @version  2.6.0
 * @package  WooCommerce/Abstracts
 * @category Abstract Class
 * @author   WooThemes
@@ -89,7 +89,7 @@ abstract class WC_Data {
 
 	/**
 	 * Get All Meta Data
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @return array
 	 */
 	public function get_meta_data() {
@@ -99,7 +99,7 @@ abstract class WC_Data {
 	/**
 	 * Internal meta keys we don't want exposed as part of meta_data. This is in
 	 * addition to all data props with _ prefix.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @return array()
 	 */
 	protected function prefix_key( $key ) {
@@ -109,7 +109,7 @@ abstract class WC_Data {
 	/**
 	 * Internal meta keys we don't want exposed as part of meta_data. This is in
 	 * addition to all data props with _ prefix.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @return array()
 	 */
 	protected function get_internal_meta_keys() {
@@ -118,7 +118,7 @@ abstract class WC_Data {
 
 	/**
 	 * Get Meta Data by Key.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @param  string $key
 	 * @param  bool $single return first found meta with key, or all with $key
 	 * @return mixed
@@ -140,7 +140,7 @@ abstract class WC_Data {
 
 	/**
 	 * Set all meta data from array.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @param array $data Key/Value pairs
 	 */
 	public function set_meta_data( $data ) {
@@ -159,7 +159,7 @@ abstract class WC_Data {
 
 	/**
 	 * Add meta data.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @param array $key Meta key
 	 * @param array $value Meta value
 	 * @param array $unique Should this be a unique key?
@@ -177,7 +177,7 @@ abstract class WC_Data {
 
 	/**
 	 * Update meta data by key or ID, if provided.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @param  string $key
 	 * @param  string $value
 	 * @param  int $meta_id
@@ -195,7 +195,7 @@ abstract class WC_Data {
 
 	/**
 	 * Delete meta data.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @param array $key Meta key
 	 */
 	public function delete_meta_data( $key ) {
@@ -205,7 +205,7 @@ abstract class WC_Data {
 
 	/**
 	 * Read Meta Data from the database. Ignore any internal properties.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 */
 	protected function read_meta_data() {
 		$this->_meta_data = array();
@@ -250,7 +250,7 @@ abstract class WC_Data {
 
 	/**
 	 * Update Meta Data in the database.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 */
 	protected function save_meta_data() {
 		global $wpdb;
@@ -286,7 +286,7 @@ abstract class WC_Data {
 
 	/**
 	 * Table structure is slightly different between meta types, this function will return what we need to know.
-	 * @since 2.7.0
+	 * @since 2.6.0
 	 * @return array Array elements: table, object_id_field, meta_id_field
 	 */
 	protected function _get_db_info() {

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -53,7 +53,7 @@ abstract class WC_Data {
 	 * Returns the unique ID for this object.
 	 * @return int
 	 */
-	abstract  public function get_id();
+	abstract public function get_id();
 
 	/**
 	 * Returns all data for this object.
@@ -80,7 +80,7 @@ abstract class WC_Data {
 	/**
 	 * Updates object data in the database.
 	 */
-	abstract  public function delete();
+	abstract public function delete();
 
 	/**
 	 * Save should create or update based on object existance.
@@ -127,7 +127,7 @@ abstract class WC_Data {
 			if ( $single ) {
 				$value = $this->_meta_data[ current( $meta_ids ) ]->value;
 			} else {
-				$value = array_intersect_key( $this->_meta_data, $meta_ids );
+				$value = array_intersect_key( $this->_meta_data, array_flip( $meta_ids ) );
 			}
 		}
 
@@ -286,10 +286,10 @@ abstract class WC_Data {
 		$table           = $wpdb->prefix;
 		// If we are dealing with a type of metadata that is not a core type, the table should be prefixed.
 		if ( ! in_array( $this->_meta_type, array( 'post', 'user', 'comment', 'term' ) ) ) {
-			$table = 'woocommerce_';
+			$table .= 'woocommerce_';
 		}
 
-		$table = $this->_meta_type . 'meta';
+		$table .= $this->_meta_type . 'meta';
 
 		// Figure out our field names.
 		if ( 'post' === $this->_meta_type ) {

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -89,6 +89,7 @@ abstract class WC_Data {
 
 	/**
 	 * Get All Meta Data
+	 * @since 2.7.0
 	 * @return array
 	 */
 	public function get_meta_data() {
@@ -98,6 +99,7 @@ abstract class WC_Data {
 	/**
 	 * Internal meta keys we don't want exposed as part of meta_data. This is in
 	 * addition to all data props with _ prefix.
+	 * @since 2.7.0
 	 * @return array()
 	 */
 	protected function prefix_key( $key ) {
@@ -107,6 +109,7 @@ abstract class WC_Data {
 	/**
 	 * Internal meta keys we don't want exposed as part of meta_data. This is in
 	 * addition to all data props with _ prefix.
+	 * @since 2.7.0
 	 * @return array()
 	 */
 	protected function get_internal_meta_keys() {
@@ -115,6 +118,7 @@ abstract class WC_Data {
 
 	/**
 	 * Get Meta Data by Key.
+	 * @since 2.7.0
 	 * @param  string $key
 	 * @param  bool $single return first found meta with key, or all with $key
 	 * @return mixed
@@ -136,6 +140,7 @@ abstract class WC_Data {
 
 	/**
 	 * Set all meta data from array.
+	 * @since 2.7.0
 	 * @param array $data Key/Value pairs
 	 */
 	public function set_meta_data( $data ) {
@@ -155,6 +160,7 @@ abstract class WC_Data {
 
 	/**
 	 * Add meta data.
+	 * @since 2.7.0
 	 * @param array $key Meta key
 	 * @param array $value Meta value
 	 * @param array $unique Should this be a unique key?
@@ -172,6 +178,7 @@ abstract class WC_Data {
 
 	/**
 	 * Update meta data by key or ID, if provided.
+	 * @since 2.7.0
 	 * @param  string $key
 	 * @param  string $value
 	 * @param  int $meta_id
@@ -189,6 +196,7 @@ abstract class WC_Data {
 
 	/**
 	 * Delete meta data.
+	 * @since 2.7.0
 	 * @param array $key Meta key
 	 */
 	public function delete_meta_data( $key ) {
@@ -198,6 +206,7 @@ abstract class WC_Data {
 
 	/**
 	 * Read Meta Data from the database. Ignore any internal properties.
+	 * @since 2.7.0
 	 */
 	protected function read_meta_data() {
 		$this->_meta_data = array();
@@ -223,14 +232,15 @@ abstract class WC_Data {
 			$raw_meta_data = $wpdb->get_results( $wpdb->prepare( "
 				SELECT " . $db_info['meta_id_field'] . ", meta_key, meta_value
 				FROM " . $db_info['table'] . "
-				WHERE " . $db_info['object_id_field'] . " = %d ORDER BY meta_id
+				WHERE " . $db_info['object_id_field'] . " = %d ORDER BY " . $db_info['meta_id_field'] . "
 			", $this->get_id() ) );
 
 			foreach ( $raw_meta_data as $meta ) {
 				if ( in_array( $meta->meta_key, $this->get_internal_meta_keys() ) ) {
 					continue;
 				}
-				$this->_meta_data[ $meta->meta_id ] = (object) array( 'key' => $meta->meta_key, 'value' => $meta->meta_value );
+
+				$this->_meta_data[ $meta->{$db_info['meta_id_field']} ] = (object) array( 'key' => $meta->meta_key, 'value' => $meta->meta_value );
 			}
 
 			if ( ! empty ( $this->_cache_group ) ) {
@@ -241,6 +251,7 @@ abstract class WC_Data {
 
 	/**
 	 * Update Meta Data in the database.
+	 * @since 2.7.0
 	 */
 	protected function save_meta_data() {
 		global $wpdb;
@@ -276,6 +287,7 @@ abstract class WC_Data {
 
 	/**
 	 * Table structure is slightly different between meta types, this function will return what we need to know.
+	 * @since 2.7.0
 	 * @return array Array elements: table, object_id_field, meta_id_field
 	 */
 	private function _get_db_info() {

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -157,7 +157,6 @@ abstract class WC_Data {
 		}
 	}
 
-
 	/**
 	 * Add meta data.
 	 * @since 2.7.0
@@ -290,35 +289,27 @@ abstract class WC_Data {
 	 * @since 2.7.0
 	 * @return array Array elements: table, object_id_field, meta_id_field
 	 */
-	private function _get_db_info() {
+	protected function _get_db_info() {
 		global $wpdb;
 
-		$object_id_field = '';
 		$meta_id_field   = 'meta_id'; // for some reason users calls this umeta_id so we need to track this as well.
 		$table           = $wpdb->prefix;
+
 		// If we are dealing with a type of metadata that is not a core type, the table should be prefixed.
 		if ( ! in_array( $this->_meta_type, array( 'post', 'user', 'comment', 'term' ) ) ) {
 			$table .= 'woocommerce_';
 		}
 
 		$table .= $this->_meta_type . 'meta';
+		$object_id_field = $this->_meta_type . '_id';
 
 		// Figure out our field names.
-		if ( 'post' === $this->_meta_type ) {
-			$object_id_field = 'post_id';
-		} elseif ( 'user' === $this->_meta_type ) {
-			$object_id_field = 'user_id';
+		if ( 'user' === $this->_meta_type ) {
 			$meta_id_field   = 'umeta_id';
-		} else if ( 'comment' === $this->_meta_type ) {
-			$object_id_field = 'comment_id';
-		} else if ( 'term' === $this->_meta_data ) {
-			$object_id_field = 'term_id';
-		} else {
-			if ( ! empty ( $this->object_id_field_for_meta ) ) {
-				$object_id_field = $this->object_id_field_for_meta;
-			} else {
-				$object_id_field = 'post_id'; // default to post_id
-			}
+		}
+
+		if ( ! empty( $this->object_id_field_for_meta ) ) {
+			$object_id_field = $this->object_id_field_for_meta;
 		}
 
 		return array(

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -1,0 +1,319 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+* Abstract WC Data Class
+*
+* Implemented by classes using the same CRUD(s) pattern.
+*
+* @version  2.7.0
+* @package  WooCommerce/Abstracts
+* @category Abstract Class
+* @author   WooThemes
+*/
+abstract class WC_Data {
+
+	/**
+	 * Stores meta in cache for future reads.
+	 * A group must be set to to enable caching.
+	 * @var string
+	 */
+	protected $_cache_group = '';
+
+	/**
+	 * Meta type. This should match up with
+	 * the types avaiable at https://codex.wordpress.org/Function_Reference/add_metadata.
+	 * WP defines 'post', 'user', 'comment', and 'term'.
+	 */
+	protected $_meta_type = 'post';
+
+	/**
+	 * This only needs set if you are using a custom metadata type (for example payment tokens.
+	 * This should be the name of the field your table uses for associating meta with objects.
+	 * For example, in payment_tokenmeta, this would be payment_token_id.
+	 * @var string
+	 */
+	protected $object_id_field_for_meta = '';
+
+	/**
+	 * Stores additonal meta data.
+	 * @var array
+	 */
+	protected $_meta_data = array();
+
+	/**
+	 * Internal meta keys we don't want exposed for the object.
+	 * @var array
+	 */
+	protected $_internal_meta_keys = array();
+
+	/**
+	 * Returns the unique ID for this object.
+	 * @return int
+	 */
+	abstract  public function get_id();
+
+	/**
+	 * Returns all data for this object.
+	 * @return array
+	 */
+	abstract public function get_data();
+
+	/**
+	 * Creates new object in the database.
+	 */
+	abstract public function create();
+
+	/**
+	 * Read object from the database.
+	 * @param int ID of the object to load.
+	 */
+	abstract public function read( $id );
+
+	/**
+	 * Updates object data in the database.
+	 */
+	abstract public function update();
+
+	/**
+	 * Updates object data in the database.
+	 */
+	abstract  public function delete();
+
+	/**
+	 * Save should create or update based on object existance.
+	 */
+	abstract public function save();
+
+	/**
+	 * Get All Meta Data
+	 * @return array
+	 */
+	public function get_meta_data() {
+		return $this->_meta_data;
+	}
+
+	/**
+	 * Internal meta keys we don't want exposed as part of meta_data. This is in
+	 * addition to all data props with _ prefix.
+	 * @return array()
+	 */
+	protected function prefix_key( $key ) {
+		return '_' === substr( $key, 0, 1 ) ? $key : '_' . $key;
+	}
+
+	/**
+	 * Internal meta keys we don't want exposed as part of meta_data. This is in
+	 * addition to all data props with _ prefix.
+	 * @return array()
+	 */
+	protected function get_internal_meta_keys() {
+		return array_merge( array_map( array( $this, 'prefix_key' ), array_keys( $this->_data ) ), $this->_internal_meta_keys );
+	}
+
+	/**
+	 * Get Meta Data by Key.
+	 * @param  string $key
+	 * @param  bool $single return first found meta with key, or all with $key
+	 * @return mixed
+	 */
+	public function get_meta( $key = '', $single = true ) {
+		$meta_ids = array_keys( wp_list_pluck( $this->_meta_data, 'key' ), $key );
+		$value    = '';
+
+		if ( $meta_ids ) {
+			if ( $single ) {
+				$value = $this->_meta_data[ current( $meta_ids ) ]->value;
+			} else {
+				$value = array_intersect_key( $this->_meta_data, $meta_ids );
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Set all meta data from array.
+	 * @param array $data Key/Value pairs
+	 */
+	public function set_meta_data( $data ) {
+		if ( ! empty( $data ) && is_array( $data ) ) {
+			foreach ( $data as $meta_id => $meta ) {
+				$meta = (array) $meta;
+				if ( isset( $meta['key'], $meta['value'] ) ) {
+					$this->_meta_data[ $meta_id ] = (object) array(
+						'key'   => $meta['key'],
+						'value' => $meta['value'],
+					);
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * Add meta data.
+	 * @param array $key Meta key
+	 * @param array $value Meta value
+	 * @param array $unique Should this be a unique key?
+	 */
+	public function add_meta_data( $key, $value, $unique = false ) {
+		if ( $unique ) {
+			$meta_ids = array_keys( wp_list_pluck( $this->_meta_data, 'key' ), $key );
+			$this->_meta_data = array_diff_key( $this->_meta_data, array_fill_keys( $meta_ids, '' ) );
+		}
+		$this->_meta_data[ 'new-' . sizeof( $this->_meta_data ) ] = (object) array(
+			'key'   => $key,
+			'value' => $value,
+		);
+	}
+
+	/**
+	 * Update meta data by key or ID, if provided.
+	 * @param  string $key
+	 * @param  string $value
+	 * @param  int $meta_id
+	 */
+	public function update_meta_data( $key, $value, $meta_id = '' ) {
+		if ( $meta_id && isset( $this->_meta_data[ $meta_id ] ) ) {
+			$this->_meta_data[ $meta_id ] = (object) array(
+				'key'   => $key,
+				'value' => $value,
+			);
+		} else {
+			$this->add_meta_data( $key, $value, true );
+		}
+	}
+
+	/**
+	 * Delete meta data.
+	 * @param array $key Meta key
+	 */
+	public function delete_meta_data( $key ) {
+		$meta_ids         = array_keys( wp_list_pluck( $this->_meta_data, 'key' ), $key );
+		$this->_meta_data = array_diff_key( $this->_meta_data, array_fill_keys( $meta_ids, '' ) );
+	}
+
+	/**
+	 * Read Meta Data from the database. Ignore any internal properties.
+	 */
+	protected function read_meta_data() {
+		$this->_meta_data = array();
+		$cache_loaded     = false;
+
+		if ( ! $this->get_id() ) {
+			return;
+		}
+
+		if ( ! empty ( $this->_cache_group ) ) {
+			$cache_key   = WC_Cache_Helper::get_cache_prefix( $this->_cache_group ) . $this->get_id();
+			$cached_meta = wp_cache_get( $cache_key, $this->_cache_group );
+
+			if ( false !== $cached_meta ) {
+				$this->_meta_data = $cached_meta;
+				$cache_loaded = true;
+			}
+		}
+
+		if ( ! $cache_loaded ) {
+			global $wpdb;
+			$db_info = $this->_get_db_info();
+			$raw_meta_data = $wpdb->get_results( $wpdb->prepare( "
+				SELECT " . $db_info['meta_id_field'] . ", meta_key, meta_value
+				FROM " . $db_info['table'] . "
+				WHERE " . $db_info['object_id_field'] . " = %d ORDER BY meta_id
+			", $this->get_id() ) );
+
+			foreach ( $raw_meta_data as $meta ) {
+				if ( in_array( $meta->meta_key, $this->get_internal_meta_keys() ) ) {
+					continue;
+				}
+				$this->_meta_data[ $meta->meta_id ] = (object) array( 'key' => $meta->meta_key, 'value' => $meta->meta_value );
+			}
+
+			if ( ! empty ( $this->_cache_group ) ) {
+				wp_cache_set( $cache_key, $this->_meta_data, $this->_cache_group );
+			}
+		}
+	}
+
+	/**
+	 * Update Meta Data in the database.
+	 */
+	protected function save_meta_data() {
+		global $wpdb;
+		$db_info = $this->_get_db_info();
+		$all_meta_ids = array_map( 'absint', $wpdb->get_col( $wpdb->prepare( "
+			SELECT " . $db_info['meta_id_field'] . " FROM " . $db_info['table'] . "
+			WHERE " . $db_info['object_id_field'] . " = %d", $this->get_id() ) . "
+			AND meta_key NOT IN ('" . implode( "','", array_map( 'esc_sql', $this->get_internal_meta_keys() ) ) . "');
+		" ) );
+		$set_meta_ids = array();
+
+		foreach ( $this->_meta_data as $meta_id => $meta ) {
+			if ( 'new' === substr( $meta_id, 0, 3 ) ) {
+				$set_meta_ids[] = add_metadata( $this->_meta_type, $this->get_id(), $meta->key, $meta->value, false );
+			} else {
+				update_metadata_by_mid( $this->_meta_type, $meta_id, $meta->value, $meta->key );
+				$set_meta_ids[] = absint( $meta_id );
+			}
+		}
+
+		// Delete no longer set meta data
+		$delete_meta_ids = array_diff( $all_meta_ids, $set_meta_ids );
+
+		foreach ( $delete_meta_ids as $meta_id ) {
+			delete_metadata_by_mid( $this->_meta_type, $meta_id );
+		}
+
+		if ( ! empty ( $this->_cache_group ) ) {
+			WC_Cache_Helper::incr_cache_prefix( $this->_cache_group );
+		}
+		$this->read_meta_data();
+	}
+
+	/**
+	 * Table structure is slightly different between meta types, this function will return what we need to know.
+	 * @return array Array elements: table, object_id_field, meta_id_field
+	 */
+	private function _get_db_info() {
+		global $wpdb;
+
+		$object_id_field = '';
+		$meta_id_field   = 'meta_id'; // for some reason users calls this umeta_id so we need to track this as well.
+		$table           = $wpdb->prefix;
+		// If we are dealing with a type of metadata that is not a core type, the table should be prefixed.
+		if ( ! in_array( $this->_meta_type, array( 'post', 'user', 'comment', 'term' ) ) ) {
+			$table = 'woocommerce_';
+		}
+
+		$table = $this->_meta_type . 'meta';
+
+		// Figure out our field names.
+		if ( 'post' === $this->_meta_type ) {
+			$object_id_field = 'post_id';
+		} elseif ( 'user' === $this->_meta_type ) {
+			$object_id_field = 'user_id';
+			$meta_id_field   = 'umeta_id';
+		} else if ( 'comment' === $this->_meta_type ) {
+			$object_id_field = 'comment_id';
+		} else if ( 'term' === $this->_meta_data ) {
+			$object_id_field = 'term_id';
+		} else {
+			if ( ! empty ( $this->object_id_field_for_meta ) ) {
+				$object_id_field = $this->object_id_field_for_meta;
+			} else {
+				$object_id_field = 'post_id'; // default to post_id
+			}
+		}
+
+		return array(
+			'table'           => $table,
+			'object_id_field' => $object_id_field,
+			'meta_id_field'   => $meta_id_field,
+		);
+	}
+
+}

--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category	Abstract Class
  * @author		WooThemes
  */
- abstract class WC_Payment_Token implements WC_Data {
+ abstract class WC_Payment_Token {
 
  	/** @protected int Token ID. */
  	protected $id;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -91,6 +91,7 @@ class WC_Unit_Tests_Bootstrap {
 		// framework
 		require_once( $this->tests_dir . '/framework/class-wc-unit-test-factory.php' );
 		require_once( $this->tests_dir . '/framework/class-wc-mock-session-handler.php' );
+		require_once( $this->tests_dir . '/framework/class-wc-mock-wc-data.php' );
 		require_once( $this->tests_dir . '/framework/class-wc-payment-token-stub.php' );
 
 		// test cases

--- a/tests/framework/class-wc-mock-wc-data.php
+++ b/tests/framework/class-wc-mock-wc-data.php
@@ -28,21 +28,20 @@ class WC_Mock_WC_data extends WC_Data {
 	| These functions just change the properties set above.
 	*/
 
-
-	function set_cache_group( $cache_group ) {
-		$this->_cache_group = $cache_group;
-	}
-
+	/**
+	 * Set meta type (user or post).
+	 * @param string $meta_type
+	 */
 	function set_meta_type( $meta_type ) {
 		$this->_meta_type = $meta_type;
 	}
 
+	/**
+	 * Set object ID field dynamically for testing.
+	 * @param string $object_id_field
+	 */
 	function set_object_id_field( $object_id_field ) {
 		$this->object_id_field_for_meta = $object_id_field;
-	}
-
-	function set_internal_meta_keys( $internal_meta_keys ) {
-		$this->_internal_meta_keys = $internal_meta_keys;
 	}
 
 	/*
@@ -53,24 +52,43 @@ class WC_Mock_WC_data extends WC_Data {
 	| testing the good bits.
 	*/
 
+	/**
+	 * Simple read.
+	 */
 	public function __construct( $id = '' ) {
 		if ( ! empty( $id ) ) {
 			$this->read( $id );
 		}
 	}
 
+	/**
+	 * Simple get ID.
+	 * @return integer
+	 */
 	public function get_id() {
 		return intval( $this->_data['id'] );
 	}
 
+	/**
+	 * Simple get content.
+	 * @return string
+	 */
 	public function get_content() {
 		return $this->_data['content'];
 	}
 
+	/**
+	 * SImple set content.
+	 * @param string $content
+	 */
 	public function set_content( $content ) {
 		$this->_data['content'] = $content;
 	}
 
+	/**
+	 * Simple get data as array.
+	 * @return array
+	 */
 	public function get_data() {
 		return array_merge(
 			$this->_data,
@@ -80,27 +98,45 @@ class WC_Mock_WC_data extends WC_Data {
 		);
 	}
 
+	/**
+	 * Simple create.
+	 */
 	public function create() {
 		if ( 'user' === $this->_meta_type ) {
 			$content_id = wc_create_new_customer( $this->get_content(), 'username-' . time(), 'hunter2' );
 		} else {
 			$content_id = wp_insert_post( array ( 'post_title' => $this->get_content() ) );
 		}
-
 		if ( $content_id ) {
 			$this->_data['id'] = $content_id;
 		}
 	}
 
+	/**
+	 * Simple read.
+	 */
 	public function read( $id ) {
-		if ( empty( $id ) || ! ( $post_object = get_post( $id ) ) ) {
-			return;
+
+		if ( 'user' === $this->_meta_type ) {
+			if ( empty( $id ) || ! ( $user_object = get_userdata( $id ) ) ) {
+				return;
+			}
+			$this->_data['id'] = absint( $user_object->ID );
+			$this->set_content( $user_object->user_email );
+		} else {
+			if ( empty( $id ) || ! ( $post_object = get_post( $id ) ) ) {
+				return;
+			}
+			$this->_data['id'] = absint( $post_object->ID );
+			$this->set_content( $post_object->post_title );
 		}
-		$this->_data['id'] = absint( $post_object->ID );
-		$this->set_content( $post_object->post_title );
+
 		$this->read_meta_data();
 	}
 
+	/**
+	 * Simple update.
+	 */
 	public function update() {
 		global $wpdb;
 		$content_id = $this->get_id();
@@ -112,6 +148,9 @@ class WC_Mock_WC_data extends WC_Data {
 		}
 	}
 
+	/**
+	 * Simple delete.
+	 */
 	public function delete() {
 		if ( 'user' === $this->_meta_type ) {
 			wp_delete_user( $this->get_id() );
@@ -120,6 +159,9 @@ class WC_Mock_WC_data extends WC_Data {
 		}
 	}
 
+	/**
+	 * Simple save.
+	 */
 	public function save() {
 		if ( ! $this->get_id() ) {
 			$this->create();
@@ -128,13 +170,5 @@ class WC_Mock_WC_data extends WC_Data {
 		}
 		$this->save_meta_data();
 	}
-
-	/*
-	|--------------------------------------------------------------------------
-	| Provide a public interface to a few of our.
-	|--------------------------------------------------------------------------
-	| Define the abstract methods WC_Data classes expect, so we can go on to
-	| testing the good bits.
-	*/
 
 }

--- a/tests/framework/class-wc-mock-wc-data.php
+++ b/tests/framework/class-wc-mock-wc-data.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Used for exposing and testing the various Abstract WC_Data methods.
+ */
+class WC_Mock_WC_data extends WC_Data {
+
+	/**
+	 * Data array
+	 */
+	protected $_data = array(
+		'id'      => 0,
+		'content' => '',
+	);
+
+	// see WC_Data
+	protected $_cache_group = '';
+	protected $_meta_type = 'post';
+	protected $object_id_field_for_meta = '';
+	protected $_internal_meta_keys = array();
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters for internal WC_Data properties.
+	|--------------------------------------------------------------------------
+	| Normally we wouldn't want to be able to change this once the class is defined,
+	| but to make testing different types of meta/storage, we should be able to
+	| switch out our class settings.
+	| These functions just change the properties set above.
+	*/
+
+
+	function set_cache_group( $cache_group ) {
+		$this->_cache_group = $cache_group;
+	}
+
+	function set_meta_type( $meta_type ) {
+		$this->_meta_type = $meta_type;
+	}
+
+	function set_object_id_field( $object_id_field ) {
+		$this->object_id_field_for_meta = $object_id_field;
+	}
+
+	function set_internal_meta_keys( $internal_meta_keys ) {
+		$this->_internal_meta_keys = $internal_meta_keys;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Abstract methods.
+	|--------------------------------------------------------------------------
+	| Define the abstract methods WC_Data classes expect, so we can go on to
+	| testing the good bits.
+	*/
+
+	public function __construct( $id = '' ) {
+		if ( ! empty( $id ) ) {
+			$this->read( $id );
+		}
+	}
+
+	public function get_id() {
+		return intval( $this->_data['id'] );
+	}
+
+	public function get_content() {
+		return $this->_data['content'];
+	}
+
+	public function set_content( $content ) {
+		$this->_data['content'] = $content;
+	}
+
+	public function get_data() {
+		return array_merge(
+			$this->_data,
+			array(
+				'meta_data' => $this->get_meta_data(),
+			)
+		);
+	}
+
+	public function create() {
+		if ( 'user' === $this->_meta_type ) {
+			$content_id = wc_create_new_customer( $this->get_content(), 'username-' . time(), 'hunter2' );
+		} else {
+			$content_id = wp_insert_post( array ( 'post_title' => $this->get_content() ) );
+		}
+
+		if ( $content_id ) {
+			$this->_data['id'] = $content_id;
+		}
+	}
+
+	public function read( $id ) {
+		if ( empty( $id ) || ! ( $post_object = get_post( $id ) ) ) {
+			return;
+		}
+		$this->_data['id'] = absint( $post_object->ID );
+		$this->set_content( $post_object->post_title );
+		$this->read_meta_data();
+	}
+
+	public function update() {
+		global $wpdb;
+		$content_id = $this->get_id();
+
+		if ( 'user' === $this->_meta_type ) {
+			wp_update_user( array( 'ID' => $customer_id, 'user_email' => $this->get_content() ) );
+		} else {
+			wp_update_post( array( 'ID' => $content_id, 'post_title' => $this->get_content() ) );
+		}
+	}
+
+	public function delete() {
+		if ( 'user' === $this->_meta_type ) {
+			wp_delete_user( $this->get_id() );
+		} else {
+			wp_delete_post( $this->get_id() );
+		}
+	}
+
+	public function save() {
+		if ( ! $this->get_id() ) {
+			$this->create();
+		} else {
+			$this->update();
+		}
+		$this->save_meta_data();
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Provide a public interface to a few of our.
+	|--------------------------------------------------------------------------
+	| Define the abstract methods WC_Data classes expect, so we can go on to
+	| testing the good bits.
+	*/
+
+}

--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -7,15 +7,25 @@ namespace WooCommerce\Tests\CRUD;
  */
 class Meta extends \WC_Unit_Test_Case {
 
+	/**
+	 * Create a test post we can add/test meta against.
+	 */
 	public function create_test_post() {
 		$object = new \WC_Mock_WC_data();
 		$object->set_content( 'testing' );
 		$object->save();
-		$object_id = $object->get_id();
-		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
-		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val2'  );
-		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val3'  );
-		$object->read( $object_id ); // reload to make sure we get our meta...
+		return $object;
+	}
+
+	/**
+	 * Create a test user we can add/test meta against.
+	 */
+	public function create_test_user() {
+		$object = new \WC_Mock_WC_data();
+		$object->set_meta_type( 'user' );
+		$object->set_object_id_field( 'user_id' );
+		$object->set_content( 'testing@woo.dev' );
+		$object->save();
 		return $object;
 	}
 
@@ -24,6 +34,12 @@ class Meta extends \WC_Unit_Test_Case {
 	 */
 	function test_get_meta_data() {
 		$object    = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val2'  );
+		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val3'  );
+		$object->read( $object_id );
+
 		$meta_data = $object->get_meta_data();
 		$i         = 1;
 
@@ -39,6 +55,11 @@ class Meta extends \WC_Unit_Test_Case {
 	 */
 	function test_get_meta() {
 		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val2'  );
+		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val3'  );
+		$object->read( $object_id );
 
 		// test single meta key
 		$single_meta = $object->get_meta( 'test_meta_key' );
@@ -58,49 +79,122 @@ class Meta extends \WC_Unit_Test_Case {
 	 * Test setting meta.
 	 */
 	function test_set_meta_data() {
+		global $wpdb;
+		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		add_metadata( 'post', $object_id, 'test_meta_key_2', 'val2', true );
+		$object->read( $object_id );
 
+		$metadata     = array();
+		$raw_metadata = $wpdb->get_results( $wpdb->prepare( "
+			SELECT meta_id, meta_key, meta_value
+			FROM {$wpdb->prefix}postmeta
+			WHERE post_id = %d ORDER BY meta_id
+		", $object_id ) );
+
+		foreach ( $raw_metadata as $meta ) {
+			$metadata[ $meta->meta_id ] = (object) array( 'key' => $meta->meta_key, 'value' => $meta->meta_value );
+		}
+
+		$object = new \WC_Mock_WC_data();
+		$object->set_meta_data( $metadata );
+
+		$this->assertEquals( $metadata, $object->get_meta_data() );
 	}
 
 	/**
 	 * Test adding meta data.
 	 */
 	function test_add_meta_data() {
-
+		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		$data = 'add_meta_data_' . time();
+		$object->add_meta_data( 'test_new_field', $data );
+		$meta = $object->get_meta( 'test_new_field' );
+		$this->assertEquals( $data, $meta );
 	}
 
 	/**
 	 * Test updating meta data.
 	 */
 	function test_update_meta_data() {
+		global $wpdb;
+		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		$object->read( $object_id );
 
+		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
+
+		$metadata     = array();
+		$meta_id = $wpdb->get_var( $wpdb->prepare( "
+			SELECT meta_id
+			FROM {$wpdb->prefix}postmeta
+			WHERE post_id = %d LIMIT 1
+		", $object_id ) );
+
+		$object->update_meta_data( 'test_meta_key', 'updated_value', $meta_id );
+		$this->assertEquals( 'updated_value', $object->get_meta( 'test_meta_key' ) );
 	}
 
 	/**
-	 * Test getting user meta data.
+	 * Test deleting meta.
 	 */
-	function test_user_get_meta_data() {
+	function test_delete_meta_data() {
+		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		$object->read( $object_id );
 
+		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
+
+		$object->delete_meta_data( 'test_meta_key' );
+
+		$this->assertEmpty( $object->get_meta( 'test_meta_key' ) );
+	}
+
+
+	/**
+	 * Test saving metadata.. (Actually making sure changes are written to DB)
+	 */
+	function test_save_meta_data() {
+		global $wpdb;
+		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		add_metadata( 'post', $object_id, 'test_meta_key_2', 'val2', true );
+		$object->read( $object_id );
+
+		$raw_metadata = $wpdb->get_results( $wpdb->prepare( "
+			SELECT meta_id, meta_key, meta_value
+			FROM {$wpdb->prefix}postmeta
+			WHERE post_id = %d ORDER BY meta_id
+		", $object_id ) );
+
+
+		$object->delete_meta_data( 'test_meta_key' );
+		$object->update_meta_data( 'test_meta_key_2', 'updated_value', $raw_metadata[1]->meta_id );
+
+		$object->save();
+		$object->read( $object_id ); // rereads from the DB
+
+		$this->assertEmpty( $object->get_meta( 'test_meta_key' ) );
+		$this->assertEquals( 'updated_value', $object->get_meta( 'test_meta_key_2' ) );
 	}
 
 	/**
-	 * Test setting user meta data.
+	 * Test reading/getting user meta data too.
 	 */
-	function test_user_set_meta_data() {
+	function test_usermeta() {
+		$object = $this->create_test_user();
+		$object_id = $object->get_id();
+		add_metadata( 'user', $object_id, 'test_meta_key', 'val1', true );
+		add_metadata( 'user', $object_id, 'test_meta_key_2', 'val2', true );
+		$object->read( $object_id );
 
-	}
-
-	/**
-	 * Test adding user meta data.
-	 */
-	function test_user_add_meta_data() {
-
-	}
-
-	/**
-	 * Test updating user meta data.
-	 */
-	function test_user_update_meta_data() {
-
+		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
+		$this->assertEquals( 'val2', $object->get_meta( 'test_meta_key_2' ) );
 	}
 
 }

--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -1,0 +1,106 @@
+<?php
+namespace WooCommerce\Tests\CRUD;
+
+/**
+ * Meta
+ * @package WooCommerce\Tests\CRUD
+ */
+class Meta extends \WC_Unit_Test_Case {
+
+	public function create_test_post() {
+		$object = new \WC_Mock_WC_data();
+		$object->set_content( 'testing' );
+		$object->save();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val2'  );
+		add_metadata( 'post', $object_id, 'test_multi_meta_key', 'val3'  );
+		$object->read( $object_id ); // reload to make sure we get our meta...
+		return $object;
+	}
+
+	/**
+	 * Tests reading and getting set metadata.
+	 */
+	function test_get_meta_data() {
+		$object    = $this->create_test_post();
+		$meta_data = $object->get_meta_data();
+		$i         = 1;
+
+		$this->assertNotEmpty( $meta_data );
+		foreach ( $meta_data as $mid => $data ) {
+			$this->assertEquals( "val{$i}", $data->value );
+			$i++;
+		}
+	}
+
+	/**
+	 * Test getting meta by ID.
+	 */
+	function test_get_meta() {
+		$object = $this->create_test_post();
+
+		// test single meta key
+		$single_meta = $object->get_meta( 'test_meta_key' );
+		$this->assertEquals( 'val1', $single_meta );
+
+		// test getting multiple
+		$meta = $object->get_meta( 'test_multi_meta_key', false );
+		$i    = 2;
+		foreach ( $meta as $data ) {
+			$this->assertEquals( 'test_multi_meta_key', $data->key );
+			$this->assertEquals( "val{$i}", $data->value );
+			$i++;
+		}
+	}
+
+	/**
+	 * Test setting meta.
+	 */
+	function test_set_meta_data() {
+
+	}
+
+	/**
+	 * Test adding meta data.
+	 */
+	function test_add_meta_data() {
+
+	}
+
+	/**
+	 * Test updating meta data.
+	 */
+	function test_update_meta_data() {
+
+	}
+
+	/**
+	 * Test getting user meta data.
+	 */
+	function test_user_get_meta_data() {
+
+	}
+
+	/**
+	 * Test setting user meta data.
+	 */
+	function test_user_set_meta_data() {
+
+	}
+
+	/**
+	 * Test adding user meta data.
+	 */
+	function test_user_add_meta_data() {
+
+	}
+
+	/**
+	 * Test updating user meta data.
+	 */
+	function test_user_update_meta_data() {
+
+	}
+
+}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -223,7 +223,6 @@ final class WooCommerce {
 	 * Include required core files used in admin and on the frontend.
 	 */
 	public function includes() {
-		include_once( 'includes/interfaces/interface-wc-data.php' );
 		include_once( 'includes/class-wc-autoloader.php' );
 		include_once( 'includes/wc-core-functions.php' );
 		include_once( 'includes/wc-widget-functions.php' );
@@ -256,6 +255,7 @@ final class WooCommerce {
 
 		include_once( 'includes/class-wc-auth.php' );                            // Auth Class
 		include_once( 'includes/class-wc-post-types.php' );                      // Registers post types
+		include_once( 'includes/abstracts/abstract-wc-data.php' );				 // WC_Data for CRUD
 		include_once( 'includes/abstracts/abstract-wc-payment-token.php' );      // Payment Tokens
 		include_once( 'includes/abstracts/abstract-wc-product.php' );            // Products
 		include_once( 'includes/abstracts/abstract-wc-order.php' );              // Orders


### PR DESCRIPTION
This PR replaces the WC_Data interface with an Abstract WC_Data class (the create, save, etc methods are now abstract classes that child classes implement). The class also introduces a set of meta helper methods (taken from the order branch, but updated to work with users) that all CRUD classes can use. This can also be a future home for any other shared logic. Includes tests and a mock inherited WC_Data class for testing meta methods.
