### PR TITLE
Better invalid data store handling

### DIFF
--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -72,7 +72,7 @@ class WC_Data_Store {
 		if ( array_key_exists( $object_type, $this->stores ) ) {
 			$store = apply_filters( 'woocommerce_' . $object_type . '_data_store', $this->stores[ $object_type ] );
 			if ( is_object( $store ) ) {
-				if ( ! class_implements( $store, WC_Object_Data_Store_Interface::class ) ) {
+				if ( ! $store instanceof WC_Object_Data_Store_Interface ) {
 					throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
 				}
 				$this->current_class_name = get_class( $store );

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -90,17 +90,13 @@ class WC_Data_Store {
 	}
 
 	/**
-	 * Loads a data store for us or returns null if an invalid store.
+	 * Loads a data store.
 	 *
 	 * @param string $object_type Name of object.
 	 * @since 2.7.0
 	 */
 	public static function load( $object_type ) {
-		try {
-			return new WC_Data_Store( $object_type );
-		} catch ( Exception $e ) {
-			return null;
-		}
+		return new WC_Data_Store( $object_type );
 	}
 
 	/**

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -23,13 +23,18 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Make sure ::load returns null if an invalid store is found.
+	 * Make sure ::load throws an exception for invalid data stores
 	 *
 	 * @since 2.7.0
 	 */
-	function test_invalid_store_load_returns_null() {
-		$product_store = WC_Data_Store::load( 'does-not-exist' );
-		$this->assertNull( $product_store );
+	function test_invalid_store_load_throws_exception() {
+		try {
+			$product_store = WC_Data_Store::load( 'does-not-exist' );
+		} catch ( Exception $e ) {
+			$this->assertEquals( $e->getMessage(), 'Invalid data store.' );
+			return;
+		}
+		$this->fail( 'Invalid data store exception not correctly raised.' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #13396.

The previous implementation didn't work correctly and also caused syntax errors on PHP versions < 5.5. This implementation solves those problems.

On a related note, throwing the "Invalid data store" exception doesn't generally halt execution, as it should. `::load` just silently returns a null and you get a `Fatal error: Uncaught Error: Call to a member function read() on null` shortly after that. I think failing hard with a useful message is the way to go if someone provides a bad data store, as opposed to failing hard with a fatal error that then has to be debugged. This change is also in this PR.