### PR TITLE
Filter the (JSON+LD) offers separately from the overall product data

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -190,19 +190,23 @@ class WC_Structured_Data {
 
 		$markup_offers = array();
 		foreach ( $products as $_product ) {
-			$markup_offers[] = array(
-				'@type'         => 'Offer',
-				'priceCurrency' => get_woocommerce_currency(),
-				'price'         => $_product->get_price(),
-				'availability'  => 'http://schema.org/' . $stock = ( $_product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
-				'sku'           => $_product->get_sku(),
-				'image'         => wp_get_attachment_url( $_product->get_image_id() ),
-				'description'   => $is_variable ? $_product->get_variation_description() : '',
-				'seller'        => array(
-					'@type' => 'Organization',
-					'name'  => get_bloginfo( 'name' ),
-					'url'   => get_bloginfo( 'url' ),
+			$markup_offers[] = apply_filters(
+				'woocommerce_structured_data_offer',
+				array(
+					'@type'         => 'Offer',
+					'priceCurrency' => get_woocommerce_currency(),
+					'price'         => $_product->get_price(),
+					'availability'  => 'http://schema.org/' . $stock = ( $_product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
+					'sku'           => $_product->get_sku(),
+					'image'         => wp_get_attachment_url( $_product->get_image_id() ),
+					'description'   => $is_variable ? $_product->get_variation_description() : '',
+					'seller'        => array(
+						'@type' => 'Organization',
+						'name'  => get_bloginfo( 'name' ),
+						'url'   => get_bloginfo( 'url' ),
+					),
 				),
+				$_product
 			);
 		}
 

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -191,7 +191,7 @@ class WC_Structured_Data {
 		$markup_offers = array();
 		foreach ( $products as $_product ) {
 			$markup_offers[] = apply_filters(
-				'woocommerce_structured_data_offer',
+				'woocommerce_structured_data_product_offer',
 				array(
 					'@type'         => 'Offer',
 					'priceCurrency' => get_woocommerce_currency(),


### PR DESCRIPTION
There are filters to allow the product microdata to be overriden.

However - currently the entire data structure is assembled, before being passed via the filter. This is fine if you want to modify general properties of the Product. However, for the multiple Offers that are present on a variable product, there's nothing available at that point that matches the relevant offer to a WC variation product, making it guess work to apply changes to offers. 

The attached PR adds an additional filter for each offer that is passed the individual variation for that offer. 