### PR TITLE
Product quick and bulk edit.

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -35,7 +35,9 @@
 									$all_terms = get_terms( $attribute->get_taxonomy(), apply_filters( 'woocommerce_product_attribute_terms', $args ) );
 									if ( $all_terms ) {
 										foreach ( $all_terms as $term ) {
-											echo '<option value="' . esc_attr( $term->term_id ) . '" ' . selected( in_array( $term->term_id, $attribute->get_options() ), true, false ) . '>' . esc_attr( apply_filters( 'woocommerce_product_attribute_term_name', $term->name, $term ) ) . '</option>';
+											$options = $attribute->get_options();
+											$options = ! empty( $options ) ? $options : array();
+											echo '<option value="' . esc_attr( $term->term_id ) . '" ' . selected( in_array( $term->term_id, $options ), true, false ) . '>' . esc_attr( apply_filters( 'woocommerce_product_attribute_term_name', $term->name, $term ) ) . '</option>';
 										}
 									}
 									?>

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1477,9 +1477,10 @@ class WC_API_Products extends WC_API_Resource {
 
 		// Shipping class
 		if ( isset( $data['shipping_class'] ) ) {
-			$shipping_class_term = get_term_by( 'slug', wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
-			if ( $shipping_class_term ) {
-				$product->set_shipping_class_id( $shipping_class_term->term_id );
+			$data_store         = $product->get_data_store();
+			$shipping_class_id  = $data_store->get_shipping_class_id_by_slug( wc_clean( $data['shipping_class'] ) );
+			if ( $shipping_class_id ) {
+				$product->set_shipping_class_id( $shipping_class_id );
 			}
 		}
 

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1976,9 +1976,10 @@ class WC_API_Products extends WC_API_Resource {
 
 		// Shipping class
 		if ( isset( $data['shipping_class'] ) ) {
-			$shipping_class_term = get_term_by( 'slug', wc_clean( $data['shipping_class'] ), 'product_shipping_class' );
-			if ( $shipping_class_term ) {
-				$product->set_shipping_class_id( $shipping_class_term->term_id );
+			$data_store         = $product->get_data_store();
+			$shipping_class_id  = $data_store->get_shipping_class_id_by_slug( wc_clean( $data['shipping_class'] ) );
+			if ( $shipping_class_id ) {
+				$product->set_shipping_class_id( $shipping_class_id );
 			}
 		}
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -352,7 +352,7 @@ class WC_Product_Variable extends WC_Product {
 
 		// Otherwise revert to status the children have.
 		} else {
-			$this->set_stock_status( $product->child_is_in_stock() ? 'instock' : 'outofstock' );
+			$this->set_stock_status( $this->child_is_in_stock() ? 'instock' : 'outofstock' );
 		}
 	}
 

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -867,4 +867,20 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_CPT implements WC_Object_D
 		update_post_meta( $product->get_id(), '_wc_rating_count', $product->get_rating_counts( 'edit' ) );
 	}
 
+	/**
+	 * Get shipping class ID by slug.
+	 *
+	 * @since 2.7.0
+	 * @param $slug string
+	 * @return int|false
+	 */
+	public function get_shipping_class_id_by_slug( $slug ) {
+		$shipping_class_term = get_term_by( 'slug', $slug, 'product_shipping_class' );
+		if ( $shipping_class_term ) {
+			return $shipping_class_term->term_id;
+		} else {
+			return false;
+		}
+	}
+
 }

--- a/includes/data-stores/interfaces/wc-product-data-store-interface.php
+++ b/includes/data-stores/interfaces/wc-product-data-store-interface.php
@@ -93,4 +93,11 @@ interface WC_Product_Data_Store_Interface {
 	 * @param  string $operation set, increase and decrease.
 	 */
 	function update_product_stock( $product_id_with_stock, $stock_quantity = null, $operation = 'set' );
+
+	/**
+	 * Get shipping class ID by slug.
+	 * @param $slug string
+	 * @return int|false
+	 */
+	public function get_shipping_class_id_by_slug( $slug );
 }


### PR DESCRIPTION
I originally set out to do bulk and quick edit for all types, but it looks like order's actions were already updated. Coupon's doesn't actually have custom bulk edit code -- maybe something we could add in a future version.

Closes #12325.

So that just left products. This PR handles that.