### PR TITLE
Deprecated hook handler unit tests

### DIFF
--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -18,8 +18,10 @@ include_once( 'abstracts/abstract-wc-deprecated-hooks.php' );
 include_once( 'class-wc-deprecated-action-hooks.php' );
 include_once( 'class-wc-deprecated-filter-hooks.php' );
 
-new WC_Deprecated_Action_Hooks();
-new WC_Deprecated_Filter_Hooks();
+add_action( 'woocommerce_init', function(){
+	WC()->deprecated_hook_handlers['actions'] = new WC_Deprecated_Action_Hooks();
+	WC()->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
+});
 
 /**
  * Runs a deprecated action with notice only if used.

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -18,7 +18,7 @@ include_once( 'abstracts/abstract-wc-deprecated-hooks.php' );
 include_once( 'class-wc-deprecated-action-hooks.php' );
 include_once( 'class-wc-deprecated-filter-hooks.php' );
 
-add_action( 'woocommerce_init', function(){
+add_action( 'woocommerce_init', function() {
 	WC()->deprecated_hook_handlers['actions'] = new WC_Deprecated_Action_Hooks();
 	WC()->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
 });

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -18,10 +18,11 @@ include_once( 'abstracts/abstract-wc-deprecated-hooks.php' );
 include_once( 'class-wc-deprecated-action-hooks.php' );
 include_once( 'class-wc-deprecated-filter-hooks.php' );
 
-add_action( 'woocommerce_init', function() {
+function wc_initialize_deprecated_hook_handlers() {
 	WC()->deprecated_hook_handlers['actions'] = new WC_Deprecated_Action_Hooks();
 	WC()->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
-});
+}
+add_action( 'woocommerce_init', 'wc_initialize_deprecated_hook_handlers' );
 
 /**
  * Runs a deprecated action with notice only if used.

--- a/tests/unit-tests/util/deprecated-hooks.php
+++ b/tests/unit-tests/util/deprecated-hooks.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Classes WC_Deprecated_Filter_Hooks & WC_Deprecated_Action_Hooks.
+ * @package WooCommerce\Tests\Util
+ * @since 2.7
+ */
+class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
+
+	protected $handlers = array();
+
+	function setUp() {
+		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		$this->handlers = WC()->deprecated_hook_handlers;
+	}
+
+	/**
+	 * Test the deprecated hook handlers are initialized
+	 *
+	 * @since 2.7
+	 */
+	function test_deprecated_hook_handlers_exist() {
+		$this->assertArrayHasKey( 'filters', $this->handlers );
+		$this->assertInstanceOf( 'WC_Deprecated_Filter_Hooks', $this->handlers['filters'] );
+
+		$this->assertArrayHasKey( 'actions', $this->handlers );
+		$this->assertInstanceOf( 'WC_Deprecated_Action_Hooks', $this->handlers['actions'] );
+	}
+
+	/**
+	 * Test the get_old_hooks method
+	 *
+	 * @since 2.7
+	 */
+	function test_get_old_hooks() {
+		$old_filters = $this->handlers['filters']->get_old_hooks( 'woocommerce_structured_data_order' );
+		$old_actions = $this->handlers['actions']->get_old_hooks( 'woocommerce_new_order_item' );
+
+		$this->assertContains( 'woocommerce_email_order_schema_markup', $old_filters );
+		$this->assertContains( 'woocommerce_order_add_shipping', $old_actions );
+	}
+
+	/**
+	 * Test the hook_in method
+	 *
+	 * @since 2.7
+	 */
+	function test_hook_in() {
+		$this->assertTrue( (bool) has_filter( 'woocommerce_structured_data_order', array( $this->handlers['filters'], 'maybe_handle_deprecated_hook' ) ) );
+		$this->assertTrue( (bool) has_action( 'woocommerce_new_order_item', array( $this->handlers['actions'], 'maybe_handle_deprecated_hook' ) ) );
+	}
+
+	/**
+	 * Test the handle_deprecated_hook method in the filters handler
+	 *
+	 * @since 2.7
+	 */
+	function test_handle_deprecated_hook_filter() {
+		$new_hook = 'wc_new_hook';
+		$old_hook = 'wc_old_hook';
+		$args = array( false );
+		$return = -1;
+
+		add_filter( $old_hook, function( $value ) {
+			return ! $value;
+		} );
+
+		$result = $this->handlers['filters']->handle_deprecated_hook( $new_hook, $old_hook, $args, $return );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test the handle_deprecated_hook method in the actions handler
+	 *
+	 * @since 2.7
+	 */
+	function test_handle_deprecated_hook_action() {
+		$new_hook = 'wc_new_hook';
+		$old_hook = 'wc_old_hook';
+		$test_value = false;
+		$args = array(  &$test_value );
+		$return = -1;
+
+		add_action( $old_hook, function( &$value ) {
+			$value = true;
+		} );
+
+		$this->handlers['actions']->handle_deprecated_hook( $new_hook, $old_hook, $args, $return );
+		$this->assertTrue( $test_value );
+	}
+
+	/**
+	 * Test a complete deprecated filter mapping
+	 *
+	 * @since 2.7
+	 */
+	function test_filter_handler() {
+		$test_width = 1;
+
+		add_filter( 'woocommerce_product_width', function( $width ) {
+			return -1 * $width;
+		} );
+
+		$new_width = apply_filters( 'woocommerce_product_get_width', $test_width );
+		$this->assertEquals( -1, $new_width );
+	}
+
+	/**
+	 * Test a complete deprecated action mapping
+	 *
+	 * @since 2.7
+	 */
+	function test_action_handler() {
+		$test_product = WC_Helper_Product::create_simple_product();
+		$test_order = WC_Helper_Order::create_order( 1, $test_product );
+		$test_order_id = $test_order->get_id();
+		$test_items = $test_order->get_items();
+		$test_item = reset( $test_items );
+		$test_item_id = $test_item->get_id();
+
+		add_action( 'woocommerce_order_edit_product', function( $order_id, $item_id, $item ) {
+			$this->assertInstanceOf( 'WC_Order_Item_Product', $item );
+			update_post_meta( $order_id, 'wc_action_test_order_meta', true );
+		}, 10, 3 );
+
+		do_action( 'woocommerce_update_order_item', $test_item_id, $test_item, $test_order_id );
+
+		$order_update_worked = (bool) get_post_meta( $test_order_id, 'wc_action_test_order_meta', true );
+		$this->assertTrue( $order_update_worked );
+	}
+}

