### PR TITLE
[2.6] Admin multiselect CSS tweak

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -4993,7 +4993,6 @@ table.bar_chart {
 	font-size: inherit;
 	font-weight: inherit;
 	padding: 3px 5px;
-	width: 100% !important;
 }
 .select2-container {
 	line-height: 1.85em;


### PR DESCRIPTION
Looks like a placeholder width was added in SHA 40a26c52b3598b2cab234b605baee5fc86ad6afc -- however, this is causing placeholders to get cut off when viewed (tested Chrome / Firefox / Safari):
http://cloud.skyver.ge/3p3J192r0u3C

Removing it allows the field to set the width to be set automatically, which shows the full placeholder instead.
