### PR TITLE
[2.7] Fix non-object error when clearing product transients

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -160,7 +160,7 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		// Does this product have a parent?
 		$product = wc_get_product( $post_id );
 
-		if ( $product->get_parent_id() > 0 ) {
+		if ( $product && $product->get_parent_id() > 0 ) {
 			wc_delete_product_transients( $product->get_parent_id() );
 		}
 	}


### PR DESCRIPTION
In some cases, an attempt might be made to delete transients of a product that has already been deleted.

This PR fixes an error when attempting to call `get_parent_id` on a non-onject.