### PR TITLE
fixed order status for downloaded or virtual product #13017

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -115,7 +115,7 @@ class WC_Order extends WC_Abstract_Order {
 				if ( sizeof( $this->get_items() ) > 0 ) {
 					foreach ( $this->get_items() as $item ) {
 						if ( $item->is_type( 'line_item' ) && ( $product = $item->get_product() ) ) {
-							$virtual_downloadable_item = $product->is_downloadable() && $product->is_virtual();
+							$virtual_downloadable_item = $product->is_downloadable() || $product->is_virtual();
 
 							if ( apply_filters( 'woocommerce_order_item_needs_processing', ! $virtual_downloadable_item, $product, $this->get_id() ) ) {
 								$order_needs_processing = true;


### PR DESCRIPTION
Condition for checking if product is downloadable was wrong, because a product can't be both virtual and downloadable as mentioned in #13017 issue. 