### PR TITLE
Include child prices in grouped_price_html filter

### DIFF
--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -155,7 +155,7 @@ class WC_Product_Grouped extends WC_Product {
 			if ( $is_free ) {
 				$price = apply_filters( 'woocommerce_grouped_free_price_html', __( 'Free!', 'woocommerce' ), $this );
 			} else {
-				$price = apply_filters( 'woocommerce_grouped_price_html', $price . $this->get_price_suffix(), $this );
+				$price = apply_filters( 'woocommerce_grouped_price_html', $price . $this->get_price_suffix(), $this, $child_prices );
 			}
 		} else {
 			$price = apply_filters( 'woocommerce_grouped_empty_price_html', '', $this );


### PR DESCRIPTION
This will allow other plugins/themes to determine how to display the range of prices without needing to recalculate the prices themselves. This allows plugins and themes to be automatically compatible with possible future changes to the tax display settings that are handled in the get_price_html method.

One such display change that would be made easier by this PR would be overriding the range to exclude free products. This is useful when the free products are just an addon that is useless without one of the paid child products.
