### PR TITLE
Replace DELETE FROM to TRUNCATE to empty woocommerce_sessions table

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -95,7 +95,7 @@ class WC_Admin_Status {
 				break;
 				case 'clear_sessions' :
 
-					$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_sessions" );
+					$wpdb->query( "TRUNCATE {$wpdb->prefix}woocommerce_sessions" );
 
 					wp_cache_flush();
 


### PR DESCRIPTION
If the size of the woocommerce_sessions table is 3.4 GB before the
**Clear all sessions** button is clicked, then it will delete all rows, but
leave the table size 3.3 GB. Truncating/emptying the table resets the size
of the table, and deletes all rows.

Before delete:

<img width="1125" alt="screenshot 2016-03-24 13 56 12" src="https://cloud.githubusercontent.com/assets/3452849/14037938/33134566-f207-11e5-97af-e97ff9aec96c.png">

After delete:

<img width="1126" alt="screenshot 2016-03-24 14 05 38" src="https://cloud.githubusercontent.com/assets/3452849/14037945/595ce574-f207-11e5-9855-281b08675c68.png">

After truncate:

<img width="1102" alt="screenshot 2016-03-24 14 08 09" src="https://cloud.githubusercontent.com/assets/3452849/14037951/6afd9b52-f207-11e5-8f4b-fd86b5474533.png">
