### PR TITLE
Allow string indexes for shipping packages

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -156,7 +156,7 @@ jQuery( function( $ ) {
 		shipping_method_selected: function( evt ) {
 			var target = evt.target;
 
-			var shipping_methods = [];
+			var shipping_methods = {};
 
 			$( 'select.shipping_method, input[name^=shipping_method][type=radio]:checked, input[name^=shipping_method][type=hidden]' ).each( function() {
 				shipping_methods[ $( target ).data( 'index' ) ] = $( target ).val();

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -249,7 +249,7 @@ jQuery( function( $ ) {
 			};
 
 			if ( false !== args.update_shipping_method ) {
-				var shipping_methods = [];
+				var shipping_methods = {};
 
 				$( 'select.shipping_method, input[name^="shipping_method"][type="radio"]:checked, input[name^="shipping_method"][type="hidden"]' ).each( function() {
 					shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();


### PR DESCRIPTION
At the moment WC is (I think unintentionally) enforcing shipping package indexes to be integers.

This is because the JavaScript used in the cart/checkout ajax which grabs the shipping methods uses an array to store the values, rather than an object, and JavaScript arrays can not have string indexes.

This patch changes the `shipping_methods` object type to be an array.

The reason string keys are handy is because with Subscriptions, we sometimes need to allow customers to choose recurring shipping method/s as well as shipping method/s on the initial order (e.g. https://cloudup.com/cW_EhXtJBzR). Because WC allows for multiple different packages, we also need to account for that and need to prefix our shipping methods with something unique enough that having multiple packages won't conflict with it. A string key for that helps a lot. 
