### PR TITLE
Customer CRUD/API exceptions

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -265,6 +265,16 @@ abstract class WC_Data {
 	}
 
 	/**
+	 * Callback to remove unwanted meta data.
+	 *
+	 * @param object $meta
+	 * @return bool
+	 */
+	protected function exclude_internal_meta_keys( $meta ) {
+		return ! in_array( $meta->meta_key, $this->get_internal_meta_keys() );
+	}
+
+	/**
 	 * Read Meta Data from the database. Ignore any internal properties.
 	 * @since 2.6.0
 	 */
@@ -296,10 +306,8 @@ abstract class WC_Data {
 			", $this->get_id() ) );
 
 			if ( $raw_meta_data ) {
+				$raw_meta_data = array_filter( $raw_meta_data, array( $this, 'exclude_internal_meta_keys' ) );
 				foreach ( $raw_meta_data as $meta ) {
-					if ( in_array( $meta->meta_key, $this->get_internal_meta_keys() ) ) {
-						continue;
-					}
 					$this->_meta_data[] = (object) array(
 						'id'    => (int) $meta->{ $db_info['meta_id_field'] },
 						'key'   => $meta->meta_key,
@@ -390,6 +398,9 @@ abstract class WC_Data {
 
 		foreach ( $props as $prop => $value ) {
 			try {
+				if ( 'meta_data' === $prop ) {
+					continue;
+				}
 				$setter = "set_$prop";
 				if ( ! is_null( $value ) && is_callable( array( $this, $setter ) ) ) {
 					$this->{$setter}( $value );

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -495,6 +495,29 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'meta_data' => array(
+					'description' => __( 'Order meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'Meta ID.', 'woocommerce' ),
+							'type'        => 'int',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'key' => array(
+							'description' => __( 'Meta key.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'value' => array(
+							'description' => __( 'Meta value.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
 			),
 		);
 		return $this->add_additional_fields_schema( $schema );

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -507,7 +507,7 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( $last_order_data = $customer->get_last_order() ) {
 			$data['last_order'] = array(
 				'id'   => $last_order_data->get_id(),
-				'date' => wc_rest_prepare_date_response( $last_order_data->get_date_created() ),
+				'date' => $last_order_data->get_date_created() ? wc_rest_prepare_date_response( $last_order_data->get_date_created() ) : null,
 			);
 		}
 
@@ -535,6 +535,15 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	 */
 	protected function update_customer_meta_fields( $customer, $request ) {
 		$schema = $this->get_item_schema();
+
+		// Meta data
+		if ( isset( $request['meta_data'] ) ) {
+			if ( is_array( $request['meta_data'] ) ) {
+				foreach ( $request['meta_data'] as $meta ) {
+					$coupon->update_meta_data( $meta['key'], $meta['value'], $meta['id'] );
+				}
+			}
+		}
 
 		// Customer first name.
 		if ( isset( $request['first_name'] ) ) {
@@ -796,6 +805,35 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 						),
 						'country' => array(
 							'description' => __( 'ISO code of the country.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'is_paying_customer' => array(
+					'description' => __( 'Is the customer a paying customer?', 'woocommerce' ),
+					'type'        => 'bool',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'meta_data' => array(
+					'description' => __( 'Order meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'Meta ID.', 'woocommerce' ),
+							'type'        => 'int',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'key' => array(
+							'description' => __( 'Meta key.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'value' => array(
+							'description' => __( 'Meta value.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -117,7 +117,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( ! wc_rest_check_user_permissions( 'read' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
-
 		return true;
 	}
 
@@ -131,7 +130,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( ! wc_rest_check_user_permissions( 'create' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
-
 		return true;
 	}
 
@@ -147,7 +145,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( ! wc_rest_check_user_permissions( 'read', $id ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
-
 		return true;
 	}
 
@@ -163,7 +160,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( ! wc_rest_check_user_permissions( 'edit', $id ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you are not allowed to edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
-
 		return true;
 	}
 
@@ -179,7 +175,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( ! wc_rest_check_user_permissions( 'delete', $id ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'Sorry, you are not allowed to delete this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
-
 		return true;
 	}
 
@@ -193,7 +188,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 		if ( ! wc_rest_check_user_permissions( 'batch' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_batch', __( 'Sorry, you are not allowed to batch manipulate this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
-
 		return true;
 	}
 
@@ -301,49 +295,53 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function create_item( $request ) {
-		if ( ! empty( $request['id'] ) ) {
-			return new WP_Error( 'woocommerce_rest_customer_exists', __( 'Cannot create existing resource.', 'woocommerce' ), array( 'status' => 400 ) );
+		try {
+			if ( ! empty( $request['id'] ) ) {
+				throw new WC_REST_Exception( 'woocommerce_rest_customer_exists', __( 'Cannot create existing resource.', 'woocommerce' ), 400 );
+			}
+
+			// Sets the username.
+			$request['username'] = ! empty( $request['username'] ) ? $request['username'] : '';
+
+			// Sets the password.
+			$request['password'] = ! empty( $request['password'] ) ? $request['password'] : '';
+
+			// Create customer.
+			$customer = new WC_Customer;
+			$customer->set_username( $request['username'] );
+			$customer->set_password( $request['password'] );
+			$customer->set_email( $request['email'] );
+			$customer->create();
+
+			if ( ! $customer->get_id() ) {
+				throw new WC_REST_Exception( 'woocommerce_rest_cannot_create', __( 'This resource cannot be created.', 'woocommerce' ), 400 );
+			}
+
+			$this->update_customer_meta_fields( $customer, $request );
+			$customer->save();
+
+			$user_data = get_user_by( 'id', $customer->get_id() );
+			$this->update_additional_fields_for_object( $user_data, $request );
+
+			/**
+			 * Fires after a customer is created or updated via the REST API.
+			 *
+			 * @param WP_User         $user_data Data used to create the customer.
+			 * @param WP_REST_Request $request   Request object.
+			 * @param boolean         $creating  True when creating customer, false when updating customer.
+			 */
+			do_action( 'woocommerce_rest_insert_customer', $user_data, $request, true );
+
+			$request->set_param( 'context', 'edit' );
+			$response = $this->prepare_item_for_response( $user_data, $request );
+			$response = rest_ensure_response( $response );
+			$response->set_status( 201 );
+			$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $customer->get_id() ) ) );
+
+			return $response;
+		} catch ( Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
-
-		// Sets the username.
-		$request['username'] = ! empty( $request['username'] ) ? $request['username'] : '';
-
-		// Sets the password.
-		$request['password'] = ! empty( $request['password'] ) ? $request['password'] : '';
-
-		// Create customer.
-		$customer = new WC_Customer;
-		$customer->set_username( $request['username'] );
-		$customer->set_password( $request['password'] );
-		$customer->set_email( $request['email'] );
-		$customer->create();
-
-		if ( ! $customer->get_id() ) {
-			return new WP_Error( 'woocommerce_rest_cannot_create', __( 'This resource cannot be created.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
-
-		$this->update_customer_meta_fields( $customer, $request );
-		$customer->save();
-
-		$user_data = get_user_by( 'id', $customer->get_id() );
-		$this->update_additional_fields_for_object( $user_data, $request );
-
-		/**
-		 * Fires after a customer is created or updated via the REST API.
-		 *
-		 * @param WP_User         $user_data Data used to create the customer.
-		 * @param WP_REST_Request $request   Request object.
-		 * @param boolean         $creating  True when creating customer, false when updating customer.
-		 */
-		do_action( 'woocommerce_rest_insert_customer', $user_data, $request, true );
-
-		$request->set_param( 'context', 'edit' );
-		$response = $this->prepare_item_for_response( $user_data, $request );
-		$response = rest_ensure_response( $response );
-		$response->set_status( 201 );
-		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $customer->get_id() ) ) );
-
-		return $response;
 	}
 
 	/**
@@ -373,50 +371,54 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		$id       = (int) $request['id'];
-		$customer = new WC_Customer( $id );
+		try {
+			$id       = (int) $request['id'];
+			$customer = new WC_Customer( $id );
 
-		if ( ! $customer->get_id() ) {
-			return new WP_Error( 'woocommerce_rest_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), array( 'status' => 400 ) );
+			if ( ! $customer->get_id() ) {
+				throw new WC_REST_Exception( 'woocommerce_rest_invalid_id', __( 'Invalid resource ID.', 'woocommerce' ), 400 );
+			}
+
+			if ( ! empty( $request['email'] ) && email_exists( $request['email'] ) && $request['email'] !== $customer->get_email() ) {
+				throw new WC_REST_Exception( 'woocommerce_rest_customer_invalid_email', __( 'Email address is invalid.', 'woocommerce' ), 400 );
+			}
+
+			if ( ! empty( $request['username'] ) && $request['username'] !== $customer->get_username() ) {
+				throw new WC_REST_Exception( 'woocommerce_rest_customer_invalid_argument', __( "Username isn't editable.", 'woocommerce' ), 400 );
+			}
+
+			// Customer email.
+			if ( isset( $request['email'] ) ) {
+				$customer->set_email( sanitize_email( $request['email'] ) );
+			}
+
+			// Customer password.
+			if ( isset( $request['password'] ) ) {
+				$customer->set_password( wc_clean( $request['password'] ) );
+			}
+
+			$this->update_customer_meta_fields( $customer, $request );
+			$customer->save();
+
+			$user_data = get_userdata( $customer->get_id() );
+			$this->update_additional_fields_for_object( $user_data, $request );
+
+			/**
+			 * Fires after a customer is created or updated via the REST API.
+			 *
+			 * @param WP_User         $customer  Data used to create the customer.
+			 * @param WP_REST_Request $request   Request object.
+			 * @param boolean         $creating  True when creating customer, false when updating customer.
+			 */
+			do_action( 'woocommerce_rest_insert_customer', $user_data, $request, false );
+
+			$request->set_param( 'context', 'edit' );
+			$response = $this->prepare_item_for_response( $user_data, $request );
+			$response = rest_ensure_response( $response );
+			return $response;
+		} catch ( Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
-
-		if ( ! empty( $request['email'] ) && email_exists( $request['email'] ) && $request['email'] !== $customer->get_email() ) {
-			return new WP_Error( 'woocommerce_rest_customer_invalid_email', __( 'Email address is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
-		}
-
-		if ( ! empty( $request['username'] ) && $request['username'] !== $customer->get_username() ) {
-			return new WP_Error( 'woocommerce_rest_customer_invalid_argument', __( "Username isn't editable.", 'woocommerce' ), array( 'status' => 400 ) );
-		}
-
-		// Customer email.
-		if ( isset( $request['email'] ) ) {
-			$customer->set_email( sanitize_email( $request['email'] ) );
-		}
-
-		// Customer password.
-		if ( isset( $request['password'] ) ) {
-			$customer->set_password( wc_clean( $request['password'] ) );
-		}
-
-		$this->update_customer_meta_fields( $customer, $request );
-		$customer->save();
-
-		$user_data = get_userdata( $customer->get_id() );
-		$this->update_additional_fields_for_object( $user_data, $request );
-
-		/**
-		 * Fires after a customer is created or updated via the REST API.
-		 *
-		 * @param WP_User         $customer  Data used to create the customer.
-		 * @param WP_REST_Request $request   Request object.
-		 * @param boolean         $creating  True when creating customer, false when updating customer.
-		 */
-		do_action( 'woocommerce_rest_insert_customer', $user_data, $request, false );
-
-		$request->set_param( 'context', 'edit' );
-		$response = $this->prepare_item_for_response( $user_data, $request );
-		$response = rest_ensure_response( $response );
-		return $response;
 	}
 
 	/**
@@ -839,7 +841,6 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 	 */
 	protected function get_role_names() {
 		global $wp_roles;
-
 		return array_keys( $wp_roles->role_names );
 	}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -308,82 +308,38 @@ class WC_AJAX {
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
 		WC()->session->set( 'chosen_payment_method', empty( $_POST['payment_method'] ) ? '' : $_POST['payment_method'] );
-
-		if ( isset( $_POST['country'] ) ) {
-			WC()->customer->set_billing_country( $_POST['country'] );
-		}
-
-		if ( isset( $_POST['state'] ) ) {
-			WC()->customer->set_billing_state( $_POST['state'] );
-		}
-
-		if ( isset( $_POST['postcode'] ) ) {
-			WC()->customer->set_billing_postcode( $_POST['postcode'] );
-		}
-
-		if ( isset( $_POST['city'] ) ) {
-			WC()->customer->set_billing_city( $_POST['city'] );
-		}
-
-		if ( isset( $_POST['address'] ) ) {
-			WC()->customer->set_billing_address( $_POST['address'] );
-		}
-
-		if ( isset( $_POST['address_2'] ) ) {
-			WC()->customer->set_billing_address_2( $_POST['address_2'] );
-		}
+		WC()->customer->set_props( array(
+			'billing_country'   => isset( $_POST['country'] ) ? $_POST['country']     : null,
+			'billing_state'     => isset( $_POST['state'] ) ? $_POST['state']         : null,
+			'billing_postcode'  => isset( $_POST['postcode'] ) ? $_POST['postcode']   : null,
+			'billing_city'      => isset( $_POST['city'] ) ? $_POST['city']           : null,
+			'billing_address_1' => isset( $_POST['address'] ) ? $_POST['address']     : null,
+			'billing_address_2' => isset( $_POST['address_2'] ) ? $_POST['address_2'] : null,
+		) );
 
 		if ( wc_ship_to_billing_address_only() ) {
-
+			WC()->customer->set_props( array(
+				'shipping_country'   => isset( $_POST['country'] ) ? $_POST['country']     : null,
+				'shipping_state'     => isset( $_POST['state'] ) ? $_POST['state']         : null,
+				'shipping_postcode'  => isset( $_POST['postcode'] ) ? $_POST['postcode']   : null,
+				'shipping_city'      => isset( $_POST['city'] ) ? $_POST['city']           : null,
+				'shipping_address_1' => isset( $_POST['address'] ) ? $_POST['address']     : null,
+				'shipping_address_2' => isset( $_POST['address_2'] ) ? $_POST['address_2'] : null,
+			) );
 			if ( ! empty( $_POST['country'] ) ) {
-				WC()->customer->set_shipping_country( $_POST['country'] );
 				WC()->customer->set_calculated_shipping( true );
-			}
-
-			if ( isset( $_POST['state'] ) ) {
-				WC()->customer->set_shipping_state( $_POST['state'] );
-			}
-
-			if ( isset( $_POST['postcode'] ) ) {
-				WC()->customer->set_shipping_postcode( $_POST['postcode'] );
-			}
-
-			if ( isset( $_POST['city'] ) ) {
-				WC()->customer->set_shipping_city( $_POST['city'] );
-			}
-
-			if ( isset( $_POST['address'] ) ) {
-				WC()->customer->set_shipping_address( $_POST['address'] );
-			}
-
-			if ( isset( $_POST['address_2'] ) ) {
-				WC()->customer->set_shipping_address_2( $_POST['address_2'] );
 			}
 		} else {
-
+			WC()->customer->set_props( array(
+				'shipping_country'   => isset( $_POST['s_country'] ) ? $_POST['s_country']     : null,
+				'shipping_state'     => isset( $_POST['s_state'] ) ? $_POST['s_state']         : null,
+				'shipping_postcode'  => isset( $_POST['s_postcode'] ) ? $_POST['s_postcode']   : null,
+				'shipping_city'      => isset( $_POST['s_city'] ) ? $_POST['s_city']           : null,
+				'shipping_address_1' => isset( $_POST['s_address'] ) ? $_POST['s_address']     : null,
+				'shipping_address_2' => isset( $_POST['s_address_2'] ) ? $_POST['s_address_2'] : null,
+			) );
 			if ( ! empty( $_POST['s_country'] ) ) {
-				WC()->customer->set_shipping_country( $_POST['s_country'] );
 				WC()->customer->set_calculated_shipping( true );
-			}
-
-			if ( isset( $_POST['s_state'] ) ) {
-				WC()->customer->set_shipping_state( $_POST['s_state'] );
-			}
-
-			if ( isset( $_POST['s_postcode'] ) ) {
-				WC()->customer->set_shipping_postcode( $_POST['s_postcode'] );
-			}
-
-			if ( isset( $_POST['s_city'] ) ) {
-				WC()->customer->set_shipping_city( $_POST['s_city'] );
-			}
-
-			if ( isset( $_POST['s_address'] ) ) {
-				WC()->customer->set_shipping_address( $_POST['s_address'] );
-			}
-
-			if ( isset( $_POST['s_address_2'] ) ) {
-				WC()->customer->set_shipping_address_2( $_POST['s_address_2'] );
 			}
 		}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1562,7 +1562,7 @@ class WC_Cart {
 				return false;
 
 			if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
-				if ( ! WC()->customer->get_calculated_shipping() ) {
+				if ( ! WC()->customer->has_calculated_shipping() ) {
 					if ( ! WC()->customer->get_shipping_country() || ( ! WC()->customer->get_shipping_state() && ! WC()->customer->get_shipping_postcode() ) ) {
 						return false;
 					}

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -1006,24 +1006,6 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
-	 * Set if customer has tax exemption.
-	 * @param bool $is_vat_exempt
-	 * @throws WC_Data_Exception
-	 */
-	public function set_is_vat_exempt( $is_vat_exempt ) {
-		$this->_is_vat_exempt = (bool) $is_vat_exempt;
-	}
-
-	/**
-	 * Calculated shipping?
-	 * @param boolean $calculated
-	 * @throws WC_Data_Exception
-	 */
-	public function set_calculated_shipping( $calculated = true ) {
-		$this->_calculated_shipping = (bool) $calculated;
-	}
-
-	/**
 	 * Set if the user a paying customer.
 	 * @since 2.7.0
 	 * @param boolean $is_paying_customer
@@ -1033,6 +1015,22 @@ class WC_Customer extends WC_Legacy_Customer {
 		$this->_data['is_paying_customer'] = (bool) $is_paying_customer;
 	}
 
+	/**
+	 * Set if customer has tax exemption.
+	 * @param bool $is_vat_exempt
+	 */
+	public function set_is_vat_exempt( $is_vat_exempt ) {
+		$this->_is_vat_exempt = (bool) $is_vat_exempt;
+	}
+
+	/**
+	 * Calculated shipping?
+	 * @param boolean $calculated
+	 */
+	public function set_calculated_shipping( $calculated = true ) {
+		$this->_calculated_shipping = (bool) $calculated;
+	}
+	
 	/*
 	 |--------------------------------------------------------------------------
 	 | CRUD methods

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -618,6 +618,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set customer ID.
 	 * @since 2.7.0
 	 * @param int $value
+	 * @throws WC_Data_Exception
 	 */
 	protected function set_id( $value ) {
 		$this->_data['id'] = absint( $value );
@@ -627,6 +628,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set customer's username.
 	 * @since 2.7.0
 	 * @param string $username
+	 * @throws WC_Data_Exception
 	 */
 	public function set_username( $username ) {
 		$this->_data['username'] = $username;
@@ -635,16 +637,21 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer's email.
 	 * @since 2.7.0
-	 * @param string $email
+	 * @param string $value
+	 * @throws WC_Data_Exception
 	 */
-	public function set_email( $email ) {
-		$this->_data['email'] = sanitize_email( $email );
+	public function set_email( $value ) {
+		if ( $value && ! is_email( $value ) ) {
+			$this->error( 'customer_invalid_email', __( 'Invalid email address', 'woocommerce' ) );
+		}
+		$this->_data['email'] = sanitize_email( $value );
 	}
 
 	/**
 	 * Set customer's first name.
 	 * @since 2.7.0
 	 * @param string $first_name
+	 * @throws WC_Data_Exception
 	 */
 	public function set_first_name( $first_name ) {
 		$this->_data['first_name'] = $first_name;
@@ -654,6 +661,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set customer's last name.
 	 * @since 2.7.0
 	 * @param string $last_name
+	 * @throws WC_Data_Exception
 	 */
 	public function set_last_name( $last_name ) {
 		$this->_data['last_name'] = $last_name;
@@ -663,8 +671,14 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set customer's user role(s).
 	 * @since 2.7.0
 	 * @param mixed $role
+	 * @throws WC_Data_Exception
 	 */
 	public function set_role( $role ) {
+		global $wp_roles;
+
+		if ( $role && ! empty( $wp_roles->roles ) && ! in_array( $role, array_keys( $wp_roles->roles ) ) ) {
+			$this->error( 'customer_invalid_role', __( 'Invalid role', 'woocommerce' ) );
+		}
 		$this->_data['role'] = $role;
 	}
 
@@ -672,6 +686,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set customer's password.
 	 * @since 2.7.0
 	 * @param string $password
+	 * @throws WC_Data_Exception
 	 */
 	public function set_password( $password ) {
 		$this->_data['password'] = wc_clean( $password );
@@ -681,6 +696,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set the date this customer was last updated.
 	 * @since 2.7.0
 	 * @param integer $timestamp
+	 * @throws WC_Data_Exception
 	 */
 	public function set_date_modified( $timestamp ) {
 		$this->_data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
@@ -690,6 +706,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Set the date this customer was last updated.
 	 * @since 2.7.0
 	 * @param integer $timestamp
+	 * @throws WC_Data_Exception
 	 */
 	public function set_date_created( $timestamp ) {
 		$this->_data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
@@ -698,6 +715,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer address to match shop base address.
 	 * @since 2.7.0
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_to_base() {
 		$base = wc_get_customer_default_location();
@@ -710,6 +728,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer shipping address to base address.
 	 * @since 2.7.0
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_to_base() {
 		$base = wc_get_customer_default_location();
@@ -725,6 +744,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $state
 	 * @param string $postcode
 	 * @param string $city
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$this->_data['shipping_country']  = $country;
@@ -739,6 +759,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $state
 	 * @param string $postcode
 	 * @param string $city
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_location( $country, $state, $postcode = '', $city = '' ) {
 		$this->_data['billing_country']  = $country;
@@ -750,6 +771,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set billing first name.
 	 * @return string
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_first_name( $value ) {
 		$this->_data['billing_first_name'] = $value;
@@ -758,6 +780,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set billing last name.
 	 * @return string
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_last_name( $value ) {
 		$this->_data['billing_last_name'] = $value;
@@ -766,6 +789,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set billing company.
 	 * @return string
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_company( $value ) {
 		$this->_data['billing_company'] = $value;
@@ -774,6 +798,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set billing phone.
 	 * @return string
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_phone( $value ) {
 		$this->_data['billing_phone'] = $value;
@@ -781,15 +806,21 @@ class WC_Customer extends WC_Legacy_Customer {
 
 	/**
 	 * Set billing email.
+	 * @param string $value
 	 * @return string
+	 * @throws WC_Data_Exception
 	 */
-	public function set_billing_email( $email ) {
-		$this->_data['billing_email'] = sanitize_email( $email );
+	public function set_billing_email( $value ) {
+		if ( $value && ! is_email( $value ) ) {
+			$this->error( 'customer_invalid_billing_email', __( 'Invalid billing email address', 'woocommerce' ) );
+		}
+		$this->_data['billing_email'] = sanitize_email( $value );
 	}
 
 	/**
 	 * Set customer country.
 	 * @param mixed $country
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_country( $country ) {
 		$this->_data['billing_country'] = $country;
@@ -798,6 +829,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer state.
 	 * @param mixed $state
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_state( $state ) {
 		$this->_data['billing_state'] = $state;
@@ -806,6 +838,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Sets customer postcode.
 	 * @param mixed $postcode
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_postcode( $postcode ) {
 		$this->_data['billing_postcode'] = $postcode;
@@ -814,6 +847,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Sets customer city.
 	 * @param mixed $city
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_city( $city ) {
 		$this->_data['billing_city'] = $city;
@@ -822,6 +856,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer address.
 	 * @param mixed $address
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address( $address ) {
 		$this->_data['billing_address_1'] = $address;
@@ -830,6 +865,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer address.
 	 * @param mixed $address
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_1( $address ) {
 		$this->set_billing_address( $address );
@@ -838,6 +874,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer's second address.
 	 * @param mixed $address
+	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_2( $address ) {
 		$this->_data['billing_address_2'] = $address;
@@ -846,6 +883,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Sets customer shipping first name.
 	 * @param string $first_name
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_first_name( $first_name ) {
 		$this->_data['shipping_first_name'] = $first_name;
@@ -854,6 +892,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Sets customer shipping last name.
 	 * @param string $last_name
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_last_name( $last_name ) {
 		$this->_data['shipping_last_name'] = $last_name;
@@ -862,6 +901,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Sets customer shipping company.
 	 * @param string $company.
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_company( $company ) {
 		$this->_data['shipping_company'] = $company;
@@ -870,6 +910,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set shipping country.
 	 * @param string $country
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_country( $country ) {
 		$this->_data['shipping_country'] = $country;
@@ -878,6 +919,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set shipping state.
 	 * @param string $state
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_state( $state ) {
 		$this->_data['shipping_state'] = $state;
@@ -886,6 +928,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set shipping postcode.
 	 * @param string $postcode
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_postcode( $postcode ) {
 		$this->_data['shipping_postcode'] = $postcode;
@@ -894,6 +937,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Sets shipping city.
 	 * @param string $city
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_city( $city ) {
 		$this->_data['shipping_city'] = $city;
@@ -902,6 +946,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set shipping address.
 	 * @param string $address
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address( $address ) {
 		$this->_data['shipping_address_1'] = $address;
@@ -910,6 +955,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set customer shipping address.
 	 * @param mixed $address
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_1( $address ) {
 		$this->set_shipping_address( $address );
@@ -918,6 +964,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set second shipping address.
 	 * @param string $address
+	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_2( $address ) {
 		$this->_data['shipping_address_2'] = $address;
@@ -926,23 +973,26 @@ class WC_Customer extends WC_Legacy_Customer {
 	/**
 	 * Set if customer has tax exemption.
 	 * @param bool $is_vat_exempt
+	 * @throws WC_Data_Exception
 	 */
 	public function set_is_vat_exempt( $is_vat_exempt ) {
-		$this->_data['is_vat_exempt'] = $is_vat_exempt;
+		$this->_data['is_vat_exempt'] = (bool) $is_vat_exempt;
 	}
 
 	/**
 	 * Calculated shipping?
 	 * @param boolean $calculated
+	 * @throws WC_Data_Exception
 	 */
 	public function set_calculated_shipping( $calculated = true ) {
-		$this->_data['calculated_shipping'] = $calculated;
+		$this->_data['calculated_shipping'] = (bool) $calculated;
 	}
 
 	/**
 	 * Set if the user a paying customer.
 	 * @since 2.7.0
 	 * @param boolean $is_paying_customer
+	 * @throws WC_Data_Exception
 	 */
 	function set_is_paying_customer( $is_paying_customer ) {
 		$this->_data['is_paying_customer'] = (bool) $is_paying_customer;

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -21,38 +21,39 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @var array
 	 */
 	protected $_data = array(
-		'id'                  => 0,
-		'email'               => '',
-		'first_name'          => '',
-		'last_name'           => '',
-		'role'                => 'customer',
-		'username'            => '', // read only on existing users
-		'password'            => '', // write only
-		'date_created'        => '', // read only
-		'date_modified'       => '', // read only
-		'billing_first_name'  => '',
-		'billing_last_name'   => '',
-		'billing_company'     => '',
-		'billing_phone'       => '',
-		'billing_email'       => '',
-		'billing_address_1'   => '',
-		'billing_address_2'   => '',
-		'billing_state'       => '',
-		'billing_postcode'    => '',
-		'billing_city'        => '',
-		'billing_country'     => '',
-		'shipping_first_name'  => '',
-		'shipping_last_name'   => '',
-		'shipping_company'     => '',
-		'shipping_postcode'   => '',
-		'shipping_city'       => '',
-		'shipping_address_1'  => '',
-		'shipping_address_2'  => '',
-		'shipping_state'      => '',
-		'shipping_country'    => '',
-		'is_paying_customer'  => false,
-		'is_vat_exempt'       => false, // session only.
-		'calculated_shipping' => false, // session only
+		'id'                 => 0,
+		'date_created'       => '',
+		'date_modified'      => '',
+		'email'              => '',
+		'first_name'         => '',
+		'last_name'          => '',
+		'role'               => 'customer',
+		'username'           => '',
+		'billing'            => array(
+			'first_name'     => '',
+			'last_name'      => '',
+			'company'        => '',
+			'address_1'      => '',
+			'address_2'      => '',
+			'city'           => '',
+			'state'          => '',
+			'postcode'       => '',
+			'country'        => '',
+			'email'          => '',
+			'phone'          => '',
+		),
+		'shipping'           => array(
+			'first_name'     => '',
+			'last_name'      => '',
+			'company'        => '',
+			'address_1'      => '',
+			'address_2'      => '',
+			'city'           => '',
+			'state'          => '',
+			'postcode'       => '',
+			'country'        => '',
+		),
+		'is_paying_customer' => false,
 	);
 
 	/**
@@ -100,6 +101,24 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @var boolean
 	 */
 	protected $_is_session = false;
+
+	/**
+	 * Stores a password if this needs to be changed. Write-only and hidden from _data.
+	 * @var string
+	 */
+	protected $_password = '';
+
+	/**
+	 * Stores if user is VAT exempt for this session.
+	 * @var string
+	 */
+	protected $_is_vat_exempt = false;
+
+	/**
+	 * Stores if user has calculated shipping in this session.
+	 * @var string
+	 */
+	protected $_calculated_shipping = false;
 
 	/**
 	 * Load customer data based on how WC_Customer is called.
@@ -262,6 +281,22 @@ class WC_Customer extends WC_Legacy_Customer {
 		return false;
 	}
 
+	/**
+	 * Is customer VAT exempt?
+	 * @return bool
+	 */
+	public function is_vat_exempt() {
+		return $this->get_is_vat_exempt();
+	}
+
+	/**
+	 * Has calculated shipping?
+	 * @return bool
+	 */
+	public function has_calculated_shipping() {
+		return $this->get_calculated_shipping();
+	}
+
 	/*
 	 |--------------------------------------------------------------------------
 	 | Getters
@@ -364,7 +399,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_first_name() {
-		return $this->_data['billing_first_name'];
+		return $this->_data['billing']['first_name'];
 	}
 
 	/**
@@ -372,7 +407,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_last_name() {
-		return $this->_data['billing_last_name'];
+		return $this->_data['billing']['last_name'];
 	}
 
 	/**
@@ -380,7 +415,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_company() {
-		return $this->_data['billing_company'];
+		return $this->_data['billing']['company'];
 	}
 
 	/**
@@ -388,7 +423,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_phone() {
-		return $this->_data['billing_phone'];
+		return $this->_data['billing']['phone'];
 	}
 
 	/**
@@ -396,7 +431,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_email() {
-		return $this->_data['billing_email'];
+		return $this->_data['billing']['email'];
 	}
 
 	/**
@@ -404,7 +439,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_postcode() {
-		return wc_format_postcode( $this->_data['billing_postcode'], $this->get_billing_country() );
+		return wc_format_postcode( $this->_data['billing']['postcode'], $this->get_billing_country() );
 	}
 
 	/**
@@ -412,7 +447,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_city() {
-		return $this->_data['billing_city'];
+		return $this->_data['billing']['city'];
 	}
 
 	/**
@@ -420,7 +455,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_address() {
-		return $this->_data['billing_address_1'];
+		return $this->_data['billing']['address_1'];
 	}
 
 	/**
@@ -436,7 +471,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_address_2() {
-		return $this->_data['billing_address_2'];
+		return $this->_data['billing']['address_2'];
 	}
 
 	/**
@@ -444,7 +479,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_state() {
-		return $this->_data['billing_state'];
+		return $this->_data['billing']['state'];
 	}
 
 	/**
@@ -452,7 +487,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_country() {
-		return $this->_data['billing_country'];
+		return $this->_data['billing']['country'];
 	}
 
 	/**
@@ -460,7 +495,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_first_name() {
-		return $this->_data['shipping_first_name'];
+		return $this->_data['shipping']['first_name'];
 	}
 
 	/**
@@ -468,7 +503,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_last_name() {
-		return $this->_data['shipping_last_name'];
+		return $this->_data['shipping']['last_name'];
 	}
 
 	/**
@@ -476,7 +511,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_company() {
-		return $this->_data['shipping_company'];
+		return $this->_data['shipping']['company'];
 	}
 
 	/**
@@ -484,7 +519,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_state() {
-		return $this->_data['shipping_state'];
+		return $this->_data['shipping']['state'];
 	}
 
 	/**
@@ -492,7 +527,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_country() {
-		return $this->_data['shipping_country'];
+		return $this->_data['shipping']['country'];
 	}
 
 	/**
@@ -500,7 +535,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_postcode() {
-		return wc_format_postcode( $this->_data['shipping_postcode'], $this->get_shipping_country() );
+		return wc_format_postcode( $this->_data['shipping']['postcode'], $this->get_shipping_country() );
 	}
 
 	/**
@@ -508,7 +543,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_city() {
-		return $this->_data['shipping_city'];
+		return $this->_data['shipping']['city'];
 	}
 
 	/**
@@ -516,7 +551,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_address() {
-		return $this->_data['shipping_address_1'];
+		return $this->_data['shipping']['address_1'];
 	}
 
 	/**
@@ -532,7 +567,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_address_2() {
-		return $this->_data['shipping_address_2'];
+		return $this->_data['shipping']['address_2'];
 	}
 
 	/**
@@ -541,7 +576,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return bool
 	 */
 	public function get_is_vat_exempt() {
-		return ( ! empty( $this->_data['is_vat_exempt'] ) ) ? true : false;
+		return $this->_is_vat_exempt;
 	}
 
 	/**
@@ -549,7 +584,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return bool
 	 */
 	public function get_calculated_shipping() {
-		return ! empty( $this->_data['calculated_shipping'] );
+		return $this->_calculated_shipping;
 	}
 
 	/**
@@ -689,7 +724,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_password( $password ) {
-		$this->_data['password'] = wc_clean( $password );
+		$this->_password = wc_clean( $password );
 	}
 
 	/**
@@ -719,10 +754,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_billing_address_to_base() {
 		$base = wc_get_customer_default_location();
-		$this->_data['billing_country']  = $base['country'];
-		$this->_data['billing_state']    = $base['state'];
-		$this->_data['billing_postcode'] = '';
-		$this->_data['billing_city']     = '';
+		$this->_data['billing']['country']  = $base['country'];
+		$this->_data['billing']['state']    = $base['state'];
+		$this->_data['billing']['postcode'] = '';
+		$this->_data['billing']['city']     = '';
 	}
 
 	/**
@@ -732,10 +767,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_shipping_address_to_base() {
 		$base = wc_get_customer_default_location();
-		$this->_data['shipping_country']  = $base['country'];
-		$this->_data['shipping_state']    = $base['state'];
-		$this->_data['shipping_postcode'] = '';
-		$this->_data['shipping_city']     = '';
+		$this->_data['shipping']['country']  = $base['country'];
+		$this->_data['shipping']['state']    = $base['state'];
+		$this->_data['shipping']['postcode'] = '';
+		$this->_data['shipping']['city']     = '';
 	}
 
 	/**
@@ -747,10 +782,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
-		$this->_data['shipping_country']  = $country;
-		$this->_data['shipping_state']    = $state;
-		$this->_data['shipping_postcode'] = $postcode;
-		$this->_data['shipping_city']     = $city;
+		$this->_data['shipping']['country']  = $country;
+		$this->_data['shipping']['state']    = $state;
+		$this->_data['shipping']['postcode'] = $postcode;
+		$this->_data['shipping']['city']     = $city;
 	}
 
 	/**
@@ -762,10 +797,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_location( $country, $state, $postcode = '', $city = '' ) {
-		$this->_data['billing_country']  = $country;
-		$this->_data['billing_state']    = $state;
-		$this->_data['billing_postcode'] = $postcode;
-		$this->_data['billing_city']     = $city;
+		$this->_data['billing']['country']  = $country;
+		$this->_data['billing']['state']    = $state;
+		$this->_data['billing']['postcode'] = $postcode;
+		$this->_data['billing']['city']     = $city;
 	}
 
 	/**
@@ -774,7 +809,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_first_name( $value ) {
-		$this->_data['billing_first_name'] = $value;
+		$this->_data['billing']['first_name'] = $value;
 	}
 
 	/**
@@ -783,7 +818,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_last_name( $value ) {
-		$this->_data['billing_last_name'] = $value;
+		$this->_data['billing']['last_name'] = $value;
 	}
 
 	/**
@@ -792,7 +827,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_company( $value ) {
-		$this->_data['billing_company'] = $value;
+		$this->_data['billing']['company'] = $value;
 	}
 
 	/**
@@ -801,7 +836,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_phone( $value ) {
-		$this->_data['billing_phone'] = $value;
+		$this->_data['billing']['phone'] = $value;
 	}
 
 	/**
@@ -814,7 +849,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		if ( $value && ! is_email( $value ) ) {
 			$this->error( 'customer_invalid_billing_email', __( 'Invalid billing email address', 'woocommerce' ) );
 		}
-		$this->_data['billing_email'] = sanitize_email( $value );
+		$this->_data['billing']['email'] = sanitize_email( $value );
 	}
 
 	/**
@@ -823,7 +858,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_country( $country ) {
-		$this->_data['billing_country'] = $country;
+		$this->_data['billing']['country'] = $country;
 	}
 
 	/**
@@ -832,7 +867,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_state( $state ) {
-		$this->_data['billing_state'] = $state;
+		$this->_data['billing']['state'] = $state;
 	}
 
 	/**
@@ -841,7 +876,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_postcode( $postcode ) {
-		$this->_data['billing_postcode'] = $postcode;
+		$this->_data['billing']['postcode'] = $postcode;
 	}
 
 	/**
@@ -850,7 +885,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_city( $city ) {
-		$this->_data['billing_city'] = $city;
+		$this->_data['billing']['city'] = $city;
 	}
 
 	/**
@@ -859,7 +894,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address( $address ) {
-		$this->_data['billing_address_1'] = $address;
+		$this->_data['billing']['address_1'] = $address;
 	}
 
 	/**
@@ -877,7 +912,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_2( $address ) {
-		$this->_data['billing_address_2'] = $address;
+		$this->_data['billing']['address_2'] = $address;
 	}
 
 	/**
@@ -886,7 +921,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_first_name( $first_name ) {
-		$this->_data['shipping_first_name'] = $first_name;
+		$this->_data['shipping']['first_name'] = $first_name;
 	}
 
 	/**
@@ -895,7 +930,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_last_name( $last_name ) {
-		$this->_data['shipping_last_name'] = $last_name;
+		$this->_data['shipping']['last_name'] = $last_name;
 	}
 
 	/**
@@ -904,7 +939,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_company( $company ) {
-		$this->_data['shipping_company'] = $company;
+		$this->_data['shipping']['company'] = $company;
 	}
 
 	/**
@@ -913,7 +948,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_country( $country ) {
-		$this->_data['shipping_country'] = $country;
+		$this->_data['shipping']['country'] = $country;
 	}
 
 	/**
@@ -922,7 +957,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_state( $state ) {
-		$this->_data['shipping_state'] = $state;
+		$this->_data['shipping']['state'] = $state;
 	}
 
 	/**
@@ -931,7 +966,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_postcode( $postcode ) {
-		$this->_data['shipping_postcode'] = $postcode;
+		$this->_data['shipping']['postcode'] = $postcode;
 	}
 
 	/**
@@ -940,7 +975,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_city( $city ) {
-		$this->_data['shipping_city'] = $city;
+		$this->_data['shipping']['city'] = $city;
 	}
 
 	/**
@@ -949,7 +984,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address( $address ) {
-		$this->_data['shipping_address_1'] = $address;
+		$this->_data['shipping']['address_1'] = $address;
 	}
 
 	/**
@@ -967,7 +1002,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_2( $address ) {
-		$this->_data['shipping_address_2'] = $address;
+		$this->_data['shipping']['address_2'] = $address;
 	}
 
 	/**
@@ -976,7 +1011,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_is_vat_exempt( $is_vat_exempt ) {
-		$this->_data['is_vat_exempt'] = (bool) $is_vat_exempt;
+		$this->_is_vat_exempt = (bool) $is_vat_exempt;
 	}
 
 	/**
@@ -985,7 +1020,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_calculated_shipping( $calculated = true ) {
-		$this->_data['calculated_shipping'] = (bool) $calculated;
+		$this->_calculated_shipping = (bool) $calculated;
 	}
 
 	/**
@@ -1013,7 +1048,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	  * @since 2.7.0.
 	  */
 	public function create() {
-		$customer_id = wc_create_new_customer( $this->get_email(), $this->get_username(), $this->_data['password'] );
+		$customer_id = wc_create_new_customer( $this->get_email(), $this->get_username(), $this->_password );
 
 		if ( ! is_wp_error( $customer_id ) ) {
 			$this->_data['id'] = $customer_id;
@@ -1089,8 +1124,6 @@ class WC_Customer extends WC_Legacy_Customer {
 			'role'               => ! empty ( $user_object->roles[0] ) ? $user_object->roles[0] : 'customer',
 		) );
 		$this->read_meta_data();
-
-		unset( $this->_data['password'] ); // password is write only, never ever read it
 	}
 
 	/**
@@ -1102,9 +1135,9 @@ class WC_Customer extends WC_Legacy_Customer {
 
 		wp_update_user( array( 'ID' => $customer_ID, 'user_email' => $this->get_email() ) );
 		// Only update password if a new one was set with set_password
-		if ( isset( $this->_data['password'] ) ) {
-			wp_update_user( array( 'ID' => $customer_ID, 'user_pass' => $this->_data['password'] ) );
-			unset( $this->_data['password'] );
+		if ( ! empty( $this->_password ) ) {
+			wp_update_user( array( 'ID' => $customer_ID, 'user_pass' => $this->_password ) );
+			$this->_password = '';
 		}
 
 		update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -91,12 +91,6 @@ class WC_Customer extends WC_Legacy_Customer {
 	protected $_meta_type = 'user';
 
 	/**
-	 * Was data changed in the database for this class?
-	 * @var boolean
-	 */
-	protected $_changed = false;
-
-	/**
 	 * If this is the customer session, this is true. When true, guest accounts will not be saved to the DB.
 	 * @var boolean
 	 */
@@ -136,17 +130,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		if ( $is_session ) {
 			$this->_is_session = true;
 			$this->load_session();
-			add_action( 'shutdown', array( $this, 'save_session_if_changed' ), 10 );
-		}
-	}
-
-	/**
-	 * Saves customer information to the current session if any data changed.
-	 * @since 2.7.0
-	 */
-	public function save_session_if_changed() {
-		if ( $this->_changed ) {
-			$this->save_to_session();
+			add_action( 'shutdown', array( $this, 'save_to_session' ), 10 );
 		}
 	}
 
@@ -1030,7 +1014,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_calculated_shipping( $calculated = true ) {
 		$this->_calculated_shipping = (bool) $calculated;
 	}
-	
+
 	/*
 	 |--------------------------------------------------------------------------
 	 | CRUD methods
@@ -1201,7 +1185,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function save() {
 		if ( $this->_is_session ) {
-			$this->save_session_if_changed();
+			$this->save_to_session();
 		} elseif ( ! $this->get_id() ) {
 			$this->create();
 		} else {
@@ -1222,7 +1206,9 @@ class WC_Customer extends WC_Legacy_Customer {
 			}
 			$data[ $session_key ] = $this->{"get_$function_key"}();
 		}
-		WC()->session->set( 'customer', $data );
+		if ( $data !== WC()->session->get( 'customer' ) ) {
+			WC()->session->set( 'customer', $data );
+		}
 	}
 
 }

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -292,20 +292,12 @@ class WC_Form_Handler {
 
 				do_action( 'woocommerce_before_pay_action', $order );
 
-				// Set customer location to order location
-				if ( $order->get_billing_country() ) {
-					WC()->customer->set_country( $order->get_billing_country() );
-				}
-				if ( $order->get_billing_state() ) {
-					WC()->customer->set_state( $order->get_billing_state() );
-				}
-				if ( $order->get_billing_postcode() ) {
-					WC()->customer->set_postcode( $order->get_billing_postcode() );
-				}
-				if ( $order->get_billing_city() ) {
-					WC()->customer->set_city( $order->get_billing_city() );
-				}
-
+				WC()->customer->set_props( array(
+					'country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
+					'state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
+					'postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
+					'city'     => $order->get_billing_city() ? $order->get_billing_city()         : null,
+				) );
 				WC()->customer->save();
 
 				// Terms

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -293,10 +293,10 @@ class WC_Form_Handler {
 				do_action( 'woocommerce_before_pay_action', $order );
 
 				WC()->customer->set_props( array(
-					'country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
-					'state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
-					'postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
-					'city'     => $order->get_billing_city() ? $order->get_billing_city()         : null,
+					'billing_country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
+					'billing_state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
+					'billing_postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
+					'billing_city'     => $order->get_billing_city() ? $order->get_billing_city()         : null,
 				) );
 				WC()->customer->save();
 

--- a/includes/legacy/class-wc-legacy-customer.php
+++ b/includes/legacy/class-wc-legacy-customer.php
@@ -20,7 +20,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	 */
 	public function __isset( $key ) {
 		$legacy_keys = array(
-			'country', 'state', 'postcode' ,'city', 'address_1', 'address', 'address_2', 'shipping_country', 'shipping_state',
+			'id', 'country', 'state', 'postcode' ,'city', 'address_1', 'address', 'address_2', 'shipping_country', 'shipping_state',
 			'shipping_postcode', 'shipping_city', 'shipping_address_1', 'shipping_address', 'shipping_address_2', 'is_vat_exempt', 'calculated_shipping',
 		);
 		$key = $this->filter_legacy_key( $key );
@@ -39,7 +39,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 		if ( in_array( $key, array( 'country', 'state', 'postcode' ,'city', 'address_1', 'address', 'address_2' ) ) ) {
 			$key = 'billing_' . $key;
 		}
-		return is_callable( $this, "get_{$key}" ) ? $this->{"get_{$key}"}() : '';
+		return is_callable( array( $this, "get_{$key}" ) ) ? $this->{"get_{$key}"}() : '';
 	}
 
 	/**
@@ -52,7 +52,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 		_doing_it_wrong( $key, 'Customer properties should not be set directly.', '2.7' );
 		$key = $this->filter_legacy_key( $key );
 
-		if ( is_callable( $this, "set_{$key}" ) ) {
+		if ( is_callable( array( $this, "set_{$key}" ) ) ) {
 			$this->{"set_{$key}"}( $value );
 		}
 	}

--- a/includes/legacy/class-wc-legacy-customer.php
+++ b/includes/legacy/class-wc-legacy-customer.php
@@ -39,7 +39,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 		if ( in_array( $key, array( 'country', 'state', 'postcode' ,'city', 'address_1', 'address', 'address_2' ) ) ) {
 			$key = 'billing_' . $key;
 		}
-		return isset( $this->_data[ $key ] ) ? $this->_data[ $key ] : '';
+		return is_callable( $this, "get_{$key}" ) ? $this->{"get_{$key}"}() : '';
 	}
 
 	/**
@@ -51,8 +51,10 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	public function __set( $key, $value ) {
 		_doing_it_wrong( $key, 'Customer properties should not be set directly.', '2.7' );
 		$key = $this->filter_legacy_key( $key );
-		$this->_data[ $key ] = $value;
-		$this->_changed = true;
+
+		if ( is_callable( $this, "set_{$key}" ) ) {
+			$this->{"set_{$key}"}( $value );
+		}
 	}
 
 	/**
@@ -70,6 +72,19 @@ abstract class WC_Legacy_Customer extends WC_Data {
 			$key = 'shipping_address_1';
 		}
 		return $key;
+	}
+
+	/**
+	 * Sets session data for the location.
+	 *
+	 * @param string $country
+	 * @param string $state
+	 * @param string $postcode (default: '')
+	 * @param string $city (default: '')
+	 */
+	public function set_location( $country, $state, $postcode = '', $city = '' ) {
+		$this->set_billing_location( $country, $state, $postcode, $city );
+		$this->set_shipping_location( $country, $state, $postcode, $city );
 	}
 
 	/**

--- a/includes/legacy/class-wc-legacy-customer.php
+++ b/includes/legacy/class-wc-legacy-customer.php
@@ -69,8 +69,6 @@ abstract class WC_Legacy_Customer extends WC_Data {
 		if ( 'shipping_address' === $key ) {
 			$key = 'shipping_address_1';
 		}
-
-
 		return $key;
 	}
 

--- a/includes/legacy/class-wc-legacy-customer.php
+++ b/includes/legacy/class-wc-legacy-customer.php
@@ -75,24 +75,6 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	}
 
 	/**
-	 * Is customer VAT exempt?
-	 * @return bool
-	 */
-	public function is_vat_exempt() {
-		_deprecated_function( 'WC_Customer::is_vat_exempt', '2.7', 'WC_Customer::get_is_vat_exempt' );
-		return $this->get_is_vat_exempt();
-	}
-
-	/**
-	 * Has calculated shipping?
-	 * @return bool
-	 */
-	public function has_calculated_shipping() {
-		_deprecated_function( 'WC_Customer::has_calculated_shipping', '2.7', 'WC_Customer::get_calculated_shipping' );
-		return $this->get_calculated_shipping();
-	}
-
-	/**
 	 * Get default country for a customer.
 	 * @return string
 	 */

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -93,18 +93,11 @@ class WC_Shortcode_Checkout {
 			if ( $order->get_id() == $order_id && $order->get_order_key() == $order_key ) {
 
 				if ( $order->needs_payment() ) {
-
-					// Set customer location to order location
-					if ( $order->get_billing_country() ) {
-						WC()->customer->set_country( $order->get_billing_country() );
-					}
-					if ( $order->get_billing_state() ) {
-						WC()->customer->set_state( $order->get_billing_state() );
-					}
-					if ( $order->get_billing_postcode() ) {
-						WC()->customer->set_postcode( $order->get_billing_postcode() );
-					}
-
+					WC()->customer->set_props( array(
+						'country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
+						'state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
+						'postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
+					) );
 					WC()->customer->save();
 
 					$available_gateways = WC()->payment_gateways->get_available_payment_gateways();

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -94,9 +94,9 @@ class WC_Shortcode_Checkout {
 
 				if ( $order->needs_payment() ) {
 					WC()->customer->set_props( array(
-						'country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
-						'state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
-						'postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
+						'billing_country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
+						'billing_state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
+						'billing_postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
 					) );
 					WC()->customer->save();
 

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -304,7 +304,7 @@ function wc_cart_totals_order_total_html() {
 
 		if ( ! empty( $tax_string_array ) ) {
 			$taxable_address = WC()->customer->get_taxable_address();
-			$estimated_text  = WC()->customer->is_customer_outside_base() && ! WC()->customer->get_calculated_shipping()
+			$estimated_text  = WC()->customer->is_customer_outside_base() && ! WC()->customer->has_calculated_shipping()
 				? sprintf( ' ' . __( 'estimated for %s', 'woocommerce' ), WC()->countries->estimated_for_prefix( $taxable_address[0] ) . WC()->countries->countries[ $taxable_address[0] ] )
 				: '';
 			$value .= '<small class="includes_tax">' . sprintf( __( '(includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) . $estimated_text ) . '</small>';

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				printf( '%3$s <input type="hidden" name="shipping_method[%1$d]" data-index="%1$d" id="shipping_method_%1$d" value="%2$s" class="shipping_method" />', $index, esc_attr( $method->id ), wc_cart_totals_shipping_method_label( $method ) );
 				do_action( 'woocommerce_after_shipping_rate', $method, $index );
 			?>
-		<?php elseif ( ! WC()->customer->get_calculated_shipping() ) : ?>
+		<?php elseif ( ! WC()->customer->has_calculated_shipping() ) : ?>
 			<?php echo wpautop( __( 'Shipping costs will be calculated once you have provided your address.', 'woocommerce' ) ); ?>
 		<?php else : ?>
 			<?php echo apply_filters( is_cart() ? 'woocommerce_cart_no_shipping_available_html' : 'woocommerce_no_shipping_available_html', wpautop( __( 'There are no shipping methods available. Please double check your address, or contact us if you need any help.', 'woocommerce' ) ) ); ?>

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div class="cart_totals <?php if ( WC()->customer->get_calculated_shipping() ) echo 'calculated_shipping'; ?>">
+<div class="cart_totals <?php if ( WC()->customer->has_calculated_shipping() ) echo 'calculated_shipping'; ?>">
 
 	<?php do_action( 'woocommerce_before_cart_totals' ); ?>
 
@@ -67,7 +67,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php if ( wc_tax_enabled() && 'excl' === WC()->cart->tax_display_cart ) :
 			$taxable_address = WC()->customer->get_taxable_address();
-			$estimated_text  = WC()->customer->is_customer_outside_base() && ! WC()->customer->get_calculated_shipping()
+			$estimated_text  = WC()->customer->is_customer_outside_base() && ! WC()->customer->has_calculated_shipping()
 					? sprintf( ' <small>(' . __( 'estimated for %s', 'woocommerce' ) . ')</small>', WC()->countries->estimated_for_prefix( $taxable_address[0] ) . WC()->countries->countries[ $taxable_address[0] ] )
 					: '';
 

--- a/tests/framework/helpers/class-wc-helper-customer.php
+++ b/tests/framework/helpers/class-wc-helper-customer.php
@@ -60,7 +60,7 @@ class WC_Helper_Customer {
 		$customer->set_username( $username );
 		$customer->set_password( $password );
 		$customer->set_email( $email );
-		$customer->create();
+		$customer->save();
 		return $customer;
 	}
 

--- a/tests/unit-tests/api/coupons.php
+++ b/tests/unit-tests/api/coupons.php
@@ -406,7 +406,7 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 23, count( $properties ) );
+		$this->assertEquals( 24, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'code', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );

--- a/tests/unit-tests/api/customers.php
+++ b/tests/unit-tests/api/customers.php
@@ -18,8 +18,8 @@ class Customers extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Test route registration.
-     *
-     * @since 2.7.0
+	 *
+	 * @since 2.7.0
 	 */
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
@@ -29,88 +29,90 @@ class Customers extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( '/wc/v1/customers/batch', $routes );
 	}
 
-    /**
-     * Test getting customers.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_customers() {
-	    wp_set_current_user( 1 );
+	/**
+	 * Test getting customers.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_customers() {
+		wp_set_current_user( 1 );
 
-	    $customer_1 = WC_Helper_Customer::create_customer();
-	    WC_Helper_Customer::create_customer( 'test2', 'test2', 'test2@woo.local' );
+		$customer_1 = WC_Helper_Customer::create_customer();
+		WC_Helper_Customer::create_customer( 'test2', 'test2', 'test2@woo.local' );
 
-	    $request = new WP_REST_Request( 'GET', '/wc/v1/customers' );
-	    $request->set_query_params( array(
+		$request = new WP_REST_Request( 'GET', '/wc/v1/customers' );
+		$request->set_query_params( array(
 			'orderby' => 'id',
 		) );
-	    $response  = $this->server->dispatch( $request );
-	    $customers = $response->get_data();
+		$response  = $this->server->dispatch( $request );
+		$customers = $response->get_data();
 
-	    $this->assertEquals( 200, $response->get_status() );
-	    $this->assertEquals( 2, count( $customers ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $customers ) );
 
-	    $this->assertContains( array(
-	        'id'            => $customer_1->get_id(),
-	        'date_created'  => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer_1->get_date_created() ) ),
-	        'date_modified' => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer_1->get_date_modified() ) ),
-	        'email'         => 'test@woo.local',
-	        'first_name'    => 'Justin',
-	        'last_name'     => '',
-	        'username'      => 'testcustomer',
-	        'last_order'    => null,
-	        'orders_count'  => 0,
-	        'total_spent'   => '0.00',
-	        'avatar_url'    => $customer_1->get_avatar_url(),
-	        'billing' => array(
-	            'first_name' => '',
-	            'last_name'  => '',
-	            'company'    => '',
-	            'address_1'  => '123 South Street',
-	            'address_2'  => 'Apt 1',
-	            'city'       => 'Philadelphia',
-	            'state'      => 'PA',
-	            'postcode'   => '19123',
-	            'country'    => 'US',
-	            'email'      => '',
-	            'phone'      => '',
-	        ),
-	        'shipping' => array(
-	            'first_name' => '',
-	            'last_name'  => '',
-	            'company'    => '',
-	            'address_1'  => '123 South Street',
-	            'address_2'  => 'Apt 1',
-	            'city'       => 'Philadelphia',
-	            'state'      => 'PA',
-	            'postcode'   => '19123',
-	            'country'    => 'US',
-	        ),
-	        '_links' => array(
-	            'self'       => array(
-	                array(
-	                    'href' => rest_url( '/wc/v1/customers/' . $customer_1->get_id() . '' ),
-	                ),
-	            ),
-	            'collection' => array(
-	                array(
-	                    'href' => rest_url( '/wc/v1/customers' ),
-	                ),
-	            ),
-	        ),
-	    ), $customers );
-    }
+		$this->assertContains( array(
+			'id'            => $customer_1->get_id(),
+			'date_created'  => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer_1->get_date_created() ) ),
+			'date_modified' => wc_rest_prepare_date_response( date( 'Y-m-d H:i:s', $customer_1->get_date_modified() ) ),
+			'email'         => 'test@woo.local',
+			'first_name'    => 'Justin',
+			'last_name'     => '',
+			'username'      => 'testcustomer',
+			'billing' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '123 South Street',
+				'address_2'  => 'Apt 1',
+				'city'       => 'Philadelphia',
+				'state'      => 'PA',
+				'postcode'   => '19123',
+				'country'    => 'US',
+				'email'      => '',
+				'phone'      => '',
+			),
+			'shipping' => array(
+				'first_name' => '',
+				'last_name'  => '',
+				'company'    => '',
+				'address_1'  => '123 South Street',
+				'address_2'  => 'Apt 1',
+				'city'       => 'Philadelphia',
+				'state'      => 'PA',
+				'postcode'   => '19123',
+				'country'    => 'US',
+			),
+			'is_paying_customer' => false,
+			'last_order'    => null,
+			'orders_count'  => 0,
+			'total_spent'   => '0.00',
+			'avatar_url'    => $customer_1->get_avatar_url(),
+			'meta_data' => array(),
+			'_links' => array(
+				'self'       => array(
+					array(
+						'href' => rest_url( '/wc/v1/customers/' . $customer_1->get_id() . '' ),
+					),
+				),
+				'collection' => array(
+					array(
+						'href' => rest_url( '/wc/v1/customers' ),
+					),
+				),
+			),
+		), $customers );
+	}
 
-    /**
-     * Test getting customers without valid permissions.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_customers_without_permission() {
+	/**
+	 * Test getting customers without valid permissions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_customers_without_permission() {
 		wp_set_current_user( 0 );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/customers' ) );
 		$this->assertEquals( 401, $response->get_status() );
-    }
+	}
 
 	/**
 	 * Test creating a new customer.
@@ -139,10 +141,6 @@ class Customers extends WC_REST_Unit_Test_Case {
 			'first_name'    => '',
 			'last_name'     => '',
 			'username'      => 'create_customer_test',
-			'last_order'    => null,
-			'orders_count'  => 0,
-			'total_spent'   => '0',
-			'avatar_url'    => $data['avatar_url'],
 			'billing' => array(
 				'first_name' => '',
 				'last_name'  => '',
@@ -167,12 +165,18 @@ class Customers extends WC_REST_Unit_Test_Case {
 				'postcode'   => '',
 				'country'    => '',
 			),
+			'is_paying_customer' => false,
+			'meta_data' => array(),
+			'last_order'    => null,
+			'orders_count'  => 0,
+			'total_spent'   => '0.00',
+			'avatar_url'    => $data['avatar_url'],
 		), $data );
 
 		// Test extra data
 		$request = new WP_REST_Request( 'POST', '/wc/v1/customers' );
 		$request->set_body_params( array(
-		    'username' => 'create_customer_test2',
+			'username' => 'create_customer_test2',
 			'password' => 'test123',
 			'email'    => 'create_customer_test2@woo.local',
 			'first_name' => 'Test',
@@ -198,10 +202,6 @@ class Customers extends WC_REST_Unit_Test_Case {
 			'first_name'    => 'Test',
 			'last_name'     => 'McTestFace',
 			'username'      => 'create_customer_test2',
-			'last_order'    => null,
-			'orders_count'  => 0,
-			'total_spent'   => '0',
-			'avatar_url'    => $data['avatar_url'],
 			'billing' => array(
 				'first_name' => '',
 				'last_name'  => '',
@@ -226,6 +226,12 @@ class Customers extends WC_REST_Unit_Test_Case {
 				'postcode'   => '',
 				'country'    => 'US',
 			),
+			'is_paying_customer' => false,
+			'meta_data' => array(),
+			'last_order'    => null,
+			'orders_count'  => 0,
+			'total_spent'   => '0.00',
+			'avatar_url'    => $data['avatar_url'],
 		), $data );
 
 		// Test without required field
@@ -275,12 +281,6 @@ class Customers extends WC_REST_Unit_Test_Case {
 			'date_modified' => $data['date_modified'],
 			'email'         => 'get_customer_test@woo.local',
 			'first_name'    => 'Justin',
-			'last_name'     => '',
-			'username'      => 'get_customer_test',
-			'last_order'    => null,
-			'orders_count'  => 0,
-			'total_spent'   => '0.00',
-			'avatar_url'    => $data['avatar_url'],
 			'billing' => array(
 				'first_name' => '',
 				'last_name'  => '',
@@ -305,6 +305,14 @@ class Customers extends WC_REST_Unit_Test_Case {
 				'postcode'   => '19123',
 				'country'    => 'US',
 			),
+			'is_paying_customer' => false,
+			'meta_data' => array(),
+			'last_name'     => '',
+			'username'      => 'get_customer_test',
+			'last_order'    => null,
+			'orders_count'  => 0,
+			'total_spent'   => '0.00',
+			'avatar_url'    => $data['avatar_url'],
 		), $data );
 	}
 
@@ -483,7 +491,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 14, count( $properties ) );
+		$this->assertEquals( 16, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'date_modified', $properties );

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -110,8 +110,6 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests backwards compat / legacy handling.
-	 * @expectedDeprecated WC_Customer::is_vat_exempt
-	 * @expectedDeprecated WC_Customer::has_calculated_shipping
 	 * @expectedDeprecated WC_Customer::get_default_country
 	 * @expectedDeprecated WC_Customer::get_default_state
 	 * @expectedDeprecated WC_Customer::is_paying_customer

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -149,17 +149,17 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 		$this->assertEquals( $customer->get_shipping_address(), $customer->shipping_address_1 );
 		$this->assertEquals( $customer->get_shipping_address_2(), $customer->shipping_address_2 );
 		$this->assertEquals( $customer->get_is_vat_exempt(), $customer->is_vat_exempt );
-		$this->assertEquals( $customer->get_calculated_shipping(), $customer->calculated_shipping );
+		$this->assertEquals( $customer->has_calculated_shipping(), $customer->calculated_shipping );
 
 		// Functions
 		$this->assertEquals( $customer->get_is_vat_exempt(), $customer->is_vat_exempt() );
-		$this->assertEquals( $customer->get_calculated_shipping(), $customer->has_calculated_shipping() );
+		$this->assertEquals( $customer->has_calculated_shipping(), $customer->has_calculated_shipping() );
 		$default = wc_get_customer_default_location();
 		$this->assertEquals( $default['country'], $customer->get_default_country() );
 		$this->assertEquals( $default['state'], $customer->get_default_state() );
-		$this->assertFalse( $customer->get_calculated_shipping() );
+		$this->assertFalse( $customer->has_calculated_shipping() );
 		$customer->calculated_shipping( true );
-		$this->assertTrue( $customer->get_calculated_shipping() );
+		$this->assertTrue( $customer->has_calculated_shipping() );
 		$this->assertEquals( $customer->get_is_paying_customer(), $customer->is_paying_customer() );
 	}
 


### PR DESCRIPTION
Makes the API and CRUD endpoints match, and adds exception handling.

I did un-deprecate has_calculated_shipping conditional since that one makes sense to keep around.

Tweaked meta handling to exclude some WP options we don’t need to reveal.

Unit tests updated.
