### PR TITLE
[Product CRUD] Product crud price html

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -147,6 +147,17 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	}
 
 	/**
+	 * Adjust a products price dynamically.
+	 *
+	 * @deprecated 2.7.0
+	 * @param mixed $price
+	 */
+	public function adjust_price( $price ) {
+		_deprecated_function( 'WC_Product::adjust_price', '2.7', 'WC_Product::set_price / WC_Product::get_price' );
+		$this->data['price'] = $this->data['price'] + $price;
+	}
+
+	/**
 	 * Returns the availability of the product.
 	 *
 	 * If stock management is enabled at global and product level, a stock message

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -120,6 +120,19 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	}
 
 	/**
+	 * Returns the price including or excluding tax, based on the 'woocommerce_tax_display_shop' setting.
+	 *
+	 * @deprecated 2.7.0 Use wc_get_price_to_display instead.
+	 * @param  string  $price to calculate, left blank to just use get_price()
+	 * @param  integer $qty   passed on to get_price_including_tax() or get_price_excluding_tax()
+	 * @return string
+	 */
+	public function get_display_price( $price = '', $qty = 1 ) {
+		_deprecated_function( 'WC_Product::get_display_price', '2.7', 'wc_get_price_to_display' );
+		return wc_get_price_to_display( $this, array( 'qty' => $qty, 'price' => $price ) );
+	}
+
+	/**
 	 * Returns the price (excluding tax) - ignores tax_class filters since the price may *include* tax and thus needs subtracting.
 	 * Uses store base tax rates. Can work for a specific $qty for more accurate taxes.
 	 *

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -107,6 +107,33 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	}
 
 	/**
+	 * Returns the price (including tax). Uses customer tax rates. Can work for a specific $qty for more accurate taxes.
+	 *
+	 * @deprecated 2.7.0 Use wc_get_price_including_tax instead.
+	 * @param  int $qty
+	 * @param  string $price to calculate, left blank to just use get_price()
+	 * @return string
+	 */
+	public function get_price_including_tax( $qty = 1, $price = '' ) {
+		_deprecated_function( 'WC_Product::get_price_including_tax', '2.7', 'wc_get_price_including_tax' );
+		return wc_get_price_including_tax( $this, array( 'qty' => $qty, 'price' => $price ) );
+	}
+
+	/**
+	 * Returns the price (excluding tax) - ignores tax_class filters since the price may *include* tax and thus needs subtracting.
+	 * Uses store base tax rates. Can work for a specific $qty for more accurate taxes.
+	 *
+	 * @deprecated 2.7.0 Use wc_get_price_excluding_tax instead.
+	 * @param  int $qty
+	 * @param  string $price to calculate, left blank to just use get_price()
+	 * @return string
+	 */
+	public function get_price_excluding_tax( $qty = 1, $price = '' ) {
+		_deprecated_function( 'WC_Product::get_price_excluding_tax', '2.7', 'wc_get_price_excluding_tax' );
+		return wc_get_price_excluding_tax( $this, array( 'qty' => $qty, 'price' => $price ) );
+	}
+
+	/**
 	 * Returns the availability of the product.
 	 *
 	 * If stock management is enabled at global and product level, a stock message

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1662,25 +1662,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	}
 
 	/**
-	 * Returns the price including or excluding tax, based on the 'woocommerce_tax_display_shop' setting.
-	 *
-	 * @param  string  $price to calculate, left blank to just use get_price()
-	 * @param  integer $qty   passed on to get_price_including_tax() or get_price_excluding_tax()
-	 * @return string
-	 */
-	public function get_display_price( $price = '', $qty = 1 ) {
-
-		if ( '' === $price ) {
-			$price = $this->get_price();
-		}
-
-		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-		$display_price    = ( 'incl' === $tax_display_mode ) ? $this->get_price_including_tax( $qty, $price ) : $this->get_price_excluding_tax( $qty, $price );
-
-		return $display_price;
-	}
-
-	/**
 	 * Returns the price in html format.
 	 *
 	 * @return string

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -37,6 +37,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		'description'        => '',
 		'short_description'  => '',
 		'sku'                => '',
+		'price'              => '', // @todo save and set this
 		'regular_price'      => '',
 		'sale_price'         => '',
 		'date_on_sale_from'  => '',
@@ -61,8 +62,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		'attributes'         => array(),
 		'default_attributes' => array(),
 		'menu_order'         => 0,
-		'virtual' => false, // @todo
-		'downloadable' => false, // @todo
+		'virtual'            => false, // @todo
+		'downloadable'       => false, // @todo
 	);
 
 	/**
@@ -219,6 +220,15 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 */
 	public function get_sku() {
 		return apply_filters( 'woocommerce_get_sku', $this->data['sku'], $this );
+	}
+
+	/**
+	 * Returns the product's active price.
+	 *
+	 * @return string price
+	 */
+	public function get_price() {
+		return apply_filters( 'woocommerce_get_price', $this->data['price'], $this );
 	}
 
 	/**
@@ -625,6 +635,15 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	}
 
 	/**
+	 * Set the product's active price.
+	 *
+	 * @param string $price Price.
+	 */
+	public function set_price( $price ) {
+		$this->data['price'] = wc_format_decimal( $price );
+	}
+
+	/**
 	 * Set the product's regular price.
 	 *
 	 * @since 2.7.0
@@ -975,6 +994,11 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			'default_attributes' => get_post_meta( $id, '_default_attributes', true ),
 			'menu_order'         => $post_object->menu_order,
 		) );
+		if ( $this->is_on_sale() ) {
+			$this->set_price( $this->get_sale_price() );
+		} else {
+			$this->set_price( $this->get_regular_price() );
+		}
 		$this->read_meta_data();
 	}
 
@@ -1085,6 +1109,12 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		update_post_meta( $id, '_purchase_note', $this->get_purchase_note() );
 		update_post_meta( $id, '_attributes', $this->get_attributes() );
 		update_post_meta( $id, '_default_attributes', $this->get_default_attributes() );
+
+		if ( $this->is_on_sale() ) {
+			update_post_meta( $id, '_price', $this->get_sale_price() );
+		} else {
+			update_post_meta( $id, '_price', $this->get_regular_price() );
+		}
 	}
 
 	/*
@@ -1197,7 +1227,20 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return bool
 	 */
 	public function is_on_sale() {
-		return apply_filters( 'woocommerce_product_is_on_sale', ( $this->get_sale_price() !== $this->get_regular_price() && $this->get_sale_price() === $this->get_price() ), $this );
+		if ( '' !== $this->get_sale_price() && $this->get_regular_price() > $this->get_sale_price() ) {
+			$onsale = true;
+
+			if ( '' !== $this->get_date_on_sale_from() && $this->get_date_on_sale_from() > strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+				$onsale = false;
+			}
+
+			if ( '' !== $this->get_date_on_sale_to() && $this->get_date_on_sale_to() < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+				$onsale = false;
+			}
+		} else {
+			$onsale = false;
+		}
+		return apply_filters( 'woocommerce_product_is_on_sale', $onsale, $this );
 	}
 
 	/**
@@ -1306,6 +1349,25 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	| Non-CRUD Getters
 	|--------------------------------------------------------------------------
 	*/
