### PR TITLE
Orders Data Store: Search Method

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -38,6 +38,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		'_payment_tokens',
 	);
 
+	/**
+	 * A mapping of meta keys to their prop name.
+	 * @since 2.7.0
+	 * @var array
+	 */
 	private $meta_key_to_props = array(
 		'_order_currency'     => 'currency',
 		'_cart_discount'      => 'discount_total',
@@ -313,14 +318,22 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		update_post_meta( $order->get_id(), '_payment_tokens', $token_ids );
 	}
 
+	/**
+	 * Returns a mapping of properties to their table or meta keys.
+	 * Meta keys are stored in 'meta'.
+	 *
+	 * @since  2.7.0
+	 * @return array
+	 */
 	protected function get_prop_mappings() {
 		$meta_mappings = array_flip( $this->meta_key_to_props );
 		$core_mappings = array(
-			'parent_id'            => 'post_parent',
-			'status'               => 'post_status',
-			'date_created'         => 'post_date',
-			'date_modified'        => 'post_modified',
+			'parent_id'     => 'post_parent',
+			'status'        => 'post_status',
+			'date_created'  => 'post_date',
+			'date_modified' => 'post_modified',
 		);
 		return array_merge( array( 'meta' => $meta_mappings ), $core_mappings );
 	}
+
 }

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -38,6 +38,18 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		'_payment_tokens',
 	);
 
