### PR TITLE
Fix flushing of rewrite rules after attribute taxonomy change

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -125,7 +125,7 @@ class WC_Admin_Attributes {
 
 		do_action( 'woocommerce_attribute_added', $wpdb->insert_id, $attribute );
 
-		flush_rewrite_rules();
+		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 
 		return true;
@@ -200,7 +200,7 @@ class WC_Admin_Attributes {
 
 		echo '<div class="updated"><p>' . __( 'Attribute updated successfully', 'woocommerce' ) . '</p></div>';
 
-		flush_rewrite_rules();
+		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 
 		return true;

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -87,7 +87,7 @@ class WC_Admin_Settings {
 		delete_transient( 'woocommerce_cache_excluded_uris' );
 		WC()->query->init_query_vars();
 		WC()->query->add_endpoints();
-		flush_rewrite_rules();
+		do_action( 'woocommerce_flush_rewrite_rules' );
 
 		do_action( 'woocommerce_settings_saved' );
 	}

--- a/includes/api/class-wc-rest-product-attributes-controller.php
+++ b/includes/api/class-wc-rest-product-attributes-controller.php
@@ -285,7 +285,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 		$response->header( 'Location', rest_url( '/' . $this->namespace . '/' . $this->rest_base . '/' . $attribute->attribute_id ) );
 
 		// Clear transients.
-		flush_rewrite_rules();
+		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 
 		return $response;
@@ -386,7 +386,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 		$response = $this->prepare_item_for_response( $attribute, $request );
 
 		// Clear transients.
-		flush_rewrite_rules();
+		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 
 		return rest_ensure_response( $response );
@@ -449,7 +449,7 @@ class WC_REST_Product_Attributes_Controller extends WC_REST_Controller {
 		do_action( 'woocommerce_attribute_deleted', $attribute->attribute_id, $attribute->attribute_name, $taxonomy );
 
 		// Clear transients.
-		flush_rewrite_rules();
+		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 
 		return $response;

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -2759,7 +2759,7 @@ class WC_API_Products extends WC_API_Resource {
 			do_action( 'woocommerce_api_create_product_attribute', $id, $data );
 
 			// Clear transients.
-			flush_rewrite_rules();
+			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
 
 			$this->server->send_status( 201 );
@@ -2843,7 +2843,7 @@ class WC_API_Products extends WC_API_Resource {
 			do_action( 'woocommerce_api_edit_product_attribute', $id, $data );
 
 			// Clear transients.
-			flush_rewrite_rules();
+			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
 
 			return $this->get_product_attribute( $id );
@@ -2903,7 +2903,7 @@ class WC_API_Products extends WC_API_Resource {
 			do_action( 'woocommerce_api_delete_product_attribute', $id, $this );
 
 			// Clear transients.
-			flush_rewrite_rules();
+			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
 
 			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -187,7 +187,7 @@ class WC_Install {
 		self::update_wc_version();
 
 		// Flush rules after install
-		flush_rewrite_rules();
+		do_action( 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
 
 		/*

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -29,6 +29,7 @@ class WC_Post_types {
 		add_action( 'init', array( __CLASS__, 'register_post_status' ), 9 );
 		add_action( 'init', array( __CLASS__, 'support_jetpack_omnisearch' ) );
 		add_filter( 'rest_api_allowed_post_types', array( __CLASS__, 'rest_api_allowed_post_types' ) );
+		add_action( 'woocommerce_flush_rewrite_rules', array( __CLASS__, 'flush_rewrite_rules' ) );
 	}
 
 	/**
@@ -501,6 +502,13 @@ class WC_Post_types {
 		foreach ( $order_statuses as $order_status => $values ) {
 			register_post_status( $order_status, $values );
 		}
+	}
+
+	/**
+	 * Flush rewrite rules.
+	 */
+	public static function flush_rewrite_rules() {
+		flush_rewrite_rules();
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -776,7 +776,7 @@ function wc_get_page_children( $page_id ) {
 function flush_rewrite_rules_on_shop_page_save( $post_id ) {
 	$shop_page_id = wc_get_page_id( 'shop' );
 	if ( $shop_page_id === $post_id || in_array( $post_id, wc_get_page_children( $shop_page_id ) ) ) {
-		flush_rewrite_rules();
+		do_action( 'woocommerce_flush_rewrite_rules' );
 	}
 }
 add_action( 'save_post', 'flush_rewrite_rules_on_shop_page_save' );


### PR DESCRIPTION
Permalinks will not work if product taxonomy "public" status changed.

This is related on that 'flush_rewrite_rules()' is called directly after saving the changes. But the taxonomies are not registered with the change public flag at this point.

For 2.6 also it will be nice to have

Nwe Pll request see #12072
