### PR TITLE
Add NOT IN operator to WC_Admin_Report::get_order_report_data()

### DIFF
--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -242,14 +242,14 @@ class WC_Admin_Report {
 
 				$key = is_array( $value['meta_key'] ) ? $value['meta_key'][0] . '_array' : $value['meta_key'];
 
-				if ( strtolower( $value['operator'] ) == 'in' ) {
+				if ( strtolower( $value['operator'] ) == 'in' || strtolower( $value['operator'] ) == 'not in' ) {
 
 					if ( is_array( $value['meta_value'] ) ) {
 						$value['meta_value'] = implode( "','", $value['meta_value'] );
 					}
 
 					if ( ! empty( $value['meta_value'] ) ) {
-						$where_value = "IN ('{$value['meta_value']}')";
+						$where_value = "{$value['operator']} ('{$value['meta_value']}')";
 					}
 				} else {
 					$where_value = "{$value['operator']} '{$value['meta_value']}'";
@@ -289,14 +289,14 @@ class WC_Admin_Report {
 
 			foreach ( $where as $value ) {
 
-				if ( strtolower( $value['operator'] ) == 'in' ) {
+				if ( strtolower( $value['operator'] ) == 'in' || strtolower( $value['operator'] ) == 'not in' ) {
 
 					if ( is_array( $value['value'] ) ) {
 						$value['value'] = implode( "','", $value['value'] );
 					}
 
 					if ( ! empty( $value['value'] ) ) {
-						$where_value = "IN ('{$value['value']}')";
+						$where_value = "{$value['operator']} ('{$value['value']}')";
 					}
 				} else {
 					$where_value = "{$value['operator']} '{$value['value']}'";


### PR DESCRIPTION
There was already an 'IN' operator but no 'NOT IN'. I see the following snippet as one of many uses cases for this addition:

``` php
add_filter( 'woocommerce_reports_get_order_report_data_args', function( $data ) {
    $wholesale_customer_ids = wp_list_pluck( get_users( array(
        'role'   => 'wholesale_customer',
        'fields' => array( 'ID' ),
    ) ), 'ID' );

    if ( ! isset( $data['where_meta'] ) ) {
        $data['where_meta'] = array();
    }

    $operator = ( $_REQUEST['role'] === 'wholesale_customer' ) ? 'IN' : 'NOT IN';

    $data['where_meta'][] = array(
        'meta_key'   => '_customer_user',
        'meta_value' => $wholesale_customer_ids,
        'operator'   => $operator,
    );

    return $data;
} );
```
