### PR TITLE
Adding extra filters and hooks

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -120,6 +120,10 @@ if ( wc_tax_enabled() ) {
 	<button type="button" class="button bulk-delete-items"><?php _e( 'Delete selected row(s)', 'woocommerce' ); ?></button>
 	<button type="button" class="button bulk-decrease-stock"><?php _e( 'Reduce stock', 'woocommerce' ); ?></button>
 	<button type="button" class="button bulk-increase-stock"><?php _e( 'Increase stock', 'woocommerce' ); ?></button>
+	<?php
+		// allow adding custom bulk action buttons
+		do_action( 'woocommerce_order_item_add_bulk_action_buttons', $order );
+	?>	
 </div>
 <div class="wc-order-data-row wc-order-totals-items wc-order-items-editable">
 	<?php

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -396,7 +396,7 @@ class WC_Product_Variation extends WC_Product {
 	 * @return int
 	 */
 	public function get_stock_quantity() {
-		return apply_filters( 'woocommerce_get_stock_quantity', $this->managing_stock() ? wc_stock_amount( $this->stock ) : $this->parent->get_stock_quantity(), $this );
+		return apply_filters( 'woocommerce_get_variation_stock_quantity', $this->managing_stock() ? wc_stock_amount( $this->stock ) : $this->parent->get_stock_quantity(), $this );
 	}
 
 	/**

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -396,7 +396,7 @@ class WC_Product_Variation extends WC_Product {
 	 * @return int
 	 */
 	public function get_stock_quantity() {
-		return true === $this->managing_stock() ? wc_stock_amount( $this->stock ) : $this->parent->get_stock_quantity();
+		return apply_filters( 'woocommerce_get_stock_quantity', $this->managing_stock() ? wc_stock_amount( $this->stock ) : $this->parent->get_stock_quantity(), $this );
 	}
 
 	/**


### PR DESCRIPTION
Within abstract-wc-product.php there is the filter `woocommerce_get_stock_quantity` when calling the `get_stock_quantity()` function.
But there is no such filter for variable products when calling the class `get_stock_quantity()` function in class-wc-product-variation.php
Can the same filter be used for variations as well so we can check the object type ('simple' || 'variation') when calling this filter.
