### PR TITLE
[2.6] Tweak admin order items display

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1078,7 +1078,7 @@ ul.wc_coupon_list_block {
 			.line_cost,
 			.line_tax,
 			.tax_class,
-			.item_cost {
+			.item_price {
 				text-align: right;
 
 				label {
@@ -2087,7 +2087,7 @@ table.wc_input_table {
 		background-color: #fefbcc;
 	}
 
-	.item_cost,
+	.item_price,
 	.cost {
 		text-align: right;
 

--- a/includes/admin/meta-boxes/views/html-order-fee.php
+++ b/includes/admin/meta-boxes/views/html-order-fee.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php do_action( 'woocommerce_admin_order_item_values', null, $item, absint( $item_id ) ); ?>
 
-	<td class="item_cost" width="1%">&nbsp;</td>
+	<td class="item_cost item_price" width="1%">&nbsp;</td>
 	<td class="quantity" width="1%">&nbsp;</td>
 
 	<td class="line_cost" width="1%">

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -49,7 +49,7 @@ $item_subtotal = ( isset( $item['line_subtotal'] ) ) ? esc_attr( wc_format_local
 
 	<?php do_action( 'woocommerce_admin_order_item_values', $_product, $item, absint( $item_id ) ); ?>
 
-	<td class="item_cost" width="1%" data-sort-value="<?php echo esc_attr( $order->get_item_subtotal( $item, false, true ) ); ?>">
+	<td class="item_cost item_price" width="1%" data-sort-value="<?php echo esc_attr( $order->get_item_subtotal( $item, false, true ) ); ?>">
 		<div class="view">
 			<?php
 				if ( isset( $item['line_total'] ) ) {

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -49,7 +49,7 @@ if ( wc_tax_enabled() ) {
 			<tr>
 				<th class="item sortable" colspan="2" data-sort="string-ins"><?php _e( 'Item', 'woocommerce' ); ?></th>
 				<?php do_action( 'woocommerce_admin_order_item_headers', $order ); ?>
-				<th class="item_cost sortable" data-sort="float"><?php _e( 'Cost', 'woocommerce' ); ?></th>
+				<th class="item_cost item_price sortable" data-sort="float"><?php _e( 'Price', 'woocommerce' ); ?></th>
 				<th class="quantity sortable" data-sort="int"><?php _e( 'Qty', 'woocommerce' ); ?></th>
 				<th class="line_cost sortable" data-sort="float"><?php _e( 'Total', 'woocommerce' ); ?></th>
 				<?php

--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -27,7 +27,7 @@ $who_refunded = new WP_User( $refund->post->post_author );
 
 	<?php do_action( 'woocommerce_admin_order_item_values', null, $refund, absint( $refund->id ) ); ?>
 
-	<td class="item_cost" width="1%">&nbsp;</td>
+	<td class="item_cost item_price" width="1%">&nbsp;</td>
 	<td class="quantity" width="1%">&nbsp;</td>
 
 	<td class="line_cost" width="1%">

--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -54,7 +54,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php do_action( 'woocommerce_admin_order_item_values', null, $item, absint( $item_id ) ); ?>
 
-	<td class="item_cost" width="1%">&nbsp;</td>
+	<td class="item_cost item_price" width="1%">&nbsp;</td>
 	<td class="quantity" width="1%">&nbsp;</td>
 
 	<td class="line_cost" width="1%">


### PR DESCRIPTION
When viewing an order, the product price is currently displayed in a "Cost" column, which is inconsistent with the way this is shown on the products list and while editing products, as there it's referred to as "Price".

Since this screen is already changing in 2.6, it may be a good time to change this to "Price" for consistency with the way this is referred to on product pages as well, and for improved accuracy, as "cost" isn’t necessarily was this represents, but rather the price the customer paid for the item. 

New view: http://cloud.skyver.ge/0s151e2s3Z2l
