### PR TITLE
[2.7] Fix wc_paying_customer() refund check

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -179,7 +179,7 @@ function wc_paying_customer( $order_id ) {
 	$order       = wc_get_order( $order_id );
 	$customer_id = $order->get_customer_id();
 
-	if ( $customer_id > 0 && 'refund' !== $order->get_type() ) {
+	if ( $customer_id > 0 && 'shop_order_refund' !== $order->get_type() ) {
 		$customer = new WC_Customer( $customer_id );
 		$customer->set_is_paying_customer( true );
 		$customer->save();


### PR DESCRIPTION
`wc_paying_customer()` was checking that an order was not a refund by checking that `WC_Order_Refund::get_type()` did not return `'refund'`. However, it needs to check that the order is not a `'shop_order_refund'` type, which is the actual return value of [`WC_Order_Refund::get_type()`](https://github.com/woocommerce/woocommerce/blob/9d513737ed909b739cc17d24116581f9304bae4e/includes/class-wc-order-refund.php#L55:L57). No other order object in WC core will has a `'refund'` type, so a customer would always be declared as a paying customer even, for refund orders.

This fixes that.