### PR TITLE
Use function argument as default filter value for single_product_archive_thumbnail_size

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -728,16 +728,16 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	 */
 	function woocommerce_get_product_thumbnail( $size = 'shop_catalog', $deprecated1 = 0, $deprecated2 = 0 ) {
 		global $post;
-		$size = apply_filters( 'single_product_archive_thumbnail_size', 'shop_catalog' );
+		$image_size = apply_filters( 'single_product_archive_thumbnail_size', $size );
 
 		if ( has_post_thumbnail() ) {
 			$props = wc_get_product_attachment_props( get_post_thumbnail_id(), $post );
-			return get_the_post_thumbnail( $post->ID, $size, array(
+			return get_the_post_thumbnail( $post->ID, $image_size, array(
 				'title'	 => $props['title'],
 				'alt'    => $props['alt'],
 			) );
 		} elseif ( wc_placeholder_img_src() ) {
-			return wc_placeholder_img( $size );
+			return wc_placeholder_img( $image_size );
 		}
 	}
 }


### PR DESCRIPTION
Even though core never uses the $size argument in woocommerce_get_product_thumbnail(), it's probably best not to override it incase somebody is using the woocommerce_template_loop_product_thumbnail() function with the $size arg in the theme.
