### PR TITLE
Fixes reset cache and version assignment for variable product prices

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -265,7 +265,7 @@ class WC_Product_Variable extends WC_Product {
 
 			// If the product version has changed, reset cache
 			if ( empty( $prices_array['version'] ) || $prices_array['version'] !== WC_Cache_Helper::get_transient_version( 'product' ) ) {
-				$this->prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
+				$prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
 			}
 
 			// If the prices are not stored for this hash, generate them

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -265,7 +265,7 @@ class WC_Product_Variable extends WC_Product {
 
 			// If the product version has changed, reset cache
 			if ( empty( $prices_array['version'] ) || $prices_array['version'] !== WC_Cache_Helper::get_transient_version( 'product' ) ) {
-				$prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
+				$this->prices_array = $prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
 			}
 
 			// If the prices are not stored for this hash, generate them


### PR DESCRIPTION
Fixes #11812

$this->array was only used to return to the user. Comparison was done with $prices_array, which did not contain the version information because it was never saved in the transient.
