### PR TITLE
bugfix precision problem for free shipping

### DIFF
--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -166,7 +166,8 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				$total = $total - WC()->cart->get_cart_discount_total();
 			}
 
-			if ( $total >= $this->min_amount ) {
+			$epsilon = pow( 10, - wc_get_price_decimals() );
+			if ( abs( $total - $this->min_amount ) < $epsilon || $total > $this->min_amount ) {
 				$has_met_min_amount = true;
 			}
 		}


### PR DESCRIPTION
Precision problem for minimal shipping amount. Sometimes the calculated
value does not match the minimal shipping amount, even it should. The difference is in a deep decimal difference. 
For example:

$total is 2.9999999
and $this->min_amount is 3.0

Then the condition would not lead to free shipping because in this case
$total < $this->min_amount

Maybe rounding would do the same trick? I chose to look at an epsilon to decide if the min_amount was reached.
