### PR TITLE
Incorect code causing zero impact

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -267,9 +267,6 @@ class WC_Shortcodes {
 
 		ob_start();
 
-		// Reset loop/columns globals when starting a new loop
-		$woocommerce_loop['loop'] = $woocommerce_loop['column'] = '';
-
 		if ( $product_categories ) {
 			woocommerce_product_loop_start();
 


### PR DESCRIPTION
- Global variable `$woocommerce_loop` should not be reset before starting the loop. 
- Only the `loop` index should be set to 0 which is done in `woocommerce_product_loop_start`. Hence `$woocommerce_loop['loop'] = ''` has no use.
- `$woocommerce['columns']` which is incorrectly set as `column` , if reset will not display the `first` and `last` clases for display no. of columns.
