### PR TITLE
Fix: usermeta table name, in a multisite the usermeta table is common…

### DIFF
--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -131,6 +131,7 @@ class WC_Data_Store_WP {
 		// Figure out our field names.
 		if ( 'user' === $this->meta_type ) {
 			$meta_id_field = 'umeta_id';
+			$table         = $wpdb->usermeta;
 		}
 
 		if ( ! empty( $this->object_id_field_for_meta ) ) {


### PR DESCRIPTION
Fix the usermeta table name, in a multisite the usermeta table is common.

In a multisite installation, in the log there's a Wordpress database error

WordPress database error Table 'multisite.wp_2_usermeta' doesn't exist for query 
SELECT umeta_id as meta_id, meta_key, meta_value
FROM wp_2_usermeta
WHERE user_id=1 AND meta_key NOT LIKE 'wp\_%' ORDER BY umeta_id

made by require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, WooCommerce->init, WC_Customer->__construct, WC_Data_Store->read, WC_Customer_Data_Store->read, WC_Data->read_meta_data, WC_Data_Store->__call, WC_Data_Store_WP->read_meta, QM_DB->query