### PR TITLE
Fix taxonomies names

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -38,9 +38,6 @@ class WC_Admin_Menus {
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 
-		// Rename taxonomies at Appearance > Menus > Pages
-		add_filter( 'nav_menu_meta_box_object', array( $this, 'rename_nav_menu_meta_boxes' ) );
-
 		// Add endpoints custom URLs in Appearance > Menus > Pages
 		add_action( 'admin_init', array( $this, 'add_nav_menu_meta_boxes' ) );
 
@@ -226,23 +223,6 @@ class WC_Admin_Menus {
 	 */
 	public function addons_page() {
 		WC_Admin_Addons::output();
-	}
-
-	/**
-	 * Rename taxonomies in admin menus meta boxes.
-	 * @param  object $tax
-	 * @return object
-	 */
-	public function rename_nav_menu_meta_boxes( $tax ) {
-		if ( isset( $tax->name ) ) {
-			if ( 'product_cat' === $tax->name ) {
-				$tax->labels->name = __( 'Product Categories', 'woocommerce' );
-			} elseif ( 'product_tag' === $tax->name ) {
-				$tax->labels->name = __( 'Product Tags', 'woocommerce' );
-			}
-		}
-
-		return $tax;
 	}
 
 	/**

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -62,7 +62,7 @@ class WC_Post_types {
 				'update_count_callback' => '_wc_term_recount',
 				'label'                 => __( 'Categories', 'woocommerce' ),
 				'labels' => array(
-						'name'              => __( 'Categories', 'woocommerce' ),
+						'name'              => __( 'Product Categories', 'woocommerce' ),
 						'singular_name'     => __( 'Category', 'woocommerce' ),
 						'menu_name'         => _x( 'Categories', 'Admin menu name', 'woocommerce' ),
 						'search_items'      => __( 'Search Categories', 'woocommerce' ),
@@ -98,7 +98,7 @@ class WC_Post_types {
 				'update_count_callback' => '_wc_term_recount',
 				'label'                 => __( 'Product Tags', 'woocommerce' ),
 				'labels'                => array(
-						'name'                       => __( 'Tags', 'woocommerce' ),
+						'name'                       => __( 'Product Tags', 'woocommerce' ),
 						'singular_name'              => __( 'Tag', 'woocommerce' ),
 						'menu_name'                  => _x( 'Tags', 'Admin menu name', 'woocommerce' ),
 						'search_items'               => __( 'Search Tags', 'woocommerce' ),
@@ -135,7 +135,7 @@ class WC_Post_types {
 				'update_count_callback' => '_update_post_term_count',
 				'label'                 => __( 'Shipping Classes', 'woocommerce' ),
 				'labels' => array(
-						'name'              => __( 'Shipping Classes', 'woocommerce' ),
+						'name'              => __( 'Product Shipping Classes', 'woocommerce' ),
 						'singular_name'     => __( 'Shipping Class', 'woocommerce' ),
 						'menu_name'         => _x( 'Shipping Classes', 'Admin menu name', 'woocommerce' ),
 						'search_items'      => __( 'Search Shipping Classes', 'woocommerce' ),
@@ -175,7 +175,7 @@ class WC_Post_types {
 						'hierarchical'          => true,
 						'update_count_callback' => '_update_post_term_count',
 						'labels'                => array(
-								'name'              => $label,
+								'name'              => sprintf( _x( 'Product %s', 'Product Attribute', 'woocommerce' ), $label ),
 								'singular_name'     => $label,
 								'search_items'      => sprintf( __( 'Search %s', 'woocommerce' ), $label ),
 								'all_items'         => sprintf( __( 'All %s', 'woocommerce' ), $label ),


### PR DESCRIPTION
Since we change the name of the taxonomies it's difficult to see the difference between product categories/tags over post categories/tags.

We used a small hack to rename it on the menu meta box, however this don't solve all the problems, for example like for the Tag Cloud Widget: #12011
