### PR TITLE
Set customer role for user if it not a customer on the current blog

### DIFF
--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -403,6 +403,10 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 			$user_data = get_userdata( $customer->get_id() );
 			$this->update_additional_fields_for_object( $user_data, $request );
 
+			if ( ! is_user_member_of_blog( $user_data->ID ) ) {
+				$user_data->add_role( 'customer' );
+			}
+
 			/**
 			 * Fires after a customer is created or updated via the REST API.
 			 *


### PR DESCRIPTION
On Creation of a new user the role 'customer' will be set. But if a user will be updated on a different site the rolle will not be set. 

We need a way to set the role to other sites with the rest api. So the user can use the store correctly where he will be updated over the rest api.