### PR TITLE
Settings & API Fixes

### DIFF
--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -186,6 +186,140 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Validate a text value for a text based setting.
+	 *
+	 * @since 2.7.0
+	 * @param string $value
+	 * @param array  $setting
+	 * @return string
+	 */
+	public function validate_setting_text_field( $value, $setting ) {
+		$value = is_null( $value ) ? '' : $value;
+		return wp_kses_post( trim( stripslashes( $value ) ) );
+		return $value;
+	}
+
+	/**
+	 * Validate select based settings.
+	 *
+	 * @since 2.7.0
+	 * @param string $value
+	 * @param array  $setting
+	 * @return string|WP_Error
+	 */
+	public function validate_setting_select_field( $value, $setting ) {
+		if ( array_key_exists( $value, $setting['options'] ) ) {
+			return $value;
+		} else {
+			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+	}
+
+	/**
+	 * Validate multiselect based settings.
+	 *
+	 * @since 2.7.0
+	 * @param array $values
+	 * @param array  $setting
+	 * @return string|WP_Error
+	 */
+	public function validate_setting_multiselect_field( $values, $setting ) {
+		if ( empty( $values ) ) {
+			return array();
+		}
+
+		if ( ! is_array( $values ) ) {
+			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$final_values = array();
+		foreach ( $values as $value ) {
+			if ( array_key_exists( $value, $setting['options'] ) ) {
+				$final_values[] = $value;
+			}
+		}
+
+		return $final_values;
+	}
+
+	/**
+	 * Validate image_width based settings.
+	 *
+	 * @since 2.7.0
+	 * @param array $value
+	 * @param array $setting
+	 * @return string|WP_Error
+	 */
+	public function validate_setting_image_width_field( $values, $setting ) {
+		if ( ! is_array( $values ) ) {
+			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
+		$current = $setting['value'];
+		if ( isset( $values['width'] ) ) {
+			$current['width'] = intval( $values['width'] );
+		}
+		if ( isset( $values['height'] ) ) {
+			$current['height'] = intval( $values['height'] );
+		}
+		if ( isset( $values['crop'] ) ) {
+			$current['crop'] = (bool) $values['crop'];
+		}
+		return $current;
+	}
+
+	/**
+	 * Validate radio based settings.
+	 *
+	 * @since 2.7.0
+	 * @param string $value
+	 * @param array  $setting
+	 * @return string|WP_Error
+	 */
+	public function validate_setting_radio_field( $value, $setting ) {
+		return $this->validate_setting_select_field( $value, $setting );
+	}
+
+	/**
+	 * Validate checkbox based settings.
+	 *
+	 * @since 2.7.0
+	 * @param string $value
+	 * @param array  $setting
+	 * @return string|WP_Error
+	 */
+	public function validate_setting_checkbox_field( $value, $setting ) {
+		if ( in_array( $value, array( 'yes', 'no' ) ) ) {
+			return $value;
+		} elseif ( empty( $value ) ) {
+			$value = isset( $setting['default'] ) ? $setting['default'] : 'no';
+			return $value;
+		} else {
+			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+	}
+
+	/**
+	 * Validate textarea based settings.
+	 *
+	 * @since 2.7.0
+	 * @param string $value
+	 * @param array  $setting
+	 * @return string
+	 */
+	public function validate_setting_textarea_field( $value, $setting ) {
+		$value = is_null( $value ) ? '' : $value;
+		return wp_kses( trim( stripslashes( $value ) ),
+			array_merge(
+				array(
+					'iframe' => array( 'src' => true, 'style' => true, 'id' => true, 'class' => true ),
+				),
+				wp_kses_allowed_html( 'post' )
+			)
+		);
+	}
+
+	/**
 	 * Get the batch schema, conforming to JSON Schema.
 	 *
 	 * @return array

--- a/includes/abstracts/abstract-wc-rest-shipping-zones-controller.php
+++ b/includes/abstracts/abstract-wc-rest-shipping-zones-controller.php
@@ -46,7 +46,7 @@ abstract class WC_REST_Shipping_Zones_Controller_Base extends WC_REST_Controller
 		$zone = WC_Shipping_Zones::get_zone_by( 'zone_id', $zone_id );
 
 		if ( false === $zone ) {
-			return new WP_Error( 'woocommerce_rest_shipping_zone_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_shipping_zone_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		return $zone;

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -217,7 +217,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		// Get taxonomy.
 		$taxonomy = $this->get_taxonomy( $request );
 		if ( ! $taxonomy ) {
-			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( "Taxonomy doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Taxonomy does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		// Check permissions for a single term.
@@ -225,7 +225,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$term = get_term( $id, $taxonomy );
 
 			if ( ! $term || $term->taxonomy !== $taxonomy ) {
-				return new WP_Error( 'woocommerce_rest_term_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 			}
 
 			return wc_rest_check_product_term_permissions( $taxonomy, $context, $term->term_id );
@@ -370,7 +370,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$parent = get_term( (int) $request['parent'], $taxonomy );
 
 			if ( ! $parent ) {
-				return new WP_Error( 'woocommerce_rest_term_invalid', __( "Parent resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 			}
 
 			$args['parent'] = $parent->term_id;
@@ -474,7 +474,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$parent = get_term( (int) $request['parent'], $taxonomy );
 
 			if ( ! $parent ) {
-				return new WP_Error( 'woocommerce_rest_term_invalid', __( "Parent resource doesn't exist.", 'woocommerce' ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 400 ) );
 			}
 
 			$prepared_args['parent'] = $parent->term_id;

--- a/includes/api/class-wc-rest-customer-downloads-controller.php
+++ b/includes/api/class-wc-rest-customer-downloads-controller.php
@@ -61,7 +61,7 @@ class WC_REST_Customer_Downloads_Controller extends WC_REST_Controller {
 		$customer = get_user_by( 'id', (int) $request['customer_id'] );
 
 		if ( ! $customer ) {
-			return new WP_Error( "woocommerce_rest_customer_invalid", __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_customer_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		if ( ! wc_rest_check_user_permissions( 'read', $customer->id ) ) {

--- a/includes/api/class-wc-rest-payment-gateways-controller.php
+++ b/includes/api/class-wc-rest-payment-gateways-controller.php
@@ -133,7 +133,7 @@ class WC_REST_Payment_Gateways_Controller extends WC_REST_Controller {
 		$gateway = $this->get_gateway( $request );
 
 		if ( is_null( $gateway ) ) {
-			return new WP_Error( 'woocommerce_rest_payment_gateway_invalid', __( "Resource does not exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_payment_gateway_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$gateway = $this->prepare_item_for_response( $gateway, $request );
@@ -150,7 +150,7 @@ class WC_REST_Payment_Gateways_Controller extends WC_REST_Controller {
 		$gateway = $this->get_gateway( $request );
 
 		if ( is_null( $gateway ) ) {
-			return new WP_Error( 'woocommerce_rest_payment_gateway_invalid', __( "Resource does not exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_payment_gateway_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		// Update settings if present

--- a/includes/api/class-wc-rest-product-attributes-controller.php
+++ b/includes/api/class-wc-rest-product-attributes-controller.php
@@ -143,7 +143,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( ! $this->get_taxonomy( $request ) ) {
-			return new WP_Error( "woocommerce_rest_taxonomy_invalid", __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		if ( ! wc_rest_check_manager_permissions( 'attributes', 'read' ) ) {
@@ -161,7 +161,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 	 */
 	public function update_item_permissions_check( $request ) {
 		if ( ! $this->get_taxonomy( $request ) ) {
-			return new WP_Error( "woocommerce_rest_taxonomy_invalid", __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		if ( ! wc_rest_check_manager_permissions( 'attributes', 'edit' ) ) {
@@ -179,7 +179,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 	 */
 	public function delete_item_permissions_check( $request ) {
 		if ( ! $this->get_taxonomy( $request ) ) {
-			return new WP_Error( "woocommerce_rest_taxonomy_invalid", __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		if ( ! wc_rest_check_manager_permissions( 'attributes', 'delete' ) ) {
@@ -617,7 +617,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 		 ", $id ) );
 
 		if ( is_wp_error( $attribute ) || is_null( $attribute ) ) {
-			return new WP_Error( 'woocommerce_rest_attribute_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_attribute_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		return $attribute;

--- a/includes/api/class-wc-rest-settings-controller.php
+++ b/includes/api/class-wc-rest-settings-controller.php
@@ -185,7 +185,7 @@ class WC_REST_Settings_Controller extends WC_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'              => 'http://json-schema.org/draft-04/schema#',
-			'title'                => 'settings-group',
+			'title'                => 'setting_group',
 			'type'                 => 'object',
 			'properties'           => array(
 				'id'               => array(

--- a/includes/api/class-wc-rest-settings-options-controller.php
+++ b/includes/api/class-wc-rest-settings-options-controller.php
@@ -139,7 +139,7 @@ class WC_REST_Settings_Options_Controller extends WC_REST_Controller {
 			// Get the option value
 			if ( is_array( $option_key ) ) {
 				$option           = get_option( $option_key[0] );
-				$setting['value'] = $option[ $option_key[1] ];
+				$setting['value'] = isset( $option[ $option_key[1] ] ) ? $option[ $option_key[1] ] : '';
 			} else {
 				$setting['value'] = WC_Admin_Settings::get_option( $option_key );
 			}

--- a/includes/api/class-wc-rest-shipping-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-methods-controller.php
@@ -113,7 +113,7 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
         $wc_shipping = WC_Shipping::instance();
         $methods     = $wc_shipping->get_shipping_methods();
         if ( empty( $methods[ $request['id'] ] ) ) {
-            return new WP_Error( 'woocommerce_rest_shipping_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+            return new WP_Error( 'woocommerce_rest_shipping_method_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
         }
 
         $method   = $methods[ $request['id'] ];

--- a/includes/api/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-methods-controller.php
@@ -155,6 +155,9 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		}
 
 		$method = $this->update_fields( $instance_id, $method, $request );
+		if ( is_wp_error( $method ) ) {
+			return $method;
+		}
 
 		$data = $this->prepare_item_for_response( $method, $request );
 		return rest_ensure_response( $data );
@@ -192,6 +195,10 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		}
 
 		$method = $this->update_fields( $instance_id, $method, $request );
+		if ( is_wp_error( $method ) ) {
+			return $method;
+		}
+
 		$request->set_param( 'context', 'view' );
 		$response = $this->prepare_item_for_response( $method, $request );
 
@@ -244,6 +251,9 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		}
 
 		$method = $this->update_fields( $instance_id, $method, $request );
+		if ( is_wp_error( $method ) ) {
+			return $method;
+		}
 
 		$data = $this->prepare_item_for_response( $method, $request );
 		return rest_ensure_response( $data );
@@ -264,11 +274,26 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		if ( isset( $request['settings'] ) ) {
 			$method->init_instance_settings();
 			$instance_settings = $method->instance_settings;
+			$errors_found      = false;
 			foreach ( $method->get_instance_form_fields() as $key => $field ) {
 				if ( isset( $request['settings'][ $key ] ) ) {
-					$instance_settings[ $key ] = $request['settings'][ $key ];
+					if ( is_callable( array( $this, 'validate_setting_' . $field['type'] . '_field' ) ) ) {
+						$value = $this->{'validate_setting_' . $field['type'] . '_field'}( $request['settings'][ $key ], $field );
+					} else {
+						$value = $this->validate_setting_text_field( $request['settings'][ $key ], $field );
+					}
+					if ( is_wp_error( $value ) ) {
+						$errors_found = true;
+						break;
+					}
+					$instance_settings[ $key ] = $value;
 				}
 			}
+
+			if ( $errors_found ) {
+				return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
+			}
+
 			update_option( $method->get_instance_option_key(), apply_filters( 'woocommerce_shipping_' . $method->id . '_instance_settings_values', $instance_settings, $method ) );
 		}
 

--- a/includes/api/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-methods-controller.php
@@ -93,7 +93,7 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		}
 
 		if ( false === $method ) {
-			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$data = $this->prepare_item_for_response( $method, $request );
@@ -188,7 +188,7 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		}
 
 		if ( false === $method ) {
-			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$method = $this->update_fields( $instance_id, $method, $request );
@@ -240,7 +240,7 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 		}
 
 		if ( false === $method ) {
-			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( "Resource doesn't exist.", 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_shipping_zone_method_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		$method = $this->update_fields( $instance_id, $method, $request );

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -230,7 +230,13 @@ class WC_API extends WC_Legacy_API {
 	public function register_wp_admin_settings() {
 		$pages = WC_Admin_Settings::get_settings_pages();
 		foreach ( $pages as $page ) {
-			new WC_Register_WP_Admin_Settings( $page );
+			new WC_Register_WP_Admin_Settings( $page, 'page' );
+		}
+
+		$emails = WC_Emails::instance();
+		foreach ( $emails->get_emails() as $email ) {
+			new WC_Register_WP_Admin_Settings( $email, 'email' );
 		}
 	}
+
 }

--- a/includes/class-wc-register-wp-admin-settings.php
+++ b/includes/class-wc-register-wp-admin-settings.php
@@ -109,6 +109,9 @@ class WC_Register_WP_Admin_Settings {
 		foreach ( $sections as $section => $section_label ) {
 			$settings_from_section = $this->object->get_settings( $section );
 			foreach ( $settings_from_section as $setting ) {
+				if ( ! isset( $setting['id'] ) ) {
+					continue;
+				}
 				$setting['option_key'] = $setting['id'];
 				$new_setting           = $this->register_setting( $setting );
 				if ( $new_setting ) {
@@ -120,12 +123,11 @@ class WC_Register_WP_Admin_Settings {
 	}
 
 	/**
-	 * Register's a specific setting (from WC_Settings_Page::get_settings() )
-	 * into the format expected for the REST API Settings Controller.
+	 * Register a setting into the format expected for the Settings REST API.
 	 *
 	 * @since 2.7.0
-	 * @param  array $setting Settings array, as produced by a subclass of WC_Settings_Page.
-	 * @return array|bool boolean False if setting has no ID or converted array.
+	 * @param  array $setting
+	 * @return array|bool
 	 */
 	public function register_setting( $setting ) {
 		if ( ! isset( $setting['id'] ) ) {

--- a/includes/class-wc-register-wp-admin-settings.php
+++ b/includes/class-wc-register-wp-admin-settings.php
@@ -13,18 +13,62 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Register_WP_Admin_Settings {
 
-	/** @var class Current settings class. Used to pull settings. */
-	protected $page;
+	/** @var class Contains the current class to pull settings from. Either a admin page object or WC_Email object. */
+	protected $object;
 
 	/**
 	 * Hooks into the settings API and starts registering our settings.
 	 *
 	 * @since 2.7.0
+	 * @param WC_Email|WC_Settings_Page $object The object that contains the settings to register.
+	 * @param string                    $type   Type of settings to register (email or page).
 	 */
-	public function __construct( $page ) {
-		$this->page = $page;
-		add_filter( 'woocommerce_settings_groups', array( $this, 'register_group' ) );
-		add_filter( 'woocommerce_settings-' . $this->page->get_id(),  array( $this, 'register_settings' ) );
+	public function __construct( $object, $type ) {
+		$this->object = $object;
+		if ( 'page' === $type ) {
+			add_filter( 'woocommerce_settings_groups', array( $this, 'register_page_group' ) );
+			add_filter( 'woocommerce_settings-' . $this->object->get_id(),  array( $this, 'register_page_settings' ) );
+		} else if ( 'email' === $type ) {
+			add_filter( 'woocommerce_settings_groups', array( $this, 'register_email_group' ) );
+			add_filter( 'woocommerce_settings-email_' . $this->object->id,  array( $this, 'register_email_settings' ) );
+		}
+	}
+
+	/**
+	 * Register's all of our different notification emails as sub groups
+	 * of email settings.
+	 *
+	 * @since  2.7.0
+	 * @param  array $groups Existing registered groups.
+	 * @return array
+	 */
+	public function register_email_group( $groups ) {
+		$groups[] = array(
+			'id'          => 'email_' . $this->object->id,
+			'label'       => $this->object->title,
+			'description' => $this->object->description,
+			'parent_id'   => 'email',
+		);
+		return $groups;
+	}
+
+	/**
+	 * Registers all of the setting form fields for emails to each email type's group.
+	 *
+	 * @since  2.7.0
+	 * @param  array $settings Existing registered settings.
+	 * @return array
+	 */
+	public function register_email_settings( $settings ) {
+		foreach ( $this->object->form_fields as $id => $setting ) {
+			$setting['id']         = $id;
+			$setting['option_key'] = array( $this->object->get_option_key(), $id );
+			$new_setting      = $this->register_setting( $setting );
+			if ( $new_setting ) {
+				$settings[] = $new_setting;
+			}
+		}
+		return $settings;
 	}
 
 	/**
@@ -34,10 +78,10 @@ class WC_Register_WP_Admin_Settings {
 	 * @param  array $groups Array of previously registered groups.
 	 * @return array
 	 */
-	public function register_group( $groups ) {
+	public function register_page_group( $groups ) {
 		$groups[] = array(
-			'id'    => $this->page->get_id(),
-			'label' => $this->page->get_label(),
+			'id'    => $this->object->get_id(),
+			'label' => $this->object->get_label(),
 		);
 		return $groups;
 	}
@@ -49,23 +93,24 @@ class WC_Register_WP_Admin_Settings {
 	 * @param  array $settings Existing registered settings
 	 * @return array
 	 */
-	public function register_settings( $settings ) {
+	public function register_page_settings( $settings ) {
 		/**
 		 * wp-admin settings can be broken down into separate sections from
 		 * a UI standpoint. This will grab all the sections associated with
 		 * a particular setting group (like 'products') and register them
 		 * to the REST API.
 		 */
-		$sections = $this->page->get_sections();
+		$sections = $this->object->get_sections();
 		if ( empty( $sections ) ) {
 			// Default section is just an empty string, per admin page classes
 			$sections = array( '' );
 		}
 
 		foreach ( $sections as $section => $section_label ) {
-			$settings_from_section = $this->page->get_settings( $section );
+			$settings_from_section = $this->object->get_settings( $section );
 			foreach ( $settings_from_section as $setting ) {
-				$new_setting = $this->register_setting( $setting );
+				$setting['option_key'] = $setting['id'];
+				$new_setting           = $this->register_setting( $setting );
 				if ( $new_setting ) {
 					$settings[] = $new_setting;
 				}
@@ -86,12 +131,22 @@ class WC_Register_WP_Admin_Settings {
 		if ( ! isset( $setting['id'] ) ) {
 			return false;
 		}
+
+		$description = '';
+		if ( ! empty ( $setting['desc'] ) ) {
+			$description = $setting['desc'];
+		} else if ( ! empty( $setting['description'] ) ) {
+			$description = $setting['description'];
+		}
+
 		$new_setting = array(
 			'id'          => $setting['id'],
 			'label'       => ( ! empty( $setting['title'] ) ? $setting['title'] : '' ),
-			'description' => ( ! empty( $setting['desc'] ) ? $setting['desc'] : '' ),
+			'description' => $description,
 			'type'        => $setting['type'],
+			'option_key'  => $setting['option_key'],
 		);
+
 		if ( isset( $setting['default'] ) ) {
 			$new_setting['default'] = $setting['default'];
 		}
@@ -100,12 +155,13 @@ class WC_Register_WP_Admin_Settings {
 		}
 		if ( isset( $setting['desc_tip'] ) ) {
 			if ( true === $setting['desc_tip'] ) {
-				$new_setting['tip'] = $setting['desc'];
-			} elseif ( ! empty( $setting['desc_tip'] ) ) {
+				$new_setting['tip'] = $description;
+			} else if ( ! empty( $setting['desc_tip'] ) ) {
 				$new_setting['tip'] = $setting['desc_tip'];
 			}
 		}
 
 		return $new_setting;
 	}
+
 }

--- a/tests/framework/helpers/class-wc-helper-settings.php
+++ b/tests/framework/helpers/class-wc-helper-settings.php
@@ -30,19 +30,23 @@ class WC_Helper_Settings {
 			'bad'         => 'value',
 			'label'       => __( 'Test Extension', 'woocommerce' ),
 			'description' => __( 'My awesome test settings.', 'woocommerce' ),
+			'option_key'  => '',
 		);
 		$groups[] = array(
 			'id'          => 'sub-test',
 			'parent_id'   => 'test',
 			'label'       => __( 'Sub test', 'woocommerce' ),
 			'description' => '',
+			'option_key'  => '',
 		);
 		$groups[] = array(
 			'id'    => 'coupon-data',
 			'label' => __( 'Coupon Data', 'woocommerce' ),
+			'option_key'  => '',
 		);
 		$groups[] = array(
 			'id' => 'invalid',
+			'option_key'  => '',
 		);
 		return $groups;
 	}
@@ -66,6 +70,7 @@ class WC_Helper_Settings {
 				'subcategories' => __( 'Show categories &amp; subcategories', 'woocommerce' ),
 				'both'          => __( 'Show both', 'woocommerce' ),
 			),
+			'option_key'  => 'woocommerce_shop_page_display',
 		);
 		$settings[] = array(
 			'id'            => 'woocommerce_enable_lightbox',
@@ -74,6 +79,7 @@ class WC_Helper_Settings {
 			'default'       => 'yes',
 			'tip'           => __( 'Product gallery images will open in a lightbox.', 'woocommerce' ),
 			'type'          => 'checkbox',
+			'option_key'    => 'woocommerce_enable_lightbox',
 		);
 		return $settings;
 	}

--- a/tests/unit-tests/api/payment-gateways.php
+++ b/tests/unit-tests/api/payment-gateways.php
@@ -184,6 +184,26 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'PayPal - New Title', $paypal['settings']['title']['value'] );
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'yes', $paypal['settings']['testmode']['value'] );
+
+		// test bogus
+		$request = new WP_REST_Request( 'POST', '/wc/v1/payment_gateways/paypal' );
+		$request->set_body_params( array(
+			'settings' => array(
+				'paymentaction' => 'afasfasf',
+			)
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v1/payment_gateways/paypal' );
+		$request->set_body_params( array(
+			'settings' => array(
+				'paymentaction' => 'authorization',
+			)
+		) );
+		$response = $this->server->dispatch( $request );
+		$paypal   = $response->get_data();
+		$this->assertEquals( 'authorization', $paypal['settings']['paymentaction']['value'] );
 	}
 
 	/**

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -603,6 +603,29 @@ class Settings extends WC_REST_Unit_Test_Case {
 			'tip'         => 'This controls the email subject line. Leave blank to use the default subject: <code>[{site_title}] New customer order ({order_number}) - {order_date}</code>.',
 			'value'       => 'This is my subject',
 		), $setting );
+
+		// test updating another subject and making sure it works with a "similar" id
+		$request = new WP_REST_Request( 'GET', sprintf( '/wc/v1/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+
+		$this->assertEmpty( $setting['value'] );
+
+		// test update
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v1/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
+		$request->set_body_params( array(
+			'value' => 'This is my new subject',
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+
+		$this->assertEquals( 'This is my new subject', $setting['value'] );
+
+		// make sure the other is what we left it
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/settings/email_new_order/subject' ) );
+		$setting  = $response->get_data();
+
+		$this->assertEquals( 'This is my subject', $setting['value'] );
 	}
 
 }

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -677,6 +677,17 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'cost', $data['settings'] );
 		$this->assertEquals( '10', $data['settings']['cost']['value'] );
 
+		// Test bogus
+		$request = new WP_REST_Request( 'POST', '/wc/v1/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
+		$request->set_body_params( array(
+			'settings' => array(
+				'cost'       => 10,
+				'tax_status' => 'this_is_not_a_valid_option',
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
 		// Test other parameters
 		$this->assertTrue( $data['enabled'] );
 		$this->assertEquals( 1, $data['order'] );

--- a/tests/unit-tests/settings/register-wp-admin-settings.php
+++ b/tests/unit-tests/settings/register-wp-admin-settings.php
@@ -41,10 +41,10 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 	 * @covers WC_Register_WP_Admin_Settings::__construct
 	 */
 	public function test_constructor() {
-		$settings = new WC_Register_WP_Admin_Settings( $this->page );
+		$settings = new WC_Register_WP_Admin_Settings( $this->page, 'page' );
 
-		$this->assertEquals( has_filter( 'woocommerce_settings_groups', array( $settings, 'register_group' ) ), 10 );
-		$this->assertEquals( has_filter( 'woocommerce_settings-' . $this->page->get_id(), array( $settings, 'register_settings' ) ), 10 );
+		$this->assertEquals( has_filter( 'woocommerce_settings_groups', array( $settings, 'register_page_group' ) ), 10 );
+		$this->assertEquals( has_filter( 'woocommerce_settings-' . $this->page->get_id(), array( $settings, 'register_page_settings' ) ), 10 );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 	 * @covers WC_Register_WP_Admin_Settings::register_group
 	 */
 	public function test_register_group() {
-		$settings = new WC_Register_WP_Admin_Settings( $this->page );
+		$settings = new WC_Register_WP_Admin_Settings( $this->page, 'page' );
 
 		$existing = array(
 			'id'    => 'existing-id',
@@ -66,7 +66,7 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 				'label' => $this->page->get_label(),
 			),
 		);
-		$actual = $settings->register_group( $initial );
+		$actual = $settings->register_page_group( $initial );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -79,19 +79,21 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 			// No "id" case
 			array(
 				array(
-					'type' => 'some-type-with-no-id',
+					'type'       => 'some-type-with-no-id',
+					'option_key' => '',
 				),
 				false,
 			),
 			// All optional properties except 'desc_tip'
 			array(
 				array(
-					'id'      => 'setting-id',
-					'type'    => 'select',
-					'title'   => 'Setting Name',
-					'desc'    => 'Setting Description',
-					'default' => 'one',
-					'options' => array( 'one', 'two' ),
+					'id'         => 'setting-id',
+					'type'       => 'select',
+					'title'      => 'Setting Name',
+					'desc'       => 'Setting Description',
+					'default'    => 'one',
+					'options'    => array( 'one', 'two' ),
+					'option_key' => '',
 				),
 				array(
 					'id'          => 'setting-id',
@@ -100,16 +102,18 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 					'description' => 'Setting Description',
 					'default'     => 'one',
 					'options'     => array( 'one', 'two' ),
+					'option_key'  => '',
 				),
 			),
 			// Boolean 'desc_tip' defaulting to 'desc' value
 			array(
 				array(
-					'id'       => 'setting-id',
-					'type'     => 'select',
-					'title'    => 'Setting Name',
-					'desc'     => 'Setting Description',
-					'desc_tip' => true,
+					'id'        => 'setting-id',
+					'type'      => 'select',
+					'title'     => 'Setting Name',
+					'desc'      => 'Setting Description',
+					'desc_tip'  => true,
+					'option_key' => '',
 				),
 				array(
 					'id'          => 'setting-id',
@@ -117,16 +121,18 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 					'label'       => 'Setting Name',
 					'description' => 'Setting Description',
 					'tip'         => 'Setting Description',
+					'option_key'  => '',
 				),
 			),
 			// String 'desc_tip'
 			array(
 				array(
-					'id'       => 'setting-id',
-					'type'     => 'select',
-					'title'    => 'Setting Name',
-					'desc'     => 'Setting Description',
-					'desc_tip' => 'Setting Tip',
+					'id'         => 'setting-id',
+					'type'       => 'select',
+					'title'      => 'Setting Name',
+					'desc'       => 'Setting Description',
+					'desc_tip'   => 'Setting Tip',
+					'option_key' => '',
 				),
 				array(
 					'id'          => 'setting-id',
@@ -134,19 +140,22 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 					'label'       => 'Setting Name',
 					'description' => 'Setting Description',
 					'tip'         => 'Setting Tip',
+					'option_key'  => '',
 				),
 			),
 			// Empty 'title' and 'desc'
 			array(
 				array(
-					'id'       => 'setting-id',
-					'type'     => 'select',
+					'id'         => 'setting-id',
+					'type'       => 'select',
+					'option_key' => '',
 				),
 				array(
 					'id'          => 'setting-id',
 					'type'        => 'select',
 					'label'       => '',
 					'description' => '',
+					'option_key'  => '',
 				),
 			),
 		);
@@ -158,7 +167,7 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 	 * @covers WC_Register_WP_Admin_Settings::register_setting
 	 */
 	public function test_register_setting( $input, $expected ) {
-		$settings = new WC_Register_WP_Admin_Settings( $this->page );
+		$settings = new WC_Register_WP_Admin_Settings( $this->page, 'page' );
 
 		$actual = $settings->register_setting( $input );
 
@@ -181,10 +190,10 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 			->with( $this->equalTo( 0 ) )
 			->will( $this->returnValue( array() ) );
 
-		$settings = new WC_Register_WP_Admin_Settings( $this->page );
+		$settings = new WC_Register_WP_Admin_Settings( $this->page, 'page' );
 
 		$expected = array();
-		$actual   = $settings->register_settings( array() );
+		$actual   = $settings->register_page_settings( array() );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -201,15 +210,18 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 
 		$settings = array(
 			array(
-				'id'   => 'setting-1',
-				'type' => 'text',
+				'id'          => 'setting-1',
+				'type'        => 'text',
+				'option_key'  => '',
 			),
 			array(
-				'type' => 'no-id',
+				'type'        => 'no-id',
+				'option_key'  => '',
 			),
 			array(
-				'id'   => 'setting-2',
-				'type' => 'textarea',
+				'id'          => 'setting-2',
+				'type'        => 'textarea',
+				'option_key'  => '',
 			),
 		);
 
@@ -218,7 +230,7 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 			->method( 'get_settings' )
 			->will( $this->returnValue( $settings ) );
 
-		$settings = new WC_Register_WP_Admin_Settings( $this->page );
+		$settings = new WC_Register_WP_Admin_Settings( $this->page, 'page' );
 
 		$expected = array(
 			array(
@@ -226,15 +238,17 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 				'type'        => 'text',
 				'label'       => '',
 				'description' => '',
+				'option_key'  => 'setting-1',
 			),
 			array(
 				'id'          => 'setting-2',
 				'type'        => 'textarea',
 				'label'       => '',
 				'description' => '',
+				'option_key'  => 'setting-2',
 			),
 		);
-		$actual = $settings->register_settings( array() );
+		$actual = $settings->register_page_settings( array() );
 
 		$this->assertEquals( $expected, $actual );
 	}


### PR DESCRIPTION
This PR makes a few changes to the Settings API:
- Registers all notification email settings to the API (Settings > Emails > New order, etc).
- Validates on update based on the 'type' of the setting (so a select setting can only accept certain options, checkboxes can accept yes or no).
- Fixes for a few setting types (like multiselect/multiselect countries).
- Fixed 404 error messages based on feedback from my previous PR.
- Made it so setting IDs don't have to be unique across the entire system -- just their group (so you can have an enabled setting under one email and one under another).
- More tests.
