### PR TITLE
Lazy update products

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -423,6 +423,7 @@ abstract class WC_Data {
 			if ( is_null( $meta->value ) ) {
 				if ( ! empty( $meta->id ) ) {
 					$this->data_store->delete_meta( $this, $meta );
+					unset( $this->meta_data[ $array_key ] );
 				}
 			} elseif ( empty( $meta->id ) ) {
 				$new_meta_id                       = $this->data_store->add_meta( $this, $meta );
@@ -435,8 +436,6 @@ abstract class WC_Data {
 		if ( ! empty( $this->cache_group ) ) {
 			WC_Cache_Helper::incr_cache_prefix( $this->cache_group );
 		}
-
-		$this->read_meta_data( true );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -642,28 +642,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	}
 
 	/**
-	 * Count terms. These are done at this point so all product props are set in advance.
-	 *
-	 * @param WC_Product
-	 * @since 2.7.0
-	 */
-	protected function update_term_counts( &$product ) {
-		if ( ! wp_defer_term_counting() ) {
-			global $wc_allow_term_recount;
-
-			$wc_allow_term_recount = true;
-
-			$post_type = $product->is_type( 'variation' ) ? 'product_variation' : 'product';
-
-			// Update counts for the post's terms.
-			foreach ( (array) get_object_taxonomies( $post_type ) as $taxonomy ) {
-				$tt_ids = wc_get_object_terms( $product->get_id(), $taxonomy, 'term_taxonomy_id' );
-				wp_update_term_count( $tt_ids, $taxonomy );
-			}
-		}
-	}
-
-	/**
 	 * Clear any caches.
 	 *
 	 * @param WC_Product

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -93,7 +93,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$product->set_id( $id );
 			$this->update_post_meta( $product );
 			$this->update_terms( $product );
-			$this->update_visibility( $product )
+			$this->update_visibility( $product );
 			$this->update_attributes( $product );
 			$this->update_version_and_type( $product );
 			$product->save_meta_data();
@@ -147,7 +147,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$changes = $product->get_changes();
 
 		// Only update the post when the post data changes.
-		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order' ), array_keys( $changes ) ) {
+		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order' ), array_keys( $changes ) ) ) {
 			wp_update_post( array(
 				'ID'             => $product->get_id(),
 				'post_content'   => $product->get_description(),
@@ -162,7 +162,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$this->update_post_meta( $product );
 		$this->update_terms( $product );
-		$this->update_visibility( $product )
+		$this->update_visibility( $product );
 		$this->update_attributes( $product );
 		$this->update_version_and_type( $product );
 		$product->save_meta_data();

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -123,7 +123,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 			$product->apply_changes();
 			$this->update_version_and_type( $product );
-			$this->update_term_counts( $product );
 			$this->clear_caches( $product );
 		}
 	}
@@ -154,7 +153,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		$product->apply_changes();
 		$this->update_version_and_type( $product );
-		$this->update_term_counts( $product );
 		$this->clear_caches( $product );
 	}
 


### PR DESCRIPTION
Fixes #13157 

Checks ‘changes’ for terms, meta, and the post object update to prevent un-necessary writes to the DB.

Also removes the ‘read meta’ after saving meta. @justinshreve can you check this part?