### PR TITLE
Fix undefined index notice in WC_Webhook:: should_deliver()

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -139,12 +139,12 @@ class WC_Webhook {
 			$should_deliver = false;
 		} elseif ( in_array( $current_action, array( 'delete_post', 'wp_trash_post' ), true ) ) {
 			// Only deliver deleted event for coupons, orders, and products.
-			if ( ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product' ) ) ) {
+			if ( isset( $GLOBALS['post_type'] ) && ! in_array( $GLOBALS['post_type'], array( 'shop_coupon', 'shop_order', 'product' ) ) ) {
 				$should_deliver = false;
 			}
 
 			// Check if is delivering for the correct resource.
-			if ( str_replace( 'shop_', '', $GLOBALS['post_type'] ) !== $this->get_resource() ) {
+			if ( isset( $GLOBALS['post_type'] ) && str_replace( 'shop_', '', $GLOBALS['post_type'] ) !== $this->get_resource() ) {
 				$should_deliver = false;
 			}
 		} elseif ( 'delete_user' == $current_action ) {


### PR DESCRIPTION
Fix undefined index notice in `WC_Webhook:: should_deliver()` by making sure `$GLOBALS['post_type']` is set before attempting to access its value.

Stacktrace that triggered the notice below. I'm not sure if it's related to Action Scheduler doing something unusual.  I suspect `$GLOBALS['post_type']` is not always set when `wp_trash_post()` is called, though it is definitely set when an admin user deletes post types via the admin area.

```
Notice:  Undefined index: post_type in /wc27/wp-content/plugins/woocommerce/includes/class-wc-webhook.php on line 147
Stack trace:
  1. {main}() /wc27/index.php:0
  2. require() /wc27/index.php:17
  3. require_once() /wc27/wp-blog-header.php:13
  4. require_once() /wc27/wp-load.php:37
  5. require_once() /wc27/wp-config.php:88
  6. do_action() /wc27/wp-settings.php:470
  7. WP_Hook->do_action() /wc27/wp-includes/plugin.php:453
  8. WP_Hook->apply_filters() /wc27/wp-includes/class-wp-hook.php:323
  9. WCS_User_Change_Status_Handler::maybe_change_users_subscription() /wc27/wp-includes/class-wp-hook.php:298
 10. WCS_User_Change_Status_Handler::change_users_subscription() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/class-wcs-user-change-status-handler.php:35
 11. WC_Subscription->update_status() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/class-wcs-user-change-status-handler.php:65
 12. do_action() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/class-wc-subscription.php:500
 13. WP_Hook->do_action() /wc27/wp-includes/plugin.php:453
 14. WP_Hook->apply_filters() /wc27/wp-includes/class-wp-hook.php:323
 15. WCS_Action_Scheduler->update_status() /wc27/wp-includes/class-wp-hook.php:298
 16. WCS_Action_Scheduler->unschedule_actions() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/class-wcs-action-scheduler.php:118
 17. wc_unschedule_action() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/class-wcs-action-scheduler.php:187
 18. ActionScheduler_wpPostStore->cancel_action() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/libraries/action-scheduler/functions.php:83
 19. wp_trash_post() /wc27/wp-content/plugins/woocommerce-subscriptions/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore.php:320
 20. do_action() /wc27/wp-includes/post.php:2605
 21. WP_Hook->do_action() /wc27/wp-includes/plugin.php:453
 22. WP_Hook->apply_filters() /wc27/wp-includes/class-wp-hook.php:323
 23. WC_Webhook->process() /wc27/wp-includes/class-wp-hook.php:298
 24. WC_Webhook->should_deliver() /wc27/wp-content/plugins/woocommerce/includes/class-wc-webhook.php:106
```