### PR TITLE
Merge WC_Data::$extra_data in WC_Data::__construct()

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -83,6 +83,9 @@ abstract class WC_Data {
 	 * @param int|object|array $read ID to load from the DB (optional) or already queried data.
 	 */
 	public function __construct( $read = 0 ) {
+
+		$this->data = array_merge( $this->data, $this->extra_data );
+
 		$this->default_data = $this->data;
 	}
 

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -57,7 +57,6 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @param int|object|array $item ID to load from the DB, or WC_Order_Item Object
 	 */
 	public function __construct( $item = 0 ) {
-		$this->data = array_merge( $this->data, $this->extra_data );
 		parent::__construct( $item );
 
 		if ( $item instanceof WC_Order_Item ) {

--- a/includes/class-wc-order-refund.php
+++ b/includes/class-wc-order-refund.php
@@ -39,16 +39,6 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	);
 
 	/**
-	 * Extend the abstract _data properties and then read the order object.
-	 *
-	 * @param int|object|WC_Order $read Order to init.
-	 */
-	 public function __construct( $read = 0 ) {
-		$this->data = array_merge( $this->data, $this->extra_data );
-		parent::__construct( $read );
-	}
-
-	/**
 	 * Get internal type (post type.)
 	 * @return string
 	 */

--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -27,15 +27,6 @@ class WC_Product_External extends WC_Product {
 	);
 
 	/**
-	 * Merges external product data into the parent object.
-	 * @param int|WC_Product|object $product Product to init.
-	 */
-	public function __construct( $product = 0 ) {
-		$this->data = array_merge( $this->data, $this->extra_data );
-		parent::__construct( $product );
-	}
-
-	/**
 	 * Get internal type.
 	 * @return string
 	 */

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -26,15 +26,6 @@ class WC_Product_Grouped extends WC_Product {
 	);
 
 	/**
-	 * Merges grouped product data into the parent object.
-	 * @param int|WC_Product|object $product Product to init.
-	 */
-	public function __construct( $product = 0 ) {
-		$this->data = array_merge( $this->data, $this->extra_data );
-		parent::__construct( $product );
-	}
-
-	/**
 	 * Get internal type.
 	 * @return string
 	 */


### PR DESCRIPTION
This PR refactors the way the `WC_Data::$extra_data` is handled by default.

Prior to this patch, child classes were required to merge `WC_Data::$extra_data`, as well as define it. If `WC_Data::$extra_data` is not defined in a child class, then the merge call will have no effect as `WC_Data::$extra_data` will be an the empty array. It makes sense for `WC_Data` to take care of merging it automatically when it is defined, rather than requiring it to be manually merged in the child class's constructor, as well as being defined.

This helps reduce duplicate code by removing the merging from child classes, and in some cases, that means whole child constructor definition can be removed. It also avoids a gotcha for developers (like myself) setting their own `$extra_data` values only to find they aren't being set on the classes `$data` property.