### PR TITLE
Reports 12425

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -829,6 +829,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->items[ $items_key ] = $this->get_items( $item->get_type() );
 		}
 
+		// Set parent.
+		$item->set_order_id( $this->get_id() );
+
 		// Append new row with generated temporary ID
 		if ( $item->get_id() ) {
 			$this->items[ $items_key ][ $item->get_id() ] = $item;

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -47,9 +47,6 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_quantity( $value ) {
-		if ( 0 > $value ) {
-			$this->error( 'order_item_product_invalid_quantity', __( 'Quantity must be positive', 'woocommerce' ) );
-		}
 		$this->set_prop( 'quantity', wc_stock_amount( $value ) );
 	}
 

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -174,22 +174,6 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		return is_array( $type ) ? in_array( $this->get_type(), $type ) : $type === $this->get_type();
 	}
 
-	/**
-	 * Save properties specific to this order item.
-	 * @return int Item ID
-	 */
-	public function save() {
-		parent::save();
-
-		if ( $this->data_store ) {
-			$this->data_store->save_item_data( $this );
-		}
-
-		$this->apply_changes();
-
-		return $this->get_id();
-	}
-
 	/*
 	|--------------------------------------------------------------------------
 	| Meta Data Handling

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -26,6 +26,9 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 			'order_id'        => $item->get_order_id(),
 		) );
 		$item->set_id( $wpdb->insert_id );
+		$this->save_item_data( $item );
+		$item->save_meta_data();
+		$item->apply_changes();
 
 		do_action( 'woocommerce_new_order_item', $item->get_id(), $item, $item->get_order_id() );
 	}
@@ -44,6 +47,10 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 			'order_item_type' => $item->get_type(),
 			'order_id'        => $item->get_order_id(),
 		), array( 'order_item_id' => $item->get_id() ) );
+
+		$this->save_item_data( $item );
+		$item->save_meta_data();
+		$item->apply_changes();
 
 		do_action( 'woocommerce_update_order_item', $item->get_id(), $item, $item->get_order_id() );
 	}
@@ -90,4 +97,13 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 		$item->read_meta_data();
 		$item->set_object_read( true );
 	}
+
+	/**
+	 * Saves an item's data to the database / item meta.
+	 * Ran after both create and update, so $item->get_id() will be set.
+	 *
+	 * @since 2.7.0
+	 * @param WC_Order_Item $item
+	 */
+	public function save_item_data( &$item ) {}
 }

--- a/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -57,6 +57,8 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 	 * @since 2.7.0
 	 */
 	protected function update_post_meta( &$refund ) {
+		parent::update_post_meta( $refund );
+
 		$updated_props     = array();
 		$changed_props     = $refund->get_changes();
 		$meta_key_to_props = array(

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -534,7 +534,7 @@ function wc_create_refund( $args = array() ) {
 				}
 
 				if ( is_callable( array( $refunded_item, 'set_quantity' ) ) ) {
-					$refunded_item->set_quantity( $qty );
+					$refunded_item->set_quantity( $qty * -1 );
 				}
 
 				$refund->add_item( $refunded_item );


### PR DESCRIPTION
This tweaks the loop over partial refunds so it adds up correctly, and stops removing shipping from the net sales amount because it’s already removed.

Fixes #12425