### PR TITLE
Check post type during read of coupons, posts, and products.

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -82,7 +82,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function read( &$order ) {
 		$order->set_defaults();
 
-		if ( ! $order->get_id() || ! ( $post_object = get_post( $order->get_id() ) ) ) {
+		if ( ! $order->get_id() || ! ( $post_object = get_post( $order->get_id() ) ) || 'shop_order' !== $post_object->post_type ) {
 			throw new Exception( __( 'Invalid order.', 'woocommerce' ) );
 		}
 

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -85,7 +85,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	public function read( &$coupon ) {
 		$coupon->set_defaults();
 
-		if ( ! $coupon->get_id() || ! ( $post_object = get_post( $coupon->get_id() ) ) ) {
+		if ( ! $coupon->get_id() || ! ( $post_object = get_post( $coupon->get_id() ) ) || 'shop_coupon' !== $post_object->post_type ) {
 			throw new Exception( __( 'Invalid coupon.', 'woocommerce' ) );
 		}
 

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -113,7 +113,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function read( &$product ) {
 		$product->set_defaults();
 
-		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) ) {
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || 'product' !== $post_object->post_type ) {
 			throw new Exception( __( 'Invalid product.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
If you pass an ID for another object to WC_Order, WC_Product, or WC_Coupon, we keep trying to load it (usually resulting in a half broken object with meta loaded).

We should throw an invalid exception in these cases (and calls to get_post_type or get_post in other areas of the code base can instead just rely on the exception handling).