### PR TITLE
WooCommerce CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,13 @@ Thumbs.db
 # ApiGen
 /wc-apidocs/
 
+# Behat/CLI Tests
+tests/cli/installer
+tests/cli/composer.phar
+tests/cli/composer.lock
+tests/cli/composer.json
+tests/cli/vendor
+
 # Unit tests
 /tmp
 /tests/bin/tmp

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -212,6 +212,7 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 		}
 
 		// Refunds.
+		$data['refunds'] = array();
 		foreach ( $order->get_refunds() as $refund ) {
 			$data['refunds'][] = array(
 				'id'     => $refund->get_id(),

--- a/includes/class-wc-cli.php
+++ b/includes/class-wc-cli.php
@@ -1,6 +1,34 @@
 <?php
 /**
- * Deprecated. No longer needed.
+ * Enables WooCommerce, via the the command line.
  *
+ * @version	2.7.0
  * @package WooCommerce
+ * @author  WooCommerce
  */
+class WC_CLI {
+	/**
+	 * Load required files and hooks to make the CLI work.
+	 */
+	public function __construct() {
+		$this->includes();
+		$this->hooks();
+	}
+
+	/**
+	 * Load command files.
+	 */
+	private function includes() {
+		require_once __DIR__ . '/cli/class-wc-cli-runner.php';
+		require_once __DIR__ . '/cli/class-wc-cli-rest-command.php';
+		require_once __DIR__ . '/cli/class-wc-cli-tool-command.php';
+	}
+
+	/**
+	 * Sets up and hooks WP CLI to our CLI code.
+	 */
+	private function hooks() {
+		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Runner::after_wp_load' );
+		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tool_Command::register_tool_commands' );
+	}
+}

--- a/includes/class-wc-cli.php
+++ b/includes/class-wc-cli.php
@@ -2,7 +2,7 @@
 /**
  * Enables WooCommerce, via the the command line.
  *
- * @version	2.7.0
+ * @version 2.7.0
  * @package WooCommerce
  * @author  WooCommerce
  */

--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -1,0 +1,422 @@
+<?php
+/**
+ * Main Command for WooCommere CLI.
+ *
+ * Since a lot of WC operations can be handled via the REST API, we base our CLI
+ * off of Restful to generate commands for each WooCommerce REST API endpoint
+ * so most of the logic is shared.
+ *
+ *
+ * @version	2.7.0
+ * @package WooCommerce
+ * @author  WooCommerce
+ */
+class WC_CLI_REST_Command {
+	/**
+	 * Endpoints that have a parent ID.
+	 * Ex: Product reviews, which has a product ID and a review ID.
+	 */
+	protected $routes_with_parent_id = array(
+		'customer_download',
+		'product_review',
+		'order_note',
+		'shop_order_refund',
+	);
+
+	/**
+	 * Name of command/endpoint object.
+	 */
+	private $name;
+
+	/**
+	 * Endpoint route.
+	 */
+	private $route;
+
+	/**
+	 * Main resource ID.
+	 */
+	private $resource_identifier;
+
+	/**
+	 * Schema for command.
+	 */
+	private $schema;
+
+	/**
+	 * Nesting level.
+	 */
+	private $output_nesting_level = 0;
+
+	/**
+	 * Sets up REST Command.
+	 *
+	 * @param string $name   Name of endpoint object (comes from schema)
+	 * @param string $route  Path to route of this endpoint
+	 * @param array  $schema Schema object
+	 */
+	public function __construct( $name, $route, $schema ) {
+		$this->name   = $name;
+		$parsed_args  = preg_match_all( '#\([^\)]+\)#', $route, $matches );
+		$first_match  = $matches[0];
+		$resource_id  = ! empty( $matches[0] ) ? array_pop( $matches[0] ) : null;
+		$this->route  = rtrim( $route );
+		$this->schema = $schema;
+
+		$this->resource_identifier = $resource_id;
+		if ( in_array( $name, $this->routes_with_parent_id ) ) {
+			$is_singular = $resource_id === substr( $this->route, - strlen( $resource_id ) );
+			if ( ! $is_singular ) {
+				$this->resource_identifier = $first_match[0];
+			}
+		}
+	}
+
+	/**
+	 * Create a new item.
+	 *
+	 * @subcommand create
+	 */
+	public function create_item( $args, $assoc_args ) {
+		$assoc_args = self::decode_json( $assoc_args );
+		list( $status, $body ) = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+			WP_CLI::line( $body['id'] );
+		} else {
+			WP_CLI::success( "Created {$this->name} {$body['id']}." );
+		}
+	}
+
+	/**
+	 * Delete an existing item.
+	 *
+	 * @subcommand delete
+	 */
+	public function delete_item( $args, $assoc_args ) {
+		list( $status, $body ) = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+			WP_CLI::line( $body['id'] );
+		} else {
+			if ( empty( $assoc_args['force'] ) ) {
+				WP_CLI::success( __( 'Trashed', 'woocommerce' ) . " {$this->name} {$body['id']}" );
+			} else {
+				WP_CLI::success( __( 'Deleted', 'woocommerce' ) . " {$this->name} {$body['id']}." );
+			}
+		}
+	}
+
+	/**
+	 * Get a single item.
+	 *
+	 * @subcommand get
+	 */
+	public function get_item( $args, $assoc_args ) {
+		$route = $this->get_filled_route( $args );
+		list( $status, $body, $headers ) = $this->do_request( 'GET', $route, $assoc_args );
+
+		if ( ! empty( $assoc_args['fields'] ) ) {
+			$body = self::limit_item_to_fields( $body, $fields );
+		}
+
+		if ( 'headers' === $assoc_args['format'] ) {
+			echo json_encode( $headers );
+		} elseif ( 'body' === $assoc_args['format'] ) {
+			echo json_encode( $body );
+		} elseif ( 'envelope' === $assoc_args['format'] ) {
+			echo json_encode( array(
+				'body'    => $body,
+				'headers' => $headers,
+				'status'  => $status,
+			) );
+		} else {
+			$formatter = $this->get_formatter( $assoc_args );
+			$formatter->display_item( $body );
+		}
+	}
+
+	/**
+	 * List all items.
+	 *
+	 * @subcommand list
+	 */
+	public function list_items( $args, $assoc_args ) {
+		if ( ! empty( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
+			$method = 'HEAD';
+		} else {
+			$method = 'GET';
+		}
+
+		list( $status, $body, $headers ) = $this->do_request( $method, $this->get_filled_route( $args ), $assoc_args );
+		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
+			$items = array_column( $body, 'id' );
+		} else {
+			$items = $body;
+		}
+
+		if ( ! empty( $assoc_args['fields'] ) ) {
+			foreach ( $items as $key => $item ) {
+				$items[ $key ] = self::limit_item_to_fields( $item, $fields );
+			}
+		}
+
+		if ( ! empty( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
+			echo (int) $headers['X-WP-Total'];
+		} elseif ( 'headers' === $assoc_args['format'] ) {
+			echo json_encode( $headers );
+		} elseif ( 'body' === $assoc_args['format'] ) {
+			echo json_encode( $body );
+		} elseif ( 'envelope' === $assoc_args['format'] ) {
+			echo json_encode( array(
+				'body'    => $body,
+				'headers' => $headers,
+				'status'  => $status,
+				'api_url' => $this->api_url,
+			) );
+		} else {
+			$formatter = $this->get_formatter( $assoc_args );
+			$formatter->display_items( $items );
+		}
+	}
+
+	/**
+	 * Update an existing item.
+	 *
+	 * @subcommand update
+	 */
+	public function update_item( $args, $assoc_args ) {
+		$assoc_args = self::decode_json( $assoc_args );
+		list( $status, $body ) = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
+			WP_CLI::line( $body['id'] );
+		} else {
+			WP_CLI::success( __( 'Updated', 'woocommerce' ) . " {$this->name} {$body['id']}." );
+		}
+	}
+
+	/**
+	 * Do a REST Request
+	 *
+	 * @param string $method
+	 *
+	 */
+	private function do_request( $method, $route, $assoc_args ) {
+		if ( ! defined( 'REST_REQUEST' ) ) {
+			define( 'REST_REQUEST', true );
+		}
+		$request = new WP_REST_Request( $method, $route );
+		if ( in_array( $method, array( 'POST', 'PUT' ) ) ) {
+			$request->set_body_params( $assoc_args );
+		} else {
+			foreach( $assoc_args as $key => $value ) {
+				$request->set_param( $key, $value );
+			}
+		}
+		if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+			$original_queries = is_array( $GLOBALS['wpdb']->queries ) ? array_keys( $GLOBALS['wpdb']->queries ) : array();
+		}
+		$response = rest_do_request( $request );
+		if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+			$performed_queries = array();
+			foreach( (array) $GLOBALS['wpdb']->queries as $key => $query ) {
+				if ( in_array( $key, $original_queries ) ) {
+					continue;
+				}
+				$performed_queries[] = $query;
+			}
+			usort( $performed_queries, function( $a, $b ){
+				if ( $a[1] === $b[1] ) {
+					return 0;
+				}
+				return ( $a[1] > $b[1] ) ? -1 : 1;
+			});
+
+			$query_count = count( $performed_queries );
+			$query_total_time = 0;
+			foreach( $performed_queries as $query ) {
+				$query_total_time += $query[1];
+			}
+			$slow_query_message = '';
+			if ( $performed_queries && 'wc' === WP_CLI::get_config( 'debug' ) ) {
+				$slow_query_message .= '. Ordered by slowness, the queries are:' . PHP_EOL;
+				foreach( $performed_queries as $i => $query ) {
+					$i++;
+					$bits = explode( ', ', $query[2] );
+					$backtrace = implode( ', ', array_slice( $bits, 13 ) );
+					$seconds = round( $query[1], 6 );
+					$slow_query_message .= <<<EOT
+{$i}:
+- {$seconds} seconds
+- {$backtrace}
+- {$query[0]}
+EOT;
+					$slow_query_message .= PHP_EOL;
+				}
+			} elseif ( 'wc' !== WP_CLI::get_config( 'debug' ) ) {
+				$slow_query_message = '. Use --debug=wc to see all queries.';
+			}
+			$query_total_time = round( $query_total_time, 6 );
+			WP_CLI::debug( "wc command executed {$query_count} queries in {$query_total_time} seconds{$slow_query_message}", 'wc' );
+		}
+		if ( $error = $response->as_error() ) {
+			WP_CLI::error( $error );
+		}
+		return array( $response->get_status(), $response->get_data(), $response->get_headers() );
+	}
+
+	/**
+	 * Get Formatter object based on supplied parameters.
+	 *
+	 * @param array $assoc_args Parameters passed to command. Determines formatting.
+	 * @return \WP_CLI\Formatter
+	 */
+	protected function get_formatter( &$assoc_args ) {
+		if ( ! empty( $assoc_args['fields'] ) ) {
+			if ( is_string( $assoc_args['fields'] ) ) {
+				$fields = explode( ',', $assoc_args['fields'] );
+			} else {
+				$fields = $assoc_args['fields'];
+			}
+		} else {
+			if ( ! empty( $assoc_args['context'] ) ) {
+				$fields = $this->get_context_fields( $assoc_args['context'] );
+			} else {
+				$fields = $this->get_context_fields( 'view' );
+			}
+		}
+		return new \WP_CLI\Formatter( $assoc_args, $fields );
+	}
+
+	/**
+	 * Get a list of fields present in a given context
+	 *
+	 * @param string $context
+	 * @return array
+	 */
+	private function get_context_fields( $context ) {
+		$fields = array();
+		foreach( $this->schema['properties'] as $key => $args ) {
+			if ( empty( $args['context'] ) || in_array( $context, $args['context'] ) ) {
+				$fields[] = $key;
+			}
+		}
+		return $fields;
+	}
+
+	/**
+	 * Get the route for this resource
+	 *
+	 * @param  array $args
+	 * @return string
+	 */
+	private function get_filled_route( $args = array() ) {
+		$parent_id_matched = false;
+		$route             = $this->route;
+		if ( strpos( $route, '<customer_id>') !== false && ! empty( $args ) ) {
+			$route             = str_replace( '(?P<customer_id>[\d]+)', $args[0], $route );
+			$parent_id_matched = true;
+		} elseif ( strpos( $this->route, '<product_id>') !== false && ! empty( $args ) ) {
+			$route             = str_replace( '(?P<product_id>[\d]+)', $args[0], $route );
+			$parent_id_matched = true;
+		} elseif ( strpos( $this->route, '<order_id>') !== false && ! empty( $args ) ) {
+			$route             = str_replace( '(?P<order_id>[\d]+)', $args[0], $route );
+			$parent_id_matched = true;
+		} elseif ( strpos( $this->route, '<refund_id>') !== false && ! empty( $args ) ) {
+			$route             = str_replace( '(?P<refund_id>[\d]+)', $args[0], $route );
+			$parent_id_matched = true;
+		}
+
+		$route = str_replace( array( '(?P<id>[\d]+)', '(?P<id>[\w-]+)' ), ( $parent_id_matched && ! empty( $args[1] ) ? $args[1] : $args[0] ), $route );
+		return rtrim( $route );
+	}
+
+	/**
+	 * Output a line to be added
+	 *
+	 * @param string
+	 */
+	private function add_line( $line ) {
+		$this->nested_line( $line, 'add' );
+	}
+
+	/**
+	 * Output a line to be removed
+	 *
+	 * @param string
+	 */
+	private function remove_line( $line ) {
+		$this->nested_line( $line, 'remove' );
+	}
+
+	/**
+	 * Output a line that's appropriately nested
+	 */
+	private function nested_line( $line, $change = false ) {
+		if ( 'add' == $change ) {
+			$label = '+ ';
+		} else if ( 'remove' == $change ) {
+			$label = '- ';
+		} else {
+			$label = false;
+		}
+
+		$spaces = ( $this->output_nesting_level * 2 ) + 2;
+		if ( $label ) {
+			$line = $label . $line;
+			$spaces = $spaces - 2;
+		}
+		WP_CLI::line( str_pad( ' ', $spaces ) . $line );
+	}
+
+	/**
+	 * Whether or not this is an associative array
+	 *
+	 * @param array
+	 * @return bool
+	 */
+	private function is_assoc_array( $array ) {
+		if ( ! is_array( $array ) ) {
+			return false;
+		}
+		return array_keys( $array ) !== range( 0, count( $array ) - 1 );
+	}
+
+	/**
+	 * Reduce an item to specific fields.
+	 *
+	 * @param  array $item
+	 * @param  array $fields
+	 * @return array
+	 */
+	private static function limit_item_to_fields( $item, $fields ) {
+		if ( empty( $fields ) ) {
+			return $item;
+		}
+		if ( is_string( $fields ) ) {
+			$fields = explode( ',', $fields );
+		}
+		foreach ( $item as $i => $field ) {
+			if ( ! in_array( $i, $fields ) ) {
+				unset( $item[ $i ] );
+			}
+		}
+		return $item;
+	}
+
+	/**
+	 * JSON can be passed in some more complicated objects, like the payment gateway settings array.
+	 * This function decodes the json (if present) and tries to get it's value.
+	 *
+	 * @param array $arr
+	 */
+	protected function decode_json( $arr ) {
+		foreach ( $arr as $key => $value ) {
+			if ( '[' === substr( $value, 0, 1 ) || '{' === substr( $value, 0, 1 ) ) {
+				$arr[ $key ] = json_decode( $value, true );
+			} else {
+				continue;
+			}
+		}
+		return $arr;
+	}
+
+}

