### PR TITLE
Use of dashicons glyph for product gallery sortable placeholder

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2847,7 +2847,7 @@ img.help_tip {
 					position: relative;
 
 					&:after {
-						@include icon( "\e00c" );
+						@include icon_dashicons( "\f161" );
 						font-size: 2.618em;
 						line-height: 72px;
 						color: #ddd;


### PR DESCRIPTION
CC @jameskoster 
![gallery-glyph](https://cloud.githubusercontent.com/assets/3774827/14102642/9b5dba04-f5bb-11e5-8ec8-835a9171a860.png)
