### PR TITLE
Add 'woocommerce_shipping_package_details_array' filter

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -207,6 +207,7 @@ function wc_cart_totals_shipping_html() {
 			foreach ( $package['contents'] as $item_id => $values ) {
 				$product_names[] = $values['data']->get_name() . ' &times;' . $values['quantity'];
 			}
+			$product_names = apply_filters( 'woocommerce_shipping_package_details_array', $product_names, $package );
 		}
 
 		wc_get_template( 'cart/cart-shipping.php', array(


### PR DESCRIPTION
Allows shipping package details to be filtered (e.g. grouped or re-formatted).

Filter applied only if `sizeof( $packages ) > 1`. 