### PR TITLE
Tax rate matching logic

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -234,12 +234,11 @@ class WC_Tax {
 		}
 
 		$postcode          = wc_clean( $postcode );
-		$valid_postcodes   = self::_get_wildcard_postcodes( $postcode );
 		$cache_key         = WC_Cache_Helper::get_cache_prefix( 'taxes' ) . 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $country, $state, $city, $postcode, $tax_class ) );
 		$matched_tax_rates = wp_cache_get( $cache_key, 'taxes' );
 
 		if ( false === $matched_tax_rates ) {
-			$matched_tax_rates = self::get_matched_tax_rates( $country, $state, $postcode, $city, $tax_class, $valid_postcodes );
+			$matched_tax_rates = self::get_matched_tax_rates( $country, $state, $postcode, $city, $tax_class );
 			wp_cache_set( $cache_key, $matched_tax_rates, 'taxes' );
 		}
 
@@ -275,49 +274,49 @@ class WC_Tax {
 	 * @param  string $postcode
 	 * @param  string $city
 	 * @param  string $tax_class
-	 * @param  string[] $valid_postcodes
 	 * @return array
 	 */
-	private static function get_matched_tax_rates( $country, $state, $postcode, $city, $tax_class, $valid_postcodes ) {
+	private static function get_matched_tax_rates( $country, $state, $postcode, $city, $tax_class ) {
 		global $wpdb;
 
-		$valid_postcodes = array_map( 'esc_sql', array_map( 'wc_clean', $valid_postcodes ) );
-		$match_country   = esc_sql( strtoupper( wc_clean( $country ) ) );
-		$match_state     = esc_sql( strtoupper( wc_clean( $state ) ) );
-		$match_tax_class = esc_sql( sanitize_title( $tax_class ) );
-		$match_city      = esc_sql( strtoupper( wc_clean( $city ) ) );
-		$found_rates     = $wpdb->get_results( "
+		// Query criteria - these will be ANDed
+		$criteria   = array();
+		$criteria[] = $wpdb->prepare( "tax_rate_country IN ( %s, '' )", strtoupper( wc_clean( $country ) ) );
+		$criteria[] = $wpdb->prepare( "tax_rate_state IN ( %s, '' )", strtoupper( wc_clean( $state ) ) );
+		$criteria[] = $wpdb->prepare( "tax_rate_class = %s", sanitize_title( $tax_class ) );
+
+		// Location matching criteria - ORed
+		$locations_criteria   = array();
+		$locations_criteria[] = "locations.location_type IS NULL"; // No locations matches all
+		$locations_criteria[] = $wpdb->prepare( "locations.location_type = 'city' AND locations.location_code = %s", strtoupper( wc_clean( $city ) ) ); // City match
+		$locations_criteria[] = "0 = (
+			SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rate_locations as sublocations
+			WHERE sublocations.location_type = 'city'
+			AND sublocations.tax_rate_id = tax_rates.tax_rate_id
+		)"; // No cities
+
+		$criteria[] = ' ( ' . implode( ' ) OR ( ', $locations_criteria ) . ' ) ';
+
+		// Pre-query for postcode range and wildcard matching
+		$rates_with_postcodes = $wpdb->get_results( "SELECT tax_rate_id, location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE location_type = 'postcode';" );
+
+		if ( $rates_with_postcodes ) {
+			$rates_with_postcodes_ids = array_unique( wp_list_pluck( $rates_with_postcodes, 'tax_rate_id' ) );
+			$matches                  = wc_postcode_location_matcher( $postcode, $rates_with_postcodes, 'tax_rate_id', 'location_code' );
+			$do_not_match             = array_unique( array_diff( $rates_with_postcodes_ids, $matches ) );
+
+			// Do not match any rate with a postcode which didn't match the customer postcode
+			if ( $do_not_match ) {
+				$criteria[] = "tax_rates.tax_rate_id NOT IN (" . implode( ',', array_map( 'esc_sql', $do_not_match ) ) . ")";
+			}
+		}
+
+		$found_rates = $wpdb->get_results( "
 			SELECT tax_rates.*
 			FROM {$wpdb->prefix}woocommerce_tax_rates as tax_rates
 			LEFT OUTER JOIN {$wpdb->prefix}woocommerce_tax_rate_locations as locations ON tax_rates.tax_rate_id = locations.tax_rate_id
 			LEFT OUTER JOIN {$wpdb->prefix}woocommerce_tax_rate_locations as locations2 ON tax_rates.tax_rate_id = locations2.tax_rate_id
-			WHERE tax_rate_country IN ( '{$match_country}', '' )
-			AND tax_rate_state IN ( '{$match_state}', '' )
-			AND tax_rate_class = '{$match_tax_class}'
-			AND (
-				locations.location_type IS NULL
-				OR (
-					locations.location_type = 'postcode'
-					AND locations.location_code IN ('" . implode( "','", $valid_postcodes ) . "')
-					AND (
-						locations2.location_type = 'city' AND locations2.location_code = '{$match_city}'
-						OR 0 = (
-							SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rate_locations as sublocations
-							WHERE sublocations.location_type = 'city'
-							AND sublocations.tax_rate_id = tax_rates.tax_rate_id
-						)
-					)
-				)
-				OR (
-					locations.location_type = 'city'
-					AND locations.location_code = '{$match_city}'
-					AND 0 = (
-							SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rate_locations as sublocations
-							WHERE sublocations.location_type = 'postcode'
-							AND sublocations.tax_rate_id = tax_rates.tax_rate_id
-						)
-				)
-			)
+			WHERE 1=1 AND ( " . implode( ' ) AND ( ', $criteria ) . " )
 			GROUP BY tax_rate_id
 			ORDER BY tax_rate_priority, tax_rate_order
 		" );
@@ -809,7 +808,6 @@ class WC_Tax {
 			$postcodes = explode( ';', $postcodes );
 		}
 		$postcodes = array_filter( array_diff( array_map( array( __CLASS__, 'format_tax_rate_postcode' ), $postcodes ), array( '*' ) ) );
-		$postcodes = self::_get_expanded_numeric_ranges_from_array( $postcodes );
 
 		self::_update_tax_rate_locations( $tax_rate_id, $postcodes, 'postcode' );
 	}
@@ -868,59 +866,6 @@ class WC_Tax {
 		}
 
 		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
-	}
-
-	/**
-	 * Expands ranges in an array (used for zipcodes). e.g. 101-105 would expand to 101, 102, 103, 104, 105.
-	 *
-	 * Internal use only.
-	 *
-	 * @since 2.3.0
-	 * @access private
-	 *
-	 * @param  array  $values array of values
-	 * @return array expanded values
-	 */
-	private static function _get_expanded_numeric_ranges_from_array( $values = array() ) {
-		$expanded = array();
-		foreach ( $values as $value ) {
-			if ( strstr( $value, '-' ) ) {
-				$parts = array_map( 'absint', array_map( 'trim', explode( '-', $value ) ) );
-
-				for ( $expanded_value = $parts[0]; $expanded_value <= $parts[1]; $expanded_value ++ ) {
-					if ( strlen( $expanded_value ) < strlen( $parts[0] ) ) {
-						$expanded_value = str_pad( $expanded_value, strlen( $parts[0] ), "0", STR_PAD_LEFT );
-					}
-					$expanded[] = $expanded_value;
-				}
-			} else {
-				$expanded[] = trim( $value );
-			}
-		}
-		return array_filter( $expanded );
-	}
-
-	/**
-	 * Get postcode wildcards in array format.
-	 *
-	 * Internal use only.
-	 *
-	 * @since 2.3.0
-	 * @access private
-	 *
-	 * @param  string  $postcode array of values
-	 * @return string[] Array of postcodes with wildcards
-	 */
-	private static function _get_wildcard_postcodes( $postcode ) {
-		$postcodes         = array( '*', strtoupper( $postcode ), strtoupper( $postcode ) . '*' );
-		$postcode_length   = strlen( $postcode );
-		$wildcard_postcode = strtoupper( $postcode );
-
-		for ( $i = 0; $i < $postcode_length; $i ++ ) {
-			$wildcard_postcode = substr( $wildcard_postcode, 0, -1 );
-			$postcodes[] = $wildcard_postcode . '*';
-		}
-		return $postcodes;
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1226,6 +1226,7 @@ function wc_help_tip( $tip, $allow_html = false ) {
 
 /**
  * Return a list of potential postcodes for wildcard searching.
+ * @since 2.6.0
  * @param  string $postcode
  * @return array
  */
@@ -1244,6 +1245,7 @@ function wc_get_wildcard_postcodes( $postcode ) {
 /**
  * Used by shipping zones and taxes to compare a given $postcode to stored
  * postcodes to find matches for numerical ranges, and wildcards.
+ * @since 2.6.0
  * @param string $postcode Postcode you want to match against stored postcodes
  * @param array $objects Array of postcode objects from Database
  * @param string $object_compare_key DB column name for the ID.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1248,19 +1248,18 @@ function wc_get_wildcard_postcodes( $postcode ) {
  * @param array $objects Array of postcode objects from Database
  * @param string $object_compare_key DB column name for the ID.
  * @param string $object_compare_key DB column name for the value.
- * @return array Array of matching IDs
+ * @return array Array of matching object ID and values.
  */
 function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $object_compare_key ) {
 	$matches            = array();
 	$wildcard_postcodes = array_map( 'wc_clean', wc_get_wildcard_postcodes( $postcode ) );
+	$postcodes          = wp_list_pluck( $objects, $object_compare_key, $object_id_key );
 
-	foreach ( $objects as $object ) {
-		$compare         = $postcode;
-		$compare_against = $object->$object_compare_key;
-		$object_id       = absint( $object->$object_id_key );
+	foreach ( $postcodes as $object_id => $compare_against ) {
+		$compare = $postcode;
 
 		// Handle postcodes containing ranges
-		if ( strstr( '-', $compare_against ) ) {
+		if ( strstr( $compare_against, '-' ) ) {
 			$range = array_map( 'trim', explode( '-', $compare_against ) );
 
 			if ( 2 !== sizeof( $range ) ) {
@@ -1277,12 +1276,12 @@ function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $obj
 			}
 
 			if ( $compare >= $min && $compare <= $max ) {
-				$matches[] = $object_id;
+				$matches[ $object_id ] = $compare_against;
 			}
 
 		// Wildcard and standard comparison
 		} elseif ( in_array( $compare_against, $wildcard_postcodes ) ) {
-			$matches[] = $object_id;
+			$matches[ $object_id ] = $compare_against;
 		}
 	}
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1223,3 +1223,68 @@ function wc_help_tip( $tip, $allow_html = false ) {
 
 	return '<span class="woocommerce-help-tip" data-tip="' . $tip . '"></span>';
 }
+
+/**
+ * Return a list of potential postcodes for wildcard searching.
+ * @param  string $postcode
+ * @return array
+ */
+function wc_get_wildcard_postcodes( $postcode ) {
+	$postcodes         = array( '*', strtoupper( $postcode ), strtoupper( $postcode ) . '*' );
+	$postcode_length   = strlen( $postcode );
+	$wildcard_postcode = strtoupper( $postcode );
+
+	for ( $i = 0; $i < $postcode_length; $i ++ ) {
+		$wildcard_postcode = substr( $wildcard_postcode, 0, -1 );
+		$postcodes[] = $wildcard_postcode . '*';
+	}
+	return $postcodes;
+}
+
+/**
+ * Used by shipping zones and taxes to compare a given $postcode to stored
+ * postcodes to find matches for numerical ranges, and wildcards.
+ * @param string $postcode Postcode you want to match against stored postcodes
+ * @param array $objects Array of postcode objects from Database
+ * @param string $object_compare_key DB column name for the ID.
+ * @param string $object_compare_key DB column name for the value.
+ * @return array Array of matching IDs
+ */
+function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $object_compare_key ) {
+	$matches            = array();
+	$wildcard_postcodes = array_map( 'wc_clean', wc_get_wildcard_postcodes( $postcode ) );
+
+	foreach ( $objects as $object ) {
+		$compare         = $postcode;
+		$compare_against = $object->$object_compare_key;
+		$object_id       = absint( $object->$object_id_key );
+
+		// Handle postcodes containing ranges
+		if ( strstr( '-', $compare_against ) ) {
+			$range = array_map( 'trim', explode( '-', $compare_against ) );
+
+			if ( 2 !== sizeof( $range ) ) {
+				continue;
+			}
+
+			list( $min, $max ) = $range;
+
+			// If the postcode is non-numeric, make it numeric
+			if ( ! is_numeric( $min ) || ! is_numeric( $max ) ) {
+				$compare = wc_make_numeric_postcode( $compare );
+				$min     = str_pad( wc_make_numeric_postcode( $min ), strlen( $encoded_postcode ), '0' );
+				$max     = str_pad( wc_make_numeric_postcode( $max ), strlen( $encoded_postcode ), '0' );
+			}
+
+			if ( $compare >= $min && $compare <= $max ) {
+				$matches[] = $object_id;
+			}
+
+		// Wildcard and standard comparison
+		} elseif ( in_array( $compare_against, $wildcard_postcodes ) ) {
+			$matches[] = $object_id;
+		}
+	}
+
+	return $matches;
+}


### PR DESCRIPTION
Fixes #10765

This handles postcode ranges with PHP rather then MYSQL meaning they don't need to be expanded and stored in the DB as separate rows.

This logic can also be re-used in zones since it had something very similar.

The drawback is 1 extra query when getting rates (to get the postcodes with - in them), however, the actual matching could be faster if less rows are involved.

@claudiosmweb feedback?
