### PR TITLE
Add: post_type in map_legacy args for retrocompatibility with old wc …

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -77,6 +77,7 @@ function wc_get_products( $args ) {
 		'post_parent'    => 'parent',
 		'posts_per_page' => 'limit',
 		'paged'          => 'page',
+        'post_type'      => 'type',
 	);
 
 	foreach ( $map_legacy as $from => $to ) {


### PR DESCRIPTION
To convert the old get_posts in wc_get_products I think is nice to have the post_type arg in legacy map. If I create a wrapper function that check the current version of WooCommerce and use the new or the old method it's it's ease have the same arguments.