### PR TITLE
Restore WC_Logger remove and clear functionality

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -216,11 +216,14 @@ class WC_Logger {
 	 *
 	 * @deprecated 2.7.0
 	 *
+	 * @param string $handle
+	 *
 	 * @return bool
 	 */
-	public function clear() {
+	public function clear( $handle ) {
 		wc_deprecated_function( 'WC_Logger::clear', '2.7', 'WC_Log_Handler_File::clear' );
-		return false;
+		$handler = new WC_Log_Handler_File();
+		return $handler->clear( $handle );
 	}
 
 	/**
@@ -228,10 +231,13 @@ class WC_Logger {
 	 *
 	 * @deprecated 2.7.0
 	 *
+	 * @param string $handle
+	 *
 	 * @return bool
 	 */
-	public function remove() {
+	public function remove( $handle ) {
 		wc_deprecated_function( 'WC_Logger::remove', '2.7', 'WC_Log_Handler_File::remove' );
-		return false;
+		$handler = new WC_Log_Handler_File();
+		return $handler->remove( $handle );
 	}
 }

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -225,19 +225,4 @@ class WC_Logger {
 		$handler = new WC_Log_Handler_File();
 		return $handler->clear( $handle );
 	}
-
-	/**
-	 * Remove/delete the chosen file.
-	 *
-	 * @deprecated 2.7.0
-	 *
-	 * @param string $handle
-	 *
-	 * @return bool
-	 */
-	public function remove( $handle ) {
-		wc_deprecated_function( 'WC_Logger::remove', '2.7', 'WC_Log_Handler_File::remove' );
-		$handler = new WC_Log_Handler_File();
-		return $handler->remove( $handle );
-	}
 }

--- a/tests/unit-tests/log/logger.php
+++ b/tests/unit-tests/log/logger.php
@@ -47,20 +47,6 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test remove().
-	 *
-	 * @since 2.7
-	 */
-	public function test_remove() {
-		$file = wc_get_log_file_path( 'unit-tests' );
-		touch( $file );
-		$log = new WC_Logger();
-		$log->remove( 'unit-tests' );
-		$this->assertFileNotExists( $file );
-		$this->setExpectedDeprecated( 'WC_Logger::remove' );
-	}
-
-	/**
 	 * Test log() complains for bad levels.
 	 *
 	 * @since 2.7.0

--- a/tests/unit-tests/log/logger.php
+++ b/tests/unit-tests/log/logger.php
@@ -47,6 +47,20 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test remove().
+	 *
+	 * @since 2.7
+	 */
+	public function test_remove() {
+		$file = wc_get_log_file_path( 'unit-tests' );
+		touch( $file );
+		$log = new WC_Logger();
+		$log->remove( 'unit-tests' );
+		$this->assertFileNotExists( $file );
+		$this->setExpectedDeprecated( 'WC_Logger::remove' );
+	}
+
+	/**
 	 * Test log() complains for bad levels.
 	 *
 	 * @since 2.7.0

--- a/tests/unit-tests/log/logger.php
+++ b/tests/unit-tests/log/logger.php
@@ -38,8 +38,11 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 * @since 2.4
 	 */
 	public function test_clear() {
-		$log = new WC_Logger( null, 'debug' );
-		$log->clear( 'log' );
+		$file = wc_get_log_file_path( 'unit-tests' );
+		file_put_contents( $file, 'Test file content.' );
+		$log = new WC_Logger();
+		$log->clear( 'unit-tests' );
+		$this->assertEquals( '', file_get_contents( $file ) );
 		$this->setExpectedDeprecated( 'WC_Logger::clear' );
 	}
 


### PR DESCRIPTION
`WC_Logger::clear` and `WC_Logger::remove` were deprecated in favor of the `WC_Log_Handler_File` methods of the same name. The functionality was also removed.

This restores the functionality to improve compatibility with existing code.