### PR TITLE
deliver webhook when product variations deleted

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -139,7 +139,7 @@ class WC_Webhook {
 			$should_deliver = false;
 
 		// only deliver deleted event for coupons, orders, and products
-		} elseif ( 'delete_post' === $current_action && ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product' ) ) ) {
+		} elseif ( 'delete_post' === $current_action && ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product', 'product_variation' ) ) ) {
 			$should_deliver = false;
 
 		} elseif ( 'delete_user' == $current_action ) {


### PR DESCRIPTION
It would be useful to also receive webhooks when a variation is deleted from a product.

The change haven't been tested, I don't have knowledge about woocommerce codebase, this is a proposal feel free to do any changes or discuss possibilities.