### PR TITLE
[WC 2.5/2.6] Add order line item args filter to wc api/cli set_line_item method

### DIFF
--- a/includes/api/class-wc-api-orders.php
+++ b/includes/api/class-wc-api-orders.php
@@ -979,6 +979,8 @@ class WC_API_Orders extends WC_API_Resource {
 			$item_args['totals']['subtotal_tax'] = floatval( $item['subtotal_tax'] );
 		}
 
+		$item_args = apply_filters( 'woocommerce_api_order_line_item_args', $item_args, $item, $order, $action );
+
 		if ( $creating ) {
 
 			$item_id = $order->add_product( $product, $item_args['qty'], $item_args );

--- a/includes/cli/class-wc-cli-order.php
+++ b/includes/cli/class-wc-cli-order.php
@@ -986,6 +986,8 @@ class WC_CLI_Order extends WC_CLI_Command {
 			$item_args['totals']['subtotal_tax'] = floatval( $item['subtotal_tax'] );
 		}
 
+		$item_args = apply_filters( 'woocommerce_cli_order_line_item_args', $item_args, $item, $order, $action );
+
 		if ( $creating ) {
 
 			$item_id = $order->add_product( $product, $item_args['qty'], $item_args );


### PR DESCRIPTION
Filters `woocommerce_api_order_line_item_args` and `woocommerce_cli_order_line_item_args` added before creating/editing a product in `set_line_item` method of the `WC_CLI_Order` and `WC_API_Order` classes.

Can be used to add various data that can be consumed inside the `woocommerce_order_add_product` action hook.

For instance, this could be used in order to trigger the creation of additional line items associated with a specific "container" item, or to create/edit specific metadata associated with the created/edited line item.

Extensions such as Addons could use this hook to add full API/CLI support by modifying line item totals / meta based on custom data passed to the initial `line_item` array.
