### PR TITLE
fix photoswipe template be always loaded, even if lightbox is disabled

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2474,7 +2474,9 @@ if ( ! function_exists( 'woocommerce_photoswipe' ) ) {
 	 *
 	 */
 	function woocommerce_photoswipe() {
-		wc_get_template( 'single-product/photoswipe.php' );
+		if ( current_theme_supports( 'wc-product-gallery-lightbox' ) ) {
+			wc_get_template( 'single-product/photoswipe.php' );
+		}
 	}
 }
 


### PR DESCRIPTION
Currently the photoswipe template is loaded in any case, so even if theme support for the woo gallery lightbox is not set.

This commit fixes that.