### PR TITLE
Focus on modal, enable esc-close + init tooltips

### DIFF
--- a/assets/js/admin/backbone-modal.js
+++ b/assets/js/admin/backbone-modal.js
@@ -88,6 +88,8 @@
 			}).append( this.$el );
 
 			this.resizeContent();
+			this.$el.focus();
+			$( document.body ).trigger( 'init_tooltips' );
 
 			$( document.body ).trigger( 'wc_backbone_modal_loaded', this._target );
 		},


### PR DESCRIPTION
When opening the modal it doesn't allow you to close it with the ESC key unless you click on the modal first.
Focussing on the modal when its loaded resolves that.

Also adding tooltip initialisation so tooltips will show if they are present. I don't believe core is using tooltips in there right now, but I guess its useful for the future / 3rd party devs that may have a use for it (like me)
