### PR TITLE
Removed empty string param in _deprecated_function function

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-order.php
+++ b/includes/abstracts/abstract-wc-legacy-order.php
@@ -571,7 +571,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return array
 	 */
 	public function expand_item_meta( $item ) {
-		_deprecated_function( 'expand_item_meta', '2.7', '' );
+		_deprecated_function( 'expand_item_meta', '2.7' );
 		return $item;
 	}
 

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -508,7 +508,7 @@ class WC_Query {
 	public function order_by_rating_post_clauses( $args ) {
 		global $wpdb;
 
-		_deprecated_function( 'order_by_rating_post_clauses', '2.7', '' );
+		_deprecated_function( 'order_by_rating_post_clauses', '2.7' );
 
 		$args['fields'] .= ", AVG( $wpdb->commentmeta.meta_value ) as average_rating ";
 		$args['where']  .= " AND ( $wpdb->commentmeta.meta_key = 'rating' OR $wpdb->commentmeta.meta_key IS null ) ";
@@ -738,7 +738,7 @@ class WC_Query {
 	 * @deprecated 2.6.0
 	 */
 	public function layered_nav_init() {
-		_deprecated_function( 'layered_nav_init', '2.6', '' );
+		_deprecated_function( 'layered_nav_init', '2.6' );
 	}
 
 	/**
@@ -746,7 +746,7 @@ class WC_Query {
 	 * @deprecated 2.6.0 due to performance concerns
 	 */
 	public function get_products_in_view() {
-		_deprecated_function( 'get_products_in_view', '2.6', '' );
+		_deprecated_function( 'get_products_in_view', '2.6' );
 	}
 
 	/**
@@ -754,6 +754,6 @@ class WC_Query {
 	 * @deprecated 2.6.0 due to performance concerns
 	 */
 	public function layered_nav_query( $filtered_posts ) {
-		_deprecated_function( 'layered_nav_query', '2.6', '' );
+		_deprecated_function( 'layered_nav_query', '2.6' );
 	}
 }

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -402,7 +402,7 @@ class WC_Shipping {
 	 * @deprecated 2.6.0 Was previously used to determine sort order of methods, but this is now controlled by zones and thus unused.
 	 */
 	public function sort_shipping_methods() {
-		_deprecated_function( 'sort_shipping_methods', '2.6', '' );
+		_deprecated_function( 'sort_shipping_methods', '2.6' );
 		return $this->shipping_methods;
 	}
 }

--- a/includes/legacy/class-wc-legacy-coupon.php
+++ b/includes/legacy/class-wc-legacy-coupon.php
@@ -140,7 +140,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 * @return array
 	 */
 	public function format_array( $array ) {
-		_deprecated_function( 'format_array', '2.7', '' );
+		_deprecated_function( 'format_array', '2.7' );
 		if ( ! is_array( $array ) ) {
 			if ( is_serialized( $array ) ) {
 				$array = maybe_unserialize( $array );
@@ -158,7 +158,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 * @return bool
 	 */
 	public function apply_before_tax() {
-		_deprecated_function( 'apply_before_tax', '2.7', '' );
+		_deprecated_function( 'apply_before_tax', '2.7' );
 		return true;
 	}
 

--- a/includes/legacy/class-wc-legacy-customer.php
+++ b/includes/legacy/class-wc-legacy-customer.php
@@ -152,7 +152,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	 * Set default data for a customer.
 	 */
 	public function set_default_data() {
-		_deprecated_function( 'WC_Customer::set_default_data', '2.7', '' );
+		_deprecated_function( 'WC_Customer::set_default_data', '2.7' );
 	}
 
 	/**

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -25,25 +25,25 @@ function woocommerce_show_messages() {
  * @deprecated
  */
 function woocommerce_weekend_area_js() {
-	_deprecated_function( 'woocommerce_weekend_area_js', '2.1', '' );
+	_deprecated_function( 'woocommerce_weekend_area_js', '2.1' );
 }
 /**
  * @deprecated
  */
 function woocommerce_tooltip_js() {
-	_deprecated_function( 'woocommerce_tooltip_js', '2.1', '' );
+	_deprecated_function( 'woocommerce_tooltip_js', '2.1' );
 }
 /**
  * @deprecated
  */
 function woocommerce_datepicker_js() {
-	_deprecated_function( 'woocommerce_datepicker_js', '2.1', '' );
+	_deprecated_function( 'woocommerce_datepicker_js', '2.1' );
 }
 /**
  * @deprecated
  */
 function woocommerce_admin_scripts() {
-	_deprecated_function( 'woocommerce_admin_scripts', '2.1', '' );
+	_deprecated_function( 'woocommerce_admin_scripts', '2.1' );
 }
 /**
  * @deprecated

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1108,7 +1108,7 @@ if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
 	 * @subpackage	Product/Tabs
 	 */
 	function woocommerce_product_reviews_tab() {
-		_deprecated_function( 'woocommerce_product_reviews_tab', '2.4', '' );
+		_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );
 	}
 }
 


### PR DESCRIPTION
`_deprecated_function` has conditional which is checking if third param (replacement) is null. Passing replacement as empty string to this function will fail this test and the end of triggered error will look like this: `Use instead.` instead of `with no alternative available.`. This PR removes all occurrences of empty strings in this function.