### PR TITLE
Admin Report JS - Add ability to have non-date index in export

### DIFF
--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -136,6 +136,7 @@ jQuery(function( $ ) {
 		exclude_series    = exclude_series.split( ',' );
 		var xaxes_label   = $( this ).data( 'xaxes' );
 		var groupby       = $( this ) .data( 'groupby' );
+		var index_type    = $( this ).data( 'index_type' );
 		var export_format = $( this ).data( 'export' );
 		var csv_data      = 'data:application/csv;charset=utf-8,';
 		var s, series_data, d;
@@ -217,10 +218,14 @@ jQuery(function( $ ) {
 			$.each( xaxis, function( index, value ) {
 				var date = new Date( parseInt( index, 10 ) );
 
-				if ( groupby === 'day' ) {
-					csv_data += '"' + date.getUTCFullYear() + '-' + parseInt( date.getUTCMonth() + 1, 10 ) + '-' + date.getUTCDate() + '",';
+				if ( 'none' === index_type ) {
+					csv_data += '"' + index + '",';
 				} else {
-					csv_data += '"' + date.getUTCFullYear() + '-' + parseInt( date.getUTCMonth() + 1, 10 ) + '",';
+					if ( groupby === 'day' ) {
+						csv_data += '"' + date.getUTCFullYear() + '-' + parseInt( date.getUTCMonth() + 1, 10 ) + '-' + date.getUTCDate() + '",';
+					} else {
+						csv_data += '"' + date.getUTCFullYear() + '-' + parseInt( date.getUTCMonth() + 1, 10 ) + '",';
+					}
 				}
 
 				for ( var d = 0; d < value.length; ++d ) {


### PR DESCRIPTION
Currently the export function only allows for formatting an index as a date. For extending reports there are many situations where it would be desirable to have a non-date index.

This change will add a new data flag "index_type", if set to "none" it will leave the index as is and not try to convert it to a date.