### PR TITLE
Fix typo

### DIFF
--- a/includes/admin/views/html-notice-legacy-shipping.php
+++ b/includes/admin/views/html-notice-legacy-shipping.php
@@ -18,6 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php if ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) : ?>
 			<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>"><?php _e( 'Setup shipping zones', 'woocommerce' ); ?></a>
 		<?php endif; ?>
-		<a class="button-secondary" href="<?php echo esc_url( 'https://docs.woothemes.com/document/setting-up-shipping-zones/' ); ?>"><?php _e( 'Lean more about shipping zones', 'woocommerce' ); ?></a>
+		<a class="button-secondary" href="<?php echo esc_url( 'https://docs.woothemes.com/document/setting-up-shipping-zones/' ); ?>"><?php _e( 'Learn more about shipping zones', 'woocommerce' ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-no-shipping-methods.php
+++ b/includes/admin/views/html-notice-no-shipping-methods.php
@@ -16,6 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p class="submit">
 		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>"><?php _e( 'Setup shipping zones', 'woocommerce' ); ?></a>
-		<a class="button-secondary" href="<?php echo esc_url( 'https://docs.woothemes.com/document/setting-up-shipping-zones/' ); ?>"><?php _e( 'Lean more about shipping zones', 'woocommerce' ); ?></a>
+		<a class="button-secondary" href="<?php echo esc_url( 'https://docs.woothemes.com/document/setting-up-shipping-zones/' ); ?>"><?php _e( 'Learn more about shipping zones', 'woocommerce' ); ?></a>
 	</p>
 </div>


### PR DESCRIPTION
Fixes typo in shipping zones message.

The link is actually broken (404). Not sure if that's because the link is wrong, or just that the destination page isn't published yet?
