### PR TITLE
Set the $state default to '' to prevent warning

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -790,7 +790,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $city
 	 * @throws WC_Data_Exception
 	 */
-	public function set_billing_location( $country, $state, $postcode = '', $city = '' ) {
+	public function set_billing_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$billing             = $this->get_prop( 'billing', 'edit' );
 		$billing['country']  = $country;
 		$billing['state']    = $state;


### PR DESCRIPTION
I was getting the following warning
```
[01-Mar-2017 18:44:23 UTC] PHP Warning:  Missing argument 2 for WC_Customer::set_billing_location(), called in /wordpress/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-data.php on line 503 and defined in /wordpress/wp-content/plugins/woocommerce/includes/class-wc-customer.php on line 793
[01-Mar-2017 18:44:23 UTC] PHP Stack trace:
[01-Mar-2017 18:44:23 UTC] PHP   1. {main}() /wordpress/index.php:0
[01-Mar-2017 18:44:23 UTC] PHP   2. require() /wordpress/index.php:17
[01-Mar-2017 18:44:23 UTC] PHP   3. require_once() /wordpress/wp-blog-header.php:13
[01-Mar-2017 18:44:23 UTC] PHP   4. require_once() /wordpress/wp-load.php:37
[01-Mar-2017 18:44:23 UTC] PHP   5. require_once() /wordpress/wp-config.php:96
[01-Mar-2017 18:44:23 UTC] PHP   6. do_action() /wordpress/wp-settings.php:449
[01-Mar-2017 18:44:23 UTC] PHP   7. WP_Hook->do_action() /wordpress/wp-includes/plugin.php:453
[01-Mar-2017 18:44:23 UTC] PHP   8. WP_Hook->apply_filters() /wordpress/wp-includes/class-wp-hook.php:323
[01-Mar-2017 18:44:23 UTC] PHP   9. WooCommerce->init() /wordpress/wp-includes/class-wp-hook.php:298
[01-Mar-2017 18:44:23 UTC] PHP  10. WC_Customer->__construct() /wordpress/wp-content/plugins/woocommerce/woocommerce.php:438
[01-Mar-2017 18:44:23 UTC] PHP  11. WC_Data_Store->read() /wordpress/wp-content/plugins/woocommerce/includes/class-wc-customer.php:104
[01-Mar-2017 18:44:23 UTC] PHP  12. WC_Customer_Data_Store->read() /wordpress/wp-content/plugins/woocommerce/includes/class-wc-data-store.php:123
[01-Mar-2017 18:44:23 UTC] PHP  13. WC_Data->set_props() /wordpress/wp-content/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store.php:133
[01-Mar-2017 18:44:23 UTC] PHP  14. WC_Customer->set_billing_location() /wordpress/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-data.php:503
```

Caused by the state not being available/set for all countries. 