### PR TITLE
Removes the State/Province field for Kuwait and Lebanon

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -103,6 +103,8 @@ class WC_Countries {
 			'IS' => array(),
 			'IL' => array(),
 			'KR' => array(),
+			'KW' => array(),
+			'LB' => array(),
 			'MQ' => array(),
 			'NL' => array(),
 			'NO' => array(),


### PR DESCRIPTION
As noted in support ticket #507320 (and verified) neither Kuwait nor Lebanon have States/Provinces.