### PR TITLE
Prevent unset search query_var when no orders match

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1568,7 +1568,7 @@ class WC_Admin_Post_Types {
 			$post_ids = false;
 		}
 
-		if ( is_array( $post_ids ) ) {
+		if ( ! empty( $post_ids ) ) {
 			// Remove s - we don't want to search order name
 			unset( $wp->query_vars['s'] );
 
@@ -1576,7 +1576,7 @@ class WC_Admin_Post_Types {
 			$wp->query_vars['shop_order_search'] = true;
 
 			// Search by found posts
-			$wp->query_vars['post__in'] = array_merge( $post_ids, array( 0 ) );
+			$wp->query_vars['post__in'] = $post_ids;
 		}
 	}
 


### PR DESCRIPTION
Update #10599 @mikejolley 

> if ( is_array( $post_ids ) )

This will allows to unset **$wp->query_vars['s']** even when no order match found. And it doesn't allowed other hook to perform search action.

Example: I am trying to search order term even in order item meta that needs another custom hook, and this condition unset _search term_ and couldn't perform action.

An **empty** check will allow only if order_ids get in previous queries. If doesn't then will not unset **$wp->query_vars['s']**.
