### PR TITLE
Remove redundant WC_Product::get_data() method

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -146,23 +146,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	*/
 
 	/**
-	 * Get all class data in array format.
-	 * @since 2.7.0
-	 * @return array
-	 */
-	public function get_data() {
-		return array_merge(
-			array(
-				'id' => $this->get_id(),
-			),
-			$this->data,
-			array(
-				'meta_data' => $this->get_meta_data(),
-			)
-		);
-	}
-
-	/**
 	 * Get product name.
 	 *
 	 * @since 2.7.0


### PR DESCRIPTION
`WC_Product::get_data()` is functionally the same as `WC_Data::get_data()`, which is already inherited from `WC_Abstract_Legacy_Product`. The only difference between `WC_Product::get_data()` & `WC_Data::get_data()` is whitespace. Given that, it's unecessary to define `WC_Product::get_data()`, which is why this PR removes it.