### PR TITLE
CRUD - Fixes and improviments for the REST API

### DIFF
--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -140,8 +140,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 	 * @return WP_REST_Response $data
 	 */
 	public function prepare_item_for_response( $post, $request ) {
-		$code           = wc_get_coupon_code_by_id( $post->ID );
-		$coupon         = new WC_Coupon( $code );
+		$coupon         = new WC_Coupon( (int) $post->ID );
 		$data           = $coupon->get_data();
 		$format_decimal = array( 'amount', 'minimum_amount', 'maximum_amount' );
 		$format_date    = array( 'date_created', 'date_modified', 'date_expires' );

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -125,7 +125,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 		global $wpdb;
 
 		if ( ! empty( $request['code'] ) ) {
-			$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish'", $request['code'] ) );
+			$id = wc_get_coupon_id_by_code( $request['code'] );
 			$args['post__in'] = array( $id );
 		}
 

--- a/includes/api/legacy/v1/class-wc-api-coupons.php
+++ b/includes/api/legacy/v1/class-wc-api-coupons.php
@@ -97,17 +97,16 @@ class WC_API_Coupons extends WC_API_Resource {
 	public function get_coupon( $id, $fields = null ) {
 		$id = $this->validate_request( $id, 'shop_coupon', 'read' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
-
-		// get the coupon code
-		$code = wc_get_coupon_code_by_id( $id );
-
-		if ( empty( $code ) ) {
-			return new WP_Error( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
-		$coupon = new WC_Coupon( $code );
+		$coupon = new WC_Coupon( $id );
+
+		if ( 0 === $coupon->get_id() ) {
+			throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
+		}
+
 		$coupon_data = array(
 			'id'                           => $coupon->get_id(),
 			'code'                         => $coupon->get_code(),

--- a/includes/api/legacy/v1/class-wc-api-coupons.php
+++ b/includes/api/legacy/v1/class-wc-api-coupons.php
@@ -108,15 +108,12 @@ class WC_API_Coupons extends WC_API_Resource {
 		}
 
 		$coupon = new WC_Coupon( $code );
-
-		$coupon_post = get_post( $coupon->get_id() );
-
 		$coupon_data = array(
 			'id'                           => $coupon->get_id(),
 			'code'                         => $coupon->get_code(),
 			'type'                         => $coupon->get_discount_type(),
-			'created_at'                   => $this->server->format_datetime( $coupon_post->post_date_gmt ),
-			'updated_at'                   => $this->server->format_datetime( $coupon_post->post_modified_gmt ),
+			'created_at'                   => $this->server->format_datetime( $coupon->get_date_created(), false, true ),
+			'updated_at'                   => $this->server->format_datetime( $coupon->get_date_modified(), false, true ),
 			'amount'                       => wc_format_decimal( $coupon->get_amount(), 2 ),
 			'individual_use'               => $coupon->get_individual_use(),
 			'product_ids'                  => array_map( 'absint', (array) $coupon->get_product_ids() ),
@@ -125,7 +122,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			'usage_limit_per_user'         => $coupon->get_usage_limit_per_user() ? $coupon->get_usage_limit_per_user() : null,
 			'limit_usage_to_x_items'       => (int) $coupon->get_limit_usage_to_x_items(),
 			'usage_count'                  => (int) $coupon->get_usage_count(),
-			'expiry_date'                  => $this->server->format_datetime( $coupon->get_date_expires() ),
+			'expiry_date'                  => $this->server->format_datetime( $coupon->get_date_expires(), false, true ),
 			'enable_free_shipping'         => $coupon->get_free_shipping(),
 			'product_category_ids'         => array_map( 'absint', (array) $coupon->get_product_categories() ),
 			'exclude_product_category_ids' => array_map( 'absint', (array) $coupon->get_excluded_product_categories() ),

--- a/includes/api/legacy/v1/class-wc-api-customers.php
+++ b/includes/api/legacy/v1/class-wc-api-customers.php
@@ -132,13 +132,13 @@ class WC_API_Customers extends WC_API_Resource {
 		$last_order    = $customer->get_last_order();
 		$customer_data = array(
 			'id'               => $customer->get_id(),
-			'created_at'       => $this->server->format_datetime( $customer->get_date_created() ),
+			'created_at'       => $this->server->format_datetime( $customer->get_date_created(), false, true ),
 			'email'            => $customer->get_email(),
 			'first_name'       => $customer->get_first_name(),
 			'last_name'        => $customer->get_last_name(),
 			'username'         => $customer->get_username(),
 			'last_order_id'    => is_object( $last_order ) ? $last_order->get_id() : null,
-			'last_order_date'  => is_object( $last_order ) ? $this->server->format_datetime( $last_order->get_date_created() ) : null,
+			'last_order_date'  => is_object( $last_order ) ? $this->server->format_datetime( $last_order->get_date_created(), false, true ) : null,
 			'orders_count'     => $customer->get_order_count(),
 			'total_spent'      => wc_format_decimal( $customer->get_total_spent(), 2 ),
 			'avatar_url'       => $customer->get_avatar_url(),

--- a/includes/api/legacy/v1/class-wc-api-orders.php
+++ b/includes/api/legacy/v1/class-wc-api-orders.php
@@ -116,9 +116,9 @@ class WC_API_Orders extends WC_API_Resource {
 		$order_data = array(
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),
-			'created_at'                => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_created() ) ) ),
-			'updated_at'                => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_modified() ) ) ),
-			'completed_at'              => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_completed() ) ) ),
+			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ) ),
+			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ) ),
+			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ) ),
 			'status'                    => $order->get_status(),
 			'currency'                  => $order->get_currency(),
 			'total'                     => wc_format_decimal( $order->get_total(), 2 ),

