### PR TITLE
Improve password reset using WP functions

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -277,19 +277,8 @@ class WC_Shortcode_My_Account {
 			return false;
 		}
 
-		$key = wp_generate_password( 20, false );
-
-		do_action( 'retrieve_password_key', $user_login, $key );
-
-		// Now insert the key, hashed, into the DB.
-		if ( empty( $wp_hasher ) ) {
-			require_once ABSPATH . 'wp-includes/class-phpass.php';
-			$wp_hasher = new PasswordHash( 8, true );
-		}
-
-		$hashed = $wp_hasher->HashPassword( $key );
-
-		$wpdb->update( $wpdb->users, array( 'user_activation_key' => $hashed ), array( 'user_login' => $user_login ) );
+		// Get password reset key (function introduced in WordPress 4.4).
+		$key = get_password_reset_key( $user_data );
 
 		// Send email notification
 		WC()->mailer(); // load email classes
@@ -305,40 +294,19 @@ class WC_Shortcode_My_Account {
 	 *
 	 * @param string $key Hash to validate sending user's password
 	 * @param string $login The user login
-	 * @return WP_USER|bool User's database row on success, false for invalid keys
+	 * @return WP_User|bool User's database row on success, false for invalid keys
 	 */
 	public static function check_password_reset_key( $key, $login ) {
-		global $wpdb, $wp_hasher;
+		// Check for the password reset key.
+		// Get user data or an error message in case of invalid or expired key.
+		$user = check_password_reset_key( $key, $login );
 
-		$key = preg_replace( '/[^a-z0-9]/i', '', $key );
-
-		if ( empty( $key ) || ! is_string( $key ) ) {
-			wc_add_notice( __( 'Invalid key', 'woocommerce' ), 'error' );
+		if ( is_wp_error( $user ) ) {
+			wc_add_notice( $user->get_error_message(), 'error' );
 			return false;
 		}
 
-		if ( empty( $login ) || ! is_string( $login ) ) {
-			wc_add_notice( __( 'Invalid key', 'woocommerce' ), 'error' );
-			return false;
-		}
-
-		$user = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->users WHERE user_login = %s", $login ) );
-
-		if ( ! empty( $user ) ) {
-			if ( empty( $wp_hasher ) ) {
-				require_once ABSPATH . 'wp-includes/class-phpass.php';
-				$wp_hasher = new PasswordHash( 8, true );
-			}
-
-			$valid = $wp_hasher->CheckPassword( $key, $user->user_activation_key );
-		}
-
-		if ( empty( $user ) || empty( $valid ) ) {
-			wc_add_notice( __( 'Invalid key', 'woocommerce' ), 'error' );
-			return false;
-		}
-
-		return get_userdata( $user->ID );
+		return $user;
 	}
 
 	/**


### PR DESCRIPTION
This reduce our customized code for reset passwords.

This uses [`get_password_reset_key()`](https://developer.wordpress.org/reference/functions/get_password_reset_key/) introduced since WordPress 4.4, and now can handle how generate password reset keys.
And after we use [`check_password_reset_key()`](https://developer.wordpress.org/reference/functions/check_password_reset_key/) to check if the reset key is valid.
