### PR TITLE
Move queries from coupon-functions.php to the coupon data store.

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -14,6 +14,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Method to create a new coupon in the database.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 */
 	public function create( &$coupon ) {
@@ -40,6 +42,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Method to read a coupon.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 */
 	public function read( &$coupon ) {
@@ -82,6 +86,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Updates a coupon in the database.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 */
 	public function update( &$coupon ) {
@@ -98,6 +104,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Deletes a coupon from the database.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 * @param bool $force_delete True to permently delete, false to trash.
 	 */
@@ -114,6 +122,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Helper method that updates all the post meta for a coupon based on it's settings in the WC_Coupon class.
+	 *
 	 * @since 2.7.0
 	 */
 	private function update_post_meta( $coupon ) {
@@ -172,6 +181,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Increase usage count for current coupon.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 * @param string $used_by Either user ID or billing email
 	 */
@@ -185,6 +196,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Decrease usage count for current coupon.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 * @param string $used_by Either user ID or billing email
 	 */
@@ -206,6 +219,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 
 	/**
 	 * Get the number of uses for a coupon by user ID.
+	 *
+	 * @since 2.7.0
 	 * @param WC_Coupon
 	 * @param id $user_id
 	 * @return int
@@ -215,4 +230,34 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Coupon_Da
 		return $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value = %d;", $coupon->get_id(), $user_id ) );
 	}
 
+	/**
+	 * Return a coupon code for a specific ID.
+	 *
+	 * @since 2.7.0
+	 * @param int $id
+	 * @return string Coupon Code
+	 */
+	public function get_code_by_id( $id ) {
+		global $wpdb;
+		return $wpdb->get_var( $wpdb->prepare( "
+			SELECT post_title
+			FROM $wpdb->posts
+			WHERE ID = %d
+			AND post_type = 'shop_coupon'
+			AND post_status = 'publish';
+		", $id ) );
+	}
+
+	/**
+	 * Return an array of IDs for for a specific coupon code.
+	 * Can return multiple to check for existence.
+	 *
+	 * @since 2.7.0
+	 * @param string $code
+	 * @return array Array of IDs.
+	 */
+	public function get_ids_by_code( $code ) {
+		global $wpdb;
+		return $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC;", $code ) );
+	}
 }

--- a/includes/data-stores/interfaces/interface-wc-coupon-data-store.php
+++ b/includes/data-stores/interfaces/interface-wc-coupon-data-store.php
@@ -34,4 +34,19 @@ interface WC_Coupon_Data_Store {
 	 * @return int
 	 */
 	public function get_usage_by_user_id( &$coupon, $user_id );
+
+	/**
+	 * Return a coupon code for a specific ID.
+	 * @param int $id
+	 * @return string Coupon Code
+	 */
+	 public function get_code_by_id( $id );
+
+	 /**
+	  * Return an array of IDs for for a specific coupon code.
+	  * Can return multiple to check for existence.
+	  * @param string $code
+	  * @return array Array of IDs.
+	  */
+	 public function get_ids_by_code( $code );
 }

--- a/includes/wc-coupon-functions.php
+++ b/includes/wc-coupon-functions.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * WooCommerce Coupons Functions
  *
@@ -7,12 +11,8 @@
  * @author 		WooThemes
  * @category 	Core
  * @package 	WooCommerce/Functions
- * @version     2.1.0
+ * @version     2.7.0
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
 
 /**
  * Get coupon types.
@@ -79,17 +79,8 @@ function wc_coupons_enabled() {
  * @return string
  */
 function wc_get_coupon_code_by_id( $id ) {
-	global $wpdb;
-
-	$code = $wpdb->get_var( $wpdb->prepare( "
-		SELECT post_title
-		FROM $wpdb->posts
-		WHERE ID = %d
-		AND post_type = 'shop_coupon'
-		AND post_status = 'publish';
-	", $id ) );
-
-	return (string) $code;
+	$data_store = WC_Data_Store::load( 'coupon' );
+	return (string) $data_store->get_code_by_id( $id );
 }
 
 /**
@@ -101,14 +92,11 @@ function wc_get_coupon_code_by_id( $id ) {
  * @return int
  */
 function wc_get_coupon_id_by_code( $code, $exclude = 0 ) {
-	global $wpdb;
-
-	$ids = wp_cache_get( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $code, 'coupons' );
+	$data_store = WC_Data_Store::load( 'coupon' );
+	$ids        = wp_cache_get( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $code, 'coupons' );
 
 	if ( false === $ids ) {
-		$sql = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC;", $code );
-		$ids = $wpdb->get_col( $sql );
-
+		$ids = $data_store->get_ids_by_code( $code );
 		if ( $ids ) {
 			wp_cache_set( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $code, $ids, 'coupons' );
 		}

--- a/tests/unit-tests/coupon/functions.php
+++ b/tests/unit-tests/coupon/functions.php
@@ -61,4 +61,22 @@ class WC_Tests_Functions extends WC_Unit_Test_Case {
 
 		$this->assertEmpty( wc_get_coupon_code_by_id( 0 ) );
 	}
+
+	/**
+	 * Test wc_get_coupon_id_by_code().
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_wc_get_coupon_id_by_code() {
+		// Create coupon.
+		$code   = 'testcoupon';
+		$coupon = WC_Helper_Coupon::create_coupon( $code );
+
+		$this->assertEquals( $coupon->get_id(), wc_get_coupon_id_by_code( $coupon->get_code() ) );
+
+		// Delete coupon.
+		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
+
+		$this->assertEmpty( wc_get_coupon_id_by_code( 0 ) );
+	}
 }


### PR DESCRIPTION
Title explains it all. Adds a test for `wc_get_coupon_id_by_code`.