### PR TITLE
Fix products API WP_Query filtering with post_status 

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -130,11 +130,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function query_args( $args, $request ) {
 		// Set post_status.
-		if ( ! empty( $request['filter'] ) && ! empty( $request['filter']['post_status'] ) ) {
-			$args['post_status'] = $request['filter']['post_status'];
-		} else {
-			$args['post_status'] = $request['status'];
-		}
+		$args['post_status'] = $request['status'];
 
 		// Taxonomy query to filter products by type, category,
 		// tag, shipping class, and attribute.
@@ -201,6 +197,11 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 			);
 
 			$args['post_type'] = array( 'product', 'product_variation' );
+		}
+
+		if ( is_array( $request['filter'] ) ) {
+			$args = array_merge( $args, $request['filter'] );
+			unset( $args['filter'] );
 		}
 
 		return $args;

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -130,7 +130,11 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function query_args( $args, $request ) {
 		// Set post_status.
-		$args['post_status'] = $request['status'];
+		if ( ! empty( $request['filter'] ) && ! empty( $request['filter']['post_status'] ) ) {
+			$args['post_status'] = $request['filter']['post_status'];
+		} else {
+			$args['post_status'] = $request['status'];
+		}
 
 		// Taxonomy query to filter products by type, category,
 		// tag, shipping class, and attribute.

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests for Products API.
+ *
+ * @package WooCommerce\Tests\API
+ * @since 2.7.0
+ */
+
+class Products_API extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Products_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+    /**
+     * Tests to make sure you can filter products post statuses by both
+     * the status query arg and WP_Query.
+     *
+     * @since 2.7.0
+     */
+    public function test_products_filter_post_status() {
+        wp_set_current_user( $this->user );
+        for ( $i = 0; $i < 8; $i++ ) {
+            $product = WC_Helper_Product::create_simple_product();
+            if ( 0 === $i % 2 ) {
+                wp_update_post( array(
+                    'ID'          => $product->get_id(),
+                    'post_status' => 'draft',
+                ) );
+            }
+        }
+
+        // Test filtering with filter[post_status]=publish
+        $request = new WP_REST_Request( 'GET', '/wc/v1/products' );
+        $request->set_param( 'filter', array( 'post_status' => 'publish' ) );
+        $response = $this->server->dispatch( $request );
+        $products = $response->get_data();
+
+        $this->assertEquals( 4, count( $products ) );
+        foreach ( $products as $product ) {
+            $this->assertEquals( 'publish', $product['status'] );
+        }
+
+        // Test filtering with filter[post_status]=draft
+        $request = new WP_REST_Request( 'GET', '/wc/v1/products' );
+        $request->set_param( 'filter', array( 'post_status' => 'draft' ) );
+        $response = $this->server->dispatch( $request );
+        $products = $response->get_data();
+
+        $this->assertEquals( 4, count( $products ) );
+        foreach ( $products as $product ) {
+            $this->assertEquals( 'draft', $product['status'] );
+        }
+
+        // Test filtering with status=publish
+        $request = new WP_REST_Request( 'GET', '/wc/v1/products' );
+        $request->set_param( 'status', 'publish' );
+        $response = $this->server->dispatch( $request );
+        $products = $response->get_data();
+
+        $this->assertEquals( 4, count( $products ) );
+        foreach ( $products as $product ) {
+            $this->assertEquals( 'publish', $product['status'] );
+        }
+
+        // Test filtering with status=draft
+        $request = new WP_REST_Request( 'GET', '/wc/v1/products' );
+        $request->set_param( 'status', 'draft' );
+        $response = $this->server->dispatch( $request );
+        $products = $response->get_data();
+
+        $this->assertEquals( 4, count( $products ) );
+        foreach ( $products as $product ) {
+            $this->assertEquals( 'draft', $product['status'] );
+        }
+
+        // Test filtering with status=draft and filter[post_status]=publish
+        // filter[post_status]=publish should win
+        $request = new WP_REST_Request( 'GET', '/wc/v1/products' );
+        $request->set_param( 'status', 'draft' );
+        $request->set_param( 'filter', array( 'post_status' => 'publish' ) );
+        $response = $this->server->dispatch( $request );
+        $products = $response->get_data();
+
+        $this->assertEquals( 4, count( $products ) );
+        foreach ( $products as $product ) {
+            $this->assertEquals( 'publish', $product['status'] );
+        }
+
+        // Test filtering with no filters - which should return 'any' (all 8)
+        $request = new WP_REST_Request( 'GET', '/wc/v1/products' );
+        $response = $this->server->dispatch( $request );
+        $products = $response->get_data();
+
+        $this->assertEquals( 8, count( $products ) );
+    }
+
+}


### PR DESCRIPTION
Filtering by `post_status` with the WP_Query `filter` arg ends up just filtering by `any`instead of the intended status because of the line below.

I'm aware you can just filter with `status` -- but it seems like we should make sure to support all the WP_Query arguments. It might lead to some confusion/problems. if you are used to WP-API based APIs and expect `filter[post_status]` to work and it returns other things.

My fix is to give the filter arg precedence, so if both arguments are present, `filter[post_status]`'s value will be used instead. Otherwise, you can just pick one and filter with it.

Test included. Which should fail without the other change.

cc @claudiosmweb 
