### PR TITLE
Remove the $id parameter from CRUD update_post_meta & reduce dulpicate code

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -711,7 +711,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 
 		if ( $coupon_id ) {
 			$this->set_id( $coupon_id );
-			$this->update_post_meta( $coupon_id );
+			$this->update_post_meta();
 			$this->save_meta_data();
 			do_action( 'woocommerce_new_coupon', $coupon_id );
 		}
@@ -731,7 +731,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		);
 
 		wp_update_post( $post_data );
-		$this->update_post_meta( $coupon_id );
+		$this->update_post_meta();
 		$this->save_meta_data();
 		do_action( 'woocommerce_update_coupon', $coupon_id );
 	}
@@ -761,26 +761,25 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	/**
 	 * Helper method that updates all the post meta for a coupon based on it's settings in the WC_Coupon class.
 	 * @since 2.7.0
-	 * @param int $coupon_id
 	 */
-	private function update_post_meta( $coupon_id ) {
-		update_post_meta( $coupon_id, 'discount_type', $this->get_discount_type() );
-		update_post_meta( $coupon_id, 'coupon_amount', $this->get_amount() );
-		update_post_meta( $coupon_id, 'individual_use', ( true === $this->get_individual_use() ) ? 'yes' : 'no' );
-		update_post_meta( $coupon_id, 'product_ids', implode( ',', array_filter( array_map( 'intval', $this->get_product_ids() ) ) ) );
-		update_post_meta( $coupon_id, 'exclude_product_ids', implode( ',', array_filter( array_map( 'intval', $this->get_excluded_product_ids() ) ) ) );
-		update_post_meta( $coupon_id, 'usage_limit', $this->get_usage_limit() );
-		update_post_meta( $coupon_id, 'usage_limit_per_user', $this->get_usage_limit_per_user() );
-		update_post_meta( $coupon_id, 'limit_usage_to_x_items', $this->get_limit_usage_to_x_items() );
-		update_post_meta( $coupon_id, 'usage_count', $this->get_usage_count() );
-		update_post_meta( $coupon_id, 'expiry_date', $this->get_date_expires() );
-		update_post_meta( $coupon_id, 'free_shipping', ( true === $this->get_free_shipping() ) ? 'yes' : 'no' );
-		update_post_meta( $coupon_id, 'product_categories', array_filter( array_map( 'intval', $this->get_product_categories() ) ) );
-		update_post_meta( $coupon_id, 'exclude_product_categories', array_filter( array_map( 'intval', $this->get_excluded_product_categories() ) ) );
-		update_post_meta( $coupon_id, 'exclude_sale_items', ( true === $this->get_exclude_sale_items() ) ? 'yes' : 'no' );
-		update_post_meta( $coupon_id, 'minimum_amount', $this->get_minimum_amount() );
-		update_post_meta( $coupon_id, 'maximum_amount', $this->get_maximum_amount() );
-		update_post_meta( $coupon_id, 'customer_email', array_filter( array_map( 'sanitize_email', $this->get_email_restrictions() ) ) );
+	private function update_post_meta() {
+		update_post_meta( $this->get_id(), 'discount_type', $this->get_discount_type() );
+		update_post_meta( $this->get_id(), 'coupon_amount', $this->get_amount() );
+		update_post_meta( $this->get_id(), 'individual_use', ( true === $this->get_individual_use() ) ? 'yes' : 'no' );
+		update_post_meta( $this->get_id(), 'product_ids', implode( ',', array_filter( array_map( 'intval', $this->get_product_ids() ) ) ) );
+		update_post_meta( $this->get_id(), 'exclude_product_ids', implode( ',', array_filter( array_map( 'intval', $this->get_excluded_product_ids() ) ) ) );
+		update_post_meta( $this->get_id(), 'usage_limit', $this->get_usage_limit() );
+		update_post_meta( $this->get_id(), 'usage_limit_per_user', $this->get_usage_limit_per_user() );
+		update_post_meta( $this->get_id(), 'limit_usage_to_x_items', $this->get_limit_usage_to_x_items() );
+		update_post_meta( $this->get_id(), 'usage_count', $this->get_usage_count() );
+		update_post_meta( $this->get_id(), 'expiry_date', $this->get_date_expires() );
+		update_post_meta( $this->get_id(), 'free_shipping', ( true === $this->get_free_shipping() ) ? 'yes' : 'no' );
+		update_post_meta( $this->get_id(), 'product_categories', array_filter( array_map( 'intval', $this->get_product_categories() ) ) );
+		update_post_meta( $this->get_id(), 'exclude_product_categories', array_filter( array_map( 'intval', $this->get_excluded_product_categories() ) ) );
+		update_post_meta( $this->get_id(), 'exclude_sale_items', ( true === $this->get_exclude_sale_items() ) ? 'yes' : 'no' );
+		update_post_meta( $this->get_id(), 'minimum_amount', $this->get_minimum_amount() );
+		update_post_meta( $this->get_id(), 'maximum_amount', $this->get_maximum_amount() );
+		update_post_meta( $this->get_id(), 'customer_email', array_filter( array_map( 'sanitize_email', $this->get_email_restrictions() ) ) );
 	}
 
 	/**

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -1073,36 +1073,43 @@ class WC_Customer extends WC_Legacy_Customer {
 
 		if ( ! is_wp_error( $customer_id ) ) {
 			$this->set_id( $customer_id );
-			update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
-			update_user_meta( $this->get_id(), 'billing_last_name', $this->get_billing_last_name() );
-			update_user_meta( $this->get_id(), 'billing_company', $this->get_billing_company() );
-			update_user_meta( $this->get_id(), 'billing_phone', $this->get_billing_phone() );
-			update_user_meta( $this->get_id(), 'billing_email', $this->get_billing_email() );
-			update_user_meta( $this->get_id(), 'billing_postcode', $this->get_billing_postcode() );
-			update_user_meta( $this->get_id(), 'billing_city', $this->get_billing_city() );
-			update_user_meta( $this->get_id(), 'billing_address_1', $this->get_billing_address() );
-			update_user_meta( $this->get_id(), 'billing_address_2', $this->get_billing_address_2() );
-			update_user_meta( $this->get_id(), 'billing_state', $this->get_billing_state() );
-			update_user_meta( $this->get_id(), 'billing_country', $this->get_billing_country() );
-			update_user_meta( $this->get_id(), 'shipping_first_name', $this->get_shipping_first_name() );
-			update_user_meta( $this->get_id(), 'shipping_last_name', $this->get_shipping_last_name() );
-			update_user_meta( $this->get_id(), 'shipping_company', $this->get_shipping_company() );
-			update_user_meta( $this->get_id(), 'shipping_postcode', $this->get_shipping_postcode() );
-			update_user_meta( $this->get_id(), 'shipping_city', $this->get_shipping_city() );
-			update_user_meta( $this->get_id(), 'shipping_address_1', $this->get_shipping_address() );
-			update_user_meta( $this->get_id(), 'shipping_address_2', $this->get_shipping_address_2() );
-			update_user_meta( $this->get_id(), 'shipping_state', $this->get_shipping_state() );
-			update_user_meta( $this->get_id(), 'shipping_country', $this->get_shipping_country() );
-			update_user_meta( $this->get_id(), 'paying_customer', $this->get_is_paying_customer() );
-			update_user_meta( $this->get_id(), 'last_update',  $this->get_date_modified() );
-			update_user_meta( $this->get_id(), 'first_name', $this->get_first_name() );
-			update_user_meta( $this->get_id(), 'last_name', $this->get_last_name() );
+			$this->update_post_meta();
 			wp_update_user( array( 'ID' => $this->get_id(), 'role' => $this->get_role() ) );
 			$wp_user = new WP_User( $this->get_id() );
 			$this->set_date_created( strtotime( $wp_user->user_registered ) );
 			$this->set_date_modified( get_user_meta( $this->get_id(), 'last_update', true ) );
 			$this->read_meta_data();
 		}
+	}
+
+	/**
+	 * Helper method that updates all the meta for a customer. Used for update & create.
+	 * @since 2.7.0
+	 */
+	private function update_post_meta() {
+		update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
+		update_user_meta( $this->get_id(), 'billing_last_name', $this->get_billing_last_name() );
+		update_user_meta( $this->get_id(), 'billing_company', $this->get_billing_company() );
+		update_user_meta( $this->get_id(), 'billing_phone', $this->get_billing_phone() );
+		update_user_meta( $this->get_id(), 'billing_email', $this->get_billing_email() );
+		update_user_meta( $this->get_id(), 'billing_postcode', $this->get_billing_postcode() );
+		update_user_meta( $this->get_id(), 'billing_city', $this->get_billing_city() );
+		update_user_meta( $this->get_id(), 'billing_address_1', $this->get_billing_address() );
+		update_user_meta( $this->get_id(), 'billing_address_2', $this->get_billing_address_2() );
+		update_user_meta( $this->get_id(), 'billing_state', $this->get_billing_state() );
+		update_user_meta( $this->get_id(), 'billing_country', $this->get_billing_country() );
+		update_user_meta( $this->get_id(), 'shipping_first_name', $this->get_shipping_first_name() );
+		update_user_meta( $this->get_id(), 'shipping_last_name', $this->get_shipping_last_name() );
+		update_user_meta( $this->get_id(), 'shipping_company', $this->get_shipping_company() );
+		update_user_meta( $this->get_id(), 'shipping_postcode', $this->get_shipping_postcode() );
+		update_user_meta( $this->get_id(), 'shipping_city', $this->get_shipping_city() );
+		update_user_meta( $this->get_id(), 'shipping_address_1', $this->get_shipping_address() );
+		update_user_meta( $this->get_id(), 'shipping_address_2', $this->get_shipping_address_2() );
+		update_user_meta( $this->get_id(), 'shipping_state', $this->get_shipping_state() );
+		update_user_meta( $this->get_id(), 'shipping_country', $this->get_shipping_country() );
+		update_user_meta( $this->get_id(), 'paying_customer', $this->get_is_paying_customer() );
+		update_user_meta( $this->get_id(), 'first_name', $this->get_first_name() );
+		update_user_meta( $this->get_id(), 'last_name', $this->get_last_name() );
 	}
 
 	/**
@@ -1159,33 +1166,7 @@ class WC_Customer extends WC_Legacy_Customer {
 			$this->password = '';
 		}
 
-		update_user_meta( $this->get_id(), 'billing_first_name', $this->get_billing_first_name() );
-		update_user_meta( $this->get_id(), 'billing_last_name', $this->get_billing_last_name() );
-		update_user_meta( $this->get_id(), 'billing_company', $this->get_billing_company() );
-		update_user_meta( $this->get_id(), 'billing_phone', $this->get_billing_phone() );
-		update_user_meta( $this->get_id(), 'billing_email', $this->get_billing_email() );
-		update_user_meta( $this->get_id(), 'billing_postcode', $this->get_billing_postcode() );
-		update_user_meta( $this->get_id(), 'billing_city', $this->get_billing_city() );
-		update_user_meta( $this->get_id(), 'billing_address_1', $this->get_billing_address() );
-		update_user_meta( $this->get_id(), 'billing_address_2', $this->get_billing_address_2() );
-		update_user_meta( $this->get_id(), 'billing_state', $this->get_billing_state() );
-		update_user_meta( $this->get_id(), 'shipping_first_name', $this->get_shipping_first_name() );
-		update_user_meta( $this->get_id(), 'shipping_last_name', $this->get_shipping_last_name() );
-		update_user_meta( $this->get_id(), 'shipping_company', $this->get_shipping_company() );
-		update_user_meta( $this->get_id(), 'billing_country', $this->get_billing_country() );
-		update_user_meta( $this->get_id(), 'shipping_first_name', $this->get_shipping_first_name() );
-		update_user_meta( $this->get_id(), 'shipping_last_name', $this->get_shipping_last_name() );
-		update_user_meta( $this->get_id(), 'shipping_company', $this->get_shipping_company() );
-		update_user_meta( $this->get_id(), 'shipping_postcode', $this->get_shipping_postcode() );
-		update_user_meta( $this->get_id(), 'shipping_city', $this->get_shipping_city() );
-		update_user_meta( $this->get_id(), 'shipping_address_1', $this->get_shipping_address() );
-		update_user_meta( $this->get_id(), 'shipping_address_2', $this->get_shipping_address_2() );
-		update_user_meta( $this->get_id(), 'shipping_state', $this->get_shipping_state() );
-		update_user_meta( $this->get_id(), 'shipping_country', $this->get_shipping_country() );
-		update_user_meta( $this->get_id(), 'paying_customer', $this->get_is_paying_customer() );
-		update_user_meta( $this->get_id(), 'first_name', $this->get_first_name() );
-		update_user_meta( $this->get_id(), 'last_name', $this->get_last_name() );
-		wp_update_user( array( 'ID' => $this->get_id(), 'role' => $this->get_role() ) );
+		$this->update_post_meta();
 		$this->set_date_modified( get_user_meta( $this->get_id(), 'last_update', true ) );
 		$this->save_meta_data();
 	}


### PR DESCRIPTION
This is already fixed in the product crud branch, but we pass in `$id` to a private `update_post_meta` function to set meta for both create and update operations. This isn't needed since we can just use `$this->get_id()`. This PR also reduces some duplicate code in the Customer CRUD class.
