### PR TITLE
Add hooks to woocommerce_content() function

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -277,6 +277,14 @@ if ( ! function_exists( 'woocommerce_content' ) ) {
 	 */
 	function woocommerce_content() {
 
+		/**
+		 * woocommerce_before_main_content hook
+		 *
+		 * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
+		 * @hooked woocommerce_breadcrumb - 20
+		 */
+		do_action( 'woocommerce_before_main_content' );
+
 		if ( is_singular( 'product' ) ) {
 
 			while ( have_posts() ) : the_post();
@@ -320,6 +328,13 @@ if ( ! function_exists( 'woocommerce_content' ) ) {
 			<?php endif;
 
 		}
+		/**
+		 * woocommerce_after_main_content hook
+		 *
+		 * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
+		 */
+		do_action( 'woocommerce_after_main_content' );
+
 	}
 }
 


### PR DESCRIPTION
I have a plugin that hooks into 'woocommerce_before_main_content' action and third party themes that call woocommerce_content() don't call these functions. This allows those hooks to be called without the
third party themes having to add that action in.
