### PR TITLE
WC_Tax::get_tax_class_slugs()

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1038,11 +1038,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			// Inherit tax class from items
 			if ( 'inherit' === $shipping_tax_class ) {
 				$tax_rates         = array();
-				$tax_classes       = array_merge( array( '' ), WC_Tax::get_tax_classes() );
+				$tax_classes       = array_merge( array( '' ), WC_Tax::get_tax_class_slugs() );
 				$found_tax_classes = $this->get_items_tax_classes();
 
 				foreach ( $tax_classes as $tax_class ) {
-					$tax_class = sanitize_title( $tax_class );
 					if ( in_array( $tax_class, $found_tax_classes ) ) {
 						$tax_rates = WC_Tax::find_shipping_rates( array(
 							'country'   => $args['country'],

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -81,9 +81,9 @@ class WC_Settings_Tax extends WC_Settings_Page {
 	public function output() {
 		global $current_section;
 
-		$tax_classes = WC_Tax::get_tax_classes();
+		$tax_classes = WC_Tax::get_tax_class_slugs();
 
-		if ( 'standard' === $current_section || in_array( $current_section, array_map( 'sanitize_title', $tax_classes ) ) ) {
+		if ( 'standard' === $current_section || in_array( $current_section, $tax_classes ) ) {
 			$this->output_tax_rates();
 		} else {
 			$settings = $this->get_settings();

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -2622,7 +2622,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 			$params['tax_class'] = array(
 				'description'       => __( 'Limit result set to products with a specific tax class.', 'woocommerce' ),
 				'type'              => 'string',
-				'enum'              => array_map( 'sanitize_title', array_merge( array( 'standard' ), WC_Tax::get_tax_classes() ) ),
+				'enum'              => array_merge( array( 'standard' ), WC_Tax::get_tax_class_slugs() ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'validate_callback' => 'rest_validate_request_arg',
 			);

--- a/includes/api/class-wc-rest-taxes-controller.php
+++ b/includes/api/class-wc-rest-taxes-controller.php
@@ -626,7 +626,7 @@ class WC_REST_Taxes_Controller extends WC_REST_Controller {
 					'description' => __( 'Tax class.', 'woocommerce' ),
 					'type'        => 'string',
 					'default'     => 'standard',
-					'enum'        => array_merge( array( 'standard' ), array_map( 'sanitize_title', WC_Tax::get_tax_classes() ) ),
+					'enum'        => array_merge( array( 'standard' ), WC_Tax::get_tax_class_slugs() ),
 					'context'     => array( 'view', 'edit' ),
 				),
 			),
@@ -684,7 +684,7 @@ class WC_REST_Taxes_Controller extends WC_REST_Controller {
 		);
 		$params['class'] = array(
 			'description'        => __( 'Sort by tax class.', 'woocommerce' ),
-			'enum'               => array_merge( array( 'standard' ), array_map( 'sanitize_title', WC_Tax::get_tax_classes() ) ),
+			'enum'               => array_merge( array( 'standard' ), WC_Tax::get_tax_class_slugs() ),
 			'sanitize_callback'  => 'sanitize_title',
 			'type'               => 'string',
 			'validate_callback'  => 'rest_validate_request_arg',

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -41,7 +41,7 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_tax_class( $value ) {
-		if ( $value && ! in_array( $value, WC_Tax::get_tax_classes() ) ) {
+		if ( $value && ! in_array( $value, WC_Tax::get_tax_class_slugs() ) ) {
 			$this->error( 'order_item_fee_invalid_tax_class', __( 'Invalid tax class', 'woocommerce' ) );
 		}
 		$this->set_prop( 'tax_class', $value );

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -57,7 +57,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_tax_class( $value ) {
-		if ( $value && ! in_array( $value, WC_Tax::get_tax_classes() ) ) {
+		if ( $value && ! in_array( $value, WC_Tax::get_tax_class_slugs() ) ) {
 			$this->error( 'order_item_product_invalid_tax_class', __( 'Invalid tax class', 'woocommerce' ) );
 		}
 		$this->set_prop( 'tax_class', $value );

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -550,10 +550,9 @@ class WC_Tax {
 
 				// If multiple classes are found, use the first one found unless a standard rate item is found. This will be the first listed in the 'additonal tax class' section.
 				if ( sizeof( $cart_tax_classes ) > 1 && ! in_array( '', $cart_tax_classes ) ) {
-					$tax_classes = self::get_tax_classes();
+					$tax_classes = self::get_tax_class_slugs();
 
 					foreach ( $tax_classes as $tax_class ) {
-						$tax_class = sanitize_title( $tax_class );
 						if ( in_array( $tax_class, $cart_tax_classes ) ) {
 							$matched_tax_rates = self::find_shipping_rates( array(
 								'country' 	=> $country,
@@ -698,6 +697,16 @@ class WC_Tax {
 	}
 
 	/**
+	 * Get store tax classes as slugs.
+	 *
+	 * @since  2.7.0
+	 * @return array
+	 */
+	public static function get_tax_class_slugs() {
+		return array_map( 'sanitize_title', self::get_tax_classes() );
+	}
+
+	/**
 	 * format the city.
 	 * @param  string $city
 	 * @return string
@@ -759,9 +768,9 @@ class WC_Tax {
 	 * @return string
 	 */
 	public static function format_tax_rate_class( $class ) {
-		$class = sanitize_title( $class );
-		$sanitized_classes = array_map( 'sanitize_title', self::get_tax_classes() );
-		if ( ! in_array( $class, $sanitized_classes ) ) {
+		$class   = sanitize_title( $class );
+		$classes = self::get_tax_class_slugs();
+		if ( ! in_array( $class, $classes ) ) {
 			$class = '';
 		}
 		return ( 'standard' === $class ) ? '' : $class;

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -690,7 +690,7 @@ class WC_Tax {
 
 	/**
 	 * Get store tax classes.
-	 * @return array
+	 * @return array Array of class names ("Reduced rate", "Zero rate", etc).
 	 */
 	public static function get_tax_classes() {
 		return array_filter( array_map( 'trim', explode( "\n", get_option( 'woocommerce_tax_classes' ) ) ) );
@@ -700,7 +700,7 @@ class WC_Tax {
 	 * Get store tax classes as slugs.
 	 *
 	 * @since  2.7.0
-	 * @return array
+	 * @return array Array of class slugs ("reduced-rate", "zero-rate", etc).
 	 */
 	public static function get_tax_class_slugs() {
 		return array_map( 'sanitize_title', self::get_tax_classes() );

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -442,8 +442,10 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	 */
 	public function test_get_tax_classes() {
 		$tax_classes = WC_Tax::get_tax_classes();
-
 		$this->assertEquals( $tax_classes, array( 'Reduced rate', 'Zero rate' ) );
+
+		$tax_classes = WC_Tax::get_tax_class_slugs();
+		$this->assertEquals( $tax_classes, array( 'reduced-rate', 'zero-rate' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12859.

There are many places sanitize_title is used on the return value of `get_tax_classes` (and as seen in #12859, some places where it should have been used). In the spirit of DYI, `get_tax_class_slugs`  return slugs instead of name.