### PR TITLE
Trash and post status for orders

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -470,14 +470,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$new_status = 'wc-' === substr( $new_status, 0, 3 ) ? substr( $new_status, 3 ) : $new_status;
 
 		// Only allow valid new status
-		if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses() ) ) {
+		if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses() ) && 'trash' !== $new_status ) {
 			$new_status = 'pending';
 		}
 
 		$this->set_prop( 'status', $new_status );
 
 		// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-		if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses() ) ) {
+		if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses() ) && 'trash' !== $old_status ) {
 			$old_status = 'pending';
 		}
 

--- a/includes/legacy/abstract-wc-legacy-order.php
+++ b/includes/legacy/abstract-wc-legacy-order.php
@@ -417,7 +417,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 		} elseif ( 'status' === $key ) {
 			return $this->get_status();
 		} elseif ( 'post_status' === $key ) {
-			return 'wc-' . $this->get_status();
+			return get_post_status( $this->get_id() );
 		} elseif ( 'customer_message' === $key || 'customer_note' === $key ) {
 			return $this->get_customer_note();
 		} elseif ( in_array( $key, array( 'user_id', 'customer_user' ) ) ) {


### PR DESCRIPTION
Makes the legacy handler use`get_post_status` rather than a wc- prefixed order status.

Also allows `set_status` to set trash so order status is trash rather than pending.

@thenbrent Is there more needed for that request?

Fixes #13273