### PR TITLE
2.7: Pass $order to callbacks on checkout line item creation hooks

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -370,7 +370,7 @@ class WC_Checkout {
 			 * Action hook to adjust item before save.
 			 * @since 2.7.0
 			 */
-			do_action( 'woocommerce_checkout_create_order_line_item', $item, $cart_item_key, $values );
+			do_action( 'woocommerce_checkout_create_order_line_item', $item, $cart_item_key, $values, $order );
 
 			// Add item to order and save.
 			$order->add_item( $item );
@@ -401,7 +401,7 @@ class WC_Checkout {
 			 * Action hook to adjust item before save.
 			 * @since 2.7.0
 			 */
-			do_action( 'woocommerce_checkout_create_order_fee_item', $item, $fee_key, $fee );
+			do_action( 'woocommerce_checkout_create_order_fee_item', $item, $fee_key, $fee, $order );
 
 			// Add item to order and save.
 			$order->add_item( $item );
@@ -437,7 +437,7 @@ class WC_Checkout {
 				 * Action hook to adjust item before save.
 				 * @since 2.7.0
 				 */
-				do_action( 'woocommerce_checkout_create_order_shipping_item', $item, $package_key, $package );
+				do_action( 'woocommerce_checkout_create_order_shipping_item', $item, $package_key, $package, $order );
 
 				// Add item to order and save.
 				$order->add_item( $item );
@@ -467,7 +467,7 @@ class WC_Checkout {
 				 * Action hook to adjust item before save.
 				 * @since 2.7.0
 				 */
-				do_action( 'woocommerce_checkout_create_order_tax_item', $item, $tax_rate_id );
+				do_action( 'woocommerce_checkout_create_order_tax_item', $item, $tax_rate_id, $order );
 
 				// Add item to order and save.
 				$order->add_item( $item );
@@ -493,7 +493,7 @@ class WC_Checkout {
 			 * Action hook to adjust item before save.
 			 * @since 2.7.0
 			 */
-			do_action( 'woocommerce_checkout_create_order_coupon_item', $item, $code, $coupon );
+			do_action( 'woocommerce_checkout_create_order_coupon_item', $item, $code, $coupon, $order );
 
 			// Add item to order and save.
 			$order->add_item( $item );


### PR DESCRIPTION
In WC 2.7 hooks triggered when adding a line item on checkout, there is no way to find out what order the line item is associated with as the order has not been saved yet, so there is no order ID to set on the line item yet - i.e. `$item->get_order_id()` will return `0`.

With WC < 2.7 equivalent hooks (e.g. `'woocommerce_add_order_item_meta'`), it was possible to find the order ID by the line item ID.

This patch proposes passing the corresponding `$order` item to callbacks on the hooks.