### PR TITLE
Fix `get_remaining_refund_items` on `WC_Order`

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1683,6 +1683,6 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return int
 	 */
 	public function get_remaining_refund_items() {
-		return absint( $this->get_item_count() - $this->get_item_count_refunded() );
+		return $this->get_item_count() - absint( $this->get_item_count_refunded() );
 	}
 }


### PR DESCRIPTION
Right now `get_remaining_refund_items` on `WC_Order` returns 2 if `get_item_count` returns 1 and `get_item_count_refunded` returns -1 since 1 - -1 it's 2 (https://3v4l.org/lMX53) and that's wrong since `get_remaining_refund_items` should return 0.