### PR TITLE
Remove deprecation notices on woocommerce_get_children

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -144,9 +144,6 @@ class WC_Product_Variable extends WC_Product {
 			wc_deprecated_argument( 'visible_only', '2.7', 'WC_Product_Variable::get_visible_children' );
 			return $visible_only ? $this->get_visible_children() : $this->get_children();
 		}
-		if ( has_filter( 'woocommerce_get_children' ) ) {
-			wc_deprecated_function( 'The woocommerce_get_children filter', '', 'woocommerce_product_get_children or woocommerce_product_get_visible_children' );
-		}
 		return apply_filters( 'woocommerce_get_children', $this->children, $this, false );
 	}
 
@@ -157,9 +154,6 @@ class WC_Product_Variable extends WC_Product {
 	 * @return array Children ids
 	 */
 	public function get_visible_children() {
-		if ( has_filter( 'woocommerce_get_children' ) ) {
-			wc_deprecated_function( 'The woocommerce_get_children filter', '', 'woocommerce_product_get_children or woocommerce_product_get_visible_children' );
-		}
 		return apply_filters( 'woocommerce_get_children', $this->visible_children, $this, true );
 	}
 


### PR DESCRIPTION
Fixes #12812.

We deprecated a filter and recommended replacements, but then didn't actually apply the replacements. This PR fixes that :).