### PR TITLE
[2.7] Remaining inline comments about pointers

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -126,7 +126,7 @@ abstract class WC_Data {
 	 */
 	public function save() {
 		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			// Trigger action before saving to the DB. Allows you to adjust object props before save.
 			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 			if ( $this->get_id() ) {

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -175,7 +175,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function save() {
 		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			// Trigger action before saving to the DB. Allows you to adjust object props before save.
 			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 			if ( $this->get_id() ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -319,7 +319,7 @@ class WC_Checkout {
 			$this->create_order_coupon_lines( $order );
 
 			/**
-			 * Action hook to adjust order before save. To change $order, use a pointer (&$order) in your hooked function.
+			 * Action hook to adjust order before save.
 			 * @since 2.7.0
 			 */
 			do_action( 'woocommerce_checkout_create_order', $order, $data );

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -215,7 +215,7 @@ class WC_Order extends WC_Abstract_Order {
 	public function save() {
 		$this->maybe_set_user_billing_email();
 		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			// Trigger action before saving to the DB. Allows you to adjust object props before save.
 			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 			if ( $this->get_id() ) {

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -365,7 +365,7 @@ class WC_Product_Variable extends WC_Product {
 	public function save() {
 		$this->validate_props();
 		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			// Trigger action before saving to the DB. Allows you to adjust object props before save.
 			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 			if ( $this->get_id() ) {

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -248,7 +248,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 			$this->set_zone_name( $this->generate_zone_name() );
 		}
 		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
+			// Trigger action before saving to the DB. Allows you to adjust object props before save.
 			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 			if ( null === $this->get_id() ) {


### PR DESCRIPTION
Ref: 01aba1fd2ba832e82f26f107ce6c771d5c5f1846

As discussed, it's not possible to use a real pointer due to the way `call_user_func_array` works with WP hooks.

Object props can be safely modified in hooked functions without requiring true pass-by-reference.

This PR cleans up some stray references in comments.