### PR TITLE
WC pages not excluded from the cache for permalinks w/o trailing slash

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -157,7 +157,7 @@ class WC_Cache_Helper {
 
 		if ( ( $page_id = wc_get_page_id( $wc_page ) ) && $page_id > 0 && ( $page = get_post( $page_id ) ) ) {
 			$wc_page_uris[] = 'p=' . $page_id;
-			$wc_page_uris[] = '/' . $page->post_name . '/';
+			$wc_page_uris[] = '/' . $page->post_name;
 		}
 
 		return $wc_page_uris;


### PR DESCRIPTION
To reproduce, set permalinks to /%postname%
The constant DONOTCACHEPAGE is then not set on account, cart and checkout pages.