### PR TITLE
get_payment_method relies on a more generic DOM element

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -77,7 +77,7 @@ jQuery( function( $ ) {
 			$payment_methods.filter( ':checked' ).eq(0).trigger( 'click' );
 		},
 		get_payment_method: function() {
-			return wc_checkout_form.$order_review.find( 'input[name="payment_method"]:checked' ).val();
+			return wc_checkout_form.$checkout_form.find( 'input[name="payment_method"]:checked' ).val();
 		},
 		payment_method_selected: function() {
 			if ( $( '.payment_methods input.input-radio' ).length > 1 ) {


### PR DESCRIPTION
When checking the payment method, I think it would be better to rely on a more generic DOM element to make sure the find() method will find what it is looking for, in case theme authors have changed the position of things inside the form.

Ive stumble into this because I wanted to display the order review in the top of the page, before the billing form, but I wanted to keep the payment form at the end of the page, so, after changing the order_review DIV position, I did:

```
remove_action( 'woocommerce_checkout_order_review', 'woocommerce_checkout_payment', 20);
add_action( 'woocommerce_checkout_after_customer_details', 'woocommerce_checkout_payment');
```

After I did this, the get_payment_method stopped working.

I might be wrong, but I think this proposal gives more flexibility to theme authors, while not breaking anything. This tweak Ive done dont look really ugly to me, I think I should be able to move things inside the checkout form around.

Thanks for looking into it

cheers