### PR TITLE
Add fields to Product Attributes Admin Add and Edit screens

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -4,18 +4,18 @@
  *
  * The attributes section lets users add custom attributes to assign to products - they can also be used in the layered nav widget.
  *
- * @author 		WooThemes
- * @category 	Admin
- * @package 	WooCommerce/Admin
- * @version   2.3.0
+ * @author      WooThemes
+ * @category    Admin
+ * @package     WooCommerce/Admin
+ * @version     2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 /**
- * WC_Admin_Attributes Class
+ * WC_Admin_Attributes Class.
  */
 class WC_Admin_Attributes {
 
@@ -26,40 +26,40 @@ class WC_Admin_Attributes {
 	 * The added attributes are stored in the database and can be used for layered navigation.
 	 */
 	public static function output() {
-			$result = '';
-			$action = '';
+		$result = '';
+		$action = '';
 
-			// Action to perform: add, edit, delete or none
-			if ( ! empty( $_POST['add_new_attribute'] ) ) {
-					$action = 'add';
-			} elseif ( ! empty( $_POST['save_attribute'] ) && ! empty( $_GET['edit'] ) ) {
-					$action = 'edit';
-			} elseif ( ! empty( $_GET['delete'] ) ) {
-					$action = 'delete';
-			}
+		// Action to perform: add, edit, delete or none
+		if ( ! empty( $_POST['add_new_attribute'] ) ) {
+			$action = 'add';
+		} elseif ( ! empty( $_POST['save_attribute'] ) && ! empty( $_GET['edit'] ) ) {
+			$action = 'edit';
+		} elseif ( ! empty( $_GET['delete'] ) ) {
+			$action = 'delete';
+		}
 
-			switch ( $action ) {
-					case 'add' :
-							$result = self::process_add_attribute();
-					break;
-					case 'edit' :
-							$result = self::process_edit_attribute();
-					break;
-					case 'delete' :
-							$result = self::process_delete_attribute();
-					break;
-			}
+		switch ( $action ) {
+			case 'add' :
+				$result = self::process_add_attribute();
+			break;
+			case 'edit' :
+				$result = self::process_edit_attribute();
+			break;
+			case 'delete' :
+				$result = self::process_delete_attribute();
+			break;
+		}
 
-			if ( is_wp_error( $result ) ) {
-					echo '<div id="woocommerce_errors" class="error"><p>' . $result->get_error_message() . '</p></div>';
-			}
+		if ( is_wp_error( $result ) ) {
+			echo '<div id="woocommerce_errors" class="error"><p>' . $result->get_error_message() . '</p></div>';
+		}
 
-			// Show admin interface
-			if ( ! empty( $_GET['edit'] ) ) {
-					self::edit_attribute();
-			} else {
-					self::add_attribute();
-			}
+		// Show admin interface
+		if ( ! empty( $_GET['edit'] ) ) {
+			self::edit_attribute();
+		} else {
+			self::add_attribute();
+		}
 	}
 
 	/**
@@ -67,27 +67,27 @@ class WC_Admin_Attributes {
 	 * @return array
 	 */
 	private static function get_posted_attribute() {
-			$attribute = array(
-					'attribute_label'   		=> isset( $_POST['attribute_label'] ) ? wc_clean( stripslashes( $_POST['attribute_label'] ) ) : '',
-					'attribute_name'    		=> isset( $_POST['attribute_name'] ) ? wc_sanitize_taxonomy_name( stripslashes( $_POST['attribute_name'] ) ) : '',
-					'attribute_type'    		=> isset( $_POST['attribute_type'] ) ? wc_clean( $_POST['attribute_type'] ) : 'select',
-					'attribute_orderby' 		=> isset( $_POST['attribute_orderby'] ) ? wc_clean( $_POST['attribute_orderby'] ) : '',
-					'attribute_public'  		=> isset( $_POST['attribute_public'] ) ? 1 : 0,
-					'attribute_description' => isset( $_POST['attribute_description'] ) ? wc_clean( stripslashes( $_POST['attribute_description'] ) ) : '',
-					'attribute_thumbnail_id' 		=> isset( $_POST['attribute_thumbnail_id'] ) ? absint( $_POST['attribute_thumbnail_id'] ) : ''
-			);
+		$attribute = array(
+			'attribute_label'   => isset( $_POST['attribute_label'] )   ? wc_clean( stripslashes( $_POST['attribute_label'] ) ) : '',
+			'attribute_name'    => isset( $_POST['attribute_name'] )    ? wc_sanitize_taxonomy_name( stripslashes( $_POST['attribute_name'] ) ) : '',
+			'attribute_type'    => isset( $_POST['attribute_type'] )    ? wc_clean( $_POST['attribute_type'] ) : 'select',
+			'attribute_orderby' => isset( $_POST['attribute_orderby'] ) ? wc_clean( $_POST['attribute_orderby'] ) : '',
+			'attribute_public'  => isset( $_POST['attribute_public'] )  ? 1 : 0
+			'attribute_description' => isset( $_POST['attribute_description'] ) ? wc_clean( stripslashes( $_POST['attribute_description'] ) ) : '',
+			'attribute_thumbnail_id'=> isset( $_POST['attribute_thumbnail_id'] ) ? absint( $_POST['attribute_thumbnail_id'] ) : ''
+		);
 
-			if ( empty( $attribute['attribute_type'] ) ) {
-					$attribute['attribute_type'] = 'select';
-			}
-			if ( empty( $attribute['attribute_label'] ) ) {
-					$attribute['attribute_label'] = ucfirst( $attribute['attribute_name'] );
-			}
-			if ( empty( $attribute['attribute_name'] ) ) {
-					$attribute['attribute_name'] = wc_sanitize_taxonomy_name( $attribute['attribute_label'] );
-			}
+		if ( empty( $attribute['attribute_type'] ) ) {
+			$attribute['attribute_type'] = 'select';
+		}
+		if ( empty( $attribute['attribute_label'] ) ) {
+			$attribute['attribute_label'] = ucfirst( $attribute['attribute_name'] );
+		}
+		if ( empty( $attribute['attribute_name'] ) ) {
+			$attribute['attribute_name'] = wc_sanitize_taxonomy_name( $attribute['attribute_label'] );
+		}
 
-			return $attribute;
+		return $attribute;
 	}
 
 	/**
@@ -96,13 +96,13 @@ class WC_Admin_Attributes {
 	 * @return bool|WP_error result
 	 */
 	private static function valid_attribute_name( $attribute_name ) {
-			if ( strlen( $attribute_name ) >= 28 ) {
-					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
-			} elseif ( wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
-					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
-			}
+		if ( strlen( $attribute_name ) >= 28 ) {
+			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
+		} elseif ( wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
+		}
 
-			return true;
+		return true;
 	}
 
 	/**
@@ -110,27 +110,27 @@ class WC_Admin_Attributes {
 	 * @return bool|WP_Error
 	 */
 	private static function process_add_attribute() {
-			global $wpdb;
-			check_admin_referer( 'woocommerce-add-new_attribute' );
+		global $wpdb;
+		check_admin_referer( 'woocommerce-add-new_attribute' );
 
-			$attribute = self::get_posted_attribute();
+		$attribute = self::get_posted_attribute();
 
-			if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
-					return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
-			} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
-					return $valid_attribute_name;
-			} elseif ( taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ) ) {
-					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
-			}
+		if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
+			return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
+		} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
+			return $valid_attribute_name;
+		} elseif ( taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ) ) {
+			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
+		}
 
-			$wpdb->insert( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute );
+		$wpdb->insert( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute );
 
-			do_action( 'woocommerce_attribute_added', $wpdb->insert_id, $attribute );
+		do_action( 'woocommerce_attribute_added', $wpdb->insert_id, $attribute );
 
-			flush_rewrite_rules();
-			delete_transient( 'wc_attribute_taxonomies' );
+		flush_rewrite_rules();
+		delete_transient( 'wc_attribute_taxonomies' );
 
-			return true;
+		return true;
 	}
 
 	/**
@@ -138,74 +138,74 @@ class WC_Admin_Attributes {
 	 * @return bool|WP_Error
 	 */
 	private static function process_edit_attribute() {
-			global $wpdb;
-			$attribute_id = absint( $_GET['edit'] );
-			check_admin_referer( 'woocommerce-save-attribute_' . $attribute_id );
+		global $wpdb;
+		$attribute_id = absint( $_GET['edit'] );
+		check_admin_referer( 'woocommerce-save-attribute_' . $attribute_id );
 
-			$attribute = self::get_posted_attribute();
+		$attribute = self::get_posted_attribute();
 
-			if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
-					return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
-			} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
-					return $valid_attribute_name;
+		if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
+			return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
+		} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
+			return $valid_attribute_name;
+		}
+
+		$taxonomy_exists    = taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) );
+		$old_attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
+		if ( $old_attribute_name != $attribute['attribute_name'] && wc_sanitize_taxonomy_name( $old_attribute_name ) != $attribute['attribute_name'] && $taxonomy_exists ) {
+			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
+		}
+
+		$wpdb->update( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute, array( 'attribute_id' => $attribute_id ) );
+
+		do_action( 'woocommerce_attribute_updated', $attribute_id, $attribute, $old_attribute_name );
+
+		if ( $old_attribute_name != $attribute['attribute_name'] && ! empty( $old_attribute_name ) ) {
+			// Update taxonomies in the wp term taxonomy table
+			$wpdb->update(
+				$wpdb->term_taxonomy,
+				array( 'taxonomy' => wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ),
+				array( 'taxonomy' => 'pa_' . $old_attribute_name )
+			);
+
+			// Update taxonomy ordering term meta
+			if ( get_option( 'db_version' ) < 34370 ) {
+				$wpdb->update(
+					$wpdb->prefix . 'woocommerce_termmeta',
+					array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
+					array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
+				);
+			} else {
+				$wpdb->update(
+					$wpdb->termmeta,
+					array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
+					array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
+				);
 			}
 
-			$taxonomy_exists    = taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) );
-			$old_attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
-			if ( $old_attribute_name != $attribute['attribute_name'] && wc_sanitize_taxonomy_name( $old_attribute_name ) != $attribute['attribute_name'] && $taxonomy_exists ) {
-					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
-			}
+			// Update product attributes which use this taxonomy
+			$old_attribute_name_length = strlen( $old_attribute_name ) + 3;
+			$attribute_name_length     = strlen( $attribute['attribute_name'] ) + 3;
 
-			$wpdb->update( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute, array( 'attribute_id' => $attribute_id ) );
+			$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->postmeta} SET meta_value = REPLACE( meta_value, %s, %s ) WHERE meta_key = '_product_attributes'",
+				's:' . $old_attribute_name_length . ':"pa_' . $old_attribute_name . '"',
+				's:' . $attribute_name_length . ':"pa_' . $attribute['attribute_name'] . '"'
+			) );
 
-			do_action( 'woocommerce_attribute_updated', $attribute_id, $attribute, $old_attribute_name );
+			// Update variations which use this taxonomy
+			$wpdb->update(
+				$wpdb->postmeta,
+				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
+				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $old_attribute_name ) )
+			);
+		}
 
