### PR TITLE
Hide "Empty Trash" button in blank state after removing all data

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1965,7 +1965,7 @@ class WC_Admin_Post_Types {
 				break;
 			}
 
-			echo '<style type="text/css">#posts-filter .wp-list-table, #posts-filter .tablenav.top, .wrap .subsubsub  { display: none; } </style></div>';
+			echo '<style type="text/css">#posts-filter .wp-list-table, #posts-filter .tablenav.top, .tablenav.bottom .actions, .wrap .subsubsub  { display: none; } </style></div>';
 		}
 	}
 


### PR DESCRIPTION
![orders woocommerce wordpress](https://cloud.githubusercontent.com/assets/3774827/21340399/4a4284fa-c6ae-11e6-9315-41c5bbb8d65c.png)
