### PR TITLE
Shipping Zone Data Store

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -481,6 +481,14 @@ abstract class WC_Data {
 	}
 
 	/**
+	 * Get object read property.
+	 * @return boolean
+	 */
+	public function get_object_read() {
+		return (bool) $this->object_read;
+	}
+
+	/**
 	 * Set a collection of props in one go, collect any errors, and return the result.
 	 * Only sets using public methods.
 	 * @param array $props Key value pairs to set. Key is the prop and should map to a setter function name.

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -235,7 +235,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		wp_localize_script( 'wc-shipping-zone-methods', 'shippingZoneMethodsLocalizeScript', array(
 			'methods'                 => $zone->get_shipping_methods(),
 			'zone_name'               => $zone->get_zone_name(),
-			'zone_id'                 => $zone->get_zone_id(),
+			'zone_id'                 => $zone->get_id(),
 			'wc_shipping_zones_nonce' => wp_create_nonce( 'wc_shipping_zones_nonce' ),
 			'strings'                 => array(
 				'unload_confirmation_msg' => __( 'Your changed data will be lost if you leave this page without saving.', 'woocommerce' ),

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <table class="form-table wc-shipping-zone-settings">
 	<tbody>
-		<?php if ( 0 !== $zone->get_zone_id() ) : ?>
+		<?php if ( 0 !== $zone->get_id() ) : ?>
 			<tr valign="top" class="">
 				<th scope="row" class="titledesc">
 					<label for="zone_name"><?php esc_html_e( 'Zone name', 'woocommerce' ); ?></label>

--- a/includes/admin/settings/views/html-admin-page-shipping-zones-instance.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zones-instance.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <h2>
 	<a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=shipping' ); ?>"><?php _e( 'Shipping zones', 'woocommerce' ); ?></a> &gt;
-	<a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . absint( $zone->get_zone_id() ) ); ?>"><?php echo esc_html( $zone->get_zone_name() ); ?></a> &gt;
+	<a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=' . absint( $zone->get_id() ) ); ?>"><?php echo esc_html( $zone->get_zone_name() ); ?></a> &gt;
 	<?php echo esc_html( $shipping_method->get_method_title() ); ?>
 </h2>
 

--- a/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<td class="wc-shipping-zone-name">
 				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&zone_id=0' ) ); ?>"><?php esc_html_e( 'Rest of the World', 'woocommerce' ); ?></a>
 				<div class="row-actions">
-					<a href="admin.php?page=wc-settings&amp;tab=shipping&amp;zone_id={{ data.zone_id }}"><?php _e( 'Edit', 'woocommerce' ); ?></a>
+					<a href="admin.php?page=wc-settings&amp;tab=shipping&amp;zone_id=0"><?php _e( 'Edit', 'woocommerce' ); ?></a>
 				</div>
 			</td>
 			<td class="wc-shipping-zone-region"><?php _e( 'This zone is <b>optionally</b> used for regions that are not included in any other shipping zone.', 'woocommerce' ); ?></td>

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2469,7 +2469,7 @@ class WC_AJAX {
 
 		wp_send_json_success( array(
 			'instance_id' => $instance_id,
-			'zone_id'     => $zone->get_zone_id(),
+			'zone_id'     => $zone->get_id(),
 			'zone_name'   => $zone->get_zone_name(),
 			'methods'     => $zone->get_shipping_methods(),
 		) );
@@ -2567,7 +2567,7 @@ class WC_AJAX {
 		$zone->save();
 
 		wp_send_json_success( array(
-			'zone_id'   => $zone->get_zone_id(),
+			'zone_id'   => $zone->get_id(),
 			'zone_name' => $zone->get_zone_name(),
 			'methods'   => $zone->get_shipping_methods(),
 		) );
@@ -2599,7 +2599,7 @@ class WC_AJAX {
 		$shipping_method->process_admin_options();
 
 		wp_send_json_success( array(
-			'zone_id'   => $zone->get_zone_id(),
+			'zone_id'   => $zone->get_id(),
 			'zone_name' => $zone->get_zone_name(),
 			'methods'   => $zone->get_shipping_methods(),
 			'errors'    => $shipping_method->get_errors(),

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -80,7 +80,6 @@ class WC_Data_Store {
 	 */
 	public static function load( $object_type ) {
 		try {
-			error_log( print_r ( $object_type, 1 ) );
 			return new WC_Data_Store( $object_type );
 		} catch ( Exception $e ) {
 			return null;

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -35,8 +35,8 @@ class WC_Data_Store {
 		'product_variation' => 'WC_Product_Variation_Data_Store_CPT',
 		'customer'          => 'WC_Customer_Data_Store',
 		'customer-session'  => 'WC_Customer_Data_Store_Session',
-		'payment-token'    => 'WC_Payment_Token_Data_Store',
-		'shipping-zone'    => 'WC_Shipping_Zone_Data_Store',
+		'payment-token'     => 'WC_Payment_Token_Data_Store',
+		'shipping-zone'     => 'WC_Shipping_Zone_Data_Store',
 	);
 
 	/**
@@ -80,6 +80,7 @@ class WC_Data_Store {
 	 */
 	public static function load( $object_type ) {
 		try {
+			error_log( print_r ( $object_type, 1 ) );
 			return new WC_Data_Store( $object_type );
 		} catch ( Exception $e ) {
 			return null;

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -29,13 +29,14 @@ class WC_Data_Store {
 	 */
 	private $stores = array(
 		'coupon'            => 'WC_Coupon_Data_Store_CPT',
-		'payment-token'     => 'WC_Payment_Token_Data_Store_Table',
 		'product'           => 'WC_Product_Data_Store_CPT',
 		'product_grouped'   => 'WC_Product_Grouped_Data_Store_CPT',
 		'product_variable'  => 'WC_Product_Variable_Data_Store_CPT',
 		'product_variation' => 'WC_Product_Variation_Data_Store_CPT',
 		'customer'          => 'WC_Customer_Data_Store',
 		'customer-session'  => 'WC_Customer_Data_Store_Session',
+		'payment-token'    => 'WC_Payment_Token_Data_Store',
+		'shipping-zone'    => 'WC_Shipping_Zone_Data_Store',
 	);
 
 	/**

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -51,7 +51,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 		}
 
 		$this->data_store = WC_Data_Store::load( 'shipping-zone' );
-		if ( ! is_null( $zone ) ) {
+		if ( false === $this->get_object_read() ) {
 			$this->data_store->read( $this );
 		}
 	}

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -104,7 +104,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 		$all_continents = WC()->countries->get_continents();
 		$all_countries  = WC()->countries->get_countries();
 		$all_states     = WC()->countries->get_states();
-		$locations      = $this->get_zone_locations();
+		$locations      = $this->get_zone_locations( $context );
 		$continents     = array_filter( $locations, array( $this, 'location_is_continent' ) );
 		$countries      = array_filter( $locations, array( $this, 'location_is_country' ) );
 		$states         = array_filter( $locations, array( $this, 'location_is_state' ) );

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -56,15 +56,20 @@ class WC_Shipping_Zones {
 	public static function get_zone_by( $by = 'zone_id', $id = 0 ) {
 		switch ( $by ) {
 			case 'zone_id' :
-				return new WC_Shipping_Zone( $id );
+				$zone_id = $id;
 			break;
 			case 'instance_id' :
 				$data_store = WC_Data_Store::load( 'shipping-zone' );
 				$zone_id    = $data_store->get_zone_id_by_instance_id( $id );
-				if ( false !== $zone_id ) {
-					return new WC_Shipping_Zone( $zone_id );
-				}
 			break;
+		}
+
+		if ( false !== $zone_id ) {
+			try {
+				return new WC_Shipping_Zone( $zone_id );
+			} catch ( Exception $e ) {
+				return false;
+			}
 		}
 
 		return false;

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -29,6 +29,7 @@ class WC_Shipping_Zones {
 		foreach ( $raw_zones as $raw_zone ) {
 			$zone                                                     = new WC_Shipping_Zone( $raw_zone );
 			$zones[ $zone->get_id() ]                            = $zone->get_data();
+			$zones[ $zone->get_id() ]['zone_id']                 = $zone->get_id();
 			$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
 			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods();
 		}

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -9,10 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class 		WC_Shipping_Zones
  * @since 		2.6.0
- * @version		2.6.0
+ * @version		2.7.0
  * @package		WooCommerce/Classes
  * @category	Class
- * @author 		WooThemes
+ * @author 		WooCommerce
  */
 class WC_Shipping_Zones {
 
@@ -56,27 +56,19 @@ class WC_Shipping_Zones {
 	 */
 	public static function get_zone_by( $by = 'zone_id', $id = 0 ) {
 		global $wpdb;
-
-		$raw_zone = false;
-
 		switch ( $by ) {
 			case 'zone_id' :
-				if ( 0 === $id ) {
-					return new WC_Shipping_Zone( 0 );
-				} else {
-					$raw_zone = $wpdb->get_row( $wpdb->prepare( "SELECT zone_id, zone_name, zone_order FROM {$wpdb->prefix}woocommerce_shipping_zones WHERE zone_id = %d LIMIT 1;", $id ) );
-				}
+				return new WC_Shipping_Zone( $id );
 			break;
 			case 'instance_id' :
 				$zone_id = $wpdb->get_var( $wpdb->prepare( "SELECT zone_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods as methods WHERE methods.instance_id = %d LIMIT 1;", $id ) );
-
 				if ( false !== $zone_id ) {
 					return self::get_zone_by( 'zone_id', absint( $zone_id ) );
 				}
 			break;
 		}
 
-		return $raw_zone ? new WC_Shipping_Zone( $raw_zone ) : false;
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -22,16 +22,15 @@ class WC_Shipping_Zones {
 	 * @return array of arrays
 	 */
 	public static function get_zones() {
-		global $wpdb;
-
-		$raw_zones = $wpdb->get_results( "SELECT zone_id, zone_name, zone_order FROM {$wpdb->prefix}woocommerce_shipping_zones order by zone_order ASC;" );
-		$zones     = array();
+		$data_store = WC_Data_Store::load( 'shipping-zone' );
+		$raw_zones  = $data_store->get_zones();
+		$zones      = array();
 
 		foreach ( $raw_zones as $raw_zone ) {
 			$zone                                                     = new WC_Shipping_Zone( $raw_zone );
-			$zones[ $zone->get_zone_id() ]                            = $zone->get_data();
-			$zones[ $zone->get_zone_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
-			$zones[ $zone->get_zone_id() ]['shipping_methods']        = $zone->get_shipping_methods();
+			$zones[ $zone->get_id() ]                            = $zone->get_data();
+			$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
+			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods();
 		}
 
 		return $zones;
@@ -55,15 +54,15 @@ class WC_Shipping_Zones {
 	 * @return WC_Shipping_Zone|bool
 	 */
 	public static function get_zone_by( $by = 'zone_id', $id = 0 ) {
-		global $wpdb;
 		switch ( $by ) {
 			case 'zone_id' :
 				return new WC_Shipping_Zone( $id );
 			break;
 			case 'instance_id' :
-				$zone_id = $wpdb->get_var( $wpdb->prepare( "SELECT zone_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods as methods WHERE methods.instance_id = %d LIMIT 1;", $id ) );
+				$data_store = WC_Data_Store::load( 'shipping-zone' );
+				$zone_id    = $data_store->get_zone_id_by_instance_id( $id );
 				if ( false !== $zone_id ) {
-					return self::get_zone_by( 'zone_id', absint( $zone_id ) );
+					return new WC_Shipping_Zone( $zone_id );
 				}
 			break;
 		}
@@ -77,8 +76,8 @@ class WC_Shipping_Zones {
 	 * @return WC_Shipping_Meethod|bool
 	 */
 	public static function get_shipping_method( $instance_id ) {
-		global $wpdb;
-		$raw_shipping_method = $wpdb->get_row( $wpdb->prepare( "SELECT instance_id, method_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE instance_id = %d LIMIT 1;", $instance_id ) );
+		$data_store          = WC_Data_Store::load( 'shipping-zone' );
+		$raw_shipping_method = $data_store->get_method( $instance_id );
 		$wc_shipping         = WC_Shipping::instance();
 		$allowed_classes     = $wc_shipping->get_shipping_method_class_names();
 
@@ -110,8 +109,6 @@ class WC_Shipping_Zones {
 	 * @return WC_Shipping_Zone
 	 */
 	public static function get_zone_matching_package( $package ) {
-		global $wpdb;
-
 		$country          = strtoupper( wc_clean( $package['destination']['country'] ) );
 		$state            = strtoupper( wc_clean( $package['destination']['state'] ) );
 		$continent        = strtoupper( wc_clean( WC()->countries->get_continent_code_for_country( $country ) ) );
@@ -120,35 +117,8 @@ class WC_Shipping_Zones {
 		$matching_zone_id = wp_cache_get( $cache_key, 'shipping_zones' );
 
 		if ( false === $matching_zone_id ) {
-
-			// Work out criteria for our zone search
-			$criteria = array();
-			$criteria[] = $wpdb->prepare( "( ( location_type = 'country' AND location_code = %s )", $country );
-			$criteria[] = $wpdb->prepare( "OR ( location_type = 'state' AND location_code = %s )", $country . ':' . $state );
-			$criteria[] = $wpdb->prepare( "OR ( location_type = 'continent' AND location_code = %s )", $continent );
-			$criteria[] = "OR ( location_type IS NULL ) )";
-
-			// Postcode range and wildcard matching
-			$postcode_locations = $wpdb->get_results( "SELECT zone_id, location_code FROM {$wpdb->prefix}woocommerce_shipping_zone_locations WHERE location_type = 'postcode';" );
-
-			if ( $postcode_locations ) {
-				$zone_ids_with_postcode_rules = array_map( 'absint', wp_list_pluck( $postcode_locations, 'zone_id' ) );
-				$matches                      = wc_postcode_location_matcher( $postcode, $postcode_locations, 'zone_id', 'location_code', $country );
-				$do_not_match                 = array_unique( array_diff( $zone_ids_with_postcode_rules, array_keys( $matches ) ) );
-
-				if ( ! empty( $do_not_match ) ) {
-					$criteria[] = "AND zones.zone_id NOT IN (" . implode( ',', $do_not_match ) . ")";
-				}
-			}
-
-			// Get matching zones
-			$matching_zone_id = $wpdb->get_var( "
-				SELECT zones.zone_id FROM {$wpdb->prefix}woocommerce_shipping_zones as zones
-				LEFT OUTER JOIN {$wpdb->prefix}woocommerce_shipping_zone_locations as locations ON zones.zone_id = locations.zone_id AND location_type != 'postcode'
-				WHERE " . implode( ' ', $criteria ) . "
-				ORDER BY zone_order ASC LIMIT 1
-			" );
-
+			$data_store       = WC_Data_Store::load( 'shipping-zone' );
+			$matching_zone_id = $data_store->get_zone_id_from_package( $package );
 			wp_cache_set( $cache_key, $matching_zone_id, 'shipping_zones' );
 		}
 

--- a/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/includes/data-stores/class-wc-payment-token-data-store.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category Class
  * @author   WooThemes
  */
-class WC_Payment_Token_Data_Store_Table implements WC_Payment_Token_Data_Store_Interface, WC_Object_Data_Store {
+class WC_Payment_Token_Data_Store implements WC_Payment_Token_Data_Store_Interface, WC_Object_Data_Store {
 
 	/**
 	 * Create a new payment token in the database.

--- a/includes/data-stores/class-wc-shipping-zone-data-store-table.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store-table.php
@@ -33,7 +33,7 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 	}
 
 	/**
-	 * Update zone in the database
+	 * Update zone in the database.
 	 *
 	 * @since 2.7.0
 	 * @param WC_Shipping_Zone
@@ -52,7 +52,6 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 		WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}
-
 
 	/**
 	 * Method to read a shipping zone from the database.
@@ -81,7 +80,7 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 	/**
 	 * Deletes a shipping zone from the database.
 	 *
-	 * @since 2.7.0
+	 * @since  2.7.0
 	 * @param  WC_Shipping_Zone
 	 * @param  array $args Array of args to pass to the delete method.
 	 * @return bool result
@@ -98,9 +97,9 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 	}
 
 	/**
-	 * Get a list of shipping methods for a specific sone.
+	 * Get a list of shipping methods for a specific zone.
 	 *
-	 * @since 2.7.0
+	 * @since  2.7.0
 	 * @param  int   $zone_id      Zone ID
 	 * @param  bool  $enabled_only True to request enabled methods only.
 	 * @return array               Array of objects containing method_id, method_order, instance_id, is_enabled
@@ -114,7 +113,7 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 	/**
 	 * Get count of methods for a zone.
 	 *
-	 * @since 2.7.0
+	 * @since  2.7.0
 	 * @param  int Zone ID
 	 * @return int Method Count
 	 */
@@ -189,7 +188,7 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 		$postcode         = wc_normalize_postcode( wc_clean( $package['destination']['postcode'] ) );
 
 		// Work out criteria for our zone search
-		$criteria = array();
+		$criteria   = array();
 		$criteria[] = $wpdb->prepare( "( ( location_type = 'country' AND location_code = %s )", $country );
 		$criteria[] = $wpdb->prepare( "OR ( location_type = 'state' AND location_code = %s )", $country . ':' . $state );
 		$criteria[] = $wpdb->prepare( "OR ( location_type = 'continent' AND location_code = %s )", $continent );
@@ -232,8 +231,8 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 	/**
 	 * Return a zone ID from an instance ID.
 	 *
-	 * @since 2.7.0
-	 * @param int
+	 * @since  2.7.0
+	 * @param  int
 	 * @return int
 	 */
 	public function get_zone_id_by_instance_id( $id ) {

--- a/includes/data-stores/class-wc-shipping-zone-data-store-table.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store-table.php
@@ -1,0 +1,140 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Shipping Zone Data Store: Custom Table.
+ *
+ * @version  2.7.0
+ * @category Class
+ * @author   WooCommerce
+ */
+class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_Interface, WC_Object_Data_Store {
+
+	/**
+	 * Method to create a new shipping zone.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Shipping_Zone
+	 */
+	public function create( &$zone ) {
+		global $wpdb;
+		$wpdb->insert( $wpdb->prefix . 'woocommerce_shipping_zones', array(
+			'zone_name'  => $zone->get_zone_name(),
+			'zone_order' => $zone->get_zone_order(),
+		) );
+		$zone->set_id( $wpdb->insert_id );
+		$zone->save_meta_data();
+		$this->save_locations( $zone );
+		$zone->apply_changes();
+		WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+	}
+
+	/**
+	 * Update zone in the database
+	 *
+	 * @since 2.7.0
+	 * @param WC_Shipping_Zone
+	 */
+	public function update( &$zone ) {
+		global $wpdb;
+		if ( $zone->get_id() ) {
+			$wpdb->update( $wpdb->prefix . 'woocommerce_shipping_zones', array(
+				'zone_name'  => $zone->get_zone_name(),
+				'zone_order' => $zone->get_zone_order(),
+			), array( 'zone_id' => $zone->get_id() ) );
+		}
+		$zone->save_meta_data();
+		$this->save_locations( $zone );
+		$zone->apply_changes();
+		WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+	}
+
+
+	/**
+	 * Method to read a shipping zone from the database.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Shipping_Zone
+	 */
+	public function read( &$zone ) {
+		global $wpdb;
+		if ( 0 === $zone->get_id() || "0" === $zone->get_id() ) {
+			$this->read_zone_locations( $zone );
+			$zone->set_zone_name( __( 'Rest of the World', 'woocommerce' ) );
+			$zone->read_meta_data();
+			$zone->set_object_read( true );
+			do_action( 'woocommerce_shipping_zone_loaded', $zone );
+		} elseif ( $zone_data = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_shipping_zones WHERE zone_id = %d LIMIT 1;", $zone->get_id() ) ) ) {
+			$zone->set_zone_name( $zone_data->zone_name );
+			$zone->set_zone_order( $zone_data->zone_order );
+			$this->read_zone_locations( $zone );
+			$zone->read_meta_data();
+			$zone->set_object_read( true );
+			do_action( 'woocommerce_shipping_zone_loaded', $zone );
+		}
+	}
+
+	/**
+	 * Deletes a shipping zone from the database.
+	 *
+	 * @since 2.7.0
+	 * @param  WC_Shipping_Zone
+	 * @param  array $args Array of args to pass to the delete method.
+	 * @return bool result
+	 */
+	public function delete( &$zone, $args = array() ) {
+		if ( $zone->get_id() ) {
+			global $wpdb;
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array( 'zone_id' => $zone->get_id() ) );
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_locations', array( 'zone_id' => $zone->get_id() ) );
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zones', array( 'zone_id' => $zone->get_id() ) );
+			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+			$zone->set_id( null );
+		}
+	}
+
+	/**
+	 * Read location data from the database.
+	 *
+	 * @param WC_Shipping_Zone
+	 */
+	private function read_zone_locations( &$zone ) {
+		global $wpdb;
+		if ( $locations = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_shipping_zone_locations WHERE zone_id = %d;", $zone->get_id() ) ) ) {
+			foreach ( $locations as $location ) {
+				$zone->add_location( $location->location_code, $location->location_type );
+			}
+		}
+	}
+
+	/**
+	 * Save locations to the DB.
+	 * This function clears old locations, then re-inserts new if any changes are found.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Shipping_Zone
+	 */
+	private function save_locations( &$zone ) {
+		$updated_props = array();
+		$changed_props = array_keys( $zone->get_changes() );
+		if ( ! in_array( 'zone_locations', $changed_props ) ) {
+			return false;
+		}
+
+		global $wpdb;
+		$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_locations', array( 'zone_id' => $zone->get_id() ) );
+
+		foreach ( $zone->get_zone_locations( 'edit' ) as $location ) {
+			$wpdb->insert( $wpdb->prefix . 'woocommerce_shipping_zone_locations', array(
+				'zone_id'       => $zone->get_id(),
+				'location_code' => $location->code,
+				'location_type' => $location->type,
+			) );
+		}
+	}
+
+}

--- a/includes/data-stores/class-wc-shipping-zone-data-store-table.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store-table.php
@@ -74,6 +74,8 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 			$zone->read_meta_data();
 			$zone->set_object_read( true );
 			do_action( 'woocommerce_shipping_zone_loaded', $zone );
+		} else {
+			throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
 		}
 	}
 

--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -61,7 +61,6 @@ class WC_Shipping_Zone_Data_Store implements WC_Shipping_Zone_Data_Store_Interfa
 	 */
 	public function read( &$zone ) {
 		global $wpdb;
-		error_log( print_r ( $zone->get_id(), 1 ) );
 		if ( 0 === $zone->get_id() || "0" === $zone->get_id() ) {
 			$this->read_zone_locations( $zone );
 			$zone->set_zone_name( __( 'Rest of the World', 'woocommerce' ) );

--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -4,13 +4,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WC Shipping Zone Data Store: Custom Table.
+ * WC Shipping Zone Data Store.
  *
  * @version  2.7.0
  * @category Class
  * @author   WooCommerce
  */
-class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_Interface, WC_Object_Data_Store {
+class WC_Shipping_Zone_Data_Store implements WC_Shipping_Zone_Data_Store_Interface, WC_Object_Data_Store {
 
 	/**
 	 * Method to create a new shipping zone.
@@ -61,6 +61,7 @@ class WC_Shipping_Zone_Data_Store_Table implements WC_Shipping_Zone_Data_Store_I
 	 */
 	public function read( &$zone ) {
 		global $wpdb;
+		error_log( print_r ( $zone->get_id(), 1 ) );
 		if ( 0 === $zone->get_id() || "0" === $zone->get_id() ) {
 			$this->read_zone_locations( $zone );
 			$zone->set_zone_name( __( 'Rest of the World', 'woocommerce' ) );

--- a/includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php
+++ b/includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php
@@ -13,5 +13,60 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author   WooCommerce
  */
 interface WC_Shipping_Zone_Data_Store_Interface {
+	/**
+	 * Get a list of shipping methods for a specific sone.
+	 * @param  int   $zone_id      Zone ID
+	 * @param  bool  $enabled_only True to request enabled methods only.
+	 * @return array               Array of objects containing method_id, method_order, instance_id, is_enabled
+	 */
+	public function get_methods( $zone_id, $enabled_only );
 
+	/**
+	 * Get count of methods for a zone.
+	 * @param  int Zone ID
+	 * @return int Method Count
+	 */
+	public function get_method_count( $zone_id );
+
+	/**
+	 * Add a shipping method to a zone.
+	 * @param  int    $zone_id Zone ID
+	 * @param  string $type    Method Type/ID
+	 * @param  int    $order   Method Order
+	 * @return int             Instance ID
+	 */
+	public function add_method( $zone_id, $type, $order );
+
+	/**
+	 * Delete a method instance.
+	 * @param int $instance_id
+	 */
+	public function delete_method( $instance_id );
+
+	/**
+	 * Get a shipping zone method instance.
+	 * @param  int
+	 * @return object
+	 */
+	public function get_method( $instance_id );
+
+	/**
+	 * Find a matching zone ID for a given package.
+	 * @param  object $package
+	 * @return int
+	 */
+	public function get_zone_id_from_package( $package );
+
+	/**
+	 * Return an ordered list of zones.
+	 * @return array An array of objects containing a zone_id, zone_name, and zone_order.
+	 */
+	public function get_zones();
+
+	/**
+	 * Return a zone ID from an instance ID.
+	 * @param  int
+	 * @return int
+	 */
+	public function get_zone_id_by_instance_id( $id );
 }

--- a/includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php
+++ b/includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php
@@ -1,0 +1,17 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Shipping Zone Data Store Interface
+ *
+ * Functions that must be defined by shipping zone store classes.
+ *
+ * @version  2.7.0
+ * @category Interface
+ * @author   WooCommerce
+ */
+interface WC_Shipping_Zone_Data_Store_Interface {
+
+}

--- a/includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php
+++ b/includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * WC Shipping Zone Data Store Interface
+ * WC Shipping Zone Data Store Interface.
  *
  * Functions that must be defined by shipping zone store classes.
  *
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 interface WC_Shipping_Zone_Data_Store_Interface {
 	/**
-	 * Get a list of shipping methods for a specific sone.
+	 * Get a list of shipping methods for a specific zone.
 	 * @param  int   $zone_id      Zone ID
 	 * @param  bool  $enabled_only True to request enabled methods only.
 	 * @return array               Array of objects containing method_id, method_order, instance_id, is_enabled

--- a/includes/legacy/class-wc-legacy-shipping-zone.php
+++ b/includes/legacy/class-wc-legacy-shipping-zone.php
@@ -1,0 +1,66 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Legacy Shipping Zone.
+ *
+ * @version  2.7.0
+ * @package  WooCommerce/Classes
+ * @category Class
+ * @author   WooThemes
+ */
+abstract class WC_Legacy_Shipping_Zone extends WC_Data {
+
+	/**
+	 * Get zone ID
+	 * @return int|null Null if the zone does not exist. 0 is the default zone.
+	 * @deprecated 2.7
+	 */
+	public function get_zone_id() {
+		//wc_soft_deprecated_function( 'WC_Shipping_Zone::get_zone_id', '2.7', '2.8', 'WC_Shipping_Zone::get_id' );
+		return $this->get_id();
+	}
+
+	/**
+	 * Read a shipping zone by ID.
+	 * @deprecated 2.7.0 - Init a shipping zone with an ID.
+	 */
+	public function read( $zone_id ) {
+		//wc_soft_deprecated_function( 'WC_Shipping_Zone::read', '2.7', '2.8', 'Init a shipping zone with an ID.' );
+		$this->set_id( $zone_id );
+		$data_store = WC_Data_Store::load( 'shipping-zone' );
+		$data_store->read( $this );
+	}
+
+	/**
+	 * Update a zone.
+	 * @deprecated 2.7.0 - Use ::save instead.
+	 */
+	public function update() {
+		//wc_soft_deprecated_function( 'WC_Shipping_Zone::update', '2.7', '2.8', 'Use ::save instead.' );
+		$data_store = WC_Data_Store::load( 'shipping-zone' );
+		try {
+			$data_store->update( $this );
+		} catch ( Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Create a zone.
+	 * @deprecated 2.7.0 - Use ::save instead.
+	 */
+	public function create() {
+		//wc_soft_deprecated_function( 'WC_Shipping_Zone::create', '2.7', '2.8', 'Use ::save instead.' );
+		$data_store = WC_Data_Store::load( 'shipping-zone' );
+		try {
+			$data_store->create( $this );
+		} catch ( Exception $e ) {
+			return false;
+		}
+	}
+
+
+}

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -286,7 +286,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 	public function test_update_shipping_zone_invalid_id() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'PUT', '/wc/v1/shipping/zones/1' );
+		$request = new WP_REST_Request( 'PUT', '/wc/v1/shipping/zones/555555' );
 		$request->set_body_params( array(
 			'name'  => 'Zone Test',
 			'order' => 2,
@@ -332,7 +332,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_shipping_zone_invalid_id() {
 		wp_set_current_user( $this->user );
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v1/shipping/zones/0' );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v1/shipping/zones/555555' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -264,11 +264,11 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_locations(), array(
-			2 => (object) array(
+			0 => (object) array(
 				'code' => 'US',
 				'type' => 'country',
 			),
-			3 => (object) array(
+			1 => (object) array(
 				'code' => '90210',
 				'type' => 'postcode',
 			),
@@ -320,4 +320,38 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		// Clean
 		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
+
+	/**
+	 * Test legacy zone functions.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_wc_shipping_zone_legacy() {
+		// Create a single zone.
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'Local' );
+		$zone->set_zone_order( 1 );
+		$zone->add_location( 'GB', 'country' );
+		$zone->add_location( 'CB*', 'postcode' );
+		$zone->save();
+		$zone_id = $zone->get_id();
+
+		$zone_read = new WC_Shipping_Zone();
+		$zone_read->read( $zone_id );
+		$this->assertEquals( $zone_id, $zone_read->get_id() );
+
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'Test' );
+		$zone->set_zone_order( 2 );
+		$zone->create();
+
+		$this->assertEquals( 'Test', $zone->get_zone_name() );
+		$this->assertNotEmpty( $zone->get_id() );
+
+		$zone->set_zone_name( 'Test 2' );
+		$zone->update();
+
+		$this->assertEquals( 'Test 2', $zone->get_zone_name() );
+	}
+
 }

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -25,7 +25,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: WC_Shipping_Zones::get_zone_id
+	 * Test: WC_Shipping_Zones::get_id
 	 */
 	public function test_get_zone_id() {
 		// Setup
@@ -35,7 +35,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert
-		$this->assertEquals( $zone->get_zone_id(), 1 );
+		$this->assertEquals( $zone->get_id(), 1 );
 
 		// Clean
 		WC_Helper_Shipping_Zones::remove_mock_zones();

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -277,6 +277,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-integration.php' ); // An integration with a service
 		include_once( WC_ABSPATH . 'includes/class-wc-product-factory.php' ); // Product factory
 		include_once( WC_ABSPATH . 'includes/class-wc-payment-tokens.php' ); // Payment tokens controller
+		include_once( WC_ABSPATH . 'includes/class-wc-shipping-zone.php' );
 		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-cc.php' ); // CC Payment Gateway
 		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-echeck.php' ); // eCheck Payment Gateway
 		include_once( WC_ABSPATH . 'includes/class-wc-countries.php' ); // Defines countries and states
@@ -291,6 +292,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/wc-product-variable-data-store-interface.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/wc-customer-data-store-interface.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/class-wc-payment-token-data-store-interface.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-payment-token-data-store-table.php' );
@@ -300,6 +302,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-variation-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store-session.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-shipping-zone-data-store-table.php' );
 
 		$this->query = new WC_Query();
 		$this->api   = new WC_API();

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -295,14 +295,14 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/interfaces/class-wc-shipping-zone-data-store-interface.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php' );
-		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-payment-token-data-store-table.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-grouped-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-variable-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-product-variation-data-store-cpt.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-payment-token-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store-session.php' );
-		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-shipping-zone-data-store-table.php' );
+		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-shipping-zone-data-store.php' );
 
 		$this->query = new WC_Query();
 		$this->api   = new WC_API();


### PR DESCRIPTION
Handles all the updates for shipping zones - both in the data class, and in the shipping zones class. Also does getters/setters and updates a few old parts of shipping zones since it was a 2.6 class.

All tests pass.