### PR TITLE
woocommerce_taxonomy_archive_description

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -620,7 +620,7 @@ if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 	 * @subpackage	Archives
 	 */
 	function woocommerce_taxonomy_archive_description() {
-		if ( is_tax( array( 'product_cat', 'product_tag' ) ) && 0 === absint( get_query_var( 'paged' ) ) ) {
+		if ( ( is_tax( array( 'product_cat', 'product_tag' ) ) || is_product_taxonomy() ) && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$description = wc_format_content( term_description() );
 			if ( $description ) {
 				echo '<div class="term-description">' . $description . '</div>';


### PR DESCRIPTION
Check for `is_product_taxonomy()` to show the description on the product attribute archives.
