### PR TITLE
Fix 'Undefined offset: 0' notice

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -336,7 +336,7 @@ class WC_Emails {
 			'orderNumber'    => strval( $order->get_order_number() ),
 			'priceCurrency'  => $order->get_order_currency(),
 			'price'          => $order->get_total(),
-			'acceptedOffer'  => count( $accepted_offers ) > 1 ? $accepted_offers : $accepted_offers[0],
+			'acceptedOffer'  => $accepted_offers,
 			'url'            => $order->get_view_order_url(),
 		);
 


### PR DESCRIPTION
SHA: f0d3162c1a87d6 changed the logic when setting `acceptedOffer` to use `$accepted_offers[0]` if the `$accepted_offers` array had less than one element (which means `$accepted_offers[0]` wouldn't actually be set).

With this patch, `acceptedOffer` will now be an empty array if there are no values in `$accepted_offers`. I'm not sure whether that is the correct default for the Order email schema though?

I'm also not sure how possible it is for `$accepted_offers` to end up empty in real usage because it would require either no items on an order or for all items to be marked as invisible via the `'woocommerce_order_item_visible'` filter. I encountered the notice while running unit tests.