+
+	/**
+	 * Returns the price in html format.
+	 * @todo Should this be moved out of the classes?
+	 * @return string
+	 */
+	public function get_price_html( $deprecated = '' ) {
+		if ( '' === $this->get_price() ) {
+			return apply_filters( 'woocommerce_empty_price_html', '', $this );
+		}
+
+		if ( $this->is_on_sale() ) {
+			$price = wc_format_price_range( wc_get_price_to_display( $this, array( 'price' => $this->get_regular_price() ) ), wc_get_price_to_display( $this ) ) . wc_get_price_suffix( $this );
+		} else {
+			$price = wc_price( wc_get_price_to_display( $this ) ) . wc_get_price_suffix( $this );
+		}
+
+		return apply_filters( 'woocommerce_get_price_html', $price, $this );
+	}
 
 	/**
 	 * Get product name with SKU or ID. Used within admin.
@@ -1621,63 +1683,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 
 		// allow overriding based on the particular file being requested
 		return apply_filters( 'woocommerce_product_file_download_path', $file_path, $this, $download_id );
-	}
-
-	/*
-	|--------------------------------------------------------------------------
-	| @todo price functions
-	|--------------------------------------------------------------------------
-	*/
-
-	/**
-	 * Set a products price dynamically.
-	 *
-	 * @param float $price Price to set.
-	 */
-	public function set_price( $price ) {
-		$this->price = $price;
-	}
-
-	/**
-	 * Adjust a products price dynamically.
-	 *
-	 * @param mixed $price
-	 */
-	public function adjust_price( $price ) {
-		$this->price = $this->price + $price;
-	}
-
-	/**
-	 * Returns the product's active price.
-	 *
-	 * @return string price
-	 */
-	public function get_price() {
-		if ( $this->is_on_sale() ) {
-			$price = $this->get_sale_price();
-		} else {
-			$price = $this->get_regular_price();
-		}
-		return apply_filters( 'woocommerce_get_price', $price, $this );
-	}
-
-	/**
-	 * Returns the price in html format.
-	 *
-	 * @return string
-	 */
-	public function get_price_html( $deprecated = '' ) {
-		if ( '' === $this->get_price() ) {
-			return apply_filters( 'woocommerce_empty_price_html', '', $this );
-		}
-
-		if ( $this->is_on_sale() ) {
-			$price = wc_format_price_range( $this->get_display_price( $this->get_regular_price() ), $this->get_display_price() ) . wc_get_price_suffix( $this );
-		} else {
-			$price = wc_price( $this->get_display_price() ) . wc_get_price_suffix( $this );
-		}
-
-		return apply_filters( 'woocommerce_get_price_html', $price, $this );
 	}
 
 	/*

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -940,3 +940,22 @@ function wc_get_price_excluding_tax( $product, $args ) {
 
 	return apply_filters( 'woocommerce_get_price_excluding_tax', $price, $qty, $product );
 }
+
+/**
+ * Returns the price including or excluding tax, based on the 'woocommerce_tax_display_shop' setting.
+ * @since  2.7.0
+ * @param  WC_Product $product
+ * @param  array $args
+ * @return float
+ */
+public function wc_get_price_to_display( $product, $args ) {
+	$args = wp_parse_args( $args, array(
+		'qty'   => 1,
+		'price' => $product->get_price(),
+	) );
+
+	$price = $args['price'];
+	$qty   = $args['qty'];
+
+	return 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) ? wc_get_price_including_tax( $product, array( 'qty' => $qty, 'price' => $price ) ) : wc_get_price_excluding_tax( $product, array( 'qty' => $qty, 'price' => $price );
+}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -872,7 +872,7 @@ function wc_get_related_products_query( $cats_array, $tags_array, $exclude_ids, 
  * @param  array $args
  * @return float
  */
-function wc_get_price_including_tax( $product, $args ) {
+function wc_get_price_including_tax( $product, $args = array() ) {
 	$args = wp_parse_args( $args, array(
 		'qty'   => 1,
 		'price' => $product->get_price(),
@@ -921,7 +921,7 @@ function wc_get_price_including_tax( $product, $args ) {
  * @param  array $args
  * @return float
  */
-function wc_get_price_excluding_tax( $product, $args ) {
+function wc_get_price_excluding_tax( $product, $args = array() ) {
 	$args = wp_parse_args( $args, array(
 		'qty'   => 1,
 		'price' => $product->get_price(),
@@ -948,7 +948,7 @@ function wc_get_price_excluding_tax( $product, $args ) {
  * @param  array $args
  * @return float
  */
-public function wc_get_price_to_display( $product, $args ) {
+function wc_get_price_to_display( $product, $args = array() ) {
 	$args = wp_parse_args( $args, array(
 		'qty'   => 1,
 		'price' => $product->get_price(),
@@ -957,5 +957,5 @@ public function wc_get_price_to_display( $product, $args ) {
 	$price = $args['price'];
 	$qty   = $args['qty'];
 
-	return 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) ? wc_get_price_including_tax( $product, array( 'qty' => $qty, 'price' => $price ) ) : wc_get_price_excluding_tax( $product, array( 'qty' => $qty, 'price' => $price );
+	return 'incl' === get_option( 'woocommerce_tax_display_shop' ) ? wc_get_price_including_tax( $product, array( 'qty' => $qty, 'price' => $price ) ) : wc_get_price_excluding_tax( $product, array( 'qty' => $qty, 'price' => $price ) );
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2500,14 +2500,13 @@ function wc_get_price_suffix( $product, $price = '', $qty = 1 ) {
 		);
 
 		$replace = array(
-			wc_price( $product->get_price_including_tax( $qty, $price ) ),
-			wc_price( $product->get_price_excluding_tax( $qty, $price ) ),
+			wc_price( wc_get_price_including_tax( $product, array( 'qty' => $qty, 'price' => $price ) ) ),
+			wc_price( wc_get_price_excluding_tax( $product, array( 'qty' => $qty, 'price' => $price ) ) ),
 		);
 
 		$price_display_suffix = str_replace( $find, $replace, $price_display_suffix );
 	} else {
 		$price_display_suffix = '';
 	}
-
 	return apply_filters( 'woocommerce_get_price_suffix', $price_display_suffix, $product );
 }


### PR DESCRIPTION
Sets ‘price’ and moves some of the tax logic functions out of the class.

I’ve left get_price_html inside here for now - it seems that is something that does vary quite heavily between product types, so it may be more convenient to keep it here. @justinshreve your thoughts?
