### PR TITLE
Fix and standardize e-mail sending

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -130,7 +130,7 @@ class WC_Meta_Box_Order_Actions {
 				if ( ! empty( $mails ) ) {
 					foreach ( $mails as $mail ) {
 						if ( $mail->id == $email_to_send ) {
-							$mail->trigger( $order->get_id() );
+							$mail->trigger( $order->get_id(), $order );
 							/* translators: %s: email title */
 							$order->add_order_note( sprintf( __( '%s email notification manually sent.', 'woocommerce' ), $mail->title ), false, true );
 						}

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -260,7 +260,12 @@ class WC_Emails {
 	 */
 	public function customer_invoice( $order ) {
 		$email = $this->emails['WC_Email_Customer_Invoice'];
-		$email->trigger( $order );
+
+		if ( ! is_object( $order ) ) {
+			$order = wc_get_order( absint( $order ) );
+		}
+
+		$email->trigger( $order->get_id(), $order );
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -65,12 +65,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	 *
 	 * @param int|WC_Order $order
 	 */
-	public function trigger( $order ) {
-
-		if ( ! is_object( $order ) ) {
-			$order = wc_get_order( absint( $order ) );
-		}
-
+	public function trigger( $order_id, $order ) {
 		if ( $order ) {
 			$this->object                  = $order;
 			$this->recipient               = $this->object->get_billing_email();


### PR DESCRIPTION
The Order Actions metabox is only passing in one of the`trigger` params, causing big errors on the email classes that expect two params for `trigger` (e.g. WC_Email_New_Order).

I've modified the metabox to pass in two params and modified WC_Email_Customer_Invoice to expect two params so all of the order emails have the same params for `trigger`.

It seems like the next step is to get rid of `trigger`'s first `$order_id` param, because all the order email classes use the second `$order` param for everything. Or am I missing something?