### PR TITLE
Shipping Methods API

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Extended by shipping methods to handle shipping calculations etc.
  *
  * @class       WC_Shipping_Method
- * @version     2.6.0
+ * @version     2.7.0
  * @package     WooCommerce/Abstracts
  * @category    Abstract Class
  * @author      WooThemes

--- a/includes/api/class-wc-rest-shipping-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-methods-controller.php
@@ -93,14 +93,14 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-        $wc_shipping = WC_Shipping::instance();
-        $response    = array();
-        foreach ( $wc_shipping->get_shipping_methods() as $id => $shipping_method ) {
-            $method = $this->prepare_item_for_response( $shipping_method, $request );
+		$wc_shipping = WC_Shipping::instance();
+		$response    = array();
+		foreach ( $wc_shipping->get_shipping_methods() as $id => $shipping_method ) {
+			$method = $this->prepare_item_for_response( $shipping_method, $request );
 			$method = $this->prepare_response_for_collection( $method );
 			$response[] = $method;
-        }
-        return rest_ensure_response( $response );
+		}
+		return rest_ensure_response( $response );
 	}
 
     /**
@@ -112,7 +112,7 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
     public function get_item( $request ) {
         $wc_shipping = WC_Shipping::instance();
         $methods     = $wc_shipping->get_shipping_methods();
-        if ( empty ( $methods[ $request['id'] ] ) ) {
+        if ( empty( $methods[ $request['id'] ] ) ) {
             return new WP_Error( 'woocommerce_rest_shipping_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
         }
 

--- a/includes/api/class-wc-rest-shipping-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-methods-controller.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * REST API WC Shipping Methods controller
+ *
+ * Handles requests to the /shipping_methods endpoint.
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'shipping_methods';
+
+	/**
+	 * Register the route for /shipping_methods and /shipping_methods/<method>
+	 */
+	public function register_routes() {
+        register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => $this->get_collection_params(),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+	}
+
+    /**
+	 * Check whether a given request has permission to view system status.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+        if ( ! wc_rest_check_manager_permissions( 'shipping_methods', 'read' ) ) {
+        	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+    /**
+	 * Check if a given request has access to read a shipping method.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'shipping_methods', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+    /**
+	 * Get shipping methods.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+        $wc_shipping = WC_Shipping::instance();
+        $response    = array();
+        foreach ( $wc_shipping->get_shipping_methods() as $id => $shipping_method ) {
+            $method = $this->prepare_item_for_response( $shipping_method, $request );
+			$method = $this->prepare_response_for_collection( $method );
+			$response[] = $method;
+        }
+        return rest_ensure_response( $response );
+	}
+
+    /**
+     * Get a single Shipping Method.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_item( $request ) {
+        $wc_shipping = WC_Shipping::instance();
+        $methods     = $wc_shipping->get_shipping_methods();
+        if ( empty ( $methods[ $request['id'] ] ) ) {
+            return new WP_Error( 'woocommerce_rest_shipping_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+        }
+
+        $method   = $methods[ $request['id'] ];
+        $response = $this->prepare_item_for_response( $method, $request );
+
+        return rest_ensure_response( $response );
+    }
+
+    /**
+     * Prepare a shipping method for response.
+     *
+     * @param WP_Comment $method Shipping method object.
+     * @param WP_REST_Request $request Request object.
+     * @return WP_REST_Response $response Response data.
+     */
+    public function prepare_item_for_response( $method, $request ) {
+        $data = array(
+            'id'           => $method->id,
+            'title'        => $method->method_title,
+            'description'  => $method->method_description,
+        );
+
+        $context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+        $data    = $this->add_additional_fields_to_object( $data, $request );
+        $data    = $this->filter_response_by_context( $data, $context );
+
+        // Wrap the data in a response object.
+        $response = rest_ensure_response( $data );
+
+        $response->add_links( $this->prepare_links( $method, $request ) );
+
+        /**
+         * Filter product reviews object returned from the REST API.
+         *
+         * @param WP_REST_Response $response The response object.
+         * @param Object           $method   Product review object used to create response.
+         * @param WP_REST_Request  $request  Request object.
+         */
+        return apply_filters( 'woocommerce_rest_prepare_shipping_method', $response, $method, $request );
+    }
+
+    /**
+	 * Prepare links for the request.
+	 *
+	 * @param Object $method Shipping method object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given product review.
+	 */
+	protected function prepare_links( $method, $request ) {
+		$links      = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $method->id ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+    /**
+	 * Get the shipping method schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'shipping_method',
+			'type'       => 'object',
+			'properties' => array(
+                'id' => array(
+                    'description' => __( 'Method ID.', 'woocommerce' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view' ),
+                ),
+                'title' => array(
+                    'description' => __( 'Shipping method title.', 'woocommerce' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view' ),
+                ),
+                'description' => array(
+                    'description' => __( 'Shipping method description.', 'woocommerce' ),
+                    'type'        => 'string',
+                    'context'     => array( 'view' ),
+                ),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get any query params needed.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+		);
+	}
+
+}

--- a/includes/api/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-methods-controller.php
@@ -32,6 +32,12 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 
@@ -40,6 +46,23 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+				'args'                => array(
+					'force' => array(
+						'default'     => false,
+						'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
+					),
+				),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -103,6 +126,195 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 	}
 
 	/**
+	 * Create a new shipping zone method instance.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Request|WP_Error
+	 */
+	public function create_item( $request ) {
+		global $wpdb;
+
+		$method_id = $request['method_id'];
+		$zone      = $this->get_zone( $request['zone_id'] );
+		if ( is_wp_error( $zone ) ) {
+			return $zone;
+		}
+
+		$instance_id     = 0;
+		$wc_shipping     = WC_Shipping::instance();
+		$allowed_classes = $wc_shipping->get_shipping_method_class_names();
+		$count           = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE zone_id = %d", $zone->get_id() ) );
+		if ( in_array( $method_id, array_keys( $allowed_classes ) ) ) {
+			$wpdb->insert(
+				$wpdb->prefix . 'woocommerce_shipping_zone_methods',
+				array(
+					'method_id'    => $method_id ,
+					'zone_id'      => $zone->get_id(),
+					'method_order' => ( $count + 1 )
+				),
+				array(
+					'%s',
+					'%d',
+					'%d'
+				)
+			);
+			$instance_id = $wpdb->insert_id;
+		}
+
+		if ( $instance_id ) {
+			do_action( 'woocommerce_shipping_zone_method_added', $instance_id, $method_id, $zone->get_id() );
+		}
+
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+
+		$methods     = $zone->get_shipping_methods();
+		$method      = false;
+
+		foreach ( $methods as $method_obj ) {
+			if ( $instance_id === $method_obj->instance_id ) {
+				$method = $method_obj;
+				break;
+			}
+		}
+
+		if ( false === $method ) {
+			return new WP_Error( 'woocommerce_rest_shipping_zone_not_created', __( "Resource cannot be created.", 'woocommerce' ), array( 'status' => 500 ) );
+		}
+
+		$method = $this->update_fields( $instance_id, $method, $request );
+
+		$data = $this->prepare_item_for_response( $method, $request );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Delete a shipping method instance.
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|boolean
+	 */
+	public function delete_item( $request ) {
+		global $wpdb;
+
+		$zone = $this->get_zone( $request['zone_id'] );
+		if ( is_wp_error( $zone ) ) {
+			return $zone;
+		}
+
+		$instance_id = (int) $request['instance_id'];
+		$force       = $request['force'];
+		$methods     = $zone->get_shipping_methods();
+		$method      = false;
+
+		foreach ( $methods as $method_obj ) {
+			if ( $instance_id === $method_obj->instance_id ) {
+				$method = $method_obj;
+				break;
+			}
+		}
+
+		if ( false === $method ) {
+			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$method = $this->update_fields( $instance_id, $method, $request );
+		$request->set_param( 'context', 'view' );
+		$response = $this->prepare_item_for_response( $method, $request );
+
+		if ( $force ) {
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array( 'instance_id' => $instance_id ) );
+		} else {
+			return new WP_Error( 'rest_trash_not_supported', __( 'Shipping methods do not support trashing.' ), array( 'status' => 501 ) );
+		}
+
+		/**
+		 * Fires after a product review is deleted via the REST API.
+		 *
+		 * @param object           $method
+		 * @param WP_REST_Response $response        The response data.
+		 * @param WP_REST_Request  $request         The request sent to the API.
+		 */
+		do_action( 'rest_delete_product_review', $method, $response, $request );
+
+		return $response;
+	}
+
+	/**
+	 * Update A Single Shipping Zone Method.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		global $wpdb;
+
+		$zone = $this->get_zone( $request['zone_id'] );
+		if ( is_wp_error( $zone ) ) {
+			return $zone;
+		}
+
+		$instance_id = (int) $request['instance_id'];
+		$methods     = $zone->get_shipping_methods();
+		$method      = false;
+
+		foreach ( $methods as $method_obj ) {
+			if ( $instance_id === $method_obj->instance_id ) {
+				$method = $method_obj;
+				break;
+			}
+		}
+
+		if ( false === $method ) {
+			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$method = $this->update_fields( $instance_id, $method, $request );
+
+		$data = $this->prepare_item_for_response( $method, $request );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Updates settings, order, and enabled status on create.
+	 *
+	 * @param $instance_id integer
+	 * @param $method
+	 * @param WP_REST_Request $request
+	 * @return $method
+	 */
+	public function update_fields( $instance_id, $method, $request ) {
+		global $wpdb;
+
+		// Update settings if present
+		if ( isset( $request['settings'] ) ) {
+			$method->init_instance_settings();
+			$instance_settings = $method->instance_settings;
+			foreach ( $method->get_instance_form_fields() as $key => $field ) {
+				if ( isset( $request['settings'][ $key ] ) ) {
+					$instance_settings[ $key ] = $request['settings'][ $key ];
+				}
+			}
+			update_option( $method->get_instance_option_key(), apply_filters( 'woocommerce_shipping_' . $method->id . '_instance_settings_values', $instance_settings, $method ) );
+		}
+
+		// Update order
+		if ( isset( $request['order'] ) ) {
+			$wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'method_order' => absint( $request['order'] ) ), array( 'instance_id' => absint( $instance_id ) ) );
+			$method->method_order = absint( $request['order'] );
+		}
+
+		// Update if this method is enabled or not.
+		if ( isset( $request['enabled'] ) ) {
+			if ( $wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'is_enabled' => $request['enabled'] ), array( 'instance_id' => absint( $instance_id ) ) ) ) {
+				do_action( 'woocommerce_shipping_zone_method_status_toggled', $instance_id, $method->id, $request['zone_id'], $request['enabled'] );
+				$method->enabled = ( true === $request['enabled'] ? 'yes' : 'no' );
+			}
+		}
+
+		return $method;
+	}
+
+	/**
 	 * Prepare the Shipping Zone Method for the REST response.
 	 *
 	 * @param array $item Shipping Zone Method.
@@ -118,6 +330,7 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 			'method_id'          => $item->id,
 			'method_title'       => $item->method_title,
 			'method_description' => $item->method_description,
+			'settings'           => $this->get_settings( $item ),
 		);
 
 		$context = empty( $request['context'] ) ? 'view' : $request['context'];
@@ -132,6 +345,31 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		$response = $this->prepare_response_for_collection( $response );
 
 		return $response;
+	}
+
+	/**
+	 * Return settings associated with this shipping zone method instance.
+	 */
+	public function get_settings( $item ) {
+		$item->init_instance_settings();
+		$settings = array();
+		foreach ( $item->get_instance_form_fields() as $id => $field ) {
+			$data = array(
+				'id'          => $id,
+				'label'       => $field['title'],
+				'description' => ( empty( $field['description'] ) ? '' : $field['description'] ),
+				'type'        => $field['type'],
+				'value'       => $item->instance_settings[ $id ],
+				'default'     => ( empty( $field['default'] ) ? '' : $field['default'] ),
+				'tip'         => ( empty( $field['description'] ) ? '' : $field['description'] ),
+				'placeholder' => ( empty( $field['placeholder'] ) ? '' : $field['placeholder'] ),
+			);
+			if ( ! empty( $field['options'] ) ) {
+				$data['options'] = $field['options'];
+			}
+			$settings[ $id ] = $data;
+		}
+		return $settings;
 	}
 
 	/**
@@ -195,9 +433,9 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 					'required'    => false,
 				),
 				'method_id' => array(
-					'description' => __( 'Shipping method ID.', 'woocommerce' ),
+					'description' => __( 'Shipping method ID. Write on create only.', 'woocommerce' ),
 					'type'        => 'string',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit.' ),
 				),
 				'method_title' => array(
 					'description' => __( 'Shipping method title.', 'woocommerce' ),
@@ -208,6 +446,11 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 					'description' => __( 'Shipping method description.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
+				),
+				'settings' => array(
+					'description' => __( 'Shipping method settings.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
 				),
 			),
 		);

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -174,6 +174,7 @@ class WC_API extends WC_Legacy_API {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-webhooks-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-system-status-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-system-status-tools-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-shipping-methods-controller.php' );
 	}
 
 	/**
@@ -212,6 +213,7 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Webhooks_Controller',
 			'WC_REST_System_Status_Controller',
 			'WC_REST_System_Status_Tools_Controller',
+			'WC_REST_Shipping_Methods_Controller',
 		);
 
 		foreach ( $controllers as $controller ) {

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -487,4 +487,25 @@ class WC_Shipping_Zone extends WC_Data {
 
 		return $instance_id;
 	}
+
+	/**
+	 * Delete a shipping method from a zone.
+	 * @param int $instance_id
+	 * @return True on success, false on failure
+	 */
+	public function delete_shipping_method( $instance_id ) {
+		global $wpdb;
+
+		if ( null === $this->get_id() ) {
+			return false;
+		}
+
+		$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array( 'instance_id' => $instance_id ) );
+		do_action( 'woocommerce_shipping_zone_method_deleted', $instance_id, $this->get_id() );
+
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+
+		return true;
+	}
+
 }

