### PR TITLE
Moved refund logic

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -183,7 +183,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 */
 	public function reduce_stock( $amount = 1 ) {
 		wc_deprecated_function( 'WC_Product::reduce_stock', '2.7', 'wc_update_product_stock' );
-		wc_update_product_stock( $this, $amount, 'decrease' );
+		return wc_update_product_stock( $this, $amount, 'decrease' );
 	}
 
 	/**
@@ -195,7 +195,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 */
 	public function increase_stock( $amount = 1 ) {
 		wc_deprecated_function( 'WC_Product::increase_stock', '2.7', 'wc_update_product_stock' );
-		wc_update_product_stock( $this, $amount, 'increase' );
+		return wc_update_product_stock( $this, $amount, 'increase' );
 	}
 
 	/**

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1236,7 +1236,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				if ( isset( $request['stock_quantity'] ) ) {
 					$product->set_stock_quantity( wc_stock_amount( $request['stock_quantity'] ) );
 				} elseif ( isset( $request['inventory_delta'] ) ) {
-					$stock_quantity  = wc_stock_amount( $product->get_stock_amount() );
+					$stock_quantity  = wc_stock_amount( $product->get_stock_quantity() );
 					$stock_quantity += wc_stock_amount( $request['inventory_delta'] );
 					$product->set_stock_quantity( wc_stock_amount( $stock_quantity ) );
 				}
@@ -1441,7 +1441,7 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 				if ( isset( $data['stock_quantity'] ) ) {
 					$variation->set_stock_quantity( $data['stock_quantity'] );
 				} elseif ( isset( $data['inventory_delta'] ) ) {
-					$stock_quantity  = wc_stock_amount( $variation->get_stock_amount() );
+					$stock_quantity  = wc_stock_amount( $variation->get_stock_quantity() );
 					$stock_quantity += wc_stock_amount( $data['inventory_delta'] );
 					$variation->set_stock_quantity( $stock_quantity );
 				}

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1618,7 +1618,7 @@ class WC_API_Products extends WC_API_Resource {
 				if ( isset( $data['stock_quantity'] ) ) {
 					$product->set_stock_quantity( wc_stock_amount( $data['stock_quantity'] ) );
 				} elseif ( isset( $data['inventory_delta'] ) ) {
-					$stock_quantity  = wc_stock_amount( $product->get_stock_amount() );
+					$stock_quantity  = wc_stock_amount( $product->get_stock_quantity() );
 					$stock_quantity += wc_stock_amount( $data['inventory_delta'] );
 					$product->set_stock_quantity( wc_stock_amount( $stock_quantity ) );
 				}
@@ -1845,7 +1845,7 @@ class WC_API_Products extends WC_API_Resource {
 				if ( isset( $data['stock_quantity'] ) ) {
 					$variation->set_stock_quantity( $data['stock_quantity'] );
 				} elseif ( isset( $data['inventory_delta'] ) ) {
-					$stock_quantity  = wc_stock_amount( $variation->get_stock_amount() );
+					$stock_quantity  = wc_stock_amount( $variation->get_stock_quantity() );
 					$stock_quantity += wc_stock_amount( $data['inventory_delta'] );
 					$variation->set_stock_quantity( $stock_quantity );
 				}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1469,11 +1469,13 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return array of WC_Order_Refund objects
 	 */
 	public function get_refunds() {
-		$this->refunds = wc_get_orders( array(
-			'type'   => 'shop_order_refund',
-			'parent' => $this->get_id(),
-			'limit'  => -1,
-		) );
+		if ( empty( $this->refunds ) ) {
+			$this->refunds = wc_get_orders( array(
+				'type'   => 'shop_order_refund',
+				'parent' => $this->get_id(),
+				'limit'  => -1,
+			) );
+		}
 		return $this->refunds;
 	}
 


### PR DESCRIPTION
Moves refund and stock logic into wc_create_refund function so that it’s ran in admin and via API.

Also fixes a few related bugs I found when testing.

Closes #12973