### PR TITLE
fixes issue #11207

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -184,7 +184,7 @@ class WC_Payment_Gateways {
 		}
 
 		$current = WC()->session->get( 'chosen_payment_method' );
-		if ( empty($current) && isset( $default_token_gateway ) ) {
+		if ( empty( $current ) && isset( $default_token_gateway ) ) {
 			$current = $default_token_gateway;
 		}
 

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -183,7 +183,10 @@ class WC_Payment_Gateways {
 			}
 		}
 
-		$current = ( isset( $default_token_gateway ) ? $default_token_gateway : WC()->session->get( 'chosen_payment_method' ) );
+		$current = WC()->session->get( 'chosen_payment_method' );
+		if ( empty($current) && isset( $default_token_gateway ) ) {
+			$current = $default_token_gateway;
+		}
 
 		if ( $current && isset( $gateways[ $current ] ) ) {
 			$current_gateway = $gateways[ $current ];


### PR DESCRIPTION
if update_checkout was called during checkout, recurring customer weren't able to change the payment method on checkout because woocommerce favored $default_token_gateway over the session content
