### PR TITLE
Add tests, create, update, delete, and batch to the Product Reviews API

### DIFF
--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * REST API Product Reviews controller
+ * REST API Product Reviews Controller.
  *
- * Handles requests to the /products/<product_id>/reviews endpoint.
+ * Handles requests to /products/<product_id>/reviews.
  *
  * @author   WooThemes
  * @category API
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * REST API Products controller class.
+ * REST API Product Reviews Controller Class.
  *
  * @package WooCommerce/API
  * @extends WC_REST_Controller
@@ -137,7 +137,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to create a new  product review.
+	 * Check if a given request has access to create a new product review.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -186,7 +186,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 */
 	public function batch_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( 'product', 'batch' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot manipulate product reviews.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot batch manipulate product reviews.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -264,7 +264,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		}
 
 		if ( empty( $request['email'] ) ) {
-			return new WP_Error( 'woocommerce_rest_product_review_invalid_email', __( 'Product review email is required.', 'woocommerce' ), array( 'status' => 400 ) );
+			return new WP_Error( 'woocommerce_rest_product_review_invalid_email', __( 'Product review author email is required.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		$data = array(
@@ -275,7 +275,6 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 			'comment_approved'     => 1,
 			'comment_type'         => 'review',
 		);
-
 		$product_review_id = wp_insert_comment( $data );
 		update_comment_meta( $product_review_id, 'rating', ( ! empty( $request['rating'] ) ? $request['rating'] : '0' ) );
 
@@ -323,22 +322,17 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 
 		// Update fields
 		$commentdata = array( 'comment_ID' => $id );
-
 		if ( ! empty( $request['name'] ) ) {
 			$commentdata['comment_author'] = $request['name' ];
 		}
-
 		if ( ! empty( $request['email'] ) ) {
 			$commentdata['comment_author_email'] = $request['email' ];
 		}
-
 		if ( ! empty( $request['review'] ) ) {
 			$commentdata['comment_content'] = $request['review' ];
 		}
 
-
 		wp_update_comment( $commentdata );
-
 		if ( ! empty( $request['rating'] ) ) {
 			update_comment_meta( $id, 'rating', $request['rating'] );
 		}
@@ -368,10 +362,9 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function delete_item( $request ) {
-		$id  = is_array( $request['id'] ) ? $request['id']['id'] : $request['id'];
+		$id    = is_array( $request['id'] ) ? $request['id']['id'] : $request['id'];
 		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
 
-		// We don't support trashing for this type, error out.
 		if ( ! $force ) {
 			return new WP_Error( 'woocommerce_rest_trash_not_supported', __( 'Product reviews do not support trashing.', 'woocommerce' ), array( 'status' => 501 ) );
 		}

--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -47,6 +47,22 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'                => $this->get_collection_params(),
 			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+					'review' => array(
+						'required' => true,
+					),
+					'name' => array(
+						'required' => true,
+					),
+					'email' => array(
+						'required' => true,
+					),
+				) ),
+			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 
@@ -57,6 +73,23 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 				'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				'args'                => array(
 					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				'args'                => array(
+					'force' => array(
+						'default'     => false,
+						'description' => __( 'Required to be true, as resource does not support trashing.', 'woocommerce' ),
+					),
 				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
@@ -78,7 +111,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to read a webhook develivery.
+	 * Check if a given request has access to read a  product review.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
@@ -90,6 +123,48 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to create a new  product review.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function create_item_permissions_check( $request ) {
+		$post = get_post( (int) $request['product_id'] );
+		if ( $post && ! wc_rest_check_post_permissions( 'product', 'create', $post->ID ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you cannot create new resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to update a product review.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		$post = get_post( (int) $request['product_id'] );
+		if ( $post && ! wc_rest_check_post_permissions( 'product', 'edit', $post->ID ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to delete a product review.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$post = get_post( (int) $request['product_id'] );
+		if ( $post && ! wc_rest_check_post_permissions( 'product', 'delete', $post->ID ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot delete product reviews.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
 		return true;
 	}
 
@@ -141,6 +216,158 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		$response = rest_ensure_response( $delivery );
 
 		return $response;
+	}
+
+
+	/**
+	 * Create a product review.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		$product = get_post( (int) $request['product_id'] );
+
+		if ( empty( $product->post_type ) || 'product' !== $product->post_type ) {
+			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		if ( empty( $request['review'] ) ) {
+			return new WP_Error( 'woocommerce_rest_product_review_invalid_review', __( 'Product review content is required.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		if ( empty( $request['name'] ) ) {
+			return new WP_Error( 'woocommerce_rest_product_review_invalid_name', __( 'Product review author name is required.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		if ( empty( $request['email'] ) ) {
+			return new WP_Error( 'woocommerce_rest_product_review_invalid_email', __( 'Product review email is required.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+
+		$data = array(
+			'comment_post_ID'      => $product->id,
+			'comment_author'       => $request['name'],
+			'comment_author_email' => $request['email'],
+			'comment_content'      => $request['review'],
+			'comment_approved'     => 1,
+			'comment_type'         => 'review',
+		);
+		$product_review_id = wp_insert_comment( $data );
+		update_comment_meta( $product_review_id, 'rating', ( ! empty( $request['rating'] ) ? $request['rating'] : '0' ) );
+
+		$comment = get_comment( $product_review_id );
+		$this->update_additional_fields_for_object( $comment, $request );
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param WP_Comment         $comment      Inserted object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "woocommerce_rest_insert_product_review", $comment, $request, true );
+
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $comment, $request );
+		$response = rest_ensure_response( $response );
+		$response->set_status( 201 );
+		$base = str_replace( '(?P<product_id>[\d]+)', $product->id, $this->rest_base );
+		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $base, $product_review_id ) ) );
+
+		return $response;
+	}
+
+	/**
+	 * Update a single product review.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		$id      = (int) $request['id'];
+		$product = get_post( (int) $request['product_id'] );
+
+
+		if ( empty( $product->post_type ) || 'product' !== $product->post_type ) {
+			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$review = get_comment( $id );
+
+		if ( empty( $id ) || empty( $review ) || intval( $review->comment_post_ID ) !== intval( $product->ID ) ) {
+			return new WP_Error( 'woocommerce_rest_product_review_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		// Update fields
+		$commentdata = array( 'comment_ID' => $id );
+
+		if ( ! empty( $request['name'] ) ) {
+			$commentdata['comment_author'] = $request['name' ];
+		}
+
+		if ( ! empty( $request['email'] ) ) {
+			$commentdata['comment_author_email'] = $request['email' ];
+		}
+
+		if ( ! empty( $request['review'] ) ) {
+			$commentdata['comment_content'] = $request['review' ];
+		}
+
+
+		wp_update_comment( $commentdata );
+
+		if ( ! empty( $request['rating'] ) ) {
+			update_comment_meta( $id, 'rating', $request['rating'] );
+		}
+
+		$comment = get_comment( $id );
+		$this->update_additional_fields_for_object( $comment, $request );
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param WP_Comment         $comment      Inserted object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( "woocommerce_rest_insert_product_review", $comment, $request, true );
+
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $comment, $request );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Delete a product review.
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|boolean
+	 */
+	public function delete_item( $request ) {
+		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+
+		// We don't support trashing for this type, error out.
+		if ( ! $force ) {
+			return new WP_Error( 'woocommerce_rest_trash_not_supported', __( 'Product reviews do not support trashing.', 'woocommerce' ), array( 'status' => 501 ) );
+		}
+
+		$result = wp_delete_comment( $request['id'], true );
+
+		/**
+		 * Fires after a product review is deleted via the REST API.
+		 *
+		 * @param object           $post     The deleted item.
+		 * @param WP_REST_Response $response The response data.
+		 * @param WP_REST_Request  $request  The request sent to the API.
+		 */
+		do_action( 'rest_delete_product_revie', $result, $request );
+		if ( $result ) {
+			return true;
+		} else {
+			return new WP_Error( 'rest_cannot_delete', __( 'The product review cannot be deleted.' ), array( 'status' => 500 ) );
+		}
 	}
 
 	/**
@@ -219,37 +446,38 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 				'id' => array(
 					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 					'type'        => 'integer',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
+				),
+				'review' => array(
+					'description' => __( 'The content of the review.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
 				),
 				'date_created' => array(
 					'description' => __( "The date the review was created, in the site's timezone.", 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
 				),
 				'rating' => array(
 					'description' => __( 'Review rating (0 to 5).', 'woocommerce' ),
 					'type'        => 'integer',
-					'context'     => array( 'view' ),
-					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
 				),
 				'name' => array(
 					'description' => __( 'Reviewer name.', 'woocommerce' ),
 					'type'        => 'string',
-					'context'     => array( 'view' ),
-					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
 				),
 				'email' => array(
 					'description' => __( 'Reviewer email.', 'woocommerce' ),
 					'type'        => 'string',
-					'context'     => array( 'view' ),
-					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
 				),
 				'verified' => array(
 					'description' => __( 'Shows if the reviewer bought the product or not.', 'woocommerce' ),
 					'type'        => 'boolean',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 			),

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -239,4 +239,27 @@ class WC_Helper_Product {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
 	}
 
+	/**
+	 * Creates a new product review on a specific product.
+	 *
+	 * @since 2.7
+	 * @param $product_id integer Product ID that the review is for
+	 * @param $revieww_content string Content to use for the product review
+	 * @return integer Product Review ID
+	 */
+	public static function create_product_review( $product_id, $review_content = 'Review content here' ) {
+		$data = array(
+			'comment_post_ID'      => $product_id,
+		    'comment_author'       => 'admin',
+		    'comment_author_email' => 'woo@woo.local',
+		    'comment_author_url'   => '',
+			'comment_date'         => '2016-01-01T11:11:11',
+		    'comment_content'      => $review_content,
+    		'comment_approved'     => 1,
+			'comment_type'         => 'review',
+		);
+
+		return wp_insert_comment( $data );
+	}
+
 }

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -31,7 +31,7 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	}
 
     /**
-     *
+     * Test getting all product reviews.
      *
      * @since 2.7.0
      */
@@ -74,7 +74,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
                 ),
             ),
         ), $product_reviews );
-
     }
 
     /**

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Tests for the product reviews REST API.
+ *
+ * @package WooCommerce\Tests\API
+ * @since 2.7.0
+ */
+
+class Product_Reviews extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Product_Reviews_Controller();
+        $this->user = $this->factory->user->create( array(
+            'role' => 'administrator',
+        ) );
+	}
+
+	/**
+	 * Test route registration.
+     *
+     * @since 2.7.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/v1/products/(?P<product_id>[\d]+)/reviews', $routes );
+		$this->assertArrayHasKey( '/wc/v1/products/(?P<product_id>[\d]+)/reviews/(?P<id>[\d]+)', $routes );
+	}
+
+    /**
+     *
+     *
+     * @since 2.7.0
+     */
+    public function test_get_product_reviews() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        // Create 10 products reviews for the product
+        for ( $i = 0; $i < 10; $i++ ) {
+            WC_Helper_Product::create_product_review( $product->id );
+        }
+
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/reviews' ) );
+        $product_reviews = $response->get_data();
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( 10, count( $product_reviews ) );
+        $this->assertContains( array(
+            'id'           => 2,
+            'date_created' => '2016-01-01T11:11:11',
+            'review'       => 'Review content here',
+            'rating'       => 0,
+            'name'         => 'admin',
+            'email'        => 'woo@woo.local',
+            'verified'     => false,
+            '_links' => array(
+                'self'       => array(
+                    array(
+                        'href' => rest_url( '/wc/v1/products/' . $product->id . '/reviews/2' ),
+                    ),
+                ),
+                'collection' => array(
+                    array(
+                        'href' => rest_url( '/wc/v1/products/' . $product->id . '/reviews' ),
+                    ),
+                ),
+                'up' => array(
+                    array(
+                        'href' => rest_url( '/wc/v1/products/' . $product->id ),
+                    ),
+                ),
+            ),
+        ), $product_reviews );
+
+    }
+
+    /**
+     * Tests to make sure product reviews cannot be viewed without valid permissions.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_product_reviews_without_permission() {
+        wp_set_current_user( 0 );
+        $product = WC_Helper_Product::create_simple_product();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/reviews' ) );
+		$this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Tests to make sure an error is returned when an invalid product is loaded.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_product_reviews_invalid_product() {
+        wp_set_current_user( $this->user );
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/0/reviews' ) );
+        $this->assertEquals( 404, $response->get_status() );
+    }
+
+    /**
+     * Tests getting a single product review.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_product_review() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        $product_review_id = WC_Helper_Product::create_product_review( $product->id );
+
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id ) );
+        $data     = $response->get_data();
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( array(
+            'id'           => $product_review_id ,
+            'date_created' => '2016-01-01T11:11:11',
+            'review'       => 'Review content here',
+            'rating'       => 0,
+            'name'         => 'admin',
+            'email'        => 'woo@woo.local',
+            'verified'     => false,
+        ), $data );
+    }
+
+    /**
+     * Tests getting a single product review without the correct permissions.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_product_review_without_permission() {
+        wp_set_current_user( 0 );
+        $product = WC_Helper_Product::create_simple_product();
+        $product_review_id = WC_Helper_Product::create_product_review( $product->id );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id ) );
+		$this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Tests getting a product review with an invalid ID.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_product_review_invalid_id() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/reviews/0' ) );
+        $this->assertEquals( 404, $response->get_status() );
+    }
+
+    /**
+     * Tests creating a product review.
+     *
+     * @since 2.7.0
+     */
+    public function test_create_product_review() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        $request = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/reviews' );
+        $request->set_body_params( array(
+            'review' => 'Hello world.',
+            'name'   => 'Admin',
+            'email'  => 'woo@woo.local',
+            'rating' => '5',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+
+        $this->assertEquals( 201, $response->get_status() );
+        $this->assertEquals( array(
+            'id'           => $data['id'],
+            'date_created' => $data['date_created'],
+            'review'       => 'Hello world.',
+            'rating'       => 5,
+            'name'         => 'Admin',
+            'email'        => 'woo@woo.local',
+            'verified'     => false,
+        ), $data );
+    }
+
+    /**
+     * Tests creating a product review without required fields.
+     *
+     * @since 2.7.0
+     */
+    public function test_create_product_review_invalid_fields() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+
+        // missing review
+        $request = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/reviews' );
+        $request->set_body_params( array(
+            'name'   => 'Admin',
+            'email'  => 'woo@woo.local',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+
+        $this->assertEquals( 400, $response->get_status() );
+
+        // missing name
+        $request = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/reviews' );
+        $request->set_body_params( array(
+            'review' => 'Hello world.',
+            'email'  => 'woo@woo.local',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+
+        $this->assertEquals( 400, $response->get_status() );
+
+        // missing email
+        $request = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/reviews' );
+        $request->set_body_params( array(
+            'review' => 'Hello world.',
+            'name'   => 'Admin',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+
+        $this->assertEquals( 400, $response->get_status() );
+    }
+
+    /**
+     * Tests updating a product review.
+     *
+     * @since 2.7.0
+     */
+    public function test_update_product_review() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        $product_review_id = WC_Helper_Product::create_product_review( $product->id );
+
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id ) );
+        $data     = $response->get_data();
+        $this->assertEquals( 'Review content here', $data['review'] );
+        $this->assertEquals( 'admin', $data['name'] );
+        $this->assertEquals( 'woo@woo.local', $data['email'] );
+        $this->assertEquals( 0, $data['rating'] );
+
+        $request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id );
+        $request->set_body_params( array(
+            'review' => 'Hello world - updated.',
+            'name'   => 'Justin',
+            'email'  => 'woo2@woo.local',
+            'rating' => 3,
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+        $this->assertEquals( 'Hello world - updated.', $data['review'] );
+        $this->assertEquals( 'Justin', $data['name'] );
+        $this->assertEquals( 'woo2@woo.local', $data['email'] );
+        $this->assertEquals( 3, $data['rating'] );
+    }
+
+    /**
+     * Tests updating a product review without the correct permissions.
+     *
+     * @since 2.7.0
+     */
+    public function test_update_product_review_without_permission() {
+        wp_set_current_user( 0 );
+        $product = WC_Helper_Product::create_simple_product();
+        $product_review_id = WC_Helper_Product::create_product_review( $product->id );
+
+        $request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id );
+        $request->set_body_params( array(
+            'review' => 'Hello world.',
+            'name'   => 'Admin',
+            'email'  => 'woo@woo.dev',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+
+        $this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Tests that updating a product review with an invalid id fails.
+     *
+     * @since 2.7.0
+     */
+    public function test_update_product_review_invalid_id() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+
+        $request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $product->id . '/reviews/0' );
+        $request->set_body_params( array(
+            'review' => 'Hello world.',
+            'name'   => 'Admin',
+            'email'  => 'woo@woo.dev',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+
+        $this->assertEquals( 404, $response->get_status() );
+    }
+
+    /**
+     * Test deleting a product review.
+     *
+     * @since 2.7.0
+     */
+    public function test_delete_product_review() {
+		wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        $product_review_id = WC_Helper_Product::create_product_review( $product->id );
+
+        $request = new WP_REST_Request( 'DELETE', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id );
+		$request->set_param( 'force', true );
+        $response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+    }
+
+    /**
+     * Test deleting a product review without permission/creds.
+     *
+     * @since 2.7.0
+     */
+    public function test_delete_product_without_permission() {
+		wp_set_current_user( 0 );
+        $product = WC_Helper_Product::create_simple_product();
+        $product_review_id = WC_Helper_Product::create_product_review( $product->id );
+
+        $request = new WP_REST_Request( 'DELETE', '/wc/v1/products/' . $product->id . '/reviews/' . $product_review_id );
+        $response = $this->server->dispatch( $request );
+
+        $this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Test deleting a product review with an invalid id.
+     *
+     * @since 2.7.0
+     */
+    public function test_delete_product_review_invalid_id() {
+		wp_set_current_user( $this->user );
+		$product = WC_Helper_Product::create_simple_product();
+		$product_review_id = WC_Helper_Product::create_product_review( $product->id );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v1/products/' . $product->id . '/reviews/0' );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 500, $response->get_status() );
+    }
+
+    /**
+     * Test the product review schema.
+     *
+     * @since 2.7.0
+     */
+    public function test_product_review_schema() {
+        wp_set_current_user( $this->user );
+        $product = WC_Helper_Product::create_simple_product();
+        $request = new WP_REST_Request( 'OPTIONS', '/wc/v1/products/' . $product->id . '/reviews' );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+        $properties = $data['schema']['properties'];
+
+        $this->assertEquals( 7, count( $properties ) );
+        $this->assertArrayHasKey( 'id', $properties );
+        $this->assertArrayHasKey( 'review', $properties );
+        $this->assertArrayHasKey( 'date_created', $properties );
+        $this->assertArrayHasKey( 'rating', $properties );
+        $this->assertArrayHasKey( 'name', $properties );
+        $this->assertArrayHasKey( 'email', $properties );
+        $this->assertArrayHasKey( 'verified', $properties );
+    }
+
+}


### PR DESCRIPTION
This PR adds the following capabilities to the existing product reviews controller:
- Create/POST
- Update/PUT
- DELETE
- Batch operations (for all of the above)
- Full set of tests for the above, plus existing GET operations
