### PR TITLE
Nav menus metabox

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -39,7 +39,7 @@ class WC_Admin_Menus {
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 
 		// Rename taxonomies at Appearance > Menus > Pages
-		add_action( 'nav_menu_meta_box_object', array( $this, 'rename_nav_menu_meta_boxes' ) );
+		add_filter( 'nav_menu_meta_box_object', array( $this, 'rename_nav_menu_meta_boxes' ) );
 
 		// Add endpoints custom URLs in Appearance > Menus > Pages
 		add_action( 'admin_init', array( $this, 'add_nav_menu_meta_boxes' ) );

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -38,6 +38,9 @@ class WC_Admin_Menus {
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 
+		// Rename taxonomies at Appearance > Menus > Pages
+		add_action( 'nav_menu_meta_box_object', array( $this, 'rename_nav_menu_meta_boxes' ) );
+
 		// Add endpoints custom URLs in Appearance > Menus > Pages
 		add_action( 'admin_init', array( $this, 'add_nav_menu_meta_boxes' ) );
 
@@ -224,6 +227,19 @@ class WC_Admin_Menus {
 	 */
 	public function addons_page() {
 		WC_Admin_Addons::output();
+	}
+
+	/**
+	 * Rename taxonomies in admin menus meta boxes.
+	 */
+	public function rename_nav_menu_meta_boxes( $tax ) {
+		if ( 'product_cat' === $tax->name ) {
+			$tax->labels->name = __( 'Product Categories', 'woocommerce' );
+		} elseif ( 'product_tag' === $tax->name ) {
+			$tax->labels->name = __( 'Product Tags', 'woocommerce' );
+		}
+
+		return $tax;
 	}
 
 	/**


### PR DESCRIPTION
This is confusing: http://cld.wthms.co/134fk/4ViqL7Ni

Using this filter: https://github.com/WordPress/WordPress/blob/5025f72fd32addc4f5a4b7cdf899899ea0734573/wp-admin/includes/nav-menu.php#L227, we can rename the taxonomies in the screen options and meta boxes: http://cld.wthms.co/1jI6V/LX5JITn4.

This comes up a bit in the forums, so I'm thinking this could help lower the support need. Screen options is still widely under-used, so maybe it'd be worth adding some type of link here that will trigger the screen options to open? http://cld.wthms.co/11LR0/47ktudnG

Like "Looking for WooCommerce Categories or Tags? Click here."
