### PR TITLE
Add before and after date arguments to wc_get_orders

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -367,6 +367,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$wp_query_args['no_found_rows'] = true;
 		}
 
+		if ( ! empty( $args['date_before'] ) ) {
+			$wp_query_args['date_query']['before'] = $args['date_before'];
+		}
+
+		if ( ! empty( $args['date_after'] ) ) {
+			$wp_query_args['date_query']['after'] = $args['date_after'];
+		}
+
 		// Get results.
 		$orders = new WP_Query( apply_filters( 'woocommerce_order_data_store_cpt_get_orders_query', $wp_query_args, $args, $this ) );
 

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -28,6 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *      limit int Maximum of orders to retrieve.
  *      offset int Offset of orders to retrieve.
  *      page int Page of orders to retrieve. Ignored when using the 'offset' arg.
+ *      date_before string Get orders before a certain date ( strtotime() compatibile string )
+ *      date_after string Get orders after a certain date ( strtotime() compatibile string )
  *      exclude array Order IDs to exclude from the query.
  *      orderby string Order by date, title, id, modified, rand etc
  *      order string ASC or DESC
@@ -46,19 +48,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function wc_get_orders( $args ) {
 	$args = wp_parse_args( $args, array(
-		'status'   => array_keys( wc_get_order_statuses() ),
-		'type'     => wc_get_order_types( 'view-orders' ),
-		'parent'   => null,
-		'customer' => null,
-		'email'    => '',
-		'limit'    => get_option( 'posts_per_page' ),
-		'offset'   => null,
-		'page'     => 1,
-		'exclude'  => array(),
-		'orderby'  => 'date',
-		'order'    => 'DESC',
-		'return'   => 'objects',
-		'paginate' => false,
+		'status'      => array_keys( wc_get_order_statuses() ),
+		'type'        => wc_get_order_types( 'view-orders' ),
+		'parent'      => null,
+		'customer'    => null,
+		'email'       => '',
+		'limit'       => get_option( 'posts_per_page' ),
+		'offset'      => null,
+		'page'        => 1,
+		'exclude'     => array(),
+		'orderby'     => 'date',
+		'order'       => 'DESC',
+		'return'      => 'objects',
+		'paginate'    => false,
+		'date_before' => '',
+		'date_after'  => '',
 	) );
 
 	// Handle some BW compatibility arg names where wp_query args differ in naming.

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -158,11 +158,11 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order->set_date_created( '2015-01-01 05:20:30' );
 		$order->save();
 		$order_1 = $order->get_id();
-		$order = WC_Helper_Order::create_order();
+		$order   = WC_Helper_Order::create_order();
 		$order->set_date_created( '2017-01-01' );
 		$order->save();
 		$order_2 = $order->get_id();
-		$order = WC_Helper_Order::create_order();
+		$order   = WC_Helper_Order::create_order();
 		$order->set_date_created( '2017-01-01' );
 		$order->save();
 		$order_3 = $order->get_id();

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -147,4 +147,45 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
 		$this->assertCount( 1, $order->get_payment_tokens() );
 	}
+
+	/**
+	 * Test the before and after date parameters for wc_get_orders.
+	 *
+	 * @since 2.7
+	 */
+	public function test_wc_get_orders_date_params() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_date_created( '2015-01-01 05:20:30' );
+		$order->save();
+		$order_1 = $order->get_id();
+		$order = WC_Helper_Order::create_order();
+		$order->set_date_created( '2017-01-01' );
+		$order->save();
+		$order_2 = $order->get_id();
+		$order = WC_Helper_Order::create_order();
+		$order->set_date_created( '2017-01-01' );
+		$order->save();
+		$order_3 = $order->get_id();
+
+		$orders   = wc_get_orders( array( 'date_before' => '2017-01-15', 'return' => 'ids' ) );
+		$expected = array( $order_1, $order_2, $order_3 );
+		$this->assertEquals( sort( $expected ), sort( $orders ) );
+
+		$orders   = wc_get_orders( array( 'date_before' => '2017-01-01', 'return' => 'ids' ) );
+		$expected = array( $order_1 );
+		$this->assertEquals( sort( $expected ), sort( $orders ) );
+
+		$orders   = wc_get_orders( array( 'date_before' => '2016-12-31', 'return' => 'ids' ) );
+		$expected = array( $order_1 );
+		$this->assertEquals( sort( $expected ), sort( $orders ) );
+
+		$orders   = wc_get_orders( array( 'date_after' => '2015-01-01 00:00:00', 'return' => 'ids' ) );
+		$expected = array( $order_1, $order_2, $order_3 );
+		$this->assertEquals( sort( $expected ), sort( $orders ) );
+
+		$orders   = wc_get_orders( array( 'date_after' => '2016-01-01', 'return' => 'ids' ) );
+		$expected = array( $order_2, $order_3 );
+		$this->assertEquals( sort( $expected ), sort( $orders ) );
+
+	}
 }


### PR DESCRIPTION
Deposits (and other extensions) have queries to get orders before or after certain dates. This PR adds new arguments to wc_get_orders so these queries can be switched over to use it instead.

You can test with `phpunit --filter=test_wc_get_orders_date_params`.