### PR TITLE
_usort_terms_by_ID is deprecated in Wordpress 4.7

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -228,7 +228,9 @@ function wc_product_post_type_link( $permalink, $post ) {
 	$terms = get_the_terms( $post->ID, 'product_cat' );
 
 	if ( ! empty( $terms ) ) {
-		usort( $terms, '_usort_terms_by_ID' ); // order by ID
+		
+		// _usort_terms_by_ID is deprecated since version 4.7.0! 
+		usort( $terms, 'wp_list_sort' ); // order by ID
 
 		$category_object = apply_filters( 'wc_product_post_type_link_product_cat', $terms[0], $terms, $post );
 		$category_object = get_term( $category_object, 'product_cat' );


### PR DESCRIPTION
Showing error on add or edit product.
**Notice:** _usort_terms_by_ID is **deprecated** since version 4.7.0! Use wp_list_sort instead. in **/var/www/html/wp/wp-includes/functions.php** on line **3783**

`_usort_terms_by_ID` is replaced with `wp_list_sort` since WordPress 4.7 