### PR TITLE
Don't use get_the_title during product read

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -120,7 +120,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$id = $product->get_id();
 
 		$product->set_props( array(
-			'name'              => get_the_title( $post_object ),
+			'name'              => $post_object->post_title,
 			'slug'              => $post_object->post_name,
 			'date_created'      => $post_object->post_date,
 			'date_modified'     => $post_object->post_modified,


### PR DESCRIPTION
We are using `get_the_title` in a couple places when setting a products name prop. `get_the_title` runs a few filters (applying private or public prefix to the product depending on access level, and `the_title` filter. This can cause an infinite loop if someone uses `the_title` and calls `wc_get_product`. 

I don't think there is any reason for use to use `get_the_title` over just accessing `$post_object->post_title` like the rest of the properties (post_name, post_date, etc). It breaks code that worked before (https://github.com/woocommerce/woocommerce-cart-add-ons/blob/master/woocommerce-cart-add-ons.php#L614).