### PR TITLE
REST API: Include image sizes in products API endpoint

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -291,7 +291,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				continue;
 			}
 
-			$images[] = array(
+			$imageData = array(
 				'id'            => (int) $attachment_id,
 				'date_created'  => wc_rest_prepare_date_response( $attachment_post->post_date_gmt ),
 				'date_modified' => wc_rest_prepare_date_response( $attachment_post->post_modified_gmt ),
@@ -299,8 +299,13 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				'name'          => get_the_title( $attachment_id ),
 				'alt'           => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
 				'position'      => (int) $position,
-				'sizes'         => $this->get_image_sizes( $attachment_id )
 			);
+
+			if($_GET['include'] == 'image-sizes')
+			{
+				$imageData['sizes'] = $this->get_image_sizes( $attachment_id );
+			}
+			$images[] = $imageData;
 		}
 
 		// Set a placeholder image if the product has no images set.


### PR DESCRIPTION
If you build a custom JS front for WooCommerce you want to get product images in appropriate sizes straight from the API. As it is now, you only get the full size image which is heavy to load and it would be a hassle to guess the filename of the images in the store or generate new thumbnails in JavaScript. 
Therefore I really think the images sizes should be included in the response on the `/products` API endpoint.

As this might have a slight performance penalty I also made the inclusion of the image sizes optional by adding `?include=image-sizes` at the end of the request URL, for example: `/wp-json/wc/v1/products/1385?include=image-sizes`. This is all in the second commit.

I was going to add unit tests for this as well, but I did not see any tests for the products endpoint. I thought that was a bit weird because most of the other, less important, endpoints seams to be covered. What is going on there? Have I missed something?

This should be 100% backwards compatible. 
