### PR TITLE
Fix {$taxonomy}_pre_add_form hook for attributes

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -42,8 +42,8 @@ class WC_Admin_Taxonomies {
 		$attribute_taxonomies = wc_get_attribute_taxonomies();
 
 		if ( $attribute_taxonomies ) {
-			foreach ( array_keys( $attribute_taxonomies ) as $attribute ) {
-				add_action( $attribute . '_pre_add_form', array( $this, 'product_attribute_description' ) );
+			foreach ( $attribute_taxonomies as $attribute ) {
+				add_action( 'pa_' . $attribute->attribute_name . '_pre_add_form', array( $this, 'product_attribute_description' ) );
 			}
 		}
 


### PR DESCRIPTION
previous `{$taxonomy}_pre_add_form` hook inside of `wc_get_attribute_taxonomies()` loop was not written to work with the results of `wc_get_attribute_taxonomies()`. Before this fix the product_attribute_description() function ( "Attribute terms can be assigned to products and variations...." ) was not printing on the attributes edit-tags.php screen.

`commit 1e5785da3f6ab7ac31d01d6cd67aaff7157fa7fe`
