### PR TITLE
Only display price meta when price is not empty

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -944,7 +944,7 @@ class WC_Product {
 		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
 		$display_price    = ( 'incl' === $tax_display_mode ) ? $this->get_price_including_tax( $qty, $price ) : $this->get_price_excluding_tax( $qty, $price );
 
-		return $display_price;
+		return apply_filters('woocommerce_get_display_price', $display_price, $price, $qty, $price );
 	}
 
 	/**

--- a/templates/single-product/price.php
+++ b/templates/single-product/price.php
@@ -27,8 +27,10 @@ global $product;
 
 	<p class="price"><?php echo $product->get_price_html(); ?></p>
 
-	<meta itemprop="price" content="<?php echo esc_attr( $product->get_display_price() ); ?>" />
-	<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
+	<?php if ($product->get_display_price()): ?>
+		<meta itemprop="price" content="<?php echo esc_attr( $product->get_display_price() ); ?>" />
+		<meta itemprop="priceCurrency" content="<?php echo esc_attr( get_woocommerce_currency() ); ?>" />
+	<?php endif; ?>
 	<link itemprop="availability" href="http://schema.org/<?php echo $product->is_in_stock() ? 'InStock' : 'OutOfStock'; ?>" />
 
 </div>


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-catalog-visibility-options/issues/9