-			if ( $old_attribute_name != $attribute['attribute_name'] && ! empty( $old_attribute_name ) ) {
-					// Update taxonomies in the wp term taxonomy table
-					$wpdb->update(
-							$wpdb->term_taxonomy,
-							array( 'taxonomy' => wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ),
-							array( 'taxonomy' => 'pa_' . $old_attribute_name )
-					);
+		echo '<div class="updated"><p>' . __( 'Attribute updated successfully', 'woocommerce' ) . '</p></div>';
 
-					// Update taxonomy ordering term meta
-					if ( get_option( 'db_version' ) < 34370 ) {
-							$wpdb->update(
-									$wpdb->prefix . 'woocommerce_termmeta',
-									array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
-									array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
-							);
-					} else {
-							$wpdb->update(
-									$wpdb->termmeta,
-									array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
-									array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
-							);
-					}
+		flush_rewrite_rules();
+		delete_transient( 'wc_attribute_taxonomies' );
 
-					// Update product attributes which use this taxonomy
-					$old_attribute_name_length = strlen( $old_attribute_name ) + 3;
-					$attribute_name_length     = strlen( $attribute['attribute_name'] ) + 3;
-
-					$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->postmeta} SET meta_value = REPLACE( meta_value, %s, %s ) WHERE meta_key = '_product_attributes_ext'",
-							's:' . $old_attribute_name_length . ':"pa_' . $old_attribute_name . '"',
-							's:' . $attribute_name_length . ':"pa_' . $attribute['attribute_name'] . '"'
-					) );
-
-					// Update variations which use this taxonomy
-					$wpdb->update(
-							$wpdb->postmeta,
-							array( 'meta_key' => 'attribute_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
-							array( 'meta_key' => 'attribute_pa_' . sanitize_title( $old_attribute_name ) )
-					);
-			}
-
-			echo '<div class="updated"><p>' . __( 'Attribute updated successfully', 'woocommerce' ) . '</p></div>';
-
-			flush_rewrite_rules();
-			delete_transient( 'wc_attribute_taxonomies' );
-
-			return true;
+		return true;
 	}
 
 	/**
@@ -213,31 +213,31 @@ class WC_Admin_Attributes {
 	 * @return bool
 	 */
 	private static function process_delete_attribute() {
-			global $wpdb;
+		global $wpdb;
 
-			$attribute_id = absint( $_GET['delete'] );
+		$attribute_id = absint( $_GET['delete'] );
 
-			check_admin_referer( 'woocommerce-delete-attribute_' . $attribute_id );
+		check_admin_referer( 'woocommerce-delete-attribute_' . $attribute_id );
 
-			$attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
-			$taxonomy       = wc_attribute_taxonomy_name( $attribute_name );
+		$attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
+		$taxonomy       = wc_attribute_taxonomy_name( $attribute_name );
 
-			do_action( 'woocommerce_before_attribute_delete', $attribute_id, $attribute_name, $taxonomy );
+		do_action( 'woocommerce_before_attribute_delete', $attribute_id, $attribute_name, $taxonomy );
 
-			if ( $attribute_name && $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" ) ) {
-					if ( taxonomy_exists( $taxonomy ) ) {
-							$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
-							foreach ( $terms as $term ) {
-									wp_delete_term( $term->term_id, $taxonomy );
-							}
-					}
-
-					do_action( 'woocommerce_attribute_deleted', $attribute_id, $attribute_name, $taxonomy );
-					delete_transient( 'wc_attribute_taxonomies' );
-					return true;
+		if ( $attribute_name && $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" ) ) {
+			if ( taxonomy_exists( $taxonomy ) ) {
+				$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
+				foreach ( $terms as $term ) {
+					wp_delete_term( $term->term_id, $taxonomy );
+				}
 			}
 
-			return false;
+			do_action( 'woocommerce_attribute_deleted', $attribute_id, $attribute_name, $taxonomy );
+			delete_transient( 'wc_attribute_taxonomies' );
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -246,188 +246,185 @@ class WC_Admin_Attributes {
 	 * Shows the interface for changing an attributes type between select and text.
 	 */
 	public static function edit_attribute() {
-			global $wpdb;
+		global $wpdb;
 
-			$edit = absint( $_GET['edit'] );
+		$edit = absint( $_GET['edit'] );
 
-			$attribute_to_edit = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies WHERE attribute_id = '$edit'" );
+		$attribute_to_edit = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies WHERE attribute_id = '$edit'" );
 
-			wp_enqueue_media();
-			// echo '<pre>'; var_dump($attribute_to_edit); echo '</pre>';
-			?>
-			<div class="wrap woocommerce">
-					<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
-					<h1><?php _e( 'Edit Attribute', 'woocommerce' ) ?></h1>
+		?>
+		<div class="wrap woocommerce">
+			<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
+			<h1><?php _e( 'Edit Attribute', 'woocommerce' ) ?></h1>
 
-					<?php
-
-							if ( ! $attribute_to_edit ) {
-									echo '<div id="woocommerce_errors" class="error"><p>' . __( 'Error: non-existing attribute ID.', 'woocommerce' ) . '</p></div>';
-							} else {
-									$att_type    = $attribute_to_edit->attribute_type;
-									$att_label   = $attribute_to_edit->attribute_label;
-									$att_name    = $attribute_to_edit->attribute_name;
-									$att_desc    = $attribute_to_edit->attribute_description;
-									$att_orderby = $attribute_to_edit->attribute_orderby;
-									$att_public  = $attribute_to_edit->attribute_public;
-									$thumbnail_id = $attribute_to_edit->attribute_thumbnail_id;
-									if ( $thumbnail_id ) {
-											$image = wp_get_attachment_thumb_url( $thumbnail_id );
-									} else {
-											$image = wc_placeholder_img_src();
-									}
-
-
-							?>
-
-							<form action="edit.php?post_type=product&amp;page=product_attributes&amp;edit=<?php echo absint( $edit ); ?>" method="post">
-									<table class="form-table">
-											<tbody>
-													<tr class="form-field form-required">
-															<th scope="row" valign="top">
-																	<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
-															</th>
-															<td>
-																	<input name="attribute_label" id="attribute_label" type="text" value="<?php echo esc_attr( $att_label ); ?>" />
-																	<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
-															</td>
-													</tr>
-													<tr class="form-field form-required">
-															<th scope="row" valign="top">
-																	<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
-															</th>
-															<td>
-																	<input name="attribute_name" id="attribute_name" type="text" value="<?php echo esc_attr( $att_name ); ?>" maxlength="28" />
-																	<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
-															</td>
-													</tr>
-													<tr class="form-field">
-															<th scope="row" valign="top">
-																	<label for="attribute_description"><?php _e( 'Description', 'woocommerce' ); ?></label>
-															</th>
-															<td>
-																	<textarea name="attribute_description" id="attribute_description" rows="4"><?php echo esc_attr( $att_desc ); ?></textarea>
-																	<p class="description"><?php _e( 'Description for the attribute, optional.', 'woocommerce' ); ?></p>
-															</td>
-													</tr>
-													<tr class="form-field">
-									            <th scope="row" valign="top">
-																<label><?php _e( 'Attribute Graphic', 'woocommerce' ); ?></label>
-															</th>
-									            <td>
-									                <div id="attribute_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( $image ); ?>" width="60px" height="60px" /></div>
-									                <div style="line-height: 60px;">
-									                    <input type="hidden" id="attribute_thumbnail_id" name="attribute_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
-									                    <button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
-									                    <button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
-									                </div>
-									                <script type="text/javascript">
-
-									                    // Only show the "remove image" button when needed
-									                    if ( '0' === jQuery( '#attribute_thumbnail_id' ).val() ) {
-									                        jQuery( '.remove_image_button' ).hide();
-									                    }
-
-									                    // Uploading files
-									                    var file_frame;
-
-									                    jQuery( document ).on( 'click', '.upload_image_button', function( event ) {
-
-									                        event.preventDefault();
-
-									                        // If the media frame already exists, reopen it.
-									                        if ( file_frame ) {
-									                            file_frame.open();
-									                            return;
-									                        }
-
-									                        // Create the media frame.
-									                        file_frame = wp.media.frames.downloadable_file = wp.media({
-									                            title: '<?php _e( "Choose an image", "woocommerce" ); ?>',
-									                            button: {
-									                                text: '<?php _e( "Use image", "woocommerce" ); ?>'
-									                            },
-									                            multiple: false
-									                        });
-
-									                        // When an image is selected, run a callback.
-									                        file_frame.on( 'select', function() {
-									                            var attachment = file_frame.state().get( 'selection' ).first().toJSON();
-
-									                            jQuery( '#attribute_thumbnail_id' ).val( attachment.id );
-									                            jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', attachment.url );
-									                            jQuery( '.remove_image_button' ).show();
-									                        });
-
-									                        // Finally, open the modal.
-									                        file_frame.open();
-									                    });
-
-									                    jQuery( document ).on( 'click', '.remove_image_button', function() {
-									                        jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
-									                        jQuery( '#attribute_thumbnail_id' ).val( '' );
-									                        jQuery( '.remove_image_button' ).hide();
-									                        return false;
-									                    });
-
-									                </script>
-									                <div class="clear"></div>
-									            </td>
-									        </tr>
-													<tr class="form-field form-required">
-															<th scope="row" valign="top">
-																	<label for="attribute_public"><?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
-															</th>
-															<td>
-																	<input name="attribute_public" id="attribute_public" type="checkbox" value="1" <?php checked( $att_public, 1 ); ?> />
-																	<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
-															</td>
-													</tr>
-													<tr class="form-field form-required">
-															<th scope="row" valign="top">
-																	<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
-															</th>
-															<td>
-																	<select name="attribute_type" id="attribute_type">
-																			<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
-																					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $att_type, $key ); ?>><?php echo esc_attr( $value ); ?></option>
-																			<?php endforeach; ?>
-
-																			<?php
-
-																					/**
-																					 * Deprecated action in favor of product_attributes_type_selector filter.
-																					 *
-																					 * @deprecated 2.4.0
-																					 */
-																					do_action( 'woocommerce_admin_attribute_types' );
-																			?>
-																	</select>
-																	<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
-															</td>
-													</tr>
-													<tr class="form-field form-required">
-															<th scope="row" valign="top">
-																	<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
-															</th>
-															<td>
-																	<select name="attribute_orderby" id="attribute_orderby">
-																			<option value="menu_order" <?php selected( $att_orderby, 'menu_order' ); ?>><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
-																			<option value="name" <?php selected( $att_orderby, 'name' ); ?>><?php _e( 'Name', 'woocommerce' ); ?></option>
-																			<option value="name_num" <?php selected( $att_orderby, 'name_num' ); ?>><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
-																			<option value="id" <?php selected( $att_orderby, 'id' ); ?>><?php _e( 'Term ID', 'woocommerce' ); ?></option>
-																	</select>
-																	<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
-															</td>
-													</tr>
-											</tbody>
-									</table>
-									<p class="submit"><input type="submit" name="save_attribute" id="submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'woocommerce' ); ?>"></p>
-									<?php wp_nonce_field( 'woocommerce-save-attribute_' . $edit ); ?>
-							</form>
-					<?php } ?>
-			</div>
 			<?php
+
+				if ( ! $attribute_to_edit ) {
+					echo '<div id="woocommerce_errors" class="error"><p>' . __( 'Error: non-existing attribute ID.', 'woocommerce' ) . '</p></div>';
+				} else {
+					$att_type    = $attribute_to_edit->attribute_type;
+					$att_label   = $attribute_to_edit->attribute_label;
+					$att_name    = $attribute_to_edit->attribute_name;
+					$att_orderby = $attribute_to_edit->attribute_orderby;
+					$att_public  = $attribute_to_edit->attribute_public;
+					$att_desc    = $attribute_to_edit->attribute_description;
+					$thumbnail_id = $attribute_to_edit->attribute_thumbnail_id;
+					if ( $thumbnail_id ) {
+							$image = wp_get_attachment_thumb_url( $thumbnail_id );
+					} else {
+							$image = wc_placeholder_img_src();
+					}
+
+				?>
+
+				<form action="edit.php?post_type=product&amp;page=product_attributes&amp;edit=<?php echo absint( $edit ); ?>" method="post">
+					<table class="form-table">
+						<tbody>
+							<tr class="form-field form-required">
+								<th scope="row" valign="top">
+									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
+								</th>
+								<td>
+									<input name="attribute_label" id="attribute_label" type="text" value="<?php echo esc_attr( $att_label ); ?>" />
+									<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
+								</td>
+							</tr>
+							<tr class="form-field form-required">
+								<th scope="row" valign="top">
+									<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
+								</th>
+								<td>
+									<input name="attribute_name" id="attribute_name" type="text" value="<?php echo esc_attr( $att_name ); ?>" maxlength="28" />
+									<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
+								</td>
+							</tr>
+							<tr class="form-field">
+									<th scope="row" valign="top">
+											<label for="attribute_description"><?php _e( 'Description', 'woocommerce' ); ?></label>
+									</th>
+									<td>
+											<textarea name="attribute_description" id="attribute_description" rows="4"><?php echo esc_attr( $att_desc ); ?></textarea>
+											<p class="description"><?php _e( 'Description for the attribute, optional.', 'woocommerce' ); ?></p>
+									</td>
+							</tr>
+							<tr class="form-field">
+									<th scope="row" valign="top">
+										<label><?php _e( 'Attribute Graphic', 'woocommerce' ); ?></label>
+									</th>
+									<td>
+											<div id="attribute_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( $image ); ?>" width="60px" height="60px" /></div>
+											<div style="line-height: 60px;">
+													<input type="hidden" id="attribute_thumbnail_id" name="attribute_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
+													<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
+													<button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
+											</div>
+											<script type="text/javascript">
+
+													// Only show the "remove image" button when needed
+													if ( '0' === jQuery( '#attribute_thumbnail_id' ).val() ) {
+															jQuery( '.remove_image_button' ).hide();
+													}
+
+													// Uploading files
+													var file_frame;
+
+													jQuery( document ).on( 'click', '.upload_image_button', function( event ) {
+
+															event.preventDefault();
+
+															// If the media frame already exists, reopen it.
+															if ( file_frame ) {
+																	file_frame.open();
+																	return;
+															}
+
+															// Create the media frame.
+															file_frame = wp.media.frames.downloadable_file = wp.media({
+																	title: '<?php _e( "Choose an image", "woocommerce" ); ?>',
+																	button: {
+																			text: '<?php _e( "Use image", "woocommerce" ); ?>'
+																	},
+																	multiple: false
+															});
+
+															// When an image is selected, run a callback.
+															file_frame.on( 'select', function() {
+																	var attachment = file_frame.state().get( 'selection' ).first().toJSON();
+
+																	jQuery( '#attribute_thumbnail_id' ).val( attachment.id );
+																	jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', attachment.url );
+																	jQuery( '.remove_image_button' ).show();
+															});
+
+															// Finally, open the modal.
+															file_frame.open();
+													});
+
+													jQuery( document ).on( 'click', '.remove_image_button', function() {
+															jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+															jQuery( '#attribute_thumbnail_id' ).val( '' );
+															jQuery( '.remove_image_button' ).hide();
+															return false;
+													});
+
+											</script>
+											<div class="clear"></div>
+									</td>
+							</tr>
+							<tr class="form-field form-required">
+								<th scope="row" valign="top">
+									<label for="attribute_public"><?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
+								</th>
+								<td>
+									<input name="attribute_public" id="attribute_public" type="checkbox" value="1" <?php checked( $att_public, 1 ); ?> />
+									<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
+								</td>
+							</tr>
+							<tr class="form-field form-required">
+								<th scope="row" valign="top">
+									<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
+								</th>
+								<td>
+									<select name="attribute_type" id="attribute_type">
+										<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
+											<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $att_type, $key ); ?>><?php echo esc_attr( $value ); ?></option>
+										<?php endforeach; ?>
+
+										<?php
+
+											/**
+											 * Deprecated action in favor of product_attributes_type_selector filter.
+											 *
+											 * @deprecated 2.4.0
+											 */
+											do_action( 'woocommerce_admin_attribute_types' );
+										?>
+									</select>
+									<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
+								</td>
+							</tr>
+							<tr class="form-field form-required">
+								<th scope="row" valign="top">
+									<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
+								</th>
+								<td>
+									<select name="attribute_orderby" id="attribute_orderby">
+										<option value="menu_order" <?php selected( $att_orderby, 'menu_order' ); ?>><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
+										<option value="name" <?php selected( $att_orderby, 'name' ); ?>><?php _e( 'Name', 'woocommerce' ); ?></option>
+										<option value="name_num" <?php selected( $att_orderby, 'name_num' ); ?>><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
+										<option value="id" <?php selected( $att_orderby, 'id' ); ?>><?php _e( 'Term ID', 'woocommerce' ); ?></option>
+									</select>
+									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+					<p class="submit"><input type="submit" name="save_attribute" id="submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'woocommerce' ); ?>"></p>
+					<?php wp_nonce_field( 'woocommerce-save-attribute_' . $edit ); ?>
+				</form>
+			<?php } ?>
+		</div>
+		<?php
 	}
 
 	/**
@@ -436,263 +433,262 @@ class WC_Admin_Attributes {
 	 * Shows the interface for adding new attributes.
 	 */
 	public static function add_attribute() {
-		wp_enqueue_media();
-			?>
-			<div class="wrap woocommerce">
-					<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
-					<h1><?php _e( 'Attributes', 'woocommerce' ); ?></h1>
-					<br class="clear" />
-					<div id="col-container">
-							<div id="col-right">
-									<div class="col-wrap">
-											<table class="widefat attributes-table wp-list-table ui-sortable" style="width:100%">
-													<thead>
-															<tr>
-																	<th scope="col"><?php _e( 'Image', 'woocommerce' ); ?></th>
-																	<th scope="col"><?php _e( 'Name', 'woocommerce' ); ?></th>
-																	<th scope="col"><?php _e( 'Slug', 'woocommerce' ); ?></th>
-																	<th scope="col"><?php _e( 'Type', 'woocommerce' ); ?></th>
-																	<th scope="col"><?php _e( 'Order by', 'woocommerce' ); ?></th>
-																	<th scope="col" colspan="2"><?php _e( 'Terms', 'woocommerce' ); ?></th>
-															</tr>
-													</thead>
-													<tbody>
-															<?php
-																	if ( $attribute_taxonomies = wc_get_attribute_taxonomies() ) :
-																			foreach ( $attribute_taxonomies as $tax ) :
-																					?><tr>
-																							<td>
-																								<?php
-																								$thumbnail_id = $tax->attribute_thumbnail_id;
+		?>
+		<div class="wrap woocommerce">
+			<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
+			<h1><?php _e( 'Attributes', 'woocommerce' ); ?></h1>
+			<br class="clear" />
+			<div id="col-container">
+				<div id="col-right">
+					<div class="col-wrap">
+						<table class="widefat attributes-table wp-list-table ui-sortable" style="width:100%">
+							<thead>
+								<tr>
+									<th scope="col"><?php _e( 'Image', 'woocommerce' ); ?></th>
+									<th scope="col"><?php _e( 'Name', 'woocommerce' ); ?></th>
+									<th scope="col"><?php _e( 'Slug', 'woocommerce' ); ?></th>
+									<th scope="col"><?php _e( 'Type', 'woocommerce' ); ?></th>
+									<th scope="col"><?php _e( 'Order by', 'woocommerce' ); ?></th>
+									<th scope="col" colspan="2"><?php _e( 'Terms', 'woocommerce' ); ?></th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php
+									if ( $attribute_taxonomies = wc_get_attribute_taxonomies() ) :
+										foreach ( $attribute_taxonomies as $tax ) :
+											?><tr>
 
-																								if ( $thumbnail_id ) {
-																										$image = wp_get_attachment_thumb_url( $thumbnail_id );
-																								} else {
-																										$image = wc_placeholder_img_src();
-																								}
-																								echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr__( 'Thumbnail', 'woocommerce' ) . '" class="wp-post-image" height="48" width="48" />';
-																								?>
-																							</td>
-																							<td>
-																									<strong><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product"><?php echo esc_html( $tax->attribute_label ); ?></a></strong>
+												<td>
+													<?php
+													$thumbnail_id = $tax->attribute_thumbnail_id;
 
-																									<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes_ext' ) ); ?>"><?php _e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes_ext' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php _e( 'Delete', 'woocommerce' ); ?></a></span></div>
-																							</td>
-																							<td><?php echo esc_html( $tax->attribute_name ); ?></td>
-																							<td><?php echo esc_html( ucfirst( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? '(' . __( 'Public', 'woocommerce' ) . ')' : ''; ?></td>
-																							<td><?php
-																									switch ( $tax->attribute_orderby ) {
-																											case 'name' :
-																													_e( 'Name', 'woocommerce' );
-																											break;
-																											case 'name_num' :
-																													_e( 'Name (numeric)', 'woocommerce' );
-																											break;
-																											case 'id' :
-																													_e( 'Term ID', 'woocommerce' );
-																											break;
-																											default:
-																													_e( 'Custom ordering', 'woocommerce' );
-																											break;
-																									}
-																							?></td>
-																							<td class="attribute-terms"><?php
-																									$taxonomy = wc_attribute_taxonomy_name( $tax->attribute_name );
+													if ( $thumbnail_id ) {
+															$image = wp_get_attachment_thumb_url( $thumbnail_id );
+													} else {
+															$image = wc_placeholder_img_src();
+													}
+													echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr__( 'Thumbnail', 'woocommerce' ) . '" class="wp-post-image" height="48" width="48" />';
+													?>
+												</td>
+												<td>
+													<strong><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product"><?php echo esc_html( $tax->attribute_label ); ?></a></strong>
 
-																									if ( taxonomy_exists( $taxonomy ) ) {
-																											$terms = get_terms( $taxonomy, 'hide_empty=0' );
+													<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ) ); ?>"><?php _e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php _e( 'Delete', 'woocommerce' ); ?></a></span></div>
+												</td>
+												<td><?php echo esc_html( $tax->attribute_name ); ?></td>
+												<td><?php echo esc_html( ucfirst( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? '(' . __( 'Public', 'woocommerce' ) . ')' : ''; ?></td>
+												<td><?php
+													switch ( $tax->attribute_orderby ) {
+														case 'name' :
+															_e( 'Name', 'woocommerce' );
+														break;
+														case 'name_num' :
+															_e( 'Name (numeric)', 'woocommerce' );
+														break;
+														case 'id' :
+															_e( 'Term ID', 'woocommerce' );
+														break;
+														default:
+															_e( 'Custom ordering', 'woocommerce' );
+														break;
+													}
+												?></td>
+												<td class="attribute-terms"><?php
+													$taxonomy = wc_attribute_taxonomy_name( $tax->attribute_name );
 
-																											switch ( $tax->attribute_orderby ) {
-																													case 'name_num' :
-																															usort( $terms, '_wc_get_product_terms_name_num_usort_callback' );
-																													break;
-																													case 'parent' :
-																															usort( $terms, '_wc_get_product_terms_parent_usort_callback' );
-																													break;
-																											}
+													if ( taxonomy_exists( $taxonomy ) ) {
+														$terms = get_terms( $taxonomy, 'hide_empty=0' );
 
-																											$terms_string = implode( ', ', wp_list_pluck( $terms, 'name' ) );
-																											if ( $terms_string ) {
-																													echo $terms_string;
-																											} else {
-																													echo '<span class="na">&ndash;</span>';
-																											}
-																									} else {
-																											echo '<span class="na">&ndash;</span>';
-																									}
-																							?></td>
-																							<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button alignright tips configure-terms" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
-																					</tr><?php
-																			endforeach;
-																	else :
-																			?><tr><td colspan="6"><?php _e( 'No attributes currently exist.', 'woocommerce' ) ?></td></tr><?php
-																	endif;
-															?>
-													</tbody>
-											</table>
-									</div>
-							</div>
-							<div id="col-left">
-									<div class="col-wrap">
-											<div class="form-wrap">
-													<h2><?php _e( 'Add New Attribute', 'woocommerce' ); ?></h2>
-													<p><?php _e( 'Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the "layered nav" widgets. Please note: you cannot rename an attribute later on.', 'woocommerce' ); ?></p>
-													<form action="edit.php?post_type=product&amp;page=product_attributes" method="post">
-															<div class="form-field">
-																	<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
-																	<input name="attribute_label" id="attribute_label" type="text" value="" />
-																	<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
-															</div>
+														switch ( $tax->attribute_orderby ) {
+															case 'name_num' :
+																usort( $terms, '_wc_get_product_terms_name_num_usort_callback' );
+															break;
+															case 'parent' :
+																usort( $terms, '_wc_get_product_terms_parent_usort_callback' );
+															break;
+														}
 
-															<div class="form-field">
-																	<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
-																	<input name="attribute_name" id="attribute_name" type="text" value="" maxlength="28" />
-																	<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
-															</div>
-
-															<div class="form-field">
-																	<label for="attribute_description"><?php _e( 'Description', 'woocommerce' ); ?></label>
-																	<textarea name="attribute_description" id="attribute_description" value="" rows="4"></textarea>
-																	<p class="description"><?php _e( 'Description for the attribute, optional.', 'woocommerce' ); ?></p>
-															</div>
-
-															<div class="form-field term-thumbnail-wrap">
-											            <label><?php _e( 'Attribute Graphic', 'woocommerce' ); ?></label>
-											            <div id="attribute_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_placeholder_img_src() ); ?>" width="60px" height="60px" /></div>
-											            <div style="line-height: 60px;">
-											                <input type="hidden" id="attribute_thumbnail_id" name="attribute_thumbnail_id" />
-											                <button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
-											                <button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
-											            </div>
-											            <script type="text/javascript">
-
-											                // Only show the "remove image" button when needed
-											                if ( ! jQuery( '#attribute_thumbnail_id' ).val() ) {
-											                    jQuery( '.remove_image_button' ).hide();
-											                }
-
-											                // Uploading files
-											                var file_frame;
-
-											                jQuery( document ).on( 'click', '.upload_image_button', function( event ) {
-
-											                    event.preventDefault();
-
-											                    // If the media frame already exists, reopen it.
-											                    if ( file_frame ) {
-											                        file_frame.open();
-											                        return;
-											                    }
-
-											                    // Create the media frame.
-											                    file_frame = wp.media.frames.downloadable_file = wp.media({
-											                        title: '<?php _e( "Choose an image", "woocommerce" ); ?>',
-											                        button: {
-											                            text: '<?php _e( "Use image", "woocommerce" ); ?>'
-											                        },
-											                        multiple: false
-											                    });
-
-											                    // When an image is selected, run a callback.
-											                    file_frame.on( 'select', function() {
-											                        var attachment = file_frame.state().get( 'selection' ).first().toJSON();
-
-											                        jQuery( '#attribute_thumbnail_id' ).val( attachment.id );
-											                        jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', attachment.thumbnail.url );
-											                        jQuery( '.remove_image_button' ).show();
-											                    });
-
-											                    // Finally, open the modal.
-											                    file_frame.open();
-											                });
-
-											                jQuery( document ).on( 'click', '.remove_image_button', function() {
-											                    jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
-											                    jQuery( '#attribute_thumbnail_id' ).val( '' );
-											                    jQuery( '.remove_image_button' ).hide();
-											                    return false;
-											                });
-
-											                jQuery( document ).ajaxComplete( function( event, request, options ) {
-											                    if ( request && 4 === request.readyState && 200 === request.status
-											                        && options.data && 0 <= options.data.indexOf( 'action=add-tag' ) ) {
-
-											                        var res = wpAjax.parseAjaxResponse( request.responseXML, 'ajax-response' );
-											                        if ( ! res || res.errors ) {
-											                            return;
-											                        }
-											                        // Clear Thumbnail fields on submit
-											                        jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
-											                        jQuery( '#attribute_thumbnail_id' ).val( '' );
-											                        jQuery( '.remove_image_button' ).hide();
-											                        // Clear Display type field on submit
-											                        jQuery( '#display_type' ).val( '' );
-											                        return;
-											                    }
-											                } );
-
-											            </script>
-											            <div class="clear"></div>
-											        </div>
-
-															<div class="form-field">
-																	<label for="attribute_public"><input name="attribute_public" id="attribute_public" type="checkbox" value="1" /> <?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
-
-																	<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
-															</div>
-
-															<div class="form-field">
-																	<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
-																	<select name="attribute_type" id="attribute_type">
-																			<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
-																					<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $value ); ?></option>
-																			<?php endforeach; ?>
-
-																			<?php
-
-																					/**
-																					 * Deprecated action in favor of product_attributes_type_selector filter.
-																					 *
-																					 * @deprecated 2.4.0
-																					 */
-																					do_action( 'woocommerce_admin_attribute_types' );
-																			?>
-																	</select>
-																	<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
-															</div>
-
-															<div class="form-field">
-																	<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
-																	<select name="attribute_orderby" id="attribute_orderby">
-																			<option value="menu_order"><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
-																			<option value="name"><?php _e( 'Name', 'woocommerce' ); ?></option>
-																			<option value="name_num"><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
-																			<option value="id"><?php _e( 'Term ID', 'woocommerce' ); ?></option>
-																	</select>
-																	<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
-															</div>
-
-															<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Add Attribute', 'woocommerce' ); ?>"></p>
-															<?php wp_nonce_field( 'woocommerce-add-new_attribute' ); ?>
-													</form>
-											</div>
-									</div>
-							</div>
+														$terms_string = implode( ', ', wp_list_pluck( $terms, 'name' ) );
+														if ( $terms_string ) {
+															echo $terms_string;
+														} else {
+															echo '<span class="na">&ndash;</span>';
+														}
+													} else {
+														echo '<span class="na">&ndash;</span>';
+													}
+												?></td>
+												<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button alignright tips configure-terms" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
+											</tr><?php
+										endforeach;
+									else :
+										?><tr><td colspan="6"><?php _e( 'No attributes currently exist.', 'woocommerce' ) ?></td></tr><?php
+									endif;
+								?>
+							</tbody>
+						</table>
 					</div>
-					<script type="text/javascript">
-					/* <![CDATA[ */
+				</div>
+				<div id="col-left">
+					<div class="col-wrap">
+						<div class="form-wrap">
+							<h2><?php _e( 'Add New Attribute', 'woocommerce' ); ?></h2>
+							<p><?php _e( 'Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the "layered nav" widgets. Please note: you cannot rename an attribute later on.', 'woocommerce' ); ?></p>
+							<form action="edit.php?post_type=product&amp;page=product_attributes" method="post">
+								<div class="form-field">
+									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
+									<input name="attribute_label" id="attribute_label" type="text" value="" />
+									<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
+								</div>
 
-							jQuery( 'a.delete' ).click( function() {
-									if ( window.confirm( '<?php _e( "Are you sure you want to delete this attribute?", "woocommerce" ); ?>' ) ) {
-											return true;
-									}
-									return false;
-							});
+								<div class="form-field">
+									<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
+									<input name="attribute_name" id="attribute_name" type="text" value="" maxlength="28" />
+									<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
+								</div>
 
-					/* ]]> */
-					</script>
+								<div class="form-field">
+										<label for="attribute_description"><?php _e( 'Description', 'woocommerce' ); ?></label>
+										<textarea name="attribute_description" id="attribute_description" value="" rows="4"></textarea>
+										<p class="description"><?php _e( 'Description for the attribute, optional.', 'woocommerce' ); ?></p>
+								</div>
+
+								<div class="form-field term-thumbnail-wrap">
+										<label><?php _e( 'Attribute Graphic', 'woocommerce' ); ?></label>
+										<div id="attribute_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_placeholder_img_src() ); ?>" width="60px" height="60px" /></div>
+										<div style="line-height: 60px;">
+												<input type="hidden" id="attribute_thumbnail_id" name="attribute_thumbnail_id" />
+												<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
+												<button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
+										</div>
+										<script type="text/javascript">
+
+												// Only show the "remove image" button when needed
+												if ( ! jQuery( '#attribute_thumbnail_id' ).val() ) {
+														jQuery( '.remove_image_button' ).hide();
+												}
+
+												// Uploading files
+												var file_frame;
+
+												jQuery( document ).on( 'click', '.upload_image_button', function( event ) {
+
+														event.preventDefault();
+
+														// If the media frame already exists, reopen it.
+														if ( file_frame ) {
+																file_frame.open();
+																return;
+														}
+
+														// Create the media frame.
+														file_frame = wp.media.frames.downloadable_file = wp.media({
+																title: '<?php _e( "Choose an image", "woocommerce" ); ?>',
+																button: {
+																		text: '<?php _e( "Use image", "woocommerce" ); ?>'
+																},
+																multiple: false
+														});
+
+														// When an image is selected, run a callback.
+														file_frame.on( 'select', function() {
+																var attachment = file_frame.state().get( 'selection' ).first().toJSON();
+
+																jQuery( '#attribute_thumbnail_id' ).val( attachment.id );
+																jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', attachment.thumbnail.url );
+																jQuery( '.remove_image_button' ).show();
+														});
+
+														// Finally, open the modal.
+														file_frame.open();
+												});
+
+												jQuery( document ).on( 'click', '.remove_image_button', function() {
+														jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+														jQuery( '#attribute_thumbnail_id' ).val( '' );
+														jQuery( '.remove_image_button' ).hide();
+														return false;
+												});
+
+												jQuery( document ).ajaxComplete( function( event, request, options ) {
+														if ( request && 4 === request.readyState && 200 === request.status
+																&& options.data && 0 <= options.data.indexOf( 'action=add-tag' ) ) {
+
+																var res = wpAjax.parseAjaxResponse( request.responseXML, 'ajax-response' );
+																if ( ! res || res.errors ) {
+																		return;
+																}
+																// Clear Thumbnail fields on submit
+																jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+																jQuery( '#attribute_thumbnail_id' ).val( '' );
+																jQuery( '.remove_image_button' ).hide();
+																// Clear Display type field on submit
+																jQuery( '#display_type' ).val( '' );
+																return;
+														}
+												} );
+
+										</script>
+										<div class="clear"></div>
+								</div>
+
+								<div class="form-field">
+									<label for="attribute_public"><input name="attribute_public" id="attribute_public" type="checkbox" value="1" /> <?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
+
+									<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
+								</div>
+
+								<div class="form-field">
+									<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
+									<select name="attribute_type" id="attribute_type">
+										<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
+											<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $value ); ?></option>
+										<?php endforeach; ?>
+
+										<?php
+
+											/**
+											 * Deprecated action in favor of product_attributes_type_selector filter.
+											 *
+											 * @deprecated 2.4.0
+											 */
+											do_action( 'woocommerce_admin_attribute_types' );
+										?>
+									</select>
+									<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
+								</div>
+
+								<div class="form-field">
+									<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
+									<select name="attribute_orderby" id="attribute_orderby">
+										<option value="menu_order"><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
+										<option value="name"><?php _e( 'Name', 'woocommerce' ); ?></option>
+										<option value="name_num"><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
+										<option value="id"><?php _e( 'Term ID', 'woocommerce' ); ?></option>
+									</select>
+									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
+								</div>
+
+								<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Add Attribute', 'woocommerce' ); ?>"></p>
+								<?php wp_nonce_field( 'woocommerce-add-new_attribute' ); ?>
+							</form>
+						</div>
+					</div>
+				</div>
 			</div>
-			<?php
-	}
+			<script type="text/javascript">
+			/* <![CDATA[ */
 
+				jQuery( 'a.delete' ).click( function() {
+					if ( window.confirm( '<?php _e( "Are you sure you want to delete this attribute?", "woocommerce" ); ?>' ) ) {
+						return true;
+					}
+					return false;
+				});
+
+			/* ]]> */
+			</script>
+		</div>
+		<?php
+	}
 }

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -4,18 +4,18 @@
  *
  * The attributes section lets users add custom attributes to assign to products - they can also be used in the layered nav widget.
  *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin
