### PR TITLE
Function to check if product ID is in cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -843,6 +843,25 @@ class WC_Cart {
 		}
 
 		/**
+		 * Check if product is in the cart based on product ID.
+		 *
+		 * @param mixed $product_id - id of product to find in the cart
+		 * @return bool
+		 */
+		public function is_product_in_cart( $product_id = false ) {
+			if ( $product_id !== false ) {
+				if ( is_array( $this->cart_contents ) ) {
+					foreach ( $this->cart_contents as $cart_item_key => $cart_item ) {
+						if ( $product_id === $cart_item['product_id'] ) {
+							return true;
+						}
+					}
+				}
+			}
+			return false;
+		}
+
+		/**
 		 * Generate a unique ID for the cart item being added.
 		 *
 		 * @param int $product_id - id of the product the key is being generated for


### PR DESCRIPTION
Add a new function `is_product_in_cart()` in `WC_Cart` to check if a product is in the cart based on a product's ID, which is much more useful to a theme developer - rather than using the product's cart ID in `find_product_in_cart()`
