### PR TITLE
Legacy API tweaks

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -264,7 +264,7 @@ class WC_API_Products extends WC_API_Resource {
 			$product->set_description( isset( $data['description'] ) ? $post_content : '' );
 
 			// Attempts to create the new product.
-			$product->create();
+			$product->save();
 			$id = $product->get_id();
 
 			// Checks for an error in the product creation
@@ -1498,7 +1498,7 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	private function save_downloadable_files( $product, $downloads, $deprecated = 0 ) {
 		if ( $deprecated ) {
-			wc_deprecated_argument( 'variation_id', '2.7', 'save_downloadable_files() not requires a variation_id anymore.' );
+			wc_deprecated_argument( 'variation_id', '2.7', 'save_downloadable_files() does not require a variation_id anymore.' );
 		}
 
 		$files = array();

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -983,6 +983,10 @@ class WC_API_Orders extends WC_API_Resource {
 		}
 
 		$item_id = $line_item->save();
+
+		if ( ! $item_id ) {
+			throw new WC_API_Exception( 'woocommerce_cannot_create_line_item', __( 'Cannot create line item, try again.', 'woocommerce' ), 500 );
+		}
 	}
 
 	/**

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -318,7 +318,7 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			// Attempts to create the new product.
-			$product->create();
+			$product->save();
 			$id = $product->get_id();
 
 			// Checks for an error in the product creation.
@@ -1997,7 +1997,7 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	private function save_downloadable_files( $product, $downloads, $deprecated = 0 ) {
 		if ( $deprecated ) {
-			wc_deprecated_argument( 'variation_id', '2.7', 'save_downloadable_files() not requires a variation_id anymore.' );
+			wc_deprecated_argument( 'variation_id', '2.7', 'save_downloadable_files() does not require a variation_id anymore.' );
 		}
 
 		$files = array();


### PR DESCRIPTION
Closes #13405.

- There were some calls to `$product->create()` which should have been `$product->save()`. `create()` isn't a method. :)
- The v3 API was missing a check that was present in v2.
- Improve grammar in deprecated function notices.

I've checked the classes for other non-existent functions and didn't find any. I've made a bunch of requests against the legacy APIs and didn't encounter any further PHP errors.