### PR TITLE
Implement Variation Endpoints & Tests

### DIFF
--- a/includes/abstracts/abstract-wc-rest-posts-controller.php
+++ b/includes/abstracts/abstract-wc-rest-posts-controller.php
@@ -476,9 +476,10 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @param WP_Post $post Post object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given post.
 	 */
-	protected function prepare_links( $post ) {
+	protected function prepare_links( $post, $request ) {
 		$links = array(
 			'self' => array(
 				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $post->ID ) ),

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -166,7 +166,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
-		$response->add_links( $this->prepare_links( $post ) );
+		$response->add_links( $this->prepare_links( $post, $request ) );
 
 		/**
 		 * Filter the data for a response.

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -161,7 +161,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $refund ) );
+		$response->add_links( $this->prepare_links( $refund, $request ) );
 
 		/**
 		 * Filter the data for a response.
@@ -180,9 +180,10 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @param WC_Order_Refund $refund Comment object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given order refund.
 	 */
-	protected function prepare_links( $refund ) {
+	protected function prepare_links( $refund, $request ) {
 		$order_id = $refund->get_parent_id();
 		$base     = str_replace( '(?P<order_id>[\d]+)', $order_id, $this->rest_base );
 		$links    = array(

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -224,7 +224,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
-		$response->add_links( $this->prepare_links( $order ) );
+		$response->add_links( $this->prepare_links( $order, $request ) );
 
 		/**
 		 * Filter the data for a response.
@@ -243,9 +243,10 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @param WC_Order $order Order object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given order.
 	 */
-	protected function prepare_links( $order ) {
+	protected function prepare_links( $order, $request ) {
 		$links = array(
 			'self' => array(
 				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $order->get_id() ) ),

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -1,0 +1,637 @@
+<?php
+/**
+ * REST API variations controller
+ *
+ * Handles requests to the /products/<product_id>/variations endpoints.
+ *
+ * @author   WooThemes
+ * @category API
+ * @package  WooCommerce/API
+ * @since    2.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API variations controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Products_Controller
+ */
+class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller {
+
+	/**
+	* Endpoint namespace.
+	*
+	* @var string
+	*/
+	protected $namespace = 'wc/v1';
+
+	/**
+	* Route base.
+	*
+	* @var string
+	*/
+	protected $rest_base = 'products/(?P<product_id>[\d]+)/variations';
+
+	/**
+	 * Post type.
+	 *
+	 * @var string
+	 */
+	protected $post_type = 'product_variation';
+
+	/**
+	 * Initialize product actions (parent).
+	 */
+	public function __construct() {
+		add_filter( "woocommerce_rest_{$this->post_type}_query", array( $this, 'add_product_id' ), 9, 2 );
+		parent::__construct();
+	}
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args'                => $this->get_collection_params(),
+			),
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_item' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				'args'                => array(
+					'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_item' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'delete_item' ),
+				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+				'args'                => array(
+					'force' => array(
+						'default'     => false,
+						'description' => __( 'Whether to bypass trash and force deletion.', 'woocommerce' ),
+					),
+					'reassign' => array(),
+				),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		) );
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/batch', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'batch_items' ),
+				'permission_callback' => array( $this, 'batch_items_permissions_check' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+			),
+			'schema' => array( $this, 'get_public_batch_schema' ),
+		) );
+	}
+
+	/**
+	 * Adds the parent product ID to the query so we filter / get the correct variations.
+	 *
+	 * @param array $args
+	 * @param WP_REST_Request $request
+	 * @return array
+	 */
+	public function add_product_id( $args, $request ) {
+		$args['post_parent'] = $request['product_id'];
+		return $args;
+	}
+
+	/**
+	 * Prepare a single variation output for response.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $data
+	 */
+	public function prepare_item_for_response( $post, $request ) {
+		$variation = wc_get_product( $post );
+		$post_data = get_post( $variation->get_variation_id() );
+		$data      = array(
+			'id'                 => $variation->get_variation_id(),
+			'date_created'       => wc_rest_prepare_date_response( $post_data->post_date_gmt ),
+			'date_modified'      => wc_rest_prepare_date_response( $post_data->post_modified_gmt ),
+			'description'        => $variation->get_variation_description(),
+			'permalink'          => $variation->get_permalink(),
+			'sku'                => $variation->get_sku(),
+			'price'              => $variation->get_price(),
+			'regular_price'      => $variation->get_regular_price(),
+			'sale_price'         => $variation->get_sale_price(),
+			'date_on_sale_from'  => $variation->sale_price_dates_from ? date( 'Y-m-d', $variation->sale_price_dates_from ) : '',
+			'date_on_sale_to'    => $variation->sale_price_dates_to ? date( 'Y-m-d', $variation->sale_price_dates_to ) : '',
+			'on_sale'            => $variation->is_on_sale(),
+			'visible'            => $variation->is_visible(),
+			'purchasable'        => $variation->is_purchasable(),
+			'virtual'            => $variation->is_virtual(),
+			'downloadable'       => $variation->is_downloadable(),
+			'downloads'          => $this->get_downloads( $variation ),
+			'download_limit'     => '' !== $variation->download_limit ? (int) $variation->download_limit : -1,
+			'download_expiry'    => '' !== $variation->download_expiry ? (int) $variation->download_expiry : -1,
+			'tax_status'         => $variation->get_tax_status(),
+			'tax_class'          => $variation->get_tax_class(),
+			'manage_stock'       => $variation->managing_stock(),
+			'stock_quantity'     => $variation->get_stock_quantity(),
+			'in_stock'           => $variation->is_in_stock(),
+			'backorders'         => $variation->backorders,
+			'backorders_allowed' => $variation->backorders_allowed(),
+			'backordered'        => $variation->is_on_backorder(),
+			'weight'             => $variation->get_weight(),
+			'dimensions'         => array(
+				'length' => $variation->get_length(),
+				'width'  => $variation->get_width(),
+				'height' => $variation->get_height(),
+			),
+			'shipping_class'     => $variation->get_shipping_class(),
+			'shipping_class_id'  => $variation->get_shipping_class_id(),
+			'image'              => $this->get_images( $variation ),
+			'attributes'         => $this->get_attributes( $variation ),
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $variation, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->post_type, refers to post_type of the post being
+		 * prepared for the response.
+		 *
+		 * @param WP_REST_Response   $response   The response object.
+		 * @param WP_Post            $post       Post object.
+		 * @param WP_REST_Request    $request    Request object.
+		 */
+		return apply_filters( "woocommerce_rest_prepare_{$this->post_type}", $response, $post, $request );
+	}
+
+	/**
+	 * Prepare a single variation for create or update.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_Error|stdClass $data Post object.
+	 */
+	protected function prepare_item_for_database( $request ) {
+		$data = new stdClass;
+
+		// ID.
+		if ( isset( $request['id'] ) ) {
+			$data->ID = absint( $request['id'] );
+		}
+
+		// Post content.
+		if ( isset( $request['description'] ) ) {
+			$data->post_content = wp_filter_post_kses( $request['description'] );
+		}
+
+		$data->post_parent = $request['product_id'];
+		$data->post_author = get_current_user_id();
+		$data->post_status = 'publish';
+
+		// Only when creating
+		if ( empty( $request['id'] ) ) {
+			$data->post_type = $this->post_type;
+			$data->ping_status = 'closed';
+		}
+
+		/**
+		 * Filter the query_vars used in `get_items` for the constructed query.
+		 *
+		 * The dynamic portion of the hook name, $this->post_type, refers to post_type of the post being
+		 * prepared for insertion.
+		 *
+		 * @param stdClass        $data An object representing a single item prepared
+		 *                                       for inserting or updating the database.
+		 * @param WP_REST_Request $request       Request object.
+		 */
+		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}", $data, $request );
+	}
+
+	/**
+	 * Update post meta fields.
+	 *
+	 * @param WP_Post $post
+	 * @param WP_REST_Request $request
+	 * @return bool|WP_Error
+	 */
+	protected function update_post_meta_fields( $post, $request ) {
+		try {
+			$variable_product = wc_get_product( $post );
+			$product          = $variable_product->parent;
+			$this->save_variations_data( $product, $request, true );
+			return true;
+		} catch ( WC_REST_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Add post meta fields.
+	 *
+	 * @param WP_Post $post
+	 * @param WP_REST_Request $request
+	 * @return bool|WP_Error
+	 */
+	protected function add_post_meta_fields( $post, $request ) {
+		try {
+			$variable_product = wc_get_product( $post->ID );
+			$product          = $variable_product->parent;
+			$request['id']    = $post->ID;
+			$this->save_variations_data( $product, $request, true );
+			return true;
+		} catch ( WC_REST_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+	}
+
+	/**
+	 * Delete a variation.
+	 *
+	 * @param WP_REST_Request $request Full details about the request
+	 * @return WP_Error|boolean
+	 */
+	public function delete_item( $request ) {
+		$request['id'] = is_array( $request['id'] ) ? $request['id']['id'] : $request['id'];
+		return parent::delete_item( $request );
+	}
+
+	/**
+	 * Bulk create, update and delete items.
+	 *
+	 * @since  2.7.0
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array Of WP_Error or WP_REST_Response.
+	 */
+	public function batch_items( $request ) {
+		$items       = array_filter( $request->get_params() );
+		$params      = $request->get_url_params();
+		$product_id  = $params['product_id'];
+		$body_params = array();
+
+		foreach ( array( 'update', 'create', 'delete' ) as $batch_type ) {
+			if ( ! empty( $items[ $batch_type ] ) ) {
+				$injected_items = array();
+				foreach ( $items[ $batch_type ] as $item ) {
+					$injected_items[] = array_merge( array( 'product_id' => $product_id ), $item );
+				}
+				$body_params[ $batch_type ] = $injected_items;
+			}
+		}
+
+		$request = new WP_REST_Request( $request->get_method() );
+		$request->set_body_params( $body_params );
+
+		return parent::batch_items( $request );
+	}
+
+	/**
+	 * Get the Variation's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$schema         = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->post_type,
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created' => array(
+					'description' => __( "The date the variation was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified' => array(
+					'description' => __( "The date the variation was last modified, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'Variation description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'permalink' => array(
+					'description' => __( 'Variation URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'sku' => array(
+					'description' => __( 'Unique identifier.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price' => array(
+					'description' => __( 'Current variation price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'regular_price' => array(
+					'description' => __( 'Variation regular price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sale_price' => array(
+					'description' => __( 'Variation sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from' => array(
+					'description' => __( 'Start date of sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to' => array(
+					'description' => __( 'End data of sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'on_sale' => array(
+					'description' => __( 'Shows if the variation is on sale.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'visible' => array(
+					'description' => __( "Define if the attribute is visible on the \"Additional Information\" tab in the product's page.", 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'purchasable' => array(
+					'description' => __( 'Shows if the variation can be bought.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'virtual' => array(
+					'description' => __( 'If the variation is virtual.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloadable' => array(
+					'description' => __( 'If the variation is downloadable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloads' => array(
+					'description' => __( 'List of downloadable files.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'File MD5 hash.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'name' => array(
+							'description' => __( 'File name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'file' => array(
+							'description' => __( 'File URL.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'download_limit' => array(
+					'description' => __( 'Amount of times the variation can be downloaded.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'download_expiry' => array(
+					'description' => __( 'Number of days that the customer has up to be able to download the variation.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_status' => array(
+					'description' => __( 'Tax status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'taxable',
+					'enum'        => array( 'taxable', 'shipping', 'none' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_class' => array(
+					'description' => __( 'Tax class.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'manage_stock' => array(
+					'description' => __( 'Stock management at variation level.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'stock_quantity' => array(
+					'description' => __( 'Stock quantity.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'in_stock' => array(
+					'description' => __( 'Controls whether or not the variation is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders' => array(
+					'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'no',
+					'enum'        => array( 'no', 'notify', 'yes' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders_allowed' => array(
+					'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'backordered' => array(
+					'description' => __( 'Shows if the variation is on backordered.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'weight' => array(
+					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'dimensions' => array(
+					'description' => __( 'Variation dimensions.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'length' => array(
+							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'width' => array(
+							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'height' => array(
+							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'shipping_class' => array(
+					'description' => __( 'Shipping class slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'shipping_class_id' => array(
+					'description' => __( 'Shipping class ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'image' => array(
+					'description' => __( 'Variation image data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'Image ID.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'date_created' => array(
+							'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_modified' => array(
+							'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'src' => array(
+							'description' => __( 'Image URL.', 'woocommerce' ),
+							'type'        => 'string',
+							'format'      => 'uri',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'name' => array(
+							'description' => __( 'Image name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'alt' => array(
+							'description' => __( 'Image alternative text.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'position' => array(
+							'description' => __( 'Image position. 0 means that the image is featured.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'attributes' => array(
+					'description' => __( 'List of attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id' => array(
+							'description' => __( 'Attribute ID.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'name' => array(
+							'description' => __( 'Attribute name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'option' => array(
+							'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param WC_Product $product Product object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return array Links for the given product.
+	 */
+	protected function prepare_links( $variation, $request ) {
+		$product_id = (int) $request['product_id'];
+		$base       = str_replace( '(?P<product_id>[\d]+)', $product_id, $this->rest_base );
+		$links      = array(
+			'self' => array(
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $base, $variation->get_variation_id() ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $base) ),
+			),
+			'up' => array(
+				'href' => rest_url( sprintf( '/%s/products/%d', $this->namespace, $product_id ) ),
+			),
+		);
+		return $links;
+	}
+
+}

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -627,7 +627,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $product ) );
+		$response->add_links( $this->prepare_links( $product, $request ) );
 
 		/**
 		 * Filter the data for a response.
@@ -646,9 +646,10 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 	 * Prepare links for the request.
 	 *
 	 * @param WC_Product $product Product object.
+	 * @param WP_REST_Request $request Request object.
 	 * @return array Links for the given product.
 	 */