--- a/tests/unit-tests/util/deprecated-hooks.php
+++ b/tests/unit-tests/util/deprecated-hooks.php
@@ -118,14 +118,15 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 		$test_item = reset( $test_items );
 		$test_item_id = $test_item->get_id();
 
-		add_action( 'woocommerce_order_edit_product', function( $order_id, $item_id, $item ) {
-			$this->assertInstanceOf( 'WC_Order_Item_Product', $item );
+		add_action( 'woocommerce_order_edit_product', function( $order_id, $item_id ) {
 			update_post_meta( $order_id, 'wc_action_test_order_meta', true );
-		}, 10, 3 );
-
+			update_post_meta( $item_id, 'wc_action_test_item_meta', true );
+		}, 10, 2 );
 		do_action( 'woocommerce_update_order_item', $test_item_id, $test_item, $test_order_id );
 
 		$order_update_worked = (bool) get_post_meta( $test_order_id, 'wc_action_test_order_meta', true );
+		$item_update_worked = (bool) get_post_meta( $test_item_id, 'wc_action_test_item_meta', true );
 		$this->assertTrue( $order_update_worked );
+		$this->assertTrue( $item_update_worked );
 	}
 }

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -109,6 +109,13 @@ final class WooCommerce {
 	public $structured_data = null;
 
 	/**
+	 * Array of deprecated hook handlers.
+	 *
+	 * @var array of WC_Deprecated_Hooks
+	 */
+	public $deprecated_hook_handlers = array();
+
+	/**
 	 * Main WooCommerce Instance.
 	 *
 	 * Ensures only one instance of WooCommerce is loaded or can be loaded.


### PR DESCRIPTION
These are unit tests for the recently merged deprecated action handlers. In order to make the classes testable, I've added them to the WooCommerce object so I could fetch them as needed.

I've tested methods as well as the whole functionality. I didn't see a need to test `maybe_handle_deprecated_hook` and `trigger_hook` because those get used behind-the-scenes throughout the course of the other tests, so you'll notice quickly if those break.

Testing filters is fairly straightforward: Just hook a deprecated filter, fire the non-deprecated filter, and verify everything worked properly. See `test_filter_handler`. Testing actions is more complicated, since they don't really return anything, but works on the same basic principle. See `test_action_handler`.