### PR TITLE
Allow password resets when account page isn’t set

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -22,11 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string
  */
 function wc_lostpassword_url( $default_url = '' ) {
-	$wc_password_reset_url  = wc_get_page_permalink( 'myaccount' );
+	$wc_account_page_url    = wc_get_page_permalink( 'myaccount' );
+	$wc_account_page_exists = wc_get_page_id( 'myaccount' ) > 0;
 	$lost_password_endpoint = get_option( 'woocommerce_myaccount_lost_password_endpoint' );
 
-	if ( false !== $wc_password_reset_url && ! empty( $lost_password_endpoint ) ) {
-		return wc_get_endpoint_url( $lost_password_endpoint, '', $wc_password_reset_url );
+	if ( $wc_account_page_exists && ! empty( $lost_password_endpoint ) ) {
+		return wc_get_endpoint_url( $lost_password_endpoint, '', $wc_account_page_url );
 	} else {
 		return $default_url;
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/13027. Posted a description of what causes this issue there.

Ensured that this will work in the rare cases where My Account is set to be the home page as well. Otherwise would have just checked $wc_account_page_url against get_home_url().

Manually delete `woocommerce_myaccount_page_id` from the options table for quick testing.