### PR TITLE
Delete cached object when updating stock

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -35,6 +35,7 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 		delete_transient( 'wc_low_stock_count' );
 		delete_transient( 'wc_outofstock_count' );
 		delete_transient( 'wc_product_children_' . ( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id() ) );
+		wp_cache_delete( 'product-' . $product_id_with_stock, 'products' );
 
 		// Re-read product data after updating stock, then have stock status calculated and saved.
 		$product_with_stock = wc_get_product( $product_id_with_stock );

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -145,6 +145,27 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
+	public function test_wc_update_product_stock_increase_decrease() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		update_post_meta( $product->get_id(), '_manage_stock', 'yes' );
+		wc_update_product_stock( $product->get_id(), 5 );
+
+		$new_value = wc_update_product_stock( $product->get_id(), 1, 'increase' );
+
+		$product = new WC_Product_Simple( $product->get_id() );
+		$this->assertEquals( 6, $product->get_stock_quantity() );
+		$this->assertEquals( 6, $new_value );
+
+		$new_value = wc_update_product_stock( $product->get_id(), 1, 'decrease' );
+
+		$product = new WC_Product_Simple( $product->get_id() );
+		$this->assertEquals( 5, $product->get_stock_quantity() );
+		$this->assertEquals( 5, $new_value );
+
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
 	/**
 	 * Test wc_delete_product_transients().
 	 *


### PR DESCRIPTION
This relates to #13320.

`wc_get_product` caches the product when it fetches it. In `wc_update_product_stock()`, If `$product` and `$product_with_stock` are the same product, fetching the product after updating the stock will just fetch the cached product which will have incorrect stock info.