### PR TITLE
Add WC_Abstract_Order::get_valid_statuses()

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -447,6 +447,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		return apply_filters( 'woocommerce_order_get_tax_totals', $tax_totals, $this );
 	}
 
+	/**
+	 * Get all valid statuses for this order
+	 *
+	 * @since 2.7.0
+	 * @return array Internal status keys e.g. 'wc-processing'
+	 */
+	protected function get_valid_statuses() {
+		return array_keys( wc_get_order_statuses() );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Setters
@@ -484,14 +494,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$new_status = 'wc-' === substr( $new_status, 0, 3 ) ? substr( $new_status, 3 ) : $new_status;
 
 		// Only allow valid new status
-		if ( ! in_array( 'wc-' . $new_status, array_keys( wc_get_order_statuses() ) ) ) {
+		if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses() ) ) {
 			$new_status = 'pending';
 		}
 
 		$this->set_prop( 'status', $new_status );
 
 		// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-		if ( $old_status && ! in_array( 'wc-' . $old_status, array_keys( wc_get_order_statuses() ) ) ) {
+		if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses() ) ) {
 			$old_status = 'pending';
 		}
 


### PR DESCRIPTION
So that classes which extend `WC_Abstract_Order` can define custom statuses specifically for their order type and have those statuses used for validation in `WC_Abstract_Order::set_status()` instead of just the order statuses defined by `wc_get_order_statuses()`.

For example, the subscription order type has a number of custom order statuses, like `'wc-active'`, `'wc-switched'` and `'wc-expired'`, which do not apply to orders, but are valid statuses for `WC_Subscription` objects, which extend `WC_Abstract_Order`. The `WC_Abstract_Order::get_valid_statuses()` method saves `WC_Subscription` having to reimplement the `set_status()` method just to allow `WC_Subscription` objects to have those statuses.