### PR TITLE
Provide 2 hooks for adding fields to the attribute creation form

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -440,7 +440,7 @@ class WC_Admin_Attributes {
 							<h2><?php _e( 'Add New Attribute', 'woocommerce' ); ?></h2>
 							<p><?php _e( 'Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the "layered nav" widgets. Please note: you cannot rename an attribute later on.', 'woocommerce' ); ?></p>
 							<form action="edit.php?post_type=product&amp;page=product_attributes" method="post">
-								<?php do_action( 'woocommerce_add_attribute_top' ) ?>
+								<?php do_action( 'woocommerce_add_attribute_fields_before' ) ?>
 								<div class="form-field">
 									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
 									<input name="attribute_label" id="attribute_label" type="text" value="" />
@@ -489,7 +489,7 @@ class WC_Admin_Attributes {
 									</select>
 									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
 								</div>
-								<?php do_action( 'woocommerce_add_attribute_bottom' ) ?>
+								<?php do_action( 'woocommerce_add_attribute_fields_after' ) ?>
 								<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Add Attribute', 'woocommerce' ); ?>"></p>
 								<?php wp_nonce_field( 'woocommerce-add-new_attribute' ); ?>
 							</form>

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -440,6 +440,7 @@ class WC_Admin_Attributes {
 							<h2><?php _e( 'Add New Attribute', 'woocommerce' ); ?></h2>
 							<p><?php _e( 'Attributes let you define extra product data, such as size or colour. You can use these attributes in the shop sidebar using the "layered nav" widgets. Please note: you cannot rename an attribute later on.', 'woocommerce' ); ?></p>
 							<form action="edit.php?post_type=product&amp;page=product_attributes" method="post">
+								<?php do_action( 'woocommerce_add_attribute_top' ) ?>
 								<div class="form-field">
 									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
 									<input name="attribute_label" id="attribute_label" type="text" value="" />
@@ -488,7 +489,7 @@ class WC_Admin_Attributes {
 									</select>
 									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
 								</div>
-
+								<?php do_action( 'woocommerce_add_attribute_bottom' ) ?>
 								<p class="submit"><input type="submit" name="add_new_attribute" id="submit" class="button button-primary" value="<?php esc_attr_e( 'Add Attribute', 'woocommerce' ); ?>"></p>
 								<?php wp_nonce_field( 'woocommerce-add-new_attribute' ); ?>
 							</form>

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -271,7 +271,8 @@ class WC_Admin_Attributes {
 				<form action="edit.php?post_type=product&amp;page=product_attributes&amp;edit=<?php echo absint( $edit ); ?>" method="post">
 					<table class="form-table">
 						<tbody>
-							<tr class="form-field form-required">
+						<?php do_action( 'woocommerce_edit_attribute_fields_before' ) ?>
+						<tr class="form-field form-required">
 								<th scope="row" valign="top">
 									<label for="attribute_label"><?php _e( 'Name', 'woocommerce' ); ?></label>
 								</th>
@@ -335,6 +336,7 @@ class WC_Admin_Attributes {
 									<p class="description"><?php _e( 'Determines the sort order of the terms on the frontend shop product pages. If using custom ordering, you can drag and drop the terms in this attribute.', 'woocommerce' ); ?></p>
 								</td>
 							</tr>
+							<?php do_action( 'woocommerce_edit_attribute_fields_after' ) ?>
 						</tbody>
 					</table>
 					<p class="submit"><input type="submit" name="save_attribute" id="submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'woocommerce' ); ?>"></p>


### PR DESCRIPTION
Instead of hardcoding specific fields as proposed in #11549, let's just allow developers to hook into the form with a hook at the top and bottom of the form. This is cleaner, more flexible and probably should have been there all along. I'm certainly not against adding new markup for fields that are required by WC itself, but that shuts out plugin developers and forces them to use ugly JS-based hacks in order to inject fields

The `woocommerce_attribute_added` hook can then be used to store the information in an option, so there's no further code needed there.

See also #11529 which requests exactly what my PR does, but ends up adding markup as mentioned above
