### PR TITLE
Add an index to the field comment_type

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -404,9 +404,13 @@ class WC_Install {
 
 		dbDelta( self::get_schema() );
 
-		// Add an index to the field comment_type to improve the response time of the query
-		// used by WC_Comments::wp_count_comments() to get the number of comments by type.
-		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
+		$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE Column_name = 'comment_type' and Key_name = 'comment_type'" );
+
+		if ( is_null( $index_exists ) ) {
+			// Add an index to the field comment_type to improve the response time of the query
+			// used by WC_Comments::wp_count_comments() to get the number of comments by type.
+			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
+		}
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -403,6 +403,10 @@ class WC_Install {
 		}
 
 		dbDelta( self::get_schema() );
+
+		// Add an index to the field comment_type to improve the response time of the query
+		// used by WC_Comments::wp_count_comments() to get the number of comments by type.
+		$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
 	}
 
 	/**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -987,3 +987,15 @@ function wc_update_270_webhooks() {
 		$webhook->set_topic( 'product.updated' );
 	}
 }
+
+/**
+ * Add an index to the field comment_type to improve the response time of the query
+ * used by WC_Comments::wp_count_comments() to get the number of comments by type.
+ *
+ * @return null
+ */
+function wc_update_270_comment_type_index() {
+	global $wpdb;
+
+	$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
+}


### PR DESCRIPTION
This index improves the response time of the query used by WC_Comments::wp_count_comments() to get the number of comments by type.

This is the first time I'm using WC update and install routines so I'm not sure if I got it right. Specially I'm not sure if `WC_Install::create_tables()` is the best place to add the query to create the new index when installing WC.

Fixes #11560 
