### PR TITLE
Move price sorting into WC_Product_Variable::sort_variation_prices()

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -68,7 +68,14 @@ class WC_Product_Variable extends WC_Product {
 	 */
 	public function get_variation_prices( $include_taxes = false ) {
 		$data_store = $this->get_data_store();
-		return $data_store->read_price_data( $this, $include_taxes );
+
+		$prices = $data_store->read_price_data( $this, $include_taxes );
+
+		foreach ( $prices as $price_key => $variation_prices ) {
+			$prices[ $price_key ] = $this->sort_variation_prices( $variation_prices );
+		}
+
+		return $prices;
 	}
 
 	/**
@@ -484,5 +491,16 @@ class WC_Product_Variable extends WC_Product {
 			}
 		}
 		return $product;
+	}
+
+	/**
+	 * Sort an associativate array of $variation_id => $price pairs in order of min and max prices.
+	 *
+	 * @param array $prices Associativate array of $variation_id => $price pairs
+	 * @return array
+	 */
+	protected function sort_variation_prices( $prices ) {
+		asort( $prices );
+		return $prices;
 	}
 }

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -205,10 +205,6 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					}
 				}
 
-				asort( $prices );
-				asort( $regular_prices );
-				asort( $sale_prices );
-
 				$transient_cached_prices_array[ $price_hash ] = array(
 					'price'         => $prices,
 					'regular_price' => $regular_prices,


### PR DESCRIPTION
Although the calls to `asort()` in `WC_Product_Variable_Data_Store_CPT::read_price_data()` are only a few lines of code, they break the neat separation of business logic between `WC_Product_Variable` and `WC_Product_Variable_Data_Store_CPT`.

It makes sense to keep `WC_Product_Variable` responsible for all variable product business logic, like determining min/max prices, and have `WC_Product_Variable_Data_Store_CPT` only responsible for moving data in and out of the database. This makes `WC_Product_Variable_Data_Store_CPT` reusable for other variable product types.

This patch adds a new `WC_Product_Variable::sort_variation_prices()` function to move the variation sorting logic inside the variable product class. Although its a fairly trivial function in `WC_Product_Variable`, with just a call to `asort()`, it makes it possible for extensions like Subscriptions to implement much more complex sorting logic without changing the way the variation data is stored in `WC_Product_Variable_Data_Store_CPT::read_price_data()`.

The approach used in this PR calls the sorting function after retrieving the data. The upside of this approach is that the sorting is completely encapsulated within `WC_Product_Variable`. The store class doesn't even know the data needs to be sorted for display. The downside is that the values aren't cached in their sorted order, which will have a minor impact on performance. If this is an issue, the `WC_Product_Variable::sort_variation_prices()` method could be made public and instead called from within `WC_Product_Variable_Data_Store_CPT::read_price_data()` like this: https://cloudup.com/c9D1guiKhzU