--- a/includes/api/legacy/v1/class-wc-api-orders.php
+++ b/includes/api/legacy/v1/class-wc-api-orders.php
@@ -116,9 +116,9 @@ class WC_API_Orders extends WC_API_Resource {
 		$order_data = array(
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),
-			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ) ),
-			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ) ),
-			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ) ),
+			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ),
+			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ),
+			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ),
 			'status'                    => $order->get_status(),
 			'currency'                  => $order->get_currency(),
 			'total'                     => wc_format_decimal( $order->get_total(), 2 ),

--- a/includes/api/legacy/v1/class-wc-api-orders.php
+++ b/includes/api/legacy/v1/class-wc-api-orders.php
@@ -106,8 +106,9 @@ class WC_API_Orders extends WC_API_Resource {
 		// ensure order ID is valid & user has permission to read
 		$id = $this->validate_request( $id, 'shop_order', 'read' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		$order      = wc_get_order( $id );
 		$order_data = array(
@@ -126,8 +127,8 @@ class WC_API_Orders extends WC_API_Resource {
 			'cart_tax'                  => wc_format_decimal( $order->get_cart_tax(), 2 ),
 			'shipping_tax'              => wc_format_decimal( $order->get_shipping_tax(), 2 ),
 			'total_discount'            => wc_format_decimal( $order->get_total_discount(), 2 ),
-			'cart_discount'             => wc_format_decimal( $order->get_cart_discount(), 2 ),
-			'order_discount'            => wc_format_decimal( $order->get_order_discount(), 2 ),
+			'cart_discount'             => wc_format_decimal( 0, 2 ),
+			'order_discount'            => wc_format_decimal( 0, 2 ),
 			'shipping_methods'          => $order->get_shipping_method(),
 			'payment_details' => array(
 				'method_id'    => $order->get_payment_method(),

--- a/includes/api/legacy/v1/class-wc-api-orders.php
+++ b/includes/api/legacy/v1/class-wc-api-orders.php
@@ -109,10 +109,7 @@ class WC_API_Orders extends WC_API_Resource {
 		if ( is_wp_error( $id ) )
 			return $id;
 
-		$order = wc_get_order( $id );
-
-		$order_post = get_post( $id );
-
+		$order      = wc_get_order( $id );
 		$order_data = array(
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),

--- a/includes/api/legacy/v1/class-wc-api-products.php
+++ b/includes/api/legacy/v1/class-wc-api-products.php
@@ -267,8 +267,8 @@ class WC_API_Products extends WC_API_Resource {
 		return array(
 			'title'              => $product->get_name(),
 			'id'                 => $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $product->get_date_created() ),
-			'updated_at'         => $this->server->format_datetime( $product->get_date_modified() ),
+			'created_at'         => $this->server->format_datetime( $product->get_date_created(), false, true ),
+			'updated_at'         => $this->server->format_datetime( $product->get_date_modified(), false, true ),
 			'type'               => $product->get_type(),
 			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
@@ -347,8 +347,8 @@ class WC_API_Products extends WC_API_Resource {
 
 			$variations[] = array(
 				'id'                => $variation->get_id(),
-				'created_at'        => $this->server->format_datetime( $variation->get_date_created() ),
-				'updated_at'        => $this->server->format_datetime( $variation->get_date_modified() ),
+				'created_at'        => $this->server->format_datetime( $variation->get_date_created(), false, true ),
+				'updated_at'        => $this->server->format_datetime( $variation->get_date_modified(), false, true ),
 				'downloadable'      => $variation->is_downloadable(),
 				'virtual'           => $variation->is_virtual(),
 				'permalink'         => $variation->get_permalink(),

--- a/includes/api/legacy/v1/class-wc-api-server.php
+++ b/includes/api/legacy/v1/class-wc-api-server.php
@@ -661,9 +661,17 @@ class WC_API_Server {
 	 * @since 2.1
 	 * @param int|string $timestamp unix timestamp or MySQL datetime
 	 * @param bool $convert_to_utc
+	 * @param bool $convert_to_gmt Use GMT timezone.
 	 * @return string RFC3339 datetime
 	 */
-	public function format_datetime( $timestamp, $convert_to_utc = false ) {
+	public function format_datetime( $timestamp, $convert_to_utc = false, $convert_to_gmt = false ) {
+		if ( $convert_to_gmt ) {
+			if ( is_numeric( $timestamp ) ) {
+				$timestamp = date( 'Y-m-d H:i:s', $timestamp );
+			}
+
+			$timestamp = get_gmt_from_date( $timestamp );
+		}
 
 		if ( $convert_to_utc ) {
 			$timezone = new DateTimeZone( wc_timezone_string() );

--- a/includes/api/legacy/v2/class-wc-api-coupons.php
+++ b/includes/api/legacy/v2/class-wc-api-coupons.php
@@ -111,14 +111,12 @@ class WC_API_Coupons extends WC_API_Resource {
 				return $id;
 			}
 
-			// get the coupon code
-			$code = wc_get_coupon_code_by_id( $id );
+			$coupon = new WC_Coupon( $id );
 
-			if ( empty( $code ) ) {
+			if ( 0 === $coupon->get_id() ) {
 				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
 			}
 
-			$coupon = new WC_Coupon( $code );
 			$coupon_data = array(
 				'id'                           => $coupon->get_id(),
 				'code'                         => $coupon->get_code(),

--- a/includes/api/legacy/v2/class-wc-api-coupons.php
+++ b/includes/api/legacy/v2/class-wc-api-coupons.php
@@ -118,14 +118,13 @@ class WC_API_Coupons extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
 			}
 
-			$coupon      = new WC_Coupon( $code );
-			$coupon_post = get_post( $coupon->get_id() );
+			$coupon = new WC_Coupon( $code );
 			$coupon_data = array(
 				'id'                           => $coupon->get_id(),
 				'code'                         => $coupon->get_code(),
 				'type'                         => $coupon->get_discount_type(),
-				'created_at'                   => $this->server->format_datetime( $coupon_post->post_date_gmt ),
-				'updated_at'                   => $this->server->format_datetime( $coupon_post->post_modified_gmt ),
+				'created_at'                   => $this->server->format_datetime( $coupon->get_date_created(), false, true ),
+				'updated_at'                   => $this->server->format_datetime( $coupon->get_date_modified(), false, true ),
 				'amount'                       => wc_format_decimal( $coupon->get_amount(), 2 ),
 				'individual_use'               => $coupon->get_individual_use(),
 				'product_ids'                  => array_map( 'absint', (array) $coupon->get_product_ids() ),

--- a/includes/api/legacy/v2/class-wc-api-customers.php
+++ b/includes/api/legacy/v2/class-wc-api-customers.php
@@ -150,14 +150,14 @@ class WC_API_Customers extends WC_API_Resource {
 		$last_order    = $customer->get_last_order();
 		$customer_data = array(
 			'id'               => $customer->get_id(),
-			'created_at'       => $this->server->format_datetime( $customer->get_date_created() ),
+			'created_at'       => $this->server->format_datetime( $customer->get_date_created(), false, true ),
 			'email'            => $customer->get_email(),
 			'first_name'       => $customer->get_first_name(),
 			'last_name'        => $customer->get_last_name(),
 			'username'         => $customer->get_username(),
 			'role'             => $customer->get_role(),
 			'last_order_id'    => is_object( $last_order ) ? $last_order->get_id() : null,
-			'last_order_date'  => is_object( $last_order ) ? $this->server->format_datetime( $last_order->get_date_created() ) : null,
+			'last_order_date'  => is_object( $last_order ) ? $this->server->format_datetime( $last_order->get_date_created(), false, true ) : null,
 			'orders_count'     => $customer->get_order_count(),
 			'total_spent'      => wc_format_decimal( $customer->get_total_spent(), 2 ),
 			'avatar_url'       => $customer->get_avatar_url(),

--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -151,8 +151,6 @@ class WC_API_Orders extends WC_API_Resource {
 		// Get the decimal precession
 		$dp         = ( isset( $filter['dp'] ) ? intval( $filter['dp'] ) : 2 );
 		$order      = wc_get_order( $id );
-		$order_post = get_post( $id );
-
 		$order_data = array(
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),

--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -156,9 +156,9 @@ class WC_API_Orders extends WC_API_Resource {
 		$order_data = array(
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),
-			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ) ),
-			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ) ),
-			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ) ),
+			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ),
+			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ),
+			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ),
 			'status'                    => $order->get_status(),
 			'currency'                  => $order->get_currency(),
 			'total'                     => wc_format_decimal( $order->get_total(), $dp ),
@@ -1534,7 +1534,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$order_refund = array(
 				'id'         => $refund->id,
-				'created_at' => $this->server->format_datetime( $refund->get_date_created(), false, true ) ),
+				'created_at' => $this->server->format_datetime( $refund->get_date_created(), false, true ),
 				'amount'     => wc_format_decimal( $refund->get_amount(), 2 ),
 				'reason'     => $refund->get_reason(),
 				'line_items' => $line_items,

--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -156,9 +156,9 @@ class WC_API_Orders extends WC_API_Resource {
 		$order_data = array(
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),
-			'created_at'                => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_created() ) ) ),
-			'updated_at'                => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_modified() ) ) ),
-			'completed_at'              => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_completed() ) ) ),
+			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ) ),
+			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ) ),
+			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ) ),
 			'status'                    => $order->get_status(),
 			'currency'                  => $order->get_currency(),
 			'total'                     => wc_format_decimal( $order->get_total(), $dp ),
