### PR TITLE
Make the `GET /system_status` API response more customisable

### DIFF
--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -83,6 +83,8 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			$response[ $section ] = $values;
 		}
 
+		$response = $this->prepare_item_for_response( $response, $request );
+
 		return rest_ensure_response( $response );
 	}
 
@@ -847,5 +849,28 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		return array(
 			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 		);
+	}
+
+	/**
+	 * Prepare the system status response
+	 *
+	 * @param array $system_status
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $system_status, $request ) {
+		$data = $this->add_additional_fields_to_object( $system_status, $request );
+		$data = $this->filter_response_by_context( $data, 'view' );
+
+		$response = rest_ensure_response( $data );
+
+		/**
+		 * Filter the system status returned from the REST API.
+		 *
+		 * @param WP_REST_Response   $response The response object.
+		 * @param mixed              $system_status System status
+		 * @param WP_REST_Request    $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_system_status', $response, $system_status, $request );
 	}
 }


### PR DESCRIPTION
Currently the new [WC_REST_System_Status_Controller](https://github.com/woocommerce/woocommerce/blob/dec792b731dbbea6d34aa3ddcd6a3bf05bf43077/includes/api/class-wc-rest-system-status-controller.php) class seems to be missing a few function calls to make the responses editable like `add_additional_fields_to_object` and `apply_filters`.

Not sure if other missing functions like [`add_links()`](https://github.com/woocommerce/woocommerce/blob/1675aa51fb262d1ce986ba56e21f9fe72644f2cb/includes/api/class-wc-rest-system-status-tools-controller.php#L258) should also be added to the System_Status_Controller endpoint as well.

This is to allow extensions like Subscriptions to add our custom environment variables like `WCS_DEBUG` and other plugins to add additional fields to the response if necessary.

---

snippet of the code used to test the patch using `register_rest_field`:

```
function mycustom_system_status_field() {
    register_rest_field( 'system_status',
        'custom_status_field',
        array(
            'get_callback'    => 'slug_get_custom_status_field',
            'update_callback' => null,
            'schema'          => null,
        )
    );
}
add_action( 'rest_api_init', 'mycustom_system_status_field' );

/**
 * Add value for my custom_status_field
 */
function slug_get_custom_status_field( $object, $field_name, $request ) {
    return 'mycustom_status_data';
}
```