### PR TITLE
Fix "MySQL Version" on the system status page

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -180,7 +180,7 @@ global $wpdb;
 			$ver = mysql_get_server_info();
 		}
 
-		if ( ! empty( $wpdb->is_mysql ) && stristr( $ver, 'MySQL' ) ) : ?>
+		if ( ! empty( $wpdb->is_mysql ) ) : ?>
 			<tr>
 				<td data-export-label="MySQL Version"><?php _e( 'MySQL Version', 'woocommerce' ); ?>:</td>
 				<td class="help"><?php echo wc_help_tip( __( 'The version of MySQL installed on your hosting server.', 'woocommerce' ) ); ?></td>
@@ -349,7 +349,7 @@ global $wpdb;
 		<tr>
 			<td data-export-label="WC Database Prefix"><?php _e( 'Database Prefix', 'woocommerce' ); ?></td>
 			<td class="help">&nbsp;</td>
-			<td><?php 
+			<td><?php
 				if ( strlen( $wpdb->prefix ) > 20 ) {
 					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s - We recommend using a prefix with less than 20 characters. See: %s', 'woocommerce' ), esc_html( $wpdb->prefix ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . __( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -173,14 +173,7 @@ global $wpdb;
 				<td><?php echo extension_loaded( 'suhosin' ) ? '<span class="dashicons dashicons-yes"></span>' : '&ndash;'; ?></td>
 			</tr>
 		<?php endif; ?>
-		<?php
-		if ( $wpdb->use_mysqli ) {
-			$ver = mysqli_get_server_info( $wpdb->dbh );
-		} else {
-			$ver = mysql_get_server_info();
-		}
-
-		if ( ! empty( $wpdb->is_mysql ) ) : ?>
+		<?php if ( ! empty( $wpdb->is_mysql ) ) : ?>
 			<tr>
 				<td data-export-label="MySQL Version"><?php _e( 'MySQL Version', 'woocommerce' ); ?>:</td>
 				<td class="help"><?php echo wc_help_tip( __( 'The version of MySQL installed on your hosting server.', 'woocommerce' ) ); ?></td>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -172,8 +172,15 @@ global $wpdb;
 				<td class="help"><?php echo wc_help_tip( __( 'Suhosin is an advanced protection system for PHP installations. It was designed to protect your servers on the one hand against a number of well known problems in PHP applications and on the other hand against potential unknown vulnerabilities within these applications or the PHP core itself. If enabled on your server, Suhosin may need to be configured to increase its data submission limits.', 'woocommerce' ) ); ?></td>
 				<td><?php echo extension_loaded( 'suhosin' ) ? '<span class="dashicons dashicons-yes"></span>' : '&ndash;'; ?></td>
 			</tr>
-		<?php endif; ?>
-		<?php if ( ! empty( $wpdb->is_mysql ) ) : ?>
+		<?php endif;
+
+		if ( $wpdb->use_mysqli ) {
+			$ver = mysqli_get_server_info( $wpdb->dbh );
+		} else {
+			$ver = mysql_get_server_info();
+		}
+
+		if ( ! empty( $wpdb->is_mysql ) && ! stristr( $ver, 'MariaDB' ) ) : ?>
 			<tr>
 				<td data-export-label="MySQL Version"><?php _e( 'MySQL Version', 'woocommerce' ); ?>:</td>
 				<td class="help"><?php echo wc_help_tip( __( 'The version of MySQL installed on your hosting server.', 'woocommerce' ) ); ?></td>


### PR DESCRIPTION
I noticed the entire "MySQL Version" row was missing on my system status page. It turns out we were checking for the existence of "MySQL" in the version string. Even the `mysql_get_server_info` example shows a string with no "MySQL". So no row.

This small PR just removes that check (which allows us to remove a few other lines - since we already use `wpdb`'s `db_version` function a few lines down below.
