### PR TITLE
If woocommerce_adjust_non_base_location_prices is false, remove modded tax, not base tax

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -883,40 +883,43 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 		'qty'   => '',
 		'price' => '',
 	) );
-	$price = (float) max( 0, $args['price'] ? $args['price'] : $product->get_price() );
-	$qty   = (int) $args['qty'] ? $args['qty'] : 1;
+	$price        = (float) max( 0, $args['price'] ? $args['price'] : $product->get_price() );
+	$qty          = (int) $args['qty'] ? $args['qty']               : 1;
+	$line_price   = $price * $qty;
+	$return_price = $line_price;
 
-	if ( ! $product->is_taxable() ) {
-		$price = $price * $qty;
-	} elseif ( ! wc_prices_include_tax() ) {
-		$tax_rates  = WC_Tax::get_rates( $product->get_tax_class() );
-		$taxes      = WC_Tax::calc_tax( $price * $qty, $tax_rates, false );
-		$tax_amount = WC_Tax::get_tax_total( $taxes );
-		$price      = round( $price * $qty + $tax_amount, wc_get_price_decimals() );
-	} else {
-		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class() );
-		$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );
-
-		if ( ! empty( WC()->customer ) && WC()->customer->get_is_vat_exempt() ) {
-			$base_taxes         = WC_Tax::calc_tax( $price * $qty, $base_tax_rates, true );
-			$base_tax_amount    = array_sum( $base_taxes );
-			$price              = round( $price * $qty - $base_tax_amount, wc_get_price_decimals() );
-
-		/**
-		 * The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations.
-		 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
-		 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
-		 */
-		} elseif ( $tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
-			$base_taxes         = WC_Tax::calc_tax( $price * $qty, $base_tax_rates, true );
-			$modded_taxes       = WC_Tax::calc_tax( ( $price * $qty ) - array_sum( $base_taxes ), $tax_rates, false );
-			$price              = round( ( $price * $qty ) - array_sum( $base_taxes ) + array_sum( $modded_taxes ), wc_get_price_decimals() );
-
+	if ( $product->is_taxable() ) {
+		if ( ! wc_prices_include_tax() ) {
+			$tax_rates    = WC_Tax::get_rates( $product->get_tax_class() );
+			$taxes        = WC_Tax::calc_tax( $line_price, $tax_rates, false );
+			$tax_amount   = WC_Tax::get_tax_total( $taxes );
+			$return_price = round( $line_price + $tax_amount, wc_get_price_decimals() );
 		} else {
-			$price = $price * $qty;
+			$tax_rates      = WC_Tax::get_rates( $product->get_tax_class() );
+			$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );
+
+			/**
+			 * If the customer is excempt from VAT, remove the taxes here.
+			 * Either remove the base or the user taxes depending on woocommerce_adjust_non_base_location_prices setting.
+			 */
+			if ( ! empty( WC()->customer ) && WC()->customer->get_is_vat_exempt() ) {
+				$remove_taxes = apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ? WC_Tax::calc_tax( $line_price, $base_tax_rates, true ) : WC_Tax::calc_tax( $line_price, $tax_rates, true );
+				$remove_tax   = array_sum( $remove_taxes );
+				$return_price = round( $line_price - $remove_tax, wc_get_price_decimals() );
+
+			/**
+			 * The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations.
+			 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
+			 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
+			 */
+			} elseif ( $tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
+				$base_taxes   = WC_Tax::calc_tax( $line_price, $base_tax_rates, true );
+				$modded_taxes = WC_Tax::calc_tax( $line_price - array_sum( $base_taxes ), $tax_rates, false );
+				$return_price = round( $line_price - array_sum( $base_taxes ) + array_sum( $modded_taxes ), wc_get_price_decimals() );
+			}
 		}
 	}
-	return apply_filters( 'woocommerce_get_price_including_tax', $price, $qty, $product );
+	return apply_filters( 'woocommerce_get_price_including_tax', $return_price, $qty, $product );
 }
 
 /**


### PR DESCRIPTION
Adjust the logic to work with the woocommerce_adjust_non_base_location_prices filter. 

When this filter is set to false, tax inclusive prices do not include ‘base taxes’, only the taxes which apply to customers.

Fixes #13011