### PR TITLE
Reinstate old show/hide logic for download links and purchase notes in email order item table

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2367,7 +2367,7 @@ if ( ! function_exists( 'wc_get_email_order_items' ) ) {
 		$args     = wp_parse_args( $args, $defaults );
 		$template = $args['plain_text'] ? 'emails/plain/email-order-items.php' : 'emails/email-order-items.php';
 
-		wc_get_template( $template, array(
+		wc_get_template( $template, apply_filters( 'woocommerce_email_order_items_args', array(
 			'order'               => $order,
 			'items'               => $order->get_items(),
 			'show_download_links' => $order->is_download_permitted() && ! $args['sent_to_admin'],
@@ -2377,7 +2377,7 @@ if ( ! function_exists( 'wc_get_email_order_items' ) ) {
 			'image_size'          => $args['image_size'],
 			'plain_text'          => $args['plain_text'],
 			'sent_to_admin'       => $args['sent_to_admin'],
-		) );
+		) ) );
 
 		return apply_filters( 'woocommerce_email_order_items_table', ob_get_clean(), $order );
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2370,9 +2370,9 @@ if ( ! function_exists( 'wc_get_email_order_items' ) ) {
 		wc_get_template( $template, array(
 			'order'               => $order,
 			'items'               => $order->get_items(),
-			'show_download_links' => $order->is_download_permitted(),
+			'show_download_links' => $order->is_download_permitted() && ! $args['sent_to_admin'],
 			'show_sku'            => $args['show_sku'],
-			'show_purchase_note'  => $order->is_paid(),
+			'show_purchase_note'  => $order->is_paid() && ! $args['sent_to_admin'],
 			'show_image'          => $args['show_image'],
 			'image_size'          => $args['image_size'],
 			'plain_text'          => $args['plain_text'],


### PR DESCRIPTION
When SHA: 7b3a9b introduced `wc_get_email_order_items()`, it slightly changed the logic applied to determine whether to display:
* download links; and
* purchase notes.

In WC 2.6.13 and older, `WC_Abstract_Order::email_order_items_table()` would only display [download links](https://github.com/woocommerce/woocommerce/blob/4d155a1f28c3f21e123ff2e45c568510db40a6d1/includes/abstracts/abstract-wc-order.php#L2056) and [purchase notes](https://github.com/woocommerce/woocommerce/blob/4d155a1f28c3f21e123ff2e45c568510db40a6d1/includes/abstracts/abstract-wc-order.php#L2058) in emails _not_ sent to the admin by checking `$args['sent_to_admin']`. I couldn't see any reason in SHA: 7b3a9b or #11208 to explain why that would have been changed intentionally, so I'm guessing it is a bug. This patch reinstates the old behaviour. 