### PR TITLE
product gallery lightbox trigger always opening main product image

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -198,10 +198,14 @@ jQuery( function( $ ) {
 			var pswpElement = $( '.pswp' )[0],
 				items  = wc_product_gallery.get_gallery_items(),
 				target = $( e.target ),
-				index  = -1;
+				index  = -1,
+				clicked;
 
 			if ( ! target.is( '.woocommerce-product-gallery__trigger' ) ) {
-				var clicked = e.target.closest( 'figure' );
+				clicked = e.target.closest( 'figure' );
+				index = $( clicked ).index();
+			} else {
+				clicked = target.parents( '.woocommerce-product-gallery' ).find( '.flex-active-slide' );
 				index = $( clicked ).index();
 			}
 


### PR DESCRIPTION
This pull request fixes the issue, where clicking on the woocommerce-product-gallery__trigger, when zoom in enabled, will always only open the main product image in the lightbox, regardless which image is currently active.

It seems to make sense that the currently active image is loaded in the lightbox, when the magnifying glass is clicked, also when zoom is enabled, which would also reflect the behaviour of the promo video: https://www.youtube.com/watch?v=ialMKuaVHm8