### PR TITLE
Fix call to non-existent method for cart_discount.

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-order.php
+++ b/includes/abstracts/abstract-wc-legacy-order.php
@@ -428,7 +428,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 		} elseif ( 'display_cart_ex_tax' === $key ) {
 			return 'excl' === get_option( 'woocommerce_tax_display_cart' );
 		} elseif ( 'cart_discount' === $key ) {
-			return $this->get_discount();
+			return $this->get_total_discount();
 		} elseif ( 'cart_discount_tax' === $key ) {
 			return $this->get_discount_tax();
 		} elseif ( 'order_tax' === $key ) {


### PR DESCRIPTION
While working on a fix for https://github.com/woocommerce/woocommerce-points-and-rewards/issues/140, I found out that in [this place](https://github.com/woocommerce/woocommerce-points-and-rewards/blob/master/includes/class-wc-points-rewards-order.php#L131) we are referencing to `cart_discount`.

But then WC tries to call the non-existent method `get_discount`, and an error appears:
`Fatal error: Uncaught Error: Call to undefined method WC_Order::get_discount()`