### PR TITLE
Merging percent based coupon types

### DIFF
--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -21,7 +21,7 @@ jQuery(function( $ ) {
 			// Get value
 			var select_val = $( this ).val();
 
-			if ( select_val === 'fixed_product' || select_val === 'percent_product' ) {
+			if ( select_val !== 'fixed_cart' ) {
 				$( '.limit_usage_to_x_items_field' ).show();
 			} else {
 				$( '.limit_usage_to_x_items_field' ).hide();

--- a/assets/js/admin/meta-boxes-coupon.min.js
+++ b/assets/js/admin/meta-boxes-coupon.min.js
@@ -1,1 +1,1 @@
-jQuery(function(a){var b={init:function(){a("select#discount_type").on("change",this.type_options).change()},type_options:function(){var b=a(this).val();"fixed_product"===b||"percent_product"===b?a(".limit_usage_to_x_items_field").show():a(".limit_usage_to_x_items_field").hide()}};b.init()});
+jQuery(function(a){var b={init:function(){a("select#discount_type").on("change",this.type_options).change()},type_options:function(){var b=a(this).val();"fixed_cart"!==b?a(".limit_usage_to_x_items_field").show():a(".limit_usage_to_x_items_field").hide()}};b.init()});

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -966,32 +966,6 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Exclude sale items from cart.
-	 *
-	 * @throws Exception
-	 */
-	private function validate_cart_excluded_sale_items() {
-		if ( $this->get_exclude_sale_items() ) {
-			$valid_for_cart = true;
-			$product_ids_on_sale = wc_get_product_ids_on_sale();
-			if ( ! WC()->cart->is_empty() ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					if ( ! empty( $cart_item['variation_id'] ) ) {
-						if ( in_array( $cart_item['variation_id'], $product_ids_on_sale, true ) ) {
-							$valid_for_cart = false;
-						}
-					} elseif ( in_array( $cart_item['product_id'], $product_ids_on_sale, true ) ) {
-						$valid_for_cart = false;
-					}
-				}
-			}
-			if ( ! $valid_for_cart ) {
-				throw new Exception( self::E_WC_COUPON_NOT_VALID_SALE_ITEMS );
-			}
-		}
-	}
-
-	/**
 	 * Check if a coupon is valid.
 	 *
 	 * @return boolean validity

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -106,7 +106,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return bool
 	 */
 	public function is_type( $type ) {
-		return ( $this->get_discount_type() == $type || ( is_array( $type ) && in_array( $this->get_discount_type(), $type ) ) );
+		return ( $this->get_discount_type() === $type || ( is_array( $type ) && in_array( $this->get_discount_type(), $type ) ) );
 	}
 
 	/**
@@ -359,7 +359,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$discount      = 0;
 		$cart_item_qty = is_null( $cart_item ) ? 1 : $cart_item['quantity'];
 
-		if ( $this->is_type( array( 'percent_product', 'percent' ) ) ) {
+		if ( $this->is_type( array( 'percent' ) ) ) {
 			$discount = $this->get_amount() * ( $discounting_amount / 100 );
 		} elseif ( $this->is_type( 'fixed_cart' ) && ! is_null( $cart_item ) && WC()->cart->subtotal_ex_tax ) {
 			/**
@@ -386,7 +386,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$discount = min( $discount, $discounting_amount );
 
 		// Handle the limit_usage_to_x_items option
-		if ( $this->is_type( array( 'percent_product', 'fixed_product' ) ) ) {
+		if ( ! $this->is_type( array( 'fixed_cart' ) ) ) {
 			if ( $discounting_amount ) {
 				if ( ! $this->get_limit_usage_to_x_items() ) {
 					$limit_usage_qty = $cart_item_qty;
@@ -445,6 +445,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_discount_type( $discount_type ) {
+		if ( 'percent_product' === $discount_type ) {
+			$discount_type = 'percent'; // Backwards compatibility.
+		}
 		if ( ! in_array( $discount_type, array_keys( wc_get_coupon_types() ) ) ) {
 			$this->error( 'coupon_invalid_discount_type', __( 'Invalid discount type', 'woocommerce' ) );
 		}
@@ -867,7 +870,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws Exception
 	 */
 	private function validate_sale_items() {
-		if ( $this->get_exclude_sale_items() && $this->is_type( wc_get_product_coupon_types() ) ) {
+		if ( $this->get_exclude_sale_items() ) {
 			$valid_for_cart      = false;
 			$product_ids_on_sale = wc_get_product_ids_on_sale();
 
@@ -915,7 +918,6 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( ! $this->is_type( wc_get_product_coupon_types() ) ) {
 			$this->validate_cart_excluded_product_ids();
 			$this->validate_cart_excluded_product_categories();
-			$this->validate_cart_excluded_sale_items();
 		}
 	}
 

--- a/includes/wc-coupon-functions.php
+++ b/includes/wc-coupon-functions.php
@@ -21,10 +21,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function wc_get_coupon_types() {
 	return (array) apply_filters( 'woocommerce_coupon_discount_types', array(
-		'fixed_cart'      => __( 'Cart discount', 'woocommerce' ),
-		'percent'         => __( 'Cart % discount', 'woocommerce' ),
-		'fixed_product'   => __( 'Product discount', 'woocommerce' ),
-		'percent_product' => __( 'Product % discount', 'woocommerce' ),
+		'percent'         => __( 'Percentage discount', 'woocommerce' ),
+		'fixed_cart'      => __( 'Fixed cart discount', 'woocommerce' ),
+		'fixed_product'   => __( 'Fixed product discount', 'woocommerce' ),
 	) );
 }
 
@@ -46,7 +45,7 @@ function wc_get_coupon_type( $type = '' ) {
  * @return array
  */
 function wc_get_product_coupon_types() {
-	return (array) apply_filters( 'woocommerce_product_coupon_types', array( 'fixed_product', 'percent_product' ) );
+	return (array) apply_filters( 'woocommerce_product_coupon_types', array( 'fixed_product', 'percent' ) );
 }
 
 /**
@@ -56,7 +55,7 @@ function wc_get_product_coupon_types() {
  * @return array
  */
 function wc_get_cart_coupon_types() {
-	return (array) apply_filters( 'woocommerce_cart_coupon_types', array( 'fixed_cart', 'percent' ) );
+	return (array) apply_filters( 'woocommerce_cart_coupon_types', array( 'fixed_cart' ) );
 }
 
 /**

--- a/tests/cli/features/shop_coupon.feature
+++ b/tests/cli/features/shop_coupon.feature
@@ -37,7 +37,7 @@ Scenario: CRUD a coupon
 	When I run `wp wc shop_coupon create --user=admin --code='coupon code' --discount_type='fixed_product' --amount='5.00'  --porcelain`
 	Then save STDOUT as {COUPON_ID}
 
-	When I run `wp wc shop_coupon update {COUPON_ID} --user=admin --discount_type="percent_product" --amount='2' --porcelain`
+	When I run `wp wc shop_coupon update {COUPON_ID} --user=admin --discount_type="percent" --amount='2' --porcelain`
 	Then STDOUT should be a number
 
 	When I run `wp wc shop_coupon get {COUPON_ID} --user=admin`
@@ -47,7 +47,7 @@ Scenario: CRUD a coupon
 		"""
 	And STDOUT should contain:
 		"""
-		percent_product
+		percent
 		"""
 
 	When I run `wp wc shop_coupon get {COUPON_ID} --user=admin --field=amount`

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -123,64 +123,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test percent cart discount method.
-	 *
-	 * @since 2.3
-	 */
-	public function test_percent_cart_discount() {
-
-		// Create product
-		$product = WC_Helper_Product::create_simple_product();
-		update_post_meta( $product->get_id(), '_price', '10' );
-		update_post_meta( $product->get_id(), '_regular_price', '10' );
-
-		// Create coupon
-		$coupon = WC_Helper_Coupon::create_coupon();
-		update_post_meta( $coupon->get_id(), 'discount_type', 'percent' );
-		update_post_meta( $coupon->get_id(), 'coupon_amount', '5' );
-
-		// Create a flat rate method
-		WC_Helper_Shipping::create_simple_flat_rate();
-
-		// We need this to have the calculate_totals() method calculate totals
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
-		// Add product to cart
-		WC()->cart->add_to_cart( $product->get_id(), 1 );
-
-		// Add coupon
-		WC()->cart->add_discount( $coupon->get_code() );
-
-		// Set the flat_rate shipping method
-		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
-		WC()->cart->calculate_totals();
-
-		// Test if the cart total amount is equal 19.5
-		$this->assertEquals( 19.5, WC()->cart->total );
-
-		// Clearing WC notices
-		wc_clear_notices();
-
-		// Clean up the cart
-		WC()->cart->empty_cart();
-
-		// Remove coupons
-		WC()->cart->remove_coupons();
-
-		// Delete the flat rate method
-		WC()->session->set( 'chosen_shipping_methods', array() );
-		WC_Helper_Shipping::delete_simple_flat_rate();
-
-		// Delete coupon
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
-	}
-
-	/**
 	 * Test fixed product discount method.
 	 *
 	 * @since 2.3
@@ -249,7 +191,7 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 *
 	 * @since 2.3
 	 */
-	public function test_percent_product_discount() {
+	public function test_percent_discount() {
 
 		// Create product
 		$product = WC_Helper_Product::create_simple_product();
@@ -258,7 +200,7 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Create coupon
 		$coupon = WC_Helper_Coupon::create_coupon();
-		update_post_meta( $coupon->get_id(), 'discount_type', 'percent_product' );
+		update_post_meta( $coupon->get_id(), 'discount_type', 'percent' );
 		update_post_meta( $coupon->get_id(), 'coupon_amount', '5' );
 
 		// Create a flat rate method

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -159,7 +159,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 		$standard_getters_and_setters = array(
 			'code' => 'test',
 			'description' => 'hello world',
-			'discount_type' => 'percent_product',
+			'discount_type' => 'percent',
 			'amount' => 10.50,
 			'date_expires' => time(),
 			'usage_count' => 5,

--- a/tests/unit-tests/coupon/functions.php
+++ b/tests/unit-tests/coupon/functions.php
@@ -30,7 +30,7 @@ class WC_Tests_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_get_coupon_type() {
 
-		$this->assertEquals( 'Cart discount', wc_get_coupon_type( 'fixed_cart' ) );
+		$this->assertEquals( 'Fixed cart discount', wc_get_coupon_type( 'fixed_cart' ) );
 		$this->assertEmpty( wc_get_coupon_type( 'bogus_type' ) );
 	}
 

--- a/tests/unit-tests/coupon/functions.php
+++ b/tests/unit-tests/coupon/functions.php
@@ -15,10 +15,9 @@ class WC_Tests_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_coupon_types() {
 
 		$coupon_types = array(
-			'fixed_cart'      => 'Cart discount',
-			'percent'         => 'Cart % discount',
-			'fixed_product'   => 'Product discount',
-			'percent_product' => 'Product % discount',
+			'percent'       => __( 'Percentage discount', 'woocommerce' ),
+			'fixed_cart'    => __( 'Fixed cart discount', 'woocommerce' ),
+			'fixed_product' => __( 'Fixed product discount', 'woocommerce' ),
 		);
 
 		$this->assertEquals( $coupon_types, wc_get_coupon_types() );


### PR DESCRIPTION
This is my take on the problem raised (quite frequently) in #12473.

2.6.x has 4 coupon types.

1. fixed_product
2. fixed_cart
3. percent (cart)
4. percent_product

Percent and percent product actually discount the exact same amount in most cases. The only difference really is how validation rules are applied.

With the cart percent coupons, if a product is found in the cart that is not eligible for discount, the entire coupon is not applied.

With product percent coupons, if a product is found in the cart which is not eligible for discount, the coupon is applied for eligible items only.

In both cases, if applied, the discount amount is the same. So really, this just penalises customers who want to buy a non-eligible item in the same cart (they can remove it, and purchase separately which is a major annoyance I’m sure).

For shop owners, I see #12473 quite frequently. They expect it to apply to eligible items which it does not and cannot.

My suggestion in this PR is to merge our percent coupon types into one and use the ‘product’ type logic to do validation rules. This is both fair and easier to understand. This also rewords the coupon types, so we have 3:

1. Percentage discount
2. Fixed cart discount
3. Fixed product discount.

The validation logic for the other cart coupon type remains unchanged (fixed discounts cannot be applied in the same way as percent so this needs to be left alone).

Related tests pass. Backwards compatibility is handled in CRUD however API request etc to set percent_product (instead of percent) will be rejected as this is no longer a valid discount type.

Thoughts? Feelings? Feedback?

@mattyza @justinshreve @claudiosanches @jameskoster 