### PR TITLE
Add 'updated_cart_totals' JS trigger

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -269,6 +269,7 @@ jQuery( function( $ ) {
 				dataType: 'html',
 				success: function( response ) {
 					$( 'div.cart_totals' ).replaceWith( response );
+					$( document.body ).trigger( 'updated_cart_totals' );
 				}
 			} );
 		},


### PR DESCRIPTION
A similar trigger is available in the checkout, but not in the cart.

In my scenario I'd like to do a check/action when the cart totals (shipping rates) are loaded.
