### PR TITLE
Product name should be in quotes after being removed in cart page

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -486,8 +486,8 @@ class WC_Form_Handler {
 				$product = wc_get_product( $cart_item['product_id'] );
 
 				$item_removed_title = apply_filters( 'woocommerce_cart_item_removed_title', $product ? $product->get_title() : __( 'Item', 'woocommerce' ), $cart_item );
-				
-				$item_removed_title = sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), $item_removed_title);
+
+				$item_removed_title = sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), $item_removed_title );
 
 				// Don't show undo link if removed item is out of stock.
 				if ( $product->is_in_stock() && $product->has_enough_stock( $cart_item['quantity'] ) ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -486,6 +486,8 @@ class WC_Form_Handler {
 				$product = wc_get_product( $cart_item['product_id'] );
 
 				$item_removed_title = apply_filters( 'woocommerce_cart_item_removed_title', $product ? $product->get_title() : __( 'Item', 'woocommerce' ), $cart_item );
+				
+				$item_removed_title = sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), $item_removed_title);
 
 				// Don't show undo link if removed item is out of stock.
 				if ( $product->is_in_stock() && $product->has_enough_stock( $cart_item['quantity'] ) ) {


### PR DESCRIPTION
The product name should be in quotes after being removed in cart page.

in the single product, product name is in quotes:
![single-product](https://cloud.githubusercontent.com/assets/108828/19185026/1316cf08-8c80-11e6-9f1a-b8cad3f464da.JPG)

in the cart page, produt name is _not_ in quotes:
![cart](https://cloud.githubusercontent.com/assets/108828/19185030/17dc69a8-8c80-11e6-9f13-97dfa1032871.JPG)

This pull request adds quotes to the product name, when printed in the string: %s removed.

Thank you.
