### PR TITLE
Allow wc_get_orders() to accept arguments used by 3rd party plugins

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -117,8 +117,11 @@ function wc_get_orders( $args ) {
 		$wp_query_args['no_found_rows'] = true;
 	}
 
+	// Make sure to keep arguments possibly used by 3rd party plugins to filter the query
+	$args = array_merge( $args, $wp_query_args );
+
 	// Get results.
-	$orders = new WP_Query( $wp_query_args );
+	$orders = new WP_Query( $args );
 
 	if ( 'objects' === $args['return'] ) {
 		$return = array_map( 'wc_get_order', $orders->posts );


### PR DESCRIPTION
Hi!

This PR aims to fix a regression introduced in WooCommerce 2.6.

The code below allows to pass the argument 'lang' to the orders query, allowing the query to be filtered according to this argument: 

```
add_filter( 'woocommerce_my_account_my_orders_query', 'account_orders_query' );

function account_orders_query( $args ) {
    $args['lang'] = 'en';
    return $args;
}
```

Since WooCommerce 2.6 and the introduction of the function `wc_get_orders()`, unknown arguments are not passed to the query.

See #11464
