### PR TITLE
Proposed solution for issue #12840

### DIFF
--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -139,9 +139,17 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 				$_response = $this->create_item( $_item );
 
 				if ( is_wp_error( $_response ) ) {
+					$data = $_response->get_error_data();
+
+					if ($_response->get_error_code() == 'woocommerce_rest_product_sku_already_exists')
+					{
+						$product_id = wc_get_product_id_by_sku( wc_clean( $item['sku'] ) );
+						$data['conflict_item_id'] = intval($product_id);
+					}
+
 					$response['create'][] = array(
 						'id'    => 0,
-						'error' => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $_response->get_error_data() ),
+						'error' => array( 'code' => $_response->get_error_code(), 'message' => $_response->get_error_message(), 'data' => $data ),
 					);
 				} else {
 					$response['create'][] = $wp_rest_server->response_to_data( $_response, '' );


### PR DESCRIPTION
## Problem

When syncing data between an ERP and WooCommerce, during a products batch insert, if I have a "woocommerce_rest_product_sku_already_exists" error, the error info doesn't return the product WooCommerce id. So, if I need to take some action based on this id, I need to call "products" endpoint, with "sku" filter, to get this info. The problem is: if I have lots of products on this situation (I'm on a batch insert), I'll need to do lots of calls to "products" endpoint.

## Proposed solution

On a "woocommerce_rest_product_sku_already_exists" error, server could return the product WooCommerce id as a "conflict_item_id" in something like this:

{
  "create":[
    {
      "id":0,
      "error": {
        "code": "woocommerce_rest_product_sku_already_exists",
        "message": "O REF j\\u00e1 existe em outro produto.",
        "data": {
            "status":400,
            "conflict_item_id": 12345
          }
      }
    }
  ]
}