### PR TITLE
Fixes comparison functions for customer total orders / spent

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -463,7 +463,8 @@ function wc_get_customer_available_downloads( $customer_id ) {
  * @return string
  */
 function wc_get_customer_total_spent( $user_id ) {
-	if ( ! $spent = get_user_meta( $user_id, '_money_spent', true ) ) {
+	$spent = get_user_meta( $user_id, '_money_spent', true );
+	if ( '' === $spent ) {
 		global $wpdb;
 
 		$spent = $wpdb->get_var( "SELECT SUM(meta2.meta_value)
@@ -491,7 +492,8 @@ function wc_get_customer_total_spent( $user_id ) {
  * @return int
  */
 function wc_get_customer_order_count( $user_id ) {
-	if ( ! $count = get_user_meta( $user_id, '_order_count', true ) ) {
+	$count = get_user_meta( $user_id, '_order_count', true );
+	if ( '' === $count ) {
 		global $wpdb;
 
 		$count = $wpdb->get_var( "SELECT COUNT(*)


### PR DESCRIPTION
No issue. For much performance improvement.

If the money spent is 0, or the total order count is 0, but actually set, the `if` clause will return false. Even after the body recalculates, for example the money spent, it will still be 0 in some cases, which means it will never be stored on the user meta, and that body won't be short circuited.

In the case of sites with a lot of orders (customer has ~100k), that query takes about 13 seconds, and due to how the API works, during one request, it runs 4 times (we're working on solving that one though, different issue).

We probably want to see whether the meta is set or not. If it's not set, it will be an empty string. Ref: https://codex.wordpress.org/Function_Reference/get_user_meta
