### PR TITLE
#12518 Make product attributes link through to archives

### DIFF
--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -43,22 +43,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<td><?php
 				$values = array();
 
-				if ( $attribute->is_taxonomy() ) :
+				if ( $attribute->is_taxonomy() ) {
 
 					$attribute_taxonomy = $attribute->get_taxonomy_object();
 					$attribute_values = wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'all' ) );
 
-					foreach ( $attribute_values as $attribute_value ) :
-						if ( $attribute_taxonomy->attribute_public ) :
-							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $attribute_value->name . '</a>';
-						else:
-							$values[] = $attribute_value->name;
-						endif;
-					endforeach;
+					foreach ( $attribute_values as $attribute_value ) {
 
-				else :
+						$value_name = esc_html( $attribute_value->name );
+
+						if ( $attribute_taxonomy->attribute_public ) {
+							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
+						} else {
+							$values[] = $value_name;
+						}
+
+					}
+
+				} else {
+
 					$values = $attribute->get_options();
-				endif;
+
+					foreach ( $values as &$value ) {
+						$value = esc_html( $value );
+					}
+
+				}
 
 				echo apply_filters( 'woocommerce_attribute', wpautop( wptexturize( implode( ', ', $values ) ) ), $attribute, $values );
 			?></td>

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -55,7 +55,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						if ( $attribute_taxonomy->attribute_public ) {
 							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
 						} else {
-							$values[] = esc_html( $value_name );
+							$values[] = $value_name;
 						}
 
 					}

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -41,7 +41,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<tr>
 			<th><?php echo wc_attribute_label( $attribute->get_name() ); ?></th>
 			<td><?php
-				$values = $attribute->is_taxonomy() ? wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'names' ) ) : $attribute->get_options();
+				$values = array();
+
+				if ( $attribute->is_taxonomy() ) :
+
+					$attribute_taxonomy = $attribute->get_taxonomy_object();
+					$attribute_values = wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'all' ) );
+
+					foreach ( $attribute_values as $attribute_value ) :
+						if ( $attribute_taxonomy->attribute_public ) :
+							$values[] = '<a href="'. esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $attribute_value->name . '</a>';
+						else:
+							$values[] = $attribute_value->name;
+						endif;
+					endforeach;
+
+				else :
+					$values = $attribute->get_options();
+				endif;
+
 				echo apply_filters( 'woocommerce_attribute', wpautop( wptexturize( implode( ', ', $values ) ) ), $attribute, $values );
 			?></td>
 		</tr>

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -50,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 					foreach ( $attribute_values as $attribute_value ) :
 						if ( $attribute_taxonomy->attribute_public ) :
-							$values[] = '<a href="'. esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $attribute_value->name . '</a>';
+							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $attribute_value->name . '</a>';
 						else:
 							$values[] = $attribute_value->name;
 						endif;

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -55,7 +55,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						if ( $attribute_taxonomy->attribute_public ) {
 							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
 						} else {
-							$values[] = $value_name;
+							$values[] = esc_html( $value_name );
 						}
 
 					}


### PR DESCRIPTION
This relates to issue #12518. 

In the "Additional information" tab for products, link public attributes to their archive pages when possible.