### PR TITLE
Order Item Tax set_rate fixes

### DIFF
--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -104,10 +104,12 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_rate( $tax_rate_id ) {
+		$tax_rate = WC_Tax::_get_tax_rate( $tax_rate_id, OBJECT );
+
 		$this->set_rate_id( $tax_rate_id );
-		$this->set_rate_code( WC_Tax::get_rate_code( $tax_rate_id ) );
-		$this->set_label( WC_Tax::get_rate_label( $tax_rate_id ) );
-		$this->set_compound( WC_Tax::is_compound( $tax_rate_id ) );
+		$this->set_rate_code( WC_Tax::get_rate_code( $tax_rate ) );
+		$this->set_label( WC_Tax::get_rate_label( $tax_rate ) );
+		$this->set_compound( WC_Tax::is_compound( $tax_rate ) );
 	}
 
 	/*

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -106,7 +106,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	public function set_rate( $tax_rate_id ) {
 		$this->set_rate_id( $tax_rate_id );
 		$this->set_rate_code( WC_Tax::get_rate_code( $tax_rate_id ) );
-		$this->set_label( WC_Tax::get_rate_code( $tax_rate_id ) );
+		$this->set_label( WC_Tax::get_rate_label( $tax_rate_id ) );
 		$this->set_compound( WC_Tax::get_rate_code( $tax_rate_id ) );
 	}
 

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -107,7 +107,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 		$this->set_rate_id( $tax_rate_id );
 		$this->set_rate_code( WC_Tax::get_rate_code( $tax_rate_id ) );
 		$this->set_label( WC_Tax::get_rate_label( $tax_rate_id ) );
-		$this->set_compound( WC_Tax::get_rate_code( $tax_rate_id ) );
+		$this->set_compound( WC_Tax::is_compound( $tax_rate_id ) );
 	}
 
 	/*

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -594,12 +594,21 @@ class WC_Tax {
 	/**
 	 * Return true/false depending on if a rate is a compound rate.
 	 *
-	 * @param   int		key
+	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format
 	 * @return  bool
 	 */
-	public static function is_compound( $key ) {
+	public static function is_compound( $key_or_rate ) {
 		global $wpdb;
-		return $wpdb->get_var( $wpdb->prepare( "SELECT tax_rate_compound FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %s", $key ) ) ? true : false;
+
+		if ( is_object( $key_or_rate ) ) {
+			$key       = $key_or_rate->tax_rate_id;
+			$compound  = $key_or_rate->tax_rate_compound;
+		} else {
+			$key 	   = $key_or_rate;
+			$compound  = $wpdb->get_var( $wpdb->prepare( "SELECT tax_rate_compound FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %s", $key ) ) ? true : false;
+		}
+
+		return (bool) apply_filters( 'woocommerce_rate_compound', $compound, $key );
 	}
 
 	/**


### PR DESCRIPTION
This relates to #13249.

The VAT-1 title @Chouby noticed is the rate code for the tax rate. (The rate code is made up of COUNTRY-STATE-NAME-Priority. E.g GB-VAT-1, US-AL-TAX-1.) It should be the rate label, which is the name for the tax rate.

I noticed a similar problem with the setting of the compound, so I've fixed that in this PR, too.
