### PR TITLE
Only target v2 of the WC REST API when generating CLI commands.

### DIFF
--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -31,6 +31,12 @@ class WC_CLI_Runner {
 	);
 
 	/**
+	 * The version of the REST API we should target to
+	 * generate commands.
+	 */
+	private static $target_rest_version = 'v2';
+
+	/**
 	 * Register's all endpoints as commands once WP and WC have all loaded.
 	 */
 	public static function after_wp_load() {
@@ -48,10 +54,11 @@ class WC_CLI_Runner {
 
 		// Loop through all of our endpoints and register any valid WC endpoints.
 		foreach ( $response_data['routes'] as $route => $route_data ) {
-			// Only register WC endpoints
-			if ( substr( $route, 0, 4 ) !== '/wc/' ) {
+			// Only register endpoints for WC and our target version.
+			if ( '/wc/' . self::$target_rest_version !== substr( $route, 0, 4 + strlen( self::$target_rest_version ) ) ) {
 				continue;
 			}
+
 			// Only register endpoints with schemas
 			if ( empty( $route_data['schema']['title'] ) ) {
 				WP_CLI::debug( sprintf( __( 'No schema title found for %s, skipping REST command registration.', 'woocommerce' ), $route ), 'wc' );


### PR DESCRIPTION
I earlier verified that the CLI commands were correctly using v2. That's still true, but we are still generating commands for v1 anyway. They just never get called.

This PR fixes that behavior by setting a target version in CLI Runner. We will discard any REST endpoints on other versions when generating the CLI commands.

To Test:

Add some debug in CLI Runner's `after_wp_load` right before `register_route_commands` is called and output `$route`. Before the change you would see v1 and v2 URLs listed. After the change you should just see v2 endpoints.