### PR TITLE
Convert WC_Payment_Tokens to use the new WC_Data

### DIFF
--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -16,34 +16,48 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category	Abstract Class
  * @author		WooThemes
  */
- abstract class WC_Payment_Token {
+ abstract class WC_Payment_Token extends WC_Data {
 
- 	/** @protected int Token ID. */
- 	protected $id;
- 	/** @protected array Core Token Data (stored in the payment_tokens table). */
- 	protected $data;
- 	/** @protected array Meta Token Data (extra data associated with a payment token, stored in the payment_token_meta table). */
- 	protected $meta;
+ 	/**
+ 	 * Token Data (stored in the payment_tokens table).
+ 	 * @var array
+ 	 */
+ 	protected $_data = array(
+ 		'id'         => 0,
+ 		'gateway_id' => '',
+ 		'token'      => '',
+ 		'is_default' => 0,
+ 		'user_id'    => 0,
+ 	);
+
+ 	/**
+ 	 * Meta type. Payment tokens are a new object type.
+ 	 * @var string
+ 	 */
+ 	protected $_meta_type = 'payment_token';
 
  	/**
 	 * Initialize a payment token.
 	 *
 	 * These fields are accepted by all payment tokens:
-	 * default      - boolean Optional - Indicates this is the default payment token for a user
+	 * is_default   - boolean Optional - Indicates this is the default payment token for a user
 	 * token        - string  Required - The actual token to store
 	 * gateway_id   - string  Required - Identifier for the gateway this token is associated with
 	 * user_id      - int     Optional - ID for the user this token is associated with. 0 if this token is not associated with a user
 	 *
 	 * @since 2.6.0
-	 * @param string $id Token ID
-	 * @param array $data Core token data
-	 * @param array $meta Meta token data
+	 * @param mixed $token
 	 */
-	public function __construct( $id = 0, $data = array(), $meta = array() ) {
-		$this->id = $id;
-		$this->data = $data;
-		$this->data['type'] = $this->type;
-		$this->meta = $meta;
+	public function __construct( $token = '' ) {
+		if ( is_numeric( $token ) ) {
+			$this->read( $token );
+		} else if ( is_object( $token ) && ! empty( $token->get_id() ) ) {
+			$this->read( $token->get_id() );
+		}
+		// Set token type (cc, echeck)
+		if ( ! empty( $this->type ) ) {
+			$this->_data['type'] = $this->type;
+		}
 	}
 
 	/**
@@ -52,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return ID Token ID
 	 */
 	public function get_id() {
-		return absint( $this->id );
+		return absint( $this->_data['id'] );
 	}
 
 	/**
@@ -61,7 +75,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return string Raw token
 	 */
 	public function get_token() {
-		return $this->data['token'];
+		return $this->_data['token'];
 	}
 
 	/**
@@ -70,7 +84,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param string $token
 	 */
 	public function set_token( $token ) {
-		$this->data['token'] = $token;
+		$this->_data['token'] = $token;
 	}
 
 	/**
@@ -79,7 +93,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return string Payment Token Type (CC, eCheck)
 	 */
 	public function get_type() {
-		return isset( $this->data['type'] ) ? $this->data['type'] : '';
+		return isset( $this->_data['type'] ) ? $this->_data['type'] : '';
 	}
 
 	/**
@@ -88,7 +102,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return int User ID if this token is associated with a user or 0 if no user is associated
 	 */
 	public function get_user_id() {
-		return ( isset( $this->data['user_id'] ) && $this->data['user_id'] > 0 ) ? absint( $this->data['user_id'] ) : 0;
+		return ( isset( $this->_data['user_id'] ) && $this->_data['user_id'] > 0 ) ? absint( $this->_data['user_id'] ) : 0;
 	}
 
 	/**
@@ -97,7 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param int $user_id
 	 */
 	public function set_user_id( $user_id ) {
-		$this->data['user_id'] = $user_id;
+		$this->_data['user_id'] = absint( $user_id );
 	}
 
 	/**
@@ -106,7 +120,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return string Gateway ID
 	 */
 	public function get_gateway_id() {
-		return $this->data['gateway_id'];
+		return $this->_data['gateway_id'];
 	}
 
 	/**
@@ -115,7 +129,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param string $gateway_id
 	 */
 	public function set_gateway_id( $gateway_id ) {
-		$this->data['gateway_id'] = $gateway_id;
+		$this->_data['gateway_id'] = $gateway_id;
 	}
 
 	/**
@@ -124,7 +138,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return boolean True if the token is default
 	 */
 	public function is_default() {
-		return ! empty( $this->data['is_default'] );
+		return ! empty( $this->_data['is_default'] );
 	}
 
 	/**
@@ -133,16 +147,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param boolean $is_default True or false
 	 */
 	public function set_default( $is_default ) {
-		$this->data['is_default'] = (bool) $is_default;
-	}
-
-	/**
-	 * Returns a dump of the token data (combined data and meta).
-	 * @since 2.6.0
-	 * @return mixed array representation
-	 */
-	public function get_data() {
-		return array_merge( $this->data, array( 'meta' => $this->meta ) );
+		$this->_data['is_default'] = (bool) $is_default;
 	}
 
 	/**
@@ -151,11 +156,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return boolean True if the passed data is valid
 	 */
 	public function validate() {
-		if ( empty( $this->data['token'] ) ) {
+		if ( empty( $this->_data['token'] ) ) {
 			return false;
 		}
 
-		if ( empty( $this->data['type'] ) ) {
+		if ( empty( $this->_data['type'] ) ) {
 			return false;
 		}
 
@@ -170,18 +175,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	public function read( $token_id ) {
 		global $wpdb;
 		if ( $token = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_payment_tokens WHERE token_id = %d LIMIT 1;", $token_id ) ) ) {
-			$this->id = $token->token_id;
+			$token_id = $token->token_id;
 			$token = (array) $token;
 			unset( $token['token_id'] );
-			$this->data = $token;
-			$meta =  get_metadata( 'payment_token', $token_id );
-			$passed_meta = array();
-			if ( ! empty( $meta ) ) {
-				foreach( $meta as $meta_key => $meta_value ) {
-					$passed_meta[ $meta_key ] = $meta_value[0];
-				}
-			}
-			$this->meta = $passed_meta;
+			$this->_data = $token;
+			$this->_data['id'] = $token_id;
+			$this->read_meta_data();
 		}
 	}
 
@@ -197,10 +196,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		global $wpdb;
 
-		$wpdb->update( $wpdb->prefix . 'woocommerce_payment_tokens', $this->data, array( 'token_id' => $this->get_id() ) );
-		foreach ( $this->meta as $meta_key => $meta_value ) {
-			update_metadata( 'payment_token', $this->get_id(), $meta_key, $meta_value );
-		}
+		$payment_token_data = array(
+			'gateway_id' => $this->get_gateway_id(),
+			'token'      => $this->get_token(),
+			'user_id'    => $this->get_user_id(),
+			'type'       => $this->get_type(),
+		);
+
+		$wpdb->update(
+			$wpdb->prefix . 'woocommerce_payment_tokens',
+			$payment_token_data,
+			array( 'token_id' => $this->get_id() )
+		);
+
+		$this->save_meta_data();
 
 		// Make sure all other tokens are not set to default
 		if ( $this->is_default() && $this->get_user_id() > 0 ) {
@@ -230,11 +239,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 			}
 		}
 
-		$wpdb->insert( $wpdb->prefix . 'woocommerce_payment_tokens', $this->data );
-		$this->id = $token_id = $wpdb->insert_id;
-		foreach ( $this->meta as $meta_key => $meta_value ) {
-			add_metadata( 'payment_token', $token_id, $meta_key, $meta_value, true );
-		}
+		$payment_token_data = array(
+			'gateway_id' => $this->get_gateway_id(),
+			'token'      => $this->get_token(),
+			'user_id'    => $this->get_user_id(),
+			'type'       => $this->get_type(),
+		);
+
+		$wpdb->insert( $wpdb->prefix . 'woocommerce_payment_tokens', $payment_token_data );
+		$this->_data['id'] = $token_id = $wpdb->insert_id;
+		$this->save_meta_data();
 
 		// Make sure all other tokens are not set to default
 		if ( $this->is_default() && $this->get_user_id() > 0 ) {

--- a/includes/payment-tokens/class-wc-payment-token-cc.php
+++ b/includes/payment-tokens/class-wc-payment-token-cc.php
@@ -1,5 +1,4 @@
 <?php
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -37,27 +36,27 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 			return false;
 		}
 
-		if ( empty( $this->meta['last4'] ) ) {
+		if ( empty( $this->get_meta( 'last4' ) ) ) {
 			return false;
 		}
 
-		if ( empty( $this->meta['expiry_year'] ) ) {
+		if ( empty( $this->get_meta( 'expiry_year' ) ) ) {
 			return false;
 		}
 
-		if ( empty( $this->meta['expiry_month'] ) ) {
+		if ( empty( $this->get_meta( 'expiry_month' ) ) ) {
 			return false;
 		}
 
-		if ( empty ( $this->meta['card_type'] ) ) {
+		if ( empty ( $this->get_meta( 'card_type' ) ) ) {
 			return false;
 		}
 
-		if ( 4 !== strlen( $this->meta['expiry_year'] ) ) {
+		if ( 4 !== strlen( $this->get_meta( 'expiry_year' ) ) ) {
 			return false;
 		}
 
-		if ( 2 !== strlen( $this->meta['expiry_month'] ) ) {
+		if ( 2 !== strlen( $this->get_meta( 'expiry_month' ) ) ) {
 			return false;
 		}
 
@@ -70,7 +69,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @return string Card type
 	 */
 	public function get_card_type() {
-		return isset( $this->meta['card_type'] ) ? $this->meta['card_type'] : null;
+		return $this->get_meta( 'card_type' );
 	}
 
 	/**
@@ -79,7 +78,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @param string $type
 	 */
 	public function set_card_type( $type ) {
-		$this->meta['card_type'] = $type;
+		$this->add_meta_data( 'card_type', $type, true );
 	}
 
 	/**
@@ -88,7 +87,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @return string Expiration year
 	 */
 	public function get_expiry_year() {
-		return isset( $this->meta['expiry_year'] ) ? $this->meta['expiry_year'] : null;
+		return $this->get_meta( 'expiry_year' );
 	}
 
 	/**
@@ -97,7 +96,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @param string $year
 	 */
 	public function set_expiry_year( $year ) {
-		$this->meta['expiry_year'] = $year;
+		$this->add_meta_data( 'expiry_year', $year, true );
 	}
 
 	/**
@@ -106,7 +105,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @return string Expiration month
 	 */
 	public function get_expiry_month() {
-		return isset( $this->meta['expiry_month'] ) ? $this->meta['expiry_month'] : null;
+		return $this->get_meta( 'expiry_month' );
 	}
 
 	/**
@@ -115,7 +114,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @param string $month
 	 */
 	public function set_expiry_month( $month ) {
-		$this->meta['expiry_month'] = $month;
+		$this->add_meta_data( 'expiry_month', $month, true );
 	}
 
 	/**
@@ -124,7 +123,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @return string Last 4 digits
 	 */
 	public function get_last4() {
-		return isset( $this->meta['last4'] ) ? $this->meta['last4'] : null;
+		return $this->get_meta( 'last4' );
 	}
 
 	/**
@@ -133,7 +132,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @param string $last4
 	 */
 	public function set_last4( $last4 ) {
-		$this->meta['last4'] = $last4;
+		$this->add_meta_data( 'last4', $last4, true );
 	}
 
 }

--- a/includes/payment-tokens/class-wc-payment-token-echeck.php
+++ b/includes/payment-tokens/class-wc-payment-token-echeck.php
@@ -34,7 +34,7 @@ class WC_Payment_Token_eCheck extends WC_Payment_Token {
 			return false;
 		}
 
-		if ( empty( $this->meta['last4'] ) ) {
+		if ( empty( $this->get_meta( 'last4' ) ) ) {
 			return false;
 		}
 		return true;
@@ -46,7 +46,7 @@ class WC_Payment_Token_eCheck extends WC_Payment_Token {
 	 * @return string Last 4 digits
 	 */
 	public function get_last4() {
-		return isset( $this->meta['last4'] ) ? $this->meta['last4'] : null;
+		return $this->get_meta( 'last4' );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class WC_Payment_Token_eCheck extends WC_Payment_Token {
 	 * @param string $last4
 	 */
 	public function set_last4( $last4 ) {
-		$this->meta['last4'] = $last4;
+		$this->add_meta_data( 'last4', $last4, true );
 	}
 
 }

--- a/tests/framework/class-wc-payment-token-stub.php
+++ b/tests/framework/class-wc-payment-token-stub.php
@@ -2,25 +2,29 @@
 /**
  * Stub/Dummy class to test WC_Payment_Token methods only
  *
- * @since 2.6
+ * @since 2.6.0
  */
 class WC_Payment_Token_Stub extends \WC_Payment_Token {
+
 	/** @protected string Token Type String */
 	protected $type = 'stub';
 
 	/**
-	 * Returns meta
+	 * Returns meta.
+	 * @since 2.6.0
 	 * @return string
 	 */
 	public function get_extra() {
-		return isset( $this->meta['extra'] ) ? $this->meta['extra'] : '';
+		return $this->get_meta( 'extra' );
 	}
 
 	/**
-	 * Set meta
+	 * Set meta.
+	 * @since 2.6.0
 	 * @param string $extra
 	 */
 	public function set_extra( $extra ) {
-		$this->meta['extra'] = $extra;
+		$this->add_meta_data( 'extra', $extra, true );
 	}
+
 }

--- a/tests/unit-tests/payment-tokens/cc.php
+++ b/tests/unit-tests/payment-tokens/cc.php
@@ -12,7 +12,7 @@ class Payment_Token_CC extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_token_cc_validate_empty() {
-		$token = new \WC_Payment_Token_CC( 1 );
+		$token = new \WC_Payment_Token_CC();
 		$token->set_token( time() . ' ' . __FUNCTION__ );
 		$this->assertFalse( $token->validate() );
 		$token->set_last4( '1111' );
@@ -27,7 +27,7 @@ class Payment_Token_CC extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_token_cc_validate_expiry_length() {
-		$token = new \WC_Payment_Token_CC( 1 );
+		$token = new \WC_Payment_Token_CC();
 		$token->set_token( time() . ' ' . __FUNCTION__ );
 		$this->assertFalse( $token->validate() );
 
@@ -39,6 +39,7 @@ class Payment_Token_CC extends \WC_Unit_Test_Case {
 		$this->assertFalse( $token->validate() );
 
 		$token->set_expiry_year( '2016' );
+
 		$this->assertTrue( $token->validate() );
 
 		$token->set_expiry_month( '8' );
@@ -46,92 +47,54 @@ class Payment_Token_CC extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting a card type.
+	 * Tes get/set card type.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_cc_get_card_type() {
-		$token = new \WC_Payment_Token_CC( 1, array(), array( 'card_type' => 'mastercard' ) );
-		$this->assertEquals( 'mastercard', $token->get_card_type() );
-	}
-
-	/**
-	 * Test setting a token's card type.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_cc_set_card_type() {
-		$token = new \WC_Payment_Token_CC( 1 );
+	public function test_wc_payment_token_cc_card_type() {
+		$token = new \WC_Payment_Token_CC();
 		$token->set_card_type( 'visa' );
 		$this->assertEquals( 'visa', $token->get_card_type() );
 	}
 
 	/**
-	 * Test getting expiry year.
+	 * Test get/set expiry year.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_cc_get_expiry_year() {
-		$token = new \WC_Payment_Token_CC( 1, array(), array( 'expiry_year' => '2016' ) );
-		$this->assertEquals( '2016', $token->get_expiry_year() );
-	}
-
-	/**
-	 * Test setting a token's expiry year.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_cc_set_expiry_year() {
-		$token = new \WC_Payment_Token_CC( 1 );
+	public function test_wc_payment_token_cc_expiry_year() {
+		$token = new \WC_Payment_Token_CC();
 		$token->set_expiry_year( '2016' );
 		$this->assertEquals( '2016', $token->get_expiry_year() );
 	}
 
 	/**
-	 * Test getting expiry month.
+	 * Test get/set expiry month.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_cc_get_expiry_month() {
-		$token = new \WC_Payment_Token_CC( 1, array(), array( 'expiry_month' => '08' ) );
-		$this->assertEquals( '08', $token->get_expiry_month() );
-	}
-
-	/**
-	 * Test setting a token's expiry month.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_cc_set_expiry_month() {
-		$token = new \WC_Payment_Token_CC( 1 );
+	public function test_wc_payment_token_cc_expiry_month() {
+		$token = new \WC_Payment_Token_CC();
 		$token->set_expiry_month( '08' );
 		$this->assertEquals( '08', $token->get_expiry_month() );
 	}
 
 	/**
-	 * Test getting last4.
+	 * Test get/set last4.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_cc_get_last4() {
-		$token = new \WC_Payment_Token_CC( 1, array(), array( 'last4' => '1111' ) );
+	public function test_wc_payment_token_cc_last4() {
+		$token = new \WC_Payment_Token_CC();
+		$token->set_last4( '1111' );
 		$this->assertEquals( '1111', $token->get_last4() );
 	}
 
-	/**
-	 * Test setting a token's last4.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_cc_set_last4() {
-		$token = new \WC_Payment_Token_CC( 1 );
-		$token->set_last4( '2222' );
-		$this->assertEquals( '2222', $token->get_last4() );
-	}
-
-	/**
+	/*
 	 * Test reading/getting a token from DB correctly sets meta.
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_cc_read_pulls_meta() {
 		$token = \WC_Helper_Payment_Token::create_cc_token();
 		$token_id = $token->get_id();
-
 		$token_read = new \WC_Payment_Token_CC();
 		$token_read->read( $token_id );
-
 		$this->assertEquals( '1234', $token_read->get_last4() );
 	}
 

--- a/tests/unit-tests/payment-tokens/echeck.php
+++ b/tests/unit-tests/payment-tokens/echeck.php
@@ -12,7 +12,7 @@ class Payment_Token_eCheck extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_token_echeck_validate_empty() {
-		$token = new \WC_Payment_Token_eCheck( 1 );
+		$token = new \WC_Payment_Token_eCheck();
 		$token->set_token( time() . ' ' . __FUNCTION__ );
 		$this->assertFalse( $token->validate() );
 		$token->set_last4( '1111' );
@@ -20,22 +20,13 @@ class Payment_Token_eCheck extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting last4.
+	 * Test get/set last4.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_echeck_get_last4() {
-		$token = new \WC_Payment_Token_eCheck( 1, array(), array( 'last4' => '1111' ) );
+	public function test_wc_payment_token_echeck_last4() {
+		$token = new \WC_Payment_Token_eCheck();
+		$token->set_last4( '1111' );
 		$this->assertEquals( '1111', $token->get_last4() );
-	}
-
-	/**
-	 * Test setting a token's last4.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_echeck_set_last4() {
-		$token = new \WC_Payment_Token_eCheck( 1 );
-		$token->set_last4( '2222' );
-		$this->assertEquals( '2222', $token->get_last4() );
 	}
 
 	/**

--- a/tests/unit-tests/payment-tokens/payment-token.php
+++ b/tests/unit-tests/payment-tokens/payment-token.php
@@ -8,50 +8,32 @@ namespace WooCommerce\Tests\Payment_Tokens;
 class Payment_Token extends \WC_Unit_Test_Case {
 
 	/**
-	 * Test get_id to make sure it returns the ID passed into the class.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_get_id() {
-		$token = new \WC_Payment_Token_Stub( 1 );
-		$this->assertEquals( 1, $token->get_id() );
-	}
-
-	/**
 	 * Test get type returns the class name/type.
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_get_type() {
-		$token = new \WC_Payment_Token_Stub( 1 );
+		$token = new \WC_Payment_Token_Stub();
 		$this->assertEquals( 'stub', $token->get_type() );
 	}
 
 	/**
-	 * Test get token to make sure it returns the passed token.
+	 * Test set/get token to make sure it returns the passed token.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_get_token() {
+	public function test_wc_payment_token_token() {
 		$raw_token = time() . ' ' . __FUNCTION__;
-		$token = new \WC_Payment_Token_Stub( 1, array( 'token' => $raw_token ) );
-		$this->assertEquals( $raw_token, $token->get_token() );
-	}
-
-	/**
-	 * Test set token to make sure it sets the pased token.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_set_token() {
-		$raw_token = time() . ' ' . __FUNCTION__;
-		$token = new \WC_Payment_Token_Stub( 1 );
+		$token = new \WC_Payment_Token_Stub();
 		$token->set_token( $raw_token );
 		$this->assertEquals( $raw_token, $token->get_token() );
 	}
 
 	/**
-	 * Test get user ID to make sure it passes the correct ID.
+	 * Test set/get user ID to make sure it passes the correct ID.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_get_user_id() {
-		$token = new \WC_Payment_Token_Stub( 1, array( 'user_id' => 1 ) );
+	public function test_wc_payment_user_id() {
+		$token = new \WC_Payment_Token_Stub();
+		$token->set_user_id( 1 );
 		$this->assertEquals( 1, $token->get_user_id() );
 	}
 
@@ -60,44 +42,25 @@ class Payment_Token extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_get_user_id_defaults_to_0() {
-		$token = new \WC_Payment_Token_Stub( 1 );
+		$token = new \WC_Payment_Token_Stub();
 		$this->assertEquals( 0, $token->get_user_id() );
 	}
 
 	/**
-	 * Test set user ID to make sure it passes the correct ID.
+	 * Test get/set the gateway ID.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_set_user_id() {
-		$token = new \WC_Payment_Token_Stub( 1 );
-		$token->set_user_id( 5 );
-		$this->assertEquals( 5, $token->get_user_id() );
-	}
-
-	/**
-	 * Test getting the gateway ID.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_get_gateway_id() {
-		$token = new \WC_Payment_Token_Stub( 1, array( 'gateway_id' => 'paypal' ) );
-		$this->assertEquals( 'paypal', $token->get_gateway_id() );
-	}
-
-	/**
-	 * Test set the gateway ID.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_set_gateway_id() {
-		$token = new \WC_Payment_Token_Stub( 1 );
+	public function test_wc_payment_gateway_id() {
+		$token = new \WC_Payment_Token_Stub();
 		$token->set_gateway_id( 'paypal' );
 		$this->assertEquals( 'paypal', $token->get_gateway_id() );
 	}
 
 	/**
-	 * Test setting a token as default.
+	 * Test set/is a token as default.
 	 * @since 2.6.0
 	 */
-	public function test_wc_payment_token_set_default() {
+	public function test_wc_payment_token_is_default() {
 		$token = new \WC_Payment_Token_Stub( 1 );
 		$token->set_default( true );
 		$this->assertTrue( $token->is_default() );
@@ -105,18 +68,6 @@ class Payment_Token extends \WC_Unit_Test_Case {
 		$this->assertFalse( $token->is_default() );
 	}
 
-	/**
-	 * Test is_default.
-	 * @since 2.6.0
-	 */
-	public function test_wc_payment_token_is_default_returns_correct_state() {
-		$token = new \WC_Payment_Token_Stub( 1, array( 'is_default' => true ) );
-		$this->assertTrue( $token->is_default() );
-		$token = new \WC_Payment_Token_Stub( 1 );
-		$this->assertFalse( $token->is_default() );
-		$token = new \WC_Payment_Token_Stub( 1, array( 'is_default' => false ) );
-		$this->assertFalse( $token->is_default() );
-	}
 
 	/**
 	 * Test that get_data returns the correct internal representation for a token.
@@ -124,10 +75,9 @@ class Payment_Token extends \WC_Unit_Test_Case {
 	 */
 	public function test_wc_payment_token_get_data() {
 		$raw_token = time() . ' ' . __FUNCTION__;
-		$token = new \WC_Payment_Token_Stub( 1, array(
-			'token'      => $raw_token,
-			'gateway_id' => 'paypal'
-		) );
+		$token = new \WC_Payment_Token_Stub();
+		$token->set_token( $raw_token );
+		$token->set_gateway_id( 'paypal' );
 		$token->set_extra( 'woocommerce' );
 
 		$data = $token->get_data();
@@ -135,7 +85,8 @@ class Payment_Token extends \WC_Unit_Test_Case {
 		$this->assertEquals( $raw_token, $data['token'] );
 		$this->assertEquals( 'paypal', $data['gateway_id'] );
 		$this->assertEquals( 'stub', $data['type'] );
-		$this->assertEquals( 'woocommerce', $data['meta']['extra'] );
+		$this->assertEquals( 'extra', $data['meta_data'][0]->key );
+		$this->assertEquals( 'woocommerce', $data['meta_data'][0]->value );
 	}
 
 	/**
@@ -143,11 +94,11 @@ class Payment_Token extends \WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_validation() {
-		$token = new \WC_Payment_Token_Stub( 1 );
+		$token = new \WC_Payment_Token_Stub();
 		$token->set_token( time() . ' ' . __FUNCTION__ );
 		$this->assertTrue( $token->validate() );
 
-		$token = new \WC_Payment_Token_Stub( 1 );
+		$token = new \WC_Payment_Token_Stub();
 		$this->assertFalse( $token->validate() );
 	}
 


### PR DESCRIPTION
The PR needs #10579 applied/merged otherwise there are some issues with some of the meta handling and one of the tests will fail.

This PR makes WC_Payment_Token use WC_Data which requires some changes around how we were storing data and meta (since tokens were created before all the recent CRUD stuff).
