### PR TITLE
fixed empty exception-object condition that always true

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -730,7 +730,7 @@ class WC_Checkout {
 				}
 			}
 		} catch ( Exception $e ) {
-			if ( ! empty( $e ) ) {
+			if ( ! empty( $e->getMessage() ) ) {
 				wc_add_notice( $e->getMessage(), 'error' );
 			}
 		}


### PR DESCRIPTION
Empty error message appears while processing checkout
