### PR TITLE
Fix shipping tax calculations in WC_Abstract_Order::calculate_taxes()

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -762,7 +762,7 @@ abstract class WC_Abstract_Order {
 				) );
 			}
 
-			$line_taxes          = WC_Tax::calc_tax( $item->get_total(), $tax_rates, false );
+			$line_taxes          = WC_Tax::calc_tax( $item['cost'], $tax_rates, false );
 			$line_tax            = max( 0, array_sum( $line_taxes ) );
 			$shipping_tax_total += $line_tax;
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -731,9 +731,6 @@ abstract class WC_Abstract_Order {
 			}
 		}
 
-
-
-
 		// Calc taxes for shipping
 		foreach ( $this->get_shipping_methods() as $item_id => $item ) {
 			$shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -743,10 +743,10 @@ abstract class WC_Abstract_Order {
 					$tax_class = sanitize_title( $tax_class );
 					if ( in_array( $tax_class, $found_tax_classes ) ) {
 						$tax_rates = WC_Tax::find_shipping_rates( array(
-							'country'   => $args['country'],
-							'state'     => $args['state'],
-							'postcode'  => $args['postcode'],
-							'city'      => $args['city'],
+							'country'   => $country,
+							'state'     => $state,
+							'postcode'  => $postcode,
+							'city'      => $city,
 							'tax_class' => $tax_class,
 						) );
 						break;
@@ -754,10 +754,10 @@ abstract class WC_Abstract_Order {
 				}
 			} else {
 				$tax_rates = WC_Tax::find_shipping_rates( array(
-					'country'   => $args['country'],
-					'state'     => $args['state'],
-					'postcode'  => $args['postcode'],
-					'city'      => $args['city'],
+					'country'   => $country,
+					'state'     => $state,
+					'postcode'  => $postcode,
+					'city'      => $city,
 					'tax_class' => 'standard' === $shipping_tax_class ? '' : $shipping_tax_class,
 				) );
 			}


### PR DESCRIPTION
SHA: c9095abf8e8d54933e30 saved and calculated shipping line item taxes whenever `WC_Abstract_Order::calculate_taxes()` was called. However, it had two issues.

Firstly, it attempted to get the country, state, postcode and city values from an undefined `$args` variable. This is fixed with SHA: 8ae4b5ad2406da8c3faa, which uses the variables with those values set earlier.

Secondly, it tried to calculate taxes using the base cost derived from `$item->get_total()`, but `$item` is an array not an object (an example of this array is below for reference). SHA: 29692a22c57 fixes this by using `$item['cost']` value.

```
Array
(
    [name] => Flat Rate
    [type] => shipping
    [item_meta] => Array
        (
            [method_id] => Array
                (
                    [0] => flat_rate:13
                )

            [cost] => Array
                (
                    [0] => 11.00
                )

            [taxes] => Array
                (
                    [0] => a:1:{i:4;s:3:"1.1";}
                )

            [Items] => Array
                (
                    [0] => Grouped Album Subscriptions &rarr; Grouped Album Subscription #3 &times; 1
                )

        )

    [item_meta_array] => Array
        (
            [46927] => stdClass Object
                (
                    [key] => method_id
                    [value] => flat_rate:13
                )

            [46928] => stdClass Object
                (
                    [key] => cost
                    [value] => 11.00
                )

            [46929] => stdClass Object
                (
                    [key] => taxes
                    [value] => a:1:{i:4;s:3:"1.1";}
                )

            [46930] => stdClass Object
                (
                    [key] => Items
                    [value] => Grouped Album Subscriptions &rarr; Grouped Album Subscription #3 &times; 1
                )

        )

    [method_id] => flat_rate:13
    [cost] => 11.00
    [taxes] => a:1:{i:4;s:3:"1.1";}
    [Items] => Grouped Album Subscriptions &rarr; Grouped Album Subscription #3 &times; 1
)
```
