### PR TITLE
Fix so shipping address is not included when local_pickup is used

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -2745,6 +2745,13 @@ abstract class WC_Abstract_Order {
 		$needs_address = false;
 
 		foreach ( $this->get_shipping_methods() as $shipping_method ) {
+
+			// Added due to shipping zones in 2.6 will set the method_id with a # like local_pickup:2
+			// if 'local_pickup' is in the hide array & there's a string match to 'local_pickup', set method to 'local_pickup'
+			if ( in_array( 'local_pickup', $hide ) && stristr( $shipping_method['method_id'], 'local_pickup' ) ) {
+				$shipping_method['method_id'] = 'local_pickup';
+			}
+
 			if ( ! in_array( $shipping_method['method_id'], $hide ) ) {
 				$needs_address = true;
 				break;


### PR DESCRIPTION
With 2.6 shipping methods changed due to shipping zones. Because of this, the test in `needs_shipping_address()` always returns true, even if `local_pickup` is the shipping method.

This adds a string match test to see if `local_pickup` is in the `$shipping_method['method_id']`, and also if `local_pickup` is still in the `$hide` array. If both are true, then  `$shipping_method['method_id']` is set to `local_pickup` so that the test on line `2757` returns as it should.
