### PR TITLE
Check post type during read of product variations

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -37,7 +37,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	public function read( &$product ) {
 		$product->set_defaults();
 
-		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) ) {
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || 'product_variation' !== $post_object->post_type ) {
 			return;
 		}
 


### PR DESCRIPTION
#12795 changed the `read()` method for a number of data stores to check the post type, including the post type for `'product'` data. It didn't add the post type check for the variation data store.

I couldn't see a reason why, so I suspect the half broken object  issue fixed in #12795 still exists for product variations. This PR fixes that. It also makes the validation in `read()` more consistent.