### PR TITLE
Only ouput zones UI when in that section, don't default to it

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -129,20 +129,16 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		if ( '' == $current_section ) {
 			$this->output_zones_screen();
-			return;
 		} elseif ( 'options' === $current_section ) {
 			$settings = $this->get_settings();
 			WC_Admin_Settings::output_fields( $settings );
-			return;
 		} elseif ( 'classes' === $current_section ) {
 			$hide_save_button = true;
 			$this->output_shipping_class_screen();
-			return;
 		} else {
 			foreach ( $shipping_methods as $method ) {
 				if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ) ) && $method->has_settings() ) {
 					$method->admin_options();
-					return;
 				}
 			}
 		}

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -127,7 +127,10 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		// Load shipping methods so we can show any global options they may have
 		$shipping_methods = WC()->shipping->load_shipping_methods();
 
-		if ( 'options' === $current_section ) {
+		if ( '' == $current_section ) {
+			$this->output_zones_screen();
+			return;
+		} elseif ( 'options' === $current_section ) {
 			$settings = $this->get_settings();
 			WC_Admin_Settings::output_fields( $settings );
 			return;
@@ -143,9 +146,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				}
 			}
 		}
-
-		// Default to zones screen
-		$this->output_zones_screen();
 	}
 
 	/**


### PR DESCRIPTION
I'm not sure if the Shipping Zones UI was showing by default for a reason, but with 3 of my plugins it was showing the Zones UI unwanted (screenshot)

Could be fixed with a (bit ugly) workaround in my plugins, but I think this solution is more elegant as its in line with what it was + in line with the other sections.

In case it was done to catch legacy shipping method pages it may not work for that..

![image](https://cloud.githubusercontent.com/assets/5774447/14599247/8ecf3b28-0556-11e6-86e7-f9d42afddf71.png)