- * @version     2.3.0
+ * @author 		WooThemes
+ * @category 	Admin
+ * @package 	WooCommerce/Admin
+ * @version   2.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	exit; // Exit if accessed directly
 }
 
 /**
- * WC_Admin_Attributes Class.
+ * WC_Admin_Attributes Class
  */
 class WC_Admin_Attributes {
 
@@ -26,40 +26,40 @@ class WC_Admin_Attributes {
 	 * The added attributes are stored in the database and can be used for layered navigation.
 	 */
 	public static function output() {
-		$result = '';
-		$action = '';
+			$result = '';
+			$action = '';
 
-		// Action to perform: add, edit, delete or none
-		if ( ! empty( $_POST['add_new_attribute'] ) ) {
-			$action = 'add';
-		} elseif ( ! empty( $_POST['save_attribute'] ) && ! empty( $_GET['edit'] ) ) {
-			$action = 'edit';
-		} elseif ( ! empty( $_GET['delete'] ) ) {
-			$action = 'delete';
-		}
+			// Action to perform: add, edit, delete or none
+			if ( ! empty( $_POST['add_new_attribute'] ) ) {
+					$action = 'add';
+			} elseif ( ! empty( $_POST['save_attribute'] ) && ! empty( $_GET['edit'] ) ) {
+					$action = 'edit';
+			} elseif ( ! empty( $_GET['delete'] ) ) {
+					$action = 'delete';
+			}
 
-		switch ( $action ) {
-			case 'add' :
-				$result = self::process_add_attribute();
-			break;
-			case 'edit' :
-				$result = self::process_edit_attribute();
-			break;
-			case 'delete' :
-				$result = self::process_delete_attribute();
-			break;
-		}
+			switch ( $action ) {
+					case 'add' :
+							$result = self::process_add_attribute();
+					break;
+					case 'edit' :
+							$result = self::process_edit_attribute();
+					break;
+					case 'delete' :
+							$result = self::process_delete_attribute();
+					break;
+			}
 
-		if ( is_wp_error( $result ) ) {
-			echo '<div id="woocommerce_errors" class="error"><p>' . $result->get_error_message() . '</p></div>';
-		}
+			if ( is_wp_error( $result ) ) {
+					echo '<div id="woocommerce_errors" class="error"><p>' . $result->get_error_message() . '</p></div>';
+			}
 
-		// Show admin interface
-		if ( ! empty( $_GET['edit'] ) ) {
-			self::edit_attribute();
-		} else {
-			self::add_attribute();
-		}
+			// Show admin interface
+			if ( ! empty( $_GET['edit'] ) ) {
+					self::edit_attribute();
+			} else {
+					self::add_attribute();
+			}
 	}
 
 	/**
@@ -67,25 +67,27 @@ class WC_Admin_Attributes {
 	 * @return array
 	 */
 	private static function get_posted_attribute() {
-		$attribute = array(
-			'attribute_label'   => isset( $_POST['attribute_label'] )   ? wc_clean( stripslashes( $_POST['attribute_label'] ) ) : '',
-			'attribute_name'    => isset( $_POST['attribute_name'] )    ? wc_sanitize_taxonomy_name( stripslashes( $_POST['attribute_name'] ) ) : '',
-			'attribute_type'    => isset( $_POST['attribute_type'] )    ? wc_clean( $_POST['attribute_type'] ) : 'select',
-			'attribute_orderby' => isset( $_POST['attribute_orderby'] ) ? wc_clean( $_POST['attribute_orderby'] ) : '',
-			'attribute_public'  => isset( $_POST['attribute_public'] )  ? 1 : 0
-		);
+			$attribute = array(
+					'attribute_label'   		=> isset( $_POST['attribute_label'] ) ? wc_clean( stripslashes( $_POST['attribute_label'] ) ) : '',
+					'attribute_name'    		=> isset( $_POST['attribute_name'] ) ? wc_sanitize_taxonomy_name( stripslashes( $_POST['attribute_name'] ) ) : '',
+					'attribute_type'    		=> isset( $_POST['attribute_type'] ) ? wc_clean( $_POST['attribute_type'] ) : 'select',
+					'attribute_orderby' 		=> isset( $_POST['attribute_orderby'] ) ? wc_clean( $_POST['attribute_orderby'] ) : '',
+					'attribute_public'  		=> isset( $_POST['attribute_public'] ) ? 1 : 0,
+					'attribute_description' => isset( $_POST['attribute_description'] ) ? wc_clean( stripslashes( $_POST['attribute_description'] ) ) : '',
+					'attribute_thumbnail_id' 		=> isset( $_POST['attribute_thumbnail_id'] ) ? absint( $_POST['attribute_thumbnail_id'] ) : ''
+			);
 
-		if ( empty( $attribute['attribute_type'] ) ) {
-			$attribute['attribute_type'] = 'select';
-		}
-		if ( empty( $attribute['attribute_label'] ) ) {
-			$attribute['attribute_label'] = ucfirst( $attribute['attribute_name'] );
-		}
-		if ( empty( $attribute['attribute_name'] ) ) {
-			$attribute['attribute_name'] = wc_sanitize_taxonomy_name( $attribute['attribute_label'] );
-		}
+			if ( empty( $attribute['attribute_type'] ) ) {
+					$attribute['attribute_type'] = 'select';
+			}
+			if ( empty( $attribute['attribute_label'] ) ) {
+					$attribute['attribute_label'] = ucfirst( $attribute['attribute_name'] );
+			}
+			if ( empty( $attribute['attribute_name'] ) ) {
+					$attribute['attribute_name'] = wc_sanitize_taxonomy_name( $attribute['attribute_label'] );
+			}
 
-		return $attribute;
+			return $attribute;
 	}
 
 	/**
@@ -94,13 +96,13 @@ class WC_Admin_Attributes {
 	 * @return bool|WP_error result
 	 */
 	private static function valid_attribute_name( $attribute_name ) {
-		if ( strlen( $attribute_name ) >= 28 ) {
-			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
-		} elseif ( wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
-			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
-		}
+			if ( strlen( $attribute_name ) >= 28 ) {
+					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
+			} elseif ( wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
+			}
 
-		return true;
+			return true;
 	}
 
 	/**
@@ -108,27 +110,27 @@ class WC_Admin_Attributes {
 	 * @return bool|WP_Error
 	 */
 	private static function process_add_attribute() {
-		global $wpdb;
-		check_admin_referer( 'woocommerce-add-new_attribute' );
+			global $wpdb;
+			check_admin_referer( 'woocommerce-add-new_attribute' );
 
-		$attribute = self::get_posted_attribute();
+			$attribute = self::get_posted_attribute();
 
-		if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
-			return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
-		} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
-			return $valid_attribute_name;
-		} elseif ( taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ) ) {
-			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
-		}
+			if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
+					return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
+			} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
+					return $valid_attribute_name;
+			} elseif ( taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ) ) {
+					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
+			}
 
