### PR TITLE
[2.6] Add 'woocommerce_admin_stock_html' filter

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -397,16 +397,19 @@ class WC_Admin_Post_Types {
 				echo '</a>';
 				break;
 			case 'is_in_stock' :
+
 				if ( $the_product->is_in_stock() ) {
-					echo '<mark class="instock">' . __( 'In stock', 'woocommerce' ) . '</mark>';
+					$stock_html = '<mark class="instock">' . __( 'In stock', 'woocommerce' ) . '</mark>';
 				} else {
-					echo '<mark class="outofstock">' . __( 'Out of stock', 'woocommerce' ) . '</mark>';
+					$stock_html = '<mark class="outofstock">' . __( 'Out of stock', 'woocommerce' ) . '</mark>';
 				}
 
 				// If the product has children, a single stock level would be misleading as some could be -ve and some +ve, some managed/some unmanaged etc so hide stock level in this case.
 				if ( $the_product->managing_stock() && ! sizeof( $the_product->get_children() ) ) {
-					echo ' (' . $the_product->get_total_stock() . ')';
+					$stock_html .= ' (' . $the_product->get_total_stock() . ')';
 				}
+
+				echo apply_filters( 'woocommerce_admin_stock_html', $stock_html, $the_product );
 
 				break;
 			default :

--- a/includes/admin/reports/class-wc-report-stock.php
+++ b/includes/admin/reports/class-wc-report-stock.php
@@ -112,10 +112,11 @@ class WC_Report_Stock extends WP_List_Table {
 
 			case 'stock_status' :
 				if ( $product->is_in_stock() ) {
-					echo '<mark class="instock">' . __( 'In stock', 'woocommerce' ) . '</mark>';
+					$stock_html = '<mark class="instock">' . __( 'In stock', 'woocommerce' ) . '</mark>';
 				} else {
-					echo '<mark class="outofstock">' . __( 'Out of stock', 'woocommerce' ) . '</mark>';
+					$stock_html = '<mark class="outofstock">' . __( 'Out of stock', 'woocommerce' ) . '</mark>';
 				}
+				echo apply_filters( 'woocommerce_admin_stock_html', $stock_html, $product );
 			break;
 
 			case 'stock_level' :


### PR DESCRIPTION
Hope there's still time to review this before RC1.

There is sometimes a need to filter the availability html of a product on the admin side, and it seems that (probably for performance reasons, among others?), this markup is not rendered using `$product->get_availability()`, but relies on a less expensive `->is_in_stock()` call.

This PR adds a `woocommerce_admin_stock_html` filter wrapped around the markup, which can be used to display additional / more detailed information, when needed.

Alternatively, we could consider using the existing front-end approach to generate this markup in the admin area (?).

I could only find these two places where availability html is displayed in the admin area - not sure if there are more that I missed.
