### PR TITLE
Sync variation names

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -31,6 +31,9 @@ class WC_Admin_Post_Types {
 		// Disable Auto Save
 		add_action( 'admin_print_scripts', array( $this, 'disable_autosave' ) );
 
+		// Extra post data.
+		add_action( 'edit_form_top', array( $this, 'edit_form_top' ) );
+
 		// WP List table columns. Defined here so they are always available for events such as inline editing.
 		add_filter( 'manage_product_posts_columns', array( $this, 'product_columns' ) );
 		add_filter( 'manage_shop_coupon_posts_columns', array( $this, 'shop_coupon_columns' ) );
@@ -1758,6 +1761,14 @@ class WC_Admin_Post_Types {
 		if ( $post && in_array( get_post_type( $post->ID ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
 			wp_dequeue_script( 'autosave' );
 		}
+	}
+
+	/**
+	 * Output extra data on post forms.
+	 * @param  WP_Post $post
+	 */
+	public function edit_form_top( $post ) {
+		echo '<input type="hidden" id="original_post_title" name="original_post_title" value="' . esc_attr( $post->post_title ) . '" />';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -308,6 +308,10 @@ class WC_Meta_Box_Product_Data {
 
 		$product->save();
 
+		if ( $product->is_type( 'variable' ) ) {
+			$product->get_data_store()->sync_variation_names( $product, wc_clean( $_POST['original_post_title'] ), wc_clean( $_POST['post_title'] ) );
+		}
+
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
 	}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -523,7 +523,7 @@ class WC_AJAX {
 			foreach ( $variation_ids as $variation_id ) {
 				if ( 'product_variation' === get_post_type( $variation_id ) ) {
 					$variation = wc_get_product( $variation_id );
-					$variation->delete();
+					$variation->delete( true );
 				}
 			}
 		}
@@ -1457,7 +1457,7 @@ class WC_AJAX {
 			if ( $refund_id && 'shop_order_refund' === get_post_type( $refund_id ) ) {
 				$refund   = wc_get_order( $refund_id );
 				$order_id = $refund->get_parent_id();
-				$refund->delete();
+				$refund->delete( true );
 				do_action( 'woocommerce_refund_deleted', $refund_id, $order_id );
 			}
 		}
@@ -1819,7 +1819,7 @@ class WC_AJAX {
 		if ( isset( $data['allowed'] ) && 'true' === $data['allowed'] ) {
 			foreach ( $variations as $variation_id ) {
 				$variation = wc_get_product( $variation_id );
-				$variation->delete();
+				$variation->delete( true );
 			}
 		}
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -338,12 +338,17 @@ class WC_Product_Variable extends WC_Product {
 			// Trigger action before saving to the DB. Allows you to adjust object props before save.
 			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
+			// Get names before save.
+			$previous_name = $this->data['name'];
+			$new_name      = $this->get_name( 'edit' );
+
 			if ( $this->get_id() ) {
 				$this->data_store->update( $this );
 			} else {
 				$this->data_store->create( $this );
 			}
 
+			$this->data_store->sync_variation_names( $this, $previous_name, $new_name );
 			$this->data_store->sync_managed_variation_stock_status( $this );
 
 			return $this->get_id();

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -282,6 +282,32 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	}
 
 	/**
+	 * Syncs all variation names if the parent name is changed.
+	 *
+	 * @param WC_Product $product
+	 * @param string $previous_name
+	 * @param string $new_name
+	 * @since 2.7.0
+	 */
+	public function sync_variation_names( &$product, $previous_name = '', $new_name = '' ) {
+		if ( $new_name !== $previous_name ) {
+			global $wpdb;
+
+			$wpdb->query( $wpdb->prepare(
+				"
+					UPDATE {$wpdb->posts}
+					SET post_title = REPLACE( post_title, %s, %s )
+					WHERE post_type = 'product_variation'
+					AND post_parent = %d
+				",
+				$previous_name,
+				$new_name,
+				$product->get_id()
+			 ) );
+		}
+	}
+
+	/**
 	 * Stock managed at the parent level - update children being managed by this product.
 	 * This sync function syncs downwards (from parent to child) when the variable product is saved.
 	 *

--- a/includes/data-stores/interfaces/wc-product-variable-data-store-interface.php
+++ b/includes/data-stores/interfaces/wc-product-variable-data-store-interface.php
@@ -38,6 +38,16 @@ interface WC_Product_Variable_Data_Store_Interface {
 	public function child_is_in_stock( $product );
 
 	/**
+	 * Syncs all variation names if the parent name is changed.
+	 *
+	 * @param WC_Product $product
+	 * @param string $previous_name
+	 * @param string $new_name
+	 * @since 2.7.0
+	 */
+	public function sync_variation_names( &$product, $previous_name = '', $new_name = '' );
+
+	/**
 	 * Stock managed at the parent level - update children being managed by this product.
 	 * This sync function syncs downwards (from parent to child) when the variable product is saved.
 	 *


### PR DESCRIPTION
Adds a method to sync variation names when the post title changes. Fixes #12707