-		$wpdb->insert( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute );
+			$wpdb->insert( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute );
 
-		do_action( 'woocommerce_attribute_added', $wpdb->insert_id, $attribute );
+			do_action( 'woocommerce_attribute_added', $wpdb->insert_id, $attribute );
 
-		flush_rewrite_rules();
-		delete_transient( 'wc_attribute_taxonomies' );
+			flush_rewrite_rules();
+			delete_transient( 'wc_attribute_taxonomies' );
 
-		return true;
+			return true;
 	}
 
 	/**
@@ -136,74 +138,74 @@ class WC_Admin_Attributes {
 	 * @return bool|WP_Error
 	 */
 	private static function process_edit_attribute() {
-		global $wpdb;
-		$attribute_id = absint( $_GET['edit'] );
-		check_admin_referer( 'woocommerce-save-attribute_' . $attribute_id );
+			global $wpdb;
+			$attribute_id = absint( $_GET['edit'] );
+			check_admin_referer( 'woocommerce-save-attribute_' . $attribute_id );
 
-		$attribute = self::get_posted_attribute();
+			$attribute = self::get_posted_attribute();
 
-		if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
-			return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
-		} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
-			return $valid_attribute_name;
-		}
-
-		$taxonomy_exists    = taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) );
-		$old_attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
-		if ( $old_attribute_name != $attribute['attribute_name'] && wc_sanitize_taxonomy_name( $old_attribute_name ) != $attribute['attribute_name'] && $taxonomy_exists ) {
-			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
-		}
-
-		$wpdb->update( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute, array( 'attribute_id' => $attribute_id ) );
-
-		do_action( 'woocommerce_attribute_updated', $attribute_id, $attribute, $old_attribute_name );
-
-		if ( $old_attribute_name != $attribute['attribute_name'] && ! empty( $old_attribute_name ) ) {
-			// Update taxonomies in the wp term taxonomy table
-			$wpdb->update(
-				$wpdb->term_taxonomy,
-				array( 'taxonomy' => wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ),
-				array( 'taxonomy' => 'pa_' . $old_attribute_name )
-			);
-
-			// Update taxonomy ordering term meta
-			if ( get_option( 'db_version' ) < 34370 ) {
-				$wpdb->update(
-					$wpdb->prefix . 'woocommerce_termmeta',
-					array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
-					array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
-				);
-			} else {
-				$wpdb->update(
-					$wpdb->termmeta,
-					array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
-					array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
-				);
+			if ( empty( $attribute['attribute_name'] ) || empty( $attribute['attribute_label'] ) ) {
+					return new WP_Error( 'error', __( 'Please, provide an attribute name and slug.', 'woocommerce' ) );
+			} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
+					return $valid_attribute_name;
 			}
 
-			// Update product attributes which use this taxonomy
-			$old_attribute_name_length = strlen( $old_attribute_name ) + 3;
-			$attribute_name_length     = strlen( $attribute['attribute_name'] ) + 3;
+			$taxonomy_exists    = taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) );
+			$old_attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
+			if ( $old_attribute_name != $attribute['attribute_name'] && wc_sanitize_taxonomy_name( $old_attribute_name ) != $attribute['attribute_name'] && $taxonomy_exists ) {
+					return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
+			}
 
