### PR TITLE
Change ran (past) to run (present)

### DIFF
--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -212,7 +212,7 @@ class WC_Admin_Help {
 			'title'     => __( 'Education', 'woocommerce' ),
 			'content'   =>
 				'<h2>' . __( 'Education', 'woocommerce' ) . '</h2>' .
-				'<p>' . __( 'If you would like to learn about using WooCommerce from an expert, consider following a WooCommerce course ran by one of our educational partners.', 'woocommerce' ) . '</p>' .
+				'<p>' . __( 'If you would like to learn about using WooCommerce from an expert, consider following a WooCommerce course run by one of our educational partners.', 'woocommerce' ) . '</p>' .
 				'<p><a href="' . 'https://woocommerce.com/educational-partners/?utm_source=helptab&utm_medium=product&utm_content=edupartners&utm_campaign=woocommerceplugin' . '" class="button button-primary">' . __( 'View Education Partners', 'woocommerce' ) . '</a></p>'
 		) );
 


### PR DESCRIPTION
Discussed with a couple of people at WordCamp Brighton I believe that the sentence 

If you would like to learn about using WooCommerce from an expert, consider following a WooCommerce course ran by one of our educational partners.

Would be improved if the word 'ran' becomes 'run'.
