### PR TITLE
[2.7] Add 'id' to WC_Abstract_Legacy_Product::__isset

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -33,6 +33,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	public function __isset( $key ) {
 		return
 			in_array( $key, array_merge( array(
+				'id',
 				'variation_id',
 				'variation_data',
 				'variation_has_stock',


### PR DESCRIPTION
### Issue description

Found a back-compat issue where calling `isset( $product->id )` returns `false`.

Can't think of any other props/methods where this could be an issue, but it might be worth having another look at the list.