### PR TITLE
Use empty for args check in woocommerce_quantity_input

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1023,12 +1023,12 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 		$args = apply_filters( 'woocommerce_quantity_input_args', wp_parse_args( $args, $defaults ), $product );
 
 		// Apply sanity to min/max args - min cannot be lower than 0
-		if ( '' !== $args['min_value'] && is_numeric( $args['min_value'] ) && $args['min_value'] < 0 ) {
+		if ( ! empty( $args['min_value'] ) && is_numeric( $args['min_value'] ) && $args['min_value'] < 0 ) {
 			$args['min_value'] = 0; // Cannot be lower than 0
 		}
 
 		// Max cannot be lower than 0 or min
-		if ( '' !== $args['max_value'] && is_numeric( $args['max_value'] ) ) {
+		if ( ! empty( $args['max_value'] ) && is_numeric( $args['max_value'] ) ) {
 			$args['max_value'] = $args['max_value'] < 0 ? 0 : $args['max_value'];
 			$args['max_value'] = $args['max_value'] < $args['min_value'] ? $args['min_value'] : $args['max_value'];
 		}


### PR DESCRIPTION
I notice that `woocommerce_quantity_input` has `'' !== $args['min_value']` but since you can unset `min_value` it should check with `empty` instead.
