### PR TITLE
Enable plugins to write custom settings sections in Shipping tab

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -146,10 +146,16 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			$hide_save_button = true;
 			$this->output_shipping_class_screen();
 		} else {
+			$is_shipping_method = false;
 			foreach ( $shipping_methods as $method ) {
 				if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ) ) && $method->has_settings() ) {
+					$is_shipping_method = true;
 					$method->admin_options();
 				}
+			}
+			if ( !$is_shipping_method ) {
+				$settings = apply_filters( 'woocommerce_get_settings_' . $this->id, '' );
+				WC_Admin_Settings::output_fields( $settings );
 			}
 		}
 	}


### PR DESCRIPTION
Allow plugins to create their own settings sections under Shipping tab (while still allowing the current shipping method OOP features)

**Caveats:**

- Slight possibility for name collisions between shipping classes and section names? (very unlikely)

- This does not fix the API inconsistency of missing $current_section parameter in woocommerce_get_section_shipping. Plugins will have to use `global $current_section`