### PR TITLE
[2.7] Fix name of get_order_count() param

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -312,14 +312,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	}
 
 	/**
-	 * Return count of orders with type.
+	 * Return count of orders with a specific status.
 	 *
-	 * @param  string $type
+	 * @param  string $status
 	 * @return int
 	 */
-	public function get_order_count( $type ) {
+	public function get_order_count( $status ) {
 		global $wpdb;
-		return absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM {$wpdb->posts} WHERE post_type = 'shop_order' AND post_status = %s", $type ) ) );
+		return absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( * ) FROM {$wpdb->posts} WHERE post_type = 'shop_order' AND post_status = %s", $status ) ) );
 	}
 
 	/**

--- a/includes/interfaces/class-wc-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-data-store-interface.php
@@ -46,11 +46,11 @@ interface WC_Order_Data_Store_Interface {
 	public function get_order_id_by_order_key( $order_key );
 
 	/**
-	 * Return count of orders with type.
-	 * @param  string $type
+	 * Return count of orders with a specific status.
+	 * @param  string $status
 	 * @return int
 	 */
-	public function get_order_count( $type );
+	public function get_order_count( $status );
 
 	/**
 	 * Get all orders matching the passed in args.


### PR DESCRIPTION
The parameters for `WC_Order_Data_Store_Interface::get_order_count()` and `WC_Order_Data_Store_CPT::get_order_count()` were both named `$type`. However, the query in `WC_Order_Data_Store_CPT::get_order_count()` uses this parameter to filter by order status.

The only public used of `WC_Order_Data_Store_CPT::get_order_count()` is in `wc_orders_count()`, which also passes an order status as the parameter value. Therefore, I suspect the parameter should be named `$status`, not `$type`.