### PR TITLE
Helpful notices when deleted items in re-order

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -604,7 +604,8 @@ class WC_Form_Handler {
 		}
 
 		// Copy products from the order to the cart
-		foreach ( $order->get_items() as $item ) {
+		$order_items = $order->get_items();
+		foreach ( $order_items as $item ) {
 			// Load all product info including variation data
 			$product_id   = (int) apply_filters( 'woocommerce_add_to_cart_product_id', $item->get_product_id() );
 			$quantity     = $item->get_quantity();
@@ -630,8 +631,26 @@ class WC_Form_Handler {
 
 		do_action( 'woocommerce_ordered_again', $order->get_id() );
 
+		$num_items_in_cart = count( WC()->cart->get_cart() );
+		$num_items_in_original_order = count( $order_items );
+
+		if ( $num_items_in_original_order > $num_items_in_cart ) {
+			wc_add_notice(
+				sprintf( _n(
+					'%d item from your previous order is currently unavailable and could not be added to your cart.',
+					'%d items from your previous order are currently unavailable and could not be added to your cart.',
+					$num_items_in_original_order - $num_items_in_cart,
+					'woocommerce'
+				), $num_items_in_original_order - $num_items_in_cart ),
+				'error'
+			);
+		}
+
+		if ( $num_items_in_cart > 0 ) {
+			wc_add_notice( __( 'The cart has been filled with the items from your previous order.', 'woocommerce' ) );
+		}
+
 		// Redirect to cart
-		wc_add_notice( __( 'The cart has been filled with the items from your previous order.', 'woocommerce' ) );
 		wp_safe_redirect( wc_get_cart_url() );
 		exit;
 	}


### PR DESCRIPTION
This PR relates to #13240.

I've modified the re-order form handler to display a helpful notice when 1+ re-ordered items can not be added to the cart. I've also modified it to only display the success message when 1+ items are added to the cart.