### PR TITLE
Added exit after wp_safe_redirect.

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -132,6 +132,7 @@ class WC_Install {
 		if ( ! empty( $_GET['force_update_woocommerce'] ) ) {
 			do_action( 'wp_wc_updater_cron' );
 			wp_safe_redirect( admin_url( 'admin.php?page=wc-settings' ) );
+			exit;
 		}
 	}
 


### PR DESCRIPTION
Here not add exit after wp_safe_redirect.

wp_safe_redirect() does not exit automatically and should almost always be followed by exit.