### PR TITLE
Don't treat non-products like products when syncing stock!

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -174,7 +174,7 @@ class WC_Post_Data {
 	 * @param  mixed $_meta_value
 	 */
 	public static function sync_product_stock_status( $meta_id, $object_id, $meta_key, $_meta_value ) {
-		if ( '_stock' === $meta_key && 'product' !== get_post_type( $object_id ) ) {
+		if ( '_stock' === $meta_key && 'product' === get_post_type( $object_id ) ) {
 			$product = wc_get_product( $object_id );
 			$product->check_stock_status();
 		}


### PR DESCRIPTION
This change alters the conditional in `WC_Post_Data::sync_product_stock_status()` to ensure it is looking at post meta for a _product,_ otherwise:
- `wc_get_product( $object_id )` can return false
- `$product->check_stock_status()` fatals out

https://github.com/woothemes/woocommerce/issues/11852
