### PR TITLE
Update class-wc-https.php

### DIFF
--- a/includes/class-wc-https.php
+++ b/includes/class-wc-https.php
@@ -123,7 +123,7 @@ class WC_HTTPS {
 	 */
 	public static function http_api_curl( $handle, $r, $url ) {
 		if ( strstr( $url, 'https://' ) && ( strstr( $url, '.paypal.com/nvp' ) || strstr( $url, '.paypal.com/cgi-bin/webscr' ) ) ) {
-			curl_setopt( $handle, CURLOPT_SSLVERSION, 1 );
+			curl_setopt( $handle, CURLOPT_SSLVERSION, 6 );
 		}
 	}
 }


### PR DESCRIPTION
Paypal will not allow anything other than TLS 1.2 so just set it to that.
