### PR TITLE
[2.7] Calculate REST order item totals excluding tax if undefined (?)

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -559,7 +559,8 @@ class WC_REST_Orders_Controller extends WC_REST_Posts_Controller {
 			$item->set_product( $product );
 
 			if ( 'create' === $action ) {
-				$total = $product->get_price() * ( isset( $posted['quantity'] ) ? $posted['quantity'] : 1 );
+				$quantity = isset( $posted['quantity'] ) ? $posted['quantity'] : 1;
+				$total    = wc_get_price_excluding_tax( $product, array( 'qty' => $quantity ) );
 				$item->set_total( $total );
 				$item->set_subtotal( $total );
 			}


### PR DESCRIPTION
- Create an order with one product using standard checkout, or with `WC_Order::add_product`.
- Now recreate the same order using the REST API, without defining any line item totals.

You will notice that the line item total/tax amounts in these two scenarios differ.

When using REST and item totals are undefined, `get_price()` is used, which seems inconsistent with standard checkout. Shouldn't item totals be excl tax by default?