### PR TITLE
Add filters in attribute selection UI (html-product-attribute.php)

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -29,10 +29,14 @@
 
 								<select multiple="multiple" data-placeholder="<?php esc_attr_e( 'Select terms', 'woocommerce' ); ?>" class="multiselect attribute_values wc-enhanced-select" name="attribute_values[<?php echo $i; ?>][]">
 									<?php
-									$all_terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
+									$args = array(
+										'orderby'    => 'name',
+										'hide_empty' => 0
+									);
+									$all_terms = get_terms( $taxonomy, apply_filters( 'woocommerce_product_attribute_terms', $args ) );
 									if ( $all_terms ) {
 										foreach ( $all_terms as $term ) {
-											echo '<option value="' . esc_attr( $term->slug ) . '" ' . selected( has_term( absint( $term->term_id ), $taxonomy, $thepostid ), true, false ) . '>' . $term->name . '</option>';
+											echo '<option value="' . esc_attr( $term->slug ) . '" ' . selected( has_term( absint( $term->term_id ), $taxonomy, $thepostid ), true, false ) . '>' . esc_attr( apply_filters( 'woocommerce_product_attribute_term_name', $term->name, $term ) ) . '</option>';
 										}
 									}
 									?>


### PR DESCRIPTION
Hi!

I made a request for couple of filters in attribute selection UI in WordPress.org (https://wordpress.org/support/topic/filter-request-attribute-select-in-html-product-attributephp) and was guided to make a pull request here.

I added two filters:
1. Attributes get_terms arguments
2. Attribute name (+ escaping with esc_attr)

Use cases:
1. Multilingual filtering (show attributes only in current language), exclude or include terms based on custom logic
2. Adding information for the name like count, language, parent name

Possible problems:
1. "Fields" argument shouldn't probably be messed with. We could force it to be what it is by overriding it after filter. 
2. I solved HTML/JS injection with esc_attr so nothing here

Originally, I wanted to pass the product id for the filters but then I realised that there is no way to do this when creating a new product (or any post in general).
