### PR TITLE
add generic class to make it easier to style admin billing/shipping fields

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -971,7 +971,8 @@ ul.wc_coupon_list_block {
 		._shipping_first_name_field,
 		._shipping_address_1_field,
 		._shipping_city_field,
-		._shipping_country_field {
+		._shipping_country_field,
+		.first_column {
 			float: left;
 		}
 
@@ -983,13 +984,15 @@ ul.wc_coupon_list_block {
 		._shipping_last_name_field,
 		._shipping_address_2_field,
 		._shipping_postcode_field,
-		._shipping_state_field {
+		._shipping_state_field,
+		.second_column {
 			float: right;
 		}
 
 		._billing_company_field,
 		._shipping_company_field,
-		._transaction_id_field {
+		._transaction_id_field,
+		.full_width {
 			clear: both;
 			width: 100%;
 		}


### PR DESCRIPTION
I noticed that when adding billing/shipping fields that the inputs smash into each other:

![image](https://cloud.githubusercontent.com/assets/507025/23143459/367a20d6-f787-11e6-9236-5fd6e8144366.png)

Thought that I would add a small wrapper class that makes it easy to style these fields without loading a custom style sheet for such a small rule. Now adding the fields can add this generic wrapper class and they are automagically styled.

```
function admin_shipping_fields( $fields ) {
	$fields['key'] = array(
		'label' 		=> 'Some Label',
		'wrapper_class'	=> 'second_column',
	);
	return $fields;
}
add_filter( 'woocommerce_admin_shipping_fields' , 'admin_shipping_fields' );
```