--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -6,10 +6,11 @@
  * off of Restful to generate commands for each WooCommerce REST API endpoint
  * so most of the logic is shared.
  *
+ * Forked from wp-cli/restful (by Daniel Bachhuber, released under the MIT license https://opensource.org/licenses/MIT).
+ * https://github.com/wp-cli/restful
  *
- * @version	2.7.0
+ * @version 2.7.0
  * @package WooCommerce
- * @author  WooCommerce
  */
 class WC_CLI_REST_Command {
 	/**

--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * WC API to WC CLI Bridge.
+ *
+ * Hooks into the REST API, figures out which endpoints come from WC,
+ * and registers them as CLI commands.
+ *
+ * @version	2.7.0
+ * @package WooCommerce
+ * @author  WooCommerce
+ */
+class WC_CLI_Runner {
+	/**
+	 * Endpoints to disable (meaning they will not be avaiable as CLI commands).
+	 * Some of these can either be done via WP already, or are offered with
+	 * some other changes (like tools).
+	 */
+	private static $disabled_endpoints = array(
+		'settings',
+		'settings/(?P<group>[\w-]+)',
+		'settings/(?P<group>[\w-]+)/batch',
+		'settings/(?P<group>[\w-]+)/(?P<id>[\w-]+)',
+		'system_status',
+		'system_status/tools',
+		'system_status/tools/(?P<id>[\w-]+)',
+		'reports',
+		'reports/sales',
+		'reports/top_sellers',
+	);
+
+	/**
+	 * Register's all endpoints as commands once WP and WC have all loaded.
+	 */
+	public static function after_wp_load() {
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server;
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		$request = new WP_REST_Request( 'GET', '/' );
+		$request->set_param( 'context', 'help' );
+		$response      = $wp_rest_server->dispatch( $request );
+		$response_data = $response->get_data();
+		if ( empty( $response_data ) ) {
+			return;
+		}
+
+		// Loop through all of our endpoints and register any valid WC endpoints.
+		foreach( $response_data['routes'] as $route => $route_data ) {
+			// Only register WC endpoints
+			if ( substr( $route, 0, 4 ) !== '/wc/' ) {
+				continue;
+			}
+			// Only register endpoints with schemas
+			if ( empty( $route_data['schema']['title'] ) ) {
+				WP_CLI::debug( sprintf( __( 'No schema title found for %s, skipping REST command registration.', 'woocommerce' ), $route ), 'wc' );
+				continue;
+			}
+			// Ignore batch endpoints
+			if ( 'batch' === $route_data['schema']['title'] ) {
+				continue;
+			}
+			// Disable specific endpoints
+			$route_pieces   = explode( '/', $route );
+			$endpoint_piece = str_replace( '/wc/' . $route_pieces[2] . '/', '', $route );
+			if ( in_array( $endpoint_piece, self::$disabled_endpoints ) ) {
+				continue;
+			}
+
+			self::register_route_commands( new WC_CLI_REST_Command( $route_data['schema']['title'], $route, $route_data['schema'] ), $route, $route_data );
+		}
+	}
+
+	/**
+	 * Generates command information and tells WP CLI about all
+	 * commands avaiable from a route.
+	 *
+	 * @param string $rest_command
+	 * @param string $route
+	 * @param array  $route_data
+	 * @param array  $command_args
+	*/
+	private static function register_route_commands( $rest_command, $route, $route_data, $command_args = array() ) {
+		$parent			 = "wc {$route_data['schema']['title']}";
+		$supported_commands = array();
+
+		// Get a list of supported commands for each route.
+		foreach ( $route_data['endpoints'] as $endpoint ) {
+			$parsed_args   = preg_match_all( '#\([^\)]+\)#', $route, $matches );
+			$first_match   = $matches[0];
+			$resource_id   = ! empty( $matches[0] ) ? array_pop( $matches[0] ) : null;
+			$trimmed_route = rtrim( $route );
+			$is_singular   = $resource_id === substr( $trimmed_route, - strlen( $resource_id ) );
+			if ( ! $is_singular ) {
+				$resource_id = $first_match;
+			}
+			$command = '';
+
+			// List a collection
+			if ( array( 'GET' ) == $endpoint['methods'] && ! $is_singular ) {
+				$supported_commands['list'] = ! empty( $endpoint['args'] ) ? $endpoint['args'] : array();
+			}
+			// Create a specific resource
+			if ( array( 'POST' ) == $endpoint['methods'] && ! $is_singular ) {
+				$supported_commands['create'] = ! empty( $endpoint['args'] ) ? $endpoint['args'] : array();
+			}
+			// Get a specific resource
+			if ( array( 'GET' ) == $endpoint['methods'] && $is_singular ) {
+				$supported_commands['get'] = ! empty( $endpoint['args'] ) ? $endpoint['args'] : array();
+			}
+			// Update a specific resource
+			if ( in_array( 'POST', $endpoint['methods'] ) && $is_singular ) {
+				$supported_commands['update'] = ! empty( $endpoint['args'] ) ? $endpoint['args'] : array();
+			}
+			// Delete a specific resource
+			if ( array( 'DELETE' ) == $endpoint['methods'] && $is_singular ) {
+				$supported_commands['delete'] = ! empty( $endpoint['args'] ) ? $endpoint['args'] : array();
+			}
+		}
+
+		foreach( $supported_commands as $command => $endpoint_args ) {
+			$synopsis = array();
+			$arg_regs = array();
+
+			if ( strpos( $route, '<product_id>') !== false ) {
+				$synopsis[] = array(
+					'name'		  => 'product_id',
+					'type'		  => 'positional',
+					'description' => __( 'Product ID.', 'woocommerce' ),
+				);
+			}
+
+			if ( strpos( $route, '<customer_id>') !== false ) {
+				$synopsis[] = array(
+					'name'		  => 'customer_id',
+					'type'		  => 'positional',
+					'description' => __( 'Customer ID.', 'woocommerce' ),
+				);
+			}
+
+			if ( strpos( $route, '<order_id>') !== false ) {
+				$synopsis[] = array(
+					'name'		  => 'order_id',
+					'type'		  => 'positional',
+					'description' => __( 'Order ID.', 'woocommerce' ),
+				);
+			}
+
+			if ( strpos( $route, '<refund_id>') !== false ) {
+				$synopsis[] = array(
+					'name'		  => 'refund_id',
+					'type'		  => 'positional',
+					'description' => __( 'Refund ID.', 'woocommerce' ),
+				);
+			}
+
+			if ( in_array( $command, array( 'delete', 'get', 'update' ) ) ) {
+				$synopsis[] = array(
+					'name'		  => 'id',
+					'type'		  => 'positional',
+					'description' => __( 'The id for the resource.', 'woocommerce' ),
+					'optional'	  => false,
+				);
+			}
+
+			foreach ( $endpoint_args as $name => $args ) {
+				$arg_regs[] = array(
+					'name'		  => $name,
+					'type'		  => 'assoc',
+					'description' => ! empty( $args['description'] ) ? $args['description'] : '',
+					'optional'	  => empty( $args['required'] ) ? true : false,
+				);
+			}
+
+			foreach ( $arg_regs as $arg_reg ) {
+				$synopsis[] = $arg_reg;
+			}
+
+			if ( in_array( $command, array( 'list', 'get' ) ) ) {
+				$synopsis[] = array(
+					'name'		  => 'fields',
+					'type'		  => 'assoc',
+					'description' => __( 'Limit response to specific fields. Defaults to all fields.', 'woocommerce' ),
+					'optional'	  => true,
+				);
+				$synopsis[] = array(
+					'name'		  => 'field',
+					'type'		  => 'assoc',
+					'description' => __( 'Get the value of an individual field.', 'woocommerce' ),
+					'optional'	  => true,
+				);
+				$synopsis[] = array(
+					'name'		  => 'format',
+					'type'		  => 'assoc',
+					'description' => __( 'Render response in a particular format.', 'woocommerce' ),
+					'optional'	  => true,
+					'default'	  => 'table',
+					'options'	  => array(
+						'table',
+						'json',
+						'csv',
+						'ids',
+						'yaml',
+						'count',
+						'headers',
+						'body',
+						'envelope',
+					),
+				);
+			}
+
+			if ( in_array( $command, array( 'create', 'update', 'delete' ) ) ) {
+				$synopsis[] = array(
+					'name'		  => 'porcelain',
+					'type'		  => 'flag',
+					'description' => __( 'Output just the id when the operation is successful.', 'woocommerce' ),
+					'optional'	  => true,
+				);
+			}
+
+			$methods = array(
+				'list'   => 'list_items',
+				'create' => 'create_item',
+				'delete' => 'delete_item',
+				'get'	 => 'get_item',
+				'update' => 'update_item',
+			);
+
+			$before_invoke = null;
+			if ( empty( $command_args['when'] ) && \WP_CLI::get_config( 'debug' ) ) {
+				$before_invoke = function() {
+					if ( ! defined( 'SAVEQUERIES' ) ) {
+						define( 'SAVEQUERIES', true );
+					}
+				};
+			}
+
+			WP_CLI::add_command( "{$parent} {$command}", array( $rest_command, $methods[ $command ] ), array(
+				'synopsis'	    => $synopsis,
+				'when'		    => ! empty( $command_args['when'] ) ? $command_args['when'] : '',
+				'before_invoke' => $before_invoke,
+			) );
+		}
+	}
+}

--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -5,9 +5,11 @@
  * Hooks into the REST API, figures out which endpoints come from WC,
  * and registers them as CLI commands.
  *
- * @version	2.7.0
+ * Forked from wp-cli/restful (by Daniel Bachhuber, released under the MIT license https://opensource.org/licenses/MIT).
+ * https://github.com/wp-cli/restful
+ *
+ * @version 2.7.0
  * @package WooCommerce
- * @author  WooCommerce
  */
 class WC_CLI_Runner {
 	/**

--- a/includes/cli/class-wc-cli-tool-command.php
+++ b/includes/cli/class-wc-cli-tool-command.php
@@ -2,9 +2,11 @@
 /**
  * Hooks up our system status tools to the CLI.
  *
- * @version	2.7.0
+ * Forked from wp-cli/restful (by Daniel Bachhuber, released under the MIT license https://opensource.org/licenses/MIT).
+ * https://github.com/wp-cli/restful
+ *
+ * @version 2.7.0
  * @package WooCommerce
- * @author  WooCommerce
  */
 class WC_CLI_Tool_Command {
 

--- a/includes/cli/class-wc-cli-tool-command.php
+++ b/includes/cli/class-wc-cli-tool-command.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Hooks up our system status tools to the CLI.
+ *
+ * @version	2.7.0
+ * @package WooCommerce
+ * @author  WooCommerce
+ */
+class WC_CLI_Tool_Command {
+
+	/**
+	 * Registers just a 'list' and 'run' command to the WC CLI
+	 * since we only want to enable certain actions on the system status
+	 * tools endpoints.
+	 */
+	public static function register_tool_commands() {
+		global $wp_rest_server;
+
+		$request       = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status/tools' );
+		$response      = $wp_rest_server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		$parent	            = "wc tool";
+		$supported_commands = array( 'list', 'run' );
+		foreach ( $supported_commands as $command ) {
+			$synopsis = array();
+			if ( 'run' === $command ) {
+				$synopsis[] = array(
+					'name'		  => 'id',
+					'type'		  => 'positional',
+					'description' => __( 'The id for the resource.', 'woocommerce' ),
+					'optional'	  => false,
+				);
+				$method = 'update_item';
+				$route  = '/wc/v1/system_status/tools/(?P<id>[\w-]+)';
+			} elseif ( 'list' === $command ) {
+				$synopsis[] = array(
+					'name'		  => 'fields',
+					'type'		  => 'assoc',
+					'description' => __( 'Limit response to specific fields. Defaults to all fields.', 'woocommerce' ),
+					'optional'    => true,
+				);
+				$synopsis[] = array(
+					'name'		  => 'field',
+					'type'		  => 'assoc',
+					'description' => __( 'Get the value of an individual field.', 'woocommerce' ),
+					'optional'	  => true,
+				);
+				$synopsis[] = array(
+					'name'		  => 'format',
+					'type'		  => 'assoc',
+					'description' => __( 'Render response in a particular format.', 'woocommerce' ),
+					'optional'	  => true,
+					'default'	  => 'table',
+					'options'	  => array(
+						'table',
+						'json',
+						'csv',
+						'ids',
+						'yaml',
+						'count',
+						'headers',
+						'body',
+						'envelope',
+					),
+				);
+				$method = 'list_items';
+				$route  = '/wc/v1/system_status/tools';
+			}
+
+			$before_invoke = null;
+			if ( empty( $command_args['when'] ) && WP_CLI::get_config( 'debug' ) ) {
+				$before_invoke = function() {
+					if ( ! defined( 'SAVEQUERIES' ) ) {
+						define( 'SAVEQUERIES', true );
+					}
+				};
+			}
+
+			$rest_command = new WC_CLI_REST_Command( 'system_status_tool', $route, $response_data['schema'] );
+
+			WP_CLI::add_command( "{$parent} {$command}", array( $rest_command, $method ), array(
+				'synopsis'	    => $synopsis,
+				'when'		    => ! empty( $command_args['when'] ) ? $command_args['when'] : '',
+				'before_invoke' => $before_invoke,
+			) );
+
+		}
+	}
+
+}

--- a/tests/cli/bin/install-package-tests.sh
+++ b/tests/cli/bin/install-package-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -ex
+
+PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+install_wp_cli() {
+
+	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
+	mkdir -p $WP_CLI_BIN_DIR
+	download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
+	chmod +x $WP_CLI_BIN_DIR/wp
+
+}
+
+download_behat() {
+
+	cd $PACKAGE_DIR
+	download https://getcomposer.org/installer installer
+	php installer
+	php composer.phar require --dev behat/behat='~2.5'
+
+}
+
+install_db() {
+	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
+}
+
+install_wp_cli
+download_behat
+install_db

--- a/tests/cli/credits.txt
+++ b/tests/cli/credits.txt
@@ -1,0 +1,2 @@
+WC-CLI and the related testing code is based on wp-cli/restful (which was released under the MIT license https://opensource.org/licenses/MIT) by Daniel Bachhuber
+https://github.com/wp-cli/restful

--- a/tests/cli/features/bootstrap/FeatureContext.php
+++ b/tests/cli/features/bootstrap/FeatureContext.php
@@ -1,0 +1,330 @@
+<?php
+
+use Behat\Behat\Context\ClosuredContextInterface,
+    Behat\Behat\Context\TranslatedContextInterface,
+    Behat\Behat\Context\BehatContext,
+    Behat\Behat\Event\SuiteEvent;
+
+use \WP_CLI\Process;
+use \WP_CLI\Utils;
+
+// Inside a community package
+if ( file_exists( __DIR__ . '/utils.php' ) ) {
+	require_once __DIR__ . '/utils.php';
+	require_once __DIR__ . '/Process.php';
+	$project_composer = dirname( dirname( dirname( __FILE__ ) ) ) . '/composer.json';
+	if ( file_exists( $project_composer ) ) {
+		$composer = json_decode( file_get_contents( $project_composer ) );
+		if ( ! empty( $composer->autoload->files ) ) {
+			$contents = 'require:' . PHP_EOL;
+			foreach( $composer->autoload->files as $file ) {
+				$contents .= '  - ' . dirname( dirname( dirname( __FILE__ ) ) ) . '/' . $file;
+			}
+			@mkdir( sys_get_temp_dir() . '/wp-cli-package-test/' );
+			$project_config = sys_get_temp_dir() . '/wp-cli-package-test/config.yml';
+			file_put_contents( $project_config, $contents );
+			putenv( 'WP_CLI_CONFIG_PATH=' . $project_config );
+		}
+	}
+// Inside WP-CLI
+} else {
+	require_once __DIR__ . '/../../php/utils.php';
+	require_once __DIR__ . '/../../php/WP_CLI/Process.php';
+	require_once __DIR__ . '/../../vendor/autoload.php';
+}
+
+/**
+ * Features context.
+ */
+class FeatureContext extends BehatContext implements ClosuredContextInterface {
+
+	private static $cache_dir, $suite_cache_dir;
+
+	private static $db_settings = array(
+		'dbname' => 'wp_cli_test',
+		'dbuser' => 'wp_cli_test',
+		'dbpass' => 'password1',
+		'dbhost' => '127.0.0.1',
+	);
+
+	private $running_procs = array();
+
+	public $variables = array();
+
+	/**
+	 * Get the environment variables required for launched `wp` processes
+	 * @beforeSuite
+	 */
+	private static function get_process_env_variables() {
+		// Ensure we're using the expected `wp` binary
+		$bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ?: realpath( __DIR__ . "/../../bin" );
+		$env = array(
+			'PATH' =>  $bin_dir . ':' . getenv( 'PATH' ),
+			'BEHAT_RUN' => 1,
+			'HOME' => '/tmp/wp-cli-home',
+		);
+		if ( $config_path = getenv( 'WP_CLI_CONFIG_PATH' ) ) {
+			$env['WP_CLI_CONFIG_PATH'] = $config_path;
+		}
+		return $env;
+	}
+
+	// We cache the results of `wp core download` to improve test performance
+	// Ideally, we'd cache at the HTTP layer for more reliable tests
+	private static function cache_wp_files() {
+		self::$cache_dir = sys_get_temp_dir() . '/wp-cli-test core-download-cache';
+
+		if ( is_readable( self::$cache_dir . '/wp-config-sample.php' ) )
+			return;
+
+		$cmd = Utils\esc_cmd( 'wp core download --force --path=%s', self::$cache_dir );
+		Process::create( $cmd, null, self::get_process_env_variables() )->run_check();
+	}
+
+	/**
+	 * @BeforeSuite
+	 */
+	public static function prepare( SuiteEvent $event ) {
+		$result = Process::create( 'wp cli info', null, self::get_process_env_variables() )->run_check();
+		echo PHP_EOL;
+		echo $result->stdout;
+		echo PHP_EOL;
+		self::cache_wp_files();
+	}
+
+	/**
+	 * @AfterSuite
+	 */
+	public static function afterSuite( SuiteEvent $event ) {
+		if ( self::$suite_cache_dir ) {
+			Process::create( Utils\esc_cmd( 'rm -r %s', self::$suite_cache_dir ), null, self::get_process_env_variables() )->run();
+		}
+	}
+
+	/**
+	 * @BeforeScenario
+	 */
+	public function beforeScenario( $event ) {
+		$this->variables['SRC_DIR'] = realpath( __DIR__ . '/../..' );
+	}
+
+	/**
+	 * @AfterScenario
+	 */
+	public function afterScenario( $event ) {
+		if ( isset( $this->variables['RUN_DIR'] ) ) {
+			// remove altered WP install, unless there's an error
+			if ( $event->getResult() < 4 ) {
+				$this->proc( Utils\esc_cmd( 'rm -r %s', $this->variables['RUN_DIR'] ) )->run();
+			}
+		}
+
+		foreach ( $this->running_procs as $proc ) {
+			self::terminate_proc( $proc );
+		}
+	}
+
+	/**
+	 * Terminate a process and any of its children.
+	 */
+	private static function terminate_proc( $proc ) {
+		$status = proc_get_status( $proc );
+
+		$master_pid = $status['pid'];
+
+		$output = `ps -o ppid,pid,command | grep $master_pid`;
+
+		foreach ( explode( PHP_EOL, $output ) as $line ) {
+			if ( preg_match( '/^\s*(\d+)\s+(\d+)/', $line, $matches ) ) {
+				$parent = $matches[1];
+				$child = $matches[2];
+
+				if ( $parent == $master_pid ) {
+					if ( ! posix_kill( (int) $child, 9 ) ) {
+						throw new RuntimeException( posix_strerror( posix_get_last_error() ) );
+					}
+				}
+			}
+		}
+
+		if ( ! posix_kill( (int) $master_pid, 9 ) ) {
+			throw new RuntimeException( posix_strerror( posix_get_last_error() ) );
+		}
+	}
+
+	public static function create_cache_dir() {
+		self::$suite_cache_dir = sys_get_temp_dir() . '/' . uniqid( "wp-cli-test-suite-cache-", TRUE );
+		mkdir( self::$suite_cache_dir );
+		return self::$suite_cache_dir;
+	}
+
+	/**
+	 * Initializes context.
+	 * Every scenario gets it's own context object.
+	 *
+	 * @param array $parameters context parameters (set them up through behat.yml)
+	 */
+	public function __construct( array $parameters ) {
+		$this->drop_db();
+		$this->set_cache_dir();
+		$this->variables['CORE_CONFIG_SETTINGS'] = Utils\assoc_args_to_str( self::$db_settings );
+	}
+
+	public function getStepDefinitionResources() {
+		return glob( __DIR__ . '/../steps/*.php' );
+	}
+
+	public function getHookDefinitionResources() {
+		return array();
+	}
+
+	public function replace_variables( $str ) {
+		return preg_replace_callback( '/\{([A-Z_]+)\}/', array( $this, '_replace_var' ), $str );
+	}
+
+	private function _replace_var( $matches ) {
+		$cmd = $matches[0];
+
+		foreach ( array_slice( $matches, 1 ) as $key ) {
+			$cmd = str_replace( '{' . $key . '}', $this->variables[ $key ], $cmd );
+		}
+
+		return $cmd;
+	}
+
+	public function create_run_dir() {
+		if ( !isset( $this->variables['RUN_DIR'] ) ) {
+			$this->variables['RUN_DIR'] = sys_get_temp_dir() . '/' . uniqid( "wp-cli-test-run-", TRUE );
+			mkdir( $this->variables['RUN_DIR'] );
+		}
+	}
+
+	public function build_phar( $version = 'same' ) {
+		$this->variables['PHAR_PATH'] = $this->variables['RUN_DIR'] . '/' . uniqid( "wp-cli-build-", TRUE ) . '.phar';
+
+		$this->proc( Utils\esc_cmd(
+			'php -dphar.readonly=0 %1$s %2$s --version=%3$s && chmod +x %2$s',
+			__DIR__ . '/../../utils/make-phar.php',
+			$this->variables['PHAR_PATH'],
+			$version
+		) )->run_check();
+	}
+
+	private function set_cache_dir() {
+		$path = sys_get_temp_dir() . '/wp-cli-test-cache';
+		$this->proc( Utils\esc_cmd( 'mkdir -p %s', $path ) )->run_check();
+		$this->variables['CACHE_DIR'] = $path;
+	}
+
+	private static function run_sql( $sql ) {
+		Utils\run_mysql_command( 'mysql --no-defaults', array(
+			'execute' => $sql,
+			'host' => self::$db_settings['dbhost'],
+			'user' => self::$db_settings['dbuser'],
+			'pass' => self::$db_settings['dbpass'],
+		) );
+	}
+
+	public function create_db() {
+		$dbname = self::$db_settings['dbname'];
+		self::run_sql( "CREATE DATABASE IF NOT EXISTS $dbname" );
+	}
+
+	public function drop_db() {
+		$dbname = self::$db_settings['dbname'];
+		self::run_sql( "DROP DATABASE IF EXISTS $dbname" );
+	}
+
+	public function proc( $command, $assoc_args = array(), $path = '' ) {
+		if ( !empty( $assoc_args ) )
+			$command .= Utils\assoc_args_to_str( $assoc_args );
+
+		$env = self::get_process_env_variables();
+		if ( isset( $this->variables['SUITE_CACHE_DIR'] ) ) {
+			$env['WP_CLI_CACHE_DIR'] = $this->variables['SUITE_CACHE_DIR'];
+		}
+
+		if ( isset( $this->variables['RUN_DIR'] ) ) {
+			$cwd = "{$this->variables['RUN_DIR']}/{$path}";
+		} else {
+			$cwd = null;
+		}
+
+		return Process::create( $command, $cwd, $env );
+	}
+
+	/**
+	 * Start a background process. Will automatically be closed when the tests finish.
+	 */
+	public function background_proc( $cmd ) {
+		$descriptors = array(
+			0 => STDIN,
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+
+		$proc = proc_open( $cmd, $descriptors, $pipes, $this->variables['RUN_DIR'], self::get_process_env_variables() );
+
+		sleep(1);
+
+		$status = proc_get_status( $proc );
+
+		if ( !$status['running'] ) {
+			throw new RuntimeException( stream_get_contents( $pipes[2] ) );
+		} else {
+			$this->running_procs[] = $proc;
+		}
+	}
+
+	public function move_files( $src, $dest ) {
+		rename( $this->variables['RUN_DIR'] . "/$src", $this->variables['RUN_DIR'] . "/$dest" );
+	}
+
+	public function add_line_to_wp_config( &$wp_config_code, $line ) {
+		$token = "/* That's all, stop editing!";
+
+		$wp_config_code = str_replace( $token, "$line\n\n$token", $wp_config_code );
+	}
+
+	public function download_wp( $subdir = '' ) {
+		$dest_dir = $this->variables['RUN_DIR'] . "/$subdir";
+
+		if ( $subdir ) {
+			mkdir( $dest_dir );
+		}
+
+		$this->proc( Utils\esc_cmd( "cp -r %s/* %s", self::$cache_dir, $dest_dir ) )->run_check();
+
+		// disable emailing
+		mkdir( $dest_dir . '/wp-content/mu-plugins' );
+		copy( __DIR__ . '/../extra/no-mail.php', $dest_dir . '/wp-content/mu-plugins/no-mail.php' );
+		symlink( dirname( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ),  $dest_dir . '/wp-content/plugins/woocommerce' );
+	}
+
+	public function create_config( $subdir = '' ) {
+		$params = self::$db_settings;
+		$params['dbprefix'] = $subdir ?: 'wp_';
+
+		$params['skip-salts'] = true;
+		$this->proc( 'wp core config', $params, $subdir )->run_check();
+	}
+
+	public function install_wp( $subdir = '' ) {
+		$this->create_db();
+		$this->create_run_dir();
+		$this->download_wp( $subdir );
+
+		$this->create_config( $subdir );
+
+		$install_args = array(
+			'url' => 'http://example.com',
+			'title' => 'WP CLI Site',
+			'admin_user' => 'admin',
+			'admin_email' => 'admin@example.com',
+			'admin_password' => 'password1'
+		);
+
+		$this->proc( 'wp core install', $install_args, $subdir )->run_check();
+		$this->proc( 'wp plugin activate woocommerce', array(), $subdir )->run_check();
+	}
+}

--- a/tests/cli/features/bootstrap/Process.php
+++ b/tests/cli/features/bootstrap/Process.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace WP_CLI;
+
+/**
+ * Run a system process, and learn what happened.
+ */
+class Process {
+
+	/**
+	 * @param string $command Command to execute.
+	 * @param string $cwd Directory to execute the command in.
+	 * @param array $env Environment variables to set when running the command.
+	 */
+	public static function create( $command, $cwd = null, $env = array() ) {
+		$proc = new self;
+
+		$proc->command = $command;
+		$proc->cwd = $cwd;
+		$proc->env = $env;
+
+		return $proc;
+	}
+
+	private $command, $cwd, $env;
+
+	private function __construct() {}
+
+	/**
+	 * Run the command.
+	 *
+	 * @return ProcessRun
+	 */
+	public function run() {
+		$cwd = $this->cwd;
+
+		$descriptors = array(
+			0 => STDIN,
+			1 => array( 'pipe', 'w' ),
+			2 => array( 'pipe', 'w' ),
+		);
+
+		$proc = proc_open( $this->command, $descriptors, $pipes, $cwd, $this->env );
+
+		$stdout = stream_get_contents( $pipes[1] );
+		fclose( $pipes[1] );
+
+		$stderr = stream_get_contents( $pipes[2] );
+		fclose( $pipes[2] );
+
+		return new ProcessRun( array(
+			'stdout' => $stdout,
+			'stderr' => $stderr,
+			'return_code' => proc_close( $proc ),
+			'command' => $this->command,
+			'cwd' => $cwd,
+			'env' => $this->env
+		) );
+	}
+
+	/**
+	 * Run the command, but throw an Exception on error.
+	 *
+	 * @return ProcessRun
+	 */
+	public function run_check() {
+		$r = $this->run();
+
+		if ( $r->return_code || !empty( $r->STDERR ) ) {
+			throw new \RuntimeException( $r );
+		}
+
+		return $r;
+	}
+}
+
+/**
+ * Results of an executed command.
+ */
+class ProcessRun {
+
+	/**
+	 * @var array $props Properties of executed command.
+	 */
+	public function __construct( $props ) {
+		foreach ( $props as $key => $value ) {
+			$this->$key = $value;
+		}
+	}
+
+	/**
+	 * Return properties of executed command as a string.
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		$out  = "$ $this->command\n";
+		$out .= "$this->stdout\n$this->stderr";
+		$out .= "cwd: $this->cwd\n";
+		$out .= "exit status: $this->return_code";
+
+		return $out;
+	}
+
+}

--- a/tests/cli/features/bootstrap/support.php
+++ b/tests/cli/features/bootstrap/support.php
@@ -1,0 +1,188 @@
+<?php
+
+// Utility functions used by Behat steps
+
+function assertEquals( $expected, $actual ) {
+	if ( $expected != $actual ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
+function assertNumeric( $actual ) {
+	if ( !is_numeric( $actual ) ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
+function assertNotNumeric( $actual ) {
+	if ( is_numeric( $actual ) ) {
+		throw new Exception( "Actual value: " . var_export( $actual, true ) );
+	}
+}
+
+function checkString( $output, $expected, $action, $message = false ) {
+	switch ( $action ) {
+
+	case 'be':
+		$r = $expected === rtrim( $output, "\n" );
+		break;
+
+	case 'contain':
+		$r = false !== strpos( $output, $expected );
+		break;
+
+	case 'not contain':
+		$r = false === strpos( $output, $expected );
+		break;
+
+	default:
+		throw new Behat\Behat\Exception\PendingException();
+	}
+
+	if ( !$r ) {
+		if ( false === $message )
+			$message = $output;
+		throw new Exception( $message );
+	}
+}
+
+function compareTables( $expected_rows, $actual_rows, $output ) {
+	// the first row is the header and must be present
+	if ( $expected_rows[0] != $actual_rows[0] ) {
+		throw new \Exception( $output );
+	}
+
+	unset( $actual_rows[0] );
+	unset( $expected_rows[0] );
+
+	$missing_rows = array_diff( $expected_rows, $actual_rows );
+	if ( !empty( $missing_rows ) ) {
+		throw new \Exception( $output );
+	}
+}
+
+function compareContents( $expected, $actual ) {
+	if ( gettype( $expected ) != gettype( $actual ) ) {
+		return false;
+	}
+
+	if ( is_object( $expected ) ) {
+		foreach ( get_object_vars( $expected ) as $name => $value ) {
+			if ( ! compareContents( $value, $actual->$name ) )
+				return false;
+		}
+	} else if ( is_array( $expected ) ) {
+		foreach ( $expected as $key => $value ) {
+			if ( ! compareContents( $value, $actual[$key] ) )
+				return false;
+		}
+	} else {
+		return $expected === $actual;
+	}
+
+	return true;
+}
+
+/**
+ * Compare two strings containing JSON to ensure that @a $actualJson contains at
+ * least what the JSON string @a $expectedJson contains.
+ *
+ * @return whether or not @a $actualJson contains @a $expectedJson
+ *     @retval true  @a $actualJson contains @a $expectedJson
+ *     @retval false @a $actualJson does not contain @a $expectedJson
+ *
+ * @param[in] $actualJson   the JSON string to be tested
+ * @param[in] $expectedJson the expected JSON string
+ *
+ * Examples:
+ *   expected: {'a':1,'array':[1,3,5]}
+ *
+ *   1 )
+ *   actual: {'a':1,'b':2,'c':3,'array':[1,2,3,4,5]}
+ *   return: true
+ *
+ *   2 )
+ *   actual: {'b':2,'c':3,'array':[1,2,3,4,5]}
+ *   return: false
+ *     element 'a' is missing from the root object
+ *
+ *   3 )
+ *   actual: {'a':0,'b':2,'c':3,'array':[1,2,3,4,5]}
+ *   return: false
+ *     the value of element 'a' is not 1
+ *
+ *   4 )
+ *   actual: {'a':1,'b':2,'c':3,'array':[1,2,4,5]}
+ *   return: false
+ *     the contents of 'array' does not include 3
+ */
+function checkThatJsonStringContainsJsonString( $actualJson, $expectedJson ) {
+	$actualValue   = json_decode( $actualJson );
+	$expectedValue = json_decode( $expectedJson );
+
+	if ( !$actualValue ) {
+		return false;
+	}
+
+	return compareContents( $expectedValue, $actualValue );
+}
+
+/**
+ * Compare two strings to confirm $actualCSV contains $expectedCSV
+ * Both strings are expected to have headers for their CSVs.
+ * $actualCSV must match all data rows in $expectedCSV
+ *
+ * @param  string   A CSV string
+ * @param  array    A nested array of values
+ * @return bool     Whether $actualCSV contains $expectedCSV
+ */
+function checkThatCsvStringContainsValues( $actualCSV, $expectedCSV ) {
+	$actualCSV = array_map( 'str_getcsv', explode( PHP_EOL, $actualCSV ) );
+
+	if ( empty( $actualCSV ) )
+		return false;
+
+	// Each sample must have headers
+	$actualHeaders = array_values( array_shift( $actualCSV ) );
+	$expectedHeaders = array_values( array_shift( $expectedCSV ) );
+
+	// Each expectedCSV must exist somewhere in actualCSV in the proper column
+	$expectedResult = 0;
+	foreach ( $expectedCSV as $expected_row ) {
+		$expected_row = array_combine( $expectedHeaders, $expected_row );
+		foreach ( $actualCSV as $actual_row ) {
+
+			if ( count( $actualHeaders ) != count( $actual_row ) )
+				continue;
+
+			$actual_row = array_intersect_key( array_combine( $actualHeaders, $actual_row ), $expected_row );
+			if ( $actual_row == $expected_row )
+				$expectedResult++;
+		}
+	}
+
+	return $expectedResult >= count( $expectedCSV );
+}
+
+/**
+ * Compare two strings containing YAML to ensure that @a $actualYaml contains at
+ * least what the YAML string @a $expectedYaml contains.
+ *
+ * @return whether or not @a $actualYaml contains @a $expectedJson
+ *     @retval true  @a $actualYaml contains @a $expectedJson
+ *     @retval false @a $actualYaml does not contain @a $expectedJson
+ *
+ * @param[in] $actualYaml   the YAML string to be tested
+ * @param[in] $expectedYaml the expected YAML string
+ */
+function checkThatYamlStringContainsYamlString( $actualYaml, $expectedYaml ) {
+	$actualValue   = spyc_load( $actualYaml );
+	$expectedValue = spyc_load( $expectedYaml );
+
+	if ( !$actualValue ) {
+		return false;
+	}
+
+	return compareContents( $expectedValue, $actualValue );
+}
+

--- a/tests/cli/features/bootstrap/utils.php
+++ b/tests/cli/features/bootstrap/utils.php
@@ -1,0 +1,757 @@
+<?php
+
+// Utilities that do NOT depend on WordPress code.
+
+namespace WP_CLI\Utils;
+
+use \Composer\Semver\Comparator;
+use \Composer\Semver\Semver;
+use \WP_CLI\Dispatcher;
+use \WP_CLI\Iterators\Transform;
+
+function inside_phar() {
+	return 0 === strpos( WP_CLI_ROOT, 'phar://' );
+}
+
+// Files that need to be read by external programs have to be extracted from the Phar archive.
+function extract_from_phar( $path ) {
+	if ( ! inside_phar() ) {
+		return $path;
+	}
+
+	$fname = basename( $path );
+
+	$tmp_path = get_temp_dir() . "wp-cli-$fname";
+
+	copy( $path, $tmp_path );
+
+	register_shutdown_function( function() use ( $tmp_path ) {
+		@unlink( $tmp_path );
+	} );
+
+	return $tmp_path;
+}
+
+function load_dependencies() {
+	if ( inside_phar() ) {
+		require WP_CLI_ROOT . '/vendor/autoload.php';
+		return;
+	}
+
+	$has_autoload = false;
+
+	foreach ( get_vendor_paths() as $vendor_path ) {
+		if ( file_exists( $vendor_path . '/autoload.php' ) ) {
+			require $vendor_path . '/autoload.php';
+			$has_autoload = true;
+			break;
+		}
+	}
+
+	if ( !$has_autoload ) {
+		fputs( STDERR, "Internal error: Can't find Composer autoloader.\nTry running: composer install\n" );
+		exit(3);
+	}
+}
+
+function get_vendor_paths() {
+	$vendor_paths = array(
+		WP_CLI_ROOT . '/../../../vendor',  // part of a larger project / installed via Composer (preferred)
+		WP_CLI_ROOT . '/vendor',           // top-level project / installed as Git clone
+	);
+	$maybe_composer_json = WP_CLI_ROOT . '/../../../composer.json';
+	if ( file_exists( $maybe_composer_json ) && is_readable( $maybe_composer_json ) ) {
+		$composer = json_decode( file_get_contents( $maybe_composer_json ) );
+		if ( ! empty( $composer->config ) && ! empty( $composer->config->{'vendor-dir'} ) ) {
+			array_unshift( $vendor_paths, WP_CLI_ROOT . '/../../../' . $composer->config->{'vendor-dir'} );
+		}
+	}
+	return $vendor_paths;
+}
+
+// Using require() directly inside a class grants access to private methods to the loaded code
+function load_file( $path ) {
+	require_once $path;
+}
+
+function load_command( $name ) {
+	$path = WP_CLI_ROOT . "/php/commands/$name.php";
+
+	if ( is_readable( $path ) ) {
+		include_once $path;
+	}
+}
+
+function load_all_commands() {
+	$cmd_dir = WP_CLI_ROOT . '/php/commands';
+
+	$iterator = new \DirectoryIterator( $cmd_dir );
+
+	foreach ( $iterator as $filename ) {
+		if ( '.php' != substr( $filename, -4 ) )
+			continue;
+
+		include_once "$cmd_dir/$filename";
+	}
+}
+
+/**
+ * Like array_map(), except it returns a new iterator, instead of a modified array.
+ *
+ * Example:
+ *
+ *     $arr = array('Football', 'Socker');
+ *
+ *     $it = iterator_map($arr, 'strtolower', function($val) {
+ *       return str_replace('foo', 'bar', $val);
+ *     });
+ *
+ *     foreach ( $it as $val ) {
+ *       var_dump($val);
+ *     }
+ *
+ * @param array|object Either a plain array or another iterator
+ * @param callback The function to apply to an element
+ * @return object An iterator that applies the given callback(s)
+ */
+function iterator_map( $it, $fn ) {
+	if ( is_array( $it ) ) {
+		$it = new \ArrayIterator( $it );
+	}
+
+	if ( !method_exists( $it, 'add_transform' ) ) {
+		$it = new Transform( $it );
+	}
+
+	foreach ( array_slice( func_get_args(), 1 ) as $fn ) {
+		$it->add_transform( $fn );
+	}
+
+	return $it;
+}
+
+/**
+ * Search for file by walking up the directory tree until the first file is found or until $stop_check($dir) returns true
+ * @param string|array The files (or file) to search for
+ * @param string|null The directory to start searching from; defaults to CWD
+ * @param callable Function which is passed the current dir each time a directory level is traversed
+ * @return null|string Null if the file was not found
+ */
+function find_file_upward( $files, $dir = null, $stop_check = null ) {
+	$files = (array) $files;
+	if ( is_null( $dir ) ) {
+		$dir = getcwd();
+	}
+	while ( @is_readable( $dir ) ) {
+		// Stop walking up when the supplied callable returns true being passed the $dir
+		if ( is_callable( $stop_check ) && call_user_func( $stop_check, $dir ) ) {
+			return null;
+		}
+
+		foreach ( $files as $file ) {
+			$path = $dir . DIRECTORY_SEPARATOR . $file;
+			if ( file_exists( $path ) ) {
+				return $path;
+			}
+		}
+
+		$parent_dir = dirname( $dir );
+		if ( empty($parent_dir) || $parent_dir === $dir ) {
+			break;
+		}
+		$dir = $parent_dir;
+	}
+	return null;
+}
+
+function is_path_absolute( $path ) {
+	// Windows
+	if ( isset($path[1]) && ':' === $path[1] )
+		return true;
+
+	return $path[0] === '/';
+}
+
+/**
+ * Composes positional arguments into a command string.
+ *
+ * @param array
+ * @return string
+ */
+function args_to_str( $args ) {
+	return ' ' . implode( ' ', array_map( 'escapeshellarg', $args ) );
+}
+
+/**
+ * Composes associative arguments into a command string.
+ *
+ * @param array
+ * @return string
+ */
+function assoc_args_to_str( $assoc_args ) {
+	$str = '';
+
+	foreach ( $assoc_args as $key => $value ) {
+		if ( true === $value )
+			$str .= " --$key";
+		else
+			$str .= " --$key=" . escapeshellarg( $value );
+	}
+
+	return $str;
+}
+
+/**
+ * Given a template string and an arbitrary number of arguments,
+ * returns the final command, with the parameters escaped.
+ */
+function esc_cmd( $cmd ) {
+	if ( func_num_args() < 2 )
+		trigger_error( 'esc_cmd() requires at least two arguments.', E_USER_WARNING );
+
+	$args = func_get_args();
+
+	$cmd = array_shift( $args );
+
+	return vsprintf( $cmd, array_map( 'escapeshellarg', $args ) );
+}
+
+function locate_wp_config() {
+	static $path;
+
+	if ( null === $path ) {
+		if ( file_exists( ABSPATH . 'wp-config.php' ) )
+			$path = ABSPATH . 'wp-config.php';
+		elseif ( file_exists( ABSPATH . '../wp-config.php' ) && ! file_exists( ABSPATH . '/../wp-settings.php' ) )
+			$path = ABSPATH . '../wp-config.php';
+		else
+			$path = false;
+
+		if ( $path )
+			$path = realpath( $path );
+	}
+
+	return $path;
+}
+
+function wp_version_compare( $since, $operator ) {
+	return version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), $since, $operator );
+}
+
+/**
+ * Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or count.
+ *
+ * Given a collection of items with a consistent data structure:
+ *
+ * ```
+ * $items = array(
+ *     array(
+ *         'key'   => 'foo',
+ *         'value'  => 'bar',
+ *     )
+ * );
+ * ```
+ *
+ * Render `$items` as an ASCII table:
+ *
+ * ```
+ * WP_CLI\Utils\format_items( 'table', $items, array( 'key', 'value' ) );
+ *
+ * # +-----+-------+
+ * # | key | value |
+ * # +-----+-------+
+ * # | foo | bar   |
+ * # +-----+-------+
+ * ```
+ *
+ * Or render `$items` as YAML:
+ *
+ * ```
+ * WP_CLI\Utils\format_items( 'yaml', $items, array( 'key', 'value' ) );
+ *
+ * # ---
+ * # -
+ * #   key: foo
+ * #   value: bar
+ * ```
+ *
+ * @access public
+ * @category Output
+ *
+ * @param string        $format     Format to use: 'table', 'json', 'csv', 'yaml', 'ids', 'count'
+ * @param array         $items      An array of items to output.
+ * @param array|string  $fields     Named fields for each item of data. Can be array or comma-separated list.
+ * @return null
+ */
+function format_items( $format, $items, $fields ) {
+	$assoc_args = compact( 'format', 'fields' );
+	$formatter = new \WP_CLI\Formatter( $assoc_args );
+	$formatter->display_items( $items );
+}
+
+/**
+ * Write data as CSV to a given file.
+ *
+ * @access public
+ *
+ * @param resource $fd         File descriptor
+ * @param array    $rows       Array of rows to output
+ * @param array    $headers    List of CSV columns (optional)
+ */
+function write_csv( $fd, $rows, $headers = array() ) {
+	if ( ! empty( $headers ) ) {
+		fputcsv( $fd, $headers );
+	}
+
+	foreach ( $rows as $row ) {
+		if ( ! empty( $headers ) ) {
+			$row = pick_fields( $row, $headers );
+		}
+
+		fputcsv( $fd, array_values( $row ) );
+	}
+}
+
+/**
+ * Pick fields from an associative array or object.
+ *
+ * @param array|object Associative array or object to pick fields from
+ * @param array List of fields to pick
+ * @return array
+ */
+function pick_fields( $item, $fields ) {
+	$item = (object) $item;
+
+	$values = array();
+
+	foreach ( $fields as $field ) {
+		$values[ $field ] = isset( $item->$field ) ? $item->$field : null;
+	}
+
+	return $values;
+}
+
+/**
+ * Launch system's $EDITOR for the user to edit some text.
+ *
+ * @access public
+ * @category Input
+ *
+ * @param  string  $content  Some form of text to edit (e.g. post content)
+ * @return string|bool       Edited text, if file is saved from editor; false, if no change to file.
+ */
+function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
+
+	$tmpdir = get_temp_dir();
+
+	do {
+		$tmpfile = basename( $filename );
+		$tmpfile = preg_replace( '|\.[^.]*$|', '', $tmpfile );
+		$tmpfile .= '-' . substr( md5( rand() ), 0, 6 );
+		$tmpfile = $tmpdir . $tmpfile . '.tmp';
+		$fp = @fopen( $tmpfile, 'x' );
+		if ( ! $fp && is_writable( $tmpdir ) && file_exists( $tmpfile ) ) {
+			$tmpfile = '';
+			continue;
+		}
+		if ( $fp ) {
+			fclose( $fp );
+		}
+	} while( ! $tmpfile );
+
+	if ( ! $tmpfile ) {
+		\WP_CLI::error( 'Error creating temporary file.' );
+	}
+
+	$output = '';
+	file_put_contents( $tmpfile, $input );
+
+	$editor = getenv( 'EDITOR' );
+	if ( !$editor ) {
+		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) )
+			$editor = 'notepad';
+		else
+			$editor = 'vi';
+	}
+
+	$descriptorspec = array( STDIN, STDOUT, STDERR );
+	$process = proc_open( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
+	$r = proc_close( $process );
+	if ( $r ) {
+		exit( $r );
+	}
+
+	$output = file_get_contents( $tmpfile );
+
+	unlink( $tmpfile );
+
+	if ( $output === $input )
+		return false;
+
+	return $output;
+}
+
+/**
+ * @param string MySQL host string, as defined in wp-config.php
+ * @return array
+ */
+function mysql_host_to_cli_args( $raw_host ) {
+	$assoc_args = array();
+
+	$host_parts = explode( ':',  $raw_host );
+	if ( count( $host_parts ) == 2 ) {
+		list( $assoc_args['host'], $extra ) = $host_parts;
+		$extra = trim( $extra );
+		if ( is_numeric( $extra ) ) {
+			$assoc_args['port'] = intval( $extra );
+			$assoc_args['protocol'] = 'tcp';
+		} else if ( $extra !== '' ) {
+			$assoc_args['socket'] = $extra;
+		}
+	} else {
+		$assoc_args['host'] = $raw_host;
+	}
+
+	return $assoc_args;
+}
+
+function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
+	if ( !$descriptors )
+		$descriptors = array( STDIN, STDOUT, STDERR );
+
+	if ( isset( $assoc_args['host'] ) ) {
+		$assoc_args = array_merge( $assoc_args, mysql_host_to_cli_args( $assoc_args['host'] ) );
+	}
+
+	$pass = $assoc_args['pass'];
+	unset( $assoc_args['pass'] );
+
+	$old_pass = getenv( 'MYSQL_PWD' );
+	putenv( 'MYSQL_PWD=' . $pass );
+
+	$final_cmd = $cmd . assoc_args_to_str( $assoc_args );
+
+	$proc = proc_open( $final_cmd, $descriptors, $pipes );
+	if ( !$proc )
+		exit(1);
+
+	$r = proc_close( $proc );
+
+	putenv( 'MYSQL_PWD=' . $old_pass );
+
+	if ( $r ) exit( $r );
+}
+
+/**
+ * Render PHP or other types of files using Mustache templates.
+ *
+ * IMPORTANT: Automatic HTML escaping is disabled!
+ */
+function mustache_render( $template_name, $data = array() ) {
+	if ( ! file_exists( $template_name ) )
+		$template_name = WP_CLI_ROOT . "/templates/$template_name";
+
+	$template = file_get_contents( $template_name );
+
+	$m = new \Mustache_Engine( array(
+		'escape' => function ( $val ) { return $val; }
+	) );
+
+	return $m->render( $template, $data );
+}
+
+/**
+ * Create a progress bar to display percent completion of a given operation.
+ *
+ * Progress bar is written to STDOUT, and disabled when command is piped. Progress
+ * advances with `$progress->tick()`, and completes with `$progress->finish()`.
+ * Process bar also indicates elapsed time and expected total time.
+ *
+ * ```
+ * # `wp user generate` ticks progress bar each time a new user is created.
+ * #
+ * # $ wp user generate --count=500
+ * # Generating users  22 % [=======>                             ] 0:05 / 0:23
+ *
+ * $progress = \WP_CLI\Utils\make_progress_bar( 'Generating users', $count );
+ * for ( $i = 0; $i < $count; $i++ ) {
+ *     // uses wp_insert_user() to insert the user
+ *     $progress->tick();
+ * }
+ * $progress->finish();
+ * ```
+ *
+ * @access public
+ * @category Output
+ *
+ * @param string  $message  Text to display before the progress bar.
+ * @param integer $count    Total number of ticks to be performed.
+ * @return cli\progress\Bar|WP_CLI\NoOp
+ */
+function make_progress_bar( $message, $count ) {
+	if ( \cli\Shell::isPiped() )
+		return new \WP_CLI\NoOp;
+
+	return new \cli\progress\Bar( $message, $count );
+}
+
+function parse_url( $url ) {
+	$url_parts = \parse_url( $url );
+
+	if ( !isset( $url_parts['scheme'] ) ) {
+		$url_parts = parse_url( 'http://' . $url );
+	}
+
+	return $url_parts;
+}
+
+/**
+ * Check if we're running in a Windows environment (cmd.exe).
+ */
+function is_windows() {
+	return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+}
+
+/**
+ * Replace magic constants in some PHP source code.
+ *
+ * @param string $source The PHP code to manipulate.
+ * @param string $path The path to use instead of the magic constants
+ */
+function replace_path_consts( $source, $path ) {
+	$replacements = array(
+		'__FILE__' => "'$path'",
+		'__DIR__'  => "'" . dirname( $path ) . "'"
+	);
+
+	$old = array_keys( $replacements );
+	$new = array_values( $replacements );
+
+	return str_replace( $old, $new, $source );
+}
+
+/**
+ * Make a HTTP request to a remote URL.
+ *
+ * Wraps the Requests HTTP library to ensure every request includes a cert.
+ *
+ * ```
+ * # `wp core download` verifies the hash for a downloaded WordPress archive
+ *
+ * $md5_response = Utils\http_request( 'GET', $download_url . '.md5' );
+ * if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
+ *      WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})" );
+ * }
+ * ```
+ *
+ * @access public
+ *
+ * @param string $method    HTTP method (GET, POST, DELETE, etc.)
+ * @param string $url       URL to make the HTTP request to.
+ * @param array $headers    Add specific headers to the request.
+ * @param array $options
+ * @return object
+ */
+function http_request( $method, $url, $data = null, $headers = array(), $options = array() ) {
+
+	$cert_path = '/rmccue/requests/library/Requests/Transport/cacert.pem';
+	if ( inside_phar() ) {
+		// cURL can't read Phar archives
+		$options['verify'] = extract_from_phar(
+		WP_CLI_ROOT . '/vendor' . $cert_path );
+	} else {
+		foreach( get_vendor_paths() as $vendor_path ) {
+			if ( file_exists( $vendor_path . $cert_path ) ) {
+				$options['verify'] = $vendor_path . $cert_path;
+				break;
+			}
+		}
+		if ( empty( $options['verify'] ) ){
+			WP_CLI::error_log( "Cannot find SSL certificate." );
+		}
+	}
+
+	try {
+		$request = \Requests::request( $url, $headers, $data, $method, $options );
+		return $request;
+	} catch( \Requests_Exception $ex ) {
+		// Handle SSL certificate issues gracefully
+		\WP_CLI::warning( $ex->getMessage() );
+		$options['verify'] = false;
+		try {
+			return \Requests::request( $url, $headers, $data, $method, $options );
+		} catch( \Requests_Exception $ex ) {
+			\WP_CLI::error( $ex->getMessage() );
+		}
+	}
+}
+
+/**
+ * Increments a version string using the "x.y.z-pre" format
+ *
+ * Can increment the major, minor or patch number by one
+ * If $new_version == "same" the version string is not changed
+ * If $new_version is not a known keyword, it will be used as the new version string directly
+ *
+ * @param  string $current_version
+ * @param  string $new_version
+ * @return string
+ */
+function increment_version( $current_version, $new_version ) {
+	// split version assuming the format is x.y.z-pre
+	$current_version    = explode( '-', $current_version, 2 );
+	$current_version[0] = explode( '.', $current_version[0] );
+
+	switch ( $new_version ) {
+		case 'same':
+			// do nothing
+		break;
+
+		case 'patch':
+			$current_version[0][2]++;
+
+			$current_version = array( $current_version[0] ); // drop possible pre-release info
+		break;
+
+		case 'minor':
+			$current_version[0][1]++;
+			$current_version[0][2] = 0;
+
+			$current_version = array( $current_version[0] ); // drop possible pre-release info
+		break;
+
+		case 'major':
+			$current_version[0][0]++;
+			$current_version[0][1] = 0;
+			$current_version[0][2] = 0;
+
+			$current_version = array( $current_version[0] ); // drop possible pre-release info
+		break;
+
+		default: // not a keyword
+			$current_version = array( array( $new_version ) );
+		break;
+	}
+
+	// reconstruct version string
+	$current_version[0] = implode( '.', $current_version[0] );
+	$current_version    = implode( '-', $current_version );
+
+	return $current_version;
+}
+
+/**
+ * Compare two version strings to get the named semantic version.
+ *
+ * @access public
+ *
+ * @param string $new_version
+ * @param string $original_version
+ * @return string $name 'major', 'minor', 'patch'
+ */
+function get_named_sem_ver( $new_version, $original_version ) {
+
+	if ( ! Comparator::greaterThan( $new_version, $original_version ) ) {
+		return '';
+	}
+
+	$parts = explode( '-', $original_version );
+	list( $major, $minor, $patch ) = explode( '.', $parts[0] );
+
+	if ( Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
+		return 'patch';
+	} else if ( Semver::satisfies( $new_version, "{$major}.x.x" ) ) {
+		return 'minor';
+	} else {
+		return 'major';
+	}
+}
+
+/**
+ * Return the flag value or, if it's not set, the $default value.
+ *
+ * Because flags can be negated (e.g. --no-quiet to negate --quiet), this
+ * function provides a safer alternative to using
+ * `isset( $assoc_args['quiet'] )` or similar.
+ *
+ * @access public
+ * @category Input
+ *
+ * @param array  $assoc_args  Arguments array.
+ * @param string $flag        Flag to get the value.
+ * @param mixed  $default     Default value for the flag. Default: NULL
+ * @return mixed
+ */
+function get_flag_value( $assoc_args, $flag, $default = null ) {
+	return isset( $assoc_args[ $flag ] ) ? $assoc_args[ $flag ] : $default;
+}
+
+/**
+ * Get the system's temp directory. Warns user if it isn't writable.
+ *
+ * @access public
+ * @category System
+ *
+ * @return string
+ */
+function get_temp_dir() {
+	static $temp = '';
+
+	$trailingslashit = function( $path ) {
+		return rtrim( $path ) . '/';
+	};
+
+	if ( $temp )
+		return $trailingslashit( $temp );
+
+	if ( function_exists( 'sys_get_temp_dir' ) ) {
+		$temp = sys_get_temp_dir();
+	} else if ( ini_get( 'upload_tmp_dir' ) ) {
+		$temp = ini_get( 'upload_tmp_dir' );
+	} else {
+		$temp = '/tmp/';
+	}
+
+	if ( ! @is_writable( $temp ) ) {
+		WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
+	}
+
+	return $trailingslashit( $temp );
+}
+
+/**
+ * Parse a SSH url for its host, port, and path.
+ *
+ * Similar to parse_url(), but adds support for defined SSH aliases.
+ *
+ * ```
+ * host OR host/path/to/wordpress OR host:port/path/to/wordpress
+ * ```
+ *
+ * @access public
+ *
+ * @return mixed
+ */
+function parse_ssh_url( $url, $component = -1 ) {
+	preg_match( '#^([^:/~]+)(:([\d]+))?((/|~)(.+))?$#', $url, $matches );
+	$bits = array();
+	foreach( array(
+		1 => 'host',
+		3 => 'port',
+		4 => 'path',
+	) as $i => $key ) {
+		if ( ! empty( $matches[ $i ] ) ) {
+			$bits[ $key ] = $matches[ $i ];
+		}
+	}
+	switch ( $component ) {
+		case PHP_URL_HOST:
+			return isset( $bits['host'] ) ? $bits['host'] : null;
+		case PHP_URL_PATH:
+			return isset( $bits['path'] ) ? $bits['path'] : null;
+		case PHP_URL_PORT:
+			return isset( $bits['port'] ) ? $bits['port'] : null;
+		default:
+			return $bits;
+	}
+}

--- a/tests/cli/features/customer.feature
+++ b/tests/cli/features/customer.feature
@@ -1,0 +1,63 @@
+Feature: Manage WooCommerce customers
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc customer --help`
+	Then STDOUT should contain:
+		"""
+		wp wc customer <command>
+		"""
+	And STDOUT should contain:
+		"""
+		create
+		"""
+	And STDOUT should contain:
+		"""
+		delete
+		"""
+	And STDOUT should contain:
+		"""
+		get
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+	And STDOUT should contain:
+		"""
+		update
+		"""
+
+Scenario: Get the value of an individual post field
+
+ 	When I run `wp wc customer get 1 --field=username --user=1`
+	Then STDOUT should contain:
+		"""
+		admin
+		"""
+
+Scenario: CRUD a post
+
+	When I run `wp wc customer create --user=admin --username="testuser" --password="hunter2" --email="woo@woo.local"  --porcelain`
+	Then STDOUT should be a number
+	And save STDOUT as {CUSTOMER_ID}
+
+	When I run `wp wc customer update {CUSTOMER_ID} --user=admin --first_name="Test" --billing='{"city":"Portland","state":"OR"}' --porcelain`
+	Then STDOUT should be a number
+
+	When I run `wp wc customer get {CUSTOMER_ID} --user=admin`
+	Then STDOUT should contain:
+		"""
+		Portland
+		"""
+	And STDOUT should contain:
+		"""
+		woo@woo.local
+		"""
+
+	When I run `wp wc customer delete {CUSTOMER_ID} --force=true --user=admin --porcelain`
+	Then STDOUT should be a number

--- a/tests/cli/features/customer_download.feature
+++ b/tests/cli/features/customer_download.feature
@@ -1,0 +1,25 @@
+Feature: List WooCommerce customer downloads
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc customer_download --help`
+	Then STDOUT should contain:
+		"""
+		wp wc customer_download <command>
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+
+Scenario: List a specific customer's downloads
+
+	When I run `wp wc customer_download list 1 --user=1`
+	Then STDOUT should contain:
+		"""
+		download_url
+		"""

--- a/tests/cli/features/extra/no-mail.php
+++ b/tests/cli/features/extra/no-mail.php
@@ -1,0 +1,6 @@
+<?php
+
+function wp_mail() {
+	// do nothing
+}
+

--- a/tests/cli/features/payment_gateway.feature
+++ b/tests/cli/features/payment_gateway.feature
@@ -1,0 +1,71 @@
+Feature: Manage WooCommerce Payment Gateways
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc payment_gateway --help`
+	Then STDOUT should contain:
+		"""
+		wp wc payment_gateway <command>
+		"""
+	And STDOUT should contain:
+		"""
+		get
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+	And STDOUT should contain:
+		"""
+		update
+		"""
+
+Scenario: List Payment Gateways
+
+	When I run `wp wc payment_gateway list --user=admin`
+	Then STDOUT should contain:
+		"""
+		cod
+		"""
+	And STDOUT should contain:
+		"""
+		BACS
+		"""
+	And STDOUT should contain:
+		"""
+		id
+		"""
+	And STDOUT should contain:
+		"""
+		method_title
+		"""
+
+Scenario: Read & Update Payment Gateways
+
+	When I run `wp wc payment_gateway update bacs --user=admin --title="Updated Direct Bank Transfer" --settings='{"instructions":"These are test instructions"}' --porcelain`
+	Then STDOUT should contain:
+		"""
+		bacs
+		"""
+
+	When I run `wp wc payment_gateway get bacs --user=admin`
+	Then STDOUT should contain:
+		"""
+		BACS
+		"""
+	And STDOUT should contain:
+		"""
+		Updated Direct Bank Transfer
+		"""
+	And STDOUT should contain:
+		"""
+		Updated Direct Bank Transfer
+		"""
+	And STDOUT should contain:
+		"""
+		These are test instructions
+		"""

--- a/tests/cli/features/product.feature
+++ b/tests/cli/features/product.feature
@@ -1,0 +1,89 @@
+Feature: Manage WooCommerce Products
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc product --help`
+	Then STDOUT should contain:
+		"""
+		wp wc product <command>
+		"""
+	And STDOUT should contain:
+		"""
+		create
+		"""
+	And STDOUT should contain:
+		"""
+		delete
+		"""
+	And STDOUT should contain:
+		"""
+		get
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+	And STDOUT should contain:
+		"""
+		update
+		"""
+
+Scenario: CRUD a product
+
+	When I run `wp wc product create --user=admin --name='Test Simple Product' --type='simple' --regular_price='10.00' --sale_price='7.99' --porcelain`
+	Then save STDOUT as {PRODUCT_ID}
+
+	When I run `wp wc product update {PRODUCT_ID} --user=admin --description="Test product description" --sku='TEST SKU' --attributes='[{ "id": 0, "name": "Color", "position": 0, "visible": true, "variation": false, "options": ["Red", "Blue", "Green", "Yellow"]}]' --porcelain`
+	Then STDOUT should be a number
+
+	When I run `wp wc product get {PRODUCT_ID} --user=admin`
+	Then STDOUT should contain:
+		"""
+		10.00
+		"""
+	And STDOUT should contain:
+		"""
+		7.99
+		"""
+	And STDOUT should contain:
+		"""
+		TEST SKU
+		"""
+	And STDOUT should contain:
+		"""
+		Test product description
+		"""
+	And STDOUT should contain:
+		"""
+		Color
+		"""
+	And STDOUT should contain:
+		"""
+		Yellow
+		"""
+
+	When I run `wp wc product get {PRODUCT_ID} --user=admin --field=price`
+	Then STDOUT should contain:
+		"""
+		7.99
+		"""
+
+	When I run `wp wc product list --user=admin`
+	Then STDOUT should contain:
+		"""
+		date_created
+		"""
+	And STDOUT should contain:
+		"""
+		Test Simple Product
+		"""
+
+	When I run `wp wc product delete {PRODUCT_ID} --force=true --user=admin`
+ 	Then STDOUT should contain:
+		"""
+		Success
+		"""

--- a/tests/cli/features/product_review.feature
+++ b/tests/cli/features/product_review.feature
@@ -1,0 +1,75 @@
+Feature: Manage WooCommerce Product Reviews
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc product_review --help`
+	Then STDOUT should contain:
+		"""
+		wp wc product_review <command>
+		"""
+	And STDOUT should contain:
+		"""
+		create
+		"""
+	And STDOUT should contain:
+		"""
+		delete
+		"""
+	And STDOUT should contain:
+		"""
+		get
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+	And STDOUT should contain:
+		"""
+		update
+		"""
+
+Scenario: CRUD a product review
+
+	When I run `wp wc product create --user=admin --name='Test Simple Product'  --porcelain`
+	Then save STDOUT as {PRODUCT_ID}
+
+	When I run `wp wc product_review create {PRODUCT_ID} --user=admin --review='Testing' --name='Mr. Test' --email='woo@woo.local' --porcelain`
+	Then STDOUT should be a number
+	And save STDOUT as {PRODUCT_REVIEW_ID}
+
+	When I run `wp wc product_review update {PRODUCT_ID} {PRODUCT_REVIEW_ID} --user=admin --review="Updated" --porcelain`
+	Then STDOUT should be a number
+
+	When I run `wp wc product_review get {PRODUCT_ID} {PRODUCT_REVIEW_ID} --user=admin`
+	Then STDOUT should contain:
+		"""
+		Updated
+		"""
+	And STDOUT should contain:
+		"""
+		woo@woo.local
+		"""
+	And STDOUT should contain:
+		"""
+		Mr. Test
+		"""
+
+	When I run `wp wc product_review list {PRODUCT_ID} --user=admin`
+	Then STDOUT should contain:
+		"""
+		date_created
+		"""
+	And STDOUT should contain:
+		"""
+		Updated
+		"""
+
+	When I run `wp wc product_review delete {PRODUCT_ID} {PRODUCT_REVIEW_ID} --force=true --user=admin`
+ 	Then STDOUT should contain:
+		"""
+		Success
+		"""

--- a/tests/cli/features/shop_coupon.feature
+++ b/tests/cli/features/shop_coupon.feature
@@ -1,0 +1,81 @@
+Feature: Manage WooCommerce Coupons
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc shop_coupon --help`
+	Then STDOUT should contain:
+		"""
+		wp wc shop_coupon <command>
+		"""
+	And STDOUT should contain:
+		"""
+		create
+		"""
+	And STDOUT should contain:
+		"""
+		delete
+		"""
+	And STDOUT should contain:
+		"""
+		get
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+	And STDOUT should contain:
+		"""
+		update
+		"""
+
+Scenario: CRUD a coupon
+
+	When I run `wp wc shop_coupon create --user=admin --code='coupon code' --discount_type='fixed_product' --amount='5.00'  --porcelain`
+	Then save STDOUT as {COUPON_ID}
+
+	When I run `wp wc shop_coupon update {COUPON_ID} --user=admin --discount_type="percent_product" --amount='2' --porcelain`
+	Then STDOUT should be a number
+
+	When I run `wp wc shop_coupon get {COUPON_ID} --user=admin`
+	Then STDOUT should contain:
+		"""
+		coupon code
+		"""
+	And STDOUT should contain:
+		"""
+		percent_product
+		"""
+
+	When I run `wp wc shop_coupon get {COUPON_ID} --user=admin --field=amount`
+	Then STDOUT should contain:
+		"""
+		2.00
+		"""
+
+	When I run `wp wc shop_coupon list --user=admin`
+	Then STDOUT should contain:
+		"""
+		id
+		"""
+	And STDOUT should contain:
+		"""
+		code
+		"""
+	And STDOUT should contain:
+		"""
+		date_created
+		"""
+	And STDOUT should contain:
+		"""
+		coupon code
+		"""
+
+	When I run `wp wc shop_coupon delete {COUPON_ID} --force=true --user=admin`
+ 	Then STDOUT should contain:
+		"""
+		Success
+		"""

--- a/tests/cli/features/steps/given.php
+++ b/tests/cli/features/steps/given.php
@@ -1,0 +1,157 @@
+<?php
+
+use Behat\Gherkin\Node\PyStringNode,
+    Behat\Gherkin\Node\TableNode,
+    WP_CLI\Process;
+
+$steps->Given( '/^an empty directory$/',
+	function ( $world ) {
+		$world->create_run_dir();
+	}
+);
+
+$steps->Given( '/^an empty cache/',
+	function ( $world ) {
+		$world->variables['SUITE_CACHE_DIR'] = FeatureContext::create_cache_dir();
+	}
+);
+
+$steps->Given( '/^an? ([^\s]+) file:$/',
+	function ( $world, $path, PyStringNode $content ) {
+		$content = (string) $content . "\n";
+		$full_path = $world->variables['RUN_DIR'] . "/$path";
+		Process::create( \WP_CLI\utils\esc_cmd( 'mkdir -p %s', dirname( $full_path ) ) )->run_check();
+		file_put_contents( $full_path, $content );
+	}
+);
+
+$steps->Given( '/^WP files$/',
+	function ( $world ) {
+		$world->download_wp();
+	}
+);
+
+$steps->Given( '/^wp-config\.php$/',
+	function ( $world ) {
+		$world->create_config();
+	}
+);
+
+$steps->Given( '/^a database$/',
+	function ( $world ) {
+		$world->create_db();
+	}
+);
+
+$steps->Given( '/^a WP install$/',
+	function ( $world ) {
+		$world->install_wp();
+	}
+);
+
+$steps->Given( "/^a WP install in '([^\s]+)'$/",
+	function ( $world, $subdir ) {
+		$world->install_wp( $subdir );
+	}
+);
+
+$steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
+	function ( $world, $type = 'subdirectory' ) {
+		$world->install_wp();
+		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
+		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run_check();
+	}
+);
+
+$steps->Given( '/^these installed and active plugins:$/',
+	function( $world, $stream ) {
+		$plugins = implode( ' ', array_map( 'trim', explode( PHP_EOL, (string)$stream ) ) );
+		$world->proc( "wp plugin install $plugins --activate" )->run_check();
+	}
+);
+
+$steps->Given( '/^a custom wp-content directory$/',
+	function ( $world ) {
+		$wp_config_path = $world->variables['RUN_DIR'] . "/wp-config.php";
+
+		$wp_config_code = file_get_contents( $wp_config_path );
+
+		$world->move_files( 'wp-content', 'my-content' );
+		$world->add_line_to_wp_config( $wp_config_code,
+			"define( 'WP_CONTENT_DIR', dirname(__FILE__) . '/my-content' );" );
+
+		$world->move_files( 'my-content/plugins', 'my-plugins' );
+		$world->add_line_to_wp_config( $wp_config_code,
+			"define( 'WP_PLUGIN_DIR', __DIR__ . '/my-plugins' );" );
+
+		file_put_contents( $wp_config_path, $wp_config_code );
+	}
+);
+
+$steps->Given( '/^download:$/',
+	function ( $world, TableNode $table ) {
+		foreach ( $table->getHash() as $row ) {
+			$path = $world->replace_variables( $row['path'] );
+			if ( file_exists( $path ) ) {
+				// assume it's the same file and skip re-download
+				continue;
+			}
+
+			Process::create( \WP_CLI\Utils\esc_cmd( 'curl -sSL %s > %s', $row['url'], $path ) )->run_check();
+		}
+	}
+);
+
+$steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?as \{(\w+)\}$/',
+	function ( $world, $stream, $output_filter, $key ) {
+
+		$stream = strtolower( $stream );
+
+		if ( $output_filter ) {
+			$output_filter = '/' . trim( str_replace( '%s', '(.+[^\b])', $output_filter ), "' " ) . '/';
+			if ( false !== preg_match( $output_filter, $world->result->$stream, $matches ) )
+				$output = array_pop( $matches );
+			else
+				$output = '';
+		} else {
+			$output = $world->result->$stream;
+		}
+		$world->variables[ $key ] = trim( $output, "\n" );
+	}
+);
+
+$steps->Given( '/^a new Phar(?: with version "([^"]+)")$/',
+	function ( $world, $version ) {
+		$world->build_phar( $version );
+	}
+);
+
+$steps->Given( '/^save the (.+) file ([\'].+[^\'])?as \{(\w+)\}$/',
+	function ( $world, $filepath, $output_filter, $key ) {
+		$full_file = file_get_contents( $world->replace_variables( $filepath ) );
+
+		if ( $output_filter ) {
+			$output_filter = '/' . trim( str_replace( '%s', '(.+[^\b])', $output_filter ), "' " ) . '/';
+			if ( false !== preg_match( $output_filter, $full_file, $matches ) )
+				$output = array_pop( $matches );
+			else
+				$output = '';
+		} else {
+			$output = $full_file;
+		}
+		$world->variables[ $key ] = trim( $output, "\n" );
+	}
+);
+
+$steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
+	function($world) {
+		$wp_config_path = $world->variables['RUN_DIR'] . "/wp-config.php";
+
+		$wp_config_code = file_get_contents( $wp_config_path );
+
+		$world->add_line_to_wp_config( $wp_config_code,
+			"define( 'WP_CONTENT_DIR', '' );" );
+
+		file_put_contents( $wp_config_path, $wp_config_code );
+	}
+);

