### PR TITLE
Fix WC_Payment_Tokens for older versions of php

### DIFF
--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -51,8 +51,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	public function __construct( $token = '' ) {
 		if ( is_numeric( $token ) ) {
 			$this->read( $token );
-		} else if ( is_object( $token ) && ! empty( $token->get_id() ) ) {
-			$this->read( $token->get_id() );
+		} else if ( is_object( $token ) ) {
+			$token_id = $token->get_id();
+			if ( ! empty( $token_id ) ) {
+				$this->read( $token->get_id() );
+			}
 		}
 		// Set token type (cc, echeck)
 		if ( ! empty( $this->type ) ) {


### PR DESCRIPTION
Older versions of php cannot check `empty()` with a non-variable. Fixes
fatal introduced in 1d35fd6d731139f95f41b73af7c24fa4400385bf

cc @justinshreve 
