### PR TITLE
[2.7] Fix incorrect variable product price suffix 

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -134,9 +134,13 @@ class WC_Product_Variable extends WC_Product {
 		if ( $min_price !== $max_price ) {
 			$price = apply_filters( 'woocommerce_variable_price_html', wc_format_price_range( $min_price, $max_price ), $this );
 		} else {
-			$variation_id = key( $prices['price'] );
-			$variation    = wc_get_product( $variation_id );
-			$price        = apply_filters( 'woocommerce_variable_price_html', $variation->get_price_html(), $this );
+			$suffix = '';
+			if ( ( $suffix = get_option( 'woocommerce_price_display_suffix' ) ) && wc_tax_enabled() ) {
+				$variation_id = key( $prices['price'] );
+				$variation    = wc_get_product( $variation_id );
+				$suffix       = $variation->get_price_suffix();
+			}
+			$price = apply_filters( 'woocommerce_variable_price_html', wc_price( $min_price ) . $suffix, $this );
 		}
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -134,7 +134,7 @@ class WC_Product_Variable extends WC_Product {
 		if ( $min_price !== $max_price ) {
 			$price = apply_filters( 'woocommerce_variable_price_html', wc_format_price_range( $min_price, $max_price ), $this );
 		} else {
-			$price = apply_filters( 'woocommerce_variable_price_html', wc_price( $min_price ) . $this->get_price_suffix(), $this );
+			$price = apply_filters( 'woocommerce_variable_price_html', wc_price( $min_price ) . $this->get_price_suffix( $min_price ), $this );
 		}
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -134,7 +134,9 @@ class WC_Product_Variable extends WC_Product {
 		if ( $min_price !== $max_price ) {
 			$price = apply_filters( 'woocommerce_variable_price_html', wc_format_price_range( $min_price, $max_price ), $this );
 		} else {
-			$price = apply_filters( 'woocommerce_variable_price_html', wc_price( $min_price ) . $this->get_price_suffix( $min_price ), $this );
+			$variation_id = key( $prices['price'] );
+			$variation    = wc_get_product( $variation_id );
+			$price        = apply_filters( 'woocommerce_variable_price_html', $variation->get_price_html(), $this );
 		}
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -135,7 +135,7 @@ class WC_Product_Variable extends WC_Product {
 			$price = apply_filters( 'woocommerce_variable_price_html', wc_format_price_range( $min_price, $max_price ), $this );
 		} else {
 			$suffix = '';
-			if ( ( $suffix = get_option( 'woocommerce_price_display_suffix' ) ) && wc_tax_enabled() ) {
+			if ( get_option( 'woocommerce_price_display_suffix' ) && wc_tax_enabled() ) {
 				$variation_id = key( $prices['price'] );
 				$variation    = wc_get_product( $variation_id );
 				$suffix       = $variation->get_price_suffix();


### PR DESCRIPTION
When variation price or ID filters are used, `WC_Product_Variable::get_price_suffix` may display incorrect prices incl/excl tax if called without explicitly passing the variation price.

This is because:

1. `get_price_suffix` uses `get_price` when called with an empty `$price` parameter -- and (under specific conditions) the price of the variable product may not be the same as the minimum variation price. 
2. `wc_get_price_including_tax` and `wc_get_price_excluding_tax` are called by passing the **variable** product instead of the variation with the minimum price. However, the tax class of the latter one may not be the same as the tax class of the former.

If it wasn't fox taxes, an easy fix for one would be [this](https://github.com/woocommerce/woocommerce/commit/33ebfd1f39074c6b6a9ae7b709a5508995650da2), but with taxes added into the picture, it becomes necessary to get the suffix from a variation object.

Note that the proposed patch is **insufficient in some edge cases**. For example, if the variation with the min price has a different tax class than the variation with the max price, the display price might be the same but their prices including or excluding tax could be different, possibly resulting in different suffixes depending on which variation we are looking at. In this (edge) case the displayed variable product suffix could be ambiguous.