### PR TITLE
Add `public` keyword to public various methods

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -200,7 +200,7 @@ class WC_Customer {
 	 *
 	 * @return bool
 	 */
-	function is_paying_customer( $user_id ) {
+	public function is_paying_customer( $user_id ) {
 		return '1' === get_user_meta( $user_id, 'paying_customer', true );
 	}
 

--- a/includes/class-wc-geo-ip.php
+++ b/includes/class-wc-geo-ip.php
@@ -1506,7 +1506,7 @@ class WC_Geo_IP {
 	 * @param  int $ipnum
 	 * @return string
 	 */
-	function _geoip_seek_country_v6( $ipnum ) {
+	public function _geoip_seek_country_v6( $ipnum ) {
 		// arrays from unpack start with offset 1
 		// yet another php mystery. array_merge work around
 		// this broken behaviour

--- a/includes/widgets/class-wc-widget-product-search.php
+++ b/includes/widgets/class-wc-widget-product-search.php
@@ -42,7 +42,7 @@ class WC_Widget_Product_Search extends WC_Widget {
 	 * @param array $args
 	 * @param array $instance
 	 */
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 		$this->widget_start( $args, $instance );
 
 		get_product_search_form();

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -50,7 +50,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 	 * @param array $args
 	 * @param array $instance
 	 */
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 
 		$viewed_products = ! empty( $_COOKIE['woocommerce_recently_viewed'] ) ? (array) explode( '|', $_COOKIE['woocommerce_recently_viewed'] ) : array();
 		$viewed_products = array_filter( array_map( 'absint', $viewed_products ) );


### PR DESCRIPTION
The same as #10797 but for four various methods, with this PR all methods that are public uses `public` keyword :)
