### PR TITLE
get_meta should return empty array sometimes

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -239,7 +239,7 @@ abstract class WC_Data {
 	public function get_meta( $key = '', $single = true, $context = 'view' ) {
 		$this->maybe_read_meta_data();
 		$array_keys = array_keys( wp_list_pluck( $this->get_meta_data(), 'key' ), $key );
-		$value    = '';
+		$value      = $single ? '' : array();
 
 		if ( ! empty( $array_keys ) ) {
 			if ( $single ) {

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -121,6 +121,21 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting meta that hasn't been set
+	 */
+	function test_get_meta_no_meta() {
+		$object = $this->create_test_post();
+		$object_id = $object->get_id();
+		$object = new WC_Mock_WC_Data( $object_id );
+
+		$single_on = $object->get_meta( 'doesnt-exist', true );
+		$single_off = $object->get_meta( 'also-doesnt-exist', false );
+
+		$this->assertEquals( '', $single_on );
+		$this->assertEquals( array(), $single_off );
+	}
+
+	/**
 	 * Test setting meta.
 	 */
 	function test_set_meta_data() {


### PR DESCRIPTION
Closes #13427.

When `$single` is true and no meta exists, return `''`.
When `$single` is false and no meta exists, return an empty array.

Tests already exist for the case where meta exists, so I've added tests for the case where meta doesn't exist.