### PR TITLE
When saving coupons, return wp_error if necessary

### DIFF
--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -350,6 +350,11 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 	public function save_coupon( $request ) {
 		try {
 			$coupon = $this->prepare_item_for_database( $request );
+
+			if ( is_wp_error( $coupon ) ) {
+				return $coupon;
+			}
+
 			$coupon->save();
 			return $coupon->get_id();
 		} catch ( WC_Data_Exception $e ) {


### PR DESCRIPTION
Exception handling will catch things from WC_Coupon/WC_Data, but `$coupon` can become a `WP_Error` object from `prepare_item_for_database` -- leading to a potential `Call to undefined method WP_Error::save()`.

Tiny PR fixes that.

