### PR TITLE
Fixed the problem with the price filter widget

### DIFF
--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -153,7 +153,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		$meta_query_sql = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
 		$tax_query_sql  = $tax_query->get_sql( $wpdb->posts, 'ID' );
 
-		$sql  = "SELECT min( CAST( price_meta.meta_value AS DECIMAL(2) ) ) as min_price, max( CAST( price_meta.meta_value AS DECIMAL(2) ) ) as max_price FROM {$wpdb->posts} ";
+		$sql  = "SELECT min( CAST( price_meta.meta_value AS DECIMAL ) ) as min_price, max( CAST( price_meta.meta_value AS DECIMAL ) ) as max_price FROM {$wpdb->posts} ";
 		$sql .= " LEFT JOIN {$wpdb->postmeta} as price_meta ON {$wpdb->posts}.ID = price_meta.post_id " . $tax_query_sql['join'] . $meta_query_sql['join'];
 		$sql .= " 	WHERE {$wpdb->posts}.post_type IN ('" . implode( "','", array_map( 'esc_sql', apply_filters( 'woocommerce_price_filter_post_type', array( 'product' ) ) ) ) . "')
 					AND {$wpdb->posts}.post_status = 'publish'


### PR DESCRIPTION
Hello.

The price filter widget has stopped to work after the plugin update from 2.6.4 to 2.6.6. I've made some investigation and found that the _get_filtered_price_ method is always returning two digit minimum and maximum prices. As a result, in the most of cases this widget doesn't display because the minimal and maximal prices are the same and equal 99.

I've changed the price type from **DECIMAL(2)** to **DECIMAL** in SQL query to fix it.
