### PR TITLE
Allow for individual template locations to be filtered

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -77,6 +77,8 @@ class WC_Template_Loader {
 
 		}
 
+		$find = apply_filters( 'woocommerce_template_location', $find , $template );
+
 		if ( $file ) {
 			$template       = locate_template( array_unique( $find ) );
 			if ( ! $template || WC_TEMPLATE_DEBUG_MODE ) {


### PR DESCRIPTION
Adding a filter for individual template locations allows for a template hierarchy rather than just an override.
ie. currently only woocommerce_template_path can be filtered, so all templates are loaded from that path.
This means that while you could change to templates/woocommerce in a Child Theme,
you cannot use templates/woocommerce/ with a fallback to woocommerce/ - or filter individual templates.
Plus allowing be individually filtered like template parts adds much needed consistency and flexibility here.
