### PR TITLE
Fix variation title syncing

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -313,7 +313,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					WHERE post_type = 'product_variation'
 					AND post_parent = %d
 				",
-				$previous_name,
+				$previous_name ? $previous_name : __( 'Auto Draft' ),
 				$new_name,
 				$product->get_id()
 			 ) );

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -70,17 +70,16 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$product->set_attributes( wc_get_product_variation_attributes( $product->get_id() ) );
 
 		/**
-		 * Clean up old variation titles.
-		 * The "Product #" text is intentionally not wrapped in translation functions for a faster comparision. It was not inserted as a translated string:
-		 * https://github.com/woocommerce/woocommerce/blob/5fc88694d211e2e176bded16d7fb95cf6285249e/includes/class-wc-ajax.php#L776
+		 * If a variation title is not in sync with the parent e.g. saved prior to 2.7, or if the parent title has changed, detect here and update.
 		 */
-		if ( __( 'Variation #', 'woocommerce' ) === substr( $post_object->post_title, 0, 11 ) || ( 'Product #' . $product->get_parent_id() . ' Variation' ) === $post_object->post_title ) {
-			$new_title   = $this->generate_product_title( $product );
+		if ( version_compare( get_post_meta( $product->get_id(), '_product_version', true ), '2.7', '<' ) && 0 !== strpos( $post_object->post_title, get_post_field( 'post_title', $product->get_parent_id() ) ) )  {
+			$new_title = $this->generate_product_title( $product );
 			$product->set_name( $new_title );
 			wp_update_post( array(
 				'ID'             => $product->get_id(),
 				'post_title'     => $new_title,
 			) );
+			exit;
 		}
 
 		// Set object_read true once all data is read.
@@ -198,9 +197,9 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		$include_attribute_names = apply_filters( 'woocommerce_product_variation_title_include_attribute_names', $include_attribute_names, $product );
-		$title_base_text = get_post_field( 'post_title', $product->get_parent_id() );
-		$title_attributes_text = wc_get_formatted_variation( $product, true, $include_attribute_names );
-		$separator = ! empty( $title_attributes_text ) ? ' &ndash; ' : '';
+		$title_base_text         = get_post_field( 'post_title', $product->get_parent_id() );
+		$title_attributes_text   = wc_get_formatted_variation( $product, true, $include_attribute_names );
+		$separator               = ! empty( $title_attributes_text ) ? ' &ndash; ' : '';
 
 		return apply_filters( 'woocommerce_product_variation_title',
 			$title_base_text . $separator . $title_attributes_text,


### PR DESCRIPTION
Fixes #13361 and fixes #13363 

Handles auto-draft if the previous title was blank.

Syncs titles if the product version is lower than 2.7 and the current title is not prefixed with the parent title.