### PR TITLE
fix issue 12004 (sales price does not automatically revert to regular…

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -434,6 +434,9 @@ function wc_scheduled_sales() {
 
 			// Sync parent
 			if ( $parent ) {
+                                // Clear prices transient for variable products.
+				delete_transient( 'wc_var_prices_' . $parent );
+                            
 				// Grouped products need syncing via a function
 				$this_product = wc_get_product( $product_id );
 				if ( $this_product->is_type( 'simple' ) ) {

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -434,7 +434,7 @@ function wc_scheduled_sales() {
 
 			// Sync parent
 			if ( $parent ) {
-                                // Clear prices transient for variable products.
+                // Clear prices transient for variable products.
 				delete_transient( 'wc_var_prices_' . $parent );
                             
 				// Grouped products need syncing via a function


### PR DESCRIPTION
This pull request fixes the issue #12004 (sales price does not automatically revert to the regular price on the store front at the end of the sales event).
Please see the ticket for details.
