### PR TITLE
[Product CRUD] Product Datastore

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -526,7 +526,7 @@ abstract class WC_Data {
 	 *
 	 * @since 2.7.0
 	 */
-	protected function apply_changes() {
+	public function apply_changes() {
 		$this->data = array_merge( $this->data, $this->changes );
 		$this->changes = array();
 	}

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -661,10 +661,11 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Match a variation to a given set of attributes using a WP_Query.
-	 * @deprecated 2.7.0 in favour of wc_find_matching_product_variation.
+	 * @deprecated 2.7.0 in favour of Product data store's find_matching_product_variation.
 	 */
 	public function get_matching_variation( $match_attributes = array() ) {
-		_deprecated_function( 'WC_Product::get_matching_variation', '2.7', 'wc_find_matching_product_variation' );
-		return wc_find_matching_product_variation( $this, $match_attributes );
+		_deprecated_function( 'WC_Product::get_matching_variation', '2.7', 'Product data store find_matching_product_variation' );
+		$data_store = WC_Data_Store::load( 'product' );
+		return $data_store->find_matching_product_variation( $this, $match_attributes );
 	}
 }

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -59,6 +59,11 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return mixed
 	 */
 	public function __get( $key ) {
+
+		if ( 'post_type' === $key ) {
+			return $this->post_type;
+		}
+
 		_doing_it_wrong( $key, __( 'Product properties should not be accessed directly.', 'woocommerce' ), '2.7' );
 
 		switch ( $key ) {

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -296,11 +296,12 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
 	 * Builds the related posts query.
-	 * @deprecated 2.7.0 Use wc_get_related_products_query instead.
+	 * @deprecated 2.7.0 Use Product Data Store get_related_products_query instead.
 	 */
 	protected function build_related_query( $cats_array, $tags_array, $exclude_ids, $limit ) {
-		_deprecated_function( 'WC_Product::build_related_query', '2.7', 'wc_get_related_products_query' );
-		return wc_get_related_products_query( $cats_array, $tags_array, $exclude_ids, $limit );
+		_deprecated_function( 'WC_Product::build_related_query', '2.7', 'Product Data Store get_related_products_query' );
+		$data_store = WC_Data_Store::load( 'product' );
+		return $data_store->get_related_products_query( $cats_array, $tags_array, $exclude_ids, $limit );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -139,6 +139,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$this->read( absint( $product->get_id() ) );
 		} elseif ( ! empty( $product->ID ) ) {
 			$this->read( absint( $product->ID ) );
+		} else {
+			$this->set_object_read( true );
 		}
 	}
 
@@ -909,7 +911,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 *
 	 * @param string $status New status.
 	 */
-	public function set_stock_status( $status ) {
+	public function set_stock_status( $status = '' ) {
 		$this->set_prop( 'stock_status', 'outofstock' === $status ? 'outofstock' : 'instock' );
 	}
 
@@ -977,7 +979,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * Set upsell IDs.
 	 *
 	 * @since 2.7.0
-	 * @param string $upsell_ids IDs from the up-sell products.
+	 * @param array $upsell_ids IDs from the up-sell products.
 	 */
 	public function set_upsell_ids( $upsell_ids ) {
 		$this->set_prop( 'upsell_ids', array_filter( (array) $upsell_ids ) );
@@ -987,7 +989,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * Set crosssell IDs.
 	 *
 	 * @since 2.7.0
-	 * @param string $cross_sell_ids IDs from the cross-sell products.
+	 * @param array $cross_sell_ids IDs from the cross-sell products.
 	 */
 	public function set_cross_sell_ids( $cross_sell_ids ) {
 		$this->set_prop( 'cross_sell_ids', array_filter( (array) $cross_sell_ids ) );
@@ -1057,7 +1059,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $default_attributes List of default attributes.
 	 */
 	public function set_default_attributes( $default_attributes ) {
-		$this->set_prop( 'default_attributes', $default_attributes );
+		$this->set_prop( 'default_attributes', array_filter( (array) $default_attributes ) );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -134,13 +134,18 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );
 		if ( is_numeric( $product ) && $product > 0 ) {
-			$this->read( $product );
+			$this->set_id( $product );
 		} elseif ( $product instanceof self ) {
-			$this->read( absint( $product->get_id() ) );
+			$this->set_id( absint( $product->get_id() ) );
 		} elseif ( ! empty( $product->ID ) ) {
-			$this->read( absint( $product->ID ) );
+			$this->set_id( absint( $product->ID ) );
 		} else {
 			$this->set_object_read( true );
+		}
+
+		$this->data_store = WC_Data_Store::load( 'product_' . $this->get_type() );
+		if ( $this->get_id() > 0 ) {
+			$this->data_store->read( $this );
 		}
 	}
 
@@ -1229,29 +1234,9 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 
 	/*
 	|--------------------------------------------------------------------------
-	| CRUD methods
+	| Other Methods
 	|--------------------------------------------------------------------------
-	|
-	| Methods which create, read, update and delete products from the database.
-	|
-	| A save method is included for convenience (chooses update or create based
-	| on if the order exists yet).
 	*/
-
-	/**
-	 * Get and store terms from a taxonomy.
-	 *
-	 * @since  2.7.0
-	 * @param  string $taxonomy Taxonomy name e.g. product_cat
-	 * @return array of terms
-	 */
-	protected function get_term_ids( $taxonomy ) {
-		$terms = get_the_terms( $this->get_id(), $taxonomy );
-		if ( false === $terms || is_wp_error( $terms ) ) {
-			return array();
-		}
-		return wp_list_pluck( $terms, 'term_id' );
-	}
 
 	/**
 	 * Get term ids from either a list of names, ids, or terms.
@@ -1276,174 +1261,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			}
 		}
 		return $term_ids;
-	}
-
-	/**
-	 * Reads a product from the database and sets its data to the class.
-	 *
-	 * @since 2.7.0
-	 * @param int $id Product ID.
-	 */
-	public function read( $id ) {
-		$this->set_defaults();
-
-		if ( ! $id || ! ( $post_object = get_post( $id ) ) ) {
-			return;
-		}
-
-		$this->set_id( $id );
-		$this->set_props( array(
-			'name'              => get_the_title( $post_object ),
-			'slug'              => $post_object->post_name,
-			'date_created'      => $post_object->post_date,
-			'date_modified'     => $post_object->post_modified,
-			'status'            => $post_object->post_status,
-			'description'       => $post_object->post_content,
-			'short_description' => $post_object->post_excerpt,
-			'parent_id'         => $post_object->post_parent,
-			'menu_order'        => $post_object->menu_order,
-			'reviews_allowed'   => 'open' === $post_object->comment_status,
-		) );
-		$this->read_meta_data();
-		$this->read_attributes();
-		$this->read_product_data();
-
-		// Set object_read true once all data is read.
-		$this->set_object_read( true );
-	}
-
-	/**
-	 * Read product data. Can be overridden by child classes to load other props.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function read_product_data() {
-		$id = $this->get_id();
-		$this->set_props( array(
-			'featured'           => get_post_meta( $id, '_featured', true ),
-			'catalog_visibility' => get_post_meta( $id, '_visibility', true ),
-			'sku'                => get_post_meta( $id, '_sku', true ),
-			'regular_price'      => get_post_meta( $id, '_regular_price', true ),
-			'sale_price'         => get_post_meta( $id, '_sale_price', true ),
-			'price'              => get_post_meta( $id, '_price', true ),
-			'date_on_sale_from'  => get_post_meta( $id, '_sale_price_dates_from', true ),
-			'date_on_sale_to'    => get_post_meta( $id, '_sale_price_dates_to', true ),
-			'total_sales'        => get_post_meta( $id, 'total_sales', true ),
-			'tax_status'         => get_post_meta( $id, '_tax_status', true ),
-			'tax_class'          => get_post_meta( $id, '_tax_class', true ),
-			'manage_stock'       => get_post_meta( $id, '_manage_stock', true ),
-			'stock_quantity'     => get_post_meta( $id, '_stock', true ),
-			'stock_status'       => get_post_meta( $id, '_stock_status', true ),
-			'backorders'         => get_post_meta( $id, '_backorders', true ),
-			'sold_individually'  => get_post_meta( $id, '_sold_individually', true ),
-			'weight'             => get_post_meta( $id, '_weight', true ),
-			'length'             => get_post_meta( $id, '_length', true ),
-			'width'              => get_post_meta( $id, '_width', true ),
-			'height'             => get_post_meta( $id, '_height', true ),
-			'upsell_ids'         => get_post_meta( $id, '_upsell_ids', true ),
-			'cross_sell_ids'     => get_post_meta( $id, '_crosssell_ids', true ),
-			'purchase_note'      => get_post_meta( $id, '_purchase_note', true ),
-			'default_attributes' => get_post_meta( $id, '_default_attributes', true ),
-			'category_ids'       => $this->get_term_ids( 'product_cat' ),
-			'tag_ids'            => $this->get_term_ids( 'product_tag' ),
-			'shipping_class_id'  => current( $this->get_term_ids( 'product_shipping_class' ) ),
-			'virtual'            => get_post_meta( $id, '_virtual', true ),
-			'downloadable'       => get_post_meta( $id, '_downloadable', true ),
-			'downloads'          => array_filter( (array) get_post_meta( $id, '_downloadable_files', true ) ),
-			'gallery_image_ids'  => array_filter( explode( ',', get_post_meta( $id, '_product_image_gallery', true ) ) ),
-			'download_limit'     => get_post_meta( $id, '_download_limit', true ),
-			'download_expiry'    => get_post_meta( $id, '_download_expiry', true ),
-			'image_id'           => get_post_thumbnail_id( $id ),
-		) );
-	}
-
-	/**
-	 * Read attributes from post meta.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function read_attributes() {
-		$meta_values = maybe_unserialize( get_post_meta( $this->get_id(), '_product_attributes', true ) );
-
-		if ( $meta_values ) {
-			$attributes = array();
-			foreach ( $meta_values as $meta_value ) {
-				if ( ! empty( $meta_value['is_taxonomy'] ) ) {
-					if ( ! taxonomy_exists( $meta_value['name'] ) ) {
-						continue;
-					}
-					$options = wp_get_post_terms( $this->get_id(), $meta_value['name'], array( 'fields' => 'ids' ) );
-				} else {
-					$options = wc_get_text_attributes( $meta_value['value'] );
-				}
-				$attribute = new WC_Product_Attribute();
-				$attribute->set_id( wc_attribute_taxonomy_id_by_name( $meta_value['name'] ) );
-				$attribute->set_name( $meta_value['name'] );
-				$attribute->set_options( $options );
-				$attribute->set_position( $meta_value['position'] );
-				$attribute->set_visible( $meta_value['is_visible'] );
-				$attribute->set_variation( $meta_value['is_variation'] );
-				$attributes[] = $attribute;
-			}
-			$this->set_attributes( $attributes );
-		}
-	}
-
-	/**
-	 * Create a new product.
-	 *
-	 * @since 2.7.0
-	 */
-	public function create() {
-		$this->set_date_created( current_time( 'timestamp' ) );
-
-		$id = wp_insert_post( apply_filters( 'woocommerce_new_product_data', array(
-			'post_type'      => $this->post_type,
-			'post_status'    => $this->get_status() ? $this->get_status() : 'publish',
-			'post_author'    => get_current_user_id(),
-			'post_title'     => $this->get_name() ? $this->get_name() : __( 'Product', 'woocommerce' ),
-			'post_content'   => $this->get_description(),
-			'post_excerpt'   => $this->get_short_description(),
-			'post_parent'    => $this->get_parent_id(),
-			'comment_status' => $this->get_reviews_allowed() ? 'open' : 'closed',
-			'ping_status'    => 'closed',
-			'menu_order'     => $this->get_menu_order(),
-			'post_date'      => date( 'Y-m-d H:i:s', $this->get_date_created() ),
-			'post_date_gmt'  => get_gmt_from_date( date( 'Y-m-d H:i:s', $this->get_date_created() ) ),
-		) ), true );
-
-		if ( $id && ! is_wp_error( $id ) ) {
-			$this->set_id( $id );
-			$this->update_post_meta();
-			$this->update_terms();
-			$this->update_attributes();
-			$this->save_meta_data();
-			do_action( 'woocommerce_new_' . $this->post_type, $id );
-		}
-	}
-
-	/**
-	 * Updates an existing product.
-	 *
-	 * @since 2.7.0
-	 */
-	public function update() {
-		$post_data = array(
-			'ID'             => $this->get_id(),
-			'post_content'   => $this->get_description(),
-			'post_excerpt'   => $this->get_short_description(),
-			'post_title'     => $this->get_name(),
-			'post_parent'    => $this->get_parent_id(),
-			'comment_status' => $this->get_reviews_allowed() ? 'open' : 'closed',
-			'post_status'    => $this->get_status() ? $this->get_status() : 'publish',
-			'menu_order'     => $this->get_menu_order(),
-		);
-		wp_update_post( $post_data );
-		$this->update_post_meta();
-		$this->update_terms();
-		$this->update_attributes();
-		$this->save_meta_data();
-		do_action( 'woocommerce_update_' . $this->post_type, $this->get_id() );
 	}
 
 	/**
@@ -1474,231 +1291,14 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function save() {
 		$this->validate_props();
 
-		if ( $this->get_id() ) {
-			$this->update();
-		} else {
-			$this->create();
-		}
-
-		$this->apply_changes();
-		$this->update_product_type();
-		$this->update_product_version();
-		$this->update_term_counts();
-		$this->clear_caches();
-
-		return $this->get_id();
-	}
-
-	/**
-	 * Make sure we store the product type.
-	 */
-	protected function update_product_type() {
-		if ( 'product' === $this->post_type ) {
-			$type_term = get_term_by( 'name', $this->get_type(), 'product_type' );
-			wp_set_object_terms( $this->get_id(), absint( $type_term->term_id ), 'product_type' );
-		}
-	}
-
-	/**
-	 * Version is set to current WC version to track data changes.
-	 */
-	protected function update_product_version() {
-		update_post_meta( $this->get_id(), '_product_version', WC_VERSION );
-	}
-
-	/**
-	 * Count terms. These are done at this point so all product props are set in advance.
-	 */
-	protected function update_term_counts() {
-		if ( ! wp_defer_term_counting() ) {
-			global $wc_allow_term_recount;
-
-			$wc_allow_term_recount = true;
-
-			// Update counts for the post's terms.
-			foreach ( (array) get_object_taxonomies( $this->post_type ) as $taxonomy ) {
-				$tt_ids = wp_get_object_terms( $this->get_id(), $taxonomy, array( 'fields' => 'tt_ids' ) );
-				wp_update_term_count( $tt_ids, $taxonomy );
-			}
-		}
-	}
-
-	/**
-	 * Clear any caches.
-	 */
-	protected function clear_caches() {
-		wc_delete_product_transients( $this->get_id() );
-	}
-
-	/**
-	 * Delete product from the database.
-	 *
-	 * @since 2.7.0
-	 */
-	public function delete( $force_delete = false ) {
-		wp_delete_post( $this->get_id() );
-		do_action( 'woocommerce_delete_' . $this->post_type, $this->get_id() );
-		$this->set_id( 0 );
-	}
-
-	/**
-	 * Helper method that updates all the post meta for a product based on it's settings in the WC_Product class.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function update_post_meta() {
-		$updated_props     = array();
-		$changed_props     = array_keys( $this->get_changes() );
-		$meta_key_to_props = array(
-			'_visibility'            => 'catalog_visibility',
-			'_sku'                   => 'sku',
-			'_regular_price'         => 'regular_price',
-			'_sale_price'            => 'sale_price',
-			'_sale_price_dates_from' => 'date_on_sale_from',
-			'_sale_price_dates_to'   => 'date_on_sale_to',
-			'total_sales'            => 'total_sales',
-			'_tax_status'            => 'tax_status',
-			'_tax_class'             => 'tax_class',
-			'_manage_stock'          => 'manage_stock',
-			'_backorders'            => 'backorders',
-			'_sold_individually'     => 'sold_individually',
-			'_weight'                => 'weight',
-			'_length'                => 'length',
-			'_width'                 => 'width',
-			'_height'                => 'height',
-			'_upsell_ids'            => 'upsell_ids',
-			'_crosssell_ids'         => 'cross_sell_ids',
-			'_purchase_note'         => 'purchase_note',
-			'_default_attributes'    => 'default_attributes',
-			'_virtual'               => 'virtual',
-			'_downloadable'          => 'downloadable',
-			'_product_image_gallery' => 'gallery_image_ids',
-			'_download_limit'        => 'download_limit',
-			'_download_expiry'       => 'download_expiry',
-			'_featured'              => 'featured',
-			'_thumbnail_id'          => 'image_id',
-			'_downloadable_files'    => 'downloads',
-			'_stock'                 => 'stock_quantity',
-			'_stock_status'          => 'stock_status',
-		);
-
-		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( ! in_array( $prop, $changed_props ) ) {
-				continue;
-			}
-			$value = $this->{"get_$prop"}( 'edit' );
-			switch ( $prop ) {
-				case 'virtual' :
-				case 'downloadable' :
-				case 'manage_stock' :
-				case 'featured' :
-				case 'sold_individually' :
-					$updated = update_post_meta( $this->get_id(), $meta_key, wc_bool_to_string( $value ) );
-					break;
-				case 'gallery_image_ids' :
-					$updated = update_post_meta( $this->get_id(), $meta_key, implode( ',', $value ) );
-					break;
-				case 'image_id' :
-					if ( ! empty( $value ) ) {
-						set_post_thumbnail( $this->get_id(), $value );
-					} else {
-						delete_post_meta( $this->get_id(), '_thumbnail_id' );
-					}
-					$updated = true;
-					break;
-				default :
-					$updated = update_post_meta( $this->get_id(), $meta_key, $value );
-					break;
-			}
-			if ( $updated ) {
-				$updated_props[] = $prop;
-			}
-		}
-
-		if ( in_array( 'date_on_sale_from', $updated_props ) || in_array( 'date_on_sale_to', $updated_props ) || in_array( 'regular_price', $updated_props ) || in_array( 'sale_price', $updated_props ) ) {
-			if ( $this->is_on_sale() ) {
-				update_post_meta( $this->get_id(), '_price', $this->get_sale_price() );
+		if ( $this->data_store ) {
+			if ( $this->get_id() ) {
+				$this->data_store->update( $this );
 			} else {
-				update_post_meta( $this->get_id(), '_price', $this->get_regular_price() );
+				$this->data_store->create( $this );
 			}
+			return $this->get_id();
 		}
-
-		if ( in_array( 'featured', $updated_props ) ) {
-			delete_transient( 'wc_featured_products' );
-		}
-
-		if ( in_array( 'catalog_visibility', $updated_props ) ) {
-			do_action( 'woocommerce_product_set_visibility',  $this->get_id(), $this->get_catalog_visibility() );
-		}
-
-		if ( in_array( 'downloads', $updated_props ) ) {
-			// grant permission to any newly added files on any existing orders for this product prior to saving.
-			if ( $this->is_type( 'variation' ) ) {
-				do_action( 'woocommerce_process_product_file_download_paths', $this->get_parent_id(), $this->get_id(), $this->get_downloads() );
-			} else {
-				do_action( 'woocommerce_process_product_file_download_paths', $this->get_id(), 0, $this->get_downloads() );
-			}
-		}
-
-		if ( in_array( 'stock_quantity', $updated_props ) ) {
-			do_action( $this->is_type( 'variation' ) ? 'woocommerce_variation_set_stock' : 'woocommerce_product_set_stock' , $this );
-		}
-
-		if ( in_array( 'stock_status', $updated_props ) ) {
-			do_action( $this->is_type( 'variation' ) ? 'woocommerce_variation_set_stock_status' : 'woocommerce_product_set_stock_status' , $this->get_id(), $this->get_stock_status() );
-		}
-	}
-
-	/**
-	 * For all stored terms in all taxonomies, save them to the DB.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function update_terms() {
-		wp_set_post_terms( $this->get_id(), $this->get_category_ids( 'edit' ), 'product_cat', false );
-		wp_set_post_terms( $this->get_id(), $this->get_tag_ids( 'edit' ), 'product_tag', false );
-		wp_set_post_terms( $this->get_id(), array( $this->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
-	}
-
-	/**
-	 * Update attributes which are a mix of terms and meta data.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function update_attributes() {
-		$attributes  = $this->get_attributes();
-		$meta_values = array();
-
-		if ( $attributes ) {
-			foreach ( $attributes as $attribute_key => $attribute ) {
-				$value = '';
-
-				if ( is_null( $attribute ) ) {
-					if ( taxonomy_exists( $attribute_key ) ) {
-						// Handle attributes that have been unset.
-						wp_set_object_terms( $this->get_id(), array(), $attribute_key );
-					}
-					continue;
-
-				} elseif ( $attribute->is_taxonomy() ) {
-					wp_set_object_terms( $this->get_id(), wp_list_pluck( $attribute->get_terms(), 'term_id' ), $attribute->get_name() );
-
-				} else {
-					$value = wc_implode_text_attributes( $attribute->get_options() );
-				}
-
-				// Store in format WC uses in meta.
-				$meta_values[ $attribute_key ] = array(
-					'name'         => $attribute->get_name(),
-					'value'        => $value,
-					'position'     => $attribute->get_position(),
-					'is_visible'   => $attribute->get_visible() ? 1 : 0,
-					'is_variation' => $attribute->get_variation() ? 1 : 0,
-					'is_taxonomy'  => $attribute->is_taxonomy() ? 1 : 0,
-				);
-			}
-		}
-		update_post_meta( $this->get_id(), '_product_attributes', $meta_values );
 	}
 
 	/*

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1932,7 +1932,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 			// (Note that internally this falls through to `wp_delete_post` if
 			// the trash is disabled.)
 			$product->delete();
-			$result = $product->get_id() > 0 ? false : true;
+			$result = 'trash' === $product->get_status();
 		}
 
 		if ( ! $result ) {

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1858,7 +1858,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 
 		// Delete product.
 		$product = wc_get_product( $post->ID );
-		$product->delete();
+		$product->delete( true );
 	}
 
 	/**
@@ -1904,7 +1904,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 			if ( $product->is_type( 'variable' ) ) {
 				foreach ( $product->get_children() as $child_id ) {
 					$child = wc_get_product( $child_id );
-					$child->delete();
+					$child->delete( true );
 				}
 			} elseif ( $product->is_type( 'grouped' ) ) {
 				foreach ( $product->get_children() as $child_id ) {
@@ -1914,7 +1914,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				}
 			}
 
-			$product->delete();
+			$product->delete( true );
 			$result = $product->get_id() > 0 ? false : true;
 		} else {
 			// If we don't support trashing for this type, error out.
@@ -1931,7 +1931,8 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 
 			// (Note that internally this falls through to `wp_delete_post` if
 			// the trash is disabled.)
-			$result = wp_trash_post( $id );
+			$product->delete();
+			$result = $product->get_id() > 0 ? false : true;
 		}
 
 		if ( ! $result ) {

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -420,7 +420,7 @@ class WC_API_Products extends WC_API_Resource {
 			if ( $product->is_type( 'variable' ) ) {
 				foreach ( $product->get_children() as $child_id ) {
 					$child = wc_get_product( $child_id );
-					$child->delete();
+					$child->delete( true );
 				}
 			} elseif ( $product->is_type( 'grouped' ) ) {
 				foreach ( $product->get_children() as $child_id ) {
@@ -430,10 +430,11 @@ class WC_API_Products extends WC_API_Resource {
 				}
 			}
 
-			$product->delete();
+			$product->delete( true );
 			$result = $product->get_id() > 0 ? false : true;
 		} else {
-			$result = wp_trash_post( $id );
+			$product->delete();
+			$result = 'trash' === $product->get_status();
 		}
 
 		if ( ! $result ) {

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -479,7 +479,7 @@ class WC_API_Products extends WC_API_Resource {
 			if ( $product->is_type( 'variable' ) ) {
 				foreach ( $product->get_children() as $child_id ) {
 					$child = wc_get_product( $child_id );
-					$child->delete();
+					$child->delete( true );
 				}
 			} elseif ( $product->is_type( 'grouped' ) ) {
 				foreach ( $product->get_children() as $child_id ) {
@@ -489,10 +489,11 @@ class WC_API_Products extends WC_API_Resource {
 				}
 			}
 
-			$product->delete();
+			$product->delete( true );
 			$result = $product->get_id() > 0 ? false : true;
 		} else {
-			$result = wp_trash_post( $id );
+			$product->delete();
+			$result = 'trash' === $product->get_status();
 		}
 
 		if ( ! $result ) {
@@ -3175,7 +3176,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		// Delete product
 		$product = wc_get_product( $product_id );
-		$product->delete();
+		$product->delete( true );
 	}
 
 	/**

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -440,7 +440,8 @@ class WC_AJAX {
 			die();
 		}
 
-		$variation_id = wc_find_matching_product_variation( $variable_product, wp_unslash( $_POST ) );
+		$data_store   = WC_Data_Store::load( 'product' );
+		$variation_id = $data_store->find_matching_product_variation( $variable_product, wp_unslash( $_POST ) );
 
 		if ( $variation_id ) {
 			$variation = $variable_product->get_available_variation( $variation_id );

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -28,11 +28,13 @@ class WC_Data_Store {
 	 * Ran through `woocommerce_data_stores`.
 	 */
 	private $stores = array(
-		'coupon'           => 'WC_Coupon_Data_Store_CPT',
-		'product'          => 'WC_Product_Data_Store_CPT',
-		'product_grouped'  => 'WC_Product_Grouped_Data_Store_CPT',
-		'product_variable' => 'WC_Product_Variable_Data_Store_CPT',
+		'coupon'            => 'WC_Coupon_Data_Store_CPT',
+		'product'           => 'WC_Product_Data_Store_CPT',
+		'product_grouped'   => 'WC_Product_Grouped_Data_Store_CPT',
+		'product_variable'  => 'WC_Product_Variable_Data_Store_CPT',
+		'product_variation' => 'WC_Product_Variation_Data_Store_CPT',
 	);
+
 	/**
 	 * Contains the name of the current data store's class name.
 	 */

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -28,7 +28,10 @@ class WC_Data_Store {
 	 * Ran through `woocommerce_data_stores`.
 	 */
 	private $stores = array(
-		'coupon' => 'WC_Coupon_Data_Store_CPT',
+		'coupon'           => 'WC_Coupon_Data_Store_CPT',
+		'product'          => 'WC_Product_Data_Store_CPT',
+		'product_grouped'  => 'WC_Product_Grouped_Data_Store_CPT',
+		'product_variable' => 'WC_Product_Variable_Data_Store_CPT',
 	);
 	/**
 	 * Contains the name of the current data store's class name.

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -801,7 +801,8 @@ class WC_Form_Handler {
 
 		// If no variation ID is set, attempt to get a variation ID from posted attributes.
 		if ( empty( $variation_id ) ) {
-			wc_find_matching_product_variation( $adding_to_cart, wp_unslash( $_POST ) );
+			$data_store   = WC_Data_Store::load( 'product' );
+			$variation_id = $data_store->find_matching_product_variation( $adding_to_cart, wp_unslash( $_POST ) );
 		}
 
 		$variation = wc_get_product( $variation_id );

--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -121,7 +121,7 @@ class WC_Product_External extends WC_Product {
 	 * @since 2.7.0
 	 * @param bool
 	 */
-	public function set_stock_status( $stock_status ) {
+	public function set_stock_status( $stock_status = '' ) {
 		$this->set_prop( 'stock_status', 'instock' );
 
 		if ( 'instock' !== $stock_status ) {

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * The WooCommerce product factory creating the right product object.
  *
  * @class 		WC_Product_Factory
- * @version		2.3.0
+ * @version		2.7.0
  * @package		WooCommerce/Classes
  * @category	Class
  * @author 		WooThemes
@@ -20,32 +20,53 @@ class WC_Product_Factory {
 	/**
 	 * Get a product.
 	 *
-	 * @param bool $the_product (default: false)
-	 * @param array $args (default: array())
-	 * @return WC_Product|bool false if the product cannot be loaded
+	 * @param mixed $product_id (default: false)
+	 * @param array $deprecated
+	 * @return WC_Product|null Product object or null if the product cannot be loaded.
 	 */
-	public function get_product( $the_product = false, $args = array() ) {
-		try {
-			$the_product = $this->get_product_object( $the_product );
-
-			if ( ! $the_product ) {
-				throw new Exception( 'Product object does not exist', 422 );
-			}
-
-			$classname = $this->get_product_class( $the_product, $args );
-
-			if ( ! $classname ) {
-				throw new Exception( 'Missing classname', 422 );
-			}
-
-			if ( ! class_exists( $classname ) ) {
-				$classname = 'WC_Product_Simple';
-			}
-
-			return new $classname( $the_product, $args );
-
-		} catch ( Exception $e ) {
+	public function get_product( $product_id = false, $deprecated = array() ) {
+		$product_id = $this->get_product_id( $product_id );
+		if ( ! $product_id ) {
 			return false;
+		}
+
+		$product_type = $this->get_product_type( $product_id );
+		$classname    = $this->get_classname_from_product_type( $product_type );
+
+		// backwards compat filter
+		$post_type = 'variation' === $product_type ? 'product_variation' : 'product';
+		$classname = apply_filters( 'woocommerce_product_class', $classname, $product_type, $post_type, $product_id );
+
+		if ( ! $classname ) {
+			return null;
+		}
+
+		if ( ! class_exists( $classname ) ) {
+			$classname = 'WC_Product_Simple';
+		}
+
+		try {
+			return new $classname( $product_id );
+		} catch ( Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Get the product type for a product.
+	 *
+	 * @since 2.7.0
+	 * @param  int $product_id
+	 * @return string|false
+	 */
+	public static function get_product_type( $product_id ) {
+		// Allow the overriding of the lookup in this function. Return the product type here.
+		$override = apply_filters( 'woocommerce_product_type_query', false, $product_id );
+		if ( ! $override ) {
+			$terms = get_the_terms( $product_id, 'product_type' );
+			return ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
+		} else {
+			return $override;
 		}
 	}
 
@@ -59,51 +80,21 @@ class WC_Product_Factory {
 	}
 
 	/**
-	 * Get the product class name.
-	 * @param  WP_Post $the_product
-	 * @param  array $args (default: array())
-	 * @return string
+	 * Get the product ID depending on what was passed.
+	 *
+	 * @since 2.7.0
+	 * @param  mixed $product
+	 * @return int|bool false on failure
 	 */
-	private function get_product_class( $the_product, $args = array() ) {
-		$product_id = absint( $the_product->ID );
-		$post_type  = $the_product->post_type;
-
-		if ( 'product' === $post_type ) {
-			if ( isset( $args['product_type'] ) ) {
-				$product_type = $args['product_type'];
-			} else {
-				$terms        = get_the_terms( $the_product, 'product_type' );
-				$product_type = ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
-			}
-		} elseif ( 'product_variation' === $post_type ) {
-			$product_type = 'variation';
+	private function get_product_id( $product ) {
+		if ( is_numeric( $product ) ) {
+			return $product;
+		} elseif ( $product instanceof WC_Product ) {
+			return $product->get_id();
+		} elseif ( ! empty( $product->ID ) ) {
+			return $product->ID;
 		} else {
-			$product_type = false;
+			return false;
 		}
-
-		$classname = $this->get_classname_from_product_type( $product_type );
-
-		// Filter classname so that the class can be overridden if extended.
-		return apply_filters( 'woocommerce_product_class', $classname, $product_type, $post_type, $product_id );
-	}
-
-	/**
-	 * Get the product object.
-	 * @param  mixed $the_product
-	 * @uses   WP_Post
-	 * @return WP_Post|bool false on failure
-	 */
-	private function get_product_object( $the_product ) {
-		if ( false === $the_product ) {
-			$the_product = $GLOBALS['post'];
-		} elseif ( is_numeric( $the_product ) ) {
-			$the_product = get_post( $the_product );
-		} elseif ( $the_product instanceof WC_Product ) {
-			$the_product = get_post( $the_product->get_id() );
-		} elseif ( ! ( $the_product instanceof WP_Post ) ) {
-			$the_product = false;
-		}
-
-		return apply_filters( 'woocommerce_product_object', $the_product );
 	}
 }

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -63,6 +63,9 @@ class WC_Product_Factory {
 		// Allow the overriding of the lookup in this function. Return the product type here.
 		$override = apply_filters( 'woocommerce_product_type_query', false, $product_id );
 		if ( ! $override ) {
+			if ( 'product_variation' === get_post_type( $product_id ) ) {
+				return 'variation';
+			}
 			$terms = get_the_terms( $product_id, 'product_type' );
 			return ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
 		} else {

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -148,46 +148,4 @@ class WC_Product_Grouped extends WC_Product {
 	public function set_children( $children ) {
 		$this->set_prop( 'children', array_filter( wp_parse_id_list( (array) $children ) ) );
 	}
-
-	/*
-	|--------------------------------------------------------------------------
-	| CRUD methods
-	|--------------------------------------------------------------------------
-	*/
-
-	/**
-	 * Read post data.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function read_product_data() {
-		parent::read_product_data();
-
-		$this->set_props( array(
-			'children' => wp_parse_id_list( get_post_meta( $this->get_id(), '_children', true ) ),
-		) );
-	}
-
-	/**
-	 * Helper method that updates all the post meta for a grouped product.
-	 */
-	protected function update_post_meta() {
-		if ( update_post_meta( $this->get_id(), '_children', $this->get_children() ) ) {
-			$child_prices = array();
-			foreach ( $this->get_children() as $child_id ) {
-				$child = wc_get_product( $child_id );
-				if ( $child ) {
-					$child_prices[] = $child->get_price();
-				}
-			}
-			$child_prices = array_filter( $child_prices );
-			delete_post_meta( $this->get_id(), '_price' );
-
-			if ( ! empty( $child_prices ) ) {
-				add_post_meta( $this->get_id(), '_price', min( $child_prices ) );
-				add_post_meta( $this->get_id(), '_price', max( $child_prices ) );
-			}
-		}
-		parent::update_post_meta();
-	}
 }

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -276,22 +276,52 @@ class WC_Product_Variable extends WC_Product {
 	|--------------------------------------------------------------------------
 	*/
 
+	/**
+	 * Sets an array of variation prices.
+	 *
+	 * @since 2.7.0
+	 * @param array
+	 */
 	public function set_variation_prices( $variation_prices ) {
 		$this->set_prop( 'variation_prices', $variation_prices  );
 	}
 
+	/**
+	 * Sets an array of variation prices, including taxes.
+	 *
+	 * @since 2.7.0
+	 * @param array
+	 */
 	public function set_variation_prices_including_taxes( $variation_prices_including_taxes ) {
 		$this->set_prop( 'variation_prices_including_taxes', $variation_prices_including_taxes  );
 	}
 
+	/**
+	 * Sets an array of variation attributes
+	 *
+	 * @since 2.7.0
+	 * @param array
+	 */
 	public function set_variation_attributes( $variation_attributes ) {
 		$this->set_prop( 'variation_attributes', $variation_attributes  );
 	}
 
+	/**
+	 * Sets an array of children for the product.
+	 *
+	 * @since 2.7.0
+	 * @param array
+	 */
 	public function set_children( $children ) {
 		$this->set_prop( 'children', array_filter( wp_parse_id_list( (array) $children ) ) );
 	}
 
+	/**
+	 * Sets an array of visible children only.
+	 *
+	 * @since 2.7.0
+	 * @param array
+	 */
 	public function set_visible_children( $visible_children ) {
 		$this->set_prop( 'visible_children', array_filter( wp_parse_id_list( (array) $visible_children ) ) );
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -217,6 +217,7 @@ class WC_Product_Variable extends WC_Product {
 		$available_variations = array();
 
 		foreach ( $this->get_children() as $child_id ) {
+			error_log( print_r ( $child_id, 1 ) );
 			$variation = wc_get_product( $child_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked
@@ -357,7 +358,8 @@ class WC_Product_Variable extends WC_Product {
 	 * @return bool
 	 */
 	public function is_on_sale() {
-		$prices = $this->read_price_data();
+		$data_store = WC_Data_Store::load( 'product_variable' );
+		$prices = $data_store->read_price_data( $this );
 		return apply_filters( 'woocommerce_product_is_on_sale', $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price'], $this );
 	}
 
@@ -370,7 +372,7 @@ class WC_Product_Variable extends WC_Product {
 		$in_stock       = get_transient( $transient_name );
 
 		if ( false === $in_stock ) {
-			$in_stock = $this->data_store->child_is_in_stock( $product );
+			$in_stock = $this->data_store->child_is_in_stock( $this );
 			set_transient( $transient_name, $in_stock, DAY_IN_SECONDS * 30 );
 		}
 		return (bool) $in_stock;
@@ -385,7 +387,7 @@ class WC_Product_Variable extends WC_Product {
 		$has_weight     = get_transient( $transient_name );
 
 		if ( false === $has_weight ) {
-			$has_weight = $this->data_store->child_has_weight( $product );
+			$has_weight = $this->data_store->child_has_weight( $this );
 			set_transient( $transient_name, $has_weight, DAY_IN_SECONDS * 30 );
 		}
 		return (bool) $has_weight;
@@ -400,7 +402,7 @@ class WC_Product_Variable extends WC_Product {
 		$has_dimension  = get_transient( $transient_name );
 
 		if ( false === $has_dimension ) {
-			$has_dimension = $this->data_store->child_has_dimensions( $product );
+			$has_dimension = $this->data_store->child_has_dimensions( $this );
 			set_transient( $transient_name, $has_dimension, DAY_IN_SECONDS * 30 );
 		}
 		return (bool) $has_dimension;

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -29,13 +29,6 @@ class WC_Product_Variable extends WC_Product {
 	);
 
 	/**
-	 * Cached & hashed prices array for child variations.
-	 *
-	 * @var array
-	 */
-	private $prices_array = array();
-
-	/**
 	 * Merges variable product data into the parent object.
 	 *
 	 * @param int|WC_Product|object $product Product to init.
@@ -279,6 +272,32 @@ class WC_Product_Variable extends WC_Product {
 
 	/*
 	|--------------------------------------------------------------------------
+	| Setters
+	|--------------------------------------------------------------------------
+	*/
+
+	public function set_variation_prices( $variation_prices ) {
+		$this->set_prop( 'variation_prices', $variation_prices  );
+	}
+
+	public function set_variation_prices_including_taxes( $variation_prices_including_taxes ) {
+		$this->set_prop( 'variation_prices_including_taxes', $variation_prices_including_taxes  );
+	}
+
+	public function set_variation_attributes( $variation_attributes ) {
+		$this->set_prop( 'variation_attributes', $variation_attributes  );
+	}
+
+	public function set_children( $children ) {
+		$this->set_prop( 'children', array_filter( wp_parse_id_list( (array) $children ) ) );
+	}
+
+	public function set_visible_children( $visible_children ) {
+		$this->set_prop( 'visible_children', array_filter( wp_parse_id_list( (array) $visible_children ) ) );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
 	| CRUD methods
 	|--------------------------------------------------------------------------
 	*/
@@ -314,248 +333,16 @@ class WC_Product_Variable extends WC_Product {
 	 */
 	public function save() {
 		$this->validate_props();
-
-		if ( $this->get_id() ) {
-			$this->update();
-		} else {
-			$this->create();
-		}
-
-		$this->sync_managed_variation_stock_status();
-		$this->apply_changes();
-		$this->update_product_type();
-		$this->update_product_version();
-		$this->update_term_counts();
-		$this->clear_caches();
-
-		return $this->get_id();
-	}
-
-	/**
-	 * Read product data.
-	 *
-	 * @since 2.7.0
-	 */
-	public function read_product_data() {
-		parent::read_product_data();
-
-		$this->read_children();
-
-		// Set directly since individual data needs changed at the WC_Product_Variation level -- these datasets just pull.
-		$this->data['variation_prices']                 = $this->read_price_data();
-		$this->data['variation_prices_including_taxes'] = $this->read_price_data( true );
-		$this->data['variation_attributes']             = $this->read_variation_attributes();
-	}
-
-	/**
-	 * Loads variation child IDs.
-	 * @param  bool $force_read True to bypass the transient.
-	 * @return array
-	 */
-	public function read_children( $force_read = false ) {
-		$children_transient_name = 'wc_product_children_' . $this->get_id();
-		$children                = get_transient( $children_transient_name );
-
-		if ( empty( $children ) || ! is_array( $children ) || ! isset( $children['all'] ) || ! isset( $children['visible'] ) || $force_read ) {
-			$all_args = $visible_only_args = array(
-				'post_parent' => $this->get_id(),
-				'post_type'   => 'product_variation',
-				'orderby'     => 'menu_order',
-				'order'       => 'ASC',
-				'fields'      => 'ids',
-				'post_status' => 'publish',
-				'numberposts' => -1,
-			);
-			if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-				$visible_only_args['meta_query'][] = array(
-					'key'     => '_stock_status',
-					'value'   => 'instock',
-					'compare' => '=',
-				);
-			}
-			$children['all']     = get_posts( apply_filters( 'woocommerce_variable_children_args', $all_args, $this, false ) );
-			$children['visible'] = get_posts( apply_filters( 'woocommerce_variable_children_args', $visible_only_args, $this, true ) );
-
-			set_transient( $children_transient_name, $children, DAY_IN_SECONDS * 30 );
-		}
-
-		$this->data['children']         = wp_parse_id_list( (array) $children['all'] );
-		$this->data['visible_children'] = wp_parse_id_list( (array) $children['visible'] );
-	}
-
-	/**
-	 * Loads an array of attributes used for variations, as well as their possible values.
-	 *
-	 * @return array Attributes and their available values
-	 */
-	private function read_variation_attributes() {
-		global $wpdb;
-
-		$variation_attributes = array();
-		$attributes           = $this->get_attributes();
-		$child_ids            = $this->get_children();
-
-		if ( ! empty( $child_ids ) && ! empty( $attributes ) ) {
-			foreach ( $attributes as $attribute ) {
-				if ( empty( $attribute['is_variation'] ) ) {
-					continue;
-				}
-
-				// Get possible values for this attribute, for only visible variations.
-				$values = array_unique( $wpdb->get_col( $wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (" . implode( ',', array_map( 'esc_sql', $child_ids ) ) . ")",
-					wc_variation_attribute_name( $attribute['name'] )
-				) ) );
-
-				// Empty value indicates that all options for given attribute are available.
-				if ( in_array( '', $values ) || empty( $values ) ) {
-					$values = $attribute['is_taxonomy'] ? wp_get_post_terms( $this->get_id(), $attribute['name'], array( 'fields' => 'slugs' ) ) : wc_get_text_attributes( $attribute['value'] );
-				// Get custom attributes (non taxonomy) as defined.
-				} elseif ( ! $attribute['is_taxonomy'] ) {
-					$text_attributes          = wc_get_text_attributes( $attribute['value'] );
-					$assigned_text_attributes = $values;
-					$values                   = array();
-
-					// Pre 2.4 handling where 'slugs' were saved instead of the full text attribute
-					if ( version_compare( get_post_meta( $this->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
-						$assigned_text_attributes = array_map( 'sanitize_title', $assigned_text_attributes );
-						foreach ( $text_attributes as $text_attribute ) {
-							if ( in_array( sanitize_title( $text_attribute ), $assigned_text_attributes ) ) {
-								$values[] = $text_attribute;
-							}
-						}
-					} else {
-						foreach ( $text_attributes as $text_attribute ) {
-							if ( in_array( $text_attribute, $assigned_text_attributes ) ) {
-								$values[] = $text_attribute;
-							}
-						}
-					}
-				}
-				$variation_attributes[ $attribute['name'] ] = array_unique( $values );
-			}
-		}
-		return $variation_attributes;
-	}
-
-	/**
-	 * Get an array of all sale and regular prices from all variations. This is used for example when displaying the price range at variable product level or seeing if the variable product is on sale.
-	 *
-	 * Can be filtered by plugins which modify costs, but otherwise will include the raw meta costs unlike get_price() which runs costs through the woocommerce_get_price filter.
-	 * This is to ensure modified prices are not cached, unless intended.
-	 *
-	 * @since  2.7.0
-	 * @param  bool $include_taxes If taxes should be calculated or not.
-	 * @return array() Array of RAW prices, regular prices, and sale prices with keys set to variation ID.
-	 */
-	private function read_price_data( $include_taxes = false ) {
-		global $wp_filter;
-
-		/**
-		 * Transient name for storing prices for this product (note: Max transient length is 45)
-		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
-		 */
-		$transient_name = 'wc_var_prices_' . $this->get_id();
-
-		/**
-		 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
-		 * DEVELOPERS should filter this hash if offering conditonal pricing to keep it unique.
-		 * @var string
-		 */
-		$price_hash   = $include_taxes ? array( get_option( 'woocommerce_tax_display_shop', 'excl' ), WC_Tax::get_rates() ) : array( false );
-		$filter_names = array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' );
-
-		foreach ( $filter_names as $filter_name ) {
-			if ( ! empty( $wp_filter[ $filter_name ] ) ) {
-				$price_hash[ $filter_name ] = array();
-
-				foreach ( $wp_filter[ $filter_name ] as $priority => $callbacks ) {
-					$price_hash[ $filter_name ][] = array_values( wp_list_pluck( $callbacks, 'function' ) );
-				}
-			}
-		}
-
-		$price_hash[] = WC_Cache_Helper::get_transient_version( 'product' );
-		$price_hash   = md5( json_encode( apply_filters( 'woocommerce_get_variation_prices_hash', $price_hash, $this, $include_taxes ) ) );
-
-		/**
-		 * $this->prices_array is an array of values which may have been modified from what is stored in transients - this may not match $transient_cached_prices_array.
-		 * If the value has already been generated, we don't need to grab the values again so just return them. They are already filtered.
-		 */
-		if ( ! empty( $this->prices_array[ $price_hash ] ) ) {
-			return $this->prices_array[ $price_hash ];
-
-		/**
-		 * No locally cached value? Get the data from the transient or generate it.
-		 */
-		} else {
-			// Get value of transient
-			$transient_cached_prices_array = array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) );
-
-			// If the product version has changed since the transient was last saved, reset the transient cache.
-			if ( empty( $transient_cached_prices_array['version'] ) || WC_Cache_Helper::get_transient_version( 'product' ) !== $transient_cached_prices_array['version'] ) {
-				$transient_cached_prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
+		if ( $this->data_store ) {
+			if ( $this->get_id() ) {
+				$this->data_store->update( $this );
+			} else {
+				$this->data_store->create( $this );
 			}
 
-			// If the prices are not stored for this hash, generate them and add to the transient.
-			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ) {
-				$prices         = array();
-				$regular_prices = array();
-				$sale_prices    = array();
-				$variation_ids  = $this->get_visible_children();
-				foreach ( $variation_ids as $variation_id ) {
-					if ( $variation = wc_get_product( $variation_id, array( 'parent_id' => $this->get_id(), 'parent' => $this ) ) ) {
-						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->get_price(), $variation, $this );
-						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price(), $variation, $this );
-						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price(), $variation, $this );
+			$this->data_store->sync_managed_variation_stock_status( $this );
 
-						// Skip empty prices
-						if ( '' === $price ) {
-							continue;
-						}
-
-						// If sale price does not equal price, the product is not yet on sale
-						if ( $sale_price === $regular_price || $sale_price !== $price ) {
-							$sale_price = $regular_price;
-						}
-
-						// If we are getting prices for display, we need to account for taxes
-						if ( $include_taxes ) {
-							if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
-								$price         = '' === $price ? ''         : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
-								$regular_price = '' === $regular_price ? '' : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $regular_price ) );
-								$sale_price    = '' === $sale_price ? ''    : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $sale_price ) );
-							} else {
-								$price         = '' === $price ? ''         : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
-								$regular_price = '' === $regular_price ? '' : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $regular_price ) );
-								$sale_price    = '' === $sale_price ? ''    : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $sale_price ) );
-							}
-						}
-
-						$prices[ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
-						$regular_prices[ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
-						$sale_prices[ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
-					}
-				}
-
-				asort( $prices );
-				asort( $regular_prices );
-				asort( $sale_prices );
-
-				$transient_cached_prices_array[ $price_hash ] = array(
-					'price'         => $prices,
-					'regular_price' => $regular_prices,
-					'sale_price'    => $sale_prices,
-				);
-
-				set_transient( $transient_name, json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
-			}
-
-			/**
-			 * Give plugins one last chance to filter the variation prices array which has been generated and store locally to the class.
-			 * This value may differ from the transient cache. It is filtered once before storing locally.
-			 */
-			return $this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $this, $include_taxes );
+			return $this->get_id();
 		}
 	}
 
@@ -579,14 +366,11 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function child_is_in_stock() {
-		global $wpdb;
-
 		$transient_name = 'wc_child_is_in_stock_' . $this->get_id();
 		$in_stock       = get_transient( $transient_name );
 
 		if ( false === $in_stock ) {
-			$children = $this->get_visible_children( 'edit' );
-			$in_stock = $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_stock_status' AND meta_value = 'instock' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+			$in_stock = $this->data_store->child_is_in_stock( $product );
 			set_transient( $transient_name, $in_stock, DAY_IN_SECONDS * 30 );
 		}
 		return (bool) $in_stock;
@@ -597,14 +381,11 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function child_has_weight() {
-		global $wpdb;
-
 		$transient_name = 'wc_child_has_weight_' . $this->get_id();
 		$has_weight     = get_transient( $transient_name );
 
 		if ( false === $has_weight ) {
-			$children   = $this->get_visible_children( 'edit' );
-			$has_weight = $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_weight' AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+			$has_weight = $this->data_store->child_has_weight( $product );
 			set_transient( $transient_name, $has_weight, DAY_IN_SECONDS * 30 );
 		}
 		return (bool) $has_weight;
@@ -615,14 +396,11 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function child_has_dimensions() {
-		global $wpdb;
-
 		$transient_name = 'wc_child_has_dimensions_' . $this->get_id();
 		$has_dimension  = get_transient( $transient_name );
 
 		if ( false === $has_dimension ) {
-			$children      = $this->get_visible_children( 'edit' );
-			$has_dimension = $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key IN ( '_length', '_width', '_height' ) AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+			$has_dimension = $this->data_store->child_has_dimensions( $product );
 			set_transient( $transient_name, $has_dimension, DAY_IN_SECONDS * 30 );
 		}
 		return (bool) $has_dimension;
@@ -677,30 +455,6 @@ class WC_Product_Variable extends WC_Product {
 	*/
 
 	/**
-	 * Stock managed at the parent level - update children being managed by this product.
-	 *
-	 * This sync function syncs downwards (from parent to child) when the variable product is saved.
-	 */
-	private function sync_managed_variation_stock_status() {
-		global $wpdb;
-
-		if ( $this->get_manage_stock() ) {
-			$status           = $this->get_stock_status();
-			$children         = $this->get_children();
-			$managed_children = $children ? array_unique( $wpdb->get_col( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_manage_stock' AND meta_value != 'yes' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) ) : array();
-			$changed          = false;
-			foreach ( $managed_children as $managed_child ) {
-				if ( update_post_meta( $managed_child, '_stock_status', $status ) ) {
-					$changed = true;
-				}
-			}
-			if ( $changed ) {
-				$this->read_children( true );
-			}
-		}
-	}
-
-	/**
 	 * Sync the variable product with it's children.
 	 *
 	 * These sync functions sync upwards (from child to parent) when the variation is saved.
@@ -719,6 +473,7 @@ class WC_Product_Variable extends WC_Product {
 
 	/**
 	 * Sync variable product prices with children.
+	 *
 	 * @since 2.7.0
 	 * @param WC_Product|int $product
 	 */
@@ -726,24 +481,12 @@ class WC_Product_Variable extends WC_Product {
 		if ( ! is_a( $product, 'WC_Product' ) ) {
 			$product = wc_get_product( $product );
 		}
-		global $wpdb;
-
-		$children = $product->get_visible_children( 'edit' );
-		$prices   = $children ? array_unique( $wpdb->get_col( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_price' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) ) : array();
-
-		delete_post_meta( $product->get_id(), '_price' );
-
-		if ( $prices ) {
-			sort( $prices );
-			// To allow sorting and filtering by multiple values, we have no choice but to store child prices in this manner.
-			foreach ( $prices as $price ) {
-				add_post_meta( $product->get_id(), '_price', $price, false );
-			}
-		}
+		$this->data_store->sync_price( $product );
 	}
 
 	/**
 	 * Sync VARIATIONS with the PARENT.
+	 *
 	 * @param WC_Product|int $product
 	 */
 	public static function sync_stock_status( &$product, $saving = false ) {

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -217,7 +217,6 @@ class WC_Product_Variable extends WC_Product {
 		$available_variations = array();
 
 		foreach ( $this->get_children() as $child_id ) {
-			error_log( print_r ( $child_id, 1 ) );
 			$variation = wc_get_product( $child_id );
 
 			// Hide out of stock variations if 'Hide out of stock items from the catalog' is checked

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -267,12 +267,12 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @return string
 	 */
 	public function get_image_id( $context = 'view' ) {
-		$value = $this->get_prop( 'image_id', $context );
+		$image_id = $this->get_prop( 'image_id', $context );
 
 		if ( 'view' === $context && ! $image_id ) {
-			$value = $this->parent_data['image_id'];
+			$vimage_id = $this->parent_data['image_id'];
 		}
-		return $value;
+		return $image_id;
 	}
 
 	/*

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -292,6 +292,16 @@ class WC_Product_Variation extends WC_Product_Simple {
 	}
 
 	/**
+	 * Set the parent data array for this variation.
+	 *
+	 * @since 2.7.0
+	 * @param array
+	 */
+	public function set_parent_data( $parent_data ) {
+		$this->parent_data = $parent_data;
+	}
+
+	/**
 	 * Set attributes. Unlike the parent product which uses terms, variations are assigned
 	 * specific attributes using name value pairs.
 	 * @param array
@@ -311,223 +321,22 @@ class WC_Product_Variation extends WC_Product_Simple {
 	}
 
 	/**
-	 * Reads a product from the database and sets its data to the class.
-	 *
-	 * @since 2.7.0
-	 * @param int $id Variation ID.
-	 */
-	public function read( $id ) {
-		$this->set_defaults();
-
-		if ( ! $id || ! ( $post_object = get_post( $id ) ) ) {
-			return;
-		}
-
-		$this->set_id( $id );
-		$this->set_parent_id( $post_object->post_parent );
-
-		// The post doesn't have a parent id, therefore its invalid and we should prevent this being created.
-		if ( empty( $this->get_parent_id() ) ) {
-			throw new Exception( sprintf( 'No parent product set for variation #%d', $this->get_id() ), 422 );
-		}
-
-		// The post parent is not a valid variable product so we should prevent this being created.
-		if ( 'product' !== get_post_type( $this->get_parent_id() ) ) {
-			throw new Exception( sprintf( 'Invalid parent for variation #%d', $this->get_id() ), 422 );
-		}
-
-		$this->set_props( array(
-			'name'              => get_the_title( $post_object ),
-			'slug'              => $post_object->post_name,
-			'date_created'      => $post_object->post_date,
-			'date_modified'     => $post_object->post_modified,
-			'status'            => $post_object->post_status,
-			'menu_order'        => $post_object->menu_order,
-			'reviews_allowed'   => 'open' === $post_object->comment_status,
-		) );
-		$this->read_product_data();
-		$this->read_meta_data();
-		$this->read_attributes();
-
-		// Set object_read true once all data is read.
-		$this->set_object_read( true );
-	}
-
-	/**
-	 * Read post data. Can be overridden by child classes to load other props.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function read_product_data() {
-		$id = $this->get_id();
-		$this->set_props( array(
-			'description'       => get_post_meta( $id, '_variation_description', true ),
-			'regular_price'     => get_post_meta( $id, '_regular_price', true ),
-			'sale_price'        => get_post_meta( $id, '_sale_price', true ),
-			'date_on_sale_from' => get_post_meta( $id, '_sale_price_dates_from', true ),
-			'date_on_sale_to'   => get_post_meta( $id, '_sale_price_dates_to', true ),
-			'tax_status'        => get_post_meta( $id, '_tax_status', true ),
-			'manage_stock'      => get_post_meta( $id, '_manage_stock', true ),
-			'stock_status'      => get_post_meta( $id, '_stock_status', true ),
-			'shipping_class_id' => current( $this->get_term_ids( 'product_shipping_class' ) ),
-			'virtual'           => get_post_meta( $id, '_virtual', true ),
-			'downloadable'      => get_post_meta( $id, '_downloadable', true ),
-			'downloads'         => array_filter( (array) get_post_meta( $id, '_downloadable_files', true ) ),
-			'gallery_image_ids' => array_filter( explode( ',', get_post_meta( $id, '_product_image_gallery', true ) ) ),
-			'download_limit'    => get_post_meta( $id, '_download_limit', true ),
-			'download_expiry'   => get_post_meta( $id, '_download_expiry', true ),
-			'image_id'          => get_post_thumbnail_id( $id ),
-			'backorders'        => get_post_meta( $id, '_backorders', true ),
-			'sku'               => get_post_meta( $id, '_sku', true ),
-			'stock_quantity'    => get_post_meta( $id, '_stock', true ),
-			'weight'            => get_post_meta( $id, '_weight', true ),
-			'length'            => get_post_meta( $id, '_length', true ),
-			'width'             => get_post_meta( $id, '_width', true ),
-			'height'            => get_post_meta( $id, '_height', true ),
-			'tax_class'         => get_post_meta( $id, '_tax_class', true ),
-		) );
-
-		if ( $this->is_on_sale() ) {
-			$this->set_price( $this->get_sale_price() );
-		} else {
-			$this->set_price( $this->get_regular_price() );
-		}
-
-		$this->parent_data = array(
-			'sku'            => get_post_meta( $this->get_parent_id(), '_sku', true ),
-			'manage_stock'   => get_post_meta( $this->get_parent_id(), '_manage_stock', true ),
-			'backorders'     => get_post_meta( $this->get_parent_id(), '_backorders', true ),
-			'stock_quantity' => get_post_meta( $this->get_parent_id(), '_stock', true ),
-			'weight'         => get_post_meta( $this->get_parent_id(), '_weight', true ),
-			'length'         => get_post_meta( $this->get_parent_id(), '_length', true ),
-			'width'          => get_post_meta( $this->get_parent_id(), '_width', true ),
-			'height'         => get_post_meta( $this->get_parent_id(), '_height', true ),
-			'tax_class'      => get_post_meta( $this->get_parent_id(), '_tax_class', true ),
-			'image_id'       => get_post_thumbnail_id( $this->get_parent_id() ),
-		);
-	}
-
-	/**
-	 * Create a new product.
-	 *
-	 * @since 2.7.0
-	 */
-	public function create() {
-		$this->set_date_created( current_time( 'timestamp' ) );
-
-		$id = wp_insert_post( apply_filters( 'woocommerce_new_product_variation_data', array(
-			'post_type'      => $this->post_type,
-			'post_status'    => $this->get_status() ? $this->get_status() : 'publish',
-			'post_author'    => get_current_user_id(),
-			'post_title'     => get_the_title( $this->get_parent_id() ) . ' &ndash;' . wc_get_formatted_variation( $this->get_attributes(), true ),
-			'post_content'   => '',
-			'post_parent'    => $this->get_parent_id(),
-			'comment_status' => 'closed',
-			'ping_status'    => 'closed',
-			'menu_order'     => $this->get_menu_order(),
-			'post_date'      => date( 'Y-m-d H:i:s', $this->get_date_created() ),
-			'post_date_gmt'  => get_gmt_from_date( date( 'Y-m-d H:i:s', $this->get_date_created() ) ),
-		) ), true );
-
-		if ( $id && ! is_wp_error( $id ) ) {
-			$this->set_id( $id );
-			$this->update_post_meta();
-			$this->update_terms();
-			$this->update_attributes();
-			$this->save_meta_data();
-			do_action( 'woocommerce_create_' . $this->post_type, $id );
-		}
-	}
-
-	/**
-	 * Updates an existing product.
-	 *
-	 * @since 2.7.0
-	 */
-	public function update() {
-		$post_data = array(
-			'ID'             => $this->get_id(),
-			'post_title'     => get_the_title( $this->get_parent_id() ) . ' &ndash;' . wc_get_formatted_variation( $this->get_attributes(), true ),
-			'post_parent'    => $this->get_parent_id(),
-			'comment_status' => 'closed',
-			'post_status'    => $this->get_status() ? $this->get_status() : 'publish',
-			'menu_order'     => $this->get_menu_order(),
-		);
-		wp_update_post( $post_data );
-		$this->update_post_meta();
-		$this->update_terms();
-		$this->update_attributes();
-		$this->save_meta_data();
-		do_action( 'woocommerce_update_' . $this->post_type, $this->get_id() );
-	}
-
-	/**
-	 * Helper method that updates all the post meta for a product based on it's settings in the WC_Product class.
-	 *
-	 * @since 2.7.0
-	 */
-	public function update_post_meta() {
-		update_post_meta( $this->get_id(), '_variation_description', $this->get_description() );
-		parent::update_post_meta();
-	}
-
-	/**
 	 * Save data (either create or update depending on if we are working on an existing product).
 	 *
 	 * @since 2.7.0
 	 */
 	public function save() {
-		parent::save();
+		$this->validate_props();
 
-		wp_schedule_single_event( time(), 'woocommerce_deferred_product_sync', array( 'product_id' => $this->get_parent_id() ) );
+		if ( $this->data_store ) {
+			if ( $this->get_id() ) {
+				$this->data_store->update( $this );
+			} else {
+				$this->data_store->create( $this );
+			}
 
-		return $this->get_id();
-	}
-
-	/**
-	 * Clear any caches.
-	 */
-	protected function clear_caches() {
-		wc_delete_product_transients( $this->get_id() );
-		wc_delete_product_transients( $this->get_parent_id() );
-	}
-
-	/**
-	 * For all stored terms in all taxonomies, save them to the DB.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function update_terms() {
-		wp_set_post_terms( $this->get_id(), array( $this->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
-	}
-
-	/**
-	 * Read attributes from post meta.
-	 *
-	 * @since 2.7.0
-	 */
-	protected function read_attributes() {
-		$this->set_attributes( wc_get_product_variation_attributes( $this->get_id() ) );
-	}
-
-	/**
-	 * Update attribute meta values.
-	 * @since 2.7.0
-	 */
-	protected function update_attributes() {
-		global $wpdb;
-		$attributes             = $this->get_attributes();
-		$updated_attribute_keys = array();
-		foreach ( $attributes as $key => $value ) {
-			update_post_meta( $this->get_id(), 'attribute_' . $key, $value );
-			$updated_attribute_keys[] = 'attribute_' . $key;
-		}
-
-		// Remove old taxonomies attributes so data is kept up to date - first get attribute key names.
-		$delete_attribute_keys = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key LIKE 'attribute_%%' AND meta_key NOT IN ( '" . implode( "','", array_map( 'esc_sql', $updated_attribute_keys ) ) . "' ) AND post_id = %d;", $this->get_id() ) );
-
-		foreach ( $delete_attribute_keys as $key ) {
-			delete_post_meta( $this->get_id(), $key );
+			wp_schedule_single_event( time(), 'woocommerce_deferred_product_sync', array( 'product_id' => $this->get_parent_id() ) );
+			return $this->get_id();
 		}
 	}
 

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -20,7 +20,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * Post type.
 	 * @var string
 	 */
-	protected $post_type = 'product_variation';
+	public $post_type = 'product_variation';
 
 	/**
 	 * Parent data.

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -202,7 +202,7 @@ class WC_Structured_Data {
 					'availability'  => 'http://schema.org/' . $stock = ( $_product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
 					'sku'           => $_product->get_sku(),
 					'image'         => wp_get_attachment_url( $_product->get_image_id() ),
-					'description'   => $is_variable ? $_product->get_description() : '',
+					'description'   => $_product->get_description(),
 					'seller'        => array(
 						'@type' => 'Organization',
 						'name'  => $shop_name,

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -202,7 +202,7 @@ class WC_Structured_Data {
 					'availability'  => 'http://schema.org/' . $stock = ( $_product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
 					'sku'           => $_product->get_sku(),
 					'image'         => wp_get_attachment_url( $_product->get_image_id() ),
-					'description'   => $is_variable ? $_product->get_variation_description() : '',
+					'description'   => $is_variable ? $_product->get_description() : '',
 					'seller'        => array(
 						'@type' => 'Organization',
 						'name'  => $shop_name,

--- a/includes/data-stores/class-wc-data-store-cpt.php
+++ b/includes/data-stores/class-wc-data-store-cpt.php
@@ -12,4 +12,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Data_Store_CPT {
 
+	/**
+	 * Get and store terms from a taxonomy.
+	 *
+	 * @since  2.7.0
+	 * @param  WC_Product
+	 * @param  string $taxonomy Taxonomy name e.g. product_cat
+	 * @return array of terms
+	 */
+	protected function get_term_ids( $product, $taxonomy ) {
+		$terms = get_the_terms( $product->get_id(), $taxonomy );
+		if ( false === $terms || is_wp_error( $terms ) ) {
+			return array();
+		}
+		return wp_list_pluck( $terms, 'term_id' );
+	}
+
 }

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -47,7 +47,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_D
 
 		if ( $id && ! is_wp_error( $id ) ) {
 			$product->set_id( $id );
-			$this->update_post_meta( $product );
+			$product = $this->update_post_meta( $product );
 			$this->update_terms( $product );
 			$this->update_attributes( $product );
 			$product->save_meta_data();
@@ -111,7 +111,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_D
 		);
 		wp_update_post( $post_data );
 
-		$this->update_post_meta( $product );
+		$product = $this->update_post_meta( $product );
 		$this->update_terms( $product );
 		$this->update_attributes( $product );
 		$product->save_meta_data();
@@ -246,6 +246,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_D
 	 * Helper method that updates all the post meta for a product based on it's settings in the WC_Product class.
 	 *
 	 * @param WC_Product
+	 * @return WC_Product
 	 * @since 2.7.0
 	 */
 	protected function update_post_meta( $product ) {
@@ -320,8 +321,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_D
 		if ( in_array( 'date_on_sale_from', $updated_props ) || in_array( 'date_on_sale_to', $updated_props ) || in_array( 'regular_price', $updated_props ) || in_array( 'sale_price', $updated_props ) ) {
 			if ( $product->is_on_sale() ) {
 				update_post_meta( $product->get_id(), '_price', $product->get_sale_price() );
+				$product->set_price( $product->get_sale_price() );
 			} else {
 				update_post_meta( $product->get_id(), '_price', $product->get_regular_price() );
+				$product->set_price( $product->get_regular_price() );
 			}
 		}
 
@@ -360,6 +363,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_D
 				}
 			}
 		}
+
+		return $product;
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1,0 +1,463 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Product Data Store: Stored in CPT.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_Data_Store {
+
+	/**
+	 * If we have already saved our extra data, don't do automatic / default handling.
+	 */
+	protected $extra_data_saved = false;
+
+	/*
+	|--------------------------------------------------------------------------
+	| CRUD Methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Method to create a new product in the database.
+	 * @param WC_Product
+	 */
+	public function create( &$product ) {
+		$product->set_date_created( current_time( 'timestamp' ) );
+
+		$id = wp_insert_post( apply_filters( 'woocommerce_new_product_data', array(
+			'post_type'      => $product->post_type,
+			'post_status'    => $product->get_status() ? $product->get_status() : 'publish',
+			'post_author'    => get_current_user_id(),
+			'post_title'     => $product->get_name() ? $product->get_name() : __( 'Product', 'woocommerce' ),
+			'post_content'   => $product->get_description(),
+			'post_excerpt'   => $product->get_short_description(),
+			'post_parent'    => $product->get_parent_id(),
+			'comment_status' => $product->get_reviews_allowed() ? 'open' : 'closed',
+			'ping_status'    => 'closed',
+			'menu_order'     => $product->get_menu_order(),
+			'post_date'      => date( 'Y-m-d H:i:s', $product->get_date_created() ),
+			'post_date_gmt'  => get_gmt_from_date( date( 'Y-m-d H:i:s', $product->get_date_created() ) ),
+		) ), true );
+
+		if ( $id && ! is_wp_error( $id ) ) {
+			$product->set_id( $id );
+			$this->update_post_meta( $product );
+			$this->update_terms( $product );
+			$this->update_attributes( $product );
+			$product->save_meta_data();
+
+			do_action( 'woocommerce_new_' . $product->post_type, $id );
+
+			$product->apply_changes();
+			$this->update_version_and_type( $product );
+			$this->update_term_counts( $product );
+			$this->clear_caches( $product );
+		}
+	}
+
+	/**
+	 * Method to read a product from the database.
+	 * @param WC_Product
+	 */
+	public function read( &$product ) {
+		$product->set_defaults();
+
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) ) {
+			throw new Exception( __( 'Invalid product.', 'woocommerce' ) );
+			return;
+		}
+
+		$id = $product->get_id();
+
+		$product->set_props( array(
+			'name'              => get_the_title( $post_object ),
+			'slug'              => $post_object->post_name,
+			'date_created'      => $post_object->post_date,
+			'date_modified'     => $post_object->post_modified,
+			'status'            => $post_object->post_status,
+			'description'       => $post_object->post_content,
+			'short_description' => $post_object->post_excerpt,
+			'parent_id'         => $post_object->post_parent,
+			'menu_order'        => $post_object->menu_order,
+			'reviews_allowed'   => 'open' === $post_object->comment_status,
+		) );
+
+		$product->read_meta_data();
+		$product = $this->read_attributes( $product );
+		$product = $this->read_product_data( $product );
+		$product->set_object_read( true );
+	}
+
+	/**
+	 * Method to update a product in the database.
+	 * @param WC_Product
+	 */
+	public function update( &$product ) {
+		$post_data = array(
+			'ID'             => $product->get_id(),
+			'post_content'   => $product->get_description(),
+			'post_excerpt'   => $product->get_short_description(),
+			'post_title'     => $product->get_name(),
+			'post_parent'    => $product->get_parent_id(),
+			'comment_status' => $product->get_reviews_allowed() ? 'open' : 'closed',
+			'post_status'    => $product->get_status() ? $product->get_status() : 'publish',
+			'menu_order'     => $product->get_menu_order(),
+		);
+		wp_update_post( $post_data );
+
+		$this->update_post_meta( $product );
+		$this->update_terms( $product );
+		$this->update_attributes( $product );
+		$product->save_meta_data();
+
+		do_action( 'woocommerce_update_' . $product->post_type, $product->get_id() );
+
+		$product->apply_changes();
+		$this->update_version_and_type( $product );
+		$this->update_term_counts( $product );
+		$this->clear_caches( $product );
+	}
+
+	/**
+	 * Method to delete a product from the database.
+	 * @param WC_Product
+	 */
+	public function delete( &$product, $force_delete = false ) {
+		$id = $product->get_id();
+		$post_type = $product->is_type( 'variation' ) ? 'product_variation' : 'product';
+
+		if ( $force_delete ) {
+			wp_delete_post( $product->get_id() );
+			$product->set_id( 0 );
+		} else {
+			wp_trash_post( $product->get_id() );
+			$product->set_status( 'trash' );
+		}
+		do_action( 'woocommerce_delete_' . $post_type, $id );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Additional Methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Read product data. Can be overridden by child classes to load other props.
+	 *
+	 * @param WC_Product
+	 * @return WC_Product
+	 * @since 2.7.0
+	 */
+	protected function read_product_data( $product ) {
+		$id = $product->get_id();
+		$product->set_props( array(
+			'featured'           => get_post_meta( $id, '_featured', true ),
+			'catalog_visibility' => get_post_meta( $id, '_visibility', true ),
+			'sku'                => get_post_meta( $id, '_sku', true ),
+			'regular_price'      => get_post_meta( $id, '_regular_price', true ),
+			'sale_price'         => get_post_meta( $id, '_sale_price', true ),
+			'price'              => get_post_meta( $id, '_price', true ),
+			'date_on_sale_from'  => get_post_meta( $id, '_sale_price_dates_from', true ),
+			'date_on_sale_to'    => get_post_meta( $id, '_sale_price_dates_to', true ),
+			'total_sales'        => get_post_meta( $id, 'total_sales', true ),
+			'tax_status'         => get_post_meta( $id, '_tax_status', true ),
+			'tax_class'          => get_post_meta( $id, '_tax_class', true ),
+			'manage_stock'       => get_post_meta( $id, '_manage_stock', true ),
+			'stock_quantity'     => get_post_meta( $id, '_stock', true ),
+			'stock_status'       => get_post_meta( $id, '_stock_status', true ),
+			'backorders'         => get_post_meta( $id, '_backorders', true ),
+			'sold_individually'  => get_post_meta( $id, '_sold_individually', true ),
+			'weight'             => get_post_meta( $id, '_weight', true ),
+			'length'             => get_post_meta( $id, '_length', true ),
+			'width'              => get_post_meta( $id, '_width', true ),
+			'height'             => get_post_meta( $id, '_height', true ),
+			'upsell_ids'         => get_post_meta( $id, '_upsell_ids', true ),
+			'cross_sell_ids'     => get_post_meta( $id, '_crosssell_ids', true ),
+			'purchase_note'      => get_post_meta( $id, '_purchase_note', true ),
+			'default_attributes' => get_post_meta( $id, '_default_attributes', true ),
+			'category_ids'       => $this->get_term_ids( $product, 'product_cat' ),
+			'tag_ids'            => $this->get_term_ids( $product, 'product_tag' ),
+			'shipping_class_id'  => current( $this->get_term_ids( $product, 'product_shipping_class' ) ),
+			'virtual'            => get_post_meta( $id, '_virtual', true ),
+			'downloadable'       => get_post_meta( $id, '_downloadable', true ),
+			'downloads'          => array_filter( (array) get_post_meta( $id, '_downloadable_files', true ) ),
+			'gallery_image_ids'  => array_filter( explode( ',', get_post_meta( $id, '_product_image_gallery', true ) ) ),
+			'download_limit'     => get_post_meta( $id, '_download_limit', true ),
+			'download_expiry'    => get_post_meta( $id, '_download_expiry', true ),
+			'image_id'           => get_post_thumbnail_id( $id ),
+		) );
+
+		// Gets extra data associated with the product.
+		// Like button text or product URL for external products.
+		foreach ( $product->get_extra_data_keys() as $key ) {
+			$function = 'set_' . $key;
+			if ( is_callable( array( $product, $function ) ) ) {
+				$product->{$function}( get_post_meta( $product->get_id(), '_' . $key, true ) );
+			}
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Read attributes from post meta.
+	 *
+	 * @param WC_Product
+	 * @return WC_Product
+	 * @since 2.7.0
+	 */
+	protected function read_attributes( $product ) {
+		$meta_values = maybe_unserialize( get_post_meta( $product->get_id(), '_product_attributes', true ) );
+
+		if ( $meta_values ) {
+			$attributes = array();
+			foreach ( $meta_values as $meta_value ) {
+				if ( ! empty( $meta_value['is_taxonomy'] ) ) {
+					if ( ! taxonomy_exists( $meta_value['name'] ) ) {
+						continue;
+					}
+					$options = wp_get_post_terms( $product->get_id(), $meta_value['name'], array( 'fields' => 'ids' ) );
+				} else {
+					$options = wc_get_text_attributes( $meta_value['value'] );
+				}
+				$attribute = new WC_Product_Attribute();
+				$attribute->set_id( wc_attribute_taxonomy_id_by_name( $meta_value['name'] ) );
+				$attribute->set_name( $meta_value['name'] );
+				$attribute->set_options( $options );
+				$attribute->set_position( $meta_value['position'] );
+				$attribute->set_visible( $meta_value['is_visible'] );
+				$attribute->set_variation( $meta_value['is_variation'] );
+				$attributes[] = $attribute;
+			}
+			$product->set_attributes( $attributes );
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Helper method that updates all the post meta for a product based on it's settings in the WC_Product class.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function update_post_meta( $product ) {
+		$updated_props     = array();
+		$changed_props     = array_keys( $product->get_changes() );
+		$meta_key_to_props = array(
+			'_visibility'            => 'catalog_visibility',
+			'_sku'                   => 'sku',
+			'_regular_price'         => 'regular_price',
+			'_sale_price'            => 'sale_price',
+			'_sale_price_dates_from' => 'date_on_sale_from',
+			'_sale_price_dates_to'   => 'date_on_sale_to',
+			'total_sales'            => 'total_sales',
+			'_tax_status'            => 'tax_status',
+			'_tax_class'             => 'tax_class',
+			'_manage_stock'          => 'manage_stock',
+			'_backorders'            => 'backorders',
+			'_sold_individually'     => 'sold_individually',
+			'_weight'                => 'weight',
+			'_length'                => 'length',
+			'_width'                 => 'width',
+			'_height'                => 'height',
+			'_upsell_ids'            => 'upsell_ids',
+			'_crosssell_ids'         => 'cross_sell_ids',
+			'_purchase_note'         => 'purchase_note',
+			'_default_attributes'    => 'default_attributes',
+			'_virtual'               => 'virtual',
+			'_downloadable'          => 'downloadable',
+			'_product_image_gallery' => 'gallery_image_ids',
+			'_download_limit'        => 'download_limit',
+			'_download_expiry'       => 'download_expiry',
+			'_featured'              => 'featured',
+			'_thumbnail_id'          => 'image_id',
+			'_downloadable_files'    => 'downloads',
+			'_stock'                 => 'stock_quantity',
+			'_stock_status'          => 'stock_status',
+		);
+
+		foreach ( $meta_key_to_props as $meta_key => $prop ) {
+			if ( ! in_array( $prop, $changed_props ) ) {
+				continue;
+			}
+			$value = $product->{"get_$prop"}( 'edit' );
+			switch ( $prop ) {
+				case 'virtual' :
+				case 'downloadable' :
+				case 'manage_stock' :
+				case 'featured' :
+				case 'sold_individually' :
+					$updated = update_post_meta( $product->get_id(), $meta_key, wc_bool_to_string( $value ) );
+					break;
+				case 'gallery_image_ids' :
+					$updated = update_post_meta( $product->get_id(), $meta_key, implode( ',', $value ) );
+					break;
+				case 'image_id' :
+					if ( ! empty( $value ) ) {
+						set_post_thumbnail( $product->get_id(), $value );
+					} else {
+						delete_post_meta( $product->get_id(), '_thumbnail_id' );
+					}
+					$updated = true;
+					break;
+				default :
+					$updated = update_post_meta( $product->get_id(), $meta_key, $value );
+					break;
+			}
+			if ( $updated ) {
+				$updated_props[] = $prop;
+			}
+		}
+
+		if ( in_array( 'date_on_sale_from', $updated_props ) || in_array( 'date_on_sale_to', $updated_props ) || in_array( 'regular_price', $updated_props ) || in_array( 'sale_price', $updated_props ) ) {
+			if ( $product->is_on_sale() ) {
+				update_post_meta( $product->get_id(), '_price', $product->get_sale_price() );
+			} else {
+				update_post_meta( $product->get_id(), '_price', $product->get_regular_price() );
+			}
+		}
+
+		if ( in_array( 'featured', $updated_props ) ) {
+			delete_transient( 'wc_featured_products' );
+		}
+
+		if ( in_array( 'catalog_visibility', $updated_props ) ) {
+			do_action( 'woocommerce_product_set_visibility',  $product->get_id(), $product->get_catalog_visibility() );
+		}
+
+		if ( in_array( 'downloads', $updated_props ) ) {
+			// grant permission to any newly added files on any existing orders for this product prior to saving.
+			if ( $product->is_type( 'variation' ) ) {
+				do_action( 'woocommerce_process_product_file_download_paths', $product->get_parent_id(), $product->get_id(), $product->get_downloads() );
+			} else {
+				do_action( 'woocommerce_process_product_file_download_paths', $product->get_id(), 0, $product->get_downloads() );
+			}
+		}
+
+		if ( in_array( 'stock_quantity', $updated_props ) ) {
+			do_action( $product->is_type( 'variation' ) ? 'woocommerce_variation_set_stock' : 'woocommerce_product_set_stock' , $product );
+		}
+
+		if ( in_array( 'stock_status', $updated_props ) ) {
+			do_action( $product->is_type( 'variation' ) ? 'woocommerce_variation_set_stock_status' : 'woocommerce_product_set_stock_status' , $product->get_id(), $product->get_stock_status() );
+		}
+
+		// Update extra data associated with the product.
+		// Like button text or product URL for external products.
+		if ( ! $this->extra_data_saved ) {
+			foreach ( $product->get_extra_data_keys() as $key ) {
+				$function = 'get_' . $key;
+				if ( in_array( $key, $changed_props ) && is_callable( array( $product, $function ) ) ) {
+					update_post_meta( $product->get_id(), '_' . $key, $product->{$function}( 'edit' ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * For all stored terms in all taxonomies, save them to the DB.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function update_terms( $product ) {
+		wp_set_post_terms( $product->get_id(), $product->get_category_ids( 'edit' ), 'product_cat', false );
+		wp_set_post_terms( $product->get_id(), $product->get_tag_ids( 'edit' ), 'product_tag', false );
+		wp_set_post_terms( $product->get_id(), array( $product->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
+	}
+
+	/**
+	 * Update attributes which are a mix of terms and meta data.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function update_attributes( $product ) {
+		$attributes  = $product->get_attributes();
+		$meta_values = array();
+
+		if ( $attributes ) {
+			foreach ( $attributes as $attribute_key => $attribute ) {
+				$value = '';
+
+				if ( is_null( $attribute ) ) {
+					if ( taxonomy_exists( $attribute_key ) ) {
+						// Handle attributes that have been unset.
+						wp_set_object_terms( $product->get_id(), array(), $attribute_key );
+					}
+					continue;
+
+				} elseif ( $attribute->is_taxonomy() ) {
+					wp_set_object_terms( $product->get_id(), wp_list_pluck( $attribute->get_terms(), 'term_id' ), $attribute->get_name() );
+
+				} else {
+					$value = wc_implode_text_attributes( $attribute->get_options() );
+				}
+
+				// Store in format WC uses in meta.
+				$meta_values[ $attribute_key ] = array(
+					'name'         => $attribute->get_name(),
+					'value'        => $value,
+					'position'     => $attribute->get_position(),
+					'is_visible'   => $attribute->get_visible() ? 1 : 0,
+					'is_variation' => $attribute->get_variation() ? 1 : 0,
+					'is_taxonomy'  => $attribute->is_taxonomy() ? 1 : 0,
+				);
+			}
+		}
+		update_post_meta( $product->get_id(), '_product_attributes', $meta_values );
+	}
+
+	/**
+	 * Make sure we store the product type and version (to track data changes).
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function update_version_and_type( $product ) {
+		if ( 'product' === $product->post_type ) {
+			$type_term = get_term_by( 'name', $product->get_type(), 'product_type' );
+			wp_set_object_terms( $product->get_id(), absint( $type_term->term_id ), 'product_type' );
+		}
+		update_post_meta( $product->get_id(), '_product_version', WC_VERSION );
+	}
+
+	/**
+	 * Count terms. These are done at this point so all product props are set in advance.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function update_term_counts( $product ) {
+		if ( ! wp_defer_term_counting() ) {
+			global $wc_allow_term_recount;
+
+			$wc_allow_term_recount = true;
+
+			// Update counts for the post's terms.
+			foreach ( (array) get_object_taxonomies( $product->post_type ) as $taxonomy ) {
+				$tt_ids = wp_get_object_terms( $product->get_id(), $taxonomy, array( 'fields' => 'tt_ids' ) );
+				wp_update_term_count( $tt_ids, $taxonomy );
+			}
+		}
+	}
+
+	/**
+	 * Clear any caches.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function clear_caches( $product ) {
+		wc_delete_product_transients( $product->get_id() );
+	}
+
+}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category Class
  * @author   WooThemes
  */
-class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_Data_Store {
+class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_Data_Store, WC_Product_Data_Store {
 
 	/**
 	 * If we have already saved our extra data, don't do automatic / default handling.

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -16,10 +16,9 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 * Helper method that updates all the post meta for a grouped product.
 	 *
 	 * @param WC_Product
-	 * @return WC_Product
 	 * @since 2.7.0
 	 */
-	protected function update_post_meta( $product ) {
+	protected function update_post_meta( &$product ) {
 		if ( update_post_meta( $product->get_id(), '_children', $product->get_children( 'edit' ) ) ) {
 			$child_prices = array();
 			foreach ( $product->get_children( 'edit' ) as $child_id ) {
@@ -39,8 +38,7 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 			$this->extra_data_saved = true;
 		}
 
-		$product = parent::update_post_meta( $product );
-		return $product;
+		parent::update_post_meta( $product );
 	}
 
 }

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -16,6 +16,7 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 * Helper method that updates all the post meta for a grouped product.
 	 *
 	 * @param WC_Product
+	 * @return WC_Product
 	 * @since 2.7.0
 	 */
 	protected function update_post_meta( $product ) {
@@ -38,7 +39,8 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 			$this->extra_data_saved = true;
 		}
 
-		parent::update_post_meta( $product );
+		$product = parent::update_post_meta( $product );
+		return $product;
 	}
 
 }

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -1,0 +1,44 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Grouped Product Data Store: Stored in CPT.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store {
+
+	/**
+	 * Helper method that updates all the post meta for a grouped product.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function update_post_meta( $product ) {
+		if ( update_post_meta( $product->get_id(), '_children', $product->get_children( 'edit' ) ) ) {
+			$child_prices = array();
+			foreach ( $product->get_children( 'edit' ) as $child_id ) {
+				$child = wc_get_product( $child_id );
+				if ( $child ) {
+					$child_prices[] = $child->get_price();
+				}
+			}
+			$child_prices = array_filter( $child_prices );
+			delete_post_meta( $product->get_id(), '_price' );
+
+			if ( ! empty( $child_prices ) ) {
+				add_post_meta( $product->get_id(), '_price', min( $child_prices ) );
+				add_post_meta( $product->get_id(), '_price', max( $child_prices ) );
+			}
+
+			$this->extra_data_saved = true;
+		}
+
+		parent::update_post_meta( $product );
+	}
+
+}

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -1,0 +1,363 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Variable Product Data Store: Stored in CPT.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store {
+
+	/**
+	 * Cached & hashed prices array for child variations.
+	 *
+	 * @var array
+	 */
+	private $prices_array = array();
+
+	/**
+	 * Read product data.
+	 *
+	 * @since 2.7.0
+	 */
+	public function read_product_data( $product ) {
+		$product = parent::read_product_data( $product );
+		$product = $this->read_children( $product );
+
+		// Set directly since individual data needs changed at the WC_Product_Variation level -- these datasets just pull.
+		$product = $this->read_price_data( $product );
+		$product = $this->read_price_data( $product, true );
+		$product = $this->read_variation_attributes( $product );
+
+		return $product;
+	}
+
+	/**
+	 * Loads variation child IDs.
+	 * @param  WC_Product
+	 * @param  bool $force_read True to bypass the transient.
+	 * @return WC_Product
+	 */
+	public function read_children( $product, $force_read = false ) {
+		$children_transient_name = 'wc_product_children_' . $product->get_id();
+		$children                = get_transient( $children_transient_name );
+
+		if ( empty( $children ) || ! is_array( $children ) || ! isset( $children['all'] ) || ! isset( $children['visible'] ) || $force_read ) {
+			$all_args = $visible_only_args = array(
+				'post_parent' => $product->get_id(),
+				'post_type'   => 'product_variation',
+				'orderby'     => 'menu_order',
+				'order'       => 'ASC',
+				'fields'      => 'ids',
+				'post_status' => 'publish',
+				'numberposts' => -1,
+			);
+			if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+				$visible_only_args['meta_query'][] = array(
+					'key'     => '_stock_status',
+					'value'   => 'instock',
+					'compare' => '=',
+				);
+			}
+			$children['all']     = get_posts( apply_filters( 'woocommerce_variable_children_args', $all_args, $product, false ) );
+			$children['visible'] = get_posts( apply_filters( 'woocommerce_variable_children_args', $visible_only_args, $product, true ) );
+
+			set_transient( $children_transient_name, $children, DAY_IN_SECONDS * 30 );
+		}
+
+		$product->set_children( wp_parse_id_list( (array) $children['all'] ) );
+		$product->set_visible_children( wp_parse_id_list( (array) $children['visible'] ) );
+
+		return $product;
+	}
+
+	/**
+	 * Loads an array of attributes used for variations, as well as their possible values.
+	 *
+	 * @param WC_Product
+	 * @return WC_Product
+	 */
+	private function read_variation_attributes( $product ) {
+		global $wpdb;
+
+		$variation_attributes = array();
+		$attributes           = $product->get_attributes();
+		$child_ids            = $product->get_children();
+
+		if ( ! empty( $child_ids ) && ! empty( $attributes ) ) {
+			foreach ( $attributes as $attribute ) {
+				if ( empty( $attribute['is_variation'] ) ) {
+					continue;
+				}
+
+				// Get possible values for this attribute, for only visible variations.
+				$values = array_unique( $wpdb->get_col( $wpdb->prepare(
+					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (" . implode( ',', array_map( 'esc_sql', $child_ids ) ) . ")",
+					wc_variation_attribute_name( $attribute['name'] )
+				) ) );
+
+				// Empty value indicates that all options for given attribute are available.
+				if ( in_array( '', $values ) || empty( $values ) ) {
+					$values = $attribute['is_taxonomy'] ? wp_get_post_terms( $product->get_id(), $attribute['name'], array( 'fields' => 'slugs' ) ) : wc_get_text_attributes( $attribute['value'] );
+				// Get custom attributes (non taxonomy) as defined.
+				} elseif ( ! $attribute['is_taxonomy'] ) {
+					$text_attributes          = wc_get_text_attributes( $attribute['value'] );
+					$assigned_text_attributes = $values;
+					$values                   = array();
+
+					// Pre 2.4 handling where 'slugs' were saved instead of the full text attribute
+					if ( version_compare( get_post_meta( $product->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
+						$assigned_text_attributes = array_map( 'sanitize_title', $assigned_text_attributes );
+						foreach ( $text_attributes as $text_attribute ) {
+							if ( in_array( sanitize_title( $text_attribute ), $assigned_text_attributes ) ) {
+								$values[] = $text_attribute;
+							}
+						}
+					} else {
+						foreach ( $text_attributes as $text_attribute ) {
+							if ( in_array( $text_attribute, $assigned_text_attributes ) ) {
+								$values[] = $text_attribute;
+							}
+						}
+					}
+				}
+				$variation_attributes[ $attribute['name'] ] = array_unique( $values );
+			}
+		}
+
+		$product->set_variation_attributes( $variation_attributes );
+
+		return $product;
+	}
+
+	/**
+	 * Get an array of all sale and regular prices from all variations. This is used for example when displaying the price range at variable product level or seeing if the variable product is on sale.
+	 *
+	 * Can be filtered by plugins which modify costs, but otherwise will include the raw meta costs unlike get_price() which runs costs through the woocommerce_get_price filter.
+	 * This is to ensure modified prices are not cached, unless intended.
+	 *
+	 * @since  2.7.0
+	 * @param  WC_Product
+	 * @param  bool $include_taxes If taxes should be calculated or not.
+	 * @return WC_Product
+	 */
+	private function read_price_data( $product, $include_taxes = false ) {
+		global $wp_filter;
+
+		/**
+		 * Transient name for storing prices for this product (note: Max transient length is 45)
+		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
+		 */
+		$transient_name = 'wc_var_prices_' . $product->get_id();
+
+		/**
+		 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
+		 * DEVELOPERS should filter this hash if offering conditonal pricing to keep it unique.
+		 * @var string
+		 */
+		$price_hash   = $include_taxes ? array( get_option( 'woocommerce_tax_display_shop', 'excl' ), WC_Tax::get_rates() ) : array( false );
+		$filter_names = array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' );
+
+		foreach ( $filter_names as $filter_name ) {
+			if ( ! empty( $wp_filter[ $filter_name ] ) ) {
+				$price_hash[ $filter_name ] = array();
+
+				foreach ( $wp_filter[ $filter_name ] as $priority => $callbacks ) {
+					$price_hash[ $filter_name ][] = array_values( wp_list_pluck( $callbacks, 'function' ) );
+				}
+			}
+		}
+
+		$price_hash[] = WC_Cache_Helper::get_transient_version( 'product' );
+		$price_hash   = md5( json_encode( apply_filters( 'woocommerce_get_variation_prices_hash', $price_hash, $product, $include_taxes ) ) );
+
+		/**
+		 * $this->prices_array is an array of values which may have been modified from what is stored in transients - this may not match $transient_cached_prices_array.
+		 * If the value has already been generated, we don't need to grab the values again so just return them. They are already filtered.
+		 */
+		if ( ! empty( $this->prices_array[ $price_hash ] ) ) {
+			if ( $include_taxes ) {
+				$product->set_variation_prices_including_taxes( $this->prices_array[ $price_hash ] );
+			} else {
+				$product->set_variation_prices( $this->prices_array[ $price_hash ] );
+			}
+
+			return $product;
+
+		/**
+		 * No locally cached value? Get the data from the transient or generate it.
+		 */
+		} else {
+			// Get value of transient
+			$transient_cached_prices_array = array_filter( (array) json_decode( strval( get_transient( $transient_name ) ), true ) );
+
+			// If the product version has changed since the transient was last saved, reset the transient cache.
+			if ( empty( $transient_cached_prices_array['version'] ) || WC_Cache_Helper::get_transient_version( 'product' ) !== $transient_cached_prices_array['version'] ) {
+				$transient_cached_prices_array = array( 'version' => WC_Cache_Helper::get_transient_version( 'product' ) );
+			}
+
+			// If the prices are not stored for this hash, generate them and add to the transient.
+			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ) {
+				$prices         = array();
+				$regular_prices = array();
+				$sale_prices    = array();
+				$variation_ids  = $product->get_visible_children();
+				foreach ( $variation_ids as $variation_id ) {
+					if ( $variation = wc_get_product( $variation_id ) ) { // @todo loop from missing args? remember?
+						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->get_price(), $variation, $product );
+						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price(), $variation, $product );
+						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price(), $variation, $product );
+
+						// Skip empty prices
+						if ( '' === $price ) {
+							continue;
+						}
+
+						// If sale price does not equal price, the product is not yet on sale
+						if ( $sale_price === $regular_price || $sale_price !== $price ) {
+							$sale_price = $regular_price;
+						}
+
+						// If we are getting prices for display, we need to account for taxes
+						if ( $include_taxes ) {
+							if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
+								$price         = '' === $price ? ''         : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
+								$regular_price = '' === $regular_price ? '' : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $regular_price ) );
+								$sale_price    = '' === $sale_price ? ''    : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $sale_price ) );
+							} else {
+								$price         = '' === $price ? ''         : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
+								$regular_price = '' === $regular_price ? '' : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $regular_price ) );
+								$sale_price    = '' === $sale_price ? ''    : wc_get_price_excluding_tax( $variation, array( 'qty' => 1, 'price' => $sale_price ) );
+							}
+						}
+
+						$prices[ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
+						$regular_prices[ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
+						$sale_prices[ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
+					}
+				}
+
+				asort( $prices );
+				asort( $regular_prices );
+				asort( $sale_prices );
+
+				$transient_cached_prices_array[ $price_hash ] = array(
+					'price'         => $prices,
+					'regular_price' => $regular_prices,
+					'sale_price'    => $sale_prices,
+				);
+
+				set_transient( $transient_name, json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
+			}
+
+			/**
+			 * Give plugins one last chance to filter the variation prices array which has been generated and store locally to the class.
+			 * This value may differ from the transient cache. It is filtered once before storing locally.
+			 */
+			$this->prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices', $transient_cached_prices_array[ $price_hash ], $product, $include_taxes );
+
+			if ( $include_taxes ) {
+				$product->set_variation_prices_including_taxes( $this->prices_array[ $price_hash ] );
+			} else {
+				$product->set_variation_prices( $this->prices_array[ $price_hash ] );
+			}
+
+			return $product;
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Does a child have a weight set?
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 * @return boolean
+	 */
+	public function child_has_weight( $product ) {
+		global $wpdb;
+		$children = $product->get_visible_children( 'edit' );
+		return $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_weight' AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+	}
+
+	/**
+	 * Does a child have dimensions set?
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 * @return boolean
+	 */
+	public function child_has_dimensions( $product ) {
+		global $wpdb;
+		$children = $product->get_visible_children( 'edit' );
+		return $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key IN ( '_length', '_width', '_height' ) AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+	}
+
+	/**
+	 * Is a child in stock?
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 * @return boolean
+	 */
+	public function child_is_in_stock( $product ) {
+		global $wpdb;
+		$children = $this->get_visible_children( 'edit' );
+		return $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_stock_status' AND meta_value = 'instock' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+	}
+
+	/**
+	 * Stock managed at the parent level - update children being managed by this product.
+	 * This sync function syncs downwards (from parent to child) when the variable product is saved.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	public function sync_managed_variation_stock_status( &$product ) {
+		global $wpdb;
+
+		if ( $product->get_manage_stock() ) {
+			$status           = $product->get_stock_status();
+			$children         = $product->get_children();
+			$managed_children = $children ? array_unique( $wpdb->get_col( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_manage_stock' AND meta_value != 'yes' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) ) : array();
+			$changed          = false;
+			foreach ( $managed_children as $managed_child ) {
+				if ( update_post_meta( $managed_child, '_stock_status', $status ) ) {
+					$changed = true;
+				}
+			}
+			if ( $changed ) {
+				$product = $this->read_children( $product, true );
+			}
+		}
+	}
+
+	/**
+	 * Sync variable product prices with children.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product|int $product
+	 */
+	public function sync_price( &$product ) {
+		global $wpdb;
+
+		$children = $product->get_visible_children( 'edit' );
+		$prices   = $children ? array_unique( $wpdb->get_col( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_price' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) ) : array();
+
+		delete_post_meta( $product->get_id(), '_price' );
+
+		if ( $prices ) {
+			sort( $prices );
+			// To allow sorting and filtering by multiple values, we have no choice but to store child prices in this manner.
+			foreach ( $prices as $price ) {
+				add_post_meta( $product->get_id(), '_price', $price, false );
+			}
+		}
+	}
+
+}

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -24,16 +24,14 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 *
 	 * @since 2.7.0
 	 */
-	public function read_product_data( $product ) {
-		$product = parent::read_product_data( $product );
-		$product = $this->read_children( $product );
+	public function read_product_data( &$product ) {
+		parent::read_product_data( $product );
+		$this->read_children( $product );
 
 		// Set directly since individual data needs changed at the WC_Product_Variation level -- these datasets just pull.
-		$product = $this->read_price_data( $product );
-		$product = $this->read_price_data( $product, true );
-		$product = $this->read_variation_attributes( $product );
-
-		return $product;
+		$this->read_price_data( $product );
+	 	$this->read_price_data( $product, true );
+		$this->read_variation_attributes( $product );
 	}
 
 	/**
@@ -42,7 +40,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @param  bool $force_read True to bypass the transient.
 	 * @return WC_Product
 	 */
-	public function read_children( $product, $force_read = false ) {
+	public function read_children( &$product, $force_read = false ) {
 		$children_transient_name = 'wc_product_children_' . $product->get_id();
 		$children                = get_transient( $children_transient_name );
 
@@ -71,17 +69,14 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 
 		$product->set_children( wp_parse_id_list( (array) $children['all'] ) );
 		$product->set_visible_children( wp_parse_id_list( (array) $children['visible'] ) );
-
-		return $product;
 	}
 
 	/**
 	 * Loads an array of attributes used for variations, as well as their possible values.
 	 *
 	 * @param WC_Product
-	 * @return WC_Product
 	 */
-	private function read_variation_attributes( $product ) {
+	private function read_variation_attributes( &$product ) {
 		global $wpdb;
 
 		$variation_attributes = array();
@@ -130,8 +125,6 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		}
 
 		$product->set_variation_attributes( $variation_attributes );
-
-		return $product;
 	}
 
 	/**
@@ -143,9 +136,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @since  2.7.0
 	 * @param  WC_Product
 	 * @param  bool $include_taxes If taxes should be calculated or not.
-	 * @return WC_Product
 	 */
-	private function read_price_data( $product, $include_taxes = false ) {
+	private function read_price_data( &$product, $include_taxes = false ) {
 		global $wp_filter;
 
 		/**
@@ -185,9 +177,6 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			} else {
 				$product->set_variation_prices( $this->prices_array[ $price_hash ] );
 			}
-
-			return $product;
-
 		/**
 		 * No locally cached value? Get the data from the transient or generate it.
 		 */
@@ -265,11 +254,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 			} else {
 				$product->set_variation_prices( $this->prices_array[ $price_hash ] );
 			}
-
-			return $product;
 		}
-
-		return $product;
 	}
 
 	/**
@@ -332,7 +317,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 				}
 			}
 			if ( $changed ) {
-				$product = $this->read_children( $product, true );
+				$this->read_children( $product, true );
 			}
 		}
 	}

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -24,7 +24,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 *
 	 * @since 2.7.0
 	 */
-	public function read_product_data( &$product ) {
+	protected function read_product_data( &$product ) {
 		parent::read_product_data( $product );
 		$this->read_children( $product );
 

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category Class
  * @author   WooThemes
  */
-class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store {
+class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store, WC_Product_Variable_Data_Store {
 
 	/**
 	 * Cached & hashed prices array for child variations.

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -1,0 +1,254 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Variation Product Data Store: Stored in CPT.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooThemes
+ */
+class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT implements WC_Object_Data_Store {
+
+	/*
+	|--------------------------------------------------------------------------
+	| CRUD Methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Reads a product from the database and sets its data to the class.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 */
+	public function read( &$product ) {
+		$product->set_defaults();
+
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) ) {
+			return;
+		}
+
+		$id = $product->get_id();
+		$product->set_parent_id( $post_object->post_parent );
+
+		// The post doesn't have a parent id, therefore its invalid and we should prevent this being created.
+		if ( empty( $product->get_parent_id() ) ) {
+			throw new Exception( sprintf( 'No parent product set for variation #%d', $product->get_id() ), 422 );
+		}
+
+		// The post parent is not a valid variable product so we should prevent this being created.
+		if ( 'product' !== get_post_type( $product->get_parent_id() ) ) {
+			throw new Exception( sprintf( 'Invalid parent for variation #%d', $product->get_id() ), 422 );
+		}
+
+		$product->set_props( array(
+			'name'              => get_the_title( $post_object ),
+			'slug'              => $post_object->post_name,
+			'date_created'      => $post_object->post_date,
+			'date_modified'     => $post_object->post_modified,
+			'status'            => $post_object->post_status,
+			'menu_order'        => $post_object->menu_order,
+			'reviews_allowed'   => 'open' === $post_object->comment_status,
+		) );
+
+		$product = $this->read_product_data( $product );
+		$product->read_meta_data();
+		$product->set_attributes( wc_get_product_variation_attributes( $product->get_id() ) );
+
+		// Set object_read true once all data is read.
+		$product->set_object_read( true );
+	}
+
+	/**
+	 * Create a new product.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 */
+	public function create( &$product ) {
+		$product->set_date_created( current_time( 'timestamp' ) );
+
+		$id = wp_insert_post( apply_filters( 'woocommerce_new_product_variation_data', array(
+			'post_type'      => $product->post_type,
+			'post_status'    => $product->get_status() ? $product->get_status() : 'publish',
+			'post_author'    => get_current_user_id(),
+			'post_title'     => get_the_title( $product->get_parent_id() ) . ' &ndash;' . wc_get_formatted_variation( $product->get_attributes(), true ),
+			'post_content'   => '',
+			'post_parent'    => $product->get_parent_id(),
+			'comment_status' => 'closed',
+			'ping_status'    => 'closed',
+			'menu_order'     => $product->get_menu_order(),
+			'post_date'      => date( 'Y-m-d H:i:s', $product->get_date_created() ),
+			'post_date_gmt'  => get_gmt_from_date( date( 'Y-m-d H:i:s', $product->get_date_created() ) ),
+		) ), true );
+
+		if ( $id && ! is_wp_error( $id ) ) {
+			$product->set_id( $id );
+			$product = $this->update_post_meta( $product );
+			$this->update_terms( $product );
+			$this->update_attributes( $product );
+			$product->save_meta_data();
+
+			do_action( 'woocommerce_create_' . $product->post_type, $id );
+
+			$product->apply_changes();
+			$this->update_version_and_type( $product );
+			$this->update_term_counts( $product );
+			$this->clear_caches( $product );
+		}
+	}
+
+	/**
+	 * Updates an existing product.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 */
+	public function update( &$product ) {
+		$post_data = array(
+			'ID'             => $product->get_id(),
+			'post_title'     => get_the_title( $product->get_parent_id() ) . ' &ndash;' . wc_get_formatted_variation( $product->get_attributes(), true ),
+			'post_parent'    => $product->get_parent_id(),
+			'comment_status' => 'closed',
+			'post_status'    => $product->get_status() ? $product->get_status() : 'publish',
+			'menu_order'     => $product->get_menu_order(),
+		);
+		wp_update_post( $post_data );
+		$product = $this->update_post_meta( $product );
+		$this->update_terms( $product );
+		$this->update_attributes( $product );
+		$product->save_meta_data();
+
+		do_action( 'woocommerce_update_' . $product->post_type, $product->get_id() );
+
+		$product->apply_changes();
+		$this->update_version_and_type( $product );
+		$this->update_term_counts( $product );
+		$this->clear_caches( $product );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Additional Methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Read post data.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 * @return WC_Product
+	 */
+	protected function read_product_data( $product ) {
+		$id = $product->get_id();
+		$product->set_props( array(
+			'description'       => get_post_meta( $id, '_variation_description', true ),
+			'regular_price'     => get_post_meta( $id, '_regular_price', true ),
+			'sale_price'        => get_post_meta( $id, '_sale_price', true ),
+			'date_on_sale_from' => get_post_meta( $id, '_sale_price_dates_from', true ),
+			'date_on_sale_to'   => get_post_meta( $id, '_sale_price_dates_to', true ),
+			'tax_status'        => get_post_meta( $id, '_tax_status', true ),
+			'manage_stock'      => get_post_meta( $id, '_manage_stock', true ),
+			'stock_status'      => get_post_meta( $id, '_stock_status', true ),
+			'shipping_class_id' => current( $this->get_term_ids( $product, 'product_shipping_class' ) ),
+			'virtual'           => get_post_meta( $id, '_virtual', true ),
+			'downloadable'      => get_post_meta( $id, '_downloadable', true ),
+			'downloads'         => array_filter( (array) get_post_meta( $id, '_downloadable_files', true ) ),
+			'gallery_image_ids' => array_filter( explode( ',', get_post_meta( $id, '_product_image_gallery', true ) ) ),
+			'download_limit'    => get_post_meta( $id, '_download_limit', true ),
+			'download_expiry'   => get_post_meta( $id, '_download_expiry', true ),
+			'image_id'          => get_post_thumbnail_id( $id ),
+			'backorders'        => get_post_meta( $id, '_backorders', true ),
+			'sku'               => get_post_meta( $id, '_sku', true ),
+			'stock_quantity'    => get_post_meta( $id, '_stock', true ),
+			'weight'            => get_post_meta( $id, '_weight', true ),
+			'length'            => get_post_meta( $id, '_length', true ),
+			'width'             => get_post_meta( $id, '_width', true ),
+			'height'            => get_post_meta( $id, '_height', true ),
+			'tax_class'         => get_post_meta( $id, '_tax_class', true ),
+		) );
+
+		if ( $product->is_on_sale() ) {
+			$product->set_price( $product->get_sale_price() );
+		} else {
+			$product->set_price( $product->get_regular_price() );
+		}
+
+		$product->set_parent_data( array(
+			'sku'            => get_post_meta( $product->get_parent_id(), '_sku', true ),
+			'manage_stock'   => get_post_meta( $product->get_parent_id(), '_manage_stock', true ),
+			'backorders'     => get_post_meta( $product->get_parent_id(), '_backorders', true ),
+			'stock_quantity' => get_post_meta( $product->get_parent_id(), '_stock', true ),
+			'weight'         => get_post_meta( $product->get_parent_id(), '_weight', true ),
+			'length'         => get_post_meta( $product->get_parent_id(), '_length', true ),
+			'width'          => get_post_meta( $product->get_parent_id(), '_width', true ),
+			'height'         => get_post_meta( $product->get_parent_id(), '_height', true ),
+			'tax_class'      => get_post_meta( $product->get_parent_id(), '_tax_class', true ),
+			'image_id'       => get_post_thumbnail_id( $product->get_parent_id() ),
+		) );
+
+		return $product;
+	}
+
+	/**
+	 * For all stored terms in all taxonomies, save them to the DB.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 */
+	protected function update_terms( $product ) {
+		wp_set_post_terms( $product->get_id(), array( $product->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
+	}
+
+	/**
+	 * Update attribute meta values.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 */
+	protected function update_attributes( $product ) {
+		global $wpdb;
+		$attributes             = $product->get_attributes();
+		$updated_attribute_keys = array();
+		foreach ( $attributes as $key => $value ) {
+			update_post_meta( $product->get_id(), 'attribute_' . $key, $value );
+			$updated_attribute_keys[] = 'attribute_' . $key;
+		}
+
+		// Remove old taxonomies attributes so data is kept up to date - first get attribute key names.
+		$delete_attribute_keys = $wpdb->get_col( $wpdb->prepare( "SELECT meta_key FROM {$wpdb->postmeta} WHERE meta_key LIKE 'attribute_%%' AND meta_key NOT IN ( '" . implode( "','", array_map( 'esc_sql', $updated_attribute_keys ) ) . "' ) AND post_id = %d;", $product->get_id() ) );
+
+		foreach ( $delete_attribute_keys as $key ) {
+			delete_post_meta( $product->get_id(), $key );
+		}
+	}
+
+	/**
+	 * Helper method that updates all the post meta for a product based on it's settings in the WC_Product class.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 * @return WC_Product
+	 */
+	public function update_post_meta( $product ) {
+		update_post_meta( $product->get_id(), '_variation_description', $product->get_description() );
+		$product = parent::update_post_meta( $product );
+		return $product;
+	}
+
+	/**
+	 * Clear any caches.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Product
+	 */
+	protected function clear_caches( $product ) {
+		wc_delete_product_transients( $product->get_id() );
+		wc_delete_product_transients( $product->get_parent_id() );
+	}
+
+}

--- a/includes/data-stores/interfaces/interface-wc-product-data-store.php
+++ b/includes/data-stores/interfaces/interface-wc-product-data-store.php
@@ -1,0 +1,96 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Coupon Data Store Interface
+ *
+ * Functions that must be defined by coupon store classes.
+ *
+ * @version  2.7.0
+ * @category Interface
+ * @author   WooThemes
+ */
+interface WC_Product_Data_Store {
+
+	/**
+	 * Returns an array of on sale products, as an array of objects with an
+	 * ID and parent_id present. Example: $return[0]->id, $return[0]->parent_id.
+	 *
+	 * @return array
+	 */
+	public function get_on_sale_products();
+
+	/**
+	 * Returns a list of product IDs ( id as key => parent as value) that are
+	 * featured. Uses get_posts instead of wc_get_products since we want
+	 * some extra meta queries and ALL products (posts_per_page = -1).
+	 *
+	 * @return array
+	 */
+	public function get_featured_product_ids();
+
+	/**
+	 * Check if product sku is found for any other product IDs.
+	 *
+	 * @param int $product_id
+	 * @param string $sku
+	 * @return bool
+	 */
+	public function sku_found( $product_id, $sku );
+
+	/**
+	 * Return product ID based on SKU.
+	 *
+	 * @param string $sku
+	 * @return int
+	 */
+	public function get_product_id_by_sku( $sku );
+
+	/**
+	 * Returns an array of IDs of products that have sales starting soon.
+	 *
+	 * @return array
+	 */
+	public function get_starting_sales();
+
+	/**
+	 * Returns an array of IDs of products that have sales which are due to end.
+	 *
+	 * @return array
+	 */
+	public function get_ending_sales();
+
+	/**
+	 * Find a matching (enabled) variation within a variable product.
+	 *
+	 * @param  WC_Product $product Variable product.
+	 * @param  array $match_attributes Array of attributes we want to try to match.
+	 * @return int Matching variation ID or 0.
+	 */
+	public function find_matching_product_variation( $product, $match_attributes = array() );
+
+	/**
+	 * Return a list of related products (using data like categories and IDs).
+	 *
+	 * @param array $cats_array  List of categories IDs.
+	 * @param array $tags_array  List of tags IDs.
+	 * @param array $exclude_ids Excluded IDs.
+	 * @param int   $limit       Limit of results.
+	 * @param int   $product_id
+	 * @return array
+	 */
+	public function get_related_products( $cats_array, $tags_array, $exclude_ids, $limit, $product_id );
+
+	/**
+	 * Update a product's stock amount directly.
+	 *
+	 * Uses queries rather than update_post_meta so we can do this in one query (to avoid stock issues).
+	 *
+	 * @param  int
+	 * @param  int|null $stock_quantity
+	 * @param  string $operation set, increase and decrease.
+	 */
+	function update_product_stock( $product_id_with_stock, $stock_quantity = null, $operation = 'set' );
+}

--- a/includes/data-stores/interfaces/interface-wc-product-data-store.php
+++ b/includes/data-stores/interfaces/interface-wc-product-data-store.php
@@ -4,9 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WC Coupon Data Store Interface
+ * WC Product Data Store Interface
  *
- * Functions that must be defined by coupon store classes.
+ * Functions that must be defined by product store classes.
  *
  * @version  2.7.0
  * @category Interface

--- a/includes/data-stores/interfaces/interface-wc-product-data-store.php
+++ b/includes/data-stores/interfaces/interface-wc-product-data-store.php
@@ -38,7 +38,7 @@ interface WC_Product_Data_Store {
 	 * @param string $sku
 	 * @return bool
 	 */
-	public function sku_found( $product_id, $sku );
+	public function is_existing_sku( $product_id, $sku );
 
 	/**
 	 * Return product ID based on SKU.

--- a/includes/data-stores/interfaces/interface-wc-product-variable-data-store.php
+++ b/includes/data-stores/interfaces/interface-wc-product-variable-data-store.php
@@ -1,0 +1,54 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Product Variable Data Store Interface
+ *
+ * Functions that must be defined by product variable store classes.
+ *
+ * @version  2.7.0
+ * @category Interface
+ * @author   WooThemes
+ */
+interface WC_Product_Variable_Data_Store {
+	/**
+	 * Does a child have a weight set?
+	 *
+	 * @param WC_Product
+	 * @return boolean
+	 */
+	public function child_has_weight( $product );
+
+	/**
+	 * Does a child have dimensions set?
+	 *
+	 * @param WC_Product
+	 * @return boolean
+	 */
+	public function child_has_dimensions( $product );
+
+	/**
+	 * Is a child in stock?
+	 *
+	 * @param WC_Product
+	 * @return boolean
+	 */
+	public function child_is_in_stock( $product );
+
+	/**
+	 * Stock managed at the parent level - update children being managed by this product.
+	 * This sync function syncs downwards (from parent to child) when the variable product is saved.
+	 *
+	 * @param WC_Product
+	 */
+	public function sync_managed_variation_stock_status( &$product );
+
+	/**
+	 * Sync variable product prices with children.
+	 *
+	 * @param WC_Product|int $product
+	 */
+	public function sync_price( &$product );
+}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * WooCommerce Product Functions
  *
@@ -7,12 +11,8 @@
  * @author   WooThemes
  * @category Core
  * @package  WooCommerce/Functions
- * @version  2.3.0
+ * @version  2.7.0
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
 
 /**
  * Products wrapper for get_posts.
@@ -244,8 +244,9 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		}
 
 		// Does this product have a parent?
-		if ( $parent_id = wp_get_post_parent_id( $post_id ) ) {
-			wc_delete_product_transients( $parent_id );
+		$product = wc_get_product( $post_id );
+		if ( $product->get_parent_id() > 0 ) {
+			wc_delete_product_transients( $product->get_parent_id() );
 		}
 	}
 
@@ -264,12 +265,9 @@ function wc_delete_product_transients( $post_id = 0 ) {
  * Function that returns an array containing the IDs of the products that are on sale.
  *
  * @since 2.0
- * @access public
  * @return array
  */
 function wc_get_product_ids_on_sale() {
-	global $wpdb;
-
 	// Load from cache
 	$product_ids_on_sale = get_transient( 'wc_products_onsale' );
 
@@ -278,21 +276,9 @@ function wc_get_product_ids_on_sale() {
 		return $product_ids_on_sale;
 	}
 
-	$on_sale_posts = $wpdb->get_results( "
-		SELECT post.ID, post.post_parent FROM `$wpdb->posts` AS post
-		LEFT JOIN `$wpdb->postmeta` AS meta ON post.ID = meta.post_id
-		LEFT JOIN `$wpdb->postmeta` AS meta2 ON post.ID = meta2.post_id
-		WHERE post.post_type IN ( 'product', 'product_variation' )
-			AND post.post_status = 'publish'
-			AND meta.meta_key = '_sale_price'
-			AND meta2.meta_key = '_price'
-			AND CAST( meta.meta_value AS DECIMAL ) >= 0
-			AND CAST( meta.meta_value AS CHAR ) != ''
-			AND CAST( meta.meta_value AS DECIMAL ) = CAST( meta2.meta_value AS DECIMAL )
-		GROUP BY post.ID;
-	" );
-
-	$product_ids_on_sale = array_unique( array_map( 'absint', array_merge( wp_list_pluck( $on_sale_posts, 'ID' ), array_diff( wp_list_pluck( $on_sale_posts, 'post_parent' ), array( 0 ) ) ) ) );
+	$data_store          = WC_Data_Store::load( 'product' );
+	$on_sale_products    = $data_store->get_on_sale_products();
+	$product_ids_on_sale = array_unique( array_map( 'absint', array_merge( wp_list_pluck( $on_sale_products, 'id' ), array_diff( wp_list_pluck( $on_sale_products, 'parent_id' ), array( 0 ) ) ) ) );
 
 	set_transient( 'wc_products_onsale', $product_ids_on_sale, DAY_IN_SECONDS * 30 );
 
@@ -303,11 +289,9 @@ function wc_get_product_ids_on_sale() {
  * Function that returns an array containing the IDs of the featured products.
  *
  * @since 2.1
- * @access public
  * @return array
  */
 function wc_get_featured_product_ids() {
-
 	// Load from cache
 	$featured_product_ids = get_transient( 'wc_featured_products' );
 
@@ -315,24 +299,8 @@ function wc_get_featured_product_ids() {
 	if ( false !== $featured_product_ids )
 		return $featured_product_ids;
 
-	$featured = get_posts( array(
-		'post_type'      => array( 'product', 'product_variation' ),
-		'posts_per_page' => -1,
-		'post_status'    => 'publish',
-		'meta_query'     => array(
-			array(
-				'key' 		=> '_visibility',
-				'value' 	=> array( 'catalog', 'visible' ),
-				'compare' 	=> 'IN',
-			),
-			array(
-				'key' 	=> '_featured',
-				'value' => 'yes',
-			),
-		),
-		'fields' => 'id=>parent',
-	) );
-
+	$data_store           = WC_Data_Store::load( 'product' );
+	$featured             = $data_store->get_featured_product_ids();
 	$product_ids          = array_keys( $featured );
 	$parent_ids           = array_values( array_filter( $featured ) );
 	$featured_product_ids = array_unique( array_merge( $product_ids, $parent_ids ) );
@@ -440,7 +408,6 @@ function wc_placeholder_img( $size = 'shop_thumbnail' ) {
  *
  * Gets a formatted version of variation data or item meta.
  *
- * @access public
  * @param string $variation
  * @param bool $flat (default: false)
  * @return string
@@ -492,49 +459,35 @@ function wc_get_formatted_variation( $variation, $flat = false ) {
 
 /**
  * Function which handles the start and end of scheduled sales via cron.
- *
- * @access public
  */
 function wc_scheduled_sales() {
-	global $wpdb;
+	$data_store = WC_Data_Store::load( 'product' );
 
 	// Sales which are due to start
-	$product_ids = $wpdb->get_col( $wpdb->prepare( "
-		SELECT postmeta.post_id FROM {$wpdb->postmeta} as postmeta
-		LEFT JOIN {$wpdb->postmeta} as postmeta_2 ON postmeta.post_id = postmeta_2.post_id
-		LEFT JOIN {$wpdb->postmeta} as postmeta_3 ON postmeta.post_id = postmeta_3.post_id
-		WHERE postmeta.meta_key = '_sale_price_dates_from'
-		AND postmeta_2.meta_key = '_price'
-		AND postmeta_3.meta_key = '_sale_price'
-		AND postmeta.meta_value > 0
-		AND postmeta.meta_value < %s
-		AND postmeta_2.meta_value != postmeta_3.meta_value
-	", current_time( 'timestamp' ) ) );
-
+	$product_ids = $data_store->get_starting_sales();
 	if ( $product_ids ) {
 		foreach ( $product_ids as $product_id ) {
-			$sale_price = get_post_meta( $product_id, '_sale_price', true );
+			$product = wc_get_product( $product_id );
+			$sale_price = $product->get_sale_price();
 
 			if ( $sale_price ) {
-				update_post_meta( $product_id, '_price', $sale_price );
+				$product->set_price( $sale_price );
 			} else {
-				// No sale price!
-				update_post_meta( $product_id, '_sale_price_dates_from', '' );
-				update_post_meta( $product_id, '_sale_price_dates_to', '' );
+				$product->set_date_on_sale_to( '' );
+				$product->set_date_on_sale_from( '' );
 			}
 
-			$parent = wp_get_post_parent_id( $product_id );
+			$product->save();
 
+			$parent = $product->get_parent_id();
 			// Sync parent
 			if ( $parent ) {
 				// Clear prices transient for variable products.
 				delete_transient( 'wc_var_prices_' . $parent );
 
 				// Grouped products need syncing via a function
-				$this_product = wc_get_product( $product_id );
-
-				if ( $this_product->is_type( 'simple' ) ) {
-					$this_product->grouped_product_sync();
+				if ( $product->is_type( 'simple' ) ) {
+					$product->grouped_product_sync();
 				}
 			}
 		}
@@ -543,28 +496,18 @@ function wc_scheduled_sales() {
 	}
 
 	// Sales which are due to end
-	$product_ids = $wpdb->get_col( $wpdb->prepare( "
-		SELECT postmeta.post_id FROM {$wpdb->postmeta} as postmeta
-		LEFT JOIN {$wpdb->postmeta} as postmeta_2 ON postmeta.post_id = postmeta_2.post_id
-		LEFT JOIN {$wpdb->postmeta} as postmeta_3 ON postmeta.post_id = postmeta_3.post_id
-		WHERE postmeta.meta_key = '_sale_price_dates_to'
-		AND postmeta_2.meta_key = '_price'
-		AND postmeta_3.meta_key = '_regular_price'
-		AND postmeta.meta_value > 0
-		AND postmeta.meta_value < %s
-		AND postmeta_2.meta_value != postmeta_3.meta_value
-	", current_time( 'timestamp' ) ) );
-
+	$product_ids = $data_store->get_ending_sales();
 	if ( $product_ids ) {
 		foreach ( $product_ids as $product_id ) {
-			$regular_price = get_post_meta( $product_id, '_regular_price', true );
+			$product       = wc_get_product( $product_id );
+			$regular_price = $product->get_regular_price();
+			$product->set_price( $regular_price );
+			$product->set_sale_price( '' );
+			$product->set_date_on_sale_to( '' );
+			$product->set_date_on_sale_from( '' );
+			$product->save();
 
-			update_post_meta( $product_id, '_price', $regular_price );
-			update_post_meta( $product_id, '_sale_price', '' );
-			update_post_meta( $product_id, '_sale_price_dates_from', '' );
-			update_post_meta( $product_id, '_sale_price_dates_to', '' );
-
-			$parent = wp_get_post_parent_id( $product_id );
+			$parent = $product->get_parent_id();
 
 			// Sync parent
 			if ( $parent ) {
@@ -572,9 +515,8 @@ function wc_scheduled_sales() {
 				delete_transient( 'wc_var_prices_' . $parent );
 
 				// Grouped products need syncing via a function
-				$this_product = wc_get_product( $product_id );
-				if ( $this_product->is_type( 'simple' ) ) {
-					$this_product->grouped_product_sync();
+				if ( $product->is_type( 'simple' ) ) {
+					$product->grouped_product_sync();
 				}
 			}
 		}
@@ -672,21 +614,14 @@ function wc_get_product_types() {
  *
  * @since 2.2
  * @param int $product_id
- * @param string $sku Will be slashed to work around https://core.trac.wordpress.org/ticket/27421
+ * @param string $sku
  * @return bool
  */
 function wc_product_has_unique_sku( $product_id, $sku ) {
 	global $wpdb;
 
-	$sku_found = $wpdb->get_var( $wpdb->prepare( "
-		SELECT $wpdb->posts.ID
-		FROM $wpdb->posts
-		LEFT JOIN $wpdb->postmeta ON ( $wpdb->posts.ID = $wpdb->postmeta.post_id )
-		WHERE $wpdb->posts.post_type IN ( 'product', 'product_variation' )
-		AND $wpdb->posts.post_status = 'publish'
-		AND $wpdb->postmeta.meta_key = '_sku' AND $wpdb->postmeta.meta_value = '%s'
-		AND $wpdb->postmeta.post_id <> %d LIMIT 1
-	 ", wp_slash( $sku ), $product_id ) );
+	$data_store = WC_Data_Store::load( 'product' );
+	$sku_found  = $data_store->sku_found( $product_id, $sku );
 
 	if ( apply_filters( 'wc_product_has_unique_sku', $sku_found, $product_id, $sku ) ) {
 		return false;
@@ -705,20 +640,15 @@ function wc_product_has_unique_sku( $product_id, $sku ) {
 function wc_get_product_id_by_sku( $sku ) {
 	global $wpdb;
 
-	$product_id = $wpdb->get_var( $wpdb->prepare( "
-		SELECT posts.ID
-		FROM $wpdb->posts AS posts
-		LEFT JOIN $wpdb->postmeta AS postmeta ON ( posts.ID = postmeta.post_id )
-		WHERE posts.post_type IN ( 'product', 'product_variation' )
-		AND postmeta.meta_key = '_sku' AND postmeta.meta_value = '%s'
-		LIMIT 1
-	 ", $sku ) );
+	$data_store = WC_Data_Store::load( 'product' );
+	$product_id = $data_store->get_product_id_by_sku( $sku );
 
 	return ( $product_id ) ? intval( $product_id ) : 0;
 }
 
 /**
  * Get attibutes/data for an individual variation from the database and maintain it's integrity.
+ * @param revisit?
  * @since  2.4.0
  * @param  int $variation_id
  * @return array
@@ -961,8 +891,8 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 		if ( empty( $cats_array ) && empty( $tags_array ) && ! apply_filters( 'woocommerce_product_related_posts_force_display', false, $product_id ) ) {
 			$related_posts = array();
 		} else {
-			// Generate query - but query an extra 10 results to give the appearance of random results when later shuffled.
-			$related_posts = $wpdb->get_col( implode( ' ', apply_filters( 'woocommerce_product_related_posts_query', wc_get_related_products_query( $cats_array, $tags_array, $exclude_ids, $limit + 10 ), $product_id ) ) );
+			$data_store    = WC_Data_Store::load( 'product' );
+			$related_posts = $data_store->get_related_products( $cats_array, $tags_array, $exclude_ids, $limit + 10, $product_id );
 		}
 
 		set_transient( $transient_name, $related_posts, DAY_IN_SECONDS );
@@ -984,68 +914,6 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 function wc_get_product_term_ids( $product_id, $taxonomy ) {
 	$terms = get_the_terms( $product_id, $taxonomy );
 	return ! empty( $terms ) ? wp_list_pluck( $terms, 'term_id' ) : array();
-}
-
-/**
- * Builds the related posts query.
- *
- * @since 2.7.0
- * @param array $cats_array  List of categories IDs.
- * @param array $tags_array  List of tags IDs.
- * @param array $exclude_ids Excluded IDs.
- * @param int   $limit       Limit of results.
- * @return string
- */
-function wc_get_related_products_query( $cats_array, $tags_array, $exclude_ids, $limit ) {
-	global $wpdb;
-
-	// Arrays to string.
-	$exclude_ids = implode( ',', array_map( 'absint', $exclude_ids ) );
-	$cats_array  = implode( ',', array_map( 'absint', $cats_array ) );
-	$tags_array  = implode( ',', array_map( 'absint', $tags_array ) );
-
-	$limit           = absint( $limit );
-	$query           = array();
-	$query['fields'] = "SELECT DISTINCT ID FROM {$wpdb->posts} p";
-	$query['join']   = " INNER JOIN {$wpdb->postmeta} pm ON ( pm.post_id = p.ID AND pm.meta_key='_visibility' )";
-	$query['join']  .= " INNER JOIN {$wpdb->term_relationships} tr ON (p.ID = tr.object_id)";
-	$query['join']  .= " INNER JOIN {$wpdb->term_taxonomy} tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id)";
-	$query['join']  .= " INNER JOIN {$wpdb->terms} t ON (t.term_id = tt.term_id)";
-
-	if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-		$query['join'] .= " INNER JOIN {$wpdb->postmeta} pm2 ON ( pm2.post_id = p.ID AND pm2.meta_key='_stock_status' )";
-	}
-
-	$query['where']  = ' WHERE 1=1';
-	$query['where'] .= " AND p.post_status = 'publish'";
-	$query['where'] .= " AND p.post_type = 'product'";
-	$query['where'] .= " AND p.ID NOT IN ( {$exclude_ids} )";
-	$query['where'] .= " AND pm.meta_value IN ( 'visible', 'catalog' )";
-
-	if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-		$query['where'] .= " AND pm2.meta_value = 'instock'";
-	}
-
-	if ( $cats_array || $tags_array ) {
-		$query['where'] .= ' AND (';
-
-		if ( $cats_array ) {
-			$query['where'] .= " ( tt.taxonomy = 'product_cat' AND t.term_id IN ( {$cats_array} ) ) ";
-			if ( $tags_array ) {
-				$query['where'] .= ' OR ';
-			}
-		}
-
-		if ( $tags_array ) {
-			$query['where'] .= " ( tt.taxonomy = 'product_tag' AND t.term_id IN ( {$tags_array} ) ) ";
-		}
-
-		$query['where'] .= ')';
-	}
-
-	$query['limits'] = " LIMIT {$limit} ";
-
-	return $query;
 }
 
 /**
@@ -1295,58 +1163,6 @@ function wc_products_array_orderby_price( $a, $b ) {
  * @return int Matching variation ID or 0.
  */
 function wc_find_matching_product_variation( $product, $match_attributes = array() ) {
-	$query_args = array(
-		'post_parent' => $product->get_id(),
-		'post_type'   => 'product_variation',
-		'orderby'     => 'menu_order',
-		'order'       => 'ASC',
-		'fields'      => 'ids',
-		'post_status' => 'publish',
-		'numberposts' => 1,
-		'meta_query'  => array(),
-	);
-
-	// Allow large queries in case user has many variations or attributes.
-	$GLOBALS['wpdb']->query( 'SET SESSION SQL_BIG_SELECTS=1' );
-
-	foreach ( $product->get_attributes() as $attribute ) {
-		if ( ! $attribute->get_variation() ) {
-			continue;
-		}
-
-		$attribute_field_name = 'attribute_' . sanitize_title( $attribute->get_name() );
-
-		if ( ! isset( $match_attributes[ $attribute_field_name ] ) ) {
-			return 0;
-		}
-
-		$value = wc_clean( $match_attributes[ $attribute_field_name ] );
-
-		$query_args['meta_query'][] = array(
-			'relation' => 'OR',
-			array(
-				'key'     => $attribute_field_name,
-				'value'   => array( '', $value ),
-				'compare' => 'IN',
-			),
-			array(
-				'key'     => $attribute_field_name,
-				'compare' => 'NOT EXISTS',
-			)
-		);
-	}
-
-	$variations = get_posts( $query_args );
-
-	if ( $variations && ! is_wp_error( $variations ) ) {
-		return current( $variations );
- 	} elseif ( version_compare( get_post_meta( $product->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
-		/**
-		 * Pre 2.4 handling where 'slugs' were saved instead of the full text attribute.
-		 * Fallback is here because there are cases where data will be 'synced' but the product version will remain the same.
-		 */
-		return ( array_map( 'sanitize_title', $match_attributes ) === $match_attributes ) ? 0 : wc_find_matching_product_variation( $product, array_map( 'sanitize_title', $match_attributes ) );
-	}
-
-	return 0;
+	$data_store = WC_Data_Store::load( 'product' );
+	return $data_store->find_matching_product_variation( $product, $match_attributes );
 }

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -84,7 +84,7 @@ function wc_get_products( $args ) {
 	 * Generate WP_Query args.
 	 */
 	$wp_query_args = array(
-		'post_type'      => 'variation' === $args['type'] ? 'product_variation' : 'product',
+		'post_type'      => array( 'product', 'product_variation' ),
 		'post_status'    => $args['status'],
 		'posts_per_page' => $args['limit'],
 		'meta_query'     => array(),
@@ -97,13 +97,11 @@ function wc_get_products( $args ) {
 		$wp_query_args['fields'] = 'ids';
 	}
 
-	if ( 'variation' !== $args['type'] ) {
-		$wp_query_args['tax_query'][] = array(
-			'taxonomy' => 'product_type',
-			'field'    => 'slug',
-			'terms'    => $args['type'],
-		);
-	}
+	$wp_query_args['tax_query'][] = array(
+		'taxonomy' => 'product_type',
+		'field'    => 'slug',
+		'terms'    => $args['type'],
+	);
 
 	if ( ! empty( $args['sku'] ) ) {
 		$wp_query_args['meta_query'][] = array(

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -179,15 +179,15 @@ function wc_get_products( $args ) {
  * @since 2.2.0
  *
  * @param mixed $the_product Post object or post ID of the product.
- * @param array $args (default: array()) Contains all arguments to be used to get this product.
- * @return WC_Product
+ * @param array $deprecated
+ * @return WC_Product|null
  */
-function wc_get_product( $the_product = false, $args = array() ) {
+function wc_get_product( $the_product = false, $deprecated = array() ) {
 	if ( ! did_action( 'woocommerce_init' ) ) {
 		_doing_it_wrong( __FUNCTION__, __( 'wc_get_product should not be called before the woocommerce_init action.', 'woocommerce' ), '2.5' );
 		return false;
 	}
-	return WC()->product_factory->get_product( $the_product, $args );
+	return WC()->product_factory->get_product( $the_product );
 }
 
 /**

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -53,7 +53,7 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 		delete_transient( 'wc_outofstock_count' );
 
 		// Re-read product data after updating stock, then have stock status calculated and saved.
-		$product_with_stock->read( $product_with_stock->get_id() );
+		$product_with_stock = wc_get_product( $product_with_stock->get_id() );
 		$product_with_stock->set_stock_status();
 		$product_with_stock->save();
 

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -7,6 +7,17 @@
 class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 	/**
+	 * Make sure the default product store loads.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_product_store_loads() {
+		$product_store = new WC_Data_Store( 'product' );
+		$this->assertTrue( is_callable( array( $product_store, 'read' ) ) );
+		$this->assertEquals( 'WC_Product_Data_Store_CPT', $product_store->get_current_class_name() );
+	}
+
+	/**
 	 * Test creating a new product.
 	 *
 	 * @since 2.7.0
@@ -15,7 +26,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		 $product = new WC_Product;
 		 $product->set_regular_price( 42 );
 		 $product->set_name( 'My Product' );
-		 $product->create();
+		 $product->save();
 
 		 $read_product = new WC_Product( $product->get_id() );
 
@@ -55,13 +66,24 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test trashing a product.
+	 *
+	 * @since 2.7.0
+	 */
+	function test_product_trash() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->delete();
+		$this->assertEquals( 'trash', $product->get_status() );
+	}
+
+	/**
 	 * Test deleting a product.
 	 *
 	 * @since 2.7.0
 	 */
 	function test_product_delete() {
 		$product = WC_Helper_Product::create_simple_product();
-		$product->delete();
+		$product->delete( true );
 		$this->assertEquals( 0, $product->get_id() );
 	}
 
@@ -75,7 +97,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$product = new WC_Product_Grouped;
 		$product->set_children( array( $simple_product->get_id() ) );
 		$product->set_name( 'My Grouped Product' );
-		$product->create();
+		$product->save();
 		$read_product = new WC_Product_Grouped( $product->get_id() );
 		$this->assertEquals( 'My Grouped Product', $read_product->get_name() );
 		$this->assertEquals( array( $simple_product->get_id() ), $read_product->get_children() );
@@ -124,7 +146,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		 $product->set_button_text( 'Test CRUD' );
 		 $product->set_product_url( 'http://automattic.com' );
 		 $product->set_name( 'My External Product' );
-		 $product->create();
+		 $product->save();
 
 		 $read_product = new WC_Product_External( $product->get_id() );
 
@@ -211,6 +233,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 2.7.0
 	 */
+
 	function test_variable_create_and_update() {
 		$product = new WC_Product_Variable;
 		$product->set_name( 'Variable Product' );
@@ -223,7 +246,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$attribute->set_variation( true );
 
 		$product->set_attributes( array( $attribute ) );
-		$product->create();
+		$product->save();
 
 		$this->assertEquals( 'Variable Product', $product->get_name() );
 
@@ -255,7 +278,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_attributes, $product->get_variation_attributes() );
 
 		$product->set_name( 'Renamed Variable Product' );
-		$product->update();
+		$product->save();
 
 		$this->assertEquals( 'Renamed Variable Product', $product->get_name() );
 	}

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * CRUD Functions.
+ * Data Store Tests: Tests WC_Products's WC_Data_Store.
  * @package WooCommerce\Tests\Product
  * @since 2.7.0
  */
-class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
+class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 	/**
 	 * Test creating a new product.
@@ -66,87 +66,6 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test product setters and getters
-	 * @todo needs tests for attributes
-	 * @since 2.7.0
-	 */
-	public function test_product_getters_and_setters() {
-		$getters_and_setters = array(
-			'name'               => 'Test',
-			'slug'               => 'test',
-			'status'             => 'publish',
-			'catalog_visibility' => 'search',
-			'featured'           => false,
-			'description'        => 'Hello world',
-			'short_description'  => 'hello',
-			'sku'                => 'TEST SKU',
-			'regular_price'      => 15.00,
-			'sale_price'         => 10.00,
-			'date_on_sale_from'  => '1475798400',
-			'date_on_sale_to'    => '1477267200',
-			'total_sales'        => 20,
-			'tax_status'         => 'none',
-			'tax_class'          => '',
-			'manage_stock'       => true,
-			'stock_quantity'     => 10,
-			'stock_status'       => 'instock',
-			'backorders'         => 'notify',
-			'sold_individually'  => false,
-			'weight'             => 100,
-			'length'             => 10,
-			'width'              => 10,
-			'height'             => 10,
-			'upsell_ids'         => array( 2, 3 ),
-			'cross_sell_ids'     => array( 4, 5 ),
-			'parent_id'          => 0,
-			'reviews_allowed'    => true,
-			'default_attributes' => array(),
-			'purchase_note'      => 'A note',
-			'menu_order'         => 2,
-			'gallery_image_ids'  => array(),
-			'download_type'      => 'standard',
-			'download_expiry'    => -1,
-			'download_limit'     => 5,
-			'image_id'           => 2,
-		 );
-		$product = new WC_Product;
-		foreach ( $getters_and_setters as $function => $value ) {
-			$product->{"set_{$function}"}( $value );
-		}
-		$product->create();
-		$product = new WC_Product_Simple( $product->get_id() );
-		foreach ( $getters_and_setters as $function => $value ) {
-			$this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
-		}
-	 }
-
-	/**
-	 * Test product term setters and getters
-	 * @since 2.7.0
-	 */
-	public function test_product_term_getters_and_setters() {
-		$test_cat_1 = wp_insert_term( 'Testing 1', 'product_cat' );
-		$test_cat_2 = wp_insert_term( 'Testing 2', 'product_cat' );
-
-		$test_tag_1 = wp_insert_term( 'Tag 1', 'product_tag' );
-		$test_tag_2 = wp_insert_term( 'Tag 2', 'product_tag' );
-
-		$getters_and_setters = array(
-			'tag_ids'      => array( 'Tag 1', 'Tag 2' ),
-			'category_ids' => array( $test_cat_1['term_id'], $test_cat_2['term_id'] ),
-		);
-		$product = new WC_Product;
-		foreach ( $getters_and_setters as $function => $value ) {
-			$product->{"set_{$function}"}( $value );
-		}
-		$product->create();
-		$product = new WC_Product_Simple( $product->get_id() );
-
-		$this->assertEquals( array( $test_cat_1['term_id'], $test_cat_2['term_id'] ), $product->get_category_ids() );
-		$this->assertEquals( array( $test_tag_1['term_id'], $test_tag_2['term_id'] ), $product->get_tag_ids() );
-	}
-
-	/**
 	 * Test creating a new grouped product.
 	 *
 	 * @since 2.7.0
@@ -168,7 +87,7 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 	 * @since 2.7.0
 	 */
 	function test_grouped_product_read() {
-		$product      = WC_Helper_Product::create_grouped_product();
+		$product	  = WC_Helper_Product::create_grouped_product();
 		$read_product = new WC_Product_Grouped( $product->get_id() );
 		$this->assertEquals( 'Dummy Grouped Product', $read_product->get_name() );
 		$this->assertEquals( 2, count( $read_product->get_children() ) );
@@ -179,7 +98,7 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 	 * @since 2.7.0
 	 */
 	function test_grouped_product_update() {
-		$product        = WC_Helper_Product::create_grouped_product();
+		$product		= WC_Helper_Product::create_grouped_product();
 		$simple_product = WC_Helper_Product::create_simple_product();
 		$this->assertEquals( 'Dummy Grouped Product', $product->get_name() );
 		$this->assertEquals( 2, count( $product->get_children() ) );
@@ -193,21 +112,6 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 		$this->assertEquals( 3, count( $product->get_children() ) );
 		$this->assertEquals( 'Dummy Grouped Product 2', $product->get_name() );
 	}
-	/**
-	 * Test grouped product setters and getters
-	 *
-	 * @since 2.7.0
-	 */
-	 public function test_grouped_product_getters_and_setters() {
-		$getters_and_setters = array(
-			'children' => array( 1, 2, 3 ),
-		);
-		$product = new WC_Product_Grouped;
-		foreach ( $getters_and_setters as $function => $value ) {
-			$product->{"set_{$function}"}( $value );
-			$this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
-		}
-	 }
 
 	/**
 	 * Test creating a new external product.
@@ -268,24 +172,6 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test external product setters and getters
-	 *
-	 * @since 2.7.0
-	 */
-	 public function test_external_product_getters_and_setters() {
-		 $time = time();
-		 $getters_and_setters = array(
-			 'button_text' => 'Test Button Text',
-			 'product_url' => 'http://wordpress.org',
-		 );
-		 $product = new WC_Product_External;
-		  foreach ( $getters_and_setters as $function => $value ) {
-			 $product->{"set_{$function}"}( $value );
-			 $this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
-		 }
-	 }
-
-	 /**
 	 * Test reading a variable product.
 	 *
 	 * @since 2.7.0
@@ -328,14 +214,15 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 	function test_variable_create_and_update() {
 		$product = new WC_Product_Variable;
 		$product->set_name( 'Variable Product' );
-		$product->set_attributes( array( array(
-			'name'         => 'pa_size',
-			'value'        => 'small | large',
-			'position'     => '1',
-			'is_visible'   => 0,
-			'is_variation' => 1,
-			'is_taxonomy'  => 0,
-		) ) );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( 'pa_color' );
+		$attribute->set_options( explode( WC_DELIMITER, 'green | red' ) );
+		$attribute->set_visible( false );
+		$attribute->set_variation( true );
+
+		$product->set_attributes( array( $attribute ) );
 		$product->create();
 
 		$this->assertEquals( 'Variable Product', $product->get_name() );
@@ -355,7 +242,7 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 		update_post_meta( $variation_id, '_downloadable', 'no' );
 		update_post_meta( $variation_id, '_virtual', 'no' );
 		update_post_meta( $variation_id, '_stock_status', 'instock' );
-		update_post_meta( $variation_id, 'attribute_pa_size', 'small' );
+		update_post_meta( $variation_id, 'attribute_pa_color', 'green' );
 
 		delete_transient( 'wc_product_children_' . $product->get_id() );
 		delete_transient( 'wc_var_prices_' . $product->get_id() );
@@ -364,13 +251,13 @@ class WC_Tests_Product_CRUD extends WC_Unit_Test_Case {
 		$children = $product->get_children();
 		$this->assertEquals( $variation_id, $children[0] );
 
-		$expected_attributes = array( 'pa_size' => array( 'small' ) );
+		$expected_attributes = array( 'pa_color' => array( 'green' ) );
 		$this->assertEquals( $expected_attributes, $product->get_variation_attributes() );
 
 		$product->set_name( 'Renamed Variable Product' );
 		$product->update();
 
 		$this->assertEquals( 'Renamed Variable Product', $product->get_name() );
-	 }
+	}
 
 }

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -81,12 +81,11 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 			'tag_ids'      => array( 'Tag 1', 'Tag 2' ),
 			'category_ids' => array( $test_cat_1['term_id'], $test_cat_2['term_id'] ),
 		);
-		$product = new WC_Product;
+		$product = new WC_Product_Simple;
 		foreach ( $getters_and_setters as $function => $value ) {
 			$product->{"set_{$function}"}( $value );
 		}
-		$product->create();
-		$product = new WC_Product_Simple( $product->get_id() );
+		$product->save();
 
 		$this->assertEquals( array( $test_cat_1['term_id'], $test_cat_2['term_id'] ), $product->get_category_ids() );
 		$this->assertEquals( array( $test_tag_1['term_id'], $test_tag_2['term_id'] ), $product->get_tag_ids() );

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Data Functions.
+ * @package WooCommerce\Tests\Product
+ * @since 2.7.0
+ */
+class WC_Tests_Product_Data extends WC_Unit_Test_Case {
+
+	/**
+	 * Test product setters and getters
+	 * @todo needs tests for attributes
+	 * @since 2.7.0
+	 */
+	public function test_product_getters_and_setters() {
+		global $wpdb;
+		$getters_and_setters = array(
+			'name'               => 'Test',
+			'slug'               => 'test',
+			'status'             => 'publish',
+			'catalog_visibility' => 'search',
+			'featured'           => false,
+			'description'        => 'Hello world',
+			'short_description'  => 'hello',
+			'sku'                => 'TEST SKU',
+			'regular_price'      => 15.00,
+			'sale_price'         => 10.00,
+			'date_on_sale_from'  => '1475798400',
+			'date_on_sale_to'    => '1477267200',
+			'total_sales'        => 20,
+			'tax_status'         => 'none',
+			'tax_class'          => '',
+			'manage_stock'       => true,
+			'stock_quantity'     => 10,
+			'stock_status'       => 'instock',
+			'backorders'         => 'notify',
+			'sold_individually'  => false,
+			'weight'             => 100,
+			'length'             => 10,
+			'width'              => 10,
+			'height'             => 10,
+			'upsell_ids'         => array( 2, 3 ),
+			'cross_sell_ids'     => array( 4, 5 ),
+			'parent_id'          => 0,
+			'reviews_allowed'    => true,
+			'default_attributes' => array(),
+			'purchase_note'      => 'A note',
+			'menu_order'         => 2,
+			'gallery_image_ids'  => array(),
+			'download_expiry'    => -1,
+			'download_limit'     => 5,
+		 );
+		$product = new WC_Product();
+		foreach ( $getters_and_setters as $function => $value ) {
+			$product->{"set_{$function}"}( $value );
+		}
+		$product->save();
+		$product = new WC_Product_Simple( $product->get_id() );
+		foreach ( $getters_and_setters as $function => $value ) {
+			$this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
+		}
+
+		$image_url = media_sideload_image( "https://cldup.com/Dr1Bczxq4q.png", $product->get_id(), '', 'src' );
+		$image_id  = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $image_url ) );
+		$product->set_image_id( $image_id[0] );
+		$product->save();
+		$this->assertEquals( $image_id[0], $product->get_image_id() );
+	 }
+
+	/**
+	 * Test product term setters and getters
+	 * @since 2.7.0
+	 */
+	public function test_product_term_getters_and_setters() {
+		$test_cat_1 = wp_insert_term( 'Testing 1', 'product_cat' );
+		$test_cat_2 = wp_insert_term( 'Testing 2', 'product_cat' );
+
+		$test_tag_1 = wp_insert_term( 'Tag 1', 'product_tag' );
+		$test_tag_2 = wp_insert_term( 'Tag 2', 'product_tag' );
+
+		$getters_and_setters = array(
+			'tag_ids'      => array( 'Tag 1', 'Tag 2' ),
+			'category_ids' => array( $test_cat_1['term_id'], $test_cat_2['term_id'] ),
+		);
+		$product = new WC_Product;
+		foreach ( $getters_and_setters as $function => $value ) {
+			$product->{"set_{$function}"}( $value );
+		}
+		$product->create();
+		$product = new WC_Product_Simple( $product->get_id() );
+
+		$this->assertEquals( array( $test_cat_1['term_id'], $test_cat_2['term_id'] ), $product->get_category_ids() );
+		$this->assertEquals( array( $test_tag_1['term_id'], $test_tag_2['term_id'] ), $product->get_tag_ids() );
+	}
+
+	/**
+	 * Test grouped product setters and getters
+	 *
+	 * @since 2.7.0
+	 */
+	 public function test_grouped_product_getters_and_setters() {
+		$getters_and_setters = array(
+			'children' => array( 1, 2, 3 ),
+		);
+		$product = new WC_Product_Grouped;
+		foreach ( $getters_and_setters as $function => $value ) {
+			$product->{"set_{$function}"}( $value );
+			$this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
+		}
+	 }
+
+	/**
+	 * Test external product setters and getters
+	 *
+	 * @since 2.7.0
+	 */
+	 public function test_external_product_getters_and_setters() {
+		 $time = time();
+		 $getters_and_setters = array(
+			 'button_text' => 'Test Button Text',
+			 'product_url' => 'http://wordpress.org',
+		 );
+		 $product = new WC_Product_External;
+		  foreach ( $getters_and_setters as $function => $value ) {
+			 $product->{"set_{$function}"}( $value );
+			 $this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
+		 }
+	 }
+
+}

--- a/tests/unit-tests/product/factory.php
+++ b/tests/unit-tests/product/factory.php
@@ -7,25 +7,40 @@
 class WC_Tests_Product_Factory extends WC_Unit_Test_Case {
 
 	/**
-	 * <Description>
+	 * Test getting product type.
 	 *
 	 * @since 2.7.0
 	 */
 	function test_get_product_type() {
+		$simple = WC_Helper_Product::create_simple_product();
+		$external = WC_Helper_Product::create_external_product();
+		$grouped = WC_Helper_Product::create_grouped_product();
+		$variable = WC_Helper_Product::create_variation_product();
+		$children = $variable->get_children();
+		$child_id = $children[0];
 
+		$this->assertEquals( 'simple', WC()->product_factory->get_product_type( $simple->get_id() ) );
+		$this->assertEquals( 'external', WC()->product_factory->get_product_type( $external->get_id() ) );
+		$this->assertEquals( 'grouped', WC()->product_factory->get_product_type( $grouped->get_id() ) );
+		$this->assertEquals( 'variable', WC()->product_factory->get_product_type( $variable->get_id() ) );
+		$this->assertEquals( 'variation', WC()->product_factory->get_product_type( $child_id ) );
 	}
 
 	/**
-	 * <Description>
+	 * Test the helper method that returns a class name for a specific product type.
 	 *
 	 * @since 2.7.0
 	 */
 	function test_get_classname_from_product_type() {
-
+		$this->assertEquals( 'WC_Product_Grouped', WC()->product_factory->get_classname_from_product_type( 'grouped' ) );
+		$this->assertEquals( 'WC_Product_Simple', WC()->product_factory->get_classname_from_product_type( 'simple' ) );
+		$this->assertEquals( 'WC_Product_Variable', WC()->product_factory->get_classname_from_product_type( 'variable' ) );
+		$this->assertEquals( 'WC_Product_Variation', WC()->product_factory->get_classname_from_product_type( 'variation' ) );
+		$this->assertEquals( 'WC_Product_External', WC()->product_factory->get_classname_from_product_type( 'external' ) );
 	}
 
 	/**
-	 * <Description>
+	 * Tests getting a product using the factory.
 	 *
 	 * @since 2.7.0
 	 */
@@ -36,7 +51,7 @@ class WC_Tests_Product_Factory extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * <Description>
+	 * Tests that an incorrect product returns null.
 	 *
 	 * @since 2.7.0
 	 */

--- a/tests/unit-tests/product/factory.php
+++ b/tests/unit-tests/product/factory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Products Factory Tests
+ * @package WooCommerce\Tests\Product
+ * @since 2.7.0
+ */
+class WC_Tests_Product_Factory extends WC_Unit_Test_Case {
+
+	/**
+	 * <Description>
+	 *
+	 * @since 2.7.0
+	 */
+	function test_get_product_type() {
+
+	}
+
+	/**
+	 * <Description>
+	 *
+	 * @since 2.7.0
+	 */
+	function test_get_classname_from_product_type() {
+
+	}
+
+	/**
+	 * <Description>
+	 *
+	 * @since 2.7.0
+	 */
+	function test_get_product() {
+		$test_product = WC_Helper_Product::create_simple_product();
+ 		$get_product  = WC()->product_factory->get_product( $test_product->get_id() );
+		$this->assertEquals( $test_product, $get_product );
+	}
+
+	/**
+	 * <Description>
+	 *
+	 * @since 2.7.0
+	 */
+	function test_get_invalid_product_returns_null() {
+		$product = WC()->product_factory->get_product( 50000 );
+		$this->assertNull( $product );
+	}
+
+}

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -56,9 +56,8 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( array( $draft->get_id() ), $products );
 
 		// test type
-		$products = wc_get_products( array( 'return' => 'ids', 'type' => array( 'variable', 'variation' ) ) );
-		$this->assertEquals( 3, count( $products ) );
-		$this->assertContains( $variation->get_id(), $products );
+		$products = wc_get_products( array( 'return' => 'ids', 'type' => array( 'variation' ) ) );
+		$this->assertEquals( 2, count( $products ) );
 
 		// test parent
 		$products = wc_get_products( array( 'return' => 'ids', 'parent' => $variation->get_id() ) );
@@ -135,8 +134,9 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$product = WC_Helper_Product::create_simple_product();
 
 		update_post_meta( $product->get_id(), '_manage_stock', 'yes' );
-
 		wc_update_product_stock( $product->get_id(), 5 );
+
+		$product = new WC_Product_Simple( $product->get_id() );
 		$this->assertEquals( 5, $product->get_stock_quantity() );
 
 		// Delete Product

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -49,18 +49,18 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$draft->set_status( 'draft' );
 		$draft->save();
 
-		$this->assertEquals( 10, count( wc_get_products( array( 'return' => 'ids' ) ) ) );
+		$this->assertEquals( 9, count( wc_get_products( array( 'return' => 'ids' ) ) ) );
 
 		// test status
 		$products = wc_get_products( array( 'return' => 'ids', 'status' => 'draft' ) );
 		$this->assertEquals( array( $draft->get_id() ), $products );
 
 		// test type
-		$products = wc_get_products( array( 'return' => 'ids', 'type' => array( 'variation' ) ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'type' => 'variation' ) );
 		$this->assertEquals( 2, count( $products ) );
 
 		// test parent
-		$products = wc_get_products( array( 'return' => 'ids', 'parent' => $variation->get_id() ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'type' => 'variation', 'parent' => $variation->get_id() ) );
 		$this->assertEquals( 2, count( $products ) );
 
 		// test skus
@@ -88,17 +88,17 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( 5, count( $products ) );
 
 		// test offset
-		$products = wc_get_products( array( 'return' => 'ids', 'limit' => 5 ) );
-		$products_offset = wc_get_products( array( 'return' => 'ids', 'limit' => 5, 'offset' => 5 ) );
-		$this->assertEquals( 5, count( $products ) );
-		$this->assertEquals( 5, count( $products_offset ) );
+		$products = wc_get_products( array( 'return' => 'ids', 'limit' => 2 ) );
+		$products_offset = wc_get_products( array( 'return' => 'ids', 'limit' => 2, 'offset' => 2 ) );
+		$this->assertEquals( 2, count( $products ) );
+		$this->assertEquals( 2, count( $products_offset ) );
 		$this->assertNotEquals( $products, $products_offset );
 
 		// test page
-		$products_page_1 = wc_get_products( array( 'return' => 'ids', 'limit' => 5 ) );
-		$products_page_2 = wc_get_products( array( 'return' => 'ids', 'limit' => 5, 'page' => 2 ) );
-		$this->assertEquals( 5, count( $products_page_1 ) );
-		$this->assertEquals( 5, count( $products_page_2 ) );
+		$products_page_1 = wc_get_products( array( 'return' => 'ids', 'limit' => 2 ) );
+		$products_page_2 = wc_get_products( array( 'return' => 'ids', 'limit' => 2, 'page' => 2 ) );
+		$this->assertEquals( 2, count( $products_page_1 ) );
+		$this->assertEquals( 2, count( $products_page_2 ) );
 		$this->assertNotEquals( $products_page_1, $products_page_2 );
 
 		// test exclude

--- a/tests/unit-tests/product/product-simple.php
+++ b/tests/unit-tests/product/product-simple.php
@@ -18,7 +18,9 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 'Add to cart', $product->add_to_cart_text() );
 
-		$product->stock_status = 'outofstock';
+		$product->set_stock_status( 'outofstock' );
+		$product->save();
+
 		$this->assertEquals( 'Read more', $product->add_to_cart_text() );
 
 		// Delete product
@@ -79,7 +81,7 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->assertEquals( $product->sku, $product->get_sku() );
+		$this->assertEquals( 'DUMMY SKU', $product->get_sku() );
 
 		// Delete product
 		WC_Helper_Product::delete_product( $product->get_id() );
@@ -99,58 +101,6 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		$product->manage_stock = 'yes';
 
 		$this->assertEquals( 0, $product->get_stock_quantity() );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
-	}
-
-	/**
-	 * Test set_stock().
-	 *
-	 * @since 2.3
-	 */
-	public function test_set_stock() {
-		// Create product
-		$product = WC_Helper_Product::create_simple_product();
-
-		$product->manage_stock = 'yes';
-		$this->assertEquals( 5, $product->set_stock( 5 ) );
-		$this->assertEquals( 2, $product->set_stock( 3, 'subtract' ) );
-		$this->assertEquals( 5, $product->set_stock( 3, 'add' ) );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
-	}
-
-	/**
-	 * Test reduce_stock().
-	 *
-	 * @since 2.3
-	 */
-	public function test_reduce_stock() {
-		// Create product
-		$product = WC_Helper_Product::create_simple_product();
-
-		$product->manage_stock = 'yes';
-		$product->set_stock( 5 );
-		$this->assertEquals( 2, $product->reduce_stock( 3 ) );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
-	}
-
-	/**
-	 * Test increase_stock().
-	 *
-	 * @since 2.3
-	 */
-	public function test_increase_stock() {
-		// Create product
-		$product = WC_Helper_Product::create_simple_product();
-
-		$product->manage_stock = 'yes';
-		$product->set_stock( 5 );
-		$this->assertEquals( 8, $product->increase_stock( 3 ) );
 
 		// Delete product
 		WC_Helper_Product::delete_product( $product->get_id() );
@@ -185,10 +135,10 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 
 		$this->assertEmpty( $product->is_downloadable() );
 
-		$product->downloadable = 'yes';
+		$product->set_downloadable( 'yes' );
 		$this->assertTrue( $product->is_downloadable() );
 
-		$product->downloadable = 'no';
+		$product->set_downloadable( 'no' );
 		$this->assertFalse( $product->is_downloadable() );
 
 		// Delete product
@@ -206,10 +156,10 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 
 		$this->assertEmpty( $product->is_virtual() );
 
-		$product->virtual = 'yes';
+		$product->set_virtual( 'yes' );
 		$this->assertTrue( $product->is_virtual() );
 
-		$product->virtual = 'no';
+		$product->set_virtual( 'no' );
 		$this->assertFalse( $product->is_virtual() );
 
 		// Delete product
@@ -225,10 +175,10 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$product->virtual = 'yes';
+		$product->set_virtual( 'yes' );
 		$this->assertFalse( $product->needs_shipping() );
 
-		$product->virtual = 'no';
+		$product->set_virtual( 'no' );
 		$this->assertTrue( $product->needs_shipping() );
 
 		// Delete product
@@ -244,10 +194,10 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$product->sold_individually = 'yes';
+		$product->set_sold_individually( 'yes' );
 		$this->assertTrue( $product->is_sold_individually() );
 
-		$product->sold_individually = 'no';
+		$product->set_sold_individually( 'no' );
 		$this->assertFalse( $product->is_sold_individually() );
 
 		// Delete product
@@ -263,13 +213,13 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$product->backorders = 'yes';
+		$product->set_backorders( 'yes' );
 		$this->assertTrue( $product->backorders_allowed() );
 
-		$product->backorders = 'notify';
+		$product->set_backorders( 'notify' );
 		$this->assertTrue( $product->backorders_allowed() );
 
-		$product->backorders = 'no';
+		$product->set_backorders( 'no' );
 		$this->assertFalse( $product->backorders_allowed() );
 
 		// Delete product
@@ -285,18 +235,18 @@ class WC_Tests_Product_Simple extends WC_Unit_Test_Case {
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
 
-		$product->backorders = 'notify';
-		$product->manage_stock = 'yes';
+		$product->set_backorders( 'notify' );
+		$product->set_manage_stock( 'yes' );
 		$this->assertTrue( $product->backorders_require_notification() );
 
-		$product->backorders = 'yes';
+		$product->set_backorders( 'yes' );
 		$this->assertFalse( $product->backorders_require_notification() );
 
-		$product->backorders = 'no';
+		$product->set_backorders( 'no' );
 		$this->assertFalse( $product->backorders_require_notification() );
 
-		$product->backorders = 'yes';
-		$product->manage_stock = 'no';
+		$product->set_backorders( 'yes' );
+		$product->set_manage_stock( 'no' );
 		$this->assertFalse( $product->backorders_require_notification() );
 
 		// Delete product

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -289,6 +289,9 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-coupon-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-grouped-data-store-cpt.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-variable-data-store-cpt.php' );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once( WC_ABSPATH . 'includes/class-wc-cli.php' );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -292,6 +292,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-grouped-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-variable-data-store-cpt.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-variation-data-store-cpt.php' );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once( WC_ABSPATH . 'includes/class-wc-cli.php' );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -287,6 +287,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-data-store.php' ); // WC_Data_Store for CRUD
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-object-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-coupon-data-store.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-product-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php' );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -288,6 +288,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-object-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-coupon-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-product-data-store.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/interface-wc-product-variable-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php' );


### PR DESCRIPTION
Phew. This PR introduces datastore classes for products. This includes moving things like queries from `wc-product-functions.php` as well, so things are pluggable and can be updated.

This PR also fixes up some tests that were failing on the `product-crud branch`. All test files in `unit-tests/product/*` pass now!