--- a/includes/wc-rest-functions.php
+++ b/includes/wc-rest-functions.php
@@ -306,10 +306,11 @@ function wc_rest_check_product_term_permissions( $taxonomy, $context = 'read', $
  */
 function wc_rest_check_manager_permissions( $object, $context = 'read' ) {
 	$objects = array(
-		'reports'       => 'view_woocommerce_reports',
-		'settings'      => 'manage_woocommerce',
-		'system_status' => 'manage_woocommerce',
-		'attributes'    => 'manage_product_terms',
+		'reports'          => 'view_woocommerce_reports',
+		'settings'         => 'manage_woocommerce',
+		'system_status'    => 'manage_woocommerce',
+		'attributes'       => 'manage_product_terms',
+		'shipping_methods' => 'manage_woocommerce',
 	);
 
 	$permission = current_user_can( $objects[ $object ] );

--- a/tests/unit-tests/api/shipping-methods.php
+++ b/tests/unit-tests/api/shipping-methods.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Tests for the Shipping Methods REST API.
+ *
+ * @package WooCommerce\Tests\API
+ * @since 2.7.0
+ */
+
+class Shipping_Methods extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Shipping_Methods_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+        $this->assertArrayHasKey( '/wc/v1/shipping_methods', $routes );
+		$this->assertArrayHasKey( '/wc/v1/shipping_methods/(?P<id>[\w-]+)', $routes );
+	}
+
+	/**
+	 * Test getting all shipping methods.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_shipping_methods() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/shipping_methods' ) );
+		$methods = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+        $this->assertContains( array(
+			'id'          => 'free_shipping',
+			'title'       => 'Free Shipping',
+			'description' => 'Free Shipping is a special method which can be triggered with coupons and minimum spends.',
+			'_links' => array(
+				'self'       => array(
+					array(
+						'href' => rest_url( '/wc/v1/shipping_methods/free_shipping' ),
+					),
+				),
+				'collection' => array(
+					array(
+						'href' => rest_url( '/wc/v1/shipping_methods' ),
+					),
+				),
+			),
+		), $methods );
+	}
+
+	/**
+	 * Tests to make sure shipping methods cannot viewed without valid permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_shipping_methods_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/shipping_methods' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Tests getting a single shipping method.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_shipping_method() {
+		wp_set_current_user( $this->user );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/shipping_methods/local_pickup' ) );
+		$method   = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( array(
+            'id'          => 'local_pickup',
+            'title'       => 'Local Pickup',
+            'description' => 'Allow customers to pick up orders themselves. By default, when using local pickup store base taxes will apply regardless of customer address.',
+        ), $method );
+	}
+
+	/**
+	 * Tests getting a single shipping method without the correct permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_shipping_method_without_permission() {
+		wp_set_current_user( 0 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/shipping_methods/local_pickup' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Tests getting a shipping method with an invalid ID.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_shipping_method_invalid_id() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/shipping_methods/fake_method' ) );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test the product review schema.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_shipping_method_schema() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v1/shipping_methods' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 3, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'title', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
+	}
+
+}


### PR DESCRIPTION
This PR adds two new endpoints: `/wc/v1/shipping_methods` and `/wc/v1/shipping_methods/$method`. These endpoints return the method id, title/label, and description, which can be used for the add method dialog/flow.

This PR also adds some more endpoints to the shipping ZONE methods controller. This is where you can create a new instance of a shipping method under a zone. Or delete it. Or update its settings. Basically enabling us to build an interface for attaching methods to zones, managing them, etc. These were missing from the earlier zone controller.

Tests included.
Closes #11607.
