### PR TITLE
Added email ID to locate core template for email

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -626,7 +626,7 @@ class WC_Email extends WC_Settings_API {
 
 					// Locate template file
 					$core_file     = $this->template_base . $template;
-					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base );
+					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base, $this->id );
 
 					// Copy template file
 					copy( $template_file, $theme_file );
@@ -755,7 +755,7 @@ class WC_Email extends WC_Settings_API {
 
 					$local_file    = $this->get_theme_template_file( $template );
 					$core_file     = $this->template_base . $template;
-					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base );
+					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base, $this->id );
 					$template_dir  = apply_filters( 'woocommerce_template_directory', 'woocommerce', $template );
 					?>
 					<div class="template <?php echo $template_type; ?>">


### PR DESCRIPTION
This PR adds email id to `woocommerce_locate_core_template` filter. It would be useful for custom emails created by plugins, which have got default email templates.