### PR TITLE
Add `public` keyword to public email methods

### DIFF
--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -22,7 +22,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->id             = 'customer_completed_order';
 		$this->customer_email = true;
@@ -51,7 +51,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	 *
 	 * @param int $order_id
 	 */
-	function trigger( $order_id ) {
+	public function trigger( $order_id ) {
 
 		if ( $order_id ) {
 			$this->object                  = wc_get_order( $order_id );
@@ -77,7 +77,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_subject() {
+	public function get_subject() {
 		if ( ! empty( $this->object ) && $this->object->has_downloadable_item() ) {
 			return apply_filters( 'woocommerce_email_subject_customer_completed_order', $this->format_string( $this->subject_downloadable ), $this->object );
 		} else {
@@ -91,7 +91,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_heading() {
+	public function get_heading() {
 		if ( ! empty( $this->object ) && $this->object->has_downloadable_item() ) {
 			return apply_filters( 'woocommerce_email_heading_customer_completed_order', $this->format_string( $this->heading_downloadable ), $this->object );
 		} else {
@@ -105,7 +105,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -120,7 +120,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	 *
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -133,7 +133,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 	/**
 	 * Initialise settings form fields.
 	 */
-	function init_form_fields() {
+	public function init_form_fields() {
 		$this->form_fields = array(
 			'enabled' => array(
 				'title'         => __( 'Enable/Disable', 'woocommerce' ),

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -36,7 +36,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->id             = 'customer_invoice';
 		$this->title          = __( 'Customer invoice', 'woocommerce' );
@@ -65,7 +65,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	 *
 	 * @param int|WC_Order $order
 	 */
-	function trigger( $order ) {
+	public function trigger( $order ) {
 
 		if ( ! is_object( $order ) ) {
 			$order = wc_get_order( absint( $order ) );
@@ -95,7 +95,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_subject() {
+	public function get_subject() {
 		if ( $this->object->has_status( array( 'processing', 'completed' ) ) ) {
 			return apply_filters( 'woocommerce_email_subject_customer_invoice_paid', $this->format_string( $this->subject_paid ), $this->object );
 		} else {
@@ -109,7 +109,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_heading() {
+	public function get_heading() {
 		if ( $this->object->has_status( array( 'completed', 'processing' ) ) ) {
 			return apply_filters( 'woocommerce_email_heading_customer_invoice_paid', $this->format_string( $this->heading_paid ), $this->object );
 		} else {
@@ -123,7 +123,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -139,7 +139,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -152,7 +152,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	/**
 	 * Initialise settings form fields.
 	 */
-	function init_form_fields() {
+	public function init_form_fields() {
 		$this->form_fields = array(
 			'subject' => array(
 				'title'         => __( 'Email Subject', 'woocommerce' ),

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -50,7 +50,7 @@ class WC_Email_Customer_New_Account extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->id             = 'customer_new_account';
 		$this->customer_email = true;
@@ -74,7 +74,7 @@ class WC_Email_Customer_New_Account extends WC_Email {
 	 * @param string $user_pass
 	 * @param bool $password_generated
 	 */
-	function trigger( $user_id, $user_pass = '', $password_generated = false ) {
+	public function trigger( $user_id, $user_pass = '', $password_generated = false ) {
 
 		if ( $user_id ) {
 			$this->object             = new WP_User( $user_id );
@@ -99,7 +99,7 @@ class WC_Email_Customer_New_Account extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'email_heading'      => $this->get_heading(),
 			'user_login'         => $this->user_login,
@@ -118,7 +118,7 @@ class WC_Email_Customer_New_Account extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'email_heading'      => $this->get_heading(),
 			'user_login'         => $this->user_login,

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -29,7 +29,7 @@ class WC_Email_Customer_Note extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->id             = 'customer_note';
 		$this->customer_email = true;
@@ -54,7 +54,7 @@ class WC_Email_Customer_Note extends WC_Email {
 	 *
 	 * @param array $args
 	 */
-	function trigger( $args ) {
+	public function trigger( $args ) {
 
 		if ( $args ) {
 
@@ -94,7 +94,7 @@ class WC_Email_Customer_Note extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -111,7 +111,7 @@ class WC_Email_Customer_Note extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -22,7 +22,7 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->id               = 'customer_on_hold_order';
 		$this->customer_email   = true;
 		$this->title            = __( 'Order on-hold', 'woocommerce' );
@@ -44,7 +44,7 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 	 *
 	 * @param int $order_id
 	 */
-	function trigger( $order_id ) {
+	public function trigger( $order_id ) {
 
 		if ( $order_id ) {
 			$this->object       = wc_get_order( $order_id );
@@ -70,7 +70,7 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -86,7 +86,7 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -22,7 +22,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->id               = 'customer_processing_order';
 		$this->customer_email   = true;
 		$this->title            = __( 'Processing order', 'woocommerce' );
@@ -44,7 +44,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	 *
 	 * @param int $order_id
 	 */
-	function trigger( $order_id ) {
+	public function trigger( $order_id ) {
 
 		if ( $order_id ) {
 			$this->object       = wc_get_order( $order_id );
@@ -70,7 +70,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),
@@ -86,7 +86,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'order'         => $this->object,
 			'email_heading' => $this->get_heading(),

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -43,7 +43,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	/**
 	 * Constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 
 		$this->id               = 'customer_reset_password';
 		$this->title            = __( 'Reset password', 'woocommerce' );
@@ -69,7 +69,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	 * @param string $user_login
 	 * @param string $reset_key
 	 */
-	function trigger( $user_login = '', $reset_key = '' ) {
+	public function trigger( $user_login = '', $reset_key = '' ) {
 		if ( $user_login && $reset_key ) {
 			$this->object     = get_user_by( 'login', $user_login );
 
@@ -93,7 +93,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_html() {
+	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'email_heading' => $this->get_heading(),
 			'user_login'    => $this->user_login,
@@ -111,7 +111,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	 * @access public
 	 * @return string
 	 */
-	function get_content_plain() {
+	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'email_heading' => $this->get_heading(),
 			'user_login'    => $this->user_login,


### PR DESCRIPTION
Since most of the code base uses `public` keyword before public methods and some email classes does, let's add it to the email classes that don't have it.
