### PR TITLE
When updating payment tokens, only update the props that have changed & fire off a hook of the changed props.

### DIFF
--- a/tests/unit-tests/payment-tokens/payment-token.php
+++ b/tests/unit-tests/payment-tokens/payment-token.php
@@ -122,10 +122,12 @@ class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 		$token = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
 		$this->assertEquals( __FUNCTION__, $token->get_extra() );
 		$token->set_extra( ':)' );
+		$token->set_user_id( 2 );
 		$token->save();
 
 		$token = new WC_Payment_Token_Stub( $token->get_id() );
 		$this->assertEquals( ':)', $token->get_extra() );
+		$this->assertEquals( 2, $token->get_user_id() );
 	}
 
 	/**


### PR DESCRIPTION
See the comment here: https://github.com/woocommerce/woocommerce/pull/12968#pullrequestreview-18284222