### PR TITLE
[2.7] Separate trash and delete CRUD object hooks

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -134,11 +134,12 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $id );
 			$order->set_id( 0 );
+			do_action( 'woocommerce_delete_order', $id );
 		} else {
 			wp_trash_post( $id );
 			$order->set_status( 'trash' );
+			do_action( 'woocommerce_trash_order', $id );
 		}
-		do_action( 'woocommerce_delete_order', $id );
 	}
 
 	/*

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -155,10 +155,11 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $coupon->get_id() );
 			$coupon->set_id( 0 );
+			do_action( 'woocommerce_delete_coupon', $id );
 		} else {
 			wp_trash_post( $coupon->get_id() );
+			do_action( 'woocommerce_trash_coupon', $id );
 		}
-		do_action( 'woocommerce_delete_coupon', $id );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -186,11 +186,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $product->get_id() );
 			$product->set_id( 0 );
+			do_action( 'woocommerce_delete_' . $post_type, $id );
 		} else {
 			wp_trash_post( $product->get_id() );
 			$product->set_status( 'trash' );
+			do_action( 'woocommerce_trash_' . $post_type, $id );
 		}
-		do_action( 'woocommerce_delete_' . $post_type, $id );
 	}
 
 	/*


### PR DESCRIPTION
In many cases, a "clean-up" task may only need to run when a CRUD object gets permanently deleted (not trashed), therefore it should be possible to tell whether a CRUD object has been deleted or trashed from the hook that fires after such an event.

This PR introduces `_trash_` in the place of `_delete_` hooks for CRUD objects that get trashed.