### PR TITLE
Change "Configure terms" into a link

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -367,7 +367,7 @@ class WC_Admin_Attributes {
 									<th scope="col"><?php _e( 'Slug', 'woocommerce' ); ?></th>
 									<th scope="col"><?php _e( 'Type', 'woocommerce' ); ?></th>
 									<th scope="col"><?php _e( 'Order by', 'woocommerce' ); ?></th>
-									<th scope="col" colspan="2"><?php _e( 'Terms', 'woocommerce' ); ?></th>
+									<th scope="col"><?php _e( 'Terms', 'woocommerce' ); ?></th>
 								</tr>
 							</thead>
 							<tbody>
@@ -422,8 +422,9 @@ class WC_Admin_Attributes {
 													} else {
 														echo '<span class="na">&ndash;</span>';
 													}
-												?></td>
-												<td class="attribute-actions"><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="button alignright tips configure-terms" data-tip="<?php esc_attr_e( 'Configure terms', 'woocommerce' ); ?>"><?php _e( 'Configure terms', 'woocommerce' ); ?></a></td>
+												?>
+												<br /><a href="edit-tags.php?taxonomy=<?php echo esc_html( wc_attribute_taxonomy_name( $tax->attribute_name ) ); ?>&amp;post_type=product" class="configure-terms"><?php _e( 'Configure terms', 'woocommerce' ); ?></a>
+												</td>
 											</tr><?php
 										endforeach;
 									else :


### PR DESCRIPTION
As suggested by @kellychoffman in https://github.com/woothemes/woocommerce/pull/11704#issuecomment-239922224

![screenshot from 2016-08-18 00-01-20](https://cloud.githubusercontent.com/assets/1264099/17760590/360b27be-64d7-11e6-9d8c-324265db9336.png)
