### PR TITLE
Add callback for `topic_count_text_callback` on product tag widget

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -183,3 +183,13 @@ function wc_check_if_attribute_name_is_reserved( $attribute_name ) {
 
 	return in_array( $attribute_name, $reserved_terms );
 }
+
+/**
+ * Return the title attribute for the tagcloud callback
+ *
+ * @param  int $count
+ * @return string
+ */
+function wc_product_tag_cloud_title_callback( $count ) {
+	return sprintf( _n( '%s Product', '%s Products', $count, 'woocommerce' ), number_format_i18n( $count ) );
+}

--- a/includes/widgets/class-wc-widget-product-tag-cloud.php
+++ b/includes/widgets/class-wc-widget-product-tag-cloud.php
@@ -54,7 +54,7 @@ class WC_Widget_Product_Tag_Cloud extends WC_Widget {
 
 		echo '<div class="tagcloud">';
 
-		wp_tag_cloud( apply_filters( 'woocommerce_product_tag_cloud_widget_args', array( 'taxonomy' => $current_taxonomy ) ) );
+		wp_tag_cloud( apply_filters( 'woocommerce_product_tag_cloud_widget_args', array( 'taxonomy' => $current_taxonomy, 'topic_count_text_callback' => 'wc_product_tag_cloud_title_callback' ) ) );
 
 		echo '</div>';
 


### PR DESCRIPTION
The idea is to add a callback on the product tag widget in order to fix
the title attributes of the tag links. (Issue #10958)
