### PR TITLE
[2.7] Add order item meta creation hooks

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -206,6 +206,25 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					if ( $item_id !== $item_key ) {
 						$this->items[ $item_group ][ $item_id ] = $item;
 						unset( $this->items[ $item_group ][ $item_key ] );
+
+						// Legacy action handler
+						switch ( $item_group ) {
+							case 'fee_lines' :
+								if ( isset( $item->legacy_fee, $item->legacy_fee_key ) ) {
+									wc_do_deprecated_action( 'woocommerce_add_order_fee_meta', array( $this->get_id(), $item_id, $item->legacy_fee, $item->legacy_fee_key ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+								}
+							break;
+							case 'shipping_lines' :
+								if ( isset( $item->legacy_package_key ) ) {
+									wc_do_deprecated_action( 'woocommerce_add_shipping_order_item', array( $this->get_id(), $item_id, $item->legacy_package_key ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+								}
+							break;
+							case 'line_items' :
+								if ( isset( $item->legacy_values, $item->legacy_cart_item_key ) ) {
+									wc_do_deprecated_action( 'woocommerce_add_order_item_meta', array( $item_id, $item->legacy_values, $item->legacy_cart_item_key ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+								}
+							break;
+						}
 					}
 				}
 			}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -206,25 +206,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					if ( $item_id !== $item_key ) {
 						$this->items[ $item_group ][ $item_id ] = $item;
 						unset( $this->items[ $item_group ][ $item_key ] );
-
-						// Legacy action handler
-						switch ( $item_group ) {
-							case 'fee_lines' :
-								if ( isset( $item->legacy_fee, $item->legacy_fee_key ) ) {
-									wc_do_deprecated_action( 'woocommerce_add_order_fee_meta', array( $this->get_id(), $item_id, $item->legacy_fee, $item->legacy_fee_key ), '2.7', 'Use woocommerce_new_order_item action instead.' );
-								}
-							break;
-							case 'shipping_lines' :
-								if ( isset( $item->legacy_package_key ) ) {
-									wc_do_deprecated_action( 'woocommerce_add_shipping_order_item', array( $item_id, $item->legacy_package_key ), '2.7', 'Use woocommerce_new_order_item action instead.' );
-								}
-							break;
-							case 'line_items' :
-								if ( isset( $item->legacy_values, $item->legacy_cart_item_key ) ) {
-									wc_do_deprecated_action( 'woocommerce_add_order_item_meta', array( $item_id, $item->legacy_values, $item->legacy_cart_item_key ), '2.7', 'Use woocommerce_new_order_item action instead.' );
-								}
-							break;
-						}
 					}
 				}
 			}

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -336,7 +336,7 @@ class WC_Checkout {
 			foreach ( $order->get_items( 'shipping' ) as $item_id => $item ) {
 				$packages = WC()->shipping->get_packages();
 				if ( isset( $item->package_key ) ) {
-					do_action( 'woocommerce_add_shipping_order_item', $item_id, $item->package_key );
+					do_action( 'woocommerce_add_shipping_order_item', $order_id, $item_id, $item->package_key );
 				}
 			}
 

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -335,8 +335,7 @@ class WC_Checkout {
 
 			foreach ( $order->get_items( 'shipping' ) as $item_id => $item ) {
 				$packages = WC()->shipping->get_packages();
-				if ( isset( $item->package_key ) && isset( $packages[ $item->package_key ] ) ) {
-					$package = $packages[ $item->package_key ];
+				if ( isset( $item->package_key ) ) {
 					do_action( 'woocommerce_add_shipping_order_item', $item_id, $item->package_key );
 				}
 			}


### PR DESCRIPTION
In WC 2.7 the following hooks have been deprecated, ~~likely due to a difficulty in getting the different classes to exchange the necessary data in a clean manner~~:

- `woocommerce_add_order_fee_meta`
- `woocommerce_add_shipping_order_item`
- `woocommerce_add_order_item_meta`

The last one is especially important for extensions/plugins, since it's commonly used to create order item meta based on custom cart item data values.

Note that these ~~need to~~ fire after the order and all order items have been saved in the DB, which means they encourage multiple unnecessary reads/sets/saves.

After deprecating these hooks, there is no way to associate order item IDs with cart item / fee / shipping package keys after the order has been saved. There is no other hook that can be used for this purpose (or I can't find it), which means that a hack might be required to do a task that should be straightforward.

For convenience when working with WC, equivalent hooks should ideally reside in `class-wc-checkout.php`, ~~right after~~ before the order is saved.