### PR TITLE
Add method for getting order id from order item id.

### DIFF
--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -119,4 +119,19 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 		return get_metadata( 'order_item', $item_id, $key, $single );
 	}
 
+	/**
+	 * Get order ID by order item ID.
+	 *
+	 * @since 2.7.0
+	 * @param  mixed $item_id
+	 * @return int
+	 */
+	function get_order_id_by_order_item_id( $item_id ) {
+		global $wpdb;
+		return $wpdb->get_var( $wpdb->prepare(
+			"SELECT order_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d",
+			$item_id
+		) );
+	}
+
 }

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -68,9 +68,9 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * Update term meta.
 	 *
 	 * @since  2.7.0
-	 * @param  mixed $item_id
-	 * @param  mixed $meta_key
-	 * @param  mixed $meta_value
+	 * @param  int    $item_id
+	 * @param  string $meta_key
+	 * @param  mixed  $meta_value
 	 * @param  string $prev_value (default: '')
 	 * @return bool
 	 */
@@ -82,11 +82,11 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * Add term meta.
 	 *
 	 * @since  2.7.0
-	 * @param  mixed $item_id
-	 * @param  mixed $meta_key
-	 * @param  mixed $meta_value
-	 * @param  bool $unique (default: false)
-	 * @return int New row ID or 0
+	 * @param  int    $item_id
+	 * @param  string $meta_key
+	 * @param  mixed  $meta_value
+	 * @param  bool   $unique (default: false)
+	 * @return int    New row ID or 0
 	 */
 	function add_metadata( $item_id, $meta_key, $meta_value, $unique = false ) {
 		return add_metadata( 'order_item', $item_id, $meta_key, $meta_value, $unique );
@@ -96,10 +96,10 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * Delete term meta.
 	 *
 	 * @since  2.7.0
-	 * @param  mixed $item_id
-	 * @param  mixed $meta_key
+	 * @param  int    $item_id
+	 * @param  string $meta_key
 	 * @param  string $meta_value (default: '')
-	 * @param  bool $delete_all (default: false)
+	 * @param  bool   $delete_all (default: false)
 	 * @return bool
 	 */
 	function delete_metadata( $item_id, $meta_key, $meta_value = '', $delete_all = false ) {
@@ -110,9 +110,9 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * Get term meta.
 	 *
 	 * @since  2.7.0
-	 * @param  mixed $item_id
-	 * @param  mixed $key
-	 * @param  bool $single (default: true)
+	 * @param  int    $item_id
+	 * @param  string $key
+	 * @param  bool   $single (default: true)
 	 * @return mixed
 	 */
 	function get_metadata( $item_id, $key, $single = true ) {
@@ -123,12 +123,12 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * Get order ID by order item ID.
 	 *
 	 * @since 2.7.0
-	 * @param  mixed $item_id
+	 * @param  int $item_id
 	 * @return int
 	 */
 	function get_order_id_by_order_item_id( $item_id ) {
 		global $wpdb;
-		return $wpdb->get_var( $wpdb->prepare(
+		return (int) $wpdb->get_var( $wpdb->prepare(
 			"SELECT order_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d",
 			$item_id
 		) );

--- a/includes/interfaces/class-wc-order-item-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-data-store-interface.php
@@ -74,4 +74,11 @@ interface WC_Order_Item_Data_Store_Interface {
 	 * @return mixed
 	 */
 	function get_metadata( $item_id, $key, $single = true );
+
+	/**
+	 * Get order ID by order item ID.
+	 * @param  mixed $item_id
+	 * @return int
+	 */
+	function get_order_id_by_order_item_id( $item_id );
 }

--- a/includes/interfaces/class-wc-order-item-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-data-store-interface.php
@@ -17,7 +17,7 @@ interface WC_Order_Item_Data_Store_Interface {
 	 * Add an order item to an order.
 	 * @param  int   $order_id
 	 * @param  array $item. order_item_name and order_item_type.
-	 * @return int Order Item ID
+	 * @return int   Order Item ID
 	 */
 	public function add_order_item( $order_id, $item );
 
@@ -37,9 +37,9 @@ interface WC_Order_Item_Data_Store_Interface {
 
 	/**
 	 * Update term meta.
-	 * @param  mixed $item_id
-	 * @param  mixed $meta_key
-	 * @param  mixed $meta_value
+	 * @param  int    $item_id
+	 * @param  string $meta_key
+	 * @param  mixed  $meta_value
 	 * @param  string $prev_value (default: '')
 	 * @return bool
 	 */
@@ -47,37 +47,37 @@ interface WC_Order_Item_Data_Store_Interface {
 
 	/**
 	 * Add term meta.
-	 * @param  mixed $item_id
-	 * @param  mixed $meta_key
-	 * @param  mixed $meta_value
-	 * @param  bool $unique (default: false)
-	 * @return int New row ID or 0
+	 * @param  int    $item_id
+	 * @param  string $meta_key
+	 * @param  mixed  $meta_value
+	 * @param  bool   $unique (default: false)
+	 * @return int    New row ID or 0
 	 */
 	function add_metadata( $item_id, $meta_key, $meta_value, $unique = false );
 
 
 	/**
 	 * Delete term meta.
-	 * @param  mixed $item_id
-	 * @param  mixed $meta_key
+	 * @param  int    $item_id
+	 * @param  string $meta_key
 	 * @param  string $meta_value (default: '')
-	 * @param  bool $delete_all (default: false)
+	 * @param  bool   $delete_all (default: false)
 	 * @return bool
 	 */
 	function delete_metadata( $item_id, $meta_key, $meta_value = '', $delete_all = false );
 
 	/**
 	 * Get term meta.
-	 * @param  mixed $item_id
-	 * @param  mixed $key
-	 * @param  bool $single (default: true)
+	 * @param  int    $item_id
+	 * @param  string $key
+	 * @param  bool   $single (default: true)
 	 * @return mixed
 	 */
 	function get_metadata( $item_id, $key, $single = true );
 
 	/**
 	 * Get order ID by order item ID.
-	 * @param  mixed $item_id
+	 * @param  int $item_id
 	 * @return int
 	 */
 	function get_order_id_by_order_item_id( $item_id );

--- a/includes/wc-order-item-functions.php
+++ b/includes/wc-order-item-functions.php
@@ -158,3 +158,8 @@ function wc_get_order_item_meta( $item_id, $key, $single = true ) {
 	$data_store = WC_Data_Store::load( 'order-item' );
 	return $data_store->get_metadata( $item_id, $key, $single );
 }
+
+function wc_get_order_id_by_order_item_id( $item_id ) {
+	$data_store = WC_Data_Store::load( 'order-item' );
+	return $data_store->get_order_id_by_order_item_id( $item_id );
+}

--- a/includes/wc-order-item-functions.php
+++ b/includes/wc-order-item-functions.php
@@ -159,6 +159,12 @@ function wc_get_order_item_meta( $item_id, $key, $single = true ) {
 	return $data_store->get_metadata( $item_id, $key, $single );
 }
 
+/**
+ * Get order ID by order item ID.
+ *
+ * @param  int $item_id
+ * @return int
+ */
 function wc_get_order_id_by_order_item_id( $item_id ) {
 	$data_store = WC_Data_Store::load( 'order-item' );
 	return $data_store->get_order_id_by_order_item_id( $item_id );


### PR DESCRIPTION
A common pattern is getting an order ID from an item ID -- usually by direct query (since otherwise, you need to get the item type, create a new instance of the class, and then call` get_order_id`). I'm currently trying to replace these in the deposits extension.

This PR adds a helper method for getting a proper order ID from an item - ran through the data store.