### PR TITLE
[2.7] Shipping order item taxes array not saved on checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -420,7 +420,9 @@ class WC_Checkout {
 					'method_title' => $shipping_rate->label,
 					'method_id'    => $shipping_rate->id,
 					'total'        => wc_format_decimal( $shipping_rate->cost ),
-					'taxes'        => $shipping_rate->taxes,
+					'taxes'        => array(
+						'total' => $shipping_rate->taxes,
+					),
 					'meta_data'    => $shipping_rate->get_meta_data(),
 				) );
 


### PR DESCRIPTION
Noticed this while looking at the checkout class earlier. Apologies for sending multiple PRs for the same file based on `master` -- this is a one-liner so conflicts should be manageable.

If it's too much trouble I can merge and re-submit.

### Issue description

- Enable tax calculations for shipping
- Make an order
- Go to WooCommerce > Orders and look at the tax items' column
- Note that the tax amount of the shipping item is missing, but order totals are correct.
- https://cl.ly/160g3W2i2t0S

Looks like the tax array is not passed to the object correctly (?). 