### PR TITLE
add animationLoop to woocommerce_single_product_carousel_options filter

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -124,7 +124,7 @@ jQuery( function( $ ) {
 				controlNav:     wc_single_product_params.flexslider.controlNav,
 				slideshow:      wc_single_product_params.flexslider.slideshow,
 				animationSpeed: wc_single_product_params.flexslider.animationSpeed,
-				animationLoop:  false // Breaks photoswipe pagination if true. It's hard disabled because we don't need it anyway (no next/prev enabled in flex).
+				animationLoop:  wc_single_product_params.flexslider.animationLoop // Breaks photoswipe pagination if true.
 			});
 		},
 

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -431,6 +431,7 @@ class WC_Frontend_Scripts {
 						'controlNav'     => 'thumbnails',
 						'slideshow'      => false,
 						'animationSpeed' => 500,
+						'animationLoop'  => false, // Breaks photoswipe pagination if true.
 					) ),
 				);
 			break;


### PR DESCRIPTION
If a different lightbox script is used, e.g. by a thme it would make sense to make the animationLoop param also filterable.