### PR TITLE
[ISO_3166-1]'Western Samoa' should be 'Samoa', #11017

### DIFF
--- a/i18n/countries.php
+++ b/i18n/countries.php
@@ -261,7 +261,7 @@ return array(
 	'VN' => __( 'Vietnam', 'woocommerce' ),
 	'WF' => __( 'Wallis and Futuna', 'woocommerce' ),
 	'EH' => __( 'Western Sahara', 'woocommerce' ),
-	'WS' => __( 'Western Samoa', 'woocommerce' ),
+	'WS' => __( 'Samoa', 'woocommerce' ),
 	'YE' => __( 'Yemen', 'woocommerce' ),
 	'ZM' => __( 'Zambia', 'woocommerce' ),
 	'ZW' => __( 'Zimbabwe', 'woocommerce' )


### PR DESCRIPTION
Fix following issue.
https://github.com/woothemes/woocommerce/issues/11017
