### PR TITLE
Fix is_checkout_pay_page conditional never returning true

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -110,7 +110,7 @@ if ( ! function_exists( 'is_checkout_pay_page' ) ) {
 	function is_checkout_pay_page() {
 		global $wp;
 
-		return is_checkout() && ! empty( $wp->query_vars['order-pay'] );
+		return is_checkout() || ! empty( $wp->query_vars['order-pay'] );
 	}
 }
 


### PR DESCRIPTION
`is_checkout_pay_page` is suppose to check if on checkout page or pay order page, but the condition will never return true due to the `&&`.
