### PR TITLE
Add option to add secure attribute on all Woocommerce cookies for PCI…

### DIFF
--- a/includes/admin/settings/class-wc-settings-general.php
+++ b/includes/admin/settings/class-wc-settings-general.php
@@ -159,6 +159,14 @@ class WC_Settings_General extends WC_Settings_Page {
 				'autoload' => false
 			),
 
+			array(
+				'title'   => __( 'Secure Cookies', 'woocommerce' ),
+				'desc'    => __( 'Enable site-wide secure cookies (for PCI Compliance)', 'woocommerce' ),
+				'id'      => 'woocommerce_secure_cookies',
+				'default' => 'no',
+				'type'    => 'checkbox'
+			),
+
 			array( 'type' => 'sectionend', 'id' => 'general_options'),
 
 			array( 'title' => __( 'Currency Options', 'woocommerce' ), 'type' => 'title', 'desc' => __( 'The following options affect how prices are displayed on the frontend.', 'woocommerce' ), 'id' => 'pricing_options' ),

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -726,6 +726,9 @@ function wc_print_js() {
  * @param  string  $secure Whether the cookie should be served only over https.
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false ) {
+	if ( $secure === false && get_option( 'woocommerce_secure_cookies' ) === 'yes' ) {
+		$secure = true;
+	}
 	if ( ! headers_sent() ) {
 		setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure );
 	} elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {


### PR DESCRIPTION
Simple addition of an option field in the Woocommerce > Settings > General page to allow users to make Woocommerce cookies secure. The only additional change is a conditional statement added in the wc_setcookies core function to read the option setting IF the $secure variable is set to default setting (false). This retains backward compatibility while giving developers an unobtrusive, simple fix to a PCI compliance scan issue that is difficult to resolve otherwise. Furthermore, Google recommends running SSL across all pages of a website and if a user does this, this is a badly needed featured to complete that process.
