### PR TITLE
Fix credit card JS validation

### DIFF
--- a/includes/gateways/class-wc-payment-gateway-cc.php
+++ b/includes/gateways/class-wc-payment-gateway-cc.php
@@ -52,7 +52,6 @@ class WC_Payment_Gateway_CC extends WC_Payment_Gateway {
 	public function form() {
 		wp_enqueue_script( 'wc-credit-card-form' );
 
-		$html   = '';
 		$fields = array();
 
 		$cvc_field = '<p class="form-row form-row-last">

--- a/includes/gateways/class-wc-payment-gateway-cc.php
+++ b/includes/gateways/class-wc-payment-gateway-cc.php
@@ -50,6 +50,8 @@ class WC_Payment_Gateway_CC extends WC_Payment_Gateway {
 	 * @since 2.6.0
 	 */
 	public function form() {
+		wp_enqueue_script( 'wc-credit-card-form' );
+
 		$html   = '';
 		$fields = array();
 


### PR DESCRIPTION
While testing WooCommerce 2.6 on my local copy of woothemes.com, I noticed the following JS error when trying to purchase an item:

```
TypeError: jQuery(...).payment is not a function
var expires = jQuery('#stripe-card-expiry').payment( 'cardExpiryVal' );
wp-content/plugins/woocommerce-gateway-stripe/assets/js/stripe.js?ver=2.6.1 (line 38)
```

This is happening because `wc-credit-card-form` (and thus `jquery-payment`) stopped being included whenever the credit card form is displayed after https://github.com/woothemes/woocommerce/commit/c0b74296ff7af48cf3d9dac138102ca9b67d221c#diff-4eec8dfc945e898cf03f429ac795043fL350

I'm assuming that this was an error and that `wc-credit-card-form` should still be enqueued so I'm opening this PR. But I'm not familiar with WooCommerce so I might be missing something (maybe from now on woocommerce-gateway-stripe plugin should enqueue `jquery-payment` instead of assuming that it is available?).
