### PR TITLE
Coding standards

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,7 @@
+{
+    "preset": "wordpress",
+    "fileExtensions": [ ".js" ],
+    "excludeFiles": [
+    	"**.min.js"
+    ]
+}

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -11,7 +11,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Note: get_option( 'woocommerce_lock_down_admin', true ) is a deprecated option here for backwards compat. Defaults to true.
  *
  * @access public
- * @param bool $show_admin_bar
+ * @param bool $show_admin_bar Whether we should show the admin-bar or not.
  * @return bool
  */
 function wc_disable_admin_bar( $show_admin_bar ) {
@@ -120,7 +120,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 /**
  * Login a customer (set auth cookie and set global user object).
  *
- * @param int $customer_id
+ * @param int $customer_id The customer ID.
  */
 function wc_set_customer_auth_cookie( $customer_id ) {
 	global $current_user;
@@ -133,7 +133,7 @@ function wc_set_customer_auth_cookie( $customer_id ) {
 /**
  * Get past orders (by email) and update them.
  *
- * @param  int $customer_id
+ * @param  int $customer_id The customer ID.
  * @return int
  */
 function wc_update_new_customer_past_orders( $customer_id ) {
@@ -172,8 +172,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 /**
  * Order Status completed - This is a paying customer.
  *
- * @access public
- * @param int $order_id
+ * @param int $order_id The order ID.
  */
 function wc_paying_customer( $order_id ) {
 	$order       = wc_get_order( $order_id );
@@ -194,9 +193,10 @@ add_action( 'woocommerce_order_status_completed', 'wc_paying_customer' );
 
 /**
  * Checks if a user (by email or ID or both) has bought an item.
- * @param string $customer_email
- * @param int $user_id
- * @param int $product_id
+ *
+ * @param string $customer_email The customer e-mail.
+ * @param int    $user_id        The user ID.
+ * @param int    $product_id     The product ID.
  * @return bool
  */
 function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
@@ -221,7 +221,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 
 		$customer_data = array_map( 'esc_sql', array_filter( array_unique( $customer_data ) ) );
 
-		if ( sizeof( $customer_data ) == 0 ) {
+		if ( 0 == count( $customer_data ) ) {
 			return false;
 		}
 
@@ -247,9 +247,9 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
  * Checks if a user has a certain capability.
  *
  * @access public
- * @param array $allcaps
- * @param array $caps
- * @param array $args
+ * @param array $allcaps All available capabilities.
+ * @param array $caps    The capabilities.
+ * @param array $args    Arguments array.
  * @return bool
  */
 function wc_customer_has_capability( $allcaps, $caps, $args ) {
@@ -268,7 +268,7 @@ function wc_customer_has_capability( $allcaps, $caps, $args ) {
 				$order_id = isset( $args[2] ) ? $args[2] : null;
 
 				// When no order ID, we assume it's a new order
-				// and thus, customer can pay for it
+				// and thus, customer can pay for it.
 				if ( ! $order_id ) {
 					$allcaps['pay_for_order'] = true;
 					break;
@@ -311,12 +311,13 @@ add_filter( 'user_has_cap', 'wc_customer_has_capability', 10, 3 );
 
 /**
  * Modify the list of editable roles to prevent non-admin adding admin users.
- * @param  array $roles
+ *
+ * @param  array $roles User-Roles array.
  * @return array
  */
 function wc_modify_editable_roles( $roles ){
 	if ( ! current_user_can( 'administrator' ) ) {
-		unset( $roles[ 'administrator' ] );
+		unset( $roles['administrator'] );
 	}
 	return $roles;
 }
@@ -327,10 +328,10 @@ add_filter( 'editable_roles', 'wc_modify_editable_roles' );
  *
  * $args[0] will be the user being edited in this case.
  *
- * @param  array $caps Array of caps
- * @param  string $cap Name of the cap we are checking
- * @param  int $user_id ID of the user being checked against
- * @param  array $args
+ * @param  array  $caps    Array of caps.
+ * @param  string $cap     Name of the cap we are checking.
+ * @param  int    $user_id ID of the user being checked against.
+ * @param  array  $args    Arguments array.
  * @return array
  */
 function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
@@ -355,7 +356,7 @@ add_filter( 'map_meta_cap', 'wc_modify_map_meta_cap', 10, 4 );
 /**
  * Get customer download permissions from the database.
  *
- * @param int $customer_id Customer/User ID
+ * @param int $customer_id Customer/User ID.
  * @return array
  */
 function wc_get_customer_download_permissions( $customer_id ) {
@@ -388,7 +389,7 @@ function wc_get_customer_download_permissions( $customer_id ) {
 /**
  * Get customer available downloads.
  *
- * @param int $customer_id Customer/User ID
+ * @param int $customer_id Customer/User ID.
  * @return array
  */
 function wc_get_customer_available_downloads( $customer_id ) {
@@ -397,18 +398,18 @@ function wc_get_customer_available_downloads( $customer_id ) {
 	$order       = null;
 	$file_number = 0;
 
-	// Get results from valid orders only
+	// Get results from valid orders only.
 	$results = wc_get_customer_download_permissions( $customer_id );
 
 	if ( $results ) {
 		foreach ( $results as $result ) {
 			if ( ! $order || $order->get_id() != $result->order_id ) {
-				// new order
+				// New order.
 				$order    = wc_get_order( $result->order_id );
 				$_product = null;
 			}
 
-			// Make sure the order exists for this download
+			// Make sure the order exists for this download.
 			if ( ! $order ) {
 				continue;
 			}
@@ -421,19 +422,19 @@ function wc_get_customer_available_downloads( $customer_id ) {
 			$product_id = intval( $result->product_id );
 
 			if ( ! $_product || $_product->id != $product_id ) {
-				// new product
+				// New product.
 				$file_number = 0;
 				$_product    = wc_get_product( $product_id );
 			}
 
-			// Check product exists and has the file
+			// Check product exists and has the file.
 			if ( ! $_product || ! $_product->exists() || ! $_product->has_file( $result->download_id ) ) {
 				continue;
 			}
 
 			$download_file = $_product->get_file( $result->download_id );
 
-			// Download name will be 'Product Name' for products with a single downloadable file, and 'Product Name - File X' for products with multiple files
+			// Download name will be 'Product Name' for products with a single downloadable file, and 'Product Name - File X' for products with multiple files.
 			$download_name = apply_filters(
 				'woocommerce_downloadable_product_name',
 				$_product->get_title() . ' &ndash; ' . $download_file['name'],
@@ -471,7 +472,8 @@ function wc_get_customer_available_downloads( $customer_id ) {
 
 /**
  * Get total spent by customer.
- * @param  int $user_id
+ *
+ * @param  int $user_id The user ID.
  * @return string
  */
 function wc_get_customer_total_spent( $user_id ) {
@@ -500,7 +502,8 @@ function wc_get_customer_total_spent( $user_id ) {
 
 /**
  * Get total orders by customer.
- * @param  int $user_id
+ *
+ * @param  int $user_id The user ID.
  * @return int
  */
 function wc_get_customer_order_count( $user_id ) {
@@ -527,7 +530,8 @@ function wc_get_customer_order_count( $user_id ) {
 
 /**
  * Reset _customer_user on orders when a user is deleted.
- * @param int $user_id
+ *
+ * @param int $user_id The user ID.
  */
 function wc_reset_order_customer_id_on_deleted_user( $user_id ) {
 	global $wpdb;
@@ -539,7 +543,8 @@ add_action( 'deleted_user', 'wc_reset_order_customer_id_on_deleted_user' );
 
 /**
  * Get review verification status.
- * @param  int $comment_id
+ *
+ * @param  int $comment_id The comment ID.
  * @return bool
  */
 function wc_review_is_from_verified_owner( $comment_id ) {
@@ -597,7 +602,7 @@ add_action( 'profile_update', 'wc_update_profile_last_update_time', 10, 2 );
 function wc_meta_update_last_update_time( $meta_id, $user_id, $meta_key, $_meta_value ) {
 	$keys_to_track = apply_filters( 'woocommerce_user_last_update_fields', array( 'first_name', 'last_name' ) );
 	$update_time   = false;
-	if ( in_array( $meta_key, $keys_to_track ) ) {
+	if ( in_array( $meta_key, $keys_to_track, true ) ) {
 		$update_time = true;
 	}
 	if ( 'billing_' === substr( $meta_key, 0, 8 ) ) {
@@ -628,7 +633,7 @@ function wc_set_user_last_update_time( $user_id ) {
  * Get customer saved payment methods list.
  *
  * @since 2.6.0
- * @param int $customer_id
+ * @param int $customer_id The customer ID.
  * @return array
  */
 function wc_get_customer_saved_methods_list( $customer_id ) {

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -9,7 +9,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+
+	<!-- Set a description for this ruleset. -->
+	<description>A custom set of code standard rules to check for WordPress themes and plugins.</description>
+
+	<!-- Include the WordPress ruleset, with exclusions. -->
+	<rule ref="WordPress">
+		<exclude name="WordPress.Files.FileName.UnderscoresNotAllowed" />
+
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized" />
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput.MissingUnslash" />
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput.InputNotValidated" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.url_to_postid" />
+		<exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />
+		<exclude name="WordPress.VIP.DirectDatabaseQuery.DirectQuery" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.user_meta" />
+		<exclude name="WordPress.VIP.OrderByRand.orderby" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.wp_get_post_terms" />
+		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.get_term_by" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.get_term_link" />
+		<exclude name="WordPress.VIP.FileSystemWritesDisallow.FileWriteDetected" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.get_pages" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.count_user_posts" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.wp_remote_get" />
+		<exclude name="WordPress.VIP.RestrictedFunctions.extract" />
+		<exclude name="WordPress.VIP.SuperGlobalInputUsage.AccessDetected" />
+		<exclude name="WordPress.VIP.SlowDBQuery.slow_db_query" />
+
+		<exclude name="WordPress.PHP.StrictComparisons.LooseComparison" />
+		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
+
+		<exclude name="Squiz.PHP.CommentedOutCode.Found" />
+
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen" />
+
+		<exclude name="WordPress.XSS.EscapeOutput.OutputNotEscaped" />
+		<exclude name="WordPress.XSS.EscapeOutput.UnsafePrintingFunction" />
+		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedScript" />
+		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet" />
+		<exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
+		<exclude name="WordPress.WP.PreparedSQL.NotPrepared" />
+		<exclude name="WordPress.Variables.GlobalVariables.OverrideProhibited" />
+
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+	</rule>
+</ruleset>

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -16,11 +16,29 @@
  * @category Core
  * @author WooThemes
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-if ( ! class_exists( 'WooCommerce' ) ) :
+/**
+ * Main instance of WooCommerce.
+ *
+ * Returns the main instance of WC to prevent the need to use globals.
+ *
+ * @since  2.1
+ * @return WooCommerce
+ */
+function WC() {
+	return WooCommerce::instance();
+}
+
+// Global for backwards compatibility.
+$GLOBALS['woocommerce'] = WC();
+
+if ( ! class_exists( 'WooCommerce' ) ) {
+	return;
+}
 
 /**
  * Main WooCommerce Class.
@@ -120,6 +138,7 @@ final class WooCommerce {
 
 	/**
 	 * Cloning is forbidden.
+	 *
 	 * @since 2.1
 	 */
 	public function __clone() {
@@ -128,6 +147,7 @@ final class WooCommerce {
 
 	/**
 	 * Unserializing instances of this class is forbidden.
+	 *
 	 * @since 2.1
 	 */
 	public function __wakeup() {
@@ -136,11 +156,12 @@ final class WooCommerce {
 
 	/**
 	 * Auto-load in-accessible properties on demand.
-	 * @param mixed $key
+	 *
+	 * @param mixed $key The key we're looking for.
 	 * @return mixed
 	 */
 	public function __get( $key ) {
-		if ( in_array( $key, array( 'payment_gateways', 'shipping', 'mailer', 'checkout' ) ) ) {
+		if ( in_array( $key, array( 'payment_gateways', 'shipping', 'mailer', 'checkout' ), true ) ) {
 			return $this->$key();
 		}
 	}
@@ -158,6 +179,7 @@ final class WooCommerce {
 
 	/**
 	 * Hook into actions and filters.
+	 *
 	 * @since  2.3
 	 */
 	private function init_hooks() {
@@ -194,8 +216,8 @@ final class WooCommerce {
 	/**
 	 * Define constant if not already set.
 	 *
-	 * @param  string $name
-	 * @param  string|bool $value
+	 * @param  string      $name  The name of the constant we're defining.
+	 * @param  string|bool $value The value of the constant we're defining.
 	 */
 	private function define( $name, $value ) {
 		if ( ! defined( $name ) ) {
@@ -238,7 +260,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-post-data.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-ajax.php' );
 
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php' ); // WC_Data for CRUD
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php' ); // WC_Data for CRUD.
 		include_once( WC_ABSPATH . 'includes/class-wc-data-exception.php' );
 
 		if ( $this->is_request( 'admin' ) ) {
@@ -257,26 +279,26 @@ final class WooCommerce {
 			include_once( WC_ABSPATH . 'includes/class-wc-tracker.php' );
 		}
 
-		include_once( WC_ABSPATH . 'includes/class-wc-query.php' ); // The main query class
-		include_once( WC_ABSPATH . 'includes/class-wc-api.php' ); // API Class
-		include_once( WC_ABSPATH . 'includes/class-wc-auth.php' ); // Auth Class
-		include_once( WC_ABSPATH . 'includes/class-wc-post-types.php' ); // Registers post types
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php' );				 // WC_Data for CRUD
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-token.php' ); // Payment Tokens
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-product.php' ); // Products
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-order.php' ); // Orders
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-settings-api.php' ); // Settings API (for gateways, shipping, and integrations)
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-shipping-method.php' ); // A Shipping method
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-gateway.php' ); // A Payment gateway
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-integration.php' ); // An integration with a service
-		include_once( WC_ABSPATH . 'includes/class-wc-product-factory.php' ); // Product factory
-		include_once( WC_ABSPATH . 'includes/class-wc-payment-tokens.php' ); // Payment tokens controller
-		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-cc.php' ); // CC Payment Gateway
-		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-echeck.php' ); // eCheck Payment Gateway
-		include_once( WC_ABSPATH . 'includes/class-wc-countries.php' ); // Defines countries and states
-		include_once( WC_ABSPATH . 'includes/class-wc-integrations.php' ); // Loads integrations
-		include_once( WC_ABSPATH . 'includes/class-wc-cache-helper.php' ); // Cache Helper
-		include_once( WC_ABSPATH . 'includes/class-wc-https.php' ); // https Helper
+		include_once( WC_ABSPATH . 'includes/class-wc-query.php' ); // The main query class.
+		include_once( WC_ABSPATH . 'includes/class-wc-api.php' ); // API Class.
+		include_once( WC_ABSPATH . 'includes/class-wc-auth.php' ); // Auth Class.
+		include_once( WC_ABSPATH . 'includes/class-wc-post-types.php' ); // Registers post types.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php' );	// WC_Data for CRUD.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-token.php' ); // Payment Tokens.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-product.php' ); // Products.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-order.php' ); // Orders.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-settings-api.php' ); // Settings API (for gateways, shipping, and integrations).
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-shipping-method.php' ); // A Shipping method.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-gateway.php' ); // A Payment gateway.
+		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-integration.php' ); // An integration with a service.
+		include_once( WC_ABSPATH . 'includes/class-wc-product-factory.php' ); // Product factory.
+		include_once( WC_ABSPATH . 'includes/class-wc-payment-tokens.php' ); // Payment tokens controller.
+		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-cc.php' ); // CC Payment Gateway.
+		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-echeck.php' ); // eCheck Payment Gateway.
+		include_once( WC_ABSPATH . 'includes/class-wc-countries.php' ); // Defines countries and states.
+		include_once( WC_ABSPATH . 'includes/class-wc-integrations.php' ); // Loads integrations.
+		include_once( WC_ABSPATH . 'includes/class-wc-cache-helper.php' ); // Cache Helper.
+		include_once( WC_ABSPATH . 'includes/class-wc-https.php' ); // HTTPS Helper.
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once( WC_ABSPATH . 'includes/class-wc-cli.php' );
@@ -322,10 +344,10 @@ final class WooCommerce {
 		$this->load_plugin_textdomain();
 
 		// Load class instances.
-		$this->product_factory = new WC_Product_Factory();                      // Product Factory to create new product instances
-		$this->order_factory   = new WC_Order_Factory();                        // Order Factory to create new order instances
-		$this->countries       = new WC_Countries();                            // Countries class
-		$this->integrations    = new WC_Integrations();                         // Integrations class
+		$this->product_factory = new WC_Product_Factory(); // Product Factory to create new product instances.
+		$this->order_factory   = new WC_Order_Factory();   // Order Factory to create new order instances.
+		$this->countries       = new WC_Countries();       // Countries class.
+		$this->integrations    = new WC_Integrations();    // Integrations class.
 
 		// Session class, handles session data for users - can be overwritten if custom handler is needed.
 		if ( $this->is_request( 'frontend' ) || $this->is_request( 'cron' ) ) {
@@ -335,8 +357,8 @@ final class WooCommerce {
 
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
-			$this->cart     = new WC_Cart();                                    // Cart class, stores the cart contents
-			$this->customer = new WC_Customer( get_current_user_id(), true );   // Customer class, handles data such as customer location
+			$this->cart     = new WC_Cart();                                  // Cart class, stores the cart contents.
+			$this->customer = new WC_Customer( get_current_user_id(), true ); // Customer class, handles data such as customer location.
 		}
 
 		$this->load_webhooks();
@@ -401,6 +423,7 @@ final class WooCommerce {
 
 	/**
 	 * Get the plugin url.
+	 *
 	 * @return string
 	 */
 	public function plugin_url() {
@@ -409,6 +432,7 @@ final class WooCommerce {
 
 	/**
 	 * Get the plugin path.
+	 *
 	 * @return string
 	 */
 	public function plugin_path() {
@@ -417,6 +441,7 @@ final class WooCommerce {
 
 	/**
 	 * Get the template path.
+	 *
 	 * @return string
 	 */
 	public function template_path() {
@@ -425,6 +450,7 @@ final class WooCommerce {
 
 	/**
 	 * Get Ajax URL.
+	 *
 	 * @return string
 	 */
 	public function ajax_url() {
@@ -434,13 +460,13 @@ final class WooCommerce {
 	/**
 	 * Return the WC API URL for a given request.
 	 *
-	 * @param string $request
-	 * @param mixed $ssl (default: null)
+	 * @param string $request The request.
+	 * @param mixed  $ssl (default: null).
 	 * @return string
 	 */
 	public function api_request_url( $request, $ssl = null ) {
 		if ( is_null( $ssl ) ) {
-			$scheme = parse_url( home_url(), PHP_URL_SCHEME );
+			$scheme = wp_parse_url( home_url(), PHP_URL_SCHEME );
 		} elseif ( $ssl ) {
 			$scheme = 'https';
 		} else {
@@ -469,7 +495,7 @@ final class WooCommerce {
 				'fields'         => 'ids',
 				'post_type'      => 'shop_webhook',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1
+				'posts_per_page' => -1,
 			) );
 			set_transient( 'woocommerce_webhook_ids', $webhooks );
 		}
@@ -497,6 +523,7 @@ final class WooCommerce {
 
 	/**
 	 * Get Checkout Class.
+	 *
 	 * @return WC_Checkout
 	 */
 	public function checkout() {
@@ -505,6 +532,7 @@ final class WooCommerce {
 
 	/**
 	 * Get gateways class.
+	 *
 	 * @return WC_Payment_Gateways
 	 */
 	public function payment_gateways() {
@@ -513,6 +541,7 @@ final class WooCommerce {
 
 	/**
 	 * Get shipping class.
+	 *
 	 * @return WC_Shipping
 	 */
 	public function shipping() {
@@ -527,20 +556,3 @@ final class WooCommerce {
 		return WC_Emails::instance();
 	}
 }
-
-endif;
-
-/**
- * Main instance of WooCommerce.
- *
- * Returns the main instance of WC to prevent the need to use globals.
- *
- * @since  2.1
- * @return WooCommerce
- */
-function WC() {
-	return WooCommerce::instance();
-}
-
-// Global for backwards compatibility.
-$GLOBALS['woocommerce'] = WC();


### PR DESCRIPTION
It would be a great to have automatic testing for PHPCS, jshint & JSCS.
However in order to get there we have to lay the foundations, so some basic coding-standards fixes have to be applied first.

That includes online docs, escaping strings where appropriate, sanitizations, properly formatted code, yoda conditions and so on.

This is an effort to make WooCommerce compliant with WP Coding standards.
