### PR TITLE
[2.7] Set order item object as read before reading child class data (and more)

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -241,7 +241,10 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		}
 
 		if ( array_key_exists( $offset, $this->data ) ) {
-			$this->data[ $offset ] = $value;
+			$setter = "set_$offset";
+			if ( is_callable( array( $this, $setter ) ) ) {
+				$this->$setter( $value );
+			}
 		}
 
 		$this->update_meta_data( '_' . $offset, $value );
@@ -301,7 +304,10 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		if ( 'item_meta' === $offset ) {
 			return $meta_values;
 		} elseif ( array_key_exists( $offset, $this->data ) ) {
-			return $this->data[ $offset ];
+			$getter = "get_$offset";
+			if ( is_callable( array( $this, $getter ) ) ) {
+				return $this->$getter();
+			}
 		} elseif ( array_key_exists( '_' . $offset, $meta_values ) ) {
 			// Item meta was expanded in previous versions, with prefixes removed. This maintains support.
 			return $meta_values[ '_' . $offset ];

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -111,7 +111,6 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 			'type'     => $data->order_item_type,
 		) );
 		$item->read_meta_data();
-		$item->set_object_read( true );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-item-coupon-data-store.php
+++ b/includes/data-stores/class-wc-order-item-coupon-data-store.php
@@ -31,6 +31,7 @@ class WC_Order_Item_Coupon_Data_Store extends Abstract_WC_Order_Item_Type_Data_S
 			'discount'     => get_metadata( 'order_item', $item->get_id(), 'discount_amount', true ),
 			'discount_tax' => get_metadata( 'order_item', $item->get_id(), 'discount_amount_tax', true ),
 		) );
+		$item->set_object_read( true );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-item-fee-data-store.php
+++ b/includes/data-stores/class-wc-order-item-fee-data-store.php
@@ -32,6 +32,7 @@ class WC_Order_Item_Fee_Data_Store extends Abstract_WC_Order_Item_Type_Data_Stor
 			'total'      => get_metadata( 'order_item', $item->get_id(), '_line_total', true ),
 			'taxes'      => get_metadata( 'order_item', $item->get_id(), '_line_tax_data', true ),
 		) );
+		$item->set_object_read( true );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-item-product-store.php
+++ b/includes/data-stores/class-wc-order-item-product-store.php
@@ -35,6 +35,7 @@ class WC_Order_Item_Product_Data_Store extends Abstract_WC_Order_Item_Type_Data_
 			'total'        => get_metadata( 'order_item', $item->get_id(), '_line_total', true ),
 			'taxes'        => get_metadata( 'order_item', $item->get_id(), '_line_tax_data', true ),
 		) );
+		$item->set_object_read( true );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-item-shipping-data-store.php
+++ b/includes/data-stores/class-wc-order-item-shipping-data-store.php
@@ -31,6 +31,7 @@ class WC_Order_Item_Shipping_Data_Store extends Abstract_WC_Order_Item_Type_Data
 			'total'     => get_metadata( 'order_item', $item->get_id(), 'cost', true ),
 			'taxes'     => get_metadata( 'order_item', $item->get_id(), 'taxes', true ),
 		) );
+		$item->set_object_read( true );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-item-tax-data-store.php
+++ b/includes/data-stores/class-wc-order-item-tax-data-store.php
@@ -33,6 +33,7 @@ class WC_Order_Item_Tax_Data_Store extends Abstract_WC_Order_Item_Type_Data_Stor
 			'tax_total'          => get_metadata( 'order_item', $item->get_id(), 'tax_amount', true ),
 			'shipping_tax_total' => get_metadata( 'order_item', $item->get_id(), 'shipping_tax_amount', true ),
 		) );
+		$item->set_object_read( true );
 	}
 
 	/**


### PR DESCRIPTION
### Issue 1

Currently, when reading order item data, the item is set as read (past participle) when the `Abstract_WC_Order_Item_Type_Data_Store` has finished reading data.

As a result, any data read by a child class is registered as a "change" and not written to the `data` property.

While this doesn't cause any issues in core, it breaks compatibility with `offsetSet/Get()`: These only look at the `data` prop to resolve the value of the property that's being asked.

While this PR fixes this, it might be a good idea to look for other classes that might be affected.

### Issue 2 (related, likely major)

Issue 1 would be a non-issue if it wasn't for something else:

It seems to me that the way `offsetSet/Get()` work in `WC_Order_Item` and possibly other classes needs to be revised: 

Currently, data keys/values are being get/set directly in the `data` prop which bypasses the `changes` prop. This means that data being set could be overwritten when saving, and data being read could be wrong if a change has been made (as evident by this issue).

Instead of setting/getting directly on the `data` prop, `offsetSet/Get( $key )` should probably work by using `get_prop/set_prop` or perhaps calling `get_$key/set_$key` to avoid these issues.