### PR TITLE
Only remove comments button on product embeds

### DIFF
--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -32,13 +32,24 @@ class WC_Embed {
 		add_filter( 'the_excerpt_embed', array( __CLASS__, 'the_excerpt' ), 10 );
 
 		// Make sure no comments display. Doesn't make sense for products.
-		remove_action( 'embed_content_meta', 'print_embed_comments_button' );
+		add_action( 'embed_content_meta', array( __CLASS__, 'remove_comments_button' ), 5 );
 
 		// In the comments place let's display the product rating.
 		add_action( 'embed_content_meta', array( __CLASS__, 'get_ratings' ), 5 );
 
 		// Add some basic styles.
 		add_action( 'embed_head', array( __CLASS__, 'print_embed_styles' ) );
+	}
+	
+	/**
+	 * Remove comments button on product embeds.
+	 * 
+	 * @since 2.5.6
+	 */
+	public static function remove_comments_button() {
+		if (is_product()) {
+			remove_action('embed_content_meta', 'print_embed_comments_button');
+		}
 	}
 
 	/**


### PR DESCRIPTION
I noticed that my post and other custom post type's embeds doesn't show a comments button. I checked and found this issue.
