### PR TITLE
Shows the "customer pay page" link for any order that needs payment

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -201,7 +201,7 @@ class WC_Meta_Box_Order_Data {
 						</p>
 
 						<p class="form-field form-field-wide wc-order-status"><label for="order_status"><?php _e( 'Order status:', 'woocommerce' ) ?> <?php
-							if ( $order->has_status( 'pending' ) ) {
+							if ( $order->needs_payment() ) {
 								printf( '<a href="%s">%s &rarr;</a>',
 									esc_url( $order->get_checkout_payment_url() ),
 									__( 'Customer payment page', 'woocommerce' )


### PR DESCRIPTION
Devs can filter which orders need payment for the "pay" link in the customer account, but can't show that link in "View Order". This commit changes the hardcoded check for `pending` status to see if the order needs payment instead.
