### PR TITLE
[2.7] Add 'woocommerce_rest_set_order_item' REST API hook

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -673,6 +673,12 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 		// Prepare item data
 		$item = $this->$method( $posted, $action );
 
+		/**
+		 * Action hook to adjust item before save.
+		 * @since 2.7.0
+		 */
+		do_action( 'woocommerce_rest_set_order_item', $item, $posted );
+
 		// Save or add to order
 		if ( 'create' === $action ) {
 			$order->add_item( $item );


### PR DESCRIPTION
This is the REST API equivalent of #12639 -- 

Makes it possible to associate a custom field submitted in a `line_item` with the created object. The submitted data can be used to perform operations on the object that can be intercepted downstream at `woocommerce_rest_pre_insert_shop_order`, and modify the order object there.

The hook will be used in the following scenario:

- Submit a `bundle_configuration` array, which contains data about the contents/configuration of a product bundle.
- The `bundle_configuration` array is validated in `woocommerce_rest_set_order_item` and if validation passes, it is saved in the order item object. Otherwise, a REST exception is thrown to indicate that the config is faulty.
- The config data is intercepted in `woocommerce_rest_pre_insert_shop_order` and the order is modified to include the missing line items, complete with all parent/child meta associations.

I haven't been able to track down any other useful hooks to use upstream.

