### PR TITLE
[2.7] Fix variation attributes formatting in stock reports

### DIFF
--- a/includes/admin/reports/class-wc-report-stock.php
+++ b/includes/admin/reports/class-wc-report-stock.php
@@ -89,16 +89,9 @@ class WC_Report_Stock extends WP_List_Table {
 
 				echo esc_html( $product->get_name() );
 
-				// Get variation data
+				// Get variation data.
 				if ( $product->is_type( 'variation' ) ) {
-					$list_attributes = array();
-					$attributes = $product->get_variation_attributes();
-
-					foreach ( $attributes as $name => $attribute ) {
-						$list_attributes[] = wc_attribute_label( str_replace( 'attribute_', '', $name ) ) . ': <strong>' . $attribute . '</strong>';
-					}
-
-					echo '<div class="description">' . implode( ', ', $list_attributes ) . '</div>';
+					echo '<div class="description">' . wc_get_formatted_variation( $product, true ) . '</div>';
 				}
 			break;
 


### PR DESCRIPTION
### Issue Description

https://cl.ly/2L3e3k3u1Q0U

This PR uses `wc_get_formatted_variation` to format variation attributes.

TBH I find that the displayed information is not DRY when `get_name` (which displays the entire variation post title along with attribute values) is used in combination with `wc_get_formatted_variation`.



A more general issue IMO is the way `get_name` alone is used in 2.7 to display variations data in this and other contexts as well, such as cart/order details: It's lacking attribute names, which are often required in order to understand how a variation is configured.

Example:

Variable Product has attributes A, B and C with values Value 1, Value 2, Value 3 common in all attributes.

A combination such as "Variable Product -- Value 1, Value 1, Value 1" is more confusing than helpful.

Same applies to attributes that describe the same kind of property, e.g. a color.

Example 2:

Attribute Names: Ceiling Color, Walls Color, Details Color.
 
A variation title such as "Colors Bundle: Blue, Red, White" is not helpful for the same reason as before -- the user needs to remember/know/guess the sequence of attribute names.



Instead of `get_name`, I'd rather see `get_title` used in combination with a breakdown of the attributes configuration including attribute names -- at least in most front-end templates.
