### PR TITLE
[2.6] [REST API] Throw exception when product image ID is not a valid attachment

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -844,6 +844,10 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 					$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $product->get_id() );
 				}
 
+				if ( ! wp_attachment_is_image( $attachment_id ) ) {
+					throw new WC_REST_Exception( 'woocommerce_product_ĩnvalid_image_id', sprintf( __( '#%s is an invalid image ID.', 'woocommerce' ), $attachment_id ), 400 );
+				}
+
 				if ( isset( $image['position'] ) && 0 === $image['position'] ) {
 					$product->set_image_id( $attachment_id );
 				} else {


### PR DESCRIPTION
Ref: #12509