### PR TITLE
Fix paypal when not want install-it

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -75,7 +75,6 @@ class WC_Payment_Gateways {
 			'WC_Gateway_BACS',
 			'WC_Gateway_Cheque',
 			'WC_Gateway_COD',
-			'WC_Gateway_Paypal',
 		);
 
 		/**


### PR DESCRIPTION
I had a problem when I jumped the payment gateway stage, opting not to use paypal.
Breaking the site on the checkout page and wc_settings
