### PR TITLE
[2.6] Use existing $form var to block/unblock specific `variations_form` element

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -118,13 +118,13 @@
 					// Get a matchihng variation via ajax
 					data.product_id = $product_id;
 
-					$( '.variations_form' ).block({
+					$form.block( {
 						message: null,
 						overlayCSS: {
 							background: '#fff',
 							opacity: 0.6
 						}
-					});
+					} );
 
 					$xhr = $.ajax( {
 						url: wc_cart_fragments_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'get_variation' ),
@@ -140,7 +140,7 @@
 							}
 						},
 						complete: function() {
-							$( '.variations_form' ).unblock();
+							$form.unblock();
 						}
 					} );
 				} else {


### PR DESCRIPTION
Existing code could cause other `.variations_form` elements on the same page to block/unblock as well. Issue introduced in https://github.com/woothemes/woocommerce/commit/0cb2f2760c1e39a5a5636489aa3efe45b087bcd5.

Added a couple spaces for consistency with the coding style in the same file.
