### PR TITLE
Add action hooks to myaccount/navigation.php

### DIFF
--- a/templates/myaccount/navigation.php
+++ b/templates/myaccount/navigation.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-do_action( 'woocommerce_before_myaccount_navigation' ); 
+do_action( 'woocommerce_before_account_navigation' ); 
 ?>
 
 <nav class="woocommerce-MyAccount-navigation">
@@ -33,4 +33,4 @@ do_action( 'woocommerce_before_myaccount_navigation' );
 	</ul>
 </nav>
 
-<?php do_action( 'woocommerce_after_myaccount_navigation' ); ?>
+<?php do_action( 'woocommerce_after_account_navigation' ); ?>

--- a/templates/myaccount/navigation.php
+++ b/templates/myaccount/navigation.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+do_action( 'woocommerce_before_myaccount_navigation' ); 
 ?>
 
 <nav class="woocommerce-MyAccount-navigation">
@@ -31,3 +32,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endforeach; ?>
 	</ul>
 </nav>
+
+<?php do_action( 'woocommerce_after_myaccount_navigation' ); ?>


### PR DESCRIPTION
This is just 2 action hooks, which enable users to add their own stuff before and after the myaccount navigation. I added classic Woocommerce hook names to make this consistent.

For us @ ThemeFusion, we would especially need the before hook, so that we can get rid of a navigation template override.

Matty asked me to add @mikejolley and @mattyza.

Thanks guys for checking!
