### PR TITLE
Data Stores & update_post_meta: Update changed & keys that don't exist.

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -341,6 +341,22 @@ class WC_Order extends WC_Abstract_Order {
 	}
 
 	/**
+	 * Expands the shipping and billing information in the changes array.
+	 */
+	public function get_changes() {
+		$changed_props = parent::get_changes();
+		$subs          = array( 'shipping', 'billing' );
+		foreach ( $subs as $sub ) {
+			if ( ! empty( $changed_props[ $sub ] ) ) {
+				foreach ( $changed_props[ $sub ] as $sub_prop => $value ) {
+					$changed_props[ $sub . '_' . $sub_prop ] = $value;
+				}
+			}
+		}
+		return $changed_props;
+	}
+
+	/**
 	 * get_order_number function.
 	 *
 	 * Gets the order number for display (by default, order ID).

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -68,7 +68,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		if ( $id && ! is_wp_error( $id ) ) {
 			$order->set_id( $id );
-			$this->update_post_meta( $order, true );
+			$this->update_post_meta( $order );
 			$order->save_meta_data();
 			$order->apply_changes();
 			$this->clear_caches( $order );
@@ -205,12 +205,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * Helper method that updates all the post meta for an order based on it's settings in the WC_Order class.
 	 *
 	 * @param WC_Order
-	 * @param bool $force Force all props to be written even if not changed. This is used during creation.
 	 * @since 2.7.0
 	 */
