### PR TITLE
Add phpunit coverage whitelist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 matrix:
   include:
   - php: 5.6
-    env: WP_VERSION=latest WP_MULTISITE=1 PHP_LATEST_STABLE="7.1"
+    env: WP_VERSION=latest WP_MULTISITE=1 PHP_LATEST_STABLE=7.1
 
 before_script:
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,7 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">.</directory>
 			<exclude>
 				<directory suffix=".php">./apigen/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,24 +15,27 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<blacklist>
-			<directory suffix=".php">./apigen/</directory>
-			<directory suffix=".php">./i18n/</directory>
-			<directory suffix=".php">./includes/api/legacy/</directory>
-			<directory suffix=".php">./includes/gateways/simplify-commerce-deprecated/</directory>
-			<directory suffix=".php">./includes/gateways/simplify-commerce/includes/</directory>
-			<directory suffix=".php">./includes/libraries/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-flat-rate/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-free-shipping/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-international-delivery/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-local-delivery/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-local-pickup/</directory>
-			<directory suffix=".php">./includes/updates/</directory>
-			<directory suffix=".php">./includes/widgets/</directory>
-			<directory suffix=".php">./templates/</directory>
-			<directory>./tests/</directory>
-			<directory suffix=".php">./tmp/</directory>
-		</blacklist>
+		<whitelist>
+			<directory suffix=".php">.</directory>
+			<exclude>
+				<directory suffix=".php">./apigen/</directory>
+				<directory suffix=".php">./i18n/</directory>
+				<directory suffix=".php">./includes/api/legacy/</directory>
+				<directory suffix=".php">./includes/gateways/simplify-commerce-deprecated/</directory>
+				<directory suffix=".php">./includes/gateways/simplify-commerce/includes/</directory>
+				<directory suffix=".php">./includes/libraries/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-flat-rate/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-free-shipping/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-international-delivery/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-local-delivery/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-local-pickup/</directory>
+				<directory suffix=".php">./includes/updates/</directory>
+				<directory suffix=".php">./includes/widgets/</directory>
+				<directory suffix=".php">./templates/</directory>
+				<directory>./tests/</directory>
+				<directory suffix=".php">./tmp/</directory>
+			</exclude>
+		</whitelist>
 	</filter>
 	<logging>
 		<log type="coverage-html" target="./tmp/coverage" charset="UTF-8" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,23 +15,26 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<blacklist>
-			<directory suffix=".php">./apigen/</directory>
-			<directory suffix=".php">./i18n/</directory>
-			<directory suffix=".php">./includes/api/legacy/</directory>
-			<directory suffix=".php">./includes/gateways/simplify-commerce-deprecated/</directory>
-			<directory suffix=".php">./includes/gateways/simplify-commerce/includes/</directory>
-			<directory suffix=".php">./includes/libraries/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-flat-rate/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-free-shipping/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-international-delivery/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-local-delivery/</directory>
-			<directory suffix=".php">./includes/shipping/legacy-local-pickup/</directory>
-			<directory suffix=".php">./includes/updates/</directory>
-			<directory suffix=".php">./includes/widgets/</directory>
-			<directory suffix=".php">./templates/</directory>
-			<directory>./tests/</directory>
-			<directory suffix=".php">./tmp/</directory>
-		</blacklist>
+		<whitelist>
+			<directory suffix=".php">.</directory>
+			<exclude>
+				<directory suffix=".php">./apigen/</directory>
+				<directory suffix=".php">./i18n/</directory>
+				<directory suffix=".php">./includes/api/legacy/</directory>
+				<directory suffix=".php">./includes/gateways/simplify-commerce-deprecated/</directory>
+				<directory suffix=".php">./includes/gateways/simplify-commerce/includes/</directory>
+				<directory suffix=".php">./includes/libraries/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-flat-rate/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-free-shipping/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-international-delivery/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-local-delivery/</directory>
+				<directory suffix=".php">./includes/shipping/legacy-local-pickup/</directory>
+				<directory suffix=".php">./includes/updates/</directory>
+				<directory suffix=".php">./includes/widgets/</directory>
+				<directory suffix=".php">./templates/</directory>
+				<directory>./tests/</directory>
+				<directory suffix=".php">./tmp/</directory>
+			</exclude>
+		</whitelist>
 	</filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@
 		</testsuite>
 	</testsuites>
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">.</directory>
 			<exclude>
 				<directory suffix=".php">./apigen/</directory>


### PR DESCRIPTION
PHPUnit requires `whitelist` to be defined. Travis generated coverage reports have likely been broken since a PHPUnit upgrade.

This PR translates the current `<blacklist>` filter into `<whitelist>` + `<exclude>`.

Also adds `addUncoveredFilesFromWhitelist`, which should generate more accurate reports by informing that untested whitelisted files are, in fact, uncovered.

No coverage examples:
https://travis-ci.org/woocommerce/woocommerce/jobs/192417274#L352
> Configuration: /home/travis/build/woocommerce/woocommerce/phpunit.xml.dist
> Error:         No whitelist configured, no code coverage will be generated

and
https://travis-ci.org/woocommerce/woocommerce/jobs/192417274#L441
> Notifying that no code coverage data is available for repository "g/woocommerce/woocommerce" and revision "f212128e266112ef1a0a6c9e6e3382e7707643c2"... Done