### PR TITLE
Only print js for free shipping fields in admin

### DIFF
--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -107,31 +107,33 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 	 * @return array
 	 */
 	public function get_instance_form_fields() {
-		wc_enqueue_js( "
-			jQuery( function( $ ) {
-				function wcFreeShippingShowHideMinAmountField( el ) {
-					var form = $( el ).closest( 'form' );
-					var minAmountField = $( '#woocommerce_free_shipping_min_amount', form ).closest( 'tr' );
-					if ( 'coupon' === $( el ).val() || '' === $( el ).val() ) {
-						minAmountField.hide();
-					} else {
-						minAmountField.show();
+		if ( is_admin() ) {
+			wc_enqueue_js( "
+				jQuery( function( $ ) {
+					function wcFreeShippingShowHideMinAmountField( el ) {
+						var form = $( el ).closest( 'form' );
+						var minAmountField = $( '#woocommerce_free_shipping_min_amount', form ).closest( 'tr' );
+						if ( 'coupon' === $( el ).val() || '' === $( el ).val() ) {
+							minAmountField.hide();
+						} else {
+							minAmountField.show();
+						}
 					}
-				}
 
-				$( document.body ).on( 'change', '#woocommerce_free_shipping_requires', function() {
-					wcFreeShippingShowHideMinAmountField( this );
+					$( document.body ).on( 'change', '#woocommerce_free_shipping_requires', function() {
+						wcFreeShippingShowHideMinAmountField( this );
+					});
+
+					// Change while load.
+					$( '#woocommerce_free_shipping_requires' ).change();
+					$( document.body ).on( 'wc_backbone_modal_loaded', function( evt, target ) {
+						if ( 'wc-modal-shipping-method-settings' === target ) {
+							wcFreeShippingShowHideMinAmountField( $( '#wc-backbone-modal-dialog #woocommerce_free_shipping_requires', evt.currentTarget ) );
+						}
+					} );
 				});
-
-				// Change while load.
-				$( '#woocommerce_free_shipping_requires' ).change();
-				$( document.body ).on( 'wc_backbone_modal_loaded', function( evt, target ) {
-					if ( 'wc-modal-shipping-method-settings' === target ) {
-						wcFreeShippingShowHideMinAmountField( $( '#wc-backbone-modal-dialog #woocommerce_free_shipping_requires', evt.currentTarget ) );
-					}
-				} );
-			});
-		" );
+			" );
+		}
 
 		return parent::get_instance_form_fields();
 	}


### PR DESCRIPTION
Since `WC_Shipping_Method->get_option()` calls `$this->get_instance_form_fields()` it prints out the JS even when getting an option outside of wp-admin.

For example this code to get the free shipping object (used in the theme for displaying how much is required for free shipping) makes the JS code print out in the footer.

``` php
function get_free_shipping_object() {
    $packages = WC()->cart->get_shipping_packages();
    $package = reset( $packages );

    $shipping_zone    = WC_Shipping_Zones::get_zone_matching_package( $package );
    foreach ( $shipping_zone->get_shipping_methods( true ) as $shipping_method ) {
        if ( $shipping_method instanceof WC_Shipping_Free_Shipping ) {
            return $shipping_method;
        }
    }
}
```
