### PR TITLE
Show shipping method titles in Add shipping method modal

### DIFF
--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -106,7 +106,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 										if ( ! $method->supports( 'shipping-zones' ) ) {
 											continue;
 										}
-										echo '<option data-description="' . esc_attr( $method->method_description ) . '" value="' . esc_attr( $method->id ) . '">' . esc_attr( $method->title ) . '</li>';
+
+										echo '<option data-description="' . esc_attr( $method->method_description ) . '" value="' . esc_attr( $method->id ) . '">' . esc_attr( $method->method_title ) . '</li>';
 									}
 								?>
 							</select>

--- a/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -154,7 +154,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 										if ( ! $method->supports( 'shipping-zones' ) ) {
 											continue;
 										}
-										echo '<option data-description="' . esc_attr( $method->method_description ) . '" value="' . esc_attr( $method->id ) . '">' . esc_attr( $method->title ) . '</li>';
+										echo '<option data-description="' . esc_attr( $method->method_description ) . '" value="' . esc_attr( $method->id ) . '">' . esc_attr( $method->method_title ) . '</li>';
 									}
 								?>
 							</select>


### PR DESCRIPTION
The modal was calling shipping method titles with $method->title this resulted in blank select options. I replaced it with $method->method_title to fix this.
