### PR TITLE
Add 'priority' support to product data tabs

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -75,43 +75,64 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function get_product_data_tabs() {
-		return apply_filters( 'woocommerce_product_data_tabs', array(
+		$tabs = apply_filters( 'woocommerce_product_data_tabs', array(
 			'general' => array(
-				'label'  => __( 'General', 'woocommerce' ),
-				'target' => 'general_product_data',
-				'class'  => array( 'hide_if_grouped' ),
+				'label'    => __( 'General', 'woocommerce' ),
+				'target'   => 'general_product_data',
+				'class'    => array( 'hide_if_grouped' ),
+				'priority' => 10,
 			),
 			'inventory' => array(
-				'label'  => __( 'Inventory', 'woocommerce' ),
-				'target' => 'inventory_product_data',
-				'class'  => array( 'show_if_simple', 'show_if_variable', 'show_if_grouped', 'show_if_external' ),
+				'label'    => __( 'Inventory', 'woocommerce' ),
+				'target'   => 'inventory_product_data',
+				'class'    => array( 'show_if_simple', 'show_if_variable', 'show_if_grouped', 'show_if_external' ),
+				'priority' => 20,
 			),
 			'shipping' => array(
-				'label'  => __( 'Shipping', 'woocommerce' ),
-				'target' => 'shipping_product_data',
-				'class'  => array( 'hide_if_virtual', 'hide_if_grouped', 'hide_if_external' ),
+				'label'    => __( 'Shipping', 'woocommerce' ),
+				'target'   => 'shipping_product_data',
+				'class'    => array( 'hide_if_virtual', 'hide_if_grouped', 'hide_if_external' ),
+				'priority' => 30,
 			),
 			'linked_product' => array(
-				'label'  => __( 'Linked Products', 'woocommerce' ),
-				'target' => 'linked_product_data',
-				'class'  => array(),
+				'label'    => __( 'Linked Products', 'woocommerce' ),
+				'target'   => 'linked_product_data',
+				'class'    => array(),
+				'priority' => 40,
 			),
 			'attribute' => array(
-				'label'  => __( 'Attributes', 'woocommerce' ),
-				'target' => 'product_attributes',
-				'class'  => array(),
+				'label'    => __( 'Attributes', 'woocommerce' ),
+				'target'   => 'product_attributes',
+				'class'    => array(),
+				'priority' => 50,
 			),
 			'variations' => array(
-				'label'  => __( 'Variations', 'woocommerce' ),
-				'target' => 'variable_product_options',
-				'class'  => array( 'variations_tab', 'show_if_variable' ),
+				'label'    => __( 'Variations', 'woocommerce' ),
+				'target'   => 'variable_product_options',
+				'class'    => array( 'variations_tab', 'show_if_variable' ),
+				'priority' => 60,
 			),
 			'advanced' => array(
-				'label'  => __( 'Advanced', 'woocommerce' ),
-				'target' => 'advanced_product_data',
-				'class'  => array(),
+				'label'    => __( 'Advanced', 'woocommerce' ),
+				'target'   => 'advanced_product_data',
+				'class'    => array(),
+				'priority' => 70,
 			),
 		) );
+
+		// Sort tabs based on priority
+		uasort( $tabs, array( __CLASS__, 'product_data_tabs_sort' ) );
+
+		return $tabs;
+	}
+
+	/**
+	 * Callback to sort product data tabs on priority.
+	 */
+	private static function product_data_tabs_sort( $a, $b ) {
+		if ( ! isset( $a['priority'], $b['priority'] ) ) return -1;
+		if ( $a['priority'] == $b['priority'] ) return 0;
+		return $a['priority'] < $b['priority'] ? -1 : 1;
 	}
 
 	/**


### PR DESCRIPTION
Adding support for a 'priority' option to be set when adding a custom product data tab (or modify existing).

Still adds custom tabs that have no priority to the bottom, the ones that do have a priority will be sorted accordingly.