### PR TITLE
Allow more schemas

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -217,12 +217,13 @@ class WC_Meta_Box_Product_Data {
 						'min'	=> '0'
 					) ) );
 
-					 // Download Type
-					woocommerce_wp_select( array( 'id' => '_download_type', 'label' => __( 'Download type', 'woocommerce' ), 'description' => sprintf( __( 'Choose a download type - this controls the <a href="%s">schema</a>.', 'woocommerce' ), 'http://schema.org/' ), 'options' => array(
+					// Download Type
+					$download_types = array(
 						''            => __( 'Standard Product', 'woocommerce' ),
-						'application' => __( 'Application/Software', 'woocommerce' ),
-						'music'       => __( 'Music', 'woocommerce' ),
-					) ) );
+						'SoftwareApplication' => __( 'Application/Software', 'woocommerce' ),
+						'MusicAlbum'       => __( 'Music', 'woocommerce' ),
+					);
+					woocommerce_wp_select( array( 'id' => '_download_type', 'label' => __( 'Download type', 'woocommerce' ), 'description' => sprintf( __( 'Choose a download type - this controls the <a href="%s">schema</a>.', 'woocommerce' ), 'http://schema.org/' ), 'options' =>  apply_filters( 'woocommerce_download_types', $download_types ) ) );
 
 					do_action( 'woocommerce_product_options_downloads' );
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -606,7 +606,7 @@ if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 		if ( is_search() ) {
 			return;
 		}
-		
+
 		if ( is_post_type_archive( 'product' ) && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$shop_page   = get_post( wc_get_page_id( 'shop' ) );
 			if ( $shop_page ) {
@@ -700,24 +700,14 @@ if ( ! function_exists( 'woocommerce_get_product_schema' ) ) {
 	function woocommerce_get_product_schema() {
 		global $product;
 
-		$schema = "Product";
+		$schema = 'Product';
 
 		// Downloadable product schema handling
-		if ( $product->is_downloadable() ) {
-			switch ( $product->download_type ) {
-				case 'application' :
-					$schema = "SoftwareApplication";
-				break;
-				case 'music' :
-					$schema = "MusicAlbum";
-				break;
-				default :
-					$schema = "Product";
-				break;
-			}
+		if ( $product->is_downloadable() && !empty($product->download_type) ) {
+			$schema = $product->download_type;
 		}
 
-		return 'http://schema.org/' . $schema;
+		return 'http://schema.org/' . apply_filters( 'woocommerce_product_schema', $schema, $product );
 	}
 }
 


### PR DESCRIPTION
Often your kind of product is not limited to "Product" or the ones available by default for downloadable product. 
There are how-tos online that suggest to override template files to add custom schema types but I thought it could be built-in :)
