### PR TITLE
wrong information on checkout page for not logged in users

### DIFF
--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -62,7 +62,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="create-account">
 
-				<p><?php _e( 'Create an account by entering the information below. If you are a returning customer please login at the top of the page.', 'woocommerce' ); ?></p>
+				<p>
+					<?php
+					_e( 'Create an account by entering the information below.', 'woocommerce' );
+					if( 'yes' === get_option( 'woocommerce_enable_checkout_login_reminder' ) ){
+						_e( 'If you are a returning customer please login at the top of the page.', 'woocommerce' );
+					}
+					?>
+				</p>
 
 				<?php foreach ( $checkout->get_checkout_fields( 'account' )  as $key => $field ) : ?>
 


### PR DESCRIPTION
if the option woocommerce_enable_checkout_login_reminder (under WooCommerce > Settings > Accounts and look for login option) is unchecked in checkout appears the string "If you are a returning customer please login at the top of the page.", but there aren't any login box at the top of page.

Look this screenshot for more details: 

![image](https://cloud.githubusercontent.com/assets/14902963/21177609/35b1d458-c1ec-11e6-86e3-015f528aba59.png)


