### PR TITLE
Fix session locking in background processing class

### DIFF
--- a/includes/libraries/wp-async-request.php
+++ b/includes/libraries/wp-async-request.php
@@ -141,6 +141,9 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 		 * Check for correct nonce and pass to handler.
 		 */
 		public function maybe_handle() {
+			// Don't lock up other requests while processing
+			session_write_close();
+
 			check_ajax_referer( $this->identifier, 'nonce' );
 
 			$this->handle();

--- a/includes/libraries/wp-background-process.php
+++ b/includes/libraries/wp-background-process.php
@@ -159,6 +159,9 @@ if ( ! class_exists( 'WP_Background_Process' ) ) {
 		 * the process is not already running.
 		 */
 		public function maybe_handle() {
+			// Don't lock up other requests while processing
+			session_write_close();
+
 			if ( $this->is_process_running() ) {
 				// Background process already running.
 				wp_die();


### PR DESCRIPTION
Hi Guys,

I've just pushed a fix to https://github.com/A5hleyRich/wp-background-processing, which resolves an issue we uncovered in WP Offload S3. Long story short, long running processes were locking up all other requests to the site. For example, on a background process that would run for 20 seconds, all other requests would hang until the background process completed. Check out the PHP docs, which has numerous reports of this behavior:

http://php.net/manual/en/function.session-write-close.php
