### PR TITLE
Cache the result of WC_Comments::wp_count_comments() in a transient

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -42,6 +42,10 @@ class WC_Comments {
 		// Count comments
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 10, 2 );
 
+		// Delete comments count cache whenever there is a new comment or a comment status changes
+		add_action( 'wp_insert_comment', array( __CLASS__, 'delete_comments_count_cache' ) );
+		add_action( 'wp_set_comment_status', array( __CLASS__, 'delete_comments_count_cache' ) );
+
 		// Support avatars for `review` comment type
 		add_filter( 'get_avatar_comment_types', array( __CLASS__, 'add_avatar_for_review_comment_type' ) );
 
@@ -238,6 +242,18 @@ class WC_Comments {
 	}
 
 	/**
+	 * Delete comments count cache whenever there is
+	 * new comment or the status of a comment changes. Cache
+	 * will be regenerated next time WC_Comments::wp_count_comments()
+	 * is called.
+	 *
+	 * @return void
+	 */
+	public static function delete_comments_count_cache() {
+		delete_transient( 'wc_count_comments' );
+	}
+
+	/**
 	 * Remove order notes from wp_count_comments().
 	 * @since  2.2
 	 * @param  object $stats
@@ -248,37 +264,37 @@ class WC_Comments {
 		global $wpdb;
 
 		if ( 0 === $post_id ) {
+			$stats = get_transient( 'wc_count_comments' );
 
-			$count = wp_cache_get( 'comments-0', 'counts' );
-			if ( false !== $count ) {
-				return $count;
-			}
+			if ( ! $stats ) {
+				$stats = array();
 
-			$count = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type != 'order_note' GROUP BY comment_approved", ARRAY_A );
+				$count = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type != 'order_note' GROUP BY comment_approved", ARRAY_A );
 
-			$total = 0;
-			$approved = array( '0' => 'moderated', '1' => 'approved', 'spam' => 'spam', 'trash' => 'trash', 'post-trashed' => 'post-trashed' );
+				$total = 0;
+				$approved = array( '0' => 'moderated', '1' => 'approved', 'spam' => 'spam', 'trash' => 'trash', 'post-trashed' => 'post-trashed' );
 
-			foreach ( (array) $count as $row ) {
-				// Don't count post-trashed toward totals
-				if ( 'post-trashed' != $row['comment_approved'] && 'trash' != $row['comment_approved'] ) {
-					$total += $row['num_comments'];
+				foreach ( (array) $count as $row ) {
+					// Don't count post-trashed toward totals
+					if ( 'post-trashed' != $row['comment_approved'] && 'trash' != $row['comment_approved'] ) {
+						$total += $row['num_comments'];
+					}
+					if ( isset( $approved[ $row['comment_approved'] ] ) ) {
+						$stats[ $approved[ $row['comment_approved'] ] ] = $row['num_comments'];
+					}
 				}
-				if ( isset( $approved[ $row['comment_approved'] ] ) ) {
-					$stats[ $approved[ $row['comment_approved'] ] ] = $row['num_comments'];
-				}
-			}
 
-			$stats['total_comments'] = $total;
-			$stats['all'] = $total;
-			foreach ( $approved as $key ) {
-				if ( empty( $stats[ $key ] ) ) {
-					$stats[ $key ] = 0;
+				$stats['total_comments'] = $total;
+				$stats['all'] = $total;
+				foreach ( $approved as $key ) {
+					if ( empty( $stats[ $key ] ) ) {
+						$stats[ $key ] = 0;
+					}
 				}
-			}
 
-			$stats = (object) $stats;
-			wp_cache_set( 'comments-0', $stats, 'counts' );
+				$stats = (object) $stats;
+				set_transient( 'wc_count_comments', $stats );
+			}
 		}
 
 		return $stats;


### PR DESCRIPTION
The query to count comments inside WC_Comments::wp_count_comments() is super slow when the site has a significant number of comments (for example, this query takes about 5s to run on WooCommerce.com with 70k comments) and this is a problem specially considering that this method is called on every admin page.

This commit changes WC_Comments::wp_count_comments() to store the comments count in a transient. With this change, the method will run the query to count comments only if the number of comments or their statuses had changed. Before this commit, WC_Comments::wp_count_comments() would run the database query every time a admin page was requested.

As a side note, there is a open WP core ticket discussing the addition of a index to the comment_type field. This significantly reduces the amount of time required to run the query (on WooCommerce.com with the index the query run in about 0.5s which is still slow but way much better):

https://core.trac.wordpress.org/ticket/31072
