### PR TITLE
Use print_r() to stringify cart session

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -184,7 +184,7 @@ class WC_Checkout {
 				'status'        => apply_filters( 'woocommerce_default_order_status', 'pending' ),
 				'customer_id'   => $this->customer_id,
 				'customer_note' => isset( $this->posted['order_comments'] ) ? $this->posted['order_comments'] : '',
-				'cart_hash'     => md5( json_encode( WC()->cart->get_cart_for_session() ) . WC()->cart->total ),
+				'cart_hash'     => md5( print_r( WC()->cart->get_cart_for_session(), true ) . WC()->cart->total ),
 				'created_via'   => 'checkout'
 			);
 


### PR DESCRIPTION
SHA: a71a4de1b899ea introduced the concept of a cart hash to validate that an order being paid for has not had its contents changed.

This PR changes the cart hash to use `print_r()` to stringify the cart data instead of `json_encode()` because `json_encode()` takes variable types into account. This means numbers may end up being represented in the encoded JSON as a string, e.g. `"1"` instead of `1`, which can lead to the hash being different for identical cart contents and ultimately a new order being created instead of payment being processed on the existing order in `WC()->session->order_awaiting_payment` even though the order's contents are identical.

I'm not sure if the issue would ever surface with the way WC uses the cart hash and `WC()->session->order_awaiting_payment`, but it definitely occurs with Subscriptions when attempting to pay for a renewal order via the cart/checkout. This is because Subscriptions creates the cart hash immediately after adding line items to the cart, so the items `quantity` property is encoded with `json_encode()` as an `int` (`WC_Cart->add_to_cart()` makes `$quantity` an `int`, even if it's passed `(string)$quantity`). When WC encodes the `WC()->cart->get_cart_for_session()` in the request to checkout, the cart items are pulled from the database, and are encoded as a strings, including the quantity `int`.

Subscriptions could change the way it creates a cart hash to account for this, but I figured the cart hash really doesn't want to be taking variable types into account so this patch may prevent other issues as well.

An alternative approach was to use `JSON_NUMERIC_CHECK` bitmask as a 2nd param on the `json_encode()` call to make sure quantity and other `int` values are treats as numbers. But that bitmask is only available in PHP 5.3.3+ (it can also have unintended consequences on strings that look like numbers, like phone numbers, but that's pretty irrelevant for the purpose of creating a `md5` hash).
