### PR TITLE
Deprecated hook handling

### DIFF
--- a/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -1,0 +1,93 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Deprecated_Hooks class maps old actions and filters to new ones. This is the base class for handling those deprecated hooks.
+ *
+ * Based on the WCS_Hook_Deprecator class by Prospress.
+ *
+ * @since 2.7.0
+ */
+abstract class WC_Deprecated_Hooks {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = array();
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		array_walk( array_keys( $this->deprecated_hooks ), array( $this, 'hook_in' ) );
+	}
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 *
+	 * @param  string $hook_name
+	 */
+	abstract function hook_in( $hook_name );
+
+	/**
+	 * Get old hooks to map to new hook.
+	 *
+	 * @param  string $new_hook
+	 * @return array
+	 */
+	public function get_old_hooks( $new_hook ) {
+		$old_hooks = isset( $this->deprecated_hooks[ $new_hook ] ) ? $this->deprecated_hooks[ $new_hook ] : array();
+		$old_hooks = is_array( $old_hooks ) ? $old_hooks : array( $old_hooks );
+
+		return $old_hooks;
+	}
+
+	/**
+	 * If the hook is Deprecated, call the old hooks here.
+	 */
+	public function maybe_handle_deprecated_hook() {
+		$new_hook          = current_filter();
+		$old_hooks         = $this->get_old_hooks( $new_hook );
+		$new_callback_args = func_get_args();
+		$return_value      = $new_callback_args[0];
+
+		foreach ( $old_hooks as $old_hook ) {
+			$return_value = $this->handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
+		}
+
+		return $return_value;
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param string $new_hook
+	 * @param string $old_hook
+	 * @param array $new_callback_args
+	 * @param mixed $return_value
+	 * @return mixed
+	 */
+	abstract function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
+
+	/**
+	 * Display a deprecated notice for old hooks.
+	 *
+	 * @since 2.0
+	 */
+	protected static function display_notice( $old_hook, $new_hook ) {
+		_deprecated_function( sprintf( 'The "%s" hook uses out of date data structures so', esc_html( $old_hook ) ), false, esc_html( $new_hook ) );
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook
+	 * @param  array $new_callback_args
+	 * @return mixed
+	 */
+	abstract function trigger_hook( $old_hook, $new_callback_args );
+}

--- a/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -23,7 +23,8 @@ abstract class WC_Deprecated_Hooks {
 	 * Constructor.
 	 */
 	public function __construct() {
-		array_walk( array_keys( $this->deprecated_hooks ), array( $this, 'hook_in' ) );
+		$new_hooks = array_keys( $this->deprecated_hooks );
+		array_walk( $new_hooks, array( $this, 'hook_in' ) );
 	}
 
 	/**
@@ -89,5 +90,5 @@ abstract class WC_Deprecated_Hooks {
 	 * @param  array $new_callback_args
 	 * @return mixed
 	 */
-	abstract function trigger_hook( $old_hook, $new_callback_args );
+	abstract protected function trigger_hook( $old_hook, $new_callback_args );
 }

--- a/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -76,11 +76,9 @@ abstract class WC_Deprecated_Hooks {
 
 	/**
 	 * Display a deprecated notice for old hooks.
-	 *
-	 * @since 2.0
 	 */
-	protected static function display_notice( $old_hook, $new_hook ) {
-		_deprecated_function( sprintf( 'The "%s" hook uses out of date data structures so', esc_html( $old_hook ) ), false, esc_html( $new_hook ) );
+	protected function display_notice( $old_hook, $new_hook ) {
+		_deprecated_function( sprintf( 'The "%s" hook uses out of date data structures and', esc_html( $old_hook ) ), WC_VERSION, esc_html( $new_hook ) );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-legacy-order.php
+++ b/includes/abstracts/abstract-wc-legacy-order.php
@@ -383,18 +383,19 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	}
 
 	/**
-	 * Magic __isset method for backwards compatibility.
+	 * Magic __isset method for backwards compatibility. Handles legacy properties which could be accessed directly in the past.
+	 *
 	 * @param string $key
 	 * @return bool
 	 */
 	public function __isset( $key ) {
-		// Legacy properties which could be accessed directly in the past.
 		$legacy_props = array( 'completed_date', 'id', 'order_type', 'post', 'status', 'post_status', 'customer_note', 'customer_message', 'user_id', 'customer_user', 'prices_include_tax', 'tax_display_cart', 'display_totals_ex_tax', 'display_cart_ex_tax', 'order_date', 'modified_date', 'cart_discount', 'cart_discount_tax', 'order_shipping', 'order_shipping_tax', 'order_total', 'order_tax', 'billing_first_name', 'billing_last_name', 'billing_company', 'billing_address_1', 'billing_address_2', 'billing_city', 'billing_state', 'billing_postcode', 'billing_country', 'billing_phone', 'billing_email', 'shipping_first_name', 'shipping_last_name', 'shipping_company', 'shipping_address_1', 'shipping_address_2', 'shipping_city', 'shipping_state', 'shipping_postcode', 'shipping_country', 'customer_ip_address', 'customer_user_agent', 'payment_method_title', 'payment_method', 'order_currency' );
 		return $this->get_id() ? ( in_array( $key, $legacy_props ) || metadata_exists( 'post', $this->get_id(), '_' . $key ) ) : false;
 	}
 
 	/**
 	 * Magic __get method for backwards compatibility.
+	 *
 	 * @param string $key
 	 * @return mixed
 	 */

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -203,24 +203,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 						$this->items[ $item_group ][ $item_id ] = $item;
 						unset( $this->items[ $item_group ][ $item_key ] );
 
-						// Legacy action handler
-						switch ( $item_group ) {
-							case 'fee_lines' :
-								if ( isset( $item->legacy_fee, $item->legacy_fee_key ) ) {
-									wc_do_deprecated_action( 'woocommerce_add_order_fee_meta', array( $this->get_id(), $item_id, $item->legacy_fee, $item->legacy_fee_key ), '2.7', 'CRUD and woocommerce_checkout_create_order_fee_item action instead' );
-								}
-							break;
-							case 'shipping_lines' :
-								if ( isset( $item->legacy_package_key ) ) {
-									wc_do_deprecated_action( 'woocommerce_add_shipping_order_item', array( $this->get_id(), $item_id, $item->legacy_package_key ), '2.7', 'CRUD woocommerce_checkout_create_order_shipping_item action instead' );
-								}
-							break;
-							case 'line_items' :
-								if ( isset( $item->legacy_values, $item->legacy_cart_item_key ) ) {
-									wc_do_deprecated_action( 'woocommerce_add_order_item_meta', array( $item_id, $item->legacy_values, $item->legacy_cart_item_key ), '2.7', 'CRUD and woocommerce_checkout_create_order_line_item action instead' );
-								}
-							break;
-						}
+						// Fire an action for the new item in the database. This is used for firing legacy hooks in particular.
+						do_action( 'woocommerce_order_item_created', $item, $this );
+					} else {
+						// Fire an action for the new item in the database. This is used for firing legacy hooks in particular.
+						do_action( 'woocommerce_order_item_updated', $item, $this );
 					}
 				}
 			}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -201,13 +201,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					// If ID changed (new item saved to DB)...
 					if ( $item_id !== $item_key ) {
 						$this->items[ $item_group ][ $item_id ] = $item;
-						unset( $this->items[ $item_group ][ $item_key ] );
 
-						// Fire an action for the new item in the database. This is used for firing legacy hooks in particular.
-						do_action( 'woocommerce_order_item_created', $item, $this );
-					} else {
-						// Fire an action for the new item in the database. This is used for firing legacy hooks in particular.
-						do_action( 'woocommerce_order_item_updated', $item, $this );
+						unset( $this->items[ $item_group ][ $item_key ] );
 					}
 				}
 			}

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -929,7 +929,7 @@ class WC_Checkout {
 					throw new Exception( $order->get_error_message() );
 				}
 
