### PR TITLE
Set line item prices on legacy API order create

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -918,6 +918,10 @@ class WC_API_Orders extends WC_API_Resource {
 		}
 		if ( isset( $item['total'] ) ) {
 			$line_item->set_total( floatval( $item['total'] ) );
+		} elseif ( $creating ) {
+			$total = wc_get_price_excluding_tax( $product, array( 'qty' => $line_item->get_quantity() ) );
+			$line_item->set_total( $total );
+			$line_item->set_subtotal( $total );
 		}
 		if ( isset( $item['total_tax'] ) ) {
 			$line_item->set_total_tax( floatval( $item['total_tax'] ) );

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -967,6 +967,10 @@ class WC_API_Orders extends WC_API_Resource {
 		}
 		if ( isset( $item['total'] ) ) {
 			$line_item->set_total( floatval( $item['total'] ) );
+		} elseif ( $creating ) {
+			$total = wc_get_price_excluding_tax( $product, array( 'qty' => $line_item->get_quantity() ) );
+			$line_item->set_total( $total );
+			$line_item->set_subtotal( $total );
 		}
 		if ( isset( $item['total_tax'] ) ) {
 			$line_item->set_total_tax( floatval( $item['total_tax'] ) );


### PR DESCRIPTION
Fixes #13458.

I've modified the code to set the order line item prices when an order is being created with the legacy API. It does this in the same way the current version of the API handles it. To test, you can just follow the steps to reproduce in the linked issue, but verify prices are set.