### PR TITLE
[Product CRUD] External Products

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -22,14 +22,13 @@ include_once( 'abstract-wc-legacy-product.php' );
 class WC_Product extends WC_Abstract_Legacy_Product {
 
 	/**
-	 * Stores customer data.
+	 * Stores product data.
 	 *
 	 * @var array
 	 */
 	protected $data = array(
 		'name'               => '',
 		'slug'               => '',
-		//'permalink'          => '',
 		'date_created'       => '',
 		'date_modified'      => '',
 		'status'             => '',
@@ -87,6 +86,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param int|WC_Product|object $product Product to init.
 	 */
 	public function __construct( $product = 0 ) {
+		parent::__construct( $product );
 		if ( is_numeric( $product ) && $product > 0 ) {
 			$this->read( $product );
 		} elseif ( $product instanceof self ) {
@@ -925,8 +925,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		$this->save_taxonomy_terms( $terms_id, 'tag' );
 	}
 
-
-
 	/*
 	|--------------------------------------------------------------------------
 	| CRUD methods
@@ -991,8 +989,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			'menu_order'         => $post_object->menu_order,
 		) );
 		$this->read_meta_data();
-
-		do_action( 'woocommerce_product_loaded', $this );
 	}
 
 	/**
@@ -1007,7 +1003,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			'post_type'     => 'product',
 			'post_status'   => 'publish',
 			'post_author'   => get_current_user_id(),
-			'post_title'    => $this->get_code(),
+			'post_title'    => $this->get_name(),
 			'post_content'  => '',
 			'post_excerpt'  => $this->get_description(),
 			'post_date'     => date( 'Y-m-d H:i:s', $this->get_date_created() ),
@@ -1028,7 +1024,15 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @since 2.7.0
 	 */
 	public function update() {
+		$post_data = array(
+			'ID'           => $this->get_id(),
+			// @todo implement other post fields
+		);
+		wp_update_post( $post_data );
 
+		$this->update_post_meta( $this->get_id() );
+		$this->save_meta_data();
+		do_action( 'woocommerce_update_product', $this->get_id() );
 	}
 
 	/**
@@ -1061,8 +1065,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @since 2.7.0
 	 * @param int $id Object ID.
 	 */
-	private function update_post_meta( $id ) {
-		// update_post_meta( $id, 'discount_type', $this->get_discount_type() );
+	protected function update_post_meta( $id ) {
+		 update_post_meta( $id, '_regular_price', $this->get_regular_price() );
 	}
 
 	/*

--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -10,12 +10,39 @@ if ( ! defined( 'ABSPATH' ) ) {
  * External products cannot be bought; they link offsite. Extends simple products.
  *
  * @class 		WC_Product_External
- * @version		2.0.0
+ * @version		2.7.0
  * @package		WooCommerce/Classes/Products
  * @category	Class
  * @author 		WooThemes
  */
 class WC_Product_External extends WC_Product {
+
+	/**
+	 * Stores product data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = array(
+		'product_url' => '',
+		'button_text' => '',
+	);
+
+	/**
+	 * Merges external product data into the parent object.
+	 * @param int|WC_Product|object $product Product to init.
+	 */
+	public function __construct( $product = 0 ) {
+		$this->data = array_merge( $this->data, $this->extra_data );
+		parent::__construct( $product );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Getters
+	|--------------------------------------------------------------------------
+	|
+	| Methods for getting data from the product object.
+	*/
 
 	/**
 	 * Get internal type.
@@ -24,6 +51,60 @@ class WC_Product_External extends WC_Product {
 	public function get_type() {
 		return 'external';
 	}
+
+	/**
+	 * Get product url.
+	 *
+	 * @return string
+	 */
+	public function get_product_url() {
+		return esc_url( $this->data['product_url'] );
+	}
+
+	/**
+	 * Get button text.
+	 *
+	 * @return string
+	 */
+	public function get_button_text() {
+		return $this->data['button_text'] ? $this->data['button_text'] : __( 'Buy product', 'woocommerce' );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters
+	|--------------------------------------------------------------------------
+	|
+	| Functions for setting product data. These should not update anything in the
+	| database itself and should only change what is stored in the class
+	| object.
+	*/
+
+	/**
+	 * Set product URL.
+	 *
+	 * @since 2.7.0
+	 * @param string $product_url Product URL.
+	 */
+	public function set_product_url( $product_url ) {
+		$this->data['product_url'] = $product_url;
+	}
+
+	/**
+	 * Set button text.
+	 *
+	 * @since 2.7.0
+	 * @param string $button_text Button text.
+	 */
+	public function set_button_text( $button_text ) {
+		$this->data['button_text'] = $button_text;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Other Actions
+	|--------------------------------------------------------------------------
+	*/
 
 	/**
 	 * Returns false if the product cannot be bought.
@@ -65,23 +146,37 @@ class WC_Product_External extends WC_Product {
 		return apply_filters( 'woocommerce_product_single_add_to_cart_text', $this->get_button_text(), $this );
 	}
 
+	/*
+	|--------------------------------------------------------------------------
+	| CRUD methods
+	|--------------------------------------------------------------------------
+	*/
+
 	/**
-	 * Get product url.
+	 * Reads a product from the database and sets its data to the class.
 	 *
-	 * @access public
-	 * @return string
+	 * @since 2.7.0
+	 * @param int $id Product ID.
 	 */
-	public function get_product_url() {
-		return esc_url( $this->product_url );
+	public function read( $id ) {
+		parent::read( $id );
+		$this->set_props( array(
+			'product_url' => get_post_meta( $id, '_product_url', true ),
+			'button_text' => get_post_meta( $id, '_button_text', true ),
+		) );
+		do_action( 'woocommerce_product_loaded', $this );
+		do_action( 'woocommerce_product_' . $this->get_type() . '_loaded', $this );
 	}
 
 	/**
-	 * Get button text.
+	 * Helper method that updates all the post meta for an external product.
 	 *
-	 * @access public
-	 * @return string
+	 * @since 2.7.0
+	 * @param int $id
 	 */
-	public function get_button_text() {
-		return $this->button_text ? $this->button_text : __( 'Buy product', 'woocommerce' );
+	protected function update_post_meta( $id ) {
+		parent::update_post_meta( $id );
+		update_post_meta( $id, '_product_url', $this->get_product_url() );
+		update_post_meta( $id, '_button_text', $this->get_button_text() );
 	}
 }

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -55,6 +55,37 @@ class WC_Helper_Product {
 	}
 
 	/**
+	 * Create external product.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @return WC_Product_External
+	 */
+	public static function create_external_product() {
+		// Create the product
+		$product = wp_insert_post( array(
+			'post_title'  => 'Dummy External Product',
+			'post_type'   => 'product',
+			'post_status' => 'publish',
+		) );
+		update_post_meta( $product, '_price', '10' );
+		update_post_meta( $product, '_regular_price', '10' );
+		update_post_meta( $product, '_sale_price', '' );
+		update_post_meta( $product, '_sku', 'DUMMY EXTERNAL SKU' );
+		update_post_meta( $product, '_manage_stock', 'no' );
+		update_post_meta( $product, '_tax_status', 'taxable' );
+		update_post_meta( $product, '_downloadable', 'no' );
+		update_post_meta( $product, '_virtual', 'taxable' );
+		update_post_meta( $product, '_visibility', 'visible' );
+		update_post_meta( $product, '_stock_status', 'instock' );
+
+		update_post_meta( $product, '_product_url', 'http://woocommerce.com' );
+		update_post_meta( $product, '_button_text', 'Buy external product' );
+
+		return new WC_Product_External( $product );
+	}
+
+	/**
 	 * Create a dummy variation product.
 	 *
 	 * @since 2.3

--- a/tests/unit-tests/product/crud.php
+++ b/tests/unit-tests/product/crud.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * CRUD Functions.
+ * @package WooCommerce\Tests\Product
+ * @since 2.7.0
+ */
+class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
+
+	/**
+	 * Test creating a new external product.
+	 *
+	 * @since 2.7.0
+	 */
+	 function test_external_product_create() {
+		 $product = new WC_Product_External;
+		 $product->set_regular_price( 42 );
+		 $product->set_button_text( 'Test CRUD' );
+		 $product->set_product_url( 'http://automattic.com' );
+		 $product->set_name( 'My External Product' );
+		 $product->create();
+
+		 $read_product = new WC_Product_External( $product->get_id() );
+
+		 $this->assertEquals( '42', $read_product->get_regular_price() );
+		 $this->assertEquals( 'Test CRUD', $read_product->get_button_text() );
+		 $this->assertEquals( 'http://automattic.com', $read_product->get_product_url() );
+		 $this->assertEquals( 'My External Product', $read_product->get_name() );
+	 }
+
+	/**
+	 * Test getting / reading an external product. Make sure both our external
+	 * product data and the main product data are present.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_external_product_read() {
+		$product = WC_Helper_Product::create_external_product();
+		$product = new WC_Product_External( $product->get_id() );
+
+		$this->assertEquals( 'Buy external product', $product->get_button_text() );
+		$this->assertEquals( '10', $product->get_regular_price() );
+	}
+
+	/**
+	 * Test updating an external product. Make sure both our external
+	 * product data and the main product data are written to and present.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_external_product_update() {
+		$product = WC_Helper_Product::create_external_product();
+
+		$this->assertEquals( 'Buy external product', $product->get_button_text() );
+		$this->assertEquals( '10', $product->get_regular_price() );
+
+		$product->set_button_text( 'Buy my external product' );
+		$product->set_regular_price( 15 );
+		$product->save();
+
+		// Reread from database
+		$product = new WC_Product_External( $product->get_id() );
+
+		$this->assertEquals( 'Buy my external product', $product->get_button_text() );
+		$this->assertEquals( '15', $product->get_regular_price() );
+	}
+
+	/**
+	 * Test deleting a product.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_product_delete() {
+		$product = WC_Helper_Product::create_external_product();
+		$product->delete();
+		$this->assertEquals( 0, $product->get_id() );
+	}
+
+	/**
+	 * Test external product setters and getters
+	 *
+	 * @since 2.7.0
+	 */
+	 public function test_external_product_getters_and_setters() {
+		 $time = time();
+		 $getters_and_setters = array(
+			 'button_text' => 'Test Button Text',
+			 'product_url' => 'http://wordpress.org',
+		 );
+		 $product = new WC_Product_External;
+		  foreach ( $getters_and_setters as $function => $value ) {
+			 $product->{"set_{$function}"}( $value );
+			 $this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
+		 }
+	 }
+}


### PR DESCRIPTION
Here's a first pass at implementing CRUD for the external product type. Includes some tests so we can make sure both the general product data (name, price, etc) and type specific data is updated and read correctly.
