### PR TITLE
Fix: ship_to_different_address

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -376,7 +376,7 @@ class WC_Checkout {
 			$this->posted['createaccount']             = isset( $_POST['createaccount'] ) && ! empty( $_POST['createaccount'] ) ? 1 : 0;
 			$this->posted['payment_method']            = isset( $_POST['payment_method'] ) ? stripslashes( $_POST['payment_method'] ) : '';
 			$this->posted['shipping_method']           = isset( $_POST['shipping_method'] ) ? $_POST['shipping_method'] : '';
-			$this->posted['ship_to_different_address'] = isset( $_POST['ship_to_different_address'] ) ? true : false;
+			$this->posted['ship_to_different_address'] = isset( $_POST['ship_to_different_address'] ) && ! empty( $_POST['ship_to_different_address'] ) ? true : false;
 
 			if ( isset( $_POST['shiptobilling'] ) ) {
 				_deprecated_argument( 'WC_Checkout::process_checkout()', '2.1', 'The "shiptobilling" field is deprecated. The template files are out of date' );


### PR DESCRIPTION
In my development, I have created a group of radio buttons with the name "ship_to_different_address", some have value="1" and some have value="0" , where value="0" it needs to skip the shipping in WC_Checkout, however the condition isset() returns true in this case.
