### PR TITLE
[2.6] Use WC_ROUNDING_PRECISION as a min wc_get_rounding_precision boundary

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1355,15 +1355,16 @@ function wc_product_attribute_uasort_comparison( $a, $b ) {
 }
 
 /**
- * Get rounding precision.
+ * Get rounding precision for internal WC calculations.
+ * Will increase the precision of wc_get_price_decimals by 2 decimals, unless WC_ROUNDING_PRECISION is set to a higher number.
  *
  * @since 2.6.3
  * @return int
  */
 function wc_get_rounding_precision() {
-	if ( defined( 'WC_ROUNDING_PRECISION' ) ) {
-		return absint( WC_ROUNDING_PRECISION );
+	$precision = wc_get_price_decimals() + 2;
+	if ( absint( WC_ROUNDING_PRECISION ) > $precision ) {
+		$precision = absint( WC_ROUNDING_PRECISION );
 	}
-
-	return wc_get_price_decimals() + 2;
+	return $precision;
 }

--- a/tests/unit-tests/util/main-class.php
+++ b/tests/unit-tests/util/main-class.php
@@ -46,6 +46,7 @@ class WC_Tests_Main_Class extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $this->wc->version, WC_VERSION );
 		$this->assertEquals( WC_VERSION, WOOCOMMERCE_VERSION );
+		$this->assertEquals( 4, WC_ROUNDING_PRECISION );
 		$this->assertContains( WC_TAX_ROUNDING_MODE, array( 2, 1 ) );
 		$this->assertEquals( '|', WC_DELIMITER );
 		$this->assertNotEquals( WC_LOG_DIR, '' );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -181,6 +181,7 @@ final class WooCommerce {
 		$this->define( 'WC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 		$this->define( 'WC_VERSION', $this->version );
 		$this->define( 'WOOCOMMERCE_VERSION', $this->version );
+		$this->define( 'WC_ROUNDING_PRECISION', 4 );
 		$this->define( 'WC_DISCOUNT_ROUNDING_MODE', 2 );
 		$this->define( 'WC_TAX_ROUNDING_MODE', 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1 );
 		$this->define( 'WC_DELIMITER', '|' );


### PR DESCRIPTION
A possible solution for https://github.com/woothemes/woocommerce/issues/11490

WC_ROUNDING_PRECISION is defined and used as a low boundary in `wc_get_rounding_precision()`.

@mikejolley @claudiosmweb 
