### PR TITLE
Add a payment fail result filter

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -702,7 +702,9 @@ class WC_Checkout {
 							wp_redirect( $result['redirect'] );
 							exit;
 						}
-					}
+					} else { 
+						$result = apply_filters( 'woocommerce_payment_fail_result', $result, $order_id );
+					}	
 				} else {
 
 					if ( empty( $order ) ) {


### PR DESCRIPTION
This filter would be useful for gift card plugins that cannot unwind pre-payment transaction usage. It may also be useful for triggering additional automation or passing additional information back to the front in an ajax scenario.