### PR TITLE
[2.7] Make variable data store private methods protected

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -17,7 +17,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 *
 	 * @var array
 	 */
-	private $prices_array = array();
+	protected $prices_array = array();
 
 	/**
 	 * Read product data.
@@ -41,7 +41,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @param  bool $force_read True to bypass the transient.
 	 * @return array
 	 */
-	private function read_children( &$product, $force_read = false ) {
+	protected function read_children( &$product, $force_read = false ) {
 		$children_transient_name = 'wc_product_children_' . $product->get_id();
 		$children                = get_transient( $children_transient_name );
 
@@ -80,7 +80,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * @param WC_Product
 	 * @return array
 	 */
-	private function read_variation_attributes( &$product ) {
+	protected function read_variation_attributes( &$product ) {
 		global $wpdb;
 
 		$variation_attributes = array();


### PR DESCRIPTION
`WC_Product_Variable_Data_Store_CPT` has some `private` methods and a `private` property that are handy for other variable product types, like variable subscriptions. This makes them available for classes that need to extend `WC_Product_Variable_Data_Store_CPT` to override other methods but not these methods.