### PR TITLE
[Product CRUD] Add a wc_get_products wrapper

### DIFF
--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -8,6 +8,103 @@
 class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 
 	/**
+	 * Tests wc_get_products().
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_wc_get_products() {
+		$test_cat_1 = wp_insert_term( 'Testing 1', 'product_cat' );
+		$test_tag_1 = wp_insert_term( 'Tag 1', 'product_tag' );
+		$test_tag_2 = wp_insert_term( 'Tag 2', 'product_tag' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_tag_ids( array( $test_tag_1['term_id'] ) );
+		$product->set_category_ids( array( $test_cat_1['term_id'] ) );
+		$product->set_sku( 'GET TEST SKU SIMPLE' );
+		$product->save();
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$product_2->set_category_ids( array( $test_cat_1['term_id'] ) );
+		$product_2->save();
+
+		$external = WC_Helper_Product::create_simple_product();
+		$external->set_category_ids( array( $test_cat_1['term_id'] ) );
+		$external->set_sku( 'GET TEST SKU EXTERNAL' );
+		$external->save();
+
+		$external_2 = WC_Helper_Product::create_simple_product();
+		$external_2->set_tag_ids( array( $test_tag_2['term_id'] ) );
+		$external_2->save();
+
+		$grouped = WC_Helper_Product::create_grouped_product();
+
+		$variation = WC_Helper_Product::create_variation_product();
+		$variation->set_tag_ids( array( $test_tag_1['term_id'] ) );
+		$variation->save();
+
+		$draft = WC_Helper_Product::create_simple_product();
+		$draft->set_status( 'draft' );
+		$draft->save();
+
+		$this->assertEquals( 10, count( wc_get_products( array( 'return' => 'ids' ) ) ) );
+
+		// test status
+		$products = wc_get_products( array( 'return' => 'ids', 'status' => 'draft' ) );
+		$this->assertEquals( array( $draft->get_id() ), $products );
+
+		// test type
+		$products = wc_get_products( array( 'return' => 'ids', 'type' => array( 'variable', 'variation' ) ) );
+		$this->assertEquals( 3, count( $products ) );
+		$this->assertContains( $variation->get_id(), $products );
+
+		// test parent
+		$products = wc_get_products( array( 'return' => 'ids', 'parent' => $variation->get_id() ) );
+		$this->assertEquals( 2, count( $products ) );
+
+		// test skus
+		$products = wc_get_products( array( 'return' => 'ids', 'sku' => 'GET TEST SKU' ) );
+		$this->assertEquals( 2, count( $products ) );
+		$this->assertContains( $product->get_id(), $products );
+		$this->assertContains( $external->get_id(), $products );
+
+		// test categories
+		$products = wc_get_products( array( 'return' => 'ids', 'category' => array( $test_cat_1['term_id'] ) ) );
+		$this->assertEquals( 3, count( $products ) );
+
+		// test tags
+		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $test_tag_1['term_id'] ) ) );
+		$this->assertEquals( 2, count( $products ) );
+
+		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $test_tag_2['term_id'] ) ) );
+		$this->assertEquals( 1, count( $products ) );
+
+		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $test_tag_1['term_id'], $test_tag_2['term_id'] ) ) );
+		$this->assertEquals( 3, count( $products ) );
+
+		// test limit
+		$products = wc_get_products( array( 'return' => 'ids', 'limit' => 5 ) );
+		$this->assertEquals( 5, count( $products ) );
+
+		// test offset
+		$products = wc_get_products( array( 'return' => 'ids', 'limit' => 5 ) );
+		$products_offset = wc_get_products( array( 'return' => 'ids', 'limit' => 5, 'offset' => 5 ) );
+		$this->assertEquals( 5, count( $products ) );
+		$this->assertEquals( 5, count( $products_offset ) );
+		$this->assertNotEquals( $products, $products_offset );
+
+		// test page
+		$products_page_1 = wc_get_products( array( 'return' => 'ids', 'limit' => 5 ) );
+		$products_page_2 = wc_get_products( array( 'return' => 'ids', 'limit' => 5, 'page' => 2 ) );
+		$this->assertEquals( 5, count( $products_page_1 ) );
+		$this->assertEquals( 5, count( $products_page_2 ) );
+		$this->assertNotEquals( $products_page_1, $products_page_2 );
+
+		// test exclude
+		$products = wc_get_products( array( 'return' => 'ids', 'limit' => 200, 'exclude' => array( $product->get_id() ) ) );
+		$this->assertNotContains( $product->get_id(), $products );
+	}
+
+	/**
 	 * Test wc_get_product().
 	 *
 	 * @since 2.3
@@ -17,12 +114,12 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$product_copy = wc_get_product( $product->id );
+		$product_copy = wc_get_product( $product->get_id() );
 
-		$this->assertEquals( $product->id, $product_copy->id );
+		$this->assertEquals( $product->get_id(), $product_copy->get_id() );
 
 		// Delete Product
-		WC_Helper_Product::delete_product( $product->id );
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -34,13 +131,15 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		update_post_meta( $product->id, '_manage_stock', 'yes' );
+		update_post_meta( $product->get_id(), '_manage_stock', 'yes' );
 
-		wc_update_product_stock( $product->id, 5 );
-		$this->assertEquals( 5, $product->stock );
+		wc_update_product_stock( $product->get_id(), 5 );
+
+		$product = new WC_Product_Simple( $product->get_id() );
+		$this->assertEquals( 5, $product->get_stock_quantity() );
 
 		// Delete Product
-		WC_Helper_Product::delete_product( $product->id );
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -52,10 +151,10 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		update_post_meta( $product->id, '_regular_price', wc_format_decimal( 10 ) );
-		update_post_meta( $product->id, '_price', wc_format_decimal( 5 ) );
-		update_post_meta( $product->id, '_sale_price', wc_format_decimal( 5 ) );
-		update_post_meta( $product->id, '_featured', 'yes' );
+		update_post_meta( $product->get_id(), '_regular_price', wc_format_decimal( 10 ) );
+		update_post_meta( $product->get_id(), '_price', wc_format_decimal( 5 ) );
+		update_post_meta( $product->get_id(), '_sale_price', wc_format_decimal( 5 ) );
+		update_post_meta( $product->get_id(), '_featured', 'yes' );
 
 		wc_get_product_ids_on_sale();  // Creates the transient for on sale products
 		wc_get_featured_product_ids(); // Creates the transient for featured products
@@ -65,7 +164,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$this->assertFalse( get_transient( 'wc_products_onsale' ) );
 		$this->assertFalse( get_transient( 'wc_featured_products' ) );
 
-		WC_Helper_Product::delete_product( $product->id );
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -81,14 +180,14 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		update_post_meta( $product->id, '_regular_price', wc_format_decimal( 10 ) );
-		update_post_meta( $product->id, '_price', wc_format_decimal( 5 ) );
-		update_post_meta( $product->id, '_sale_price', wc_format_decimal( 5 ) );
+		update_post_meta( $product->get_id(), '_regular_price', wc_format_decimal( 10 ) );
+		update_post_meta( $product->get_id(), '_price', wc_format_decimal( 5 ) );
+		update_post_meta( $product->get_id(), '_sale_price', wc_format_decimal( 5 ) );
 
-		$this->assertEquals( array( $product->id ), wc_get_product_ids_on_sale() );
+		$this->assertEquals( array( $product->get_id() ), wc_get_product_ids_on_sale() );
 
 		// Delete Product
-		WC_Helper_Product::delete_product( $product->id );
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -104,12 +203,12 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		update_post_meta( $product->id, '_featured', 'yes' );
+		update_post_meta( $product->get_id(), '_featured', 'yes' );
 
-		$this->assertEquals( array( $product->id ), wc_get_featured_product_ids() );
+		$this->assertEquals( array( $product->get_id() ), wc_get_featured_product_ids() );
 
 		// Delete Product
-		WC_Helper_Product::delete_product( $product->id );
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -157,16 +256,20 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 	public function test_wc_product_has_unique_sku() {
 		$product_1 = WC_Helper_Product::create_simple_product();
 
-		$this->assertEquals( true, wc_product_has_unique_sku( $product_1->id, $product_1->sku ) );
+		$this->assertEquals( true, wc_product_has_unique_sku( $product_1->get_id(), $product_1->get_sku() ) );
 
 		$product_2 = WC_Helper_Product::create_simple_product();
-		$this->assertEquals( false, wc_product_has_unique_sku( $product_2->id, $product_2->sku ) );
+		// we need to manually set a sku, because WC_Product now uses wc_product_has_unique_sku before setting
+		// so we need to manually set it to test the functionality.
+		update_post_meta( $product_2->get_id(), '_sku', $product_1->get_sku() );
 
-		WC_Helper_Product::delete_product( $product_1->id );
+		$this->assertEquals( false, wc_product_has_unique_sku( $product_2->get_id(), $product_1->get_sku() ) );
 
-		$this->assertEquals( true, wc_product_has_unique_sku( $product_2->id, $product_2->sku ) );
+		WC_Helper_Product::delete_product( $product_1->get_id() );
 
-		WC_Helper_Product::delete_product( $product_2->id );
+		$this->assertEquals( true, wc_product_has_unique_sku( $product_2->get_id(), $product_2->get_sku() ) );
+
+		WC_Helper_Product::delete_product( $product_2->get_id() );
 	}
 
 	/**
@@ -178,9 +281,9 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->assertEquals( $product->id, wc_get_product_id_by_sku( $product->sku ) );
+		$this->assertEquals( $product->get_id(), wc_get_product_id_by_sku( $product->get_sku() ) );
 
 		// Delete Product
-		WC_Helper_Product::delete_product( $product->id );
+		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 }


### PR DESCRIPTION
Introduces a `wc_get_products` (with test). See #12065.

Also fixes a few of the product/functions.php tests (minus one which is getting a deprecated notice from some stock functions we still have marked as todo).
