### PR TITLE
Added two useful filters to woocommerce_form_field()-function

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1921,7 +1921,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		$field           = '';
 		$label_id        = $args['id'];
 		$sort            = $args['priority'] ? $args['priority'] : '';
-		$field_container = '<p class="form-row %1$s" id="%2$s" data-sort="' . esc_attr( $sort ) . '">%3$s</p>';
+		$field_container = apply_filters( 'woocommerce_form_field_container', '<p class="form-row %1$s" id="%2$s" data-sort="' . esc_attr( $sort ) . '">%3$s</p>', $key, $args, $value );
 
 		switch ( $args['type'] ) {
 			case 'country' :
@@ -2036,6 +2036,8 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				break;
 		}
+
+		$field = apply_filters( 'woocommerce_form_field_before_container_' . $args['type'], $field, $key, $args, $value );
 
 		if ( ! empty( $field ) ) {
 			$field_html = '';


### PR DESCRIPTION
I added the filters `woocommerce_form_field_container` and `woocommerce_form_field_before_container_<type>` to the `woocommerce_form_field()` function.

The `woocommerce_form_field_container` filter is for the case where you want to make changes to the field container across all fields. 

The `woocommerce_form_field_before_container_<type>` filter is for when you want change the HTML of a field type, but you want to keep the same container HTML. In most cases when you want to change the HTML of one field you probably want to keep the same container as before. This is quite messy to do with the current `woocommerce_form_field_<type>` filter as you just get a HTML string and you do not have access to the `$container_class` variable and requires some copy pasting from the `woocommerce_form_field()` function witch makes the code harder to maintain. 

This makes the `woocommerce_form_field_<type>` filter almost redundant, but it should probably be kept to maintain backwards compatibility. 
Also, I'm not really sure about the name of the `woocommerce_form_field_before_container_<type>` filter so feel free to change it to something better.