### PR TITLE
Fix layered nav links on product attribute archives

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -272,7 +272,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		} elseif ( is_product_tag() ) {
 			$link = get_term_link( get_query_var( 'product_tag' ), 'product_tag' );
 		} else {
-			$link = get_term_link( get_query_var( 'term' ), get_query_var( 'taxonomy' ) );
+			$queried_object = get_queried_object();
+			$link = get_term_link( $queried_object->slug, $queried_object->taxonomy );
 		}
 
 		// Min/Max


### PR DESCRIPTION
If the option 'Enable archives' is selected for a product attribute, then the layered nav widget can also be used to filter that archive.
However the widget then doesn't work correctly in 'List' and 'OR' mode for that archive (although it works fine on the main shop page).

Example:
The attribute "product-type" is created and archives are enabled. It has values like "Courses", "One-to-one-tuition", "Equipment rental" and so on. Another product attribute "teaching-level" is created which uses values of "Beginner", "Intermediate" and "Advanced".
When the archive `http://www.domain.com/pa_product-type/courses/` is visited the correct products are displayed. A layered nav widget is added in 'List' and 'OR' mode for the attribute 'teaching-level'. Clicking on any of "Beginner", "Intermediate" and "Advanced" will work fine the first time as the links are correctly generated in the form `http://www.domain.com/pa_product-type/courses/?filter_teaching-level=advanced&query_type_teaching-level=or`. (Advanced used for the example). However once one has been clicked, the links generated are now incorrect - they are in the form `http://www.domain.com/?taxonomy=pa_teaching-level&term=advanced&filter_teaching-level=advanced%2Cbeginner&query_type_teaching-level=or`.

Using `get_queried_object` instead of `get_query_var` fixes the problem.
