### PR TITLE
Filter for backorders

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -641,7 +641,7 @@ class WC_Product {
 	 * @return bool
 	 */
 	public function backorders_require_notification() {
-		return $this->managing_stock() && $this->backorders === 'notify' ? true : false;
+		return apply_filters( 'woocommerce_product_backorders_require_notification', $this->managing_stock() && $this->backorders === 'notify' ? true : false, $this->id, $this );
 	}
 
 	/**


### PR DESCRIPTION
It's possible to change backorder status using filters via `woocommerce_product_backorders_allowed`.
However, it's not possible to set `$product->backorder` to `"notify"`.
Added a filter similar to `woocommerce_product_backorders_allowed`
