### PR TITLE
Make sure get_hook_prefix is present on all of our classes.

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -109,6 +109,16 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		return ( $this->get_discount_type() == $type || ( is_array( $type ) && in_array( $this->get_discount_type(), $type ) ) );
 	}
 
+	/**
+	 * Prefix for action and filter hooks on data.
+	 *
+	 * @since  2.7.0
+	 * @return string
+	 */
+	protected function get_hook_prefix() {
+		return 'woocommerce_get_coupon_';
+	}
+
 	/*
 	 |--------------------------------------------------------------------------
 	 | Getters

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -113,19 +113,14 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
-	 * Callback to remove unwanted meta data.
+	 * Prefix for action and filter hooks on data.
 	 *
-	 * @param object $meta
-	 * @return bool
+	 * @since  2.7.0
+	 * @return string
 	 */
-	protected function exclude_internal_meta_keys( $meta ) {
-		global $wpdb;
-		return ! in_array( $meta->meta_key, $this->get_internal_meta_keys() )
-			&& 0 !== strpos( $meta->meta_key, 'closedpostboxes_' )
-			&& 0 !== strpos( $meta->meta_key, 'metaboxhidden_' )
-			&& 0 !== strpos( $meta->meta_key, 'manageedit-' )
-			&& ! strstr( $meta->meta_key, $wpdb->prefix );
-	 }
+	protected function get_hook_prefix() {
+		return 'woocommerce_get_customer_';
+	}
 
 	/**
 	 * Delete a customer and reassign posts..

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -69,6 +69,16 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		}
 	}
 
+	/**
+	 * Prefix for action and filter hooks on data.
+	 *
+	 * @since  2.7.0
+	 * @return string
+	 */
+	protected function get_hook_prefix() {
+		return 'woocommerce_get_order_item_';
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Getters

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -56,6 +56,16 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 		}
 	}
 
+	/**
+	 * Prefix for action and filter hooks on data.
+	 *
+	 * @since  2.7.0
+	 * @return string
+	 */
+	protected function get_hook_prefix() {
+		return 'woocommerce_get_shipping_zone_';
+	}
+
 	/*
 	 |--------------------------------------------------------------------------
 	 | Getters

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -64,6 +64,21 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 	protected $meta_type = 'user';
 
 	/**
+	 * Callback to remove unwanted meta data.
+	 *
+	 * @param object $meta
+	 * @return bool
+	 */
+	protected function exclude_internal_meta_keys( $meta ) {
+		global $wpdb;
+		return ! in_array( $meta->meta_key, $this->internal_meta_keys )
+			&& 0 !== strpos( $meta->meta_key, 'closedpostboxes_' )
+			&& 0 !== strpos( $meta->meta_key, 'metaboxhidden_' )
+			&& 0 !== strpos( $meta->meta_key, 'manageedit-' )
+			&& ! strstr( $meta->meta_key, $wpdb->prefix );
+	 }
+
+	/**
 	 * Method to create a new customer in the database.
 	 *
 	 * @since 2.7.0


### PR DESCRIPTION
* Makes sure get_hook_prefix is present on all of our classes.
* Fixes up an exclude internal keys call for the customer data store.