-	protected function update_post_meta( &$order, $force = false ) {
+	protected function update_post_meta( &$order ) {
 		$updated_props     = array();
-		$changed_props     = array_keys( $order->get_changes() );
 		$meta_key_to_props = array(
 			'_order_currency'     => 'currency',
 			'_cart_discount'      => 'discount_total',
@@ -222,18 +220,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'_order_version'      => 'version',
 			'_prices_include_tax' => 'prices_include_tax',
 		);
-		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( ! in_array( $prop, $changed_props ) && ! $force ) {
-				continue;
-			}
-			$value = $order->{"get_$prop"}( 'edit' );
 
-			if ( '' !== $value ) {
-				$updated = update_post_meta( $order->get_id(), $meta_key, $value );
-			} else {
-				$updated = delete_post_meta( $order->get_id(), $meta_key );
-			}
-
+		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
+		foreach ( $props_to_update as $meta_key => $prop ) {
+			$value   = $order->{"get_$prop"}( 'edit' );
+			$updated = update_post_meta( $order->get_id(), $meta_key, $value );
 			if ( $updated ) {
 				$updated_props[] = $prop;
 			}

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -69,7 +69,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 
 		if ( $coupon_id ) {
 			$coupon->set_id( $coupon_id );
-			$this->update_post_meta( $coupon, true );
+			$this->update_post_meta( $coupon );
 			$coupon->save_meta_data();
 			$coupon->apply_changes();
 			do_action( 'woocommerce_new_coupon', $coupon_id );
@@ -166,13 +166,10 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * Helper method that updates all the post meta for a coupon based on it's settings in the WC_Coupon class.
 	 *
 	 * @param WC_Coupon
-	 * @param bool $force Force all props to be written even if not changed. This is used during creation.
 	 * @since 2.7.0
 	 */
-	private function update_post_meta( &$coupon, $force = false ) {
+	private function update_post_meta( &$coupon ) {
 		$updated_props     = array();
-		$changed_props     = array_keys( $coupon->get_changes() );
-
 		$meta_key_to_props = array(
 			'discount_type'              => 'discount_type',
 			'coupon_amount'              => 'amount',
@@ -193,10 +190,8 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			'customer_email'             => 'email_restrictions',
 		);
 
-		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( ! in_array( $prop, $changed_props ) && ! $force ) {
-				continue;
-			}
+		$props_to_update = $this->get_props_to_update( $coupon, $meta_key_to_props );
+		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $coupon->{"get_$prop"}( 'edit' );
 			switch ( $prop ) {
 				case 'individual_use' :

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -178,8 +178,6 @@ class WC_Data_Store_WP {
 		$props_to_update = array();
 		$changed_props   = $object->get_changes();
 
-		error_log( print_r( $changed_props, 1 ) );
-
 		// Props should be updated if they are a part of the $changed array or don't exist yet.
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
 			if ( array_key_exists( $prop, $changed_props ) || ! metadata_exists( $meta_type, $object->get_id(), $meta_key ) ) {

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -178,23 +178,11 @@ class WC_Data_Store_WP {
 		$props_to_update = array();
 		$changed_props   = $object->get_changes();
 
-		// Normalize billing / shipping / other keys that might be part of a sub array.
-		$subs = array( 'shipping', 'billing' );
-		foreach ( $subs as $sub ) {
-			if ( ! empty( $changed_props[ $sub ] ) ) {
-				foreach ( $changed_props[ $sub ] as $sub_prop => $value ) {
-					$changed_props[ $sub . '_' . $sub_prop ] = $value;
-				}
-				unset( $changed_props[ $sub ] );
-			}
-		}
+		error_log( print_r( $changed_props, 1 ) );
 
 		// Props should be updated if they are a part of the $changed array or don't exist yet.
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( array_key_exists( $prop, $changed_props ) ) {
-				$props_to_update[ $meta_key ] = $prop;
-			}
-			if ( ! metadata_exists( $meta_type, $object->get_id(), $meta_key ) ) {
+			if ( array_key_exists( $prop, $changed_props ) || ! metadata_exists( $meta_type, $object->get_id(), $meta_key ) ) {
 				$props_to_update[ $meta_key ] = $prop;
 			}
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -138,12 +138,10 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * Helper method that updates all the post meta for an order based on it's settings in the WC_Order class.
 	 *
 	 * @param WC_Order
-	 * @param bool $force Force all props to be written even if not changed. This is used during creation.
 	 * @since 2.7.0
 	 */
-	protected function update_post_meta( &$order, $force = false ) {
+	protected function update_post_meta( &$order ) {
 		$updated_props     = array();
-		$changed_props     = $order->get_changes();
 		$meta_key_to_props = array(
 			'_order_key'            => 'order_key',
 			'_customer_user'        => 'customer_id',
@@ -158,15 +156,11 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			'_cart_hash'            => 'cart_hash',
 		);
 
-		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( ! array_key_exists( $prop, $changed_props ) && ! $force ) {
-				continue;
-			}
+		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
+		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $order->{"get_$prop"}( 'edit' );
-
-			if ( '' !== $value ? update_post_meta( $order->get_id(), $meta_key, $value ) : delete_post_meta( $order->get_id(), $meta_key ) ) {
-				$updated_props[] = $prop;
-			}
+			update_post_meta( $order->get_id(), $meta_key, $value );
+			$updated_props[] = $prop;
 		}
 
 		$address_props = array(
@@ -197,21 +191,16 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		);
 
 		foreach ( $address_props as $props_key => $props ) {
-			foreach ( $props as $meta_key => $prop ) {
-				$prop_key = substr( $prop, 8 );
-				if ( ! $force && ( ! isset( $changed_props[ $props_key ] ) || ! array_key_exists( $prop_key, $changed_props[ $props_key ] ) ) ) {
-					continue;
-				}
+			$props_to_update = $this->get_props_to_update( $order, $props );
+			foreach ( $props_to_update as $meta_key => $prop ) {
 				$value = $order->{"get_$prop"}( 'edit' );
-
-				if ( '' !== $value ? update_post_meta( $order->get_id(), $meta_key, $value ) : delete_post_meta( $order->get_id(), $meta_key ) ) {
-					$updated_props[] = $prop;
-					$updated_props[] = $props_key;
-				}
+				update_post_meta( $order->get_id(), $meta_key, $value );
+				$updated_props[] = $prop;
+				$updated_props[] = $props_key;
 			}
 		}
 
-		parent::update_post_meta( $order, $force );
+		parent::update_post_meta( $order );
 
 		// If address changed, store concatinated version to make searches faster.
 		if ( in_array( 'billing', $updated_props ) || ! metadata_exists( 'post', $order->get_id(), '_billing_address_index' ) ) {

--- a/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -57,26 +57,21 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 	 * @param bool $force Force all props to be written even if not changed. This is used during creation.
 	 * @since 2.7.0
 	 */
-	protected function update_post_meta( &$refund, $force = false ) {
-		parent::update_post_meta( $refund, $force );
+	protected function update_post_meta( &$refund ) {
+		parent::update_post_meta( $refund );
 
 		$updated_props     = array();
-		$changed_props     = $refund->get_changes();
 		$meta_key_to_props = array(
 			'_refund_amount' => 'amount',
 			'_refunded_by'   => 'refunded_by',
 			'_refund_reason' => 'reason',
 		);
 
-		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( ! array_key_exists( $prop, $changed_props ) && ! $force ) {
-				continue;
-			}
+		$props_to_update = $this->get_props_to_update( $refund, $meta_key_to_props );
+		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $refund->{"get_$prop"}( 'edit' );
-
-			if ( '' !== $value ? update_post_meta( $refund->get_id(), $meta_key, $value ) : delete_post_meta( $refund->get_id(), $meta_key ) ) {
-				$updated_props[] = $prop;
-			}
+			update_post_meta( $refund->get_id(), $meta_key, $value );
+			$updated_props[] = $prop;
 		}
 	}
 

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -16,10 +16,9 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 * Helper method that updates all the post meta for a grouped product.
 	 *
 	 * @param WC_Product
-	 * @param bool $force Force all props to be written even if not changed. This is used during creation.
 	 * @since 2.7.0
 	 */
-	protected function update_post_meta( &$product, $force = false ) {
+	protected function update_post_meta( &$product ) {
 		if ( update_post_meta( $product->get_id(), '_children', $product->get_children( 'edit' ) ) ) {
 			$child_prices = array();
 			foreach ( $product->get_children( 'edit' ) as $child_id ) {
@@ -39,7 +38,7 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 			$this->extra_data_saved = true;
 		}
 
-		parent::update_post_meta( $product, $force );
+		parent::update_post_meta( $product );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -250,10 +250,9 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 *
 	 * @since 2.7.0
 	 * @param WC_Product
-	 * @param bool $force Force all props to be written even if not changed. This is used during creation.
 	 */
-	public function update_post_meta( &$product, $force = false ) {
+	public function update_post_meta( &$product ) {
 		update_post_meta( $product->get_id(), '_variation_description', $product->get_description() );
-		parent::update_post_meta( $product, $force );
+		parent::update_post_meta( $product );
 	}
 }


### PR DESCRIPTION
@mikejolley I used the idea you came up with here: https://github.com/woocommerce/woocommerce/pull/12842#issuecomment-274469142

It nicely removes the force logic and seems to handle things correctly. Fixed the coupons bug, and I tested updating various order and product properties as well.

Moving to a new PR/branch since it's different from the original attempt.

Fixes #12816.