### PR TITLE
Check SHOP_IS_ON_FRONT existence before defining it

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -285,7 +285,9 @@ class WC_Query {
 			}
 
 			// Define a variable so we know this is the front page shop later on
-			define( 'SHOP_IS_ON_FRONT', true );
+			if ( ! defined( 'SHOP_IS_ON_FRONT' ) ) {
+				define( 'SHOP_IS_ON_FRONT', true );
+			}
 
 			// Get the actual WP page to avoid errors and let us use is_front_page()
 			// This is hacky but works. Awaiting https://core.trac.wordpress.org/ticket/21096


### PR DESCRIPTION
I propose to introduce this check to allow to call the WC_Query::pre_get_posts() action several times in integration tests with phpunit.