### PR TITLE
Return order item type if accessed via array.

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -303,6 +303,8 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 
 		if ( 'item_meta' === $offset ) {
 			return $meta_values;
+		} elseif ( 'type' === $offset ) {
+			return $this->get_type();
 		} elseif ( array_key_exists( $offset, $this->data ) ) {
 			$getter = "get_$offset";
 			if ( is_callable( array( $this, $getter ) ) ) {


### PR DESCRIPTION
Order item type is not a part of `$this->data`, so it needs its own special case for the `ArrayAccess`/ backwards compatibility handling.