### PR TITLE
[Product CRUD] Variable

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -375,4 +375,18 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 		_deprecated_function( 'WC_Product::get_cross_sells', '2.7', 'WC_Product::get_cross_sell_ids' );
 		return apply_filters( 'woocommerce_product_crosssell_ids', (array) maybe_unserialize( $this->crosssell_ids ), $this );
 	}
+
+	/**
+	 * Check if variable product has default attributes set.
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function has_default_attributes() {
+		_deprecated_function( 'WC_Product_Variable::has_default_attributes', '2.7', 'Check WC_Product::get_default_attributes directly' );
+		if ( ! $this->get_default_attributes() ) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -359,6 +359,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the upsell product ids.
 	 *
+	 * @deprecated 2.7.0
 	 * @return array
 	 */
 	public function get_upsells() {
@@ -369,6 +370,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Returns the cross sell product ids.
 	 *
+	 * @deprecated 2.7.0
 	 * @return array
 	 */
 	public function get_cross_sells() {
@@ -379,7 +381,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * Check if variable product has default attributes set.
 	 *
-	 * @access public
+	 * @deprecated 2.7.0
 	 * @return bool
 	 */
 	public function has_default_attributes() {

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -460,7 +460,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		// Check for any attributes which have been removed globally
 		if ( is_array( $attributes ) && count( $attributes ) > 0 ) {
 			foreach ( $attributes as $key => $attribute ) {
-				if ( ! empty( $attribute['is_taxonomy'] ) && $attribute['is_taxonomy'] ) {
+				if ( ! empty( $attribute['is_taxonomy'] ) ) {
 					if ( ! in_array( substr( $attribute['name'], 3 ), $taxonomies ) ) {
 						unset( $attributes[ $key ] );
 					}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -460,7 +460,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		// Check for any attributes which have been removed globally
 		if ( is_array( $attributes ) && count( $attributes ) > 0 ) {
 			foreach ( $attributes as $key => $attribute ) {
-				if ( $attribute['is_taxonomy'] ) {
+				if ( ! empty( $attribute['is_taxonomy'] ) && $attribute['is_taxonomy'] ) {
 					if ( ! in_array( substr( $attribute['name'], 3 ), $taxonomies ) ) {
 						unset( $attributes[ $key ] );
 					}
@@ -888,7 +888,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $attributes List of product attributes.
 	 */
 	public function set_attributes( $attributes ) {
-		$this->data['attributes'] = $attributes; // @todo ensure unserialised, array, and filtered out empty values
+		$this->data['attributes'] = array_filter(  (array) maybe_unserialize( $attributes ) );
 	}
 
 	/**
@@ -990,7 +990,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			'parent_id'          => $post_object->post_parent,
 			'reviews_allowed'    => $post_object->comment_status,
 			'purchase_note'      => get_post_meta( $id, '_purchase_note', true ),
-			'attributes'         => get_post_meta( $id, '_attributes', true ),
+			'attributes'         => get_post_meta( $id, '_product_attributes', true ),
 			'default_attributes' => get_post_meta( $id, '_default_attributes', true ),
 			'menu_order'         => $post_object->menu_order,
 		) );
@@ -1107,7 +1107,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		update_post_meta( $id, '_upsell_ids', $this->get_upsell_ids() );
 		update_post_meta( $id, '_crosssell_ids', $this->get_cross_sell_ids() );
 		update_post_meta( $id, '_purchase_note', $this->get_purchase_note() );
-		update_post_meta( $id, '_attributes', $this->get_attributes() );
+		update_post_meta( $id, '_product_attributes', $this->get_attributes() );
 		update_post_meta( $id, '_default_attributes', $this->get_default_attributes() );
 
 		if ( $this->is_on_sale() ) {

--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -1,7 +1,6 @@
 <?php
-
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 /**

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -76,14 +76,7 @@ class WC_Product_Grouped extends WC_Product {
 	 */
 	public function is_on_sale() {
 		global $wpdb;
-		$on_sale = false;
-		if ( $this->has_child() ) {
-			$on_sale = 1 === $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_sale_price' AND meta_value > 0 AND post_id IN (" . implode( ',', array_map( 'esc_sql', $this->get_children() ) ) . ");" );
-		} else {
-			if ( $this->get_sale_price() && $this->get_sale_price() == $this->get_price() ) {
-				$on_sale = true;
-			}
-		}
+		$on_sale = $this->get_children() && 1 === $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_sale_price' AND meta_value > 0 AND post_id IN (" . implode( ',', array_map( 'esc_sql', $this->get_children() ) ) . ");" );
 		return apply_filters( 'woocommerce_product_is_on_sale', $on_sale, $this );
 	}
 

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -76,7 +76,14 @@ class WC_Product_Grouped extends WC_Product {
 	 */
 	public function is_on_sale() {
 		global $wpdb;
-		$on_sale = 1 === $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_sale_price' AND meta_value > 0 AND post_id IN (" . implode( ',', array_map( 'esc_sql', $this->get_children() ) ) . ");" );
+		$on_sale = false;
+		if ( $this->has_child() ) {
+			$on_sale = 1 === $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_sale_price' AND meta_value > 0 AND post_id IN (" . implode( ',', array_map( 'esc_sql', $this->get_children() ) ) . ");" );
+		} else {
+			if ( $this->get_sale_price() && $this->get_sale_price() == $this->get_price() ) {
+				$on_sale = true;
+			}
+		}
 		return apply_filters( 'woocommerce_product_is_on_sale', $on_sale, $this );
 	}
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -1,7 +1,6 @@
 <?php
-
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 /**
@@ -10,18 +9,47 @@ if ( ! defined( 'ABSPATH' ) ) {
  * The WooCommerce product class handles individual product data.
  *
  * @class 		WC_Product_Variable
- * @version		2.0.0
+ * @version		2.7.0
  * @package		WooCommerce/Classes/Products
  * @category	Class
  * @author 		WooThemes
  */
 class WC_Product_Variable extends WC_Product {
 
-	/** @public array Array of child products/posts/variations. */
-	public $children = null;
+	/**
+	 * Stores product data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = array(
+		'children'                          => array(),
+		'variation_prices'                  => array(),
+		'variation_prices_including_taxes'  => array(),
+		'variation_attributes'              => array(),
+	);
 
-	/** @private array Array of variation prices. */
+	/**
+	 * Cached & hashed prices array, used to populate variation_prices
+	 * @var array
+	 */
 	private $prices_array = array();
+
+	/**
+	 * Merges variable product data into the parent object.
+	 * @param int|WC_Product|object $product Product to init.
+	 */
+	public function __construct( $product = 0 ) {
+		$this->data = array_merge( $this->data, $this->extra_data );
+		parent::__construct( $product );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Getters
+	|--------------------------------------------------------------------------
+	|
+	| Methods for getting data from the product object.
+	*/
 
 	/**
 	 * Get internal type.
@@ -32,309 +60,87 @@ class WC_Product_Variable extends WC_Product {
 	}
 
 	/**
-	 * Get the add to cart button text.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function add_to_cart_text() {
-		$text = $this->is_purchasable() && $this->is_in_stock() ? __( 'Select options', 'woocommerce' ) : __( 'Read more', 'woocommerce' );
-
-		return apply_filters( 'woocommerce_product_add_to_cart_text', $text, $this );
-	}
-
-	/**
-	 * Set stock level of the product.
-	 *
-	 * @param mixed $amount (default: null)
-	 * @param string $mode can be set, add, or subtract
-	 * @return int Stock
-	 */
-	public function set_stock( $amount = null, $mode = 'set' ) {
-		$this->total_stock = '';
-		delete_transient( 'wc_product_total_stock_' . $this->id . WC_Cache_Helper::get_transient_version( 'product' ) );
-		return parent::set_stock( $amount, $mode );
-	}
-
-	/**
-	 * Performed after a stock level change at product level.
-	 */
-	public function check_stock_status() {
-		$set_child_stock_status = '';
-
-		if ( ! $this->backorders_allowed() && $this->get_stock_quantity() <= get_option( 'woocommerce_notify_no_stock_amount' ) ) {
-			$set_child_stock_status = 'outofstock';
-		} elseif ( $this->backorders_allowed() || $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount' ) ) {
-			$set_child_stock_status = 'instock';
-		}
-
-		if ( $set_child_stock_status ) {
-			foreach ( $this->get_children() as $child_id ) {
-				if ( 'yes' !== get_post_meta( $child_id, '_manage_stock', true ) ) {
-					wc_update_product_stock_status( $child_id, $set_child_stock_status );
-				}
-			}
-
-			// Children statuses changed, so sync self
-			self::sync_stock_status( $this->id );
-		}
-	}
-
-	/**
-	 * Set stock status.
-	 */
-	public function set_stock_status( $status ) {
-		$status = 'outofstock' === $status ? 'outofstock' : 'instock';
-
-		if ( update_post_meta( $this->id, '_stock_status', $status ) ) {
-			do_action( 'woocommerce_product_set_stock_status', $this->id, $status );
-		}
-	}
-
-	/**
 	 * Return a products child ids.
 	 *
-	 * @param  boolean $visible_only Only return variations which are not hidden
-	 * @return array of children ids
+	 * @param  boolean $deprecated
+	 * @return array Children ids
 	 */
-	public function get_children( $visible_only = false ) {
-		$key            = $visible_only ? 'visible' : 'all';
-		$transient_name = 'wc_product_children_' . $this->id;
-
-		// Get value of transient
-		if ( ! is_array( $this->children ) ) {
-			$this->children = get_transient( $transient_name );
+	public function get_children( $deprecated = false ) {
+		if ( $deprecated ) {
+			_deprecated_argument( 'visible_only', '2.7', 'WC_Product_Variable::get_visible_children' );
+			return $this->get_visible_children();
 		}
-
-		// Get value from DB
-		if ( empty( $this->children ) || ! is_array( $this->children ) || ! isset( $this->children[ $key ] ) ) {
-			$args = array(
-				'post_parent' => $this->id,
-				'post_type'   => 'product_variation',
-				'orderby'     => 'menu_order',
-				'order'       => 'ASC',
-				'fields'      => 'ids',
-				'post_status' => 'publish',
-				'numberposts' => -1,
-			);
-
-			if ( $visible_only ) {
-				if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-					$args['meta_query'][] = array(
-						'key'     => '_stock_status',
-						'value'   => 'instock',
-						'compare' => '=',
-					);
-				}
-			}
-
-			$args                   = apply_filters( 'woocommerce_variable_children_args', $args, $this, $visible_only );
-			$this->children[ $key ] = get_posts( $args );
-
-			set_transient( $transient_name, $this->children, DAY_IN_SECONDS * 30 );
-		}
-
-		return apply_filters( 'woocommerce_get_children', $this->children[ $key ], $this, $visible_only );
+		return apply_filters( 'woocommerce_get_children', $this->data['children'], $this, false );
 	}
 
 	/**
-	 * Get child product.
+	 * Return a products child ids - visible only.
 	 *
-	 * @access public
-	 * @param mixed $child_id
-	 * @return WC_Product_Variation
+	 * @since 2.7.0
+	 * @return array Children ids
 	 */
-	public function get_child( $child_id ) {
-		return wc_get_product( $child_id, array(
-			'parent_id' => $this->id,
-			'parent' 	=> $this,
-		) );
-	}
-
-	/**
-	 * Returns whether or not the product has any child product.
-	 *
-	 * @access public
-	 * @return bool
-	 */
-	public function has_child() {
-		return sizeof( $this->get_children() ) ? true : false;
-	}
-
-	/**
-	 * Returns whether or not the product is on sale.
-	 * @return bool
-	 */
-	public function is_on_sale() {
-		$is_on_sale = false;
-		$prices     = $this->get_variation_prices();
-
-		if ( $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price'] ) {
-			$is_on_sale = true;
-		}
-		return apply_filters( 'woocommerce_product_is_on_sale', $is_on_sale, $this );
+	public function get_visible_children() {
+		return apply_filters( 'woocommerce_get_children', $this->data['visible_children'], $this, false );
 	}
 
 	/**
 	 * Get the min or max variation regular price.
-	 * @param  string $min_or_max - min or max
-	 * @param  boolean  $display Whether the value is going to be displayed
+	 * @param  string  $min_or_max    Min or max price.
+	 * @param  boolean $include_taxes Should the price include taxes?
 	 * @return string
 	 */
-	public function get_variation_regular_price( $min_or_max = 'min', $display = false ) {
-		$prices = $this->get_variation_prices( $display );
+	public function get_variation_regular_price( $min_or_max = 'min', $include_taxes = false ) {
+		$prices = $include_taxes ? $this->data['variation_prices_including_taxes'] : $this->data['variation_prices'];
 		$price  = 'min' === $min_or_max ? current( $prices['regular_price'] ) : end( $prices['regular_price'] );
-		return apply_filters( 'woocommerce_get_variation_regular_price', $price, $this, $min_or_max, $display );
+		return apply_filters( 'woocommerce_get_variation_regular_price', $price, $this, $min_or_max, $include_taxes );
 	}
 
 	/**
 	 * Get the min or max variation sale price.
-	 * @param  string $min_or_max - min or max
-	 * @param  boolean  $display Whether the value is going to be displayed
+	 * @param  string  $min_or_max    Min or max price.
+	 * @param  boolean $include_taxes Should the price include taxes?
 	 * @return string
 	 */
-	public function get_variation_sale_price( $min_or_max = 'min', $display = false ) {
-		$prices = $this->get_variation_prices( $display );
+	public function get_variation_sale_price( $min_or_max = 'min', $inclde_taxes = false ) {
+		$prices = $include_taxes ? $this->data['variation_prices_including_taxes'] : $this->data['variation_prices'];
 		$price  = 'min' === $min_or_max ? current( $prices['sale_price'] ) : end( $prices['sale_price'] );
-		return apply_filters( 'woocommerce_get_variation_sale_price', $price, $this, $min_or_max, $display );
+		return apply_filters( 'woocommerce_get_variation_sale_price', $price, $this, $min_or_max, $include_taxes );
 	}
 
 	/**
 	 * Get the min or max variation (active) price.
-	 * @param  string $min_or_max - min or max
-	 * @param  boolean  $display Whether the value is going to be displayed
+	 * @param  string  $min_or_max    Min or max price.
+	 * @param  boolean $include_taxes Should the price include taxes?
 	 * @return string
 	 */
-	public function get_variation_price( $min_or_max = 'min', $display = false ) {
-		$prices = $this->get_variation_prices( $display );
+	public function get_variation_price( $min_or_max = 'min', $include_taxes = false ) {
+		$prices = $include_taxes ? $this->data['variation_prices_including_taxes'] : $this->data['variation_prices'];
 		$price  = 'min' === $min_or_max ? current( $prices['price'] ) : end( $prices['price'] );
-		return apply_filters( 'woocommerce_get_variation_price', $price, $this, $min_or_max, $display );
+		return apply_filters( 'woocommerce_get_variation_price', $price, $this, $min_or_max, $include_taxes );
 	}
 
 	/**
 	 * Get an array of all sale and regular prices from all variations. This is used for example when displaying the price range at variable product level or seeing if the variable product is on sale.
 	 *
-	 * Can be filtered by plugins which modify costs, but otherwise will include the raw meta costs unlike get_price() which runs costs through the woocommerce_get_price filter.
-	 * This is to ensure modified prices are not cached, unless intended.
-	 *
-	 * @param  bool $display Are prices for display? If so, taxes will be calculated.
+	 * @param  bool $deprecated
 	 * @return array() Array of RAW prices, regular prices, and sale prices with keys set to variation ID.
 	 */
-	public function get_variation_prices( $display = false ) {
-		global $wp_filter;
-
-		/**
-		 * Transient name for storing prices for this product (note: Max transient length is 45)
-		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
-		 */
-		$transient_name = 'wc_var_prices_' . $this->id;
-
-		/**
-		 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
-		 * DEVELOPERS should filter this hash if offering conditonal pricing to keep it unique.
-		 * @var string
-		 */
-		if ( $display ) {
-			$price_hash = array( get_option( 'woocommerce_tax_display_shop', 'excl' ), WC_Tax::get_rates() );
-		} else {
-			$price_hash = array( false );
+	public function get_variation_prices( $deprecated = false ) {
+		if ( $deprecated ) {
+			_deprecated_argument( 'display', '2.7', 'Use WC_Product_Variable::get_variation_prices_including_taxes' );
+			return $this->get_variation_prices_including_taxes();
 		}
+		return $this->data['variation_prices'];
+	}
 
-		$filter_names = array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' );
-
-		foreach ( $filter_names as $filter_name ) {
-			if ( ! empty( $wp_filter[ $filter_name ] ) ) {
-				$price_hash[ $filter_name ] = array();
-
-				foreach ( $wp_filter[ $filter_name ] as $priority => $callbacks ) {
-					$price_hash[ $filter_name ][] = array_values( wp_list_pluck( $callbacks, 'function' ) );
-				}
-			}
-		}
-
-		$price_hash[] = WC_Cache_Helper::get_transient_version( 'product' );
-		$price_hash   = md5( json_encode( apply_filters( 'woocommerce_get_variation_prices_hash', $price_hash, $this, $display ) ) );
-
-		/**
-		 * $this->prices_array is an array of values which may have been modified from what is stored in transients - this may not match $transient_cached_prices_array.
-		 * If the value has already been generated, we don't need to grab the values again so just return them. They are already filtered.
-		 */
-		if ( ! empty( $this->prices_array[ $price_hash ] ) ) {
-			return $this->prices_array[ $price_hash ];
-
-		/**
-		 * No locally cached value? Get the data from the transient or generate it.
-		 */
-		} else {
-			// Get value of transient
-			$transient_cached_prices_array = array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) );
-
-			// If the product version has changed since the transient was last saved, reset the transient cache.
-			if ( empty( $transient_cached_prices_array['version'] ) || WC_Cache_Helper::get_transient_version( 'product' ) !== $transient_cached_prices_array['version'] ) {
-				$transient_cached_prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
-			}
-
-			// If the prices are not stored for this hash, generate them and add to the transient.
-			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ) {
-				$prices         = array();
-				$regular_prices = array();
-				$sale_prices    = array();
-				$variation_ids  = $this->get_children( true );
-
-				foreach ( $variation_ids as $variation_id ) {
-					if ( $variation = $this->get_child( $variation_id ) ) {
-						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->price, $variation, $this );
-						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->regular_price, $variation, $this );
-						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->sale_price, $variation, $this );
-
-						// Skip empty prices
-						if ( '' === $price ) {
-							continue;
-						}
-
-						// If sale price does not equal price, the product is not yet on sale
-						if ( $sale_price === $regular_price || $sale_price !== $price ) {
-							$sale_price = $regular_price;
-						}
-
-						// If we are getting prices for display, we need to account for taxes
-						if ( $display ) {
-							if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
-								$price         = '' === $price ? ''         : $variation->get_price_including_tax( 1, $price );
-								$regular_price = '' === $regular_price ? '' : $variation->get_price_including_tax( 1, $regular_price );
-								$sale_price    = '' === $sale_price ? ''    : $variation->get_price_including_tax( 1, $sale_price );
-							} else {
-								$price         = '' === $price ? ''         : $variation->get_price_excluding_tax( 1, $price );
-								$regular_price = '' === $regular_price ? '' : $variation->get_price_excluding_tax( 1, $regular_price );
-								$sale_price    = '' === $sale_price ? ''    : $variation->get_price_excluding_tax( 1, $sale_price );
-							}
-						}
-
-						$prices[ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
-						$regular_prices[ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
-						$sale_prices[ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
-					}
-				}
-
-				asort( $prices );
-				asort( $regular_prices );
-				asort( $sale_prices );
-
-				$transient_cached_prices_array[ $price_hash ] = array(
-					'price'         => $prices,
-					'regular_price' => $regular_prices,
-					'sale_price'    => $sale_prices,
-				);
-
-				set_transient( $transient_name, json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
-			}
-
-			/**
-			 * Give plugins one last chance to filter the variation prices array which has been generated and store locally to the class.
-			 * This value may differ from the transient cache. It is filtered once before storing locally.
-			 */
-			return $this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $this, $display );
-		}
+	/**
+	 * Get an array of all sale and regular prices from all variations, includes taxes.
+	 *
+	 * @since 2.7.0
+	 * @return array() Array of RAW prices, regular prices, and sale prices with keys set to variation ID.
+	 */
+	public function get_variation_prices_including_taxes() {
+		return $this->data['variation_prices_including_taxes'];
 	}
 
 	/**
@@ -345,7 +151,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return string
 	 */
 	public function get_price_html( $price = '' ) {
-		$prices = $this->get_variation_prices( true );
+		$prices = $this->get_variation_prices_including_taxes();
 
 		// No variations, or no active variation prices
 		if ( $this->get_price() === '' || empty( $prices['price'] ) ) {
@@ -373,84 +179,20 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Return an array of attributes used for variations, as well as their possible values.
 	 *
-	 * @return array of attributes and their available values
+	 * @return array Attributes and their available values
 	 */
 	public function get_variation_attributes() {
-		global $wpdb;
-
-		$variation_attributes = array();
-		$attributes           = $this->get_attributes();
-		$child_ids            = $this->get_children( true );
-
-		if ( ! empty( $child_ids ) ) {
-			foreach ( $attributes as $attribute ) {
-				if ( empty( $attribute['is_variation'] ) ) {
-					continue;
-				}
-
-				// Get possible values for this attribute, for only visible variations.
-				$values = array_unique( $wpdb->get_col( $wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (" . implode( ',', array_map( 'esc_sql', $child_ids ) ) . ")",
-					wc_variation_attribute_name( $attribute['name'] )
-				) ) );
-
-				// empty value indicates that all options for given attribute are available
-				if ( in_array( '', $values ) ) {
-					$values = $attribute['is_taxonomy'] ? wp_get_post_terms( $this->id, $attribute['name'], array( 'fields' => 'slugs' ) ) : wc_get_text_attributes( $attribute['value'] );
-
-				// Get custom attributes (non taxonomy) as defined
-				} elseif ( ! $attribute['is_taxonomy'] ) {
-					$text_attributes          = wc_get_text_attributes( $attribute['value'] );
-					$assigned_text_attributes = $values;
-					$values                   = array();
-
-					// Pre 2.4 handling where 'slugs' were saved instead of the full text attribute
-					if ( version_compare( get_post_meta( $this->id, '_product_version', true ), '2.4.0', '<' ) ) {
-						$assigned_text_attributes = array_map( 'sanitize_title', $assigned_text_attributes );
-
-						foreach ( $text_attributes as $text_attribute ) {
-							if ( in_array( sanitize_title( $text_attribute ), $assigned_text_attributes ) ) {
-								$values[] = $text_attribute;
-							}
-						}
-					} else {
-						foreach ( $text_attributes as $text_attribute ) {
-							if ( in_array( $text_attribute, $assigned_text_attributes ) ) {
-								$values[] = $text_attribute;
-							}
-						}
-					}
-				}
-
-				$variation_attributes[ $attribute['name'] ] = array_unique( $values );
-			}
-		}
-
-		return $variation_attributes;
+		return $this->data['variation_attributes'];
 	}
 
 	/**
 	 * If set, get the default attributes for a variable product.
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public function get_variation_default_attributes() {
-		$default = isset( $this->default_attributes ) ? $this->default_attributes : '';
-		return apply_filters( 'woocommerce_product_default_attributes', array_filter( (array) maybe_unserialize( $default ) ), $this );
-	}
-
-	/**
-	 * Check if variable product has default attributes set.
-	 *
-	 * @access public
-	 * @return bool
-	 */
-	public function has_default_attributes() {
-		if ( ! $this->get_variation_default_attributes() ) {
-			return true;
-		}
-		return false;
+		_deprecated_function( 'WC_Product_Variable::get_variation_default_attributes', '2.7', 'WC_Product::get_default_attributes' );
+		return apply_filters( 'woocommerce_product_default_attributes', array_filter( (array) maybe_unserialize( $this->get_default_attributes() ) ), $this );
 	}
 
 	/**
@@ -460,7 +202,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return string
 	 */
 	public function get_variation_default_attribute( $attribute_name ) {
-		$defaults       = $this->get_variation_default_attributes();
+		$defaults       = $this->get_default_attributes();
 		$attribute_name = sanitize_title( $attribute_name );
 		return isset( $defaults[ $attribute_name ] ) ? $defaults[ $attribute_name ] : '';
 	}
@@ -475,7 +217,7 @@ class WC_Product_Variable extends WC_Product {
 		global $wpdb;
 
 		$query_args = array(
-			'post_parent' => $this->id,
+			'post_parent' => $this->get_id(),
 			'post_type'   => 'product_variation',
 			'orderby'     => 'menu_order',
 			'order'       => 'ASC',
@@ -525,7 +267,7 @@ class WC_Product_Variable extends WC_Product {
 		 * Pre 2.4 handling where 'slugs' were saved instead of the full text attribute.
 		 * Fallback is here because there are cases where data will be 'synced' but the product version will remain the same. @see WC_Product_Variable::sync_attributes.
 		 */
-	 	} elseif ( version_compare( get_post_meta( $this->id, '_product_version', true ), '2.4.0', '<' ) ) {
+	 } elseif ( version_compare( get_post_meta( $this->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
 			return ( array_map( 'sanitize_title', $match_attributes ) === $match_attributes ) ? 0 : $this->get_matching_variation( array_map( 'sanitize_title', $match_attributes ) );
 
 		} else {
@@ -544,12 +286,12 @@ class WC_Product_Variable extends WC_Product {
 			$variation = $this->get_child( $child_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked
-			if ( empty( $variation->variation_id ) || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
+			if ( empty( $variation->get_variation_id() ) || ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $variation->is_in_stock() ) ) {
 				continue;
 			}
 
 			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price)
-			if ( apply_filters( 'woocommerce_hide_invisible_variations', false, $this->id, $variation ) && ! $variation->variation_is_visible() ) {
+			if ( apply_filters( 'woocommerce_hide_invisible_variations', false, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
 				continue;
 			}
 
@@ -591,7 +333,7 @@ class WC_Product_Variable extends WC_Product {
 		}
 
 		return apply_filters( 'woocommerce_available_variation', array(
-			'variation_id'           => $variation->variation_id,
+			'variation_id'           => $variation->get_variation_id(),
 			'variation_is_visible'   => $variation->variation_is_visible(),
 			'variation_is_active'    => $variation->variation_is_active(),
 			'is_purchasable'         => $variation->is_purchasable(),
@@ -621,12 +363,67 @@ class WC_Product_Variable extends WC_Product {
 		), $this, $variation );
 	}
 
+	/*
+	|--------------------------------------------------------------------------
+	| Other Actions
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Get the add to cart button text.
+	 *
+	 * @access public
+	 * @return string
+	 */
+	public function add_to_cart_text() {
+		$text = $this->is_purchasable() && $this->is_in_stock() ? __( 'Select options', 'woocommerce' ) : __( 'Read more', 'woocommerce' );
+		return apply_filters( 'woocommerce_product_add_to_cart_text', $text, $this );
+	}
+
+	/**
+	 * Performed after a stock level change at product level.
+	 */
+	public function check_stock_status() {
+		$set_child_stock_status = '';
+
+		if ( ! $this->backorders_allowed() && $this->get_stock_quantity() <= get_option( 'woocommerce_notify_no_stock_amount' ) ) {
+			$set_child_stock_status = 'outofstock';
+		} elseif ( $this->backorders_allowed() || $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount' ) ) {
+			$set_child_stock_status = 'instock';
+		}
+
+		if ( $set_child_stock_status ) {
+			foreach ( $this->get_children() as $child_id ) {
+				if ( 'yes' !== get_post_meta( $child_id, '_manage_stock', true ) ) {
+					wc_update_product_stock_status( $child_id, $set_child_stock_status );
+				}
+			}
+
+			// Children statuses changed, so sync self
+			self::sync_stock_status( $this->get_id() );
+		}
+	}
+
+	/**
+	 * Returns whether or not the product is on sale.
+	 * @return bool
+	 */
+	public function is_on_sale() {
+		$is_on_sale = false;
+		$prices     = $this->read_price_data();
+
+		if ( $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price'] ) {
+			$is_on_sale = true;
+		}
+		return apply_filters( 'woocommerce_product_is_on_sale', $is_on_sale, $this );
+	}
+
 	/**
 	 * Sync variable product prices with the children lowest/highest prices.
 	 */
 	public function variable_product_sync( $product_id = '' ) {
 		if ( empty( $product_id ) ) {
-			$product_id = $this->id;
+			$product_id = $this->get_id();
 		}
 
 		// Sync prices with children
@@ -653,11 +450,11 @@ class WC_Product_Variable extends WC_Product {
 	 */
 	public static function sync_stock_status( $product_id ) {
 		$children = get_posts( array(
-			'post_parent' 	=> $product_id,
+			'post_parent' 	 => $product_id,
 			'posts_per_page' => -1,
-			'post_type' 	=> 'product_variation',
-			'fields' 		=> 'ids',
-			'post_status'	=> 'publish',
+			'post_type' 	 => 'product_variation',
+			'fields' 		 => 'ids',
+			'post_status'	 => 'publish',
 		) );
 
 		$stock_status = 'outofstock';
@@ -680,11 +477,11 @@ class WC_Product_Variable extends WC_Product {
 	public static function sync_attributes( $product_id, $children = false ) {
 		if ( ! $children ) {
 			$children = get_posts( array(
-				'post_parent' 	=> $product_id,
+				'post_parent' 	 => $product_id,
 				'posts_per_page' => -1,
-				'post_type' 	=> 'product_variation',
-				'fields' 		=> 'ids',
-				'post_status'	=> 'any',
+				'post_type' 	 => 'product_variation',
+				'fields' 		 => 'ids',
+				'post_status'	 => 'any',
 			) );
 		}
 
@@ -727,7 +524,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function child_has_weight() {
-		return (bool) get_post_meta( $this->id, '_child_has_weight', true );
+		return (bool) get_post_meta( $this->get_id(), '_child_has_weight', true );
 	}
 
 	/**
@@ -736,7 +533,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function child_has_dimensions() {
-		return (bool) get_post_meta( $this->id, '_child_has_dimensions', true );
+		return (bool) get_post_meta( $this->get_id(), '_child_has_dimensions', true );
 	}
 
 	/**
@@ -755,11 +552,11 @@ class WC_Product_Variable extends WC_Product {
 		global $wpdb;
 
 		$children = get_posts( array(
-			'post_parent' 	=> $product_id,
+			'post_parent' 	 => $product_id,
 			'posts_per_page' => -1,
-			'post_type' 	=> 'product_variation',
-			'fields' 		=> 'ids',
-			'post_status'	=> 'publish',
+			'post_type' 	 => 'product_variation',
+			'fields' 		 => 'ids',
+			'post_status'	 => 'publish',
 		) );
 
 		// No published variations - product won't be purchasable.
@@ -875,4 +672,291 @@ class WC_Product_Variable extends WC_Product {
 			do_action( 'woocommerce_variable_product_sync', $product_id, $children );
 		}
 	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters
+	|--------------------------------------------------------------------------
+	|
+	| Functions for setting product data. Most data in this class
+	| is pulled from the children products, so we don't have set_* Functions
+	| for variation prices, etc. If you want to manage a variation, do so
+	| by modifiying WC_Product_Variation.
+	*/
+
+	/**
+	 * Set stock status.
+	 */
+	public function set_stock_status( $status ) {
+		$status = 'outofstock' === $status ? 'outofstock' : 'instock';
+
+		if ( update_post_meta( $this->get_id(), '_stock_status', $status ) ) {
+			do_action( 'woocommerce_product_set_stock_status', $this->get_id(), $status );
+		}
+
+		$this->data['stock_status'] = $status;
+	}
+
+	/**
+	 * Set stock level of the product.
+	 *
+	 * @param mixed $amount (default: null)
+	 * @param string $mode can be set, add, or subtract
+	 * @return int Stock
+	 */
+	public function set_stock( $amount = null, $mode = 'set' ) {
+		$this->total_stock = '';
+		delete_transient( 'wc_product_total_stock_' . $this->get_id() . WC_Cache_Helper::get_transient_version( 'product' ) );
+		return parent::set_stock( $amount, $mode );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| CRUD methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Reads a product from the database and sets its data to the class.
+	 *
+	 * @since 2.7.0
+	 * @param int $id Product ID.
+	 */
+	public function read( $id ) {
+		parent::read( $id );
+		$children = $this->read_children();
+
+		// Set directly since individual data needs changed at the WC_Product_Variation level -- these datasets just pull
+		$this->data['children']                         = array_filter( wp_parse_id_list( (array) $children['all'] ) );
+		$this->data['children_visible']                 = array_filter( wp_parse_id_list( (array) $children['visible'] ) );
+		$this->data['variation_prices']                 = $this->read_price_data();
+		$this->data['variation_prices_including_taxes'] = $this->read_price_data( true );
+		$this->data['variation_attributes']             = $this->read_variation_attributes();
+		do_action( 'woocommerce_product_loaded', $this );
+		do_action( 'woocommerce_product_' . $this->get_type() . '_loaded', $this );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| CRUD helper methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Loads variation child IDs.
+	 *
+	 * @return array
+	 */
+	private function read_children() {
+		$children_transient_name = 'wc_product_children_' . $this->get_id();
+		$children = get_transient( $children_transient_name );
+
+		if ( empty( $children ) || ! is_array( $children ) || ! isset( $children['all'] ) || ! isset( $children['visible'] ) ) {
+			$all_args = $visible_only_args = array(
+				'post_parent' => $this->get_id(),
+				'post_type'   => 'product_variation',
+				'orderby'     => 'menu_order',
+				'order'       => 'ASC',
+				'fields'      => 'ids',
+				'post_status' => 'publish',
+				'numberposts' => -1,
+			);
+			if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+					$visible_only_args['meta_query'][] = array(
+						'key'     => '_stock_status',
+						'value'   => 'instock',
+						'compare' => '=',
+					);
+			}
+			$all_args            = apply_filters( 'woocommerce_variable_children_args', $all_args, $this, false );
+			$visible_only_args   = apply_filters( 'woocommerce_variable_children_args', $visible_only_args, $this, false );
+			$children['all']     = get_posts( $all_args );
+			$children['visible'] = get_posts( $visible_only_args );
+
+			set_transient( $children_transient_name, $children, DAY_IN_SECONDS * 30 );
+			return $children;
+		}
+
+		return $children;
+	}
+
+	/**
+	 * Loads an array of attributes used for variations, as well as their possible values.
+	 *
+	 * @return array Attributes and their available values
+	 */
+	private function read_variation_attributes() {
+		global $wpdb;
+		$variation_attributes = array();
+		$attributes           = $this->get_attributes();
+		$child_ids            = $this->get_children();
+		if ( ! empty( $child_ids ) && ! empty( $attributes ) ) {
+			foreach ( $attributes as $attribute ) {
+				if ( empty( $attribute['is_variation'] ) ) {
+					continue;
+				}
+
+				// Get possible values for this attribute, for only visible variations.
+				$values = array_unique( $wpdb->get_col( $wpdb->prepare(
+					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (" . implode( ',', array_map( 'esc_sql', $child_ids ) ) . ")",
+					wc_variation_attribute_name( $attribute['name'] )
+				) ) );
+
+				// empty value indicates that all options for given attribute are available
+				if ( in_array( '', $values ) || empty( $values ) ) {
+					$values = $attribute['is_taxonomy'] ? wp_get_post_terms( $this->get_id(), $attribute['name'], array( 'fields' => 'slugs' ) ) : wc_get_text_attributes( $attribute['value'] );
+				// Get custom attributes (non taxonomy) as defined
+				} elseif ( ! $attribute['is_taxonomy'] ) {
+					$text_attributes          = wc_get_text_attributes( $attribute['value'] );
+					$assigned_text_attributes = $values;
+					$values                   = array();
+					// Pre 2.4 handling where 'slugs' were saved instead of the full text attribute
+					if ( version_compare( get_post_meta( $this->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
+						$assigned_text_attributes = array_map( 'sanitize_title', $assigned_text_attributes );
+						foreach ( $text_attributes as $text_attribute ) {
+							if ( in_array( sanitize_title( $text_attribute ), $assigned_text_attributes ) ) {
+								$values[] = $text_attribute;
+							}
+						}
+					} else {
+						foreach ( $text_attributes as $text_attribute ) {
+							if ( in_array( $text_attribute, $assigned_text_attributes ) ) {
+								$values[] = $text_attribute;
+							}
+						}
+					}
+				}
+				$variation_attributes[ $attribute['name'] ] = array_unique( $values );
+			}
+		}
+		return $variation_attributes;
+	}
+
+	/**
+	 * Get an array of all sale and regular prices from all variations. This is used for example when displaying the price range at variable product level or seeing if the variable product is on sale.
+	 *
+	 * Can be filtered by plugins which modify costs, but otherwise will include the raw meta costs unlike get_price() which runs costs through the woocommerce_get_price filter.
+	 * This is to ensure modified prices are not cached, unless intended.
+	 *
+	 * @param  bool $include_taxes If taxes should be calculated or not.
+	 * @return array() Array of RAW prices, regular prices, and sale prices with keys set to variation ID.
+	 */
+	private function read_price_data( $include_taxes = false ) {
+		global $wp_filter;
+
+		/**
+		 * Transient name for storing prices for this product (note: Max transient length is 45)
+		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
+		 */
+		$transient_name = 'wc_var_prices_' . $this->get_id();
+
+		/**
+		 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
+		 * DEVELOPERS should filter this hash if offering conditonal pricing to keep it unique.
+		 * @var string
+		 */
+		if ( $include_taxes ) {
+			$price_hash = array( get_option( 'woocommerce_tax_display_shop', 'excl' ), WC_Tax::get_rates() );
+		} else {
+			$price_hash = array( false );
+		}
+
+		$filter_names = array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' );
+
+		foreach ( $filter_names as $filter_name ) {
+			if ( ! empty( $wp_filter[ $filter_name ] ) ) {
+				$price_hash[ $filter_name ] = array();
+
+				foreach ( $wp_filter[ $filter_name ] as $priority => $callbacks ) {
+					$price_hash[ $filter_name ][] = array_values( wp_list_pluck( $callbacks, 'function' ) );
+				}
+			}
+		}
+
+		$price_hash[] = WC_Cache_Helper::get_transient_version( 'product' );
+		$price_hash   = md5( json_encode( apply_filters( 'woocommerce_get_variation_prices_hash', $price_hash, $this, $include_taxes ) ) );
+
+		/**
+		 * $this->prices_array is an array of values which may have been modified from what is stored in transients - this may not match $transient_cached_prices_array.
+		 * If the value has already been generated, we don't need to grab the values again so just return them. They are already filtered.
+		 */
+		if ( ! empty( $this->prices_array[ $price_hash ] ) ) {
+			return $this->prices_array[ $price_hash ];
+
+		/**
+		 * No locally cached value? Get the data from the transient or generate it.
+		 */
+		} else {
+			// Get value of transient
+			$transient_cached_prices_array = array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) );
+
+			// If the product version has changed since the transient was last saved, reset the transient cache.
+			if ( empty( $transient_cached_prices_array['version'] ) || WC_Cache_Helper::get_transient_version( 'product' ) !== $transient_cached_prices_array['version'] ) {
+				$transient_cached_prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
+			}
+
+			// If the prices are not stored for this hash, generate them and add to the transient.
+			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ) {
+				$prices         = array();
+				$regular_prices = array();
+				$sale_prices    = array();
+				$children       = $this->read_children();
+				$variation_ids  = $children['visible'];
+				foreach ( $variation_ids as $variation_id ) {
+					if ( $variation = wc_get_product( $variation_id, array( 'parent_id' => $this->get_id(), 'parent' 	=> $this ) ) ) {
+						// @todo Once WC_Product_Variation is updated, these should be get_price, get_regular_price, etc -- those don't work currently
+						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->price, $variation, $this );
+						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->regular_price, $variation, $this );
+						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->sale_price, $variation, $this );
+
+						// Skip empty prices
+						if ( '' === $price ) {
+							continue;
+						}
+
+						// If sale price does not equal price, the product is not yet on sale
+						if ( $sale_price === $regular_price || $sale_price !== $price ) {
+							$sale_price = $regular_price;
+						}
+
+						// If we are getting prices for display, we need to account for taxes
+						if ( $include_taxes ) {
+							if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
+								$price         = '' === $price ? ''         : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
+								$regular_price = '' === $regular_price ? '' : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $regular_price ) );
+								$sale_price    = '' === $sale_price ? ''    : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $sale_price ) );
+							} else {
+								$price         = '' === $price ? ''         : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
+								$regular_price = '' === $regular_price ? '' : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $regular_price ) );
+								$sale_price    = '' === $sale_price ? ''    : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $sale_price ) );
+							}
+						}
+
+						$prices[ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
+						$regular_prices[ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
+						$sale_prices[ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
+					}
+				}
+
+				asort( $prices );
+				asort( $regular_prices );
+				asort( $sale_prices );
+
+				$transient_cached_prices_array[ $price_hash ] = array(
+					'price'         => $prices,
+					'regular_price' => $regular_prices,
+					'sale_price'    => $sale_prices,
+				);
+
+				set_transient( $transient_name, json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
+			}
+
+			/**
+			 * Give plugins one last chance to filter the variation prices array which has been generated and store locally to the class.
+			 * This value may differ from the transient cache. It is filtered once before storing locally.
+			 */
+			return $this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $this, $include_taxes );
+		}
+	}
+
 }

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -146,7 +146,6 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Returns the price in html format.
 	 *
-	 * @access public
 	 * @param string $price (default: '')
 	 * @return string
 	 */
@@ -372,7 +371,6 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get the add to cart button text.
 	 *
-	 * @access public
 	 * @return string
 	 */
 	public function add_to_cart_text() {
@@ -688,13 +686,7 @@ class WC_Product_Variable extends WC_Product {
 	 * Set stock status.
 	 */
 	public function set_stock_status( $status ) {
-		$status = 'outofstock' === $status ? 'outofstock' : 'instock';
-
-		if ( update_post_meta( $this->get_id(), '_stock_status', $status ) ) {
-			do_action( 'woocommerce_product_set_stock_status', $this->get_id(), $status );
-		}
-
-		$this->data['stock_status'] = $status;
+		$this->data['stock_status'] = 'outofstock' === $status ? 'outofstock' : 'instock';
 	}
 
 	/**
@@ -956,6 +948,16 @@ class WC_Product_Variable extends WC_Product {
 			 * This value may differ from the transient cache. It is filtered once before storing locally.
 			 */
 			return $this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $this, $include_taxes );
+		}
+	}
+
+	/**
+	 * Helper method that updates all the post meta
+	 */
+	protected function update_post_meta() {
+		parent::update_post_meta();
+		if ( update_post_meta( $this->get_id(), '_stock_status', $this->get_stock_status() ) ) {
+			do_action( 'woocommerce_product_set_stock_status', $this->get_id(), $this->get_stock_status() );
 		}
 	}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -333,7 +333,7 @@ function wc_product_post_class( $classes, $class = '', $post_id = '' ) {
 			$classes[] = "product-type-" . $product->get_type();
 		}
 		if ( $product->is_type( 'variable' ) ) {
-			if ( $product->has_default_attributes() ) {
+			if ( ! $product->get_default_attributes() ) {
 				$classes[] = 'has-default-attributes';
 			}
 			if ( $product->has_child() ) {

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -15,7 +15,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     2.1.3
+ * @version     2.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -33,7 +33,7 @@ ob_start();
 
 	<?php if ( $product->enable_dimensions_display() ) : ?>
 
-		<?php if ( $product->has_weight() || get_post_meta( $product->id, '_child_has_weight', true ) ) : $has_row = true; ?>
+		<?php if ( $product->has_weight() || $product->child_has_weight() ) : $has_row = true; ?>
 			<tr class="<?php if ( ( $alt = $alt * -1 ) === 1 ) echo 'alt'; ?>">
 				<th><?php _e( 'Weight', 'woocommerce' ) ?></th>
 				<td class="product_weight"><?php echo $product->get_weight() ? wc_format_localized_decimal( $product->get_weight() ) . ' ' . esc_attr( get_option( 'woocommerce_weight_unit' ) ) : __( 'N/A', 'woocommerce' ); ?></td>

--- a/tests/unit-tests/product/crud.php
+++ b/tests/unit-tests/product/crud.php
@@ -253,4 +253,93 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 			 $this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
 		 }
 	 }
+
+	 /**
+	 * Test reading a variable product.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_variable_read() {
+		$product = WC_Helper_Product::create_variation_product();
+		$children = $product->get_children();
+
+		// Test sale prices too
+		update_post_meta( $children[0], '_price', '8' );
+		update_post_meta( $children[0], '_sale_price', '8' );
+		delete_transient( 'wc_var_prices_' . $product->get_id() );
+
+		$product = new WC_Product_Variable( $product->get_id() );
+
+		$this->assertEquals( 2, count( $product->get_children() ) );
+
+		$expected_prices['price'][ $children[0] ] = 8.00;
+		$expected_prices['price'][ $children[1] ] = 15.00;
+		$expected_prices['regular_price'][ $children[0] ] = 10.00;
+		$expected_prices['regular_price'][ $children[1] ] = 15.00;
+		$expected_prices['sale_price'][ $children[0] ] = 8.00;
+		$expected_prices['sale_price'][ $children[1] ] = 15.00;
+
+		$this->assertEquals( $expected_prices, $product->get_variation_prices() );
+
+		$expected_attributes = array( 'pa_size' => array( 'small', 'large' ) );
+		$this->assertEquals( $expected_attributes, $product->get_variation_attributes() );
+	}
+
+	/**
+	 * Test creating a new variable product.
+	 *
+	 * @todo - this test can be improved. Once WC_Product_Variation is updated
+	 * with CRUD as well, this test should add a variation to a variable product
+	 * that way, and test things like get_children and attributes.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_variable_create_and_update() {
+		$product = new WC_Product_Variable;
+		$product->set_name( 'Variable Product' );
+		$product->set_attributes( array( array(
+			'name'         => 'pa_size',
+			'value'        => 'small | large',
+			'position'     => '1',
+			'is_visible'   => 0,
+			'is_variation' => 1,
+			'is_taxonomy'  => 0,
+		) ) );
+		$product->create();
+
+		$this->assertEquals( 'Variable Product', $product->get_name() );
+
+		// Create a variation
+		$variation_id = wp_insert_post( array(
+			'post_title'  => 'Variation #1 of Dummy Variable CRUD Product',
+			'post_type'   => 'product_variation',
+			'post_parent' => $product->get_id(),
+			'post_status' => 'publish',
+		) );
+
+		update_post_meta( $variation_id, '_price', '10' );
+		update_post_meta( $variation_id, '_regular_price', '10' );
+		update_post_meta( $variation_id, '_sku', 'CRUD DUMMY SKU VARIABLE SMALL' );
+		update_post_meta( $variation_id, '_manage_stock', 'no' );
+		update_post_meta( $variation_id, '_downloadable', 'no' );
+		update_post_meta( $variation_id, '_virtual', 'no' );
+		update_post_meta( $variation_id, '_stock_status', 'instock' );
+		update_post_meta( $variation_id, 'attribute_pa_size', 'small' );
+
+		delete_transient( 'wc_product_children_' . $product->get_id() );
+		delete_transient( 'wc_var_prices_' . $product->get_id() );
+
+		$product = new WC_Product_Variable( $product->get_id() );
+		$children = $product->get_children();
+		$this->assertEquals( $variation_id, $children[0] );
+
+		$expected_attributes = array( 'pa_size' => array( 'small' ) );
+		$this->assertEquals( $expected_attributes, $product->get_variation_attributes() );
+
+		$product->set_name( 'Renamed Variable Product' );
+		$product->update();
+
+		$this->assertEquals( 'Renamed Variable Product', $product->get_name() );
+	 }
+
 }


### PR DESCRIPTION
This took a little longer then I was hoping for. I ran into a couple issues that took me a bit to figure out (one related to a typo in abstract-product, the other after rebasing).

As I mentioned in Slack, I didn't provide `set_*` methods for things like prices/child IDs. Those should all update when a new `WC_Product_Variation` is created.

I want to improve the tests a bit more but want `WC_Product_Variation` CRUDified first to make it easier, so there is a todo listed for that.
