### PR TITLE
Intercept  new customer creation using filter.

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -43,6 +43,12 @@ add_filter( 'show_admin_bar', 'wc_disable_admin_bar', 10, 1 );
  */
 function wc_create_new_customer( $email, $username = '', $password = '' ) {
 
+    // Check for override function
+    if ( ! empty(get_option('woocommerce_registration_new_customer_function_override','') ) ) {
+        $function = get_option('woocommerce_registration_new_customer_function_override','');
+        if ( function_exists($function) ) return call_user_func_array($function, array($email, $username, $password));
+    }
+
 	// Check the e-mail address
 	if ( empty( $email ) || ! is_email( $email ) ) {
 		return new WP_Error( 'registration-error-invalid-email', __( 'Please provide a valid email address.', 'woocommerce' ) );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -43,11 +43,8 @@ add_filter( 'show_admin_bar', 'wc_disable_admin_bar', 10, 1 );
  */
 function wc_create_new_customer( $email, $username = '', $password = '' ) {
 
-    // Check for override function
-    if ( ! empty(get_option('woocommerce_registration_new_customer_function_override','') ) ) {
-        $function = get_option('woocommerce_registration_new_customer_function_override','');
-        if ( function_exists($function) ) return call_user_func_array($function, array($email, $username, $password));
-    }
+    $function = apply_filters( 'woocommerce_registration_new_customer', array() );
+    if ( ! empty($function) && function_exists($function) ) return call_user_func_array($function, array($email, $username, $password));
 
 	// Check the e-mail address
 	if ( empty( $email ) || ! is_email( $email ) ) {


### PR DESCRIPTION
I would like to provide a filter named 'woocommerce_registration_new_customer' at the beginning of the process of creating new user records, to be able to intercept new customer registration for the purpose of providing migration path from existing enterprise system.
