### PR TITLE
Prevent average product rating meta from being set for other post types

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -236,10 +236,13 @@ class WC_Comments {
 	 * @param int $post_id
 	 */
 	public static function clear_transients( $post_id ) {
-		delete_post_meta( $post_id, '_wc_average_rating' );
-		delete_post_meta( $post_id, '_wc_rating_count' );
-		delete_post_meta( $post_id, '_wc_review_count' );
-		WC_Product::sync_average_rating( $post_id );
+
+		if ( 'product' === get_post_type( $post_id ) ) {
+			delete_post_meta( $post_id, '_wc_average_rating' );
+			delete_post_meta( $post_id, '_wc_rating_count' );
+			delete_post_meta( $post_id, '_wc_review_count' );
+			WC_Product::sync_average_rating( $post_id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
[`WC_Comments::clear_transients`](https://github.com/woothemes/woocommerce/blob/master/includes/class-wc-comments.php#L238-L243) is called whenever WordPress updates comment counts, and results in `_wc_average_rating` meta being set for any post type if its comment count is updated, like when order notes are added. Adding a check for the product post type to prevent this.
