### PR TITLE
Pass heading product title tag to the the_title function

### DIFF
--- a/templates/single-product/title.php
+++ b/templates/single-product/title.php
@@ -10,15 +10,14 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woothemes.com/document/template-structure/
- * @author  WooThemes
- * @package WooCommerce/Templates
- * @version 1.6.4
+ * @see        https://docs.woothemes.com/document/template-structure/
+ * @author     WooThemes
+ * @package    WooCommerce/Templates
+ * @version    1.6.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
-?>
-<h1 itemprop="name" class="product_title entry-title"><?php the_title(); ?></h1>
+the_title( '<h1 itemprop="name" class="product_title entry-title">', '</h1>' );


### PR DESCRIPTION
Passing the heading tag as parameter for the_title able users to filter the title
by using 'the_title' filter, in this way we can for example hide the title product
without output the empty heading tag.
