### PR TITLE
Make WC_Logger follow FS_CHMOD_FILE when file is created

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -54,6 +54,7 @@ class WC_Logger {
 		}
 
 		if ( $this->_handles[ $handle ] = @fopen( wc_get_log_file_path( $handle ), $mode ) ) {
+			@chmod( wc_get_log_file_path( $handle ), FS_CHMOD_FILE );
 			return true;
 		}
 


### PR DESCRIPTION
When WC_Logger creates a file it should use the permissions defined in FS_CHMOD_FILE

See https://codex.wordpress.org/Editing_wp-config.php#Override_of_default_file_permissions
