### PR TITLE
Fix duplicate_post_taxonomies() when using non unique slugs

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -255,7 +255,7 @@ class WC_Admin_Duplicate_Product {
 			$post_terms_count = sizeof( $post_terms );
 
 			for ( $i = 0; $i < $post_terms_count; $i++ ) {
-				wp_set_object_terms( $new_id, $post_terms[ $i ]->slug, $taxonomy, true );
+				wp_set_object_terms( $new_id, (int) $post_terms[ $i ]->term_id, $taxonomy, true );
 			}
 		}
 	}


### PR DESCRIPTION
Since WP 4.3, it is possible to use non unique terms slugs in the same taxonomy. Currently duplicate_post_taxonomies() uses the term slug in wp_set_object_terms(), thus may set a wrong term. I propose to use term_id instead, which ensures that the correct term is set.