### PR TITLE
Add base REST API test case class for testing WP-API based WC endpoints

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,10 +98,12 @@ class WC_Unit_Tests_Bootstrap {
 		require_once( $this->tests_dir . '/framework/class-wc-mock-session-handler.php' );
 		require_once( $this->tests_dir . '/framework/class-wc-mock-wc-data.php' );
 		require_once( $this->tests_dir . '/framework/class-wc-payment-token-stub.php' );
+		require_once( $this->tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php' );
 
 		// test cases
 		require_once( $this->tests_dir . '/framework/class-wc-unit-test-case.php' );
 		require_once( $this->tests_dir . '/framework/class-wc-api-unit-test-case.php' );
+		require_once( $this->tests_dir . '/framework/class-wc-rest-unit-test-case.php' );
 
 		// Helpers
 		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-product.php' );

--- a/tests/framework/class-wc-rest-unit-test-case.php
+++ b/tests/framework/class-wc-rest-unit-test-case.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * WC REST API Unit Test Case (for WP-API Endpoints).
+ *
+ * Provides REST API specific methods and setup/teardown.
+ *
+ * @since 2.7
+ */
+
+ class WC_REST_Unit_Test_Case extends WC_Unit_Test_Case {
+
+     protected $server;
+
+    /**
+     * Setup our test server.
+     */
+    public function setUp() {
+        parent::setUp();
+        global $wp_rest_server;
+        $this->server = $wp_rest_server = new WP_Test_Spy_REST_Server;
+        do_action( 'rest_api_init' );
+    }
+
+    /**
+     * Unset the server.
+     */
+    public function tearDown() {
+        parent::tearDown();
+        global $wp_rest_server;
+        $wp_rest_server = null;
+    }
+
+}

--- a/tests/framework/vendor/class-wp-test-spy-rest-server.php
+++ b/tests/framework/vendor/class-wp-test-spy-rest-server.php
@@ -1,0 +1,42 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @version 2.0-beta13.1
+ */
+class WP_Test_Spy_REST_Server extends WP_REST_Server {
+	/**
+	 * Get the raw $endpoints data from the server
+	 *
+	 * @return array
+	 */
+	public function get_raw_endpoint_data() {
+		return $this->endpoints;
+	}
+
+	/**
+	 * Allow calling protected methods from tests
+	 *
+	 * @param string $method Method to call
+	 * @param array $args Arguments to pass to the method
+	 * @return mixed
+	 */
+	public function __call( $method, $args ) {
+		return call_user_func_array( array( $this, $method ), $args );
+	}
+
+	/**
+	 * Call dispatch() with the rest_post_dispatch filter
+	 */
+	public function dispatch( $request ) {
+		$result = parent::dispatch( $request );
+		$result = rest_ensure_response( $result );
+		if ( is_wp_error( $result ) ) {
+			$result = $this->error_to_response( $result );
+		}
+		return apply_filters( 'rest_post_dispatch', rest_ensure_response( $result ), $this, $request );
+	}
+}


### PR DESCRIPTION
We already have two PRs open for new WP-API based WC endpoints -- settings and shipping zones. Both PRs share some code for setting up unit tests and both include a copy of a framework file for testing WP-API based endpoints. All of our other new endpoints introduced in 2.6 should also have full test coverage, so this should help those future PRs as well.

This PR:
- Adds WP-API's test-spy-rest-server class to a new vendor folder in the framework folder. It's the same version as the other WP-API files currently bundled with WC.
- Creates a new unit test base class to extend off of.  Right now it just loads the test server into `$this->rest` which allows you to do things like get registered routes and test against them. This class can also be a future home for new asserts or methods related to the API tests.

Here is an example of how these tests might be used in a future webhooks test file:

``` <?php
class WC_Tests_REST_Webhooks extends WC_REST_Unit_Test_Case {

    protected $endpoint;

    public function setUp() {
        parent::setUp();
        $this->endpoint = new WC_REST_Webhooks_Controller();
    }

    public function test_register_routes() {
        $routes = $this->server->get_routes();
        $this->assertArrayHasKey( '/wc/v1/webhooks/batch', $routes );
        // other routes...
    }

}
```

If we can get merged into the 2.7 branch, I can rebase the other PRs to simplify them a bit.