-			$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->postmeta} SET meta_value = REPLACE( meta_value, %s, %s ) WHERE meta_key = '_product_attributes'",
-				's:' . $old_attribute_name_length . ':"pa_' . $old_attribute_name . '"',
-				's:' . $attribute_name_length . ':"pa_' . $attribute['attribute_name'] . '"'
-			) );
+			$wpdb->update( $wpdb->prefix . 'woocommerce_attribute_taxonomies', $attribute, array( 'attribute_id' => $attribute_id ) );
 
-			// Update variations which use this taxonomy
-			$wpdb->update(
-				$wpdb->postmeta,
-				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
-				array( 'meta_key' => 'attribute_pa_' . sanitize_title( $old_attribute_name ) )
-			);
-		}
+			do_action( 'woocommerce_attribute_updated', $attribute_id, $attribute, $old_attribute_name );
 
-		echo '<div class="updated"><p>' . __( 'Attribute updated successfully', 'woocommerce' ) . '</p></div>';
+			if ( $old_attribute_name != $attribute['attribute_name'] && ! empty( $old_attribute_name ) ) {
+					// Update taxonomies in the wp term taxonomy table
+					$wpdb->update(
+							$wpdb->term_taxonomy,
+							array( 'taxonomy' => wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ),
+							array( 'taxonomy' => 'pa_' . $old_attribute_name )
+					);
 
-		flush_rewrite_rules();
-		delete_transient( 'wc_attribute_taxonomies' );
+					// Update taxonomy ordering term meta
+					if ( get_option( 'db_version' ) < 34370 ) {
+							$wpdb->update(
+									$wpdb->prefix . 'woocommerce_termmeta',
+									array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
+									array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
+							);
+					} else {
+							$wpdb->update(
+									$wpdb->termmeta,
+									array( 'meta_key' => 'order_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
+									array( 'meta_key' => 'order_pa_' . sanitize_title( $old_attribute_name ) )
+							);
+					}
 
-		return true;
+					// Update product attributes which use this taxonomy
+					$old_attribute_name_length = strlen( $old_attribute_name ) + 3;
+					$attribute_name_length     = strlen( $attribute['attribute_name'] ) + 3;
+
+					$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->postmeta} SET meta_value = REPLACE( meta_value, %s, %s ) WHERE meta_key = '_product_attributes_ext'",
+							's:' . $old_attribute_name_length . ':"pa_' . $old_attribute_name . '"',
+							's:' . $attribute_name_length . ':"pa_' . $attribute['attribute_name'] . '"'
+					) );
+
+					// Update variations which use this taxonomy
+					$wpdb->update(
+							$wpdb->postmeta,
+							array( 'meta_key' => 'attribute_pa_' . sanitize_title( $attribute['attribute_name'] ) ),
+							array( 'meta_key' => 'attribute_pa_' . sanitize_title( $old_attribute_name ) )
+					);
+			}
+
+			echo '<div class="updated"><p>' . __( 'Attribute updated successfully', 'woocommerce' ) . '</p></div>';
+
+			flush_rewrite_rules();
+			delete_transient( 'wc_attribute_taxonomies' );
+
+			return true;
 	}
 
 	/**
@@ -211,31 +213,31 @@ class WC_Admin_Attributes {
 	 * @return bool
 	 */
 	private static function process_delete_attribute() {
-		global $wpdb;
+			global $wpdb;
 
-		$attribute_id = absint( $_GET['delete'] );
+			$attribute_id = absint( $_GET['delete'] );
 
-		check_admin_referer( 'woocommerce-delete-attribute_' . $attribute_id );
+			check_admin_referer( 'woocommerce-delete-attribute_' . $attribute_id );
 
-		$attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
-		$taxonomy       = wc_attribute_taxonomy_name( $attribute_name );
+			$attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
+			$taxonomy       = wc_attribute_taxonomy_name( $attribute_name );
 
-		do_action( 'woocommerce_before_attribute_delete', $attribute_id, $attribute_name, $taxonomy );
+			do_action( 'woocommerce_before_attribute_delete', $attribute_id, $attribute_name, $taxonomy );
 
-		if ( $attribute_name && $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" ) ) {
-			if ( taxonomy_exists( $taxonomy ) ) {
-				$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
-				foreach ( $terms as $term ) {
-					wp_delete_term( $term->term_id, $taxonomy );
-				}
+			if ( $attribute_name && $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" ) ) {
+					if ( taxonomy_exists( $taxonomy ) ) {
+							$terms = get_terms( $taxonomy, 'orderby=name&hide_empty=0' );
+							foreach ( $terms as $term ) {
+									wp_delete_term( $term->term_id, $taxonomy );
+							}
+					}
+
+					do_action( 'woocommerce_attribute_deleted', $attribute_id, $attribute_name, $taxonomy );
+					delete_transient( 'wc_attribute_taxonomies' );
+					return true;
 			}
 
-			do_action( 'woocommerce_attribute_deleted', $attribute_id, $attribute_name, $taxonomy );
-			delete_transient( 'wc_attribute_taxonomies' );
-			return true;
-		}
-
-		return false;
+			return false;
 	}
 
 	/**
@@ -244,105 +246,188 @@ class WC_Admin_Attributes {
 	 * Shows the interface for changing an attributes type between select and text.
 	 */
 	public static function edit_attribute() {
-		global $wpdb;
+			global $wpdb;
 
-		$edit = absint( $_GET['edit'] );
+			$edit = absint( $_GET['edit'] );
 
-		$attribute_to_edit = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies WHERE attribute_id = '$edit'" );
+			$attribute_to_edit = $wpdb->get_row( "SELECT * FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies WHERE attribute_id = '$edit'" );
 
-		?>
-		<div class="wrap woocommerce">
-			<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
-			<h1><?php _e( 'Edit Attribute', 'woocommerce' ) ?></h1>
+			wp_enqueue_media();
+			// echo '<pre>'; var_dump($attribute_to_edit); echo '</pre>';
+			?>
+			<div class="wrap woocommerce">
+					<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
+					<h1><?php _e( 'Edit Attribute', 'woocommerce' ) ?></h1>
 
+					<?php
+
+							if ( ! $attribute_to_edit ) {
+									echo '<div id="woocommerce_errors" class="error"><p>' . __( 'Error: non-existing attribute ID.', 'woocommerce' ) . '</p></div>';
+							} else {
+									$att_type    = $attribute_to_edit->attribute_type;
+									$att_label   = $attribute_to_edit->attribute_label;
+									$att_name    = $attribute_to_edit->attribute_name;
+									$att_desc    = $attribute_to_edit->attribute_description;
+									$att_orderby = $attribute_to_edit->attribute_orderby;
+									$att_public  = $attribute_to_edit->attribute_public;
+									$thumbnail_id = $attribute_to_edit->attribute_thumbnail_id;
+									if ( $thumbnail_id ) {
+											$image = wp_get_attachment_thumb_url( $thumbnail_id );
+									} else {
+											$image = wc_placeholder_img_src();
+									}
+
+
+							?>
+
+							<form action="edit.php?post_type=product&amp;page=product_attributes&amp;edit=<?php echo absint( $edit ); ?>" method="post">
+									<table class="form-table">
+											<tbody>
+													<tr class="form-field form-required">
+															<th scope="row" valign="top">
+																	<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
+															</th>
+															<td>
+																	<input name="attribute_label" id="attribute_label" type="text" value="<?php echo esc_attr( $att_label ); ?>" />
+																	<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
+															</td>
+													</tr>
+													<tr class="form-field form-required">
+															<th scope="row" valign="top">
+																	<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
+															</th>
+															<td>
+																	<input name="attribute_name" id="attribute_name" type="text" value="<?php echo esc_attr( $att_name ); ?>" maxlength="28" />
+																	<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
+															</td>
+													</tr>
+													<tr class="form-field">
+															<th scope="row" valign="top">
+																	<label for="attribute_description"><?php _e( 'Description', 'woocommerce' ); ?></label>
+															</th>
+															<td>
+																	<textarea name="attribute_description" id="attribute_description" rows="4"><?php echo esc_attr( $att_desc ); ?></textarea>
+																	<p class="description"><?php _e( 'Description for the attribute, optional.', 'woocommerce' ); ?></p>
+															</td>
+													</tr>
+													<tr class="form-field">
+									            <th scope="row" valign="top">
+																<label><?php _e( 'Attribute Graphic', 'woocommerce' ); ?></label>
+															</th>
+									            <td>
+									                <div id="attribute_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( $image ); ?>" width="60px" height="60px" /></div>
+									                <div style="line-height: 60px;">
+									                    <input type="hidden" id="attribute_thumbnail_id" name="attribute_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
+									                    <button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
+									                    <button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
+									                </div>
+									                <script type="text/javascript">
+
+									                    // Only show the "remove image" button when needed
+									                    if ( '0' === jQuery( '#attribute_thumbnail_id' ).val() ) {
+									                        jQuery( '.remove_image_button' ).hide();
+									                    }
+
+									                    // Uploading files
+									                    var file_frame;
+
+									                    jQuery( document ).on( 'click', '.upload_image_button', function( event ) {
+
+									                        event.preventDefault();
+
+									                        // If the media frame already exists, reopen it.
+									                        if ( file_frame ) {
+									                            file_frame.open();
+									                            return;
+									                        }
+
+									                        // Create the media frame.
+									                        file_frame = wp.media.frames.downloadable_file = wp.media({
+									                            title: '<?php _e( "Choose an image", "woocommerce" ); ?>',
+									                            button: {
+									                                text: '<?php _e( "Use image", "woocommerce" ); ?>'
+									                            },
+									                            multiple: false
+									                        });
+
+									                        // When an image is selected, run a callback.
+									                        file_frame.on( 'select', function() {
+									                            var attachment = file_frame.state().get( 'selection' ).first().toJSON();
+
+									                            jQuery( '#attribute_thumbnail_id' ).val( attachment.id );
+									                            jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', attachment.url );
+									                            jQuery( '.remove_image_button' ).show();
+									                        });
+
+									                        // Finally, open the modal.
+									                        file_frame.open();
+									                    });
+
+									                    jQuery( document ).on( 'click', '.remove_image_button', function() {
+									                        jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+									                        jQuery( '#attribute_thumbnail_id' ).val( '' );
+									                        jQuery( '.remove_image_button' ).hide();
+									                        return false;
+									                    });
+
+									                </script>
+									                <div class="clear"></div>
+									            </td>
+									        </tr>
+													<tr class="form-field form-required">
+															<th scope="row" valign="top">
+																	<label for="attribute_public"><?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
+															</th>
+															<td>
+																	<input name="attribute_public" id="attribute_public" type="checkbox" value="1" <?php checked( $att_public, 1 ); ?> />
+																	<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
+															</td>
+													</tr>
+													<tr class="form-field form-required">
+															<th scope="row" valign="top">
+																	<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
+															</th>
+															<td>
+																	<select name="attribute_type" id="attribute_type">
+																			<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
+																					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $att_type, $key ); ?>><?php echo esc_attr( $value ); ?></option>
+																			<?php endforeach; ?>
+
+																			<?php
+
+																					/**
+																					 * Deprecated action in favor of product_attributes_type_selector filter.
+																					 *
+																					 * @deprecated 2.4.0
+																					 */
+																					do_action( 'woocommerce_admin_attribute_types' );
+																			?>
+																	</select>
+																	<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
+															</td>
+													</tr>
+													<tr class="form-field form-required">
+															<th scope="row" valign="top">
+																	<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
+															</th>
+															<td>
+																	<select name="attribute_orderby" id="attribute_orderby">
+																			<option value="menu_order" <?php selected( $att_orderby, 'menu_order' ); ?>><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
+																			<option value="name" <?php selected( $att_orderby, 'name' ); ?>><?php _e( 'Name', 'woocommerce' ); ?></option>
+																			<option value="name_num" <?php selected( $att_orderby, 'name_num' ); ?>><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
+																			<option value="id" <?php selected( $att_orderby, 'id' ); ?>><?php _e( 'Term ID', 'woocommerce' ); ?></option>
+																	</select>
+																	<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
+															</td>
+													</tr>
+											</tbody>
+									</table>
+									<p class="submit"><input type="submit" name="save_attribute" id="submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'woocommerce' ); ?>"></p>
+									<?php wp_nonce_field( 'woocommerce-save-attribute_' . $edit ); ?>
+							</form>
+					<?php } ?>
+			</div>
 			<?php
-
-				if ( ! $attribute_to_edit ) {
-					echo '<div id="woocommerce_errors" class="error"><p>' . __( 'Error: non-existing attribute ID.', 'woocommerce' ) . '</p></div>';
-				} else {
-					$att_type    = $attribute_to_edit->attribute_type;
-					$att_label   = $attribute_to_edit->attribute_label;
-					$att_name    = $attribute_to_edit->attribute_name;
-					$att_orderby = $attribute_to_edit->attribute_orderby;
-					$att_public  = $attribute_to_edit->attribute_public;
-
-				?>
-
-				<form action="edit.php?post_type=product&amp;page=product_attributes&amp;edit=<?php echo absint( $edit ); ?>" method="post">
-					<table class="form-table">
-						<tbody>
-							<tr class="form-field form-required">
-								<th scope="row" valign="top">
-									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
-								</th>
-								<td>
-									<input name="attribute_label" id="attribute_label" type="text" value="<?php echo esc_attr( $att_label ); ?>" />
-									<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
-								</td>
-							</tr>
-							<tr class="form-field form-required">
-								<th scope="row" valign="top">
-									<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
-								</th>
-								<td>
-									<input name="attribute_name" id="attribute_name" type="text" value="<?php echo esc_attr( $att_name ); ?>" maxlength="28" />
-									<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
-								</td>
-							</tr>
-							<tr class="form-field form-required">
-								<th scope="row" valign="top">
-									<label for="attribute_public"><?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
-								</th>
-								<td>
-									<input name="attribute_public" id="attribute_public" type="checkbox" value="1" <?php checked( $att_public, 1 ); ?> />
-									<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
-								</td>
-							</tr>
-							<tr class="form-field form-required">
-								<th scope="row" valign="top">
-									<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
-								</th>
-								<td>
-									<select name="attribute_type" id="attribute_type">
-										<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
-											<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $att_type, $key ); ?>><?php echo esc_attr( $value ); ?></option>
-										<?php endforeach; ?>
-
-										<?php
-
-											/**
-											 * Deprecated action in favor of product_attributes_type_selector filter.
-											 *
-											 * @deprecated 2.4.0
-											 */
-											do_action( 'woocommerce_admin_attribute_types' );
-										?>
-									</select>
-									<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
-								</td>
-							</tr>
-							<tr class="form-field form-required">
-								<th scope="row" valign="top">
-									<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
-								</th>
-								<td>
-									<select name="attribute_orderby" id="attribute_orderby">
-										<option value="menu_order" <?php selected( $att_orderby, 'menu_order' ); ?>><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
-										<option value="name" <?php selected( $att_orderby, 'name' ); ?>><?php _e( 'Name', 'woocommerce' ); ?></option>
-										<option value="name_num" <?php selected( $att_orderby, 'name_num' ); ?>><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
-										<option value="id" <?php selected( $att_orderby, 'id' ); ?>><?php _e( 'Term ID', 'woocommerce' ); ?></option>
-									</select>
-									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-					<p class="submit"><input type="submit" name="save_attribute" id="submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'woocommerce' ); ?>"></p>
-					<?php wp_nonce_field( 'woocommerce-save-attribute_' . $edit ); ?>
-				</form>
-			<?php } ?>
-		</div>
-		<?php
 	}
 
 	/**
@@ -351,164 +436,263 @@ class WC_Admin_Attributes {
 	 * Shows the interface for adding new attributes.
 	 */
 	public static function add_attribute() {
-		?>
-		<div class="wrap woocommerce">
-			<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
-			<h1><?php _e( 'Attributes', 'woocommerce' ); ?></h1>
-			<br class="clear" />
-			<div id="col-container">
-				<div id="col-right">
-					<div class="col-wrap">
-						<table class="widefat attributes-table wp-list-table ui-sortable" style="width:100%">
-							<thead>
-								<tr>
-									<th scope="col"><?php _e( 'Name', 'woocommerce' ); ?></th>
-									<th scope="col"><?php _e( 'Slug', 'woocommerce' ); ?></th>
-									<th scope="col"><?php _e( 'Type', 'woocommerce' ); ?></th>
-									<th scope="col"><?php _e( 'Order by', 'woocommerce' ); ?></th>
-									<th scope="col" colspan="2"><?php _e( 'Terms', 'woocommerce' ); ?></th>
-								</tr>
-							</thead>
-							<tbody>
-								<?php
-									if ( $attribute_taxonomies = wc_get_attribute_taxonomies() ) :
-										foreach ( $attribute_taxonomies as $tax ) :
-											?><tr>
+		wp_enqueue_media();
+			?>
+			<div class="wrap woocommerce">
+					<div class="icon32 icon32-attributes" id="icon-woocommerce"><br/></div>
+					<h1><?php _e( 'Attributes', 'woocommerce' ); ?></h1>
+					<br class="clear" />
+					<div id="col-container">
+							<div id="col-right">
+									<div class="col-wrap">
+											<table class="widefat attributes-table wp-list-table ui-sortable" style="width:100%">
+													<thead>
+															<tr>
+																	<th scope="col"><?php _e( 'Image', 'woocommerce' ); ?></th>
+																	<th scope="col"><?php _e( 'Name', 'woocommerce' ); ?></th>
+																	<th scope="col"><?php _e( 'Slug', 'woocommerce' ); ?></th>
+																	<th scope="col"><?php _e( 'Type', 'woocommerce' ); ?></th>
+																	<th scope="col"><?php _e( 'Order by', 'woocommerce' ); ?></th>
+																	<th scope="col" colspan="2"><?php _e( 'Terms', 'woocommerce' ); ?></th>
+															</tr>
+													</thead>
+													<tbody>
+															<?php
+																	if ( $attribute_taxonomies = wc_get_attribute_taxonomies() ) :
+																			foreach ( $attribute_taxonomies as $tax ) :
+																					?><tr>
+																							<td>
+																								<?php
+																								$thumbnail_id = $tax->attribute_thumbnail_id;
 
-												<td>
-													<strong><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product"><?php echo esc_html( $tax->attribute_label ); ?></a></strong>
+																								if ( $thumbnail_id ) {
+																										$image = wp_get_attachment_thumb_url( $thumbnail_id );
+																								} else {
+																										$image = wc_placeholder_img_src();
+																								}
+																								echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr__( 'Thumbnail', 'woocommerce' ) . '" class="wp-post-image" height="48" width="48" />';
+																								?>
+																							</td>
+																							<td>
+																									<strong><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product"><?php echo esc_html( $tax->attribute_label ); ?></a></strong>
 
-													<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ) ); ?>"><?php _e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php _e( 'Delete', 'woocommerce' ); ?></a></span></div>
-												</td>
-												<td><?php echo esc_html( $tax->attribute_name ); ?></td>
-												<td><?php echo esc_html( ucfirst( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? '(' . __( 'Public', 'woocommerce' ) . ')' : ''; ?></td>
-												<td><?php
-													switch ( $tax->attribute_orderby ) {
-														case 'name' :
-															_e( 'Name', 'woocommerce' );
-														break;
-														case 'name_num' :
-															_e( 'Name (numeric)', 'woocommerce' );
-														break;
-														case 'id' :
-															_e( 'Term ID', 'woocommerce' );
-														break;
-														default:
-															_e( 'Custom ordering', 'woocommerce' );
-														break;
-													}
-												?></td>
-												<td class="attribute-terms"><?php
-													$taxonomy = wc_attribute_taxonomy_name( $tax->attribute_name );
+																									<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes_ext' ) ); ?>"><?php _e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes_ext' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php _e( 'Delete', 'woocommerce' ); ?></a></span></div>
+																							</td>
+																							<td><?php echo esc_html( $tax->attribute_name ); ?></td>
+																							<td><?php echo esc_html( ucfirst( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? '(' . __( 'Public', 'woocommerce' ) . ')' : ''; ?></td>
+																							<td><?php
+																									switch ( $tax->attribute_orderby ) {
+																											case 'name' :
+																													_e( 'Name', 'woocommerce' );
+																											break;
+																											case 'name_num' :
+																													_e( 'Name (numeric)', 'woocommerce' );
+																											break;
+																											case 'id' :
+																													_e( 'Term ID', 'woocommerce' );
+																											break;
+																											default:
+																													_e( 'Custom ordering', 'woocommerce' );
+																											break;
+																									}
+																							?></td>
+																							<td class="attribute-terms"><?php
+																									$taxonomy = wc_attribute_taxonomy_name( $tax->attribute_name );
 
-													if ( taxonomy_exists( $taxonomy ) ) {
-														$terms = get_terms( $taxonomy, 'hide_empty=0' );
+																									if ( taxonomy_exists( $taxonomy ) ) {
+																											$terms = get_terms( $taxonomy, 'hide_empty=0' );
 
-														switch ( $tax->attribute_orderby ) {
-															case 'name_num' :
-																usort( $terms, '_wc_get_product_terms_name_num_usort_callback' );
-															break;
-															case 'parent' :
-																usort( $terms, '_wc_get_product_terms_parent_usort_callback' );
-															break;
-														}
+																											switch ( $tax->attribute_orderby ) {
+																													case 'name_num' :
+																															usort( $terms, '_wc_get_product_terms_name_num_usort_callback' );
+																													break;
+																													case 'parent' :
+																															usort( $terms, '_wc_get_product_terms_parent_usort_callback' );
+																													break;
+																											}
 
-														$terms_string = implode( ', ', wp_list_pluck( $terms, 'name' ) );
-														if ( $terms_string ) {
-															echo $terms_string;
-														} else {
-															echo '<span class="na">&ndash;</span>';
-														}
-													} else {
-														echo '<span class="na">&ndash;</span>';
-													}
-												?></td>
-												<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button alignright tips configure-terms" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
-											</tr><?php
-										endforeach;
-									else :
-										?><tr><td colspan="6"><?php _e( 'No attributes currently exist.', 'woocommerce' ) ?></td></tr><?php
-									endif;
-								?>
-							</tbody>
-						</table>
+																											$terms_string = implode( ', ', wp_list_pluck( $terms, 'name' ) );
+																											if ( $terms_string ) {
+																													echo $terms_string;
+																											} else {
+																													echo '<span class="na">&ndash;</span>';
+																											}
+																									} else {
+																											echo '<span class="na">&ndash;</span>';
+																									}
+																							?></td>
+																							<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button alignright tips configure-terms" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
+																					</tr><?php
+																			endforeach;
+																	else :
+																			?><tr><td colspan="6"><?php _e( 'No attributes currently exist.', 'woocommerce' ) ?></td></tr><?php
+																	endif;
+															?>
+													</tbody>
+											</table>
+									</div>
+							</div>
+							<div id="col-left">
+									<div class="col-wrap">
+											<div class="form-wrap">
+													<h2><?php _e( 'Add New Attribute', 'woocommerce' ); ?></h2>
+													<p><?php _e( 'Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the "layered nav" widgets. Please note: you cannot rename an attribute later on.', 'woocommerce' ); ?></p>
+													<form action="edit.php?post_type=product&amp;page=product_attributes" method="post">
+															<div class="form-field">
+																	<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
+																	<input name="attribute_label" id="attribute_label" type="text" value="" />
+																	<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
+															</div>
+
+															<div class="form-field">
+																	<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
+																	<input name="attribute_name" id="attribute_name" type="text" value="" maxlength="28" />
+																	<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
+															</div>
+
+															<div class="form-field">
+																	<label for="attribute_description"><?php _e( 'Description', 'woocommerce' ); ?></label>
+																	<textarea name="attribute_description" id="attribute_description" value="" rows="4"></textarea>
+																	<p class="description"><?php _e( 'Description for the attribute, optional.', 'woocommerce' ); ?></p>
+															</div>
+
+															<div class="form-field term-thumbnail-wrap">
+											            <label><?php _e( 'Attribute Graphic', 'woocommerce' ); ?></label>
+											            <div id="attribute_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_placeholder_img_src() ); ?>" width="60px" height="60px" /></div>
+											            <div style="line-height: 60px;">
+											                <input type="hidden" id="attribute_thumbnail_id" name="attribute_thumbnail_id" />
+											                <button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
+											                <button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
+											            </div>
+											            <script type="text/javascript">
+
+											                // Only show the "remove image" button when needed
+											                if ( ! jQuery( '#attribute_thumbnail_id' ).val() ) {
+											                    jQuery( '.remove_image_button' ).hide();
+											                }
+
+											                // Uploading files
+											                var file_frame;
+
+											                jQuery( document ).on( 'click', '.upload_image_button', function( event ) {
+
+											                    event.preventDefault();
+
+											                    // If the media frame already exists, reopen it.
+											                    if ( file_frame ) {
+											                        file_frame.open();
+											                        return;
+											                    }
+
+											                    // Create the media frame.
+											                    file_frame = wp.media.frames.downloadable_file = wp.media({
+											                        title: '<?php _e( "Choose an image", "woocommerce" ); ?>',
+											                        button: {
+											                            text: '<?php _e( "Use image", "woocommerce" ); ?>'
+											                        },
+											                        multiple: false
+											                    });
+
+											                    // When an image is selected, run a callback.
+											                    file_frame.on( 'select', function() {
+											                        var attachment = file_frame.state().get( 'selection' ).first().toJSON();
+
+											                        jQuery( '#attribute_thumbnail_id' ).val( attachment.id );
+											                        jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', attachment.thumbnail.url );
+											                        jQuery( '.remove_image_button' ).show();
+											                    });
+
+											                    // Finally, open the modal.
+											                    file_frame.open();
+											                });
+
+											                jQuery( document ).on( 'click', '.remove_image_button', function() {
+											                    jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+											                    jQuery( '#attribute_thumbnail_id' ).val( '' );
+											                    jQuery( '.remove_image_button' ).hide();
+											                    return false;
+											                });
+
+											                jQuery( document ).ajaxComplete( function( event, request, options ) {
+											                    if ( request && 4 === request.readyState && 200 === request.status
+											                        && options.data && 0 <= options.data.indexOf( 'action=add-tag' ) ) {
+
+											                        var res = wpAjax.parseAjaxResponse( request.responseXML, 'ajax-response' );
+											                        if ( ! res || res.errors ) {
+											                            return;
+											                        }
+											                        // Clear Thumbnail fields on submit
+											                        jQuery( '#attribute_thumbnail' ).find( 'img' ).attr( 'src', '<?php echo esc_js( wc_placeholder_img_src() ); ?>' );
+											                        jQuery( '#attribute_thumbnail_id' ).val( '' );
+											                        jQuery( '.remove_image_button' ).hide();
+											                        // Clear Display type field on submit
+											                        jQuery( '#display_type' ).val( '' );
+											                        return;
+											                    }
+											                } );
+
+											            </script>
+											            <div class="clear"></div>
+											        </div>
+
+															<div class="form-field">
+																	<label for="attribute_public"><input name="attribute_public" id="attribute_public" type="checkbox" value="1" /> <?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
+
+																	<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
+															</div>
+
+															<div class="form-field">
+																	<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
+																	<select name="attribute_type" id="attribute_type">
+																			<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
+																					<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $value ); ?></option>
+																			<?php endforeach; ?>
+
+																			<?php
+
+																					/**
+																					 * Deprecated action in favor of product_attributes_type_selector filter.
+																					 *
+																					 * @deprecated 2.4.0
+																					 */
+																					do_action( 'woocommerce_admin_attribute_types' );
+																			?>
+																	</select>
+																	<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
+															</div>
+
+															<div class="form-field">
+																	<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
+																	<select name="attribute_orderby" id="attribute_orderby">
+																			<option value="menu_order"><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
+																			<option value="name"><?php _e( 'Name', 'woocommerce' ); ?></option>
+																			<option value="name_num"><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
+																			<option value="id"><?php _e( 'Term ID', 'woocommerce' ); ?></option>
+																	</select>
+																	<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
+															</div>
+
+															<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Add Attribute', 'woocommerce' ); ?>"></p>
+															<?php wp_nonce_field( 'woocommerce-add-new_attribute' ); ?>
+													</form>
+											</div>
+									</div>
+							</div>
 					</div>
-				</div>
-				<div id="col-left">
-					<div class="col-wrap">
-						<div class="form-wrap">
-							<h2><?php _e( 'Add New Attribute', 'woocommerce' ); ?></h2>
-							<p><?php _e( 'Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the "layered nav" widgets. Please note: you cannot rename an attribute later on.', 'woocommerce' ); ?></p>
-							<form action="edit.php?post_type=product&amp;page=product_attributes" method="post">
-								<div class="form-field">
-									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
-									<input name="attribute_label" id="attribute_label" type="text" value="" />
-									<p class="description"><?php _e( 'Name for the attribute (shown on the front-end).', 'woocommerce' ); ?></p>
-								</div>
+					<script type="text/javascript">
+					/* <![CDATA[ */
 
-								<div class="form-field">
-									<label for="attribute_name"><?php _e( 'Slug', 'woocommerce' ); ?></label>
-									<input name="attribute_name" id="attribute_name" type="text" value="" maxlength="28" />
-									<p class="description"><?php _e( 'Unique slug/reference for the attribute; must be shorter than 28 characters.', 'woocommerce' ); ?></p>
-								</div>
+							jQuery( 'a.delete' ).click( function() {
+									if ( window.confirm( '<?php _e( "Are you sure you want to delete this attribute?", "woocommerce" ); ?>' ) ) {
+											return true;
+									}
+									return false;
+							});
 
-								<div class="form-field">
-									<label for="attribute_public"><input name="attribute_public" id="attribute_public" type="checkbox" value="1" /> <?php _e( 'Enable Archives?', 'woocommerce' ); ?></label>
-
-									<p class="description"><?php _e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
-								</div>
-
-								<div class="form-field">
-									<label for="attribute_type"><?php _e( 'Type', 'woocommerce' ); ?></label>
-									<select name="attribute_type" id="attribute_type">
-										<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
-											<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $value ); ?></option>
-										<?php endforeach; ?>
-
-										<?php
-
-											/**
-											 * Deprecated action in favor of product_attributes_type_selector filter.
-											 *
-											 * @deprecated 2.4.0
-											 */
-											do_action( 'woocommerce_admin_attribute_types' );
-										?>
-									</select>
-									<p class="description"><?php _e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
-								</div>
-
-								<div class="form-field">
-									<label for="attribute_orderby"><?php _e( 'Default sort order', 'woocommerce' ); ?></label>
-									<select name="attribute_orderby" id="attribute_orderby">
-										<option value="menu_order"><?php _e( 'Custom ordering', 'woocommerce' ); ?></option>
-										<option value="name"><?php _e( 'Name', 'woocommerce' ); ?></option>
-										<option value="name_num"><?php _e( 'Name (numeric)', 'woocommerce' ); ?></option>
-										<option value="id"><?php _e( 'Term ID', 'woocommerce' ); ?></option>
-									</select>
-									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
-								</div>
-
-								<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Add Attribute', 'woocommerce' ); ?>"></p>
-								<?php wp_nonce_field( 'woocommerce-add-new_attribute' ); ?>
-							</form>
-						</div>
-					</div>
-				</div>
+					/* ]]> */
+					</script>
 			</div>
-			<script type="text/javascript">
-			/* <![CDATA[ */
-
-				jQuery( 'a.delete' ).click( function() {
-					if ( window.confirm( '<?php _e( "Are you sure you want to delete this attribute?", "woocommerce" ); ?>' ) ) {
-						return true;
-					}
-					return false;
-				});
-
-			/* ]]> */
-			</script>
-		</div>
-		<?php
+			<?php
 	}
+
 }


