### PR TITLE
Proof of concept search methods for orders.

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -38,6 +38,18 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		'_payment_tokens',
 	);
 
+	private $meta_key_to_props = array(
+		'_order_currency'     => 'currency',
+		'_cart_discount'      => 'discount_total',
+		'_cart_discount_tax'  => 'discount_tax',
+		'_order_shipping'     => 'shipping_total',
+		'_order_shipping_tax' => 'shipping_tax',
+		'_order_tax'          => 'cart_tax',
+		'_order_total'        => 'total',
+		'_order_version'      => 'version',
+		'_prices_include_tax' => 'prices_include_tax',
+	);
+
 	/*
 	|--------------------------------------------------------------------------
 	| CRUD Methods
@@ -211,17 +223,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected function update_post_meta( &$order, $force = false ) {
 		$updated_props     = array();
 		$changed_props     = array_keys( $order->get_changes() );
-		$meta_key_to_props = array(
-			'_order_currency'     => 'currency',
-			'_cart_discount'      => 'discount_total',
-			'_cart_discount_tax'  => 'discount_tax',
-			'_order_shipping'     => 'shipping_total',
-			'_order_shipping_tax' => 'shipping_tax',
-			'_order_tax'          => 'cart_tax',
-			'_order_total'        => 'total',
-			'_order_version'      => 'version',
-			'_prices_include_tax' => 'prices_include_tax',
-		);
+		$meta_key_to_props = $this->meta_key_to_props;
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( ! in_array( $prop, $changed_props ) && ! $force ) {
 				continue;
@@ -309,5 +311,16 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	public function update_payment_token_ids( $order, $token_ids ) {
 		update_post_meta( $order->get_id(), '_payment_tokens', $token_ids );
+	}
+
+	protected function get_prop_mappings() {
+		$meta_mappings = array_flip( $this->meta_key_to_props );
+		$core_mappings = array(
+			'parent_id'            => 'post_parent',
+			'status'               => 'post_status',
+			'date_created'         => 'post_date',
+			'date_modified'        => 'post_modified',
+		);
+		return array_merge( array( 'meta' => $meta_mappings ), $core_mappings );
 	}
 }

--- a/includes/data-stores/interfaces/wc-order-data-store-interface.php
+++ b/includes/data-stores/interfaces/wc-order-data-store-interface.php
@@ -73,7 +73,37 @@ interface WC_Order_Data_Store_Interface {
 	 * @param  string $term
 	 * @return array of ids
 	 */
-	public function search_orders( $term );
+	public function search_orders_by_term( $term );
+
+	/**
+	 * Search orders.
+	 *
+	 * Any args passed to the search function are used to
+	 * build a complex query. For example, a CPT implementation
+	 * searches the posts table and postmeta tables using WP_Query,
+	 * but you could also override the datastore and pass searches to
+	 * another engine.
+	 *
+	 * This function should handle all props supported by WC_Order/Abstract WC_Order.
+	 * Look at the data property of WC_Order and Abstract WC_Order or the CPT data
+	 * store's example `get_prop_mappings` for how to support all of these.
+	 * Anything passed to $args that is NOT a data prop, should be passed so the
+	 * data store can treat it as custom data. In the CPT implementation this is
+	 * treated as custom post meta.
+	 *
+	 * Example:
+	 * ->search( array( 'parent_id' => 2, 'customer_id' => 1, 'test_field' => 5 ) )
+	 *
+	 * parent_id and customer_id are both props and are searched according to the logic
+	 * of the datastore. test_field is not a prop, but the datastore should handle it
+	 * as custom data. The CPT will search postmeta.
+	 * @todo this explanation should be edited and posted as part of the dev docs -- putting it here for now to explain the PR POC.
+	 *
+	 * @param array $args Arguments to use for the search query.
+	 * @param string $return_type Return IDs or Objects. default: ids
+	 * @return array
+	 */
+	 public function search( $args, $return_type = 'ids' );
 
 	/**
 	 * Gets information about whether permissions were generated yet.

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -616,7 +616,7 @@ function wc_order_fully_refunded( $order_id ) {
 add_action( 'woocommerce_order_status_refunded', 'wc_order_fully_refunded' );
 
 /**
- * Search orders.
+ * Search orders by term.
  *
  * @since  2.6.0
  * @param  string $term Term to search.
@@ -624,7 +624,20 @@ add_action( 'woocommerce_order_status_refunded', 'wc_order_fully_refunded' );
  */
 function wc_order_search( $term ) {
 	$data_store = WC_Data_Store::load( 'order' );
-	return $data_store->search_orders( str_replace( 'Order #', '', wc_clean( $term ) ) );
+	return $data_store->search_orders_by_term( str_replace( 'Order #', '', wc_clean( $term ) ) );
+}
+
+/**
+ * Search orders.
+ *
+ * @since 2.7.0
+ * @param array $args Arguments to search with.
+ * @param string $return_type Return IDs or Objects. default: ids
+ * @return array List of orders.
+ */
+function wc_search_orders( $args, $return_type = 'ids' ) {
+	$data_store = WC_Data_Store::load( 'order' );
+	return $data_store->search( $args, $return_type );
 }
 
 /**


### PR DESCRIPTION
See #12677.

This PR is not complete. I'm posting this for feedback on how it works before going further, rather then a code review. There are still more todos, I want to cleanup the code a bit, and of course we should do the same for products (Should all CRUD classes have a search function?).

Essentially, the data store will have a `search` method that can be overridden. `wc_search_orders` will serve as the alias for the method.

`wc_search_orders` accepts a list of args/props and a return type. We should also support pagination but this PR doesn't do that yet. All fields passed that match a valid prop are searched as such, and anything else is treated as custom data.

The CPT implementation will pass through to WP_Query instead of trying to construct our own fragile queries.

The syntax for `wc_search_orders` is similar to WP_Query so it should be familiar to WP developers, but also easily hooked into so the fields can be passed to a different engine.

Here are two examples:

```
wc_search_orders( array(
    'customer_id' => array( 'value' => 1, 'compare' => '!=' ),
    'status' => 'cancelled',
    'date_created' => array( 'year' => '2017' )
) );
```

This will search for canceled orders, created in 2017, for all customers except customer `1`.

```
wc_search_orders( array( 'customer_id' => 1, 'status' => 'pending', 'my_custom_field' => 'test' ) );
```

This will search for all pending orders for customer `1`, with the custom meta field `test`.




