### PR TITLE
Allow failure for PHP 5.3 travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
   include:
   - php: 5.6
     env: WP_VERSION=latest WP_MULTISITE=1
+  allow_failures:
+  - php: 5.3
 
 before_script:
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Builds on this particular box fail randomly and very frequently. These failures are not related to the test suite, generating noise.

If only this box fails, consider the build a success.