### PR TITLE
[2.7] Allow update_post_meta and handle_updated_props methods to be overriden

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -485,7 +485,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @since  2.7.0
 	 * @param  WC_Product $product
 	 */
-	protected function handle_updated_props( &$product ) { error_log( print_r( $this->updated_props, 1 ) );
+	protected function handle_updated_props( &$product ) {
 
 		if ( in_array( 'date_on_sale_from', $this->updated_props ) || in_array( 'date_on_sale_to', $this->updated_props ) || in_array( 'regular_price', $this->updated_props ) || in_array( 'sale_price', $this->updated_props ) ) {
 			if ( $product->is_on_sale( 'edit' ) ) {


### PR DESCRIPTION
#13164 optimized the way props are saved to the DB and introduced `handle_updated_props` to include additional logic based on the array of updated props.

However, this structure makes it difficult to extend `WC_Product_Data_Store_CPT` -- specifically it is now hard to override `update_post_meta` and call `parent::update_post_meta` since the latter one includes all logic that finds updated props and always calls `handle_updated_props` before exiting.

As an example, look at `WC_Product_Variation_Data_Store_CPT`, which extends `WC_Product_Data_Store_CPT` and see how it overrides `update_post_meta`:

Note that the `description` prop has no way to be passed into `handle_updated_props` correctly without re-writing the entire `update_post_meta` method.

This PR makes it easier to override `update_post_meta` and `handle_updated_props` from child classes and still use parent class methods.

Some additional notes:

- `image_id` is always included in the updated props -- might be worth looking into.