-				do_action( 'woocommerce_checkout_order_processed', $order, $posted_data );
+				do_action( 'woocommerce_checkout_order_processed', $order->get_id(), $posted_data, $order );
 
 				if ( WC()->cart->needs_payment() ) {
 					$this->process_order_payment( $order, $posted_data['payment_method'] );

--- a/includes/class-wc-deprecated-action-hooks.php
+++ b/includes/class-wc-deprecated-action-hooks.php
@@ -1,0 +1,141 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles deprecation notices and triggering of legacy action hooks.
+ *
+ * @since 2.7.0
+ */
+class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = array(
+		'woocommerce_new_order_item' => array(
+			'woocommerce_order_add_shipping',
+			'woocommerce_order_add_coupon',
+			'woocommerce_order_add_tax',
+			'woocommerce_order_add_fee',
+			'woocommerce_add_shipping_order_item',
+			'woocommerce_add_order_item_meta',
+			'woocommerce_add_order_fee_meta',
+		),
+		'woocommerce_update_order_item' => array(
+			'woocommerce_order_edit_product',
+			'woocommerce_order_update_coupon',
+			'woocommerce_order_update_shipping',
+			'woocommerce_order_update_fee',
+			'woocommerce_order_update_tax',
+		),
+	);
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 * @param  string $hook_name
+	 */
+	public function hook_in( $hook_name ) {
+		add_action( $hook_name, array( $this, 'maybe_handle_deprecated_hook' ), -1000, 8 );
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param string $new_hook
+	 * @param string $old_hook
+	 * @param array $new_callback_args
+	 * @param mixed $return_value
+	 * @return mixed
+	 */
+	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
+		if ( has_action( $old_hook ) ) {
+			$this->display_notice( $old_hook, $new_hook );
+			$return_value = $this->trigger_hook( $old_hook, $new_callback_args );
+		}
+		return $return_value;
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook
+	 * @param  array $new_callback_args
+	 * @return mixed
+	 */
+	protected function trigger_hook( $old_hook, $new_callback_args ) {
+		switch ( $old_hook ) {
+			case 'woocommerce_order_add_shipping' :
+			case 'woocommerce_order_add_fee' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Shipping' ) || is_a( $item, 'WC_Order_Item_Fee' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item );
+				}
+				break;
+			case 'woocommerce_order_add_coupon' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Coupon' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item->get_code(), $item->get_discount(), $item->get_discount_tax() );
+				}
+				break;
+			case 'woocommerce_order_add_tax' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Tax' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item->get_rate_id(), $item->get_tax_total(), $item->get_shipping_tax_total() );
+				}
+				break;
+			case 'woocommerce_add_shipping_order_item' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Shipping' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item->legacy_package_key );
+				}
+				break;
+			case 'woocommerce_add_order_item_meta' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
+					do_action( $old_hook, $item_id, $item->legacy_values, $item->legacy_cart_item_key );
+				}
+				break;
+			case 'woocommerce_add_order_fee_meta' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Fee' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item->legacy_fee, $item->legacy_fee_key );
+				}
+				break;
+			case 'woocommerce_order_edit_product' :
+				$item_id  = $new_callback_args[0];
+				$item     = $new_callback_args[1];
+				$order_id = $new_callback_args[2];
+				if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item, $item->get_product() );
+				}
+				break;
+			case 'woocommerce_order_update_coupon' :
+			case 'woocommerce_order_update_shipping' :
+			case 'woocommerce_order_update_fee' :
+			case 'woocommerce_order_update_tax' :
+				if ( ! is_a( $item, 'WC_Order_Item_Product' ) ) {
+					do_action( $old_hook, $order_id, $item_id, $item );
+				}
+				break;
+			default :
+				do_action_ref_array( $old_hook, $new_callback_args );
+				break;
+		}
+	}
+}