--- a/tests/cli/features/steps/then.php
+++ b/tests/cli/features/steps/then.php
@@ -1,0 +1,192 @@
+<?php
+
+use Behat\Gherkin\Node\PyStringNode,
+    Behat\Gherkin\Node\TableNode;
+
+$steps->Then( '/^the return code should be (\d+)$/',
+	function ( $world, $return_code ) {
+		if ( $return_code != $world->result->return_code ) {
+			throw new RuntimeException( $world->result );
+		}
+	}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
+	function ( $world, $stream, $action, PyStringNode $expected ) {
+
+		$stream = strtolower( $stream );
+
+		$expected = $world->replace_variables( (string) $expected );
+
+		checkString( $world->result->$stream, $expected, $action, $world->result );
+	}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should be a number$/',
+	function ( $world, $stream ) {
+
+		$stream = strtolower( $stream );
+
+		assertNumeric( trim( $world->result->$stream, "\n" ) );
+	}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should not be a number$/',
+	function ( $world, $stream ) {
+
+		$stream = strtolower( $stream );
+
+		assertNotNumeric( trim( $world->result->$stream, "\n" ) );
+	}
+);
+
+$steps->Then( '/^STDOUT should be a table containing rows:$/',
+	function ( $world, TableNode $expected ) {
+		$output      = $world->result->stdout;
+		$actual_rows = explode( "\n", rtrim( $output, "\n" ) );
+
+		$expected_rows = array();
+		foreach ( $expected->getRows() as $row ) {
+			$expected_rows[] = $world->replace_variables( implode( "\t", $row ) );
+		}
+
+		compareTables( $expected_rows, $actual_rows, $output );
+	}
+);
+
+$steps->Then( '/^STDOUT should end with a table containing rows:$/',
+	function ( $world, TableNode $expected ) {
+		$output      = $world->result->stdout;
+		$actual_rows = explode( "\n", rtrim( $output, "\n" ) );
+
+		$expected_rows = array();
+		foreach ( $expected->getRows() as $row ) {
+			$expected_rows[] = $world->replace_variables( implode( "\t", $row ) );
+		}
+
+		$start = array_search( $expected_rows[0], $actual_rows );
+
+		if ( false === $start )
+			throw new \Exception( $world->result );
+
+		compareTables( $expected_rows, array_slice( $actual_rows, $start ), $output );
+	}
+);
+
+$steps->Then( '/^STDOUT should be JSON containing:$/',
+	function ( $world, PyStringNode $expected ) {
+		$output = $world->result->stdout;
+		$expected = $world->replace_variables( (string) $expected );
+
+		if ( !checkThatJsonStringContainsJsonString( $output, $expected ) ) {
+			throw new \Exception( $world->result );
+		}
+});
+
+$steps->Then( '/^STDOUT should be a JSON array containing:$/',
+	function ( $world, PyStringNode $expected ) {
+		$output = $world->result->stdout;
+		$expected = $world->replace_variables( (string) $expected );
+
+		$actualValues = json_decode( $output );
+		$expectedValues = json_decode( $expected );
+
+		$missing = array_diff( $expectedValues, $actualValues );
+		if ( !empty( $missing ) ) {
+			throw new \Exception( $world->result );
+		}
+});
+
+$steps->Then( '/^STDOUT should be CSV containing:$/',
+	function ( $world, TableNode $expected ) {
+		$output = $world->result->stdout;
+
+		$expected_rows = $expected->getRows();
+		foreach ( $expected as &$row ) {
+			foreach ( $row as &$value ) {
+				$value = $world->replace_variables( $value );
+			}
+		}
+
+		if ( ! checkThatCsvStringContainsValues( $output, $expected_rows ) )
+			throw new \Exception( $world->result );
+	}
+);
+
+$steps->Then( '/^STDOUT should be YAML containing:$/',
+	function ( $world, PyStringNode $expected ) {
+		$output = $world->result->stdout;
+		$expected = $world->replace_variables( (string) $expected );
+
+		if ( !checkThatYamlStringContainsYamlString( $output, $expected ) ) {
+			throw new \Exception( $world->result );
+		}
+});
+
+$steps->Then( '/^(STDOUT|STDERR) should be empty$/',
+	function ( $world, $stream ) {
+
+		$stream = strtolower( $stream );
+
+		if ( !empty( $world->result->$stream ) ) {
+			throw new \Exception( $world->result );
+		}
+	}
+);
+
+$steps->Then( '/^(STDOUT|STDERR) should not be empty$/',
+	function ( $world, $stream ) {
+
+		$stream = strtolower( $stream );
+
+		if ( '' === rtrim( $world->result->$stream, "\n" ) ) {
+			throw new Exception( $world->result );
+		}
+	}
+);
+
+$steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
+	function ( $world, $path, $type, $action, $expected = null ) {
+		$path = $world->replace_variables( $path );
+
+		// If it's a relative path, make it relative to the current test dir
+		if ( '/' !== $path[0] )
+			$path = $world->variables['RUN_DIR'] . "/$path";
+
+		if ( 'file' == $type ) {
+			$test = 'file_exists';
+		} else if ( 'directory' == $type ) {
+			$test = 'is_dir';
+		}
+
+		switch ( $action ) {
+		case 'exist':
+			if ( ! $test( $path ) ) {
+				throw new Exception( $world->result );
+			}
+			break;
+		case 'not exist':
+			if ( $test( $path ) ) {
+				throw new Exception( $world->result );
+			}
+			break;
+		default:
+			if ( ! $test( $path ) ) {
+				throw new Exception( "$path doesn't exist." );
+			}
+			$action = substr( $action, 0, -1 );
+			$expected = $world->replace_variables( (string) $expected );
+			if ( 'file' == $type ) {
+				$contents = file_get_contents( $path );
+			} else if ( 'directory' == $type ) {
+				$files = glob( rtrim( $path, '/' ) . '/*' );
+				foreach( $files as &$file ) {
+					$file = str_replace( $path . '/', '', $file );
+				}
+				$contents = implode( PHP_EOL, $files );
+			}
+			checkString( $contents, $expected, $action );
+		}
+	}
+);
+

