### PR TITLE
Update the Customers API to use the WC_Customer CRUD Class

### DIFF
--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -312,32 +312,36 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		$request['password'] = ! empty( $request['password'] ) ? $request['password'] : '';
 
 		// Create customer.
-		$customer_id = wc_create_new_customer( $request['email'], $request['username'], $request['password'] );
-		if ( is_wp_error( $customer_id ) ) {
-			return $customer_id;
+		$customer = new WC_Customer;
+		$customer->set_username( $request['username'] );
+		$customer->set_password( $request['password'] );
+		$customer->set_email( $request['email'] );
+		$customer->create();
+
+		if ( ! $customer->get_id() ) {
+			return new WP_Error( 'woocommerce_rest_cannot_create', __( 'This resource cannot be created.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
-		$customer = get_user_by( 'id', $customer_id );
-
-		$this->update_additional_fields_for_object( $customer, $request );
-
-		// Add customer data.
 		$this->update_customer_meta_fields( $customer, $request );
+		$customer->save();
+
+		$user_data = get_user_by( 'id', $customer->get_id() );
+		$this->update_additional_fields_for_object( $user_data, $request );
 
 		/**
 		 * Fires after a customer is created or updated via the REST API.
 		 *
-		 * @param WP_User         $customer  Data used to create the customer.
+		 * @param WP_User         $user_data Data used to create the customer.
 		 * @param WP_REST_Request $request   Request object.
 		 * @param boolean         $creating  True when creating customer, false when updating customer.
 		 */
-		do_action( 'woocommerce_rest_insert_customer', $customer, $request, true );
+		do_action( 'woocommerce_rest_insert_customer', $user_data, $request, true );
 
 		$request->set_param( 'context', 'edit' );
-		$response = $this->prepare_item_for_response( $customer, $request );
+		$response = $this->prepare_item_for_response( $user_data, $request );
 		$response = rest_ensure_response( $response );
 		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $customer_id ) ) );
+		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $customer->get_id() ) ) );
 
 		return $response;
 	}
