### PR TITLE
Fixed fatal error caused by wrong class name to instantiate.

### DIFF
--- a/includes/updates/woocommerce-update-2.4.php
+++ b/includes/updates/woocommerce-update-2.4.php
@@ -26,7 +26,7 @@ update_option( 'woocommerce_calc_discounts_sequentially', 'yes' );
  */
 $shipping_methods = array(
 	'woocommerce_flat_rates'                        => new WC_Shipping_Flat_Rate(),
-	'woocommerce_international_delivery_flat_rates' => new WC_Shipping_International_Delivery()
+	'woocommerce_international_delivery_flat_rates' => new WC_Shipping_Legacy_International_Delivery()
 );
 foreach ( $shipping_methods as $flat_rate_option_key => $shipping_method ) {
 	// Stop this running more than once if routine is repeated


### PR DESCRIPTION
Class WC_Shipping_International_Delivery got renamed to WC_Shipping_Legacy_International_Delivery per 119f19a.

Fixes #10837.
