### PR TITLE
Don't need to update full tax info on order save

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -290,9 +290,6 @@ function wc_save_order_items( $order_id, $items ) {
 		}
 	}
 
-	// Updates tax totals
-	$order->update_taxes();
-
 	// Calc totals - this also triggers save
 	$order->calculate_totals( false );
 


### PR DESCRIPTION
This relates to #13264.

The filtered labels get overridden when `$order->update_taxes()` is called, which removes all the tax info on an item and then rebuilds it.

I believe removing this line should solve the issue, as the call to `update_taxes` may not be necessary.

Any changes to an order's taxes are going to get handled by the ajax handler on-page, so it doesn't seem necessary to do another full update of all tax information when the order is saved. As best I can tell, everything still functions as expected without the call to `update_taxes`.

For reference, the 2.6 version of `wc_save_order_items` is at https://github.com/woocommerce/woocommerce/blob/2.6.14/includes/admin/wc-admin-functions.php#L181