### PR TITLE
Add filter for required fields error message

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -457,7 +457,7 @@ class WC_Checkout {
 								$field_label = $field['label'];
 							break;
 						}
-						wc_add_notice( sprintf( _x( '%s is a required field.', 'FIELDNAME is a required field.', 'woocommerce' ), '<strong>' . $field_label . '</strong>' ), 'error' );
+						wc_add_notice( apply_filters( 'woocommerce_required_checkout_fields_error', sprintf(  _x( '%s is a required field.', 'FIELDNAME is a required field.', 'woocommerce' ), '<strong>' . $field_label . '</strong>' ), $field_label ), 'error' ); 
 					}
 
 					if ( ! empty( $this->posted[ $key ] ) ) {


### PR DESCRIPTION
Add the ability to change required fields error message, as discussed here: https://github.com/woothemes/woocommerce/pull/10591
