### PR TITLE
Fixes for $order_url variable

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -334,6 +334,7 @@ class WC_Structured_Data {
 
 		$shop_name      = get_bloginfo( 'name' );
 		$shop_url       = home_url();
+		$order_url      = $sent_to_admin ? admin_url( 'post.php?post=' . absint( $order->get_id() ) . '&action=edit' ) : $order->get_view_order_url();
 		$order_statuses = array(
 			'pending'    => 'http://schema.org/OrderPaymentDue',
 			'processing' => 'http://schema.org/OrderProcessing',
@@ -353,7 +354,6 @@ class WC_Structured_Data {
 			$product        = apply_filters( 'woocommerce_order_item_product', $order->get_product_from_item( $item ), $item );
 			$product_exists = is_object( $product );
 			$is_visible     = $product_exists && $product->is_visible();
-			$order_url      = $sent_to_admin ? admin_url( 'post.php?post=' . absint( $order->get_id() ) . '&action=edit' ) : $order->get_view_order_url();
 
 			$markup_offers[]  = array(
 				'@type'              => 'Offer',


### PR DESCRIPTION
Fix undefined `$order_url` variable in the case of an order with no items by moving it out of the items loop. In the case of an order with more than one line item, this also avoids redundantly setting the `$order_url` multiple times.

The [`get_edit_post_link()`](https://developer.wordpress.org/reference/functions/get_edit_post_link/) function may also be handy to create the admin version of this URL instead of manually writing it out if unless it's being done manually for some reason.