### PR TITLE
Reset columns when invalid

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -87,7 +87,6 @@ class WC_Admin_Post_Types {
 			include( 'class-wc-admin-duplicate-product.php' );
 		}
 
-		// Meta-Box Class
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-meta-boxes.php' );
 
 		// Disable DFW feature pointer
@@ -96,11 +95,8 @@ class WC_Admin_Post_Types {
 		// Disable post type view mode options
 		add_filter( 'view_mode_post_types', array( $this, 'disable_view_mode_options' ) );
 
-		// If first time editing, disable columns by default.
-		if ( false === get_user_option( 'manageedit-shop_ordercolumnshidden' ) ) {
-			$user = wp_get_current_user();
-			update_user_option( $user->ID, 'manageedit-shop_ordercolumnshidden', array( 0 => 'billing_address' ), true );
-		}
+		// Update the screen options user meta.
+		add_action( 'admin_init', array( $this, 'adjust_shop_order_columns' ) );
 
 		// Show blank state
 		add_action( 'manage_posts_extra_tablenav', array( $this, 'maybe_render_blank_state' ) );
@@ -108,6 +104,19 @@ class WC_Admin_Post_Types {
 		// Hide template for CPT archive.
 		add_filter( 'theme_page_templates', array( $this, 'hide_cpt_archive_templates' ), 10, 3 );
 		add_action( 'edit_form_top', array( $this, 'show_cpt_archive_notice' ) );
+	}
+
+	/**
+	 * Adjust shop order columns for the user on certain conditions.
+	 */
+	public function adjust_shop_order_columns() {
+		$option_value = get_user_option( 'manageedit-shop_ordercolumnshidden' );
+
+		// If first time editing, disable columns by default. Likewise, CB should never be hidden.
+		if ( false === $option_value || ( is_array( $option_value ) && in_array( 'cb', $option_value ) ) ) {
+			$user = wp_get_current_user();
+			update_user_option( get_current_user_id(), 'manageedit-shop_ordercolumnshidden', array( 0 => 'billing_address' ), true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #13233 

When the CB column is hidden, for any reason, reset the view.