### PR TITLE
Fix customer logout endpoint handling

### DIFF
--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -120,7 +120,9 @@ function wc_nav_menu_items( $items ) {
 
 		if ( ! empty( $customer_logout ) ) {
 			foreach ( $items as $key => $item ) {
-				if ( strstr( $item->url, $customer_logout ) ) {
+				$path = parse_url( $item->url, PHP_URL_PATH );
+				$query = parse_url( $item->url, PHP_URL_QUERY );
+				if ( strstr( $path, $customer_logout ) || strstr( $query, $customer_logout ) ) {
 					unset( $items[ $key ] );
 				}
 			}


### PR DESCRIPTION
Ref: 424337-zd-woothemes

This is my attempt to fix the following issue.

Website URL: `http://nicola.com`
Customer logout endpoint: `nicola`

If for any reason, the `customer-logout` endpoint is contained in the main domain, that would trigger the function always when not being logged in, which results in the defined menu to not show at all because all items are removed.

My PR checks for the endpoint only in the PATH and QUERY part of the URL, so the main domain is ignored. This allows users to have a logout endpoint which includes the domain name: `http://nicola.com/nicola`
