### PR TITLE
System Status Tools API

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -41,12 +41,18 @@ class WC_Admin_Status {
 
 		if ( ! empty( $_GET['action'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'debug_action' ) ) {
 			$tools_controller = new WC_REST_System_Status_Tools_Controller;
-			$response = $tools_controller->execute_tool( $_GET['action'] );
+			$action           = wc_clean( $_GET['action'] );
+
+			if ( array_key_exists( $action, $tools ) ) {
+				$response = $tools_controller->execute_tool( $action );
+			} else {
+				$response = array( 'success' => false, 'message' => __( 'Tool does not exist.', 'woocommerce' ) );
+			}
 
 			if ( $response['success'] ) {
-				echo '<div class="updated inline"><p>' . $response['message'] . '</p></div>';
+				echo '<div class="updated inline"><p>' . esc_html( $response['message'] ) . '</p></div>';
 			} else {
-				echo '<div class="error inline"><p>' . $response['message'] . '</p></div>';
+				echo '<div class="error inline"><p>' . esc_html( $response['message'] ) . '</p></div>';
 			}
 		}
 

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -35,7 +35,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 	protected $rest_base = 'system_status';
 
 	/**
-	 * Register the routes for coupons.
+	 * Register the routes for /system_status
 	 */
 	public function register_routes() {
         register_rest_route( $this->namespace, '/' . $this->rest_base, array(

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -35,7 +35,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 	protected $rest_base = 'system_status';
 
 	/**
-	 * Register the routes for /system_status
+	 * Register the routes for /system_status and /system_status/modes
 	 */
 	public function register_routes() {
         register_rest_route( $this->namespace, '/' . $this->rest_base, array(
@@ -46,6 +46,20 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				'args'                => $this->get_collection_params(),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/modes', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_modes' ),
+				'permission_callback' => array( $this, 'get_modes_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_modes' ),
+				'permission_callback' => array( $this, 'update_modes_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			'schema' => array( $this, 'get_mode_item_schema' ),
 		) );
 	}
 
@@ -58,6 +72,32 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 	public function get_items_permissions_check( $request ) {
         if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
         	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to view system status modes.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_modes_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list system modes.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to toggle system status modes.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_modes_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'edit' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot update system modes', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -85,6 +125,104 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 
 		return rest_ensure_response( $response );
 	}
+
+	/**
+	 * A list of modes that can be toggled via WC's system status screens
+	 *
+	 * @return array
+	 */
+	public function _get_modes() {
+		$options = wp_parse_args( get_option( 'woocommerce_status_options', array() ), array(
+			'uninstall_data'      => 0,
+			'template_debug_mode' => 0,
+			'shipping_debug_mode' => 0,
+		) );
+		$modes = array(
+			'shipping_debug' => array(
+				'id'          => 'shipping_debug',
+				'name'        => __( 'Shipping Debug Mode', 'woocommerce' ),
+				'description' => __( 'Enable Shipping Debug Mode to show matching shipping zones and to bypass shipping rate cache.', 'woocommerce' ),
+				'enabled'     => (bool) $options['shipping_debug_mode'],
+			),
+			'template_debug' => array(
+				'id'          => 'template_debug',
+				'name'        => __( 'Template Debug Mode', 'woocommerce' ),
+				'description' => __( 'Enable Template Debug Mode to bypass all theme and plugin template overrides for logged-in administrators. Used for debugging purposes.', 'woocommerce' ),
+				'enabled'     => (bool) $options['template_debug_mode'],
+			),
+			'uninstall_data' => array(
+				'id'          => 'uninstall_data',
+				'name'        => __( 'Remove All Data On Uninstall Mode', 'woocommerce' ),
+				'description' => __( 'This mode will remove all WooCommerce, Product and Order data when using the "Delete" link on the plugins screen. It will also remove any setting/option prepended with "woocommerce_" so may also affect installed WooCommerce Extensions.', 'woocommerce' ),
+				'enabled'     => (bool) $options['uninstall_data'],
+			),
+		);
+
+		return $modes;
+	}
+
+	/**
+	 * Get system status modes.
+
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_modes( $request ) {
+		$modes_response = array();
+		foreach ( $this->_get_modes() as $id => $mode ) {
+			$modes_response[] = $this->prepare_response_for_collection( $this->prepare_mode_for_response ( $mode, $request ) );
+		}
+		$response = rest_ensure_response( $modes_response );
+		return $response;
+	}
+
+	/**
+	 * Update system status modes.
+
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_modes( $request ) {
+		$items   = $request->get_params();
+		$modes   = $this->_get_modes();
+		$options = wp_parse_args( get_option( 'woocommerce_status_options', array() ), array(
+			'uninstall_data'      => 0,
+			'template_debug_mode' => 0,
+			'shipping_debug_mode' => 0,
+		) );
+
+		foreach ( $items as $key => $value ) {
+			if ( ! array_key_exists( $key, $modes ) ) {
+				return new WP_Error( 'woocommerce_rest_system_status_mode_invalid', __( 'Invalid mode.', 'woocommerce' ), array( 'status' => 500 ) );
+				break;
+			}
+
+			if ( 'uninstall_data' !== $key ) {
+				$key = $key . '_mode'; // all other modes have a suffix
+			}
+
+			$options[ $key ] = (bool) $value;
+		}
+
+		update_option( 'woocommerce_status_options', $options );
+
+		return $this->get_modes( $request );
+	}
+
+	 /**
+	  * Prepare a mode for serialization.
+	  *
+	  * @param  array $item Object.
+	  * @param  WP_REST_Request $request Request object.
+	  * @return WP_REST_Response $response Response data.
+	  */
+	 public function prepare_mode_for_response( $item, $request ) {
+		 $context  = empty( $request['context'] ) ? 'view' : $request['context'];
+		 $data     = $this->add_additional_fields_to_object( $item, $request );
+		 $data     = $this->filter_response_by_context( $data, $context );
+		 $response = rest_ensure_response( $data );
+		 return $response;
+	 }
 
     /**
 	 * Get the system status schema, conforming to JSON Schema.
@@ -420,6 +558,52 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 					'context'     => array( 'view', 'edit' ),
 				),
 			)
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the system status modes schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_mode_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'system_status_option',
+			'type'       => 'object',
+			'properties' => array(
+				'id'               => array(
+					'description'  => __( 'A unique identifier for the system status mode.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_title',
+					),
+				),
+				'name'      => array(
+					'description'  => __( 'Mode name.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'description'      => array(
+					'description'  => __( 'Mode description.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'enabled'            => array(
+					'description'  => __( 'True if this mode is enabled.', 'woocommerce' ),
+					'type'         => 'boolean',
+					'context'      => array( 'view', 'edit' ),
+				),
+			),
 		);
 
 		return $this->add_additional_fields_schema( $schema );

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -1,0 +1,441 @@
+<?php
+/**
+ * REST API WC System Status Tools Controller
+ *
+ * Handles requests to the /system_status/tools/* endpoints.
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'system_status/tools';
+
+	/**
+	 * Register the routes for /system_status/tools/*.
+	 */
+	public function register_routes() {
+
+        /**
+		 * @todo implement these routes below (or similar) and remove this comment
+         * GET system_status/tools/options - Get a list of system options that can be toggled (Shipping Debug Mode, Template Debug Mode, Remove All Data)
+         * PUT system_status/tools/options - Change an option
+         */
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => $this->get_collection_params(),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+    /**
+	 * Check whether a given request has permission to view system status tools.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+        if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
+        	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to view a specific system status tool.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to execute a specific system status tool.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'edit' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot update resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * A list of avaiable tools for use in the system status section.
+	 * 'button' becomes 'action' in the API.
+	 *
+	 * @return array
+	 */
+	public function get_tools() {
+		$tools = array(
+			'clear_transients' => array(
+				'name'    => __( 'WC Transients', 'woocommerce' ),
+				'button'  => __( 'Clear transients', 'woocommerce' ),
+				'desc'    => __( 'This tool will clear the product/shop transients cache.', 'woocommerce' ),
+			),
+			'clear_expired_transients' => array(
+				'name'    => __( 'Expired Transients', 'woocommerce' ),
+				'button'  => __( 'Clear expired transients', 'woocommerce' ),
+				'desc'    => __( 'This tool will clear ALL expired transients from WordPress.', 'woocommerce' ),
+			),
+			'recount_terms' => array(
+				'name'    => __( 'Term counts', 'woocommerce' ),
+				'button'  => __( 'Recount terms', 'woocommerce' ),
+				'desc'    => __( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', 'woocommerce' ),
+			),
+			'reset_roles' => array(
+				'name'    => __( 'Capabilities', 'woocommerce' ),
+				'button'  => __( 'Reset capabilities', 'woocommerce' ),
+				'desc'    => __( 'This tool will reset the admin, customer and shop_manager roles to default. Use this if your users cannot access all of the WooCommerce admin pages.', 'woocommerce' ),
+			),
+			'clear_sessions' => array(
+				'name'    => __( 'Customer Sessions', 'woocommerce' ),
+				'button'  => __( 'Clear all sessions', 'woocommerce' ),
+				'desc'    => __( '<strong class="red">Warning:</strong> This tool will delete all customer session data from the database, including any current live carts.', 'woocommerce' ),
+			),
+			'install_pages' => array(
+				'name'    => __( 'Install WooCommerce Pages', 'woocommerce' ),
+				'button'  => __( 'Install pages', 'woocommerce' ),
+				'desc'    => __( '<strong class="red">Note:</strong> This tool will install all the missing WooCommerce pages. Pages already defined and set up will not be replaced.', 'woocommerce' ),
+			),
+			'delete_taxes' => array(
+				'name'    => __( 'Delete all WooCommerce tax rates', 'woocommerce' ),
+				'button'  => __( 'Delete ALL tax rates', 'woocommerce' ),
+				'desc'    => __( '<strong class="red">Note:</strong> This option will delete ALL of your tax rates, use with caution.', 'woocommerce' ),
+			),
+			'reset_tracking' => array(
+				'name'    => __( 'Reset Usage Tracking Settings', 'woocommerce' ),
+				'button'  => __( 'Reset usage tracking settings', 'woocommerce' ),
+				'desc'    => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
+			)
+		);
+
+		return apply_filters( 'woocommerce_debug_tools', $tools );
+	}
+
+    /**
+	 * Get a list of system status tools.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$tools = array();
+		foreach ( $this->get_tools() as $id => $tool ) {
+			$tools[] = $this->prepare_response_for_collection( $this->prepare_item_for_response ( array(
+				'id'          => $id,
+				'name'        => $tool['name'],
+				'action'      => $tool['button'],
+				'description' => $tool['desc'],
+			), $request ) );
+		}
+
+		$response = rest_ensure_response( $tools );
+		return $response;
+	}
+
+	/**
+	 * Return a single tool.
+	 *
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$tools = $this->get_tools();
+		if ( empty( $tools[ $request['id'] ] ) ) {
+			return new WP_Error( 'woocommerce_rest_system_status_tool_invalid_id', __( 'Invalid tool ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+		$tool = $tools[ $request['id'] ];
+		return rest_ensure_response( $this->prepare_item_for_response ( array(
+		   'id'          => $request['id'],
+		   'name'        => $tool['name'],
+		   'action'      => $tool['button'],
+		   'description' => $tool['desc'],
+	   ), $request ) );
+	}
+
+	/**
+	 * Update (execute) a tool.
+
+	 * @param  WP_REST_Request $request
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		$tools = $this->get_tools();
+		if ( empty( $tools[ $request['id'] ] ) ) {
+			return new WP_Error( 'woocommerce_rest_system_status_tool_invalid_id', __( 'Invalid tool ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$tool = $tools[ $request['id'] ];
+		$tool = array(
+		   'id'          => $request['id'],
+		   'name'        => $tool['name'],
+		   'action'      => $tool['button'],
+		   'description' => $tool['desc'],
+		);
+
+		$execute_return = $this->execute_tool( $request['id'] );
+		$tool = array_merge( $tool, $execute_return );
+
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $tool, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Prepare a tool item for serialization.
+	 *
+	 * @param  array $item Object.
+	 * @param  WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$context = empty( $request['context'] ) ? 'view' : $request['context'];
+		$data    = $this->add_additional_fields_to_object( $item, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item['id'] ) );
+
+		return $response;
+	}
+
+    /**
+	 * Get the system status tools schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'system_status_tool',
+			'type'       => 'object',
+			'properties' => array(
+				'id'               => array(
+					'description'  => __( 'A unique identifier for the tool.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_title',
+					),
+				),
+				'name'            => array(
+					'description'  => __( 'Tool name.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'action'            => array(
+					'description'  => __( 'What running the tool will do.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'description'      => array(
+					'description'  => __( 'Tool description.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'view', 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'success'      => array(
+					'description'  => __( 'Did the tool run successfully?', 'woocommerce' ),
+					'type'         => 'boolean',
+					'context'      => array( 'edit' ),
+				),
+				'message'      => array(
+					'description'  => __( 'Tool return message.', 'woocommerce' ),
+					'type'         => 'string',
+					'context'      => array( 'edit' ),
+					'arg_options'  => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param string $id
+	 * @return array
+	 */
+	protected function prepare_links( $id ) {
+		$base  = '/' . $this->namespace . '/' . $this->rest_base;
+		$links = array(
+			'item' => array(
+				'href'       => rest_url( trailingslashit( $base ) . $id ),
+				'embeddable' => true,
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get any query params needed.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
+	}
+
+	/**
+	 * Actually executes a a tool.
+	 *
+	 * @param  string $tool
+	 * @return array
+	 */
+	public function execute_tool( $tool ) {
+		global $wpdb;
+		$ran = true;
+		switch ( $tool ) {
+			case 'clear_transients' :
+				wc_delete_product_transients();
+				wc_delete_shop_order_transients();
+				WC_Cache_Helper::get_transient_version( 'shipping', true );
+				$message = __( 'Product Transients Cleared', 'woocommerce' );
+			break;
+			case 'clear_expired_transients' :
+				/*
+				 * Deletes all expired transients. The multi-table delete syntax is used.
+				 * to delete the transient record from table a, and the corresponding.
+				 * transient_timeout record from table b.
+				 *
+				 * Based on code inside core's upgrade_network() function.
+				 */
+				$sql = "DELETE a, b FROM $wpdb->options a, $wpdb->options b
+					WHERE a.option_name LIKE %s
+					AND a.option_name NOT LIKE %s
+					AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+					AND b.option_value < %d";
+				$rows = $wpdb->query( $wpdb->prepare( $sql, $wpdb->esc_like( '_transient_' ) . '%', $wpdb->esc_like( '_transient_timeout_' ) . '%', time() ) );
+
+				$sql = "DELETE a, b FROM $wpdb->options a, $wpdb->options b
+					WHERE a.option_name LIKE %s
+					AND a.option_name NOT LIKE %s
+					AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+					AND b.option_value < %d";
+				$rows2 = $wpdb->query( $wpdb->prepare( $sql, $wpdb->esc_like( '_site_transient_' ) . '%', $wpdb->esc_like( '_site_transient_timeout_' ) . '%', time() ) );
+
+				$message = sprintf( __( '%d Transients Rows Cleared', 'woocommerce' ), $rows + $rows2 );
+			break;
+			case 'reset_roles' :
+				// Remove then re-add caps and roles
+				WC_Install::remove_roles();
+				WC_Install::create_roles();
+				$message = __( 'Roles successfully reset', 'woocommerce' );
+			break;
+			case 'recount_terms' :
+				$product_cats = get_terms( 'product_cat', array( 'hide_empty' => false, 'fields' => 'id=>parent' ) );
+				_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), true, false );
+				$product_tags = get_terms( 'product_tag', array( 'hide_empty' => false, 'fields' => 'id=>parent' ) );
+				_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), true, false );
+				$message = __( 'Terms successfully recounted', 'woocommerce' );
+			break;
+			case 'clear_sessions' :
+				$wpdb->query( "TRUNCATE {$wpdb->prefix}woocommerce_sessions" );
+				wp_cache_flush();
+				$message = __( 'Sessions successfully cleared', 'woocommerce' );
+			break;
+			case 'install_pages' :
+				WC_Install::create_pages();
+				return __( 'All missing WooCommerce pages was installed successfully.', 'woocommerce' );
+			break;
+			case 'delete_taxes' :
+
+				$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_tax_rates;" );
+				$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_tax_rate_locations;" );
+				WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+				$message = __( 'Tax rates successfully deleted', 'woocommerce' );
+			break;
+			case 'reset_tracking' :
+				delete_option( 'woocommerce_allow_tracking' );
+				WC_Admin_Notices::add_notice( 'tracking' );
+				$message = __( 'Usage tracking settings successfully reset.', 'woocommerce' );
+			break;
+			default :
+				$tools = $this->get_tools();
+				if ( isset( $tools[ $tool ]['callback'] ) ) {
+					$callback = $tools[ $tool ]['callback'];
+					$return = call_user_func( $callback );
+					if ( $return === false ) {
+						$callback_string = is_array( $callback ) ? get_class( $callback[0] ) . '::' . $callback[1] : $callback;
+						$ran = false;
+						$message = sprintf( __( 'There was an error calling %s', 'woocommerce' ), $callback_string );
+					} else {
+						$message = __( 'Tool ran.', 'woocommerce' );
+					}
+				} else {
+					$ran     = false;
+					$message = __( 'There was an error calling this tool. There is no callback present.', 'woocommerce' );
+				}
+			break;
+		}
+
+		return array( 'success' => $ran, 'message' => $message );
+	}
+
+}

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -38,13 +38,6 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 	 * Register the routes for /system_status/tools/*.
 	 */
 	public function register_routes() {
-
-        /**
-		 * @todo implement these routes below (or similar) and remove this comment
-         * GET system_status/tools/options - Get a list of system options that can be toggled (Shipping Debug Mode, Template Debug Mode, Remove All Data)
-         * PUT system_status/tools/options - Change an option
-         */
-
         register_rest_route( $this->namespace, '/' . $this->rest_base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -173,6 +173,7 @@ class WC_API extends WC_Legacy_API {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-webhook-deliveries.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-webhooks-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-system-status-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-system-status-tools-controller.php' );
 	}
 
 	/**
@@ -210,6 +211,7 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Webhook_Deliveries_Controller',
 			'WC_REST_Webhooks_Controller',
 			'WC_REST_System_Status_Controller',
+			'WC_REST_System_Status_Tools_Controller',
 		);
 
 		foreach ( $controllers as $controller ) {

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -25,6 +25,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
         $this->assertArrayHasKey( '/wc/v1/system_status', $routes );
         $this->assertArrayHasKey( '/wc/v1/system_status/tools', $routes );
         $this->assertArrayHasKey( '/wc/v1/system_status/tools/(?P<id>[\w-]+)', $routes );
+        $this->assertArrayHasKey( '/wc/v1/system_status/modes', $routes );
     }
 
     /**
@@ -247,8 +248,6 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
         $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools/recount_terms' ) );
         $data     = $response->get_data();
 
-        error_log( print_r ( $data, 1 ) );
-
         $this->assertEquals( 200, $response->get_status() );
 
         $this->assertEquals( 'recount_terms', $data['id'] );
@@ -300,7 +299,106 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
      */
     public function test_execute_system_status_tool_without_permission() {
         wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'PUT', '/wc/v1/system_status/tools/recount_terms' ) );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/recount_terms' ) );
+        $this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Test getting a list of system status modes.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_system_status_modes() {
+        wp_set_current_user( $this->user );
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/modes' ) );
+        $data     = $response->get_data();
+        $system_status = new WC_REST_System_Status_Controller;
+        $raw_modes     = $system_status->_get_modes();
+        foreach ( $data as $mode ) {
+            $this->assertEquals( $raw_modes[ $mode['id'] ], $mode );
+        }
+    }
+
+    /**
+     * Test getting system status modes without valid permissions.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_system_status_modes_without_permission() {
+        wp_set_current_user( 0 );
+        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/modes' ) );
+        $this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Test updating system status modes.
+     *
+     * @since 2.7.0
+     */
+    public function test_update_system_status_modes() {
+        wp_set_current_user( $this->user );
+
+        // test invalid mode
+        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
+        $request->set_body_params( array(
+            'test_mode' => 'test',
+        ) );
+        $response = $this->server->dispatch( $request );
+        $this->assertEquals( 500, $response->get_status() );
+
+        // test updating single mode.
+        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
+        $request->set_body_params( array(
+            'uninstall_data' => true,
+        ) );
+        $response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+        foreach ( $data as $mode ) {
+            if ( 'uninstall_data' === $mode['id'] ) {
+                $this->assertTrue( $mode['enabled'] );
+            } else {
+                $this->assertFalse( $mode['enabled'] );
+            }
+        }
+
+        // test updating multiple
+        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
+        $request->set_body_params( array(
+            'template_debug' => true,
+            'shipping_debug' => true,
+        ) );
+        $response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+        foreach ( $data as $mode ) {
+            $this->assertTrue( $mode['enabled'] ); // all 3 should be true now
+        }
+
+        // test updating multiple, some false
+        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
+        $request->set_body_params( array(
+            'template_debug' => false,
+            'shipping_debug' => true,
+            'uninstall_data' => false,
+        ) );
+        $response = $this->server->dispatch( $request );
+        $data     = $response->get_data();
+        foreach ( $data as $mode ) {
+            if ( 'shipping_debug' === $mode['id'] ) {
+                $this->assertTrue( $mode['enabled'] );
+            } else {
+                $this->assertFalse( $mode['enabled'] );
+            }
+        }
+    }
+
+    /**
+     * Test updating system status modes without permission.
+     *
+     * @since 2.7.0
+     */
+    public function test_update_system_status_modes_without_permission() {
+        wp_set_current_user( 0 );
+        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' ) );
         $this->assertEquals( 401, $response->get_status() );
     }
 
@@ -321,6 +419,23 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
         $this->assertArrayHasKey( 'description', $properties );
         $this->assertArrayHasKey( 'success', $properties );
         $this->assertArrayHasKey( 'message', $properties );
+    }
+
+    /**
+     * Test modes schema.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_system_status_mode_schema() {
+        $request = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status/modes' );
+        $response = $this->server->dispatch( $request );
+        $data = $response->get_data();
+        $properties = $data['schema']['properties'];
+        $this->assertEquals( 4, count( $properties ) );
+        $this->assertArrayHasKey( 'id', $properties );
+        $this->assertArrayHasKey( 'name', $properties );
+        $this->assertArrayHasKey( 'description', $properties );
+        $this->assertArrayHasKey( 'enabled', $properties );
     }
 
 }

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -25,7 +25,6 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
         $this->assertArrayHasKey( '/wc/v1/system_status', $routes );
         $this->assertArrayHasKey( '/wc/v1/system_status/tools', $routes );
         $this->assertArrayHasKey( '/wc/v1/system_status/tools/(?P<id>[\w-]+)', $routes );
-        $this->assertArrayHasKey( '/wc/v1/system_status/modes', $routes );
     }
 
     /**
@@ -304,105 +303,6 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
     }
 
     /**
-     * Test getting a list of system status modes.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_modes() {
-        wp_set_current_user( $this->user );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/modes' ) );
-        $data     = $response->get_data();
-        $system_status = new WC_REST_System_Status_Controller;
-        $raw_modes     = $system_status->_get_modes();
-        foreach ( $data as $mode ) {
-            $this->assertEquals( $raw_modes[ $mode['id'] ], $mode );
-        }
-    }
-
-    /**
-     * Test getting system status modes without valid permissions.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_modes_without_permission() {
-        wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/modes' ) );
-        $this->assertEquals( 401, $response->get_status() );
-    }
-
-    /**
-     * Test updating system status modes.
-     *
-     * @since 2.7.0
-     */
-    public function test_update_system_status_modes() {
-        wp_set_current_user( $this->user );
-
-        // test invalid mode
-        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
-        $request->set_body_params( array(
-            'test_mode' => 'test',
-        ) );
-        $response = $this->server->dispatch( $request );
-        $this->assertEquals( 500, $response->get_status() );
-
-        // test updating single mode.
-        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
-        $request->set_body_params( array(
-            'uninstall_data' => true,
-        ) );
-        $response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-        foreach ( $data as $mode ) {
-            if ( 'uninstall_data' === $mode['id'] ) {
-                $this->assertTrue( $mode['enabled'] );
-            } else {
-                $this->assertFalse( $mode['enabled'] );
-            }
-        }
-
-        // test updating multiple
-        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
-        $request->set_body_params( array(
-            'template_debug' => true,
-            'shipping_debug' => true,
-        ) );
-        $response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-        foreach ( $data as $mode ) {
-            $this->assertTrue( $mode['enabled'] ); // all 3 should be true now
-        }
-
-        // test updating multiple, some false
-        $request = new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' );
-        $request->set_body_params( array(
-            'template_debug' => false,
-            'shipping_debug' => true,
-            'uninstall_data' => false,
-        ) );
-        $response = $this->server->dispatch( $request );
-        $data     = $response->get_data();
-        foreach ( $data as $mode ) {
-            if ( 'shipping_debug' === $mode['id'] ) {
-                $this->assertTrue( $mode['enabled'] );
-            } else {
-                $this->assertFalse( $mode['enabled'] );
-            }
-        }
-    }
-
-    /**
-     * Test updating system status modes without permission.
-     *
-     * @since 2.7.0
-     */
-    public function test_update_system_status_modes_without_permission() {
-        wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/modes' ) );
-        $this->assertEquals( 401, $response->get_status() );
-    }
-
-    /**
      * Test system status schema.
      *
      * @since 2.7.0
@@ -419,23 +319,6 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
         $this->assertArrayHasKey( 'description', $properties );
         $this->assertArrayHasKey( 'success', $properties );
         $this->assertArrayHasKey( 'message', $properties );
-    }
-
-    /**
-     * Test modes schema.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_mode_schema() {
-        $request = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status/modes' );
-        $response = $this->server->dispatch( $request );
-        $data = $response->get_data();
-        $properties = $data['schema']['properties'];
-        $this->assertEquals( 4, count( $properties ) );
-        $this->assertArrayHasKey( 'id', $properties );
-        $this->assertArrayHasKey( 'name', $properties );
-        $this->assertArrayHasKey( 'description', $properties );
-        $this->assertArrayHasKey( 'enabled', $properties );
     }
 
 }


### PR DESCRIPTION
This PR adds the following:
- System Stats Tools Endpoints: Get a list of tools, get info on a specific tool, and run/execute a tool.
- System Status Modes Endpoints: Allows you to toggle "modes" from the system status page (template debug, shipping debug, and uninstall data).
- Updates the system status page to use the tools controller so code is shared.
- Tests for all of the above.
