### PR TITLE
REST API hook load priority

### DIFF
--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -118,7 +118,7 @@ class WC_API extends WC_Legacy_API {
 		$this->rest_api_includes();
 
 		// Init REST API routes.
-		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
 	}
 
 	/**

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -174,8 +174,6 @@ class WC_API extends WC_Legacy_API {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-webhooks-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-system-status-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-system-status-tools-controller.php' );
-
-		do_action( 'woocommerce_api_includes' );
 	}
 
 	/**
@@ -186,7 +184,7 @@ class WC_API extends WC_Legacy_API {
 		// Register settings to the REST API.
 		$this->register_wp_admin_settings();
 
-		$controllers = apply_filters( 'woocommerce_api_controllers', array(
+		$controllers = array(
 			'WC_REST_Coupons_Controller',
 			'WC_REST_Customer_Downloads_Controller',
 			'WC_REST_Customers_Controller',
@@ -214,7 +212,7 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Webhooks_Controller',
 			'WC_REST_System_Status_Controller',
 			'WC_REST_System_Status_Tools_Controller',
-		) );
+		);
 
 		foreach ( $controllers as $controller ) {
 			$this->$controller = new $controller();


### PR DESCRIPTION
I don't think that we need to new actions/hooks here like we did with our legacy REST API, since WP REST API already provide the `rest_api_init` hook, so only a priority is enough if you need to load your class after WooCommerce.

Ref #11659 and #11668 

cc @justinshreve @gedex 
