### PR TITLE
Include trailing slash in REQUEST_URI before compare for prevent caching

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -165,7 +165,6 @@ class WC_Cache_Helper {
 
 	/**
 	 * Prevent caching on dynamic pages.
-	 * @access public
 	 */
 	public static function prevent_caching() {
 		if ( false === ( $wc_page_uris = get_transient( 'woocommerce_cache_excluded_uris' ) ) ) {
@@ -177,7 +176,7 @@ class WC_Cache_Helper {
 			self::nocache();
 		} elseif ( is_array( $wc_page_uris ) ) {
 			foreach ( $wc_page_uris as $uri ) {
-				if ( stristr( $_SERVER['REQUEST_URI'], $uri ) ) {
+				if ( stristr( trailingslashit( $_SERVER['REQUEST_URI'] ), $uri ) ) {
 					self::nocache();
 					break;
 				}


### PR DESCRIPTION
Bug reported in #12278

Since it's possible to define custom permalinks on WordPress turn easy to see URLs configured as:

```
/%year%/%monthnum%/%day%/%postname%
```

Or even cases like:

```
/%year%/%monthnum%/%day%/%postname%.html
```

Both will generate pages that don't have a trailing slash at the end of the URL and cause a bug stopping to define the `DONOTCACHEPAGE` constant.

And why not use `'/' . $page->post_name;` ?
Because will generate more errors like:

```
wp> stristr( '/cart-instructions', '/cart' )
=> string(19) "/cart-instructions/"
```

So ensuring that the both have slash will prevent problems with pages that start with similar names.

```
wp> stristr( trailingslashit( '/cart-instructions' ), '/cart/' )
=> bool(false)
wp> stristr( trailingslashit( '/cart' ), '/cart/' )
=> string(6) "/cart/"
```