### PR TITLE
[2.7] Variation always included in product search results when search term is variation ID

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1152,8 +1152,17 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		);
 
 		if ( is_numeric( $term ) ) {
-			$product_ids[] = absint( $term );
-			$product_ids[] = wp_get_post_parent_id( $term );
+			$post_id   = absint( $term );
+			$post_type = get_post_type( $post_id );
+
+			if ( $post_type ) {
+				if ( 'product_variation' === $post_type && $include_variations ) {
+					$product_ids[] = $post_id;
+					$product_ids[] = wp_get_post_parent_id( $post_id );
+				} elseif ( 'product' === $post_type ) {
+					$product_ids[] = $post_id;
+				}
+			}
 		}
 
 		return wp_parse_id_list( $product_ids );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1152,13 +1152,19 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		);
 
 		if ( is_numeric( $term ) ) {
+
 			$post_id   = absint( $term );
 			$post_type = get_post_type( $post_id );
 
 			if ( $post_type ) {
-				if ( 'product_variation' === $post_type && $include_variations ) {
-					$product_ids[] = $post_id;
+				if ( 'product_variation' === $post_type ) {
+
+					if ( $include_variations ) {
+						$product_ids[] = $post_id;
+					}
+
 					$product_ids[] = wp_get_post_parent_id( $post_id );
+
 				} elseif ( 'product' === $post_type ) {
 					$product_ids[] = $post_id;
 				}


### PR DESCRIPTION
### Issue Description

When searching for products **excluding variations** (`$include_variations === false`), if the search term is a variation ID, then the returned results will include the entered variation.

This PR ensures that only its parent will be included in the returned results when `$include_variations === false`.