### PR TITLE
[2.7] Review #12835

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1438,6 +1438,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Returns whether or not the product is on sale.
 	 *
+	 * @param string $context
 	 * @return bool
 	 */
 	public function is_on_sale( $context = 'view' ) {
@@ -1454,7 +1455,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		} else {
 			$onsale = false;
 		}
-		return 'view' === $content ? apply_filters( 'woocommerce_product_is_on_sale', $onsale, $this ) : $onsale;
+		return 'view' === $context ? apply_filters( 'woocommerce_product_is_on_sale', $onsale, $this ) : $onsale;
 	}
 
 	/**

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -55,12 +55,13 @@ class WC_Product_Grouped extends WC_Product {
 	/**
 	 * Returns whether or not the product is on sale.
 	 *
+	 * @param string $context
 	 * @return bool
 	 */
-	public function is_on_sale() {
+	public function is_on_sale( $context = 'view' ) {
 		global $wpdb;
 		$on_sale = $this->get_children() && 1 === $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_sale_price' AND meta_value > 0 AND post_id IN (" . implode( ',', array_map( 'esc_sql', $this->get_children() ) ) . ");" );
-		return apply_filters( 'woocommerce_product_is_on_sale', $on_sale, $this );
+		return 'view' === $context ? apply_filters( 'woocommerce_product_is_on_sale', $on_sale, $this ) : $on_sale;
 	}
 
 	/**

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -368,7 +368,7 @@ class WC_Product_Variable extends WC_Product {
 	 */
 	public function is_on_sale( $context = 'view' ) {
 		$prices  = $this->get_variation_prices();
-		$on_sale = $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price']
+		$on_sale = $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price'];
 		return 'view' === $context ? apply_filters( 'woocommerce_product_is_on_sale', $on_sale, $this ) : $on_sale;
 	}
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -363,11 +363,13 @@ class WC_Product_Variable extends WC_Product {
 
 	/**
 	 * Returns whether or not the product is on sale.
+	 * @param string $context
 	 * @return bool
 	 */
-	public function is_on_sale() {
-		$prices = $this->get_variation_prices();
-		return apply_filters( 'woocommerce_product_is_on_sale', $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price'], $this );
+	public function is_on_sale( $context = 'view' ) {
+		$prices  = $this->get_variation_prices();
+		$on_sale = $prices['regular_price'] !== $prices['sale_price'] && $prices['sale_price'] === $prices['price']
+		return 'view' === $context ? apply_filters( 'woocommerce_product_is_on_sale', $on_sale, $this ) : $on_sale;
 	}
 
 	/**


### PR DESCRIPTION
Fixes an issue pointed out in #12835 and adds a `context` param in `WC_Product_Variable::is_on_sale` and `WC_Product_Grouped::is_on_sale`.

Would love to have more eyes on #12835 as it doesn't feel quite right -- cc @justinshreve @mikejolley 