### PR TITLE
Changed the way customers info fields are prepared in class-wc-ajax.php

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1105,19 +1105,18 @@ class WC_AJAX {
 		$user_id      = (int) trim(stripslashes($_POST['user_id']));
 		$type_to_load = esc_attr(trim(stripslashes($_POST['type_to_load'])));
 
-		$customer_data = array(
-			$type_to_load . '_first_name' => get_user_meta( $user_id, $type_to_load . '_first_name', true ),
-			$type_to_load . '_last_name'  => get_user_meta( $user_id, $type_to_load . '_last_name', true ),
-			$type_to_load . '_company'    => get_user_meta( $user_id, $type_to_load . '_company', true ),
-			$type_to_load . '_address_1'  => get_user_meta( $user_id, $type_to_load . '_address_1', true ),
-			$type_to_load . '_address_2'  => get_user_meta( $user_id, $type_to_load . '_address_2', true ),
-			$type_to_load . '_city'       => get_user_meta( $user_id, $type_to_load . '_city', true ),
-			$type_to_load . '_postcode'   => get_user_meta( $user_id, $type_to_load . '_postcode', true ),
-			$type_to_load . '_country'    => get_user_meta( $user_id, $type_to_load . '_country', true ),
-			$type_to_load . '_state'      => get_user_meta( $user_id, $type_to_load . '_state', true ),
-			$type_to_load . '_email'      => get_user_meta( $user_id, $type_to_load . '_email', true ),
-			$type_to_load . '_phone'      => get_user_meta( $user_id, $type_to_load . '_phone', true ),
-		);
+        $user_data = get_user_meta($user_id);
+
+        //Filter to keep only the appropriate data (billing or shipping) depending on $type_to_load variable
+        $filtered_customer_keys = array_filter(array_keys($user_data), function($item) use ($type_to_load){
+            if(strpos($item, $type_to_load) !== false) return true;
+            return false;
+        });
+
+        $customer_data = array();
+        foreach ( $filtered_customer_keys as $item ) {
+            $customer_data[$item] = get_user_meta( $user_id, $item, true );
+        }
 
 		$customer_data = apply_filters( 'woocommerce_found_customer_details', $customer_data, $user_id, $type_to_load );
 


### PR DESCRIPTION
I've recently noticed that custom fields didn't load automatically when creating a new order manually from the Admin Panel. Selecting a user from the drop-down sent an ajax request and returned values only for the default customers field . I've changed the class-wc-ajax.php a bit to dynamically get all customers fields including custom ones ( following the default naming conversion  _billing , _shipping).
