### PR TITLE
Dont render empty stock descriptions

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2500,17 +2500,21 @@ function wc_display_product_attributes( $product ) {
  * @return string
  */
 function wc_get_stock_html( $product ) {
-	ob_start();
 
+	$html = "";
 	$availability = $product->get_availability();
 
-	wc_get_template( 'single-product/stock.php', array(
-		'product'      => $product,
-		'class'        => $availability['class'],
-		'availability' => $availability['availability'],
-	) );
+	if ( "" !== $availability['availability'] ) {
+		ob_start();
 
-	$html = ob_get_clean();
+		wc_get_template( 'single-product/stock.php', array(
+			'product'      => $product,
+			'class'        => $availability['class'],
+			'availability' => $availability['availability'],
+		) );
+
+		$html = ob_get_clean();
+	}
 
 	if ( has_filter( 'woocommerce_stock_html' ) ) {
 		wc_deprecated_function( 'The woocommerce_stock_html filter', '', 'woocommerce_get_stock_html' );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2504,7 +2504,7 @@ function wc_get_stock_html( $product ) {
 	$html = "";
 	$availability = $product->get_availability();
 
-	if ( "" !== $availability['availability'] ) {
+	if ( ! empty( $availability['availability'] ) ) {
 		ob_start();
 
 		wc_get_template( 'single-product/stock.php', array(

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2501,7 +2501,7 @@ function wc_display_product_attributes( $product ) {
  */
 function wc_get_stock_html( $product ) {
 
-	$html = "";
+	$html = '';
 	$availability = $product->get_availability();
 
 	if ( ! empty( $availability['availability'] ) ) {


### PR DESCRIPTION
Fixes #13415.

Don't try and render the stock template if there is no content to go inside it. I've made sure to keep all the filters working correctly.