### PR TITLE
i18n: add translators comments

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -146,6 +146,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	protected function get_post_title() {
 		// @codingStandardsIgnoreStart
+		/* translators: %s: Order date */
 		return sprintf( __( 'Order &ndash; %s', 'woocommerce' ), strftime( _x( '%b %d, %Y @ %I:%M %p', 'Order date parsed by strftime', 'woocommerce' ) ) );
 		// @codingStandardsIgnoreEnd
 	}
@@ -1511,6 +1512,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				}
 			}
 
+			/* translators: %s: shipping method */
 			$shipping .= apply_filters( 'woocommerce_order_shipping_to_display_shipped_via', '&nbsp;<small class="shipped_via">' . sprintf( __( 'via %s', 'woocommerce' ), $this->get_shipping_method() ) . '</small>', $this );
 
 		} elseif ( $this->get_shipping_method() ) {

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -694,6 +694,7 @@ class WC_Product {
 				break;
 				case 'low_amount' :
 					if ( $this->get_total_stock() <= get_option( 'woocommerce_notify_low_stock_amount' ) ) {
+						/* translators: %s: total items in stock */
 						$availability = sprintf( __( 'Only %s left in stock', 'woocommerce' ), $this->get_total_stock() );
 
 						if ( $this->backorders_allowed() && $this->backorders_require_notification() ) {
@@ -704,6 +705,7 @@ class WC_Product {
 					}
 				break;
 				default :
+					/* translators: %s: total items in stock */
 					$availability = sprintf( __( '%s in stock', 'woocommerce' ), $this->get_total_stock() );
 
 					if ( $this->backorders_allowed() && $this->backorders_require_notification() ) {
@@ -1187,8 +1189,10 @@ class WC_Product {
 
 		if ( $rating > 0 ) {
 
+			/* translators: %s: rating */
 			$rating_html  = '<div class="star-rating" title="' . sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating ) . '">';
 
+			/* translators: %s: rating */
 			$rating_html .= '<span style="width:' . ( ( $rating / 5 ) * 100 ) . '%">' . sprintf( __( '%s out of 5', 'woocommerce' ), '<strong class="rating">' . $rating . '</strong>' ) . '</span>';
 
 			$rating_html .= '</div>';

--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -93,6 +93,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		}
 
 		if ( $total > $limit ) {
+			/* translators: %s: items limit */
 			return new WP_Error( 'woocommerce_rest_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), array( 'status' => 413 ) );
 		}
 

--- a/includes/abstracts/abstract-wc-rest-posts-controller.php
+++ b/includes/abstracts/abstract-wc-rest-posts-controller.php
@@ -173,6 +173,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 
@@ -431,6 +432,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 		$supports_trash = apply_filters( "woocommerce_rest_{$this->post_type}_trashable", $supports_trash, $post );
 
 		if ( ! wc_rest_check_post_permissions( $this->post_type, 'delete', $post->ID ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_user_cannot_delete_{$this->post_type}", sprintf( __( 'Sorry, you are not allowed to delete %s.', 'woocommerce' ), $this->post_type ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -443,11 +445,13 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 		} else {
 			// If we don't support trashing for this type, error out.
 			if ( ! $supports_trash ) {
+				/* translators: %s: post type */
 				return new WP_Error( 'woocommerce_rest_trash_not_supported', sprintf( __( 'The %s does not support trashing.', 'woocommerce' ), $this->post_type ), array( 'status' => 501 ) );
 			}
 
 			// Otherwise, only trash if we haven't already.
 			if ( 'trash' === $post->post_status ) {
+				/* translators: %s: post type */
 				return new WP_Error( 'woocommerce_rest_already_trashed', sprintf( __( 'The %s has already been deleted.', 'woocommerce' ), $this->post_type ), array( 'status' => 410 ) );
 			}
 
@@ -457,6 +461,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 		}
 
 		if ( ! $result ) {
+			/* translators: %s: post type */
 			return new WP_Error( 'woocommerce_rest_cannot_delete', sprintf( __( 'The %s cannot be deleted.', 'woocommerce' ), $this->post_type ), array( 'status' => 500 ) );
 		}
 

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -143,7 +143,9 @@ class WC_Admin_Assets {
 			$decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
 
 			$params = array(
+				/* translators: %s: decimal */
 				'i18n_decimal_error'                => sprintf( __( 'Please enter in decimal (%s) format without thousand separators.', 'woocommerce' ), $decimal ),
+				/* translators: %s: price decimal separator */
 				'i18n_mon_decimal_error'            => sprintf( __( 'Please enter in monetary decimal (%s) format without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
 				'i18n_country_iso_error'            => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
 				'i18_sale_less_than_regular_error'  => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -95,8 +95,10 @@ class WC_Admin_Attributes {
 	 */
 	private static function valid_attribute_name( $attribute_name ) {
 		if ( strlen( $attribute_name ) >= 28 ) {
+			/* translators: %s: attribute name */
 			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $attribute_name ) ) {
+			/* translators: %s: attribute name */
 			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), sanitize_title( $attribute_name ) ) );
 		}
 
@@ -118,6 +120,7 @@ class WC_Admin_Attributes {
 		} elseif ( ( $valid_attribute_name = self::valid_attribute_name( $attribute['attribute_name'] ) ) && is_wp_error( $valid_attribute_name ) ) {
 			return $valid_attribute_name;
 		} elseif ( taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) ) ) {
+			/* translators: %s: attribute name */
 			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
 		}
 
@@ -151,6 +154,7 @@ class WC_Admin_Attributes {
 		$taxonomy_exists    = taxonomy_exists( wc_attribute_taxonomy_name( $attribute['attribute_name'] ) );
 		$old_attribute_name = $wpdb->get_var( "SELECT attribute_name FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = $attribute_id" );
 		if ( $old_attribute_name != $attribute['attribute_name'] && wc_sanitize_taxonomy_name( $old_attribute_name ) != $attribute['attribute_name'] && $taxonomy_exists ) {
+			/* translators: %s: attribute name */
 			return new WP_Error( 'error', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), sanitize_title( $attribute['attribute_name'] ) ) );
 		}
 

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -96,7 +96,13 @@ class WC_Admin_Dashboard {
 			<li class="sales-this-month">
 				<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=orders&range=month' ); ?>">
 					<?php echo $reports->sales_sparkline( '', max( 7, date( 'd', current_time( 'timestamp' ) ) ) ); ?>
-					<?php printf( __( '%s net sales this month', 'woocommerce' ), '<strong>' . wc_price( $report_data->net_sales ) . '</strong>' ); ?>
+					<?php
+						/* translators: %s: net sales */
+						printf(
+							__( '%s net sales this month', 'woocommerce' ),
+							'<strong>' . wc_price( $report_data->net_sales ) . '</strong>'
+							);
+					?>
 				</a>
 			</li>
 			<?php
@@ -107,7 +113,14 @@ class WC_Admin_Dashboard {
 			<li class="best-seller-this-month">
 				<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=' . $top_seller->product_id ); ?>">
 					<?php echo $reports->sales_sparkline( $top_seller->product_id, max( 7, date( 'd', current_time( 'timestamp' ) ) ), 'count' ); ?>
-					<?php printf( __( '%1$s top seller this month (sold %2$d)', 'woocommerce' ), '<strong>' . get_the_title( $top_seller->product_id ) . '</strong>', $top_seller->qty ); ?>
+					<?php
+						/* translators: 1: top seller product title 2: top seller quantity */
+						printf(
+							__( '%1$s top seller this month (sold %2$d)', 'woocommerce' ),
+							'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
+							$top_seller->qty
+						);
+					?>
 				</a>
 			</li>
 			<?php
@@ -138,12 +151,24 @@ class WC_Admin_Dashboard {
 		?>
 		<li class="processing-orders">
 			<a href="<?php echo admin_url( 'edit.php?post_status=wc-processing&post_type=shop_order' ); ?>">
-				<?php printf( _n( "<strong>%s order</strong> awaiting processing", "<strong>%s orders</strong> awaiting processing", $processing_count, 'woocommerce' ), $processing_count ); ?>
+				<?php
+					/* translators: %s: order count */
+					printf(
+						_n( '<strong>%s order</strong> awaiting processing', '<strong>%s orders</strong> awaiting processing', $processing_count, 'woocommerce' ),
+						$processing_count
+					);
+				?>
 			</a>
 		</li>
 		<li class="on-hold-orders">
 			<a href="<?php echo admin_url( 'edit.php?post_status=wc-on-hold&post_type=shop_order' ); ?>">
-				<?php printf( _n( "<strong>%s order</strong> on-hold", "<strong>%s orders</strong> on-hold", $on_hold_count, 'woocommerce' ), $on_hold_count ); ?>
+				<?php
+					/* translators: %s: order count */
+					printf(
+						_n( '<strong>%s order</strong> on-hold', '<strong>%s orders</strong> on-hold', $on_hold_count, 'woocommerce' ),
+						$on_hold_count
+					);
+				?>
 			</a>
 		</li>
 		<?php
@@ -193,12 +218,24 @@ class WC_Admin_Dashboard {
 		?>
 		<li class="low-in-stock">
 			<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ); ?>">
-				<?php printf( _n( "<strong>%s product</strong> low in stock", "<strong>%s products</strong> low in stock", $lowinstock_count, 'woocommerce' ), $lowinstock_count ); ?>
+				<?php
+					/* translators: %s: order count */
+					printf(
+						_n( '<strong>%s product</strong> low in stock', '<strong>%s products</strong> low in stock', $lowinstock_count, 'woocommerce' ),
+						$lowinstock_count
+					);
+				?>
 			</a>
 		</li>
 		<li class="out-of-stock">
 			<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=stock&report=out_of_stock' ); ?>">
-				<?php printf( _n( "<strong>%s product</strong> out of stock", "<strong>%s products</strong> out of stock", $outofstock_count, 'woocommerce' ), $outofstock_count ); ?>
+				<?php
+					/* translators: %s: order count */
+					printf(
+						_n( '<strong>%s product</strong> out of stock', '<strong>%s products</strong> out of stock', $outofstock_count, 'woocommerce' ),
+						$outofstock_count
+					);
+				?>
 			</a>
 		</li>
 		<?php
@@ -229,9 +266,10 @@ class WC_Admin_Dashboard {
 
 				$rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
 
-				echo '<div class="star-rating" title="' . esc_attr( $rating ) . '">
-					<span style="width:' . ( $rating * 20 ) . '%">' . sprintf( __( '%s out of 5', 'woocommerce' ), $rating ) . '</span></div>';
+				/* translators: %s: rating */
+				echo '<div class="star-rating" title="' . esc_attr( $rating ) . '"><span style="width:' . ( $rating * 20 ) . '%">' . sprintf( __( '%s out of 5', 'woocommerce' ), $rating ) . '</span></div>';
 
+				/* translators: %s: review author */
 				echo '<h4 class="meta"><a href="' . get_permalink( $comment->ID ) . '#comment-' . absint( $comment->comment_ID ) . '">' . esc_html( apply_filters( 'woocommerce_admin_dashboard_recent_reviews', $comment->post_title, $comment ) ) . '</a> ' . sprintf( __( 'reviewed by %s', 'woocommerce' ), esc_html( $comment->comment_author ) ) . '</h4>';
 				echo '<blockquote>' . wp_kses_data( $comment->comment_excerpt ) . ' [...]</blockquote></li>';
 

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -165,6 +165,7 @@ class WC_Admin_Duplicate_Product {
 
 		// Set title for variations
 		if ( 'product_variation' === $post->post_type ) {
+			/* translators: 1: variation id 2: product name */
 			$post_title = sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), absint( $new_post_id ), esc_html( get_the_title( $post_parent ) ) );
 			$wpdb->update(
 				$wpdb->posts,

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -103,6 +103,7 @@ class WC_Admin_Duplicate_Product {
 			wp_redirect( admin_url( 'post.php?action=edit&post=' . $new_id ) );
 			exit;
 		} else {
+			/* translators: %s: product id */
 			wp_die( sprintf( __( 'Product creation failed, could not find original product: %s', 'woocommerce' ), $id ) );
 		}
 	}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -132,12 +132,17 @@ class WC_Admin_Post_Types {
 			2 => __( 'Custom field updated.', 'woocommerce' ),
 			3 => __( 'Custom field deleted.', 'woocommerce' ),
 			4 => __( 'Product updated.', 'woocommerce' ),
+			/* translators: %s: revision title */
 			5 => isset( $_GET['revision'] ) ? sprintf( __( 'Product restored to revision from %s', 'woocommerce' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			/* translators: %s: product url */
 			6 => sprintf( __( 'Product published. <a href="%s">View Product</a>', 'woocommerce' ), esc_url( get_permalink( $post_ID ) ) ),
 			7 => __( 'Product saved.', 'woocommerce' ),
+			/* translators: %s: product url */
 			8 => sprintf( __( 'Product submitted. <a target="_blank" href="%s">Preview product</a>', 'woocommerce' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
+			/* translators: 1: date 2: product url */
 			9 => sprintf( __( 'Product scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview product</a>', 'woocommerce' ),
 			  date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post_ID ) ) ),
+			/* translators: %s: product url */
 			10 => sprintf( __( 'Product draft updated. <a target="_blank" href="%s">Preview product</a>', 'woocommerce' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) ),
 		);
 
@@ -147,10 +152,12 @@ class WC_Admin_Post_Types {
 			2 => __( 'Custom field updated.', 'woocommerce' ),
 			3 => __( 'Custom field deleted.', 'woocommerce' ),
 			4 => __( 'Order updated.', 'woocommerce' ),
+			/* translators: %s: revision title */
 			5 => isset( $_GET['revision'] ) ? sprintf( __( 'Order restored to revision from %s', 'woocommerce' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 			6 => __( 'Order updated.', 'woocommerce' ),
 			7 => __( 'Order saved.', 'woocommerce' ),
 			8 => __( 'Order submitted.', 'woocommerce' ),
+			/* translators: %s: date */
 			9 => sprintf( __( 'Order scheduled for: <strong>%1$s</strong>.', 'woocommerce' ),
 			  date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ) ),
 			10 => __( 'Order draft updated.', 'woocommerce' ),
@@ -163,10 +170,12 @@ class WC_Admin_Post_Types {
 			2 => __( 'Custom field updated.', 'woocommerce' ),
 			3 => __( 'Custom field deleted.', 'woocommerce' ),
 			4 => __( 'Coupon updated.', 'woocommerce' ),
+			/* translators: %s: revision title */
 			5 => isset( $_GET['revision'] ) ? sprintf( __( 'Coupon restored to revision from %s', 'woocommerce' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
 			6 => __( 'Coupon updated.', 'woocommerce' ),
 			7 => __( 'Coupon saved.', 'woocommerce' ),
 			8 => __( 'Coupon submitted.', 'woocommerce' ),
+			/* translators: %s: date */
 			9 => sprintf( __( 'Coupon scheduled for: <strong>%1$s</strong>.', 'woocommerce' ),
 			  date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ) ),
 			10 => __( 'Coupon draft updated.', 'woocommerce' ),
@@ -184,26 +193,41 @@ class WC_Admin_Post_Types {
 	public function bulk_post_updated_messages( $bulk_messages, $bulk_counts ) {
 
 		$bulk_messages['product'] = array(
+			/* translators: %s: product count */
 			'updated'   => _n( '%s product updated.', '%s products updated.', $bulk_counts['updated'], 'woocommerce' ),
+			/* translators: %s: product count */
 			'locked'    => _n( '%s product not updated, somebody is editing it.', '%s products not updated, somebody is editing them.', $bulk_counts['locked'], 'woocommerce' ),
+			/* translators: %s: product count */
 			'deleted'   => _n( '%s product permanently deleted.', '%s products permanently deleted.', $bulk_counts['deleted'], 'woocommerce' ),
+			/* translators: %s: product count */
 			'trashed'   => _n( '%s product moved to the Trash.', '%s products moved to the Trash.', $bulk_counts['trashed'], 'woocommerce' ),
+			/* translators: %s: product count */
 			'untrashed' => _n( '%s product restored from the Trash.', '%s products restored from the Trash.', $bulk_counts['untrashed'], 'woocommerce' ),
 		);
 
 		$bulk_messages['shop_order'] = array(
+			/* translators: %s: order count */
 			'updated'   => _n( '%s order updated.', '%s orders updated.', $bulk_counts['updated'], 'woocommerce' ),
+			/* translators: %s: order count */
 			'locked'    => _n( '%s order not updated, somebody is editing it.', '%s orders not updated, somebody is editing them.', $bulk_counts['locked'], 'woocommerce' ),
+			/* translators: %s: order count */
 			'deleted'   => _n( '%s order permanently deleted.', '%s orders permanently deleted.', $bulk_counts['deleted'], 'woocommerce' ),
+			/* translators: %s: order count */
 			'trashed'   => _n( '%s order moved to the Trash.', '%s orders moved to the Trash.', $bulk_counts['trashed'], 'woocommerce' ),
+			/* translators: %s: order count */
 			'untrashed' => _n( '%s order restored from the Trash.', '%s orders restored from the Trash.', $bulk_counts['untrashed'], 'woocommerce' ),
 		);
 
 		$bulk_messages['shop_coupon'] = array(
+			/* translators: %s: coupon count */
 			'updated'   => _n( '%s coupon updated.', '%s coupons updated.', $bulk_counts['updated'], 'woocommerce' ),
+			/* translators: %s: coupon count */
 			'locked'    => _n( '%s coupon not updated, somebody is editing it.', '%s coupons not updated, somebody is editing them.', $bulk_counts['locked'], 'woocommerce' ),
+			/* translators: %s: coupon count */
 			'deleted'   => _n( '%s coupon permanently deleted.', '%s coupons permanently deleted.', $bulk_counts['deleted'], 'woocommerce' ),
+			/* translators: %s: coupon count */
 			'trashed'   => _n( '%s coupon moved to the Trash.', '%s coupons moved to the Trash.', $bulk_counts['trashed'], 'woocommerce' ),
+			/* translators: %s: coupon count */
 			'untrashed' => _n( '%s coupon restored from the Trash.', '%s coupons restored from the Trash.', $bulk_counts['untrashed'], 'woocommerce' ),
 		);
 
@@ -462,9 +486,12 @@ class WC_Admin_Post_Types {
 		}
 		if ( $post_type_object->public ) {
 			if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ) ) ) {
-				if ( $can_edit_post )
+				if ( $can_edit_post ) {
+					/* translators: %s: product title */
 					$actions['view'] = '<a href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'woocommerce' ), $title ) ) . '" rel="permalink">' . __( 'Preview', 'woocommerce' ) . '</a>';
+				}
 			} elseif ( 'trash' != $post->post_status ) {
+				/* translators: %s: product title */
 				$actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'woocommerce' ), $title ) ) . '" rel="permalink">' . __( 'View', 'woocommerce' ) . '</a>';
 			}
 		}
@@ -647,6 +674,7 @@ class WC_Admin_Post_Types {
 			break;
 			case 'order_items' :
 
+				/* translators: %d: order items count */
 				echo '<a href="#" class="show_order_items">' . apply_filters( 'woocommerce_admin_order_item_count', sprintf( _n( '%d item', '%d items', $the_order->get_item_count(), 'woocommerce' ), $the_order->get_item_count() ), $the_order ) . '</a>';
 
 				if ( sizeof( $the_order->get_items() ) > 0 ) {
@@ -722,8 +750,10 @@ class WC_Admin_Post_Types {
 					if ( isset( $latest_note->comment_content ) && 1 == $post->comment_count ) {
 						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( $latest_note->comment_content ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
 					} elseif ( isset( $latest_note->comment_content ) ) {
+						/* translators: %d: notes count */
 						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( $latest_note->comment_content . '<br/><small style="display:block">' . sprintf( _n( 'plus %d other note', 'plus %d other notes', ( $post->comment_count - 1 ), 'woocommerce' ), $post->comment_count - 1 ) . '</small>' ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
 					} else {
+						/* translators: %d: notes count */
 						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( sprintf( _n( '%d note', '%d notes', $post->comment_count, 'woocommerce' ), $post->comment_count ) ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
 					}
 				} else {
@@ -749,6 +779,7 @@ class WC_Admin_Post_Types {
 					$username = '<a href="user-edit.php?user_id=' . absint( $user_info->ID ) . '">';
 
 					if ( $user_info->first_name || $user_info->last_name ) {
+						/* translators: 1: first name 2: last name */
 						$username .= esc_html( sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), ucfirst( $user_info->first_name ), ucfirst( $user_info->last_name ) ) );
 					} else {
 						$username .= esc_html( ucfirst( $user_info->display_name ) );
@@ -758,6 +789,7 @@ class WC_Admin_Post_Types {
 
 				} else {
 					if ( $the_order->get_billing_first_name()|| $the_order->get_billing_last_name() ) {
+						/* translators: 1: first name 2: last name */
 						$username = trim( sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $the_order->get_billing_first_name(), $the_order->get_billing_last_name() ) );
 					} elseif ( $the_order->get_billing_company() ) {
 						$username = trim( $the_order->get_billing_company() );
@@ -1516,6 +1548,7 @@ class WC_Admin_Post_Types {
 			if ( isset( $_REQUEST[ 'marked_' . str_replace( 'wc-', '', $slug ) ] ) ) {
 
 				$number = isset( $_REQUEST['changed'] ) ? absint( $_REQUEST['changed'] ) : 0;
+				/* translators: %s: orders count */
 				$message = sprintf( _n( 'Order status changed.', '%s order statuses changed.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 				echo '<div class="updated"><p>' . $message . '</p></div>';
 
@@ -1703,6 +1736,7 @@ class WC_Admin_Post_Types {
 		if ( ! empty( $_GET['_customer_user'] ) ) {
 			$user_id     = absint( $_GET['_customer_user'] );
 			$user        = get_user_by( 'id', $user_id );
+			/* translators: 1: user display name 2: user ID 3: user email */
 			$user_string = sprintf(
 				esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 				$user->display_name,

--- a/includes/admin/class-wc-admin-webhooks-table-list.php
+++ b/includes/admin/class-wc-admin-webhooks-table-list.php
@@ -160,6 +160,7 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 	private function get_status_label( $status_name, $status ) {
 		switch ( $status_name ) {
 			case 'publish' :
+				/* translators: %s: count */
 				$label = array(
 					'singular' => __( 'Activated <span class="count">(%s)</span>', 'woocommerce' ),
 					'plural'   => __( 'Activated <span class="count">(%s)</span>', 'woocommerce' ),
@@ -168,6 +169,7 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 				);
 				break;
 			case 'draft' :
+				/* translators: %s: count */
 				$label = array(
 					'singular' => __( 'Paused <span class="count">(%s)</span>', 'woocommerce' ),
 					'plural'   => __( 'Paused <span class="count">(%s)</span>', 'woocommerce' ),
@@ -176,6 +178,7 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 				);
 				break;
 			case 'pending' :
+				/* translators: %s: count */
 				$label = array(
 					'singular' => __( 'Disabled <span class="count">(%s)</span>', 'woocommerce' ),
 					'plural'   => __( 'Disabled <span class="count">(%s)</span>', 'woocommerce' ),
@@ -209,6 +212,7 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 		}
 
 		$class = empty( $class ) && empty( $_REQUEST['status'] ) ? ' class="current"' : '';
+		/* translators: %s: count */
 		$status_links['all'] = "<a href='admin.php?page=wc-settings&amp;tab=api&amp;section=webhooks'$class>" . sprintf( _nx( 'All <span class="count">(%s)</span>', 'All <span class="count">(%s)</span>', $total_posts, 'posts', 'woocommerce' ), number_format_i18n( $total_posts ) ) . '</a>';
 
 		foreach ( get_post_stati( array( 'show_in_admin_status_list' => true ), 'objects' ) as $status ) {

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -498,9 +498,9 @@ class WC_Admin_Webhooks {
 		$html = '<div class="webhook-logs-navigation">';
 
 			$html .= '<p class="info" style="float: left;"><strong>';
-			/* translators: %s: items count (i.e. 8 items) %d: current page %d: total pages */
+			/* translators: 1: items count (i.e. 8 items) 2: current page 3: total pages */
 			$html .= sprintf(
-				__( '%s &ndash; Page %d of %d', 'woocommerce' ),
+				__( '%1%s &ndash; Page %2$d of %3$d', 'woocommerce' ),
 				sprintf( _n( '%d item', '%d items', $total, 'woocommerce' ), $total ),
 				$current,
 				$pages

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -47,6 +47,7 @@ class WC_Admin_Webhooks {
 		global $wpdb;
 
 		// @codingStandardsIgnoreStart
+		/* translators: %s: date` */
 		$name = ! empty( $_POST['webhook_name'] ) ? $_POST['webhook_name'] : sprintf( __( 'Webhook created on %s', 'woocommerce' ), strftime( _x( '%b %d, %Y @ %I:%M %p', 'Webhook created on date parsed by strftime', 'woocommerce' ) ) );
 		// @codingStandardsIgnoreEnd
 		$wpdb->update( $wpdb->posts, array( 'post_title' => $name ), array( 'ID' => $webhook_id ) );
@@ -198,6 +199,7 @@ class WC_Admin_Webhooks {
 			'post_author'   => get_current_user_id(),
 			'post_password' => strlen( ( $password = uniqid( 'webhook_' ) ) ) > 20 ? substr( $password, 0, 20 ) : $password,
 			// @codingStandardsIgnoreStart
+			/* translators: %s: date */
 			'post_title'    => sprintf( __( 'Webhook created on %s', 'woocommerce' ), strftime( _x( '%b %d, %Y @ %I:%M %p', 'Webhook created on date parsed by strftime', 'woocommerce' ) ) ),
 			// @codingStandardsIgnoreEnd
 			'comment_status' => 'open',
@@ -375,19 +377,22 @@ class WC_Admin_Webhooks {
 		if ( isset( $_GET['trashed'] ) ) {
 			$trashed = absint( $_GET['trashed'] );
 
-			WC_Admin_Settings::add_message( sprintf( _n( '1 webhook moved to the Trash.', '%d webhooks moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) );
+			/* translators: %d: count */
+			WC_Admin_Settings::add_message( sprintf( _n( '%d webhook moved to the Trash.', '%d webhooks moved to the Trash.', $trashed, 'woocommerce' ), $trashed ) );
 		}
 
 		if ( isset( $_GET['untrashed'] ) ) {
 			$untrashed = absint( $_GET['untrashed'] );
 
-			WC_Admin_Settings::add_message( sprintf( _n( '1 webhook restored from the Trash.', '%d webhooks restored from the Trash.', $untrashed, 'woocommerce' ), $untrashed ) );
+			/* translators: %d: count */
+			WC_Admin_Settings::add_message( sprintf( _n( '%d webhook restored from the Trash.', '%d webhooks restored from the Trash.', $untrashed, 'woocommerce' ), $untrashed ) );
 		}
 
 		if ( isset( $_GET['deleted'] ) ) {
 			$deleted = absint( $_GET['deleted'] );
 
-			WC_Admin_Settings::add_message( sprintf( _n( '1 webhook permanently deleted.', '%d webhooks permanently deleted.', $deleted, 'woocommerce' ), $deleted ) );
+			/* translators: %d: count */
+			WC_Admin_Settings::add_message( sprintf( _n( '%d webhook permanently deleted.', '%d webhooks permanently deleted.', $deleted, 'woocommerce' ), $deleted ) );
 		}
 
 		if ( isset( $_GET['updated'] ) ) {
@@ -493,7 +498,13 @@ class WC_Admin_Webhooks {
 		$html = '<div class="webhook-logs-navigation">';
 
 			$html .= '<p class="info" style="float: left;"><strong>';
-			$html .= sprintf( '%s &ndash; Page %d of %d', _n( '1 item', sprintf( '%d items', $total ), $total, 'woocommerce' ), $current, $pages );
+			/* translators: %s: items count (i.e. 8 items) %d: current page %d: total pages */
+			$html .= sprintf(
+				__( '%s &ndash; Page %d of %d', 'woocommerce' ),
+				sprintf( _n( '%d item', '%d items', $total, 'woocommerce' ), $total ),
+				$current,
+				$pages
+			);
 			$html .= '</strong></p>';
 
 			if ( 1 < $pages ) {

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -163,9 +163,13 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 		}
 
 		// Show Result
-		echo '<div class="updated settings-error"><p>
-			' . sprintf( __( 'Import complete - imported %s tax rates.', 'woocommerce' ), '<strong>' . $loop . '</strong>' ) . '
-		</p></div>';
+		echo '<div class="updated settings-error"><p>';
+		/* translators: %s: tax rates count */
+		printf(
+			__( 'Import complete - imported %s tax rates.', 'woocommerce' ),
+			'<strong>' . $loop . '</strong>'
+		);
+		echo '</p></div>';
 
 		$this->import_end();
 	}
@@ -251,7 +255,13 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 								<input type="file" id="upload" name="import" size="25" />
 								<input type="hidden" name="action" value="save" />
 								<input type="hidden" name="max_file_size" value="<?php echo $bytes; ?>" />
-								<small><?php printf( __( 'Maximum size: %s', 'woocommerce' ), $size ); ?></small>
+								<small><?php
+									/* translators: %s: maximum upload size */
+									printf(
+										__( 'Maximum size: %s', 'woocommerce' ),
+										$size
+									);
+								?></small>
 							</td>
 						</tr>
 						<tr>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -126,6 +126,7 @@ class WC_Meta_Box_Order_Actions {
 					foreach ( $mails as $mail ) {
 						if ( $mail->id == $email_to_send ) {
 							$mail->trigger( $order->get_id() );
+							/* translators: %s: email title */
 							$order->add_order_note( sprintf( __( '%s email notification manually sent.', 'woocommerce' ), $mail->title ), false, true );
 						}
 					}

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -177,7 +177,11 @@ class WC_Meta_Box_Order_Data {
 				<p class="order_number"><?php
 
 					if ( $payment_method ) {
-						printf( __( 'Payment via %s', 'woocommerce' ), ( isset( $payment_gateways[ $payment_method ] ) ? esc_html( $payment_gateways[ $payment_method ]->get_title() ) : esc_html( $payment_method ) ) );
+						/* translators: %s: payment method */
+						printf(
+							__( 'Payment via %s', 'woocommerce' ),
+							( isset( $payment_gateways[ $payment_method ] ) ? esc_html( $payment_gateways[ $payment_method ]->get_title() ) : esc_html( $payment_method ) )
+						);
 
 						if ( $transaction_id = $order->get_transaction_id() ) {
 								if ( isset( $payment_gateways[ $payment_method ] ) && ( $url = $payment_gateways[ $payment_method ]->get_transaction_url( $order ) ) ) {
@@ -196,6 +200,7 @@ class WC_Meta_Box_Order_Data {
 					}
 
 					if ( $ip_address = get_post_meta( $post->ID, '_customer_ip_address', true ) ) {
+						/* translators: %s: IP address */
 						printf(
 							__( 'Customer IP: %s', 'woocommerce' ),
 							'<span class="woocommerce-Order-customerIP">' . esc_html( $ip_address ) . '</span>'
@@ -248,6 +253,7 @@ class WC_Meta_Box_Order_Data {
 							if ( $order->get_user_id() ) {
 								$user_id     = absint( $order->get_user_id() );
 								$user        = get_user_by( 'id', $user_id );
+								/* translators: 1: user display name 2: user ID 3: user email */
 								$user_string = sprintf(
 									esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 									$user->display_name,

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -56,9 +56,12 @@ class WC_Meta_Box_Order_Notes {
 					</div>
 					<p class="meta">
 						<abbr class="exact-date" title="<?php echo $note->comment_date; ?>"><?php printf( __( 'added on %1$s at %2$s', 'woocommerce' ), date_i18n( wc_date_format(), strtotime( $note->comment_date ) ), date_i18n( wc_time_format(), strtotime( $note->comment_date ) ) ); ?></abbr>
-						<?php if ( __( 'WooCommerce', 'woocommerce' ) !== $note->comment_author ) : ?>
-							<?php printf( ' ' . __( 'by %s', 'woocommerce' ), $note->comment_author ); ?>
-						<?php endif; ?>
+						<?php
+						if ( __( 'WooCommerce', 'woocommerce' ) !== $note->comment_author ) :
+							/* translators: %s: note author */
+							printf( ' ' . __( 'by %s', 'woocommerce' ), $note->comment_author );
+						endif;
+						?>
 						<a href="#" class="delete_note"><?php _e( 'Delete note', 'woocommerce' ); ?></a>
 					</p>
 				</li>

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1362,6 +1362,7 @@ class WC_Meta_Box_Product_Data {
 						$unique_sku = wc_product_has_unique_sku( $variation_id, $new_sku );
 
 						if ( ! $unique_sku ) {
+							/* translators: %s: variation id */
 							WC_Admin_Meta_Boxes::add_error( sprintf( __( '#%s &ndash; Variation SKU must be unique.', 'woocommerce' ), $variation_id ) );
 						} else {
 							update_post_meta( $variation_id, '_sku', $new_sku );

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -1185,6 +1185,7 @@ class WC_Meta_Box_Product_Data {
 							$extension  = pathinfo( $parsed_url, PATHINFO_EXTENSION );
 
 							if ( ! empty( $extension ) && ! in_array( $file_type['type'], $allowed_file_types ) ) {
+								/* translators: 1: file url 2: allowed file types */
 								WC_Admin_Meta_Boxes::add_error( sprintf( __( 'The downloadable file %1$s cannot be used as it does not have an allowed file type. Allowed types include: %2$s', 'woocommerce' ), '<code>' . basename( $file_url ) . '</code>', '<code>' . implode( ', ', array_keys( $allowed_file_types ) ) . '</code>' ) );
 								continue;
 							}
@@ -1309,6 +1310,7 @@ class WC_Meta_Box_Product_Data {
 				$manage_stock    = isset( $variable_manage_stock[ $i ] ) ? 'yes' : 'no';
 
 				// Generate a useful post title
+				/* translators: 1: variation id 2: product name */
 				$variation_post_title = sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), absint( $variation_id ), esc_html( get_the_title( $post_id ) ) );
 
 				// Update or Add post
@@ -1452,6 +1454,7 @@ class WC_Meta_Box_Product_Data {
 								$extension  = pathinfo( $parsed_url, PATHINFO_EXTENSION );
 
 								if ( ! empty( $extension ) && ! in_array( $file_type['type'], $allowed_file_types ) ) {
+									/* translators: 1: variation id 2: file url 3: allowed file types */
 									WC_Admin_Meta_Boxes::add_error( sprintf( __( '#%1$s &ndash; The downloadable file %2$s cannot be used as it does not have an allowed file type. Allowed types include: %3$s', 'woocommerce' ), $variation_id, '<code>' . basename( $file_url ) . '</code>', '<code>' . implode( ', ', array_keys( $allowed_file_types ) ) . '</code>' ) );
 									continue;
 								}
@@ -1459,6 +1462,7 @@ class WC_Meta_Box_Product_Data {
 
 							// Validate the file exists
 							if ( 'relative' === $file_is && ! apply_filters( 'woocommerce_downloadable_file_exists', file_exists( $file_url ), $file_url ) ) {
+								/* translators: 1: variation id 2: file url */
 								WC_Admin_Meta_Boxes::add_error( sprintf( __( '#%1$s &ndash; The downloadable file %2$s cannot be used as it does not exist on the server.', 'woocommerce' ), $variation_id, '<code>' . $file_url . '</code>' ) );
 								continue;
 							}

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -29,6 +29,7 @@ $thumbnail    = $product ? apply_filters( 'woocommerce_admin_order_item_thumbnai
 				if ( 'product_variation' === get_post_type( $item->get_variation_id() ) ) {
 					echo esc_html( $item->get_variation_id() );
 				} else {
+					/* translators: %s: variation id */
 					printf( esc_html__( '%s (No longer exists)', 'woocommerce' ), $item->get_variation_id() );
 				}
 				echo '</div>';

--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -13,6 +13,7 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 
 	<td class="name">
 		<?php
+			/* translators: 1: refund id 2: date */
 			printf( __( 'Refund #%1$s - %2$s', 'woocommerce' ), $refund->get_id(), date_i18n( get_option( 'date_format' ) . ', ' . get_option( 'time_format' ), $refund->get_date_created() ) );
 
 			if ( $who_refunded->exists() ) {

--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -52,7 +52,12 @@
 									// Text attributes should list terms pipe separated
 									echo esc_attr( implode( ' ' . WC_DELIMITER . ' ', wp_get_post_terms( $thepostid, $taxonomy, array( 'fields' => 'names' ) ) ) );
 
-								?>" placeholder="<?php echo esc_attr( sprintf( __( '"%s" separate terms', 'woocommerce' ), WC_DELIMITER ) ); ?>" />
+								?>" placeholder="<?php
+
+									/* translators: %s: WC_DELIMITER */
+									echo esc_attr( sprintf( __( '"%s" separate terms', 'woocommerce' ), WC_DELIMITER ) );
+
+								?>" />
 
 							<?php endif; ?>
 

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -30,6 +30,7 @@ extract( $variation_data );
 				$variation_selected_value = isset( $variation_data[ 'attribute_' . sanitize_title( $attribute['name'] ) ] ) ? $variation_data[ 'attribute_' . sanitize_title( $attribute['name'] ) ] : '';
 
 				// Name will be something like attribute_pa_color
+				/* translators: %s: attribute label */
 				echo '<select name="attribute_' . sanitize_title( $attribute['name'] ) . '[' . $loop . ']"><option value="">' . sprintf( __( 'Any %s&hellip;', 'woocommerce' ), esc_html( wc_attribute_label( $attribute['name'] ) ) ) . '</option>';
 
 				// Get terms for attribute taxonomy or value if its a custom attribute
@@ -88,11 +89,23 @@ extract( $variation_data );
 
 			<div class="variable_pricing">
 				<p class="form-row form-row-first">
-					<label><?php printf( __( 'Regular price (%s)', 'woocommerce' ), get_woocommerce_currency_symbol() ); ?></label>
+					<label><?php
+						/* translators: %s: currency symbol */
+						printf(
+							__( 'Regular price (%s)', 'woocommerce' ),
+							get_woocommerce_currency_symbol()
+						);
+					?></label>
 					<input type="text" size="5" name="variable_regular_price[<?php echo $loop; ?>]" value="<?php if ( isset( $_regular_price ) ) echo esc_attr( $_regular_price ); ?>" class="wc_input_price" placeholder="<?php esc_attr_e( 'Variation price (required)', 'woocommerce' ); ?>" />
 				</p>
 				<p class="form-row form-row-last">
-					<label><?php printf( __( 'Sale price (%s)', 'woocommerce' ), get_woocommerce_currency_symbol() ); ?> <a href="#" class="sale_schedule"><?php _e( 'Schedule', 'woocommerce' ); ?></a><a href="#" class="cancel_sale_schedule" style="display:none"><?php _e( 'Cancel schedule', 'woocommerce' ); ?></a></label>
+					<label><?php
+						/* translators: %s: currency symbol */
+						printf(
+							__( 'Sale price (%s)', 'woocommerce' ),
+							get_woocommerce_currency_symbol()
+						);
+					?> <a href="#" class="sale_schedule"><?php _e( 'Schedule', 'woocommerce' ); ?></a><a href="#" class="cancel_sale_schedule" style="display:none"><?php _e( 'Cancel schedule', 'woocommerce' ); ?></a></label>
 					<input type="text" size="5" name="variable_sale_price[<?php echo $loop; ?>]" value="<?php if ( isset( $_sale_price ) ) echo esc_attr( $_sale_price ); ?>" class="wc_input_price" />
 				</p>
 
@@ -170,7 +183,13 @@ extract( $variation_data );
 				<div>
 					<?php if ( wc_product_weight_enabled() ) : ?>
 						<p class="form-row hide_if_variation_virtual form-row-first">
-							<label><?php printf( __( 'Weight (%s)', 'woocommerce' ), esc_html( get_option( 'woocommerce_weight_unit' ) ) ); ?> <?php echo wc_help_tip( __( 'Enter a weight for this variation or leave blank to use the parent product weight.', 'woocommerce' ) ); ?></a></label>
+							<label><?php
+								/* translators: %s: weight unit */
+								printf(
+									__( 'Weight (%s)', 'woocommerce' ),
+									esc_html( get_option( 'woocommerce_weight_unit' ) )
+								);
+							?> <?php echo wc_help_tip( __( 'Enter a weight for this variation or leave blank to use the parent product weight.', 'woocommerce' ) ); ?></label>
 							<input type="text" size="5" name="variable_weight[<?php echo $loop; ?>]" value="<?php if ( isset( $_weight ) ) echo esc_attr( $_weight ); ?>" placeholder="<?php echo esc_attr( $parent_data['weight'] ); ?>" class="wc_input_decimal" />
 						</p>
 					<?php else : ?>
@@ -178,7 +197,13 @@ extract( $variation_data );
 					<?php endif; ?>
 					<?php if ( wc_product_dimensions_enabled() ) : ?>
 						<p class="form-row dimensions_field hide_if_variation_virtual form-row-last">
-							<label for="product_length"><?php printf( __( 'Dimensions (L&times;W&times;H) (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?></label>
+							<label for="product_length"><?php
+								/* translators: %s: dimension unit */
+								printf(
+									__( 'Dimensions (L&times;W&times;H) (%s)', 'woocommerce' ),
+									get_option( 'woocommerce_dimension_unit' )
+								);
+							?></label>
 							<input id="product_length" class="input-text wc_input_decimal" size="6" type="text" name="variable_length[<?php echo $loop; ?>]" value="<?php if ( isset( $_length ) ) echo esc_attr( $_length ); ?>" placeholder="<?php echo esc_attr( $parent_data['length'] ); ?>" />
 							<input class="input-text wc_input_decimal" size="6" type="text" name="variable_width[<?php echo $loop; ?>]" value="<?php if ( isset( $_width ) ) echo esc_attr( $_width ); ?>" placeholder="<?php echo esc_attr( $parent_data['width'] ); ?>" />
 							<input class="input-text wc_input_decimal last" size="6" type="text" name="variable_height[<?php echo $loop; ?>]" value="<?php if ( isset( $_height ) ) echo esc_attr( $_height ); ?>" placeholder="<?php echo esc_attr( $parent_data['height'] ); ?>" />
@@ -293,11 +318,11 @@ extract( $variation_data );
 			</div>
 			<div class="show_if_variation_downloadable" style="display: none;">
 				<p class="form-row form-row-first">
-					<label><?php _e( 'Download limit', 'woocommerce' ); ?> <?php echo wc_help_tip( __( 'Leave blank for unlimited re-downloads.', 'woocommerce' ) ); ?></a></label>
+					<label><?php _e( 'Download limit', 'woocommerce' ); ?> <?php echo wc_help_tip( __( 'Leave blank for unlimited re-downloads.', 'woocommerce' ) ); ?></label>
 					<input type="number" size="5" name="variable_download_limit[<?php echo $loop; ?>]" value="<?php if ( isset( $_download_limit ) ) echo esc_attr( $_download_limit ); ?>" placeholder="<?php esc_attr_e( 'Unlimited', 'woocommerce' ); ?>" step="1" min="0" />
 				</p>
 				<p class="form-row form-row-last">
-					<label><?php _e( 'Download expiry', 'woocommerce' ); ?> <?php echo wc_help_tip( __( 'Enter the number of days before a download link expires, or leave blank.', 'woocommerce' ) ); ?></a></label>
+					<label><?php _e( 'Download expiry', 'woocommerce' ); ?> <?php echo wc_help_tip( __( 'Enter the number of days before a download link expires, or leave blank.', 'woocommerce' ) ); ?></label>
 					<input type="number" size="5" name="variable_download_expiry[<?php echo $loop; ?>]" value="<?php if ( isset( $_download_expiry ) ) echo esc_attr( $_download_expiry ); ?>" placeholder="<?php esc_attr_e( 'Unlimited', 'woocommerce' ); ?>" step="1" min="0" />
 				</p>
 

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -480,8 +480,10 @@ class WC_Admin_Report {
 		}
 
 		if ( 'sales' === $type ) {
+			/* translators: 1: total income 2: days */
 			$tooltip = sprintf( __( 'Sold %1$s worth in the last %2$d days', 'woocommerce' ), strip_tags( wc_price( $total ) ), $days );
 		} else {
+			/* translators: 1: total items sold 2: days */
 			$tooltip = sprintf( _n( 'Sold 1 item in the last %2$d days', 'Sold %1$d items in the last %2$d days', $total, 'woocommerce' ), $total, $days );
 		}
 

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -105,12 +105,14 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 		$total_coupons  = absint( $this->get_order_report_data( $total_coupons_query ) );
 
 		$legend[] = array(
+			/* translators: %s: discount ammount */
 			'title' => sprintf( __( '%s discounts in total', 'woocommerce' ), '<strong>' . wc_price( $total_discount ) . '</strong>' ),
 			'color' => $this->chart_colours['discount_amount'],
 			'highlight_series' => 1,
 		);
 
 		$legend[] = array(
+			/* translators: %s: coupons ammount */
 			'title' => sprintf( __( '%s coupons used in total', 'woocommerce' ), '<strong>' . $total_coupons . '</strong>' ),
 			'color' => $this->chart_colours['coupon_count'],
 			'highlight_series' => 0,

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -37,6 +37,7 @@ class WC_Report_Customers extends WC_Admin_Report {
 		$legend   = array();
 
 		$legend[] = array(
+			/* translators: %s: signups ammount */
 			'title' => sprintf( __( '%s signups in this period', 'woocommerce' ), '<strong>' . sizeof( $this->customers ) . '</strong>' ),
 			'color' => $this->chart_colours['signups'],
 			'highlight_series' => 2,

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -93,6 +93,7 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 			}
 
 			$legend[] = array(
+				/* translators: 1: total items sold 2: category name */
 				'title'            => sprintf( __( '%1$s sales in %2$s', 'woocommerce' ), '<strong>' . wc_price( $total ) . '</strong>', $category->name ),
 				'color'            => isset( $this->chart_colours[ $index ] ) ? $this->chart_colours[ $index ] : $this->chart_colours[0],
 				'highlight_series' => $index,

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -358,18 +358,38 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 		switch ( $this->chart_groupby ) {
 			case 'day' :
-				$average_total_sales_title = sprintf( __( '%s average gross daily sales', 'woocommerce' ), '<strong>' . wc_price( $data->average_total_sales ) . '</strong>' );
-				$average_sales_title       = sprintf( __( '%s average net daily sales', 'woocommerce' ), '<strong>' . wc_price( $data->average_sales ) . '</strong>' );
+				/* translators: %s: average total sales */
+				$average_total_sales_title = sprintf(
+					__( '%s average gross daily sales', 'woocommerce' ),
+					'<strong>' . wc_price( $data->average_total_sales ) . '</strong>'
+				);
+				/* translators: %s: average sales */
+				$average_sales_title = sprintf(
+					__( '%s average net daily sales', 'woocommerce' ),
+					'<strong>' . wc_price( $data->average_sales ) . '</strong>'
+				);
 			break;
 			case 'month' :
 			default :
-				$average_total_sales_title = sprintf( __( '%s average gross monthly sales', 'woocommerce' ), '<strong>' . wc_price( $data->average_total_sales ) . '</strong>' );
-				$average_sales_title       = sprintf( __( '%s average net monthly sales', 'woocommerce' ), '<strong>' . wc_price( $data->average_sales ) . '</strong>' );
+				/* translators: %s: average total sales */
+				$average_total_sales_title = sprintf(
+					__( '%s average gross monthly sales', 'woocommerce' ),
+					'<strong>' . wc_price( $data->average_total_sales ) . '</strong>'
+				);
+				/* translators: %s: average sales */
+				$average_sales_title = sprintf(
+					__( '%s average net monthly sales', 'woocommerce' ),
+					'<strong>' . wc_price( $data->average_sales ) . '</strong>'
+				);
 			break;
 		}
 
 		$legend[] = array(
-			'title'            => sprintf( __( '%s gross sales in this period', 'woocommerce' ), '<strong>' . wc_price( $data->total_sales ) . '</strong>' ),
+			/* translators: %s: total sales */
+			'title' => sprintf(
+				__( '%s gross sales in this period', 'woocommerce' ),
+				'<strong>' . wc_price( $data->total_sales ) . '</strong>'
+			),
 			'placeholder'      => __( 'This is the sum of the order totals after any refunds and including shipping and taxes.', 'woocommerce' ),
 			'color'            => $this->chart_colours['sales_amount'],
 			'highlight_series' => 6,
@@ -383,7 +403,11 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			'title'            => sprintf( __( '%s net sales in this period', 'woocommerce' ), '<strong>' . wc_price( $data->net_sales ) . '</strong>' ),
+			/* translators: %s: net sales */
+			'title' => sprintf(
+				__( '%s net sales in this period', 'woocommerce' ),
+				'<strong>' . wc_price( $data->net_sales ) . '</strong>'
+			),
 			'placeholder'      => __( 'This is the sum of the order totals after any refunds and excluding shipping and taxes.', 'woocommerce' ),
 			'color'            => $this->chart_colours['net_sales_amount'],
 			'highlight_series' => 7,
@@ -397,13 +421,21 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			'title' => sprintf( __( '%s orders placed', 'woocommerce' ), '<strong>' . $data->total_orders . '</strong>' ),
+			/* translators: %s: total orders */
+			'title' => sprintf(
+				__( '%s orders placed', 'woocommerce' ),
+				'<strong>' . $data->total_orders . '</strong>'
+			),
 			'color' => $this->chart_colours['order_count'],
 			'highlight_series' => 1,
 		);
 
 		$legend[] = array(
-			'title' => sprintf( __( '%s items purchased', 'woocommerce' ), '<strong>' . $data->total_items . '</strong>' ),
+			/* translators: %s: total items */
+			'title' => sprintf(
+				__( '%s items purchased', 'woocommerce' ),
+				'<strong>' . $data->total_items . '</strong>'
+			),
 			'color' => $this->chart_colours['item_count'],
 			'highlight_series' => 0,
 		);
@@ -419,12 +451,20 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 8,
 		);
 		$legend[] = array(
-			'title' => sprintf( __( '%s charged for shipping', 'woocommerce' ), '<strong>' . wc_price( $data->total_shipping ) . '</strong>' ),
+			/* translators: %s: total shipping */
+			'title' => sprintf(
+				__( '%s charged for shipping', 'woocommerce' ),
+				'<strong>' . wc_price( $data->total_shipping ) . '</strong>'
+			),
 			'color' => $this->chart_colours['shipping_amount'],
 			'highlight_series' => 5,
 		);
 		$legend[] = array(
-			'title' => sprintf( __( '%s worth of coupons used', 'woocommerce' ), '<strong>' . wc_price( $data->total_coupons ) . '</strong>' ),
+			/* translators: %s: total coupons */
+			'title' => sprintf(
+				__( '%s worth of coupons used', 'woocommerce' ),
+				'<strong>' . wc_price( $data->total_coupons ) . '</strong>'
+			),
 			'color' => $this->chart_colours['coupon_amount'],
 			'highlight_series' => 4,
 		);

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -103,12 +103,14 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 		) ) );
 
 		$legend[] = array(
+			/* translators: %s: total items sold */
 			'title' => sprintf( __( '%s sales for the selected items', 'woocommerce' ), '<strong>' . wc_price( $total_sales ) . '</strong>' ),
 			'color' => $this->chart_colours['sales_amount'],
 			'highlight_series' => 1,
 		);
 
 		$legend[] = array(
+			/* translators: %s: total items purchased */
 			'title' => sprintf( __( '%s purchases for the selected items', 'woocommerce' ), '<strong>' . ( $total_items ) . '</strong>' ),
 			'color' => $this->chart_colours['item_count'],
 			'highlight_series' => 0,

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -111,6 +111,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				'css'         => 'width:300px; height: 75px;',
 				'placeholder' => __( 'N/A', 'woocommerce' ),
 				'type'        => 'textarea',
+				/* translators: %s: site name */
 				'default'     => sprintf( __( '%s - Powered by WooCommerce', 'woocommerce' ), get_bloginfo( 'name', 'display' ) ),
 				'autoload'    => false,
 				'desc_tip'    => true,
@@ -118,6 +119,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 			array(
 				'title'    => __( 'Base colour', 'woocommerce' ),
+				/* translators: %s: default color */
 				'desc'     => sprintf( __( 'The base colour for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#96588a</code>' ),
 				'id'       => 'woocommerce_email_base_color',
 				'type'     => 'color',
@@ -129,6 +131,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 			array(
 				'title'    => __( 'Background colour', 'woocommerce' ),
+				/* translators: %s: default color */
 				'desc'     => sprintf( __( 'The background colour for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#f7f7f7</code>' ),
 				'id'       => 'woocommerce_email_background_color',
 				'type'     => 'color',
@@ -140,6 +143,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 			array(
 				'title'    => __( 'Body background colour', 'woocommerce' ),
+				/* translators: %s: default color */
 				'desc'     => sprintf( __( 'The main body background colour. Default %s.', 'woocommerce' ), '<code>#ffffff</code>' ),
 				'id'       => 'woocommerce_email_body_background_color',
 				'type'     => 'color',
@@ -151,6 +155,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 			array(
 				'title'    => __( 'Body text colour', 'woocommerce' ),
+				/* translators: %s: default color */
 				'desc'     => sprintf( __( 'The main body text colour. Default %s.', 'woocommerce' ), '<code>#3c3c3c</code>' ),
 				'id'       => 'woocommerce_email_text_color',
 				'type'     => 'color',

--- a/includes/admin/settings/views/html-keys-edit.php
+++ b/includes/admin/settings/views/html-keys-edit.php
@@ -30,6 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						$curent_user_id = get_current_user_id();
 						$user_id        = ! empty( $key_data['user_id'] ) ? absint( $key_data['user_id'] ) : $curent_user_id;
 						$user           = get_user_by( 'id', $user_id );
+						/* translators: 1: user display name 2: user ID 3: user email */
 						$user_string    = sprintf(
 							esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 							$user->display_name,

--- a/includes/admin/settings/views/html-settings-tax.php
+++ b/includes/admin/settings/views/html-settings-tax.php
@@ -10,7 +10,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <div id="rates-pagination"></div>
 
-<h3><?php printf( __( '"%s" tax rates', 'woocommerce' ), $current_class ? esc_html( $current_class ) : __( 'Standard', 'woocommerce' ) ); ?></h3>
+<h3><?php
+	/* translators: %s: tax rate */
+	printf(
+		__( '"%s" tax rates', 'woocommerce' ),
+		$current_class ? esc_html( $current_class ) : __( 'Standard', 'woocommerce' )
+	);
+?></h3>
 
 <table class="wc_tax_rates wc_input_table widefat">
 	<thead>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -363,7 +363,7 @@ $pages          = $system_status->get_pages();
 					<td class="help">&nbsp;</td>
 					<td><?php
 						/* translators: %s: plugin author */
-						printf( __( 'by %s' 'woocommerce' ), $plugin['author_name'] );
+						printf( __( 'by %s', 'woocommerce' ), $plugin['author_name'] );
 						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $network_string;
 					?></td>
 				</tr>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -361,7 +361,11 @@ $pages          = $system_status->get_pages();
 				<tr>
 					<td><?php echo $plugin_name; ?></td>
 					<td class="help">&nbsp;</td>
-					<td><?php echo sprintf( _x( 'by %s', 'by author', 'woocommerce' ), $plugin['author_name'] ) . ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $network_string; ?></td>
+					<td><?php
+						/* translators: %s: plugin author */
+						printf( __( 'by %s' 'woocommerce' ), $plugin['author_name'] );
+						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $network_string;
+					?></td>
 				</tr>
 				<?php
 			}

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -494,6 +494,7 @@ $pages          = $system_status->get_pages();
 			<td><?php
 				echo esc_html( $theme['version'] );
 				if ( version_compare( $theme['version'], $theme['version_latest'], '<' ) ) {
+					/* translators: %s: theme latest version */
 					echo ' &ndash; <strong style="color:red;">' . sprintf( __( '%s is available', 'woocommerce' ), esc_html( $theme['version_latest'] ) ) . '</strong>';
 				}
 			?></td>
@@ -524,6 +525,7 @@ $pages          = $system_status->get_pages();
 			<td><?php
 				echo esc_html( $theme['parent_version'] );
 				if ( version_compare( $theme['parent_version'], $theme['parent_version_latest'], '<' ) ) {
+					/* translators: %s: parant theme latest version */
 					echo ' &ndash; <strong style="color:red;">' . sprintf( __( '%s is available', 'woocommerce' ), esc_html( $theme['parent_version_latest'] ) ) . '</strong>';
 				}
 			?></td>

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -275,6 +275,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 

--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -212,6 +212,7 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -222,6 +222,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -688,6 +688,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -500,6 +500,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'readonly'    => true,
 				),
 				'weight' => array(
+					/* translators: %s: weight unit */
 					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -510,16 +511,19 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'length' => array(
+							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width' => array(
+							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
+							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1811,6 +1811,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 		$supports_trash = apply_filters( "woocommerce_rest_{$this->post_type}_trashable", $supports_trash, $post );
 
 		if ( ! wc_rest_check_post_permissions( $this->post_type, 'delete', $post->ID ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_user_cannot_delete_{$this->post_type}", sprintf( __( 'Sorry, you are not allowed to delete %s.', 'woocommerce' ), $this->post_type ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
@@ -1842,11 +1843,13 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 		} else {
 			// If we don't support trashing for this type, error out.
 			if ( ! $supports_trash ) {
+				/* translators: %s: post type */
 				return new WP_Error( 'woocommerce_rest_trash_not_supported', sprintf( __( 'The %s does not support trashing.', 'woocommerce' ), $this->post_type ), array( 'status' => 501 ) );
 			}
 
 			// Otherwise, only trash if we haven't already.
 			if ( 'trash' === $post->post_status ) {
+				/* translators: %s: post type */
 				return new WP_Error( 'woocommerce_rest_already_trashed', sprintf( __( 'The %s has already been deleted.', 'woocommerce' ), $this->post_type ), array( 'status' => 410 ) );
 			}
 
@@ -1856,6 +1859,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 		}
 
 		if ( ! $result ) {
+			/* translators: %s: post type */
 			return new WP_Error( 'woocommerce_rest_cannot_delete', sprintf( __( 'The %s cannot be deleted.', 'woocommerce' ), $this->post_type ), array( 'status' => 500 ) );
 		}
 
@@ -2136,6 +2140,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'context'     => array( 'view', 'edit' ),
 				),
 				'weight' => array(
+					/* translators: %s: weight unit */
 					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -2146,16 +2151,19 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'length' => array(
+							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width' => array(
+							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
+							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
@@ -2562,6 +2570,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 							'readonly'    => true,
 						),
 						'weight' => array(
+							/* translators: %s: weight unit */
 							'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
@@ -2572,16 +2581,19 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'length' => array(
+									/* translators: %s: dimension unit */
 									'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
 									'type'        => 'string',
 									'context'     => array( 'view', 'edit' ),
 								),
 								'width' => array(
+									/* translators: %s: dimension unit */
 									'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
 									'type'        => 'string',
 									'context'     => array( 'view', 'edit' ),
 								),
 								'height' => array(
+									/* translators: %s: dimension unit */
 									'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
 									'type'        => 'string',
 									'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1354,6 +1354,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 			$variation_id = isset( $variation['id'] ) ? absint( $variation['id'] ) : 0;
 
 			// Generate a useful post title.
+			/* translators: 1: variation id 2: product name */
 			$variation_post_title = sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation_id, esc_html( get_the_title( $product->id ) ) );
 
 			// Update or Add post.

--- a/includes/api/class-wc-rest-report-sales-controller.php
+++ b/includes/api/class-wc-rest-report-sales-controller.php
@@ -376,6 +376,7 @@ class WC_REST_Report_Sales_Controller extends WC_REST_Controller {
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'date_min' => array(
+				/* translators: %s: date format */
 				'description'       => sprintf( __( 'Return sales for a specific start date, the date need to be in the %s format.', 'woocommerce' ), 'YYYY-MM-AA' ),
 				'type'              => 'string',
 				'format'            => 'date',
@@ -383,6 +384,7 @@ class WC_REST_Report_Sales_Controller extends WC_REST_Controller {
 				'sanitize_callback' => 'sanitize_text_field',
 			),
 			'date_max' => array(
+				/* translators: %s: date format */
 				'description'       => sprintf( __( 'Return sales for a specific end date, the date need to be in the %s format.', 'woocommerce' ), 'YYYY-MM-AA' ),
 				'type'              => 'string',
 				'format'            => 'date',

--- a/includes/api/class-wc-rest-webhooks-controller.php
+++ b/includes/api/class-wc-rest-webhooks-controller.php
@@ -128,6 +128,7 @@ class WC_REST_Webhooks_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
 		}
 
@@ -311,6 +312,7 @@ class WC_REST_Webhooks_Controller extends WC_REST_Posts_Controller {
 		$result = wp_delete_post( $id, true );
 
 		if ( ! $result ) {
+			/* translators: %s: post type */
 			return new WP_Error( 'woocommerce_rest_cannot_delete', sprintf( __( 'The %s cannot be deleted.', 'woocommerce' ), $this->post_type ), array( 'status' => 500 ) );
 		}
 

--- a/includes/api/legacy/v1/class-wc-api-authentication.php
+++ b/includes/api/legacy/v1/class-wc-api-authentication.php
@@ -145,6 +145,7 @@ class WC_API_Authentication {
 		foreach ( $param_names as $param_name ) {
 
 			if ( empty( $params[ $param_name ] ) ) {
+				/* translators: %s: parameter name */
 				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce' ), $param_name ), 404 );
 			}
 		}

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1258,6 +1258,7 @@ class WC_API_Products extends WC_API_Resource {
 			$variation_id = isset( $variation['id'] ) ? absint( $variation['id'] ) : 0;
 
 			// Generate a useful post title
+			/* translators: 1: variation id 2: product name */
 			$variation_post_title = sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation_id, esc_html( get_the_title( $id ) ) );
 
 			// Update or Add post

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1753,6 +1753,7 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			// Generate a useful post title
+			/* translators: 1: variation id 2: product name */
 			$variation_post_title = sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation_id, esc_html( get_the_title( $id ) ) );
 
 			// Update or Add post

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1753,6 +1753,7 @@ class WC_AJAX {
 		if ( ! empty( $customers ) ) {
 			foreach ( $customers as $customer ) {
 				if ( ! in_array( $customer->ID, $exclude ) ) {
+					/* translators: 1: user display name 2: user ID 3: user email */
 					$found_customers[ $customer->ID ] = sprintf(
 						esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 						$customer->display_name,

--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -173,11 +173,13 @@ class WC_Auth {
 
 		foreach ( $params as $param ) {
 			if ( empty( $_REQUEST[ $param ] ) ) {
+				/* translators: %s: parameter */
 				throw new Exception( sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param ) );
 			}
 		}
 
 		if ( ! in_array( $_REQUEST['scope'], array( 'read', 'write', 'read_write' ) ) ) {
+			/* translators: %s: scope */
 			throw new Exception( sprintf( __( 'Invalid scope %s', 'woocommerce' ), wc_clean( $_REQUEST['scope'] ) ) );
 		}
 
@@ -185,6 +187,7 @@ class WC_Auth {
 			$param = $this->get_formatted_url( $_REQUEST[ $param ] );
 
 			if ( false === filter_var( $param, FILTER_VALIDATE_URL ) ) {
+				/* translators: %s: url */
 				throw new Exception( sprintf( __( 'The %s is not a valid URL', 'woocommerce' ), $param ) );
 			}
 		}
@@ -210,8 +213,15 @@ class WC_Auth {
 	protected function create_keys( $app_name, $app_user_id, $scope ) {
 		global $wpdb;
 
-		$description = sprintf( __( '%1$s - API %2$s (created on %3$s at %4$s).', 'woocommerce' ), wc_clean( $app_name ), $this->get_i18n_scope( $scope ), date_i18n( wc_date_format() ), date_i18n( wc_time_format() ) );
-		$user        = wp_get_current_user();
+		/* translators: 1: app name 2: scope 3: date 4: time */
+		$description = sprintf(
+			__( '%1$s - API %2$s (created on %3$s at %4$s).', 'woocommerce' ),
+			wc_clean( $app_name ),
+			$this->get_i18n_scope( $scope ),
+			date_i18n( wc_date_format() ),
+			date_i18n( wc_time_format() )
+		);
+		$user = wp_get_current_user();
 
 		// Created API keys.
 		$permissions     = ( in_array( $scope, array( 'read', 'write', 'read_write' ) ) ) ? sanitize_text_field( $scope ) : 'read';
@@ -372,6 +382,7 @@ class WC_Auth {
 		} catch ( Exception $e ) {
 			$this->maybe_delete_key( $consumer_data );
 
+			/* translators: %s: error messase */
 			wp_die( sprintf( __( 'Error: %s.', 'woocommerce' ), $e->getMessage() ), __( 'Access denied', 'woocommerce' ), array( 'response' => 401 ) );
 		}
 	}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -235,6 +235,7 @@ class WC_Cart {
 
 						// Flag to indicate the stored cart should be update
 						$update_cart_session = true;
+						/* translators: %s: product name */
 						wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $_product->get_title() ), 'error' );
 						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
@@ -480,6 +481,7 @@ class WC_Cart {
 			 * Check stock based on stock-status.
 			 */
 			if ( ! $_product->is_in_stock() ) {
+				/* translators: %s: product name */
 				$error->add( 'out-of-stock', sprintf( __( 'Sorry, "%s" is not in stock. Please edit your cart and try again. We apologise for any inconvenience caused.', 'woocommerce' ), $_product->get_title() ) );
 				return $error;
 			}
@@ -494,6 +496,7 @@ class WC_Cart {
 			 * Check stock based on all items in the cart.
 			 */
 			if ( ! $_product->has_enough_stock( $check_qty ) ) {
+				/* translators: 1: product name 2: quantity in stock */
 				$error->add( 'out-of-stock', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s in stock). Please edit your cart and try again. We apologise for any inconvenience caused.', 'woocommerce' ), $_product->get_title(), $_product->get_stock_quantity() ) );
 				return $error;
 			}
@@ -529,6 +532,7 @@ class WC_Cart {
 					$not_enough_stock = true;
 				}
 				if ( $not_enough_stock ) {
+					/* translators: 1: product name 2: minutes */
 					$error->add( 'out-of-stock', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order right now. Please try again in %2$d minutes or edit your cart and try again. We apologise for any inconvenience caused.', 'woocommerce' ), $_product->get_title(), get_option( 'woocommerce_hold_stock_minutes' ) ) );
 					return $error;
 				}
@@ -922,7 +926,8 @@ class WC_Cart {
 				$in_cart_quantity = $cart_item_key ? $this->cart_contents[ $cart_item_key ]['quantity'] : 0;
 
 				if ( $in_cart_quantity > 0 ) {
-					throw new Exception( sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', wc_get_cart_url(), __( 'View cart', 'woocommerce' ), sprintf( __( 'You cannot add another &quot;%s&quot; to your cart.', 'woocommerce' ), $product_data->get_title() ) ) );
+					/* translators: %s: product name */
+					throw new Exception( sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', wc_get_cart_url(), __( 'View cart', 'woocommerce' ), sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), $product_data->get_title() ) ) );
 				}
 			}
 
@@ -937,6 +942,7 @@ class WC_Cart {
 			}
 
 			if ( ! $product_data->has_enough_stock( $quantity ) ) {
+				/* translators: 1: product name 2: quantity in stock */
 				throw new Exception( sprintf( __( 'You cannot add that amount of &quot;%1$s&quot; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce' ), $product_data->get_title(), $product_data->get_stock_quantity() ) );
 			}
 

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -502,6 +502,7 @@ class WC_Checkout {
 										$this->posted[ $key ] = wc_format_phone_number( $this->posted[ $key ] );
 
 										if ( ! WC_Validation::is_phone( $this->posted[ $key ] ) ) {
+											/* translators: %s: phone number */
 											wc_add_notice( sprintf( __( '%s is not a valid phone number.', 'woocommerce' ), '<strong>' . $field['label'] . '</strong>' ), 'error' );
 										}
 										break;
@@ -509,6 +510,7 @@ class WC_Checkout {
 										$this->posted[ $key ] = strtolower( $this->posted[ $key ] );
 
 										if ( ! is_email( $this->posted[ $key ] ) ) {
+											/* translators: %s: email address */
 											wc_add_notice( sprintf( __( '%s is not a valid email address.', 'woocommerce' ), '<strong>' . $field['label'] . '</strong>' ), 'error' );
 										}
 										break;
@@ -528,6 +530,7 @@ class WC_Checkout {
 										// Only validate if the country has specific state options
 										if ( ! empty( $valid_states ) && is_array( $valid_states ) && sizeof( $valid_states ) > 0 ) {
 											if ( ! in_array( $this->posted[ $key ], array_keys( $valid_states ) ) ) {
+												/* translators: 1: state field 2: valid states */
 												wc_add_notice( sprintf( __( '%1$s is not valid. Please enter one of the following: %2$s', 'woocommerce' ), '<strong>' . $field['label'] . '</strong>', implode( ', ', $valid_states ) ), 'error' );
 											}
 										}

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -1290,18 +1290,22 @@ class WC_Coupon extends WC_Legacy_Coupon {
 				$err = __( 'Coupon is not valid.', 'woocommerce' );
 			break;
 			case self::E_WC_COUPON_NOT_EXIST:
+				/* translators: %s: coupon code */
 				$err = sprintf( __( 'Coupon "%s" does not exist!', 'woocommerce' ), $this->get_code() );
 			break;
 			case self::E_WC_COUPON_INVALID_REMOVED:
+				/* translators: %s: coupon code */
 				$err = sprintf( __( 'Sorry, it seems the coupon "%s" is invalid - it has now been removed from your order.', 'woocommerce' ), $this->get_code() );
 			break;
 			case self::E_WC_COUPON_NOT_YOURS_REMOVED:
+				/* translators: %s: coupon code */
 				$err = sprintf( __( 'Sorry, it seems the coupon "%s" is not yours - it has now been removed from your order.', 'woocommerce' ), $this->get_code() );
 			break;
 			case self::E_WC_COUPON_ALREADY_APPLIED:
 				$err = __( 'Coupon code already applied!', 'woocommerce' );
 			break;
 			case self::E_WC_COUPON_ALREADY_APPLIED_INDIV_USE_ONLY:
+				/* translators: %s: coupon code */
 				$err = sprintf( __( 'Sorry, coupon "%s" has already been applied and cannot be used in conjunction with other coupons.', 'woocommerce' ), $this->get_code() );
 			break;
 			case self::E_WC_COUPON_USAGE_LIMIT_REACHED:
@@ -1311,9 +1315,11 @@ class WC_Coupon extends WC_Legacy_Coupon {
 				$err = __( 'This coupon has expired.', 'woocommerce' );
 			break;
 			case self::E_WC_COUPON_MIN_SPEND_LIMIT_NOT_MET:
+				/* translators: %s: coupon minimum amount */
 				$err = sprintf( __( 'The minimum spend for this coupon is %s.', 'woocommerce' ), wc_price( $this->get_minimum_amount() ) );
 			break;
 			case self::E_WC_COUPON_MAX_SPEND_LIMIT_MET:
+				/* translators: %s: coupon maximum amount */
 				$err = sprintf( __( 'The maximum spend for this coupon is %s.', 'woocommerce' ), wc_price( $this->get_maximum_amount() ) );
 			break;
 			case self::E_WC_COUPON_NOT_APPLICABLE:
@@ -1330,6 +1336,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 					}
 				}
 
+				/* translators: %s: products list */
 				$err = sprintf( __( 'Sorry, this coupon is not applicable to the products: %s.', 'woocommerce' ), implode( ', ', $products ) );
 				break;
 			case self::E_WC_COUPON_EXCLUDED_CATEGORIES:
@@ -1349,6 +1356,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 					}
 				}
 
+				/* translators: %s: categories list */
 				$err = sprintf( __( 'Sorry, this coupon is not applicable to the categories: %s.', 'woocommerce' ), implode( ', ', array_unique( $categories ) ) );
 				break;
 			case self::E_WC_COUPON_NOT_VALID_SALE_ITEMS:

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -395,9 +395,9 @@ class WC_Emails {
 	 */
 	public function low_stock( $product ) {
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product low in stock', 'woocommerce' ) );
-		/* translators: %s: product name %d: items in stock */
+		/* translators: 1: product name 2: items in stock */
 		$message = sprintf(
-			__( '%s is low in stock. There are %d left', 'woocommerce' ),
+			__( '%1$s is low in stock. There are %2$d left.', 'woocommerce' ),
 			html_entity_decode( strip_tags( $product->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
 			html_entity_decode( strip_tags( $product->get_total_stock() ) )
 		);

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -395,7 +395,12 @@ class WC_Emails {
 	 */
 	public function low_stock( $product ) {
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product low in stock', 'woocommerce' ) );
-		$message = sprintf( __( '%s is low in stock.', 'woocommerce' ), html_entity_decode( strip_tags( $product->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ) ) . ' ' . sprintf( __( 'There are %d left', 'woocommerce' ), html_entity_decode( strip_tags( $product->get_total_stock() ) ) );
+		/* translators: %s: product name %d: items in stock */
+		$message = sprintf(
+			__( '%s is low in stock. There are %d left', 'woocommerce' ),
+			html_entity_decode( strip_tags( $product->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
+			html_entity_decode( strip_tags( $product->get_total_stock() ) )
+		);
 
 		wp_mail(
 			apply_filters( 'woocommerce_email_recipient_low_stock', get_option( 'woocommerce_stock_email_recipient' ), $product ),
@@ -413,6 +418,7 @@ class WC_Emails {
 	 */
 	public function no_stock( $product ) {
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product out of stock', 'woocommerce' ) );
+		/* translators: %s: product name */
 		$message = sprintf( __( '%s is out of stock.', 'woocommerce' ), html_entity_decode( strip_tags( $product->get_formatted_name() ), ENT_QUOTES, get_bloginfo( 'charset' ) ) );
 
 		wp_mail(

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -124,7 +124,13 @@ class WC_Embed {
 		if ( self::is_embedded_product() && ( $_product = wc_get_product( get_the_ID() ) ) && $_product->get_average_rating() > 0 ) {
 			?>
 			<div class="wc-embed-rating">
-				<?php echo esc_html( sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $_product->get_average_rating() ) ); ?>
+				<?php
+					/* translators: %s: average rating */
+					printf(
+						esc_html_( 'Rated %s out of 5', 'woocommerce' ),
+						$_product->get_average_rating()
+					);
+				?>
 			</div>
 			<?php
 		}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -474,11 +474,13 @@ class WC_Order extends WC_Abstract_Order {
 	protected function status_transition() {
 		if ( $this->status_transition ) {
 			if ( ! empty( $this->status_transition['from'] ) ) {
+				/* translators: 1: old order status 2: new order status */
 				$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['from'] ), wc_get_order_status_name( $this->status_transition['to'] ) );
 
 				do_action( 'woocommerce_order_status_' . $this->status_transition['from'] . '_to_' . $this->status_transition['to'], $this->get_id() );
 				do_action( 'woocommerce_order_status_changed', $this->get_id(), $this->status_transition['from'], $this->status_transition['to'] );
 			} else {
+				/* translators: %s: new order status */
 				$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['to'] ) );
 			}
 
@@ -822,6 +824,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_formatted_billing_full_name() {
+		/* translators: 1: first name 2: last name */
 		return sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $this->get_billing_first_name(), $this->get_billing_last_name() );
 	}
 
@@ -830,6 +833,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_formatted_shipping_full_name() {
+		/* translators: 1: first name 2: last name */
 		return sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $this->get_shipping_first_name(), $this->get_shipping_last_name() );
 	}
 

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -95,6 +95,7 @@ class WC_Query {
 			break;
 			case 'orders' :
 				if ( ! empty( $wp->query_vars['orders'] ) ) {
+					/* translators: %s: page */
 					$title = sprintf( __( 'Orders (page %d)', 'woocommerce' ), intval( $wp->query_vars['orders'] ) );
 				} else {
 					$title = __( 'Orders', 'woocommerce' );
@@ -102,6 +103,7 @@ class WC_Query {
 			break;
 			case 'view-order' :
 				$order = wc_get_order( $wp->query_vars['view-order'] );
+				/* translators: %s: order number */
 				$title = ( $order ) ? sprintf( __( 'Order #%s', 'woocommerce' ), $order->get_order_number() ) : '';
 			break;
 			case 'downloads' :

--- a/includes/cli/class-wc-cli-customer.php
+++ b/includes/cli/class-wc-cli-customer.php
@@ -563,6 +563,7 @@ class WC_CLI_Customer extends WC_CLI_Command {
 		}
 
 		if ( ! $user ) {
+			/* translators: %s: id email or login */
 			throw new WC_CLI_Exception( 'woocommerce_cli_invalid_customer', sprintf( __( 'Invalid customer "%s"', 'woocommerce' ), $id_email_or_login ) );
 		}
 

--- a/includes/cli/class-wc-cli-order.php
+++ b/includes/cli/class-wc-cli-order.php
@@ -119,6 +119,7 @@ class WC_CLI_Order extends WC_CLI_Command {
 			$order = $this->create_base_order( $default_order_args, $data );
 
 			if ( is_wp_error( $order ) ) {
+				/* translators: %s: error messages */
 				throw new WC_CLI_Exception( 'woocommerce_cli_cannot_create_order', sprintf( __( 'Cannot create order: %s', 'woocommerce' ), implode( ', ', $order->get_error_messages() ) ) );
 			}
 

--- a/includes/cli/class-wc-cli-product-category.php
+++ b/includes/cli/class-wc-cli-product-category.php
@@ -121,6 +121,7 @@ class WC_CLI_Product_Category extends WC_CLI_Command {
 		$term    = get_term( $term_id, 'product_cat' );
 
 		if ( is_wp_error( $term ) || is_null( $term ) ) {
+			/* translators: %s: product category ID */
 			throw new WC_CLI_Exception( 'woocommerce_cli_invalid_product_category_id', sprintf( __( 'Invalid product category ID "%s"', 'woocommerce' ), $term_id ) );
 		}
 

--- a/includes/cli/class-wc-cli-product.php
+++ b/includes/cli/class-wc-cli-product.php
@@ -1529,6 +1529,7 @@ class WC_CLI_Product extends WC_CLI_Command {
 			$variation_id = isset( $variation['id'] ) ? absint( $variation['id'] ) : 0;
 
 			// Generate a useful post title
+			/* translators: 1: variation id 2: product name */
 			$variation_post_title = sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation_id, esc_html( get_the_title( $id ) ) );
 
 			// Update or Add post

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -108,6 +108,7 @@ class WC_Email_Cancelled_Order extends WC_Email {
 			'recipient' => array(
 				'title'         => __( 'Recipient(s)', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: admin email */
 				'description'   => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -116,6 +117,7 @@ class WC_Email_Cancelled_Order extends WC_Email {
 			'subject' => array(
 				'title'         => __( 'Subject', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default subject */
 				'description'   => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: %s.', 'woocommerce' ), '<code>' . $this->subject . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -124,6 +126,7 @@ class WC_Email_Cancelled_Order extends WC_Email {
 			'heading' => array(
 				'title'         => __( 'Email heading', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default heading */
 				'description'   => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: %s.', 'woocommerce' ), '<code>' . $this->heading . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -144,6 +144,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 			'subject' => array(
 				'title'         => __( 'Subject', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default subject */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -152,6 +153,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 			'heading' => array(
 				'title'         => __( 'Email heading', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default heading */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -160,6 +162,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 			'subject_downloadable' => array(
 				'title'         => __( 'Subject (downloadable)', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default subject */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject_downloadable . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -168,6 +171,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 			'heading_downloadable' => array(
 				'title'         => __( 'Email heading (downloadable)', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default heading */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading_downloadable . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -157,6 +157,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 			'subject' => array(
 				'title'         => __( 'Email subject', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default subject */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -165,6 +166,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 			'heading' => array(
 				'title'         => __( 'Email heading', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default heading */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -173,6 +175,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 			'subject_paid' => array(
 				'title'         => __( 'Email subject (paid)', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default subject */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject_paid . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',
@@ -181,6 +184,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 			'heading_paid' => array(
 				'title'         => __( 'Email heading (paid)', 'woocommerce' ),
 				'type'          => 'text',
+				/* translators: %s: default heading */
 				'description'   => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading_paid . '</code>' ),
 				'placeholder'   => '',
 				'default'       => '',

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -202,6 +202,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 			'subject_full' => array(
 				'title'       => __( 'Full refund subject', 'woocommerce' ),
 				'type'        => 'text',
+				/* translators: %s: default subject */
 				'description' => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject_full . '</code>' ),
 				'placeholder' => '',
 				'default'     => $this->subject_full,
@@ -210,6 +211,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 			'subject_partial' => array(
 				'title'       => __( 'Partial refund subject', 'woocommerce' ),
 				'type'        => 'text',
+				/* translators: %s: default subject */
 				'description' => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject_partial . '</code>' ),
 				'placeholder' => '',
 				'default'     => $this->subject_partial,
@@ -218,6 +220,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 			'heading_full' => array(
 				'title'       => __( 'Full refund email heading', 'woocommerce' ),
 				'type'        => 'text',
+				/* translators: %s: default heading */
 				'description' => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading_full . '</code>' ),
 				'placeholder' => '',
 				'default'     => $this->heading_full,
@@ -226,6 +229,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 			'heading_partial' => array(
 				'title'       => __( 'Partial refund email heading', 'woocommerce' ),
 				'type'        => 'text',
+				/* translators: %s: default heading */
 				'description' => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading_partial . '</code>' ),
 				'placeholder' => '',
 				'default'     => $this->heading_partial,

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -491,6 +491,7 @@ class WC_Email extends WC_Settings_API {
 			'subject'         => array(
 				'title'       => __( 'Email subject', 'woocommerce' ),
 				'type'        => 'text',
+				/* translators: %s: default subject */
 				'description' => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->subject . '</code>' ),
 				'placeholder' => '',
 				'default'     => '',
@@ -499,6 +500,7 @@ class WC_Email extends WC_Settings_API {
 			'heading'         => array(
 				'title'       => __( 'Email heading', 'woocommerce' ),
 				'type'        => 'text',
+				/* translators: %s: default heading */
 				'description' => sprintf( __( 'Defaults to %s', 'woocommerce' ), '<code>' . $this->heading . '</code>' ),
 				'placeholder' => '',
 				'default'     => '',

--- a/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
@@ -426,7 +426,13 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 		try {
 			$order_items    = $order->get_items();
 			$order_item     = array_shift( $order_items );
-			$pre_order_name = sprintf( __( '%1$s - Pre-order for "%2$s"', 'woocommerce' ), esc_html( get_bloginfo( 'name', 'display' ) ), $order_item['name'] ) . ' ' . sprintf( __( '(Order #%s)', 'woocommerce' ), $order->get_order_number() );
+			/* translators: 1: site name 2: product name 3: order number */
+			$pre_order_name = sprintf(
+				__( '%1$s - Pre-order for "%2$s" (Order #%3$s)', 'woocommerce' ),
+				esc_html( get_bloginfo( 'name', 'display' ) ),
+				$order_item['name'],
+				$order->get_order_number()
+			);
 
 			$customer_id = get_post_meta( $order->get_id(), '_simplify_customer_id', true );
 

--- a/includes/payment-tokens/class-wc-payment-token-cc.php
+++ b/includes/payment-tokens/class-wc-payment-token-cc.php
@@ -68,6 +68,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * @return string
 	 */
 	public function get_display_name() {
+		/* translators: 1: credit card type 2: last 4 digits 3: expiry month 4: expiry year */
 		$display = sprintf(
 			__( '%1$s ending in %2$s (expires %3$s/%4$s)', 'woocommerce' ),
 			wc_get_credit_card_type_label( $this->get_card_type() ),

--- a/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -51,6 +51,7 @@ if ( ! empty( $shipping_classes ) ) {
 			continue;
 		}
 		$settings[ 'class_cost_' . $shipping_class->term_id ] = array(
+			/* translators: %s: shipping class name */
 			'title'       => sprintf( __( '"%s" shipping class cost', 'woocommerce' ), esc_html( $shipping_class->name ) ),
 			'type'        => 'text',
 			'placeholder' => __( 'N/A', 'woocommerce' ),

--- a/includes/shipping/legacy-flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/includes/settings-flat-rate.php
@@ -78,6 +78,7 @@ if ( ! empty( $shipping_classes ) ) {
 			continue;
 		}
 		$settings[ 'class_cost_' . $shipping_class->term_id ] = array(
+			/* translators: %s: shipping class name */
 			'title'       => sprintf( __( '"%s" shipping class cost', 'woocommerce' ), esc_html( $shipping_class->name ) ),
 			'type'        => 'text',
 			'placeholder' => __( 'N/A', 'woocommerce' ),

--- a/includes/vendor/wp-rest-functions.php
+++ b/includes/vendor/wp-rest-functions.php
@@ -166,19 +166,23 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 
 		if ( ! empty( $args['enum'] ) ) {
 			if ( ! in_array( $value, $args['enum'] ) ) {
+				/* translators: 1: parameter 2: arguments */
 				return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not one of %2$s', 'woocommerce' ), $param, implode( ', ', $args['enum'] ) ) );
 			}
 		}
 
 		if ( 'integer' === $args['type'] && ! is_numeric( $value ) ) {
+			/* translators: 1: parameter 2: integer type */
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s', 'woocommerce' ), $param, 'integer' ) );
 		}
 
 		if ( 'boolean' === $args['type'] && ! rest_is_boolean( $value ) ) {
+			/* translators: 1: parameter 2: boolean type */
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s', 'woocommerce' ), $value, 'boolean' ) );
 		}
 
 		if ( 'string' === $args['type'] && ! is_string( $value ) ) {
+			/* translators: 1: parameter 2: string type */
 			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s', 'woocommerce' ), $param, 'string' ) );
 		}
 
@@ -197,6 +201,7 @@ if ( ! function_exists( 'rest_validate_request_arg' ) ) {
 					break;
 				case 'ipv4' :
 					if ( ! rest_is_ip_address( $value ) ) {
+						/* translators: %s: IP address */
 						return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not a valid IP address.', 'woocommerce' ), $value ) );
 					}
 					break;

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -1139,8 +1139,10 @@ function wc_reduce_stock_levels( $order_id ) {
 				$item_name = $product->get_sku() ? $product->get_sku(): $item['product_id'];
 
 				if ( ! empty( $item['variation_id'] ) ) {
+					/* translators: 1: item name 2: variation id 3: old stock quantity 4: new stock quantity */
 					$order->add_order_note( sprintf( __( 'Item %1$s variation #%2$s stock reduced from %3$s to %4$s.', 'woocommerce' ), $item_name, $item['variation_id'], $new_stock + $qty, $new_stock ) );
 				} else {
+					/* translators: 1: item name 2: old stock quantity 3: new stock quantity */
 					$order->add_order_note( sprintf( __( 'Item %1$s stock reduced from %2$s to %3$s.', 'woocommerce' ), $item_name, $new_stock + $qty, $new_stock ) );
 				}
 

--- a/includes/widgets/class-wc-widget-product-tag-cloud.php
+++ b/includes/widgets/class-wc-widget-product-tag-cloud.php
@@ -82,7 +82,7 @@ class WC_Widget_Product_Tag_Cloud extends WC_Widget {
 	 * @return string
 	 */
 	public function _topic_count_text( $count ) {
-		/* translators: %s for product quantity, e.g. 1 product and 2 products */
+		/* translators: %s: product count */
 		return sprintf( _n( '%s product', '%s products', $count, 'woocommerce' ), number_format_i18n( $count ) );
 	}
 }

--- a/includes/widgets/class-wc-widget-recent-reviews.php
+++ b/includes/widgets/class-wc-widget-recent-reviews.php
@@ -83,7 +83,7 @@ class WC_Widget_Recent_Reviews extends WC_Widget {
 
 				echo $rating_html;
 
-				/* translators: %s: comment author */
+				/* translators: %s: review author */
 				echo '<span class="reviewer">' . sprintf( __( 'by %s', 'woocommerce' ), get_comment_author() ) . '</span>';
 
 				echo '</li>';

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <p><?php
+	/* translators: 1: user display name 2: logout url */
 	printf(
 		__( 'Hello %1$s (not %1$s? <a href="%2$s">Sign out</a>)', 'woocommerce' ),
 		'<strong>' . esc_html( $current_user->display_name ) . '</strong>',

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -62,7 +62,10 @@ if ( $customer_orders ) : ?>
 								<?php echo wc_get_order_status_name( $order->get_status() ); ?>
 
 							<?php elseif ( 'order-total' === $column_id ) : ?>
-								<?php echo sprintf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count ); ?>
+								<?php
+								/* translators: 1: formatted order total 2: total order items */
+								printf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count );
+								?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -58,7 +58,10 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 								<?php echo wc_get_order_status_name( $order->get_status() ); ?>
 
 							<?php elseif ( 'order-total' === $column_id ) : ?>
-								<?php echo sprintf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count ); ?>
+								<?php
+								/* translators: 1: formatted order total 2: total order items */
+								printf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce' ), $order->get_formatted_order_total(), $item_count );
+								?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -48,6 +48,7 @@ do_action( 'woocommerce_before_account_payment_methods', $has_methods ); ?>
 								do_action( 'woocommerce_account_payment_methods_column_' . $column_id, $method );
 							} elseif ( 'method' === $column_id ) {
 								if ( ! empty( $method['method']['last4'] ) ) {
+									/* translators: 1: credit card type 2: last 4 digits */
 									echo sprintf( __( '%1$s ending in %2$s', 'woocommerce' ), esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) ), esc_html( $method['method']['last4'] ) );
 								} else {
 									echo esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) );

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <p><?php
+	/* translators: 1: order number 2: order date 3: order status */
 	printf(
 		__( 'Order #%1$s was placed on %2$s and is currently %3$s.', 'woocommerce' ),
 		'<mark class="order-number">' . $order->get_order_number() . '</mark>',

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <p class="order-info"><?php
+	/* translators: 1: order number 2: order date 3: order status */
 	echo wp_kses_post( apply_filters( 'woocommerce_order_tracking_status', sprintf(
 		__( 'Order #%1$s was placed on %2$s and is currently %3$s.', 'woocommerce' ),
 		'<mark class="order-number">' . $order->get_order_number() . '</mark>',

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -29,10 +29,12 @@ if ( ! comments_open() ) {
 <div id="reviews" class="woocommerce-Reviews">
 	<div id="comments">
 		<h2 class="woocommerce-Reviews-title"><?php
-			if ( get_option( 'woocommerce_enable_review_rating' ) === 'yes' && ( $count = $product->get_review_count() ) )
+			if ( get_option( 'woocommerce_enable_review_rating' ) === 'yes' && ( $count = $product->get_review_count() ) ) {
+				/* translators: 1: reviews count 2: product name */
 				printf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), $count, '<span>' . get_the_title() . '</span>' );
-			else
+			} else {
 				_e( 'Reviews', 'woocommerce' );
+			}
 		?></h2>
 
 		<?php if ( have_comments() ) : ?>

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -35,12 +35,21 @@ if ( $rating_count > 0 ) : ?>
 	<div class="woocommerce-product-rating">
 		<div class="star-rating" title="<?php printf( __( 'Rated %s out of 5', 'woocommerce' ), $average ); ?>">
 			<span style="width:<?php echo ( ( $average / 5 ) * 100 ); ?>%">
-				<?php printf(
+				<?php
+				/* translators: 1: average rating 2: max rating (i.e. 5) */
+				printf(
 					__( '%1$s out of %2$s', 'woocommerce' ),
 					'<strong class="rating">' . esc_html( $average ) . '</strong>',
 					'<span>5</span>'
-				); ?>
-				<?php printf( _n( 'based on %s customer rating', 'based on %s customer ratings', $rating_count, 'woocommerce' ), '<span class="rating">' . $rating_count . '</span>' ); ?>
+				);
+				?>
+				<?php
+				/* translators: %s: rating count */
+				printf(
+					_n( 'based on %s customer rating', 'based on %s customer ratings', $rating_count, 'woocommerce' ),
+					'<span class="rating">' . $rating_count . '</span>'
+				);
+				?>
 			</span>
 		</div>
 		<?php if ( comments_open() ) : ?><a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . $review_count . '</span>' ); ?>)</a><?php endif ?>


### PR DESCRIPTION
Almost all the the translation strings with `%s` placeholders have no translation comments, I see [only one translation string with translation comments](https://translate.wordpress.org/projects/wp-plugins/woocommerce/stable/he/default?filters%5Bterm%5D=&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Bwith_comment%5D=yes&filter=Filter&sort%5Bby%5D=original&sort%5Bhow%5D=asc).

It's very hard to translate strings with `%s` placeholders without knowing what you are trying to translate.

We should use translator comments `/* translators: %s: placeholder description */`. It will appear on the sidebar and help translators understand the context:

![context](https://cloud.githubusercontent.com/assets/576623/16934563/133ade84-4d60-11e6-86d3-a71508640ea8.png)
