### PR TITLE
Update class-wc-admin-attributes.php

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -423,7 +423,7 @@ class WC_Admin_Attributes {
 														echo '<span class="na">&ndash;</span>';
 													}
 												?></td>
-												<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button alignright tips configure-terms" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
+												<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button button-primary alignright tips" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
 											</tr><?php
 										endforeach;
 									else :


### PR DESCRIPTION
Greater Clarity For Accessing Variations (...and knowing / seeing where they are)
http://prnt.sc/c63bn4
# before
## ![woocommerce-variations-button-old](https://cloud.githubusercontent.com/assets/6208757/17675247/91dfa5be-62ee-11e6-99ed-343da5d1462a.png)
# after

![woocommerce-variations-button-new](https://cloud.githubusercontent.com/assets/6208757/17675262/a313f344-62ee-11e6-86de-81f39aa2f813.png)

As Bob & @mattyza talked about here: http://dothewoopodcast.com/talking-woocommerce-user-experience-matty-cohen-automattic/ 

https://www.youtube.com/watch?v=x7vblX7giOc&hd=1
