### PR TITLE
[2.7] Wrong use of 'view' context in WC_Product_Variable_Data_Store_CPT:: read_price_data

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -197,9 +197,9 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 				$variation_ids  = $product->get_visible_children();
 				foreach ( $variation_ids as $variation_id ) {
 					if ( $variation = wc_get_product( $variation_id ) ) {
-						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->get_price(), $variation, $product );
-						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price(), $variation, $product );
-						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price(), $variation, $product );
+						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->get_price( 'edit' ), $variation, $product );
+						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price( 'edit' ), $variation, $product );
+						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price( 'edit' ), $variation, $product );
 
 						// Skip empty prices
 						if ( '' === $price ) {


### PR DESCRIPTION
### Issue Description 

In WC 2.7, variation prices in `WC_Product_Variable_Data_Store_CPT:: read_price_data` are fetched using price getters in 'view' context. As a result, the returned prices are filtered.

This is not consistent with WC 2.6 -- the desired behavior here is to fetch the raw, unfiltered prices and then pass them through new filters which operate strictly within the context of caching: `woocommerce_variation_prices_price`, `woocommerce_variation_prices_regular_price` and `woocommerce_variation_prices_sale_price`.

### Proposed Solution

Use an 'edit' (or other, perhaps 'cache') context to prevent these variation prices from being passed through price filters that are used in 'view' context.