### PR TITLE
Fix product related tests after product CRUD merge

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1368,7 +1368,8 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 
 			// Thumbnail.
 			if ( isset( $data['image'] ) && is_array( $data['image'] ) ) {
-				$image = current( $data['image'] );
+				$image = $data['image'];
+				$image = current( $image );
 				if ( is_array( $image ) ) {
 					$image['position'] = 0;
 				}

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -261,7 +261,6 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( 'Variation #1 of Dummy Variable CRUD Product', $variation->get_name() );
 		$this->assertEquals( 'CRUD DUMMY SKU VARIABLE GREEN', $variation->get_sku() );
 		$this->assertEquals( 10, $variation->get_price() );
-		$product->delete();
 
 		$product = new WC_Product_Variable( $product->get_id() );
 		$children = $product->get_children();
@@ -285,7 +284,6 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( 'Variation #2 of Dummy Variable CRUD Product', $variation_2->get_name() );
 		$this->assertEquals( 'CRUD DUMMY SKU VARIABLE RED', $variation_2->get_sku() );
 		$this->assertEquals( 10, $variation_2->get_price() );
-		$product->delete();
 
 		$product = new WC_Product_Variable( $product->get_id() );
 		$children = $product->get_children();
@@ -300,7 +298,6 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$variation_2->set_sale_price( 9.99 );
 		$variation_2->set_date_on_sale_to( '32532537600' );
 		$variation_2->save();
-		$product->delete();
 
 		$product = new WC_Product_Variable( $product->get_id() );
 		$expected_prices['price'][ $children[0] ] = 10.00;


### PR DESCRIPTION
I noticed three failing tests after the CRUD merge when rebasing my shipping zones PR.

This PR fixes them.

Two were returning the following error:
`Indirect modification of overloaded element of WP_REST_Request has no effect`.

The other was failing because we were deleting the $product, and then still trying to add new children on it in the test. There is still a `->delete` at the end of the test, but we need the product to still exist until that point.