### PR TITLE
Use of wp_json_encode since WC 2.6 requires at least WP 4.4+

### DIFF
--- a/includes/admin/class-wc-admin-pointers.php
+++ b/includes/admin/class-wc-admin-pointers.php
@@ -220,7 +220,7 @@ class WC_Admin_Pointers {
 	 * @param array $pointers
 	 */
 	public function enqueue_pointers( $pointers ) {
-		$pointers = json_encode( $pointers );
+		$pointers = wp_json_encode( $pointers );
 		wp_enqueue_style( 'wp-pointer' );
 		wp_enqueue_script( 'wp-pointer' );
 		wc_enqueue_js( "


### PR DESCRIPTION
:)
