### PR TITLE
Disable coverage except on master, not PR, latest stable builds

### DIFF
--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,4 +1,4 @@
-if [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
+if [[ ${TRAVIS_BRANCH} == 'master' ]] && [[ ${TRAVIS_EVENT_TYPE} != 'pull_request' ]] && [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
 	phpunit -c phpunit.xml.dist --coverage-clover ./tmp/clover.xml
 else
 	phpunit -c phpunit.xml.dist

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -49,8 +49,8 @@ elif [ $1 == 'during' ]; then
 
 elif [ $1 == 'after' ]; then
 
-	## Only run on latest stable PHP box (defined in .travis.yml).
-	if [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
+	## Only run on master, not pull requests, latest stable PHP box (defined in .travis.yml).
+	if [[ ${TRAVIS_BRANCH} == 'master' ]] && [[ ${TRAVIS_EVENT_TYPE} != 'pull_request' ]] && [[ ${TRAVIS_PHP_VERSION} == ${PHP_LATEST_STABLE} ]]; then
 		wget https://scrutinizer-ci.com/ocular.phar
 		chmod +x ocular.phar
 		php ocular.phar code-coverage:upload --format=php-clover ./tmp/clover.xml


### PR DESCRIPTION
This PR disables PHPUnit clover coverage reports for most builds. They remain enabled for `master` branch, latest stable box (`7.1`), non-PR events.

This is based on the assumption that scrutinizer coverage reports are not relevant for the excluded builds.

If this assumption is correct and the PR is merged, we should verify that `master` `7.1` continues to generate and upload coverage reports.

This should vastly increase the speed of most automated travis builds.