--- a/includes/class-wc-deprecated-filter-hooks.php
+++ b/includes/class-wc-deprecated-filter-hooks.php
@@ -84,6 +84,6 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 	 * @return mixed
 	 */
 	protected function trigger_hook( $old_hook, $new_callback_args ) {
-		apply_filters_ref_array( $old_hook, $new_callback_args );
+		return apply_filters_ref_array( $old_hook, $new_callback_args );
 	}
 }

--- a/includes/class-wc-deprecated-filter-hooks.php
+++ b/includes/class-wc-deprecated-filter-hooks.php
@@ -1,0 +1,89 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles deprecation notices and triggering of legacy filter hooks.
+ *
+ * @since 2.7.0
+ */
+class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = array(
+		'woocommerce_structured_data_order'         => 'woocommerce_email_order_schema_markup',
+		'woocommerce_add_to_cart_fragments'         => 'add_to_cart_fragments',
+		'woocommerce_add_to_cart_redirect'          => 'add_to_cart_redirect',
+		'woocommerce_product_get_width'             => 'woocommerce_product_width',
+		'woocommerce_product_get_height'            => 'woocommerce_product_height',
+		'woocommerce_product_get_length'            => 'woocommerce_product_length',
+		'woocommerce_product_get_weight'            => 'woocommerce_product_weight',
+		'woocommerce_product_get_sku'               => 'woocommerce_get_sku',
+		'woocommerce_product_get_price'             => 'woocommerce_get_price',
+		'woocommerce_product_get_regular_price'     => 'woocommerce_get_regular_price',
+		'woocommerce_product_get_sale_price'        => 'woocommerce_get_sale_price',
+		'woocommerce_product_get_tax_class'         => 'woocommerce_product_tax_class',
+		'woocommerce_product_get_stock_quantity'    => 'woocommerce_get_stock_quantity',
+		'woocommerce_product_get_attributes'        => 'woocommerce_get_product_attributes',
+		'woocommerce_product_get_gallery_image_ids' => 'woocommerce_product_gallery_attachment_ids',
+		'woocommerce_product_get_review_count'      => 'woocommerce_product_review_count',
+		'woocommerce_product_get_downloads'         => 'woocommerce_product_files',
+		'woocommerce_order_get_currency'            => 'woocommerce_get_currency',
+		'woocommerce_order_get_discount_total'      => 'woocommerce_order_amount_discount_total',
+		'woocommerce_order_get_discount_tax'        => 'woocommerce_order_amount_discount_tax',
+		'woocommerce_order_get_shipping_total'      => 'woocommerce_order_amount_shipping_total',
+		'woocommerce_order_get_shipping_tax'        => 'woocommerce_order_amount_shipping_tax',
+		'woocommerce_order_get_cart_tax'            => 'woocommerce_order_amount_cart_tax',
+		'woocommerce_order_get_total'               => 'woocommerce_order_amount_total',
+		'woocommerce_order_get_total_tax'           => 'woocommerce_order_amount_total_tax',
+		'woocommerce_order_get_total_discount'      => 'woocommerce_order_amount_total_discount',
+		'woocommerce_order_get_subtotal'            => 'woocommerce_order_amount_subtotal',
+		'woocommerce_order_get_tax_totals'          => 'woocommerce_order_tax_totals',
+		'woocommerce_get_order_refund_get_amount'   => 'woocommerce_refund_amount',
+		'woocommerce_get_order_refund_get_reason'   => 'woocommerce_refund_reason',
+		'default_checkout_billing_country'          => 'default_checkout_country',
+		'default_checkout_billing_state'            => 'default_checkout_state',
+		'default_checkout_billing_postcode'         => 'default_checkout_postcode',
+	);
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 * @param  string $hook_name
+	 */
+	public function hook_in( $hook_name ) {
+		add_filter( $hook_name, array( $this, 'maybe_handle_deprecated_hook' ), -1000, 8 );
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param string $new_hook
+	 * @param string $old_hook
+	 * @param array $new_callback_args
+	 * @param mixed $return_value
+	 * @return mixed
+	 */
+	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
+		if ( has_filter( $old_hook ) ) {
+			$this->display_notice( $old_hook, $new_hook );
+			$return_value = $this->trigger_hook( $old_hook, $new_callback_args );
+		}
+		return $return_value;
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook
+	 * @param  array $new_callback_args
+	 * @return mixed
+	 */
+	protected function trigger_hook( $old_hook, $new_callback_args ) {
+		apply_filters_ref_array( $old_hook, $new_callback_args );
+	}
+}

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 include_once( 'abstracts/abstract-wc-deprecated-hooks.php' );
 include_once( 'class-wc-deprecated-action-hooks.php' );
