### PR TITLE
(API) Add filter to continue uploading images if one fails

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -756,6 +756,8 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					if ( is_wp_error( $upload ) ) {
 						if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $product_id, $images ) ) {
 							throw new WC_REST_Exception( 'woocommerce_product_image_upload_error', $upload->get_error_message(), 400 );
+						} else {
+							continue;
 						}
 					}
 

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -754,7 +754,9 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
 
 					if ( is_wp_error( $upload ) ) {
-						throw new WC_REST_Exception( 'woocommerce_product_image_upload_error', $upload->get_error_message(), 400 );
+						if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $product_id, $images ) ) {
+							throw new WC_REST_Exception( 'woocommerce_product_image_upload_error', $upload->get_error_message(), 400 );
+						}
 					}
 
 					$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $product_id );


### PR DESCRIPTION
Right now, when using the API to create/update products, if an image supplied fails to be upload, the API throws an exception and stops. This PR adds a filter that allows you to suppress that exception and continue creating the product.
