### PR TITLE
Set date paid for old orders

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -249,12 +249,13 @@ class WC_Order extends WC_Abstract_Order {
 	 * `payment_complete` method.
 	 *
 	 * @since 2.7.0
+	 * @param $date_paid What to set date paid to. Defaults to current time.
 	 */
-	protected function maybe_set_date_paid() {
+	public function maybe_set_date_paid( $date_paid = '' ) {
 		$payment_complete_status = apply_filters( 'woocommerce_payment_complete_order_status', $this->needs_processing() ? 'processing' : 'completed', $this->get_id() );
 
 		if ( ! $this->get_date_paid( 'edit' ) && $this->has_status( $payment_complete_status ) ) {
-			$this->set_date_paid( current_time( 'timestamp' ) );
+			$this->set_date_paid( $date_paid ? $date_paid : current_time( 'timestamp' ) );
 		}
 	}
 

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -108,6 +108,14 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				$order->set_discount_total( (double) get_post_meta( $order->get_id(), '_cart_discount', true ) - (double) get_post_meta( $order->get_id(), '_cart_discount_tax', true ) );
 			}
 		}
+
+		/**
+		 * In older versions, paid date may not have been set.
+		 * @todo When/if meta is flattened, handle this in the migration script.
+		 */
+		if ( ! $order->get_version( 'edit' ) || version_compare( $order->get_version( 'edit' ), '2.7', '<' ) ) {
+			$order->maybe_set_date_paid( $order->get_date_created( 'edit' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
If an order is old (<2.7) and has no date paid value set, and is also completed already, update the paid date to the order creation date so it’s not left blank.

Fixes #13420