### PR TITLE
[2.7] Fix undefined '$qty_ordered' variable in 'wc_reduce_stock_levels'

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -100,7 +100,7 @@ function wc_reduce_stock_levels( $order_id ) {
 					}
 
 					if ( $new_stock < 0 ) {
-						do_action( 'woocommerce_product_on_backorder', array( 'product' => $product, 'order_id' => $order_id, 'quantity' => $qty_ordered ) );
+						do_action( 'woocommerce_product_on_backorder', array( 'product' => $product, 'order_id' => $order_id, 'quantity' => $qty ) );
 					}
 				}
 			}


### PR DESCRIPTION
Resolves a PHP notice due to '$qty_ordered' not being defined.