### PR TITLE
Remove items from a pending order via rest api

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1019,7 +1019,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						// Create item.
 						if ( is_null( $item['id'] ) ) {
 							$this->set_item( $order, $line_type, $item, 'create' );
-						} elseif ( $this->item_is_null( $item ) ) {
+						} elseif ( $this->item_is_null( $item ) || 0 === $item['quantity'] ) {
 							// Delete item.
 							wc_delete_order_item( $item['id'] );
 						} else {

--- a/includes/libraries/class-emogrifier.php
+++ b/includes/libraries/class-emogrifier.php
@@ -569,7 +569,7 @@ class Emogrifier
 		// we don't try to call removeChild on a nonexistent child node
 		/** @var \DOMNode $node */
 		foreach ($nodesWithStyleDisplayNone as $node) {
-			if ($node->parentNode && is_callable([$node->parentNode, 'removeChild'])) {
+			if ( $node->parentNode && is_callable( array($node->parentNode, 'removeChild') ) ) {
 				$node->parentNode->removeChild($node);
 			}
 		}


### PR DESCRIPTION
This solves https://trello.com/c/8ZTYAzH8/93-rest-api-allow-remove-order-line-items 

We need a way to remove line items when using WooCommerce via apis.

To remove an item from an existent order, just put the quantity of that item to 0. 

A common flow would be to create a local cart on the client app, then use it to start a checkout process (the order is created in pending status), at this step the customer see all the order details, totals, taxes etc (returned by the order endpoint), it's common for the customer to review the order and decide to add or remove some item before the actual checkout/payment.
I think we shouldn't delete the entire order when he/she removes an item since we could lose this order if the customer goes away in the meanwhile (and we lose the the opportunity to try to recover that abandoned order by sending an email à la Amazon for example).
