### PR TITLE
Add hooks when error_logging deprecation notices on AJAX calls.

### DIFF
--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -40,6 +40,7 @@ function wc_do_deprecated_action( $action, $args, $deprecated_in, $replacement )
  */
 function wc_deprecated_function( $function, $version, $replacement = null ) {
 	if ( is_ajax() ) {
+		do_action( 'deprecated_function_run', $function, $replacement, $version );
 		$log_string  = "The {$function} function is deprecated since version {$version}.";
 		$log_string .= $replacement ? "Replace with {$replacement}." : '';
 		error_log( $log_string );
@@ -59,6 +60,7 @@ function wc_deprecated_function( $function, $version, $replacement = null ) {
  */
 function wc_doing_it_wrong( $function, $message, $version ) {
 	if ( is_ajax() ) {
+		do_action( 'doing_it_wrong_run', $function, $message, $version );
 		error_log( "{$function} was called incorrectly. {$message}. This message was added in version {$version}." );
 	} else {
 		_doing_it_wrong( $function, $message, $version );
@@ -75,6 +77,7 @@ function wc_doing_it_wrong( $function, $message, $version ) {
  */
 function wc_deprecated_argument( $argument, $version, $message = null ) {
 	if ( is_ajax() ) {
+		do_action( 'deprecated_argument_run', $function, $message, $version );
 		error_log( "The {$argument} argument is deprecated since version {$version}. {$message}" );
 	} else {
 		_deprecated_argument( $argument, $version, $message );


### PR DESCRIPTION
`_doing_it_wrong`, `_deprecated_function`, and `_deprecated_argument` all run a hook so you can hook in and get things like backtrace data. Since we have our own wrappers, we should do the same (using the same action names) in our `is_ajax` check so these hooks return backtrace info for both ajax and frontend calls.