### PR TITLE
Query string -> form field helper function

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -337,6 +337,31 @@ function wc_product_post_class( $classes, $class = '', $post_id = '' ) {
 	return $classes;
 }
 
+/**
+ * Outputs hidden form inputs for each query string variable.
+ * @param array $values name value pairs
+ * @param array $exclude keys to exclude
+ * @since 2.7.0
+ */
+function wc_query_string_form_fields( $values = null, $exclude = array(), $currentkey = '' ) {
+	if ( is_null( $values ) ) {
+		$values = $_GET;
+	}
+	foreach ( $values as $key => $value ) {
+		if ( in_array( $key, $exclude ) ) {
+			continue;
+		}
+		if ( $currentkey ) {
+			$key = $currentkey . '[' . $key . ']';
+		}
+		if ( is_array( $value ) ) {
+			wc_query_string_form_fields( $value, $exclude, $key );
+		} else {
+			echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '" />';
+		}
+	}
+}
+
 /** Template pages ********************************************************/
 
 if ( ! function_exists( 'woocommerce_content' ) ) {
@@ -606,7 +631,7 @@ if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 		if ( is_search() ) {
 			return;
 		}
-		
+
 		if ( is_post_type_archive( 'product' ) && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$shop_page   = get_post( wc_get_page_id( 'shop' ) );
 			if ( $shop_page ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -339,11 +339,12 @@ function wc_product_post_class( $classes, $class = '', $post_id = '' ) {
 
 /**
  * Outputs hidden form inputs for each query string variable.
- * @param array $values name value pairs
- * @param array $exclude keys to exclude
  * @since 2.7.0
+ * @param array $values Name value pairs.
+ * @param array $exclude Keys to exclude.
+ * @param string $current_key Current key we are outputting.
  */
-function wc_query_string_form_fields( $values = null, $exclude = array(), $currentkey = '' ) {
+function wc_query_string_form_fields( $values = null, $exclude = array(), $current_key = '' ) {
 	if ( is_null( $values ) ) {
 		$values = $_GET;
 	}
@@ -351,8 +352,8 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		if ( in_array( $key, $exclude ) ) {
 			continue;
 		}
-		if ( $currentkey ) {
-			$key = $currentkey . '[' . $key . ']';
+		if ( $current_key ) {
+			$key = $current_key . '[' . $key . ']';
 		}
 		if ( is_array( $value ) ) {
 			wc_query_string_form_fields( $value, $exclude, $key );

--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -27,19 +27,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $orderby, $id ); ?>><?php echo esc_html( $name ); ?></option>
 		<?php endforeach; ?>
 	</select>
-	<?php
-		// Keep query string vars intact
-		foreach ( $_GET as $key => $val ) {
-			if ( 'orderby' === $key || 'submit' === $key ) {
-				continue;
-			}
-			if ( is_array( $val ) ) {
-				foreach( $val as $innerVal ) {
-					echo '<input type="hidden" name="' . esc_attr( $key ) . '[]" value="' . esc_attr( $innerVal ) . '" />';
-				}
-			} else {
-				echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $val ) . '" />';
-			}
-		}
-	?>
+	<?php wc_query_string_form_fields( null, array( 'orderby', 'submit' ) ); ?>
 </form>


### PR DESCRIPTION
Used in orderby, this converts query strings to hidden inputs so they can be posted.

Closes #11326 

Testing: go to shop page and add a bunch of query string values. See if they appear in the source of the orderby form.

e.g. `?uf[t][product_cat][value][0]=15&uf[t][product_cat][value][1]=10&uf[t][product_cat][rel]=OR&uf[m][_price][value][0]=0&uf[m][_price][value][1]=12950&uf[m][_price][rel]=BETWEEN`
