### PR TITLE
Adding WP filter to is_order_received_page()

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -195,7 +195,7 @@ if ( ! function_exists( 'is_order_received_page' ) ) {
 	function is_order_received_page() {
 		global $wp;
 
-		return ( is_page( wc_get_page_id( 'checkout' ) ) && isset( $wp->query_vars['order-received'] ) );
+		return apply_filters( 'woocommerce_is_order_received_page', ( is_page( wc_get_page_id( 'checkout' ) ) && isset( $wp->query_vars['order-received'] ) ) );
 	}
 }
 


### PR DESCRIPTION
Many plugins and themes rely on is_order_received_page() to include special codes when the user places an order. Some plugins however alter the flow: Klarna checkout for example uses a completely custom checkout flow, some other plugins adds the option to the user to specify a WP page as "the" order received page instead of the WooCommerce default. All those plugins break codes where is_order_received_page() is being used.