### PR TITLE
Add Filters For Product Lists in Widgets

### DIFF
--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -75,14 +75,14 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 
 			$this->widget_start( $args, $instance );
 
-			echo '<ul class="product_list_widget">';
+			echo apply_filters( 'woocommerce_before_widget_product_list', '<ul class="product_list_widget">' );
 
 			while ( $r->have_posts() ) {
 				$r->the_post();
 				wc_get_template( 'content-widget-product.php' );
 			}
 
-			echo '</ul>';
+			echo apply_filters( 'woocommerce_after_widget_product_list', '</ul>' );
 
 			$this->widget_end( $args );
 		}

--- a/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/includes/widgets/class-wc-widget-top-rated-products.php
@@ -74,14 +74,14 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 
 			$this->widget_start( $args, $instance );
 
-			echo '<ul class="product_list_widget">';
+			echo apply_filters( 'woocommerce_before_widget_product_list', '<ul class="product_list_widget">' );
 
 			while ( $r->have_posts() ) {
 				$r->the_post();
 				wc_get_template( 'content-widget-product.php', array( 'show_rating' => true ) );
 			}
 
-			echo '</ul>';
+			echo apply_filters( 'woocommerce_after_widget_product_list', '</ul>' );
 
 			$this->widget_end( $args );
 		}


### PR DESCRIPTION
Came across inconsistency with how product lists are generated. `WC_Widget_Product` provides filters for the opening and closing product list but `WC_Widget_Recently_Viewed` and `WC_Widget_Top_Rated_Products` do not.
