### PR TITLE
Minor Tax Issue Adding 1 Cent on Inclusive Pricing

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -258,7 +258,10 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 		}
 
 		// Round the total cost after taxes have been calculated.
-		$total_cost = wc_format_decimal( $total_cost, wc_get_price_decimals() );
+		if( wc_prices_include_tax() || WC()->cart->tax_display_cart == 'incl' )
+			$total_cost = wc_format_decimal( $total_cost );
+		else
+			$total_cost = wc_format_decimal( $total_cost, wc_get_price_decimals() );
 
 		// Create rate object
 		$rate = new WC_Shipping_Rate( $args['id'], $args['label'], $total_cost, $taxes, $this->id );


### PR DESCRIPTION
If it does not affect anything else down the line, it would be ideal for many of my clients to not format the shipping cost here. It becomes an issue for users whose prices are inclusive of tax. For example:

An admin sets up a Flat Rate shipping to France with a shipping cost of 4.125. The tax in France is 20%. Ideally, this gives a tax inclusive shipping price of $4.95 (4.125 * 1.20), however in WooCommerce the shipping cost outputs as $4.96 because the shipping cost is rounded to $4.13 before it is added to the taxes. The tax is correctly calculated based on the 4.125 price to return 0.825, however $4.13 + $0.825 = $4.955 which rounds up one cent. 

I ran tests in multiple combinations of tax settings and did find that this is a conditional issue which is why I added an 'IF ELSE' statement. For users who do not show pricing inclusive of tax it shorted them one cent in identical cart scenarios.

It's very difficult to make WC work with shipping providers whose tax is included in the price. I certainly realize it's not a high priority, but maybe this will help others with the same dilemma whether it makes it to the core or not. It's at least a temporary solution for my clients who are frustrated with the bookkeeping errors it presents.