### PR TITLE
[2.6] Variation is_on_backorder fails when parent manages stock and child doesn't...

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -561,7 +561,7 @@ class WC_Product_Variation extends WC_Product {
 		if ( true === $this->managing_stock() ) {
 			return parent::is_on_backorder( $qty_in_cart );
 		} else {
-			return $this->parent->is_on_backorder( $qty_in_cart );
+			return $this->parent->managing_stock() && $this->parent->backorders_allowed() && ( $this->parent->get_stock_quantity() - $qty_in_cart ) < 0;
 		}
 	}
 


### PR DESCRIPTION
...but at least one variation exists that does manages stock for itself.
### Description

When a variation does not manage stock, and its parent is set to manage stock, then `$variation->is_on_backorder()` will redirect to `$variation->parent->is_on_backorder()`, which however operates based on `get_total_stock()`: https://github.com/woothemes/woocommerce/blob/master/includes/abstracts/abstract-wc-product.php#L639

However, `get_total_stock()` will also include the stock quantity of any variations that do manage stock themselves, so the outcome of `$variation->is_on_backorder()` will be based on the entire stock available in all variations.
### Fix

Replace the parent call with a version that operates on the parent but uses `get_stock_quantity()` instead of `get_total_stock()`.
