### PR TITLE
Fixes WC_Breadcrumb::generate() returning empty array on search product page

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -74,7 +74,7 @@ class WC_Breadcrumb {
 			'is_tax'
 		);
 
-		if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_front' ) == wc_get_page_id( 'shop' ) ) ) || is_paged() ) {
+		if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_front' ) === wc_get_page_id( 'shop' ) ) ) || is_paged() ) {
 			foreach ( $conditionals as $conditional ) {
 				if ( call_user_func( $conditional ) ) {
 					call_user_func( array( $this, 'add_crumbs_' . substr( $conditional, 3 ) ) );

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -74,7 +74,7 @@ class WC_Breadcrumb {
 			'is_tax'
 		);
 
-		if ( ( ! is_front_page() && ! ( is_post_type_archive() && get_option( 'page_on_front' ) === wc_get_page_id( 'shop' ) ) ) || is_paged() ) {
+		if ( ( ! is_front_page() && ! ( is_post_type_archive() && intval( get_option( 'page_on_front' ) ) === wc_get_page_id( 'shop' ) ) ) || is_paged() ) {
 			foreach ( $conditionals as $conditional ) {
 				if ( call_user_func( $conditional ) ) {
 					call_user_func( array( $this, 'add_crumbs_' . substr( $conditional, 3 ) ) );


### PR DESCRIPTION
See the related issue #11588

Could that cause problems ?
