### PR TITLE
Create base order func

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -439,7 +439,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				'customer_id'   => $request['customer_id'],
 				'customer_note' => $request['customer_note'],
 				'created_via'   => 'rest-api',
-			) );
+			), $request );
 
 			if ( is_wp_error( $order ) ) {
 				throw new WC_REST_Exception( 'woocommerce_rest_cannot_create_order', sprintf( __( 'Cannot create order: %s.', 'woocommerce' ), implode( ', ', $order->get_error_messages() ) ), 400 );
@@ -1724,9 +1724,10 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 	 *
 	 * @since 2.6
 	 * @param array $args
+	 * @param array $data
 	 * @return WC_Order
 	 */
-	protected function create_base_order( $args ) {
+	protected function create_base_order( $args, $data ) {
 		return wc_create_order( $args );
 	}
 }

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -434,7 +434,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id',__( 'Customer ID is invalid.', 'woocommerce' ), 400 );
 			}
 
-			$order = wc_create_order( array(
+			$order = $this->create_base_order( array(
 				'status'        => $request['status'],
 				'customer_id'   => $request['customer_id'],
 				'customer_note' => $request['customer_note'],
@@ -1717,5 +1717,16 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Create base WC Order object.
+	 *
+	 * @since 2.6
+	 * @param array $args
+	 * @return WC_Order
+	 */
+	protected function create_base_order( $args ) {
+		return wc_create_order( $args );
 	}
 }


### PR DESCRIPTION
Similar patches were made to the previous wc-api: https://github.com/woothemes/woocommerce/pull/7303 and https://github.com/woothemes/woocommerce/pull/7280.

These changes are mostly to avoid having to rewrite the `create_order()` function custom order types (i.e. Subscriptions) when creating our own endpoints.
