### PR TITLE
Add additional information to the WC Tracker

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -104,6 +104,13 @@ class WC_Tracker {
 		$data['active_plugins']     = $all_plugins['active_plugins'];
 		$data['inactive_plugins']   = $all_plugins['inactive_plugins'];
 
+		// Jetpack & WooCommerce Connect
+		$data['jetpack_version']    = defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : 'none';
+		$data['jetpack_connected']  = ( class_exists( 'Jetpack' ) && is_callable( 'Jetpack::is_active' ) && Jetpack::is_active() ) ? 'yes' : 'no';
+		$data['jetpack_is_staging'] = ( class_exists( 'Jetpack' ) && is_callable( 'Jetpack::is_staging_site' ) && Jetpack::is_staging_site() ) ? 'yes' : 'no';
+		$data['connect_installed']  = class_exists( 'WC_Connect_Loader' ) ? 'yes' : 'no';
+		$data['connect_active']     = ( class_exists( 'WC_Connect_Loader' ) && wp_next_scheduled( 'wc_connect_fetch_service_schemas' ) ) ? 'yes' : 'no';
+
 		// Store count info
 		$data['users']              = self::get_user_counts();
 		$data['products']           = self::get_product_counts();


### PR DESCRIPTION
This PR seeks to add a few additional data points to the WC Tracker:
- Some basic info about Jetpack: version, if connected, and if is a staging site
- Some basic info about WooCommerce Connect: if installed and if active

Testing this was somewhat cumbersome. Here's what I did:
- Ensure you have `wp-cli` access to the testing site
- Checkout this branch in a WooCommerce checkout
- Temporarily comment out lines 45-57 of `includes/class-wc-tracker.php`
- Temporarily add `var_dump( $params );` after line 62 of `includes/class-wc-tracker.php`
- Open the wp-cli shell via `wp shell`
- Execute `WC_Tracker::send_tracking_data( true );` and observe the data collected
- Ensure the data collected matches your installation in regards to Jetpack and WCC
- De-activate Jetpack and/or WCC and repeat to see if the results are accurate (note you'll need to `exit` in the wp shell and re-enter it to get stuff to reload properly)

cc @allendav @jeffstieler @nabsul  
