### PR TITLE
Add filtering for system status page tabs and actions too

### DIFF
--- a/includes/admin/views/html-admin-page-status.php
+++ b/includes/admin/views/html-admin-page-status.php
@@ -13,7 +13,7 @@ $tabs        = array(
 	'tools'  => __( 'Tools', 'woocommerce' ),
 	'logs'   => __( 'Logs', 'woocommerce' ),
 );
-
+$tabs        = apply_filters( 'woocommerce_admin_status_tabs', $tabs );
 ?>
 <div class="wrap woocommerce">
 	<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
@@ -25,7 +25,7 @@ $tabs        = array(
 			}
 		?>
 	</nav>
-	<h1 class="screen-reader-text"><?php echo esc_html( $tabs[ $current_tab ] ); ?></h1>	
+	<h1 class="screen-reader-text"><?php echo esc_html( $tabs[ $current_tab ] ); ?></h1>
 	<?php
 		switch ( $current_tab ) {
 			case "tools" :
@@ -35,7 +35,11 @@ $tabs        = array(
 				WC_Admin_Status::status_logs();
 			break;
 			default :
-				WC_Admin_Status::status_report();
+				if ( has_action( 'woocommerce_admin_status_' . $current_tab ) ) {
+					do_action( 'woocommerce_admin_status_' . $current_tab );
+				} else {
+					WC_Admin_Status::status_report();
+				}
 			break;
 		}
 	?>

--- a/includes/admin/views/html-admin-page-status.php
+++ b/includes/admin/views/html-admin-page-status.php
@@ -35,7 +35,7 @@ $tabs        = apply_filters( 'woocommerce_admin_status_tabs', $tabs );
 				WC_Admin_Status::status_logs();
 			break;
 			default :
-				if ( has_action( 'woocommerce_admin_status_' . $current_tab ) ) {
+				if ( array_key_exists( $current_tab, $tabs ) && has_action( 'woocommerce_admin_status_' . $current_tab ) ) {
 					do_action( 'woocommerce_admin_status_' . $current_tab );
 				} else {
 					WC_Admin_Status::status_report();

--- a/includes/admin/views/html-admin-page-status.php
+++ b/includes/admin/views/html-admin-page-status.php
@@ -35,8 +35,8 @@ $tabs        = apply_filters( 'woocommerce_admin_status_tabs', $tabs );
 				WC_Admin_Status::status_logs();
 			break;
 			default :
-				if ( array_key_exists( $current_tab, $tabs ) && has_action( 'woocommerce_admin_status_' . $current_tab ) ) {
-					do_action( 'woocommerce_admin_status_' . $current_tab );
+				if ( array_key_exists( $current_tab, $tabs ) && has_action( 'woocommerce_admin_status_content_' . $current_tab ) ) {
+					do_action( 'woocommerce_admin_status_content_' . $current_tab );
 				} else {
 					WC_Admin_Status::status_report();
 				}


### PR DESCRIPTION
Allow new tabs to be added to wp-admin > WooCommerce > System Status