--- a/tests/cli/features/steps/when.php
+++ b/tests/cli/features/steps/when.php
@@ -1,0 +1,46 @@
+<?php
+
+use Behat\Gherkin\Node\PyStringNode,
+    Behat\Gherkin\Node\TableNode,
+    WP_CLI\Process;
+
+function invoke_proc( $proc, $mode ) {
+	$map = array(
+		'run' => 'run_check',
+		'try' => 'run'
+	);
+	$method = $map[ $mode ];
+
+	return $proc->$method();
+}
+
+$steps->When( '/^I launch in the background `([^`]+)`$/',
+	function ( $world, $cmd ) {
+		$world->background_proc( $cmd );
+	}
+);
+
+$steps->When( '/^I (run|try) `([^`]+)`$/',
+	function ( $world, $mode, $cmd ) {
+		$cmd = $world->replace_variables( $cmd );
+		$world->result = invoke_proc( $world->proc( $cmd ), $mode );
+	}
+);
+
+$steps->When( "/^I (run|try) `([^`]+)` from '([^\s]+)'$/",
+	function ( $world, $mode, $cmd, $subdir ) {
+		$cmd = $world->replace_variables( $cmd );
+		$world->result = invoke_proc( $world->proc( $cmd, array(), $subdir ), $mode );
+	}
+);
+
+$steps->When( '/^I (run|try) the previous command again$/',
+	function ( $world, $mode ) {
+		if ( !isset( $world->result ) )
+			throw new \Exception( 'No previous command.' );
+
+		$proc = Process::create( $world->result->command, $world->result->cwd, $world->result->env );
+		$world->result = invoke_proc( $proc, $mode );
+	}
+);
+

