### PR TITLE
Fix message styles for empty cart

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -80,66 +80,6 @@ p.demo_store {
 		}
 	}
 
-	.woocommerce-message,
-	.woocommerce-error,
-	.woocommerce-info {
-		padding: 1em 2em 1em 3.5em !important;
-		margin: 0 0 2em !important;
-		position: relative;
-		background-color: lighten($secondary,5%);
-		color: $secondarytext;
-		border-top: 3px solid $primary;
-		list-style: none outside !important;
-		@include clearfix();
-		width: auto;
-		word-wrap: break-word;
-
-		&:before {
-			font-family: "WooCommerce";
-			content: "\e028";
-			display: inline-block;
-			position: absolute;
-			top: 1em;
-			left: 1.5em;
-		}
-
-		.button {
-			float: right;
-		}
-
-		li {
-			list-style: none outside !important;
-			padding-left: 0 !important;
-			margin-left: 0 !important;
-		}
-	}
-
-	.woocommerce-message {
-		border-top-color: #8fae1b;
-
-		&:before {
-			content: "\e015";
-			color: #8fae1b;
-		}
-	}
-
-	.woocommerce-info {
-		border-top-color: #1e85be;
-
-		&:before {
-			color: #1e85be;
-		}
-	}
-
-	.woocommerce-error {
-		border-top-color: #b81c23;
-
-		&:before {
-			content: "\e016";
-			color: #b81c23;
-		}
-	}
-
 	small.note {
 		display: block;
 		color: $subtext;
@@ -1546,6 +1486,66 @@ p.demo_store {
 				}
 			}
 		}
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+	padding: 1em 2em 1em 3.5em !important;
+	margin: 0 0 2em !important;
+	position: relative;
+	background-color: lighten($secondary,5%);
+	color: $secondarytext;
+	border-top: 3px solid $primary;
+	list-style: none outside !important;
+	@include clearfix();
+	width: auto;
+	word-wrap: break-word;
+
+	&:before {
+		font-family: "WooCommerce";
+		content: "\e028";
+		display: inline-block;
+		position: absolute;
+		top: 1em;
+		left: 1.5em;
+	}
+
+	.button {
+		float: right;
+	}
+
+	li {
+		list-style: none outside !important;
+		padding-left: 0 !important;
+		margin-left: 0 !important;
+	}
+}
+
+.woocommerce-message {
+	border-top-color: #8fae1b;
+
+	&:before {
+		content: "\e015";
+		color: #8fae1b;
+	}
+}
+
+.woocommerce-info {
+	border-top-color: #1e85be;
+
+	&:before {
+		color: #1e85be;
+	}
+}
+
+.woocommerce-error {
+	border-top-color: #b81c23;
+
+	&:before {
+		content: "\e016";
+		color: #b81c23;
 	}
 }
 


### PR DESCRIPTION
When you remove the last item from the cart, the `.woocommerce-message` element is currently not styled.  That's because the style applies to `.woocommerce .woocommerce-message` but the message is outside of the `.woocommerce` element.

This PR removes the CSS from the parent `.woocommerce` element and fixes the style issue.

Before:
![screen shot 2016-07-07 at 2 42 59 pm](https://cloud.githubusercontent.com/assets/3220162/16670840/253f26f2-4451-11e6-883a-fd6f9192a52f.png)

After:
![screen shot 2016-07-07 at 2 42 31 pm](https://cloud.githubusercontent.com/assets/3220162/16670842/2ac9a39a-4451-11e6-8002-9e4163efd458.png)

cc @jameskoster 
