### PR TITLE
Don't round values in get_on_sale_products

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -671,7 +671,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				AND meta2.meta_key = '_price'
 				AND CAST( meta.meta_value AS DECIMAL ) >= 0
 				AND CAST( meta.meta_value AS CHAR ) != ''
-				AND CAST( meta.meta_value AS DECIMAL(10,2) ) = CAST( meta2.meta_value AS DECIMAL(10,2) )
+				AND CAST( meta.meta_value AS DECIMAL( 10, 2 ) ) = CAST( meta2.meta_value AS DECIMAL( 10, 2 ) )
 			GROUP BY post.ID;
 		" );
 	}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -671,7 +671,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				AND meta2.meta_key = '_price'
 				AND CAST( meta.meta_value AS DECIMAL ) >= 0
 				AND CAST( meta.meta_value AS CHAR ) != ''
-				AND CAST( meta.meta_value AS DECIMAL ) = CAST( meta2.meta_value AS DECIMAL )
+				AND CAST( meta.meta_value AS DECIMAL(10,2) ) = CAST( meta2.meta_value AS DECIMAL(10,2) )
 			GROUP BY post.ID;
 		" );
 	}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -661,6 +661,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	public function get_on_sale_products() {
 		global $wpdb;
+
+		$decimals = absint( wc_get_price_decimals() );
+
 		return $wpdb->get_results( "
 			SELECT post.ID as id, post.post_parent as parent_id FROM `$wpdb->posts` AS post
 			LEFT JOIN `$wpdb->postmeta` AS meta ON post.ID = meta.post_id
@@ -671,7 +674,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				AND meta2.meta_key = '_price'
 				AND CAST( meta.meta_value AS DECIMAL ) >= 0
 				AND CAST( meta.meta_value AS CHAR ) != ''
-				AND CAST( meta.meta_value AS DECIMAL( 10, 2 ) ) = CAST( meta2.meta_value AS DECIMAL( 10, 2 ) )
+				AND CAST( meta.meta_value AS DECIMAL( 10, {$decimals} ) ) = CAST( meta2.meta_value AS DECIMAL( 10, {$decimals} ) )
 			GROUP BY post.ID;
 		" );
 	}

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -349,4 +349,34 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$_attribute = $loaded_variation->get_attributes( 'edit' );
 		$this->assertEquals( 'green', $_attribute['color'] );
 	}
+
+	function test_get_on_sale_products() {
+
+		$product_store = new WC_Product_Data_Store_CPT();
+
+		$sale_product = WC_Helper_Product::create_simple_product();
+		$sale_product->set_sale_price( 3.49 );
+		$sale_product->set_regular_price( 3.99 );
+		$sale_product->set_price( $sale_product->get_sale_price() );
+		$sale_product->save();
+
+		$not_sale_product = WC_Helper_Product::create_simple_product();
+		$not_sale_product->set_regular_price( 4.00 );
+		$not_sale_product->set_price( $not_sale_product->get_regular_price() );
+		$not_sale_product->save();
+
+		$future_sale_product = WC_Helper_Product::create_simple_product();
+		$future_sale_product->set_date_on_sale_from( 'tomorrow' );
+		$future_sale_product->set_regular_price( 6.49 );
+		$future_sale_product->set_sale_price( 5.99 );
+		$future_sale_product->set_price( $future_sale_product->get_regular_price() );
+		$future_sale_product->save();
+
+		$sale_products = $product_store->get_on_sale_products();
+		$sale_product_ids = array_map( function( $product ){ return $product->id; }, $sale_products );
+
+		$this->assertContains( $sale_product->get_id(), $sale_product_ids );
+		$this->assertNotContains( $not_sale_product->get_id(), $sale_product_ids );
+		$this->assertNotContains( $future_sale_product->get_id(), $sale_product_ids );
+	}
 }


### PR DESCRIPTION
This is a fix for issue #13106.

This modifies the query in `get_on_sale_products` to compare the sale price and the current price down to two decimal places, which is down to the cent level. I've also added a unit test for `get_on_sale_products` to verify everything is fixed and prevent regression of any functionality.