### PR TITLE
Add 'woocommerce_calc_shipping_tax' filter

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -100,7 +100,8 @@ class WC_Tax {
 	 * @return  array
 	 */
 	public static function calc_shipping_tax( $price, $rates ) {
-		return self::calc_exclusive_tax( $price, $rates );
+		$taxes = self::calc_exclusive_tax( $price, $rates );
+		return apply_filters( 'woocommerce_calc_shipping_tax', $taxes, $price, $rates );
 	}
 
 	/**


### PR DESCRIPTION
This filters `calc_shipping_tax` function the same way `calc_tax` function is filtered.

It would be nice for my project to include this filter in the core, since I haven't found any clean methods to override the value that function returns in the manner I need.

Maybe it could be useful for other developers in the future.