### PR DESCRIPTION
Re: issue #11529.

This adds two fields I needed to Attributes: description and thumbnail (id). These are different from variation level descriptions and used differently in themes.

The Attributes edit screen is not coded the usual WP way, because the main Attributes admin screen is **not** a regular WP taxonomy screen, it is a **list of taxonomies**. It is specially coded in the class `WC_Admin_Attributes::output`, which loops through each taxonomy, and unlike the `product_cat` edit screen which uses `edit-tags.php`, the Attributes custom form markup lacks any WP hooks to add meta-boxes to each attribute (taxonomy). This is also why ACF cannot add fields to Attributes.

Here I adapted the same HTML and scripts used in the class`WC_Admin_Taxonomies` to add product category images. The problem is here they cannot use meta or be hooked onto `add_form_fields`, so they are added directly to the form.

More ideal than my solution would be refactoring the forms and admin columns of the Attributes screen to use the WP/WC hooks like `do_meta_boxes`, and using **meta** for these additional fields, but after trying for two days i admit that’s beyond my capacity.

The main problem i encountered with trying to refactor is figuring out _what sort of standard WP admin screen_ the main Attributes screen is, if not the custom screen output established by the WC_Admin_Attributes class. I don't think there is a usable template for the _screen_, but i believe the _forms_ could use existing templates. Those seem to require you to pass the screen as an argument, however.

Unlike the Product Categories screen, the current Attributes screen is not templated on edit-tags.php because it is not a list of terms in a single taxonomy, it is a **list of taxonomies**.
