### PR TITLE
Use hook to include navigation.php template

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2091,6 +2091,16 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 	}
 }
 
+if ( ! function_exists( 'woocommerce_account_navigation' ) ) {
+
+	/**
+	 * My Account navigation template.
+	 */
+	function woocommerce_account_navigation() {
+		wc_get_template( 'myaccount/navigation.php' );
+	}
+}
+
 if ( ! function_exists( 'woocommerce_account_orders' ) ) {
 
 	/**

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -256,6 +256,7 @@ add_filter( 'jetpack_comment_form_enabled_for_product', '__return_false' );
 /**
  * My Account.
  */
+add_action( 'woocommerce_account_navigation', 'woocommerce_account_navigation' );
 add_action( 'woocommerce_account_orders_endpoint', 'woocommerce_account_orders' );
 add_action( 'woocommerce_account_view-order_endpoint', 'woocommerce_account_view_order' );
 add_action( 'woocommerce_account_downloads_endpoint', 'woocommerce_account_downloads' );

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -25,9 +25,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 $downloads     = WC()->customer->get_downloadable_products();
 $has_downloads = (bool) $downloads;
 
-wc_print_notices(); ?>
+wc_print_notices();
 
-<?php wc_get_template( 'myaccount/navigation.php' ); ?>
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -20,7 +20,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-wc_get_template( 'myaccount/navigation.php' ); ?>
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 	<?php if ( $available_gateways = WC()->payment_gateways->get_available_payment_gateways() ) : ?>

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -22,7 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 wc_print_notices();
 
-wc_get_template( 'myaccount/navigation.php' ); ?>
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 

--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -24,7 +24,12 @@ $page_title = ( $load_address === 'billing' ) ? __( 'Billing Address', 'woocomme
 
 wc_print_notices();
 
-wc_get_template( 'myaccount/navigation.php' ); ?>
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 

--- a/templates/myaccount/my-account.php
+++ b/templates/myaccount/my-account.php
@@ -20,9 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-wc_print_notices(); ?>
+wc_print_notices();
 
-<?php wc_get_template( 'myaccount/navigation.php' ); ?>
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 	<p>

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -23,7 +23,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 wc_print_notices();
-wc_get_template( 'myaccount/navigation.php' ); ?>
+
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -25,9 +25,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 $saved_methods = wc_get_customer_saved_methods_list( get_current_user_id() );
 $has_methods   = (bool) $saved_methods;
 $types         = wc_get_account_payment_methods_types();
-wc_print_notices(); ?>
 
-<?php wc_get_template( 'myaccount/navigation.php' ); ?>
+wc_print_notices();
+
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -22,9 +22,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-wc_print_notices(); ?>
+wc_print_notices();
 
-<?php wc_get_template( 'myaccount/navigation.php' ); ?>
+/**
+ * My Account navigation.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_account_navigation' ); ?>
 
 <div class="woocommerce-MyAccount-content">
 	<p><?php


### PR DESCRIPTION
It's more useful if you could include navigation.php template into an hook, as done for all templates of plugin. So any other developer could remove navigation and overwrite it with own or add something near navigation.
