### PR TITLE
Prevent update or list _order_count and _money_spent on WC_Customer_Data_Store

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -56,6 +56,8 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'shipping_last_name',
 		'wptests_capabilities',
 		'wptests_user_level',
+		'_order_count',
+		'_money_spent',
 	);
 
 	/**


### PR DESCRIPTION
This prevents from list `_order_count` and `_money_spent` as meta data on REST API and prevent users from update it as well.