### PR TITLE
Issue #11062 fix to reduce race condition in WC_Session_Handler.

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -66,7 +66,7 @@ class WC_Session_Handler extends WC_Session {
 		}
 
 		$this->_data = $this->get_session_data();
-		$this->_data_org = serialize($this->_data);
+		$this->_data_org = json_encode($this->_data);
 
 		// Actions
 		add_action( 'woocommerce_set_cart_cookies', array( $this, 'set_customer_session_cookie' ), 10 );
@@ -178,7 +178,7 @@ class WC_Session_Handler extends WC_Session {
 	 */
 	public function save_data() {
 		// Dirty if something changed - prevents saving nothing new
-		$data_changed = ( serialize($this->_data) != $this->_data_org );
+		$data_changed = ( json_encode($this->_data) != $this->_data_org );
 		if ( $this->_dirty && $this->has_session() && $data_changed ) {
 			global $wpdb;
 

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -36,6 +36,9 @@ class WC_Session_Handler extends WC_Session {
 	/** @var string Custom session table name */
 	private $_table;
 
+	/** @var string Original session data */
+	private $_data_org;
+
 	/**
 	 * Constructor for the session class.
 	 */
@@ -63,6 +66,7 @@ class WC_Session_Handler extends WC_Session {
 		}
 
 		$this->_data = $this->get_session_data();
+		$this->_data_org = serialize($this->_data);
 
 		// Actions
 		add_action( 'woocommerce_set_cart_cookies', array( $this, 'set_customer_session_cookie' ), 10 );
@@ -174,7 +178,8 @@ class WC_Session_Handler extends WC_Session {
 	 */
 	public function save_data() {
 		// Dirty if something changed - prevents saving nothing new
-		if ( $this->_dirty && $this->has_session() ) {
+		$dataChanged = (serialize($this->_data) != $this->_data_org);
+		if ( $this->_dirty && $this->has_session() && $dataChanged ) {
 			global $wpdb;
 
 			$wpdb->replace(

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -178,8 +178,8 @@ class WC_Session_Handler extends WC_Session {
 	 */
 	public function save_data() {
 		// Dirty if something changed - prevents saving nothing new
-		$dataChanged = (serialize($this->_data) != $this->_data_org);
-		if ( $this->_dirty && $this->has_session() && $dataChanged ) {
+		$data_changed = ( serialize($this->_data) != $this->_data_org );
+		if ( $this->_dirty && $this->has_session() && $data_changed ) {
 			global $wpdb;
 
 			$wpdb->replace(


### PR DESCRIPTION
These few lines of code should help reduce the race condition present in the WC_Session_Handler.

It reduces the number of session saves to the database by comparing the serialized session data with the original data retrieved from the database.
When they are the same, saving is bypassed.

This is what I would assume the WC_Session::$_dirty flag functionality is for, but it fails to deliver. In my use case the $_dirty flag always seems to be true at the end of the request, causing the session to be overwritten with possibly a stale version.

This occurs ~10% of the time when I add a product to my cart in our setup.
