### PR TITLE
Add database prefix to status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -350,7 +350,7 @@ global $wpdb;
 		<tr>
 			<td data-export-label="WC Database Prefix"><?php _e( 'Database Prefix', 'woocommerce' ); ?></td>
 			<td class="help"><?php echo wc_help_tip( __( 'We recommend using a prefix with less than 20 characters.', 'woocommerce' ) ); ?></td>
-			<td><?php echo esc_html( $wpdb->prefix; ) ?></td>
+			<td><?php echo esc_html( $wpdb->prefix ) ?></td>
 		</tr>
 		<?php } ?>
 		<tr>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -346,11 +346,13 @@ global $wpdb;
 			<td class="help"><?php echo wc_help_tip( __( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce Version.', 'woocommerce' ) ); ?></td>
 			<td><?php echo esc_html( get_option( 'woocommerce_db_version' ) ); ?></td>
 		</tr>
+		<?php if( strlen( esc_html( $wpdb->prefix ) ) > 20 ) { ?>
 		<tr>
 			<td data-export-label="WC Database Prefix"><?php _e( 'Database Prefix', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'We recommend using a prefix having less than 20 characters.', 'woocommerce' ) ); ?></td>
-			<td><?php echo $wpdb->prefix; ?></td>
+			<td class="help"><?php echo wc_help_tip( __( 'We recommend using a prefix with less than 20 characters.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( $wpdb->prefix; ) ?></td>
 		</tr>
+		<?php } ?>
 		<tr>
 			<?php
 			$tables = array(

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -347,6 +347,11 @@ global $wpdb;
 			<td><?php echo esc_html( get_option( 'woocommerce_db_version' ) ); ?></td>
 		</tr>
 		<tr>
+			<td data-export-label="WC Database Prefix"><?php _e( 'Database Prefix', 'woocommerce' ); ?></td>
+			<td class="help"><?php echo wc_help_tip( __( 'We recommend using a prefix having less than 20 characters.', 'woocommerce' ) ); ?></td>
+			<td><?php echo $wpdb->prefix; ?></td>
+		</tr>
+		<tr>
 			<?php
 			$tables = array(
 				'woocommerce_sessions',

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -346,13 +346,18 @@ global $wpdb;
 			<td class="help"><?php echo wc_help_tip( __( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce Version.', 'woocommerce' ) ); ?></td>
 			<td><?php echo esc_html( get_option( 'woocommerce_db_version' ) ); ?></td>
 		</tr>
-		<?php if( strlen( esc_html( $wpdb->prefix ) ) > 20 ) { ?>
 		<tr>
 			<td data-export-label="WC Database Prefix"><?php _e( 'Database Prefix', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'We recommend using a prefix with less than 20 characters.', 'woocommerce' ) ); ?></td>
-			<td><?php echo esc_html( $wpdb->prefix ) ?></td>
+			<td class="help">&nbsp;</td>
+			<td><?php 
+				if ( strlen( esc_html( $wpdb->prefix ) ) > 20 ) {
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s - We recommend using a prefix with less than 20 characters. See: %s', 'woocommerce' ), esc_html( $wpdb->prefix ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . __( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
+				} else {
+					echo '<mark class="yes">' . esc_html( esc_html( $wpdb->prefix ) ) . '</mark>';
+				}
+				?>
+			</td>
 		</tr>
-		<?php } ?>
 		<tr>
 			<?php
 			$tables = array(

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -350,10 +350,10 @@ global $wpdb;
 			<td data-export-label="WC Database Prefix"><?php _e( 'Database Prefix', 'woocommerce' ); ?></td>
 			<td class="help">&nbsp;</td>
 			<td><?php 
-				if ( strlen( esc_html( $wpdb->prefix ) ) > 20 ) {
+				if ( strlen( $wpdb->prefix ) > 20 ) {
 					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s - We recommend using a prefix with less than 20 characters. See: %s', 'woocommerce' ), esc_html( $wpdb->prefix ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . __( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {
-					echo '<mark class="yes">' . esc_html( esc_html( $wpdb->prefix ) ) . '</mark>';
+					echo '<mark class="yes">' . esc_html( $wpdb->prefix ) . '</mark>';
 				}
 				?>
 			</td>


### PR DESCRIPTION
Add database prefix to the status report. Useful to troubleshoot issues such as missing links in downloadable files URLs missing as described here: https://docs.woothemes.com/document/completed-order-email-doesnt-contain-download-links/
