### PR TITLE
Make products visible by default

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -39,7 +39,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		'date_modified'      => '',
 		'status'             => false,
 		'featured'           => false,
-		'catalog_visibility' => 'hidden',
+		'catalog_visibility' => 'visible',
 		'description'        => '',
 		'short_description'  => '',
 		'sku'                => '',


### PR DESCRIPTION
Product should be visible by default to keep backwards compatibility: #12370