### PR TITLE
Fixes #12352 - cater for just one item selected in a multiselect list

### DIFF
--- a/assets/js/admin/backbone-modal.js
+++ b/assets/js/admin/backbone-modal.js
@@ -114,8 +114,8 @@
 			$( document.body ).trigger( 'wc_backbone_modal_before_update', this._target );
 
 			$.each( $( 'form', this.$el ).serializeArray(), function( index, item ) {
-				item.name = item.name.replace( '[]', '' );
-				if ( data.hasOwnProperty( item.name ) ) {
+				if ( item.name.indexOf( '[]' ) != -1 ) {
+					item.name = item.name.replace( '[]', '' );
 					data[ item.name ] = $.makeArray( data[ item.name ] );
 					data[ item.name ].push( item.value );
 				} else {


### PR DESCRIPTION
When only one item is selected in a multiselect list we still need to pass it in an array, otherwise the server end treats it as an empty list. 