### PR TITLE
Fix func_get_args warning thrown by php7cc.

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -93,8 +93,8 @@ class WC_Emails {
 	 * @internal param array $args (default: array())
 	 */
 	public static function send_transactional_email() {
-		self::instance();
 		$args = func_get_args();
+		self::instance();
 		do_action_ref_array( current_filter() . '_notification', $args );
 	}
 

--- a/includes/gateways/simplify-commerce/includes/Simplify/AccessToken.php
+++ b/includes/gateways/simplify-commerce/includes/Simplify/AccessToken.php
@@ -60,13 +60,13 @@ class Simplify_AccessToken extends Simplify_Object {
 	 * @throws InvalidArgumentException
 	 */
 	public function refresh($authentication = null) {
+		$args = func_get_args();
 
 		$refresh_token = $this->refresh_token;
 		if (empty($refresh_token)){
 			throw new InvalidArgumentException('Cannot refresh access token; refresh token is invalid');
 		}
 
-		$args = func_get_args();
 		$authentication = Simplify_PaymentsApi::buildAuthenticationObject($authentication, $args, 1);
 
 		$props = 'refresh_token='.$refresh_token.'&grant_type=refresh_token';
@@ -84,13 +84,13 @@ class Simplify_AccessToken extends Simplify_Object {
 	 * @throws InvalidArgumentException
 	 */
 	public function revoke($authentication = null) {
+		$args = func_get_args();
 
 		$access_token = $this->access_token;
 		if (empty($access_token)){
 			throw new InvalidArgumentException('Cannot revoke access token; access token is invalid');
 		}
 
-		$args = func_get_args();
 		$authentication = Simplify_PaymentsApi::buildAuthenticationObject($authentication, $args, 2);
 
 		$props = 'token='.$access_token.'';

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -180,11 +180,11 @@ function wc_product_dropdown_categories( $args = array(), $deprecated_hierarchic
  * @return mixed
  */
 function wc_walk_category_dropdown_tree() {
+	$args = func_get_args();
+
 	if ( ! class_exists( 'WC_Product_Cat_Dropdown_Walker' ) ) {
 		include_once( WC()->plugin_path() . '/includes/walkers/class-product-cat-dropdown-walker.php' );
 	}
-
-	$args = func_get_args();
 
 	// the user's options are the third parameter
 	if ( empty( $args[2]['walker']) || !is_a($args[2]['walker'], 'Walker' ) ) {


### PR DESCRIPTION
Although unlikely to happens, this is an attempt to prevent any modification
before func_get_args().

See https://github.com/php/php-src/blob/PHP-7.0/UPGRADING#L190-L213

Fixes #11664.
