### PR TITLE
Allow top level endpoints only when using a page on the  front end

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -131,11 +131,33 @@ class WC_Query {
 	}
 
 	/**
+	 * Endpoint mask describing the places the endpoint should be added.
+	 *
+	 * @since 2.6.2
+	 * @return int
+	 */
+	protected function get_endpoints_mask() {
+		if ( 'page' === get_option( 'show_on_front' ) ) {
+			$page_on_front     = get_option( 'page_on_front' );
+			$myaccount_page_id = get_option( 'woocommerce_myaccount_page_id' );
+			$checkout_page_id  = get_option( 'woocommerce_checkout_page_id' );
+
+			if ( in_array( $page_on_front, array( $myaccount_page_id, $checkout_page_id ) ) ) {
+				return EP_ROOT | EP_PAGES;
+			}
+		}
+
+		return EP_PAGES;
+	}
+
+	/**
 	 * Add endpoints for query vars.
 	 */
 	public function add_endpoints() {
+		$mask = $this->get_endpoints_mask();
+
 		foreach ( $this->query_vars as $key => $var ) {
-			add_rewrite_endpoint( $var, EP_ROOT | EP_PAGES );
+			add_rewrite_endpoint( $var, $mask );
 		}
 	}
 


### PR DESCRIPTION
This prevents conflicts when having pages with the same name than endpoints.
