### PR TITLE
Remove unsupported versions of WordPress from Travis CI build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,6 @@ matrix:
   include:
   - php: 5.6
     env: WP_VERSION=latest WP_MULTISITE=1
-  - php: 5.6
-    env: WP_VERSION=4.3 WP_MULTISITE=0
-  - php: 5.6
-    env: WP_VERSION=4.2 WP_MULTISITE=0
-  - php: 5.6
-    env: WP_VERSION=4.1 WP_MULTISITE=0
 
 before_script:
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION


### PR DESCRIPTION
At the time of this commit, `latest` and the minimum supported version of `4.4` are one in the same.
