### PR TITLE
Page permalink not filtered when passed as parameter in various locations.

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -304,7 +304,7 @@ class WC_Admin_Menus {
 			'parent' => 'site-name',
 			'id'     => 'view-store',
 			'title'  => __( 'Visit store', 'woocommerce' ),
-			'href'   => wc_get_page_permalink( 'shop' ),
+			'href'   => apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ),
 		) );
 	}
 }

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -250,7 +250,7 @@ class WC_AJAX {
 	private static function update_order_review_expired() {
 		wp_send_json( array(
 			'fragments' => apply_filters( 'woocommerce_update_order_review_fragments', array(
-				'form.woocommerce-checkout' => '<div class="woocommerce-error">' . __( 'Sorry, your session has expired.', 'woocommerce' ) . ' <a href="' . esc_url( wc_get_page_permalink( 'shop' ) ) . '" class="wc-backward">' . __( 'Return to shop', 'woocommerce' ) . '</a></div>',
+				'form.woocommerce-checkout' => '<div class="woocommerce-error">' . __( 'Sorry, your session has expired.', 'woocommerce' ) . ' <a href="' . esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ) . '" class="wc-backward">' . __( 'Return to shop', 'woocommerce' ) . '</a></div>',
 			) ),
 		) );
 	}

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -882,7 +882,7 @@ class WC_Checkout {
 			do_action( 'woocommerce_before_checkout_process' );
 
 			if ( WC()->cart->is_empty() ) {
-				throw new Exception( sprintf( __( 'Sorry, your session has expired. <a href="%s" class="wc-backward">Return to shop</a>', 'woocommerce' ), esc_url( wc_get_page_permalink( 'shop' ) ) ) );
+				throw new Exception( sprintf( __( 'Sorry, your session has expired. <a href="%s" class="wc-backward">Return to shop</a>', 'woocommerce' ), esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ) ) );
 			}
 
 			do_action( 'woocommerce_checkout_process' );

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -392,7 +392,7 @@ class WC_Download_Handler {
 	 */
 	private static function download_error( $message, $title = '', $status = 404 ) {
 		if ( ! strstr( $message, '<a ' ) ) {
-			$message .= ' <a href="' . esc_url( wc_get_page_permalink( 'shop' ) ) . '" class="wc-forward">' . __( 'Go to shop', 'woocommerce' ) . '</a>';
+			$message .= ' <a href="' . esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ) . '" class="wc-forward">' . __( 'Go to shop', 'woocommerce' ) . '</a>';
 		}
 		wp_die( $message, $title, array( 'response' => $status ) );
 	}

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -110,7 +110,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 
 	// Output success messages
 	if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
-		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
+		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) );
 		$message   = sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
 	} else {
 		$message   = sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', esc_url( wc_get_page_permalink( 'cart' ) ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -505,7 +505,7 @@ function wc_disable_author_archives_for_customers() {
 		$user = get_user_by( 'id', $author );
 
 		if ( isset( $user->roles[0] ) && 'customer' === $user->roles[0] ) {
-			wp_redirect( wc_get_page_permalink( 'shop' ) );
+			wp_redirect( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) );
 		}
 	}
 }


### PR DESCRIPTION
Issue #12760

As stated in the issue the wc_get_page_permalink('shop') is not filtered everywhere with 'woocommerce_return_to_shop_redirect'.

Additional testing is needed.