### PR TITLE
Improve wc_orders_count() performance by running a query to count only posts of the given status

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -719,18 +719,29 @@ function wc_processing_order_count() {
  * @return int
  */
 function wc_orders_count( $status ) {
-	$count = 0;
+	global $wpdb;
 
+	$count = 0;
+	$status = 'wc-' . $status;
 	$order_statuses = array_keys( wc_get_order_statuses() );
 
-	if ( ! in_array( 'wc-' . $status, $order_statuses ) ) {
+	if ( ! in_array( $status, $order_statuses ) ) {
 		return 0;
 	}
 
-	foreach ( wc_get_order_types( 'order-count' ) as $type ) {
-		$this_count  = wp_count_posts( $type, 'readable' );
-		$count      += isset( $this_count->{'wc-' . $status} ) ? $this_count->{'wc-' . $status} : 0;
+	$cache_key = "wc-orders-{$status}";
+	$cached_count = wp_cache_get( $cache_key, 'counts' );
+
+	if ( false !== $cached_count ) {
+		return $cached_count;
 	}
+
+	foreach ( wc_get_order_types( 'order-count' ) as $type ) {
+		$query = "SELECT COUNT( * ) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s";
+		$count += $wpdb->get_var( $wpdb->prepare( $query, $type, $status ) );
+	}
+
+	wp_cache_set( $cache_key, $count, 'counts' );
 
 	return $count;
 }

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -729,7 +729,7 @@ function wc_orders_count( $status ) {
 		return 0;
 	}
 
-	$cache_key = "wc-orders-{$status}";
+	$cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . $status;
 	$cached_count = wp_cache_get( $cache_key, 'counts' );
 
 	if ( false !== $cached_count ) {


### PR DESCRIPTION
The function wc_orders_count() is called on every admin page. WooCommerce core uses it to count only orders with the status 'processing' and typically a site has only a few of those orders. But since wc_orders_count() calls internally wp_post_count() this means that MySQL will have to count the number of orders for each status. Thus, in a site with a significant number of orders, this query can be slow.

This commit changes wc_orders_count() function to query directly the database to get the number of orders for a given status instead of using wp_post_count(). On a WooCommerce installation with about a million orders, the old query takes about 2 seconds to run and the new query takes 0.002 seconds.
