### PR TITLE
CRUD reduce queries

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1217,7 +1217,13 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $image_ids
 	 */
 	public function set_gallery_image_ids( $image_ids ) {
-		$this->set_prop( 'gallery_image_ids', array_filter( array_filter( $image_ids ), 'wp_attachment_is_image' ) );
+		$image_ids = wp_parse_id_list( $image_ids );
+
+		if ( $this->get_object_read() ) {
+			$image_ids = array_filter( $image_ids, 'wp_attachment_is_image' );
+		}
+
+		$this->set_prop( 'gallery_image_ids', $image_ids );
 	}
 
 	/**

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -225,6 +225,7 @@ class WC_Cart {
 		if ( is_array( $cart ) ) {
 			// Prime meta cache to reduce future queries
 			update_meta_cache( 'post', wp_list_pluck( $cart, 'product_id' ) );
+			update_object_term_cache( wp_list_pluck( $cart, 'product_id' ), 'product' );
 
 			foreach ( $cart as $key => $values ) {
 				$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -373,6 +373,11 @@ class WC_Install {
 				'exclude-from-catalog',
 				'featured',
 				'outofstock',
+				'rated-1',
+				'rated-2',
+				'rated-3',
+				'rated-4',
+				'rated-5',
 			),
 		);
 

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -187,6 +187,11 @@ class WC_Post_Data {
 	 * @return null|bool
 	 */
 	public static function update_post_metadata( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
+		// Delete product cache if someone uses meta directly.
+		if ( in_array( get_post_type( $object_id ), array( 'product', 'product_variation' ) ) ) {
+			wp_cache_delete( 'product-' . $object_id, 'products' );
+		}
+
 		if ( ! empty( $meta_value ) && is_float( $meta_value ) && in_array( get_post_type( $object_id ), array_merge( wc_get_order_types(), array( 'shop_coupon', 'product', 'product_variation' ) ) ) ) {
 
 			// Convert float to string

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -45,7 +45,15 @@ class WC_Product_Factory {
 		}
 
 		try {
-			return new $classname( $product_id );
+			// Try to get from cache, otherwise create a new object,
+			$product = wp_cache_get( WC_Cache_Helper::get_cache_prefix( 'product-' . $product_id ), 'products' );
+
+			if ( ! is_a( $product, 'WC_Product' ) ) {
+				$product = new $classname( $product_id );
+				wp_cache_set( WC_Cache_Helper::get_cache_prefix( 'product-' . $product_id ), $product, 'products' );
+			}
+
+			return $product;
 		} catch ( Exception $e ) {
 			return false;
 		}

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -46,11 +46,11 @@ class WC_Product_Factory {
 
 		try {
 			// Try to get from cache, otherwise create a new object,
-			$product = wp_cache_get( WC_Cache_Helper::get_cache_prefix( 'product-' . $product_id ), 'products' );
+			$product = wp_cache_get( 'product-' . $product_id, 'products' );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				$product = new $classname( $product_id );
-				wp_cache_set( WC_Cache_Helper::get_cache_prefix( 'product-' . $product_id ), $product, 'products' );
+				wp_cache_set( 'product-' . $product_id, $product, 'products' );
 			}
 
 			return $product;

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -29,7 +29,6 @@ class WC_Product_Factory {
 		if ( ! $product_id ) {
 			return false;
 		}
-
 		$product_type = $this->get_product_type( $product_id );
 		$classname    = $this->get_classname_from_product_type( $product_type );
 
@@ -64,6 +63,7 @@ class WC_Product_Factory {
 		$override = apply_filters( 'woocommerce_product_type_query', false, $product_id );
 		if ( ! $override ) {
 			$post_type = get_post_type( $product_id );
+
 			if ( 'product_variation' === $post_type ) {
 				return 'variation';
 			} elseif ( 'product' === $post_type ) {

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -615,16 +615,17 @@ class WC_Query {
 			}
 		}
 
-		$product_visibility_not_in = array( is_search() && $main_query ? 'exclude-from-search' : 'exclude-from-catalog' );
+		$product_visibiity_terms   = wc_get_product_visibility_term_ids();
+		$product_visibility_not_in = array( is_search() && $main_query ? $product_visibiity_terms['exclude-from-search'] : $product_visibiity_terms['exclude-from-catalog'] );
 
 		// Hide out of stock products.
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-			$product_visibility_not_in[] = 'outofstock';
+			$product_visibility_not_in[] = $product_visibiity_terms['outofstock'];
 		}
 
 		$tax_query[] = array(
 			'taxonomy' => 'product_visibility',
-			'field'    => 'name',
+			'field'    => 'term_taxonomy_id',
 			'terms'    => $product_visibility_not_in,
 			'operator' => 'NOT IN',
 		);

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -533,62 +533,8 @@ class WC_Query {
 		if ( ! is_array( $meta_query ) ) {
 			$meta_query = array();
 		}
-
 		$meta_query['price_filter']  = $this->price_filter_meta_query();
-		$meta_query['rating_filter'] = $this->rating_filter_meta_query();
-
 		return array_filter( apply_filters( 'woocommerce_product_query_meta_query', $meta_query, $this ) );
-	}
-
-	/**
-	 * Return a meta query for filtering by price.
-	 * @return array
-	 */
-	private function price_filter_meta_query() {
-		if ( isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) ) {
-			$meta_query = wc_get_min_max_price_meta_query( $_GET );
-			$meta_query['price_filter'] = true;
-
-			return $meta_query;
-		}
-
-		return array();
-	}
-
-	/**
-	 * Return a meta query for filtering by rating.
-	 * @return array
-	 */
-	public function rating_filter_meta_query() {
-		return isset( $_GET['min_rating'] ) ? array(
-			'key'           => '_wc_average_rating',
-			'value'         => isset( $_GET['min_rating'] ) ? floatval( $_GET['min_rating'] ) : 0,
-			'compare'       => '>=',
-			'type'          => 'DECIMAL',
-			'rating_filter' => true,
-		) : array();
-	}
-
-	/**
-	 * Returns a meta query to handle product visibility.
-	 *
-	 * @deprecated 2.7.0 Replaced with taxonomy.
-	 * @param string $compare (default: 'IN')
-	 * @return array
-	 */
-	public function visibility_meta_query( $compare = 'IN' ) {
-		return array();
-	}
-
-	/**
-	 * Returns a meta query to handle product stock status.
-	 *
-	 * @deprecated 2.7.0 Replaced with taxonomy.
-	 * @param string $status (default: 'instock')
-	 * @return array
-	 */
-	public function stock_status_meta_query( $status = 'instock' ) {
-		return array();
 	}
 
 	/**
@@ -617,20 +563,90 @@ class WC_Query {
 
 		$product_visibiity_terms   = wc_get_product_visibility_term_ids();
 		$product_visibility_not_in = array( is_search() && $main_query ? $product_visibiity_terms['exclude-from-search'] : $product_visibiity_terms['exclude-from-catalog'] );
+		$product_visibility_in     = array();
 
 		// Hide out of stock products.
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$product_visibility_not_in[] = $product_visibiity_terms['outofstock'];
 		}
 
-		$tax_query[] = array(
-			'taxonomy' => 'product_visibility',
-			'field'    => 'term_taxonomy_id',
-			'terms'    => $product_visibility_not_in,
-			'operator' => 'NOT IN',
-		);
+		// Filter by rating.
+		if ( isset( $_GET['rating_filter'] ) ) {
+			$rating_filter = array_filter( array_map( 'absint', explode( ',', $_GET['rating_filter'] ) ) );
+			$rating_terms = array();
+			for ( $i = 1; $i <= 5; $i ++ ) {
+				if ( in_array( $i, $rating_filter ) && isset( $product_visibiity_terms[ 'rated-' . $i ] ) ) {
+					$rating_terms[] = $product_visibiity_terms[ 'rated-' . $i ];
+				}
+			}
+			if ( ! empty( $rating_terms ) ) {
+				$tax_query[] = array(
+					'taxonomy'      => 'product_visibility',
+					'field'         => 'term_taxonomy_id',
+					'terms'         => $rating_terms,
+					'operator'      => 'IN',
+					'rating_filter' => true,
+				);
+			}
+		}
+
+		if ( ! empty( $product_visibility_not_in ) ) {
+			$tax_query[] = array(
+				'taxonomy' => 'product_visibility',
+				'field'    => 'term_taxonomy_id',
+				'terms'    => $product_visibility_not_in,
+				'operator' => 'NOT IN',
+			);
+		}
 
 		return array_filter( apply_filters( 'woocommerce_product_query_tax_query', $tax_query, $this ) );
+	}
+
+	/**
+	 * Return a meta query for filtering by price.
+	 * @return array
+	 */
+	private function price_filter_meta_query() {
+		if ( isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) ) {
+			$meta_query = wc_get_min_max_price_meta_query( $_GET );
+			$meta_query['price_filter'] = true;
+
+			return $meta_query;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Return a meta query for filtering by rating.
+	 *
+	 * @deprecated 2.7.0 Replaced with taxonomy.
+	 * @return array
+	 */
+	public function rating_filter_meta_query() {
+		return array();
+	}
+
+	/**
+	 * Returns a meta query to handle product visibility.
+	 *
+	 * @deprecated 2.7.0 Replaced with taxonomy.
+	 * @param string $compare (default: 'IN')
+	 * @return array
+	 */
+	public function visibility_meta_query( $compare = 'IN' ) {
+		return array();
+	}
+
+	/**
+	 * Returns a meta query to handle product stock status.
+	 *
+	 * @deprecated 2.7.0 Replaced with taxonomy.
+	 * @param string $status (default: 'instock')
+	 * @return array
+	 */
+	public function stock_status_meta_query( $status = 'instock' ) {
+		return array();
 	}
 
 	/**

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -561,22 +561,22 @@ class WC_Query {
 			}
 		}
 
-		$product_visibiity_terms   = wc_get_product_visibility_term_ids();
-		$product_visibility_not_in = array( is_search() && $main_query ? $product_visibiity_terms['exclude-from-search'] : $product_visibiity_terms['exclude-from-catalog'] );
+		$product_visibility_terms   = wc_get_product_visibility_term_ids();
+		$product_visibility_not_in = array( is_search() && $main_query ? $product_visibility_terms['exclude-from-search'] : $product_visibility_terms['exclude-from-catalog'] );
 		$product_visibility_in     = array();
 
 		// Hide out of stock products.
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-			$product_visibility_not_in[] = $product_visibiity_terms['outofstock'];
+			$product_visibility_not_in[] = $product_visibility_terms['outofstock'];
 		}
 
 		// Filter by rating.
 		if ( isset( $_GET['rating_filter'] ) ) {
 			$rating_filter = array_filter( array_map( 'absint', explode( ',', $_GET['rating_filter'] ) ) );
-			$rating_terms = array();
+			$rating_terms  = array();
 			for ( $i = 1; $i <= 5; $i ++ ) {
-				if ( in_array( $i, $rating_filter ) && isset( $product_visibiity_terms[ 'rated-' . $i ] ) ) {
-					$rating_terms[] = $product_visibiity_terms[ 'rated-' . $i ];
+				if ( in_array( $i, $rating_filter ) && isset( $product_visibility_terms[ 'rated-' . $i ] ) ) {
+					$rating_terms[] = $product_visibility_terms[ 'rated-' . $i ];
 				}
 			}
 			if ( ! empty( $rating_terms ) ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -487,6 +487,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$terms[] = 'outofstock';
 		}
 
+		$rating  = max( array( 5, min( array( 1, round( $product->get_average_rating(), 0 ) ) ) ) );
+		$terms[] = 'rated-' . $rating;
+
 		switch ( $product->get_catalog_visibility() ) {
 			case 'hidden' :
 				$terms[] = 'exclude-from-search';

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -130,7 +130,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'reviews_allowed'   => 'open' === $post_object->comment_status,
 		) );
 
-		$product->read_meta_data();
 		$this->read_attributes( $product );
 		$this->read_downloads( $product );
 		$this->read_visibility( $product );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -656,6 +656,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @since 2.7.0
 	 */
 	public function get_featured_product_ids() {
+		$product_visibility_term_ids = wc_get_product_visibility_term_ids();
+
 		return get_posts( array(
 			'post_type'      => array( 'product', 'product_variation' ),
 			'posts_per_page' => -1,
@@ -664,13 +666,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'relation' => 'AND',
 				array(
 					'taxonomy' => 'product_visibility',
-					'field'    => 'name',
-					'terms'    => array( 'featured' ),
+					'field'    => 'term_taxonomy_id',
+					'terms'    => array( $product_visibility_term_ids['featured'] ),
 				),
 				array(
 					'taxonomy' => 'product_visibility',
-					'field'    => 'name',
-					'terms'    => array( 'exclude-from-catalog' ),
+					'field'    => 'term_taxonomy_id',
+					'terms'    => array( $product_visibility_term_ids['exclude-from-catalog'] ),
 					'operator' => 'NOT IN',
 				),
 			),
@@ -870,12 +872,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$query['where'] .= " AND p.post_type = 'product'";
 		$query['where'] .= " AND p.ID NOT IN ( {$exclude_ids} )";
 
-		if ( $exclude_catalog_term = get_term_by( 'name', 'exclude-from-catalog', 'product_visibility' ) ) {
-			$query['where'] .= " AND t.term_id !=" . absint( $exclude_catalog_term->term_id );
+		$product_visibility_term_ids = wc_get_product_visibility_term_ids();
+
+		if ( $product_visibility_term_ids['exclude-from-catalog'] ) {
+			$query['where'] .= " AND t.term_id !=" . $product_visibility_term_ids['exclude-from-catalog'];
 		}
 
-		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ( $outofstock_term = get_term_by( 'name', 'outofstock', 'product_visibility' ) ) ) {
-			$query['where'] .= " AND t.term_id !=" . absint( $outofstock_term->term_id );
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && $product_visibility_term_ids['outofstock'] ) {
+			$query['where'] .= " AND t.term_id !=" . $product_visibility_term_ids['outofstock'];
 		}
 
 		if ( $cats_array || $tags_array ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -615,7 +615,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	protected function clear_caches( &$product ) {
 		wc_delete_product_transients( $product->get_id() );
-		WC_Cache_Helper::incr_cache_prefix( 'product-' . $product->get_id() );
+		wp_cache_delete( 'product-' . $product->get_id(), 'products' );
 	}
 
 	/*

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -615,6 +615,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	protected function clear_caches( &$product ) {
 		wc_delete_product_transients( $product->get_id() );
+		WC_Cache_Helper::incr_cache_prefix( 'product-' . $product->get_id() );
 	}
 
 	/*

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -66,7 +66,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		) );
 
 		$this->read_product_data( $product );
-		$product->read_meta_data();
 		$product->set_attributes( wc_get_product_variation_attributes( $product->get_id() ) );
 
 		// Set object_read true once all data is read.

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -254,7 +254,7 @@ if ( ! function_exists( 'is_filtered' ) ) {
 	 * @return bool
 	 */
 	function is_filtered() {
-		return apply_filters( 'woocommerce_is_filtered', ( sizeof( WC_Query::get_layered_nav_chosen_attributes() ) > 0 || isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) || isset( $_GET['min_rating'] ) ) );
+		return apply_filters( 'woocommerce_is_filtered', ( sizeof( WC_Query::get_layered_nav_chosen_attributes() ) > 0 || isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) || isset( $_GET['rating_filter'] ) ) );
 	}
 }
 

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -757,6 +757,11 @@ function wc_get_product_visibility_term_ids() {
 			'exclude-from-search'  => 0,
 			'featured'             => 0,
 			'outofstock'           => 0,
+			'rated-1'              => 0,
+			'rated-2'              => 0,
+			'rated-3'              => 0,
+			'rated-4'              => 0,
+			'rated-5'              => 0,
 		)
 	) );
 }

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1034,24 +1034,39 @@ function wc_update_270_settings() {
 function wc_update_270_product_visibility() {
 	global $wpdb;
 
-	$featured_term        = get_term_by( 'name', 'featured', 'product_visibility' );
-	$exclude_search_term  = get_term_by( 'name', 'exclude-from-search', 'product_visibility' );
-	$exclude_catalog_term = get_term_by( 'name', 'exclude-from-catalog', 'product_visibility' );
-	$outofstock_term      = get_term_by( 'name', 'out-of-stock', 'product_visibility' );
-
-	if ( $featured_term ) {
+	if ( $featured_term = get_term_by( 'name', 'featured', 'product_visibility' ) ) {
 		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_featured' AND meta_value = 'yes';", $featured_term->term_id ) );
 	}
 
-	if ( $exclude_search_term ) {
+	if ( $exclude_search_term = get_term_by( 'name', 'exclude-from-search', 'product_visibility' ) ) {
 		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_visibility' AND meta_value IN ('hidden', 'catalog');", $exclude_search_term->term_id ) );
 	}
 
-	if ( $exclude_catalog_term ) {
+	if ( $exclude_catalog_term = get_term_by( 'name', 'exclude-from-catalog', 'product_visibility' ) ) {
 		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_visibility' AND meta_value IN ('hidden', 'search');", $exclude_catalog_term->term_id ) );
 	}
 
-	if ( $outofstock_term ) {
+	if ( $outofstock_term = get_term_by( 'name', 'out-of-stock', 'product_visibility' ) ) {
 		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_stock_status' AND meta_value IN 'outofstock';", $outofstock_term->term_id ) );
+	}
+
+	if ( $rating_term = get_term_by( 'name', 'rated-1', 'product_visibility' ) ) {
+		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_wc_average_rating' AND ROUND( meta_value ) = 1;", $rating_term->term_id ) );
+	}
+
+	if ( $rating_term = get_term_by( 'name', 'rated-2', 'product_visibility' ) ) {
+		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_wc_average_rating' AND ROUND( meta_value ) = 2;", $rating_term->term_id ) );
+	}
+
+	if ( $rating_term = get_term_by( 'name', 'rated-3', 'product_visibility' ) ) {
+		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_wc_average_rating' AND ROUND( meta_value ) = 3;", $rating_term->term_id ) );
+	}
+
+	if ( $rating_term = get_term_by( 'name', 'rated-4', 'product_visibility' ) ) {
+		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_wc_average_rating' AND ROUND( meta_value ) = 4;", $rating_term->term_id ) );
+	}
+
+	if ( $rating_term = get_term_by( 'name', 'rated-5', 'product_visibility' ) ) {
+		$wpdb->query( $wpdb->prepare( "INSERT INTO {$wpdb->term_relationships} SELECT post_id, %d, 0 FROM {$wpdb->postmeta} WHERE meta_key = '_wc_average_rating' AND ROUND( meta_value ) = 5;", $rating_term->term_id ) );
 	}
 }

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -81,8 +81,8 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 		}
 
 		// Min Rating Arg
-		if ( isset( $_GET['min_rating'] ) ) {
-			$link = add_query_arg( 'min_rating', wc_clean( $_GET['min_rating'] ), $link );
+		if ( isset( $_GET['rating_filter'] ) ) {
+			$link = add_query_arg( 'rating_filter', wc_clean( $_GET['rating_filter'] ), $link );
 		}
 
 		// All current filters
@@ -116,10 +116,10 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 		$_chosen_attributes = WC_Query::get_layered_nav_chosen_attributes();
 		$min_price          = isset( $_GET['min_price'] ) ? wc_clean( $_GET['min_price'] ) : 0;
 		$max_price          = isset( $_GET['max_price'] ) ? wc_clean( $_GET['max_price'] ) : 0;
-		$min_rating         = isset( $_GET['min_rating'] ) ? absint( $_GET['min_rating'] ) : 0;
+		$rating_filter      = isset( $_GET['rating_filter'] ) ? array_filter( array_map( 'absint', explode( ',', $_GET['rating_filter'] ) ) ) : array();
 		$base_link          = $this->get_page_base_url();
 
-		if ( 0 < count( $_chosen_attributes ) || 0 < $min_price || 0 < $max_price || 0 < $min_rating ) {
+		if ( 0 < count( $_chosen_attributes ) || 0 < $min_price || 0 < $max_price || ! empty( $rating_filter ) ) {
 
 			$this->widget_start( $args, $instance );
 
@@ -159,9 +159,12 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 				echo '<li class="chosen"><a aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . sprintf( __( 'Max %s', 'woocommerce' ), wc_price( $max_price ) ) . '</a></li>';
 			}
 
-			if ( $min_rating ) {
-				$link = remove_query_arg( 'min_rating', $base_link );
-				echo '<li class="chosen"><a aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . sprintf( __( 'Rated %s and above', 'woocommerce' ), $min_rating ) . '</a></li>';
+			if ( ! empty( $rating_filter ) ) {
+				foreach ( $rating_filter as $rating ) {
+					$link_ratings = implode( ',', array_diff( $rating_filter, array( $rating ) ) );
+					$link         = $link_ratings ? add_query_arg( 'rating_filter', $link_ratings ) : remove_query_arg( 'rating_filter', $base_link );
+					echo '<li class="chosen"><a aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating ) . '</a></li>';
+				}
 			}
 
 			echo '</ul>';

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -306,8 +306,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		}
 
 		// Min Rating Arg
-		if ( isset( $_GET['min_rating'] ) ) {
-			$link = add_query_arg( 'min_rating', wc_clean( $_GET['min_rating'] ), $link );
+		if ( isset( $_GET['rating_filter'] ) ) {
+			$link = add_query_arg( 'rating_filter', wc_clean( $_GET['rating_filter'] ), $link );
 		}
 
 		// All current filters

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -141,7 +141,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 			);
 		}
 
-		foreach ( $meta_query as $key => $query ) {
+		foreach ( $meta_query + $tax_query as $key => $query ) {
 			if ( ! empty( $query['price_filter'] ) || ! empty( $query['rating_filter'] ) ) {
 				unset( $meta_query[ $key ] );
 			}

--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -89,10 +89,11 @@ class WC_Widget_Products extends WC_Widget {
 	 * @return WP_Query
 	 */
 	public function get_products( $args, $instance ) {
-		$number  = ! empty( $instance['number'] ) ? absint( $instance['number'] ) : $this->settings['number']['std'];
-		$show    = ! empty( $instance['show'] ) ? sanitize_title( $instance['show'] ) : $this->settings['show']['std'];
-		$orderby = ! empty( $instance['orderby'] ) ? sanitize_title( $instance['orderby'] ) : $this->settings['orderby']['std'];
-		$order   = ! empty( $instance['order'] ) ? sanitize_title( $instance['order'] ) : $this->settings['order']['std'];
+		$number                      = ! empty( $instance['number'] ) ? absint( $instance['number'] )           : $this->settings['number']['std'];
+		$show                        = ! empty( $instance['show'] ) ? sanitize_title( $instance['show'] )       : $this->settings['show']['std'];
+		$orderby                     = ! empty( $instance['orderby'] ) ? sanitize_title( $instance['orderby'] ) : $this->settings['orderby']['std'];
+		$order                       = ! empty( $instance['order'] ) ? sanitize_title( $instance['order'] )     : $this->settings['order']['std'];
+		$product_visibility_term_ids = wc_get_product_visibility_term_ids();
 
 		$query_args = array(
 			'posts_per_page' => $number,
@@ -109,8 +110,8 @@ class WC_Widget_Products extends WC_Widget {
 		if ( empty( $instance['show_hidden'] ) ) {
 			$query_args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
-				'field'    => 'name',
-				'terms'    => is_search() ? 'exclude-from-search' : 'exclude-from-catalog',
+				'field'    => 'term_taxonomy_id',
+				'terms'    => is_search() ? $product_visibility_term_ids['exclude-from-search'] : $product_visibility_term_ids['exclude-from-catalog'],
 				'operator' => 'NOT IN',
 			);
 			$query_args['post_parent']  = 0;
@@ -129,8 +130,8 @@ class WC_Widget_Products extends WC_Widget {
 			$query_args['tax_query'] = array(
 				array(
 					'taxonomy' => 'product_visibility',
-					'field'    => 'name',
-					'terms'    => 'outofstock',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => $product_visibility_term_ids['outofstock'],
 					'operator' => 'NOT IN',
 				),
 			);
@@ -140,8 +141,8 @@ class WC_Widget_Products extends WC_Widget {
 			case 'featured' :
 				$query_args['tax_query'][] = array(
 					'taxonomy' => 'product_visibility',
-					'field'    => 'name',
-					'terms'    => 'featured',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => $product_visibility_term_ids['featured'],
 				);
 				break;
 			case 'onsale' :

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -101,25 +101,25 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 		$tax_query  = WC_Query::get_main_tax_query();
 		$meta_query = WC_Query::get_main_meta_query();
 
-		// Unset current rating filter
-		foreach ( $meta_query as $key => $query ) {
+		// Unset current rating filter.
+		foreach ( $tax_query as $key => $query ) {
 			if ( ! empty( $query['rating_filter'] ) ) {
-				unset( $meta_query[ $key ] );
+				unset( $tax_query[ $key ] );
+				break;
 			}
 		}
 
-		// Set new rating filter
-		$meta_query[] = array(
-			'key'           => '_wc_average_rating',
-			'value'         => $rating,
-			'compare'       => '>=',
-			'type'          => 'DECIMAL',
+		// Set new rating filter.
+		$tax_query[] = array(
+			'taxonomy'      => 'product_visibility',
+			'field'         => 'name',
+			'terms'         => 'rated-' . $rating,
+			'operator'      => 'IN',
 			'rating_filter' => true,
 		);
 
-		$meta_query = new WP_Meta_Query( $meta_query );
-		$tax_query  = new WP_Tax_Query( $tax_query );
-
+		$meta_query     = new WP_Meta_Query( $meta_query );
+		$tax_query      = new WP_Tax_Query( $tax_query );
 		$meta_query_sql = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );
 		$tax_query_sql  = $tax_query->get_sql( $wpdb->posts, 'ID' );
 
@@ -152,30 +152,35 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 
 		ob_start();
 
-		$found      = false;
-		$min_rating = isset( $_GET['min_rating'] ) ? absint( $_GET['min_rating'] ) : '';
+		$found         = false;
+		$rating_filter = isset( $_GET['rating_filter'] ) ? array_filter( array_map( 'absint', explode( ',', $_GET['rating_filter'] ) ) ) : array();
 
 		$this->widget_start( $args, $instance );
 
 		echo '<ul>';
 
-		for ( $rating = 4; $rating >= 1; $rating-- ) {
+		for ( $rating = 5; $rating >= 1; $rating-- ) {
 			$count = $this->get_filtered_product_count( $rating );
-
-			if ( ! $count ) {
+			if ( empty( $count ) ) {
 				continue;
 			}
-
 			$found = true;
 			$link  = $this->get_page_base_url();
-			$link  = $min_rating !== $rating ? add_query_arg( 'min_rating', $rating, $link ) : $link;
 
-			echo '<li class="wc-layered-nav-rating ' . ( ( ! empty( $_GET['min_rating'] ) && absint( $_GET['min_rating'] ) === $rating ) ? 'chosen' : '' ) . '">';
+			if ( in_array( $rating, $rating_filter ) ) {
+				$link_ratings = implode( ',', array_diff( $rating_filter, array( $rating ) ) );
+			} else {
+				$link_ratings = implode( ',', array_merge( $rating_filter, array( $rating ) ) );
+			}
+
+			$link  = $link_ratings ? add_query_arg( 'rating_filter', $link_ratings ) : remove_query_arg( 'rating_filter' );
+
+			echo '<li class="wc-layered-nav-rating ' . ( in_array( $rating, $rating_filter ) ? 'chosen' : '' ) . '">';
 
 			echo '<a href="' . esc_url( apply_filters( 'woocommerce_rating_filter_link', $link ) ) . '">';
 
 			echo '<span class="star-rating">
-					<span style="width:' . esc_attr( ( $rating / 5 ) * 100 ) . '%">' . sprintf( __( 'Rated %s and above', 'woocommerce' ), $rating ) . '</span>
+					<span style="width:' . esc_attr( ( $rating / 5 ) * 100 ) . '%">' . sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating ) . '</span>
 				</span> (' . esc_html( $count ) . ')';
 
 			echo '</a>';

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -110,11 +110,11 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 		}
 
 		// Set new rating filter.
-		$product_visibiity_terms = wc_get_product_visibility_term_ids();
+		$product_visibility_terms = wc_get_product_visibility_term_ids();
 		$tax_query[]             = array(
 			'taxonomy'      => 'product_visibility',
 			'field'         => 'term_taxonomy_id',
-			'terms'         => $product_visibiity_terms[ 'rated-' . $rating ],
+			'terms'         => $product_visibility_terms[ 'rated-' . $rating ],
 			'operator'      => 'IN',
 			'rating_filter' => true,
 		);

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -110,10 +110,11 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 		}
 
 		// Set new rating filter.
-		$tax_query[] = array(
+		$product_visibiity_terms = wc_get_product_visibility_term_ids();
+		$tax_query[]             = array(
 			'taxonomy'      => 'product_visibility',
-			'field'         => 'name',
-			'terms'         => 'rated-' . $rating,
+			'field'         => 'term_taxonomy_id',
+			'terms'         => $product_visibiity_terms[ 'rated-' . $rating ],
 			'operator'      => 'IN',
 			'rating_filter' => true,
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woocommerce/wo
 * Added security section in system status report.
 * Fixed attribute registration. Attributes are non-hierarchical by default (parent is not supported).
 * Performance - Converted _featured and _visibility meta data to terms for faster catalog queries. Upgrade routine handles migration. Developers may need to update queries to reflect this change.
+* Performance - Converted rating filters to visibility terms.
 * Performance - Added visibility term for outofstock products to speed those queries up also.
 * Performance - Introduced a new CRUD (create, read, update, delete) system for Products, Orders, Customers and Shipping Zones.
 * Performance - Optimised variable product sync. Upper/lower price meta is no longer stored, just the main prices, if a child has weight, and if a child has dimensions.


### PR DESCRIPTION
- Prevents needless validation queries before read
- Adds helpers to get term taxonomy ids which avoids a lookup from WP
- Adds caching to the product factory
- Lazy loads product meta data
- Updates term cache to speed up future lookups
- Replaces rating meta filters with taxonomies