### PR TITLE
Add NZ locale labels

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -804,8 +804,12 @@ class WC_Countries {
 					)
 				),
 				'NZ' => array(
+					'postcode' => array(
+						'label' => __( 'Postcode', 'woocommerce' )
+					),
 					'state' => array(
-						'required' => false
+						'required' => false,
+						'label'    => __( 'Region', 'woocommerce' )
 					)
 				),
 				'NO' => array(


### PR DESCRIPTION
New Zealand doesn't use the "ZIP" label - just Postcode. State isn't used either, but "Region" is used instead (though rarely does this field ever matter it seems).

[NZ Locale PDF](https://github.com/woothemes/woocommerce/files/216350/nz-locale.pdf)
