### PR TITLE
Fix wording on deprecation messages

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-order.php
+++ b/includes/abstracts/abstract-wc-legacy-order.php
@@ -25,7 +25,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function add_coupon( $code = array(), $discount = 0, $discount_tax = 0 ) {
-		wc_deprecated_function( 'WC_Order::add_coupon', '2.7', 'Create new WC_Order_Item_Coupon object and add to order with WC_Order::add_item()' );
+		wc_deprecated_function( 'WC_Order::add_coupon', '2.7', 'a new WC_Order_Item_Coupon object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Coupon();
 		$item->set_props( array(
@@ -36,7 +36,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 		) );
 		$item->save();
 		$this->add_item( $item );
-		wc_do_deprecated_action( 'woocommerce_order_add_coupon', array( $this->get_id(), $item->get_id(), $code, $discount, $discount_tax ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+		wc_do_deprecated_action( 'woocommerce_order_add_coupon', array( $this->get_id(), $item->get_id(), $code, $discount, $discount_tax ), '2.7', 'woocommerce_new_order_item action instead.' );
 		return $item->get_id();
 	}
 
@@ -49,7 +49,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function add_tax( $tax_rate_id, $tax_amount = 0, $shipping_tax_amount = 0 ) {
-		wc_deprecated_function( 'WC_Order::add_tax', '2.7', 'Create new WC_Order_Item_Tax object and add to order with WC_Order::add_item()' );
+		wc_deprecated_function( 'WC_Order::add_tax', '2.7', 'a new WC_Order_Item_Tax object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Tax();
 		$item->set_props( array(
@@ -61,7 +61,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 		$item->set_order_id( $this->get_id() );
 		$item->save();
 		$this->add_item( $item );
-		wc_do_deprecated_action( 'woocommerce_order_add_tax', array( $this->get_id(), $item->get_id(), $tax_rate_id, $tax_amount, $shipping_tax_amount ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+		wc_do_deprecated_action( 'woocommerce_order_add_tax', array( $this->get_id(), $item->get_id(), $tax_rate_id, $tax_amount, $shipping_tax_amount ), '2.7', 'woocommerce_new_order_item action instead.' );
 		return $item->get_id();
 	}
 
@@ -72,7 +72,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function add_shipping( $shipping_rate ) {
-		wc_deprecated_function( 'WC_Order::add_shipping', '2.7', 'Create new WC_Order_Item_Shipping object and add to order with WC_Order::add_item()' );
+		wc_deprecated_function( 'WC_Order::add_shipping', '2.7', 'a new WC_Order_Item_Shipping object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Shipping();
 		$item->set_props( array(
@@ -87,7 +87,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 		}
 		$item->save();
 		$this->add_item( $item );
-		wc_do_deprecated_action( 'woocommerce_order_add_shipping', array( $this->get_id(), $item->get_id(), $shipping_rate ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+		wc_do_deprecated_action( 'woocommerce_order_add_shipping', array( $this->get_id(), $item->get_id(), $shipping_rate ), '2.7', 'woocommerce_new_order_item action instead.' );
 		return $item->get_id();
 	}
 
@@ -99,7 +99,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function add_fee( $fee ) {
-		wc_deprecated_function( 'WC_Order::add_fee', '2.7', 'Create new WC_Order_Item_Fee object and add to order with WC_Order::add_item()' );
+		wc_deprecated_function( 'WC_Order::add_fee', '2.7', 'a new WC_Order_Item_Fee object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Fee();
 		$item->set_props( array(
@@ -114,7 +114,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 		) );
 		$item->save();
 		$this->add_item( $item );
-		wc_do_deprecated_action( 'woocommerce_order_add_fee', array( $this->get_id(), $item->get_id(), $fee ), '2.7', 'Use woocommerce_new_order_item action instead.' );
+		wc_do_deprecated_action( 'woocommerce_order_add_fee', array( $this->get_id(), $item->get_id(), $fee ), '2.7', 'woocommerce_new_order_item action instead.' );
 		return $item->get_id();
 	}
 
@@ -130,7 +130,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	 public function update_product( $item, $product, $args ) {
-		wc_deprecated_function( 'WC_Order::update_product', '2.7', 'Interact with WC_Order_Item_Product class' );
+		wc_deprecated_function( 'WC_Order::update_product', '2.7', 'an interaction with the WC_Order_Item_Product class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
 		}
@@ -179,7 +179,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function update_coupon( $item, $args ) {
-		wc_deprecated_function( 'WC_Order::update_coupon', '2.7', 'Interact with WC_Order_Item_Coupon class' );
+		wc_deprecated_function( 'WC_Order::update_coupon', '2.7', 'an interaction with the WC_Order_Item_Coupon class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
 		}
@@ -218,7 +218,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function update_shipping( $item, $args ) {
-		wc_deprecated_function( 'WC_Order::update_shipping', '2.7', 'Interact with WC_Order_Item_Shipping class' );
+		wc_deprecated_function( 'WC_Order::update_shipping', '2.7', 'an interaction with the WC_Order_Item_Shipping class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
 		}
@@ -255,7 +255,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function update_fee( $item, $args ) {
-		wc_deprecated_function( 'WC_Order::update_fee', '2.7', 'Interact with WC_Order_Item_Fee class' );
+		wc_deprecated_function( 'WC_Order::update_fee', '2.7', 'an interaction with the WC_Order_Item_Fee class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
 		}
@@ -286,7 +286,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @throws WC_Data_Exception
 	 */
 	public function update_tax( $item, $args ) {
-		wc_deprecated_function( 'WC_Order::update_tax', '2.7', 'Interact with WC_Order_Item_Tax class' );
+		wc_deprecated_function( 'WC_Order::update_tax', '2.7', 'an interaction with the WC_Order_Item_Tax class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
 		}

--- a/includes/abstracts/abstract-wc-legacy-payment-token.php
+++ b/includes/abstracts/abstract-wc-legacy-payment-token.php
@@ -22,7 +22,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 * @deprecated 2.7.0 - Init a token class with an ID.
 	 */
 	public function read( $token_id ) {
-		wc_deprecated_function( 'WC_Payment_Token::read', '2.7', 'Init a token class with an ID.' );
+		wc_deprecated_function( 'WC_Payment_Token::read', '2.7', 'a new token class initialized with an ID.' );
 		$this->set_id( $token_id );
 		$data_store = WC_Data_Store::load( 'payment-token' );
 		$data_store->read( $this );
@@ -33,7 +33,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 * @deprecated 2.7.0 - Use ::save instead.
 	 */
 	public function update() {
-		wc_deprecated_function( 'WC_Payment_Token::update', '2.7', 'Use ::save instead.' );
+		wc_deprecated_function( 'WC_Payment_Token::update', '2.7', '::save instead.' );
 		$data_store = WC_Data_Store::load( 'payment-token' );
 		try {
 			$data_store->update( $this );
@@ -47,7 +47,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 * @deprecated 2.7.0 - Use ::save instead.
 	 */
 	public function create() {
-		wc_deprecated_function( 'WC_Payment_Token::create', '2.7', 'Use ::save instead.' );
+		wc_deprecated_function( 'WC_Payment_Token::create', '2.7', '::save instead.' );
 		$data_store = WC_Data_Store::load( 'payment-token' );
 		try {
 			$data_store->create( $this );

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -417,7 +417,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return bool
 	 */
 	public function has_default_attributes() {
-		wc_deprecated_function( 'WC_Product_Variable::has_default_attributes', '2.7', 'Check WC_Product::get_default_attributes directly' );
+		wc_deprecated_function( 'WC_Product_Variable::has_default_attributes', '2.7', 'a check against WC_Product::get_default_attributes directly' );
 		if ( ! $this->get_default_attributes() ) {
 			return true;
 		}
@@ -431,7 +431,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return int
 	 */
 	public function get_variation_id() {
-		wc_deprecated_function( 'WC_Product::get_variation_id', '2.7', 'WC_Product::get_id() will always be the variation ID if this is a variation.' );
+		wc_deprecated_function( 'WC_Product::get_variation_id', '2.7', 'WC_Product::get_id(). It will always be the variation ID if this is a variation.' );
 		return $this->get_id();
 	}
 
@@ -453,7 +453,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return boolean
 	 */
 	public function has_all_attributes_set() {
-		wc_deprecated_function( 'WC_Product::has_all_attributes_set', '2.7', 'Use array filter on get_variation_attributes for a quick solution.' );
+		wc_deprecated_function( 'WC_Product::has_all_attributes_set', '2.7', 'an array filter on get_variation_attributes for a quick solution.' );
 		$set = true;
 
 		// undefined attributes have null strings as array values
@@ -484,7 +484,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return int
 	 */
 	public function get_total_stock() {
-		wc_deprecated_function( 'WC_Product::get_total_stock', '2.7', 'Use get_stock_quantity on each child. Beware of performance issues in doing so.' );
+		wc_deprecated_function( 'WC_Product::get_total_stock', '2.7', 'get_stock_quantity on each child. Beware of performance issues in doing so.' );
 		if ( sizeof( $this->get_children() ) > 0 ) {
 			$total_stock = max( 0, $this->get_stock_quantity() );
 

--- a/includes/legacy/class-wc-legacy-shipping-zone.php
+++ b/includes/legacy/class-wc-legacy-shipping-zone.php
@@ -28,7 +28,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 * @deprecated 2.7.0 - Init a shipping zone with an ID.
 	 */
 	public function read( $zone_id ) {
-		wc_deprecated_function( 'WC_Shipping_Zone::read', '2.7', 'Init a shipping zone with an ID.' );
+		wc_deprecated_function( 'WC_Shipping_Zone::read', '2.7', 'a shipping zone initialized with an ID.' );
 		$this->set_id( $zone_id );
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		$data_store->read( $this );
@@ -39,7 +39,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 * @deprecated 2.7.0 - Use ::save instead.
 	 */
 	public function update() {
-		wc_deprecated_function( 'WC_Shipping_Zone::update', '2.7', 'Use ::save instead.' );
+		wc_deprecated_function( 'WC_Shipping_Zone::update', '2.7', '::save instead.' );
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		try {
 			$data_store->update( $this );
@@ -53,7 +53,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 * @deprecated 2.7.0 - Use ::save instead.
 	 */
 	public function create() {
-		wc_deprecated_function( 'WC_Shipping_Zone::create', '2.7', 'Use ::save instead.' );
+		wc_deprecated_function( 'WC_Shipping_Zone::create', '2.7', '::save instead.' );
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		try {
 			$data_store->create( $this );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/13025

Each message will already start with "Replace with $x" (wc_deprecated_function) or "Use $x" (_deprecated_function). This PR helps fix some of the grammar.