### PR TITLE
Add $load_address to 'woocommerce_my_account_edit_address_title'

### DIFF
--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -30,7 +30,7 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 
 	<form method="post">
 
-		<h3><?php echo apply_filters( 'woocommerce_my_account_edit_address_title', $page_title ); ?></h3>
+		<h3><?php echo apply_filters( 'woocommerce_my_account_edit_address_title', $page_title, $load_address ); ?></h3>
 
 		<?php do_action( "woocommerce_before_edit_address_form_{$load_address}" ); ?>
 


### PR DESCRIPTION
Added $load_address to the 'woocommerce_my_account_edit_address_title' filter so that scripts can determine which address is being edited. Currently there is no obvious way to determine what address is being edited if it is not the 'billing' or 'shipping' built-in addresses. By adding $load_address we can use that to detect the name of the address being edited and display the corresponding title.
