### PR TITLE
Fix legacy order status response.

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-order.php
+++ b/includes/abstracts/abstract-wc-legacy-order.php
@@ -411,7 +411,9 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 			return $this->get_id();
 		} elseif ( 'post' === $key ) {
 			return get_post( $this->get_id() );
-		} elseif ( 'status' === $key || 'post_status' === $key ) {
+		} elseif ( 'status' === $key ) {
+			return $this->get_status();
+		} elseif ( 'post_status' === $key ) {
 			return 'wc-' . $this->get_status();
 		} elseif ( 'customer_message' === $key || 'customer_note' === $key ) {
 			return $this->get_customer_note();


### PR DESCRIPTION
Fixes #12705.

`status` and `post_status` are different. `status` should match `get_status` exactly. Confirmed with all status types.