### PR TITLE
Schema.org offer markup changes.

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1036,11 +1036,24 @@ if ( ! function_exists( 'woocommerce_variable_schema_offers' ) ) {
 	function woocommerce_variable_schema_offers() {
 		global $product;
 
-		$all_variations = $product->get_available_variations();
-		foreach ( $all_variations as $variation ) {
-			$variable_product = wc_get_product( $variation['variation_id'] );
-			wc_get_template( 'single-product/schema-offers/variation.php', array(
-				'variable_product' => $variable_product
+		$variation_count = sizeof( $product->get_children() );
+		$show_variations = $variation_count <= apply_filters( 'woocommerce_ajax_variation_threshold', 30, $product );
+		$show_variations = apply_filters( 'woocommerce_show_variation_schema_data', $show_variations, $product );
+
+		if ( $show_variations ) {
+			$all_variations = $product->get_available_variations();
+			foreach ( $all_variations as $variation ) {
+				$variation_product = wc_get_product( $variation['variation_id'] );
+				wc_get_template( 'single-product/schema-offers/variation.php', array(
+					'variation_product' => $variation_product,
+				) );
+			}
+		} else {
+			wc_get_template( 'single-product/schema-offers/variation-aggregate.php', array(
+				'low_price'        => $product->get_variation_price('min'),
+				'high_price'       => $product->get_variation_price('max'),
+				'offer_count'      => $variation_count,
+				'variable_product' => $product,
 			) );
 		}
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1002,6 +1002,50 @@ if ( ! function_exists( 'woocommerce_external_add_to_cart' ) ) {
 	}
 }
 
+if ( ! function_exists( 'woocommerce_simple_schema_offer' ) ) {
+
+	/**
+	 * Output the schema.org offer information for simple products.
+	 *
+	 * @subpackage	Product
+	 */
+	function woocommerce_simple_schema_offer() {
+		wc_get_template( 'single-product/schema-offers/simple.php' );
+	}
+}
+
+if ( ! function_exists( 'woocommerce_external_schema_offer' ) ) {
+
+	/**
+	 * Output the schema.org offer information for external products.
+	 *
+	 * @subpackage	Product
+	 */
+	function woocommerce_external_schema_offer() {
+		wc_get_template( 'single-product/schema-offers/simple.php' );
+	}
+}
+
+if ( ! function_exists( 'woocommerce_variable_schema_offers' ) ) {
+
+	/**
+	 * Output the schema.org offer information for variable products.
+	 *
+	 * @subpackage	Product
+	 */
+	function woocommerce_variable_schema_offers() {
+		global $product;
+
+		$all_variations = $product->get_available_variations();
+		foreach ( $all_variations as $variation ) {
+			$variable_product = wc_get_product( $variation['variation_id'] );
+			wc_get_template( 'single-product/schema-offers/variation.php', array(
+				'variable_product' => $variable_product
+			) );
+		}
+	}
+}
+
 if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 
 	/**

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -179,6 +179,17 @@ add_action( 'woocommerce_single_variation', 'woocommerce_single_variation', 10 )
 add_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
 
 /**
+ * Product schema.org Offer metadata.
+ *
+ * @see woocommerce_simple_schema_offer
+ * @see woocommerce_external_schema_offer
+ * @see woocommerce_variable_schema_offer
+ */
+add_action( 'woocommerce_simple_add_to_cart', 'woocommerce_simple_schema_offer', 30 );
+add_action( 'woocommerce_external_add_to_cart', 'woocommerce_external_schema_offer', 30 );
+add_action( 'woocommerce_variable_add_to_cart', 'woocommerce_variable_schema_offers', 30 );
+
+/**
  * Pagination after shop loops.
  *
  * @see woocommerce_pagination()

--- a/templates/single-product/price.php
+++ b/templates/single-product/price.php
@@ -23,12 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $product;
 
 ?>
-<div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+<div>
 
 	<p class="price"><?php echo $product->get_price_html(); ?></p>
-
-	<meta itemprop="price" content="<?php echo esc_attr( $product->get_display_price() ); ?>" />
-	<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
-	<link itemprop="availability" href="http://schema.org/<?php echo $product->is_in_stock() ? 'InStock' : 'OutOfStock'; ?>" />
 
 </div>

--- a/templates/single-product/schema-offers/simple.php
+++ b/templates/single-product/schema-offers/simple.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Offer microdata for single product pages for SEO.
+ *
+ * Used for both Simple products, and External products.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/single-product/schema-offers/simple.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woothemes.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 2.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+global $product;
+
+?>
+<div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+
+	<?php do_action( 'woocommerce_simple_schema_offer_before_schema' ); ?>
+	<meta itemprop="price" content="<?php echo esc_attr( $product->get_display_price() ); ?>" />
+	<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
+	<link itemprop="availability" href="http://schema.org/<?php echo $product->is_in_stock() ? 'InStock' : 'OutOfStock'; ?>" />
+	<?php do_action( 'woocommerce_simple_schema_offer_after_schema' ); ?>
+
+</div>

--- a/templates/single-product/schema-offers/variation-aggregate.php
+++ b/templates/single-product/schema-offers/variation-aggregate.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Schema.org aggregate offer microdata for a variable product.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/single-product/schema-offers/variation-aggregate.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woothemes.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 2.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+<div itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">
+
+	<?php do_action( 'woocommerce_variation_schema_offer_before_aggregate_schema', $variable_product ); ?>
+	<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
+	<meta itemprop="lowPrice" content="<?php echo esc_attr( $low_price ); ?>" />
+	<meta itemprop="highPrice" content="<?php echo esc_attr( $high_price ); ?>" />
+	<meta itemprop="offerCount" content="<?php echo esc_attr( $offer_count ); ?>" />
+	<?php do_action( 'woocommerce_variation_schema_offer_after_aggregate_schema', $variable_product ); ?>
+
+</div>

--- a/templates/single-product/schema-offers/variation.php
+++ b/templates/single-product/schema-offers/variation.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Schema.org offer microdata for a single variation on a variable product.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/single-product/schema-offers/variation.php
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woothemes.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 2.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+<div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+
+	<?php do_action( 'woocommerce_variation_schema_offer_before_schema', $variable_product ); ?>
+	<meta itemprop="price" content="<?php echo esc_attr( $variable_product->get_price() ); ?>" />
+	<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
+	<link itemprop="availability" href="http://schema.org/<?php echo $variable_product->is_in_stock() ? 'InStock' : 'OutOfStock'; ?>" />
+	<meta itemprop="name" content="<?php echo esc_attr( $variable_product->get_title() ) . ' (' . esc_attr( $variable_product->get_formatted_variation_attributes(true) ) . ')'; ?>" />
+	<?php do_action( 'woocommerce_variation_schema_offer_after_schema', $variable_product ); ?>
+
+</div>

--- a/templates/single-product/schema-offers/variation.php
+++ b/templates/single-product/schema-offers/variation.php
@@ -23,11 +23,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
 
-	<?php do_action( 'woocommerce_variation_schema_offer_before_schema', $variable_product ); ?>
-	<meta itemprop="price" content="<?php echo esc_attr( $variable_product->get_price() ); ?>" />
+	<?php do_action( 'woocommerce_variation_schema_offer_before_schema', $variation_product ); ?>
+	<meta itemprop="price" content="<?php echo esc_attr( $variation_product->get_price() ); ?>" />
 	<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
-	<link itemprop="availability" href="http://schema.org/<?php echo $variable_product->is_in_stock() ? 'InStock' : 'OutOfStock'; ?>" />
-	<meta itemprop="name" content="<?php echo esc_attr( $variable_product->get_title() ) . ' (' . esc_attr( $variable_product->get_formatted_variation_attributes(true) ) . ')'; ?>" />
-	<?php do_action( 'woocommerce_variation_schema_offer_after_schema', $variable_product ); ?>
+	<link itemprop="availability" href="http://schema.org/<?php echo $variation_product->is_in_stock() ? 'InStock' : 'OutOfStock'; ?>" />
+	<meta itemprop="name" content="<?php echo esc_attr( $variation_product->get_title() ) . ' (' . esc_attr( $variation_product->get_formatted_variation_attributes(true) ) . ')'; ?>" />
+	<?php do_action( 'woocommerce_variation_schema_offer_after_schema', $variation_product ); ?>
 
 </div>


### PR DESCRIPTION
This PR is a first attempt to address the schema.org markup issues raised in #11281. The PR contains the following changes:
- Schema.org markup only output for simple products, variable products, and external products
- No markup output for grouped products
- Markup attached to the woocommerce_*_add_to_cart hooks, no longer part of price template
- New template files added under single-product/schema-offers/
- Multiple offers output for variable products, one per available variation

There are probably still some issues to be worked through before this finally goes in, my thoughts so far are:
- Probably needs to go into a major release due to new template files?
- Can we output sensible schema markup for grouped products?
- What (if anything) do we need to do for Composite products and any other similar add-ons - do they currently generate schema markup?

So - PR for discussion at this stage
