### PR TITLE
Add WC_Logger_Interface

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -3,6 +3,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+if ( ! interface_exists( 'WC_Logger_Interface' ) ) {
+	include_once( dirname( __FILE__ ) . '/interfaces/wc-logger-interface.php' );
+}
+
 /**
  * Provides logging capabilities for debugging purposes.
  *
@@ -12,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category       Class
  * @author         WooThemes
  */
-class WC_Logger {
+class WC_Logger implements WC_Logger_Interface {
 
 	/**
 	 * Stores registered log handlers.

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -3,10 +3,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! interface_exists( 'WC_Logger_Interface' ) ) {
-	include_once( dirname( __FILE__ ) . '/interfaces/wc-logger-interface.php' );
-}
-
 /**
  * Provides logging capabilities for debugging purposes.
  *

--- a/includes/interfaces/wc-logger-interface.php
+++ b/includes/interfaces/wc-logger-interface.php
@@ -1,0 +1,132 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * WC Logger Interface
+ *
+ * Functions that must be defined to correctly fulfill logger API.
+ *
+ * @version        1.0.0
+ * @category       Interface
+ * @author         WooThemes
+ */
+interface WC_Logger_Interface {
+
+	/**
+	 * Add a log entry.
+	 *
+	 * This is not the preferred method for adding log messages. Please use log() or any one of
+	 * the level methods (debug(), info(), etc.). This method may be deprecated in the future.
+	 *
+	 * @param string $handle
+	 * @param string $message
+	 * @return bool True if log was added, otherwise false.
+	 */
+	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE );
+
+	/**
+	 * Add a log entry.
+	 *
+	 * @param string $level One of the following:
+	 *     'emergency': System is unusable.
+	 *     'alert': Action must be taken immediately.
+	 *     'critical': Critical conditions.
+	 *     'error': Error conditions.
+	 *     'warning': Warning conditions.
+	 *     'notice': Normal but significant condition.
+	 *     'informational': Informational messages.
+	 *     'debug': Debug-level messages.
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function log( $level, $message, $context = array() );
+
+	/**
+	 * Adds an emergency level message.
+	 *
+	 * System is unusable.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function emergency( $message, $context = array() );
+
+	/**
+	 * Adds an alert level message.
+	 *
+	 * Action must be taken immediately.
+	 * Example: Entire website down, database unavailable, etc.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function alert( $message, $context = array() );
+
+	/**
+	 * Adds a critical level message.
+	 *
+	 * Critical conditions.
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function critical( $message, $context = array() );
+
+	/**
+	 * Adds an error level message.
+	 *
+	 * Runtime errors that do not require immediate action but should typically be logged
+	 * and monitored.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function error( $message, $context = array() );
+
+	/**
+	 * Adds a warning level message.
+	 *
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things that are not
+	 * necessarily wrong.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function warning( $message, $context = array() );
+
+	/**
+	 * Adds a notice level message.
+	 *
+	 * Normal but significant events.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function notice( $message, $context = array() );
+
+	/**
+	 * Adds a info level message.
+	 *
+	 * Interesting events.
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function info( $message, $context = array() );
+
+	/**
+	 * Adds a debug level message.
+	 *
+	 * Detailed debug information.
+	 *
+	 * @param string $message Log message.
+	 * @param array $context Optional. Additional information for log handlers.
+	 */
+	public function debug( $message, $context = array() );
+}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1412,15 +1412,33 @@ function wc_get_rounding_precision() {
 }
 
 /**
- * Returns a new instance of a WC Logger.
- * Use woocommerce_logging_class filter to change the logging class.
+ * Get a shared logger instance.
+ *
+ * Use the woocommerce_logging_class filter to change the logging class. The provided class *must*
+ * implement WC_Logger_Interface.
+ *
+ * @see WC_Logger_Interface
+ *
  * @return WC_Logger
  */
 function wc_get_logger() {
 	static $logger = null;
 	if ( null === $logger ) {
 		$class = apply_filters( 'woocommerce_logging_class', 'WC_Logger' );
-		$logger = new $class;
+		$implements = class_implements( $class );
+		if ( is_array( $implements ) && in_array( 'WC_Logger_Interface', $implements ) ) {
+			$logger = new $class;
+		} else {
+			wc_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					__( 'The class <code>%s</code> provided by woocommerce_logging_class filter must implement <code>WC_Logger_Interface</code>.', 'woocommerce' ),
+					esc_html( $class )
+				),
+				'2.7'
+			);
+			$logger = new WC_Logger();
+		}
 	}
 	return $logger;
 }

--- a/tests/unit-tests/util/core-functions.php
+++ b/tests/unit-tests/util/core-functions.php
@@ -244,12 +244,27 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @since 2.7.0
 	 */
 	public function test_wc_get_logger() {
+		// This filter should have no effect because the class does not implement WC_Logger_Interface
+		add_filter( 'woocommerce_logging_class', array( $this, 'return_bad_logger' ) );
+
+		$this->setExpectedIncorrectUsage( 'wc_get_logger' );
 		$log_a = wc_get_logger();
 		$log_b = wc_get_logger();
 
 		$this->assertInstanceOf( 'WC_Logger', $log_a );
 		$this->assertInstanceOf( 'WC_Logger', $log_b );
 		$this->assertSame( $log_a, $log_b, '`wc_get_logger()` should return the same instance' );
+	}
+
+	/**
+	 * Return class which does not implement WC_Logger_Interface
+	 *
+	 * This is a helper function to test woocommerce_logging_class filter and wc_get_logger.
+	 *
+	 * @return string Class name
+	 */
+	public function return_bad_logger() {
+		return __CLASS__;
 	}
 
 	/**

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -287,6 +287,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-gateway.php' ); // A Payment gateway
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-integration.php' ); // An integration with a service
 		include_once( WC_ABSPATH . 'includes/abstracts/abstract-wc-log-handler.php' );
+		include_once( WC_ABSPATH . 'includes/interfaces/wc-logger-interface.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-product-factory.php' ); // Product factory
 		include_once( WC_ABSPATH . 'includes/class-wc-payment-tokens.php' ); // Payment tokens controller
 		include_once( WC_ABSPATH . 'includes/class-wc-shipping-zone.php' );


### PR DESCRIPTION
With `wc_get_logger`, one of the goals is to make it easy to replace the provided logger with another.

Providing an interface makes it easier and safer to replace `WC_Logger` with your own class.

This PR adds `WC_Logger_Interface` and adds the `implements WC_Logger_Interface` declaration to `WC_Logger`.

When a different class is provided via the `woocommerce_logging_class` filter, `wc_get_logger` will now validate that the class implements `WC_Logger_Interface`. If not, a `doing_it_wrong` message is provided and built in `WC_Logger` is returned.