### PR TITLE
Remove checkbox options in system status tools

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -95,7 +95,6 @@ class WC_Admin_Menus {
 	 */
 	public function status_menu() {
 		add_submenu_page( 'woocommerce', __( 'WooCommerce Status', 'woocommerce' ),  __( 'System Status', 'woocommerce' ) , 'manage_woocommerce', 'wc-status', array( $this, 'status_page' ) );
-		register_setting( 'woocommerce_status_settings_fields', 'woocommerce_status_options' );
 	}
 
 	/**

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -111,6 +111,16 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				'show_if_checked' => 'option',
 			),
 
+			array(
+				'title'    => __( 'Debug Mode', 'woocommerce' ),
+				'desc'     => __( 'Enable Debug Mode', 'woocommerce' ),
+				'desc_tip' => __( 'Enable Shipping Debug Mode to show matching shipping zones and to bypass shipping rate cache.', 'woocommerce' ),
+				'id'       => 'woocommerce_shipping_debug_mode',
+				'default'  => 'no',
+				'type'     => 'checkbox',
+				'autoload' => false
+			),
+
 			array( 'type' => 'sectionend', 'id' => 'shipping_options' ),
 
 		) );

--- a/includes/admin/views/html-admin-page-status-tools.php
+++ b/includes/admin/views/html-admin-page-status-tools.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <form method="post" action="options.php">
 	<?php settings_fields( 'woocommerce_status_settings_fields' ); ?>
-	<?php $options = wp_parse_args( get_option( 'woocommerce_status_options', array() ), array( 'uninstall_data' => 0, 'template_debug_mode' => 0, 'shipping_debug_mode' => 0 ) ); ?>
 	<table class="wc_status_table widefat" cellspacing="0">
 		<tbody class="tools">
 			<?php foreach ( $tools as $action => $tool ) : ?>
@@ -24,39 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</td>
 				</tr>
 			<?php endforeach; ?>
-			<tr>
-				<td><?php _e( 'Shipping Debug Mode', 'woocommerce' ); ?></td>
-				<td>
-					<p>
-						<label><input type="checkbox" class="checkbox" name="woocommerce_status_options[shipping_debug_mode]" value="1" <?php checked( '1', $options['shipping_debug_mode'] ); ?> /> <?php _e( 'Enabled', 'woocommerce' ); ?></label>
-					</p>
-					<p>
-						<span class="description"><?php _e( 'Enable Shipping Debug Mode to show matching shipping zones and to bypass shipping rate cache.', 'woocommerce' ); ?></span>
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td><?php _e( 'Template Debug Mode', 'woocommerce' ); ?></td>
-				<td>
-					<p>
-						<label><input type="checkbox" class="checkbox" name="woocommerce_status_options[template_debug_mode]" value="1" <?php checked( '1', $options['template_debug_mode'] ); ?> /> <?php _e( 'Enabled', 'woocommerce' ); ?></label>
-					</p>
-					<p>
-						<span class="description"><?php _e( 'Enable Template Debug Mode to bypass all theme and plugin template overrides for logged-in administrators. Used for debugging purposes.', 'woocommerce' ); ?></span>
-					</p>
-				</td>
-			</tr>
-			<tr>
-				<td><?php _e( 'Remove All Data', 'woocommerce' ); ?></td>
-				<td>
-					<p>
-						<label><input type="checkbox" class="checkbox" name="woocommerce_status_options[uninstall_data]" value="1" <?php checked( '1', $options['uninstall_data'] ); ?> /> <?php _e( 'Enabled', 'woocommerce' ); ?></label>
-					</p>
-					<p>
-						<span class="description"><?php _e( 'This tool will remove all WooCommerce, Product and Order data when using the "Delete" link on the plugins screen. It will also remove any setting/option prepended with "woocommerce_" so may also affect installed WooCommerce Extensions.', 'woocommerce' ); ?></span>
-					</p>
-				</td>
-			</tr>
 		</tbody>
 	</table>
 	<p class="submit">

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -132,12 +132,12 @@ class WC_Shipping {
 	 */
 	public function load_shipping_methods( $package = array() ) {
 		if ( ! empty( $package ) ) {
-			$status_options         = get_option( 'woocommerce_status_options', array() );
+			$debug_mode             = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
 			$shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
 			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
 
 			// Debug output
-			if ( ! empty( $status_options['shipping_debug_mode'] ) && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! wc_has_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' ) ) {
+			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! wc_has_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' ) ) {
 				wc_add_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' );
 			}
 		} else {
@@ -353,7 +353,7 @@ class WC_Shipping {
 		$session_key    = 'shipping_for_package_' . $package_key;
 		$stored_rates   = WC()->session->get( $session_key );
 
-		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || ! empty( $status_options['shipping_debug_mode'] ) ) {
+		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
 			// Calculate shipping method rates
 			$package['rates'] = array();
 

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -348,10 +348,9 @@ class WC_Shipping {
 			unset( $package_to_hash['contents'][ $item_id ]['data'] );
 		}
 
-		$package_hash   = 'wc_ship_' . md5( json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
-		$status_options = get_option( 'woocommerce_status_options', array() );
-		$session_key    = 'shipping_for_package_' . $package_key;
-		$stored_rates   = WC()->session->get( $session_key );
+		$package_hash = 'wc_ship_' . md5( json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
+		$session_key  = 'shipping_for_package_' . $package_key;
+		$stored_rates = WC()->session->get( $session_key );
 
 		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
 			// Calculate shipping method rates

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -894,21 +894,6 @@ function wc_deliver_webhook_async( $webhook_id, $arg ) {
 add_action( 'woocommerce_deliver_webhook_async', 'wc_deliver_webhook_async', 10, 2 );
 
 /**
- * Enables template debug mode.
- */
-function wc_template_debug_mode() {
-	if ( ! defined( 'WC_TEMPLATE_DEBUG_MODE' ) ) {
-		$status_options = get_option( 'woocommerce_status_options', array() );
-		if ( ! empty( $status_options['template_debug_mode'] ) && current_user_can( 'manage_options' ) ) {
-			define( 'WC_TEMPLATE_DEBUG_MODE', true );
-		} else {
-			define( 'WC_TEMPLATE_DEBUG_MODE', false );
-		}
-	}
-}
-add_action( 'after_setup_theme', 'wc_template_debug_mode', 20 );
-
-/**
  * Formats a string in the format COUNTRY:STATE into an array.
  *
  * @since 2.3.0

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,7 +71,7 @@ class WC_Unit_Tests_Bootstrap {
 
 		// clean existing install first
 		define( 'WP_UNINSTALL_PLUGIN', true );
-		update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
+		define( 'WC_REMOVE_ALL_DATA', true );
 		include( $this->plugin_dir . '/uninstall.php' );
 
 		WC_Install::install();

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -32,7 +32,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 		// clean existing install first
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );
-			update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
+			define( 'WC_REMOVE_ALL_DATA', true );
 		}
 
 		include( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php' );
@@ -86,7 +86,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 		// Clean existing install first
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			define( 'WP_UNINSTALL_PLUGIN', true );
-			update_option( 'woocommerce_status_options', array( 'uninstall_data' => 1 ) );
+			define( 'WC_REMOVE_ALL_DATA', true );
 		}
 		include( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php' );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,7 +24,10 @@ wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
 $status_options = get_option( 'woocommerce_status_options', array() );
 
-if ( ! empty( $status_options['uninstall_data'] ) ) {
+// Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's
+// wp-config.php. This is to prevent data loss when deleting the plugin from the backend
+// and to ensure only the site owner can perform this action.
+if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Roles + caps.
 	include_once( dirname( __FILE__ ) . '/includes/class-wc-install.php' );
 	WC_Install::remove_roles();

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,8 +22,6 @@ wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
 wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
-$status_options = get_option( 'woocommerce_status_options', array() );
-
 // Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's
 // wp-config.php. This is to prevent data loss when deleting the plugin from the backend
 // and to ensure only the site owner can perform this action.

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -188,6 +188,7 @@ final class WooCommerce {
 		$this->define( 'WC_DELIMITER', '|' );
 		$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
 		$this->define( 'WC_SESSION_CACHE_GROUP', 'wc_session_id' );
+		$this->define( 'WC_TEMPLATE_DEBUG_MODE', false );
 	}
 
 	/**


### PR DESCRIPTION
Closed #11691 

@claudiosmweb @justinshreve 

This removes the 3 options in system status tools which don’t really fit.

Shipping debug - Moved to shipping options

Template debug mode - WC_TEMPLATE_DEBUG_MODE constant

Uninstall all data - WC_REMOVE_ALL_DATA constant
