### PR TITLE
[2.7] Fix WC_Order_Refund_Data_Store_CPT::read() and Abstract_WC_Order_Data_Store_CPT's support for other custom order types

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -82,7 +82,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function read( &$order ) {
 		$order->set_defaults();
 
-		if ( ! $order->get_id() || ! ( $post_object = get_post( $order->get_id() ) ) || 'shop_order' !== $post_object->post_type ) {
+		if ( ! $order->get_id() || ! ( $post_object = get_post( $order->get_id() ) ) || ! in_array( $post_object->post_type, wc_get_order_types() ) ) {
 			throw new Exception( __( 'Invalid order.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
`Abstract_WC_Order_Data_Store_CPT::read()` hardcoded its validation against the `'shop_order'` post type. However, custom order types created via the `wc_register_order_type()` API can use different post types. For example, refunds have the post type `'shop_order_refund'` which meant `WC_Order_Refund_Data_Store_CPT`'s inheritance of the `read()` method was broken.

This patch changes the `Abstract_WC_Order_Data_Store_CPT::read()` validation to check that the post type is any of the registered order types.

Another suitable alternative which may be nicer would be for the data store to define its post type as a property which `Abstract_WC_Order_Data_Store_CPT::read()` can check against and `WC_Order_Refund_Data_Store_CPT` could modify.

This fixes refunds in WooCommerce core (which as far I could see were completely broken because any attempt to read refund data would result in the `Invalid order` exception). It also allows 3rd party custom order types, like subscriptions, to use the `Abstract_WC_Order_Data_Store_CPT::read()` method.