### PR TITLE
Fix CLI documentation for commands with multiple IDs.

### DIFF
--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -92,6 +92,7 @@ class WC_CLI_Runner {
 				'attribute_id' => __( 'Attribute ID.', 'woocommerce' ),
 		);
 		$rest_command->set_supported_ids( $supported_ids );
+		$positional_args = array_merge( array( 'id' ), array_keys( $supported_ids ) );
 
 		$parent			 = "wc {$route_data['schema']['title']}";
 		$supported_commands = array();
@@ -137,9 +138,10 @@ class WC_CLI_Runner {
 			foreach ( $supported_ids as $id_name => $id_desc ) {
 				if ( strpos( $route, '<' . $id_name . '>' ) !== false ) {
 					$synopsis[] = array(
-						'name'		  => $id_name,
-						'type'		  => 'positional',
+						'name'        => $id_name,
+						'type'        => 'positional',
 						'description' => $id_desc,
+						'optional'    => false,
 					);
 				}
 			}
@@ -154,12 +156,14 @@ class WC_CLI_Runner {
 			}
 
 			foreach ( $endpoint_args as $name => $args ) {
-				$arg_regs[] = array(
-					'name'		  => $name,
-					'type'		  => 'assoc',
-					'description' => ! empty( $args['description'] ) ? $args['description'] : '',
-					'optional'	  => empty( $args['required'] ) ? true : false,
-				);
+				if ( ! in_array( $name, $positional_args ) ) {
+					$arg_regs[] = array(
+						'name'		  => $name,
+						'type'		  => 'assoc',
+						'description' => ! empty( $args['description'] ) ? $args['description'] : '',
+						'optional'	  => empty( $args['required'] ) ? true : false,
+					);
+				}
 			}
 
 			foreach ( $arg_regs as $arg_reg ) {


### PR DESCRIPTION
Some commands accept a parent ID and ID. For example when managing attribute terms, an ID is needed for the attribute and another for the term. 

The built-in CLI documentation would generate double entries for the IDs based on the schema. This PR adds a check so those IDs are listed as positional arguments and generated correctly.

Prior to this PR, the output was:

```
wp wc product_attribute_term
usage: wp wc product_attribute_term create <attribute_id> [--attribute_id=<attribute_id>] --name=<name> [--slug=<slug>] [--description=<description>] [--menu_order=<menu_order>] [--porcelain]
   or: wp wc product_attribute_term delete <attribute_id> <id> [--id=<id>] [--attribute_id=<attribute_id>] [--force=<force>] [--porcelain]
   or: wp wc product_attribute_term get <attribute_id> <id> [--id=<id>] [--attribute_id=<attribute_id>] [--context=<context>] [--fields=<fields>] [--field=<field>] [--format=<format>]
   or: wp wc product_attribute_term list <attribute_id> [--attribute_id=<attribute_id>] [--context=<context>] [--page=<page>] [--per_page=<per_page>] [--search=<search>] [--exclude=<exclude>] [--include=<include>] [--order=<order>] [--orderby=<orderby>] [--hide_empty=<hide_empty>] [--parent=<parent>] [--product=<product>] [--slug=<slug>] [--fields=<fields>] [--field=<field>] [--format=<format>]
   or: wp wc product_attribute_term update <attribute_id> <id> [--id=<id>] [--attribute_id=<attribute_id>] [--name=<name>] [--slug=<slug>] [--description=<description>] [--menu_order=<menu_order>] [--porcelain]
```

The new correct output:

```
wp wc product_attribute_term
usage: wp wc product_attribute_term create <attribute_id> --name=<name> [--slug=<slug>] [--description=<description>] [--menu_order=<menu_order>] [--porcelain]
   or: wp wc product_attribute_term delete <attribute_id> <id> [--force=<force>] [--porcelain]
   or: wp wc product_attribute_term get <attribute_id> <id> [--context=<context>] [--fields=<fields>] [--field=<field>] [--format=<format>]
   or: wp wc product_attribute_term list <attribute_id> [--context=<context>] [--page=<page>] [--per_page=<per_page>] [--search=<search>] [--exclude=<exclude>] [--include=<include>] [--order=<order>] [--orderby=<orderby>] [--hide_empty=<hide_empty>] [--parent=<parent>] [--product=<product>] [--slug=<slug>] [--fields=<fields>] [--field=<field>] [--format=<format>]
   or: wp wc product_attribute_term update <attribute_id> <id> [--name=<name>] [--slug=<slug>] [--description=<description>] [--menu_order=<menu_order>] [--porcelain]
```

cc @theMikeD.