### PR TITLE
Improve individual use coupon handling

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1736,21 +1736,6 @@ class WC_Cart {
 			return false;
 		}
 
-		// Check to see if an individual use coupon is set
-		if ( $this->applied_coupons ) {
-			foreach ( $this->applied_coupons as $code ) {
-				$coupon = new WC_Coupon( $code );
-
-				if ( $coupon->get_individual_use() && false === apply_filters( 'woocommerce_apply_with_individual_use_coupon', false, $the_coupon, $coupon, $this->applied_coupons ) ) {
-
-					// Reject new coupon
-					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED_INDIV_USE_ONLY );
-
-					return false;
-				}
-			}
-		}
-
 		// If its individual use then remove other coupons
 		if ( $the_coupon->get_individual_use() ) {
 			$coupons_to_keep = apply_filters( 'woocommerce_apply_individual_use_coupon', array(), $the_coupon, $this->applied_coupons );
@@ -1766,6 +1751,21 @@ class WC_Cart {
 
 			if ( ! empty( $coupons_to_keep ) ) {
 				$this->applied_coupons += $coupons_to_keep;
+			}
+		}
+
+		// Check to see if an individual use coupon is set
+		if ( $this->applied_coupons ) {
+			foreach ( $this->applied_coupons as $code ) {
+				$coupon = new WC_Coupon( $code );
+
+				if ( $coupon->get_individual_use() && false === apply_filters( 'woocommerce_apply_with_individual_use_coupon', false, $the_coupon, $coupon, $this->applied_coupons ) ) {
+
+					// Reject new coupon
+					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED_INDIV_USE_ONLY );
+
+					return false;
+				}
 			}
 		}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1738,7 +1738,19 @@ class WC_Cart {
 
 		// If its individual use then remove other coupons
 		if ( $the_coupon->get_individual_use() ) {
-			$this->applied_coupons = apply_filters( 'woocommerce_apply_individual_use_coupon', array(), $the_coupon, $this->applied_coupons );
+			$coupons_to_keep = apply_filters( 'woocommerce_apply_individual_use_coupon', array(), $the_coupon, $this->applied_coupons );
+
+			foreach ( $this->applied_coupons as $applied_coupon ) {
+				$keep_key = array_search( $applied_coupon, $coupons_to_keep );
+				if ( false !== $keep_key ) {
+					$this->remove_coupon( $applied_coupon );
+					unset( $coupons_to_keep[ $keep_key ] );
+				}
+			}
+
+			if ( ! empty( $coupons_to_keep ) ) {
+				$this->applied_coupons += $coupons_to_keep;
+			}
 		}
 
 		if ( $this->applied_coupons ) {

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1736,23 +1736,7 @@ class WC_Cart {
 			return false;
 		}
 
-		// If its individual use then remove other coupons
-		if ( $the_coupon->get_individual_use() ) {
-			$coupons_to_keep = apply_filters( 'woocommerce_apply_individual_use_coupon', array(), $the_coupon, $this->applied_coupons );
-
-			foreach ( $this->applied_coupons as $applied_coupon ) {
-				$keep_key = array_search( $applied_coupon, $coupons_to_keep );
-				if ( false !== $keep_key ) {
-					$this->remove_coupon( $applied_coupon );
-					unset( $coupons_to_keep[ $keep_key ] );
-				}
-			}
-
-			if ( ! empty( $coupons_to_keep ) ) {
-				$this->applied_coupons += $coupons_to_keep;
-			}
-		}
-
+		// Check to see if an individual use coupon is set
 		if ( $this->applied_coupons ) {
 			foreach ( $this->applied_coupons as $code ) {
 				$coupon = new WC_Coupon( $code );
@@ -1764,6 +1748,24 @@ class WC_Cart {
 
 					return false;
 				}
+			}
+		}
+
+		// If its individual use then remove other coupons
+		if ( $the_coupon->get_individual_use() ) {
+			$coupons_to_keep = apply_filters( 'woocommerce_apply_individual_use_coupon', array(), $the_coupon, $this->applied_coupons );
+
+			foreach ( $this->applied_coupons as $applied_coupon ) {
+				$keep_key = array_search( $applied_coupon, $coupons_to_keep );
+				if ( false === $keep_key ) {
+					$this->remove_coupon( $applied_coupon );
+				} else {
+					unset( $coupons_to_keep[ $keep_key ] );
+				}
+			}
+
+			if ( ! empty( $coupons_to_keep ) ) {
+				$this->applied_coupons += $coupons_to_keep;
 			}
 		}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1713,30 +1713,30 @@ class WC_Cart {
 	 * @return bool	True if the coupon is applied, false if it does not exist or cannot be applied
 	 */
 	public function add_discount( $coupon_code ) {
-		// Coupons are globally disabled
+		// Coupons are globally disabled.
 		if ( ! wc_coupons_enabled() ) {
 			return false;
 		}
 
-		// Sanitize coupon code
+		// Sanitize coupon code.
 		$coupon_code = wc_format_coupon_code( $coupon_code );
 
-		// Get the coupon
+		// Get the coupon.
 		$the_coupon = new WC_Coupon( $coupon_code );
 
-		// Check it can be used with cart
+		// Check it can be used with cart.
 		if ( ! $the_coupon->is_valid() ) {
 			wc_add_notice( $the_coupon->get_error_message(), 'error' );
 			return false;
 		}
 
-		// Check if applied
+		// Check if applied.
 		if ( $this->has_discount( $coupon_code ) ) {
 			$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED );
 			return false;
 		}
 
-		// If its individual use then remove other coupons
+		// If its individual use then remove other coupons.
 		if ( $the_coupon->get_individual_use() ) {
 			$coupons_to_keep = apply_filters( 'woocommerce_apply_individual_use_coupon', array(), $the_coupon, $this->applied_coupons );
 
@@ -1754,14 +1754,14 @@ class WC_Cart {
 			}
 		}
 
-		// Check to see if an individual use coupon is set
+		// Check to see if an individual use coupon is set.
 		if ( $this->applied_coupons ) {
 			foreach ( $this->applied_coupons as $code ) {
 				$coupon = new WC_Coupon( $code );
 
 				if ( $coupon->get_individual_use() && false === apply_filters( 'woocommerce_apply_with_individual_use_coupon', false, $the_coupon, $coupon, $this->applied_coupons ) ) {
 
-					// Reject new coupon
+					// Reject new coupon.
 					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_ALREADY_APPLIED_INDIV_USE_ONLY );
 
 					return false;
@@ -1771,7 +1771,7 @@ class WC_Cart {
 
 		$this->applied_coupons[] = $coupon_code;
 
-		// Choose free shipping
+		// Choose free shipping.
 		if ( $the_coupon->get_free_shipping() ) {
 			$packages = WC()->shipping->get_packages();
 			$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -645,7 +645,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$coupons = WC()->cart->get_coupons();
 
 		$this->assertEquals( count( $coupons ), 1 );
-		$this->assertEquals( 'code1', reset( $coupons )->get_code() );
+		$this->assertEquals( 'code2', reset( $coupons )->get_code() );
 
 		// Clean up
 		WC()->cart->empty_cart();

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -587,7 +587,50 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 	}
 
-	public function test_add_individual_use_coupons() {
+	public function test_add_invidual_use_coupon() {
+		$iu_coupon = WC_Helper_Coupon::create_coupon( 'code1' );
+		$iu_coupon->set_individual_use( true );
+		$iu_coupon->save();
+		$coupon = WC_Helper_Coupon::create_coupon();
+
+		WC()->cart->add_discount( $iu_coupon->get_code() );
+		WC()->cart->add_discount( $coupon->get_code() );
+
+		$coupons = WC()->cart->get_coupons();
+
+		$this->assertEquals( count( $coupons ), 1 );
+		$this->assertEquals( 'code1', reset( $coupons )->get_code() );
+
+		// Clean up
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		WC_Helper_Coupon::delete_coupon( $coupon->get_code() );
+		WC_Helper_Coupon::delete_coupon( $iu_coupon->get_code() );
+	}
+
+	public function test_add_individual_use_coupon_removal() {
+		$coupon = WC_Helper_Coupon::create_coupon();
+		$iu_coupon = WC_Helper_Coupon::create_coupon( 'code1' );
+		$iu_coupon->set_individual_use( true );
+		$iu_coupon->save();
+
+		WC()->cart->add_discount( $coupon->get_code() );
+		WC()->cart->add_discount( $iu_coupon->get_code() );
+
+		$coupons = WC()->cart->get_coupons();
+
+		$this->assertEquals( count( $coupons ), 1 );
+		$this->assertEquals( 'code1', reset( $coupons )->get_code() );
+		$this->assertEquals( 1, did_action( 'woocommerce_removed_coupon' ) );
+
+		// Clean up
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		WC_Helper_Coupon::delete_coupon( $coupon->get_code() );
+		WC_Helper_Coupon::delete_coupon( $iu_coupon->get_code() );
+	}
+
+	public function test_add_individual_use_coupon_double_individual() {
 		$iu_coupon1 = WC_Helper_Coupon::create_coupon( 'code1' );
 		$iu_coupon1->set_individual_use( true );
 		$iu_coupon1->save();

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -568,7 +568,6 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	 * Test cart coupons.
 	 */
 	public function test_get_coupons() {
-
 		// Create coupon
 		$coupon = WC_Helper_Coupon::create_coupon();
 
@@ -586,5 +585,29 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		// Delete coupon
 		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
 
+	}
+
+	public function test_add_individual_use_coupons() {
+		$iu_coupon1 = WC_Helper_Coupon::create_coupon( 'code1' );
+		$iu_coupon1->set_individual_use( true );
+		$iu_coupon1->save();
+
+		$iu_coupon2 = WC_Helper_Coupon::create_coupon( 'code2' );
+		$iu_coupon2->set_individual_use( true );
+		$iu_coupon2->save();
+
+		WC()->cart->add_discount( $iu_coupon1->get_code() );
+		WC()->cart->add_discount( $iu_coupon2->get_code() );
+
+		$coupons = WC()->cart->get_coupons();
+
+		$this->assertEquals( count( $coupons ), 1 );
+		$this->assertEquals( 'code1', reset( $coupons )->get_code() );
+
+		// Clean up
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		WC_Helper_Coupon::delete_coupon( $iu_coupon1->get_code() );
+		WC_Helper_Coupon::delete_coupon( $iu_coupon2->get_code() );
 	}
 }


### PR DESCRIPTION
Fixes #13480.

When coupons get removed by the individual use coupon now, the `woocommerce_removed_coupon` action will get fired.