### PR TITLE
Access data store consistently

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -67,9 +67,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return array() Array of RAW prices, regular prices, and sale prices with keys set to variation ID.
 	 */
 	public function get_variation_prices( $include_taxes = false ) {
-		$data_store = $this->get_data_store();
-
-		$prices = $data_store->read_price_data( $this, $include_taxes );
+		$prices = $this->data_store->read_price_data( $this, $include_taxes );
 
 		foreach ( $prices as $price_key => $variation_prices ) {
 			$prices[ $price_key ] = $this->sort_variation_prices( $variation_prices );


### PR DESCRIPTION
`WC_Product_Variable::get_variation_prices()` accesses the `WC_Product_Variable::$data_store` property via `$this-> get_data_store()`. In non-static contexts, a `WC_Data` object normally accesses its data store directly via the `$this->data_store` property.

This patch uses that approach in `WC_Product_Variable::get_variation_prices()` for consistency.

AFAICS, this should be safe as `WC_Product_Variable::$data_store` will be set in `WC_Product::__construct`.