### PR TITLE
Change travis setup to exclude coverage from all but latest stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,22 +12,20 @@ php:
   - hhvm
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
 
 # Additonal tests against stable PHP (min recommended version is 5.6) and past supported versions of WP.
 matrix:
   include:
   - php: 5.6
-    env: WP_VERSION=latest WP_MULTISITE=1
-  allow_failures:
-  - php: 5.3
+    env: WP_VERSION=latest WP_MULTISITE=1 PHP_LATEST_STABLE="7.1"
 
 before_script:
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/travis.sh before
 
 script:
-  - phpunit -c phpunit.xml.dist
+  - bash tests/bin/phpunit.sh
   - bash tests/bin/travis.sh during
 
 after_script:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,7 +34,4 @@
 			<directory suffix=".php">./tmp/</directory>
 		</blacklist>
 	</filter>
-	<logging>
-		<log type="coverage-clover" target="./tmp/clover.xml" charset="UTF-8" />
-	</logging>
 </phpunit>

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,0 +1,5 @@
+if [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
+	phpunit -c phpunit.xml.dist --coverage-clover ./tmp/clover.xml
+else
+	phpunit -c phpunit.xml.dist
+fi

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -4,16 +4,16 @@
 if [ $1 == 'before' ]; then
 
 	# Composer install fails in PHP 5.2
-	[ $TRAVIS_PHP_VERSION == '5.2' ] && exit;
+	[[ ${TRAVIS_PHP_VERSION} == '5.2' ]] && exit;
 
 	# No Xdebug and therefore no coverage in PHP 5.3
-	[ $TRAVIS_PHP_VERSION == '5.3' ] && exit;
+	[[ ${TRAVIS_PHP_VERSION} == '5.3' ]] && exit;
 
 	composer self-update
 	composer install --no-interaction
 
-	## Only run on 7.0 box.
-	if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+	## Only run on latest stable PHP box (defined in .travis.yml).
+	if [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
 		# Install CodeSniffer for WordPress Coding Standards checks. Only check once.
 		git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git /tmp/phpcs
 		# Install WordPress Coding Standards.
@@ -29,8 +29,8 @@ if [ $1 == 'before' ]; then
 
 elif [ $1 == 'during' ]; then
 
-	## Only run on 7.0 box.
-	if [ $TRAVIS_PHP_VERSION == "7.0" ]; then
+	## Only run on latest stable PHP box (defined in .travis.yml).
+	if [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
 		# WordPress Coding Standards.
 		# @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
 		# @link http://pear.php.net/package/PHP_CodeSniffer/
@@ -49,8 +49,8 @@ elif [ $1 == 'during' ]; then
 
 elif [ $1 == 'after' ]; then
 
-	## Only run on 7.0 box.
-	if [ $TRAVIS_PHP_VERSION == "7.0" ]; then
+	## Only run on latest stable PHP box (defined in .travis.yml).
+	if [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
 		wget https://scrutinizer-ci.com/ocular.phar
 		chmod +x ocular.phar
 		php ocular.phar code-coverage:upload --format=php-clover ./tmp/clover.xml


### PR DESCRIPTION
Failures on `5.3` box have been irritating me. This PR takes a different approach to fixing the problem by circumventing it.

I noticed that the failures occur during code coverage tests, but only `7.0` code coverage report was being used in `travis.sh after`. This means we were doing a lot of wasted work, and by skipping code coverage tests on `5.3`, I suspect we'll stop seeing build failures.

I also added an environment variable so that the box used to generate coverage can be modified without touching the scripts, you just have to modify the variable in `.travis.yml`. I've set this variable to `7.1`, the current stable PHP version, which is a change from the current hard-coded `7.0`.

---

Add `phpunit.sh` to conditionally include coverage in build via phpunit CLI invocation.
Add `PHP_LATEST_STABLE="7.1"` environment variable to `.travis.yml`. This variable defines the version which will be used for coverage testing.
Homogenize bash conditional syntax.
Remove `allow_failure` for `5.3` box.