### PR TITLE
Fix the embed template for WordPress 4.5+

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -42,6 +42,10 @@ class WC_Template_Loader {
 		$find = array( 'woocommerce.php' );
 		$file = '';
 
+		if ( is_embed() ) {
+			return $template;
+		}
+
 		if ( is_single() && get_post_type() == 'product' ) {
 
 			$file 	= 'single-product.php';


### PR DESCRIPTION
Because of a change in WordPRess 4.5, WooCommerce now falsely filters the template hierarchy and displays the single product page instead of the embed template.

This fixes #10772. 
