### PR TITLE
Conflict in get_availability

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -704,7 +704,7 @@ class WC_Product {
 				break;
 			}
 		} else {
-			$availability = '';
+			$availability = __( 'In stock', 'woocommerce' );
 		}
 		return apply_filters( 'woocommerce_get_availability_text', $availability, $this );
 	}


### PR DESCRIPTION
When calling `get_availability` it returns an array of `get_availabilty_text` and `get_availability_class`. The `get_availability_class` returns `in-stock` as default ( https://github.com/ibndawood/woocommerce/blob/6d1dcd193ab755b4e9ffbac5e11ec04fb170b3c7/includes/abstracts/abstract-wc-product.php#L707 ) while `get_availability_text` returns empty string. Both class and text should have the same default. I have updated `get_availability_text` to return `__( 'In stock', 'woocommerce' )`

Also please note that the API docs is not updated with the latest code : https://docs.woocommerce.com/wc-apidocs/source-class-WC_Product.html#674-675
