### PR TITLE
Variations UX

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -269,6 +269,8 @@
 				current_settings       = {},
 				$form                  = $( this );
 
+			$form.trigger( 'update_variation_values' );
+
 			$attribute_selects.each( function() {
 				var attribute_name = $( this ).data( 'attribute_name' ) || $( this ).attr( 'name' );
 				var value          = $( this ).val() || '';
@@ -298,11 +300,8 @@
 					window.alert( wc_add_to_cart_variation_params.i18n_no_matching_variations_text );
 				}
 
-				$form.trigger( 'update_variation_values', [ matching_variations, current_settings ] );
-
 			} else {
 
-				$form.trigger( 'update_variation_values', [ matching_variations, current_settings ] );
 				$form.trigger( 'reset_data' );
 				$single_variation.slideUp( 200 ).trigger( 'hide_variation' );
 			}
@@ -317,10 +316,19 @@
 		} )
 
 		// Disable option fields that are unavaiable for current set of attributes
-		.on( 'update_variation_values', function( event, matching_variations, current_settings ) {
+		.on( 'update_variation_values', function( event ) {
 			if ( $use_ajax ) {
 				return;
 			}
+
+			// Collect current settings.
+			var current_settings = {};
+
+			$attribute_selects.each( function( setts_index, setts_el ) {
+				var attribute_name = $( this ).data( 'attribute_name' ) || $( this ).attr( 'name' ),
+					value          = $( this ).val() || '';
+				current_settings[ attribute_name ] = value;
+			} );
 
 			// Loop through selects and disable/enable options based on selections
 			$attribute_selects.each( function( index, el ) {

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -354,7 +354,7 @@
 
 				// The attribute of this select field should not be taken into account when calculating its matching variations:
 				// The constraints of this attribute are shaped by the values of the other attributes.
-				var settings = $.extend( {}, current_settings, true );
+				var settings = $.extend( true, {}, current_settings );
 
 				// Selections UX is 'non-locking': The constraints of this attribute are shaped by the values of all preceding attributes.
 				if ( 'non-locking' === ux ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1001,6 +1001,12 @@ if ( ! function_exists( 'woocommerce_variable_add_to_cart' ) ) {
 			'available_variations' => $get_variations ? $product->get_available_variations() : false,
 			'attributes'           => $product->get_variation_attributes(),
 			'selected_attributes'  => $product->get_default_attributes(),
+			/*
+			 * Selection UX:
+			 * - 'locking':     Attribute selections in the n-th attribute are constrained by selections in all atributes other than n.
+			 * - 'non-locking': Attribute selections in the n-th attribute are constrained by selections in all atributes before n.
+			 */
+			'selection_ux'         => apply_filters( 'woocommerce_variation_attributes_selection_ux', 'locking', $product )
 		) );
 	}
 }
@@ -2159,16 +2165,17 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 			'name'             => '',
 			'id'               => '',
 			'class'            => '',
-			'show_option_none' => __( 'Choose an option', 'woocommerce' ),
+			'show_option_none' => __( 'Choose an option', 'woocommerce' )
 		) );
 
-		$options          = $args['options'];
-		$product          = $args['product'];
-		$attribute        = $args['attribute'];
-		$name             = $args['name'] ? $args['name'] : 'attribute_' . sanitize_title( $attribute );
-		$id               = $args['id'] ? $args['id'] : sanitize_title( $attribute );
-		$class            = $args['class'];
-		$show_option_none = $args['show_option_none'] ? true : false;
+		$options               = $args['options'];
+		$product               = $args['product'];
+		$attribute             = $args['attribute'];
+		$name                  = $args['name'] ? $args['name'] : 'attribute_' . sanitize_title( $attribute );
+		$id                    = $args['id'] ? $args['id'] : sanitize_title( $attribute );
+		$class                 = $args['class'];
+		$show_option_none      = $args['show_option_none'] ? true : false;
+		$show_option_none_text = $args['show_option_none'] ? $args['show_option_none'] : __( 'Choose an option', 'woocommerce' ); // We'll do our best to hide the placeholder, but we'll need to show something when resetting options.
 
 		if ( empty( $options ) && ! empty( $product ) && ! empty( $attribute ) ) {
 			$attributes = $product->get_variation_attributes();
@@ -2176,10 +2183,7 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		}
 
 		$html = '<select id="' . esc_attr( $id ) . '" class="' . esc_attr( $class ) . '" name="' . esc_attr( $name ) . '" data-attribute_name="attribute_' . esc_attr( sanitize_title( $attribute ) ) . '" data-show_option_none="' . ( $show_option_none ? 'yes' : 'no' ) . '">';
-
-		if ( $show_option_none ) {
-			$html .= '<option value="">' . esc_html( $args['show_option_none'] ) . '</option>';
-		}
+		$html .= '<option value="">' . esc_html( $show_option_none_text ) . '</option>';
 
 		if ( ! empty( $options ) ) {
 			if ( $product && taxonomy_exists( $attribute ) ) {

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -25,7 +25,7 @@ $attribute_keys = array_keys( $attributes );
 
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="variations_form cart" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo htmlspecialchars( wp_json_encode( $available_variations ) ) ?>">
+<form class="variations_form cart" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo htmlspecialchars( wp_json_encode( $available_variations ) ) ?>" data-selection_ux="<?php echo $selection_ux; ?>">
 	<?php do_action( 'woocommerce_before_variations_form' ); ?>
 
 	<?php if ( empty( $available_variations ) && false !== $available_variations ) : ?>


### PR DESCRIPTION
### Review Needed ###

This PR implements the ideas discussed in #12487 and fixes the issues reported in #12565 and #12487 . Note that it should be treated as WIP since I have not tested the changes extensively.

At some point in the future, it might be a good idea to refactor the entire variations script logic (its current structure hurts a bit).

The PR:

(1) 

Fixes the logic issues reported in #12565 

Demo of the scenario reported in #12565 --

https://cl.ly/153k2q3p0N2q

(2) 

Fixes the clearing issues reported in #12487 when "Choose an option" is hidden from variation attribute drop-downs using `show_option_none`.

Demo of the scenario reported in #12565 with `$args['show_option_none'] = false` --

https://cl.ly/3w3w3d091l0n

Note: **Clear** is still visible. Instead of making complex modifications to the template file, it makes more sense to assume that a developer who passes `$args['show_option_none'] = false` can opt to hide/not hide the **Clear** button, if desired. From a UX perspective, I find it desirable to always show the **Clear** button in all cases.

(3)

Implements a "non-locking" UI that can be activated using `woocommerce_variation_attributes_selection_ux` -- see https://github.com/franticpsyx/woocommerce/blob/variations-ux/includes/wc-template-functions.php#L1009 

This is passed to the variable product template since it's considered as a local setting that can be activated for individual products.

Demo of the scenario reported in #12565 with the "non-locking" UX and placeholders visible --

https://cl.ly/1P2q46250K3A

Demo of the scenario reported in #12565 with the "non-locking" UX and placeholders hidden (`$args['show_option_none'] = false`) --

https://cl.ly/1O1d0k3e1s3V

### Non-Locking UX Notes ###

1. The selections available in an attribute depend on the selections of the previous attributes, combined.
2. When an attribute selection is changed, any incompatible selections in subsequent attributes are "cleared" === changed to the placeholder option. I think that this provides sufficient feedback without being obtrusive -- I find it preferable to showing a separate pop-up or dialog.
3. When placeholder options are set to be hidden, any attribute that is "reset" will be populated with the placeholder option until a selection is made. This prevents issues with resetting to invalid attribute combinations and results in a predictable behavior.

Further testing and feedback needed.

@mikejolley @jameskoster 