### PR TITLE
Instance ID have to be checked

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -413,7 +413,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 */
 	public function get_option( $key, $empty_value = null ) {
 		// Instance options take priority over global options
-		if ( array_key_exists( $key, $this->get_instance_form_fields() ) ) {
+		if ( $this->instance_id && array_key_exists( $key, $this->get_instance_form_fields() ) ) {
 			return $this->get_instance_option( $key, $empty_value );
 		}
 


### PR DESCRIPTION
Because on using settings and instance settings together every time the instance settings will be fetched. In this case the global settings site will not work anymore and will show no data.
