### PR TITLE
Make customer download links available for admins

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-download-permission.php
+++ b/includes/admin/meta-boxes/views/html-order-download-permission.php
@@ -26,6 +26,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<label><?php _e( 'Access expires', 'woocommerce' ); ?></label>
 					<input type="text" class="short date-picker" name="access_expires[<?php echo $loop; ?>]" value="<?php echo $download->access_expires > 0 ? date_i18n( 'Y-m-d', strtotime( $download->access_expires ) ) : ''; ?>" maxlength="10" placeholder="<?php esc_attr_e( 'Never', 'woocommerce' ); ?>" pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])" />
 				</td>
+				<td>
+					<label><?php _e( 'Customer download link', 'woocommerce' ); ?></label>
+					<?php
+						$download_link =  add_query_arg( array(
+							'download_file' => $download->product_id,
+							'order'         => $download->order_key,
+							'email'         => urlencode( $download->user_email ),
+							'key'           => $download->download_id
+						), trailingslashit( home_url() ) );
+
+						echo '<a href="' . $download_link . '">' . $file_count . '</a>';
+					?>
+				</td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
Add the download link to the order downloads meta box. Per https://github.com/woothemes/woocommerce/issues/10867

This can help store owners test the download links that customers are getting, as well as make it easy to send the link to customers manually if need be.

![customer download link](http://cld.wthms.co/cbx4/2SwCnVyN+)
