### PR TITLE
Change and add a filter for archive images

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1677,7 +1677,7 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 	 * @subpackage	Loop
 	 */
 	function woocommerce_subcategory_thumbnail( $category ) {
-		$small_thumbnail_size  	= apply_filters( 'single_product_small_thumbnail_size', 'shop_catalog' );
+		$small_thumbnail_size  	= apply_filters( 'subcategory_archive_thumbnail_size', 'shop_catalog' );
 		$dimensions    			= wc_get_image_size( $small_thumbnail_size );
 		$thumbnail_id  			= get_woocommerce_term_meta( $category->term_id, 'thumbnail_id', true  );
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -728,6 +728,7 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	 */
 	function woocommerce_get_product_thumbnail( $size = 'shop_catalog', $deprecated1 = 0, $deprecated2 = 0 ) {
 		global $post;
+		$size = apply_filters( 'single_product_archive_thumbnail_size', 'shop_catalog' );
 
 		if ( has_post_thumbnail() ) {
 			$props = wc_get_product_attachment_props( get_post_thumbnail_id(), $post );


### PR DESCRIPTION
The first commit renames the `single_product_small_thumbnail_size` filter. This filter is also used at: https://github.com/woothemes/woocommerce/blob/fa30a38c58373d9c3706cc0b7ae22032de3a2985/templates/single-product/product-thumbnails.php#L51, and it has a different default value.

Second commit adds in a `single_product_archive_thumbnail_size` filter so the whole `woocommerce_get_product_thumbnail` function doesn't need to be overwritten.
