### PR TITLE
Apply custom css for nav tag but not in h2 tag

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2483,7 +2483,7 @@ img.help_tip {
 }
 
 .woocommerce {
-	.woo-nav-tab-wrapper {
+	nav.woo-nav-tab-wrapper {
 		margin: 1.5em 0 1em !important;
 		border-bottom: 1px solid #ccc;
 	}


### PR DESCRIPTION
For ref: https://github.com/woothemes/woocommerce/commit/2d2c64d2abdc59e783d755cb2e3b6cd2c823f588

@mikejolley custom styles in needed only for `nav` tag used in settings page but not for System Status and others which has `h2` as it has predefined styles by WP :)
