### PR TITLE
use strict comparison for in array check 

### DIFF
--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -242,7 +242,7 @@ class WC_Shipping_Zone extends WC_Data {
 		$methods         = array();
 
 		foreach ( $raw_methods as $raw_method ) {
-			if ( in_array( $raw_method->method_id, array_keys( $allowed_classes ) ) ) {
+			if ( in_array( $raw_method->method_id, array_keys( $allowed_classes ), true ) ) {
 				$class_name = $allowed_classes[ $raw_method->method_id ];
 
 				// The returned array may contain instances of shipping methods, as well


### PR DESCRIPTION
`0 == "anystring"` will return true, which results in an error notice.

This may be an edge case due to multiple upgrades / downgrades but still a good check to avoid false positives.
