### PR TITLE
Make product tabs and ratings work when product page is loaded via ajax

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -34,24 +34,16 @@ jQuery( function( $ ) {
 
 			$tab.closest( 'li' ).addClass( 'active' );
 			$tabs_wrapper.find( $tab.attr( 'href' ) ).show();
-		});
-
-	$( 'body' )
+		})
+		// Review link
 		.on( 'click', 'a.woocommerce-review-link', function() {
 			$( '.reviews_tab a' ).click();
-		return true;
-	});
-
-	// Star ratings for comments
-	$( 'body' )
+			return true;
+		})
+		// Star ratings for comments
 		.on( 'init', '#rating', function() {
 			$( '#rating' ).hide().before( '<p class="stars"><span><a class="star-1" href="#">1</a><a class="star-2" href="#">2</a><a class="star-3" href="#">3</a><a class="star-4" href="#">4</a><a class="star-5" href="#">5</a></span></p>' );
-		});
-	
-	//Init Tabs and Rating	
-	$( '.wc-tabs-wrapper, .woocommerce-tabs, #rating' ).trigger('init');
-
-	$( 'body' )
+		})
 		.on( 'click', '#respond p.stars a', function() {
 			var $star   	= $( this ),
 				$rating 	= $( this ).closest( '#respond' ).find( '#rating' ),
@@ -74,4 +66,7 @@ jQuery( function( $ ) {
 				return false;
 			}
 		});
+	
+	//Init Tabs and Star Ratings	
+	$( '.wc-tabs-wrapper, .woocommerce-tabs, #rating' ).trigger( 'init' );
 });

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -7,8 +7,8 @@ jQuery( function( $ ) {
 	}
 
 	// Tabs
-	$( '.wc-tabs-wrapper, .woocommerce-tabs' )
-		.on( 'init', function() {
+	$( 'body' )
+		.on( 'init', '.wc-tabs-wrapper, .woocommerce-tabs', function() {
 			$( '.wc-tab, .woocommerce-tabs .panel:not(.panel .panel)' ).hide();
 
 			var hash  = window.location.hash;
@@ -34,16 +34,22 @@ jQuery( function( $ ) {
 
 			$tab.closest( 'li' ).addClass( 'active' );
 			$tabs_wrapper.find( $tab.attr( 'href' ) ).show();
-		})
-		.trigger( 'init' );
+		});
 
-	$( 'a.woocommerce-review-link' ).click( function() {
-		$( '.reviews_tab a' ).click();
+	$( 'body' )
+		.on( 'click', 'a.woocommerce-review-link', function() {
+			$( '.reviews_tab a' ).click();
 		return true;
 	});
 
 	// Star ratings for comments
-	$( '#rating' ).hide().before( '<p class="stars"><span><a class="star-1" href="#">1</a><a class="star-2" href="#">2</a><a class="star-3" href="#">3</a><a class="star-4" href="#">4</a><a class="star-5" href="#">5</a></span></p>' );
+	$( 'body' )
+		.on( 'init', '#rating', function() {
+			$( '#rating' ).hide().before( '<p class="stars"><span><a class="star-1" href="#">1</a><a class="star-2" href="#">2</a><a class="star-3" href="#">3</a><a class="star-4" href="#">4</a><a class="star-5" href="#">5</a></span></p>' );
+		});
+	
+	//Init Tabs and Rating	
+	$( '.wc-tabs-wrapper, .woocommerce-tabs, #rating' ).trigger('init');
 
 	$( 'body' )
 		.on( 'click', '#respond p.stars a', function() {


### PR DESCRIPTION
.wc-tabs-wrapper, .woocommerce-tabs, #rating set as delegated events, so that on ajax loading a product page, we can call 
$( '.wc-tabs-wrapper, .woocommerce-tabs, #rating' ).trigger('init'); to make them work.
