### PR TITLE
Add user to site on login

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -164,6 +164,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woothemes/wooc
 * Improved handling of shop page rewrite rules to allow subpages.
 * Redirect to login after password reset.
 * When using authorizations in PayPal standard, automatically capture funds when the order goes processing/completed.
+* On multisite, when a user logs into a store with an account on a site, but not the current site, rather than error, add the user to the current site as a customer.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woothemes/woocommerce/master/CHANGELOG.txt).
 


### PR DESCRIPTION
On multisite, when a user logs into a store with an account on a site, but not the current site, rather than error, add the user to the current site as a customer.

Closes #11409
