### PR TITLE
[2.6] Post custom data when fetching a variation via ajax

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -116,7 +116,8 @@
 
 				if ( all_attributes_chosen ) {
 					// Get a matchihng variation via ajax
-					data.product_id = $product_id;
+					data.product_id  = $product_id;
+					data.custom_data = $form.data( 'custom_data' );
 
 					$( '.variations_form' ).block({
 						message: null,


### PR DESCRIPTION
Sometimes it is desirable to add "context" to a variations ajax request, in order to modify the returned object content. 

For example, in cases where the variation is part of a bundled variable product, we may need to modify the price, stock status or the description of the fetched variation according to the "context" set by the bundle itself.

Any custom "context" data included in the request can be intercepted early, for instance by adding an ajax handler like `add_action( 'wc_ajax_get_variation', 'woo_pr_intercept_custom_data', 0 );` in order to add any required filters.

This will allow variations contained in Bundles to be fetched via ajax, which at the moment is not possible (major slowdowns when a Bundle contains big variable products - having multiple of them on the same single-product page simply makes the issue worse). 

I can imagine other similar applications where the returned variation data may need to be modified based on context-specific variables.
