### PR TITLE
Check if the chosen method is set on the package rates. 

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -296,7 +296,7 @@ class WC_Shipping {
 				}
 
 				// Store total costs
-				if ( $chosen_method ) {
+				if ( $chosen_method && isset( $package['rates'][ $chosen_method ] ) ) {
 					$rate = $package['rates'][ $chosen_method ];
 
 					// Merge cost and taxes - label and ID will be the same


### PR DESCRIPTION
There are rare instances where store manager may disable a shipping option while the user's session is still in progress. This results in an unexpected errors and checkout page hanging. Double checking that the chosen method is accessible  on the package avoids the error.
