### PR TITLE
Fix empty string case for `WC_Order::get_total_shipping`

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -238,7 +238,7 @@ class WC_Shipping {
 	 * @param array $packages multi-dimensional array of cart items to calc shipping for
 	 */
 	public function calculate_shipping( $packages = array() ) {
-		$this->shipping_total = null;
+		$this->shipping_total = 0;
 		$this->shipping_taxes = array();
 		$this->packages       = array();
 
@@ -393,7 +393,7 @@ class WC_Shipping {
 	 */
 	public function reset_shipping() {
 		unset( WC()->session->chosen_shipping_methods );
-		$this->shipping_total = null;
+		$this->shipping_total = 0;
 		$this->shipping_taxes = array();
 		$this->packages = array();
 	}


### PR DESCRIPTION
When there are no shipping methods, the call to `$order->get_total_shipping()` will return `''`, thus producing notices in some plugins that call `number_format` (example [this](https://github.com/woocommerce/woocommerce-gateway-2checkout-inline-checkout/blob/master/includes/class-wc-2checkout-inline-checkout-gateway.php#L443)):
`Warning: number_format() expects parameter 1 to be float, string given`