### PR TITLE
[2.7] Fix get_price_html_from_to() deprecation

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -266,8 +266,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return string
 	 */
 	public function get_price_html_from_to( $from, $to ) {
-		wc_deprecated_function( 'WC_Product::get_price_html_from_to', '2.7', 'wc_format_sale_price' );
-		return apply_filters( 'woocommerce_get_price_html_from_to', wc_format_sale_price( $from, $to ), $from, $to, $this );
+		wc_deprecated_function( 'WC_Product::get_price_html_from_to', '2.7', 'wc_format_price_range' );
+		return apply_filters( 'woocommerce_get_price_html_from_to', wc_format_price_range( $from, $to ), $from, $to, $this );
 	}
 
 	/**


### PR DESCRIPTION
`WC_Product::get_price_html_from_to()` was deprecated with `wc_format_sale_price()` set as its replacement (see SHA: 76b32c9aa52eb). However, `wc_format_price_range()` appears to be the intended replacement.

Example output: 

* with `wc_format_sale_price()`: https://cloudup.com/cm3PffR-RA5
* with `wc_format_price_range()`: https://cloudup.com/i-d_dV2jGuK

`wc_format_price_range()` is also being [used in `WC_Product_Variable::get_price_html()`](https://github.com/woocommerce/woocommerce/blob/9d513737ed909b73/includes/class-wc-product-variable.php#L130) where `WC_Product::get_price_html_from_to()` was once used.

This patch sets `wc_format_price_range()` as the replacement.