### PR TITLE
Set product post with 'variable' product type term.

### DIFF
--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -74,6 +74,9 @@ class WC_Helper_Product {
 			'post_status' => 'publish'
 		) );
 
+		// Set it as variable.
+		wp_set_object_terms( $product_id, 'variable', 'product_type' );
+
 		// Price related meta
 		update_post_meta( $product_id, '_price', '10' );
 		update_post_meta( $product_id, '_min_variation_price', '10' );


### PR DESCRIPTION
If the code launch wc_get_product() and in the test I use WC_Helper_Product::create_variation_product(), wc_get_product() return me a simple product object on code and the test fails.

With this change, the issue is fixed. I think it makes more sense.
