### PR TITLE
Resolved issue #11428.

### DIFF
--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -145,6 +145,7 @@ jQuery(function( $ ) {
 			$( this ).offsetParent().find( 'thead tr,tbody tr' ).each( function() {
 				$( this ).find( 'th, td' ).each( function() {
 					var value = $( this ).text();
+                    value = value.replace( '#', '' );
 					value = value.replace( '[?]', '' );
 					csv_data += '"' + value + '"' + ',';
 				});
@@ -155,6 +156,7 @@ jQuery(function( $ ) {
 			$( this ).offsetParent().find( 'tfoot tr' ).each( function() {
 				$( this ).find( 'th, td' ).each( function() {
 					var value = $( this ).text();
+                    value = value.replace( '#', '' );
 					value = value.replace( '[?]', '' );
 					csv_data += '"' + value + '"' + ',';
 					if ( $( this ).attr( 'colspan' ) > 0 ) {


### PR DESCRIPTION
report.js export_csv of the 'table' data_format will not download if the cell data contains #.   Most likely due to the fact that #<id> is a octect character.

This is a quick fix that strips any # character from table cell data.

There may be a way to escape # however # nor HTML encoding to %23 resolved the issue.
