### PR TITLE
Added '$_product' argument to 'woocommerce_restock_refunded_item' hook

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2220,7 +2220,7 @@ class WC_AJAX {
 
 						$order->add_order_note( sprintf( __( 'Item #%s stock increased from %s to %s.', 'woocommerce' ), $order_item['product_id'], $old_stock, $new_quantity ) );
 
-						do_action( 'woocommerce_restock_refunded_item', $_product->id, $old_stock, $new_quantity, $order );
+						do_action( 'woocommerce_restock_refunded_item', $_product->id, $old_stock, $new_quantity, $order, $_product );
 					}
 				}
 			}


### PR DESCRIPTION
Currently the hook is only using $_product->id but it might be useful
not to only know the product but also the explicit variation that was
refunded. Unfortunately $_product->id does not provide these information.
