### PR TITLE
Fix type setting in API

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -678,14 +678,19 @@ class WC_REST_Products_Controller extends WC_REST_Posts_Controller {
 	 * @return WP_Error|stdClass $data Post object.
 	 */
 	protected function prepare_item_for_database( $request ) {
-		if ( isset( $request['id'] ) ) {
-			$product = wc_get_product( absint( $request['id'] ) );
-		} else {
-			$classname    = WC_Product_Factory::get_classname_from_product_type( $request['type'] );
+		// Type is the most important part here because we need to be using the correct class and methods.
+		if ( isset( $request['type'] ) ) {
+			$classname = WC_Product_Factory::get_classname_from_product_type( $request['type'] );
+
 			if ( ! class_exists( $classname ) ) {
 				$classname = 'WC_Product_Simple';
 			}
-			$product = new $classname();
+
+			$product = new $classname( absint( $request['id'] ) );
+		} elseif ( isset( $request['id'] ) ) {
+			$product = wc_get_product( absint( $request['id'] ) );
+		} else {
+			$product = new WC_Product_Simple();
 		}
 
 		// Post title.


### PR DESCRIPTION
Fixes #12955 

Type needs to be used when getting the product class or it will fail to update.