### PR TITLE
add argument on woocommerce_shipping_rate_label

### DIFF
--- a/includes/class-wc-shipping-rate.php
+++ b/includes/class-wc-shipping-rate.php
@@ -71,7 +71,7 @@ class WC_Shipping_Rate {
 	 * @return string
 	 */
 	public function get_label() {
-		return apply_filters( 'woocommerce_shipping_rate_label', $this->label );
+		return apply_filters( 'woocommerce_shipping_rate_label', $this->label, $this );
 	}
 
 	/**


### PR DESCRIPTION
add $this argument for woocommerce_shipping_rate_label.
That may be very handy for modifying a label with a specific method_id before the rate price was added.