+include_once( 'class-wc-deprecated-filter-hooks.php' );
 
 new WC_Deprecated_Action_Hooks();
 new WC_Deprecated_Filter_Hooks();

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -14,6 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+include_once( 'abstracts/abstract-wc-deprecated-hooks.php' );
+include_once( 'class-wc-deprecated-action-hooks.php' );
+
+new WC_Deprecated_Action_Hooks();
+new WC_Deprecated_Filter_Hooks();
+
 /**
  * Runs a deprecated action with notice only if used.
  *
@@ -85,45 +91,51 @@ function wc_deprecated_argument( $argument, $version, $message = null ) {
 }
 
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_show_messages() {
 	wc_deprecated_function( 'woocommerce_show_messages', '2.1', 'wc_print_notices' );
 	wc_print_notices();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_weekend_area_js() {
 	wc_deprecated_function( 'woocommerce_weekend_area_js', '2.1' );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_tooltip_js() {
 	wc_deprecated_function( 'woocommerce_tooltip_js', '2.1' );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_datepicker_js() {
 	wc_deprecated_function( 'woocommerce_datepicker_js', '2.1' );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_admin_scripts() {
 	wc_deprecated_function( 'woocommerce_admin_scripts', '2.1' );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_create_page( $slug, $option = '', $page_title = '', $page_content = '', $post_parent = 0 ) {
 	wc_deprecated_function( 'woocommerce_create_page', '2.1', 'wc_create_page' );
 	return wc_create_page( $slug, $option, $page_title, $page_content, $post_parent );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.1
  */
 function woocommerce_readfile_chunked( $file, $retbytes = true ) {
 	wc_deprecated_function( 'woocommerce_readfile_chunked', '2.1', 'WC_Download_Handler::readfile_chunked()' );
@@ -163,609 +175,668 @@ function woocommerce_get_formatted_product_name( $product ) {
  */
 function woocommerce_legacy_paypal_ipn() {
 	if ( ! empty( $_GET['paypalListener'] ) && 'paypal_standard_IPN' === $_GET['paypalListener'] ) {
-
 		WC()->payment_gateways();
-
 		do_action( 'woocommerce_api_wc_gateway_paypal' );
 	}
 }
 add_action( 'init', 'woocommerce_legacy_paypal_ipn' );
 
 /**
- * get_product soft deprecated for wc_get_product.
- *
- * @deprecated
+ * @deprecated 2.7
  */
 function get_product( $the_product = false, $args = array() ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_product' );
 	return wc_get_product( $the_product, $args );
 }
 
 /**
- * Cart functions (soft deprecated).
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_protected_product_add_to_cart( $passed, $product_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_protected_product_add_to_cart' );
 	return wc_protected_product_add_to_cart( $passed, $product_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_empty_cart() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_empty_cart' );
 	wc_empty_cart();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_load_persistent_cart( $user_login, $user = 0 ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_load_persistent_cart' );
 	return wc_load_persistent_cart( $user_login, $user );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_add_to_cart_message( $product_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_add_to_cart_message' );
 	wc_add_to_cart_message( $product_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_clear_cart_after_payment() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_clear_cart_after_payment' );
 	wc_clear_cart_after_payment();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cart_totals_subtotal_html() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cart_totals_subtotal_html' );
 	wc_cart_totals_subtotal_html();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cart_totals_shipping_html() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cart_totals_shipping_html' );
 	wc_cart_totals_shipping_html();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cart_totals_coupon_html( $coupon ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cart_totals_coupon_html' );
 	wc_cart_totals_coupon_html( $coupon );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cart_totals_order_total_html() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cart_totals_order_total_html' );
 	wc_cart_totals_order_total_html();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cart_totals_fee_html( $fee ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cart_totals_fee_html' );
 	wc_cart_totals_fee_html( $fee );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cart_totals_shipping_method_label( $method ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cart_totals_shipping_method_label' );
 	return wc_cart_totals_shipping_method_label( $method );
 }
 
 /**
- * Core functions (soft deprecated).
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_template_part( $slug, $name = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_template_part' );
 	wc_get_template_part( $slug, $name );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_template' );
 	wc_get_template( $template_name, $args, $template_path, $default_path );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_locate_template( $template_name, $template_path = '', $default_path = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_locate_template' );
 	return wc_locate_template( $template_name, $template_path, $default_path );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_mail( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = "" ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_mail' );
 	wc_mail( $to, $subject, $message, $headers, $attachments );
 }
 
 /**
- * Customer functions (soft deprecated).
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_disable_admin_bar( $show_admin_bar ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_disable_admin_bar' );
 	return wc_disable_admin_bar( $show_admin_bar );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_create_new_customer( $email, $username = '', $password = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_create_new_customer' );
 	return wc_create_new_customer( $email, $username, $password );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_set_customer_auth_cookie( $customer_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_set_customer_auth_cookie' );
 	wc_set_customer_auth_cookie( $customer_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_update_new_customer_past_orders( $customer_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_update_new_customer_past_orders' );
 	return wc_update_new_customer_past_orders( $customer_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_paying_customer( $order_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_paying_customer' );
 	wc_paying_customer( $order_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_customer_bought_product( $customer_email, $user_id, $product_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_customer_bought_product' );
 	return wc_customer_bought_product( $customer_email, $user_id, $product_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_customer_has_capability( $allcaps, $caps, $args ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_customer_has_capability' );
 	return wc_customer_has_capability( $allcaps, $caps, $args );
 }
 
 /**
- * Formatting functions (soft deprecated).
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_sanitize_taxonomy_name( $taxonomy ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_sanitize_taxonomy_name' );
 	return wc_sanitize_taxonomy_name( $taxonomy );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_filename_from_url( $file_url ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_filename_from_url' );
 	return wc_get_filename_from_url( $file_url );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_dimension( $dim, $to_unit ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_dimension' );
 	return wc_get_dimension( $dim, $to_unit );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_weight( $weight, $to_unit ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_weight' );
 	return wc_get_weight( $weight, $to_unit );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_trim_zeros( $price ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_trim_zeros' );
 	return wc_trim_zeros( $price );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_round_tax_total( $tax ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_round_tax_total' );
 	return wc_round_tax_total( $tax );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_format_decimal( $number, $dp = false, $trim_zeros = false ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_format_decimal' );
 	return wc_format_decimal( $number, $dp, $trim_zeros );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_clean( $var ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_clean' );
 	return wc_clean( $var );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_array_overlay( $a1, $a2 ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_array_overlay' );
 	return wc_array_overlay( $a1, $a2 );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_price( $price, $args = array() ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_price' );
 	return wc_price( $price, $args );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_let_to_num( $size ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_let_to_num' );
 	return wc_let_to_num( $size );
 }
 
 /**
- * @return string
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_date_format() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_date_format' );
 	return wc_date_format();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_time_format() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_time_format' );
 	return wc_time_format();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_timezone_string() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_timezone_string' );
 	return wc_timezone_string();
 }
+
 if ( ! function_exists( 'woocommerce_rgb_from_hex' ) ) {
 	/**
-	 * @deprecated
+	 * @deprecated 2.7
 	 */
 	function woocommerce_rgb_from_hex( $color ) {
+		wc_deprecated_function( __FUNCTION__, '2.7', 'wc_rgb_from_hex' );
 		return wc_rgb_from_hex( $color );
 	}
 }
+
 if ( ! function_exists( 'woocommerce_hex_darker' ) ) {
 	/**
-	 * @deprecated
+	 * @deprecated 2.7
 	 */
 	function woocommerce_hex_darker( $color, $factor = 30 ) {
+		wc_deprecated_function( __FUNCTION__, '2.7', 'wc_hex_darker' );
 		return wc_hex_darker( $color, $factor );
 	}
 }
+
 if ( ! function_exists( 'woocommerce_hex_lighter' ) ) {
 	/**
-	 * @deprecated
+	 * @deprecated 2.7
 	 */
 	function woocommerce_hex_lighter( $color, $factor = 30 ) {
+		wc_deprecated_function( __FUNCTION__, '2.7', 'wc_hex_lighter' );
 		return wc_hex_lighter( $color, $factor );
 	}
 }
+
 if ( ! function_exists( 'woocommerce_light_or_dark' ) ) {
 	/**
-	 * @deprecated
+	 * @deprecated 2.7
 	 */
 	function woocommerce_light_or_dark( $color, $dark = '#000000', $light = '#FFFFFF' ) {
+		wc_deprecated_function( __FUNCTION__, '2.7', 'wc_light_or_dark' );
 		return wc_light_or_dark( $color, $dark, $light );
 	}
 }
+
 if ( ! function_exists( 'woocommerce_format_hex' ) ) {
 	/**
-	 * @deprecated
+	 * @deprecated 2.7
 	 */
 	function woocommerce_format_hex( $hex ) {
+		wc_deprecated_function( __FUNCTION__, '2.7', 'wc_format_hex' );
 		return wc_format_hex( $hex );
 	}
 }
 
 /**
- * Order functions (soft deprecated).
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_order_id_by_order_key( $order_key ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_order_id_by_order_key' );
 	return wc_get_order_id_by_order_key( $order_key );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_downloadable_file_permission( $download_id, $product_id, $order ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_downloadable_file_permission' );
 	return wc_downloadable_file_permission( $download_id, $product_id, $order );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_downloadable_product_permissions( $order_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_downloadable_product_permissions' );
 	wc_downloadable_product_permissions( $order_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_add_order_item( $order_id, $item ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_add_order_item' );
 	return wc_add_order_item( $order_id, $item );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_delete_order_item( $item_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_delete_order_item' );
 	return wc_delete_order_item( $item_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_update_order_item_meta( $item_id, $meta_key, $meta_value, $prev_value = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_update_order_item_meta' );
 	return wc_update_order_item_meta( $item_id, $meta_key, $meta_value, $prev_value );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique = false ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_add_order_item_meta' );
 	return wc_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_delete_order_item_meta( $item_id, $meta_key, $meta_value = '', $delete_all = false ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_delete_order_item_meta' );
 	return wc_delete_order_item_meta( $item_id, $meta_key, $meta_value, $delete_all );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_order_item_meta( $item_id, $key, $single = true ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_order_item_meta' );
 	return wc_get_order_item_meta( $item_id, $key, $single );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_cancel_unpaid_orders() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_cancel_unpaid_orders' );
 	wc_cancel_unpaid_orders();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_processing_order_count() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_processing_order_count' );
 	return wc_processing_order_count();
 }
 
 /**
- * Page functions (soft deprecated).
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_page_id( $page ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_page_id' );
 	return wc_get_page_id( $page );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_endpoint_url' );
 	return wc_get_endpoint_url( $endpoint, $value, $permalink );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_lostpassword_url( $url ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_lostpassword_url' );
 	return wc_lostpassword_url( $url );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_customer_edit_account_url() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_customer_edit_account_url' );
 	return wc_customer_edit_account_url();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_nav_menu_items( $items, $args ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_nav_menu_items' );
 	return wc_nav_menu_items( $items );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_nav_menu_item_classes( $menu_items, $args ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_nav_menu_item_classes' );
 	return wc_nav_menu_item_classes( $menu_items );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_list_pages( $pages ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_list_pages' );
 	return wc_list_pages( $pages );
 }
 
 /**
- * Handle renamed filters.
- */
-global $wc_map_deprecated_filters;
-
-$wc_map_deprecated_filters = array(
-	'woocommerce_structured_data_order'         => 'woocommerce_email_order_schema_markup',
-	'woocommerce_add_to_cart_fragments'         => 'add_to_cart_fragments',
-	'woocommerce_add_to_cart_redirect'          => 'add_to_cart_redirect',
-	'woocommerce_product_get_width'             => 'woocommerce_product_width',
-	'woocommerce_product_get_height'            => 'woocommerce_product_height',
-	'woocommerce_product_get_length'            => 'woocommerce_product_length',
-	'woocommerce_product_get_weight'            => 'woocommerce_product_weight',
-	'woocommerce_product_get_sku'               => 'woocommerce_get_sku',
-	'woocommerce_product_get_price'             => 'woocommerce_get_price',
-	'woocommerce_product_get_regular_price'     => 'woocommerce_get_regular_price',
-	'woocommerce_product_get_sale_price'        => 'woocommerce_get_sale_price',
-	'woocommerce_product_get_tax_class'         => 'woocommerce_product_tax_class',
-	'woocommerce_product_get_stock_quantity'    => 'woocommerce_get_stock_quantity',
-	'woocommerce_product_get_attributes'        => 'woocommerce_get_product_attributes',
-	'woocommerce_product_get_gallery_image_ids' => 'woocommerce_product_gallery_attachment_ids',
-	'woocommerce_product_get_review_count'      => 'woocommerce_product_review_count',
-	'woocommerce_product_get_downloads'         => 'woocommerce_product_files',
-	'woocommerce_order_get_currency'            => 'woocommerce_get_currency',
-	'woocommerce_order_get_discount_total'      => 'woocommerce_order_amount_discount_total',
-	'woocommerce_order_get_discount_tax'        => 'woocommerce_order_amount_discount_tax',
-	'woocommerce_order_get_shipping_total'      => 'woocommerce_order_amount_shipping_total',
-	'woocommerce_order_get_shipping_tax'        => 'woocommerce_order_amount_shipping_tax',
-	'woocommerce_order_get_cart_tax'            => 'woocommerce_order_amount_cart_tax',
-	'woocommerce_order_get_total'               => 'woocommerce_order_amount_total',
-	'woocommerce_order_get_total_tax'           => 'woocommerce_order_amount_total_tax',
-	'woocommerce_order_get_total_discount'      => 'woocommerce_order_amount_total_discount',
-	'woocommerce_order_get_subtotal'            => 'woocommerce_order_amount_subtotal',
-	'woocommerce_order_get_tax_totals'          => 'woocommerce_order_tax_totals',
-	'woocommerce_get_order_refund_get_amount'   => 'woocommerce_refund_amount',
-	'woocommerce_get_order_refund_get_reason'   => 'woocommerce_refund_reason',
-	'default_checkout_billing_country'          => 'default_checkout_country',
-	'default_checkout_billing_state'            => 'default_checkout_state',
-	'default_checkout_billing_postcode'         => 'default_checkout_postcode',
-);
-
-foreach ( $wc_map_deprecated_filters as $new => $old ) {
-	add_filter( $new, 'woocommerce_deprecated_filter_mapping', 10, 100 );
-}
-
-function woocommerce_deprecated_filter_mapping() {
-	global $wc_map_deprecated_filters;
-
-	$filter = current_filter();
-	$args   = func_get_args();
-	$data   = $args[0];
-
-	if ( isset( $wc_map_deprecated_filters[ $filter ] ) ) {
-		if ( has_filter( $wc_map_deprecated_filters[ $filter ] ) ) {
-			$data = apply_filters_ref_array( $wc_map_deprecated_filters[ $filter ], $args );
-		}
-	}
-
-	return $data;
-}
-
-/**
- * Alias functions/soft-deprecated function names (moving from woocommerce_ to wc_). These will be deprecated with notices in future updates.
- */
-
-/**
- * Attribute functions - soft deprecated.
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_product_dropdown_categories( $args = array(), $deprecated_hierarchical = 1, $deprecated_show_uncategorized = 1, $deprecated_orderby = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_product_dropdown_categories' );
 	return wc_product_dropdown_categories( $args, $deprecated_hierarchical, $deprecated_show_uncategorized, $deprecated_orderby );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_walk_category_dropdown_tree( $a1 = '', $a2 = '', $a3 = '' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_walk_category_dropdown_tree' );
 	return wc_walk_category_dropdown_tree( $a1, $a2, $a3 );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
-function woocommerce_taxonomy_metadata_wpdbfix() {}
+function woocommerce_taxonomy_metadata_wpdbfix() {
+	wc_deprecated_function( __FUNCTION__, '2.7' );
+}
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
-function wc_taxonomy_metadata_wpdbfix() {}
+function wc_taxonomy_metadata_wpdbfix() {
+	wc_deprecated_function( __FUNCTION__, '2.7' );
+}
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_order_terms( $the_term, $next_id, $taxonomy, $index = 0, $terms = null ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_reorder_terms' );
 	return wc_reorder_terms( $the_term, $next_id, $taxonomy, $index, $terms );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_set_term_order' );
 	return wc_set_term_order( $term_id, $index, $taxonomy, $recursive );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_terms_clauses( $clauses, $taxonomies, $args ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_terms_clauses' );
 	return wc_terms_clauses( $clauses, $taxonomies, $args );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function _woocommerce_term_recount( $terms, $taxonomy, $callback, $terms_are_term_taxonomy_ids ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', '_wc_term_recount' );
 	return _wc_term_recount( $terms, $taxonomy, $callback, $terms_are_term_taxonomy_ids );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_recount_after_stock_change( $product_id ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_recount_after_stock_change' );
 	return wc_recount_after_stock_change( $product_id );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_change_term_counts( $terms, $taxonomies, $args ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_change_term_counts' );
 	return wc_change_term_counts( $terms, $taxonomies );
 }
 
 /**
- * Product functions - soft deprecated.
- */
-/**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_product_ids_on_sale() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_product_ids_on_sale' );
 	return wc_get_product_ids_on_sale();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_featured_product_ids() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_featured_product_ids' );
 	return wc_get_featured_product_ids();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_product_terms( $object_id, $taxonomy, $fields = 'all' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_product_terms' );
 	return wc_get_product_terms( $object_id, $taxonomy, array( 'fields' => $fields ) );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_product_post_type_link( $permalink, $post ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_product_post_type_link' );
 	return wc_product_post_type_link( $permalink, $post );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_placeholder_img_src() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_placeholder_img_src' );
 	return wc_placeholder_img_src();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_placeholder_img( $size = 'shop_thumbnail' ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_placeholder_img' );
 	return wc_placeholder_img( $size );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_formatted_variation( $variation = '', $flat = false ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_formatted_variation' );
 	return wc_get_formatted_variation( $variation, $flat );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_scheduled_sales() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_scheduled_sales' );
 	return wc_scheduled_sales();
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_get_attachment_image_attributes( $attr ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_get_attachment_image_attributes' );
 	return wc_get_attachment_image_attributes( $attr );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_prepare_attachment_for_js( $response ) {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_prepare_attachment_for_js' );
 	return wc_prepare_attachment_for_js( $response );
 }
+
 /**
- * @deprecated
+ * @deprecated 2.7
  */
 function woocommerce_track_product_view() {
+	wc_deprecated_function( __FUNCTION__, '2.7', 'wc_track_product_view' );
 	return wc_track_product_view();
 }
+
 /**
  * @since 2.3
  * @deprecated has no replacement
@@ -786,7 +857,6 @@ function woocommerce_calc_shipping_backwards_compatibility( $value ) {
 	}
 	return 'disabled' === get_option( 'woocommerce_ship_to_countries' ) ? 'no' : 'yes';
 }
-
 add_filter( 'pre_option_woocommerce_calc_shipping', 'woocommerce_calc_shipping_backwards_compatibility' );
 
 /**


### PR DESCRIPTION
Closes #13132 

Adds deprecation handling classes based on @thenbrent’s work to deprecate actions and filters.

Also adds correct deprecation methods for soft deprecated functions.

Maps the order line item actions to the replacements - `$item` is already backwards compatible so can be passed to the hooks directly without modification.