### PR TITLE
Move post type logic from product and order factories.

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -29,16 +29,15 @@ class WC_Order_Factory {
 			return false;
 		}
 
-		$post_type = get_post_type( $order_id );
-
-		if ( $order_type = wc_get_order_type( $post_type ) ) {
-			$classname = $order_type['class_name'];
+		$order_type = WC_Data_Store::load( 'order' )->get_order_type( $order_id );
+		if ( $order_type_data = wc_get_order_type( $order_type ) ) {
+			$classname = $order_type_data['class_name'];
 		} else {
 			$classname = false;
 		}
 
 		// Filter classname so that the class can be overridden if extended.
-		$classname = apply_filters( 'woocommerce_order_class', $classname, $post_type, $order_id );
+		$classname = apply_filters( 'woocommerce_order_class', $classname, $order_type, $order_id );
 
 		if ( ! class_exists( $classname ) ) {
 			return false;
@@ -60,8 +59,7 @@ class WC_Order_Factory {
 		global $wpdb;
 
 		if ( is_numeric( $item_id ) ) {
-			$item_data = $wpdb->get_row( $wpdb->prepare( "SELECT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item_id ) );
-			$item_type = $item_data->order_item_type;
+			$item_type = WC_Data_Store::load( 'order' )->get_order_item_type( $item_id );
 			$id        = $item_id;
 		} elseif ( $item_id instanceof WC_Order_Item ) {
 			$item_type = $item_id->get_type();

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -59,7 +59,7 @@ class WC_Order_Factory {
 		global $wpdb;
 
 		if ( is_numeric( $item_id ) ) {
-			$item_type = WC_Data_Store::load( 'order' )->get_order_item_type( $item_id );
+			$item_type = WC_Data_Store::load( 'order-item' )->get_order_item_type( $item_id );
 			$id        = $item_id;
 		} elseif ( $item_id instanceof WC_Order_Item ) {
 			$item_type = $item_id->get_type();

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -86,16 +86,7 @@ class WC_Product_Factory {
 		// Allow the overriding of the lookup in this function. Return the product type here.
 		$override = apply_filters( 'woocommerce_product_type_query', false, $product_id );
 		if ( ! $override ) {
-			$post_type = get_post_type( $product_id );
-
-			if ( 'product_variation' === $post_type ) {
-				return 'variation';
-			} elseif ( 'product' === $post_type ) {
-				$terms = get_the_terms( $product_id, 'product_type' );
-				return ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
-			} else {
-				return false;
-			}
+			return WC_Data_Store::load( 'product' )->get_product_type( $product_id );
 		} else {
 			return $override;
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -585,4 +585,28 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$order_id = WC_Order_Factory::get_order_id( $order );
 		update_post_meta( $order_id, '_order_stock_reduced', wc_bool_to_string( $set ) );
 	}
+
+	/**
+	 * Get the order type based on Order ID.
+	 *
+	 * @since 2.7.0
+	 * @param int $order_id
+	 * @return string
+	 */
+	public function get_order_type( $order_id ) {
+		return get_post_type( $order_id );
+	}
+
+	/**
+	 * Get the order item type based on Item ID.
+	 *
+	 * @since 2.7.0
+	 * @param int $item_id
+	 * @return string
+	 */
+	public function get_order_item_type( $item_id ) {
+		global $wpdb;
+		$item_data = $wpdb->get_row( $wpdb->prepare( "SELECT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item_id ) );
+		return $item_data->order_item_type;
+	}
 }

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -596,17 +596,4 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	public function get_order_type( $order_id ) {
 		return get_post_type( $order_id );
 	}
-
-	/**
-	 * Get the order item type based on Item ID.
-	 *
-	 * @since 2.7.0
-	 * @param int $item_id
-	 * @return string
-	 */
-	public function get_order_item_type( $item_id ) {
-		global $wpdb;
-		$item_data = $wpdb->get_row( $wpdb->prepare( "SELECT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item_id ) );
-		return $item_data->order_item_type;
-	}
 }

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -134,4 +134,16 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 		) );
 	}
 
+	/**
+	 * Get the order item type based on Item ID.
+	 *
+	 * @since 2.7.0
+	 * @param int $item_id
+	 * @return string
+	 */
+	public function get_order_item_type( $item_id ) {
+		global $wpdb;
+		$item_data = $wpdb->get_row( $wpdb->prepare( "SELECT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item_id ) );
+		return $item_data->order_item_type;
+	}
 }

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1197,4 +1197,23 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		return wp_parse_id_list( $product_ids );
 	}
+
+	/**
+	 * Get the product type based on product ID.
+	 *
+	 * @since 2.7.0
+	 * @param int $product_id
+	 * @return bool|string
+	 */
+	public function get_product_type( $product_id ) {
+		$post_type = get_post_type( $product_id );
+		if ( 'product_variation' === $post_type ) {
+			return 'variation';
+		} elseif ( 'product' === $post_type ) {
+			$terms = get_the_terms( $product_id, 'product_type' );
+			return ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
+		} else {
+			return false;
+		}
+	}
 }

--- a/includes/interfaces/class-wc-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-data-store-interface.php
@@ -116,4 +116,18 @@ interface WC_Order_Data_Store_Interface {
 	 * @param bool $set
 	 */
 	public function set_recorded_coupon_usage_counts( $order, $set );
+
+	/**
+	 * Get the order type based on Order ID.
+	 * @param  int $order_id
+	 * @return string
+	 */
+	public function get_order_type( $order_id );
+
+	/**
+	 * Get the order item type based on Item ID.
+	 * @param  int $item_id
+	 * @return string
+	 */
+	public function get_order_item_type( $item_id );
 }

--- a/includes/interfaces/class-wc-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-data-store-interface.php
@@ -123,11 +123,4 @@ interface WC_Order_Data_Store_Interface {
 	 * @return string
 	 */
 	public function get_order_type( $order_id );
-
-	/**
-	 * Get the order item type based on Item ID.
-	 * @param  int $item_id
-	 * @return string
-	 */
-	public function get_order_item_type( $item_id );
 }

--- a/includes/interfaces/class-wc-order-item-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-data-store-interface.php
@@ -81,4 +81,11 @@ interface WC_Order_Item_Data_Store_Interface {
 	 * @return int
 	 */
 	function get_order_id_by_order_item_id( $item_id );
+
+	/**
+	 * Get the order item type based on Item ID.
+	 * @param  int $item_id
+	 * @return string
+	 */
+	public function get_order_item_type( $item_id );
 }

--- a/includes/interfaces/class-wc-product-data-store-interface.php
+++ b/includes/interfaces/class-wc-product-data-store-interface.php
@@ -115,4 +115,11 @@ interface WC_Product_Data_Store_Interface {
 	 * @return array
 	 */
 	public function get_products( $args = array() );
+
+	/**
+	 * Get the product type based on product ID.
+	 * @param  int $product_id
+	 * @return bool|string
+	 */
+	public function get_product_type( $product_id );
 }


### PR DESCRIPTION
Orders does a get_post_type call to figure out order type, and products does a similar one (with a tag look up). These are moved to data store methods so they can be overridden.

The PR also replaces a query getting item type from the DB.