### PR TITLE
Adds 'woo commerce' to tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, jshreve, coderkevin, claudiulodro, woothemes, iCaleb
-Tags: ecommerce, e-commerce, store, sales, sell, shop, cart, checkout, downloadable, downloads, paypal, storefront
+Tags: ecommerce, e-commerce, store, sales, sell, shop, cart, checkout, downloadable, downloads, paypal, storefront, woo commerce
 Requires at least: 4.4
 Tested up to: 4.7
 Stable tag: 2.6.14


### PR DESCRIPTION
Searching ‘woo commerce’ on .org doesn’t return WooCommerce. It’s
possible that folks will search for this when trying to install. Whilst
not a guarantee to get us to No.1, adding the tag should at least help.