### PR TITLE
Make wc_get_product() return false if the specified post is not a product

### DIFF
--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -33,6 +33,10 @@ class WC_Product_Factory {
 
 		$classname = $this->get_product_class( $the_product, $args );
 
+		if ( ! $classname ) {
+			return false;
+		}
+
 		if ( ! class_exists( $classname ) ) {
 			$classname = 'WC_Product_Simple';
 		}


### PR DESCRIPTION
Currently `wc_get_product()` will return a `WC_Product_Simple` object even if the supplied post is not a product:

![image](https://cloud.githubusercontent.com/assets/1619746/14195070/012300c4-f76a-11e5-857a-29cecd39ae47.png)

This differs from the behavior of `wc_get_order()`:
![image](https://cloud.githubusercontent.com/assets/1619746/14195088/36829982-f76a-11e5-88ae-e9c12d9312be.png)

This change makes `wc_get_product()` return `false` when a product class name cannot be determined (i.e., when `WC_Product_Factory->get_product_class` returns `false`).
