### PR TITLE
Use placeholder in new shipping zone UI instead of default string

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -206,7 +206,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	protected function zone_methods_screen( $zone_id ) {
 		if ( 'new' === $zone_id ) {
 			$zone = new WC_Shipping_Zone();
-			$zone->set_zone_name( __( 'New zone', 'woocommerce' ) );
+			$zone->set_zone_name( '' );
 		} else {
 			$zone = WC_Shipping_Zones::get_zone( absint( $zone_id ) );
 		}


### PR DESCRIPTION
'Zone name' was getting pre-filled on the new shipping zone screen, so clicking in wouldn't clear it. This tiny PR fixes that. We have to set it to a blank string for the screen, since WC_Shipping_Zone has its own default too.