### PR TITLE
Fix for save card option showing for guests

### DIFF
--- a/assets/js/frontend/tokenization-form.js
+++ b/assets/js/frontend/tokenization-form.js
@@ -37,6 +37,13 @@
 
 					// Trigger change event
 					$( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', $target ).trigger( 'change' );
+
+					// Hide "save card" if "Create Account" is not checked.
+					// Check that the field is shown in the form - some plugins and force create account hide it
+					if( !$('input#createaccount').is(':checked') && $( 'input#createaccount' ).length > 0) {
+						$( '.woocommerce-SavedPaymentMethods-saveNew', $formWrap ).hide();
+      				}
+      				
 				};
 
 				this.hideForm = function() {

--- a/assets/js/frontend/tokenization-form.js
+++ b/assets/js/frontend/tokenization-form.js
@@ -39,7 +39,7 @@
 					$( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', $target ).trigger( 'change' );
 
 					// Hide "save card" if "Create Account" is not checked.
-					// Check that the field is shown in the form - some plugins and force create account hide it
+					// Check that the field is shown in the form - some plugins and force create account remove it
 					if( !$('input#createaccount').is(':checked') && $( 'input#createaccount' ).length > 0) {
 						$( '.woocommerce-SavedPaymentMethods-saveNew', $formWrap ).hide();
       				}

--- a/includes/gateways/class-wc-payment-gateway-cc.php
+++ b/includes/gateways/class-wc-payment-gateway-cc.php
@@ -18,7 +18,7 @@ class WC_Payment_Gateway_CC extends WC_Payment_Gateway {
 	 * @since 2.6.0
 	 */
 	public function payment_fields() {
-		if ( $this->supports( 'tokenization' ) && is_checkout() && is_user_logged_in() ) {
+		if ( $this->supports( 'tokenization' ) && is_checkout() ) {
 			$this->tokenization_script();
 			$this->saved_payment_methods();
 			$this->form();


### PR DESCRIPTION
When the checkout form is loaded for guests the save card option is shown, this fix hides it until the Create Account checkbox is checked.
