### PR TITLE
Duplicate products; fix variation creation and add actions

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -160,13 +160,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order' ), array_keys( $changes ) ) ) {
 			wp_update_post( array(
 				'ID'             => $product->get_id(),
-				'post_content'   => $product->get_description(),
-				'post_excerpt'   => $product->get_short_description(),
-				'post_title'     => $product->get_name(),
-				'post_parent'    => $product->get_parent_id(),
-				'comment_status' => $product->get_reviews_allowed() ? 'open' : 'closed',
-				'post_status'    => $product->get_status() ? $product->get_status() : 'publish',
-				'menu_order'     => $product->get_menu_order(),
+				'post_content'   => $product->get_description( 'edit' ),
+				'post_excerpt'   => $product->get_short_description( 'edit' ),
+				'post_title'     => $product->get_name( 'edit' ),
+				'post_parent'    => $product->get_parent_id( 'edit' ),
+				'comment_status' => $product->get_reviews_allowed( 'edit' ) ? 'open' : 'closed',
+				'post_status'    => $product->get_status( 'edit' ) ? $product->get_status( 'edit' ) : 'publish',
+				'menu_order'     => $product->get_menu_order( 'edit' ),
 			) );
 		}
 

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -16,10 +16,35 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 * Helper method that updates all the post meta for a grouped product.
 	 *
 	 * @param WC_Product
+	 * @param bool Force update. Used during create.
 	 * @since 2.7.0
 	 */
-	protected function update_post_meta( &$product ) {
-		if ( update_post_meta( $product->get_id(), '_children', $product->get_children( 'edit' ) ) ) {
+	protected function update_post_meta( &$product, $force = false ) {
+		$meta_key_to_props = array(
+			'_children' => 'children',
+		);
+
+		$props_to_update = $force ? $meta_key_to_props : $this->get_props_to_update( $product, $meta_key_to_props );
+
+		foreach ( $props_to_update as $meta_key => $prop ) {
+			$value   = $product->{"get_$prop"}( 'edit' );
+			$updated = update_post_meta( $product->get_id(), $meta_key, $value );
+			if ( $updated ) {
+				$this->updated_props[] = $prop;
+			}
+		}
+
+		parent::update_post_meta( $product );
+	}
+
+	/**
+	 * Handle updated meta props after updating meta data.
+	 *
+	 * @since  2.7.0
+	 * @param  WC_Product $product
+	 */
+	protected function handle_updated_props( &$product ) {
+		if ( in_array( 'children', $this->updated_props ) ) {
 			$child_prices = array();
 			foreach ( $product->get_children( 'edit' ) as $child_id ) {
 				$child = wc_get_product( $child_id );
@@ -34,11 +59,8 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 				add_post_meta( $product->get_id(), '_price', min( $child_prices ) );
 				add_post_meta( $product->get_id(), '_price', max( $child_prices ) );
 			}
-
-			$this->extra_data_saved = true;
 		}
-
-		parent::update_post_meta( $product );
+		parent::handle_updated_props( $product );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -137,16 +137,17 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 */
 	public function update( &$product ) {
 		$changes = $product->get_changes();
+		$title   = $this->generate_product_title( $product );
 
 		// Only update the post when the post data changes.
-		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order' ), array_keys( $changes ) ) ) {
+		if ( $title !== $product->get_name( 'edit' ) || array_intersect( array( 'parent_id', 'status', 'menu_order' ), array_keys( $changes ) ) ) {
 			wp_update_post( array(
 				'ID'             => $product->get_id(),
-				'post_title'     => $this->generate_product_title( $product ), // !
-				'post_parent'    => $product->get_parent_id(),
+				'post_title'     => $title,
+				'post_parent'    => $product->get_parent_id( 'edit' ),
 				'comment_status' => 'closed',
-				'post_status'    => $product->get_status() ? $product->get_status() : 'publish',
-				'menu_order'     => $product->get_menu_order(),
+				'post_status'    => $product->get_status( 'edit' ) ? $product->get_status( 'edit' ) : 'publish',
+				'menu_order'     => $product->get_menu_order( 'edit' ),
 			) );
 		}
 


### PR DESCRIPTION
Force allows create to make sure data is set regardless of whether it
was changed. This fixes product duplication.

Fixes #13199

Adds actions when duplicating things so objects can be changed, and
reinstates woocommerce_duplicate_product_exclude_meta which can unset
meta keys before save.

Closes #13180