### PR TITLE
Fix direct access to order_date property

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -138,7 +138,7 @@ class WC_Shortcode_Checkout {
 						</li>
 						<li class="date">
 							<?php _e( 'Date:', 'woocommerce' ); ?>
-							<strong><?php echo date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ); ?></strong>
+							<strong><?php echo date_i18n( get_option( 'date_format' ), $order->get_date_created() ); ?></strong>
 						</li>
 						<li class="total">
 							<?php _e( 'Total:', 'woocommerce' ); ?>


### PR DESCRIPTION
While working on a fix for https://github.com/woocommerce/woocommerce-gateway-sisow-ideal/issues/9, I noticed that `order_key` is specific to the plugin but `order_date` was coming from somewhere else.

After further investigation, I found it to be within WooCommerce.

To reproduce this issue, follow the usual process to get to the checkout screen while having notices enabled.

Expected:
![screen shot 2017-01-31 at 13 53 38 pm](https://cloud.githubusercontent.com/assets/1620929/22465608/dc1a2444-e7bc-11e6-9500-b62dd0c87cf4.png)

Actual:
![screen shot 2017-01-31 at 13 53 47 pm](https://cloud.githubusercontent.com/assets/1620929/22465614/df1d3488-e7bc-11e6-8129-c1d1a13cdf1c.png)