### PR TITLE
Legacy product type fix

### DIFF
--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -38,7 +38,6 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 			'total_stock',
 			'crosssell_ids',
 			'parent',
-			'product_type',
 		);
 		if ( $this->is_type( 'variation' ) ) {
 			$valid = array_merge( $valid, array(

--- a/includes/abstracts/abstract-wc-legacy-product.php
+++ b/includes/abstracts/abstract-wc-legacy-product.php
@@ -18,13 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class WC_Abstract_Legacy_Product extends WC_Data {
 
 	/**
-	 * The product's type (simple, variable etc).
-	 * @deprecated 2.7.0 get_type() method should return string instead since this prop should not be changed or be public.
-	 * @var string
-	 */
-	public $product_type = 'simple';
-
-	/**
 	 * Magic __isset method for backwards compatibility. Legacy properties which could be accessed directly in the past.
 	 *
 	 * @param  string $key Key name.
@@ -45,6 +38,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 			'total_stock',
 			'crosssell_ids',
 			'parent',
+			'product_type',
 		);
 		if ( $this->is_type( 'variation' ) ) {
 			$valid = array_merge( $valid, array(
@@ -74,6 +68,9 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 		switch ( $key ) {
 			case 'id' :
 				$value = $this->is_type( 'variation' ) ? $this->get_parent_id() : $this->get_id();
+				break;
+			case 'product_type' :
+				$value = $this->get_type();
 				break;
 			case 'product_attributes' :
 				$value = isset( $this->data['attributes'] ) ? $this->data['attributes'] : '';

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -129,12 +129,14 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 
 	/**
 	 * Get internal type. Should return string and *should be overridden* by child classes.
+	 *
+	 * The product_type property is @deprecated but is used here for BW compat with child classes which may be defining product_type and not have a get_type method.
+	 *
 	 * @since 2.7.0
 	 * @return string
 	 */
 	public function get_type() {
-		// product_type is @deprecated but here for BW compat with child classes.
-		return $this->product_type;
+		return isset( $this->product_type ) ? $this->product_type : 'simple';
 	}
 
 	/*


### PR DESCRIPTION
Uses legacy product_type variable if available, otherwise falls back to the correct get_type method call.

Fixes #13142 and passes tests.