### PR TITLE
Implement WC_Data_Store and related code & tests.

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -28,6 +28,18 @@ abstract class WC_Data {
 	protected $data = array();
 
 	/**
+	 * Core data changes for this object.
+	 * @var array
+	 */
+	protected $changes = array();
+
+	/**
+	 * This is false until the object is read from the DB.
+	 * @var bool
+	 */
+	protected $object_read = false;
+
+	/**
 	 * Extra data for this object. Name value pairs (name + default value).
 	 * Used as a standard way for sub classes (like product types) to add
 	 * additional information to an inherited class.
@@ -108,6 +120,8 @@ abstract class WC_Data {
 
 	/**
 	 * Save should create or update based on object existance.
+	 *
+	 * @return int
 	 */
 	public function save() {
 		if ( $this->data_store ) {
@@ -432,15 +446,26 @@ abstract class WC_Data {
 	 * Set all props to default values.
 	 */
 	public function set_defaults() {
-		$this->data = $this->default_data;
+		$this->data        = $this->default_data;
+		$this->changes     = array();
+		$this->set_object_read( false );
+ 	}
+
+	/**
+	 * Set object read property.
+	 * @param boolean $read
+	 */
+	public function set_object_read( $read = true ) {
+		$this->object_read = (bool) $read;
 	}
 
 	/**
 	 * Set a collection of props in one go, collect any errors, and return the result.
+	 * Only sets using public methods.
 	 * @param array $props Key value pairs to set. Key is the prop and should map to a setter function name.
 	 * @return WP_Error|bool
 	 */
-	public function set_props( $props ) {
+	public function set_props( $props, $context = 'set' ) {
 		$errors = new WP_Error();
 
 		foreach ( $props as $prop => $value ) {
@@ -450,7 +475,11 @@ abstract class WC_Data {
 				}
 				$setter = "set_$prop";
 				if ( ! is_null( $value ) && is_callable( array( $this, $setter ) ) ) {
-					$this->{$setter}( $value );
+					$reflection = new ReflectionMethod( $this, $setter );
+
+					if ( $reflection->isPublic() ) {
+						$this->{$setter}( $value );
+					}
 				}
 			} catch ( WC_Data_Exception $e ) {
 				$errors->add( $e->getErrorCode(), $e->getMessage() );
@@ -458,6 +487,80 @@ abstract class WC_Data {
 		}
 
 		return sizeof( $errors->get_error_codes() ) ? $errors : true;
+	}
+
+	/**
+	 * Sets a prop for a setter method.
+	 *
+	 * This stores changes in a special array so we can track what needs saving
+	 * the the DB later.
+	 *
+	 * @since 2.7.0
+	 * @param string $prop Name of prop to set.
+	 * @param mixed  $value Value of the prop.
+	 */
+	protected function set_prop( $prop, $value ) {
+		if ( array_key_exists( $prop, $this->data ) ) {
+			if ( true === $this->object_read ) {
+				$this->changes[ $prop ] = $value;
+			} else {
+				$this->data[ $prop ] = $value;
+			}
+		}
+	}
+
+	/**
+	 * Return data changes only.
+	 *
+	 * @since 2.7.0
+	 * @return array
+	 */
+	protected function get_changes() {
+		return $this->changes;
+	}
+
+	/**
+	 * Merge changes with data and clear.
+	 *
+	 * @since 2.7.0
+	 */
+	protected function apply_changes() {
+		$this->data = array_merge( $this->data, $this->changes );
+		$this->changes = array();
+	}
+
+	/**
+	 * Prefix for action and filter hooks on data.
+	 *
+	 * @since  2.7.0
+	 * @return string
+	 */
+	protected function get_hook_prefix() {
+		return 'woocommerce_get_';
+	}
+
+	/**
+	 * Gets a prop for a getter method.
+	 *
+	 * Gets the value from either current pending changes, or the data itself.
+	 * Context controls what happens to the value before it's returned.
+	 *
+	 * @since  2.7.0
+	 * @param  string $prop Name of prop to get.
+	 * @param  string $context What the value is for. Valid values are view and edit.
+	 * @return mixed
+	 */
+	public function get_prop( $prop, $context = 'view' ) {
+		$value = null;
+
+		if ( array_key_exists( $prop, $this->data ) ) {
+			$value = isset( $this->changes[ $prop ] ) ? $this->changes[ $prop ] : $this->data[ $prop ];
+
+			if ( 'view' === $context ) {
+				$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this );
+			}
+		}
+		return $value;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -465,7 +465,7 @@ abstract class WC_Data {
 	 * @param array $props Key value pairs to set. Key is the prop and should map to a setter function name.
 	 * @return WP_Error|bool
 	 */
-	public function set_props( $props, $context = 'set' ) {
+	public function set_props( $props ) {
 		$errors = new WP_Error();
 
 		foreach ( $props as $prop => $value ) {

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -272,7 +272,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Delete data from the database.
 	 * @since 2.7.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		wp_delete_post( $this->get_id() );
 	}
 

--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -277,7 +277,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Remove a payment token from the database.
 	 * @since 2.6.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		global $wpdb;
 		$this->read( $this->get_id() ); // Make sure we have a token to return after deletion
 		$wpdb->delete( $wpdb->prefix . 'woocommerce_payment_tokens', array( 'token_id' => $this->get_id() ), array( '%d' ) );

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -752,7 +752,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * Delete coupon from the database.
 	 * @since 2.7.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		wp_delete_post( $this->get_id() );
 		do_action( 'woocommerce_delete_coupon', $this->get_id() );
 		$this->set_id( 0 );

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -1176,7 +1176,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Delete a customer.
 	 * @since 2.7.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		if ( ! $this->get_id() ) {
 			return;
 		}

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -1,0 +1,131 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Data Store.
+ *
+ * @since    2.7.0
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Data_Store {
+
+	/**
+	 * Contains an instance of the data store class that we are working with.
+	 */
+	private $instance = null;
+
+	/**
+	 * Contains an array of default WC supported data stores.
+	 * Format of object name => class name.
+	 * Example: 'product' => 'WC_Product_Data_Store_CPT'
+	 * You can aso pass something like product_<type> for product stores and
+	 * that type will be used first when avaiable, if a store is requested like
+	 * this and doesn't exist, then the store would fall back to 'product'.
+	 * Ran through `woocommerce_data_stores`.
+	 */
+	private $stores = array(
+	);
+
+	/**
+	 * Contains the name of the current data store's class name.
+	 */
+	private $current_class_name = '';
+
+	/**
+	 * Tells WC_Data_Store which object (coupon, product, order, etc)
+	 * store we want to work with.
+	 *
+	 * @param string $object_type Name of object.
+	 */
+	public function __construct( $object_type ) {
+		$this->stores = apply_filters( 'woocommerce_data_stores', $this->stores );
+
+		// If this object type can't be found, check to see if we can load one
+		// level up (so if product_type isn't found, we try product).
+		if ( ! array_key_exists( $object_type, $this->stores ) ) {
+			$pieces = explode( '_', $object_type );
+			$object_type = $pieces[0];
+		}
+
+		if ( array_key_exists( $object_type, $this->stores ) ) {
+			$store = apply_filters( 'woocommerce_' . $object_type . '_data_store', $this->stores[ $object_type ] );
+			if ( ! class_exists( $store ) ) {
+				throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
+			}
+			$this->current_class_name = $store;
+			$this->instance           = new $store;
+		} else {
+			throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
+		}
+	}
+
+	/**
+	 * Loads a data store for us or returns null if an invalid store.
+	 *
+	 * @param string $object_type Name of object.
+	 * @since 2.7.0
+	 */
+	public static function load( $object_type ) {
+		try {
+			return new WC_Data_Store( $object_type );
+		} catch ( Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the class name of the current data store.
+	 *
+	 * @since 2.7.0
+	 * @return string
+	 */
+	public function get_current_class_name() {
+		return $this->current_class_name;
+	}
+
+	/**
+	 * Reads an object from the data store.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Data
+	 */
+	public function read( &$data ) {
+		$this->instance->read( $data );
+	}
+
+	/**
+	 * Create an object in the data store.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Data
+	 */
+	public function create( &$data ) {
+		$this->instance->create( $data );
+	}
+
+	/**
+	 * Update an object in the data store.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Data
+	 */
+	public function update( &$data ) {
+		$this->instance->update( $data );
+	}
+
+	/**
+	 * Delete an object from the data store.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Data
+	 * @param bool $force_delete True to permently delete, false to trash.
+	 */
+	public function delete( &$data, $force_delete = false ) {
+		$this->instance->delete( $data, $force_delete );
+	}
+
+}

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -249,7 +249,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * Delete data from the database.
 	 * @since 2.7.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		if ( $this->get_id() ) {
 			global $wpdb;
 			do_action( 'woocommerce_before_delete_order_item', $this->get_id() );

--- a/includes/class-wc-order-refund.php
+++ b/includes/class-wc-order-refund.php
@@ -102,7 +102,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * Delete data from the database.
 	 * @since 2.7.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		wp_delete_post( $this->get_id(), true );
 	}
 

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -107,7 +107,7 @@ class WC_Shipping_Zone extends WC_Data {
 	 * Delete a zone.
 	 * @since 2.6.0
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		if ( $this->get_id() ) {
 			global $wpdb;
 			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array( 'zone_id' => $this->get_id() ) );

--- a/includes/data-stores/class-wc-data-store-cpt.php
+++ b/includes/data-stores/class-wc-data-store-cpt.php
@@ -1,0 +1,16 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Shared logic for post/CPT data stores.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Data_Store_CPT  {
+
+
+}

--- a/includes/data-stores/interface-wc-object-data-store.php
+++ b/includes/data-stores/interface-wc-object-data-store.php
@@ -1,0 +1,38 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Data Store Interface
+ *
+ * @version  2.7.0
+ * @category Interface
+ * @author   WooThemes
+ */
+interface WC_Object_Data_Store {
+	/**
+	 * Method to create a new record of a WC_Data based object.
+	 * @param WC_Data
+	 */
+	public function create( &$data );
+
+	/**
+	 * Method to read a record. Creates a new WC_Data based object.
+	 * @param WC_Data
+	 */
+	public function read( &$data );
+
+	/**
+	 * Updates a record in the database.
+	 * @param WC_Data
+	 */
+	public function update( &$data );
+
+	/**
+	 * Deletes a record from the database.
+	 * @param WC_Data
+	 * @param bool $force_delete True to permently delete, false to trash.
+	 */
+	public function delete( &$data, $force_delete );
+}

--- a/tests/framework/class-wc-dummy-data-store.php
+++ b/tests/framework/class-wc-dummy-data-store.php
@@ -1,0 +1,36 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Dummy Data Store: CPT.
+ *
+ * Used to test swapping out data stores.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Dummy_Data_Store_CPT implements WC_Object_Data_Store {
+	public function create( &$data ) { }
+	public function read( &$data ) { }
+	public function update( &$data ) { }
+	public function delete( &$data, $force_delete = false ) { }
+}
+
+/**
+ * WC Dummy Data Store: Custom Table.
+ *
+ * Used to test swapping out data stores.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Dummy_Data_Store_Custom_Table implements WC_Object_Data_Store {
+	public function create( &$data ) { }
+	public function read( &$data ) { }
+	public function update( &$data ) { }
+	public function delete( &$data, $force_delete = false ) { }
+}

--- a/tests/framework/class-wc-mock-wc-data.php
+++ b/tests/framework/class-wc-mock-wc-data.php
@@ -164,7 +164,7 @@ class WC_Mock_WC_Data extends WC_Data {
 	/**
 	 * Simple delete.
 	 */
-	public function delete() {
+	public function delete( $force_delete = false ) {
 		if ( 'user' === $this->meta_type ) {
 			wp_delete_user( $this->get_id() );
 		} else {

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Data Store Tests
+ * @package WooCommerce\Tests\Product
+ * @since 2.7.0
+ */
+class WC_Tests_Data_Store extends WC_Unit_Test_Case {
+
+	/**
+	 * Make sure WC_Data_Store returns an exception if we try to load a data
+	 * store that doesn't exist.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_invalid_store_throws_exception() {
+		try {
+			$product_store = new WC_Data_Store( 'bogus' );
+		} catch ( Exception $e ) {
+			$this->assertEquals( $e->getMessage(), 'Invalid data store.' );
+			return;
+		}
+		$this->fail( 'Invalid data store exception not correctly raised.' );
+	}
+
+	/**
+	 * Make sure ::load returns null if an invalid store is found.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_invalid_store_load_returns_null() {
+		$product_store = WC_Data_Store::load( 'product-test' );
+		$this->assertNull( $product_store );
+	}
+
+	/**
+	 * Make sure we can swap out stores.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_store_swap() {
+		$this->load_dummy_store();
+
+		$store = new WC_Data_Store( 'dummy' );
+		$this->assertEquals( 'WC_Dummy_Data_Store_CPT', $store->get_current_class_name() );
+
+		add_filter( 'woocommerce_dummy_data_store', array( $this, 'set_dummy_store' ) );
+
+		$store = new WC_Data_Store( 'dummy' );
+		$this->assertEquals( 'WC_Dummy_Data_Store_Custom_Table', $store->get_current_class_name() );
+
+		add_filter( 'woocommerce_dummy_data_store', array( $this, 'set_default_dummy_store' ) );
+	}
+
+	/**
+	 * Test to see if `first_second ``-> returns to `first` if unregistered.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_store_sub_type() {
+		$this->load_dummy_store();
+		$store = WC_Data_Store::load( 'dummy_sub' );
+		$this->assertEquals( 'WC_Dummy_Data_Store_CPT', $store->get_current_class_name() );
+	}
+
+	// Helper Functions
+
+	/**
+	 * Loads two dummy data store classes that can be swapt out for each other. Adds to the `woocommerce_data_stores` filter.
+	 *
+	 * @since 2.7.0
+	 */
+	function load_dummy_store() {
+		include_once( dirname( dirname( dirname( __FILE__ ) ) ) . '/framework/class-wc-dummy-data-store.php' );
+		add_filter( 'woocommerce_data_stores', array( $this, 'add_dummy_data_store' ) );
+	}
+
+	/**
+	 * Adds a default class for the 'dummy' data store.
+	 *
+	 * @since 2.7.0
+	 */
+	function add_dummy_data_store( $stores ) {
+		$stores['dummy'] = 'WC_Dummy_Data_Store_CPT';
+		return $stores;
+	}
+
+	/**
+	 * Helper function/filter to swap out the default dummy store for a different one.
+	 *
+	 * @since 2.7.0
+	 */
+	function set_dummy_store( $store ) {
+		return 'WC_Dummy_Data_Store_Custom_Table';
+	}
+
+	/**
+	 * Helper function/filter to swap out the 'dummy' store for the default one.
+	 *
+	 * @since 2.7.0
+	 */
+	function set_default_product_store( $store ) {
+		return 'WC_Dummy_Data_Store_CPT';
+	}
+}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -268,7 +268,6 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-api.php' ); // API Class
 		include_once( WC_ABSPATH . 'includes/class-wc-auth.php' ); // Auth Class
 		include_once( WC_ABSPATH . 'includes/class-wc-post-types.php' ); // Registers post types
-		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php' );				 // WC_Data for CRUD
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-token.php' ); // Payment Tokens
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-product.php' ); // Products
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-order.php' ); // Orders
@@ -284,6 +283,10 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-integrations.php' ); // Loads integrations
 		include_once( WC_ABSPATH . 'includes/class-wc-cache-helper.php' ); // Cache Helper
 		include_once( WC_ABSPATH . 'includes/class-wc-https.php' ); // https Helper
+
+		include_once( WC_ABSPATH . 'includes/class-wc-data-store.php' ); // WC_Data_Store for CRUD
+		include_once( WC_ABSPATH . 'includes/data-stores/interface-wc-object-data-store.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-data-store-cpt.php' );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once( WC_ABSPATH . 'includes/class-wc-cli.php' );


### PR DESCRIPTION
This PR implements a `WC_Data_Store` system to abstract out the CRUD logic from the WC_Data class.

It implements a way of loading "data stores" for a specific object type (example: a products store or coupons store). WooCommerce will ship with default data stores for these object types - powered by custom post types. Using the filters provided by this PR, the storage mechanism can be swapped.

This PR just implements the system. Future PRs will implement it in the actual classes that should use it.

Also includes the get/set proxy logic from the products crud PR.

Includes some tests.

@mikejolley Please include this PR when you rebase product crud later. I wanted to submit it as a separate PR so it can start getting used in multiple places without it being tied to that branch.