### PR TITLE
Add 'woocommerce_admin_report_data' and 'woocommerce_admin_report_chart_data' to filter chart data by 3rd parties

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -344,6 +344,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 		// Item counts
 		$this->report_data->total_items = absint( array_sum( wp_list_pluck( $this->report_data->order_items, 'order_item_count' ) ) ) - $this->report_data->refunded_order_items;
+	
+		// 3rd party filtering of report data
+		$this->report_data = apply_filters( 'woocommerce_admin_report_data', $this->report_data );
 	}
 
 	/**
@@ -500,36 +503,45 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		global $wp_locale;
 
 		// Prepare data for report
-		$order_counts         = $this->prepare_chart_data( $this->report_data->order_counts, 'post_date', 'count', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$order_item_counts    = $this->prepare_chart_data( $this->report_data->order_items, 'post_date', 'order_item_count', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$order_amounts        = $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_sales', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$coupon_amounts       = $this->prepare_chart_data( $this->report_data->coupons, 'post_date', 'discount_amount', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$shipping_amounts     = $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_shipping', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$refund_amounts       = $this->prepare_chart_data( $this->report_data->partial_refunds, 'post_date', 'total_refund', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$shipping_tax_amounts = $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_shipping_tax', $this->chart_interval, $this->start_date, $this->chart_groupby );
-		$tax_amounts          = $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_tax', $this->chart_interval, $this->start_date, $this->chart_groupby );
+		$data = array(
+			'order_counts' => $this->prepare_chart_data( $this->report_data->order_counts, 'post_date', 'count', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'order_item_counts' => $this->prepare_chart_data( $this->report_data->order_items, 'post_date', 'order_item_count', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'order_amounts' => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_sales', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'coupon_amounts' => $this->prepare_chart_data( $this->report_data->coupons, 'post_date', 'discount_amount', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'shipping_amounts' => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_shipping', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'refund_amounts' => $this->prepare_chart_data( $this->report_data->partial_refunds, 'post_date', 'total_refund', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'shipping_tax_amounts' => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_shipping_tax', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'tax_amounts' => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_tax', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'net_order_amounts' => array(),
+			'gross_order_amounts' => array()
+		);
 
-		$net_order_amounts   = array();
-		$gross_order_amounts = array();
+		foreach ( $data['order_amounts'] as $order_amount_key => $order_amount_value ) {
+			$data['gross_order_amounts'][ $order_amount_key ]    = $order_amount_value;
+			$data['gross_order_amounts'][ $order_amount_key ][1] -= $data['refund_amounts'][ $order_amount_key ][1];
 
-		foreach ( $order_amounts as $order_amount_key => $order_amount_value ) {
-			$gross_order_amounts[ $order_amount_key ]    = $order_amount_value;
-			$gross_order_amounts[ $order_amount_key ][1] = $gross_order_amounts[ $order_amount_key ][1] - $refund_amounts[ $order_amount_key ][1];
-
-			$net_order_amounts[ $order_amount_key ]    = $order_amount_value;
-			$net_order_amounts[ $order_amount_key ][1] = $net_order_amounts[ $order_amount_key ][1] - $refund_amounts[ $order_amount_key ][1] - $shipping_amounts[ $order_amount_key ][1] - $shipping_tax_amounts[ $order_amount_key ][1] - $tax_amounts[ $order_amount_key ][1];
+			$data['net_order_amounts'][ $order_amount_key ]    = $order_amount_value;
+			// subtract the sum of the values from net order amounts
+			$data['net_order_amounts'][ $order_amount_key ][1] -= 
+				$data['refund_amounts'][ $order_amount_key ][1] +
+				$data['shipping_amounts'][ $order_amount_key ][1] + 
+				$data['shipping_tax_amounts'][ $order_amount_key ][1] + 
+				$data['tax_amounts'][ $order_amount_key ][1];
 		}
 
+		// 3rd party filtering of report data
+		$data = apply_filters( 'woocommerce_admin_report_chart_data', $data );
+	
 		// Encode in json format
 		$chart_data = json_encode( array(
-			'order_counts'        => array_values( $order_counts ),
-			'order_item_counts'   => array_values( $order_item_counts ),
-			'order_amounts'       => array_map( array( $this, 'round_chart_totals' ), array_values( $order_amounts ) ),
-			'gross_order_amounts' => array_map( array( $this, 'round_chart_totals' ), array_values( $gross_order_amounts ) ),
-			'net_order_amounts'   => array_map( array( $this, 'round_chart_totals' ), array_values( $net_order_amounts ) ),
-			'shipping_amounts'    => array_map( array( $this, 'round_chart_totals' ), array_values( $shipping_amounts ) ),
-			'coupon_amounts'      => array_map( array( $this, 'round_chart_totals' ), array_values( $coupon_amounts ) ),
-			'refund_amounts'      => array_map( array( $this, 'round_chart_totals' ), array_values( $refund_amounts ) )
+			'order_counts'        => array_values( $data['order_counts'] ),
+			'order_item_counts'   => array_values( $data['order_item_counts'] ),
+			'order_amounts'       => array_map( array( $this, 'round_chart_totals' ), array_values( $data['order_amounts'] ) ),
+			'gross_order_amounts' => array_map( array( $this, 'round_chart_totals' ), array_values( $data['gross_order_amounts'] ) ),
+			'net_order_amounts'   => array_map( array( $this, 'round_chart_totals' ), array_values( $data['net_order_amounts'] ) ),
+			'shipping_amounts'    => array_map( array( $this, 'round_chart_totals' ), array_values( $data['shipping_amounts'] ) ),
+			'coupon_amounts'      => array_map( array( $this, 'round_chart_totals' ), array_values( $data['coupon_amounts'] ) ),
+			'refund_amounts'      => array_map( array( $this, 'round_chart_totals' ), array_values( $data['refund_amounts'] ) )
 		) );
 		?>
 		<div class="chart-container">
@@ -561,7 +573,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 						},
 						{
 							label: "<?php echo esc_js( __( 'Average gross sales amount', 'woocommerce' ) ) ?>",
-							data: [ [ <?php echo min( array_keys( $order_amounts ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ], [ <?php echo max( array_keys( $order_amounts ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ] ],
+							data: [ [ <?php echo min( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ], [ <?php echo max( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ] ],
 							yaxis: 2,
 							color: '<?php echo $this->chart_colours['average']; ?>',
 							points: { show: false },
@@ -571,7 +583,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 						},
 						{
 							label: "<?php echo esc_js( __( 'Average net sales amount', 'woocommerce' ) ) ?>",
-							data: [ [ <?php echo min( array_keys( $order_amounts ) ); ?>, <?php echo $this->report_data->average_sales; ?> ], [ <?php echo max( array_keys( $order_amounts ) ); ?>, <?php echo $this->report_data->average_sales; ?> ] ],
+							data: [ [ <?php echo min( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_sales; ?> ], [ <?php echo max( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_sales; ?> ] ],
 							yaxis: 2,
 							color: '<?php echo $this->chart_colours['net_average']; ?>',
 							points: { show: false },


### PR DESCRIPTION
- Add `woocommerce_admin_report_data` to filter chart data by 3rd parties
- Refactor `get_main_chart()` to use an array of data so that it to can be filtered
- Add `woocommerce_admin_report_chart_data` to filter chart data by period (for display)

Implementation to subtract coupon amounts from net sales:

```
add_filter( 'woocommerce_admin_report_data', function( $data ){
    $data->net_sales -= $data->total_coupons;
    return $data;
} );

add_filter( 'woocommerce_admin_report_chart_data', function( $data ){
    foreach ( $data['order_amounts'] as $order_amount_key => $order_amount_value ) {
        $data['net_order_amounts'][ $order_amount_key ][1] -= $data['coupon_amounts'][ $order_amount_key ][1];
    }
    return $data;
} );
```
