### PR TITLE
Modify variable product sync hooks

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -461,7 +461,7 @@ class WC_Product_Variable extends WC_Product {
 				$product->save();
 			}
 
-			do_action( 'woocommerce_variable_product_sync', $product->get_id(), $product->get_visible_children(), $save );
+			wc_do_deprecated_action( 'woocommerce_variable_product_sync', array( $product->get_id(), $product->get_visible_children() ), '2.7', 'woocommerce_variable_product_sync_before_save' );
 		}
 		return $product;
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -459,7 +459,7 @@ class WC_Product_Variable extends WC_Product {
 				$product->save();
 			}
 
-			do_action( 'woocommerce_variable_product_sync', $product->get_id(), $product->get_visible_children( 'edit' ), $save );
+			do_action( 'woocommerce_variable_product_sync', $product->get_id(), $product->get_visible_children(), $save );
 		}
 		return $product;
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -461,6 +461,8 @@ class WC_Product_Variable extends WC_Product {
 				$product->save();
 			}
 
+			do_action( 'woocommerce_variable_product_synced', $product );
+
 			wc_do_deprecated_action( 'woocommerce_variable_product_sync', array( $product->get_id(), $product->get_visible_children() ), '2.7', 'woocommerce_variable_product_sync_before_save' );
 		}
 		return $product;

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -455,11 +455,11 @@ class WC_Product_Variable extends WC_Product {
 			$data_store->sync_stock_status( $product );
 			self::sync_attributes( $product ); // Legacy update of attributes.
 
-			do_action( 'woocommerce_variable_product_sync', $product->get_id(), $product->get_visible_children( 'edit' ), $save );
-
 			if ( $save ) {
 				$product->save();
 			}
+
+			do_action( 'woocommerce_variable_product_sync', $product->get_id(), $product->get_visible_children( 'edit' ), $save );
 		}
 		return $product;
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -455,6 +455,8 @@ class WC_Product_Variable extends WC_Product {
 			$data_store->sync_stock_status( $product );
 			self::sync_attributes( $product ); // Legacy update of attributes.
 
+			do_action( 'woocommerce_variable_product_nsync', $product, $save );
+
 			if ( $save ) {
 				$product->save();
 			}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -455,7 +455,7 @@ class WC_Product_Variable extends WC_Product {
 			$data_store->sync_stock_status( $product );
 			self::sync_attributes( $product ); // Legacy update of attributes.
 
-			do_action( 'woocommerce_variable_product_nsync', $product, $save );
+			do_action( 'woocommerce_variable_product_sync_before_save', $product );
 
 			if ( $save ) {
 				$product->save();

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -461,9 +461,7 @@ class WC_Product_Variable extends WC_Product {
 				$product->save();
 			}
 
-			do_action( 'woocommerce_variable_product_synced', $product );
-
-			wc_do_deprecated_action( 'woocommerce_variable_product_sync', array( $product->get_id(), $product->get_visible_children() ), '2.7', 'woocommerce_variable_product_sync_data' );
+			wc_do_deprecated_action( 'woocommerce_variable_product_sync', array( $product->get_id(), $product->get_visible_children() ), '2.7', 'woocommerce_variable_product_sync_data, woocommerce_new_product or woocommerce_update_product' );
 		}
 		return $product;
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -455,7 +455,7 @@ class WC_Product_Variable extends WC_Product {
 			$data_store->sync_stock_status( $product );
 			self::sync_attributes( $product ); // Legacy update of attributes.
 
-			do_action( 'woocommerce_variable_product_sync_before_save', $product );
+			do_action( 'woocommerce_variable_product_sync_data', $product );
 
 			if ( $save ) {
 				$product->save();
@@ -463,7 +463,7 @@ class WC_Product_Variable extends WC_Product {
 
 			do_action( 'woocommerce_variable_product_synced', $product );
 
-			wc_do_deprecated_action( 'woocommerce_variable_product_sync', array( $product->get_id(), $product->get_visible_children() ), '2.7', 'woocommerce_variable_product_sync_before_save' );
+			wc_do_deprecated_action( 'woocommerce_variable_product_sync', array( $product->get_id(), $product->get_visible_children() ), '2.7', 'woocommerce_variable_product_sync_data' );
 		}
 		return $product;
 	}


### PR DESCRIPTION
This PR introduces two changes to variable product sync hooks:

1. The `'woocommerce_variable_product_sync'` hook is now triggered after a variable product is saved
2. A new hook is triggered before the variable product is saved

Justification for each change below.

### Trigger `'woocommerce_variable_product_sync'` Hook After Save

Because only a product ID is passed to callbacks on `'woocommerce_variable_product_sync'`, callbacks will need to instantiate their own instance of the product to do anything useful with it. This creates a lot of potential for problems given that the product has at that stage had its data only partially saved.

For example, a callback may modify some meta data on its own instance of the product, then save that, only to immediately have that overridden if the instance of `$product` in `WC_Product_Variable::sync()` also had changes to that meta data.

To avoid that, `WC_Product_Variable::sync()` can instead trigger `'woocommerce_variable_product_sync'` only after the product has been saved. This is backward compatible because the hook was triggered at the very end of the process in WC < 2.7.

### New `'woocommerce_variable_product_nsync'` Hook

Because the existing `'woocommerce_variable_product_sync'` hook only passes callbacks the product ID, there is no way for callbacks to modify the actual instance of the product being sync'd/saved by `WC_Product_Variable::sync()`. This matters a lot more in WC 2.7+ where product properties are abstracted from their storage.

For example, to set meta data on the product:
* in older versions of WC, it was possible to simply save meta data directly using the product ID with something like `update_post_meta( $product_id, $meta_key, $meta_value )`
* in WC 2.7, `$product->add_meta_data()` should be used to make sure it is saved in that's products data store, and also so that meta data can be saved in one go rather than multiple writes

The new `'woocommerce_variable_product_nsync'` hook passes callbacks the current instance of the variable product, so that it can be modified during synchronisation (potentially before being saved).

As far as the hook name goes, I couldn't help but try to sneak in a bad 90s boy band reference, especially when the only alternatives I could come up with were clumsy sounding hooks like `'woocommerce_variable_product_in_sync'` or `'woocommerce_variable_product_sync_before_save'`.