@@ -1534,7 +1534,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$order_refund = array(
 				'id'         => $refund->id,
-				'created_at' => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $refund->get_date_created() ) ) ),
+				'created_at' => $this->server->format_datetime( $refund->get_date_created(), false, true ) ),
 				'amount'     => wc_format_decimal( $refund->get_amount(), 2 ),
 				'reason'     => $refund->get_reason(),
 				'line_items' => $line_items,

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -684,8 +684,8 @@ class WC_API_Products extends WC_API_Resource {
 		return array(
 			'title'              => $product->get_name(),
 			'id'                 => $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $product->get_date_created() ),
-			'updated_at'         => $this->server->format_datetime( $product->get_date_modified() ),
+			'created_at'         => $this->server->format_datetime( $product->get_date_created(), false, true ),
+			'updated_at'         => $this->server->format_datetime( $product->get_date_modified(), false, true ),
 			'type'               => $product->get_type(),
 			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
@@ -769,8 +769,8 @@ class WC_API_Products extends WC_API_Resource {
 
 			$variations[] = array(
 				'id'                => $variation->get_id(),
-				'created_at'        => $this->server->format_datetime( $variation->get_date_created() ),
-				'updated_at'        => $this->server->format_datetime( $variation->get_date_modified() ),
+				'created_at'        => $this->server->format_datetime( $variation->get_date_created(), false, true ),
+				'updated_at'        => $this->server->format_datetime( $variation->get_date_modified(), false, true ),
 				'downloadable'      => $variation->is_downloadable(),
 				'virtual'           => $variation->is_virtual(),
 				'permalink'         => $variation->get_permalink(),

--- a/includes/api/legacy/v2/class-wc-api-server.php
+++ b/includes/api/legacy/v2/class-wc-api-server.php
@@ -704,9 +704,17 @@ class WC_API_Server {
 	 * @since 2.1
 	 * @param int|string $timestamp unix timestamp or MySQL datetime
 	 * @param bool $convert_to_utc
+	 * @param bool $convert_to_gmt Use GMT timezone.
 	 * @return string RFC3339 datetime
 	 */
-	public function format_datetime( $timestamp, $convert_to_utc = false ) {
+	public function format_datetime( $timestamp, $convert_to_utc = false, $convert_to_gmt = false ) {
+		if ( $convert_to_gmt ) {
+			if ( is_numeric( $timestamp ) ) {
+				$timestamp = date( 'Y-m-d H:i:s', $timestamp );
+			}
+
+			$timestamp = get_gmt_from_date( $timestamp );
+		}
 
 		if ( $convert_to_utc ) {
 			$timezone = new DateTimeZone( wc_timezone_string() );

--- a/includes/api/legacy/v3/class-wc-api-coupons.php
+++ b/includes/api/legacy/v3/class-wc-api-coupons.php
@@ -111,14 +111,12 @@ class WC_API_Coupons extends WC_API_Resource {
 				return $id;
 			}
 
-			// get the coupon code
-			$code = wc_get_coupon_code_by_id( $id );
+			$coupon = new WC_Coupon( $id );
 
-			if ( empty( $code ) ) {
+			if ( 0 === $coupon->get_id() ) {
 				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
 			}
 
-			$coupon = new WC_Coupon( $code );
 			$coupon_data = array(
 				'id'                           => $coupon->get_id(),
 				'code'                         => $coupon->get_code(),

--- a/includes/api/legacy/v3/class-wc-api-coupons.php
+++ b/includes/api/legacy/v3/class-wc-api-coupons.php
@@ -118,14 +118,13 @@ class WC_API_Coupons extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
 			}
 
-			$coupon      = new WC_Coupon( $code );
-			$coupon_post = get_post( $coupon->get_id() );
+			$coupon = new WC_Coupon( $code );
 			$coupon_data = array(
 				'id'                           => $coupon->get_id(),
 				'code'                         => $coupon->get_code(),
 				'type'                         => $coupon->get_discount_type(),
-				'created_at'                   => $this->server->format_datetime( $coupon_post->post_date_gmt ),
-				'updated_at'                   => $this->server->format_datetime( $coupon_post->post_modified_gmt ),
+				'created_at'                   => $this->server->format_datetime( $coupon->get_date_created(), false, true ),
+				'updated_at'                   => $this->server->format_datetime( $coupon->get_date_modified(), false, true ),
 				'amount'                       => wc_format_decimal( $coupon->get_amount(), 2 ),
 				'individual_use'               => $coupon->get_individual_use(),
 				'product_ids'                  => array_map( 'absint', (array) $coupon->get_product_ids() ),

--- a/includes/api/legacy/v3/class-wc-api-coupons.php
+++ b/includes/api/legacy/v3/class-wc-api-coupons.php
@@ -134,7 +134,7 @@ class WC_API_Coupons extends WC_API_Resource {
 				'usage_limit_per_user'         => $coupon->get_usage_limit_per_user() ? $coupon->get_usage_limit_per_user() : null,
 				'limit_usage_to_x_items'       => (int) $coupon->get_limit_usage_to_x_items(),
 				'usage_count'                  => (int) $coupon->get_usage_count(),
-				'expiry_date'                  => $coupon->get_date_expires() ? $this->server->format_datetime( $coupon->get_date_expires() ) : null,
+				'expiry_date'                  => $coupon->get_date_expires() ? $this->server->format_datetime( $coupon->get_date_expires(), false, true ) : null,
 				'enable_free_shipping'         => $coupon->get_free_shipping(),
 				'product_category_ids'         => array_map( 'absint', (array) $coupon->get_product_categories() ),
 				'exclude_product_category_ids' => array_map( 'absint', (array) $coupon->get_excluded_product_categories() ),

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -162,9 +162,9 @@ class WC_API_Orders extends WC_API_Resource {
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),
 			'order_key'                 => $order->get_order_key(),
-			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ) ),
-			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ) ),
-			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ) ),
+			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ),
+			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ),
+			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ),
 			'status'                    => $order->get_status(),
 			'currency'                  => $order->get_currency(),
 			'total'                     => wc_format_decimal( $order->get_total(), $dp ),
@@ -1579,7 +1579,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$order_refund = array(
 				'id'         => $refund->id,
-				'created_at' => $this->server->format_datetime( $refund->get_date_created(), false, true ) ),
+				'created_at' => $this->server->format_datetime( $refund->get_date_created(), false, true ),
 				'amount'     => wc_format_decimal( $refund->get_amount(), 2 ),
 				'reason'     => $refund->get_reason(),
 				'line_items' => $line_items,

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -149,10 +149,9 @@ class WC_API_Orders extends WC_API_Resource {
 		}
 
 		// Get the decimal precession.
-		$dp         = ( isset( $filter['dp'] ) ? intval( $filter['dp'] ) : 2 );
-		$order      = wc_get_order( $id );
-		$order_post = get_post( $id );
-		$expand     = array();
+		$dp     = ( isset( $filter['dp'] ) ? intval( $filter['dp'] ) : 2 );
+		$order  = wc_get_order( $id );
+		$expand = array();
 
 		if ( ! empty( $filter['expand'] ) ) {
 			$expand = explode( ',', $filter['expand'] );

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -162,9 +162,9 @@ class WC_API_Orders extends WC_API_Resource {
 			'id'                        => $order->get_id(),
 			'order_number'              => $order->get_order_number(),
 			'order_key'                 => $order->get_order_key(),
-			'created_at'                => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_created() ) ) ),
-			'updated_at'                => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_modified() ) ) ),
-			'completed_at'              => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $order->get_date_completed() ) ) ),
+			'created_at'                => $this->server->format_datetime( $order->get_date_created(), false, true ) ),
+			'updated_at'                => $this->server->format_datetime( $order->get_date_modified(), false, true ) ),
+			'completed_at'              => $this->server->format_datetime( $order->get_date_completed(), false, true ) ),
 			'status'                    => $order->get_status(),
 			'currency'                  => $order->get_currency(),
 			'total'                     => wc_format_decimal( $order->get_total(), $dp ),
