### PR TITLE
Helpers for filter counts

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -352,8 +352,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$tax_query      = new WP_Tax_Query( $tax_query );
 		$meta_query_sql = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
 		$tax_query_sql  = $tax_query->get_sql( $wpdb->posts, 'ID' );
-		$post_type      = !is_array( $wp_the_query->query_vars['post_type'] ) ? array( $wp_the_query->query_vars['post_type'] ) : $wp_the_query->query_vars['post_type'];
-		$where          = apply_filters('woocommerce_filtered_term_product_counts_where_clause', "WHERE {$wpdb->posts}.post_type IN ('" . implode("','", array_map( 'esc_sql', $post_type )) . "') AND {$wpdb->posts}.post_status = 'publish'");
+		$post_type      = is_array( $wp_the_query->query_vars['post_type'] ) ? $wp_the_query->query_vars['post_type'] : array( $wp_the_query->query_vars['post_type'] );
+        $where          = apply_filters( 'woocommerce_get_filtered_term_product_counts_query_where', "WHERE {$wpdb->posts}.post_type IN ('" . implode("','", array_map( 'esc_sql', $post_type )) . "') AND {$wpdb->posts}.post_status = 'publish'", $term_ids, $taxonomy, $query_type );
 
 		$sql  = "
 			SELECT COUNT( {$wpdb->posts}.ID ) as term_count, term_count_relationships.term_taxonomy_id as term_count_id FROM {$wpdb->posts}

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -353,7 +353,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$meta_query_sql = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
 		$tax_query_sql  = $tax_query->get_sql( $wpdb->posts, 'ID' );
 		$post_type      = is_array( $wp_the_query->query_vars['post_type'] ) ? $wp_the_query->query_vars['post_type'] : array( $wp_the_query->query_vars['post_type'] );
-        $where          = apply_filters( 'woocommerce_get_filtered_term_product_counts_query_where', "WHERE {$wpdb->posts}.post_type IN ('" . implode("','", array_map( 'esc_sql', $post_type )) . "') AND {$wpdb->posts}.post_status = 'publish'", $term_ids, $taxonomy, $query_type );
+		$where          = apply_filters( 'woocommerce_get_filtered_term_product_counts_query_where', "WHERE {$wpdb->posts}.post_type IN ('" . implode("','", array_map( 'esc_sql', $post_type )) . "') AND {$wpdb->posts}.post_status = 'publish'", $term_ids, $taxonomy, $query_type );
 
 		$sql  = "
 			SELECT COUNT( {$wpdb->posts}.ID ) as term_count, term_count_relationships.term_taxonomy_id as term_count_id FROM {$wpdb->posts}

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -335,7 +335,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 	 * @return array
 	 */
 	protected function get_filtered_term_product_counts( $term_ids, $taxonomy, $query_type ) {
-		global $wpdb;
+		global $wpdb, $wp_the_query;
 
 		$tax_query  = WC_Query::get_main_tax_query();
 		$meta_query = WC_Query::get_main_meta_query();
@@ -352,12 +352,14 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$tax_query      = new WP_Tax_Query( $tax_query );
 		$meta_query_sql = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
 		$tax_query_sql  = $tax_query->get_sql( $wpdb->posts, 'ID' );
+		$post_type      = (array)$wp_the_query->query_vars['post_type'];
+		$where          = "WHERE {$wpdb->posts}.post_type IN ('" . implode("','", $post_type) . "') AND {$wpdb->posts}.post_status = 'publish'";
 
 		$sql  = "
 			SELECT COUNT( {$wpdb->posts}.ID ) as term_count, term_count_relationships.term_taxonomy_id as term_count_id FROM {$wpdb->posts}
 			INNER JOIN {$wpdb->term_relationships} AS term_count_relationships ON ({$wpdb->posts}.ID = term_count_relationships.object_id)
 			" . $tax_query_sql['join'] . $meta_query_sql['join'] . "
-			WHERE {$wpdb->posts}.post_type = 'product' AND {$wpdb->posts}.post_status = 'publish'
+			" . apply_filters('woocommerce_filtered_term_product_counts_where_clause', $where ) . "
 			" . $tax_query_sql['where'] . $meta_query_sql['where'] . "
 			AND term_count_relationships.term_taxonomy_id IN (" . implode( ',', array_map( 'absint', $term_ids ) ) . ")
 			GROUP BY term_count_relationships.term_taxonomy_id;


### PR DESCRIPTION
I've done 2 things here (as per our conversations earlier today):
1. Made it use the post_types set in the main query.
2. Added a filter to the "where" clause. This means I can hook in and add and additional parameter to the where clause to exclude specific posts.

Doing the above has fixed any filter count issues I have, seemingly. I'd really appreciate it if we can do this (or similar).
