### PR TITLE
[2.7] Prices retrieved in 'edit' context when writing meta

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1440,21 +1440,21 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 *
 	 * @return bool
 	 */
-	public function is_on_sale() {
-		if ( '' !== (string) $this->get_sale_price() && $this->get_regular_price() > $this->get_sale_price() ) {
+	public function is_on_sale( $context = 'view' ) {
+		if ( '' !== (string) $this->get_sale_price( $context ) && $this->get_regular_price( $context ) > $this->get_sale_price( $context ) ) {
 			$onsale = true;
 
-			if ( '' !== (string) $this->get_date_on_sale_from() && $this->get_date_on_sale_from() > strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+			if ( '' !== (string) $this->get_date_on_sale_from( $context ) && $this->get_date_on_sale_from( $context ) > strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
 				$onsale = false;
 			}
 
-			if ( '' !== (string) $this->get_date_on_sale_to() && $this->get_date_on_sale_to() < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
+			if ( '' !== (string) $this->get_date_on_sale_to( $context ) && $this->get_date_on_sale_to( $context ) < strtotime( 'NOW', current_time( 'timestamp' ) ) ) {
 				$onsale = false;
 			}
 		} else {
 			$onsale = false;
 		}
-		return apply_filters( 'woocommerce_product_is_on_sale', $onsale, $this );
+		return 'view' === $content ? apply_filters( 'woocommerce_product_is_on_sale', $onsale, $this ) : $onsale;
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -432,12 +432,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		if ( in_array( 'date_on_sale_from', $updated_props ) || in_array( 'date_on_sale_to', $updated_props ) || in_array( 'regular_price', $updated_props ) || in_array( 'sale_price', $updated_props ) ) {
-			if ( $product->is_on_sale() ) {
-				update_post_meta( $product->get_id(), '_price', $product->get_sale_price() );
-				$product->set_price( $product->get_sale_price() );
+			if ( $product->is_on_sale( 'edit' ) ) {
+				update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
+				$product->set_price( $product->get_sale_price( 'edit' ) );
 			} else {
-				update_post_meta( $product->get_id(), '_price', $product->get_regular_price() );
-				$product->set_price( $product->get_regular_price() );
+				update_post_meta( $product->get_id(), '_price', $product->get_regular_price( 'edit' ) );
+				$product->set_price( $product->get_regular_price( 'edit' ) );
 			}
 		}
 


### PR DESCRIPTION
Prices in `WC_Product_Data_Store_CPT::update_post_meta` are retrieved in `view` context when updating meta, resulting in issues with third-party code/filters.

This looks like a place where `edit` context should be used.

However, if `edit` context is used there, then `is_on_sale()` should also be callable in `edit` context in order to be usable?