### PR TITLE
Fix PHP notice that displays when running CLI commands that accept no ID arguments.

### DIFF
--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -333,17 +333,21 @@ EOT;
 	 * @return string
 	 */
 	private function get_filled_route( $args = array() ) {
-		$parent_id_matched = false;
-		$route             = $this->route;
+		$supported_id_matched = false;
+		$route                = $this->route;
 
 		foreach ( $this->get_supported_ids() as $id_name => $id_desc ) {
 			if ( strpos( $route, '<' . $id_name . '>' ) !== false && ! empty( $args ) ) {
-				$route             = str_replace( '(?P<' . $id_name . '>[\d]+)', $args[0], $route );
-				$parent_id_matched = true;
+				$route                = str_replace( '(?P<' . $id_name . '>[\d]+)', $args[0], $route );
+				$supported_id_matched = true;
 			}
 		}
 
-		$route = str_replace( array( '(?P<id>[\d]+)', '(?P<id>[\w-]+)' ), ( $parent_id_matched && ! empty( $args[1] ) ? $args[1] : $args[0] ), $route );
+		if ( ! empty( $args ) ) {
+			$id_replacement = $supported_id_matched && ! empty( $args[1] ) ? $args[1] : $args[0];
+			$route          = str_replace( array( '(?P<id>[\d]+)', '(?P<id>[\w-]+)' ), $id_replacement, $route );
+		}
+
 		return rtrim( $route );
 	}
 


### PR DESCRIPTION
Commands that don't accept ID arguments were generating a small PHP notice. The commands still worked.

```
PHP Notice:  Undefined offset: 0 in woocommerce/includes/cli/class-wc-cli-rest-command.php on line 346
```

To reproduce, run a command like `wp wc shop_coupon list --user=1`. You should see the notice in your debug log.

We should only try replacing the route if there are any parts of the route even passed (`$args).