### PR TITLE
Add actions for all object types

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -40,6 +40,12 @@ abstract class WC_Data {
 	protected $object_read = false;
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'data';
+
+	/**
 	 * Extra data for this object. Name value pairs (name + default value).
 	 * Used as a standard way for sub classes (like product types) to add
 	 * additional information to an inherited class.
@@ -120,6 +126,9 @@ abstract class WC_Data {
 	 */
 	public function save() {
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {
@@ -501,7 +510,7 @@ abstract class WC_Data {
 	 * @return string
 	 */
 	protected function get_hook_prefix() {
-		return 'woocommerce_get_';
+		return 'woocommerce_get_' . $this->object_type . '_';
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -83,6 +83,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected $data_store_name = 'order';
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'order';
+
+	/**
 	 * Get the order if ID is passed, otherwise the order is new and empty.
 	 * This class should NOT be instantiated, but the get_order function or new WC_Order_Factory.
 	 * should be used. It is possible, but the aforementioned are preferred and are the only.
@@ -122,16 +128,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function get_type() {
 		return 'shop_order';
-	}
-
-	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  2.7.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_get_order_';
 	}
 
 	/**
@@ -176,6 +172,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function save() {
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -22,6 +22,12 @@ include_once( 'abstract-wc-legacy-product.php' );
 class WC_Product extends WC_Abstract_Legacy_Product {
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'product';
+
+	/**
 	 * Post type.
 	 * @var string
 	 */
@@ -119,16 +125,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		if ( $this->get_id() > 0 ) {
 			$this->data_store->read( $this );
 		}
-	}
-
-	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  2.7.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_product_get_';
 	}
 
 	/**
@@ -1320,6 +1316,9 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		$this->validate_props();
 
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {

--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -14,6 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Customer_Download extends WC_Data implements ArrayAccess {
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'customer_download';
+
+	/**
 	 * Download Data array.
 	 *
 	 * @since 2.7.0
@@ -58,16 +64,6 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 			$this->data_store->read( $this );
 		}
  	}
-
-	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  2.7.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_get_download_';
-	}
 
 	/*
 	|--------------------------------------------------------------------------
@@ -283,6 +279,9 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 	 */
 	public function save() {
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -47,6 +47,12 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	protected $meta_type = 'order_item';
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'order_item';
+
+	/**
 	 * Constructor.
 	 * @param int|object|array $item ID to load from the DB, or WC_Order_Item Object
 	 */
@@ -67,16 +73,6 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		if ( $this->get_id() > 0 ) {
 			$this->data_store->read( $this );
 		}
-	}
-
-	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  2.7.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_get_order_item_';
 	}
 
 	/*

--- a/includes/class-wc-order-refund.php
+++ b/includes/class-wc-order-refund.php
@@ -22,6 +22,12 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	protected $data_store_name = 'order-refund';
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'order_refund';
+
+	/**
 	 * Stores product data.
 	 *
 	 * @var array
@@ -48,16 +54,6 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 */
 	public function get_type() {
 		return 'shop_order_refund';
-	}
-
-	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  2.7.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_get_order_refund_';
 	}
 
 	/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -215,6 +215,9 @@ class WC_Order extends WC_Abstract_Order {
 	public function save() {
 		$this->maybe_set_user_billing_email();
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -365,6 +365,9 @@ class WC_Product_Variable extends WC_Product {
 	public function save() {
 		$this->validate_props();
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -24,6 +24,12 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 	protected $id = null;
 
 	/**
+	 * This is the name of this object type.
+	 * @var string
+	 */
+	protected $object_type = 'shipping_zone';
+
+	/**
 	 * Zone Data
 	 * @var array
 	 */
@@ -54,16 +60,6 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 		if ( false === $this->get_object_read() ) {
 			$this->data_store->read( $this );
 		}
-	}
-
-	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  2.7.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_get_shipping_zone_';
 	}
 
 	/*
@@ -248,11 +244,13 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 	 * @return int
 	 */
 	public function save() {
-		$name = $this->get_zone_name();
-		if ( empty( $name ) ) {
+		if ( ! $this->get_zone_name() ) {
 			$this->set_zone_name( $this->generate_zone_name() );
 		}
 		if ( $this->data_store ) {
+			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 			if ( null === $this->get_id() ) {
 				$this->data_store->create( $this );
 			} else {

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -126,6 +126,15 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
+	 * Method to update an order in the database.
+	 * @param WC_Order $order
+	 */
+	public function update( &$order ) {
+		parent::update( $order );
+		do_action( 'woocommerce_update_order', $order->get_id() );
+	}
+
+	/**
 	 * Helper method that updates all the post meta for an order based on it's settings in the WC_Order class.
 	 *
 	 * @param WC_Order

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -96,14 +96,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$this->update_visibility( $product );
 			$this->update_attributes( $product );
 			$this->update_downloads( $product );
-			$product->save_meta_data();
-
-			do_action( 'woocommerce_new_product', $id );
-
-			$product->apply_changes();
 			$this->update_version_and_type( $product );
 			$this->update_term_counts( $product );
+			$product->save_meta_data();
+			$product->apply_changes();
 			$this->clear_caches( $product );
+
+			do_action( 'woocommerce_new_' . $post_type, $id );
 		}
 	}
 
@@ -162,14 +161,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$this->update_visibility( $product );
 		$this->update_attributes( $product );
 		$this->update_downloads( $product );
-		$product->save_meta_data();
-
-		do_action( 'woocommerce_update_product', $product->get_id() );
-
-		$product->apply_changes();
 		$this->update_version_and_type( $product );
 		$this->update_term_counts( $product );
+		$product->save_meta_data();
+		$product->apply_changes();
 		$this->clear_caches( $product );
+
+		do_action( 'woocommerce_update_' . $post_type, $product->get_id() );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -102,7 +102,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$product->apply_changes();
 			$this->clear_caches( $product );
 
-			do_action( 'woocommerce_new_' . $post_type, $id );
+			do_action( 'woocommerce_new_product', $id );
 		}
 	}
 
@@ -167,7 +167,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$product->apply_changes();
 		$this->clear_caches( $product );
 
-		do_action( 'woocommerce_update_' . $post_type, $product->get_id() );
+		do_action( 'woocommerce_update_product', $product->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
Adds actions before save for each CRUD object type allowing props to be set before saving to the DB.

Closes #12648