### PR TITLE
[2.6] Fix PHP 7.1 compatibility issues with non-numeric math operations

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -498,7 +498,7 @@ abstract class WC_Abstract_Order {
 		do_action( 'woocommerce_order_add_shipping', $this->id, $item_id, $shipping_rate );
 
 		// Update total
-		$this->set_total( $this->order_shipping + wc_format_decimal( $shipping_rate->cost ), 'shipping' );
+		$this->set_total( (float) $this->order_shipping + (float) wc_format_decimal( $shipping_rate->cost ), 'shipping' );
 
 		return $item_id;
 	}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -871,10 +871,7 @@ class WC_Product {
 		if ( $price === '' ) {
 			$price = $this->get_price();
 		}
-
-		if ( ! $price ) {
-			$price = 0;
-		}
+		$price = (float) $price;
 
 		if ( $this->is_taxable() ) {
 
@@ -935,10 +932,7 @@ class WC_Product {
 		if ( $price === '' ) {
 			$price = $this->get_price();
 		}
-
-		if ( ! $price ) {
-			$price = 0;
-		}
+		$price = (float) $price;
 
 		if ( $this->is_taxable() && 'yes' === get_option( 'woocommerce_prices_include_tax' ) ) {
 			$tax_rates  = WC_Tax::get_base_tax_rates( $this->tax_class );

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -12,7 +12,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 	 * Test check version.
 	 */
 	public function test_check_version() {
-		update_option( 'woocommerce_version', WC()->version - 1 );
+		update_option( 'woocommerce_version', ( (float) WC()->version - 1 ) );
 		update_option( 'woocommerce_db_version', WC()->version );
 		WC_Install::check_version();
 


### PR DESCRIPTION
Fixes #12690. 

The float cast will handle the  fix originally attempted in https://github.com/woocommerce/woocommerce/commit/0afdeb9703465b78abe88fd86fde7f4486305d5c (if an empty string is still present after the get_price call, float will cast it to 0). It should also ensure price is the correct type before using it in math operations. 

There was a similar issue with the order class and install tests that I noticed when running the unit tests on 7.1.

cc @mikejolley @MMaKenZi @bekarice 
