### PR TITLE
Added $notice as second argument of "woocommerce_demo_store" filter

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -448,7 +448,7 @@ if ( ! function_exists( 'woocommerce_demo_store' ) ) {
 			$notice = __( 'This is a demo store for testing purposes &mdash; no orders shall be fulfilled.', 'woocommerce' );
 		}
 
-		echo apply_filters( 'woocommerce_demo_store', '<p class="demo_store">' . wp_kses_post( $notice ) . '</p>'  );
+		echo apply_filters( 'woocommerce_demo_store', '<p class="demo_store">' . wp_kses_post( $notice ) . '</p>', $notice );
 	}
 }
 


### PR DESCRIPTION
I've simply passed the notice text as argument to "woocommerce_demo_store" filter, because it's easier to customize the markup having the content to put inside, instead manipulating the html string.

It's a very small fix, but it could be very useful to theme developers.

Thanks :)
