### PR TITLE
[2.7] Fix undefined variable notice

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -442,7 +442,7 @@ class WC_AJAX {
 
 			if ( wc_is_order_status( 'wc-' . $status ) && $order ) {
 				$order->update_status( $status, '', true );
-				do_action( 'woocommerce_order_edit_status', $order_id, $status );
+				do_action( 'woocommerce_order_edit_status', $order->get_id(), $status );
 			}
 		}
 


### PR DESCRIPTION
Fixes PHP notice:

```
PHP Notice:  Undefined variable: order_id in woocommerce/includes/class-wc-ajax.php on line 445
PHP Stack trace:
PHP   1. {main}() /wp-admin/admin-ajax.php:0
PHP   2. do_action() /wp-admin/admin-ajax.php:91
PHP   3. WP_Hook->do_action() /wp-includes/plugin.php:453
PHP   4. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:323
PHP   5. WC_AJAX::mark_order_status() /wp-includes/class-wp-hook.php:298
```