### PR TITLE
Fix CLI notice when using --fields.

### DIFF
--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -139,7 +139,7 @@ class WC_CLI_REST_Command {
 		list( $status, $body, $headers ) = $this->do_request( 'GET', $route, $assoc_args );
 
 		if ( ! empty( $assoc_args['fields'] ) ) {
-			$body = self::limit_item_to_fields( $body, $fields );
+			$body = self::limit_item_to_fields( $body, $assoc_args['fields'] );
 		}
 
 		if ( 'headers' === $assoc_args['format'] ) {
@@ -179,7 +179,7 @@ class WC_CLI_REST_Command {
 
 		if ( ! empty( $assoc_args['fields'] ) ) {
 			foreach ( $items as $key => $item ) {
-				$items[ $key ] = self::limit_item_to_fields( $item, $fields );
+				$items[ $key ] = self::limit_item_to_fields( $item, $assoc_args['fields'] );
 			}
 		}
 


### PR DESCRIPTION
A non-existent variable was being passed to `limit_item_to_fields`, causing a PHP notice to be displayed.
`PHP Notice:  Undefined variable: fields in includes/cli/class-wc-cli-rest-command.php on line 183`

This PR passes the correct value.

To Test:

1. Use `wp wc product list --user=1 --fields="sku,name"` on the command-line.
2. Make sure that a PHP notice does not display in your debug log.