### PR TITLE
[2.6] Add missing hooks to the form-pay.php template

### DIFF
--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -10,7 +10,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    http://docs.woothemes.com/document/template-structure/
+ * @see      http://docs.woothemes.com/document/template-structure/
  * @author   WooThemes
  * @package  WooCommerce/Templates
  * @version  2.5.0
@@ -33,13 +33,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</thead>
 		<tbody>
 			<?php if ( sizeof( $order->get_items() ) > 0 ) : ?>
-				<?php foreach ( $order->get_items() as $item ) : ?>
-					<tr>
+				<?php foreach ( $order->get_items() as $item_id => $item ) : ?>
+					<?php
+						if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+							continue;
+						}
+					?>
+					<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
 						<td class="product-name">
-							<?php echo esc_html( $item['name'] ); ?>
-							<?php $order->display_item_meta( $item ); ?>
+							<?php
+								echo apply_filters( 'woocommerce_order_item_name', esc_html( $item['name'] ), $item, false );
+
+								do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
+								$order->display_item_meta( $item );
+								do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
+							?>
 						</td>
-						<td class="product-quantity"><?php echo esc_html( $item['qty'] ); ?></td>
+						<td class="product-quantity"><?php echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', esc_html( $item['qty'] ) ) . '</strong>', $item ); ?></td>
 						<td class="product-subtotal"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
 					</tr>
 				<?php endforeach; ?>


### PR DESCRIPTION
Adds some missing hooks to bring the template in line with the `order-details-item.php` template.

Adds the following filters:
- `woocommerce_order_item_visible`
- `woocommerce_order_item_class`
- `woocommerce_order_item_name` and
- `woocommerce_order_item_quantity_html`

Also adds the missing `woocommerce_order_item_meta_start` and `woocommerce_order_item_meta_end` actions.
