### PR TITLE
[2.7] Add 'include' arg to wc_get_products

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1075,6 +1075,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$wp_query_args['paged'] = absint( $args['page'] );
 		}
 
+		if ( ! empty( $args['include'] ) ) {
+			$wp_query_args['post__in'] = array_map( 'absint', $args['include'] );
+		}
+
 		if ( ! empty( $args['exclude'] ) ) {
 			$wp_query_args['post__not_in'] = array_map( 'absint', $args['exclude'] );
 		}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -61,6 +61,7 @@ function wc_get_products( $args ) {
 		'limit'          => get_option( 'posts_per_page' ),
 		'offset'         => null,
 		'page'           => 1,
+		'include'        => array(),
 		'exclude'        => array(),
 		'orderby'        => 'date',
 		'order'          => 'DESC',


### PR DESCRIPTION
Was looking at replacing `WP_Query` with `wc_get_products` in a couple instances and this appeared to be the only missing "ingredient".