### PR TITLE
[2.7] Fixes coupon styles so admin CSS applies

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -58,7 +58,7 @@ class WC_Meta_Box_Coupon_Data {
 
 					foreach ( $coupon_data_tabs as $key => $tab ) {
 						?><li class="<?php echo $key; ?>_options <?php echo $key; ?>_tab <?php echo implode( ' ' , (array) $tab['class'] ); ?>">
-							<a href="#<?php echo $tab['target']; ?>"><?php echo esc_html( $tab['label'] ); ?></a>
+							<a href="#<?php echo $tab['target']; ?>"><span><?php echo esc_html( $tab['label'] ); ?></span></a>
 						</li><?php
 					}
 				?>


### PR DESCRIPTION
The admin CSS to put some space between icons targets `li a span`, and there was no span around the tab name.

Before: http://cloud.skyver.ge/3A1y1O2w0q09
After: http://cloud.skyver.ge/2R1k1h3D061R