### PR TITLE
[2.7] Use get_order instead of creating object in woocommerce_get_product_from_item args

### DIFF
--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -321,7 +321,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 
 		// Backwards compatible filter from WC_Order::get_product_from_item()
 		if ( has_filter( 'woocommerce_get_product_from_item' ) ) {
-			$product = apply_filters( 'woocommerce_get_product_from_item', $product, $this, wc_get_order( $this->get_order_id() ) );
+			$product = apply_filters( 'woocommerce_get_product_from_item', $product, $this, $this->get_order() );
 		}
 
 		return apply_filters( 'woocommerce_order_item_product', $product, $this );


### PR DESCRIPTION
Changed in case the order hasn't been saved yet and the item holds a reference to an unsaved order?