### PR TITLE
Update class-wc-form-handler.php - New Hook

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -136,6 +136,9 @@ class WC_Form_Handler {
 			}
 		}
 
+		// Allow plugins to return their own errors.
+		do_action_ref_array( 'woocommerce_save_addresses_errors', array( &$error ) );
+
 		if ( wc_notice_count( 'error' ) == 0 ) {
 
 			foreach ( $address as $key => $field ) {


### PR DESCRIPTION
Added a new hook ('woocommerce_save_addresses_errors') on line 140 to allow custom field validation on My Account > Billing & Shipping Address.

It is consistent with the existing hook ( 'woocommerce_save_account_details_errors') that allows custom field validation on My Account > Account Details.

I'm currently building a Woocommerce store and noticed this 'gap' in hook offerings. It's absence is a problem when you have custom field validation applied to the Checkout using the 'woocommerce_checkout_process' hook, as customers can then easily muck-up validated address fields through My Account.

I have tested this in my own child theme's functions.php without error. E.g.

add_action( 'woocommerce_save_addresses_errors', 'validate_addresses_fields' );
function validate_addresses_fields() {
  if ( !empty( $_POST['billing_postcode']) && !ctype_digit( $_POST['billing_postcode'] ) )
    wc_add_notice( __( '<strong>Billing Postcode</strong> contains non-numeric characters.' ), 'error' );
    if ( !empty( $_POST['shipping_postcode']) && !ctype_digit( $_POST['shipping_postcode'] ) )
    wc_add_notice( __( '<strong>Shipping Postcode</strong> contains non-numeric characters.' ), 'error' );
}

Hope this helps!
