### PR TITLE
Update form-billing.php

### DIFF
--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php else : ?>
 
-		<h3><?php _e( 'Billing details', 'woocommerce' ); ?></h3>
+		<h3><?php _e( 'Billing Details', 'woocommerce' ); ?></h3>
 
 	<?php endif; ?>
 


### PR DESCRIPTION
`<h3><?php _e( 'Billing Details', 'woocommerce' ); ?></h3>` should be capitalized to match the POMO.

(or need to re-create the POT and fix all PO files)