### PR TITLE
[checkbox] - make markup consistent

### DIFF
--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -47,9 +47,7 @@ if ( is_user_logged_in() ) {
 		<?php wp_nonce_field( 'woocommerce-login' ); ?>
 		<input type="submit" class="button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>" />
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ) ?>" />
-		<label for="rememberme" class="inline">
-			<input name="rememberme" type="checkbox" id="rememberme" value="forever" /> <?php _e( 'Remember me', 'woocommerce' ); ?>
-		</label>
+		<input name="rememberme" type="checkbox" id="rememberme" value="forever" /><label for="rememberme" class="inline"><?php _e( 'Remember me', 'woocommerce' ); ?></label>
 	</p>
 	<p class="lost_password">
 		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php _e( 'Lost your password?', 'woocommerce' ); ?></a>

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -54,9 +54,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p class="form-row">
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 				<input type="submit" class="woocommerce-Button button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>" />
-				<label for="rememberme" class="inline">
-					<input class="woocommerce-Input woocommerce-Input--checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <?php _e( 'Remember me', 'woocommerce' ); ?>
-				</label>
+				<input class="woocommerce-Input woocommerce-Input--checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /><label for="rememberme" class="inline"><?php _e( 'Remember me', 'woocommerce' ); ?></label>
 			</p>
 			<p class="woocommerce-LostPassword lost_password">
 				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php _e( 'Lost your password?', 'woocommerce' ); ?></a>


### PR DESCRIPTION
Hi,

Make the mark-up consistent following [this](https://github.com/woocommerce/woocommerce/blob/657c312caeef7345b225ffb899da6dbb84692936/templates/checkout/form-billing.php#L52) method. This also allows for CSS3 styling of checkboxes. 

Currently, if you style using the CSS3 method of hiding the checkbox and styling the label using pseudo selectors, then it will not work for the checkboxes I have changed making styling inconsistent.

Thanks,
Tom