### PR TITLE
Add WC_Product_Data_Store_CPT::read_extra_data()

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -136,6 +136,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$this->read_downloads( $product );
 		$this->read_visibility( $product );
 		$this->read_product_data( $product );
+		$this->read_extra_data( $product );
 		$product->set_object_read( true );
 	}
 
@@ -260,9 +261,15 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'download_expiry'    => get_post_meta( $id, '_download_expiry', true ),
 			'image_id'           => get_post_thumbnail_id( $id ),
 		) );
+	}
 
-		// Gets extra data associated with the product.
-		// Like button text or product URL for external products.
+	/**
+	 * Read extra data associated with the product, like button text or product URL for external products.
+	 *
+	 * @param WC_Product
+	 * @since 2.7.0
+	 */
+	protected function read_extra_data( &$product ) {
 		foreach ( $product->get_extra_data_keys() as $key ) {
 			$function = 'set_' . $key;
 			if ( is_callable( array( $product, $function ) ) ) {

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -66,6 +66,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		) );
 
 		$this->read_product_data( $product );
+		$this->read_extra_data( $product );
 		$product->set_attributes( wc_get_product_variation_attributes( $product->get_id() ) );
 
 		// Set object_read true once all data is read.


### PR DESCRIPTION
The PR adds a `WC_Product_Data_Store_CPT::read_extra_data()` method so that a product's `$extra_data` property can also be se by child classes of `WC_Product_Data_Store_CPT`, like `WC_Product_Variation_Data_Store_CPT`, without duplicating the code to read it that is currently used in `WC_Product_Data_Store_CPT::read_product_data()`.

The PR then calls the new `WC_Product_Variation_Data_Store_CPT::read_extra_data()` in `WC_Product_Variation_Data_Store_CPT::read()` so that classes that extend `WC_Product_Variation` can use the existing `WC_Product_Variation_Data_Store_CPT` class, rather than having to create a new data store class just to set the `WC_Product_Variation::$extra_data` values.