### PR TITLE
Use wc_get_attribute_taxonomies() in wc_attribute_label()

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -646,7 +646,7 @@ class WC_Product_Variation extends WC_Product {
 				// Get terms for attribute taxonomy or value if its a custom attribute
 				if ( $attribute[ 'is_taxonomy' ] ) {
 
-					$post_terms = wp_get_post_terms( $this->id, $attribute[ 'name' ] );
+					$post_terms = get_the_terms( $this->id, $attribute[ 'name' ] );
 
 					foreach ( $post_terms as $term ) {
 						if ( $variation_selected_value === $term->slug ) {

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -108,12 +108,9 @@ function wc_attribute_label( $name, $product = '' ) {
 	global $wpdb;
 
 	if ( taxonomy_is_product_attribute( $name ) ) {
-		$name  = wc_sanitize_taxonomy_name( str_replace( 'pa_', '', $name ) );
-		$label = $wpdb->get_var( $wpdb->prepare( "SELECT attribute_label FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name = %s;", $name ) );
-
-		if ( ! $label ) {
-			$label = $name;
-		}
+		$name       = wc_sanitize_taxonomy_name( str_replace( 'pa_', '', $name ) );
+		$all_labels = wp_list_pluck( wc_get_attribute_taxonomies(), 'attribute_label', 'attribute_name' );
+		$label      = isset( $all_labels[ $name ] ) ? $all_labels[ $name ] : $name;
 	} elseif ( $product && ( $attributes = $product->get_attributes() ) && isset( $attributes[ sanitize_title( $name ) ]['name'] ) ) {
 		// Attempt to get label from product, as entered by the user
 		$label = $attributes[ sanitize_title( $name ) ]['name'];


### PR DESCRIPTION
Currently `wc_attribute_label()` runs a SQL query every time it is called, with no caching. This swaps to using `wc_get_attribute_taxonomies()` which gives us transient caching of the underlying data.

I came across this when profiling the Product Feed plugin. This generates a list of all products, and their variants. During that it generates a title for each variation, using `get_formatted_variation_attributes()` which in turn uses `wc_attribute_label()`. For a store with 100 products, each with 4 variations against 2 attributes, this PR will save ~800 queries when generating the feed.

Other functions in `wc-attribute-functions.php` could also have similar treatment - on casual inspection `wc_attribute_taxonomy_name_by_id()`, `wc_attribute_orderby()` may also benefit from the same approach - although they aren't causing an issue for the Product Feed plugin.

Let me know if you would like a separate PR for those.
