### PR TITLE
Set the srcset property when changing the variation image

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -538,7 +538,6 @@
 			$product_img.wc_set_variation_attr( 'height', variation.image.src_h );
 			$product_img.wc_set_variation_attr( 'width', variation.image.src_w );
 			$product_img.wc_set_variation_attr( 'srcset', variation.image.srcset );
-			$product_img.wc_set_variation_attr( 'srcset', variation.image.srcset );
 			$product_img.wc_set_variation_attr( 'sizes', variation.image.sizes );
 			$product_img.wc_set_variation_attr( 'title', variation.image.title );
 			$product_img.wc_set_variation_attr( 'alt', variation.image.alt );

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -509,6 +509,7 @@
 			this.removeAttr( attr );
 		} else {
 			this.attr( attr, value );
+			this.prop( attr, value ); // Edge fix.
 		}
 	};
 
@@ -536,6 +537,7 @@
 			$product_img.wc_set_variation_attr( 'src', variation.image.src );
 			$product_img.wc_set_variation_attr( 'height', variation.image.src_h );
 			$product_img.wc_set_variation_attr( 'width', variation.image.src_w );
+			$product_img.wc_set_variation_attr( 'srcset', variation.image.srcset );
 			$product_img.wc_set_variation_attr( 'srcset', variation.image.srcset );
 			$product_img.wc_set_variation_attr( 'sizes', variation.image.sizes );
 			$product_img.wc_set_variation_attr( 'title', variation.image.title );


### PR DESCRIPTION
The change of the variant image on a product page did not work for me in Microsoft Edge (38.14393.0.0).

It seems the `srcset` property (not attribute) has to be changed in Edge to actually change the image.

![screen](https://cloud.githubusercontent.com/assets/1668766/21912840/e992b6a6-d928-11e6-926a-62917adc0e09.png)

Can you confirm this issue?

If yes, we could talk about a suitable solution for this issue. This PR is only a quick PoC fix.