### PR TITLE
Fix failing tests and array_merge error

### DIFF
--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -453,7 +453,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 			if ( ! empty( $items[ $batch_type ] ) ) {
 				$injected_items = array();
 				foreach ( $items[ $batch_type ] as $item ) {
-					$injected_items[] = array_merge( array( 'product_id' => $product_id ), $item );
+					$injected_items[] = is_array( $item ) ? array_merge( array( 'product_id' => $product_id ), $item ) : $item;
 				}
 				$body_params[ $batch_type ] = $injected_items;
 			}

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -307,7 +307,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 			if ( ! empty( $items[ $batch_type ] ) ) {
 				$injected_items = array();
 				foreach ( $items[ $batch_type ] as $item ) {
-					$injected_items[] = array_merge( array( 'product_id' => $product_id ), $item );
+					$injected_items[] = is_array( $item ) ? array_merge( array( 'product_id' => $product_id ), $item ) : $item;
 				}
 				$body_params[ $batch_type ] = $injected_items;
 			}

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -383,8 +383,8 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 'Updated review.', $data['update'][0]['review'] );
 		$this->assertEquals( 'New review.', $data['create'][0]['review'] );
-		$this->assertEquals( $review_2_id, $data['delete'][0] );
-		$this->assertEquals( $review_3_id, $data['delete'][1] );
+		$this->assertEquals( $review_2_id, $data['delete'][0]['id'] );
+		$this->assertEquals( $review_3_id, $data['delete'][1]['id'] );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->get_id() . '/reviews' );
 		$response = $this->server->dispatch( $request );

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -321,7 +321,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertContains( 'Updated description.', $data['update'][0]['description'] );
 		$this->assertEquals( 'DUMMY SKU VARIABLE MEDIUM', $data['create'][0]['sku'] );
 		$this->assertEquals( 'medium', $data['create'][0]['attributes'][0]['option'] );
-		$this->assertEquals( $children[1], $data['delete'][0] );
+		$this->assertEquals( $children[1], $data['delete'][0]['id'] );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v1/products/' . $product->get_id() . '/variations' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
Currently, the unit tests throw two `array_merge(): Argument #2 is not an array` errors when run. This is a side-effect of a recent change allowing `delete` batch items to be passed in as just integer post ids. I have modified the controllers to handle this, so the array merge error won't happen. 

I have also modified the unit tests to check the id of the response object, as I don't think the whole response of a delete is supposed to just be a post id but a full response object, and the tests fail otherwise.

@claudiosanches I'd like you to please give this a look over and make sure that I didn't undo what you were going for, since you made the recent changes to the batch delete.