### PR TITLE
Allow WP_Query to preload post data, and meta in wc_get_products()

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -88,11 +88,14 @@ function wc_get_products( $args ) {
 		'post_status'    => $args['status'],
 		'posts_per_page' => $args['limit'],
 		'meta_query'     => array(),
-		'fields'         => 'ids',
 		'orderby'        => $args['orderby'],
 		'order'          => $args['order'],
 		'tax_query'      => array(),
 	);
+	// Do not load unneccessary post data if the user only wants IDs.
+	if ( 'ids' === $args['return'] ) {
+		$wp_query_args['fields'] = 'ids';
+	}
 
 	if ( 'variation' !== $args['type'] ) {
 		$wp_query_args['tax_query'][] = array(


### PR DESCRIPTION
`wc_get_products()` runs a WP_Query to fetch the relevant post IDs **only**, and then (as long as the user hasn't specifically requested just the IDs) loads each post / product individually.

This results in a significant increase in the number of database queries executed. This change allows WP_Query to fetch the post & meta information as well, dramatically reducing the number of queries executed. 

The 'fetch-IDs-only' optimisation to WP_Query is retained as long as the user has asked for only IDs to be returned from `wc_get_products()`. 

With the following test script on my dev box:

```
<?php

$args = array(
	'status'      => array( 'publish' ),
	'limit'       => 20,
	'offset'      => 0,
	'return'      => 'objects',
);
wc_get_products($args);
```

Before this change, the code above executes 158 database queries. After this PR that is reduced to 100 queries.

If you combine it with the changes in https://github.com/woocommerce/woocommerce/pull/12288 then that number comes down to 42 queries.