### PR TITLE
[2.7] Use 'woocommerce_product_additional_information' action to render attributes

### DIFF
--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -193,6 +193,13 @@ add_filter( 'woocommerce_product_tabs', 'woocommerce_default_product_tabs' );
 add_filter( 'woocommerce_product_tabs', 'woocommerce_sort_product_tabs', 99 );
 
 /**
+ * Additional Information tab.
+ *
+ * @see wc_display_product_attributes()
+ */
+add_action( 'woocommerce_product_additional_information', 'wc_display_product_attributes', 10 );
+
+/**
  * Photoswipe.
  */
 add_action( 'wp_footer', 'woocommerce_photoswipe' );

--- a/templates/single-product/tabs/additional-information.php
+++ b/templates/single-product/tabs/additional-information.php
@@ -30,4 +30,4 @@ $heading = esc_html( apply_filters( 'woocommerce_product_additional_information_
 	<h2><?php echo $heading; ?></h2>
 <?php endif; ?>
 
-<?php wc_display_product_attributes( $product ); ?>
+<?php do_action( 'woocommerce_product_additional_information', $product ); ?>


### PR DESCRIPTION
WC 2.6 made it easy for custom product types to control the "Additional Information" tab content by overriding `list_attributes()`. 

Example: http://www.somewherewarm.net/pb/skate/product/flip-hkd-black-complete/ (listing bundled product attributes).

`list_attributes()` is now deprecated and unused in WC 2.7, which means that a hook should be added somewhere to allow rendering additional content.

Unfortunately the "Additional Information" template structure does not contain any action/filter hooks - currently it's impossible to implement what you see above in WC 2.7.

One possible solution is to replace `wc_display_product_attributes()` with an action hook and add `wc_display_product_attributes()` to it as a callback.

This makes it easy to append content under the attributes table.