### PR TITLE
CRUD Updates: Prefix & get_/set_id

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -16,30 +16,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class WC_Data {
 
 	/**
+	 * ID for this object.
+	 * @var int
+	 */
+	protected $id = 0;
+
+	/**
 	 * Core data for this object. Name value pairs (name + default value).
 	 * @var array
 	 */
-	protected $_data = array();
+	protected $data = array();
 
 	/**
 	 * Set to _data on construct so we can track and reset data if needed.
 	 * @var array
 	 */
-	protected $_default_data = array();
+	protected $default_data = array();
 
 	/**
 	 * Stores meta in cache for future reads.
 	 * A group must be set to to enable caching.
 	 * @var string
 	 */
-	protected $_cache_group = '';
+	protected $cache_group = '';
 
 	/**
 	 * Meta type. This should match up with
 	 * the types avaiable at https://codex.wordpress.org/Function_Reference/add_metadata.
 	 * WP defines 'post', 'user', 'comment', and 'term'.
 	 */
-	protected $_meta_type = 'post';
+	protected $meta_type = 'post';
 
 	/**
 	 * This only needs set if you are using a custom metadata type (for example payment tokens.
@@ -53,53 +59,55 @@ abstract class WC_Data {
 	 * Stores additonal meta data.
 	 * @var array
 	 */
-	protected $_meta_data = array();
+	protected $meta_data = array();
 
 	/**
 	 * Internal meta keys we don't want exposed for the object.
 	 * @var array
 	 */
-	protected $_internal_meta_keys = array();
+	protected $internal_meta_keys = array();
 
 	/**
 	 * Default constructor.
 	 * @param int|object|array $read ID to load from the DB (optional) or already queried data.
 	 */
 	public function __construct( $read = 0 ) {
-		$this->_default_data = $this->_data;
+		$this->default_data = $this->data;
 	}
 
 	/**
 	 * Returns the unique ID for this object.
 	 * @return int
 	 */
-	abstract public function get_id();
+	public function get_id() {
+		return $this->id;
+	}
 
 	/**
 	 * Creates new object in the database.
 	 */
-	abstract public function create();
+	public function create() {}
 
 	/**
 	 * Read object from the database.
 	 * @param int ID of the object to load.
 	 */
-	abstract public function read( $id );
+	public function read( $id ) {}
 
 	/**
 	 * Updates object data in the database.
 	 */
-	abstract public function update();
+	public function update() {}
 
 	/**
 	 * Updates object data in the database.
 	 */
-	abstract public function delete();
+	public function delete() {}
 
 	/**
 	 * Save should create or update based on object existance.
 	 */
-	abstract public function save();
+	public function save() {}
 
 	/**
 	 * Change data to JSON format.
@@ -114,7 +122,7 @@ abstract class WC_Data {
 	 * @return array
 	 */
 	public function get_data() {
-		return array_merge( $this->_data, array( 'meta_data' => $this->get_meta_data() ) );
+		return array_merge( array( 'id' => $this->get_id() ), $this->data, array( 'meta_data' => $this->get_meta_data() ) );
 	}
 
 	/**
@@ -131,7 +139,7 @@ abstract class WC_Data {
 	 * @return array
 	 */
 	public function get_meta_data() {
-		return array_filter( $this->_meta_data, array( $this, 'filter_null_meta' ) );
+		return array_filter( $this->meta_data, array( $this, 'filter_null_meta' ) );
 	}
 
 	/**
@@ -151,7 +159,7 @@ abstract class WC_Data {
 	 * @return array
 	 */
 	protected function get_internal_meta_keys() {
-		return array_merge( array_map( array( $this, 'prefix_key' ), array_keys( $this->_data ) ), $this->_internal_meta_keys );
+		return array_merge( array_map( array( $this, 'prefix_key' ), array_keys( $this->data ) ), $this->internal_meta_keys );
 	}
 
 	/**
@@ -167,9 +175,9 @@ abstract class WC_Data {
 
 		if ( ! empty( $array_keys ) ) {
 			if ( $single ) {
-				$value = $this->_meta_data[ current( $array_keys ) ]->value;
+				$value = $this->meta_data[ current( $array_keys ) ]->value;
 			} else {
-				$value = array_intersect_key( $this->_meta_data, array_flip( $array_keys ) );
+				$value = array_intersect_key( $this->meta_data, array_flip( $array_keys ) );
 			}
 		}
 
@@ -186,7 +194,7 @@ abstract class WC_Data {
 			foreach ( $data as $meta ) {
 				$meta = (array) $meta;
 				if ( isset( $meta['key'], $meta['value'], $meta['id'] ) ) {
-					$this->_meta_data[] = (object) array(
+					$this->meta_data[] = (object) array(
 						'id'    => $meta['id'],
 						'key'   => $meta['key'],
 						'value' => $meta['value'],
@@ -207,7 +215,7 @@ abstract class WC_Data {
 		if ( $unique ) {
 			$this->delete_meta_data( $key );
 		}
-		$this->_meta_data[] = (object) array(
+		$this->meta_data[] = (object) array(
 			'key'   => $key,
 			'value' => $value,
 		);
@@ -223,10 +231,10 @@ abstract class WC_Data {
 	public function update_meta_data( $key, $value, $meta_id = '' ) {
 		$array_key = '';
 		if ( $meta_id ) {
-			$array_key = array_keys( wp_list_pluck( $this->_meta_data, 'id' ), $meta_id );
+			$array_key = array_keys( wp_list_pluck( $this->meta_data, 'id' ), $meta_id );
 		}
 		if ( $array_key ) {
-			$this->_meta_data[ current( $array_key ) ] = (object) array(
+			$this->meta_data[ current( $array_key ) ] = (object) array(
 				'id'    => $meta_id,
 				'key'   => $key,
 				'value' => $value,
@@ -242,10 +250,10 @@ abstract class WC_Data {
 	 * @param array $key Meta key
 	 */
 	public function delete_meta_data( $key ) {
-		$array_keys = array_keys( wp_list_pluck( $this->_meta_data, 'key' ), $key );
+		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'key' ), $key );
 		if ( $array_keys ) {
 			foreach ( $array_keys as $array_key ) {
-				$this->_meta_data[ $array_key ]->value = null;
+				$this->meta_data[ $array_key ]->value = null;
 			}
 		}
 	}
