### PR TITLE
Added 'woocommerce_mail_content' to preview

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -180,7 +180,7 @@ class WC_Admin {
 			$email         = new WC_Email();
 
 			// wrap the content with the email template and then add styles
-			$message       = $email->style_inline( $mailer->wrap_message( $email_heading, $message ) );
+			$message       = apply_filters( 'woocommerce_mail_content', $email->style_inline( $mailer->wrap_message( $email_heading, $message ) ) );
 
 			// print the preview email
 			echo $message;

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -6,7 +6,7 @@
  * @author      WooThemes
  * @category    Admin
  * @package     WooCommerce/Admin
- * @version     2.3
+ * @version     2.3.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Added the 'woocommerce_mail_content' filter which is used before sending the email in /includes/emails/class-wc-email.php#L465 to the preview.

I think this is needed as the preview should display the same as the mail being sent.
