### PR TITLE
[2.7] Add filter woocommerce_duplicate_product_exclude_children back

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -103,7 +103,9 @@ class WC_Admin_Duplicate_Product {
 			wc_product_force_unique_sku( $duplicate->get_id() );
 		}
 
-		if ( $product->is_type( 'variable' ) || $product->is_type( 'grouped' ) ) {
+		$exclude = apply_filters( 'woocommerce_duplicate_product_exclude_children', false );
+		
+		if ( ! $exclude && ( $product->is_type( 'variable' ) || $product->is_type( 'grouped' ) ) ) {
 			foreach( $product->get_children() as $child_id ) {
 				$child = wc_get_product( $child_id );
 				$child_duplicate = clone $child;


### PR DESCRIPTION
10d3e2d580cc7ad815eddf32ca486f5c5fb2d26c updated WC_Admin_Duplicate_Product to use CRUD. The filter woocommerce_duplicate_product_exclude_children was lost in the operation. I propose to add it back.