### PR TITLE
Add counties for Republic of Ireland

### DIFF
--- a/i18n/states/IE.php
+++ b/i18n/states/IE.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Republic of Ireland
+ *
+ * @author      WooThemes
+ * @category    i18n
+ * @package     WooCommerce/i18n
+ * @version     2.7.0
+ */
+global $states;
+
+$states['IE'] = array(
+	'CE' => __( 'Clare', 'woocommerce' ),
+	'CK' => __( 'Cork', 'woocommerce' ),
+	'CN' => __( 'Cavan', 'woocommerce' ),
+	'CW' => __( 'Carlow', 'woocommerce' ),
+	'DL' => __( 'Donegal', 'woocommerce' ),
+	'DN' => __( 'Dublin', 'woocommerce' ),
+	'GY' => __( 'Galway', 'woocommerce' ),
+	'KE' => __( 'Kildare', 'woocommerce' ),
+	'KK' => __( 'Kilkenny', 'woocommerce' ),
+	'KY' => __( 'Kerry', 'woocommerce' ),
+	'LD' => __( 'Longford', 'woocommerce' ),
+	'LH' => __( 'Louth', 'woocommerce' ),
+	'LK' => __( 'Limerick', 'woocommerce' ),
+	'LM' => __( 'Leitrim', 'woocommerce' ),
+	'LS' => __( 'Laois', 'woocommerce' ),
+	'MH' => __( 'Meath', 'woocommerce' ),
+	'MN' => __( 'Monaghan', 'woocommerce' ),
+	'MO' => __( 'Mayo', 'woocommerce' ),
+	'OY' => __( 'Offaly', 'woocommerce' ),
+	'RN' => __( 'Roscommon', 'woocommerce' ),
+	'SO' => __( 'Sligo', 'woocommerce' ),
+	'TY' => __( 'Tipperary', 'woocommerce' ),
+	'WD' => __( 'Waterford', 'woocommerce' ),
+	'WH' => __( 'Westmeath', 'woocommerce' ),
+	'WW' => __( 'Wicklow', 'woocommerce' ),
+	'WX' => __( 'Wexford', 'woocommerce' ),
+);

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -792,7 +792,10 @@ class WC_Countries {
 				'IE' => array(
 					'postcode' => array(
 						'required' => false,
-						'label'    => __( 'Postcode', 'woocommerce' ),
+						'label'    => __( 'Eircode', 'woocommerce' ),
+					),
+					'state' => array(
+						'label'       => __( 'County', 'woocommerce' ),
 					),
 				),
 				'IS' => array(


### PR DESCRIPTION
This pull request makes the following changes
- Add IE.php to the /i18n/states/ folder which has a list of counties for the Republic of Ireland
- Change Republic of Ireland in class-wc-countries.php to refer to postcode as 'Eircode' and state as 'County'.

([Eircode](https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland#Eircode) is the new national postcode system)

Thanks!
