### PR TITLE
[2.7] Fix product variation hook prefix for consistency

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -44,7 +44,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @return string
 	 */
 	protected function get_hook_prefix() {
-		return 'woocommerce_product_variation_get_';
+		return 'woocommerce_get_product_variation_';
 	}
 
 	/**


### PR DESCRIPTION
It's `woocommerce_get_xxx` everywhere but here.

Note this means that any existing `woocommerce_get_[regular_/sale_]price` hooks won't work with variations in 2.7 :) Might need to add some code in the "deprecator", if this scenario can be taken into account?