### PR TITLE
Added two filter hooks in WC_AJAX class

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2510,7 +2510,7 @@ class WC_AJAX {
 					'_thumbnail_id'          => '',
 					'_sale_price_dates_from' => '',
 					'_sale_price_dates_to'   => '',
-					'_manage_stock'          => '',
+					'_manage_stock'          => apply_filters( 'woocommerce_variation_defaults_manage_stock', '' ),
 					'_stock_status'          => '',
 					'_backorders'            => null,
 					'_tax_class'             => null,

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -32,7 +32,7 @@ class WC_AJAX {
 	 * @return string
 	 */
 	public static function get_endpoint( $request = '' ) {
-		return esc_url_raw( add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ) ) ) );
+		return esc_url_raw( apply_filters( 'woocommerce_wc_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ) ) ), $request ) );
 	}
 
 	/**


### PR DESCRIPTION
The first filter hook manipulates the url returned by WC_AJAX::get_endpoint().
Might be handy in some custom ajax implementations.

The second hook sets the default value for "manage_stock" on new variations.
A store manager who has to add a lot of variable products might want to have this option preselected and not to have manually select this option every time.
