### PR TITLE
Fix coupon attribute keys for the API.

### DIFF
--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -142,8 +142,14 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 	public function prepare_item_for_response( $post, $request ) {
 		$coupon         = new WC_Coupon( (int) $post->ID );
 		$data           = $coupon->get_data();
+
+		// The API returns 'expiry_date' and 'exclude_product_ids' instead of date_expires and 'excluded_product_ids'.
+		$data['expiry_date']         = $data['date_expires'];
+		$data['exclude_product_ids'] = $data['excluded_product_ids'];
+		unset( $data['excluded_product_ids'], $data['date_expires'] );
+
 		$format_decimal = array( 'amount', 'minimum_amount', 'maximum_amount' );
-		$format_date    = array( 'date_created', 'date_modified', 'date_expires' );
+		$format_date    = array( 'date_created', 'date_modified', 'expiry_date' );
 		$format_null    = array( 'usage_limit', 'usage_limit_per_user', 'limit_usage_to_x_items' );
 
 		// Format decimal values.
@@ -415,7 +421,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'date_expires' => array(
+				'expiry_date' => array(
 					'description' => __( 'UTC DateTime when the coupon expires.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -437,7 +443,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Posts_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'excluded_product_ids' => array(
+				'exclude_product_ids' => array(
 					'description' => __( "List of product ID's the coupon cannot be used on.", 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),

--- a/tests/unit-tests/api/coupons.php
+++ b/tests/unit-tests/api/coupons.php
@@ -55,11 +55,11 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 			'date_modified'  => wc_rest_prepare_date_response( $post_1->post_modified_gmt ),
 			'discount_type'  => 'fixed_cart',
 			'description'    => 'This is a dummy coupon',
-			'date_expires'    => '',
+			'expiry_date'    => '',
 			'usage_count'    => 0,
 			'individual_use' => false,
 			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
+			'exclude_product_ids' => array(),
 			'usage_limit'    => '',
 			'usage_limit_per_user' => '',
 			'limit_usage_to_x_items' => 0,
@@ -117,11 +117,11 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 			'date_modified'  => wc_rest_prepare_date_response( $post->post_modified_gmt ),
 			'discount_type'  => 'fixed_cart',
 			'description'    => 'This is a dummy coupon',
-			'date_expires'    => null,
+			'expiry_date'    => null,
 			'usage_count'    => 0,
 			'individual_use' => false,
 			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
+			'exclude_product_ids' => array(),
 			'usage_limit'    => null,
 			'usage_limit_per_user' => null,
 			'limit_usage_to_x_items' => 0,
@@ -184,11 +184,11 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 			'date_modified'  => $data['date_modified'],
 			'discount_type'  => 'fixed_product',
 			'description'    => 'Test',
-			'date_expires'    => null,
+			'expiry_date'    => null,
 			'usage_count'    => 0,
 			'individual_use' => false,
 			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
+			'exclude_product_ids' => array(),
 			'usage_limit'    => 10,
 			'usage_limit_per_user' => null,
 			'limit_usage_to_x_items' => 0,
@@ -414,11 +414,11 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'discount_type', $properties );
 		$this->assertArrayHasKey( 'amount', $properties );
-		$this->assertArrayHasKey( 'date_expires', $properties );
+		$this->assertArrayHasKey( 'expiry_date', $properties );
 		$this->assertArrayHasKey( 'usage_count', $properties );
 		$this->assertArrayHasKey( 'individual_use', $properties );
 		$this->assertArrayHasKey( 'product_ids', $properties );
-		$this->assertArrayHasKey( 'excluded_product_ids', $properties );
+		$this->assertArrayHasKey( 'exclude_product_ids', $properties );
 		$this->assertArrayHasKey( 'usage_limit', $properties );
 		$this->assertArrayHasKey( 'usage_limit_per_user', $properties );
 		$this->assertArrayHasKey( 'limit_usage_to_x_items', $properties );


### PR DESCRIPTION
The WC API returns exclude_product_ids and expiry_date. 2.7 renames these incorrectly. This PR fixes that. We can add renaming these fields to match CRUD in v2 of the API.

Fixes #12730.