--- a/tests/cli/features/tool.feature
+++ b/tests/cli/features/tool.feature
@@ -1,0 +1,60 @@
+Feature: Running system status tools
+
+Background:
+
+	Given a WP install
+
+Scenario: Help for all available commands
+
+	When I run `wp wc tool --help`
+	Then STDOUT should contain:
+		"""
+		wp wc tool <command>
+		"""
+	And STDOUT should contain:
+		"""
+		list
+		"""
+	And STDOUT should contain:
+		"""
+		run
+		"""
+
+	When I run `wp wc tool list --help`
+	Then STDOUT should contain:
+		"""
+		wp wc tool list [--fields=<fields>] [--field=<field>]
+		"""
+
+	When I run `wp wc tool run --help`
+	Then STDOUT should contain:
+		"""
+		wp wc tool run <id>
+		"""
+
+Scenario: List all available tools
+
+	When I run `wp wc tool list --user=1`
+	Then STDOUT should be a table containing rows:
+	| id                | name          | action           | description                                             |
+	| clear_transients  | WC transients | Clear transients | This tool will clear the product/shop transients cache. |
+
+	When I run `wp wc tool list --format=ids --user=1`
+	Then STDOUT should contain:
+		"""
+		install_pages delete_taxes reset_tracking
+		"""
+
+	When I run `wp wc tool list --format=body --user=1`
+	Then STDOUT should be JSON containing:
+		"""
+		[{"id":"clear_transients"}]
+		"""
+
+Scenario: Run a specific tool
+
+	When I run `wp wc tool run clear_transients --user=1`
+	Then STDOUT should contain:
+		"""
+		Success: Updated system_status_tool clear_transients.
+		"""

