### PR TITLE
Force a meta update when a data object is created by WP_Admin.

### DIFF
--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -40,7 +40,7 @@ class WC_Admin_Meta_Boxes {
 		add_action( 'add_meta_boxes', array( $this, 'remove_meta_boxes' ), 10 );
 		add_action( 'add_meta_boxes', array( $this, 'rename_meta_boxes' ), 20 );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 30 );
-		add_action( 'save_post', array( $this, 'save_meta_boxes' ), 1, 2 );
+		add_action( 'save_post', array( $this, 'save_meta_boxes' ), 1, 3 );
 
 		/**
 		 * Save Order Meta Boxes.
@@ -185,13 +185,18 @@ class WC_Admin_Meta_Boxes {
 	/**
 	 * Check if we're saving, the trigger an action based on the post type.
 	 *
-	 * @param  int $post_id
+	 * @param  int    $post_id
 	 * @param  object $post
+	 * @param  bool   $update
 	 */
-	public function save_meta_boxes( $post_id, $post ) {
+	public function save_meta_boxes( $post_id, $post, $update ) {
 		// $post_id and $post are required
 		if ( empty( $post_id ) || empty( $post ) || self::$saved_meta_boxes ) {
 			return;
+		}
+
+		if ( ! $update ) {
+			update_post_meta( $post_id, '_woocommerce_force_meta_update', true );
 		}
 
 		// Dont' save meta boxes for revisions or autosaves

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -222,6 +222,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'_order_version'      => 'version',
 			'_prices_include_tax' => 'prices_include_tax',
 		);
+
+		if ( false === $force ) {
+			$force = (bool) get_post_meta( $order->get_id(), '_woocommerce_force_meta_update', true );
+		}
+
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( ! in_array( $prop, $changed_props ) && ! $force ) {
 				continue;

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -114,7 +114,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'post_excerpt'  => $this->get_post_excerpt( $order ),
 		) );
 
-		$this->update_post_meta( $order );
+		$this->update_post_meta( $order, $this->should_force_meta_update( $order ) );
 		$order->save_meta_data();
 		$order->apply_changes();
 		$this->clear_caches( $order );
@@ -222,10 +222,6 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'_order_version'      => 'version',
 			'_prices_include_tax' => 'prices_include_tax',
 		);
-
-		if ( false === $force ) {
-			$force = (bool) get_post_meta( $order->get_id(), '_woocommerce_force_meta_update', true );
-		}
 
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( ! in_array( $prop, $changed_props ) && ! $force ) {

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -173,6 +173,10 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$updated_props     = array();
 		$changed_props     = array_keys( $coupon->get_changes() );
 
+		if ( false === $force ) {
+			$force = (bool) get_post_meta( $coupon->get_id(), '_woocommerce_force_meta_update', true );
+		}
+
 		$meta_key_to_props = array(
 			'discount_type'              => 'discount_type',
 			'coupon_amount'              => 'amount',

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -132,7 +132,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			'post_excerpt' => $coupon->get_description(),
 		);
 		wp_update_post( $post_data );
-		$this->update_post_meta( $coupon );
+		$this->update_post_meta( $coupon, $this->should_force_meta_update( $coupon ) );
 		$coupon->save_meta_data();
 		$coupon->apply_changes();
 		do_action( 'woocommerce_update_coupon', $coupon->get_id() );
@@ -172,11 +172,6 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	private function update_post_meta( &$coupon, $force = false ) {
 		$updated_props     = array();
 		$changed_props     = array_keys( $coupon->get_changes() );
-
-		if ( false === $force ) {
-			$force = (bool) get_post_meta( $coupon->get_id(), '_woocommerce_force_meta_update', true );
-		}
-
 		$meta_key_to_props = array(
 			'discount_type'              => 'discount_type',
 			'coupon_amount'              => 'amount',

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -164,4 +164,21 @@ class WC_Data_Store_WP {
 		return ! in_array( $meta->meta_key, $this->internal_meta_keys );
 	}
 
+	/**
+	 * If the `_woocommerce_force_meta_update` meta is present, meta should be
+	 * forced to update to make sure all props are present as meta keys.
+	 * Get the value of the meta, and delete it since we only want to force the update once.
+	 * This value is passed to update_post_meta for orders, products, and coupons.
+	 *
+	 * @param  object $meta
+	 * @return bool
+	 */
+	protected function should_force_meta_update( $object ) {
+		$force = (bool) get_post_meta( $object->get_id(), '_woocommerce_force_meta_update', true );
+		if ( $force ) {
+			delete_post_meta( $object->get_id(), '_woocommerce_force_meta_update' );
+		}
+		return $force;
+	}
+
 }

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -399,6 +399,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'_wc_review_count'       => 'review_count',
 		);
 
+		if ( false === $force ) {
+			$force = (bool) get_post_meta( $product->get_id(), '_woocommerce_force_meta_update', true );
+		}
+
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( ! in_array( $prop, $changed_props ) && ! $force ) {
 				continue;

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -156,7 +156,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		);
 		wp_update_post( $post_data );
 
-		$this->update_post_meta( $product );
+		$this->update_post_meta( $product, $this->should_force_meta_update( $product ) );
 		$this->update_terms( $product );
 		$this->update_visibility( $product );
 		$this->update_attributes( $product );
@@ -398,10 +398,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'_wc_rating_count'       => 'rating_counts',
 			'_wc_review_count'       => 'review_count',
 		);
-
-		if ( false === $force ) {
-			$force = (bool) get_post_meta( $product->get_id(), '_woocommerce_force_meta_update', true );
-		}
 
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( ! in_array( $prop, $changed_props ) && ! $force ) {


### PR DESCRIPTION
Fixes #12816.

By the time we get to forcing code, it's too late to know if the post was created by WP_Admin, so we don't know if we need to force a data update (similarly, the post status will already be a proper draft or published, so we can't rely on auto-draft to decide - See https://github.com/woocommerce/woocommerce/issues/12816#issuecomment-272918353).

However, we can hook in when the meta boxes are saved and set a piece of meta so data store can look for it and force a meta update if necessary. Confirmed this fixes the coupon bug. 