-	protected function prepare_links( $product ) {
+	protected function prepare_links( $product, $request ) {
 		$links = array(
 			'self' => array(
 				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $product->id ) ),
@@ -1315,10 +1316,14 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 	 * @return bool
 	 * @throws WC_REST_Exception
 	 */
-	protected function save_variations_data( $product, $request ) {
+	protected function save_variations_data( $product, $request, $single_variation = false ) {
 		global $wpdb;
 
-		$variations = $request['variations'];
+		if ( $single_variation ) {
+			$variations = array( $request );
+		} else {
+			$variations = $request['variations'];
+		}
 		$attributes = $product->get_attributes();
 
 		foreach ( $variations as $menu_order => $variation ) {
@@ -1384,7 +1389,8 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 
 			// Thumbnail.
 			if ( isset( $variation['image'] ) && is_array( $variation['image'] ) ) {
-				$image = current( $variation['image'] );
+				$image = $variation['image'];
+				$image = current( $image );
 				if ( $image && is_array( $image ) ) {
 					if ( isset( $image['position'] ) && 0 === $image['position'] ) {
 						$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;

--- a/includes/api/class-wc-rest-webhooks-controller.php
+++ b/includes/api/class-wc-rest-webhooks-controller.php
@@ -416,7 +416,7 @@ class WC_REST_Webhooks_Controller extends WC_REST_Posts_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links( $this->prepare_links( $post ) );
+		$response->add_links( $this->prepare_links( $post, $request ) );
 
 		/**
 		 * Filter webhook object returned from the REST API.

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -159,6 +159,7 @@ class WC_API extends WC_Legacy_API {
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-product-shipping-classes-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-product-tags-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-products-controller.php' );
+		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-product-variations-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-report-sales-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-report-top-sellers-controller.php' );
 		include_once( dirname( __FILE__ ) . '/api/class-wc-rest-reports-controller.php' );
@@ -199,6 +200,7 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Product_Shipping_Classes_Controller',
 			'WC_REST_Product_Tags_Controller',
 			'WC_REST_Products_Controller',
+			'WC_REST_Product_Variations_Controller',
 			'WC_REST_Report_Sales_Controller',
 			'WC_REST_Report_Top_Sellers_Controller',
 			'WC_REST_Reports_Controller',

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -55,7 +55,7 @@ class WC_Helper_Product {
 	}
 
 	/**
-	 * Create a dummy simple product.
+	 * Create a dummy variation product.
 	 *
 	 * @since 2.3
 	 *
@@ -176,7 +176,7 @@ class WC_Helper_Product {
 
 		$return = array();
 
-		$attribute_name = 'dummyattribute';
+		$attribute_name = 'size';
 
 		// Create attribute
 		$attribute = array(
@@ -208,7 +208,7 @@ class WC_Helper_Product {
 		// Add the term_taxonomy
 		$wpdb->insert( $wpdb->prefix . 'term_taxonomy', array(
 			'term_id'     => $return['term_id'],
-			'taxonomy'    => 'pa_dummyattribute',
+			'taxonomy'    => 'pa_size',
 			'description' => '',
 			'parent'      => 0,
 			'count'       => 1,
@@ -217,6 +217,13 @@ class WC_Helper_Product {
 
 		// Delete transient
 		delete_transient( 'wc_attribute_taxonomies' );
+
+		$taxonomy_data = array(
+			'labels' => array(
+				'name' => __( 'size', 'woocommerce' ),
+			)
+		);
+		register_taxonomy( 'pa_size', array( 'product' ), $taxonomy_data );
 
 		return $return;
 	}

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -1,0 +1,372 @@
+<?php
+/**
+ * Tests for Variations API.
+ *
+ * @package WooCommerce\Tests\API
+ * @since 2.7.0
+ */
+
+class Product_Variations_API extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_Product_Variations_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/v1/products/(?P<product_id>[\d]+)/variations', $routes );
+		$this->assertArrayHasKey( '/wc/v1/products/(?P<product_id>[\d]+)/variations/(?P<id>[\d]+)', $routes );
+	}
+
+	/**
+	 * Test getting variations.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_variations() {
+		wp_set_current_user( $this->user );
+		$product    = WC_Helper_Product::create_variation_product();
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations' ) );
+		$variations = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $variations ) );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+		$this->assertEquals( 'size', $variations[0]['attributes'][0]['name'] );
+	}
+
+	/**
+	 * Test getting variations without permission.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_variations_without_permission() {
+		wp_set_current_user( 0 );
+		$product    = WC_Helper_Product::create_variation_product();
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test getting a single variation.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_variation() {
+		wp_set_current_user( $this->user );
+		$product      = WC_Helper_Product::create_variation_product();
+		$children     = $product->get_children();
+		$variation_id = $children[0];
+
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id ) );
+		$variation  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $variation_id, $variation['id'] );
+		$this->assertEquals( 'size', $variation['attributes'][0]['name'] );
+	}
+
+	/**
+	 * Test getting single variation without permission.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_variation_without_permission() {
+		wp_set_current_user( 0 );
+		$product      = WC_Helper_Product::create_variation_product();
+		$children     = $product->get_children();
+		$variation_id = $children[0];
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test deleting a single variation.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_delete_variation() {
+		wp_set_current_user( $this->user );
+		$product      = WC_Helper_Product::create_variation_product();
+		$children     = $product->get_children();
+		$variation_id = $children[0];
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations' ) );
+		$variations = $response->get_data();
+		$this->assertEquals( 1, count( $variations ) );
+	}
+
+	/**
+	 * Test deleting a single variation without permission.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_delete_variation_without_permission() {
+		wp_set_current_user( 0 );
+		$product      = WC_Helper_Product::create_variation_product();
+		$children     = $product->get_children();
+		$variation_id = $children[0];
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test deleting a single variation with an invalid ID.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_delete_variation_with_invalid_id() {
+		wp_set_current_user( 0 );
+		$product = WC_Helper_Product::create_variation_product();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v1/products/' . $product->id . '/variations/0' );
+		$request->set_param( 'force', true );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test editing a single variation.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_update_variation() {
+		wp_set_current_user( $this->user );
+		$product      = WC_Helper_Product::create_variation_product();
+		$children     = $product->get_children();
+		$variation_id = $children[0];
+
+		$response  = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id ) );
+		$variation = $response->get_data();
+
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variation['sku'] );
+		$this->assertEquals( 10, $variation['regular_price'] );
+		$this->assertEmpty( $variation['sale_price'] );
+		$this->assertEquals( 'small', $variation['attributes'][0]['option'] );
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id );
+		$request->set_body_params( array(
+			'sku'         => 'FIXED-SKU',
+			'sale_price'  => '8',
+			'description' => 'O_O',
+			'image'       => array( array( 'position' => 0, 'src' => 'https://cldup.com/Dr1Bczxq4q.png', 'alt' => 'test upload image' ) ),
+			'attributes'  => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
+		) );
+		$response  = $this->server->dispatch( $request );
+		$variation = $response->get_data();
+
+		$this->assertContains( 'O_O', $variation['description'] );
+		$this->assertEquals( '8', $variation['price'] );
+		$this->assertEquals( '8', $variation['sale_price'] );
+		$this->assertEquals( '10', $variation['regular_price'] );
+		$this->assertEquals( 'FIXED-SKU', $variation['sku'] );
+		$this->assertEquals( 'medium', $variation['attributes'][0]['option'] );
+
+		$this->assertContains( 'Dr1Bczxq4q', $variation['image'][0]['src'] );
+		$this->assertContains( 'test upload image', $variation['image'][0]['alt'] );
+	}
+
+	/**
+	 * Test updating a single variation without permission.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_update_variation_without_permission() {
+		wp_set_current_user( 0 );
+		$product      = WC_Helper_Product::create_variation_product();
+		$children     = $product->get_children();
+		$variation_id = $children[0];
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $product->id . '/variations/' . $variation_id );
+		$request->set_body_params( array(
+			'sku'         => 'FIXED-SKU-NO-PERMISSION',
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test updating a single variation with an invalid ID.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_update_variation_with_invalid_id() {
+		wp_set_current_user( 0 );
+		$product = WC_Helper_Product::create_variation_product();
+		$request = new WP_REST_Request( 'PUT', '/wc/v1/products/' . $product->id . '/variations/0' );
+		$request->set_body_params( array(
+			'sku'         => 'FIXED-SKU-NO-PERMISSION',
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test creating a single variation.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_create_variation() {
+		wp_set_current_user( $this->user );
+		$product = WC_Helper_Product::create_variation_product();
+
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations' ) );
+		$variations = $response->get_data();
+		$this->assertEquals( 2, count( $variations ) );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/variations' );
+		$request->set_body_params( array(
+			'sku'            => 'DUMMY SKU VARIABLE MEDIUM',
+			'regular_price'  => '12',
+			'description'    => 'A medium size.',
+			'attributes'     => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
+		) );
+		$response  = $this->server->dispatch( $request );
+		$variation = $response->get_data();
+
+		$this->assertContains( 'A medium size.', $variation['description'] );
+		$this->assertEquals( '12', $variation['price'] );
+		$this->assertEquals( '12', $variation['regular_price'] );
+		$this->assertTrue( $variation['purchasable'] );
+		$this->assertEquals( 'DUMMY SKU VARIABLE MEDIUM', $variation['sku'] );
+		$this->assertEquals( 'medium', $variation['attributes'][0]['option'] );
+
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations' ) );
+		$variations = $response->get_data();
+		$this->assertEquals( 3, count( $variations ) );
+	}
+
+	/**
+	 * Test creating a single variation without permission.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_create_variation_without_permission() {
+		wp_set_current_user( 0 );
+		$product      = WC_Helper_Product::create_variation_product();
+
+		$request = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/variations' );
+		$request->set_body_params( array(
+			'sku'            => 'DUMMY SKU VARIABLE MEDIUM',
+			'regular_price'  => '12',
+			'description'    => 'A medium size.',
+			'attributes'     => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
+		) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test batch managing product variations.
+	 */
+	public function test_product_variations_batch() {
+		wp_set_current_user( $this->user );
+		$product  = WC_Helper_Product::create_variation_product();
+		$children = $product->get_children();
+		$request  = new WP_REST_Request( 'POST', '/wc/v1/products/' . $product->id . '/variations/batch' );
+		$request->set_body_params( array(
+			'update' => array(
+				array(
+					'id'          => $children[0],
+					'description' => 'Updated description.',
+					'image'       => array( array( 'position' => 0, 'src' => 'https://cldup.com/Dr1Bczxq4q.png', 'alt' => 'test upload image' ) ),
+				),
+			),
+			'delete' => array(
+				array(
+					'id' => $children[1],
+				),
+			),
+			'create' => array(
+				array(
+					'sku'            => 'DUMMY SKU VARIABLE MEDIUM',
+					'regular_price'  => '12',
+					'description'    => 'A medium size.',
+					'attributes'     => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertContains( 'Updated description.', $data['update'][0]['description'] );
+		$this->assertEquals( 'DUMMY SKU VARIABLE MEDIUM', $data['create'][0]['sku'] );
+		$this->assertEquals( 'medium', $data['create'][0]['attributes'][0]['option'] );
+		$this->assertEquals( $children[1], $data['delete'][0]['id'] );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->id . '/variations' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 2, count( $data ) );
+	}
+
+	/**
+	 * Test variation schema.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_variation_schema() {
+		wp_set_current_user( $this->user );
+		$product = WC_Helper_Product::create_simple_product();
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v1/products/' . $product->id . '/variations' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 33, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'date_created', $properties );
+		$this->assertArrayHasKey( 'date_modified', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
+		$this->assertArrayHasKey( 'permalink', $properties );
+		$this->assertArrayHasKey( 'sku', $properties );
+		$this->assertArrayHasKey( 'price', $properties );
+		$this->assertArrayHasKey( 'regular_price', $properties );
+		$this->assertArrayHasKey( 'sale_price', $properties );
+		$this->assertArrayHasKey( 'date_on_sale_from', $properties );
+		$this->assertArrayHasKey( 'date_on_sale_to', $properties );
+		$this->assertArrayHasKey( 'on_sale', $properties );
+		$this->assertArrayHasKey( 'visible', $properties );
+		$this->assertArrayHasKey( 'purchasable', $properties );
+		$this->assertArrayHasKey( 'virtual', $properties );
+		$this->assertArrayHasKey( 'downloadable', $properties );
+		$this->assertArrayHasKey( 'downloads', $properties );
+		$this->assertArrayHasKey( 'download_limit', $properties );
+		$this->assertArrayHasKey( 'download_expiry', $properties );
+		$this->assertArrayHasKey( 'tax_status', $properties );
+		$this->assertArrayHasKey( 'tax_class', $properties );
+		$this->assertArrayHasKey( 'manage_stock', $properties );
+		$this->assertArrayHasKey( 'stock_quantity', $properties );
+		$this->assertArrayHasKey( 'in_stock', $properties );
+		$this->assertArrayHasKey( 'backorders', $properties );
+		$this->assertArrayHasKey( 'backorders_allowed', $properties );
+		$this->assertArrayHasKey( 'backordered', $properties );
+		$this->assertArrayHasKey( 'weight', $properties );
+		$this->assertArrayHasKey( 'dimensions', $properties );
+		$this->assertArrayHasKey( 'shipping_class', $properties );
+		$this->assertArrayHasKey( 'shipping_class_id', $properties );
+		$this->assertArrayHasKey( 'image', $properties );
+		$this->assertArrayHasKey( 'attributes', $properties );
+	}
+
+}


### PR DESCRIPTION
This PR adds a new set of endpoints for managing variations (separate from the products endpoints) since their schemas/what they contain differ -- though the endpoints share code when possible (variations extends the products endpoint).

This PR implements does not remove any variations code / fix the buggy behavior of trying to create a variation from the products endpoints. We should open a ticket for a future milestone (so when we version the API at some point in the future so we can properly separate the two and prevent people from creating variations from the root endpoint).

Closes #11775.
