### PR TITLE
Add PayPal Here as a valid transaction type

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -112,7 +112,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	 * @param string $txn_type
 	 */
 	protected function validate_transaction_type( $txn_type ) {
-		$accepted_types = array( 'cart', 'instant', 'express_checkout', 'web_accept', 'masspay', 'send_money' );
+		$accepted_types = array( 'cart', 'instant', 'express_checkout', 'web_accept', 'masspay', 'send_money', 'paypal_here' );
 
 		if ( ! in_array( strtolower( $txn_type ), $accepted_types ) ) {
 			WC_Gateway_Paypal::log( 'Aborting, Invalid type:' . $txn_type );


### PR DESCRIPTION
Other than PayPal Here, direct credit card payments via PayPal REST API for some countries also have the `txn_type` value as `paypal_here`, so this fix should also support direct credit card payment as well.

Below is an example of an IPN notification of a direct credit card payment made via REST API (from WooCommerce's log):

```
08-20-2016 @ 00:09:40 - IPN Request: Array
(
    [body] => Array
        (
            [cmd] => _notify-validate
            [mc_gross] => 100.00
            [invoice] => WC-99999
            [protection_eligibility] => Ineligible
            [item_number1] => SKU1
            [payer_id] => XXXXXXXXXXXX
            [tax] => 0.00
            [payment_date] => 08:09:27 Aug 19, 2016 PDT
            [cc_input_method] => Swipe
            [payment_status] => Completed
            [payment_method] => credit_card
            [charset] => UTF-8
            [mc_shipping] => 0.00
            [mc_handling] => 0.00
            [first_name] => 
            [mc_fee] => 3.20
            [notify_version] => 3.8
            [custom] => {"order_id":99999,"order_key":"wc_order_xxxxxxxxxxxxx"}
            [payer_status] => unverified
            [business] => john@example.com
            [num_cart_items] => 1
            [mc_handling1] => 0.00
            [verify_sign] => XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
            [mc_shipping1] => 0.00
            [tax1] => 0.00
            [txn_id] => ZZZZZZZZZZZZZZZZZ
            [payment_type] => instant
            [last_name] => 
            [item_name1] => T-shirt
            [receiver_email] => jane@example.com
            [payment_fee] => 3.20
            [quantity1] => 1
            [receiver_id] => YYYYYYYYYYYYY
            [txn_type] => paypal_here
            [mc_gross_1] => 100.00
            [mc_currency] => USD
            [residence_country] => US
            [receipt_id] => 1234-5678-9012-3456
            [transaction_subject] => 
            [payment_gross] => 100.00
            [ipn_track_id] => xxxxxxxxxxxxx
        )

    [timeout] => 60
    [httpversion] => 1.1
    [compress] => 
    [decompress] => 
    [user-agent] => WooCommerce/2.6.4
)
```
