### PR TITLE
Add Cyprus to Europe

### DIFF
--- a/i18n/continents.php
+++ b/i18n/continents.php
@@ -158,6 +158,7 @@ return array(
 			'BG',
 			'BY',
 			'CH',
+			'CY',			
 			'CZ',
 			'DE',
 			'DK',


### PR DESCRIPTION
Added missing country Cyprus (CY) to the Europe set. 

Arguably, you could also consider adding Greenland (GL), since it's one of the Overseas Countries and Territories (OCT) of the EU and you've already included Svalbard and Jan Mayen, which is equally far from Europe in a geographic sense.