### PR TITLE
Fixed emails not properly encoded in download URLs

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -446,7 +446,7 @@ function wc_get_customer_available_downloads( $customer_id ) {
 					array(
 						'download_file' => $product_id,
 						'order'         => $result->order_key,
-						'email'         => $result->user_email,
+						'email'         => urlencode( $result->user_email ),
 						'key'           => $result->download_id
 					),
 					home_url( '/' )


### PR DESCRIPTION
Emails are not being correctly encoded ( they're not using the same code as `WC_Abstract_Order->get_download_url` )

Patched up for now, not sure if you want to normalize code at some point, and just move the code somewhere else and perform the same encoding everywhere.
