### PR TITLE
Add 'woocommerce_before_attribute_delete' action

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -216,7 +216,9 @@ class WC_Admin_Attributes {
 		check_admin_referer( 'woocommerce-delete-attribute_' . $attribute_id );
 
 		$attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
-
+		
+		do_action( 'woocommerce_before_attribute_delete', $attribute_id, $attribute_name );
+		
 		if ( $attribute_name && $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" ) ) {
 
 			$taxonomy = wc_attribute_taxonomy_name( $attribute_name );

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -217,7 +217,7 @@ class WC_Admin_Attributes {
 
 		$attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
 		
-		do_action( 'woocommerce_before_attribute_delete', $attribute_id, $attribute_name );
+		do_action( 'woocommerce_before_attribute_delete', $attribute_name );
 		
 		if ( $attribute_name && $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" ) ) {
 


### PR DESCRIPTION
Simple hook to allow plugin developers to prevent attributes which are essential for their plugin to function from being deleted.
