### PR TITLE
ZIP Code formatting for Poland

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -668,6 +668,9 @@ function wc_format_postcode( $postcode, $country ) {
 		case 'JP' :
 			$postcode = trim( substr_replace( $postcode, '-', 3, 0 ) );
 			break;
+		case 'PL' :
+			$postcode = trim( substr_replace( $postcode, '-', -3, 0 ) );
+			break;
 		case 'PT' :
 			$postcode = trim( substr_replace( $postcode, '-', 4, 0 ) );
 			break;


### PR DESCRIPTION
In Poland we use ZIP code formatting: XX-XXX. So the "-" sign should
not be removed.