@@ -349,14 +353,14 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_item( $request ) {
-		$id       = (int) $request['id'];
-		$customer = get_userdata( $id );
+		$id        = (int) $request['id'];
+		$user_data = get_userdata( $id );
 
-		if ( empty( $id ) || empty( $customer->ID ) ) {
+		if ( empty( $id ) || empty( $user_data->ID ) ) {
 			return new WP_Error( 'woocommerce_rest_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		$customer = $this->prepare_item_for_response( $customer, $request );
+		$customer = $this->prepare_item_for_response( $user_data, $request );
 		$response = rest_ensure_response( $customer );
 
 		return $response;
@@ -370,34 +374,35 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	 */
 	public function update_item( $request ) {
 		$id       = (int) $request['id'];
-		$customer = get_userdata( $id );
+		$customer = new WC_Customer( $id );
 
-		if ( ! $customer ) {
+		if ( ! $customer->get_id() ) {
 			return new WP_Error( 'woocommerce_rest_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
-		if ( ! empty( $request['email'] ) && email_exists( $request['email'] ) && $request['email'] !== $customer->user_email ) {
+		if ( ! empty( $request['email'] ) && email_exists( $request['email'] ) && $request['email'] !== $customer->get_email() ) {
 			return new WP_Error( 'woocommerce_rest_customer_invalid_email', __( 'Email address is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
-		if ( ! empty( $request['username'] ) && $request['username'] !== $customer->user_login ) {
+		if ( ! empty( $request['username'] ) && $request['username'] !== $customer->get_username() ) {
 			return new WP_Error( 'woocommerce_rest_customer_invalid_argument', __( "Username isn't editable.", 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		// Customer email.
 		if ( isset( $request['email'] ) ) {
-			wp_update_user( array( 'ID' => $customer->ID, 'user_email' => sanitize_email( $request['email'] ) ) );
+			$customer->set_email( sanitize_email( $request['email'] ) );
 		}
 
 		// Customer password.
 		if ( isset( $request['password'] ) ) {
-			wp_update_user( array( 'ID' => $customer->ID, 'user_pass' => wc_clean( $request['password'] ) ) );
+			$customer->set_password( wc_clean( $request['password'] ) );
 		}
 
-		$this->update_additional_fields_for_object( $customer, $request );
-
-		// Update customer data.
 		$this->update_customer_meta_fields( $customer, $request );
+		$customer->save();
+
+		$user_data = get_userdata( $customer->get_id() );
+		$this->update_additional_fields_for_object( $user_data, $request );
 
 		/**
 		 * Fires after a customer is created or updated via the REST API.
@@ -406,10 +411,10 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		 * @param WP_REST_Request $request   Request object.
 		 * @param boolean         $creating  True when creating customer, false when updating customer.
 		 */
-		do_action( 'woocommerce_rest_insert_customer', $customer, $request, false );
+		do_action( 'woocommerce_rest_insert_customer', $user_data, $request, false );
 
 		$request->set_param( 'context', 'edit' );
-		$response = $this->prepare_item_for_response( $customer, $request );
+		$response = $this->prepare_item_for_response( $user_data, $request );
 		$response = rest_ensure_response( $response );
 		return $response;
 	}
@@ -430,8 +435,8 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 			return new WP_Error( 'woocommerce_rest_trash_not_supported', __( 'Customers do not support trashing.', 'woocommerce' ), array( 'status' => 501 ) );
 		}
 
-		$customer = get_userdata( $id );
-		if ( ! $customer ) {
+		$user_data = get_userdata( $id );
+		if ( ! $user_data ) {
 			return new WP_Error( 'woocommerce_rest_invalid_id', __( 'Invalid resource id.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
@@ -442,12 +447,18 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		}
 
 		$request->set_param( 'context', 'edit' );
-		$response = $this->prepare_item_for_response( $customer, $request );
+		$response = $this->prepare_item_for_response( $user_data, $request );
 
 		/** Include admin customer functions to get access to wp_delete_user() */
 		require_once ABSPATH . 'wp-admin/includes/user.php';
 
-		$result = wp_delete_user( $id, $reassign );
+		$customer = new WC_Customer( $id );
+
+		if ( ! is_null( $reassign ) ) {
+			$result = $customer->delete_and_reassign( $reassign );
+		} else {
+			$result = $customer->delete();
+		}
 
 		if ( ! $result ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'The resource cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
@@ -456,11 +467,11 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		/**
 		 * Fires after a customer is deleted via the REST API.
 		 *
-		 * @param WP_User          $customer The customer data.
-		 * @param WP_REST_Response $response The response returned from the API.
-		 * @param WP_REST_Request  $request  The request sent to the API.
+		 * @param WP_User          $user_data User data.
+		 * @param WP_REST_Response $response  The response returned from the API.
+		 * @param WP_REST_Request  $request   The request sent to the API.
 		 */
-		do_action( 'woocommerce_rest_delete_customer', $customer, $response, $request );
+		do_action( 'woocommerce_rest_delete_customer', $user_data, $response, $request );
 
 		return $response;
 	}
@@ -468,51 +479,50 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare a single customer output for response.
 	 *
-	 * @param WP_User $customer Customer object.
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response $response Response data.
+	 * @param WP_User           $user_data User object.
+	 * @param WP_REST_Request   $request   Request object.
+	 * @return WP_REST_Response $response  Response data.
 	 */
-	public function prepare_item_for_response( $customer, $request ) {
-		$last_order = wc_get_customer_last_order( $customer->ID );
-
-		$data = array(
-			'id'               => $customer->ID,
-			'date_created'     => wc_rest_prepare_date_response( $customer->user_registered ),
-			'date_modified'    => $customer->last_update ? wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer->last_update ) ) : null,
-			'email'            => $customer->user_email,
-			'first_name'       => $customer->first_name,
-			'last_name'        => $customer->last_name,
-			'username'         => $customer->user_login,
+	public function prepare_item_for_response( $user_data, $request ) {
+		$customer = new WC_Customer( $user_data->ID );
+		$data     = array(
+			'id'               => $customer->get_id(),
+			'date_created'     => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer->get_date_created() ) ),
+			'date_modified'    => $customer->get_date_modified() ? wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer->get_date_modified() ) ) : null,
+			'email'            => $customer->get_email(),
+			'first_name'       => $customer->get_first_name(),
+			'last_name'        => $customer->get_last_name(),
+			'username'         => $customer->get_username(),
 			'last_order'       => array(
-				'id'   => is_object( $last_order ) ? $last_order->get_id() : null,
-				'date' => is_object( $last_order ) ? wc_rest_prepare_date_response( $last_order->post->post_date_gmt ) : null
+				'id'   => $customer->get_last_order_id(),
+				'date' => wc_rest_prepare_date_response( $customer->get_last_order_date() ),
 			),
-			'orders_count'     => wc_get_customer_order_count( $customer->ID ),
-			'total_spent'      => wc_format_decimal( wc_get_customer_total_spent( $customer->ID ), 2 ),
-			'avatar_url'       => wc_get_customer_avatar_url( $customer->user_email ),
-			'billing'          => array(
-				'first_name' => $customer->billing_first_name,
-				'last_name'  => $customer->billing_last_name,
-				'company'    => $customer->billing_company,
-				'address_1'  => $customer->billing_address_1,
-				'address_2'  => $customer->billing_address_2,
-				'city'       => $customer->billing_city,
-				'state'      => $customer->billing_state,
-				'postcode'   => $customer->billing_postcode,
-				'country'    => $customer->billing_country,
-				'email'      => $customer->billing_email,
-				'phone'      => $customer->billing_phone,
+			'orders_count'     => $customer->get_orders_count(),
+			'total_spent'      => $customer->get_total_spent(),
+			'avatar_url'       => $customer->get_avatar_url(),
+			'billing' => array(
+				'first_name' => $customer->get_billing_first_name(),
+				'last_name'  => $customer->get_billing_last_name(),
+				'company'    => $customer->get_billing_company(),
+				'address_1'  => $customer->get_billing_address_1(),
+				'address_2'  => $customer->get_billing_address_2(),
+				'city'       => $customer->get_billing_city(),
+				'state'      => $customer->get_billing_state(),
+				'postcode'   => $customer->get_billing_postcode(),
+				'country'    => $customer->get_billing_country(),
+				'email'      => $customer->get_billing_email(),
+				'phone'      => $customer->get_billing_phone(),
 			),
-			'shipping'         => array(
-				'first_name' => $customer->shipping_first_name,
-				'last_name'  => $customer->shipping_last_name,
-				'company'    => $customer->shipping_company,
-				'address_1'  => $customer->shipping_address_1,
-				'address_2'  => $customer->shipping_address_2,
-				'city'       => $customer->shipping_city,
-				'state'      => $customer->shipping_state,
-				'postcode'   => $customer->shipping_postcode,
-				'country'    => $customer->shipping_country,
+			'shipping' => array(
+				'first_name' => $customer->get_shipping_first_name(),
+				'last_name'  => $customer->get_shipping_last_name(),
+				'company'    => $customer->get_shipping_company(),
+				'address_1'  => $customer->get_shipping_address_1(),
+				'address_2'  => $customer->get_shipping_address_2(),
+				'city'       => $customer->get_shipping_city(),
+				'state'      => $customer->get_shipping_state(),
+				'postcode'   => $customer->get_shipping_postcode(),
+				'country'    => $customer->get_shipping_country(),
 			),
 		);
 
@@ -523,22 +533,22 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $customer ) );
+		$response->add_links( $this->prepare_links( $user_data ) );
 
 		/**
 		 * Filter customer data returned from the REST API.
 		 *
-		 * @param WP_REST_Response $response  The response object.
-		 * @param WP_User          $customer  User object used to create response.
-		 * @param WP_REST_Request  $request   Request object.
+		 * @param WP_REST_Response $response   The response object.
+		 * @param WP_User          $user_data  User object used to create response.
+		 * @param WP_REST_Request  $request    Request object.
 		 */
-		return apply_filters( 'woocommerce_rest_prepare_customer', $response, $customer, $request );
+		return apply_filters( 'woocommerce_rest_prepare_customer', $response, $user_data, $request );
 	}
 
 	/**
 	 * Update customer meta fields.
 	 *
-	 * @param WP_User $customer
+	 * @param WC_Customer $customer
 	 * @param WP_REST_Request $request
 	 */
 	protected function update_customer_meta_fields( $customer, $request ) {
@@ -546,28 +556,28 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 
 		// Customer first name.
 		if ( isset( $request['first_name'] ) ) {
-			update_user_meta( $customer->ID, 'first_name', wc_clean( $request['first_name'] ) );
+			$customer->set_first_name( wc_clean( $request['first_name'] ) );
 		}
 
 		// Customer last name.
 		if ( isset( $request['last_name'] ) ) {
-			update_user_meta( $customer->ID, 'last_name', wc_clean( $request['last_name'] ) );
+			$customer->set_last_name( wc_clean( $request['last_name'] ) );
 		}
 
 		// Customer billing address.
 		if ( isset( $request['billing'] ) ) {
-			foreach ( array_keys( $schema['properties']['billing']['properties'] ) as $address ) {
-				if ( isset( $request['billing'][ $address ] ) ) {
-					update_user_meta( $customer->ID, 'billing_' . $address, wc_clean( $request['billing'][ $address ] ) );
+			foreach ( array_keys( $schema['properties']['billing']['properties'] ) as $field ) {
+				if ( isset( $request['billing'][ $field ] ) && is_callable( array( $customer, "set_billing_{$field}" ) ) ) {
+					$customer->{"set_billing_{$field}"}( $request['billing'][ $field ]  );
 				}
 			}
 		}
 
 		// Customer shipping address.
 		if ( isset( $request['shipping'] ) ) {
-			foreach ( array_keys( $schema['properties']['shipping']['properties'] ) as $address ) {
-				if ( isset( $request['shipping'][ $address ] ) ) {
-					update_user_meta( $customer->ID, 'shipping_' . $address, wc_clean( $request['shipping'][ $address ] ) );
+			foreach ( array_keys( $schema['properties']['shipping']['properties'] ) as $field ) {
+				if ( isset( $request['shipping'][ $field ] ) && is_callable( array( $customer, "set_shipping_{$field}" ) ) ) {
+					$customer->{"set_shipping_{$field}"}( $request['shipping'][ $field ]  );
 				}
 			}
 		}

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -21,34 +21,42 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @var array
 	 */
 	protected $_data = array(
-		'id'				  => 0,
-		'email'               => '',
-		'first_name'          => '',
-		'last_name'           => '',
-		'role'				  => 'customer',
-		'last_order_id'       => null, // read only
-		'last_order_date'     => null, // read only
-		'orders_count'        => 0, // read only
-		'total_spent'         => 0, // read only
-		'username'            => '', // read only on existing users
-		'password'            => '', // write only
-		'date_created'        => '', // read only
-		'date_modified'		  => '', // read only
-		'billing_postcode'    => '',
-		'billing_city'        => '',
-		'billing_address_1'   => '',
-		'billing_address_2'   => '',
-		'billing_state'       => '',
-		'billing_country'     => '',
-		'shipping_postcode'   => '',
-		'shipping_city'       => '',
-		'shipping_address_1'  => '',
-		'shipping_address_2'  => '',
-		'shipping_state'      => '',
-		'shipping_country'    => '',
-		'is_paying_customer'  => false,
-		'is_vat_exempt'       => false, // session only.
-		'calculated_shipping' => false, // session only
+		'id'				   => 0,
+		'email'                => '',
+		'first_name'           => '',
+		'last_name'            => '',
+		'role'				   => 'customer',
+		'last_order_id'        => null, // read only
+		'last_order_date'      => null, // read only
+		'orders_count'         => 0, // read only
+		'total_spent'          => 0, // read only
+		'username'             => '', // read only on existing users
+		'password'             => '', // write only
+		'date_created'         => '', // read only
+		'date_modified'		   => '', // read only
+		'billing_first_name'   => '',
+		'billing_last_name'    => '',
+		'billing_company'      => '',
+		'billing_phone'        => '',
+		'billing_email'        => '',
+		'billing_postcode'     => '',
+		'billing_city'         => '',
+		'billing_address_1'    => '',
+		'billing_address_2'    => '',
+		'billing_state'        => '',
+		'billing_country'      => '',
+		'shipping_first_name'  => '',
+		'shipping_last_name'   => '',
+		'shipping_company'     => '',
+		'shipping_postcode'    => '',
+		'shipping_city'        => '',
+		'shipping_address_1'   => '',
+		'shipping_address_2'   => '',
+		'shipping_state'       => '',
+		'shipping_country'     => '',
+		'is_paying_customer'   => false,
+		'is_vat_exempt'        => false, // session only.
+		'calculated_shipping'  => false, // session only
 	);
 
 	/**
@@ -56,9 +64,12 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @var array
 	 */
 	protected $_session_keys = array(
-		'billing_postcode', 'billing_city', 'billing_address_1', 'billing_address', 'billing_address_2',
-		'billing_state', 'billing_country', 'shipping_postcode', 'shipping_city', 'shipping_address_1', 'shipping_address',
-		'shipping_address_2', 'shipping_state', 'shipping_country', 'is_vat_exempt', 'calculated_shipping',
+		'billing_first_name', 'billing_last_name', 'billing_company', 'billing_postcode',
+		'billing_city', 'billing_address_1', 'billing_address', 'billing_address_2',
+		'billing_state', 'billing_country', 'shipping_first_name', 'shipping_last_name',
+		'shipping_company', 'shipping_postcode', 'shipping_city', 'shipping_address_1',
+		'shipping_address','shipping_address_2', 'shipping_state', 'shipping_country',
+		'is_vat_exempt', 'calculated_shipping', 'billing_email', 'billing_phone',
 	);
 
 	/**
@@ -67,14 +78,16 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @var array
 	 */
 	protected $_internal_meta_keys = array(
-		'billing_postcode', 'billing_city', 'billing_address_1', 'billing_address_2', 'billing_state',
-		'billing_country', 'shipping_postcode', 'shipping_city', 'shipping_address_1',
-		'shipping_address_2', 'shipping_state', 'shipping_country', 'paying_customer',
-		'last_update', 'first_name', 'last_name',
+		'billing_first_name', 'billing_last_name', 'billing_company','billing_postcode',
+		'billing_city', 'billing_address_1', 'billing_address_2', 'billing_state',
+		'billing_country', 'shipping_first_name', 'shipping_last_name', 'shipping_company',
+		'shipping_postcode', 'shipping_city', 'shipping_address_1', 'shipping_address_2',
+		'shipping_state', 'shipping_country', 'paying_customer', 'last_update',
+		'first_name', 'last_name', 'billing_email', 'billing_phone',
 	);
 
 	/**
-	 *  Internal meta type used to store user data.
+	 * Internal meta type used to store user data.
 	 * @var string
 	 */
 	protected $_meta_type = 'user';
@@ -279,6 +292,30 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
+	 * Gets customer billing first name.
+	 * @return string
+	 */
+	public function get_billing_first_name() {
+		return $this->_data['billing_first_name'];
+	}
+
+	/**
+	 * Gets customer billing last name.
+	 * @return string
+	 */
+	public function get_billing_last_name() {
+		return $this->_data['billing_last_name'];
+	}
+
+	/**
+	 * Gets customer billing company.
+	 * @return string
+	 */
+	public function get_billing_company() {
+		return $this->_data['billing_company'];
+	}
+
+	/**
 	 * Gets customer postcode.
 	 * @return string
 	 */
@@ -332,6 +369,46 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function get_billing_country() {
 		return $this->_data['billing_country'];
+	}
+
+	/**
+	 * Gets customer billing phone.
+	 * @return string
+	 */
+	public function get_billing_phone() {
+		return $this->_data['billing_phone'];
+	}
+
+	/**
+	 * Gets customer billing email.
+	 * @return string
+	 */
+	public function get_billing_email() {
+		return $this->_data['billing_email'];
+	}
+
+	/**
+	 * Gets customer shipping first name.
+	 * @return string
+	 */
+	public function get_shipping_first_name() {
+		return $this->_data['shipping_first_name'];
+	}
+
+	/**
+	 * Gets customer shipping last name.
+	 * @return string
+	 */
+	public function get_shipping_last_name() {
+		return $this->_data['shipping_last_name'];
+	}
+
+	/**
+	 * Gets customer shipping company.
+	 * @return string
+	 */
+	public function get_shipping_company() {
+		return $this->_data['shipping_company'];
 	}
 
 	/**
@@ -646,6 +723,46 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
+	 * Sets customer billing first name.
+	 * @param string $first_name
+	 */
+	public function set_billing_first_name( $first_name ) {
+		$this->_data['billing_first_name'] = $first_name;
+	}
+
+	/**
+	 * Sets customer billing last name.
+	 * @param string $last_name
+	 */
+	public function set_billing_last_name( $last_name ) {
+		$this->_data['billing_last_name'] = $last_name;
+	}
+
+	/**
+	 * Sets customer billing company.
+	 * @param string $company.
+	 */
+	public function set_billing_company( $company ) {
+		$this->_data['billing_company'] = $company;
+	}
+
+	/**
+	 * Sets customer billing phone.
+	 * @param string $phone
+	 */
+	public function set_billing_phone( $phone ) {
+		$this->_data['billing_phone'] = $phone;
+	}
+
+	/**
+	 * Sets customer billing email.
+	 * @param string $email
+	 */
+	public function set_billing_email( $email ) {
+		$this->_data['billing_email'] = $email;
+	}
+
+	/**
 	 * Sets customer postcode.
 	 * @param mixed $postcode
 	 */
@@ -683,6 +800,30 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_billing_address_2( $address ) {
 		$this->_data['billing_address_2'] = $address;
+	}
+
+	/**
+	 * Sets customer shipping first name.
+	 * @param string $first_name
+	 */
+	public function set_shipping_first_name( $first_name ) {
+		$this->_data['shipping_first_name'] = $first_name;
+	}
+
+	/**
+	 * Sets customer shipping last name.
+	 * @param string $last_name
+	 */
+	public function set_shipping_last_name( $last_name ) {
+		$this->_data['shipping_last_name'] = $last_name;
+	}
+
+	/**
+	 * Sets customer shipping company.
+	 * @param string $company.
+	 */
+	public function set_shipping_company( $company ) {
+		$this->_data['shipping_company'] = $company;
 	}
 
 	/**
@@ -810,12 +951,20 @@ class WC_Customer extends WC_Legacy_Customer {
 		unset( $this->_data['password'] );
 		if ( $customer_id ) {
 			$this->_data['id'] = $customer_id;
+			update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
+			update_user_meta( $this->get_id(), 'billing_last_name', $this->get_billing_last_name() );
+			update_user_meta( $this->get_id(), 'billing_company', $this->get_billing_company() );
+			update_user_meta( $this->get_id(), 'billing_phone', $this->get_billing_phone() );
+			update_user_meta( $this->get_id(), 'billing_email', $this->get_billing_email() );
 			update_user_meta( $this->get_id(), 'billing_postcode', $this->get_billing_postcode() );
 			update_user_meta( $this->get_id(), 'billing_city', $this->get_billing_city() );
 			update_user_meta( $this->get_id(), 'billing_address_1', $this->get_billing_address() );
 			update_user_meta( $this->get_id(), 'billing_address_2', $this->get_billing_address_2() );
 			update_user_meta( $this->get_id(), 'billing_state', $this->get_billing_state() );
 			update_user_meta( $this->get_id(), 'billing_country', $this->get_billing_country() );
+			update_user_meta( $this->get_id(), 'shipping_first_name', $this->get_shipping_first_name() );
+			update_user_meta( $this->get_id(), 'shipping_last_name', $this->get_shipping_last_name() );
+			update_user_meta( $this->get_id(), 'shipping_company', $this->get_shipping_company() );
 			update_user_meta( $this->get_id(), 'shipping_postcode', $this->get_shipping_postcode() );
 			update_user_meta( $this->get_id(), 'shipping_city', $this->get_shipping_city() );
 			update_user_meta( $this->get_id(), 'shipping_address_1', $this->get_shipping_address() );
@@ -977,12 +1126,20 @@ class WC_Customer extends WC_Legacy_Customer {
 			unset( $this->_data['password'] );
 		}
 
+		update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
+		update_user_meta( $this->get_id(), 'billing_last_name', $this->get_billing_last_name() );
+		update_user_meta( $this->get_id(), 'billing_company', $this->get_billing_company() );
+		update_user_meta( $this->get_id(), 'billing_phone', $this->get_billing_phone() );
+		update_user_meta( $this->get_id(), 'billing_email', $this->get_billing_email() );
 		update_user_meta( $this->get_id(), 'billing_postcode', $this->get_billing_postcode() );
 		update_user_meta( $this->get_id(), 'billing_city', $this->get_billing_city() );
 		update_user_meta( $this->get_id(), 'billing_address_1', $this->get_billing_address() );
 		update_user_meta( $this->get_id(), 'billing_address_2', $this->get_billing_address_2() );
 		update_user_meta( $this->get_id(), 'billing_state', $this->get_billing_state() );
 		update_user_meta( $this->get_id(), 'billing_country', $this->get_billing_country() );
+		update_user_meta( $this->get_id(), 'shipping_first_name', $this->get_shipping_first_name() );
+		update_user_meta( $this->get_id(), 'shipping_last_name', $this->get_shipping_last_name() );
+		update_user_meta( $this->get_id(), 'shipping_company', $this->get_shipping_company() );
 		update_user_meta( $this->get_id(), 'shipping_postcode', $this->get_shipping_postcode() );
 		update_user_meta( $this->get_id(), 'shipping_city', $this->get_shipping_city() );
 		update_user_meta( $this->get_id(), 'shipping_address_1', $this->get_shipping_address() );
@@ -1006,7 +1163,20 @@ class WC_Customer extends WC_Legacy_Customer {
 		if ( ! $this->get_id() ) {
 			return;
 		}
-		wp_delete_user( $this->get_id() );
+		return wp_delete_user( $this->get_id() );
+	}
+
+	/**
+	 * Delete a customer and reassign posts..
+	 *
+	 * @param int $reassign Reassign posts and links to new User ID.
+	 * @since 2.7.0
+	 */
+	public function delete_and_reassign( $reassign = null ) {
+		if ( ! $this->get_id() ) {
+			return;
+		}
+		return wp_delete_user( $this->get_id(), $reassign );
 	}
 
 	/**

--- a/tests/framework/helpers/class-wc-helper-customer.php
+++ b/tests/framework/helpers/class-wc-helper-customer.php
@@ -42,7 +42,7 @@ class WC_Helper_Customer {
 	/**
 	 * Creates a customer in the tests DB.
 	 */
-	public static function create_customer() {
+	public static function create_customer( $username = 'testcustomer', $password = 'hunter2', $email = 'test@woo.local' ) {
 		$customer = new WC_Customer();
 		$customer->set_billing_country( 'US' );
 		$customer->set_first_name( 'Justin' );
@@ -57,9 +57,9 @@ class WC_Helper_Customer {
 		$customer->set_shipping_city( 'Philadelphia' );
 		$customer->set_shipping_address( '123 South Street' );
 		$customer->set_shipping_address_2( 'Apt 1' );
-		$customer->set_username( 'testcustomer' );
-		$customer->set_password( 'hunter2' );
-		$customer->set_email( 'test@woo.local' );
+		$customer->set_username( $username );
+		$customer->set_password( $password );
+		$customer->set_email( $email );
 		$customer->create();
 		return $customer;
 	}

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -85,6 +85,8 @@ class WC_Helper_Order {
 		$order->set_shipping_tax( 0 );
 		$order->set_total( 40 ); // 4 x $10 simple helper product
 
+		$order->save();
+
 		return wc_get_order( $order->get_id() );
 	}
 }

--- a/tests/unit-tests/api/customers.php
+++ b/tests/unit-tests/api/customers.php
@@ -1,0 +1,528 @@
+<?php
+/**
+ * Tests for the Customers REST API.
+ *
+ * @package WooCommerce\Tests\API
+ * @since 2.7.0
+ */
+
+class Customers extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Customers_Controller();
+	    $this->user = $this->factory->user->create( array(
+	        'role' => 'administrator',
+	    ) );
+	}
+
+	/**
+	 * Test route registration.
+     *
+     * @since 2.7.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wc/v1/customers', $routes );
+		$this->assertArrayHasKey( '/wc/v1/customers/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wc/v1/customers/batch', $routes );
+	}
+
+    /**
+     * Test getting customers.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_customers() {
+	    wp_set_current_user( $this->user );
+
+	    $customer_1 = \WC_Helper_Customer::create_customer();
+	    \WC_Helper_Customer::create_customer( 'test2', 'test2', 'test2@woo.local' );
+
+	    $request = new WP_REST_Request( 'GET', '/wc/v1/customers' );
+	    $request->set_query_params( array(
+			'orderby' => 'id',
+		) );
+	    $response  = $this->server->dispatch( $request );
+	    $customers = $response->get_data();
+
+	    $this->assertEquals( 200, $response->get_status() );
+	    $this->assertEquals( 2, count( $customers ) );
+
+	    $this->assertContains( array(
+	        'id'            => $customer_1->get_id(),
+	        'date_created'  => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer_1->get_date_created() ) ),
+	        'date_modified' => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer_1->get_date_modified() ) ),
+	        'email'         => 'test@woo.local',
+	        'first_name'    => 'Justin',
+	        'last_name'     => '',
+	        'username'      => 'testcustomer',
+	        'last_order'    => array( 'id' => '', 'date' => '' ),
+	        'orders_count'  => 0,
+	        'total_spent'   => '0.00',
+	        'avatar_url'    => $customer_1->get_avatar_url(),
+	        'billing' => array(
+	            'first_name' => '',
+	            'last_name'  => '',
+	            'company'    => '',
+	            'address_1'  => '123 South Street',
+	            'address_2'  => 'Apt 1',
+	            'city'       => 'Philadelphia',
+	            'state'      => 'PA',
+	            'postcode'   => '19123',
+	            'country'    => 'US',
+	            'email'      => '',
+	            'phone'      => '',
+	        ),
+	        'shipping' => array(
+	            'first_name' => '',
+	            'last_name'  => '',
+	            'company'    => '',
+	            'address_1'  => '123 South Street',
+	            'address_2'  => 'Apt 1',
+	            'city'       => 'Philadelphia',
+	            'state'      => 'PA',
+	            'postcode'   => '19123',
+	            'country'    => 'US',
+	        ),
+	        '_links' => array(
+	            'self'       => array(
+	                array(
+	                    'href' => rest_url( '/wc/v1/customers/' . $customer_1->get_id() . '' ),
+	                ),
+	            ),
+	            'collection' => array(
+	                array(
+	                    'href' => rest_url( '/wc/v1/customers' ),
+	                ),
+	            ),
+	        ),
+	    ), $customers );
+    }
+
+    /**
+     * Test getting customers without valid permissions.
+     *
+     * @since 2.7.0
+     */
+    public function test_get_customers_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers' ) );
+		$this->assertEquals( 401, $response->get_status() );
+    }
+
+	/**
+	 * Test creating a new customer.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_create_customer() {
+		wp_set_current_user( $this->user );
+
+		// Test just the basics first..
+		$request = new WP_REST_Request( 'POST', '/wc/v1/customers' );
+		$request->set_body_params( array(
+			'username' => 'create_customer_test',
+			'password' => 'test123',
+			'email'    => 'create_customer_test@woo.local',
+		) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( array(
+			'id'            => $data['id'],
+			'date_created'  => $data['date_created'],
+			'date_modified' => $data['date_modified'],
+			'email'         => 'create_customer_test@woo.local',
+			'first_name'    => '',
+			'last_name'     => '',
+			'username'      => 'create_customer_test',
+			'last_order'    => array( 'id' => '', 'date' => '' ),
+			'orders_count'  => 0,
+			'total_spent'   => '0',
+			'avatar_url'    => $data['avatar_url'],
+			'billing' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '',
+				'address_2'  => '',
+				'city'       => '',
+				'state'      => '',
+				'postcode'   => '',
+				'country'    => 'GB',
+				'email'      => '',
+				'phone'      => '',
+			),
+			'shipping' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '',
+				'address_2'  => '',
+				'city'       => '',
+				'state'      => '',
+				'postcode'   => '',
+				'country'    => 'GB',
+			),
+		), $data );
+
+		// Test extra data
+		$request = new WP_REST_Request( 'POST', '/wc/v1/customers' );
+		$request->set_body_params( array(
+		    'username' => 'create_customer_test2',
+			'password' => 'test123',
+			'email'    => 'create_customer_test2@woo.local',
+			'first_name' => 'Test',
+			'last_name' => 'McTestFace',
+			'billing' => array(
+				'country' => 'US',
+				'state'   => 'WA',
+			),
+			'shipping' => array(
+				'state'   => 'CA',
+				'country' => 'US',
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( array(
+			'id'            => $data['id'],
+			'date_created'  => $data['date_created'],
+			'date_modified' => $data['date_modified'],
+			'email'         => 'create_customer_test2@woo.local',
+			'first_name'    => 'Test',
+			'last_name'     => 'McTestFace',
+			'username'      => 'create_customer_test2',
+			'last_order'    => array( 'id' => '', 'date' => '' ),
+			'orders_count'  => 0,
+			'total_spent'   => '0.00',
+			'avatar_url'    => $data['avatar_url'],
+			'billing' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '',
+				'address_2'  => '',
+				'city'       => '',
+				'state'      => 'WA',
+				'postcode'   => '',
+				'country'    => 'US',
+				'email'      => '',
+				'phone'      => '',
+			),
+			'shipping' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '',
+				'address_2'  => '',
+				'city'       => '',
+				'state'      => 'CA',
+				'postcode'   => '',
+				'country'    => 'US',
+			),
+		), $data );
+
+		// Test without required field
+		$request = new WP_REST_Request( 'POST', '/wc/v1/customers' );
+		$request->set_body_params( array(
+			'username' => 'create_customer_test3',
+			'first_name' => 'Test',
+			'last_name' => 'McTestFace',
+		) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test creating customers without valid permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_create_customer_without_permission() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'POST', '/wc/v1/customers' );
+		$request->set_body_params( array(
+			'username' => 'create_customer_test_without_permission',
+			'password' => 'test123',
+			'email'    => 'create_customer_test_without_permission@woo.local',
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test getting a single customer.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_customer() {
+		wp_set_current_user( $this->user );
+		$customer = \WC_Helper_Customer::create_customer( 'get_customer_test', 'test123', 'get_customer_test@woo.local' );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers/' . $customer->get_id() ) );
+		$data = $response->get_data();
+
+		$this->assertEquals( array(
+			'id'            => $data['id'],
+			'date_created'  => $data['date_created'],
+			'date_modified' => $data['date_modified'],
+			'email'         => 'get_customer_test@woo.local',
+			'first_name'    => 'Justin',
+			'last_name'     => '',
+			'username'      => 'get_customer_test',
+			'last_order'    => array( 'id' => '', 'date' => '' ),
+			'orders_count'  => 0,
+			'total_spent'   => '0.00',
+			'avatar_url'    => $data['avatar_url'],
+			'billing' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '123 South Street',
+				'address_2'  => 'Apt 1',
+				'city'       => 'Philadelphia',
+				'state'      => 'PA',
+				'postcode'   => '19123',
+				'country'    => 'US',
+				'email'      => '',
+				'phone'      => '',
+			),
+			'shipping' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '123 South Street',
+				'address_2'  => 'Apt 1',
+				'city'       => 'Philadelphia',
+				'state'      => 'PA',
+				'postcode'   => '19123',
+				'country'    => 'US',
+			),
+		), $data );
+	}
+
+	/**
+	 * Test getting a single customer without valid permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_customer_without_permission() {
+		wp_set_current_user( 0 );
+		$customer = \WC_Helper_Customer::create_customer( 'get_customer_test_without_permission', 'test123', 'get_customer_test_without_permission@woo.local' );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers/' . $customer->get_id() ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test getting a single customer with an invalid ID.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_customer_invalid_id() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers/0' ) );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test updating a customer.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_update_customer() {
+		wp_set_current_user( $this->user );
+		$customer = \WC_Helper_Customer::create_customer( 'update_customer_test', 'test123', 'update_customer_test@woo.local' );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers/' . $customer->get_id() ) );
+		$data     = $response->get_data();
+		$this->assertEquals( 'update_customer_test', $data['username'] );
+		$this->assertEquals( 'update_customer_test@woo.local', $data['email'] );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v1/customers/' . $customer->get_id() );
+		$request->set_body_params( array(
+			'email'      => 'updated_email@woo.local',
+			'first_name' => 'UpdatedTest',
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'updated_email@woo.local', $data['email'] );
+		$this->assertEquals( 'UpdatedTest', $data['first_name'] );
+	}
+
+	/**
+	 * Test updating a customer without valid permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_update_customer_without_permission() {
+		wp_set_current_user( 0 );
+		$customer = \WC_Helper_Customer::create_customer( 'update_customer_test_without_permission', 'test123', 'update_customer_test_without_permission@woo.local' );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers/' . $customer->get_id() ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test updating a customer with an invalid ID.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_update_customer_invalid_id() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers/0' ) );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+
+	/**
+	 * Test deleting a customer.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_delete_customer() {
+		wp_set_current_user( $this->user );
+		$customer = \WC_Helper_Customer::create_customer( 'delete_customer_test', 'test123', 'delete_customer_test@woo.local' );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v1/customers/' . $customer->get_id() );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test deleting a customer with an invalid ID.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_delete_customer_invalid_id() {
+		wp_set_current_user( $this->user );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v1/customers/0' );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test deleting a customer without valid permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_delete_customer_without_permission() {
+		wp_set_current_user( 0 );
+		$customer = \WC_Helper_Customer::create_customer( 'delete_customer_test_without_permission', 'test123', 'delete_customer_test_without_permission@woo.local' );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v1/customers/' . $customer->get_id() );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test customer batch endpoint.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_batch_customer() {
+		wp_set_current_user( $this->user );
+
+		$customer_1 = \WC_Helper_Customer::create_customer( 'test_batch_customer', 'test123', 'test_batch_customer@woo.local' );
+		$customer_2 = \WC_Helper_Customer::create_customer( 'test_batch_customer2', 'test123', 'test_batch_customer2@woo.local' );
+		$customer_3 = \WC_Helper_Customer::create_customer( 'test_batch_customer3', 'test123', 'test_batch_customer3@woo.local' );
+		$customer_4 = \WC_Helper_Customer::create_customer( 'test_batch_customer4', 'test123', 'test_batch_customer4@woo.local' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v1/customers/batch' );
+		$request->set_body_params( array(
+			'update' => array(
+				array(
+					'id'        => $customer_1->get_id(),
+					'last_name' => 'McTest',
+				),
+			),
+			'delete' => array(
+				$customer_2->get_id(),
+				$customer_3->get_id(),
+			),
+			'create' => array(
+				array(
+					'username' => 'NewUser',
+					'password'   => 'test123',
+					'email'  => 'NewUser@woo.local',
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 'McTest', $data['update'][0]['last_name'] );
+		$this->assertEquals( 'NewUser', $data['create'][0]['username'] );
+		$this->assertEmpty( $data['create'][0]['last_name'] );
+		$this->assertEquals( $customer_2->get_id(), $data['delete'][0]['id'] );
+		$this->assertEquals( $customer_3->get_id(), $data['delete'][1]['id'] );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v1/customers' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 3, count( $data ) );
+	}
+
+	/**
+	 * Test customer schema.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_customer_schema() {
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v1/customers' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 14, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'date_created', $properties );
+		$this->assertArrayHasKey( 'date_modified', $properties );
+		$this->assertArrayHasKey( 'email', $properties );
+		$this->assertArrayHasKey( 'first_name', $properties );
+		$this->assertArrayHasKey( 'last_name', $properties );
+		$this->assertArrayHasKey( 'username', $properties );
+		$this->assertArrayHasKey( 'password', $properties );
+		$this->assertArrayHasKey( 'last_order', $properties );
+		$this->assertArrayHasKey( 'id', $properties['last_order']['properties'] );
+		$this->assertArrayHasKey( 'date', $properties['last_order']['properties'] );
+		$this->assertArrayHasKey( 'orders_count', $properties );
+		$this->assertArrayHasKey( 'total_spent', $properties );
+		$this->assertArrayHasKey( 'avatar_url', $properties );
+		$this->assertArrayHasKey( 'billing', $properties );
+		$this->assertArrayHasKey( 'first_name', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'last_name', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'company', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'address_1', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'address_2', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'city', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'state', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'postcode', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'country', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'email', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'phone', $properties['billing']['properties'] );
+		$this->assertArrayHasKey( 'shipping', $properties );
+		$this->assertArrayHasKey( 'first_name', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'last_name', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'company', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'address_1', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'address_2', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'city', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'state', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'postcode', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'country', $properties['shipping']['properties'] );
+	}
+
+}

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -197,8 +197,8 @@ class CustomerCRUD extends \WC_Unit_Test_Case {
 		$customer_id = $customer->get_id();
 		$order = \WC_Helper_Order::create_order( $customer_id );
 		$customer->read( $customer_id );
-		$this->assertEquals( $order->id, $customer->get_last_order_id() );
-		$this->assertEquals( strtotime( $order->order_date ), $customer->get_last_order_date() );
+		$this->assertEquals( $order->get_id(), $customer->get_last_order_id() );
+		$this->assertEquals( $order->get_date_created(), $customer->get_last_order_date() );
 	}
 
 	/**


### PR DESCRIPTION
This PR updates the Customers API to use the WC_Customer CRUD Class

It also:
- Introduces tests for the Customer REST API, so I could make sure I didn't break anything.
- Fixes a few API and test issues from recent CRUD changes (thanks to said tests).
- Adds some missing billing_ and shipping_ meta data functions to Customer CRUD.

I ran the following test suites: `api/customers`, `customer/crud`, and `customer/customer`.

Closes #11653.
