### PR TITLE
Allow product ids in get_product_data

### DIFF
--- a/includes/api/legacy/v1/class-wc-api-products.php
+++ b/includes/api/legacy/v1/class-wc-api-products.php
@@ -260,10 +260,14 @@ class WC_API_Products extends WC_API_Resource {
 	 * Get standard product data that applies to every product type
 	 *
 	 * @since 2.1
-	 * @param WC_Product $product
+	 * @param WC_Product|int $product
 	 * @return array
 	 */
 	private function get_product_data( $product ) {
+		if ( is_numeric( $product ) ) {
+			$product = wc_get_product( $product );
+		}
+
 		return array(
 			'title'              => $product->get_name(),
 			'id'                 => $product->get_id(),

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -676,10 +676,14 @@ class WC_API_Products extends WC_API_Resource {
 	 * Get standard product data that applies to every product type
 	 *
 	 * @since 2.1
-	 * @param WC_Product $product
+	 * @param WC_Product|int $product
 	 * @return WC_Product
 	 */
 	private function get_product_data( $product ) {
+		if ( is_numeric( $product ) ) {
+			$product = wc_get_product( $product );
+		}
+
 		$prices_precision = wc_get_price_decimals();
 		return array(
 			'title'              => $product->get_name(),

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1122,10 +1122,14 @@ class WC_API_Products extends WC_API_Resource {
 	 * Get standard product data that applies to every product type
 	 *
 	 * @since 2.1
-	 * @param WC_Product $product
+	 * @param WC_Product|int $product
 	 * @return WC_Product
 	 */
 	private function get_product_data( $product ) {
+		if ( is_numeric( $product ) ) {
+			$product = wc_get_product( $product );
+		}
+
 		return array(
 			'title'              => $product->get_name(),
 			'id'                 => $product->get_id(),


### PR DESCRIPTION
Fixes #13405.

Currently, if you try and update a variation with the API it causes a fatal error. There are a couple instances where a product id is getting passed into `get_product_data`, which expects a product object. I've modified the function to accept a product or product id.