### PR TITLE
Use strict `assertTrue` and `assertFalse` over `assertEquals`

### DIFF
--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -111,7 +111,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 			'customer_email'             => '',
 		) );
 		$this->assertEquals( $code, $coupon->get_code() );
-		$this->assertEquals( true, $coupon->get_individual_use() );
+		$this->assertTrue( $coupon->get_individual_use() );
 		$this->assertEquals( 100, $coupon->get_maximum_amount() );
 
 		/**
@@ -143,9 +143,9 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 			'customer_email'             => '',
 		) );
 		$this->assertEquals( $code, $coupon->get_code() );
-		$this->assertEquals( true, $coupon->get_individual_use() );
-		$this->assertEquals( false, $coupon->get_free_shipping() );
-		$this->assertEquals( false, $coupon->get_exclude_sale_items() );
+		$this->assertTrue( $coupon->get_individual_use() );
+		$this->assertFalse( $coupon->get_free_shipping() );
+		$this->assertFalse( $coupon->get_exclude_sale_items() );
 		$this->assertEquals( array( 5, 6 ), $coupon->get_excluded_product_ids() );
 		$this->assertEquals( array(), $coupon->get_product_ids() );
 	}

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -61,7 +61,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 		$result = $object->set_props( $data_to_set );
 		$this->assertFalse( is_wp_error( $result ) );
 		$this->assertEquals( 'I am a fish', $object->get_content() );
-		$this->assertEquals( true, $object->get_bool_value() );
+		$this->assertTrue( $object->get_bool_value() );
 
 		$data_to_set = array(
 			'content'    => 'I am also a fish',

--- a/tests/unit-tests/order/crud.php
+++ b/tests/unit-tests/order/crud.php
@@ -88,7 +88,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object = new WC_Order();
 		$set_to = 'USD';
 		$object->set_prices_include_tax( 1 );
-		$this->assertEquals( true, $object->get_prices_include_tax() );
+		$this->assertTrue( $object->get_prices_include_tax() );
 	}
 
 	/**
@@ -130,7 +130,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	 */
 	function test_get_user() {
 		$object = new WC_Order();
-		$this->assertEquals( false, $object->get_user() );
+		$this->assertFalse( $object->get_user() );
 		$set_to = '1';
 		$object->set_customer_id( $set_to );
 		$this->assertInstanceOf( 'WP_User', $object->get_user() );

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -33,9 +33,8 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	 * @since 2.3.0
 	 */
 	public function test_wc_is_order_status() {
-
-		$this->assertEquals( true,  wc_is_order_status( 'wc-pending' ) );
-		$this->assertEquals( false, wc_is_order_status( 'wc-another-status' ) );
+		$this->assertTrue(  wc_is_order_status( 'wc-pending' ) );
+		$this->assertFalse( wc_is_order_status( 'wc-another-status' ) );
 	}
 
 	/**
@@ -80,10 +79,10 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$default = get_option( 'woocommerce_ship_to_destination' );
 
 		update_option( 'woocommerce_ship_to_destination', 'shipping' );
-		$this->assertEquals( false, wc_ship_to_billing_address_only() );
+		$this->assertFalse( wc_ship_to_billing_address_only() );
 
 		update_option( 'woocommerce_ship_to_destination', 'billing_only' );
-		$this->assertEquals( true, wc_ship_to_billing_address_only() );
+		$this->assertTrue( wc_ship_to_billing_address_only() );
 
 		update_option( 'woocommerce_ship_to_destination', $default );
 	}

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -258,18 +258,18 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 	public function test_wc_product_has_unique_sku() {
 		$product_1 = WC_Helper_Product::create_simple_product();
 
-		$this->assertEquals( true, wc_product_has_unique_sku( $product_1->get_id(), $product_1->get_sku() ) );
+		$this->assertTrue( wc_product_has_unique_sku( $product_1->get_id(), $product_1->get_sku() ) );
 
 		$product_2 = WC_Helper_Product::create_simple_product();
 		// we need to manually set a sku, because WC_Product now uses wc_product_has_unique_sku before setting
 		// so we need to manually set it to test the functionality.
 		update_post_meta( $product_2->get_id(), '_sku', $product_1->get_sku() );
 
-		$this->assertEquals( false, wc_product_has_unique_sku( $product_2->get_id(), $product_1->get_sku() ) );
+		$this->assertFalse( wc_product_has_unique_sku( $product_2->get_id(), $product_1->get_sku() ) );
 
 		WC_Helper_Product::delete_product( $product_1->get_id() );
 
-		$this->assertEquals( true, wc_product_has_unique_sku( $product_2->get_id(), $product_2->get_sku() ) );
+		$this->assertTrue( wc_product_has_unique_sku( $product_2->get_id(), $product_2->get_sku() ) );
 
 		WC_Helper_Product::delete_product( $product_2->get_id() );
 	}

--- a/tests/unit-tests/util/conditional-functions.php
+++ b/tests/unit-tests/util/conditional-functions.php
@@ -14,7 +14,7 @@ class WC_Tests_Conditional_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_is_store_notice_showing() {
 
-		$this->assertEquals( false, is_store_notice_showing() );
+		$this->assertFalse( is_store_notice_showing() );
 	}
 
 	/**
@@ -24,7 +24,7 @@ class WC_Tests_Conditional_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_tax_enabled() {
 
-		$this->assertEquals( false, wc_tax_enabled() );
+		$this->assertFalse( wc_tax_enabled() );
 	}
 
 	/**
@@ -34,7 +34,7 @@ class WC_Tests_Conditional_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_prices_include_tax() {
 
-		$this->assertEquals( false, wc_prices_include_tax() );
+		$this->assertFalse( wc_prices_include_tax() );
 	}
 
 	/**


### PR DESCRIPTION
Strict versions help expose potential errors, for example:

```php
// Problems may be hidden by loose comparison
public function test_pass() {
	$this->assertEquals( false, 0 );
}

// Strict version exposes possible problems
public function test_fail() {
	$this->assertFalse( 0 );
}
``` 