### PR TITLE
Honour default checkout_get_value

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -961,8 +961,11 @@ class WC_Checkout {
 			return wc_clean( $_POST[ $input ] );
 
 		} else {
-			if ( has_filter( 'woocommerce_checkout_get_value' ) ) {
-				return apply_filters( 'woocommerce_checkout_get_value', null, $input );
+
+			$value = apply_filters( 'woocommerce_checkout_get_value', null, $input );
+
+			if ( $value !== null ) {
+				return $value;
 			}
 
 			if ( is_callable( array( WC()->customer, "get_$input" ) ) ) {


### PR DESCRIPTION
Prior to SHA: 43d362d1, `WC_Checkout::get_value()` would set the default value for an `$input` if the value after being passed through filters was still `null`. This logic changed with SHA: 43d362d1 to [_always_ return the filtered value](https://github.com/woocommerce/woocommerce/commit/43d362d10792711bd34ea490c714a540cb763b1d#diff-1144db956b12f18d5935fdc3989109b3R896), even if it the value was not changed by filters and was still `null`.

This means if 3rd party code filters just some checkout values, like only `order_comments`, then all other checkout fields will default to `null`.

This patch fixes that by restoring the old logic and returning the default value if the filtered value is still `null`.

To test, run the snippet below with and without the patch in this PR:

```
function eg_destroy_all_checkout_fields( $default, $key ) {

	if ( 'order_comments' === $key ) {
		$default = 'Here is a default comment that makes all other checkout fields null, lolz.';
	}

	return $default;
}
add_filter( 'woocommerce_checkout_get_value', 'eg_destroy_all_checkout_fields', 1000, 2 );
```

Example screenshots with the above snippet running:

* with the patch from this PR: https://cloudup.com/cOL45u8kiQr
* without the patch from this PR: https://cloudup.com/c7bYxhfirQa (NB: all fields are empty)
