### PR TITLE
Use get_the_terms() instead of wp_get_post_terms()

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1235,7 +1235,11 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return array of terms
 	 */
 	protected function get_term_ids( $taxonomy ) {
-		return wp_get_post_terms( $this->get_id(), $taxonomy, array( 'fields' => 'ids' ) );
+		$terms = get_the_terms( $this->get_id(), $taxonomy );
+		if ( false === $terms || is_wp_error( $terms ) ) {
+			return array();
+		}
+		return wp_list_pluck( $terms, 'term_id' );
 	}
 
 	/**


### PR DESCRIPTION
wp_get_post_terms() is a wrapper around wp_get_object_terms() which does not
use the object cache, and generates a database query every time it is used.

get_the_terms() however can use data from the object cache if present.