### PR TITLE
filter recent reviews dashboard widget query

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -246,16 +246,18 @@ class WC_Admin_Dashboard {
 	 */
 	public function recent_reviews() {
 		global $wpdb;
-		$comments = $wpdb->get_results( "
-			SELECT posts.ID, posts.post_title, comments.comment_author, comments.comment_ID, SUBSTRING(comments.comment_content,1,100) AS comment_excerpt
-			FROM $wpdb->comments comments
-			LEFT JOIN $wpdb->posts posts ON (comments.comment_post_ID = posts.ID)
+		$query_from = apply_filters( 'woocommerce_report_recent_reviews_query_from', "FROM {$wpdb->comments} comments
+			LEFT JOIN {$wpdb->posts} posts ON (comments.comment_post_ID = posts.ID)
 			WHERE comments.comment_approved = '1'
 			AND comments.comment_type = ''
 			AND posts.post_password = ''
 			AND posts.post_type = 'product'
 			ORDER BY comments.comment_date_gmt DESC
 			LIMIT 5
+		" );
+		$comments = $wpdb->get_results( "
+			SELECT posts.ID, posts.post_title, comments.comment_author, comments.comment_ID, SUBSTRING(comments.comment_content,1,100) AS comment_excerpt
+			{$query_from};
 		" );
 
 		if ( $comments ) {


### PR DESCRIPTION
Implements a `woocommerce_report_recent_reviews_query_from` filter, like the `woocommerce_report_out_of_stock_query_from` and `woocommerce_report_low_in_stock_query_from` found in the same class.