### PR TITLE
Allow plugins to declare secure settings fields

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -177,6 +177,12 @@ abstract class WC_Settings_API {
 					$this->add_error( $e->getMessage() );
 				}
 			}
+			
+			//Allow for plugins to declare fields as secure and handle them as such
+			if ( isset( $field['secure'] ) && $field['secure'] ){
+				$this->settings[ $key ] = apply_filters( 'woocommerce_settings_api_secure_field_set', $this->settings[ $key ], $this->id, $key, $field['title'] );
+			}
+			
 		}
 
 		return update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ) );

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -177,12 +177,11 @@ abstract class WC_Settings_API {
 					$this->add_error( $e->getMessage() );
 				}
 			}
-			
-			//Allow for plugins to declare fields as secure and handle them as such
-			if ( isset( $field['secure'] ) && $field['secure'] ){
+
+			// Allow for plugins to declare fields as secure and handle them as such
+			if ( isset( $field['secure'] ) && $field['secure'] ) {
 				$this->settings[ $key ] = apply_filters( 'woocommerce_settings_api_secure_field_set', $this->settings[ $key ], $this->id, $key, $field['title'] );
 			}
-			
 		}
 
 		return update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ) );


### PR DESCRIPTION
Related to issue #11946 this provides a filter if a plugin declares a settings field as secure
