### PR TITLE
[2.6] API Fixes for 4.7

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -196,6 +196,8 @@ class WC_Admin_Status {
 	 * @return string Version number if found.
 	 */
 	public static function get_latest_theme_version( $theme ) {
+		include_once( ABSPATH . 'wp-admin/includes/theme.php' );
+
 		$api = themes_api( 'theme_information', array(
 			'slug'     => $theme->get_stylesheet(),
 			'fields'   => array(

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -509,7 +509,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 						'properties' => array(
 							'id' => array(
 								'description' => __( 'Meta ID.', 'woocommerce' ),
-								'type'        => 'int',
+								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -502,7 +502,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -504,22 +504,25 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Order meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Meta ID.', 'woocommerce' ),
-							'type'        => 'int',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'key' => array(
-							'description' => __( 'Meta key.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'value' => array(
-							'description' => __( 'Meta value.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'int',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key' => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -502,7 +502,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-customer-downloads-controller.php
+++ b/includes/api/class-wc-rest-customer-downloads-controller.php
@@ -206,7 +206,7 @@ class WC_REST_Customer_Downloads_Controller extends WC_REST_Controller {
 				),
 				'file' => array(
 					'description' => __( 'File details.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'properties' => array(

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -804,7 +804,7 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 						'properties' => array(
 							'id' => array(
 								'description' => __( 'Meta ID.', 'woocommerce' ),
-								'type'        => 'int',
+								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -799,22 +799,25 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 					'description' => __( 'Order meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Meta ID.', 'woocommerce' ),
-							'type'        => 'int',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'key' => array(
-							'description' => __( 'Meta key.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'value' => array(
-							'description' => __( 'Meta value.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'int',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key' => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -676,7 +676,7 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 				),
 				'billing' => array(
 					'description' => __( 'List of billing address data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties' => array(
 						'first_name' => array(
@@ -739,7 +739,7 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 				),
 				'shipping' => array(
 					'description' => __( 'List of shipping address data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties' => array(
 						'first_name' => array(
@@ -797,7 +797,7 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -797,7 +797,7 @@ class WC_REST_Customers_Controller extends WC_REST_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -392,7 +392,7 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Controller {
 	public function get_item_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'tax',
+			'title'      => 'order_note',
 			'type'       => 'object',
 			'properties' => array(
 				'id' => array(

--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -393,7 +393,7 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Controller {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'tax',
-			'type'       => 'order_note',
+			'type'       => 'object',
 			'properties' => array(
 				'id' => array(
 					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -336,22 +336,25 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 					'description' => __( 'Order meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Meta ID.', 'woocommerce' ),
-							'type'        => 'int',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'key' => array(
-							'description' => __( 'Meta key.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'value' => array(
-							'description' => __( 'Meta value.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'int',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key' => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -359,141 +362,153 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Item ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'name' => array(
-							'description' => __( 'Product name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'product_id' => array(
-							'description' => __( 'Product ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'variation_id' => array(
-							'description' => __( 'Variation ID, if applicable.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'quantity' => array(
-							'description' => __( 'Quantity ordered.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'tax_class' => array(
-							'description' => __( 'Tax class of product.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'subtotal' => array(
-							'description' => __( 'Line subtotal (before discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'subtotal_tax' => array(
-							'description' => __( 'Line subtotal tax (before discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'total' => array(
-							'description' => __( 'Line total (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'total_tax' => array(
-							'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'taxes' => array(
-							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Tax rate ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'total' => array(
-									'description' => __( 'Tax total.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'subtotal' => array(
-									'description' => __( 'Tax subtotal.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'Product name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'product_id' => array(
+								'description' => __( 'Product ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'variation_id' => array(
+								'description' => __( 'Variation ID, if applicable.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'quantity' => array(
+								'description' => __( 'Quantity ordered.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_class' => array(
+								'description' => __( 'Tax class of product.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'subtotal' => array(
+								'description' => __( 'Line subtotal (before discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'subtotal_tax' => array(
+								'description' => __( 'Line subtotal tax (before discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'total' => array(
+								'description' => __( 'Line total (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total_tax' => array(
+								'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'taxes' => array(
+								'description' => __( 'Line taxes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Tax rate ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'total' => array(
+											'description' => __( 'Tax total.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'subtotal' => array(
+											'description' => __( 'Tax subtotal.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
-						),
-						'meta_data' => array(
-							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'int',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+							'meta_data' => array(
+								'description' => __( 'Order item meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'int',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
-						),
-						'sku' => array(
-							'description' => __( 'Product SKU.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'price' => array(
-							'description' => __( 'Product price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'meta' => array(
-							'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => array(
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'label' => array(
-									'description' => __( 'Meta label.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
+							'sku' => array(
+								'description' => __( 'Product SKU.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'price' => array(
+								'description' => __( 'Product price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'meta' => array(
+								'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'label' => array(
+											'description' => __( 'Meta label.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+									),
 								),
 							),
 						),

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -334,7 +334,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -357,7 +357,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 				),
 				'line_items' => array(
 					'description' => __( 'Line items data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -415,7 +415,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -438,7 +438,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -473,7 +473,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						),
 						'meta' => array(
 							'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -334,7 +334,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -357,7 +357,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 				),
 				'line_items' => array(
 					'description' => __( 'Line items data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -415,7 +415,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -438,7 +438,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -473,7 +473,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						),
 						'meta' => array(
 							'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -329,7 +329,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 				),
 				'refunded_by' => array(
 					'description' => __( 'User ID of user who created the refund.', 'woocommerce' ),
-					'type'        => 'int',
+					'type'        => 'integer',
 					'context'     => array( 'view' ),
 				),
 				'meta_data' => array(
@@ -341,7 +341,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 						'properties' => array(
 							'id' => array(
 								'description' => __( 'Meta ID.', 'woocommerce' ),
-								'type'        => 'int',
+								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
@@ -453,7 +453,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 									'properties' => array(
 										'id' => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
-											'type'        => 'int',
+											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1062,22 +1062,25 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Order meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Meta ID.', 'woocommerce' ),
-							'type'        => 'int',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'key' => array(
-							'description' => __( 'Meta key.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'value' => array(
-							'description' => __( 'Meta value.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'int',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key' => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -1085,141 +1088,153 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Item ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'name' => array(
-							'description' => __( 'Product name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'product_id' => array(
-							'description' => __( 'Product ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'variation_id' => array(
-							'description' => __( 'Variation ID, if applicable.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'quantity' => array(
-							'description' => __( 'Quantity ordered.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'tax_class' => array(
-							'description' => __( 'Tax class of product.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'subtotal' => array(
-							'description' => __( 'Line subtotal (before discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'subtotal_tax' => array(
-							'description' => __( 'Line subtotal tax (before discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'total' => array(
-							'description' => __( 'Line total (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'total_tax' => array(
-							'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'taxes' => array(
-							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Tax rate ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'total' => array(
-									'description' => __( 'Tax total.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'subtotal' => array(
-									'description' => __( 'Tax subtotal.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'Product name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'product_id' => array(
+								'description' => __( 'Product ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'variation_id' => array(
+								'description' => __( 'Variation ID, if applicable.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'quantity' => array(
+								'description' => __( 'Quantity ordered.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_class' => array(
+								'description' => __( 'Tax class of product.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'subtotal' => array(
+								'description' => __( 'Line subtotal (before discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'subtotal_tax' => array(
+								'description' => __( 'Line subtotal tax (before discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'total' => array(
+								'description' => __( 'Line total (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total_tax' => array(
+								'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'taxes' => array(
+								'description' => __( 'Line taxes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Tax rate ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'total' => array(
+											'description' => __( 'Tax total.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'subtotal' => array(
+											'description' => __( 'Tax subtotal.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
-						),
-						'meta_data' => array(
-							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'int',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+							'meta_data' => array(
+								'description' => __( 'Order item meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'int',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
-						),
-						'sku' => array(
-							'description' => __( 'Product SKU.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'price' => array(
-							'description' => __( 'Product price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'meta' => array(
-							'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => array(
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'label' => array(
-									'description' => __( 'Meta label.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
+							'sku' => array(
+								'description' => __( 'Product SKU.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'price' => array(
+								'description' => __( 'Product price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'meta' => array(
+								'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'label' => array(
+											'description' => __( 'Meta label.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+									),
 								),
 							),
 						),
@@ -1230,69 +1245,75 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Item ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'rate_code' => array(
-							'description' => __( 'Tax rate code.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'rate_id' => array(
-							'description' => __( 'Tax rate ID.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'label' => array(
-							'description' => __( 'Tax rate label.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'compound' => array(
-							'description' => __( 'Show if is a compound tax rate.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'tax_total' => array(
-							'description' => __( 'Tax total (not including shipping taxes).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'shipping_tax_total' => array(
-							'description' => __( 'Shipping tax total.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'meta_data' => array(
-							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'int',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'rate_code' => array(
+								'description' => __( 'Tax rate code.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'rate_id' => array(
+								'description' => __( 'Tax rate ID.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'label' => array(
+								'description' => __( 'Tax rate label.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'compound' => array(
+								'description' => __( 'Show if is a compound tax rate.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'tax_total' => array(
+								'description' => __( 'Tax total (not including shipping taxes).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'shipping_tax_total' => array(
+								'description' => __( 'Shipping tax total.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'meta_data' => array(
+								'description' => __( 'Order item meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'int',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
 						),
@@ -1302,74 +1323,83 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Shipping lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Item ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'method_title' => array(
-							'description' => __( 'Shipping method name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'method_id' => array(
-							'description' => __( 'Shipping method ID.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'total' => array(
-							'description' => __( 'Line total (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'total_tax' => array(
-							'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'taxes' => array(
-							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Tax rate ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'total' => array(
-									'description' => __( 'Tax total.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'method_title' => array(
+								'description' => __( 'Shipping method name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'method_id' => array(
+								'description' => __( 'Shipping method ID.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total' => array(
+								'description' => __( 'Line total (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total_tax' => array(
+								'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'taxes' => array(
+								'description' => __( 'Line taxes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Tax rate ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'total' => array(
+											'description' => __( 'Tax total.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+									),
 								),
 							),
-						),
-						'meta_data' => array(
-							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'int',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+							'meta_data' => array(
+								'description' => __( 'Order item meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'int',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
 						),
@@ -1379,86 +1409,95 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Fee lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Item ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'name' => array(
-							'description' => __( 'Fee name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'tax_class' => array(
-							'description' => __( 'Tax class of fee.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'tax_status' => array(
-							'description' => __( 'Tax status of fee.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'enum'        => array( 'taxable', 'none' ),
-						),
-						'total' => array(
-							'description' => __( 'Line total (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'total_tax' => array(
-							'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'taxes' => array(
-							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Tax rate ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'total' => array(
-									'description' => __( 'Tax total.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'subtotal' => array(
-									'description' => __( 'Tax subtotal.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'Fee name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_class' => array(
+								'description' => __( 'Tax class of fee.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_status' => array(
+								'description' => __( 'Tax status of fee.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'enum'        => array( 'taxable', 'none' ),
+							),
+							'total' => array(
+								'description' => __( 'Line total (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'total_tax' => array(
+								'description' => __( 'Line total tax (after discounts).', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'taxes' => array(
+								'description' => __( 'Line taxes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Tax rate ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'total' => array(
+											'description' => __( 'Tax total.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'subtotal' => array(
+											'description' => __( 'Tax subtotal.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+									),
 								),
 							),
-						),
-						'meta_data' => array(
-							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'int',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+							'meta_data' => array(
+								'description' => __( 'Order item meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'int',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
 						),
@@ -1468,49 +1507,55 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Coupons line data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Item ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'code' => array(
-							'description' => __( 'Coupon code.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'discount' => array(
-							'description' => __( 'Discount total.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'discount_tax' => array(
-							'description' => __( 'Discount total tax.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'meta_data' => array(
-							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Meta ID.', 'woocommerce' ),
-									'type'        => 'int',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'key' => array(
-									'description' => __( 'Meta key.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'value' => array(
-									'description' => __( 'Meta value.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Item ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'code' => array(
+								'description' => __( 'Coupon code.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'discount' => array(
+								'description' => __( 'Discount total.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'discount_tax' => array(
+								'description' => __( 'Discount total tax.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'meta_data' => array(
+								'description' => __( 'Order item meta data.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'Meta ID.', 'woocommerce' ),
+											'type'        => 'int',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'key' => array(
+											'description' => __( 'Meta key.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'value' => array(
+											'description' => __( 'Meta value.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
 						),
@@ -1521,24 +1566,27 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Refund ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'reason' => array(
-							'description' => __( 'Refund reason.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'total' => array(
-							'description' => __( 'Refund total.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Refund ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'reason' => array(
+								'description' => __( 'Refund reason.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'total' => array(
+								'description' => __( 'Refund total.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
 						),
 					),
 				),

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -885,7 +885,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'billing' => array(
 					'description' => __( 'Billing address.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'first_name' => array(
@@ -948,7 +948,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'shipping' => array(
 					'description' => __( 'Shipping address.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'first_name' => array(
@@ -1060,7 +1060,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1083,7 +1083,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'line_items' => array(
 					'description' => __( 'Line items data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1141,7 +1141,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1164,7 +1164,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1199,7 +1199,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta' => array(
 							'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1227,7 +1227,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'tax_lines' => array(
 					'description' => __( 'Tax lines data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => array(
@@ -1275,7 +1275,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1300,7 +1300,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'shipping_lines' => array(
 					'description' => __( 'Shipping lines data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1332,7 +1332,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1352,7 +1352,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1377,7 +1377,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'fee_lines' => array(
 					'description' => __( 'Fee lines data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1415,7 +1415,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1441,7 +1441,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1466,7 +1466,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'coupon_lines' => array(
 					'description' => __( 'Coupons line data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1493,7 +1493,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1518,7 +1518,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'refunds' => array(
 					'description' => __( 'List of refunds.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => array(

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1067,7 +1067,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						'properties' => array(
 							'id' => array(
 								'description' => __( 'Meta ID.', 'woocommerce' ),
-								'type'        => 'int',
+								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
@@ -1179,7 +1179,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 									'properties' => array(
 										'id' => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
-											'type'        => 'int',
+											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),
@@ -1299,7 +1299,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 									'properties' => array(
 										'id' => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
-											'type'        => 'int',
+											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),
@@ -1385,7 +1385,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 									'properties' => array(
 										'id' => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
-											'type'        => 'int',
+											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),
@@ -1483,7 +1483,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 									'properties' => array(
 										'id' => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
-											'type'        => 'int',
+											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),
@@ -1541,7 +1541,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 									'properties' => array(
 										'id' => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
-											'type'        => 'int',
+											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1060,7 +1060,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'meta_data' => array(
 					'description' => __( 'Order meta data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1083,7 +1083,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'line_items' => array(
 					'description' => __( 'Line items data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1141,7 +1141,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1164,7 +1164,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1199,7 +1199,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta' => array(
 							'description' => __( 'Order item meta data (formatted).', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1227,7 +1227,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'tax_lines' => array(
 					'description' => __( 'Tax lines data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => array(
@@ -1275,7 +1275,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1300,7 +1300,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'shipping_lines' => array(
 					'description' => __( 'Shipping lines data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1332,7 +1332,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1352,7 +1352,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1377,7 +1377,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'fee_lines' => array(
 					'description' => __( 'Fee lines data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1415,7 +1415,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'taxes' => array(
 							'description' => __( 'Line taxes.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'properties'  => array(
@@ -1441,7 +1441,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1466,7 +1466,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'coupon_lines' => array(
 					'description' => __( 'Coupons line data.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1493,7 +1493,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 						),
 						'meta_data' => array(
 							'description' => __( 'Order item meta data.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -1518,7 +1518,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 				),
 				'refunds' => array(
 					'description' => __( 'List of refunds.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => array(

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -210,7 +210,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Terms_Controller {
 				),
 				'image' => array(
 					'description' => __( 'Image data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -403,7 +403,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'downloads' => array(
 					'description' => __( 'List of downloadable files.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -492,7 +492,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'dimensions' => array(
 					'description' => __( 'Variation dimensions.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'length' => array(
@@ -528,7 +528,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'image' => array(
 					'description' => __( 'Variation image data.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -573,7 +573,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'attributes' => array(
 					'description' => __( 'List of attributes.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -403,7 +403,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'downloads' => array(
 					'description' => __( 'List of downloadable files.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -573,7 +573,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'attributes' => array(
 					'description' => __( 'List of attributes.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -405,22 +405,25 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'description' => __( 'List of downloadable files.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'File MD5 hash.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'name' => array(
-							'description' => __( 'File name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'file' => array(
-							'description' => __( 'File URL.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'File name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'file' => array(
+								'description' => __( 'File URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -575,21 +578,24 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'description' => __( 'List of attributes.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Attribute ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'name' => array(
-							'description' => __( 'Attribute name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'option' => array(
-							'description' => __( 'Selected attribute term name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'option' => array(
+								'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1860,7 +1860,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'downloads' => array(
 					'description' => __( 'List of downloadable files.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2065,7 +2065,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'categories' => array(
 					'description' => __( 'List of categories.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2089,7 +2089,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'tags' => array(
 					'description' => __( 'List of tags.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2113,7 +2113,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'images' => array(
 					'description' => __( 'List of images.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2158,7 +2158,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'attributes' => array(
 					'description' => __( 'List of attributes.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2197,7 +2197,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'default_attributes' => array(
 					'description' => __( 'Defaults variation attributes.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2219,7 +2219,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'variations' => array(
 					'description' => __( 'List of variations.', 'woocommerce' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2314,7 +2314,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 						),
 						'downloads' => array(
 							'description' => __( 'List of downloadable files.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -2484,7 +2484,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 						),
 						'attributes' => array(
 							'description' => __( 'List of attributes.', 'woocommerce' ),
-							'type'        => 'object',
+							'type'        => 'array',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1862,22 +1862,25 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'List of downloadable files.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'File MD5 hash.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'name' => array(
-							'description' => __( 'File name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'file' => array(
-							'description' => __( 'File URL.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'File name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'file' => array(
+								'description' => __( 'File URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -2067,23 +2070,26 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'List of categories.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Category ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'name' => array(
-							'description' => __( 'Category name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'slug' => array(
-							'description' => __( 'Category slug.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Category ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Category name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'slug' => array(
+								'description' => __( 'Category slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
 						),
 					),
 				),
@@ -2091,23 +2097,26 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'List of tags.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Tag ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'name' => array(
-							'description' => __( 'Tag name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'slug' => array(
-							'description' => __( 'Tag slug.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Tag ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Tag name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'slug' => array(
+								'description' => __( 'Tag slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
 						),
 					),
 				),
@@ -2115,44 +2124,47 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'List of images.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Image ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'date_created' => array(
-							'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
-							'type'        => 'date-time',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'date_modified' => array(
-							'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
-							'type'        => 'date-time',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'src' => array(
-							'description' => __( 'Image URL.', 'woocommerce' ),
-							'type'        => 'string',
-							'format'      => 'uri',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'name' => array(
-							'description' => __( 'Image name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'alt' => array(
-							'description' => __( 'Image alternative text.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'position' => array(
-							'description' => __( 'Image position. 0 means that the image is featured.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Image ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'date_created' => array(
+								'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_modified' => array(
+								'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'src' => array(
+								'description' => __( 'Image URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Image name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'alt' => array(
+								'description' => __( 'Image alternative text.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'position' => array(
+								'description' => __( 'Image position. 0 means that the image is featured.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -2160,38 +2172,41 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'List of attributes.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Attribute ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'name' => array(
-							'description' => __( 'Attribute name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'position' => array(
-							'description' => __( 'Attribute position.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'visible' => array(
-							'description' => __( "Define if the attribute is visible on the \"Additional information\" tab in the product's page.", 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => false,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'variation' => array(
-							'description' => __( 'Define if the attribute can be used as variation.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => false,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'options' => array(
-							'description' => __( 'List of available term names of the attribute.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'position' => array(
+								'description' => __( 'Attribute position.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'visible' => array(
+								'description' => __( "Define if the attribute is visible on the \"Additional information\" tab in the product's page.", 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'variation' => array(
+								'description' => __( 'Define if the attribute can be used as variation.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'options' => array(
+								'description' => __( 'List of available term names of the attribute.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -2199,21 +2214,24 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Defaults variation attributes.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Attribute ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'name' => array(
-							'description' => __( 'Attribute name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'option' => array(
-							'description' => __( 'Selected attribute term name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'option' => array(
+								'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 						),
 					),
 				),
@@ -2221,286 +2239,292 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'List of variations.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
-					'properties'  => array(
-						'id' => array(
-							'description' => __( 'Variation ID.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'date_created' => array(
-							'description' => __( "The date the variation was created, in the site's timezone.", 'woocommerce' ),
-							'type'        => 'date-time',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'date_modified' => array(
-							'description' => __( "The date the variation was last modified, in the site's timezone.", 'woocommerce' ),
-							'type'        => 'date-time',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'permalink' => array(
-							'description' => __( 'Variation URL.', 'woocommerce' ),
-							'type'        => 'string',
-							'format'      => 'uri',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'description' => array(
-							'description' => __( 'Product description.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'sku' => array(
-							'description' => __( 'Unique identifier.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'price' => array(
-							'description' => __( 'Current variation price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'regular_price' => array(
-							'description' => __( 'Variation regular price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'sale_price' => array(
-							'description' => __( 'Variation sale price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'date_on_sale_from' => array(
-							'description' => __( 'Start date of sale price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'date_on_sale_to' => array(
-							'description' => __( 'End data of sale price.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'on_sale' => array(
-							'description' => __( 'Shows if the variation is on sale.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'purchasable' => array(
-							'description' => __( 'Shows if the variation can be bought.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'visible' => array(
-							'description' => __( 'If the variation is visible.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'virtual' => array(
-							'description' => __( 'If the variation is virtual.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => false,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'downloadable' => array(
-							'description' => __( 'If the variation is downloadable.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => false,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'downloads' => array(
-							'description' => __( 'List of downloadable files.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'File MD5 hash.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'name' => array(
-									'description' => __( 'File name.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'file' => array(
-									'description' => __( 'File URL.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id' => array(
+								'description' => __( 'Variation ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_created' => array(
+								'description' => __( "The date the variation was created, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_modified' => array(
+								'description' => __( "The date the variation was last modified, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'permalink' => array(
+								'description' => __( 'Variation URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'description' => array(
+								'description' => __( 'Product description.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'sku' => array(
+								'description' => __( 'Unique identifier.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'price' => array(
+								'description' => __( 'Current variation price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'regular_price' => array(
+								'description' => __( 'Variation regular price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'sale_price' => array(
+								'description' => __( 'Variation sale price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'date_on_sale_from' => array(
+								'description' => __( 'Start date of sale price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'date_on_sale_to' => array(
+								'description' => __( 'End data of sale price.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'on_sale' => array(
+								'description' => __( 'Shows if the variation is on sale.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'purchasable' => array(
+								'description' => __( 'Shows if the variation can be bought.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'visible' => array(
+								'description' => __( 'If the variation is visible.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'virtual' => array(
+								'description' => __( 'If the variation is virtual.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'downloadable' => array(
+								'description' => __( 'If the variation is downloadable.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'downloads' => array(
+								'description' => __( 'List of downloadable files.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id' => array(
+											'description' => __( 'File MD5 hash.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+											'readonly'    => true,
+										),
+										'name' => array(
+											'description' => __( 'File name.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'file' => array(
+											'description' => __( 'File URL.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
 								),
 							),
-						),
-						'download_limit' => array(
-							'description' => __( 'Amount of times the variation can be downloaded.', 'woocommerce' ),
-							'type'        => 'integer',
-							'default'     => null,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'download_expiry' => array(
-							'description' => __( 'Number of days that the customer has up to be able to download the variation.', 'woocommerce' ),
-							'type'        => 'integer',
-							'default'     => null,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'tax_status' => array(
-							'description' => __( 'Tax status.', 'woocommerce' ),
-							'type'        => 'string',
-							'default'     => 'taxable',
-							'enum'        => array( 'taxable', 'shipping', 'none' ),
-							'context'     => array( 'view', 'edit' ),
-						),
-						'tax_class' => array(
-							'description' => __( 'Tax class.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'manage_stock' => array(
-							'description' => __( 'Stock management at variation level.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => false,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'stock_quantity' => array(
-							'description' => __( 'Stock quantity.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'in_stock' => array(
-							'description' => __( 'Controls whether or not the variation is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'default'     => true,
-							'context'     => array( 'view', 'edit' ),
-						),
-						'backorders' => array(
-							'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
-							'type'        => 'string',
-							'default'     => 'no',
-							'enum'        => array( 'no', 'notify', 'yes' ),
-							'context'     => array( 'view', 'edit' ),
-						),
-						'backorders_allowed' => array(
-							'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'backordered' => array(
-							'description' => __( 'Shows if the variation is on backordered.', 'woocommerce' ),
-							'type'        => 'boolean',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'weight' => array(
-							/* translators: %s: weight unit */
-							'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'dimensions' => array(
-							'description' => __( 'Variation dimensions.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'length' => array(
-									/* translators: %s: dimension unit */
-									'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'width' => array(
-									/* translators: %s: dimension unit */
-									'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'height' => array(
-									/* translators: %s: dimension unit */
-									'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+							'download_limit' => array(
+								'description' => __( 'Amount of times the variation can be downloaded.', 'woocommerce' ),
+								'type'        => 'integer',
+								'default'     => null,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'download_expiry' => array(
+								'description' => __( 'Number of days that the customer has up to be able to download the variation.', 'woocommerce' ),
+								'type'        => 'integer',
+								'default'     => null,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_status' => array(
+								'description' => __( 'Tax status.', 'woocommerce' ),
+								'type'        => 'string',
+								'default'     => 'taxable',
+								'enum'        => array( 'taxable', 'shipping', 'none' ),
+								'context'     => array( 'view', 'edit' ),
+							),
+							'tax_class' => array(
+								'description' => __( 'Tax class.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'manage_stock' => array(
+								'description' => __( 'Stock management at variation level.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'stock_quantity' => array(
+								'description' => __( 'Stock quantity.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'in_stock' => array(
+								'description' => __( 'Controls whether or not the variation is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => true,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'backorders' => array(
+								'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
+								'type'        => 'string',
+								'default'     => 'no',
+								'enum'        => array( 'no', 'notify', 'yes' ),
+								'context'     => array( 'view', 'edit' ),
+							),
+							'backorders_allowed' => array(
+								'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'backordered' => array(
+								'description' => __( 'Shows if the variation is on backordered.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'weight' => array(
+								/* translators: %s: weight unit */
+								'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'dimensions' => array(
+								'description' => __( 'Variation dimensions.', 'woocommerce' ),
+								'type'        => 'object',
+								'context'     => array( 'view', 'edit' ),
+								'properties'  => array(
+									'length' => array(
+										/* translators: %s: dimension unit */
+										'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'width' => array(
+										/* translators: %s: dimension unit */
+										'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'height' => array(
+										/* translators: %s: dimension unit */
+										'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
 								),
 							),
-						),
-						'shipping_class' => array(
-							'description' => __( 'Shipping class slug.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-						),
-						'shipping_class_id' => array(
-							'description' => __( 'Shipping class ID.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'image' => array(
-							'description' => __( 'Variation image data.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Image ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'date_created' => array(
-									'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
-									'type'        => 'date-time',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'date_modified' => array(
-									'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
-									'type'        => 'date-time',
-									'context'     => array( 'view', 'edit' ),
-									'readonly'    => true,
-								),
-								'src' => array(
-									'description' => __( 'Image URL.', 'woocommerce' ),
-									'type'        => 'string',
-									'format'      => 'uri',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'name' => array(
-									'description' => __( 'Image name.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'alt' => array(
-									'description' => __( 'Image alternative text.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'position' => array(
-									'description' => __( 'Image position. 0 means that the image is featured.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
+							'shipping_class' => array(
+								'description' => __( 'Shipping class slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'shipping_class_id' => array(
+								'description' => __( 'Shipping class ID.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'image' => array(
+								'description' => __( 'Variation image data.', 'woocommerce' ),
+								'type'        => 'object',
+								'context'     => array( 'view', 'edit' ),
+								'properties'  => array(
+									'id' => array(
+										'description' => __( 'Image ID.', 'woocommerce' ),
+										'type'        => 'integer',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'date_created' => array(
+										'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+										'type'        => 'date-time',
+										'context'     => array( 'view', 'edit' ),
+										'readonly'    => true,
+									),
+									'date_modified' => array(
+										'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+										'type'        => 'date-time',
+										'context'     => array( 'view', 'edit' ),
+										'readonly'    => true,
+									),
+									'src' => array(
+										'description' => __( 'Image URL.', 'woocommerce' ),
+										'type'        => 'string',
+										'format'      => 'uri',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'name' => array(
+										'description' => __( 'Image name.', 'woocommerce' ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'alt' => array(
+										'description' => __( 'Image alternative text.', 'woocommerce' ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'position' => array(
+										'description' => __( 'Image position. 0 means that the image is featured.', 'woocommerce' ),
+										'type'        => 'integer',
+										'context'     => array( 'view', 'edit' ),
+									),
 								),
 							),
-						),
-						'attributes' => array(
-							'description' => __( 'List of attributes.', 'woocommerce' ),
-							'type'        => 'array',
-							'context'     => array( 'view', 'edit' ),
-							'properties'  => array(
-								'id' => array(
-									'description' => __( 'Attribute ID.', 'woocommerce' ),
-									'type'        => 'integer',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'name' => array(
-									'description' => __( 'Attribute name.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
-								),
-								'option' => array(
-									'description' => __( 'Selected attribute term name.', 'woocommerce' ),
-									'type'        => 'string',
-									'context'     => array( 'view', 'edit' ),
+							'attributes' => array(
+								'description' => __( 'List of attributes.', 'woocommerce' ),
+								'type'        => 'array',
+								'context'     => array( 'view', 'edit' ),
+								'properties'  => array(
+									'id' => array(
+										'description' => __( 'Attribute ID.', 'woocommerce' ),
+										'type'        => 'integer',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'name' => array(
+										'description' => __( 'Attribute name.', 'woocommerce' ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'option' => array(
+										'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+										'type'        => 'string',
+										'context'     => array( 'view', 'edit' ),
+									),
 								),
 							),
 						),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1860,7 +1860,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'downloads' => array(
 					'description' => __( 'List of downloadable files.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -1973,7 +1973,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'dimensions' => array(
 					'description' => __( 'Product dimensions.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'length' => array(
@@ -2065,7 +2065,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'categories' => array(
 					'description' => __( 'List of categories.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2089,7 +2089,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'tags' => array(
 					'description' => __( 'List of tags.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2113,7 +2113,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'images' => array(
 					'description' => __( 'List of images.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2158,7 +2158,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'attributes' => array(
 					'description' => __( 'List of attributes.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2197,7 +2197,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'default_attributes' => array(
 					'description' => __( 'Defaults variation attributes.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2219,7 +2219,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				),
 				'variations' => array(
 					'description' => __( 'List of variations.', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'id' => array(
@@ -2314,7 +2314,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 						),
 						'downloads' => array(
 							'description' => __( 'List of downloadable files.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -2403,7 +2403,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 						),
 						'dimensions' => array(
 							'description' => __( 'Variation dimensions.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'length' => array(
@@ -2439,7 +2439,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 						),
 						'image' => array(
 							'description' => __( 'Variation image data.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(
@@ -2484,7 +2484,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 						),
 						'attributes' => array(
 							'description' => __( 'List of attributes.', 'woocommerce' ),
-							'type'        => 'array',
+							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'properties'  => array(
 								'id' => array(

--- a/includes/api/class-wc-rest-shipping-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-methods-controller.php
@@ -38,16 +38,16 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 	 * Register the route for /shipping_methods and /shipping_methods/<method>
 	 */
 	public function register_routes() {
-        register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
-                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'                => $this->get_collection_params(),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
-        register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\w-]+)', array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_item' ),
@@ -60,20 +60,20 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 		) );
 	}
 
-    /**
+	/**
 	 * Check whether a given request has permission to view shipping methods.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-        if ( ! wc_rest_check_manager_permissions( 'shipping_methods', 'read' ) ) {
-        	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		if ( ! wc_rest_check_manager_permissions( 'shipping_methods', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
 
-    /**
+	/**
 	 * Check if a given request has access to read a shipping method.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
@@ -86,7 +86,7 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 		return true;
 	}
 
-    /**
+	/**
 	 * Get shipping methods.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -103,59 +103,59 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 		return rest_ensure_response( $response );
 	}
 
-    /**
-     * Get a single Shipping Method.
-     *
-     * @param WP_REST_Request $request
-     * @return WP_REST_Response|WP_Error
-     */
-    public function get_item( $request ) {
-        $wc_shipping = WC_Shipping::instance();
-        $methods     = $wc_shipping->get_shipping_methods();
-        if ( empty( $methods[ $request['id'] ] ) ) {
-            return new WP_Error( 'woocommerce_rest_shipping_method_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
-        }
+	/**
+	 * Get a single Shipping Method.
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$wc_shipping = WC_Shipping::instance();
+		$methods     = $wc_shipping->get_shipping_methods();
+		if ( empty( $methods[ $request['id'] ] ) ) {
+			return new WP_Error( 'woocommerce_rest_shipping_method_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
 
-        $method   = $methods[ $request['id'] ];
-        $response = $this->prepare_item_for_response( $method, $request );
+		$method   = $methods[ $request['id'] ];
+		$response = $this->prepare_item_for_response( $method, $request );
 
-        return rest_ensure_response( $response );
-    }
+		return rest_ensure_response( $response );
+	}
 
-    /**
-     * Prepare a shipping method for response.
-     *
-     * @param  WC_Shipping_Method $method   Shipping method object.
-     * @param  WP_REST_Request    $request  Request object.
-     * @return WP_REST_Response   $response Response data.
-     */
-    public function prepare_item_for_response( $method, $request ) {
-        $data = array(
-            'id'           => $method->id,
-            'title'        => $method->method_title,
-            'description'  => $method->method_description,
-        );
+	/**
+	 * Prepare a shipping method for response.
+	 *
+	 * @param  WC_Shipping_Method $method   Shipping method object.
+	 * @param  WP_REST_Request    $request  Request object.
+	 * @return WP_REST_Response   $response Response data.
+	 */
+	public function prepare_item_for_response( $method, $request ) {
+		$data = array(
+			'id'           => $method->id,
+			'title'        => $method->method_title,
+			'description'  => $method->method_description,
+		);
 
-        $context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-        $data    = $this->add_additional_fields_to_object( $data, $request );
-        $data    = $this->filter_response_by_context( $data, $context );
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
 
-        // Wrap the data in a response object.
-        $response = rest_ensure_response( $data );
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
 
-        $response->add_links( $this->prepare_links( $method, $request ) );
+		$response->add_links( $this->prepare_links( $method, $request ) );
 
-        /**
-         * Filter shipping methods object returned from the REST API.
-         *
-         * @param WP_REST_Response   $response The response object.
-         * @param WC_Shipping_Method $method   Shipping method object used to create response.
-         * @param WP_REST_Request    $request  Request object.
-         */
-        return apply_filters( 'woocommerce_rest_prepare_shipping_method', $response, $method, $request );
-    }
+		/**
+		 * Filter shipping methods object returned from the REST API.
+		 *
+		 * @param WP_REST_Response   $response The response object.
+		 * @param WC_Shipping_Method $method   Shipping method object used to create response.
+		 * @param WP_REST_Request    $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_shipping_method', $response, $method, $request );
+	}
 
-    /**
+	/**
 	 * Prepare links for the request.
 	 *
 	 * @param WC_Shipping_Method $method Shipping method object.
@@ -175,7 +175,7 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 		return $links;
 	}
 
-    /**
+	/**
 	 * Get the shipping method schema, conforming to JSON Schema.
 	 *
 	 * @return array
@@ -186,21 +186,21 @@ class WC_REST_Shipping_Methods_Controller extends WC_REST_Controller {
 			'title'      => 'shipping_method',
 			'type'       => 'object',
 			'properties' => array(
-                'id' => array(
-                    'description' => __( 'Method ID.', 'woocommerce' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view' ),
-                ),
-                'title' => array(
-                    'description' => __( 'Shipping method title.', 'woocommerce' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view' ),
-                ),
-                'description' => array(
-                    'description' => __( 'Shipping method description.', 'woocommerce' ),
-                    'type'        => 'string',
-                    'context'     => array( 'view' ),
-                ),
+				'id' => array(
+					'description' => __( 'Method ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+				),
+				'title' => array(
+					'description' => __( 'Shipping method title.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+				),
+				'description' => array(
+					'description' => __( 'Shipping method description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+				),
 			),
 		);
 

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -38,31 +38,31 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 	 * Register the route for /system_status
 	 */
 	public function register_routes() {
-        register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
-                'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				'args'                => $this->get_collection_params(),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 	}
 
-    /**
+	/**
 	 * Check whether a given request has permission to view system status.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
 	public function get_items_permissions_check( $request ) {
-        if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
-        	return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
 
-    /**
+	/**
 	 * Get a system status info, by section.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -74,19 +74,19 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		$response  = array();
 
 		foreach ( $mappings as $section => $values ) {
-			settype( $values, $schema['properties'][ $section ]['type'] );
 			foreach ( $values as $key => $value ) {
 				if ( isset( $schema['properties'][ $section ]['properties'][ $key ]['type'] ) ) {
 					settype( $values[ $key ], $schema['properties'][ $section ]['properties'][ $key ]['type'] );
 				}
 			}
+			settype( $values, $schema['properties'][ $section ]['type'] );
 			$response[ $section ] = $values;
 		}
 
 		return rest_ensure_response( $response );
 	}
 
-    /**
+	/**
 	 * Get the system status schema, conforming to JSON Schema.
 	 *
 	 * @return array
@@ -99,96 +99,96 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			'properties' => array(
 				'environment' => array(
 					'description' => __( 'Environment', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'home_url' => array(
 							'description' => __( 'Home URL', 'woocommerce' ),
 							'type'        => 'string',
-		                    'format'      => 'uri',
+							'format'      => 'uri',
 							'context'     => array( 'view', 'edit' ),
 						),
-		                'site_url' => array(
-		                    'description' => __( 'Site URL', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'format'      => 'uri',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'wc_version' => array(
-		                    'description' => __( 'WooCommerce version', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'log_directory' => array(
-		                    'description' => __( 'Log directory', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'log_directory_writable' => array(
-		                    'description' => __( 'Is log directory writable?', 'woocommerce' ),
-		                    'type'        => 'boolean',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'wp_version' => array(
-		                    'description' => __( 'WordPress version', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'wp_multisite' => array(
-		                    'description' => __( 'Is WordPress multisite?', 'woocommerce' ),
-		                    'type'        => 'boolean',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'wp_memory_limit' => array(
-		                    'description' => __( 'WordPress memory limit', 'woocommerce' ),
-		                    'type'        => 'integer',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'wp_debug_mode' => array(
-		                    'description' => __( 'Is WordPress debug mode active?', 'woocommerce' ),
-		                    'type'        => 'boolean',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'wp_cron' => array(
-		                    'description' => __( 'Are WordPress cron jobs enabled?', 'woocommerce' ),
-		                    'type'        => 'boolean',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'language' => array(
-		                    'description' => __( 'WordPress language', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'server_info' => array(
-		                    'description' => __( 'Server info', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'php_version' => array(
-		                    'description' => __( 'PHP version', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'php_post_max_size' => array(
-		                    'description' => __( 'PHP post max size', 'woocommerce' ),
-		                    'type'        => 'integer',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'php_max_execution_time' => array(
-		                    'description' => __( 'PHP max execution time', 'woocommerce' ),
-		                    'type'        => 'integer',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'php_max_input_vars' => array(
-		                    'description' => __( 'PHP max input vars', 'woocommerce' ),
-		                    'type'        => 'integer',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
-		                'curl_version' => array(
-		                    'description' => __( 'cURL version', 'woocommerce' ),
-		                    'type'        => 'string',
-		                    'context'     => array( 'view', 'edit' ),
-		                ),
+						'site_url' => array(
+							'description' => __( 'Site URL', 'woocommerce' ),
+							'type'        => 'string',
+							'format'      => 'uri',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'wc_version' => array(
+							'description' => __( 'WooCommerce version', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'log_directory' => array(
+							'description' => __( 'Log directory', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'log_directory_writable' => array(
+							'description' => __( 'Is log directory writable?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'wp_version' => array(
+							'description' => __( 'WordPress version', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'wp_multisite' => array(
+							'description' => __( 'Is WordPress multisite?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'wp_memory_limit' => array(
+							'description' => __( 'WordPress memory limit', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'wp_debug_mode' => array(
+							'description' => __( 'Is WordPress debug mode active?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'wp_cron' => array(
+							'description' => __( 'Are WordPress cron jobs enabled?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'language' => array(
+							'description' => __( 'WordPress language', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'server_info' => array(
+							'description' => __( 'Server info', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'php_version' => array(
+							'description' => __( 'PHP version', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'php_post_max_size' => array(
+							'description' => __( 'PHP post max size', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'php_max_execution_time' => array(
+							'description' => __( 'PHP max execution time', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'php_max_input_vars' => array(
+							'description' => __( 'PHP max input vars', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'curl_version' => array(
+							'description' => __( 'cURL version', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
 						'suhosin_installed' => array(
 							'description' => __( 'Is SUHOSIN installed?', 'woocommerce' ),
 							'type'        => 'boolean',
@@ -258,7 +258,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				),
 				'database' => array(
 					'description' => __( 'Database', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'wc_database_version' => array(
@@ -290,7 +290,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				),
 				'theme' => array(
 					'description' => __( 'Theme', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'name' => array(
@@ -359,7 +359,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				),
 				'settings' => array(
 					'description' => __( 'Settings', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'api_enabled' => array(
@@ -416,7 +416,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				),
 				'security' => array(
 					'description' => __( 'Security', 'woocommerce' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'secure_connection' => array(
@@ -442,7 +442,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		return $this->add_additional_fields_schema( $schema );
 	}
 
-    /**
+	/**
 	 * Return an array of sections and the data associated with each.
 	 *
 	 * @return array
@@ -471,15 +471,15 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		// Figure out cURL version, if installed.
 		$curl_version = '';
 		if ( function_exists( 'curl_version' ) ) {
-            $curl_version = curl_version();
-            $curl_version = $curl_version['version'] . ', ' . $curl_version['ssl_version'];
-        }
+			$curl_version = curl_version();
+			$curl_version = $curl_version['version'] . ', ' . $curl_version['ssl_version'];
+		}
 
 		// WP memory limit
-        $wp_memory_limit = wc_let_to_num( WP_MEMORY_LIMIT );
-        if ( function_exists( 'memory_get_usage' ) ) {
-            $wp_memory_limit = max( $wp_memory_limit, wc_let_to_num( @ini_get( 'memory_limit' ) ) );
-        }
+		$wp_memory_limit = wc_let_to_num( WP_MEMORY_LIMIT );
+		if ( function_exists( 'memory_get_usage' ) ) {
+			$wp_memory_limit = max( $wp_memory_limit, wc_let_to_num( @ini_get( 'memory_limit' ) ) );
+		}
 
 		// Test POST requests
 		$post_response = wp_safe_remote_post( 'https://www.paypal.com/cgi-bin/webscr', array(
@@ -504,23 +504,23 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 
 		// Return all environment info. Described by JSON Schema.
 		return array(
-            'home_url'                  => get_option( 'home' ),
-            'site_url'                  => get_option( 'siteurl' ),
-            'version'                => WC()->version,
-            'log_directory'             => WC_LOG_DIR,
-            'log_directory_writable'    => ( @fopen( WC_LOG_DIR . 'test-log.log', 'a' ) ? true : false ),
-            'wp_version'                => get_bloginfo( 'version' ),
-            'wp_multisite'              => is_multisite(),
-            'wp_memory_limit'           => $wp_memory_limit,
-            'wp_debug_mode'             => ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
-            'wp_cron'                   => ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ),
-            'language'                  => get_locale(),
-            'server_info'               => $_SERVER['SERVER_SOFTWARE'],
-            'php_version'               => phpversion(),
-            'php_post_max_size'         => wc_let_to_num( ini_get( 'post_max_size' ) ),
-            'php_max_execution_time'    => ini_get( 'max_execution_time' ),
-            'php_max_input_vars'        => ini_get( 'max_input_vars' ),
-            'curl_version'              => $curl_version,
+			'home_url'                  => get_option( 'home' ),
+			'site_url'                  => get_option( 'siteurl' ),
+			'version'                => WC()->version,
+			'log_directory'             => WC_LOG_DIR,
+			'log_directory_writable'    => ( @fopen( WC_LOG_DIR . 'test-log.log', 'a' ) ? true : false ),
+			'wp_version'                => get_bloginfo( 'version' ),
+			'wp_multisite'              => is_multisite(),
+			'wp_memory_limit'           => $wp_memory_limit,
+			'wp_debug_mode'             => ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
+			'wp_cron'                   => ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ),
+			'language'                  => get_locale(),
+			'server_info'               => $_SERVER['SERVER_SOFTWARE'],
+			'php_version'               => phpversion(),
+			'php_post_max_size'         => wc_let_to_num( ini_get( 'post_max_size' ) ),
+			'php_max_execution_time'    => ini_get( 'max_execution_time' ),
+			'php_max_input_vars'        => ini_get( 'max_input_vars' ),
+			'curl_version'              => $curl_version,
 			'suhosin_installed'         => extension_loaded( 'suhosin' ),
 			'max_upload_size'           => wp_max_upload_size(),
 			'mysql_version'             => ( ! empty( $wpdb->is_mysql ) ? $wpdb->db_version() : '' ),
@@ -534,7 +534,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			'remote_post_response'      => ( is_wp_error( $post_response ) ? $post_response->get_error_message() : $post_response['response']['code'] ),
 			'remote_get_successful'     => $get_response_successful,
 			'remote_get_response'       => ( is_wp_error( $get_response ) ? $get_response->get_error_message() : $get_response['response']['code'] ),
-        );
+		);
 	}
 
 	/**

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -6,156 +6,156 @@
  */
 class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
-    /**
-     * Setup our test server.
-     */
-    public function setUp() {
-        parent::setUp();
-        $this->endpoint = new WC_REST_System_Status_Controller();
-        $this->user = $this->factory->user->create( array(
-            'role' => 'administrator',
-        ) );
-    }
+	/**
+	 * Setup our test server.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->endpoint = new WC_REST_System_Status_Controller();
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+	}
 
-    /**
-     * Test route registration.
-     */
-    public function test_register_routes() {
-        $routes = $this->server->get_routes();
-        $this->assertArrayHasKey( '/wc/v1/system_status', $routes );
-        $this->assertArrayHasKey( '/wc/v1/system_status/tools', $routes );
-        $this->assertArrayHasKey( '/wc/v1/system_status/tools/(?P<id>[\w-]+)', $routes );
-    }
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/v1/system_status', $routes );
+		$this->assertArrayHasKey( '/wc/v1/system_status/tools', $routes );
+		$this->assertArrayHasKey( '/wc/v1/system_status/tools/(?P<id>[\w-]+)', $routes );
+	}
 
-    /**
-     * Test to make sure system status cannot be accessed without valid creds
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_without_permission() {
-        wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $this->assertEquals( 401, $response->get_status() );
-    }
+	/**
+	 * Test to make sure system status cannot be accessed without valid creds
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
 
-    /**
-     * Test to make sure root properties are present.
-     * (environment, theme, database, etc).
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_returns_root_properties() {
-        wp_set_current_user( $this->user );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $data = $response->get_data();
+	/**
+	 * Test to make sure root properties are present.
+	 * (environment, theme, database, etc).
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_returns_root_properties() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$data = $response->get_data();
 
-        $this->assertArrayHasKey( 'environment', $data );
-        $this->assertArrayHasKey( 'database', $data );
-        $this->assertArrayHasKey( 'active_plugins', $data );
-        $this->assertArrayHasKey( 'theme', $data );
-        $this->assertArrayHasKey( 'settings', $data );
-        $this->assertArrayHasKey( 'security', $data );
-        $this->assertArrayHasKey( 'pages', $data );
-    }
+		$this->assertArrayHasKey( 'environment', $data );
+		$this->assertArrayHasKey( 'database', $data );
+		$this->assertArrayHasKey( 'active_plugins', $data );
+		$this->assertArrayHasKey( 'theme', $data );
+		$this->assertArrayHasKey( 'settings', $data );
+		$this->assertArrayHasKey( 'security', $data );
+		$this->assertArrayHasKey( 'pages', $data );
+	}
 
-    /**
-     * Test to make sure environment response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_environment() {
-        wp_set_current_user( $this->user );
-        $response    = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $data        = $response->get_data();
-        $environment = $data['environment'];
+	/**
+	 * Test to make sure environment response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_environment() {
+		wp_set_current_user( $this->user );
+		$response    = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$data        = $response->get_data();
+		$environment = (array) $data['environment'];
 
-        // Make sure all expected data is present
-        $this->assertEquals( 30, count( $environment ) );
+		// Make sure all expected data is present
+		$this->assertEquals( 30, count( $environment ) );
 
-        // Test some responses to make sure they match up
-        $this->assertEquals( get_option( 'home' ), $environment['home_url'] );
-        $this->assertEquals( get_option( 'siteurl' ), $environment['site_url'] );
-        $this->assertEquals( WC()->version, $environment['version'] );
-    }
+		// Test some responses to make sure they match up
+		$this->assertEquals( get_option( 'home' ), $environment['home_url'] );
+		$this->assertEquals( get_option( 'siteurl' ), $environment['site_url'] );
+		$this->assertEquals( WC()->version, $environment['version'] );
+	}
 
-    /**
-     * Test to make sure database response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_database() {
-        global $wpdb;
-        wp_set_current_user( $this->user );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $data     = $response->get_data();
-        $database = $data['database'];
+	/**
+	 * Test to make sure database response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_database() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$data     = $response->get_data();
+		$database = (array) $data['database'];
 
-        $this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
-        $this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
-        $this->assertEquals( WC_Geolocation::get_local_database_path(), $database['maxmind_geoip_database'] );
-        $this->assertArrayHasKey( 'woocommerce_payment_tokens', $database['database_tables'] );
-    }
+		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
+		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
+		$this->assertEquals( WC_Geolocation::get_local_database_path(), $database['maxmind_geoip_database'] );
+		$this->assertArrayHasKey( 'woocommerce_payment_tokens', $database['database_tables'] );
+	}
 
-    /**
-     * Test to make sure active plugins response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_active_plugins() {
-        wp_set_current_user( $this->user );
+	/**
+	 * Test to make sure active plugins response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_active_plugins() {
+		wp_set_current_user( $this->user );
 
-        $actual_plugins = array( 'hello.php' );
-        update_option( 'active_plugins', $actual_plugins );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        update_option( 'active_plugins', array() );
+		$actual_plugins = array( 'hello.php' );
+		update_option( 'active_plugins', $actual_plugins );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		update_option( 'active_plugins', array() );
 
-        $data    = $response->get_data();
-        $plugins = $data['active_plugins'];
+		$data    = $response->get_data();
+		$plugins = (array) $data['active_plugins'];
 
-        $this->assertEquals( 1, count( $plugins ) );
-        $this->assertEquals( 'Hello Dolly', $plugins[0]['name'] );
-    }
+		$this->assertEquals( 1, count( $plugins ) );
+		$this->assertEquals( 'Hello Dolly', $plugins[0]['name'] );
+	}
 
-    /**
-     * Test to make sure theme response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_theme() {
-        wp_set_current_user( $this->user );
-    	$active_theme = wp_get_theme();
+	/**
+	 * Test to make sure theme response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_theme() {
+		wp_set_current_user( $this->user );
+		$active_theme = wp_get_theme();
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $data     = $response->get_data();
-        $theme    = $data['theme'];
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$data     = $response->get_data();
+		$theme    = (array) $data['theme'];
 
-        $this->assertEquals( 13, count( $theme ) );
-        $this->assertEquals( $active_theme->Name, $theme['name'] );
-    }
+		$this->assertEquals( 13, count( $theme ) );
+		$this->assertEquals( $active_theme->Name, $theme['name'] );
+	}
 
-    /**
-     * Test to make sure settings response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_settings() {
-        wp_set_current_user( $this->user );
+	/**
+	 * Test to make sure settings response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_settings() {
+		wp_set_current_user( $this->user );
 
-        $term_response = array();
-        $terms         = get_terms( 'product_type', array( 'hide_empty' => 0 ) );
-        foreach ( $terms as $term ) {
-            $term_response[ $term->slug ] = strtolower( $term->name );
-        }
+		$term_response = array();
+		$terms         = get_terms( 'product_type', array( 'hide_empty' => 0 ) );
+		foreach ( $terms as $term ) {
+			$term_response[ $term->slug ] = strtolower( $term->name );
+		}
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $data     = $response->get_data();
-        $settings = $data['settings'];
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$data     = $response->get_data();
+		$settings = (array) $data['settings'];
 
-        $this->assertEquals( 10, count( $settings ) );
-        $this->assertEquals( ( 'yes' === get_option( 'woocommerce_api_enabled' ) ), $settings['api_enabled'] );
-        $this->assertEquals( get_woocommerce_currency(), $settings['currency'] );
-        $this->assertEquals( $term_response, $settings['taxonomies'] );
-    }
+		$this->assertEquals( 10, count( $settings ) );
+		$this->assertEquals( ( 'yes' === get_option( 'woocommerce_api_enabled' ) ), $settings['api_enabled'] );
+		$this->assertEquals( get_woocommerce_currency(), $settings['currency'] );
+		$this->assertEquals( $term_response, $settings['taxonomies'] );
+	}
 
 	/**
 	 * Test to make sure security response is correct.
@@ -167,62 +167,62 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
 		$data     = $response->get_data();
-		$settings = $data['security'];
+		$settings = (array) $data['security'];
 
 		$this->assertEquals( 2, count( $settings ) );
 		$this->assertEquals( 'https' === substr( get_permalink( wc_get_page_id( 'shop' ) ), 0, 5 ), $settings['secure_connection'] );
 		$this->assertEquals( ! ( defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG && WP_DEBUG_DISPLAY ) || 0 === intval( ini_get( 'display_errors' ) ), $settings['hide_errors'] );
 	}
 
-    /**
-     * Test to make sure pages response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_info_pages() {
-        wp_set_current_user( $this->user );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
-        $data     = $response->get_data();
-        $pages = $data['pages'];
-        $this->assertEquals( 4, count( $pages ) );
-    }
+	/**
+	 * Test to make sure pages response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_info_pages() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status' ) );
+		$data     = $response->get_data();
+		$pages    = $data['pages'];
+		$this->assertEquals( 4, count( $pages ) );
+	}
 
-    /**
-     * Test system status schema.
-     *
-     * @since 2.7.0
-     */
-    public function test_system_status_schema() {
-        $request = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status' );
-        $response = $this->server->dispatch( $request );
-        $data = $response->get_data();
-        $properties = $data['schema']['properties'];
-        $this->assertEquals( 7, count( $properties ) );
-        $this->assertArrayHasKey( 'environment', $properties );
-        $this->assertArrayHasKey( 'database', $properties );
-        $this->assertArrayHasKey( 'active_plugins', $properties );
-        $this->assertArrayHasKey( 'theme', $properties );
-        $this->assertArrayHasKey( 'settings', $properties );
-        $this->assertArrayHasKey( 'security', $properties );
-        $this->assertArrayHasKey( 'pages', $properties );
-    }
+	/**
+	 * Test system status schema.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_system_status_schema() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+		$this->assertEquals( 7, count( $properties ) );
+		$this->assertArrayHasKey( 'environment', $properties );
+		$this->assertArrayHasKey( 'database', $properties );
+		$this->assertArrayHasKey( 'active_plugins', $properties );
+		$this->assertArrayHasKey( 'theme', $properties );
+		$this->assertArrayHasKey( 'settings', $properties );
+		$this->assertArrayHasKey( 'security', $properties );
+		$this->assertArrayHasKey( 'pages', $properties );
+	}
 
-    /**
-     * Test to make sure get_items (all tools) response is correct.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_tools() {
-        wp_set_current_user( $this->user );
+	/**
+	 * Test to make sure get_items (all tools) response is correct.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_tools() {
+		wp_set_current_user( $this->user );
 
-        $tools_controller = new WC_REST_System_Status_Tools_Controller;
-        $raw_tools        = $tools_controller->get_tools();
+		$tools_controller = new WC_REST_System_Status_Tools_Controller;
+		$raw_tools        = $tools_controller->get_tools();
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools' ) );
-        $data     = $response->get_data();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools' ) );
+		$data     = $response->get_data();
 
-        $this->assertEquals( 200, $response->get_status() );
-        $this->assertEquals( count( $raw_tools ), count( $data ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( count( $raw_tools ), count( $data ) );
 
 		$this->assertContains( array(
 			'id'          => 'reset_tracking',
@@ -238,105 +238,105 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 				),
 			),
 		), $data );
-    }
+	}
 
-    /**
-     * Test to make sure system status tools cannot be accessed without valid creds
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_tools_without_permission() {
-        wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools' ) );
-        $this->assertEquals( 401, $response->get_status() );
-    }
+	/**
+	 * Test to make sure system status tools cannot be accessed without valid creds
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_tools_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
 
-    /**
-     * Test to make sure we can load a single tool correctly.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_tool() {
-        wp_set_current_user( $this->user );
+	/**
+	 * Test to make sure we can load a single tool correctly.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_tool() {
+		wp_set_current_user( $this->user );
 
-        $tools_controller = new WC_REST_System_Status_Tools_Controller;
-        $raw_tools        = $tools_controller->get_tools();
-        $raw_tool         = $raw_tools['recount_terms'];
+		$tools_controller = new WC_REST_System_Status_Tools_Controller;
+		$raw_tools        = $tools_controller->get_tools();
+		$raw_tool         = $raw_tools['recount_terms'];
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools/recount_terms' ) );
-        $data     = $response->get_data();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools/recount_terms' ) );
+		$data     = $response->get_data();
 
-        $this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 200, $response->get_status() );
 
-        $this->assertEquals( 'recount_terms', $data['id'] );
-        $this->assertEquals( 'Term counts', $data['name'] );
-        $this->assertEquals( 'Recount terms', $data['action'] );
-        $this->assertEquals( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', $data['description'] );
-    }
+		$this->assertEquals( 'recount_terms', $data['id'] );
+		$this->assertEquals( 'Term counts', $data['name'] );
+		$this->assertEquals( 'Recount terms', $data['action'] );
+		$this->assertEquals( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', $data['description'] );
+	}
 
-    /**
-     * Test to make sure a single system status toolscannot be accessed without valid creds.
-     *
-     * @since 2.7.0
-     */
-    public function test_get_system_status_tool_without_permission() {
-        wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools/recount_terms' ) );
-        $this->assertEquals( 401, $response->get_status() );
-    }
+	/**
+	 * Test to make sure a single system status toolscannot be accessed without valid creds.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_get_system_status_tool_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v1/system_status/tools/recount_terms' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
 
-    /**
-     * Test to make sure we can RUN a tool correctly.
-     *
-     * @since 2.7.0
-     */
-    public function test_execute_system_tool() {
-        wp_set_current_user( $this->user );
+	/**
+	 * Test to make sure we can RUN a tool correctly.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_execute_system_tool() {
+		wp_set_current_user( $this->user );
 
-        $tools_controller = new WC_REST_System_Status_Tools_Controller;
-        $raw_tools        = $tools_controller->get_tools();
-        $raw_tool         = $raw_tools['recount_terms'];
+		$tools_controller = new WC_REST_System_Status_Tools_Controller;
+		$raw_tools        = $tools_controller->get_tools();
+		$raw_tool         = $raw_tools['recount_terms'];
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/recount_terms' ) );
-        $data     = $response->get_data();
+		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/recount_terms' ) );
+		$data     = $response->get_data();
 
-        $this->assertEquals( 'recount_terms', $data['id'] );
-        $this->assertEquals( 'Term counts', $data['name'] );
-        $this->assertEquals( 'Recount terms', $data['action'] );
-        $this->assertEquals( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', $data['description'] );
-        $this->assertTrue( $data['success'] );
+		$this->assertEquals( 'recount_terms', $data['id'] );
+		$this->assertEquals( 'Term counts', $data['name'] );
+		$this->assertEquals( 'Recount terms', $data['action'] );
+		$this->assertEquals( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', $data['description'] );
+		$this->assertTrue( $data['success'] );
 
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/not_a_real_tool' ) );
-        $this->assertEquals( 404, $response->get_status() );
-    }
+		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/not_a_real_tool' ) );
+		$this->assertEquals( 404, $response->get_status() );
+	}
 
-    /**
-     * Test to make sure a tool cannot be run without valid creds.
-     *
-     * @since 2.7.0
-     */
-    public function test_execute_system_status_tool_without_permission() {
-        wp_set_current_user( 0 );
-        $response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/recount_terms' ) );
-        $this->assertEquals( 401, $response->get_status() );
-    }
+	/**
+	 * Test to make sure a tool cannot be run without valid creds.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_execute_system_status_tool_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v1/system_status/tools/recount_terms' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
 
-    /**
-     * Test system status schema.
-     *
-     * @since 2.7.0
-     */
-    public function test_system_status_tool_schema() {
-        $request = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status/tools' );
-        $response = $this->server->dispatch( $request );
-        $data = $response->get_data();
-        $properties = $data['schema']['properties'];
-        $this->assertEquals( 6, count( $properties ) );
-        $this->assertArrayHasKey( 'id', $properties );
-        $this->assertArrayHasKey( 'name', $properties );
-        $this->assertArrayHasKey( 'action', $properties );
-        $this->assertArrayHasKey( 'description', $properties );
-        $this->assertArrayHasKey( 'success', $properties );
-        $this->assertArrayHasKey( 'message', $properties );
-    }
+	/**
+	 * Test system status schema.
+	 *
+	 * @since 2.7.0
+	 */
+	public function test_system_status_tool_schema() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status/tools' );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$properties = $data['schema']['properties'];
+		$this->assertEquals( 6, count( $properties ) );
+		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'action', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
+		$this->assertArrayHasKey( 'success', $properties );
+		$this->assertArrayHasKey( 'message', $properties );
+	}
 }


### PR DESCRIPTION
Travis is reporting errors due to no ‘items’ being present in our array definitions in the API.

This converts to OBJECT and fixes tests. Tested some endpoints and it works.

Tests pass locally.

Fixes #12532