+	private $meta_key_to_props = array(
+		'_order_currency'     => 'currency',
+		'_cart_discount'      => 'discount_total',
+		'_cart_discount_tax'  => 'discount_tax',
+		'_order_shipping'     => 'shipping_total',
+		'_order_shipping_tax' => 'shipping_tax',
+		'_order_tax'          => 'cart_tax',
+		'_order_total'        => 'total',
+		'_order_version'      => 'version',
+		'_prices_include_tax' => 'prices_include_tax',
+	);
+
 	/*
 	|--------------------------------------------------------------------------
 	| CRUD Methods
@@ -211,17 +223,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected function update_post_meta( &$order, $force = false ) {
 		$updated_props     = array();
 		$changed_props     = array_keys( $order->get_changes() );
-		$meta_key_to_props = array(
-			'_order_currency'     => 'currency',
-			'_cart_discount'      => 'discount_total',
-			'_cart_discount_tax'  => 'discount_tax',
-			'_order_shipping'     => 'shipping_total',
-			'_order_shipping_tax' => 'shipping_tax',
-			'_order_tax'          => 'cart_tax',
-			'_order_total'        => 'total',
-			'_order_version'      => 'version',
-			'_prices_include_tax' => 'prices_include_tax',
-		);
+		$meta_key_to_props = $this->meta_key_to_props;
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( ! in_array( $prop, $changed_props ) && ! $force ) {
 				continue;
@@ -309,5 +311,16 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	public function update_payment_token_ids( $order, $token_ids ) {
 		update_post_meta( $order->get_id(), '_payment_tokens', $token_ids );
+	}
+
+	protected function get_prop_mappings() {
+		$meta_mappings = array_flip( $this->meta_key_to_props );
+		$core_mappings = array(
+			'parent_id'            => 'post_parent',
+			'status'               => 'post_status',
+			'date_created'         => 'post_date',
+			'date_modified'        => 'post_modified',
+		);
+		return array_merge( array( 'meta' => $meta_mappings ), $core_mappings );
 	}
 }

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -540,7 +540,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * @since  2.7.0
 	 * @param  array  $props Props to use for the search query.
 	 * @param  array  $args  Accepts return (objects or ids, default ids), limit (default get_option( 'posts_per_page' ) ), offset, and relation (AND or OR).
-	 * @todo   add tests.
 	 * @return array Array containing results, total results, and number of pages.
 	 */
 	public function search( $props, $args = array() ) {

--- a/includes/data-stores/interfaces/wc-order-data-store-interface.php
+++ b/includes/data-stores/interfaces/wc-order-data-store-interface.php
@@ -73,7 +73,37 @@ interface WC_Order_Data_Store_Interface {
 	 * @param  string $term
 	 * @return array of ids
 	 */
-	public function search_orders( $term );
+	public function search_orders_by_term( $term );
+
+	/**
+	 * Search orders.
+	 *
+	 * Any args passed to the search function are used to
+	 * build a complex query. For example, a CPT implementation
+	 * searches the posts table and postmeta tables using WP_Query,
+	 * but you could also override the datastore and pass searches to
+	 * another engine.
+	 *
+	 * This function should handle all props supported by WC_Order/Abstract WC_Order.
+	 * Look at the data property of WC_Order and Abstract WC_Order or the CPT data
+	 * store's example `get_prop_mappings` for how to support all of these.
+	 * Anything passed to $args that is NOT a data prop, should be passed so the
+	 * data store can treat it as custom data. In the CPT implementation this is
+	 * treated as custom post meta.
+	 *
+	 * Example:
+	 * ->search( array( 'parent_id' => 2, 'customer_id' => 1, 'test_field' => 5 ) )
+	 *
+	 * parent_id and customer_id are both props and are searched according to the logic
+	 * of the datastore. test_field is not a prop, but the datastore should handle it
+	 * as custom data. The CPT will search postmeta.
+	 * @todo this explanation should be edited and posted as part of the dev docs -- putting it here for now to explain the PR POC.
+	 *
+	 * @param array $args Arguments to use for the search query.
+	 * @param string $return_type Return IDs or Objects. default: ids
+	 * @return array
+	 */
+	 public function search( $args, $return_type = 'ids' );
 
 	/**
 	 * Gets information about whether permissions were generated yet.

--- a/includes/data-stores/interfaces/wc-order-data-store-interface.php
+++ b/includes/data-stores/interfaces/wc-order-data-store-interface.php
@@ -78,32 +78,40 @@ interface WC_Order_Data_Store_Interface {
 	/**
 	 * Search orders.
 	 *
-	 * Any args passed to the search function are used to
-	 * build a complex query. For example, a CPT implementation
-	 * searches the posts table and postmeta tables using WP_Query,
-	 * but you could also override the datastore and pass searches to
-	 * another engine.
+	 * Run complex searches based on the props passed.
 	 *
 	 * This function should handle all props supported by WC_Order/Abstract WC_Order.
-	 * Look at the data property of WC_Order and Abstract WC_Order or the CPT data
-	 * store's example `get_prop_mappings` for how to support all of these.
-	 * Anything passed to $args that is NOT a data prop, should be passed so the
-	 * data store can treat it as custom data. In the CPT implementation this is
-	 * treated as custom post meta.
+	 * (see the data array in WC_Order & Abstract WC_Order or the CPT `get_prop_mappings`
+	 * for an example of these.
+	 *
+	 * Anything that is not a valid prop should still be passed along, and assumed a custom field supported
+	 * by an extension.
 	 *
 	 * Example:
 	 * ->search( array( 'parent_id' => 2, 'customer_id' => 1, 'test_field' => 5 ) )
 	 *
 	 * parent_id and customer_id are both props and are searched according to the logic
-	 * of the datastore. test_field is not a prop, but the datastore should handle it
-	 * as custom data. The CPT will search postmeta.
-	 * @todo this explanation should be edited and posted as part of the dev docs -- putting it here for now to explain the PR POC.
+	 * of the datastore. test_field is not a prop, but the datastore can handle it
+	 * as custom data.
+	 *
+	 * When implementing a search engine, your $props code should be able to handle the following:
+	 * $props = array(
+	 *     'customer_id' => 1, // Simple direct searching
+	 *	   'customer_id' => array( 'value' => 1', 'compare' => '!= ' ), // Comparison operators. See what WP_Query supports to see valid operators. Default for simple searching is =.
+	 * );
+	 *
+	 * $args = array(
+	 *     'limit'    => 5, // Limit clause
+	 *     'offset'   => 1, // Offset clause
+	 *     'relation' => 'OR', // OR or AND relation
+	 *     'return'   => 'objects', // ids or objects (return an array of IDs or an array of order objects)
+	 * );
 	 *
 	 * @param array $args Arguments to use for the search query.
 	 * @param string $return_type Return IDs or Objects. default: ids
 	 * @return array
 	 */
-	 public function search( $args, $return_type = 'ids' );
+	 public function search( $props, $args );
 
 	/**
 	 * Gets information about whether permissions were generated yet.

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -635,9 +635,9 @@ function wc_order_search( $term ) {
  * @param string $return_type Return IDs or Objects. default: ids
  * @return array List of orders.
  */
-function wc_search_orders( $args, $return_type = 'ids' ) {
+function wc_search_orders( $props, $args = array() ) {
 	$data_store = WC_Data_Store::load( 'order' );
-	return $data_store->search( $args, $return_type );
+	return $data_store->search( $props, $args );
 }
 
 /**

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -616,7 +616,7 @@ function wc_order_fully_refunded( $order_id ) {
 add_action( 'woocommerce_order_status_refunded', 'wc_order_fully_refunded' );
 
 /**
- * Search orders.
+ * Search orders by term.
  *
  * @since  2.6.0
  * @param  string $term Term to search.
@@ -624,7 +624,20 @@ add_action( 'woocommerce_order_status_refunded', 'wc_order_fully_refunded' );
  */
 function wc_order_search( $term ) {
 	$data_store = WC_Data_Store::load( 'order' );
-	return $data_store->search_orders( str_replace( 'Order #', '', wc_clean( $term ) ) );
+	return $data_store->search_orders_by_term( str_replace( 'Order #', '', wc_clean( $term ) ) );
+}
+
+/**
+ * Search orders.
+ *
+ * @since 2.7.0
+ * @param array $args Arguments to search with.
+ * @param string $return_type Return IDs or Objects. default: ids
+ * @return array List of orders.
+ */
+function wc_search_orders( $args, $return_type = 'ids' ) {
+	$data_store = WC_Data_Store::load( 'order' );
+	return $data_store->search( $args, $return_type );
 }
 
 /**


### PR DESCRIPTION
Going off the previous POC PR (#12764), this PR implements a `wc_search_orders` powered by the data store, so custom queries/searches can be implemented with a method and switched to different engines in the future.

This PR only handles orders and includes a test, using different kinds of searches.

Supports multiple fields, comparison operators, paging, and OR/AND searches which should handle most uses cases.

See #12677.

I'll work on products after this, if there are no issues with orders or anything here. Do we know what other objects should expose a search method? I'm not sure if it's needed on every single type.
