### PR TITLE
Wrap the "Any % (taxonomy)" string in a filter (to help with translation)

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -219,8 +219,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			$term_counts          = $this->get_filtered_term_product_counts( wp_list_pluck( $terms, 'term_id' ), $taxonomy, $query_type );
 			$_chosen_attributes   = WC_Query::get_layered_nav_chosen_attributes();
 			$taxonomy_filter_name = str_replace( 'pa_', '', $taxonomy );
-			$taxonomy_label       =  wc_attribute_label( $taxonomy );
-			$any_label            = apply_filters( 'woocommerce_layered_nav_any_label', sprintf( __( 'Any %s', 'woocommerce' ), $taxonomy_label ), $taxonomy_label );
+			$taxonomy_label       = wc_attribute_label( $taxonomy );
+			$any_label            = apply_filters( 'woocommerce_layered_nav_any_label', sprintf( __( 'Any %s', 'woocommerce' ), $taxonomy_label ), $taxonomy_label, $taxonomy );
 
 			echo '<select class="dropdown_layered_nav_' . esc_attr( $taxonomy_filter_name ) . '">';
 			echo '<option value="">' . esc_html( $any_label ) . '</option>';

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -219,9 +219,11 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			$term_counts          = $this->get_filtered_term_product_counts( wp_list_pluck( $terms, 'term_id' ), $taxonomy, $query_type );
 			$_chosen_attributes   = WC_Query::get_layered_nav_chosen_attributes();
 			$taxonomy_filter_name = str_replace( 'pa_', '', $taxonomy );
+			$taxonomy_label       =  wc_attribute_label( $taxonomy );
+			$any_label            = apply_filters( 'woocommerce_layered_nav_any_label', sprintf( __( 'Any %s', 'woocommerce' ), $taxonomy_label ), $taxonomy_label );
 
 			echo '<select class="dropdown_layered_nav_' . esc_attr( $taxonomy_filter_name ) . '">';
-			echo '<option value="">' . sprintf( __( 'Any %s', 'woocommerce' ), wc_attribute_label( $taxonomy ) ) . '</option>';
+			echo '<option value="">' . esc_html( $any_label ) . '</option>';
 
 			foreach ( $terms as $term ) {
 


### PR DESCRIPTION
Fixes #12025.

I did some searching around to see if anyone else in the WP community dealt with something like this, and it seems like the best way to handle it is indeed a filter. You could hook into the gettext filter and target this string specifically, but adding hooks onto gettext would be really slow. If we want to allow site owners/devs to hook in and fix it for certain sites, this seems like an easy way to do it - it wouldn't help translation packs though since %s is an unknown at that point.
