### PR TITLE
Fix get_hook_prefix format

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -510,7 +510,7 @@ abstract class WC_Data {
 	 * @return string
 	 */
 	protected function get_hook_prefix() {
-		return 'woocommerce_get_' . $this->object_type . '_';
+		return 'woocommerce_' . $this->object_type . '_get_';
 	}
 
 	/**

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -116,7 +116,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return string
 	 */
 	protected function get_hook_prefix() {
-		return 'woocommerce_get_coupon_';
+		return 'woocommerce_coupon_get_';
 	}
 
 	/*

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -119,7 +119,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return string
 	 */
 	protected function get_hook_prefix() {
-		return 'woocommerce_get_customer_';
+		return 'woocommerce_customer_get_';
 	}
 
 	/**

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -44,7 +44,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @return string
 	 */
 	protected function get_hook_prefix() {
-		return 'woocommerce_get_product_variation_';
+		return 'woocommerce_product_variation_get_';
 	}
 
 	/**


### PR DESCRIPTION
* The Payment Token Data classes use the format `woocommerce_OBJECT_get_` for filters. 
* `$wc_map_deprecated_filters` in `wc-deprecated-functions.php` also defines the new filters as `woocommerce_OBJECT_get_`. https://github.com/woocommerce/woocommerce/blob/08644c6f42227d76f67b02335810df1a5ff8cc3d/includes/wc-deprecated-functions.php#L580
* All the other data classes define their `get_hook_prefix` as `woocommerce_get_OBJECT_`.

I think having the object name first is cleaner, and it matches the deprecated functions code. I don't see anything else in 2.7 using these filters and it's early enough to change the hook prefix before release.

I'm happy to update `$wc_map_deprecated_filters` instead, but I prefer the object name first.