### PR TITLE
Fix: Return pre-WC 2.6 behavior indicating a non-free shipping method is free

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -345,6 +345,8 @@ function wc_cart_totals_shipping_method_label( $method ) {
 				$label .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
 			}
 		}
+	} elseif ( 'free_shipping' !== $method->method_id ) {
+		$label .= ' (' . __( 'Free', 'woocommerce' ) . ')';
 	}
 
 	return apply_filters( 'woocommerce_cart_shipping_method_full_label', $label, $method );


### PR DESCRIPTION
In previous versions of WooCommerce, a $0 shipping method would be explicitly labeled "Free" in the cart and at checkout: https://github.com/woothemes/woocommerce/blob/2.5.5/includes/wc-cart-functions.php#L303-L305

However, with WC 2.6+, there's no longer handling for a $0 method:
https://github.com/woothemes/woocommerce/blob/efd390e9510d168ae730b05504225aa21b2a99cc/includes/wc-cart-functions.php#L328-L351

To see this in action: Set up a shipping method with $0 cost. Add the cost to the "No shipping class" rate instead, and $0 for a "free shipping" class rate: http://cloud.skyver.ge/2d3p451k0G1c

When the product is in the "Free Shipping" class and shipping is $0, the method is still listed as "US Ground" instead of "US Ground (Free)" (previous behavior).

This commit re-introduces the previous behavior of adding the "Free" indicator for non-`free_shipping` methods that are $0. ([See comment here](https://www.sellwithwp.com/beginners-guide-woocommerce-shipping-zones/#comment-342412))
