### PR TITLE
Switch isset back to array_key_exists to keep null-default props working

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -578,7 +578,7 @@ abstract class WC_Data {
 	protected function get_prop( $prop, $context = 'view' ) {
 		$value = null;
 
-		if ( isset( $this->data[ $prop ] ) ) {
+		if ( array_key_exists( $prop, $this->data ) ) {
 			$value = isset( $this->changes[ $prop ] ) ? $this->changes[ $prop ] : $this->data[ $prop ];
 
 			if ( 'view' === $context ) {


### PR DESCRIPTION
There is a slight difference between `array_key_exists` and `isset`: `isset` does not return TRUE for array keys that correspond to a NULL value, while `array_key_exists` does. This means that `isset` doesn't play well with props that have a NULL default value. The performance difference between the two is tiny and both are super performant, but `array_key_exists` works better with the current CRUD implementation.