--- a/tests/cli/utils/behat-tags.php
+++ b/tests/cli/utils/behat-tags.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Generate a list of tags to skip during the test run.
+ *
+ * Require a minimum version of WordPress:
+ *
+ *   @require-wp-4.0
+ *   Scenario: Core translation CRUD
+ *
+ * Then use in bash script:
+ *
+ *   BEHAT_TAGS=$(php behat-tags.php)
+ *   vendor/bin/behat --format progress $BEHAT_TAGS
+ */
+
+function version_tags( $prefix, $current, $operator = '<' ) {
+	if ( ! $current )
+		return;
+
+	exec( "grep '@{$prefix}-[0-9\.]*' -h -o features/*.feature | uniq", $existing_tags );
+
+	$skip_tags = array();
+
+	foreach ( $existing_tags as $tag ) {
+		$compare = str_replace( "@{$prefix}-", '', $tag );
+		if ( version_compare( $current, $compare, $operator ) ) {
+			$skip_tags[] = $tag;
+		}
+	}
+
+	return $skip_tags;
+}
+
+$skip_tags = array_merge(
+	version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' ),
+	version_tags( 'require-php', PHP_VERSION, '<' ),
+	version_tags( 'less-than-php', PHP_VERSION, '>' )
+);
+
+# Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
+$skip_tags[] = '@github-api';
+
+if ( !empty( $skip_tags ) ) {
+	echo '--tags=~' . implode( '&&~', $skip_tags );
+}
+

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'WooCommerce' ) ) :
  * Main WooCommerce Class.
  *
  * @class WooCommerce
- * @version	2.6.0
+ * @version	2.7.0
  */
 final class WooCommerce {
 
@@ -331,6 +331,11 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/data-stores/abstract-wc-order-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-order-data-store-cpt.php' );
 		include_once( WC_ABSPATH . 'includes/data-stores/class-wc-order-refund-data-store-cpt.php' );
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			include_once( WC_ABSPATH . 'includes/class-wc-cli.php' );
+			new WC_CLI;
+		}
 
 		$this->query = new WC_Query();
 		$this->api   = new WC_API();


### PR DESCRIPTION
Here is the new REST API powered WooCommerce CLI, moved from it's separate repo into part of WC. Forked from Restful.

The main files are in `includes/cli/` and `tests/cli/features/*.feature`. Some of the files in this PR are from the behat/test scaffolding WC CLI commands use (https://github.com/wp-cli/scaffold-package-command).

You can list available commands with `wp wc --help`.

You can also run the tests by going into the tests/cli folder. Make sure `WP_CLI_BIN_DIR` is set, run `bash bin/install-package-tests.sh`, and finally run ` ./vendor/bin/behat features/` to run all tests. You can run individual test sections/commands with something like: `./vendor/bin/behat features/customer.feature`. More tests to come later.