### PR TITLE
fix search results layered nav counts issue

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -367,6 +367,17 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			" . $tax_query_sql['where'] . $meta_query_sql['where'] . "
 			AND terms.term_id IN (" . implode( ',', array_map( 'absint', $term_ids ) ) . ")
 		";
+		if ( is_search() ) {
+			$search_terms     = $wp_query->query_vars['search_terms'];
+			$count            = 0;
+			$query['search']  = " AND (";
+			foreach ( $search_terms as $search_term ) {
+				$query['search'] .= $count > 0 ? " AND " : "";
+				$query['search'] .= "(({$wpdb->posts}.post_title LIKE '%" . $search_term . "%') OR ({$wpdb->posts}.post_excerpt LIKE '%" . $search_term . "%') OR ({$wpdb->posts}.post_content LIKE '%" . $search_term . "%'))";
+				$count++;
+			}
+			$query['search'] .= ")";
+		}
 		$query['group_by'] = "GROUP BY terms.term_id";
 		$query             = apply_filters( 'woocommerce_get_filtered_term_product_counts_query', $query );
 		$query             = implode( ' ', $query );


### PR DESCRIPTION
The nav filters were showing all counts like the shop page on search results page as pointed out in issue #11335.

I added the search query terms to the SQL query when is_search returns true.
