### PR TITLE
Fix notice that displays when activating WC via the command-line.

### DIFF
--- a/includes/cli/class-wc-cli-tool-command.php
+++ b/includes/cli/class-wc-cli-tool-command.php
@@ -21,6 +21,9 @@ class WC_CLI_Tool_Command {
 		$request       = new WP_REST_Request( 'OPTIONS', '/wc/v1/system_status/tools' );
 		$response      = $wp_rest_server->dispatch( $request );
 		$response_data = $response->get_data();
+		if ( empty( $response_data ) ) {
+			return;
+		}
 
 		$parent	            = "wc tool";
 		$supported_commands = array( 'list', 'run' );


### PR DESCRIPTION
Fixes #12803.

CLI-Runner already contains a similar check https://github.com/woocommerce/woocommerce/blob/0da2f70e13532ef050d4d17d4fa9029e507f05f5/includes/cli/class-wc-cli-runner.php#L45.
