### PR TITLE
Filter the template loader files

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -39,7 +39,8 @@ class WC_Template_Loader {
 	 * @return string
 	 */
 	public static function template_loader( $template ) {
-		$find = array( 'woocommerce.php' );
+		$find = apply_filters( 'woocommerce_template_loader_files', array() );
+		$find[] = 'woocommerce.php';
 		$file = '';
 
 		if ( is_embed() ) {


### PR DESCRIPTION
Over at Roots we've been working on implementing Laravel's Blade templating engine with the next release of the Sage theme. The filters for the template hierarchy coming in WP 4.7 are going to be very valuable. Looking to accomplish the same thing with 3rd party plugins as well.

A theme using a templating engine would still be able to filter the default templates such as `archive-product.php`, however keeping the functionality that including a `woocommerce.php` file would be nice to be able to use as well.

This PR I believe adds the ability to add a file similar to `woocommerce.php` while not allowing anyone to filter any of the extra functionality away from Woocommerce.