### PR TITLE
Accept only list of term IDs while setting product categories and tags

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1086,7 +1086,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $term_ids List of terms IDs.
 	 */
 	public function set_category_ids( $term_ids ) {
-		$this->set_prop( 'category_ids', array_unique( array_map( 'intval', $term_ids, 'product_cat' ) ) );
+		$this->set_prop( 'category_ids', array_unique( array_map( 'intval', $term_ids ) ) );
 	}
 
 	/**
@@ -1096,7 +1096,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $term_ids List of terms IDs.
 	 */
 	public function set_tag_ids( $term_ids ) {
-		$this->set_prop( 'tag_ids', array_unique( array_map( 'intval', $term_ids, 'product_tag' ) ) );
+		$this->set_prop( 'tag_ids', array_unique( array_map( 'intval', $term_ids ) ) );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1086,7 +1086,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $term_ids List of terms IDs.
 	 */
 	public function set_category_ids( $term_ids ) {
-		$this->set_prop( 'category_ids', $this->sanitize_term_ids( $term_ids, 'product_cat' ) );
+		$this->set_prop( 'category_ids', array_unique( array_map( 'intval', $term_ids, 'product_cat' ) ) );
 	}
 
 	/**
@@ -1096,7 +1096,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $term_ids List of terms IDs.
 	 */
 	public function set_tag_ids( $term_ids ) {
-		$this->set_prop( 'tag_ids', $this->sanitize_term_ids( $term_ids, 'product_tag' ) );
+		$this->set_prop( 'tag_ids', array_unique( array_map( 'intval', $term_ids, 'product_tag' ) ) );
 	}
 
 	/**
@@ -1250,31 +1250,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	| Other Methods
 	|--------------------------------------------------------------------------
 	*/
-
-	/**
-	 * Get term ids from either a list of names, ids, or terms.
-	 *
-	 * @since 2.7.0
-	 * @param array $terms
-	 * @param string $taxonomy
-	 */
-	protected function sanitize_term_ids( $terms, $taxonomy ) {
-		$term_ids = array();
-		foreach ( $terms as $term ) {
-			if ( is_object( $term ) ) {
-				$term_ids[] = $term->term_id;
-			} elseif ( is_integer( $term ) ) {
-				$term_ids[] = absint( $term );
-			} else {
-				$term_object = get_term_by( 'name', $term, $taxonomy );
-
-				if ( $term_object && ! is_wp_error( $term_object ) ) {
-					$term_ids[] = $term_object->term_id;
-				}
-			}
-		}
-		return $term_ids;
-	}
 
 	/**
 	 * Ensure properties are set correctly before save.

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1134,7 +1134,6 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 	 */
 	protected function save_taxonomy_terms( $product, $terms, $taxonomy = 'cat' ) {
 		$term_ids = wp_list_pluck( $terms, 'id' );
-		$term_ids = array_unique( array_map( 'intval', $term_ids ) );
 
 		if ( 'cat' === $taxonomy ) {
 			$product->set_category_ids( $term_ids );

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1182,14 +1182,12 @@ class WC_API_Products extends WC_API_Resource {
 
 		// Product categories
 		if ( isset( $data['categories'] ) && is_array( $data['categories'] ) ) {
-			$term_ids = array_unique( array_map( 'intval', $data['categories'] ) );
-			$product->set_category_ids( $term_ids );
+			$product->set_category_ids( $data['categories'] );
 		}
 
 		// Product tags
 		if ( isset( $data['tags'] ) && is_array( $data['tags'] ) ) {
-			$term_ids = array_unique( array_map( 'intval', $data['tags'] ) );
-			$product->set_tag_ids( $term_ids );
+			$product->set_tag_ids( $data['tags'] );
 		}
 
 		// Downloadable

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1671,14 +1671,12 @@ class WC_API_Products extends WC_API_Resource {
 
 		// Product categories.
 		if ( isset( $data['categories'] ) && is_array( $data['categories'] ) ) {
-			$term_ids = array_unique( array_map( 'intval', $data['categories'] ) );
-			$product->set_category_ids( $term_ids );
+			$product->set_category_ids( $data['categories'] );
 		}
 
 		// Product tags.
 		if ( isset( $data['tags'] ) && is_array( $data['tags'] ) ) {
-			$term_ids = array_unique( array_map( 'intval', $data['tags'] ) );
-			$product->set_tag_ids( $term_ids );
+			$product->set_tag_ids( $data['tags'] );
 		}
 
 		// Downloadable.

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -982,7 +982,6 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	 */
 	protected function save_taxonomy_terms( $product, $terms, $taxonomy = 'cat' ) {
 		$term_ids = wp_list_pluck( $terms, 'id' );
-		$term_ids = array_unique( array_map( 'intval', $term_ids ) );
 
 		if ( 'cat' === $taxonomy ) {
 			$product->set_category_ids( $term_ids );

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -89,7 +89,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$test_tag_2 = wp_insert_term( 'Tag 2', 'product_tag' );
 
 		$getters_and_setters = array(
-			'tag_ids'      => array( 'Tag 1', 'Tag 2' ),
+			'tag_ids'      => array( $test_tag_1['term_id'], $test_tag_2['term_id'] ),
 			'category_ids' => array( $test_cat_1['term_id'], $test_cat_2['term_id'] ),
 		);
 		$product = new WC_Product_Simple;


### PR DESCRIPTION
In all our code we just use array of IDs and there is no reason to accept strings or `WP_Term` objects (`wp_list_pluck()` helps you doing it already :smile: ).

Fixes #13446