### PR TITLE
Added a title arg to quantity input

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1047,6 +1047,7 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 			'step'        => apply_filters( 'woocommerce_quantity_input_step', '1', $product ),
 			'pattern'     => apply_filters( 'woocommerce_quantity_input_pattern', has_filter( 'woocommerce_stock_amount', 'intval' ) ? '[0-9]*' : '' ),
 			'inputmode'   => apply_filters( 'woocommerce_quantity_input_inputmode', has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'numeric' : '' ),
+			'input_title' => apply_filters( 'woocommerce_quantity_input_title', esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ), $product )
 		);
 
 		$args = apply_filters( 'woocommerce_quantity_input_args', wp_parse_args( $args, $defaults ), $product );

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -21,5 +21,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="quantity">
-	<input type="number" step="<?php echo esc_attr( $step ); ?>" min="<?php echo esc_attr( $min_value ); ?>" max="<?php echo esc_attr( $max_value ); ?>" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $input_value ); ?>" title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ) ?>" class="input-text qty text" size="4" pattern="<?php echo esc_attr( $pattern ); ?>" inputmode="<?php echo esc_attr( $inputmode ); ?>" />
+	<input type="number" step="<?php echo esc_attr( $step ); ?>" min="<?php echo esc_attr( $min_value ); ?>" max="<?php echo esc_attr( $max_value ); ?>" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $input_value ); ?>" title="<?php echo $input_title; ?>" class="input-text qty text" size="4" pattern="<?php echo esc_attr( $pattern ); ?>" inputmode="<?php echo esc_attr( $inputmode ); ?>" />
 </div>


### PR DESCRIPTION
I added a title arg to the quantity input in the woocommerce_quantity_input
function. This allows third parties to set the input title to be
something other than 'Qty'. 'Qty' is set as a default.
