### PR TITLE
[2.7] Fix PHP 7.1 warnings/notices.

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -592,7 +592,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function set_shipping_tax( $value ) {
 		$this->set_prop( 'shipping_tax', wc_format_decimal( $value ) );
-		$this->set_total_tax( $this->get_cart_tax() + $this->get_shipping_tax() );
+		$this->set_total_tax( (float) $this->get_cart_tax() + (float) $this->get_shipping_tax() );
 	}
 
 	/**
@@ -603,7 +603,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function set_cart_tax( $value ) {
 		$this->set_prop( 'cart_tax', wc_format_decimal( $value ) );
-		$this->set_total_tax( $this->get_cart_tax() + $this->get_shipping_tax() );
+		$this->set_total_tax( (float) $this->get_cart_tax() + (float) $this->get_shipping_tax() );
 	}
 
 	/**

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -360,7 +360,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$cart_item_qty = is_null( $cart_item ) ? 1 : $cart_item['quantity'];
 
 		if ( $this->is_type( array( 'percent' ) ) ) {
-			$discount = $this->get_amount() * ( $discounting_amount / 100 );
+			$discount = (float) $this->get_amount() * ( $discounting_amount / 100 );
 		} elseif ( $this->is_type( 'fixed_cart' ) && ! is_null( $cart_item ) && WC()->cart->subtotal_ex_tax ) {
 			/**
 			 * This is the most complex discount - we need to divide the discount between rows based on their price in.
@@ -376,14 +376,14 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			} else {
 				$discount_percent = ( wc_get_price_excluding_tax( $cart_item['data'] ) * $cart_item_qty ) / WC()->cart->subtotal_ex_tax;
 			}
-			$discount = ( $this->get_amount() * $discount_percent ) / $cart_item_qty;
+			$discount = ( (float) $this->get_amount() * $discount_percent ) / $cart_item_qty;
 
 		} elseif ( $this->is_type( 'fixed_product' ) ) {
 			$discount = min( $this->get_amount(), $discounting_amount );
 			$discount = $single ? $discount : $discount * $cart_item_qty;
 		}
 
-		$discount = min( $discount, $discounting_amount );
+		$discount = (float) min( $discount, $discounting_amount );
 
 		// Handle the limit_usage_to_x_items option
 		if ( ! $this->is_type( array( 'fixed_cart' ) ) ) {

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -840,8 +840,8 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 		'qty'   => '',
 		'price' => '',
 	) );
-	$price = max( 0, $args['price'] ? $args['price'] : $product->get_price() );
-	$qty   = $args['qty'] ? $args['qty'] : 1;
+	$price = (float) max( 0, $args['price'] ? $args['price'] : $product->get_price() );
+	$qty   = (int) $args['qty'] ? $args['qty'] : 1;
 
 	if ( ! $product->is_taxable() ) {
 		$price = $price * $qty;
@@ -888,8 +888,8 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 		'qty'   => '',
 		'price' => '',
 	) );
-	$price = max( 0, $args['price'] ? $args['price'] : $product->get_price() );
-	$qty   = $args['qty'] ? $args['qty'] : 1;
+	$price = (float) max( 0, $args['price'] ? $args['price'] : $product->get_price() );
+	$qty   = (int) $args['qty'] ? $args['qty'] : 1;
 
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
 		$tax_rates  = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -10,7 +10,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 	 * Test check version.
 	 */
 	public function test_check_version() {
-		update_option( 'woocommerce_version', WC()->version - 1 );
+		update_option( 'woocommerce_version', ( (float) WC()->version - 1 ) );
 		update_option( 'woocommerce_db_version', WC()->version );
 		WC_Install::check_version();
 


### PR DESCRIPTION
This PR fixes the following errors that I found:

* Add new order. includes/abstracts/abstract-wc-order.php on line 595
* Add new order. includes/abstracts/abstract-wc-order.php on line 606
* Add a coupon with no amount value (free shipping). includes/class-wc-coupon.php on line 379
* test_check_version PHPUnit test. tests/unit-tests/util/install.php on line 13
* wc_get_price_including_tax and wc_get_price_excluding_tax in product-functions (2.6 fix)

See #12748.