@@ -1579,7 +1579,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$order_refund = array(
 				'id'         => $refund->id,
-				'created_at' => $this->server->format_datetime( get_gmt_from_date( date( 'Y-m-d H:i:s', $refund->get_date_created() ) ) ),
+				'created_at' => $this->server->format_datetime( $refund->get_date_created(), false, true ) ),
 				'amount'     => wc_format_decimal( $refund->get_amount(), 2 ),
 				'reason'     => $refund->get_reason(),
 				'line_items' => $line_items,

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1129,8 +1129,8 @@ class WC_API_Products extends WC_API_Resource {
 		return array(
 			'title'              => $product->get_name(),
 			'id'                 => $product->get_id(),
-			'created_at'         => $this->server->format_datetime( $product->get_date_created() ),
-			'updated_at'         => $this->server->format_datetime( $product->get_date_modified() ),
+			'created_at'         => $this->server->format_datetime( $product->get_date_created(), false, true ),
+			'updated_at'         => $this->server->format_datetime( $product->get_date_modified(), false, true ),
 			'type'               => $product->get_type(),
 			'status'             => $product->get_status(),
 			'downloadable'       => $product->is_downloadable(),
@@ -1227,8 +1227,8 @@ class WC_API_Products extends WC_API_Resource {
 
 			$variations[] = array(
 				'id'                 => $variation->get_id(),
-				'created_at'         => $this->server->format_datetime( $variation->get_date_created() ),
-				'updated_at'         => $this->server->format_datetime( $variation->get_date_modified() ),
+				'created_at'         => $this->server->format_datetime( $variation->get_date_created(), false, true ),
+				'updated_at'         => $this->server->format_datetime( $variation->get_date_modified(), false, true ),
 				'downloadable'       => $variation->is_downloadable(),
 				'virtual'            => $variation->is_virtual(),
 				'permalink'          => $variation->get_permalink(),

--- a/includes/api/legacy/v3/class-wc-api-server.php
+++ b/includes/api/legacy/v3/class-wc-api-server.php
@@ -710,9 +710,17 @@ class WC_API_Server {
 	 * @since 2.1
 	 * @param int|string $timestamp unix timestamp or MySQL datetime
 	 * @param bool $convert_to_utc
+	 * @param bool $convert_to_gmt Use GMT timezone.
 	 * @return string RFC3339 datetime
 	 */
-	public function format_datetime( $timestamp, $convert_to_utc = false ) {
+	public function format_datetime( $timestamp, $convert_to_utc = false, $convert_to_gmt = false ) {
+		if ( $convert_to_gmt ) {
+			if ( is_numeric( $timestamp ) ) {
+				$timestamp = date( 'Y-m-d H:i:s', $timestamp );
+			}
+
+			$timestamp = get_gmt_from_date( $timestamp );
+		}
 
 		if ( $convert_to_utc ) {
 			$timezone = new DateTimeZone( wc_timezone_string() );


### PR DESCRIPTION
Just a few fixes to take advanced about the new CRUD data and keep backwards compatibility:

- Stop extra queries only to get GMT dates
- Convert dates to GMT to keep backwards compatibility in legacy API endpoints
- Use `wc_get_coupon_id_by_code()` to while querying coupons by code.
- Stop try find a coupon code every time that needs to get a `WC_Coupon` instance.
- Remove undefined `$order->get_cart_discount()` and `$order->get_order_discount()` methods from legacy v1.
