### PR TITLE
[2.6] The woocommerce_variation_prices filter does not run for hash/values pairs loaded from the transient other than the requested one

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -258,15 +258,15 @@ class WC_Product_Variable extends WC_Product {
 		if ( empty( $this->prices_array[ $price_hash ] ) ) {
 
 			// Get value of transient
-			$this->prices_array = array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) );
+			$prices_array = array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) );
 
 			// If the product version has changed, reset cache
-			if ( empty( $this->prices_array['version'] ) || $this->prices_array['version'] !== WC_Cache_Helper::get_transient_version( 'product' ) ) {
+			if ( empty( $prices_array['version'] ) || $prices_array['version'] !== WC_Cache_Helper::get_transient_version( 'product' ) ) {
 				$this->prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
 			}
 
 			// If the prices are not stored for this hash, generate them
-			if ( empty( $this->prices_array[ $price_hash ] ) ) {
+			if ( empty( $prices_array[ $price_hash ] ) ) {
 				$prices         = array();
 				$regular_prices = array();
 				$sale_prices    = array();
@@ -311,19 +311,19 @@ class WC_Product_Variable extends WC_Product {
 				asort( $regular_prices );
 				asort( $sale_prices );
 
-				$this->prices_array[ $price_hash ] = array(
+				$prices_array[ $price_hash ] = array(
 					'price'         => $prices,
 					'regular_price' => $regular_prices,
 					'sale_price'    => $sale_prices,
 				);
 
-				set_transient( $transient_name, json_encode( $this->prices_array ), DAY_IN_SECONDS * 30 );
+				set_transient( $transient_name, json_encode( $prices_array ), DAY_IN_SECONDS * 30 );
 			}
 
 			/**
 			 * Give plugins one last chance to filter the variation prices array which has been generated.
 			 */
-			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $this->prices_array[ $price_hash ], $this, $display );
+			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $prices_array[ $price_hash ], $this, $display );
 		}
 
 		/**


### PR DESCRIPTION
When calling `get_variation_prices`, the current logic:
- Generates a unique hash based on a number of parameters.
- Attempts to find if a set of prices matching the generated hash is already stored in the `prices_array` property.
- If the key exists, the matched set is simply returned as is. If not, the generated hash is then searched in the `wc_var_prices_` transient and at the same time, the entire transient content is copied into the `prices_array` property.
- If found in the transient, the set of prices matching the generated hash is passed through the `woocommerce_variation_prices` and returned. If not, the required values are slowly retrieved, then the transient updated with the generated hash/values pair, and then the requested set passed through the `woocommerce_variation_prices` and returned.

The issue in this logic is that regardless of the generated hash, the **entire transient content is always copied into the `prices_array` property**. The implication here is that the `woocommerce_variation_prices` filter is only called for the first hash/values pair loaded from the transient. If an other hash/values pair is requested later that existed in the transient, its content will not be passed through the `woocommerce_variation_prices` filter since it has already been copied in the `prices_array` property. 

As a result, there might be cases where hashed prices that exist in the transient will not be passed through the `woocommerce_variation_prices` filter, although they should be expected to. Only the first matched set of hashed values is always/successfully passed through the filter.

**To reproduce**:
- Create a variable product, add some variations, save and view the product.
- Create a `woocommerce_variation_prices` filter that modifies variation prices.
- Instantiate the variable product in code.
- Examine a var dump of `get_variation_prices( true )` followed by `get_variation_prices( false )`.

**Example:**

```
add_action( 'init', 'wc_test_variable_bug', 100 );

function wc_test_variable_bug() {

    add_filter( 'woocommerce_variation_prices', 'wc_test_filter_get_variation_prices', 10, 3 );

    $product = wc_get_product( 3484 );

    $x = $product->get_variation_prices( true );
    var_dump( $product );
    $y = $product->get_variation_prices( false );
    var_dump( $x );
    var_dump( $y );
}


function wc_test_filter_get_variation_prices( $prices_array, $product, $display ) {

    $prices         = array();
    $regular_prices = array();
    $sale_prices    = array();

    $variation_ids  = array_keys( $prices_array[ 'price' ] );

    foreach ( $variation_ids as $variation_id ) {
        $prices[ $variation_id ]         = $prices_array[ 'price' ][ $variation_id  ] / 2.0;
        $regular_prices[ $variation_id ] = $prices_array[ 'regular_price' ][ $variation_id  ] / 2.0;
        $sale_prices[ $variation_id ]    = $prices_array[ 'sale_price' ][ $variation_id  ] / 2.0;
    }

    asort( $prices );
    asort( $regular_prices );
    asort( $sale_prices );

    $prices_array = array(
        'price'         => $prices,
        'regular_price' => $regular_prices,
        'sale_price'    => $sale_prices
    );

    return $prices_array;
}
```

**Sample Output (Bugged):**

Issue: The `f9e544f77b7eac7add281ef28ca5559f`-hashed prices array values (correspond to `get_variation_prices( false )`) are loaded into the `prices_array` property when populating variable `$x` (`get_variation_prices( true )`). Once they are loaded, they can no longer be passed through the `woocommerce_variation_prices` filter, as the dump of variable `$y` shows, which should be identical to `$x` (taxes disabled):

Product dump:

```
object(WC_Product_Variable)[276]
  public 'children' => null
  private 'prices_array' => 
    array (size=3)
      'version' => string '1464125771' (length=10)
      'f9e544f77b7eac7add281ef28ca5559f' => 
        array (size=3)
          'price' => 
            array (size=3)
              3487 => string '5' (length=1)
              3486 => string '5' (length=1)
              3485 => string '8' (length=1)
          'regular_price' => 
            array (size=3)
              3487 => string '5' (length=1)
              3486 => string '5' (length=1)
              3485 => string '8' (length=1)
          'sale_price' => 
            array (size=3)
              3487 => string '5' (length=1)
              3486 => string '5' (length=1)
              3485 => string '8' (length=1)
      '66c1c28941d8973e9e3dd1da89b301ad' => 
        array (size=3)
          'price' => 
            array (size=3)
              3487 => float 2.5
              3486 => float 2.5
              3485 => float 4
          'regular_price' => 
            array (size=3)
              3487 => float 2.5
              3486 => float 2.5
              3485 => float 4
          'sale_price' => 
            array (size=3)
              3487 => float 2.5
              3486 => float 2.5
              3485 => float 4
  public 'id' => int 3484
  public 'post' => 
    object(WP_Post)[277]
      [...]
  public 'product_type' => string 'variable' (length=8)
  protected 'shipping_class' => string '' (length=0)
  protected 'shipping_class_id' => int 0
  public 'total_stock' => null
  protected 'supports' => 
    array (size=0)
      empty
```

`$x` dump:

```
array (size=3)
  'price' => 
    array (size=3)
      3487 => float 2.5
      3486 => float 2.5
      3485 => float 4
  'regular_price' => 
    array (size=3)
      3487 => float 2.5
      3486 => float 2.5
      3485 => float 4
  'sale_price' => 
    array (size=3)
      3487 => float 2.5
      3486 => float 2.5
      3485 => float 4
```

`$y` dump:

```
array (size=3)
  'price' => 
    array (size=3)
      3487 => string '5' (length=1)
      3486 => string '5' (length=1)
      3485 => string '8' (length=1)
  'regular_price' => 
    array (size=3)
      3487 => string '5' (length=1)
      3486 => string '5' (length=1)
      3485 => string '8' (length=1)
  'sale_price' => 
    array (size=3)
      3487 => string '5' (length=1)
      3486 => string '5' (length=1)
      3485 => string '8' (length=1)
```

**Sample Output (Fixed):**

Product dump:

```
object(WC_Product_Variable)[276]
  public 'children' => null
  private 'prices_array' => 
    array (size=1)
      '66c1c28941d8973e9e3dd1da89b301ad' => 
        array (size=3)
          'price' => 
            array (size=3)
              3487 => float 2.5
              3486 => float 2.5
              3485 => float 4
          'regular_price' => 
            array (size=3)
              3487 => float 2.5
              3486 => float 2.5
              3485 => float 4
          'sale_price' => 
            array (size=3)
              3487 => float 2.5
              3486 => float 2.5
              3485 => float 4
  public 'id' => int 3484
  public 'post' => 
    object(WP_Post)[277]
      [...]
  public 'product_type' => string 'variable' (length=8)
  protected 'shipping_class' => string '' (length=0)
  protected 'shipping_class_id' => int 0
  public 'total_stock' => null
  protected 'supports' => 
    array (size=0)
      empty
```

`$y` dump same as `$y`:

```
array (size=3)
  'price' => 
    array (size=3)
      3487 => float 2.5
      3486 => float 2.5
      3485 => float 4
  'regular_price' => 
    array (size=3)
      3487 => float 2.5
      3486 => float 2.5
      3485 => float 4
  'sale_price' => 
    array (size=3)
      3487 => float 2.5
      3486 => float 2.5
      3485 => float 4
```

**Comments**

The downside of the proposed change is that the transient will need to be fetched + searched every time a hash/values pair is not found in the `prices_array` property. I don't see any big issue with this.
