### PR TITLE
Map legacy tax array keys

### DIFF
--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -209,4 +209,55 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	public function is_compound() {
 		return $this->get_compound();
 	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Array Access Methods
+	|--------------------------------------------------------------------------
+	|
+	| For backwards compat with legacy arrays.
+	|
+	*/
+
+	/**
+	 * offsetGet for ArrayAccess/Backwards compatibility.
+	 * @deprecated Add deprecation notices in future release.
+	 * @param string $offset
+	 * @return mixed
+	 */
+	public function offsetGet( $offset ) {
+		if ( 'tax_amount' === $offset ) {
+			$offset = 'tax_total';
+		} elseif ( 'shipping_tax_amount' === $offset ) {
+			$offset = 'shipping_tax_total';
+		}
+		return parent::offsetGet( $offset );
+	}
+
+	/**
+	 * offsetSet for ArrayAccess/Backwards compatibility.
+	 * @deprecated Add deprecation notices in future release.
+	 * @param string $offset
+	 * @param mixed $value
+	 */
+	public function offsetSet( $offset, $value ) {
+		if ( 'tax_amount' === $offset ) {
+			$offset = 'tax_total';
+		} elseif ( 'shipping_tax_amount' === $offset ) {
+			$offset = 'shipping_tax_total';
+		}
+		parent::offsetSet( $offset, $value );
+	}
+
+	/**
+	 * offsetExists for ArrayAccess
+	 * @param string $offset
+	 * @return bool
+	 */
+	public function offsetExists( $offset ) {
+		if ( in_array( $offset, array( 'tax_amount', 'shipping_tax_amount' ) ) ) {
+			return true;
+		}
+		return parent::offsetExists( $offset );
+	}
 }

--- a/tests/unit-tests/order/crud.php
+++ b/tests/unit-tests/order/crud.php
@@ -335,6 +335,24 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	* Test mapping from old tax array keys to CRUD functions
+	*/
+	function test_tax_legacy_arrayaccess() {
+		$tax = new WC_Order_item_Tax();
+		$tax->set_rate_id( 5 );
+		$tax->set_compound( true );
+		$tax->set_tax_total( 2.00 );
+		$tax->set_shipping_tax_total( 1.50 );
+
+		$this->assertEquals( $tax->get_rate_id(), $tax['rate_id'] );
+		$this->assertEquals( $tax->get_compound(), $tax['compound'] );
+		$this->assertEquals( $tax->get_tax_total(), $tax['tax_total'] );
+		$this->assertEquals( $tax->get_tax_total(), $tax['tax_amount'] );
+		$this->assertEquals( $tax->get_shipping_tax_total(), $tax['shipping_tax_total'] );
+		$this->assertEquals( $tax->get_shipping_tax_total(), $tax['shipping_tax_amount'] );
+	}
+
+	/**
 	 * Test: get_shipping_methods
 	 */
 	function test_get_shipping_methods() {


### PR DESCRIPTION
This relates to #13321.

Attempting to access the tax info on a WC_Order_Item_Tax object using the legacy array access and legacy array keys should work properly now. I've also checked the other WC_Order_Item_* classes to make sure nothing was forgotten in those, and they look good.