@@ -256,10 +264,10 @@ abstract class WC_Data {
 	 * @param int $mid Meta ID
 	 */
 	public function delete_meta_data_by_mid( $mid ) {
-		$array_keys         = array_keys( wp_list_pluck( $this->_meta_data, 'id' ), $mid );
+		$array_keys         = array_keys( wp_list_pluck( $this->meta_data, 'id' ), $mid );
 		if ( $array_keys ) {
 			foreach ( $array_keys as $array_key ) {
-				$this->_meta_data[ $array_key ]->value = null;
+				$this->meta_data[ $array_key ]->value = null;
 			}
 		}
 	}
@@ -279,26 +287,26 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 */
 	protected function read_meta_data() {
-		$this->_meta_data = array();
+		$this->meta_data = array();
 		$cache_loaded     = false;
 
 		if ( ! $this->get_id() ) {
 			return;
 		}
 
-		if ( ! empty( $this->_cache_group ) ) {
-			$cache_key   = WC_Cache_Helper::get_cache_prefix( $this->_cache_group ) . $this->get_id();
-			$cached_meta = wp_cache_get( $cache_key, $this->_cache_group );
+		if ( ! empty( $this->cache_group ) ) {
+			$cache_key   = WC_Cache_Helper::get_cache_prefix( $this->cache_group ) . $this->get_id();
+			$cached_meta = wp_cache_get( $cache_key, $this->cache_group );
 
 			if ( false !== $cached_meta ) {
-				$this->_meta_data = $cached_meta;
+				$this->meta_data = $cached_meta;
 				$cache_loaded = true;
 			}
 		}
 
 		if ( ! $cache_loaded ) {
 			global $wpdb;
-			$db_info = $this->_get_db_info();
+			$db_info = $this->get_db_info();
 			$raw_meta_data = $wpdb->get_results( $wpdb->prepare( "
 				SELECT " . $db_info['meta_id_field'] . ", meta_key, meta_value
 				FROM " . $db_info['table'] . "
@@ -308,7 +316,7 @@ abstract class WC_Data {
 			if ( $raw_meta_data ) {
 				$raw_meta_data = array_filter( $raw_meta_data, array( $this, 'exclude_internal_meta_keys' ) );
 				foreach ( $raw_meta_data as $meta ) {
-					$this->_meta_data[] = (object) array(
+					$this->meta_data[] = (object) array(
 						'id'    => (int) $meta->{ $db_info['meta_id_field'] },
 						'key'   => $meta->meta_key,
 						'value' => maybe_unserialize( $meta->meta_value ),
@@ -316,8 +324,8 @@ abstract class WC_Data {
 				}
 			}
 
-			if ( ! empty( $this->_cache_group ) ) {
-				wp_cache_set( $cache_key, $this->_meta_data, $this->_cache_group );
+			if ( ! empty( $this->cache_group ) ) {
+				wp_cache_set( $cache_key, $this->meta_data, $this->cache_group );
 			}
 		}
 	}
@@ -327,21 +335,21 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 */
 	protected function save_meta_data() {
-		foreach ( $this->_meta_data as $array_key => $meta ) {
+		foreach ( $this->meta_data as $array_key => $meta ) {
 			if ( is_null( $meta->value ) ) {
 				if ( ! empty( $meta->id ) ) {
-					delete_metadata_by_mid( $this->_meta_type, $meta->id );
+					delete_metadata_by_mid( $this->meta_type, $meta->id );
 				}
 			} elseif ( empty( $meta->id ) ) {
-				$new_meta_id = add_metadata( $this->_meta_type, $this->get_id(), $meta->key, $meta->value, false );
-				$this->_meta_data[ $array_key ]->id = $new_meta_id;
+				$new_meta_id = add_metadata( $this->meta_type, $this->get_id(), $meta->key, $meta->value, false );
+				$this->meta_data[ $array_key ]->id = $new_meta_id;
 			} else {
-				update_metadata_by_mid( $this->_meta_type, $meta->id, $meta->value, $meta->key );
+				update_metadata_by_mid( $this->meta_type, $meta->id, $meta->value, $meta->key );
 			}
 		}
 
-		if ( ! empty( $this->_cache_group ) ) {
-			WC_Cache_Helper::incr_cache_prefix( $this->_cache_group );
+		if ( ! empty( $this->cache_group ) ) {
+			WC_Cache_Helper::incr_cache_prefix( $this->cache_group );
 		}
 		$this->read_meta_data();
 	}
@@ -351,22 +359,22 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 * @return array Array elements: table, object_id_field, meta_id_field
 	 */
-	protected function _get_db_info() {
+	protected function get_db_info() {
 		global $wpdb;
 
 		$meta_id_field   = 'meta_id'; // for some reason users calls this umeta_id so we need to track this as well.
 		$table           = $wpdb->prefix;
 
 		// If we are dealing with a type of metadata that is not a core type, the table should be prefixed.
-		if ( ! in_array( $this->_meta_type, array( 'post', 'user', 'comment', 'term' ) ) ) {
+		if ( ! in_array( $this->meta_type, array( 'post', 'user', 'comment', 'term' ) ) ) {
 			$table .= 'woocommerce_';
 		}
 
-		$table .= $this->_meta_type . 'meta';
-		$object_id_field = $this->_meta_type . '_id';
+		$table .= $this->meta_type . 'meta';
+		$object_id_field = $this->meta_type . '_id';
 
 		// Figure out our field names.
-		if ( 'user' === $this->_meta_type ) {
+		if ( 'user' === $this->meta_type ) {
 			$meta_id_field   = 'umeta_id';
 		}
 
@@ -382,10 +390,18 @@ abstract class WC_Data {
 	}
 
 	/**
+	 * Set ID.
+	 * @param int $id
+	 */
+	public function set_id( $id ) {
+		$this->id = absint( $id );
+	}
+
+	/**
 	 * Set all props to default values.
 	 */
 	protected function set_defaults() {
-		$this->_data = $this->_default_data;
+		$this->data = $this->default_data;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -27,8 +27,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_data = array(
-		'id'                 => 0,
+	protected $data = array(
 		'parent_id'          => 0,
 		'status'             => '',
 		'currency'           => '',
@@ -50,7 +49,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_internal_meta_keys = array(
+	protected $internal_meta_keys = array(
 		'_order_currency',
 		'_cart_discount',
 		'_cart_discount_tax',
@@ -68,7 +67,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_items = array(
+	protected $items = array(
 		'line_items'     => null,
 		'coupon_lines'   => null,
 		'shipping_lines' => null,
@@ -81,20 +80,20 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_items_to_delete = array();
+	protected $items_to_delete = array();
 
 	/**
 	 *  Internal meta type used to store order data.
 	 * @var string
 	 */
-	protected $_meta_type = 'post';
+	protected $meta_type = 'post';
 
 	/**
 	 * Stores meta in cache for future reads.
 	 * A group must be set to to enable caching.
 	 * @var string
 	 */
-	protected $_cache_group = 'order';
+	protected $cache_group = 'order';
 
 	/**
 	 * Get the order if ID is passed, otherwise the order is new and empty.
@@ -200,8 +199,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			return;
 		}
 
+		$this->set_id( $id );
 		$this->set_props( array(
-			'id'                 => $id,
 			'parent_id'          => $post_object->post_parent,
 			'date_created'       => $post_object->post_date,
 			'date_modified'      => $post_object->post_modified,
@@ -302,14 +301,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	protected function save_items() {
 		// remove items
-		foreach ( $this->_items_to_delete as $item ) {
+		foreach ( $this->items_to_delete as $item ) {
 			$item->delete();
 		}
 
-		$this->_items_to_delete = array();
+		$this->items_to_delete = array();
 
 		// Add/save items
-		foreach ( $this->_items as $item_group => $items ) {
+		foreach ( $this->items as $item_group => $items ) {
 			if ( is_array( $items ) ) {
 				foreach ( $items as $item_key => $item ) {
 					$item->set_order_id( $this->get_id() );
@@ -317,8 +316,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 					// If ID changed (new item saved to DB)...
 					if ( $item_id !== $item_key ) {
-						$this->_items[ $item_group ][ $item_id ] = $item;
-						unset( $this->_items[ $item_group ][ $item_key ] );
+						$this->items[ $item_group ][ $item_id ] = $item;
+						unset( $this->items[ $item_group ][ $item_key ] );
 
 						// Legacy action handler
 						switch ( $item_group ) {
@@ -360,7 +359,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function get_data() {
 		return array_merge(
-			$this->_data,
+			$this->data,
 			array(
 				'meta_data'      => $this->get_meta_data(),
 				'line_items'     => $this->get_items( 'line_item' ),
@@ -373,21 +372,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Get order ID.
-	 * @since 2.7.0
-	 * @return integer
-	 */
-	public function get_id() {
-		return $this->_data['id'];
-	}
-
-	/**
 	 * Get parent order ID.
 	 * @since 2.7.0
 	 * @return integer
 	 */
 	public function get_parent_id() {
-		return $this->_data['parent_id'];
+		return $this->data['parent_id'];
 	}
 
 	/**
@@ -395,7 +385,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_currency() {
-		return apply_filters( 'woocommerce_get_currency', $this->_data['currency'], $this );
+		return apply_filters( 'woocommerce_get_currency', $this->data['currency'], $this );
 	}
 
 	/**
@@ -403,7 +393,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_version() {
-		return $this->_data['version'];
+		return $this->data['version'];
 	}
 
 	/**
@@ -411,7 +401,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return bool
 	 */
 	public function get_prices_include_tax() {
-		return $this->_data['prices_include_tax'];
+		return $this->data['prices_include_tax'];
 	}
 
 	/**
@@ -419,7 +409,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return int
 	 */
 	public function get_date_created() {
-		return $this->_data['date_created'];
+		return $this->data['date_created'];
 	}
 
 	/**
@@ -427,7 +417,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return int
 	 */
 	public function get_date_modified() {
-		return $this->_data['date_modified'];
+		return $this->data['date_modified'];
 	}
 
 	/**
@@ -435,7 +425,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_status() {
-		$status = $this->_data['status'];
+		$status = $this->data['status'];
 		return apply_filters( 'woocommerce_order_get_status', 'wc-' === substr( $status, 0, 3 ) ? substr( $status, 3 ) : $status, $this );
 	}
 
@@ -445,7 +435,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_discount_total( $raw = false ) {
-		$value = wc_format_decimal( $this->_data['discount_total'] );
+		$value = wc_format_decimal( $this->data['discount_total'] );
 		return $raw ? $value : apply_filters( 'woocommerce_order_amount_discount_total', $value, $this );
 	}
 
@@ -455,7 +445,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_discount_tax( $raw = false ) {
-		$value = wc_format_decimal( $this->_data['discount_tax'] );
+		$value = wc_format_decimal( $this->data['discount_tax'] );
 		return $raw ? $value : apply_filters( 'woocommerce_order_amount_discount_tax', $value, $this );
 	}
 
@@ -465,7 +455,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_shipping_total( $raw = false ) {
-		$value = wc_format_decimal( $this->_data['shipping_total'] );
+		$value = wc_format_decimal( $this->data['shipping_total'] );
 		return $raw ? $value : apply_filters( 'woocommerce_order_amount_shipping_total', $value, $this );
 	}
 
@@ -475,7 +465,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_shipping_tax( $raw = false ) {
-		$value = wc_format_decimal( $this->_data['shipping_tax'] );
+		$value = wc_format_decimal( $this->data['shipping_tax'] );
 		return $raw ? $value : apply_filters( 'woocommerce_order_amount_shipping_tax', $value, $this );
 	}
 
@@ -485,7 +475,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_cart_tax( $raw = false ) {
-		$value = wc_format_decimal( $this->_data['cart_tax'] );
+		$value = wc_format_decimal( $this->data['cart_tax'] );
 		return $raw ? $value : apply_filters( 'woocommerce_order_amount_cart_tax', $value, $this );
 	}
 
@@ -495,7 +485,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_total( $raw = false ) {
-		return $raw ? $this->_data['total'] : apply_filters( 'woocommerce_order_amount_total', $this->_data['total'], $this );
+		return $raw ? $this->data['total'] : apply_filters( 'woocommerce_order_amount_total', $this->data['total'], $this );
 	}
 
 	/**
@@ -509,7 +499,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_total_tax( $raw = false ) {
-		$value = wc_format_decimal( $this->_data['total_tax'] );
+		$value = wc_format_decimal( $this->data['total_tax'] );
 		return $raw ? $value : apply_filters( 'woocommerce_order_amount_total_tax', $value, $this );
 	}
 
@@ -586,16 +576,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	*/
 
 	/**
-	 * Set order ID.
-	 * @since 2.7.0
-	 * @param int $value
-	 * @throws WC_Data_Exception
-	 */
-	public function set_id( $value ) {
-		$this->_data['id'] = absint( $value );
-	}
-
-	/**
 	 * Set parent order ID.
 	 * @since 2.7.0
 	 * @param int $value
@@ -605,7 +585,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( $value && ! get_post( $value ) ) {
 			$this->error( 'order_invalid_parent_id', __( 'Invalid parent ID', 'woocommerce' ) );
 		}
-		$this->_data['parent_id'] = absint( $value );
+		$this->data['parent_id'] = absint( $value );
 	}
 
 	/**
@@ -623,7 +603,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$new_status = 'pending';
 		}
 
-		$this->_data['status'] = 'wc-' . $new_status;
+		$this->data['status'] = 'wc-' . $new_status;
 
 		// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
 		if ( $old_status && ! in_array( 'wc-' . $old_status, array_keys( wc_get_order_statuses() ) ) ) {
@@ -642,7 +622,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_version( $value ) {
-		$this->_data['version'] = $value;
+		$this->data['version'] = $value;
 	}
 
 	/**
@@ -654,7 +634,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( $value && ! in_array( $value, array_keys( get_woocommerce_currencies() ) ) ) {
 			$this->error( 'order_invalid_currency', __( 'Invalid currency code', 'woocommerce' ) );
 		}
-		$this->_data['currency'] = $value ? $value : get_woocommerce_currency();
+		$this->data['currency'] = $value ? $value : get_woocommerce_currency();
 	}
 
 	/**
@@ -663,7 +643,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_prices_include_tax( $value ) {
-		$this->_data['prices_include_tax'] = (bool) $value;
+		$this->data['prices_include_tax'] = (bool) $value;
 	}
 
 	/**
@@ -672,7 +652,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_created( $timestamp ) {
-		$this->_data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -681,7 +661,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_modified( $timestamp ) {
-		$this->_data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -690,7 +670,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_discount_total( $value ) {
-		$this->_data['discount_total'] = wc_format_decimal( $value );
+		$this->data['discount_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -699,7 +679,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_discount_tax( $value ) {
-		$this->_data['discount_tax'] = wc_format_decimal( $value );
+		$this->data['discount_tax'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -708,7 +688,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_total( $value ) {
-		$this->_data['shipping_total'] = wc_format_decimal( $value );
+		$this->data['shipping_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -717,7 +697,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_tax( $value ) {
-		$this->_data['shipping_tax'] = wc_format_decimal( $value );
+		$this->data['shipping_tax'] = wc_format_decimal( $value );
 		$this->set_total_tax( $this->get_cart_tax() + $this->get_shipping_tax() );
 	}
 
@@ -727,7 +707,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_cart_tax( $value ) {
-		$this->_data['cart_tax'] = wc_format_decimal( $value );
+		$this->data['cart_tax'] = wc_format_decimal( $value );
 		$this->set_total_tax( $this->get_cart_tax() + $this->get_shipping_tax() );
 	}
 
@@ -737,7 +717,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	protected function set_total_tax( $value ) {
-		$this->_data['total_tax'] = wc_format_decimal( $value );
+		$this->data['total_tax'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -751,7 +731,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			_deprecated_argument( 'total_type', '2.7', 'Use dedicated total setter methods instead.' );
 			return $this->legacy_set_total( $value, $deprecated );
 		}
-		$this->_data['total'] = wc_format_decimal( $value, wc_get_price_decimals() );
+		$this->data['total'] = wc_format_decimal( $value, wc_get_price_decimals() );
 	}
 
 	/*
@@ -774,12 +754,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM itemmeta USING {$wpdb->prefix}woocommerce_order_itemmeta itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $this->get_id(), $type ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s", $this->get_id(), $type ) );
 			if ( $group = $this->type_to_group( $type ) ) {
-				$this->_items[ $group ] = null;
+				$this->items[ $group ] = null;
 			}
 		} else {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM itemmeta USING {$wpdb->prefix}woocommerce_order_itemmeta itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $this->get_id() ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $this->get_id() ) );
-			$this->_items = array(
+			$this->items = array(
 				'line_items'     => null,
 				'coupon_lines'   => null,
 				'shipping_lines' => null,
@@ -816,11 +796,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		foreach ( $types as $type ) {
 			if ( $group = $this->type_to_group( $type ) ) {
-				if ( is_null( $this->_items[ $group ] ) ) {
-					$this->_items[ $group ] = $this->get_items_from_db( $type );
+				if ( is_null( $this->items[ $group ] ) ) {
+					$this->items[ $group ] = $this->get_items_from_db( $type );
 				}
 				// Don't use array_merge here because keys are numeric
-				$items = $items + $this->_items[ $group ];
+				$items = $items + $this->items[ $group ];
 			}
 		}
 
@@ -958,8 +938,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		// Unset and remove later
-		$this->_items_to_delete[] = $item;
-		unset( $this->_items[ $items_key ][ $item->get_id() ] );
+		$this->items_to_delete[] = $item;
+		unset( $this->items[ $items_key ][ $item->get_id() ] );
 	}
 
 	/**
@@ -973,15 +953,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		// Make sure existing items are loaded so we can append this new one.
-		if ( is_null( $this->_items[ $items_key ] ) ) {
-			$this->_items[ $items_key ] = $this->get_items( $item->get_type() );
+		if ( is_null( $this->items[ $items_key ] ) ) {
+			$this->items[ $items_key ] = $this->get_items( $item->get_type() );
 		}
 
 		// Append new row with generated temporary ID
 		if ( $item->get_id() ) {
-			$this->_items[ $items_key ][ $item->get_id() ] = $item;
+			$this->items[ $items_key ][ $item->get_id() ] = $item;
 		} else {
-			$this->_items[ $items_key ][ 'new:' . sizeof( $this->_items[ $items_key ] ) ] = $item;
+			$this->items[ $items_key ][ 'new:' . sizeof( $this->items[ $items_key ] ) ] = $item;
 		}
 	}
 

--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -1,5 +1,4 @@
 <?php
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -22,8 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Token Data (stored in the payment_tokens table).
 	 * @var array
 	 */
-	protected $_data = array(
-		 'id'         => 0,
+	protected $data = array(
 		 'gateway_id' => '',
 		 'token'      => '',
 		 'is_default' => 0,
@@ -34,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Meta type. Payment tokens are a new object type.
 	 * @var string
 	 */
-	protected $_meta_type = 'payment_token';
+	protected $meta_type = 'payment_token';
 
 	 /**
 	  * Initialize a payment token.
@@ -59,17 +57,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		// Set token type (cc, echeck)
 		if ( ! empty( $this->type ) ) {
-			$this->_data['type'] = $this->type;
+			$this->data['type'] = $this->type;
 		}
-	}
-
-	/**
-	 * Returns the payment token ID.
-	 * @since 2.6.0
-	 * @return integer Token ID
-	 */
-	public function get_id() {
-		return absint( $this->_data['id'] );
 	}
 
 	/**
@@ -78,7 +67,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return string Raw token
 	 */
 	public function get_token() {
-		return $this->_data['token'];
+		return $this->data['token'];
 	}
 
 	/**
@@ -87,7 +76,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param string $token
 	 */
 	public function set_token( $token ) {
-		$this->_data['token'] = $token;
+		$this->data['token'] = $token;
 	}
 
 	/**
@@ -96,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return string Payment Token Type (CC, eCheck)
 	 */
 	public function get_type() {
-		return isset( $this->_data['type'] ) ? $this->_data['type'] : '';
+		return isset( $this->data['type'] ) ? $this->data['type'] : '';
 	}
 
 	/**
@@ -113,7 +102,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return int User ID if this token is associated with a user or 0 if no user is associated
 	 */
 	public function get_user_id() {
-		return ( isset( $this->_data['user_id'] ) && $this->_data['user_id'] > 0 ) ? absint( $this->_data['user_id'] ) : 0;
+		return ( isset( $this->data['user_id'] ) && $this->data['user_id'] > 0 ) ? absint( $this->data['user_id'] ) : 0;
 	}
 
 	/**
@@ -122,7 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param int $user_id
 	 */
 	public function set_user_id( $user_id ) {
-		$this->_data['user_id'] = absint( $user_id );
+		$this->data['user_id'] = absint( $user_id );
 	}
 
 	/**
@@ -131,7 +120,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return string Gateway ID
 	 */
 	public function get_gateway_id() {
-		return $this->_data['gateway_id'];
+		return $this->data['gateway_id'];
 	}
 
 	/**
@@ -140,7 +129,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param string $gateway_id
 	 */
 	public function set_gateway_id( $gateway_id ) {
-		$this->_data['gateway_id'] = $gateway_id;
+		$this->data['gateway_id'] = $gateway_id;
 	}
 
 	/**
@@ -149,7 +138,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return boolean True if the token is default
 	 */
 	public function is_default() {
-		return ! empty( $this->_data['is_default'] );
+		return ! empty( $this->data['is_default'] );
 	}
 
 	/**
@@ -158,7 +147,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param boolean $is_default True or false
 	 */
 	public function set_default( $is_default ) {
-		$this->_data['is_default'] = (bool) $is_default;
+		$this->data['is_default'] = (bool) $is_default;
 	}
 
 	/**
@@ -167,11 +156,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @return boolean True if the passed data is valid
 	 */
 	public function validate() {
-		if ( empty( $this->_data['token'] ) ) {
+		if ( empty( $this->data['token'] ) ) {
 			return false;
 		}
 
-		if ( empty( $this->_data['type'] ) ) {
+		if ( empty( $this->data['type'] ) ) {
 			return false;
 		}
 
@@ -189,8 +178,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$token_id = $token->token_id;
 			$token = (array) $token;
 			unset( $token['token_id'] );
-			$this->_data = $token;
-			$this->_data['id'] = $token_id;
+			$this->data = $token;
+			$this->set_id( $token_id );
 			$this->read_meta_data();
 		}
 	}
@@ -258,7 +247,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		);
 
 		$wpdb->insert( $wpdb->prefix . 'woocommerce_payment_tokens', $payment_token_data );
-		$this->_data['id'] = $token_id = $wpdb->insert_id;
+		$token_id = $wpdb->insert_id;
+		$this->set_id( $token_id );
 		$this->save_meta_data();
 
 		// Make sure all other tokens are not set to default

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -188,7 +188,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 		$this->request     = $request;
 		$statuses          = wc_get_order_statuses();
 		$order             = wc_get_order( $post );
-		$data              = $order->get_data();
+		$data              = array_merge( array( 'id' => $order->get_id() ), $order->get_data() );
 		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
 		$format_date       = array( 'date_created', 'date_modified', 'date_completed' );
 		$format_line_items = array( 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines' );

--- a/includes/api/class-wc-rest-shipping-zones-controller.php
+++ b/includes/api/class-wc-rest-shipping-zones-controller.php
@@ -207,7 +207,7 @@ class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_Controlle
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$data = array(
-			'id'    => (int) $item['zone_id'],
+			'id'    => (int) $item['id'],
 			'name'  => $item['zone_name'],
 			'order' => (int) $item['zone_order'],
 		);

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -23,8 +23,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_data = array(
-		'id'                          => 0,
+	protected $data = array(
 		'code'                        => '',
 		'amount'                      => 0,
 		'date_created'                => '',
@@ -73,14 +72,14 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @since 2.7.0
 	 * @var string
 	 */
-	protected $_meta_type = 'post';
+	protected $meta_type = 'post';
 
 	/**
 	 * Data stored in meta keys, but not considered "meta" for a coupon.
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_internal_meta_keys = array(
+	protected $internal_meta_keys = array(
 		'discount_type',
 		'coupon_amount',
 		'expiry_date',
@@ -133,22 +132,13 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/*
-    |--------------------------------------------------------------------------
-    | Getters
-    |--------------------------------------------------------------------------
-    |
-    | Methods for getting data from the coupon object.
-    |
-    */
-
-   /**
-    * Get coupon ID.
-    * @since  2.7.0
-    * @return integer
-    */
-	public function get_id() {
-		return $this->_data['id'];
-	}
+	|--------------------------------------------------------------------------
+	| Getters
+	|--------------------------------------------------------------------------
+	|
+	| Methods for getting data from the coupon object.
+	|
+	*/
 
 	/**
 	 * Get coupon code.
@@ -156,7 +146,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return string
 	 */
 	public function get_code() {
-		return $this->_data['code'];
+		return $this->data['code'];
 	}
 
 	/**
@@ -165,7 +155,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return string
 	 */
 	public function get_description() {
-		return $this->_data['description'];
+		return $this->data['description'];
 	}
 
 	/**
@@ -174,7 +164,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return string
 	 */
 	public function get_discount_type() {
-		return $this->_data['discount_type'];
+		return $this->data['discount_type'];
 	}
 
 	/**
@@ -183,7 +173,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return float
 	 */
 	public function get_amount() {
-		return wc_format_decimal( $this->_data['amount'] );
+		return wc_format_decimal( $this->data['amount'] );
 	}
 
 	/**
@@ -192,7 +182,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return int
 	 */
 	public function get_date_expires() {
-		return $this->_data['date_expires'];
+		return $this->data['date_expires'];
 	}
 
 	/**
@@ -201,7 +191,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return int
 	 */
 	public function get_date_created() {
-		return $this->_data['date_created'];
+		return $this->data['date_created'];
 	}
 
 	/**
@@ -210,7 +200,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return int
 	 */
 	public function get_date_modified() {
-		return $this->_data['date_modified'];
+		return $this->data['date_modified'];
 	}
 
 	/**
@@ -219,7 +209,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return integer
 	 */
 	public function get_usage_count() {
-		return $this->_data['usage_count'];
+		return $this->data['usage_count'];
 	}
 
 	/**
@@ -228,7 +218,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return bool
 	 */
 	public function get_individual_use() {
-		return $this->_data['individual_use'];
+		return $this->data['individual_use'];
 	}
 
 	/**
@@ -237,7 +227,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_product_ids() {
-		return $this->_data['product_ids'];
+		return $this->data['product_ids'];
 	}
 
 	/**
@@ -246,7 +236,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_excluded_product_ids() {
-		return $this->_data['excluded_product_ids'];
+		return $this->data['excluded_product_ids'];
 	}
 
 	/**
@@ -255,7 +245,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return integer
 	 */
 	public function get_usage_limit() {
-		return $this->_data['usage_limit'];
+		return $this->data['usage_limit'];
 	}
 
 	/**
@@ -264,7 +254,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return integer
 	 */
 	public function get_usage_limit_per_user() {
-		return $this->_data['usage_limit_per_user'];
+		return $this->data['usage_limit_per_user'];
 	}
 
 	/**
@@ -273,7 +263,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return integer
 	 */
 	public function get_limit_usage_to_x_items() {
-		return $this->_data['limit_usage_to_x_items'];
+		return $this->data['limit_usage_to_x_items'];
 	}
 
 	/**
@@ -282,7 +272,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return bool
 	 */
 	public function get_free_shipping() {
-		return $this->_data['free_shipping'];
+		return $this->data['free_shipping'];
 	}
 
 	/**
@@ -291,7 +281,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_product_categories() {
-		return $this->_data['product_categories'];
+		return $this->data['product_categories'];
 	}
 
 	/**
@@ -300,7 +290,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_excluded_product_categories() {
-		return $this->_data['excluded_product_categories'];
+		return $this->data['excluded_product_categories'];
 	}
 
 	/**
@@ -309,7 +299,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return bool
 	 */
 	public function get_exclude_sale_items() {
-		return $this->_data['exclude_sale_items'];
+		return $this->data['exclude_sale_items'];
 	}
 
 	/**
@@ -318,7 +308,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return float
 	 */
 	public function get_minimum_amount() {
-		return wc_format_decimal( $this->_data['minimum_amount'] );
+		return wc_format_decimal( $this->data['minimum_amount'] );
 	}
 	/**
 	 * Get maximum spend amount.
@@ -326,7 +316,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return float
 	 */
 	public function get_maximum_amount() {
-		return wc_format_decimal( $this->_data['maximum_amount'] );
+		return wc_format_decimal( $this->data['maximum_amount'] );
 	}
 
 	/**
@@ -335,7 +325,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_email_restrictions() {
-		return $this->_data['email_restrictions'];
+		return $this->data['email_restrictions'];
 	}
 
 	/**
@@ -344,7 +334,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return array
 	 */
 	public function get_used_by() {
-		return $this->_data['used_by'];
+		return $this->data['used_by'];
 	}
 
 	/**
@@ -419,22 +409,13 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	*/
 
 	/**
-	 * Set ID
-	 * @param int $value
-	 * @throws WC_Data_Exception
-	 */
-	public function set_id( $value ) {
-		$this->_data['id'] = absint( $value );
-	}
-
-	/**
 	 * Set coupon code.
 	 * @since  2.7.0
 	 * @param  string $code
 	 * @throws WC_Data_Exception
 	 */
 	public function set_code( $code ) {
-		$this->_data['code'] = apply_filters( 'woocommerce_coupon_code', $code );
+		$this->data['code'] = apply_filters( 'woocommerce_coupon_code', $code );
 	}
 
 	/**
@@ -444,7 +425,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_description( $description ) {
-		$this->_data['description'] = $description;
+		$this->data['description'] = $description;
 	}
 
 	/**
@@ -457,7 +438,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( ! in_array( $discount_type, array_keys( wc_get_coupon_types() ) ) ) {
 			$this->error( 'coupon_invalid_discount_type', __( 'Invalid discount type', 'woocommerce' ) );
 		}
-		$this->_data['discount_type'] = $discount_type;
+		$this->data['discount_type'] = $discount_type;
 	}
 
 	/**
@@ -467,7 +448,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_amount( $amount ) {
-		$this->_data['amount'] = wc_format_decimal( $amount );
+		$this->data['amount'] = wc_format_decimal( $amount );
 	}
 
 	/**
@@ -477,7 +458,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_expires( $timestamp ) {
-		$this->_data['date_expires'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_expires'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -487,7 +468,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_created( $timestamp ) {
-		$this->_data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -497,7 +478,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_modified( $timestamp ) {
-		$this->_data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -507,7 +488,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_usage_count( $usage_count ) {
-		$this->_data['usage_count'] = absint( $usage_count );
+		$this->data['usage_count'] = absint( $usage_count );
 	}
 
 	/**
@@ -517,7 +498,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_individual_use( $is_individual_use ) {
-		$this->_data['individual_use'] = (bool) $is_individual_use;
+		$this->data['individual_use'] = (bool) $is_individual_use;
 	}
 
 	/**
@@ -527,7 +508,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_product_ids( $product_ids ) {
-		$this->_data['product_ids'] = (array) $product_ids;
+		$this->data['product_ids'] = (array) $product_ids;
 	}
 
 	/**
@@ -537,7 +518,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_excluded_product_ids( $excluded_product_ids ) {
-		$this->_data['excluded_product_ids'] = (array) $excluded_product_ids;
+		$this->data['excluded_product_ids'] = (array) $excluded_product_ids;
 	}
 
 	/**
@@ -547,7 +528,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_usage_limit( $usage_limit ) {
-		$this->_data['usage_limit'] = absint( $usage_limit );
+		$this->data['usage_limit'] = absint( $usage_limit );
 	}
 
 	/**
@@ -557,7 +538,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_usage_limit_per_user( $usage_limit ) {
-		$this->_data['usage_limit_per_user'] = absint( $usage_limit );
+		$this->data['usage_limit_per_user'] = absint( $usage_limit );
 	}
 
 	/**
@@ -567,7 +548,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_limit_usage_to_x_items( $limit_usage_to_x_items ) {
-		$this->_data['limit_usage_to_x_items'] = $limit_usage_to_x_items;
+		$this->data['limit_usage_to_x_items'] = $limit_usage_to_x_items;
 	}
 
 	/**
@@ -577,7 +558,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_free_shipping( $free_shipping ) {
-		$this->_data['free_shipping'] = (bool) $free_shipping;
+		$this->data['free_shipping'] = (bool) $free_shipping;
 	}
 
 	/**
@@ -587,7 +568,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_product_categories( $product_categories ) {
-		$this->_data['product_categories'] = (array) $product_categories;
+		$this->data['product_categories'] = (array) $product_categories;
 	}
 
 	/**
@@ -597,7 +578,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_excluded_product_categories( $excluded_product_categories ) {
-		$this->_data['excluded_product_categories'] = (array) $excluded_product_categories;
+		$this->data['excluded_product_categories'] = (array) $excluded_product_categories;
 	}
 
 	/**
@@ -607,7 +588,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_exclude_sale_items( $exclude_sale_items ) {
-		$this->_data['exclude_sale_items'] = (bool) $exclude_sale_items;
+		$this->data['exclude_sale_items'] = (bool) $exclude_sale_items;
 	}
 
 	/**
@@ -617,7 +598,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_minimum_amount( $amount ) {
-		$this->_data['minimum_amount'] = wc_format_decimal( $amount );
+		$this->data['minimum_amount'] = wc_format_decimal( $amount );
 	}
 
 	/**
@@ -627,7 +608,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_maximum_amount( $amount ) {
-		$this->_data['maximum_amount'] = wc_format_decimal( $amount );
+		$this->data['maximum_amount'] = wc_format_decimal( $amount );
 	}
 
 	/**
@@ -643,7 +624,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 				$this->error( 'coupon_invalid_email_address', __( 'Invalid email address restriction', 'woocommerce' ) );
 			}
 		}
-		$this->_data['email_restrictions'] = $emails;
+		$this->data['email_restrictions'] = $emails;
 	}
 
 	/**
@@ -653,7 +634,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_used_by( $used_by ) {
-		$this->_data['used_by'] = array_filter( $used_by );
+		$this->data['used_by'] = array_filter( $used_by );
 	}
 
 	/*
@@ -680,8 +661,8 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			return;
 		}
 
+		$this->set_id( $coupon_id );
 		$this->set_props( array(
-			'id'                          => $coupon_id,
 			'code'                        => $post_object->post_title,
 			'description'                 => $post_object->post_excerpt,
 			'date_created'                => $post_object->post_date,
@@ -729,7 +710,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		) ), true );
 
 		if ( $coupon_id ) {
-			$this->_data['id'] = $coupon_id;
+			$this->set_id( $coupon_id );
 			$this->update_post_meta( $coupon_id );
 			$this->save_meta_data();
 			do_action( 'woocommerce_new_coupon', $coupon_id );
@@ -774,6 +755,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function delete() {
 		wp_delete_post( $this->get_id() );
 		do_action( 'woocommerce_delete_coupon', $this->get_id() );
+		$this->set_id( 0 );
 	}
 
 	/**
@@ -860,7 +842,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function inc_usage_count( $used_by = '' ) {
 		if ( $this->get_id() ) {
-			$this->_data['usage_count']++;
+			$this->data['usage_count']++;
 			update_post_meta( $this->get_id(), 'usage_count', $this->get_usage_count() );
 			if ( $used_by ) {
 				add_post_meta( $this->get_id(), '_used_by', strtolower( $used_by ) );
@@ -877,7 +859,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function dcr_usage_count( $used_by = '' ) {
 		if ( $this->get_id() && $this->get_usage_count() > 0 ) {
 			global $wpdb;
-			$this->_data['usage_count']--;
+			$this->data['usage_count']--;
 			update_post_meta( $this->get_id(), 'usage_count', $this->get_usage_count() );
 			if ( $used_by ) {
 				/**

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -20,8 +20,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Stores customer data.
 	 * @var array
 	 */
-	protected $_data = array(
-		'id'                 => 0,
+	protected $data = array(
 		'date_created'       => '',
 		'date_modified'      => '',
 		'email'              => '',
@@ -60,7 +59,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Keys which are also stored in a session (so we can make sure they get updated...)
 	 * @var array
 	 */
-	protected $_session_keys = array(
+	protected $session_keys = array(
 		'billing_postcode',
 		'billing_city',
 		'billing_address_1',
@@ -92,7 +91,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_internal_meta_keys = array(
+	protected $internal_meta_keys = array(
 		'billing_postcode',
 		'billing_city',
 		'billing_address_1',
@@ -137,31 +136,31 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Internal meta type used to store user data.
 	 * @var string
 	 */
-	protected $_meta_type = 'user';
+	protected $meta_type = 'user';
 
 	/**
 	 * If this is the customer session, this is true. When true, guest accounts will not be saved to the DB.
 	 * @var boolean
 	 */
-	protected $_is_session = false;
+	protected $is_session = false;
 
 	/**
 	 * Stores a password if this needs to be changed. Write-only and hidden from _data.
 	 * @var string
 	 */
-	protected $_password = '';
+	protected $password = '';
 
 	/**
 	 * Stores if user is VAT exempt for this session.
 	 * @var string
 	 */
-	protected $_is_vat_exempt = false;
+	protected $is_vat_exempt = false;
 
 	/**
 	 * Stores if user has calculated shipping in this session.
 	 * @var string
 	 */
-	protected $_calculated_shipping = false;
+	protected $calculated_shipping = false;
 
 	/**
 	 * Load customer data based on how WC_Customer is called.
@@ -177,7 +176,7 @@ class WC_Customer extends WC_Legacy_Customer {
 			$this->read( $customer_id );
 		}
 		if ( $is_session ) {
-			$this->_is_session = true;
+			$this->is_session = true;
 			$this->load_session();
 			add_action( 'shutdown', array( $this, 'save_to_session' ), 10 );
 		}
@@ -189,7 +188,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function load_session() {
 		$data = (array) WC()->session->get( 'customer' );
 		if ( ! empty( $data ) ) {
-			foreach ( $this->_session_keys as $session_key ) {
+			foreach ( $this->session_keys as $session_key ) {
 				$function_key = $session_key;
 				if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
 					$session_key = str_replace( 'billing_', '', $session_key );
@@ -338,21 +337,12 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 
 	/**
-	 * Return a customer's user ID. Logged out users have ID 0.
-	 * @since 2.7.0
-	 * @return int
-	 */
-	public function get_id() {
-		return $this->_data['id'];
-	}
-
-	/**
 	 * Return the customer's username.
 	 * @since 2.7.0
 	 * @return string
 	 */
 	public function get_username() {
-		return $this->_data['username'];
+		return $this->data['username'];
 	}
 
 	/**
@@ -361,7 +351,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_email() {
-		return $this->_data['email'];
+		return $this->data['email'];
 	}
 
 	/**
@@ -370,7 +360,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_first_name() {
-		return $this->_data['first_name'];
+		return $this->data['first_name'];
 	}
 
 	/**
@@ -379,7 +369,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_last_name() {
-		return $this->_data['last_name'];
+		return $this->data['last_name'];
 	}
 
 	/**
@@ -388,7 +378,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_role() {
-		return $this->_data['role'];
+		return $this->data['role'];
 	}
 
 	/**
@@ -415,7 +405,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return integer
 	 */
 	public function get_date_created() {
-		return absint( $this->_data['date_created'] );
+		return absint( $this->data['date_created'] );
 	}
 
 	/**
@@ -424,7 +414,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return integer
 	 */
 	public function get_date_modified() {
-		return absint( $this->_data['date_modified'] );
+		return absint( $this->data['date_modified'] );
 	}
 
 	/**
@@ -432,7 +422,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_first_name() {
-		return $this->_data['billing']['first_name'];
+		return $this->data['billing']['first_name'];
 	}
 
 	/**
@@ -440,7 +430,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_last_name() {
-		return $this->_data['billing']['last_name'];
+		return $this->data['billing']['last_name'];
 	}
 
 	/**
@@ -448,7 +438,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_company() {
-		return $this->_data['billing']['company'];
+		return $this->data['billing']['company'];
 	}
 
 	/**
@@ -456,7 +446,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_phone() {
-		return $this->_data['billing']['phone'];
+		return $this->data['billing']['phone'];
 	}
 
 	/**
@@ -464,7 +454,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_email() {
-		return $this->_data['billing']['email'];
+		return $this->data['billing']['email'];
 	}
 
 	/**
@@ -472,7 +462,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_postcode() {
-		return wc_format_postcode( $this->_data['billing']['postcode'], $this->get_billing_country() );
+		return wc_format_postcode( $this->data['billing']['postcode'], $this->get_billing_country() );
 	}
 
 	/**
@@ -480,7 +470,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_city() {
-		return $this->_data['billing']['city'];
+		return $this->data['billing']['city'];
 	}
 
 	/**
@@ -488,7 +478,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_address() {
-		return $this->_data['billing']['address_1'];
+		return $this->data['billing']['address_1'];
 	}
 
 	/**
@@ -504,7 +494,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_address_2() {
-		return $this->_data['billing']['address_2'];
+		return $this->data['billing']['address_2'];
 	}
 
 	/**
@@ -512,7 +502,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_state() {
-		return $this->_data['billing']['state'];
+		return $this->data['billing']['state'];
 	}
 
 	/**
@@ -520,7 +510,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_billing_country() {
-		return $this->_data['billing']['country'];
+		return $this->data['billing']['country'];
 	}
 
 	/**
@@ -528,7 +518,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_first_name() {
-		return $this->_data['shipping']['first_name'];
+		return $this->data['shipping']['first_name'];
 	}
 
 	/**
@@ -536,7 +526,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_last_name() {
-		return $this->_data['shipping']['last_name'];
+		return $this->data['shipping']['last_name'];
 	}
 
 	/**
@@ -544,7 +534,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_company() {
-		return $this->_data['shipping']['company'];
+		return $this->data['shipping']['company'];
 	}
 
 	/**
@@ -552,7 +542,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_state() {
-		return $this->_data['shipping']['state'];
+		return $this->data['shipping']['state'];
 	}
 
 	/**
@@ -560,7 +550,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_country() {
-		return $this->_data['shipping']['country'];
+		return $this->data['shipping']['country'];
 	}
 
 	/**
@@ -568,7 +558,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_postcode() {
-		return wc_format_postcode( $this->_data['shipping']['postcode'], $this->get_shipping_country() );
+		return wc_format_postcode( $this->data['shipping']['postcode'], $this->get_shipping_country() );
 	}
 
 	/**
@@ -576,7 +566,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_city() {
-		return $this->_data['shipping']['city'];
+		return $this->data['shipping']['city'];
 	}
 
 	/**
@@ -584,7 +574,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_address() {
-		return $this->_data['shipping']['address_1'];
+		return $this->data['shipping']['address_1'];
 	}
 
 	/**
@@ -600,7 +590,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	public function get_shipping_address_2() {
-		return $this->_data['shipping']['address_2'];
+		return $this->data['shipping']['address_2'];
 	}
 
 	/**
@@ -609,7 +599,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return bool
 	 */
 	public function get_is_vat_exempt() {
-		return $this->_is_vat_exempt;
+		return $this->is_vat_exempt;
 	}
 
 	/**
@@ -617,7 +607,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return bool
 	 */
 	public function get_calculated_shipping() {
-		return $this->_calculated_shipping;
+		return $this->calculated_shipping;
 	}
 
 	/**
@@ -670,7 +660,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return bool
 	 */
 	function get_is_paying_customer() {
-		return (bool) $this->_data['is_paying_customer'];
+		return (bool) $this->data['is_paying_customer'];
 	}
 
 	/*
@@ -683,23 +673,13 @@ class WC_Customer extends WC_Legacy_Customer {
 	*/
 
 	/**
-	 * Set customer ID.
-	 * @since 2.7.0
-	 * @param int $value
-	 * @throws WC_Data_Exception
-	 */
-	protected function set_id( $value ) {
-		$this->_data['id'] = absint( $value );
-	}
-
-	/**
 	 * Set customer's username.
 	 * @since 2.7.0
 	 * @param string $username
 	 * @throws WC_Data_Exception
 	 */
 	public function set_username( $username ) {
-		$this->_data['username'] = $username;
+		$this->data['username'] = $username;
 	}
 
 	/**
@@ -712,7 +692,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		if ( $value && ! is_email( $value ) ) {
 			$this->error( 'customer_invalid_email', __( 'Invalid email address', 'woocommerce' ) );
 		}
-		$this->_data['email'] = sanitize_email( $value );
+		$this->data['email'] = sanitize_email( $value );
 	}
 
 	/**
@@ -722,7 +702,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_first_name( $first_name ) {
-		$this->_data['first_name'] = $first_name;
+		$this->data['first_name'] = $first_name;
 	}
 
 	/**
@@ -732,7 +712,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_last_name( $last_name ) {
-		$this->_data['last_name'] = $last_name;
+		$this->data['last_name'] = $last_name;
 	}
 
 	/**
@@ -747,7 +727,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		if ( $role && ! empty( $wp_roles->roles ) && ! in_array( $role, array_keys( $wp_roles->roles ) ) ) {
 			$this->error( 'customer_invalid_role', __( 'Invalid role', 'woocommerce' ) );
 		}
-		$this->_data['role'] = $role;
+		$this->data['role'] = $role;
 	}
 
 	/**
@@ -757,7 +737,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_password( $password ) {
-		$this->_password = wc_clean( $password );
+		$this->password = wc_clean( $password );
 	}
 
 	/**
@@ -767,7 +747,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_modified( $timestamp ) {
-		$this->_data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_modified'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -777,7 +757,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_created( $timestamp ) {
-		$this->_data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_created'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -787,10 +767,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_billing_address_to_base() {
 		$base = wc_get_customer_default_location();
-		$this->_data['billing']['country']  = $base['country'];
-		$this->_data['billing']['state']    = $base['state'];
-		$this->_data['billing']['postcode'] = '';
-		$this->_data['billing']['city']     = '';
+		$this->data['billing']['country']  = $base['country'];
+		$this->data['billing']['state']    = $base['state'];
+		$this->data['billing']['postcode'] = '';
+		$this->data['billing']['city']     = '';
 	}
 
 	/**
@@ -800,10 +780,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_shipping_address_to_base() {
 		$base = wc_get_customer_default_location();
-		$this->_data['shipping']['country']  = $base['country'];
-		$this->_data['shipping']['state']    = $base['state'];
-		$this->_data['shipping']['postcode'] = '';
-		$this->_data['shipping']['city']     = '';
+		$this->data['shipping']['country']  = $base['country'];
+		$this->data['shipping']['state']    = $base['state'];
+		$this->data['shipping']['postcode'] = '';
+		$this->data['shipping']['city']     = '';
 	}
 
 	/**
@@ -815,10 +795,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
-		$this->_data['shipping']['country']  = $country;
-		$this->_data['shipping']['state']    = $state;
-		$this->_data['shipping']['postcode'] = $postcode;
-		$this->_data['shipping']['city']     = $city;
+		$this->data['shipping']['country']  = $country;
+		$this->data['shipping']['state']    = $state;
+		$this->data['shipping']['postcode'] = $postcode;
+		$this->data['shipping']['city']     = $city;
 	}
 
 	/**
@@ -830,10 +810,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_location( $country, $state, $postcode = '', $city = '' ) {
-		$this->_data['billing']['country']  = $country;
-		$this->_data['billing']['state']    = $state;
-		$this->_data['billing']['postcode'] = $postcode;
-		$this->_data['billing']['city']     = $city;
+		$this->data['billing']['country']  = $country;
+		$this->data['billing']['state']    = $state;
+		$this->data['billing']['postcode'] = $postcode;
+		$this->data['billing']['city']     = $city;
 	}
 
 	/**
@@ -842,7 +822,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_first_name( $value ) {
-		$this->_data['billing']['first_name'] = $value;
+		$this->data['billing']['first_name'] = $value;
 	}
 
 	/**
@@ -851,7 +831,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_last_name( $value ) {
-		$this->_data['billing']['last_name'] = $value;
+		$this->data['billing']['last_name'] = $value;
 	}
 
 	/**
@@ -860,7 +840,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_company( $value ) {
-		$this->_data['billing']['company'] = $value;
+		$this->data['billing']['company'] = $value;
 	}
 
 	/**
@@ -869,7 +849,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_phone( $value ) {
-		$this->_data['billing']['phone'] = $value;
+		$this->data['billing']['phone'] = $value;
 	}
 
 	/**
@@ -882,7 +862,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		if ( $value && ! is_email( $value ) ) {
 			$this->error( 'customer_invalid_billing_email', __( 'Invalid billing email address', 'woocommerce' ) );
 		}
-		$this->_data['billing']['email'] = sanitize_email( $value );
+		$this->data['billing']['email'] = sanitize_email( $value );
 	}
 
 	/**
@@ -891,7 +871,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_country( $country ) {
-		$this->_data['billing']['country'] = $country;
+		$this->data['billing']['country'] = $country;
 	}
 
 	/**
@@ -900,7 +880,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_state( $state ) {
-		$this->_data['billing']['state'] = $state;
+		$this->data['billing']['state'] = $state;
 	}
 
 	/**
@@ -909,7 +889,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_postcode( $postcode ) {
-		$this->_data['billing']['postcode'] = $postcode;
+		$this->data['billing']['postcode'] = $postcode;
 	}
 
 	/**
@@ -918,7 +898,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_city( $city ) {
-		$this->_data['billing']['city'] = $city;
+		$this->data['billing']['city'] = $city;
 	}
 
 	/**
@@ -927,7 +907,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address( $address ) {
-		$this->_data['billing']['address_1'] = $address;
+		$this->data['billing']['address_1'] = $address;
 	}
 
 	/**
@@ -945,7 +925,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_2( $address ) {
-		$this->_data['billing']['address_2'] = $address;
+		$this->data['billing']['address_2'] = $address;
 	}
 
 	/**
@@ -954,7 +934,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_first_name( $first_name ) {
-		$this->_data['shipping']['first_name'] = $first_name;
+		$this->data['shipping']['first_name'] = $first_name;
 	}
 
 	/**
@@ -963,7 +943,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_last_name( $last_name ) {
-		$this->_data['shipping']['last_name'] = $last_name;
+		$this->data['shipping']['last_name'] = $last_name;
 	}
 
 	/**
@@ -972,7 +952,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_company( $company ) {
-		$this->_data['shipping']['company'] = $company;
+		$this->data['shipping']['company'] = $company;
 	}
 
 	/**
@@ -981,7 +961,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_country( $country ) {
-		$this->_data['shipping']['country'] = $country;
+		$this->data['shipping']['country'] = $country;
 	}
 
 	/**
@@ -990,7 +970,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_state( $state ) {
-		$this->_data['shipping']['state'] = $state;
+		$this->data['shipping']['state'] = $state;
 	}
 
 	/**
@@ -999,7 +979,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_postcode( $postcode ) {
-		$this->_data['shipping']['postcode'] = $postcode;
+		$this->data['shipping']['postcode'] = $postcode;
 	}
 
 	/**
@@ -1008,7 +988,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_city( $city ) {
-		$this->_data['shipping']['city'] = $city;
+		$this->data['shipping']['city'] = $city;
 	}
 
 	/**
@@ -1017,7 +997,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address( $address ) {
-		$this->_data['shipping']['address_1'] = $address;
+		$this->data['shipping']['address_1'] = $address;
 	}
 
 	/**
@@ -1035,7 +1015,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_2( $address ) {
-		$this->_data['shipping']['address_2'] = $address;
+		$this->data['shipping']['address_2'] = $address;
 	}
 
 	/**
@@ -1045,7 +1025,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @throws WC_Data_Exception
 	 */
 	function set_is_paying_customer( $is_paying_customer ) {
-		$this->_data['is_paying_customer'] = (bool) $is_paying_customer;
+		$this->data['is_paying_customer'] = (bool) $is_paying_customer;
 	}
 
 	/**
@@ -1053,7 +1033,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param bool $is_vat_exempt
 	 */
 	public function set_is_vat_exempt( $is_vat_exempt ) {
-		$this->_is_vat_exempt = (bool) $is_vat_exempt;
+		$this->is_vat_exempt = (bool) $is_vat_exempt;
 	}
 
 	/**
@@ -1061,7 +1041,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param boolean $calculated
 	 */
 	public function set_calculated_shipping( $calculated = true ) {
-		$this->_calculated_shipping = (bool) $calculated;
+		$this->calculated_shipping = (bool) $calculated;
 	}
 
 	/*
@@ -1079,10 +1059,10 @@ class WC_Customer extends WC_Legacy_Customer {
 	  * @since 2.7.0.
 	  */
 	public function create() {
-		$customer_id = wc_create_new_customer( $this->get_email(), $this->get_username(), $this->_password );
+		$customer_id = wc_create_new_customer( $this->get_email(), $this->get_username(), $this->password );
 
 		if ( ! is_wp_error( $customer_id ) ) {
-			$this->_data['id'] = $customer_id;
+			$this->set_id( $customer_id );
 			update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
 			update_user_meta( $this->get_id(), 'billing_last_name', $this->get_billing_last_name() );
 			update_user_meta( $this->get_id(), 'billing_company', $this->get_billing_company() );
@@ -1164,9 +1144,9 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function update() {
 		wp_update_user( array( 'ID' => $this->get_id(), 'user_email' => $this->get_email() ) );
 		// Only update password if a new one was set with set_password
-		if ( ! empty( $this->_password ) ) {
-			wp_update_user( array( 'ID' => $this->get_id(), 'user_pass' => $this->_password ) );
-			$this->_password = '';
+		if ( ! empty( $this->password ) ) {
+			wp_update_user( array( 'ID' => $this->get_id(), 'user_pass' => $this->password ) );
+			$this->password = '';
 		}
 
 		update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
@@ -1231,7 +1211,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @since 2.7.0
 	 */
 	public function save() {
-		if ( $this->_is_session ) {
+		if ( $this->is_session ) {
 			$this->save_to_session();
 		} elseif ( ! $this->get_id() ) {
 			$this->create();
@@ -1246,7 +1226,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function save_to_session() {
 		$data = array();
-		foreach ( $this->_session_keys as $session_key ) {
+		foreach ( $this->session_keys as $session_key ) {
 			$function_key = $session_key;
 			if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
 				$session_key = str_replace( 'billing_', '', $session_key );

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -21,9 +21,8 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_data = array(
+	protected $data = array(
 		'order_id' => 0,
-		'id'       => 0, // order_item_id
 		'name'     => '',
 		'type'     => '',
 	);
@@ -32,21 +31,21 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * May store an order to prevent retriving it multiple times.
 	 * @var object
 	 */
-	protected $_order;
+	protected $order;
 
 	/**
 	 * Stores meta in cache for future reads.
 	 * A group must be set to to enable caching.
 	 * @var string
 	 */
-	protected $_cache_group = 'order_itemmeta';
+	protected $cache_group = 'order_itemmeta';
 
 	/**
 	 * Meta type. This should match up with
 	 * the types avaiable at https://codex.wordpress.org/Function_Reference/add_metadata.
 	 * WP defines 'post', 'user', 'comment', and 'term'.
 	 */
-	protected $_meta_type = 'order_item';
+	protected $meta_type = 'order_item';
 
 	/**
 	 * Constructor.
@@ -88,10 +87,10 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @return int
 	 */
 	public function get_order() {
-		if ( ! $this->_order ) {
-		 	$this->_order = wc_get_order( $this->get_order_id() );
+		if ( ! $this->order ) {
+		 	$this->order = wc_get_order( $this->get_order_id() );
 		}
-		return $this->_order;
+		return $this->order;
 	}
 
 	/*
@@ -101,19 +100,11 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	*/
 
 	/**
-	 * Get order item ID.
-	 * @return int
-	 */
-	public function get_id() {
-		return $this->_data['id'];
-	}
-
-	/**
 	 * Get order ID this meta belongs to.
 	 * @return int
 	 */
 	public function get_order_id() {
-		return $this->_data['order_id'];
+		return $this->data['order_id'];
 	}
 
 	/**
@@ -121,7 +112,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @return string
 	 */
 	public function get_name() {
-		return $this->_data['name'];
+		return $this->data['name'];
 	}
 
 	/**
@@ -129,7 +120,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @return string
 	 */
 	public function get_type() {
-		return $this->_data['type'];
+		return $this->data['type'];
 	}
 
 	/*
@@ -139,21 +130,12 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	*/
 
 	/**
-	 * Set ID
-	 * @param int $value
-	 * @throws WC_Data_Exception
-	 */
-	public function set_id( $value ) {
-		$this->_data['id'] = absint( $value );
-	}
-
-	/**
 	 * Set order ID.
 	 * @param int $value
 	 * @throws WC_Data_Exception
 	 */
 	public function set_order_id( $value ) {
-		$this->_data['order_id'] = absint( $value );
+		$this->data['order_id'] = absint( $value );
 	}
 
 	/**
@@ -162,7 +144,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_name( $value ) {
-		$this->_data['name'] = wc_clean( $value );
+		$this->data['name'] = wc_clean( $value );
 	}
 
 	/**
@@ -171,7 +153,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @throws WC_Data_Exception
 	 */
 	protected function set_type( $value ) {
-		$this->_data['type'] = wc_clean( $value );
+		$this->data['type'] = wc_clean( $value );
 	}
 
 	/*
@@ -238,9 +220,9 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			return;
 		}
 
+		$this->set_id( $data->order_item_id );
 		$this->set_props( array(
 			'order_id' => $data->order_id,
-			'id'       => $data->order_item_id,
 			'name'     => $data->order_item_name,
 			'type'     => $data->order_item_type,
 		) );
@@ -343,8 +325,8 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			return;
 		}
 
-		if ( array_key_exists( $offset, $this->_data ) ) {
-			$this->_data[ $offset ] = $value;
+		if ( array_key_exists( $offset, $this->data ) ) {
+			$this->data[ $offset ] = $value;
 		}
 
 		$this->update_meta_data( '_' . $offset, $value );
@@ -356,12 +338,12 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 */
 	public function offsetUnset( $offset ) {
 		if ( 'item_meta_array' === $offset || 'item_meta' === $offset ) {
-			$this->_meta_data = array();
+			$this->meta_data = array();
 			return;
 		}
 
-		if ( array_key_exists( $offset, $this->_data ) ) {
-			unset( $this->_data[ $offset ] );
+		if ( array_key_exists( $offset, $this->data ) ) {
+			unset( $this->data[ $offset ] );
 		}
 
 		$this->delete_meta_data( '_' . $offset );
@@ -373,10 +355,10 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @return bool
 	 */
 	public function offsetExists( $offset ) {
-		if ( 'item_meta_array' === $offset || 'item_meta' === $offset || array_key_exists( $offset, $this->_data ) ) {
+		if ( 'item_meta_array' === $offset || 'item_meta' === $offset || array_key_exists( $offset, $this->data ) ) {
 			return true;
 		}
-		return array_key_exists( '_' . $offset, wp_list_pluck( $this->_meta_data, 'value', 'key' ) );
+		return array_key_exists( '_' . $offset, wp_list_pluck( $this->meta_data, 'value', 'key' ) );
 	}
 
 	/**
@@ -388,19 +370,19 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		if ( 'item_meta_array' === $offset ) {
 			$return = array();
 
-			foreach ( $this->_meta_data as $meta ) {
+			foreach ( $this->meta_data as $meta ) {
 				$return[ $meta->id ] = $meta;
 			}
 
 			return $return;
 		}
 
-		$meta_values = wp_list_pluck( $this->_meta_data, 'value', 'key' );
+		$meta_values = wp_list_pluck( $this->meta_data, 'value', 'key' );
 
 		if ( 'item_meta' === $offset ) {
 			return $meta_values;
-		} elseif ( array_key_exists( $offset, $this->_data ) ) {
-			return $this->_data[ $offset ];
+		} elseif ( array_key_exists( $offset, $this->data ) ) {
+			return $this->data[ $offset ];
 		} elseif ( array_key_exists( '_' . $offset, $meta_values ) ) {
 			// Item meta was expanded in previous versions, with prefixes removed. This maintains support.
 			return $meta_values[ '_' . $offset ];

--- a/includes/class-wc-order-refund.php
+++ b/includes/class-wc-order-refund.php
@@ -20,7 +20,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 */
 	 public function __construct( $read = 0 ) {
 		// Extend order data
-		$this->_data = array_merge( $this->_data, array(
+		$this->data = array_merge( $this->data, array(
 			'amount'      => '',
 			'reason'      => '',
 			'refunded_by' => 0,
@@ -33,7 +33,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_internal_meta_keys = array(
+	protected $internal_meta_keys = array(
 		'_order_currency',
 		'_cart_discount',
 		'_refund_amount',
@@ -137,7 +137,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_amount( $value ) {
-		$this->_data['amount'] = wc_format_decimal( $value );
+		$this->data['amount'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -145,7 +145,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @return int|float
 	 */
 	public function get_amount() {
-		return apply_filters( 'woocommerce_refund_amount', (double) $this->_data['amount'], $this );
+		return apply_filters( 'woocommerce_refund_amount', (double) $this->data['amount'], $this );
 	}
 
 	/**
@@ -163,7 +163,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_reason( $value ) {
-		$this->_data['reason'] = $value;
+		$this->data['reason'] = $value;
 	}
 
 	/**
@@ -172,7 +172,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @return int|float
 	 */
 	public function get_reason() {
-		return apply_filters( 'woocommerce_refund_reason', $this->_data['reason'], $this );
+		return apply_filters( 'woocommerce_refund_reason', $this->data['reason'], $this );
 	}
 
 	/**
@@ -181,7 +181,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_refunded_by( $value ) {
-		$this->_data['refunded_by'] = absint( $value );
+		$this->data['refunded_by'] = absint( $value );
 	}
 
 	/**
@@ -190,7 +190,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @return int
 	 */
 	public function get_refunded_by() {
-		return absint( $this->_data['refunded_by'] );
+		return absint( $this->data['refunded_by'] );
 	}
 
 	/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -22,7 +22,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_internal_meta_keys = array(
+	protected $internal_meta_keys = array(
 		'_customer_user',
 		'_order_key',
 		'_order_currency',
@@ -74,16 +74,15 @@ class WC_Order extends WC_Abstract_Order {
 	 * Stores data about status changes so relevant hooks can be fired.
 	 * @var bool|array
 	 */
-	protected $_status_transition = false;
+	protected $status_transition = false;
 
 	/**
 	 * Order Data array. This is the core order data exposed in APIs since 2.7.0.
 	 * @since 2.7.0
 	 * @var array
 	 */
-	protected $_data = array(
+	protected $data = array(
 		// Abstract order props
-		'id'                   => 0,
 		'parent_id'            => 0,
 		'status'               => '',
 		'currency'             => '',
@@ -427,8 +426,8 @@ class WC_Order extends WC_Abstract_Order {
 		$result = parent::set_status( $new_status );
 
 		if ( ! empty( $result['from'] ) && $result['from'] !== $result['to'] ) {
-			$this->_status_transition = array(
-				'from'   => ! empty( $this->_status_transition['from'] ) ? $this->_status_transition['from'] : $result['from'],
+			$this->status_transition = array(
+				'from'   => ! empty( $this->status_transition['from'] ) ? $this->status_transition['from'] : $result['from'],
 				'to'     => $result['to'],
 				'note'   => $note,
 				'manual' => (bool) $manual_update,
@@ -468,23 +467,23 @@ class WC_Order extends WC_Abstract_Order {
 	 * Handle the status transition.
 	 */
 	protected function status_transition() {
-		if ( $this->_status_transition ) {
-			if ( ! empty( $this->_status_transition['from'] ) ) {
-				$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $this->_status_transition['from'] ), wc_get_order_status_name( $this->_status_transition['to'] ) );
+		if ( $this->status_transition ) {
+			if ( ! empty( $this->status_transition['from'] ) ) {
+				$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['from'] ), wc_get_order_status_name( $this->status_transition['to'] ) );
 
-				do_action( 'woocommerce_order_status_' . $this->_status_transition['from'] . '_to_' . $this->_status_transition['to'], $this->get_id() );
-				do_action( 'woocommerce_order_status_changed', $this->get_id(), $this->_status_transition['from'], $this->_status_transition['to'] );
+				do_action( 'woocommerce_order_status_' . $this->status_transition['from'] . '_to_' . $this->status_transition['to'], $this->get_id() );
+				do_action( 'woocommerce_order_status_changed', $this->get_id(), $this->status_transition['from'], $this->status_transition['to'] );
 			} else {
-				$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $this->_status_transition['to'] ) );
+				$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['to'] ) );
 			}
 
-			do_action( 'woocommerce_order_status_' . $this->_status_transition['to'], $this->get_id() );
+			do_action( 'woocommerce_order_status_' . $this->status_transition['to'], $this->get_id() );
 
 			// Note the transition occured
-			$this->add_order_note( trim( $this->_status_transition['note'] . ' ' . $transition_note ), 0, $this->_status_transition['manual'] );
+			$this->add_order_note( trim( $this->status_transition['note'] . ' ' . $transition_note ), 0, $this->status_transition['manual'] );
 
 			// This has ran, so reset status transition variable
-			$this->_status_transition = false;
+			$this->status_transition = false;
 		}
 	}
 
@@ -504,7 +503,7 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function get_data() {
 		return array_merge(
-			$this->_data,
+			$this->data,
 			array(
 				'number'         => $this->get_order_number(),
 				'meta_data'      => $this->get_meta_data(),
@@ -534,7 +533,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_order_key() {
-		return $this->_data['order_key'];
+		return $this->data['order_key'];
 	}
 
 	/**
@@ -542,7 +541,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return int
 	 */
 	public function get_customer_id() {
-		return $this->_data['customer_id'];
+		return $this->data['customer_id'];
 	}
 
 	/**
@@ -566,7 +565,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_first_name() {
-		return $this->_data['billing']['first_name'];
+		return $this->data['billing']['first_name'];
 	}
 
 	/**
@@ -574,7 +573,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_last_name() {
-		return $this->_data['billing']['last_name'];
+		return $this->data['billing']['last_name'];
 	}
 
 	/**
@@ -582,7 +581,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_company() {
-		return $this->_data['billing']['company'];
+		return $this->data['billing']['company'];
 	}
 
 	/**
@@ -590,7 +589,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_address_1() {
-		return $this->_data['billing']['address_1'];
+		return $this->data['billing']['address_1'];
 	}
 
 	/**
@@ -598,7 +597,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string $value
 	 */
 	public function get_billing_address_2() {
-		return $this->_data['billing']['address_2'];
+		return $this->data['billing']['address_2'];
 	}
 
 	/**
@@ -606,7 +605,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string $value
 	 */
 	public function get_billing_city() {
-		return $this->_data['billing']['city'];
+		return $this->data['billing']['city'];
 	}
 
 	/**
@@ -614,7 +613,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_state() {
-		return $this->_data['billing']['state'];
+		return $this->data['billing']['state'];
 	}
 
 	/**
@@ -622,7 +621,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_postcode() {
-		return $this->_data['billing']['postcode'];
+		return $this->data['billing']['postcode'];
 	}
 
 	/**
@@ -630,7 +629,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_country() {
-		return $this->_data['billing']['country'];
+		return $this->data['billing']['country'];
 	}
 
 	/**
@@ -638,7 +637,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_email() {
-		return $this->_data['billing']['email'];
+		return $this->data['billing']['email'];
 	}
 
 	/**
@@ -646,7 +645,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_billing_phone() {
-		return $this->_data['billing']['phone'];
+		return $this->data['billing']['phone'];
 	}
 
 	/**
@@ -654,7 +653,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_first_name() {
-		return $this->_data['shipping']['first_name'];
+		return $this->data['shipping']['first_name'];
 	}
 
 	/**
@@ -662,7 +661,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_last_name() {
-		 return $this->_data['shipping']['last_name'];
+		 return $this->data['shipping']['last_name'];
 	}
 
 	/**
@@ -670,7 +669,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_company() {
-		return $this->_data['shipping']['company'];
+		return $this->data['shipping']['company'];
 	}
 
 	/**
@@ -678,7 +677,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_address_1() {
-		return $this->_data['shipping']['address_1'];
+		return $this->data['shipping']['address_1'];
 	}
 
 	/**
@@ -686,7 +685,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_address_2() {
-		return $this->_data['shipping']['address_2'];
+		return $this->data['shipping']['address_2'];
 	}
 
 	/**
@@ -694,7 +693,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_city() {
-		return $this->_data['shipping']['city'];
+		return $this->data['shipping']['city'];
 	}
 
 	/**
@@ -702,7 +701,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_state() {
-		return $this->_data['shipping']['state'];
+		return $this->data['shipping']['state'];
 	}
 
 	/**
@@ -710,7 +709,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_postcode() {
-		return $this->_data['shipping']['postcode'];
+		return $this->data['shipping']['postcode'];
 	}
 
 	/**
@@ -718,7 +717,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_country() {
-		return $this->_data['shipping']['country'];
+		return $this->data['shipping']['country'];
 	}
 
 	/**
@@ -726,7 +725,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_payment_method() {
-		return $this->_data['payment_method'];
+		return $this->data['payment_method'];
 	}
 
 	/**
@@ -734,7 +733,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_payment_method_title() {
-		return $this->_data['payment_method_title'];
+		return $this->data['payment_method_title'];
 	}
 
 	/**
@@ -742,7 +741,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_transaction_id() {
-		return $this->_data['transaction_id'];
+		return $this->data['transaction_id'];
 	}
 
 	/**
@@ -750,7 +749,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_customer_ip_address() {
-		return $this->_data['customer_ip_address'];
+		return $this->data['customer_ip_address'];
 	}
 
 	/**
@@ -758,7 +757,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_customer_user_agent() {
-		return $this->_data['customer_user_agent'];
+		return $this->data['customer_user_agent'];
 	}
 
 	/**
@@ -766,7 +765,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_created_via() {
-		return $this->_data['created_via'];
+		return $this->data['created_via'];
 	}
 
 	/**
@@ -774,7 +773,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_customer_note() {
-		return $this->_data['customer_note'];
+		return $this->data['customer_note'];
 	}
 
 	/**
@@ -782,7 +781,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return int
 	 */
 	public function get_date_completed() {
-		return absint( $this->_data['date_completed'] );
+		return absint( $this->data['date_completed'] );
 	}
 
 	/**
@@ -790,7 +789,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return int
 	 */
 	public function get_date_paid() {
-		return absint( $this->_data['date_paid'] );
+		return absint( $this->data['date_paid'] );
 	}
 
 	/**
@@ -800,7 +799,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return array The stored address after filter.
 	 */
 	public function get_address( $type = 'billing' ) {
-		return apply_filters( 'woocommerce_get_order_address', isset( $this->_data[ $type ] ) ? $this->_data[ $type ] : array(), $type, $this );
+		return apply_filters( 'woocommerce_get_order_address', isset( $this->data[ $type ] ) ? $this->data[ $type ] : array(), $type, $this );
 	}
 
 	/**
@@ -854,7 +853,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_cart_hash() {
-		return $this->_data['cart_hash'];
+		return $this->data['cart_hash'];
 	}
 
 	/*
@@ -875,7 +874,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_order_key( $value ) {
-		$this->_data['order_key'] = substr( $value, 0, 20 );
+		$this->data['order_key'] = substr( $value, 0, 20 );
 	}
 
 	/**
@@ -884,7 +883,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_customer_id( $value ) {
-		$this->_data['customer_id'] = absint( $value );
+		$this->data['customer_id'] = absint( $value );
 	}
 
 	/**
@@ -893,7 +892,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_first_name( $value ) {
-		$this->_data['billing']['first_name'] = $value;
+		$this->data['billing']['first_name'] = $value;
 	}
 
 	/**
@@ -902,7 +901,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_last_name( $value ) {
-		$this->_data['billing']['last_name'] = $value;
+		$this->data['billing']['last_name'] = $value;
 	}
 
 	/**
@@ -911,7 +910,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_company( $value ) {
-		$this->_data['billing']['company'] = $value;
+		$this->data['billing']['company'] = $value;
 	}
 
 	/**
@@ -920,7 +919,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_1( $value ) {
-		$this->_data['billing']['address_1'] = $value;
+		$this->data['billing']['address_1'] = $value;
 	}
 
 	/**
@@ -929,7 +928,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_address_2( $value ) {
-		$this->_data['billing']['address_2'] = $value;
+		$this->data['billing']['address_2'] = $value;
 	}
 
 	/**
@@ -938,7 +937,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_city( $value ) {
-		$this->_data['billing']['city'] = $value;
+		$this->data['billing']['city'] = $value;
 	}
 
 	/**
@@ -947,7 +946,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_state( $value ) {
-		$this->_data['billing']['state'] = $value;
+		$this->data['billing']['state'] = $value;
 	}
 
 	/**
@@ -956,7 +955,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_postcode( $value ) {
-		$this->_data['billing']['postcode'] = $value;
+		$this->data['billing']['postcode'] = $value;
 	}
 
 	/**
@@ -965,7 +964,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_country( $value ) {
-		$this->_data['billing']['country'] = $value;
+		$this->data['billing']['country'] = $value;
 	}
 
 	/**
@@ -990,7 +989,7 @@ class WC_Order extends WC_Abstract_Order {
 		if ( $value && ! is_email( $value ) ) {
 			$this->error( 'order_invalid_billing_email', __( 'Invalid order billing email address', 'woocommerce' ) );
 		}
-		$this->_data['billing']['email'] = sanitize_email( $value );
+		$this->data['billing']['email'] = sanitize_email( $value );
 	}
 
 	/**
@@ -999,7 +998,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_billing_phone( $value ) {
-		$this->_data['billing']['phone'] = $value;
+		$this->data['billing']['phone'] = $value;
 	}
 
 	/**
@@ -1008,7 +1007,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_first_name( $value ) {
-		$this->_data['shipping']['first_name'] = $value;
+		$this->data['shipping']['first_name'] = $value;
 	}
 
 	/**
@@ -1017,7 +1016,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_last_name( $value ) {
-		$this->_data['shipping']['last_name'] = $value;
+		$this->data['shipping']['last_name'] = $value;
 	}
 
 	/**
@@ -1026,7 +1025,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_company( $value ) {
-		$this->_data['shipping']['company'] = $value;
+		$this->data['shipping']['company'] = $value;
 	}
 
 	/**
@@ -1035,7 +1034,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_1( $value ) {
-		$this->_data['shipping']['address_1'] = $value;
+		$this->data['shipping']['address_1'] = $value;
 	}
 
 	/**
@@ -1044,7 +1043,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_address_2( $value ) {
-		$this->_data['shipping']['address_2'] = $value;
+		$this->data['shipping']['address_2'] = $value;
 	}
 
 	/**
@@ -1053,7 +1052,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_city( $value ) {
-		$this->_data['shipping']['city'] = $value;
+		$this->data['shipping']['city'] = $value;
 	}
 
 	/**
@@ -1062,7 +1061,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_state( $value ) {
-		$this->_data['shipping']['state'] = $value;
+		$this->data['shipping']['state'] = $value;
 	}
 
 	/**
@@ -1071,7 +1070,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_postcode( $value ) {
-		$this->_data['shipping']['postcode'] = $value;
+		$this->data['shipping']['postcode'] = $value;
 	}
 
 	/**
@@ -1080,7 +1079,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_country( $value ) {
-		$this->_data['shipping']['country'] = $value;
+		$this->data['shipping']['country'] = $value;
 	}
 
 	/**
@@ -1093,10 +1092,10 @@ class WC_Order extends WC_Abstract_Order {
 			$this->set_payment_method( $payment_method->id );
 			$this->set_payment_method_title( $payment_method->get_title() );
 		} elseif ( '' === $payment_method ) {
-			$this->_data['payment_method'] = '';
-			$this->_data['payment_method_title'] = '';
+			$this->data['payment_method'] = '';
+			$this->data['payment_method_title'] = '';
 		} else {
-			$this->_data['payment_method'] = $payment_method;
+			$this->data['payment_method'] = $payment_method;
 		}
 	}
 
@@ -1106,7 +1105,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_payment_method_title( $value ) {
-		$this->_data['payment_method_title'] = $value;
+		$this->data['payment_method_title'] = $value;
 	}
 
 	/**
@@ -1115,7 +1114,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_transaction_id( $value ) {
-		$this->_data['transaction_id'] = $value;
+		$this->data['transaction_id'] = $value;
 	}
 
 	/**
@@ -1124,7 +1123,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_customer_ip_address( $value ) {
-		$this->_data['customer_ip_address'] = $value;
+		$this->data['customer_ip_address'] = $value;
 	}
 
 	/**
@@ -1133,7 +1132,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_customer_user_agent( $value ) {
-		$this->_data['customer_user_agent'] = $value;
+		$this->data['customer_user_agent'] = $value;
 	}
 
 	/**
@@ -1142,7 +1141,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_created_via( $value ) {
-		$this->_data['created_via'] = $value;
+		$this->data['created_via'] = $value;
 	}
 
 	/**
@@ -1151,7 +1150,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_customer_note( $value ) {
-		$this->_data['customer_note'] = $value;
+		$this->data['customer_note'] = $value;
 	}
 
 	/**
@@ -1160,7 +1159,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_completed( $timestamp ) {
-		$this->_data['date_completed'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_completed'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -1169,7 +1168,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_date_paid( $timestamp ) {
-		$this->_data['date_paid'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
+		$this->data['date_paid'] = is_numeric( $timestamp ) ? $timestamp : strtotime( $timestamp );
 	}
 
 	/**
@@ -1178,7 +1177,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_cart_hash( $value ) {
-		$this->_data['cart_hash'] = $value;
+		$this->data['cart_hash'] = $value;
 	}
 
 	/*

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -15,12 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Shipping_Zone extends WC_Data {
 
+	protected $id = null;
+
 	/**
 	 * Zone Data
 	 * @var array
 	 */
-	protected $_data = array(
-		'zone_id'        => null,
+	protected $data = array(
 		'zone_name'      => '',
 		'zone_order'     => 0,
 		'zone_locations' => array(),
@@ -30,7 +31,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * True when location data needs to be re-saved
 	 * @var bool
 	 */
-	private $_locations_changed = false;
+	private $locations_changed = false;
 
 	/**
 	 * Constructor for zones
@@ -133,11 +134,19 @@ class WC_Shipping_Zone extends WC_Data {
 	}
 
 	/**
+	 * Set ID.
+	 * @param int|null $id
+	 */
+	public function set_id( $id ) {
+		$this->id = $id;
+	}
+
+	/**
 	 * Get ID
 	 * @return int|null Null if the zone does not exist. 0 is the default zone.
 	 */
 	public function get_id() {
-		return $this->get_zone_id();
+		return is_null( $this->id ) ? null : absint( $this->id );
 	}
 
 	/**
@@ -145,7 +154,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * @return int|null Null if the zone does not exist. 0 is the default zone.
 	 */
 	public function get_zone_id() {
-		return is_null( $this->_data['zone_id'] ) ? null : absint( $this->_data['zone_id'] );
+		return $this->get_id();
 	}
 
 	/**
@@ -153,7 +162,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * @return string
 	 */
 	public function get_zone_name() {
-		return $this->_data['zone_name'];
+		return $this->data['zone_name'];
 	}
 
 	/**
@@ -161,7 +170,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * @return int
 	 */
 	public function get_zone_order() {
-		return absint( $this->_data['zone_order'] );
+		return absint( $this->data['zone_order'] );
 	}
 
 	/**
@@ -169,7 +178,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * @return array of zone objects
 	 */
 	public function get_zone_locations() {
-		return $this->_data['zone_locations'];
+		return $this->data['zone_locations'];
 	}
 
 	/**
@@ -320,29 +329,11 @@ class WC_Shipping_Zone extends WC_Data {
 	}
 
 	/**
-	 * Set zone ID
-	 * @access private
-	 * @param int $set
-	 */
-	private function set_id( $set ) {
-		$this->set_zone_id( $set );
-	}
-
-	/**
-	 * Set zone ID
-	 * @access private
-	 * @param int $set
-	 */
-	private function set_zone_id( $set ) {
-		$this->_data['zone_id'] = is_null( $set ) ? null : absint( $set );
-	}
-
-	/**
 	 * Set zone name
 	 * @param string $set
 	 */
 	public function set_zone_name( $set ) {
-		$this->_data['zone_name'] = wc_clean( $set );
+		$this->data['zone_name'] = wc_clean( $set );
 	}
 
 	/**
@@ -350,7 +341,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * @param int $set
 	 */
 	public function set_zone_order( $set ) {
-		$this->_data['zone_order'] = absint( $set );
+		$this->data['zone_order'] = absint( $set );
 	}
 
 	/**
@@ -376,8 +367,8 @@ class WC_Shipping_Zone extends WC_Data {
 				'code' => wc_clean( $code ),
 				'type' => wc_clean( $type ),
 			);
-			$this->_data['zone_locations'][] = (object) $location;
-			$this->_locations_changed = true;
+			$this->data['zone_locations'][] = (object) $location;
+			$this->locations_changed = true;
 		}
 	}
 
@@ -389,10 +380,10 @@ class WC_Shipping_Zone extends WC_Data {
 		if ( ! is_array( $types ) ) {
 			$types = array( $types );
 		}
-		foreach ( $this->_data['zone_locations'] as $key => $values ) {
+		foreach ( $this->data['zone_locations'] as $key => $values ) {
 			if ( in_array( $values->type, $types ) ) {
-				unset( $this->_data['zone_locations'][ $key ] );
-				$this->_locations_changed = true;
+				unset( $this->data['zone_locations'][ $key ] );
+				$this->locations_changed = true;
 			}
 		}
 	}
@@ -408,7 +399,7 @@ class WC_Shipping_Zone extends WC_Data {
 			$this->add_location( $location['code'], $location['type'] );
 		}
 
-		$this->_locations_changed = true;
+		$this->locations_changed = true;
 	}
 
 	/**
@@ -423,7 +414,7 @@ class WC_Shipping_Zone extends WC_Data {
 				$this->add_location( $location->location_code, $location->location_type );
 			}
 		}
-		$this->_locations_changed = false;
+		$this->locations_changed = false;
 	}
 
 	/**
@@ -432,7 +423,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * This function clears old locations, then re-inserts new if any changes are found.
 	 */
 	private function save_locations() {
-		if ( ! $this->_locations_changed || null === $this->get_id() ) {
+		if ( ! $this->locations_changed || null === $this->get_id() ) {
 			return false;
 		}
 		global $wpdb;

--- a/tests/framework/class-wc-mock-wc-data.php
+++ b/tests/framework/class-wc-mock-wc-data.php
@@ -7,17 +7,16 @@ class WC_Mock_WC_Data extends WC_Data {
 	/**
 	 * Data array
 	 */
-	protected $_data = array(
-		'id'         => 0,
+	protected $data = array(
 		'content'    => '',
 		'bool_value' => false,
 	);
 
 	// see WC_Data
-	protected $_cache_group = '';
-	protected $_meta_type = 'post';
+	protected $cache_group = '';
+	protected $meta_type = 'post';
 	protected $object_id_field_for_meta = '';
-	protected $_internal_meta_keys = array();
+	protected $internal_meta_keys = array();
 
 	/*
 	|--------------------------------------------------------------------------
@@ -34,7 +33,7 @@ class WC_Mock_WC_Data extends WC_Data {
 	 * @param string $meta_type
 	 */
 	function set_meta_type( $meta_type ) {
-		$this->_meta_type = $meta_type;
+		$this->meta_type = $meta_type;
 	}
 
 	/**
@@ -64,19 +63,11 @@ class WC_Mock_WC_Data extends WC_Data {
 	}
 
 	/**
-	 * Simple get ID.
-	 * @return integer
-	 */
-	public function get_id() {
-		return intval( $this->_data['id'] );
-	}
-
-	/**
 	 * Simple get content.
 	 * @return string
 	 */
 	public function get_content() {
-		return $this->_data['content'];
+		return $this->data['content'];
 	}
 
 	/**
@@ -84,7 +75,7 @@ class WC_Mock_WC_Data extends WC_Data {
 	 * @param string $content
 	 */
 	public function set_content( $content ) {
-		$this->_data['content'] = $content;
+		$this->data['content'] = $content;
 	}
 
 	/**
@@ -92,7 +83,7 @@ class WC_Mock_WC_Data extends WC_Data {
 	 * @return bool
 	 */
 	public function get_bool_value() {
-		return $this->_data['bool_value'];
+		return $this->data['bool_value'];
 	}
 
 	/**
@@ -103,7 +94,7 @@ class WC_Mock_WC_Data extends WC_Data {
 		if ( ! is_bool( $value ) ) {
 			$this->error( 'invalid_bool_value', 'O noes' );
 		}
-		$this->_data['bool_value'] = $value;
+		$this->data['bool_value'] = $value;
 	}
 
 	/**
@@ -112,7 +103,7 @@ class WC_Mock_WC_Data extends WC_Data {
 	 */
 	public function get_data() {
 		return array_merge(
-			$this->_data,
+			$this->data,
 			array(
 				'meta_data' => $this->get_meta_data(),
 			)
@@ -123,13 +114,13 @@ class WC_Mock_WC_Data extends WC_Data {
 	 * Simple create.
 	 */
 	public function create() {
-		if ( 'user' === $this->_meta_type ) {
+		if ( 'user' === $this->meta_type ) {
 			$content_id = wc_create_new_customer( $this->get_content(), 'username-' . time(), 'hunter2' );
 		} else {
 			$content_id = wp_insert_post( array( 'post_title' => $this->get_content() ) );
 		}
 		if ( $content_id ) {
-			$this->_data['id'] = $content_id;
+			$this->set_id( $content_id );
 		}
 	}
 
@@ -139,17 +130,17 @@ class WC_Mock_WC_Data extends WC_Data {
 	public function read( $id ) {
 		$this->set_defaults();
 
-		if ( 'user' === $this->_meta_type ) {
+		if ( 'user' === $this->meta_type ) {
 			if ( empty( $id ) || ! ( $user_object = get_userdata( $id ) ) ) {
 				return;
 			}
-			$this->_data['id'] = absint( $user_object->ID );
+			$this->set_id( absint( $user_object->ID ) );
 			$this->set_content( $user_object->user_email );
 		} else {
 			if ( empty( $id ) || ! ( $post_object = get_post( $id ) ) ) {
 				return;
 			}
-			$this->_data['id'] = absint( $post_object->ID );
+			$this->set_id( absint( $post_object->ID ) );
 			$this->set_content( $post_object->post_title );
 		}
 
@@ -163,7 +154,7 @@ class WC_Mock_WC_Data extends WC_Data {
 		global $wpdb;
 		$content_id = $this->get_id();
 
-		if ( 'user' === $this->_meta_type ) {
+		if ( 'user' === $this->meta_type ) {
 			wp_update_user( array( 'ID' => $customer_id, 'user_email' => $this->get_content() ) );
 		} else {
 			wp_update_post( array( 'ID' => $content_id, 'post_title' => $this->get_content() ) );
@@ -174,7 +165,7 @@ class WC_Mock_WC_Data extends WC_Data {
 	 * Simple delete.
 	 */
 	public function delete() {
-		if ( 'user' === $this->_meta_type ) {
+		if ( 'user' === $this->meta_type ) {
 			wp_delete_user( $this->get_id() );
 		} else {
 			wp_delete_post( $this->get_id() );


### PR DESCRIPTION
- Stop using _ as a prefix for protected or private vars and functions. We have a keyword for that.
- Introduces set_id and get_id to WC_Data for the CRUD classes to share.
