### PR TITLE
Hide coupon free shipping conditionally

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -66,10 +66,21 @@ class WC_Meta_Box_Coupon_Data {
 			<div id="general_coupon_data" class="panel woocommerce_options_panel"><?php
 
 				// Type
-				woocommerce_wp_select( array( 'id' => 'discount_type', 'label' => __( 'Discount type', 'woocommerce' ), 'options' => wc_get_coupon_types() ) );
+				woocommerce_wp_select( array(
+					'id' => 'discount_type',
+					'label' => __( 'Discount type', 'woocommerce' ),
+					'options' => wc_get_coupon_types()
+				) );
 
 				// Amount
-				woocommerce_wp_text_input( array( 'id' => 'coupon_amount', 'label' => __( 'Coupon amount', 'woocommerce' ), 'placeholder' => wc_format_localized_price( 0 ), 'description' => __( 'Value of the coupon.', 'woocommerce' ), 'data_type' => 'price', 'desc_tip' => true ) );
+				woocommerce_wp_text_input( array(
+					'id' => 'coupon_amount',
+					'label' => __( 'Coupon amount', 'woocommerce' ),
+					'placeholder' => wc_format_localized_price( 0 ),
+					'description' => __( 'Value of the coupon.', 'woocommerce' ),
+					'data_type' => 'price',
+					'desc_tip' => true
+				) );
 
 				// Free Shipping
 				if ( wc_shipping_enabled() ) {
@@ -82,7 +93,14 @@ class WC_Meta_Box_Coupon_Data {
 
 				// Expiry date
 				$expiry_date = $coupon->get_date_expires() ? date( 'Y-m-d', $coupon->get_date_expires() ) : '';
-				woocommerce_wp_text_input( array( 'id' => 'expiry_date', 'value' => esc_attr( $expiry_date ), 'label' => __( 'Coupon expiry date', 'woocommerce' ), 'placeholder' => 'YYYY-MM-DD', 'description' => '', 'class' => 'date-picker', 'custom_attributes' => array( 'pattern' => apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ) ) );
+				woocommerce_wp_text_input( array(
+					'id' => 'expiry_date',
+					'value' => esc_attr( $expiry_date ),
+					'label' => __( 'Coupon expiry date', 'woocommerce' ),
+					'placeholder' => 'YYYY-MM-DD', 'description' => '',
+					'class' => 'date-picker',
+					'custom_attributes' => array( 'pattern' => apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) )
+				) );
 
 				do_action( 'woocommerce_coupon_options', $coupon->get_id(), $coupon );
 
@@ -92,16 +110,36 @@ class WC_Meta_Box_Coupon_Data {
 				echo '<div class="options_group">';
 
 				// minimum spend
-				woocommerce_wp_text_input( array( 'id' => 'minimum_amount', 'label' => __( 'Minimum spend', 'woocommerce' ), 'placeholder' => __( 'No minimum', 'woocommerce' ), 'description' => __( 'This field allows you to set the minimum spend (subtotal, including taxes) allowed to use the coupon.', 'woocommerce' ), 'data_type' => 'price', 'desc_tip' => true ) );
+				woocommerce_wp_text_input( array(
+					'id' => 'minimum_amount',
+					'label' => __( 'Minimum spend', 'woocommerce' ),
+					'placeholder' => __( 'No minimum', 'woocommerce' ),
+					'description' => __( 'This field allows you to set the minimum spend (subtotal, including taxes) allowed to use the coupon.', 'woocommerce' ),
+					'data_type' => 'price', 'desc_tip' => true
+				) );
 
 				// maximum spend
-				woocommerce_wp_text_input( array( 'id' => 'maximum_amount', 'label' => __( 'Maximum spend', 'woocommerce' ), 'placeholder' => __( 'No maximum', 'woocommerce' ), 'description' => __( 'This field allows you to set the maximum spend (subtotal, including taxes) allowed when using the coupon.', 'woocommerce' ), 'data_type' => 'price', 'desc_tip' => true ) );
+				woocommerce_wp_text_input( array(
+					'id' => 'maximum_amount',
+					'label' => __( 'Maximum spend', 'woocommerce' ),
+					'placeholder' => __( 'No maximum', 'woocommerce' ),
+					'description' => __( 'This field allows you to set the maximum spend (subtotal, including taxes) allowed when using the coupon.', 'woocommerce' ),
+					'data_type' => 'price', 'desc_tip' => true
+				) );
 
 				// Individual use
-				woocommerce_wp_checkbox( array( 'id' => 'individual_use', 'label' => __( 'Individual use only', 'woocommerce' ), 'description' => __( 'Check this box if the coupon cannot be used in conjunction with other coupons.', 'woocommerce' ) ) );
+				woocommerce_wp_checkbox( array(
+					'id' => 'individual_use',
+					'label' => __( 'Individual use only', 'woocommerce' ),
+					'description' => __( 'Check this box if the coupon cannot be used in conjunction with other coupons.', 'woocommerce' )
+				) );
 
 				// Exclude Sale Products
-				woocommerce_wp_checkbox( array( 'id' => 'exclude_sale_items', 'label' => __( 'Exclude sale items', 'woocommerce' ), 'description' => __( 'Check this box if the coupon should not apply to items on sale. Per-item coupons will only work if the item is not on sale. Per-cart coupons will only work if there are no sale items in the cart.', 'woocommerce' ) ) );
+				woocommerce_wp_checkbox( array(
+					'id' => 'exclude_sale_items',
+					'label' => __( 'Exclude sale items', 'woocommerce' ),
+					'description' => __( 'Check this box if the coupon should not apply to items on sale. Per-item coupons will only work if the item is not on sale. Per-cart coupons will only work if there are no sale items in the cart.', 'woocommerce' )
+				) );
 
 				echo '</div><div class="options_group">';
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -72,7 +72,13 @@ class WC_Meta_Box_Coupon_Data {
 				woocommerce_wp_text_input( array( 'id' => 'coupon_amount', 'label' => __( 'Coupon amount', 'woocommerce' ), 'placeholder' => wc_format_localized_price( 0 ), 'description' => __( 'Value of the coupon.', 'woocommerce' ), 'data_type' => 'price', 'desc_tip' => true ) );
 
 				// Free Shipping
-				woocommerce_wp_checkbox( array( 'id' => 'free_shipping', 'label' => __( 'Allow free shipping', 'woocommerce' ), 'description' => sprintf( __( 'Check this box if the coupon grants free shipping. A <a href="%s" target="_blank">free shipping method</a> must be enabled in your shipping zone and be set to require "a valid free shipping coupon" (see the "Free Shipping Requires" setting).', 'woocommerce' ), 'https://docs.woocommerce.com/document/free-shipping/' ) ) );
+				if ( wc_shipping_enabled() ) {
+					woocommerce_wp_checkbox( array(
+						'id' => 'free_shipping',
+						'label' => __( 'Allow free shipping', 'woocommerce' ),
+						'description' => sprintf( __( 'Check this box if the coupon grants free shipping. A <a href="%s" target="_blank">free shipping method</a> must be enabled in your shipping zone and be set to require "a valid free shipping coupon" (see the "Free Shipping Requires" setting).', 'woocommerce' ), 'https://docs.woocommerce.com/document/free-shipping/' )
+					) );
+				}
 
 				// Expiry date
 				$expiry_date = $coupon->get_date_expires() ? date( 'Y-m-d', $coupon->get_date_expires() ) : '';


### PR DESCRIPTION
This setting isn't necessary if the store has shipping completely disabled: http://cld.wthms.co/12FGM/1Wni0FNe

One potential downside to this change is that if a store has shipping enabled and is using free shipping coupons, but then disables shipping and re-saves some coupons, they will lose the "free shipping" setting on the coupon. So if they ever go back to using shipping, there will need to edit those coupons again. That's like a super edge case though, and fairly sure I've just had to much Mountain Dew xD