### PR TITLE
Implement CRUD in the legacy REST API

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1947,8 +1947,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		return $attribute_object->is_taxonomy() ? implode( ', ', wc_get_product_terms( $this->get_id(), $attribute_object->get_name(), array( 'fields' => 'names' ) ) ) : wc_implode_text_attributes( $attribute_object->get_options() );
 	}
 
-
-
 	/*
 	|--------------------------------------------------------------------------
 	| @todo download functions
@@ -1975,9 +1973,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return array
 	 */
 	public function get_files() {
-
-		$downloadable_files = array_filter( isset( $this->downloadable_files ) ? (array) maybe_unserialize( $this->downloadable_files ) : array() );
-
+		$downloadable_files = array_filter( ! empty( $this->get_downloads() ) ? (array) maybe_unserialize( $this->get_downloads() ) : array() );
 		if ( ! empty( $downloadable_files ) ) {
 
 			foreach ( $downloadable_files as $key => $file ) {

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1973,7 +1973,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return array
 	 */
 	public function get_files() {
-		$downloadable_files = array_filter( ! empty( $this->get_downloads() ) ? (array) maybe_unserialize( $this->get_downloads() ) : array() );
+		$downloads          = $this->get_downloads();
+		$downloadable_files = array_filter( ! empty( $downloads ) ? (array) maybe_unserialize( $downloads ) : array() );
 		if ( ! empty( $downloadable_files ) ) {
 
 			foreach ( $downloadable_files as $key => $file ) {

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -469,20 +469,19 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 	 * @return array
 	 */
 	protected function get_product_data( $product ) {
-		$post = get_post( $product->get_id() );
 		$data = array(
 			'id'                    => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(),
-			'name'                  => $product->get_title(),
-			'slug'                  => $post->post_name,
+			'name'                  => $product->get_name(),
+			'slug'                  => $product->get_slug(),
 			'permalink'             => $product->get_permalink(),
-			'date_created'          => wc_rest_prepare_date_response( $post->post_date_gmt ),
-			'date_modified'         => wc_rest_prepare_date_response( $post->post_modified_gmt ),
+			'date_created'          => wc_rest_prepare_date_response( $product->get_date_created() ),
+			'date_modified'         => wc_rest_prepare_date_response( $product->get_date_modified() ),
 			'type'                  => $product->get_type(),
-			'status'                => $post->post_status,
+			'status'                => $product->get_status(),
 			'featured'              => $product->is_featured(),
 			'catalog_visibility'    => $product->get_catalog_visibility(),
-			'description'           => wpautop( do_shortcode( $post->post_content ) ),
-			'short_description'     => apply_filters( 'woocommerce_short_description', $post->post_excerpt ),
+			'description'           => wpautop( do_shortcode( $product->get_description() ) ),
+			'short_description'     => apply_filters( 'woocommerce_short_description', $product->get_short_description() ),
 			'sku'                   => $product->get_sku(),
 			'price'                 => $product->get_price(),
 			'regular_price'         => $product->get_regular_price(),
@@ -520,13 +519,13 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 			'shipping_taxable'      => $product->is_shipping_taxable(),
 			'shipping_class'        => $product->get_shipping_class(),
 			'shipping_class_id'     => (int) $product->get_shipping_class_id(),
-			'reviews_allowed'       => ( 'open' === $post->comment_status ),
+			'reviews_allowed'       => $product->get_reviews_allowed(),
 			'average_rating'        => wc_format_decimal( $product->get_average_rating(), 2 ),
 			'rating_count'          => (int) $product->get_rating_count(),
 			'related_ids'           => array_map( 'absint', array_values( wc_get_related_products( $product->get_id() ) ) ),
 			'upsell_ids'            => array_map( 'absint', $product->get_upsell_ids() ),
 			'cross_sell_ids'        => array_map( 'absint', $product->get_cross_sell_ids() ),
-			'parent_id'             => $product->is_type( 'variation' ) ? $product->parent->id : $post->post_parent,
+			'parent_id'             => $product->get_parent_id(),
 			'purchase_note'         => wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ),
 			'categories'            => $this->get_taxonomy_terms( $product ),
 			'tags'                  => $this->get_taxonomy_terms( $product, 'tag' ),
@@ -866,7 +865,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				}
 
 				if ( isset( $image['position'] ) && 0 === $image['position'] ) {
-					$product->set_thumbnail_id( $attachment_id );
+					$product->set_image_id( $attachment_id );
 				} else {
 					$gallery[] = $attachment_id;
 				}
@@ -886,7 +885,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				$product->set_gallery_image_ids( $gallery );
 			}
 		} else {
-			$product->set_thumbnail_id( '' );
+			$product->set_image_id( '' );
 			$product->set_gallery_image_ids( array() );
 		}
 
@@ -1192,7 +1191,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 		}
 
 		// Update parent if grouped so price sorting works and stays in sync with the cheapest child.
-		if ( $product->get_parent_id() > 0 || 'grouped' === $product->get_type() ) {
+		if ( $product->get_parent_id() > 0 || $product->is_type( 'grouped' ) ) {
 
 			$clear_parent_ids = array();
 
@@ -1204,7 +1203,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				$parent->save();
 			}
 
-			if ( 'grouped' === $product->get_type() ) {
+			if ( $product->is_type( 'grouped' ) ) {
 				$clear_parent_ids[] = $product->get_id();
 			}
 
@@ -1265,40 +1264,40 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				$backorders = $product->get_backorders();
 			}
 
-			if ( 'grouped' === $product->get_type() ) {
+			if ( $product->is_type( 'grouped' ) ) {
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( 'no' );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( $status );
-			} elseif ( 'external' === $product->get_type() ) {
+			} elseif ( $product->is_type( 'external' ) ) {
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( 'no' );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( 'instock' );
 			} elseif ( 'yes' === $manage_stock ) {
 				$product->set_backorders( $backorders );
 
 				// Stock status is always determined by children so sync later.
-				if ( 'variable' !== $product->get_type() ) {
+				if ( ! $product->is_type( 'variable' ) ) {
 					$product->set_stock_status( $stock_status );
 				}
 
 				// Stock quantity.
 				if ( isset( $request['stock_quantity'] ) ) {
-					$product->set_stock( wc_stock_amount( $request['stock_quantity'] ) );
+					$product->set_stock_quantity( wc_stock_amount( $request['stock_quantity'] ) );
 				} elseif ( isset( $request['inventory_delta'] ) ) {
 					$stock_quantity  = wc_stock_amount( $product->get_stock() );
 					$stock_quantity += wc_stock_amount( $request['inventory_delta'] );
-					$product->set_stock( wc_stock_amount( $stock_quantity ) );
+					$product->set_stock_quantity( wc_stock_amount( $stock_quantity ) );
 				}
 			} else {
 				// Don't manage stock.
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( $backorders );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( $stock_status );
 			}
-		} elseif ( 'variable' !== $product->get_type() ) {
+		} elseif ( ! $product->is_type( 'variable' ) ) {
 			$product->set_stock_status( $stock_status );
 		}
 
@@ -1376,7 +1375,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 		}
 
 		// Product url and button text for external products.
-		if ( 'external' === $product->get_type() ) {
+		if ( $product->is_type( 'external' ) ) {
 			if ( isset( $request['external_url'] ) ) {
 				$product->set_product_url( $request['external_url'] );
 			}

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -8,6 +8,7 @@
  * @category    API
  * @package     WooCommerce/API
  * @since       2.1
+ * @version     2.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -156,14 +157,13 @@ class WC_API_Products extends WC_API_Resource {
 
 		// add variations to variable products
 		if ( $product->is_type( 'variable' ) && $product->has_child() ) {
-
 			$product_data['variations'] = $this->get_variation_data( $product );
 		}
 
 		// add the parent product data to an individual variation
-		if ( $product->is_type( 'variation' ) && $product->parent ) {
-
-			$product_data['parent'] = $this->get_product_data( $product->parent );
+		if ( $product->is_type( 'variation' ) && $product->get_parent_id() ) {
+			$_product = wc_get_product( $product->get_parent_id() );
+			$product_data['parent'] = $this->get_product_data( $_product );
 		}
 
 		return array( 'product' => apply_filters( 'woocommerce_api_product_response', $product_data, $product, $fields, $this->server ) );
@@ -252,34 +252,38 @@ class WC_API_Products extends WC_API_Resource {
 				$post_excerpt = $data['short_description'];
 			}
 
-			$new_product = array(
-				'post_title'   => wc_clean( $data['title'] ),
-				'post_status'  => ( isset( $data['status'] ) ? wc_clean( $data['status'] ) : 'publish' ),
-				'post_type'    => 'product',
-				'post_excerpt' => ( isset( $data['short_description'] ) ? $post_excerpt : '' ),
-				'post_content' => ( isset( $data['description'] ) ? $post_content : '' ),
-				'post_author'  => get_current_user_id(),
-			);
+			$classname = WC_Product_Factory::get_classname_from_product_type( $data['type'] );
+			if ( ! class_exists( $classname ) ) {
+				$classname = 'WC_Product_Simple';
+			}
+			$product = new $classname();
 
-			// Attempts to create the new product
-			$id = wp_insert_post( $new_product, true );
+			$product->set_name( wc_clean( $data['title'] ) );
+			$product->set_status( isset( $data['status'] ) ? wc_clean( $data['status'] ) : 'publish' );
+			$product->set_short_description( isset( $data['short_description'] ) ? $post_excerpt : '' );
+			$product->set_description( isset( $data['description'] ) ? $post_content : '' );
+
+			// Attempts to create the new product.
+			$product->create();
+			$id = $product->get_id();
 
 			// Checks for an error in the product creation
-			if ( is_wp_error( $id ) ) {
+			if ( ! $id > 0 ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_create_product', $id->get_error_message(), 400 );
 			}
 
 			// Check for featured/gallery images, upload it and set it
 			if ( isset( $data['images'] ) ) {
-				$this->save_product_images( $id, $data['images'] );
+				$product = $this->save_product_images( $product, $data['images'] );
 			}
 
 			// Save product meta fields
-			$this->save_product_meta( $id, $data );
+			$product = $this->save_product_meta( $product, $data );
+			$product->save();
 
 			// Save variations
 			if ( isset( $data['type'] ) && 'variable' == $data['type'] && isset( $data['variations'] ) && is_array( $data['variations'] ) ) {
-				$this->save_variations( $id, $data );
+				$this->save_variations( $product, $data );
 			}
 
 			do_action( 'woocommerce_api_create_product', $id, $data );
@@ -320,37 +324,37 @@ class WC_API_Products extends WC_API_Resource {
 				return $id;
 			}
 
+			$product = wc_get_product( $id );
+
 			$data = apply_filters( 'woocommerce_api_edit_product_data', $data, $this );
 
 			// Product title.
 			if ( isset( $data['title'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'post_title' => wc_clean( $data['title'] ) ) );
+				$product->set_name( wc_clean( $data['title'] ) );
 			}
 
 			// Product name (slug).
 			if ( isset( $data['name'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'post_name' => sanitize_title( $data['name'] ) ) );
+				$product->set_slug( wc_clean( $data['name'] ) );
 			}
 
 			// Product status.
 			if ( isset( $data['status'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'post_status' => wc_clean( $data['status'] ) ) );
+				$product->set_status( wc_clean( $data['status'] ) );
 			}
 
 			// Product short description.
 			if ( isset( $data['short_description'] ) ) {
 				// Enable short description html tags.
 				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
-
-				wp_update_post( array( 'ID' => $id, 'post_excerpt' => $post_excerpt ) );
+				$product->set_short_description( $post_excerpt );
 			}
 
 			// Product description.
 			if ( isset( $data['description'] ) ) {
 				// Enable description html tags.
 				$post_content = ( isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
-
-				wp_update_post( array( 'ID' => $id, 'post_content' => $post_content ) );
+				$product->set_description( $post_content );
 			}
 
 			// Validate the product type
@@ -360,17 +364,19 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check for featured/gallery images, upload it and set it
 			if ( isset( $data['images'] ) ) {
-				$this->save_product_images( $id, $data['images'] );
+				$product = $this->save_product_images( $product, $data['images'] );
 			}
 
 			// Save product meta fields
-			$this->save_product_meta( $id, $data );
+			$product = $this->save_product_meta( $product, $data );
+
+			$product->save();
 
 			// Save variations
 			$product = get_product( $id );
 			if ( $product->is_type( 'variable' ) ) {
 				if ( isset( $data['variations'] ) && is_array( $data['variations'] ) ) {
-					$this->save_variations( $id, $data );
+					$this->save_variations( $product, $data );
 				} else {
 					// Just sync variations
 					WC_Product_Variable::sync( $id );
@@ -405,30 +411,27 @@ class WC_API_Products extends WC_API_Resource {
 			return $id;
 		}
 
+		$product = wc_get_product( $id );
+
 		do_action( 'woocommerce_api_delete_product', $id, $this );
 
 		// If we're forcing, then delete permanently.
 		if ( $force ) {
-			$child_product_variations = get_children( 'post_parent=' . $id . '&post_type=product_variation' );
-
-			if ( ! empty( $child_product_variations ) ) {
-				foreach ( $child_product_variations as $child ) {
-					wp_delete_post( $child->ID, true );
+			if ( $product->is_type( 'variable' ) ) {
+				foreach ( $product->get_children() as $child_id ) {
+					$child = wc_get_product( $child_id );
+					$child->delete();
+				}
+			} elseif ( $product->is_type( 'grouped' ) ) {
+				foreach ( $product->get_children() as $child_id ) {
+					$child = wc_get_product( $child_id );
+					$child->set_parent_id( 0 );
+					$child->save();
 				}
 			}
 
-			$child_products = get_children( 'post_parent=' . $id . '&post_type=product' );
-
-			if ( ! empty( $child_products ) ) {
-				foreach ( $child_products as $child ) {
-					$child_post                = array();
-					$child_post['ID']          = $child->ID;
-					$child_post['post_parent'] = 0;
-					wp_update_post( $child_post );
-				}
-			}
-
-			$result = wp_delete_post( $id, true );
+			$product->delete();
+			$result = $product->get_id() > 0 ? false : true;
 		} else {
 			$result = wp_trash_post( $id );
 		}
@@ -676,14 +679,14 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	private function get_product_data( $product ) {
 		$prices_precision = wc_get_price_decimals();
-
+		$post             = get_post( $product->get_id() );
 		return array(
 			'title'              => $product->get_title(),
 			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $product->get_post_data()->post_date_gmt ),
-			'updated_at'         => $this->server->format_datetime( $product->get_post_data()->post_modified_gmt ),
-			'type'               => $product->product_type,
-			'status'             => $product->get_post_data()->post_status,
+			'created_at'         => $this->server->format_datetime( $post->post_date_gmt ),
+			'updated_at'         => $this->server->format_datetime( $post->post_modified_gmt ),
+			'type'               => $product->get_type(),
+			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
 			'virtual'            => $product->is_virtual(),
 			'permalink'          => $product->get_permalink(),
@@ -704,41 +707,41 @@ class WC_API_Products extends WC_API_Resource {
 			'purchaseable'       => $product->is_purchasable(),
 			'featured'           => $product->is_featured(),
 			'visible'            => $product->is_visible(),
-			'catalog_visibility' => $product->visibility,
+			'catalog_visibility' => $product->get_catalog_visibility(),
 			'on_sale'            => $product->is_on_sale(),
 			'product_url'        => $product->is_type( 'external' ) ? $product->get_product_url() : '',
 			'button_text'        => $product->is_type( 'external' ) ? $product->get_button_text() : '',
 			'weight'             => $product->get_weight() ? wc_format_decimal( $product->get_weight(), 2 ) : null,
 			'dimensions'         => array(
-				'length' => $product->length,
-				'width'  => $product->width,
-				'height' => $product->height,
+				'length' => $product->get_length(),
+				'width'  => $product->get_width(),
+				'height' => $product->get_height(),
 				'unit'   => get_option( 'woocommerce_dimension_unit' ),
 			),
 			'shipping_required'  => $product->needs_shipping(),
 			'shipping_taxable'   => $product->is_shipping_taxable(),
 			'shipping_class'     => $product->get_shipping_class(),
 			'shipping_class_id'  => ( 0 !== $product->get_shipping_class_id() ) ? $product->get_shipping_class_id() : null,
-			'description'        => wpautop( do_shortcode( $product->get_post_data()->post_content ) ),
-			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_post_data()->post_excerpt ),
-			'reviews_allowed'    => ( 'open' === $product->get_post_data()->comment_status ),
+			'description'        => wpautop( do_shortcode( $product->get_description() ) ),
+			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_short_description() ),
+			'reviews_allowed'    => $product->get_reviews_allowed(),
 			'average_rating'     => wc_format_decimal( $product->get_average_rating(), 2 ),
 			'rating_count'       => (int) $product->get_rating_count(),
-			'related_ids'        => array_map( 'absint', array_values( $product->get_related() ) ),
-			'upsell_ids'         => array_map( 'absint', $product->get_upsells() ),
-			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sells() ),
-			'parent_id'          => $product->post->post_parent,
+			'related_ids'        => array_map( 'absint', array_values( wc_get_related_products( $product->get_id() ) ) ),
+			'upsell_ids'         => array_map( 'absint', $product->get_upsell_ids() ),
+			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sell_ids() ),
+			'parent_id'          => $product->get_parent_id(),
 			'categories'         => wp_get_post_terms( $product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),
 			'tags'               => wp_get_post_terms( $product->get_id(), 'product_tag', array( 'fields' => 'names' ) ),
 			'images'             => $this->get_images( $product ),
 			'featured_src'       => (string) wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->get_id() ) ),
 			'attributes'         => $this->get_attributes( $product ),
 			'downloads'          => $this->get_downloads( $product ),
-			'download_limit'     => (int) $product->download_limit,
-			'download_expiry'    => (int) $product->download_expiry,
-			'download_type'      => $product->download_type,
-			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->purchase_note ) ) ),
-			'total_sales'        => metadata_exists( 'post', $product->get_id(), 'total_sales' ) ? (int) get_post_meta( $product->get_id(), 'total_sales', true ) : 0,
+			'download_limit'     => (int) $product->get_download_limit(),
+			'download_expiry'    => (int) $product->get_download_expiry(),
+			'download_type'      => 'standard',
+			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ),
+			'total_sales'        => $product->get_total_sales(),
 			'variations'         => array(),
 			'parent'             => array(),
 		);
@@ -746,6 +749,7 @@ class WC_API_Products extends WC_API_Resource {
 
 	/**
 	 * Get an individual variation's data
+	 * @todo after variations CRUD is done
 	 *
 	 * @since 2.1
 	 * @param WC_Product $product
@@ -757,7 +761,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		foreach ( $product->get_children() as $child_id ) {
 
-			$variation = $product->get_child( $child_id );
+			$variation = wc_get_product( $child_id );
 
 			if ( ! $variation->exists() ) {
 				continue;
@@ -798,8 +802,8 @@ class WC_API_Products extends WC_API_Resource {
 				'image'             => $this->get_images( $variation ),
 				'attributes'        => $this->get_attributes( $variation ),
 				'downloads'         => $this->get_downloads( $variation ),
-				'download_limit'    => (int) $product->download_limit,
-				'download_expiry'   => (int) $product->download_expiry,
+				'download_limit'    => (int) $product->get_download_limit(),
+				'download_expiry'   => (int) $product->get_download_expiry(),
 			);
 		}
 
@@ -810,80 +814,64 @@ class WC_API_Products extends WC_API_Resource {
 	 * Save product meta
 	 *
 	 * @since  2.2
-	 * @param  int $product_id
+	 * @param  WC_Product $product
 	 * @param  array $data
-	 * @return bool
+	 * @return WC_Product
 	 * @throws WC_API_Exception
 	 */
-	protected function save_product_meta( $product_id, $data ) {
+	protected function save_product_meta( $product, $data ) {
 		global $wpdb;
-
-		// Product Type
-		$product_type = null;
-		if ( isset( $data['type'] ) ) {
-			$product_type = wc_clean( $data['type'] );
-			wp_set_object_terms( $product_id, $product_type, 'product_type' );
-		} else {
-			$_product_type = get_the_terms( $product_id, 'product_type' );
-			if ( is_array( $_product_type ) ) {
-				$_product_type = current( $_product_type );
-				$product_type  = $_product_type->slug;
-			}
-		}
-
-		// Default total sales.
-		add_post_meta( $product_id, 'total_sales', '0', true );
 
 		// Virtual
 		if ( isset( $data['virtual'] ) ) {
-			update_post_meta( $product_id, '_virtual', ( true === $data['virtual'] ) ? 'yes' : 'no' );
+			$product->set_virtual( $data['virtual'] );
 		}
 
 		// Tax status
 		if ( isset( $data['tax_status'] ) ) {
-			update_post_meta( $product_id, '_tax_status', wc_clean( $data['tax_status'] ) );
+			$product->set_tax_status( wc_clean( $data['tax_status'] ) );
 		}
 
 		// Tax Class
 		if ( isset( $data['tax_class'] ) ) {
-			update_post_meta( $product_id, '_tax_class', wc_clean( $data['tax_class'] ) );
+			$product->set_tax_class( wc_clean( $data['tax_class'] ) );
 		}
 
 		// Catalog Visibility
 		if ( isset( $data['catalog_visibility'] ) ) {
-			update_post_meta( $product_id, '_visibility', wc_clean( $data['catalog_visibility'] ) );
+			$product->set_catalog_visibility( wc_clean( $data['catalog_visibility'] ) );
 		}
 
 		// Purchase Note
 		if ( isset( $data['purchase_note'] ) ) {
-			update_post_meta( $product_id, '_purchase_note', wc_clean( $data['purchase_note'] ) );
+			$product->set_purchase_note( wc_clean( $data['purchase_note'] ) );
 		}
 
 		// Featured Product
 		if ( isset( $data['featured'] ) ) {
-			update_post_meta( $product_id, '_featured', ( true === $data['featured'] ) ? 'yes' : 'no' );
+			$product->set_featured( $data['featured'] );
 		}
 
 		// Shipping data
-		$this->save_product_shipping_data( $product_id, $data );
+		$product = $this->save_product_shipping_data( $product, $data );
 
 		// SKU
 		if ( isset( $data['sku'] ) ) {
-			$sku     = get_post_meta( $product_id, '_sku', true );
+			$sku     = $product->get_sku();
 			$new_sku = wc_clean( $data['sku'] );
 
 			if ( '' == $new_sku ) {
-				update_post_meta( $product_id, '_sku', '' );
+				$product->set_sku( '' );
 			} elseif ( $new_sku !== $sku ) {
 				if ( ! empty( $new_sku ) ) {
-					$unique_sku = wc_product_has_unique_sku( $product_id, $new_sku );
+					$unique_sku = wc_product_has_unique_sku( $product->get_id(), $new_sku );
 					if ( ! $unique_sku ) {
 						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product', 'woocommerce' ), 400 );
 					} else {
-						update_post_meta( $product_id, '_sku', $new_sku );
+						$product->set_sku( $new_sku );
 					}
 				} else {
-					update_post_meta( $product_id, '_sku', '' );
+					$product->set_sku( '' );
 				}
 			}
 		}
@@ -913,6 +901,8 @@ class WC_API_Products extends WC_API_Resource {
 
 				if ( $is_taxonomy ) {
 
+					$attribute_id = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
+
 					if ( isset( $attribute['options'] ) ) {
 						$options = $attribute['options'];
 
@@ -929,56 +919,55 @@ class WC_API_Products extends WC_API_Resource {
 
 					// Update post terms
 					if ( taxonomy_exists( $taxonomy ) ) {
-						wp_set_object_terms( $product_id, $values, $taxonomy );
+						wp_set_object_terms( $product->get_id(), $values, $taxonomy );
 					}
 
 					if ( ! empty( $values ) ) {
-						// Add attribute to array, but don't set values
-						$attributes[ $taxonomy ] = array(
-							'name'         => $taxonomy,
-							'value'        => '',
-							'position'     => isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0',
-							'is_visible'   => ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0,
-							'is_variation' => ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0,
-							'is_taxonomy'  => $is_taxonomy,
-						);
+						// Add attribute to array, but don't set values.
+						$attribute_object = new WC_Product_Attribute();
+						$attribute_object->set_id( $attribute_id );
+						$attribute_object->set_name( $taxonomy );
+						$attribute_object->set_options( $values );
+						$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+						$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
+						$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
+						$attributes[] = $attribute_object;
 					}
 				} elseif ( isset( $attribute['options'] ) ) {
 					// Array based
 					if ( is_array( $attribute['options'] ) ) {
-						$values = wc_implode_text_attributes( array_map( 'wc_clean', $attribute['options'] ) );
+						$values = $attribute['options'];
 
 					// Text based, separate by pipe
 					} else {
-						$values = wc_implode_text_attributes( array_map( 'wc_clean', explode( WC_DELIMITER, $attribute['options'] ) ) );
+						$values = array_map( 'wc_clean', explode( WC_DELIMITER, $attribute['options'] ) );
 					}
 
-					// Custom attribute - Add attribute to array and set the values
-					$attributes[ $attribute_slug ] = array(
-						'name'         => wc_clean( $attribute['name'] ),
-						'value'        => $values,
-						'position'     => isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0',
-						'is_visible'   => ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0,
-						'is_variation' => ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0,
-						'is_taxonomy'  => $is_taxonomy,
-					);
+					// Custom attribute - Add attribute to array and set the values.
+					$attribute_object = new WC_Product_Attribute();
+					$attribute_object->set_name( $attribute['name'] );
+					$attribute_object->set_options( $values );
+					$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+					$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
+					$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
+					$attributes[] = $attribute_object;
 				}
 			}
 
 			uasort( $attributes, 'wc_product_attribute_uasort_comparison' );
 
-			update_post_meta( $product_id, '_product_attributes', $attributes );
+			$product->set_attributes( $attributes );
 		}
 
 		// Sales and prices
-		if ( in_array( $product_type, array( 'variable', 'grouped' ) ) ) {
+		if ( in_array( $product->get_type(), array( 'variable', 'grouped' ) ) ) {
 
-			// Variable and grouped products have no prices
-			update_post_meta( $product_id, '_regular_price', '' );
-			update_post_meta( $product_id, '_sale_price', '' );
-			update_post_meta( $product_id, '_sale_price_dates_from', '' );
-			update_post_meta( $product_id, '_sale_price_dates_to', '' );
-			update_post_meta( $product_id, '_price', '' );
+			// Variable and grouped products have no prices.
+			$product->set_regular_price( '' );
+			$product->set_sale_price( '' );
+			$product->set_date_on_sale_to( '' );
+			$product->set_date_on_sale_from( '' );
+			$product->set_price( '' );
 
 		} else {
 
@@ -986,86 +975,70 @@ class WC_API_Products extends WC_API_Resource {
 			if ( isset( $data['regular_price'] ) ) {
 				$regular_price = ( '' === $data['regular_price'] ) ? '' : $data['regular_price'];
 			} else {
-				$regular_price = get_post_meta( $product_id, '_regular_price', true );
+				$regular_price = $product->get_regular_price();
 			}
 
 			// Sale Price
 			if ( isset( $data['sale_price'] ) ) {
 				$sale_price = ( '' === $data['sale_price'] ) ? '' : $data['sale_price'];
 			} else {
-				$sale_price = get_post_meta( $product_id, '_sale_price', true );
+				$sale_price = $product->get_sale_price();
 			}
+
+			$product->set_regular_price( $regular_price );
+			$product->set_sale_price( $sale_price );
 
 			if ( isset( $data['sale_price_dates_from'] ) ) {
 				$date_from = $data['sale_price_dates_from'];
 			} else {
-				$date_from = get_post_meta( $product_id, '_sale_price_dates_from', true );
-				$date_from = ( '' === $date_from ) ? '' : date( 'Y-m-d', $date_from );
+				$date_from = ( $product->get_date_on_sale_from() ) ? date( 'Y-m-d', $date_from ) : '';
 			}
 
 			if ( isset( $data['sale_price_dates_to'] ) ) {
 				$date_to = $data['sale_price_dates_to'];
 			} else {
-				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', true );
-				$date_to = ( '' === $date_to ) ? '' : date( 'Y-m-d', $date_to );
+				$date_to = ( $product->get_date_on_sale_to() ) ? date( 'Y-m-d', $date_to ) : '';
 			}
 
-			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
+			if ( $date_to && ! $date_from ) {
+				$date_from = strtotime( 'NOW', current_time( 'timestamp' ) );
+			}
+
+			$product->set_date_on_sale_to( $date_to );
+			$product->set_date_on_sale_from( $date_from );
+			if ( $product->is_on_sale() ) {
+				$product->set_price( $product->get_sale_price() );
+			} else {
+				$product->set_price( $product->get_regular_price() );
+			}
 
 		}
 
 		// Product parent ID for groups
 		if ( isset( $data['parent_id'] ) ) {
-			wp_update_post( array( 'ID' => $product_id, 'post_parent' => absint( $data['parent_id'] ) ) );
+			$product->set_parent_id( absint( $data['parent_id'] ) );
 		}
 
 		// Update parent if grouped so price sorting works and stays in sync with the cheapest child
-		$_product = wc_get_product( $product_id );
-		if ( $_product->post->post_parent > 0 || 'grouped' === $product_type ) {
-
-			$clear_parent_ids = array();
-
-			if ( $_product->post->post_parent > 0 ) {
-				$clear_parent_ids[] = $_product->post->post_parent;
-			}
-
-			if ( 'grouped' === $product_type ) {
-				$clear_parent_ids[] = $product_id;
-			}
-
-			if ( ! empty( $clear_parent_ids ) ) {
-				foreach ( $clear_parent_ids as $clear_id ) {
-
-					$children_by_price = get_posts( array(
-						'post_parent'    => $clear_id,
-						'orderby'        => 'meta_value_num',
-						'order'          => 'asc',
-						'meta_key'       => '_price',
-						'posts_per_page' => 1,
-						'post_type'      => 'product',
-						'fields'         => 'ids',
-					) );
-
-					if ( $children_by_price ) {
-						foreach ( $children_by_price as $child ) {
-							$child_price = get_post_meta( $child, '_price', true );
-							update_post_meta( $clear_id, '_price', $child_price );
-						}
-					}
-				}
+		if ( $product->get_parent_id() > 0 || 'grouped' === $product->get_type() ) {
+			if ( $product->get_parent_id() > 0 ) {
+				$parent = wc_get_product( $product->get_parent_id() );
+				$children = $parent->get_children();
+				$parent->set_children( array_filter( array_merge( $children, array( $product->get_id() ) ) ) );
+				$parent->save();
 			}
 		}
 
 		// Sold Individually
 		if ( isset( $data['sold_individually'] ) ) {
-			update_post_meta( $product_id, '_sold_individually', ( true === $data['sold_individually'] ) ? 'yes' : '' );
+			$product->set_sold_individually( true === $data['sold_individually'] ? 'yes' : '' );
 		}
 
 		// Stock status
 		if ( isset( $data['in_stock'] ) ) {
 			$stock_status = ( true === $data['in_stock'] ) ? 'instock' : 'outofstock';
 		} else {
-			$stock_status = get_post_meta( $product_id, '_stock_status', true );
+			$stock_status = $product->get_stock_status();
 
 			if ( '' === $stock_status ) {
 				$stock_status = 'instock';
@@ -1077,9 +1050,9 @@ class WC_API_Products extends WC_API_Resource {
 			// Manage stock
 			if ( isset( $data['managing_stock'] ) ) {
 				$managing_stock = ( true === $data['managing_stock'] ) ? 'yes' : 'no';
-				update_post_meta( $product_id, '_manage_stock', $managing_stock );
+				$product->set_manage_stock( $managing_stock );
 			} else {
-				$managing_stock = get_post_meta( $product_id, '_manage_stock', true );
+				$managing_stock = $product->get_manage_stock() ? 'yes' : 'no';
 			}
 
 			// Backorders
@@ -1090,49 +1063,42 @@ class WC_API_Products extends WC_API_Resource {
 					$backorders = ( true === $data['backorders'] ) ? 'yes' : 'no';
 				}
 
-				update_post_meta( $product_id, '_backorders', $backorders );
+				$product->set_backorders( $backorders );
 			} else {
-				$backorders = get_post_meta( $product_id, '_backorders', true );
+				$backorders = $product->get_backorders();
 			}
 
-			if ( 'grouped' == $product_type ) {
-
-				update_post_meta( $product_id, '_manage_stock', 'no' );
-				update_post_meta( $product_id, '_backorders', 'no' );
-				update_post_meta( $product_id, '_stock', '' );
-
-				wc_update_product_stock_status( $product_id, $stock_status );
-
-			} elseif ( 'external' == $product_type ) {
-
-				update_post_meta( $product_id, '_manage_stock', 'no' );
-				update_post_meta( $product_id, '_backorders', 'no' );
-				update_post_meta( $product_id, '_stock', '' );
-
-				wc_update_product_stock_status( $product_id, 'instock' );
+			if ( 'grouped' == $product->get_type() ) {
+				$product->set_manage_stock( 'no' );
+				$product->set_backorders( 'no' );
+				$product->set_stock( '' );
+				$product->set_stock_status( $stock_status );
+			} elseif ( 'external' == $product->get_type() ) {
+				$product->set_manage_stock( 'no' );
+				$product->set_backorders( 'no' );
+				$product->set_stock( '' );
+				$product->set_stock_status( 'instock' );
 			} elseif ( 'yes' == $managing_stock ) {
-				update_post_meta( $product_id, '_backorders', $backorders );
+				$product->set_backorders( $backorders );
 
 				// Stock status is always determined by children so sync later.
-				if ( 'variable' !== $product_type ) {
-					wc_update_product_stock_status( $product_id, $stock_status );
+				if ( 'variable' !== $product->get_type() ) {
+					$product->set_stock_status( $stock_status );
 				}
 
 				// Stock quantity
 				if ( isset( $data['stock_quantity'] ) ) {
-					wc_update_product_stock( $product_id, intval( $data['stock_quantity'] ) );
+					$product->set_stock( wc_stock_amount( $data['stock_quantity'] ) );
 				}
 			} else {
-
-				// Don't manage stock
-				update_post_meta( $product_id, '_manage_stock', 'no' );
-				update_post_meta( $product_id, '_backorders', $backorders );
-				update_post_meta( $product_id, '_stock', '' );
-
-				wc_update_product_stock_status( $product_id, $stock_status );
+				// Don't manage stock.
+				$product->set_manage_stock( 'no' );
+				$product->set_backorders( $backorders );
+				$product->set_stock( '' );
+				$product->set_stock_status( $stock_status );
 			}
-		} elseif ( 'variable' !== $product_type ) {
-			wc_update_product_stock_status( $product_id, $stock_status );
+		} elseif ( 'variable' !== $product->get_type() ) {
+			$product->set_stock_status( $stock_status );
 		}
 
 		// Upsells
@@ -1147,9 +1113,9 @@ class WC_API_Products extends WC_API_Resource {
 					}
 				}
 
-				update_post_meta( $product_id, '_upsell_ids', $upsells );
+				$product->set_upsell_ids( $upsells );
 			} else {
-				delete_post_meta( $product_id, '_upsell_ids' );
+				$product->set_upsell_ids( array() );
 			}
 		}
 
@@ -1165,30 +1131,30 @@ class WC_API_Products extends WC_API_Resource {
 					}
 				}
 
-				update_post_meta( $product_id, '_crosssell_ids', $crosssells );
+				$product->set_cross_sell_ids( $crosssells );
 			} else {
-				delete_post_meta( $product_id, '_crosssell_ids' );
+				$product->set_cross_sell_ids( array() );
 			}
 		}
 
 		// Product categories
 		if ( isset( $data['categories'] ) && is_array( $data['categories'] ) ) {
 			$term_ids = array_unique( array_map( 'intval', $data['categories'] ) );
-			wp_set_object_terms( $product_id, $term_ids, 'product_cat' );
+			$product->set_category_ids( $term_ids );
 		}
 
 		// Product tags
 		if ( isset( $data['tags'] ) && is_array( $data['tags'] ) ) {
 			$term_ids = array_unique( array_map( 'intval', $data['tags'] ) );
-			wp_set_object_terms( $product_id, $term_ids, 'product_tag' );
+			$product->set_tag_ids( $term_ids );
 		}
 
 		// Downloadable
 		if ( isset( $data['downloadable'] ) ) {
 			$is_downloadable = ( true === $data['downloadable'] ) ? 'yes' : 'no';
-			update_post_meta( $product_id, '_downloadable', $is_downloadable );
+			$product->set_downloadable( $is_downloadable );
 		} else {
-			$is_downloadable = get_post_meta( $product_id, '_downloadable', true );
+			$is_downloadable = $product->get_downloadable() ? 'yes' : 'no';
 		}
 
 		// Downloadable options
@@ -1196,61 +1162,56 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Downloadable files
 			if ( isset( $data['downloads'] ) && is_array( $data['downloads'] ) ) {
-				$this->save_downloadable_files( $product_id, $data['downloads'] );
+				$product = $this->save_downloadable_files( $product, $data['downloads'] );
 			}
 
 			// Download limit
 			if ( isset( $data['download_limit'] ) ) {
-				update_post_meta( $product_id, '_download_limit', ( '' === $data['download_limit'] ) ? '' : absint( $data['download_limit'] ) );
+				$product->set_download_limit( $data['download_limit'] );
 			}
 
 			// Download expiry
 			if ( isset( $data['download_expiry'] ) ) {
-				update_post_meta( $product_id, '_download_expiry', ( '' === $data['download_expiry'] ) ? '' : absint( $data['download_expiry'] ) );
-			}
-
-			// Download type
-			if ( isset( $data['download_type'] ) ) {
-				update_post_meta( $product_id, '_download_type', wc_clean( $data['download_type'] ) );
+				$product->set_download_expiry( $data['download_expiry'] );
 			}
 		}
 
 		// Product url
-		if ( 'external' === $product_type ) {
+		if ( 'external' === $product->get_type() ) {
 			if ( isset( $data['product_url'] ) ) {
-				update_post_meta( $product_id, '_product_url', wc_clean( $data['product_url'] ) );
+				$product->set_product_url( $data['product_url'] );
 			}
 
 			if ( isset( $data['button_text'] ) ) {
-				update_post_meta( $product_id, '_button_text', wc_clean( $data['button_text'] ) );
+				$product->set_button_text( $data['button_text'] );
 			}
 		}
 
 		// Reviews allowed
 		if ( isset( $data['reviews_allowed'] ) ) {
-			$reviews_allowed = ( true === $data['reviews_allowed'] ) ? 'open' : 'closed';
-
-			$wpdb->update( $wpdb->posts, array( 'comment_status' => $reviews_allowed ), array( 'ID' => $product_id ) );
+			$product->set_reviews_allowed( $data['reviews_allowed'] );
 		}
 
 		// Do action for product type
-		do_action( 'woocommerce_api_process_product_meta_' . $product_type, $product_id, $data );
+		do_action( 'woocommerce_api_process_product_meta_' . $product->get_type(), $product->get_id(), $data );
 
-		return true;
+		return $product;
 	}
 
 	/**
 	 * Save variations
+	 * @todo after variations CRUD is done
 	 *
 	 * @since  2.2
-	 * @param  int $id
+	 * @param  WC_Product $product
 	 * @param  array $data
-	 * @return bool
+	 * @return WC_Product
 	 * @throws WC_API_Exception
 	 */
-	protected function save_variations( $id, $data ) {
+	protected function save_variations( $product, $data ) {
 		global $wpdb;
 
+		$id         = $product->get_id();
 		$variations = $data['variations'];
 		$attributes = (array) maybe_unserialize( get_post_meta( $id, '_product_attributes', true ) );
 
@@ -1554,29 +1515,30 @@ class WC_API_Products extends WC_API_Resource {
 	 * Save product shipping data
 	 *
 	 * @since 2.2
-	 * @param int $id
+	 * @param WC_Product $product
 	 * @param array $data
+	 * @return WC_Product
 	 */
-	private function save_product_shipping_data( $id, $data ) {
+	private function save_product_shipping_data( $product, $data ) {
 		if ( isset( $data['weight'] ) ) {
-			update_post_meta( $id, '_weight', ( '' === $data['weight'] ) ? '' : wc_format_decimal( $data['weight'] ) );
+			$product->set_weight( '' === $data['weight'] ? '' : wc_format_decimal( $data['weight'] ) );
 		}
 
 		// Product dimensions
 		if ( isset( $data['dimensions'] ) ) {
 			// Height
 			if ( isset( $data['dimensions']['height'] ) ) {
-				update_post_meta( $id, '_height', ( '' === $data['dimensions']['height'] ) ? '' : wc_format_decimal( $data['dimensions']['height'] ) );
+				$product->set_height( '' === $data['dimensions']['height'] ? '' : wc_format_decimal( $data['dimensions']['height'] ) );
 			}
 
 			// Width
 			if ( isset( $data['dimensions']['width'] ) ) {
-				update_post_meta( $id, '_width', ( '' === $data['dimensions']['width'] ) ? '' : wc_format_decimal( $data['dimensions']['width'] ) );
+				$product->set_width( '' === $data['dimensions']['width'] ? '' : wc_format_decimal( $data['dimensions']['width'] ) );
 			}
 
 			// Length
 			if ( isset( $data['dimensions']['length'] ) ) {
-				update_post_meta( $id, '_length', ( '' === $data['dimensions']['length'] ) ? '' : wc_format_decimal( $data['dimensions']['length'] ) );
+				$product->set_length( '' === $data['dimensions']['length'] ? '' : wc_format_decimal( $data['dimensions']['length'] ) );
 			}
 		}
 
@@ -1585,28 +1547,34 @@ class WC_API_Products extends WC_API_Resource {
 			$virtual = ( true === $data['virtual'] ) ? 'yes' : 'no';
 
 			if ( 'yes' == $virtual ) {
-				update_post_meta( $id, '_weight', '' );
-				update_post_meta( $id, '_length', '' );
-				update_post_meta( $id, '_width', '' );
-				update_post_meta( $id, '_height', '' );
+				$product->set_weight( '' );
+				$product->set_height( '' );
+				$product->set_length( '' );
+				$product->set_width( '' );
 			}
 		}
 
 		// Shipping class
 		if ( isset( $data['shipping_class'] ) ) {
-			wp_set_object_terms( $id, wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
+			$shipping_class_term = get_term_by( 'slug', wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
+			if ( $shipping_class_term ) {
+				$product->set_shipping_class_id( $shipping_class_term->term_id );
+			}
 		}
+
+		return $product;
 	}
 
 	/**
 	 * Save downloadable files
 	 *
 	 * @since 2.2
-	 * @param int $product_id
+	 * @param WC_Product $product
 	 * @param array $downloads
 	 * @param int $variation_id
+	 * @return WC_Product
 	 */
-	private function save_downloadable_files( $product_id, $downloads, $variation_id = 0 ) {
+	private function save_downloadable_files( $product, $downloads, $variation_id = 0 ) {
 		$files = array();
 
 		// File paths will be stored in an array keyed off md5(file path)
@@ -1634,10 +1602,11 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Grant permission to any newly added files on any existing orders for this product prior to saving
-		do_action( 'woocommerce_process_product_file_download_paths', $product_id, $variation_id, $files );
+		do_action( 'woocommerce_process_product_file_download_paths', $product->get_id(), $variation_id, $files );
 
-		$id = ( 0 === $variation_id ) ? $product_id : $variation_id;
-		update_post_meta( $id, '_downloadable_files', $files );
+		$product->set_downloads( $files );
+
+		return $product;
 	}
 
 	/**
@@ -1680,16 +1649,15 @@ class WC_API_Products extends WC_API_Resource {
 				// Add variation image if set
 				$attachment_ids[] = get_post_thumbnail_id( $product->get_variation_id() );
 
-			} elseif ( has_post_thumbnail( $product->get_id() ) ) {
-
+			} elseif ( ! empty( $product->get_thumbnail_id() ) ) {
 				// Otherwise use the parent product featured image if set
-				$attachment_ids[] = get_post_thumbnail_id( $product->get_id() );
+				$attachment_ids[] = $product->get_thumbnail_id();
 			}
 		} else {
 
 			// Add featured image
-			if ( has_post_thumbnail( $product->get_id() ) ) {
-				$attachment_ids[] = get_post_thumbnail_id( $product->get_id() );
+			if ( ! empty( $product->get_thumbnail_id() ) ) {
+				$attachment_ids[] = $product->get_thumbnail_id();
 			}
 
 			// Add gallery images
@@ -1743,11 +1711,11 @@ class WC_API_Products extends WC_API_Resource {
 	 * Save product images
 	 *
 	 * @since  2.2
+	 * @param WC_Product $product
 	 * @param  array $images
-	 * @param  int $id
 	 * @throws WC_API_Exception
 	 */
-	protected function save_product_images( $id, $images ) {
+	protected function save_product_images( $product, $images ) {
 		if ( is_array( $images ) ) {
 			$gallery = array();
 
@@ -1762,10 +1730,10 @@ class WC_API_Products extends WC_API_Resource {
 							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );
 						}
 
-						$attachment_id = $this->set_product_image_as_attachment( $upload, $id );
+						$attachment_id = $this->set_product_image_as_attachment( $upload, $product->get_id() );
 					}
 
-					set_post_thumbnail( $id, $attachment_id );
+					$product->set_thumbnail_id( $attachment_id );
 				} else {
 					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
@@ -1784,12 +1752,14 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			if ( ! empty( $gallery ) ) {
-				update_post_meta( $id, '_product_image_gallery', implode( ',', $gallery ) );
+				$product->set_gallery_attachment_ids( $gallery );
 			}
 		} else {
-			delete_post_thumbnail( $id );
-			update_post_meta( $id, '_product_image_gallery', '' );
+			$product->set_thumbnail_id( '' );
+			$product->set_gallery_attachment_ids( array() );
 		}
+
+		return $product;
 	}
 
 	/**
@@ -2372,7 +2342,8 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Delete product
-		wp_delete_post( $product_id, true );
+		$product = wc_get_product( $product_id );
+		$product->delete();
 	}
 
 	/**

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -268,7 +268,7 @@ class WC_API_Products extends WC_API_Resource {
 			$id = $product->get_id();
 
 			// Checks for an error in the product creation
-			if ( ! $id > 0 ) {
+			if ( 0 >= $id ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_create_product', $id->get_error_message(), 400 );
 			}
 
@@ -679,12 +679,11 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	private function get_product_data( $product ) {
 		$prices_precision = wc_get_price_decimals();
-		$post             = get_post( $product->get_id() );
 		return array(
-			'title'              => $product->get_title(),
-			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $post->post_date_gmt ),
-			'updated_at'         => $this->server->format_datetime( $post->post_modified_gmt ),
+			'title'              => $product->get_name(),
+			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(), // @todo variation
+			'created_at'         => $this->server->format_datetime( $product->get_date_created() ),
+			'updated_at'         => $this->server->format_datetime( $product->get_date_modified() ),
 			'type'               => $product->get_type(),
 			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
@@ -699,7 +698,7 @@ class WC_API_Products extends WC_API_Resource {
 			'tax_status'         => $product->get_tax_status(),
 			'tax_class'          => $product->get_tax_class(),
 			'managing_stock'     => $product->managing_stock(),
-			'stock_quantity'     => (int) $product->get_stock_quantity(),
+			'stock_quantity'     => $product->get_stock_quantity(),
 			'in_stock'           => $product->is_in_stock(),
 			'backorders_allowed' => $product->backorders_allowed(),
 			'backordered'        => $product->is_on_backorder(),
@@ -726,7 +725,7 @@ class WC_API_Products extends WC_API_Resource {
 			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_short_description() ),
 			'reviews_allowed'    => $product->get_reviews_allowed(),
 			'average_rating'     => wc_format_decimal( $product->get_average_rating(), 2 ),
-			'rating_count'       => (int) $product->get_rating_count(),
+			'rating_count'       => $product->get_rating_count(),
 			'related_ids'        => array_map( 'absint', array_values( wc_get_related_products( $product->get_id() ) ) ),
 			'upsell_ids'         => array_map( 'absint', $product->get_upsell_ids() ),
 			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sell_ids() ),
@@ -734,11 +733,11 @@ class WC_API_Products extends WC_API_Resource {
 			'categories'         => wp_get_post_terms( $product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),
 			'tags'               => wp_get_post_terms( $product->get_id(), 'product_tag', array( 'fields' => 'names' ) ),
 			'images'             => $this->get_images( $product ),
-			'featured_src'       => (string) wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->get_id() ) ),
+			'featured_src'       => wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->get_id() ) ),
 			'attributes'         => $this->get_attributes( $product ),
 			'downloads'          => $this->get_downloads( $product ),
-			'download_limit'     => (int) $product->get_download_limit(),
-			'download_expiry'    => (int) $product->get_download_expiry(),
+			'download_limit'     => $product->get_download_limit(),
+			'download_expiry'    => $product->get_download_expiry(),
 			'download_type'      => 'standard',
 			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ),
 			'total_sales'        => $product->get_total_sales(),
@@ -928,7 +927,7 @@ class WC_API_Products extends WC_API_Resource {
 						$attribute_object->set_id( $attribute_id );
 						$attribute_object->set_name( $taxonomy );
 						$attribute_object->set_options( $values );
-						$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+						$attribute_object->set_position( isset( $attribute['position'] ) ? absint( $attribute['position'] ) : 0 );
 						$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
 						$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
 						$attributes[] = $attribute_object;
@@ -947,7 +946,7 @@ class WC_API_Products extends WC_API_Resource {
 					$attribute_object = new WC_Product_Attribute();
 					$attribute_object->set_name( $attribute['name'] );
 					$attribute_object->set_options( $values );
-					$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+					$attribute_object->set_position( isset( $attribute['position'] ) ? absint( $attribute['position'] ) : 0 );
 					$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
 					$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
 					$attributes[] = $attribute_object;
@@ -1020,7 +1019,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Update parent if grouped so price sorting works and stays in sync with the cheapest child
-		if ( $product->get_parent_id() > 0 || 'grouped' === $product->get_type() ) {
+		if ( $product->get_parent_id() > 0 || $product->is_type( 'grouped' ) ) {
 			if ( $product->get_parent_id() > 0 ) {
 				$parent = wc_get_product( $product->get_parent_id() );
 				$children = $parent->get_children();
@@ -1068,36 +1067,36 @@ class WC_API_Products extends WC_API_Resource {
 				$backorders = $product->get_backorders();
 			}
 
-			if ( 'grouped' == $product->get_type() ) {
+			if ( $product->is_type( 'grouped' ) ) {
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( 'no' );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( $stock_status );
-			} elseif ( 'external' == $product->get_type() ) {
+			} elseif ( $product->is_type( 'external' ) ) {
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( 'no' );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( 'instock' );
 			} elseif ( 'yes' == $managing_stock ) {
 				$product->set_backorders( $backorders );
 
 				// Stock status is always determined by children so sync later.
-				if ( 'variable' !== $product->get_type() ) {
+				if ( ! $product->is_type( 'variable' ) ) {
 					$product->set_stock_status( $stock_status );
 				}
 
 				// Stock quantity
 				if ( isset( $data['stock_quantity'] ) ) {
-					$product->set_stock( wc_stock_amount( $data['stock_quantity'] ) );
+					$product->set_stock_quantity( wc_stock_amount( $data['stock_quantity'] ) );
 				}
 			} else {
 				// Don't manage stock.
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( $backorders );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( $stock_status );
 			}
-		} elseif ( 'variable' !== $product->get_type() ) {
+		} elseif ( ! $product->is_type( 'variable' ) ) {
 			$product->set_stock_status( $stock_status );
 		}
 
@@ -1177,7 +1176,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Product url
-		if ( 'external' === $product->get_type() ) {
+		if ( $product->is_type( 'external' ) ) {
 			if ( isset( $data['product_url'] ) ) {
 				$product->set_product_url( $data['product_url'] );
 			}
@@ -1639,25 +1638,25 @@ class WC_API_Products extends WC_API_Resource {
 	 * @return array
 	 */
 	private function get_images( $product ) {
-
-		$images = $attachment_ids = array();
+		$images        = $attachment_ids = array();
+		$product_image = $product->get_image_id();
 
 		if ( $product->is_type( 'variation' ) ) {
-
+			// @todo variation
 			if ( has_post_thumbnail( $product->get_variation_id() ) ) {
 
 				// Add variation image if set
 				$attachment_ids[] = get_post_thumbnail_id( $product->get_variation_id() );
 
-			} elseif ( ! empty( $product->get_thumbnail_id() ) ) {
+			} elseif ( ! empty( $product_image ) ) {
 				// Otherwise use the parent product featured image if set
-				$attachment_ids[] = $product->get_thumbnail_id();
+				$attachment_ids[] = $product_image;
 			}
 		} else {
 
 			// Add featured image
-			if ( ! empty( $product->get_thumbnail_id() ) ) {
-				$attachment_ids[] = $product->get_thumbnail_id();
+			if ( ! empty( $product_image ) ) {
+				$attachment_ids[] = $product_image;
 			}
 
 			// Add gallery images
@@ -1733,7 +1732,7 @@ class WC_API_Products extends WC_API_Resource {
 						$attachment_id = $this->set_product_image_as_attachment( $upload, $product->get_id() );
 					}
 
-					$product->set_thumbnail_id( $attachment_id );
+					$product->set_image_id( $attachment_id );
 				} else {
 					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
@@ -1752,11 +1751,11 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			if ( ! empty( $gallery ) ) {
-				$product->set_gallery_attachment_ids( $gallery );
+				$product->set_gallery_image_ids( $gallery );
 			}
 		} else {
-			$product->set_thumbnail_id( '' );
-			$product->set_gallery_attachment_ids( array() );
+			$product->set_image_id( '' );
+			$product->set_gallery_image_ids( array() );
 		}
 
 		return $product;

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -8,6 +8,7 @@
  * @category    API
  * @package     WooCommerce/API
  * @since       2.1
+ * @version     2.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -197,8 +198,8 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// add the parent product data to an individual variation
-		if ( $product->is_type( 'variation' ) && $product->parent ) {
-			$product_data['parent'] = $this->get_product_data( $product->parent );
+		if ( $product->is_type( 'variation' ) && $product->get_parent_id() ) {
+			$product_data['parent'] = $this->get_product_data( $product->get_parent_id() );
 		}
 
 		// Add grouped products data
@@ -206,8 +207,8 @@ class WC_API_Products extends WC_API_Resource {
 			$product_data['grouped_products'] = $this->get_grouped_products_data( $product );
 		}
 
-		if ( $product->is_type( 'simple' ) && ! empty( $product->post->post_parent ) ) {
-			$_product = wc_get_product( $product->post->post_parent );
+		if ( $product->is_type( 'simple' ) && ! empty( $product->get_parent_id() ) ) {
+			$_product = wc_get_product( $product->get_parent_id() );
 			$product_data['parent'] = $this->get_product_data( $_product );
 		}
 
@@ -297,39 +298,43 @@ class WC_API_Products extends WC_API_Resource {
 				$post_excerpt = $data['short_description'];
 			}
 
-			$new_product = array(
-				'post_title'   => wc_clean( $data['title'] ),
-				'post_status'  => isset( $data['status'] ) ? wc_clean( $data['status'] ) : 'publish',
-				'post_type'    => 'product',
-				'post_excerpt' => isset( $data['short_description'] ) ? $post_excerpt : '',
-				'post_content' => isset( $data['description'] ) ? $post_content : '',
-				'post_author'  => get_current_user_id(),
-				'menu_order'   => isset( $data['menu_order'] ) ? intval( $data['menu_order'] ) : 0,
-			);
+			$classname = WC_Product_Factory::get_classname_from_product_type( $data['type'] );
+			if ( ! class_exists( $classname ) ) {
+				$classname = 'WC_Product_Simple';
+			}
+			$product = new $classname();
+
+			$product->set_name( wc_clean( $data['title'] ) );
+			$product->set_status( isset( $data['status'] ) ? wc_clean( $data['status'] ) : 'publish' );
+			$product->set_short_description( isset( $data['short_description'] ) ? $post_excerpt : '' );
+			$product->set_description( isset( $data['description'] ) ? $post_content : '' );
+			$product->set_menu_order( isset( $data['menu_order'] ) ? intval( $data['menu_order'] ) : 0 );
 
 			if ( ! empty( $data['name'] ) ) {
-				$new_product = array_merge( $new_product, array( 'post_name' => sanitize_title( $data['name'] ) ) );
+				$product->set_slug( sanitize_title( $data['name'] ) );
 			}
 
 			// Attempts to create the new product.
-			$id = wp_insert_post( $new_product, true );
+			$product->create();
+			$id = $product->get_id();
 
 			// Checks for an error in the product creation.
-			if ( is_wp_error( $id ) ) {
+			if ( ! $id > 0 ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_create_product', $id->get_error_message(), 400 );
 			}
 
 			// Check for featured/gallery images, upload it and set it.
 			if ( isset( $data['images'] ) ) {
-				$this->save_product_images( $id, $data['images'] );
+				$product = $this->save_product_images( $product, $data['images'] );
 			}
 
 			// Save product meta fields.
-			$this->save_product_meta( $id, $data );
+			$product = $this->save_product_meta( $product, $data );
+			$product->save();
 
 			// Save variations.
 			if ( isset( $data['type'] ) && 'variable' == $data['type'] && isset( $data['variations'] ) && is_array( $data['variations'] ) ) {
-				$this->save_variations( $id, $data );
+				$this->save_variations( $product, $data );
 			}
 
 			do_action( 'woocommerce_api_create_product', $id, $data );
@@ -370,62 +375,64 @@ class WC_API_Products extends WC_API_Resource {
 				return $id;
 			}
 
+			$product = wc_get_product( $id );
+
 			$data = apply_filters( 'woocommerce_api_edit_product_data', $data, $this );
 
 			// Product title.
 			if ( isset( $data['title'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'post_title' => wc_clean( $data['title'] ) ) );
+				$product->set_name( wc_clean( $data['title'] ) );
 			}
 
 			// Product name (slug).
 			if ( isset( $data['name'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'post_name' => sanitize_title( $data['name'] ) ) );
+				$product->set_slug( wc_clean( $data['name'] ) );
 			}
 
 			// Product status.
 			if ( isset( $data['status'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'post_status' => wc_clean( $data['status'] ) ) );
+				$product->set_status( wc_clean( $data['status'] ) );
 			}
 
 			// Product short description.
 			if ( isset( $data['short_description'] ) ) {
 				// Enable short description html tags.
 				$post_excerpt = ( isset( $data['enable_html_short_description'] ) && true === $data['enable_html_short_description'] ) ? $data['short_description'] : wc_clean( $data['short_description'] );
-
-				wp_update_post( array( 'ID' => $id, 'post_excerpt' => $post_excerpt ) );
+				$product->set_short_description( $post_excerpt );
 			}
 
 			// Product description.
 			if ( isset( $data['description'] ) ) {
 				// Enable description html tags.
 				$post_content = ( isset( $data['enable_html_description'] ) && true === $data['enable_html_description'] ) ? $data['description'] : wc_clean( $data['description'] );
-
-				wp_update_post( array( 'ID' => $id, 'post_content' => $post_content ) );
+				$product->set_description( $post_content );
 			}
 
-			// Menu order.
-			if ( isset( $data['menu_order'] ) ) {
-				wp_update_post( array( 'ID' => $id, 'menu_order' => intval( $data['menu_order'] ) ) );
-			}
-
-			// Validate the product type.
+			// Validate the product type
 			if ( isset( $data['type'] ) && ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
 				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
 			}
 
+			// Menu order.
+			if ( isset( $data['menu_order'] ) ) {
+				$product->set_menu_order( intval( $data['menu_order'] ) );
+			}
+
 			// Check for featured/gallery images, upload it and set it.
 			if ( isset( $data['images'] ) ) {
-				$this->save_product_images( $id, $data['images'] );
+				$product = $this->save_product_images( $product, $data['images'] );
 			}
 
 			// Save product meta fields.
-			$this->save_product_meta( $id, $data );
+			$product = $this->save_product_meta( $product, $data );
+
+			$product->save();
 
 			// Save variations.
 			$product = get_product( $id );
 			if ( $product->is_type( 'variable' ) ) {
 				if ( isset( $data['variations'] ) && is_array( $data['variations'] ) ) {
-					$this->save_variations( $id, $data );
+					$this->save_variations( $product, $data );
 				} else {
 					// Just sync variations
 					WC_Product_Variable::sync( $id );
@@ -460,30 +467,27 @@ class WC_API_Products extends WC_API_Resource {
 			return $id;
 		}
 
+		$product = wc_get_product( $id );
+
 		do_action( 'woocommerce_api_delete_product', $id, $this );
 
 		// If we're forcing, then delete permanently.
 		if ( $force ) {
-			$child_product_variations = get_children( 'post_parent=' . $id . '&post_type=product_variation' );
-
-			if ( ! empty( $child_product_variations ) ) {
-				foreach ( $child_product_variations as $child ) {
-					wp_delete_post( $child->ID, true );
+			if ( $product->is_type( 'variable' ) ) {
+				foreach ( $product->get_children() as $child_id ) {
+					$child = wc_get_product( $child_id );
+					$child->delete();
+				}
+			} elseif ( $product->is_type( 'grouped' ) ) {
+				foreach ( $product->get_children() as $child_id ) {
+					$child = wc_get_product( $child_id );
+					$child->set_parent_id( 0 );
+					$child->save();
 				}
 			}
 
-			$child_products = get_children( 'post_parent=' . $id . '&post_type=product' );
-
-			if ( ! empty( $child_products ) ) {
-				foreach ( $child_products as $child ) {
-					$child_post                = array();
-					$child_post['ID']          = $child->ID;
-					$child_post['post_parent'] = 0;
-					wp_update_post( $child_post );
-				}
-			}
-
-			$result = wp_delete_post( $id, true );
+			$product->delete();
+			$result = $product->get_id() > 0 ? false : true;
 		} else {
 			$result = wp_trash_post( $id );
 		}
@@ -1117,13 +1121,14 @@ class WC_API_Products extends WC_API_Resource {
 	 * @return WC_Product
 	 */
 	private function get_product_data( $product ) {
+		$post = get_post( $product->get_id() );
 		return array(
 			'title'              => $product->get_title(),
 			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $product->get_post_data()->post_date_gmt ),
-			'updated_at'         => $this->server->format_datetime( $product->get_post_data()->post_modified_gmt ),
-			'type'               => $product->product_type,
-			'status'             => $product->get_post_data()->post_status,
+			'created_at'         => $this->server->format_datetime( $post->post_date_gmt ),
+			'updated_at'         => $this->server->format_datetime( $post->post_modified_gmt ),
+			'type'               => $product->get_type(),
+			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
 			'virtual'            => $product->is_virtual(),
 			'permalink'          => $product->get_permalink(),
@@ -1144,41 +1149,41 @@ class WC_API_Products extends WC_API_Resource {
 			'purchaseable'       => $product->is_purchasable(),
 			'featured'           => $product->is_featured(),
 			'visible'            => $product->is_visible(),
-			'catalog_visibility' => $product->visibility,
+			'catalog_visibility' => $product->get_catalog_visibility(),
 			'on_sale'            => $product->is_on_sale(),
 			'product_url'        => $product->is_type( 'external' ) ? $product->get_product_url() : '',
 			'button_text'        => $product->is_type( 'external' ) ? $product->get_button_text() : '',
 			'weight'             => $product->get_weight() ? $product->get_weight() : null,
 			'dimensions'         => array(
-				'length' => $product->length,
-				'width'  => $product->width,
-				'height' => $product->height,
+				'length' => $product->get_length(),
+				'width'  => $product->get_width(),
+				'height' => $product->get_height(),
 				'unit'   => get_option( 'woocommerce_dimension_unit' ),
 			),
 			'shipping_required'  => $product->needs_shipping(),
 			'shipping_taxable'   => $product->is_shipping_taxable(),
 			'shipping_class'     => $product->get_shipping_class(),
 			'shipping_class_id'  => ( 0 !== $product->get_shipping_class_id() ) ? $product->get_shipping_class_id() : null,
-			'description'        => wpautop( do_shortcode( $product->get_post_data()->post_content ) ),
-			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_post_data()->post_excerpt ),
+			'description'        => wpautop( do_shortcode( $product->get_description() ) ),
+			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_short_description() ),
 			'reviews_allowed'    => ( 'open' === $product->get_post_data()->comment_status ),
 			'average_rating'     => wc_format_decimal( $product->get_average_rating(), 2 ),
 			'rating_count'       => (int) $product->get_rating_count(),
-			'related_ids'        => array_map( 'absint', array_values( $product->get_related() ) ),
-			'upsell_ids'         => array_map( 'absint', $product->get_upsells() ),
-			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sells() ),
-			'parent_id'          => $product->is_type( 'variation' ) ? $product->parent->id : $product->post->post_parent,
+			'related_ids'        => array_map( 'absint', array_values( wc_get_related_products( $product->get_id() ) ) ),
+			'upsell_ids'         => array_map( 'absint', $product->get_upsell_ids() ),
+			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sell_ids() ),
+			'parent_id'          => $product->get_parent_id(),
 			'categories'         => wp_get_post_terms( $product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),
 			'tags'               => wp_get_post_terms( $product->get_id(), 'product_tag', array( 'fields' => 'names' ) ),
 			'images'             => $this->get_images( $product ),
 			'featured_src'       => (string) wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->get_id() ) ),
 			'attributes'         => $this->get_attributes( $product ),
 			'downloads'          => $this->get_downloads( $product ),
-			'download_limit'     => (int) $product->download_limit,
-			'download_expiry'    => (int) $product->download_expiry,
-			'download_type'      => $product->download_type,
-			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->purchase_note ) ) ),
-			'total_sales'        => metadata_exists( 'post', $product->get_id(), 'total_sales' ) ? (int) get_post_meta( $product->get_id(), 'total_sales', true ) : 0,
+			'download_limit'     => (int) $product->get_download_limit(),
+			'download_expiry'    => (int) $product->get_download_expiry(),
+			'download_type'      => 'standard',
+			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ),
+			'total_sales'        => $product->get_total_sales(),
 			'variations'         => array(),
 			'parent'             => array(),
 			'grouped_products'   => array(),
@@ -1194,11 +1199,11 @@ class WC_API_Products extends WC_API_Resource {
 	 * @return int
 	 */
 	private function get_product_menu_order( $product ) {
-		$menu_order = $product->post->menu_order;
+		$menu_order = $product->get_menu_order();
 
 		if ( $product->is_type( 'variation' ) ) {
-			$_product = get_post( $product->get_variation_id() );
-			$menu_order = $_product->menu_order;
+			$_product = wc_get_product( $product->get_variation_id() );
+			$menu_order = $_product->get_menu_order();
 		}
 
 		return apply_filters( 'woocommerce_api_product_menu_order', $menu_order, $product );
@@ -1206,6 +1211,7 @@ class WC_API_Products extends WC_API_Resource {
 
 	/**
 	 * Get an individual variation's data
+	 * @todo after variations CRUD is done
 	 *
 	 * @since 2.1
 	 * @param WC_Product $product
@@ -1216,7 +1222,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		foreach ( $product->get_children() as $child_id ) {
 
-			$variation = $product->get_child( $child_id );
+			$variation = wc_get_product( $child_id );
 
 			if ( ! $variation->exists() ) {
 				continue;
@@ -1258,8 +1264,8 @@ class WC_API_Products extends WC_API_Resource {
 				'image'             => $this->get_images( $variation ),
 				'attributes'        => $this->get_attributes( $variation ),
 				'downloads'         => $this->get_downloads( $variation ),
-				'download_limit'    => (int) $product->download_limit,
-				'download_expiry'   => (int) $product->download_expiry,
+				'download_limit'    => (int) $product->get_download_limit(),
+				'download_expiry'   => (int) $product->get_download_expiry(),
 			);
 		}
 
@@ -1278,7 +1284,7 @@ class WC_API_Products extends WC_API_Resource {
 		$products = array();
 
 		foreach ( $product->get_children() as $child_id ) {
-			$_product = $product->get_child( $child_id );
+			$_product = wc_get_product( $child_id );
 
 			if ( ! $_product->exists() ) {
 				continue;
@@ -1295,80 +1301,64 @@ class WC_API_Products extends WC_API_Resource {
 	 * Save product meta.
 	 *
 	 * @since  2.2
-	 * @param  int $product_id
+	 * @param  WC_Product $product
 	 * @param  array $data
-	 * @return bool
+	 * @return WC_Product
 	 * @throws WC_API_Exception
 	 */
-	protected function save_product_meta( $product_id, $data ) {
+	protected function save_product_meta( $product, $data ) {
 		global $wpdb;
-
-		// Product Type.
-		$product_type = null;
-		if ( isset( $data['type'] ) ) {
-			$product_type = wc_clean( $data['type'] );
-			wp_set_object_terms( $product_id, $product_type, 'product_type' );
-		} else {
-			$_product_type = get_the_terms( $product_id, 'product_type' );
-			if ( is_array( $_product_type ) ) {
-				$_product_type = current( $_product_type );
-				$product_type  = $_product_type->slug;
-			}
-		}
-
-		// Default total sales.
-		add_post_meta( $product_id, 'total_sales', '0', true );
 
 		// Virtual.
 		if ( isset( $data['virtual'] ) ) {
-			update_post_meta( $product_id, '_virtual', ( true === $data['virtual'] ) ? 'yes' : 'no' );
+			$product->set_virtual( $data['virtual'] );
 		}
 
 		// Tax status.
 		if ( isset( $data['tax_status'] ) ) {
-			update_post_meta( $product_id, '_tax_status', wc_clean( $data['tax_status'] ) );
+			$product->set_tax_status( wc_clean( $data['tax_status'] ) );
 		}
 
 		// Tax Class.
 		if ( isset( $data['tax_class'] ) ) {
-			update_post_meta( $product_id, '_tax_class', wc_clean( $data['tax_class'] ) );
+			$product->set_tax_class( wc_clean( $data['tax_class'] ) );
 		}
 
 		// Catalog Visibility.
 		if ( isset( $data['catalog_visibility'] ) ) {
-			update_post_meta( $product_id, '_visibility', wc_clean( $data['catalog_visibility'] ) );
+			$product->set_catalog_visibility( wc_clean( $data['catalog_visibility'] ) );
 		}
 
 		// Purchase Note.
 		if ( isset( $data['purchase_note'] ) ) {
-			update_post_meta( $product_id, '_purchase_note', wc_clean( $data['purchase_note'] ) );
+			$product->set_purchase_note( wc_clean( $data['purchase_note'] ) );
 		}
 
 		// Featured Product.
 		if ( isset( $data['featured'] ) ) {
-			update_post_meta( $product_id, '_featured', ( true === $data['featured'] ) ? 'yes' : 'no' );
+			$product->set_featured( $data['featured'] );
 		}
 
 		// Shipping data.
-		$this->save_product_shipping_data( $product_id, $data );
+		$product = $this->save_product_shipping_data( $product, $data );
 
 		// SKU.
 		if ( isset( $data['sku'] ) ) {
-			$sku     = get_post_meta( $product_id, '_sku', true );
+			$sku     = $product->get_sku();
 			$new_sku = wc_clean( $data['sku'] );
 
 			if ( '' == $new_sku ) {
-				update_post_meta( $product_id, '_sku', '' );
+				$product->set_sku( '' );
 			} elseif ( $new_sku !== $sku ) {
 				if ( ! empty( $new_sku ) ) {
-					$unique_sku = wc_product_has_unique_sku( $product_id, $new_sku );
+					$unique_sku = wc_product_has_unique_sku( $product->get_id(), $new_sku );
 					if ( ! $unique_sku ) {
 						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product', 'woocommerce' ), 400 );
 					} else {
-						update_post_meta( $product_id, '_sku', $new_sku );
+						$product->set_sku( $new_sku );
 					}
 				} else {
-					update_post_meta( $product_id, '_sku', '' );
+					$product->set_sku( '' );
 				}
 			}
 		}
@@ -1398,6 +1388,8 @@ class WC_API_Products extends WC_API_Resource {
 
 				if ( $is_taxonomy ) {
 
+					$attribute_id = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
+
 					if ( isset( $attribute['options'] ) ) {
 						$options = $attribute['options'];
 
@@ -1412,58 +1404,57 @@ class WC_API_Products extends WC_API_Resource {
 						$values = array();
 					}
 
-					// Update post terms.
+					// Update post terms
 					if ( taxonomy_exists( $taxonomy ) ) {
-						wp_set_object_terms( $product_id, $values, $taxonomy );
+						wp_set_object_terms( $product->get_id(), $values, $taxonomy );
 					}
 
 					if ( ! empty( $values ) ) {
 						// Add attribute to array, but don't set values.
-						$attributes[ $taxonomy ] = array(
-							'name'         => $taxonomy,
-							'value'        => '',
-							'position'     => isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0',
-							'is_visible'   => ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0,
-							'is_variation' => ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0,
-							'is_taxonomy'  => $is_taxonomy,
-						);
+						$attribute_object = new WC_Product_Attribute();
+						$attribute_object->set_id( $attribute_id );
+						$attribute_object->set_name( $taxonomy );
+						$attribute_object->set_options( $values );
+						$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+						$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
+						$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
+						$attributes[] = $attribute_object;
 					}
 				} elseif ( isset( $attribute['options'] ) ) {
 					// Array based.
 					if ( is_array( $attribute['options'] ) ) {
-						$values = wc_implode_text_attributes( array_map( 'wc_clean', $attribute['options'] ) );
+						$values = $attribute['options'];
 
 					// Text based, separate by pipe.
 					} else {
-						$values = wc_implode_text_attributes( array_map( 'wc_clean', explode( WC_DELIMITER, $attribute['options'] ) ) );
+						$values = array_map( 'wc_clean', explode( WC_DELIMITER, $attribute['options'] ) );
 					}
 
 					// Custom attribute - Add attribute to array and set the values.
-					$attributes[ $attribute_slug ] = array(
-						'name'         => wc_clean( $attribute['name'] ),
-						'value'        => $values,
-						'position'     => isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0',
-						'is_visible'   => ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0,
-						'is_variation' => ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0,
-						'is_taxonomy'  => $is_taxonomy,
-					);
+					$attribute_object = new WC_Product_Attribute();
+					$attribute_object->set_name( $attribute['name'] );
+					$attribute_object->set_options( $values );
+					$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+					$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
+					$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
+					$attributes[] = $attribute_object;
 				}
 			}
 
 			uasort( $attributes, 'wc_product_attribute_uasort_comparison' );
 
-			update_post_meta( $product_id, '_product_attributes', $attributes );
+			$product->set_attributes( $attributes );
 		}
 
 		// Sales and prices.
-		if ( in_array( $product_type, array( 'variable', 'grouped' ) ) ) {
+		if ( in_array( $product->get_type(), array( 'variable', 'grouped' ) ) ) {
 
 			// Variable and grouped products have no prices.
-			update_post_meta( $product_id, '_regular_price', '' );
-			update_post_meta( $product_id, '_sale_price', '' );
-			update_post_meta( $product_id, '_sale_price_dates_from', '' );
-			update_post_meta( $product_id, '_sale_price_dates_to', '' );
-			update_post_meta( $product_id, '_price', '' );
+			$product->set_regular_price( '' );
+			$product->set_sale_price( '' );
+			$product->set_date_on_sale_to( '' );
+			$product->set_date_on_sale_from( '' );
+			$product->set_price( '' );
 
 		} else {
 
@@ -1471,86 +1462,69 @@ class WC_API_Products extends WC_API_Resource {
 			if ( isset( $data['regular_price'] ) ) {
 				$regular_price = ( '' === $data['regular_price'] ) ? '' : $data['regular_price'];
 			} else {
-				$regular_price = get_post_meta( $product_id, '_regular_price', true );
+				$regular_price = $product->get_regular_price();
 			}
 
 			// Sale Price
 			if ( isset( $data['sale_price'] ) ) {
 				$sale_price = ( '' === $data['sale_price'] ) ? '' : $data['sale_price'];
 			} else {
-				$sale_price = get_post_meta( $product_id, '_sale_price', true );
+				$sale_price = $product->get_sale_price();
 			}
+
+			$product->set_regular_price( $regular_price );
+			$product->set_sale_price( $sale_price );
 
 			if ( isset( $data['sale_price_dates_from'] ) ) {
 				$date_from = $data['sale_price_dates_from'];
 			} else {
-				$date_from = get_post_meta( $product_id, '_sale_price_dates_from', true );
-				$date_from = ( '' === $date_from ) ? '' : date( 'Y-m-d', $date_from );
+				$date_from = ( $product->get_date_on_sale_from() ) ? date( 'Y-m-d', $date_from ) : '';
 			}
 
 			if ( isset( $data['sale_price_dates_to'] ) ) {
 				$date_to = $data['sale_price_dates_to'];
 			} else {
-				$date_to = get_post_meta( $product_id, '_sale_price_dates_to', true );
-				$date_to = ( '' === $date_to ) ? '' : date( 'Y-m-d', $date_to );
+				$date_to = ( $product->get_date_on_sale_to() ) ? date( 'Y-m-d', $date_to ) : '';
 			}
 
-			_wc_save_product_price( $product_id, $regular_price, $sale_price, $date_from, $date_to );
+			if ( $date_to && ! $date_from ) {
+				$date_from = strtotime( 'NOW', current_time( 'timestamp' ) );
+			}
 
+			$product->set_date_on_sale_to( $date_to );
+			$product->set_date_on_sale_from( $date_from );
+			if ( $product->is_on_sale() ) {
+				$product->set_price( $product->get_sale_price() );
+			} else {
+				$product->set_price( $product->get_regular_price() );
+			}
 		}
 
 		// Product parent ID for groups.
 		if ( isset( $data['parent_id'] ) ) {
-			wp_update_post( array( 'ID' => $product_id, 'post_parent' => absint( $data['parent_id'] ) ) );
+			$product->set_parent_id( absint( $data['parent_id'] ) );
 		}
 
 		// Update parent if grouped so price sorting works and stays in sync with the cheapest child.
-		$_product = wc_get_product( $product_id );
-		if ( $_product->post->post_parent > 0 || 'grouped' === $product_type ) {
-
-			$clear_parent_ids = array();
-
-			if ( $_product->post->post_parent > 0 ) {
-				$clear_parent_ids[] = $_product->post->post_parent;
-			}
-
-			if ( 'grouped' === $product_type ) {
-				$clear_parent_ids[] = $product_id;
-			}
-
-			if ( ! empty( $clear_parent_ids ) ) {
-				foreach ( $clear_parent_ids as $clear_id ) {
-
-					$children_by_price = get_posts( array(
-						'post_parent'    => $clear_id,
-						'orderby'        => 'meta_value_num',
-						'order'          => 'asc',
-						'meta_key'       => '_price',
-						'posts_per_page' => 1,
-						'post_type'      => 'product',
-						'fields'         => 'ids',
-					) );
-
-					if ( $children_by_price ) {
-						foreach ( $children_by_price as $child ) {
-							$child_price = get_post_meta( $child, '_price', true );
-							update_post_meta( $clear_id, '_price', $child_price );
-						}
-					}
-				}
+		if ( $product->get_parent_id() > 0 || 'grouped' === $product->get_type() ) {
+			if ( $product->get_parent_id() > 0 ) {
+				$parent = wc_get_product( $product->get_parent_id() );
+				$children = $parent->get_children();
+				$parent->set_children( array_filter( array_merge( $children, array( $product->get_id() ) ) ) );
+				$parent->save();
 			}
 		}
 
 		// Sold Individually.
 		if ( isset( $data['sold_individually'] ) ) {
-			update_post_meta( $product_id, '_sold_individually', ( true === $data['sold_individually'] ) ? 'yes' : '' );
+			$product->set_sold_individually( true === $data['sold_individually'] ? 'yes' : '' );
 		}
 
 		// Stock status.
 		if ( isset( $data['in_stock'] ) ) {
 			$stock_status = ( true === $data['in_stock'] ) ? 'instock' : 'outofstock';
 		} else {
-			$stock_status = get_post_meta( $product_id, '_stock_status', true );
+			$stock_status = $product->get_stock_status();
 
 			if ( '' === $stock_status ) {
 				$stock_status = 'instock';
@@ -1562,9 +1536,9 @@ class WC_API_Products extends WC_API_Resource {
 			// Manage stock.
 			if ( isset( $data['managing_stock'] ) ) {
 				$managing_stock = ( true === $data['managing_stock'] ) ? 'yes' : 'no';
-				update_post_meta( $product_id, '_manage_stock', $managing_stock );
+				$product->set_manage_stock( $managing_stock );
 			} else {
-				$managing_stock = get_post_meta( $product_id, '_manage_stock', true );
+				$managing_stock = $product->get_manage_stock() ? 'yes' : 'no';
 			}
 
 			// Backorders.
@@ -1575,54 +1549,46 @@ class WC_API_Products extends WC_API_Resource {
 					$backorders = ( true === $data['backorders'] ) ? 'yes' : 'no';
 				}
 
-				update_post_meta( $product_id, '_backorders', $backorders );
+				$product->set_backorders( $backorders );
 			} else {
-				$backorders = get_post_meta( $product_id, '_backorders', true );
+				$backorders = $product->get_backorders();
 			}
 
-			if ( 'grouped' == $product_type ) {
-
-				update_post_meta( $product_id, '_manage_stock', 'no' );
-				update_post_meta( $product_id, '_backorders', 'no' );
-				update_post_meta( $product_id, '_stock', '' );
-
-				wc_update_product_stock_status( $product_id, $stock_status );
-
-			} elseif ( 'external' == $product_type ) {
-
-				update_post_meta( $product_id, '_manage_stock', 'no' );
-				update_post_meta( $product_id, '_backorders', 'no' );
-				update_post_meta( $product_id, '_stock', '' );
-
-				wc_update_product_stock_status( $product_id, 'instock' );
+			if ( 'grouped' == $product->get_type() ) {
+				$product->set_manage_stock( 'no' );
+				$product->set_backorders( 'no' );
+				$product->set_stock( '' );
+				$product->set_stock_status( $stock_status );
+			} elseif ( 'external' == $product->get_type() ) {
+				$product->set_manage_stock( 'no' );
+				$product->set_backorders( 'no' );
+				$product->set_stock( '' );
+				$product->set_stock_status( 'instock' );
 			} elseif ( 'yes' == $managing_stock ) {
-				update_post_meta( $product_id, '_backorders', $backorders );
+				$product->set_backorders( $backorders );
 
 				// Stock status is always determined by children so sync later.
-				if ( 'variable' !== $product_type ) {
-					wc_update_product_stock_status( $product_id, $stock_status );
+				if ( 'variable' !== $product->get_type() ) {
+					$product->set_stock_status( $stock_status );
 				}
 
 				// Stock quantity.
 				if ( isset( $data['stock_quantity'] ) ) {
-					wc_update_product_stock( $product_id, wc_stock_amount( $data['stock_quantity'] ) );
+					$product->set_stock( wc_stock_amount( $data['stock_quantity'] ) );
 				} else if ( isset( $data['inventory_delta'] ) ) {
-					$stock_quantity  = wc_stock_amount( get_post_meta( $product_id, '_stock', true ) );
+					$stock_quantity  = wc_stock_amount( $product->get_stock() );
 					$stock_quantity += wc_stock_amount( $data['inventory_delta'] );
-
-					wc_update_product_stock( $product_id, wc_stock_amount( $stock_quantity ) );
+					$product->set_stock( wc_stock_amount( $stock_quantity ) );
 				}
 			} else {
-
 				// Don't manage stock.
-				update_post_meta( $product_id, '_manage_stock', 'no' );
-				update_post_meta( $product_id, '_backorders', $backorders );
-				update_post_meta( $product_id, '_stock', '' );
-
-				wc_update_product_stock_status( $product_id, $stock_status );
+				$product->set_manage_stock( 'no' );
+				$product->set_backorders( $backorders );
+				$product->set_stock( '' );
+				$product->set_stock_status( $stock_status );
 			}
-		} elseif ( 'variable' !== $product_type ) {
-			wc_update_product_stock_status( $product_id, $stock_status );
+		} elseif ( 'variable' !== $product->get_type() ) {
+			$product->set_stock_status( $stock_status );
 		}
 
 		// Upsells.
@@ -1637,9 +1603,9 @@ class WC_API_Products extends WC_API_Resource {
 					}
 				}
 
-				update_post_meta( $product_id, '_upsell_ids', $upsells );
+				$product->set_upsell_ids( $upsells );
 			} else {
-				delete_post_meta( $product_id, '_upsell_ids' );
+				$product->set_upsell_ids( array() );
 			}
 		}
 
@@ -1655,30 +1621,30 @@ class WC_API_Products extends WC_API_Resource {
 					}
 				}
 
-				update_post_meta( $product_id, '_crosssell_ids', $crosssells );
+				$product->set_cross_sell_ids( $crosssells );
 			} else {
-				delete_post_meta( $product_id, '_crosssell_ids' );
+				$product->set_cross_sell_ids( array() );
 			}
 		}
 
 		// Product categories.
 		if ( isset( $data['categories'] ) && is_array( $data['categories'] ) ) {
 			$term_ids = array_unique( array_map( 'intval', $data['categories'] ) );
-			wp_set_object_terms( $product_id, $term_ids, 'product_cat' );
+			$product->set_category_ids( $term_ids );
 		}
 
 		// Product tags.
 		if ( isset( $data['tags'] ) && is_array( $data['tags'] ) ) {
 			$term_ids = array_unique( array_map( 'intval', $data['tags'] ) );
-			wp_set_object_terms( $product_id, $term_ids, 'product_tag' );
+			$product->set_tag_ids( $term_ids );
 		}
 
 		// Downloadable.
 		if ( isset( $data['downloadable'] ) ) {
 			$is_downloadable = ( true === $data['downloadable'] ) ? 'yes' : 'no';
-			update_post_meta( $product_id, '_downloadable', $is_downloadable );
+			$product->set_downloadable( $is_downloadable );
 		} else {
-			$is_downloadable = get_post_meta( $product_id, '_downloadable', true );
+			$is_downloadable = $product->get_downloadable() ? 'yes' : 'no';
 		}
 
 		// Downloadable options.
@@ -1686,61 +1652,56 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Downloadable files.
 			if ( isset( $data['downloads'] ) && is_array( $data['downloads'] ) ) {
-				$this->save_downloadable_files( $product_id, $data['downloads'] );
+				$product = $this->save_downloadable_files( $product, $data['downloads'] );
 			}
 
 			// Download limit.
 			if ( isset( $data['download_limit'] ) ) {
-				update_post_meta( $product_id, '_download_limit', ( '' === $data['download_limit'] ) ? '' : absint( $data['download_limit'] ) );
+				$product->set_download_limit( $data['download_limit'] );
 			}
 
 			// Download expiry.
 			if ( isset( $data['download_expiry'] ) ) {
-				update_post_meta( $product_id, '_download_expiry', ( '' === $data['download_expiry'] ) ? '' : absint( $data['download_expiry'] ) );
-			}
-
-			// Download type.
-			if ( isset( $data['download_type'] ) ) {
-				update_post_meta( $product_id, '_download_type', wc_clean( $data['download_type'] ) );
+				$product->set_download_expiry( $data['download_expiry'] );
 			}
 		}
 
 		// Product url.
-		if ( 'external' === $product_type ) {
+		if ( 'external' === $product->get_type() ) {
 			if ( isset( $data['product_url'] ) ) {
-				update_post_meta( $product_id, '_product_url', wc_clean( $data['product_url'] ) );
+				$product->set_product_url( $data['product_url'] );
 			}
 
 			if ( isset( $data['button_text'] ) ) {
-				update_post_meta( $product_id, '_button_text', wc_clean( $data['button_text'] ) );
+				$product->set_button_text( $data['button_text'] );
 			}
 		}
 
 		// Reviews allowed.
 		if ( isset( $data['reviews_allowed'] ) ) {
-			$reviews_allowed = ( true === $data['reviews_allowed'] ) ? 'open' : 'closed';
-
-			$wpdb->update( $wpdb->posts, array( 'comment_status' => $reviews_allowed ), array( 'ID' => $product_id ) );
+			$product->set_reviews_allowed( $data['reviews_allowed'] );
 		}
 
 		// Do action for product type
-		do_action( 'woocommerce_api_process_product_meta_' . $product_type, $product_id, $data );
+		do_action( 'woocommerce_api_process_product_meta_' . $product->get_type(), $product->get_id(), $data );
 
-		return true;
+		return $product;
 	}
 
 	/**
 	 * Save variations
+	 * @todo after variations CRUD is done
 	 *
 	 * @since  2.2
-	 * @param  int $id
+	 * @param  WC_Product $product
 	 * @param  array $data
-	 * @return bool
+	 * @return WC_Product
 	 * @throws WC_API_Exception
 	 */
-	protected function save_variations( $id, $data ) {
+	protected function save_variations( $product, $data ) {
 		global $wpdb;
 
+		$id         = $product->get_id();
 		$variations = $data['variations'];
 		$attributes = (array) maybe_unserialize( get_post_meta( $id, '_product_attributes', true ) );
 
@@ -2076,29 +2037,30 @@ class WC_API_Products extends WC_API_Resource {
 	 * Save product shipping data
 	 *
 	 * @since 2.2
-	 * @param int $id
+	 * @param WC_Product $product
 	 * @param array $data
+	 * @return WC_Product
 	 */
-	private function save_product_shipping_data( $id, $data ) {
+	private function save_product_shipping_data( $product, $data ) {
 		if ( isset( $data['weight'] ) ) {
-			update_post_meta( $id, '_weight', ( '' === $data['weight'] ) ? '' : wc_format_decimal( $data['weight'] ) );
+			$product->set_weight( '' === $data['weight'] ? '' : wc_format_decimal( $data['weight'] ) );
 		}
 
 		// Product dimensions
 		if ( isset( $data['dimensions'] ) ) {
 			// Height
 			if ( isset( $data['dimensions']['height'] ) ) {
-				update_post_meta( $id, '_height', ( '' === $data['dimensions']['height'] ) ? '' : wc_format_decimal( $data['dimensions']['height'] ) );
+				$product->set_height( '' === $data['dimensions']['height'] ? '' : wc_format_decimal( $data['dimensions']['height'] ) );
 			}
 
 			// Width
 			if ( isset( $data['dimensions']['width'] ) ) {
-				update_post_meta( $id, '_width', ( '' === $data['dimensions']['width'] ) ? '' : wc_format_decimal( $data['dimensions']['width'] ) );
+				$product->set_width( '' === $data['dimensions']['width'] ? '' : wc_format_decimal( $data['dimensions']['width'] ) );
 			}
 
 			// Length
 			if ( isset( $data['dimensions']['length'] ) ) {
-				update_post_meta( $id, '_length', ( '' === $data['dimensions']['length'] ) ? '' : wc_format_decimal( $data['dimensions']['length'] ) );
+				$product->set_length( '' === $data['dimensions']['length'] ? '' : wc_format_decimal( $data['dimensions']['length'] ) );
 			}
 		}
 
@@ -2107,28 +2069,34 @@ class WC_API_Products extends WC_API_Resource {
 			$virtual = ( true === $data['virtual'] ) ? 'yes' : 'no';
 
 			if ( 'yes' == $virtual ) {
-				update_post_meta( $id, '_weight', '' );
-				update_post_meta( $id, '_length', '' );
-				update_post_meta( $id, '_width', '' );
-				update_post_meta( $id, '_height', '' );
+				$product->set_weight( '' );
+				$product->set_height( '' );
+				$product->set_length( '' );
+				$product->set_width( '' );
 			}
 		}
 
 		// Shipping class
 		if ( isset( $data['shipping_class'] ) ) {
-			wp_set_object_terms( $id, wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
+			$shipping_class_term = get_term_by( 'slug', wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
+			if ( $shipping_class_term ) {
+				$product->set_shipping_class_id( $shipping_class_term->term_id );
+			}
 		}
+
+		return $product;
 	}
 
 	/**
 	 * Save downloadable files
 	 *
 	 * @since 2.2
-	 * @param int $product_id
+	 * @param WC_Product $product
 	 * @param array $downloads
 	 * @param int $variation_id
+	 * @return WC_Product
 	 */
-	private function save_downloadable_files( $product_id, $downloads, $variation_id = 0 ) {
+	private function save_downloadable_files( $product, $downloads, $variation_id = 0 ) {
 		$files = array();
 
 		// File paths will be stored in an array keyed off md5(file path)
@@ -2156,10 +2124,11 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Grant permission to any newly added files on any existing orders for this product prior to saving
-		do_action( 'woocommerce_process_product_file_download_paths', $product_id, $variation_id, $files );
+		do_action( 'woocommerce_process_product_file_download_paths', $product->get_id(), $variation_id, $files );
 
-		$id = ( 0 === $variation_id ) ? $product_id : $variation_id;
-		update_post_meta( $id, '_downloadable_files', $files );
+		$product->set_downloads( $files );
+
+		return $product;
 	}
 
 	/**
@@ -2196,22 +2165,21 @@ class WC_API_Products extends WC_API_Resource {
 		$images = $attachment_ids = array();
 
 		if ( $product->is_type( 'variation' ) ) {
-
+			// @todo variation
 			if ( has_post_thumbnail( $product->get_variation_id() ) ) {
 
 				// Add variation image if set
 				$attachment_ids[] = get_post_thumbnail_id( $product->get_variation_id() );
 
-			} elseif ( has_post_thumbnail( $product->get_id() ) ) {
-
+			} elseif ( ! empty( $product->get_thumbnail_id() ) ) {
 				// Otherwise use the parent product featured image if set
-				$attachment_ids[] = get_post_thumbnail_id( $product->get_id() );
+				$attachment_ids[] = $product->get_thumbnail_id();
 			}
 		} else {
 
 			// Add featured image
-			if ( has_post_thumbnail( $product->get_id() ) ) {
-				$attachment_ids[] = get_post_thumbnail_id( $product->get_id() );
+			if ( ! empty( $product->get_thumbnail_id() ) ) {
+				$attachment_ids[] = $product->get_thumbnail_id();
 			}
 
 			// Add gallery images
@@ -2265,11 +2233,12 @@ class WC_API_Products extends WC_API_Resource {
 	 * Save product images.
 	 *
 	 * @since  2.2
+	 * @param  WC_Product $product
 	 * @param  array $images
-	 * @param  int $id
 	 * @throws WC_API_Exception
+	 * @return WC_Product
 	 */
-	protected function save_product_images( $id, $images ) {
+	protected function save_product_images( $product, $images ) {
 		if ( is_array( $images ) ) {
 			$gallery = array();
 
@@ -2284,10 +2253,10 @@ class WC_API_Products extends WC_API_Resource {
 							throw new WC_API_Exception( 'woocommerce_api_cannot_upload_product_image', $upload->get_error_message(), 400 );
 						}
 
-						$attachment_id = $this->set_product_image_as_attachment( $upload, $id );
+						$attachment_id = $this->set_product_image_as_attachment( $upload, $product->get_id() );
 					}
 
-					set_post_thumbnail( $id, $attachment_id );
+					$product->set_thumbnail_id( $attachment_id );
 				} else {
 					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
@@ -2316,12 +2285,14 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			if ( ! empty( $gallery ) ) {
-				update_post_meta( $id, '_product_image_gallery', implode( ',', $gallery ) );
+				$product->set_gallery_attachment_ids( $gallery );
 			}
 		} else {
-			delete_post_thumbnail( $id );
-			update_post_meta( $id, '_product_image_gallery', '' );
+			$product->set_thumbnail_id( '' );
+			$product->set_gallery_attachment_ids( array() );
 		}
+
+		return $product;
 	}
 
 	/**
@@ -3200,7 +3171,8 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Delete product
-		wp_delete_post( $product_id, true );
+		$product = wc_get_product( $product_id );
+		$product->delete();
 	}
 
 	/**

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -207,9 +207,12 @@ class WC_API_Products extends WC_API_Resource {
 			$product_data['grouped_products'] = $this->get_grouped_products_data( $product );
 		}
 
-		if ( $product->is_type( 'simple' ) && ! empty( $product->get_parent_id() ) ) {
-			$_product = wc_get_product( $product->get_parent_id() );
-			$product_data['parent'] = $this->get_product_data( $_product );
+		if ( $product->is_type( 'simple' ) ) {
+			$parent_id = $product->get_parent_id();
+			if ( ! empty( $parent_id ) ) {
+				$_product               = wc_get_product( $parent_id );
+				$product_data['parent'] = $this->get_product_data( $_product );
+			}
 		}
 
 		return array( 'product' => apply_filters( 'woocommerce_api_product_response', $product_data, $product, $fields, $this->server ) );
@@ -319,7 +322,7 @@ class WC_API_Products extends WC_API_Resource {
 			$id = $product->get_id();
 
 			// Checks for an error in the product creation.
-			if ( ! $id > 0 ) {
+			if ( 0 >= $id ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_create_product', $id->get_error_message(), 400 );
 			}
 
@@ -1121,12 +1124,11 @@ class WC_API_Products extends WC_API_Resource {
 	 * @return WC_Product
 	 */
 	private function get_product_data( $product ) {
-		$post = get_post( $product->get_id() );
 		return array(
-			'title'              => $product->get_title(),
-			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $post->post_date_gmt ),
-			'updated_at'         => $this->server->format_datetime( $post->post_modified_gmt ),
+			'title'              => $product->get_name(),
+			'id'                 => (int) $product->is_type( 'variation' ) ? $product->get_variation_id() : $product->get_id(), // @todo variation
+			'created_at'         => $this->server->format_datetime( $product->get_date_created() ),
+			'updated_at'         => $this->server->format_datetime( $product->get_date_modified() ),
 			'type'               => $product->get_type(),
 			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
@@ -1166,9 +1168,9 @@ class WC_API_Products extends WC_API_Resource {
 			'shipping_class_id'  => ( 0 !== $product->get_shipping_class_id() ) ? $product->get_shipping_class_id() : null,
 			'description'        => wpautop( do_shortcode( $product->get_description() ) ),
 			'short_description'  => apply_filters( 'woocommerce_short_description', $product->get_short_description() ),
-			'reviews_allowed'    => ( 'open' === $product->get_post_data()->comment_status ),
+			'reviews_allowed'    => $product->get_reviews_allowed(),
 			'average_rating'     => wc_format_decimal( $product->get_average_rating(), 2 ),
-			'rating_count'       => (int) $product->get_rating_count(),
+			'rating_count'       => $product->get_rating_count(),
 			'related_ids'        => array_map( 'absint', array_values( wc_get_related_products( $product->get_id() ) ) ),
 			'upsell_ids'         => array_map( 'absint', $product->get_upsell_ids() ),
 			'cross_sell_ids'     => array_map( 'absint', $product->get_cross_sell_ids() ),
@@ -1176,11 +1178,11 @@ class WC_API_Products extends WC_API_Resource {
 			'categories'         => wp_get_post_terms( $product->get_id(), 'product_cat', array( 'fields' => 'names' ) ),
 			'tags'               => wp_get_post_terms( $product->get_id(), 'product_tag', array( 'fields' => 'names' ) ),
 			'images'             => $this->get_images( $product ),
-			'featured_src'       => (string) wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->get_id() ) ),
+			'featured_src'       => wp_get_attachment_url( get_post_thumbnail_id( $product->is_type( 'variation' ) ? $product->variation_id : $product->get_id() ) ),
 			'attributes'         => $this->get_attributes( $product ),
 			'downloads'          => $this->get_downloads( $product ),
-			'download_limit'     => (int) $product->get_download_limit(),
-			'download_expiry'    => (int) $product->get_download_expiry(),
+			'download_limit'     => $product->get_download_limit(),
+			'download_expiry'    => $product->get_download_expiry(),
 			'download_type'      => 'standard',
 			'purchase_note'      => wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ),
 			'total_sales'        => $product->get_total_sales(),
@@ -1415,7 +1417,7 @@ class WC_API_Products extends WC_API_Resource {
 						$attribute_object->set_id( $attribute_id );
 						$attribute_object->set_name( $taxonomy );
 						$attribute_object->set_options( $values );
-						$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+						$attribute_object->set_position( isset( $attribute['position'] ) ? absint( $attribute['position'] ) : 0 );
 						$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
 						$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
 						$attributes[] = $attribute_object;
@@ -1434,7 +1436,7 @@ class WC_API_Products extends WC_API_Resource {
 					$attribute_object = new WC_Product_Attribute();
 					$attribute_object->set_name( $attribute['name'] );
 					$attribute_object->set_options( $values );
-					$attribute_object->set_position( isset( $attribute['position'] ) ? (string) absint( $attribute['position'] ) : '0' );
+					$attribute_object->set_position( isset( $attribute['position'] ) ? absint( $attribute['position'] ) : 0 );
 					$attribute_object->set_visible( ( isset( $attribute['visible'] ) && $attribute['visible'] ) ? 1 : 0 );
 					$attribute_object->set_variation( ( isset( $attribute['variation'] ) && $attribute['variation'] ) ? 1 : 0 );
 					$attributes[] = $attribute_object;
@@ -1506,7 +1508,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Update parent if grouped so price sorting works and stays in sync with the cheapest child.
-		if ( $product->get_parent_id() > 0 || 'grouped' === $product->get_type() ) {
+		if ( $product->get_parent_id() > 0 || $product->is_type( 'grouped' ) ) {
 			if ( $product->get_parent_id() > 0 ) {
 				$parent = wc_get_product( $product->get_parent_id() );
 				$children = $parent->get_children();
@@ -1554,40 +1556,40 @@ class WC_API_Products extends WC_API_Resource {
 				$backorders = $product->get_backorders();
 			}
 
-			if ( 'grouped' == $product->get_type() ) {
+			if ( $product->is_type( 'grouped' ) ) {
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( 'no' );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( $stock_status );
-			} elseif ( 'external' == $product->get_type() ) {
+			} elseif ( $product->is_type( 'external' ) ) {
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( 'no' );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( 'instock' );
 			} elseif ( 'yes' == $managing_stock ) {
 				$product->set_backorders( $backorders );
 
 				// Stock status is always determined by children so sync later.
-				if ( 'variable' !== $product->get_type() ) {
+				if ( ! $product->is_type( 'variable' ) ) {
 					$product->set_stock_status( $stock_status );
 				}
 
 				// Stock quantity.
 				if ( isset( $data['stock_quantity'] ) ) {
-					$product->set_stock( wc_stock_amount( $data['stock_quantity'] ) );
+					$product->set_stock_quantity( wc_stock_amount( $data['stock_quantity'] ) );
 				} else if ( isset( $data['inventory_delta'] ) ) {
 					$stock_quantity  = wc_stock_amount( $product->get_stock() );
 					$stock_quantity += wc_stock_amount( $data['inventory_delta'] );
-					$product->set_stock( wc_stock_amount( $stock_quantity ) );
+					$product->set_stock_quantity( wc_stock_amount( $stock_quantity ) );
 				}
 			} else {
 				// Don't manage stock.
 				$product->set_manage_stock( 'no' );
 				$product->set_backorders( $backorders );
-				$product->set_stock( '' );
+				$product->set_stock_quantity( '' );
 				$product->set_stock_status( $stock_status );
 			}
-		} elseif ( 'variable' !== $product->get_type() ) {
+		} elseif ( ! $product->is_type( 'variable' ) ) {
 			$product->set_stock_status( $stock_status );
 		}
 
@@ -1667,7 +1669,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		// Product url.
-		if ( 'external' === $product->get_type() ) {
+		if ( $product->is_type( 'external' ) ) {
 			if ( isset( $data['product_url'] ) ) {
 				$product->set_product_url( $data['product_url'] );
 			}
@@ -2161,8 +2163,8 @@ class WC_API_Products extends WC_API_Resource {
 	 * @return array
 	 */
 	private function get_images( $product ) {
-
-		$images = $attachment_ids = array();
+		$images        = $attachment_ids = array();
+		$product_image = $product->get_image_id();
 
 		if ( $product->is_type( 'variation' ) ) {
 			// @todo variation
@@ -2171,15 +2173,15 @@ class WC_API_Products extends WC_API_Resource {
 				// Add variation image if set
 				$attachment_ids[] = get_post_thumbnail_id( $product->get_variation_id() );
 
-			} elseif ( ! empty( $product->get_thumbnail_id() ) ) {
+			} elseif ( ! empty( $product_image ) ) {
 				// Otherwise use the parent product featured image if set
-				$attachment_ids[] = $product->get_thumbnail_id();
+				$attachment_ids[] = $product_image;
 			}
 		} else {
 
 			// Add featured image
-			if ( ! empty( $product->get_thumbnail_id() ) ) {
-				$attachment_ids[] = $product->get_thumbnail_id();
+			if ( ! empty( $product_image ) ) {
+				$attachment_ids[] = $product_image;
 			}
 
 			// Add gallery images
@@ -2256,7 +2258,7 @@ class WC_API_Products extends WC_API_Resource {
 						$attachment_id = $this->set_product_image_as_attachment( $upload, $product->get_id() );
 					}
 
-					$product->set_thumbnail_id( $attachment_id );
+					$product->set_image_id( $attachment_id );
 				} else {
 					$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
@@ -2285,11 +2287,11 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			if ( ! empty( $gallery ) ) {
-				$product->set_gallery_attachment_ids( $gallery );
+				$product->set_gallery_image_ids( $gallery );
 			}
 		} else {
-			$product->set_thumbnail_id( '' );
-			$product->set_gallery_attachment_ids( array() );
+			$product->set_image_id( '' );
+			$product->set_gallery_image_ids( array() );
 		}
 
 		return $product;

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -180,9 +180,13 @@ class WC_Product_Grouped extends WC_Product {
 				$child = wc_get_product( $child_id );
 				$child_prices[] = $child->get_price();
 			}
+			$child_prices = array_filter( $child_prices );
 			delete_post_meta( $this->get_id(), '_price' );
-			add_post_meta( $this->get_id(), '_price', min( $child_prices ) );
-			add_post_meta( $this->get_id(), '_price', max( $child_prices ) );
+
+			if ( ! empty( $child_prices ) ) {
+				add_post_meta( $this->get_id(), '_price', min( $child_prices ) );
+				add_post_meta( $this->get_id(), '_price', max( $child_prices ) );
+			}
 		}
 		parent::update_post_meta();
 	}

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -178,7 +178,9 @@ class WC_Product_Grouped extends WC_Product {
 			$child_prices = array();
 			foreach ( $this->get_children() as $child_id ) {
 				$child = wc_get_product( $child_id );
-				$child_prices[] = $child->get_price();
+				if ( $child ) {
+					$child_prices[] = $child->get_price();
+				}
 			}
 			$child_prices = array_filter( $child_prices );
 			delete_post_meta( $this->get_id(), '_price' );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -48,20 +48,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function wc_get_products( $args ) {
 	$args = wp_parse_args( $args, array(
-		'status'   => array( 'draft', 'pending', 'private', 'publish' ),
-		'type'     => array_merge( array_keys( wc_get_product_types() ), array( 'variation' ) ),
-		'parent'   => null,
-		'sku'      => '',
-		'category' => array(),
-		'tag'      => array(),
-		'limit'    => get_option( 'posts_per_page' ),
-		'offset'   => null,
-		'page'     => 1,
-		'exclude'  => array(),
-		'orderby'  => 'date',
-		'order'    => 'DESC',
-		'return'   => 'objects',
-		'paginate' => false,
+		'status'         => array( 'draft', 'pending', 'private', 'publish' ),
+		'type'           => array_merge( array_keys( wc_get_product_types() ), array( 'variation' ) ),
+		'parent'         => null,
+		'sku'            => '',
+		'category'       => array(),
+		'tag'            => array(),
+		'limit'          => get_option( 'posts_per_page' ),
+		'offset'         => null,
+		'page'           => 1,
+		'exclude'        => array(),
+		'orderby'        => 'date',
+		'order'          => 'DESC',
+		'return'         => 'objects',
+		'paginate'       => false,
+		'shipping_class' => array(),
 	) );
 
 	// Handle some BW compatibility arg names where wp_query args differ in naming.
@@ -112,7 +113,7 @@ function wc_get_products( $args ) {
 	if ( ! empty( $args['category'] ) ) {
 		$wp_query_args['tax_query'][] = array(
 			'taxonomy' => 'product_cat',
-			'field'    => 'term_id',
+			'field'    => 'slug',
 			'terms'   => $args['category'],
 		);
 	}
@@ -120,8 +121,16 @@ function wc_get_products( $args ) {
 	if ( ! empty( $args['tag'] ) ) {
 		$wp_query_args['tax_query'][] = array(
 			'taxonomy' => 'product_tag',
-			'field'    => 'term_id',
+			'field'    => 'slug',
 			'terms'   => $args['tag'],
+		);
+	}
+
+	if ( ! empty( $args['shipping_class'] ) ) {
+		$wp_query_args['tax_query'][] = array(
+			'taxonomy' => 'product_shipping_class',
+			'field'    => 'slug',
+			'terms'   => $args['shipping_class'],
 		);
 	}
 
@@ -156,7 +165,7 @@ function wc_get_products( $args ) {
 		return (object) array(
 			'products'      => $return,
 			'total'         => $products->found_posts,
-			'max_num_pages' => $procuts->max_num_pages,
+			'max_num_pages' => $products->max_num_pages,
 		);
 	} else {
 		return $return;
@@ -1017,7 +1026,7 @@ function wc_get_related_products_query( $cats_array, $tags_array, $exclude_ids, 
 
 		if ( $cats_array ) {
 			$query['where'] .= " ( tt.taxonomy = 'product_cat' AND t.term_id IN ( {$cats_array} ) ) ";
-			if ( $relate_by_tag ) {
+			if ( $tags_array ) {
 				$query['where'] .= ' OR ';
 			}
 		}

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -16,6 +16,9 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$test_cat_1 = wp_insert_term( 'Testing 1', 'product_cat' );
 		$test_tag_1 = wp_insert_term( 'Tag 1', 'product_tag' );
 		$test_tag_2 = wp_insert_term( 'Tag 2', 'product_tag' );
+		$term_cat_1 = get_term_by( 'id', $test_cat_1['term_id'], 'product_cat' );
+		$term_tag_1 = get_term_by( 'id', $test_tag_1['term_id'], 'product_tag' );
+		$term_tag_2 = get_term_by( 'id', $test_tag_2['term_id'], 'product_tag' );
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_tag_ids( array( $test_tag_1['term_id'] ) );
@@ -68,17 +71,17 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$this->assertContains( $external->get_id(), $products );
 
 		// test categories
-		$products = wc_get_products( array( 'return' => 'ids', 'category' => array( $test_cat_1['term_id'] ) ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'category' => array( $term_cat_1->slug ) ) );
 		$this->assertEquals( 3, count( $products ) );
 
 		// test tags
-		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $test_tag_1['term_id'] ) ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $term_tag_1->slug ) ) );
 		$this->assertEquals( 2, count( $products ) );
 
-		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $test_tag_2['term_id'] ) ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $term_tag_2->slug ) ) );
 		$this->assertEquals( 1, count( $products ) );
 
-		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $test_tag_1['term_id'], $test_tag_2['term_id'] ) ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'tag' => array( $term_tag_1->slug, $term_tag_2->slug ) ) );
 		$this->assertEquals( 3, count( $products ) );
 
 		// test limit


### PR DESCRIPTION
Implements CRUD & correct getters/setters to avoid deprecation notices in all legacy API versions.

This does not handle variations updates. Variations need to be done for both the legacy versions and the current version, once #12228 lands.