### PR TITLE
Update wc_product_post_class function

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -283,7 +283,7 @@ function wc_get_product_cat_class( $class = '', $category = null ) {
  * @return array
  */
 function wc_product_post_class( $classes, $class = '', $post_id = '' ) {
-	if ( ! $post_id || 'product' !== get_post_type( $post_id ) ) {
+	if ( ! $post_id || !in_array(get_post_type( $post_id ), apply_filters('product_post_class_post_types', array('product'))) ) {
 		return $classes;
 	}
 


### PR DESCRIPTION
I have a popular premium plugin for displaying product variations in the product loop. This check stops the first/last classes being added via the wc_get_loop_class() function, thus breaking the layout.

I propose adding a filter here so I, and others, can check the post type against custom values.
