### PR TITLE
Fix array key/meta id logic in WC_Data's meta handling

### DIFF
--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -94,7 +94,11 @@ class Meta extends \WC_Unit_Test_Case {
 		", $object_id ) );
 
 		foreach ( $raw_metadata as $meta ) {
-			$metadata[ $meta->meta_id ] = (object) array( 'key' => $meta->meta_key, 'value' => $meta->meta_value );
+			$metadata[] = (object) array(
+				'key'     => $meta->meta_key,
+				'value'   => $meta->meta_value,
+				'meta_id' =>  $meta->meta_id,
+			);
 		}
 
 		$object = new \WC_Mock_WC_data();
@@ -195,6 +199,19 @@ class Meta extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
 		$this->assertEquals( 'val2', $object->get_meta( 'test_meta_key_2' ) );
+	}
+
+	/**
+	 * Test adding meta data/updating meta data just added without keys colliding when changing
+	 * data before a save.
+	 */
+	function test_add_meta_data_overwrite_before_save() {
+		$object = new \WC_Mock_WC_data;
+		$object->add_meta_data( 'test_field_0', 'another field', true );
+		$object->add_meta_data( 'test_field_1', 'another field', true );
+		$object->add_meta_data( 'test_field_2', 'val1', true );
+		$object->update_meta_data( 'test_field_0', 'another field 2' );
+		$this->assertEquals( 'val1', $object->get_meta( 'test_field_2' ) );
 	}
 
 }


### PR DESCRIPTION
While I was updating payment tokens to use all the new `WC_Data` goodness, I found a bug with the meta handling.

Array keys can collide/get overridden if you add a key and then try to update it later (because the new- key logic can accidentally overwrite an existing key). Instead of trying to guess a new unique key to use, this PR moves the actual meta_id into each _meta_data object, and just uses PHP for incrementing/new keys.

If you run `test_add_meta_data_overwrite_before_save` without the WC_Data changes, you will see the test fail - even though this should be totally valid/allowed behavior. Running it with the changes =  :100:.

cc @mikejolley 
