### PR TITLE
Generic.ControlStructures.InlineControlStructure.NotAllowed

### DIFF
--- a/apigen/hook-docs.php
+++ b/apigen/hook-docs.php
@@ -18,31 +18,31 @@ class WC_HookFinder {
 				$dir = '';
 			}
 
-	        return self::get_files( basename( $pattern ), $flags, $dir . '/' );
+			return self::get_files( basename( $pattern ), $flags, $dir . '/' );
 
-	    } // End IF Statement
+		} // End IF Statement
 
-	    $paths = glob( $path . '*', GLOB_ONLYDIR | GLOB_NOSORT );
-	    $files = glob( $path . $pattern, $flags );
+		$paths = glob( $path . '*', GLOB_ONLYDIR | GLOB_NOSORT );
+		$files = glob( $path . $pattern, $flags );
 
-	    if ( is_array( $paths ) ) {
-		    foreach ( $paths as $p ) {
-			    $found_files = array();
-		   		$retrieved_files = (array) self::get_files( $pattern, $flags, $p . '/' );
-		   		foreach ( $retrieved_files as $file ) {
-			   		if ( ! in_array( $file, self::$found_files ) )
-			   			$found_files[] = $file;
-		   		}
+		if ( is_array( $paths ) ) {
+			foreach ( $paths as $p ) {
+				$found_files = array();
+				$retrieved_files = (array) self::get_files( $pattern, $flags, $p . '/' );
+				foreach ( $retrieved_files as $file ) {
+					if ( ! in_array( $file, self::$found_files ) )
+						$found_files[] = $file;
+				}
 
-		   		self::$found_files = array_merge( self::$found_files, $found_files );
+				self::$found_files = array_merge( self::$found_files, $found_files );
 
-		   		if ( is_array( $files ) && is_array( $found_files ) ) {
-		   			$files = array_merge( $files, $found_files );
-		   		}
-		    } // End FOREACH Loop
-	    }
-	    return $files;
-    }
+				if ( is_array( $files ) && is_array( $found_files ) ) {
+					$files = array_merge( $files, $found_files );
+				}
+			} // End FOREACH Loop
+		}
+		return $files;
+	}
 
 	private static function get_hook_link( $hook, $details = array() ) {
 		if ( ! empty( $details['class'] ) ) {
@@ -166,7 +166,7 @@ class WC_HookFinder {
 									if ( isset( self::$custom_hooks_found[ $hook ] ) ) {
 										self::$custom_hooks_found[ $hook ]['file'][] = self::$current_file;
 									} else {
-    									self::$custom_hooks_found[ $hook ] = array(
+										self::$custom_hooks_found[ $hook ] = array(
 											'line'     => $token[2],
 											'class'    => $current_class,
 											'function' => $current_function,

--- a/apigen/hook-docs.php
+++ b/apigen/hook-docs.php
@@ -30,8 +30,9 @@ class WC_HookFinder {
 				$found_files = array();
 				$retrieved_files = (array) self::get_files( $pattern, $flags, $p . '/' );
 				foreach ( $retrieved_files as $file ) {
-					if ( ! in_array( $file, self::$found_files ) )
+					if ( ! in_array( $file, self::$found_files ) ) {
 						$found_files[] = $file;
+					}
 				}
 
 				self::$found_files = array_merge( self::$found_files, $found_files );

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -369,7 +369,9 @@ class WC_Admin_Assets {
 	 */
 	public function product_taxonomy_styles() {
 
-		if ( ! current_user_can( 'manage_woocommerce' ) ) return;
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 		?>
 		<style type="text/css">
 			<?php if ( isset( $_GET['taxonomy'] ) && 'product_cat' === $_GET['taxonomy'] ) : ?>

--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -159,8 +159,9 @@ class WC_Admin_Reports {
 
 		include_once( apply_filters( 'wc_admin_reports_path', 'reports/class-wc-report-' . $name . '.php', $name, $class ) );
 
-		if ( ! class_exists( $class ) )
+		if ( ! class_exists( $class ) ) {
 			return;
+		}
 
 		$report = new $class();
 		$report->output_report();

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -153,8 +153,9 @@ class WC_Admin_Status {
 		$file_data = str_replace( "\r", "\n", $file_data );
 		$version   = '';
 
-		if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi', $file_data, $match ) && $match[1] )
+		if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi', $file_data, $match ) && $match[1] ) {
 			$version = _cleanup_header_comment( $match[1] );
+		}
 
 		return $version ;
 	}

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -192,8 +192,10 @@ class WC_Meta_Box_Coupon_Data {
 						$category_ids = $coupon->get_product_categories();
 						$categories   = get_terms( 'product_cat', 'orderby=name&hide_empty=0' );
 
-						if ( $categories ) foreach ( $categories as $cat ) {
-							echo '<option value="' . esc_attr( $cat->term_id ) . '"' . selected( in_array( $cat->term_id, $category_ids ), true, false ) . '>' . esc_html( $cat->name ) . '</option>';
+						if ( $categories ) {
+							foreach ( $categories as $cat ) {
+								echo '<option value="' . esc_attr( $cat->term_id ) . '"' . selected( in_array( $cat->term_id, $category_ids ), true, false ) . '>' . esc_html( $cat->name ) . '</option>';
+							}
 						}
 					?>
 				</select> <?php echo wc_help_tip( __( 'A product must be in this category for the coupon to remain valid or, for "Product Discounts", products in these categories will be discounted.', 'woocommerce' ) ); ?></p>
@@ -207,8 +209,10 @@ class WC_Meta_Box_Coupon_Data {
 						$category_ids = $coupon->get_excluded_product_categories();
 						$categories   = get_terms( 'product_cat', 'orderby=name&hide_empty=0' );
 
-						if ( $categories ) foreach ( $categories as $cat ) {
-							echo '<option value="' . esc_attr( $cat->term_id ) . '"' . selected( in_array( $cat->term_id, $category_ids ), true, false ) . '>' . esc_html( $cat->name ) . '</option>';
+						if ( $categories ) {
+							foreach ( $categories as $cat ) {
+								echo '<option value="' . esc_attr( $cat->term_id ) . '"' . selected( in_array( $cat->term_id, $category_ids ), true, false ) . '>' . esc_html( $cat->name ) . '</option>';
+							}
 						}
 					?>
 				</select> <?php echo wc_help_tip( __( 'Product must not be in this category for the coupon to remain valid or, for "Product Discounts", products in these categories will not be discounted.', 'woocommerce' ) ); ?></p>

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
@@ -38,8 +38,9 @@ class WC_Meta_Box_Product_Reviews {
 	 */
 	public static function save( $location, $comment_id ) {
 		// Not allowed, return regular value without updating meta
-		if ( ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) && ! isset( $_POST['rating'] ) )
+		if ( ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) && ! isset( $_POST['rating'] ) ) {
 			return $location;
+		}
 
 		// Update meta
 		update_comment_meta(

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -300,8 +300,9 @@ class WC_Admin_Report {
 					$where_value = "{$value['operator']} '{$value['value']}'";
 				}
 
-				if ( ! empty( $where_value ) )
+				if ( ! empty( $where_value ) ) {
 					$query['where'] .= " AND {$value['key']} {$where_value}";
+				}
 			}
 		}
 

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -207,12 +207,12 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 							 ?>
 						</select>
 						<input type="submit" class="submit button" value="<?php esc_attr_e( 'Show', 'woocommerce' ); ?>" />
-						<input type="hidden" name="range" value="<?php if ( ! empty( $_GET['range'] ) ) echo esc_attr( $_GET['range'] ) ?>" />
-						<input type="hidden" name="start_date" value="<?php if ( ! empty( $_GET['start_date'] ) ) echo esc_attr( $_GET['start_date'] ) ?>" />
-						<input type="hidden" name="end_date" value="<?php if ( ! empty( $_GET['end_date'] ) ) echo esc_attr( $_GET['end_date'] ) ?>" />
-						<input type="hidden" name="page" value="<?php if ( ! empty( $_GET['page'] ) ) echo esc_attr( $_GET['page'] ) ?>" />
-						<input type="hidden" name="tab" value="<?php if ( ! empty( $_GET['tab'] ) ) echo esc_attr( $_GET['tab'] ) ?>" />
-						<input type="hidden" name="report" value="<?php if ( ! empty( $_GET['report'] ) ) echo esc_attr( $_GET['report'] ) ?>" />
+						<input type="hidden" name="range" value="<?php echo ( ! empty( $_GET['range'] ) ) ? esc_attr( $_GET['range'] ) : ''; ?>" />
+						<input type="hidden" name="start_date" value="<?php echo ( ! empty( $_GET['start_date'] ) ) ? esc_attr( $_GET['start_date'] ) : ''; ?>" />
+						<input type="hidden" name="end_date" value="<?php echo ( ! empty( $_GET['end_date'] ) ) ? esc_attr( $_GET['end_date'] ) : ''; ?>" />
+						<input type="hidden" name="page" value="<?php echo ( ! empty( $_GET['page'] ) ) ? esc_attr( $_GET['page'] ) : ''; ?>" />
+						<input type="hidden" name="tab" value="<?php echo ( ! empty( $_GET['tab'] ) ) ? esc_attr( $_GET['tab'] ) : ''; ?>" />
+						<input type="hidden" name="report" value="<?php echo ( ! empty( $_GET['report'] ) ) ? esc_attr( $_GET['report'] ) : ''; ?>" />
 					<?php else : ?>
 						<span><?php _e( 'No used coupons found', 'woocommerce' ); ?></span>
 					<?php endif; ?>

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -222,12 +222,12 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 				<a href="#" class="select_none"><?php _e( 'None', 'woocommerce' ); ?></a>
 				<a href="#" class="select_all"><?php _e( 'All', 'woocommerce' ); ?></a>
 				<input type="submit" class="submit button" value="<?php esc_attr_e( 'Show', 'woocommerce' ); ?>" />
-				<input type="hidden" name="range" value="<?php if ( ! empty( $_GET['range'] ) ) echo esc_attr( $_GET['range'] ) ?>" />
-				<input type="hidden" name="start_date" value="<?php if ( ! empty( $_GET['start_date'] ) ) echo esc_attr( $_GET['start_date'] ) ?>" />
-				<input type="hidden" name="end_date" value="<?php if ( ! empty( $_GET['end_date'] ) ) echo esc_attr( $_GET['end_date'] ) ?>" />
-				<input type="hidden" name="page" value="<?php if ( ! empty( $_GET['page'] ) ) echo esc_attr( $_GET['page'] ) ?>" />
-				<input type="hidden" name="tab" value="<?php if ( ! empty( $_GET['tab'] ) ) echo esc_attr( $_GET['tab'] ) ?>" />
-				<input type="hidden" name="report" value="<?php if ( ! empty( $_GET['report'] ) ) echo esc_attr( $_GET['report'] ) ?>" />
+				<input type="hidden" name="range" value="<?php echo ( ! empty( $_GET['range'] ) ) ? esc_attr( $_GET['range'] ) : ''; ?>" />
+				<input type="hidden" name="start_date" value="<?php echo ( ! empty( $_GET['start_date'] ) ) ? esc_attr( $_GET['start_date'] ) : ''; ?>" />
+				<input type="hidden" name="end_date" value="<?php echo ( ! empty( $_GET['end_date'] ) ) ? esc_attr( $_GET['end_date'] ) : ''; ?>" />
+				<input type="hidden" name="page" value="<?php echo ( ! empty( $_GET['page'] ) ) ? esc_attr( $_GET['page'] ) : ''; ?>" />
+				<input type="hidden" name="tab" value="<?php echo ( ! empty( $_GET['tab'] ) ) ? esc_attr( $_GET['tab'] ) : ''; ?>" />
+				<input type="hidden" name="report" value="<?php echo ( ! empty( $_GET['report'] ) ) ? esc_attr( $_GET['report'] ) : ''; ?>" />
 			</div>
 			<script type="text/javascript">
 				jQuery(function(){

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -138,8 +138,9 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 
 		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
 
-		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) )
+		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) ) {
 			$current_range = '7day';
+		}
 
 		$this->calculate_current_range( $current_range );
 
@@ -203,12 +204,12 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 				<div>
 					<select class="wc-product-search" style="width:203px;" multiple="multiple" id="product_ids" name="product_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations"></select>
 					<input type="submit" class="submit button" value="<?php esc_attr_e( 'Show', 'woocommerce' ); ?>" />
-					<input type="hidden" name="range" value="<?php if ( ! empty( $_GET['range'] ) ) echo esc_attr( $_GET['range'] ) ?>" />
-					<input type="hidden" name="start_date" value="<?php if ( ! empty( $_GET['start_date'] ) ) echo esc_attr( $_GET['start_date'] ) ?>" />
-					<input type="hidden" name="end_date" value="<?php if ( ! empty( $_GET['end_date'] ) ) echo esc_attr( $_GET['end_date'] ) ?>" />
-					<input type="hidden" name="page" value="<?php if ( ! empty( $_GET['page'] ) ) echo esc_attr( $_GET['page'] ) ?>" />
-					<input type="hidden" name="tab" value="<?php if ( ! empty( $_GET['tab'] ) ) echo esc_attr( $_GET['tab'] ) ?>" />
-					<input type="hidden" name="report" value="<?php if ( ! empty( $_GET['report'] ) ) echo esc_attr( $_GET['report'] ) ?>" />
+					<input type="hidden" name="range" value="<?php echo ( ! empty( $_GET['range'] ) ) ? esc_attr( $_GET['range'] ) : ''; ?>" />
+					<input type="hidden" name="start_date" value="<?php echo ( ! empty( $_GET['start_date'] ) ) ? esc_attr( $_GET['start_date'] ) : ''; ?>" />
+					<input type="hidden" name="end_date" value="<?php echo ( ! empty( $_GET['end_date'] ) ) ? esc_attr( $_GET['end_date'] ) : ''; ?>" />
+					<input type="hidden" name="page" value="<?php echo ( ! empty( $_GET['page'] ) ) ? esc_attr( $_GET['page'] ) : ''; ?>" />
+					<input type="hidden" name="tab" value="<?php echo ( ! empty( $_GET['tab'] ) ) ? esc_attr( $_GET['tab'] ) : ''; ?>" />
+					<input type="hidden" name="report" value="<?php echo ( ! empty( $_GET['report'] ) ) ? esc_attr( $_GET['report'] ) : ''; ?>" />
 				</div>
 			</form>
 		</div>

--- a/includes/admin/settings/class-wc-settings-integrations.php
+++ b/includes/admin/settings/class-wc-settings-integrations.php
@@ -71,8 +71,9 @@ class WC_Settings_Integrations extends WC_Settings_Page {
 
 		$integrations = WC()->integrations->get_integrations();
 
-		if ( isset( $integrations[ $current_section ] ) )
+		if ( isset( $integrations[ $current_section ] ) ) {
 			$integrations[ $current_section ]->admin_options();
+		}
 	}
 }
 

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php if ( $sections ) : ?>
 		<ul class="subsubsub">
 			<?php foreach ( $sections as $section_id => $section ) : ?>
-				<li><a class="<?php echo $current_section === $section_id ? 'current' : ''; ?>" href="<?php echo admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section_id ) ); ?>"><?php echo esc_html( $section->title ); ?></a><?php if ( end( $section_keys ) !== $section_id ) echo ' |'; ?></li>
+				<li><a class="<?php echo $current_section === $section_id ? 'current' : ''; ?>" href="<?php echo admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section_id ) ); ?>"><?php echo esc_html( $section->title ); ?></a><?php echo ( end( $section_keys ) !== $section_id ) ? ' |' : ''; ?></li>
 			<?php endforeach; ?>
 		</ul>
 		<br class="clear" />

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -501,7 +501,9 @@ $pages          = $system_status->get_pages();
 					}
 				}
 
-				if ( ! $error ) echo '<mark class="yes">#' . absint( $page['page_id'] ) . ' - ' . str_replace( home_url(), '', get_permalink( $page['page_id'] ) ) . '</mark>';
+				if ( ! $error ) {
+					echo '<mark class="yes">#' . absint( $page['page_id'] ) . ' - ' . str_replace( home_url(), '', get_permalink( $page['page_id'] ) ) . '</mark>';
+				}
 
 				echo '</td></tr>';
 			}
@@ -571,13 +573,13 @@ $pages          = $system_status->get_pages();
 		<tr>
 			<td data-export-label="WooCommerce Support"><?php _e( 'WooCommerce support', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( __( 'Displays whether or not the current active theme declares WooCommerce support.', 'woocommerce' ) ); ?></td>
-			<td><?php
-				if ( ! $theme['has_woocommerce_support'] ) {
+			<td>
+				<?php if ( ! $theme['has_woocommerce_support'] ) {
 					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Not declared', 'woocommerce' ) . '</mark>';
 				} else {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
-				}
-			?></td>
+				} ?>
+			</td>
 		</tr>
 	</tbody>
 </table>

--- a/includes/admin/views/html-admin-page-status.php
+++ b/includes/admin/views/html-admin-page-status.php
@@ -20,7 +20,9 @@ $tabs        = apply_filters( 'woocommerce_admin_status_tabs', $tabs );
 		<?php
 			foreach ( $tabs as $name => $label ) {
 				echo '<a href="' . admin_url( 'admin.php?page=wc-status&tab=' . $name ) . '" class="nav-tab ';
-				if ( $current_tab == $name ) echo 'nav-tab-active';
+				if ( $current_tab == $name ) {
+					echo 'nav-tab-active';
+				}
 				echo '">' . $label . '</a>';
 			}
 		?>

--- a/includes/admin/views/html-bulk-edit-product.php
+++ b/includes/admin/views/html-bulk-edit-product.php
@@ -97,10 +97,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 						$tax_classes = WC_Tax::get_tax_classes();
 
-						if ( ! empty( $tax_classes ) )
+						if ( ! empty( $tax_classes ) ) {
 							foreach ( $tax_classes as $class ) {
 								$options[ sanitize_title( $class ) ] = esc_html( $class );
 							}
+						}
 
 						foreach ( $options as $key => $value ) {
 							echo '<option value="' . esc_attr( $key ) . '">' . $value . '</option>';

--- a/includes/admin/views/html-quick-edit-product.php
+++ b/includes/admin/views/html-quick-edit-product.php
@@ -75,10 +75,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 						$tax_classes = WC_Tax::get_tax_classes();
 
-						if ( ! empty( $tax_classes ) )
+						if ( ! empty( $tax_classes ) ) {
 							foreach ( $tax_classes as $class ) {
 								$options[ sanitize_title( $class ) ] = esc_html( $class );
 							}
+						}
 
 						foreach ( $options as $key => $value ) {
 							echo '<option value="' . esc_attr( $key ) . '">' . $value . '</option>';

--- a/includes/admin/views/html-report-by-date.php
+++ b/includes/admin/views/html-report-by-date.php
@@ -50,9 +50,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 								}
 							?>
 							<input type="hidden" name="range" value="custom" />
-							<input type="text" size="11" placeholder="yyyy-mm-dd" value="<?php if ( ! empty( $_GET['start_date'] ) ) echo esc_attr( $_GET['start_date'] ); ?>" name="start_date" class="range_datepicker from" />
+							<input type="text" size="11" placeholder="yyyy-mm-dd" value="<?php echo ( ! empty( $_GET['start_date'] ) ) ? esc_attr( $_GET['start_date'] ) : ''; ?>" name="start_date" class="range_datepicker from" />
 							<span>&ndash;</span>
-							<input type="text" size="11" placeholder="yyyy-mm-dd" value="<?php if ( ! empty( $_GET['end_date'] ) ) echo esc_attr( $_GET['end_date'] ); ?>" name="end_date" class="range_datepicker to" />
+							<input type="text" size="11" placeholder="yyyy-mm-dd" value="<?php echo ( ! empty( $_GET['end_date'] ) ) ? esc_attr( $_GET['end_date'] ) : ''; ?>" name="end_date" class="range_datepicker to" />
 							<input type="submit" class="button" value="<?php esc_attr_e( 'Go', 'woocommerce' ); ?>" />
 						</div>
 					</form>
@@ -65,6 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php if ( $legends = $this->get_chart_legend() ) : ?>
 						<ul class="chart-legend">
 							<?php foreach ( $legends as $legend ) : ?>
+								<?php // @codingStandardsIgnoreLine ?>
 								<li style="border-color: <?php echo $legend['color']; ?>" <?php if ( isset( $legend['highlight_series'] ) ) echo 'class="highlight_series ' . ( isset( $legend['placeholder'] ) ? 'tips' : '' ) . '" data-series="' . esc_attr( $legend['highlight_series'] ) . '"'; ?> data-tip="<?php echo isset( $legend['placeholder'] ) ? $legend['placeholder'] : ''; ?>">
 									<?php echo $legend['title']; ?>
 								</li>

--- a/includes/api/legacy/v1/class-wc-api-coupons.php
+++ b/includes/api/legacy/v1/class-wc-api-coupons.php
@@ -75,8 +75,9 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		foreach ( $query->posts as $coupon_id ) {
 
-			if ( ! $this->is_readable( $coupon_id ) )
+			if ( ! $this->is_readable( $coupon_id ) ) {
 				continue;
+			}
 
 			$coupons[] = current( $this->get_coupon( $coupon_id, $fields ) );
 		}
@@ -144,8 +145,9 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		$query = $this->query_coupons( $filter );
 
-		if ( ! current_user_can( 'read_private_shop_coupons' ) )
+		if ( ! current_user_can( 'read_private_shop_coupons' ) ) {
 			return new WP_Error( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce' ), array( 'status' => 401 ) );
+		}
 
 		return array( 'count' => (int) $query->found_posts );
 	}
@@ -163,8 +165,9 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC LIMIT 1;", $code ) );
 
-		if ( is_null( $id ) )
+		if ( is_null( $id ) ) {
 			return new WP_Error( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce' ), array( 'status' => 404 ) );
+		}
 
 		return $this->get_coupon( $id, $fields );
 	}
@@ -191,8 +194,9 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'shop_coupon', 'edit' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		return $this->get_coupon( $id );
 	}
@@ -208,8 +212,9 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'shop_coupon', 'delete' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		return $this->delete( $id, 'shop_coupon', ( 'true' === $force ) );
 	}

--- a/includes/api/legacy/v1/class-wc-api-customers.php
+++ b/includes/api/legacy/v1/class-wc-api-customers.php
@@ -100,8 +100,9 @@ class WC_API_Customers extends WC_API_Resource {
 
 		foreach ( $query->get_results() as $user_id ) {
 
-			if ( ! $this->is_readable( $user_id ) )
+			if ( ! $this->is_readable( $user_id ) ) {
 				continue;
+			}
 
 			$customers[] = current( $this->get_customer( $user_id, $fields ) );
 		}
@@ -182,8 +183,9 @@ class WC_API_Customers extends WC_API_Resource {
 
 		$query = $this->query_customers( $filter );
 
-		if ( ! current_user_can( 'list_users' ) )
+		if ( ! current_user_can( 'list_users' ) ) {
 			return new WP_Error( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce' ), array( 'status' => 401 ) );
+		}
 
 		return array( 'count' => count( $query->get_results() ) );
 	}
@@ -197,8 +199,9 @@ class WC_API_Customers extends WC_API_Resource {
 	 */
 	public function create_customer( $data ) {
 
-		if ( ! current_user_can( 'create_users' ) )
+		if ( ! current_user_can( 'create_users' ) ) {
 			return new WP_Error( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce' ), array( 'status' => 401 ) );
+		}
 
 		return array();
 	}
@@ -214,8 +217,9 @@ class WC_API_Customers extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'customer', 'edit' );
 
-		if ( ! is_wp_error( $id ) )
+		if ( ! is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		return $this->get_customer( $id );
 	}
@@ -230,8 +234,9 @@ class WC_API_Customers extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'customer', 'delete' );
 
-		if ( ! is_wp_error( $id ) )
+		if ( ! is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		return $this->delete( $id, 'customer' );
 	}
@@ -398,11 +403,13 @@ class WC_API_Customers extends WC_API_Resource {
 	 */
 	public function modify_user_query( $query ) {
 
-		if ( $this->created_at_min )
+		if ( $this->created_at_min ) {
 			$query->query_where .= sprintf( " AND user_registered >= STR_TO_DATE( '%s', '%%Y-%%m-%%d %%h:%%i:%%s' )", esc_sql( $this->created_at_min ) );
+		}
 
-		if ( $this->created_at_max )
+		if ( $this->created_at_max ) {
 			$query->query_where .= sprintf( " AND user_registered <= STR_TO_DATE( '%s', '%%Y-%%m-%%d %%h:%%i:%%s' )", esc_sql( $this->created_at_max ) );
+		}
 	}
 
 	/**
@@ -424,31 +431,36 @@ class WC_API_Customers extends WC_API_Resource {
 		$id = absint( $id );
 
 		// validate ID
-		if ( empty( $id ) )
+		if ( empty( $id ) ) {
 			return new WP_Error( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce' ), array( 'status' => 404 ) );
+		}
 
 		// non-existent IDs return a valid WP_User object with the user ID = 0
 		$customer = new WP_User( $id );
 
-		if ( 0 === $customer->ID )
+		if ( 0 === $customer->ID ) {
 			return new WP_Error( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce' ), array( 'status' => 404 ) );
+		}
 
 		// validate permissions
 		switch ( $context ) {
 
 			case 'read':
-				if ( ! current_user_can( 'list_users' ) )
+				if ( ! current_user_can( 'list_users' ) ) {
 					return new WP_Error( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), array( 'status' => 401 ) );
+				}
 				break;
 
 			case 'edit':
-				if ( ! current_user_can( 'edit_users' ) )
+				if ( ! current_user_can( 'edit_users' ) ) {
 					return new WP_Error( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), array( 'status' => 401 ) );
+				}
 				break;
 
 			case 'delete':
-				if ( ! current_user_can( 'delete_users' ) )
+				if ( ! current_user_can( 'delete_users' ) ) {
 					return new WP_Error( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), array( 'status' => 401 ) );
+				}
 				break;
 		}
 

--- a/includes/api/legacy/v1/class-wc-api-orders.php
+++ b/includes/api/legacy/v1/class-wc-api-orders.php
@@ -70,8 +70,9 @@ class WC_API_Orders extends WC_API_Resource {
 	 */
 	public function get_orders( $fields = null, $filter = array(), $status = null, $page = 1 ) {
 
-		if ( ! empty( $status ) )
+		if ( ! empty( $status ) ) {
 			$filter['status'] = $status;
+		}
 
 		$filter['page'] = $page;
 
@@ -81,8 +82,9 @@ class WC_API_Orders extends WC_API_Resource {
 
 		foreach ( $query->posts as $order_id ) {
 
-			if ( ! $this->is_readable( $order_id ) )
+			if ( ! $this->is_readable( $order_id ) ) {
 				continue;
+			}
 
 			$orders[] = current( $this->get_order( $order_id, $fields ) );
 		}
@@ -241,13 +243,15 @@ class WC_API_Orders extends WC_API_Resource {
 	 */
 	public function get_orders_count( $status = null, $filter = array() ) {
 
-		if ( ! empty( $status ) )
+		if ( ! empty( $status ) ) {
 			$filter['status'] = $status;
+		}
 
 		$query = $this->query_orders( $filter );
 
-		if ( ! current_user_can( 'read_private_shop_orders' ) )
+		if ( ! current_user_can( 'read_private_shop_orders' ) ) {
 			return new WP_Error( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce' ), array( 'status' => 401 ) );
+		}
 
 		return array( 'count' => (int) $query->found_posts );
 	}
@@ -266,8 +270,9 @@ class WC_API_Orders extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'shop_order', 'edit' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		$order = wc_get_order( $id );
 
@@ -306,8 +311,9 @@ class WC_API_Orders extends WC_API_Resource {
 		// ensure ID is valid order ID
 		$id = $this->validate_request( $id, 'shop_order', 'read' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		$args = array(
 			'post_id' => $id,

--- a/includes/api/legacy/v1/class-wc-api-products.php
+++ b/includes/api/legacy/v1/class-wc-api-products.php
@@ -69,8 +69,9 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	public function get_products( $fields = null, $type = null, $filter = array(), $page = 1 ) {
 
-		if ( ! empty( $type ) )
+		if ( ! empty( $type ) ) {
 			$filter['type'] = $type;
+		}
 
 		$filter['page'] = $page;
 
@@ -80,8 +81,9 @@ class WC_API_Products extends WC_API_Resource {
 
 		foreach ( $query->posts as $product_id ) {
 
-			if ( ! $this->is_readable( $product_id ) )
+			if ( ! $this->is_readable( $product_id ) ) {
 				continue;
+			}
 
 			$products[] = current( $this->get_product( $product_id, $fields ) );
 		}
@@ -103,8 +105,9 @@ class WC_API_Products extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'product', 'read' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		$product = wc_get_product( $id );
 
@@ -134,11 +137,13 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	public function get_products_count( $type = null, $filter = array() ) {
 
-		if ( ! empty( $type ) )
+		if ( ! empty( $type ) ) {
 			$filter['type'] = $type;
+		}
 
-		if ( ! current_user_can( 'read_private_products' ) )
+		if ( ! current_user_can( 'read_private_products' ) ) {
 			return new WP_Error( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce' ), array( 'status' => 401 ) );
+		}
 
 		$query = $this->query_products( $filter );
 
@@ -156,8 +161,9 @@ class WC_API_Products extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'product', 'edit' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		return $this->get_product( $id );
 	}
@@ -173,8 +179,9 @@ class WC_API_Products extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'product', 'delete' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		return $this->delete( $id, 'product', ( 'true' === $force ) );
 	}
@@ -191,8 +198,9 @@ class WC_API_Products extends WC_API_Resource {
 
 		$id = $this->validate_request( $id, 'product', 'read' );
 
-		if ( is_wp_error( $id ) )
+		if ( is_wp_error( $id ) ) {
 			return $id;
+		}
 
 		$args = array(
 			'post_id' => $id,

--- a/includes/api/legacy/v1/class-wc-api-reports.php
+++ b/includes/api/legacy/v1/class-wc-api-reports.php
@@ -77,8 +77,9 @@ class WC_API_Reports extends WC_API_Resource {
 		// check user permissions
 		$check = $this->validate_request();
 
-		if ( is_wp_error( $check ) )
+		if ( is_wp_error( $check ) ) {
 			return $check;
+		}
 
 		// set date filtering
 		$this->setup_report( $filter );
@@ -161,8 +162,9 @@ class WC_API_Reports extends WC_API_Resource {
 		$customers = $users_query->get_results();
 
 		foreach ( $customers as $key => $customer ) {
-			if ( strtotime( $customer->user_registered ) < $this->report->start_date || strtotime( $customer->user_registered ) > $this->report->end_date )
+			if ( strtotime( $customer->user_registered ) < $this->report->start_date || strtotime( $customer->user_registered ) > $this->report->end_date ) {
 				unset( $customers[ $key ] );
+			}
 		}
 
 		$total_customers = count( $customers );
@@ -303,8 +305,9 @@ class WC_API_Reports extends WC_API_Resource {
 
 			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $order->post_date ) ) : date( 'Y-m', strtotime( $order->post_date ) );
 
-			if ( ! isset( $period_totals[ $time ] ) )
+			if ( ! isset( $period_totals[ $time ] ) ) {
 				continue;
+			}
 
 			$period_totals[ $time ]['sales']    = wc_format_decimal( $order->total_sales, 2 );
 			$period_totals[ $time ]['orders']   = (int) $order->total_orders;
@@ -317,8 +320,9 @@ class WC_API_Reports extends WC_API_Resource {
 
 			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $order_item->post_date ) ) : date( 'Y-m', strtotime( $order_item->post_date ) );
 
-			if ( ! isset( $period_totals[ $time ] ) )
+			if ( ! isset( $period_totals[ $time ] ) ) {
 				continue;
+			}
 
 			$period_totals[ $time ]['items'] = (int) $order_item->order_item_count;
 		}
@@ -328,8 +332,9 @@ class WC_API_Reports extends WC_API_Resource {
 
 			$time = ( 'day' === $this->report->chart_groupby ) ? date( 'Y-m-d', strtotime( $discount->post_date ) ) : date( 'Y-m', strtotime( $discount->post_date ) );
 
-			if ( ! isset( $period_totals[ $time ] ) )
+			if ( ! isset( $period_totals[ $time ] ) ) {
 				continue;
+			}
 
 			$period_totals[ $time ]['discount'] = wc_format_decimal( $discount->discount_amount, 2 );
 		}

--- a/includes/api/legacy/v1/class-wc-api-resource.php
+++ b/includes/api/legacy/v1/class-wc-api-resource.php
@@ -62,16 +62,18 @@ class WC_API_Resource {
 	 */
 	protected function validate_request( $id, $type, $context ) {
 
-		if ( 'shop_order' === $type || 'shop_coupon' === $type )
+		if ( 'shop_order' === $type || 'shop_coupon' === $type ) {
 			$resource_name = str_replace( 'shop_', '', $type );
-		else
+		} else {
 			$resource_name = $type;
+		}
 
 		$id = absint( $id );
 
 		// validate ID
-		if ( empty( $id ) )
+		if ( empty( $id ) ) {
 			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+		}
 
 		// only custom post types have per-post type/permission checks
 		if ( 'customer' !== $type ) {
@@ -82,25 +84,29 @@ class WC_API_Resource {
 			$post_type = ( 'product_variation' === $post->post_type ) ? 'product' : $post->post_type;
 
 			// validate post type
-			if ( $type !== $post_type )
+			if ( $type !== $post_type ) {
 				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce' ), $resource_name ), array( 'status' => 404 ) );
+			}
 
 			// validate permissions
 			switch ( $context ) {
 
 				case 'read':
-					if ( ! $this->is_readable( $post ) )
+					if ( ! $this->is_readable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 
 				case 'edit':
-					if ( ! $this->is_editable( $post ) )
+					if ( ! $this->is_editable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 
 				case 'delete':
-					if ( ! $this->is_deletable( $post ) )
+					if ( ! $this->is_deletable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 			}
 		}
@@ -126,33 +132,40 @@ class WC_API_Resource {
 			$args['date_query'] = array();
 
 			// resources created after specified date
-			if ( ! empty( $request_args['created_at_min'] ) )
+			if ( ! empty( $request_args['created_at_min'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_date_gmt', 'after' => $this->server->parse_datetime( $request_args['created_at_min'] ), 'inclusive' => true );
+			}
 
 			// resources created before specified date
-			if ( ! empty( $request_args['created_at_max'] ) )
+			if ( ! empty( $request_args['created_at_max'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_date_gmt', 'before' => $this->server->parse_datetime( $request_args['created_at_max'] ), 'inclusive' => true );
+			}
 
 			// resources updated after specified date
-			if ( ! empty( $request_args['updated_at_min'] ) )
+			if ( ! empty( $request_args['updated_at_min'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_modified_gmt', 'after' => $this->server->parse_datetime( $request_args['updated_at_min'] ), 'inclusive' => true );
+			}
 
 			// resources updated before specified date
-			if ( ! empty( $request_args['updated_at_max'] ) )
+			if ( ! empty( $request_args['updated_at_max'] ) ) {
 				$args['date_query'][] = array( 'column' => 'post_modified_gmt', 'before' => $this->server->parse_datetime( $request_args['updated_at_max'] ), 'inclusive' => true );
+			}
 		}
 
 		// search
-		if ( ! empty( $request_args['q'] ) )
+		if ( ! empty( $request_args['q'] ) ) {
 			$args['s'] = $request_args['q'];
+		}
 
 		// resources per response
-		if ( ! empty( $request_args['limit'] ) )
+		if ( ! empty( $request_args['limit'] ) ) {
 			$args['posts_per_page'] = $request_args['limit'];
+		}
 
 		// resource offset
-		if ( ! empty( $request_args['offset'] ) )
+		if ( ! empty( $request_args['offset'] ) ) {
 			$args['offset'] = $request_args['offset'];
+		}
 
 		// resource page
 		$args['paged'] = ( isset( $request_args['page'] ) ) ? absint( $request_args['page'] ) : 1;
@@ -174,8 +187,9 @@ class WC_API_Resource {
 		if ( isset( $this->server->params['GET']['filter']['meta'] ) && 'true' === $this->server->params['GET']['filter']['meta'] && is_object( $resource ) ) {
 
 			// don't attempt to add meta more than once
-			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) )
+			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) ) {
 				return $data;
+			}
 
 			// define the top-level property name for the meta
 			switch ( get_class( $resource ) ) {
@@ -236,8 +250,9 @@ class WC_API_Resource {
 	 */
 	public function filter_response_fields( $data, $resource, $fields ) {
 
-		if ( ! is_array( $data ) || empty( $fields ) )
+		if ( ! is_array( $data ) || empty( $fields ) ) {
 			return $data;
+		}
 
 		$fields = explode( ',', $fields );
 		$sub_fields = array();
@@ -290,27 +305,29 @@ class WC_API_Resource {
 	 */
 	protected function delete( $id, $type, $force = false ) {
 
-		if ( 'shop_order' === $type || 'shop_coupon' === $type )
+		if ( 'shop_order' === $type || 'shop_coupon' === $type ) {
 			$resource_name = str_replace( 'shop_', '', $type );
-		else
+		} else {
 			$resource_name = $type;
+		}
 
 		if ( 'customer' === $type ) {
 
 			$result = wp_delete_user( $id );
 
-			if ( $result )
+			if ( $result ) {
 				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce' ) );
-			else
+			} else {
 				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce' ), array( 'status' => 500 ) );
-
+			}
 		} else {
 
 			// delete order/coupon/product
 			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 
-			if ( ! $result )
+			if ( ! $result ) {
 				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), $resource_name ), array( 'status' => 500 ) );
+			}
 
 			if ( $force ) {
 				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), $resource_name ) );
@@ -375,24 +392,24 @@ class WC_API_Resource {
 	 */
 	private function check_permission( $post, $context ) {
 
-		if ( ! is_a( $post, 'WP_Post' ) )
+		if ( ! is_a( $post, 'WP_Post' ) ) {
 			$post = get_post( $post );
+		}
 
-		if ( is_null( $post ) )
+		if ( is_null( $post ) ) {
 			return false;
+		}
 
 		$post_type = get_post_type_object( $post->post_type );
 
-		if ( 'read' === $context )
+		if ( 'read' === $context ) {
 			return current_user_can( $post_type->cap->read_private_posts, $post->ID );
-
-		elseif ( 'edit' === $context )
+		} elseif ( 'edit' === $context ) {
 			return current_user_can( $post_type->cap->edit_post, $post->ID );
-
-		elseif ( 'delete' === $context )
+		} elseif ( 'delete' === $context ) {
 			return current_user_can( $post_type->cap->delete_post, $post->ID );
-
-		else
+		} else {
 			return false;
+		}
 	}
 }

--- a/includes/api/legacy/v1/class-wc-api-server.php
+++ b/includes/api/legacy/v1/class-wc-api-server.php
@@ -117,10 +117,11 @@ class WC_API_Server {
 	public function __construct( $path ) {
 
 		if ( empty( $path ) ) {
-			if ( isset( $_SERVER['PATH_INFO'] ) )
+			if ( isset( $_SERVER['PATH_INFO'] ) ) {
 				$path = $_SERVER['PATH_INFO'];
-			else
+			} else {
 				$path = '/';
+			}
 		}
 
 		$this->path           = $path;
@@ -138,14 +139,13 @@ class WC_API_Server {
 		}
 
 		// determine type of request/response and load handler, JSON by default
-		if ( $this->is_json_request() )
+		if ( $this->is_json_request() ) {
 			$handler_class = 'WC_API_JSON_Handler';
-
-		elseif ( $this->is_xml_request() )
+		} elseif ( $this->is_xml_request() ) {
 			$handler_class = 'WC_API_XML_Handler';
-
-		else
+		} else {
 			$handler_class = apply_filters( 'woocommerce_api_default_response_handler', 'WC_API_JSON_Handler', $this->path, $this );
+		}
 
 		$this->handler = new $handler_class();
 	}
@@ -162,12 +162,12 @@ class WC_API_Server {
 		$user = apply_filters( 'woocommerce_api_check_authentication', null, $this );
 
 		// API requests run under the context of the authenticated user
-		if ( is_a( $user, 'WP_User' ) )
+		if ( is_a( $user, 'WP_User' ) ) {
 			wp_set_current_user( $user->ID );
-
-		// WP_Errors are handled in serve_request()
-		elseif ( ! is_wp_error( $user ) )
+		} elseif ( ! is_wp_error( $user ) ) {
+			// WP_Errors are handled in serve_request()
 			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce' ), array( 'code' => 500 ) );
+		}
 
 		return $user;
 	}
@@ -241,8 +241,9 @@ class WC_API_Server {
 
 		if ( ! $served ) {
 
-			if ( 'HEAD' === $this->method )
+			if ( 'HEAD' === $this->method ) {
 				return;
+			}
 
 			echo $this->handler->generate_response( $result );
 		}
@@ -326,16 +327,19 @@ class WC_API_Server {
 				$callback = $handler[0];
 				$supported = isset( $handler[1] ) ? $handler[1] : self::METHOD_GET;
 
-				if ( ! ( $supported & $method ) )
+				if ( ! ( $supported & $method ) ) {
 					continue;
+				}
 
 				$match = preg_match( '@^' . $route . '$@i', urldecode( $this->path ), $args );
 
-				if ( ! $match )
+				if ( ! $match ) {
 					continue;
+				}
 
-				if ( ! is_callable( $callback ) )
+				if ( ! is_callable( $callback ) ) {
 					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce' ), array( 'status' => 500 ) );
+				}
 
 				$args = array_merge( $args, $this->params['GET'] );
 				if ( $method & self::METHOD_POST ) {
@@ -363,8 +367,9 @@ class WC_API_Server {
 				}
 
 				$params = $this->sort_callback_params( $callback, $args );
-				if ( is_wp_error( $params ) )
+				if ( is_wp_error( $params ) ) {
 					return $params;
+				}
 
 				return call_user_func_array( $callback, $params );
 			}
@@ -385,10 +390,11 @@ class WC_API_Server {
 	 * @return array
 	 */
 	protected function sort_callback_params( $callback, $provided ) {
-		if ( is_array( $callback ) )
+		if ( is_array( $callback ) ) {
 			$ref_func = new ReflectionMethod( $callback[0], $callback[1] );
-		else
+		} else {
 			$ref_func = new ReflectionFunction( $callback );
+		}
 
 		$wanted = $ref_func->getParameters();
 		$ordered_parameters = array();
@@ -451,14 +457,17 @@ class WC_API_Server {
 			foreach ( self::$method_map as $name => $bitmask ) {
 				foreach ( $callbacks as $callback ) {
 					// Skip to the next route if any callback is hidden
-					if ( $callback[1] & self::HIDDEN_ENDPOINT )
+					if ( $callback[1] & self::HIDDEN_ENDPOINT ) {
 						continue 3;
+					}
 
-					if ( $callback[1] & $bitmask )
+					if ( $callback[1] & $bitmask ) {
 						$data['supports'][] = $name;
+					}
 
-					if ( $callback[1] & self::ACCEPT_DATA )
+					if ( $callback[1] & self::ACCEPT_DATA ) {
 						$data['accepts_data'] = true;
+					}
 
 					// For non-variable routes, generate links
 					if ( strpos( $route, '<' ) === false ) {
@@ -550,8 +559,9 @@ class WC_API_Server {
 			$total_pages = $query->max_num_pages;
 		}
 
-		if ( ! $page )
+		if ( ! $page ) {
 			$page = 1;
+		}
 
 		$next_page = absint( $page ) + 1;
 
@@ -569,8 +579,9 @@ class WC_API_Server {
 			}
 
 			// last
-			if ( $page != $total_pages )
+			if ( $page != $total_pages ) {
 				$this->link_header( 'last', $this->get_paginated_url( $total_pages ) );
+			}
 		}
 
 		$this->header( 'X-WC-Total', $total );
@@ -732,12 +743,14 @@ class WC_API_Server {
 	private function is_json_request() {
 
 		// check path
-		if ( false !== stripos( $this->path, '.json' ) )
+		if ( false !== stripos( $this->path, '.json' ) ) {
 			return true;
+		}
 
 		// check ACCEPT header, only 'application/json' is acceptable, see RFC 4627
-		if ( isset( $this->headers['ACCEPT'] ) && 'application/json' == $this->headers['ACCEPT'] )
+		if ( isset( $this->headers['ACCEPT'] ) && 'application/json' == $this->headers['ACCEPT'] ) {
 			return true;
+		}
 
 		return false;
 	}
@@ -752,12 +765,14 @@ class WC_API_Server {
 	private function is_xml_request() {
 
 		// check path
-		if ( false !== stripos( $this->path, '.xml' ) )
+		if ( false !== stripos( $this->path, '.xml' ) ) {
 			return true;
+		}
 
 		// check headers, 'application/xml' or 'text/xml' are acceptable, see RFC 2376
-		if ( isset( $this->headers['ACCEPT'] ) && ( 'application/xml' == $this->headers['ACCEPT'] || 'text/xml' == $this->headers['ACCEPT'] ) )
+		if ( isset( $this->headers['ACCEPT'] ) && ( 'application/xml' == $this->headers['ACCEPT'] || 'text/xml' == $this->headers['ACCEPT'] ) ) {
 			return true;
+		}
 
 		return false;
 	}

--- a/includes/api/legacy/v2/class-wc-api-resource.php
+++ b/includes/api/legacy/v2/class-wc-api-resource.php
@@ -116,18 +116,21 @@ class WC_API_Resource {
 			switch ( $context ) {
 
 				case 'read':
-					if ( ! $this->is_readable( $post ) )
+					if ( ! $this->is_readable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 
 				case 'edit':
-					if ( ! $this->is_editable( $post ) )
+					if ( ! $this->is_editable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 
 				case 'delete':
-					if ( ! $this->is_deletable( $post ) )
+					if ( ! $this->is_deletable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 			}
 		}
@@ -243,8 +246,9 @@ class WC_API_Resource {
 		if ( isset( $this->server->params['GET']['filter']['meta'] ) && 'true' === $this->server->params['GET']['filter']['meta'] && is_object( $resource ) ) {
 
 			// don't attempt to add meta more than once
-			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) )
+			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) ) {
 				return $data;
+			}
 
 			// define the top-level property name for the meta
 			switch ( get_class( $resource ) ) {

--- a/includes/api/legacy/v3/class-wc-api-resource.php
+++ b/includes/api/legacy/v3/class-wc-api-resource.php
@@ -118,18 +118,21 @@ class WC_API_Resource {
 			switch ( $context ) {
 
 				case 'read':
-					if ( ! $this->is_readable( $post ) )
+					if ( ! $this->is_readable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 
 				case 'edit':
-					if ( ! $this->is_editable( $post ) )
+					if ( ! $this->is_editable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 
 				case 'delete':
-					if ( ! $this->is_deletable( $post ) )
+					if ( ! $this->is_deletable( $post ) ) {
 						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					}
 					break;
 			}
 		}
@@ -245,8 +248,9 @@ class WC_API_Resource {
 		if ( isset( $this->server->params['GET']['filter']['meta'] ) && 'true' === $this->server->params['GET']['filter']['meta'] && is_object( $resource ) ) {
 
 			// don't attempt to add meta more than once
-			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) )
+			if ( preg_grep( '/[a-z]+_meta/', array_keys( $data ) ) ) {
 				return $data;
+			}
 
 			// define the top-level property name for the meta
 			switch ( get_class( $resource ) ) {
@@ -372,18 +376,19 @@ class WC_API_Resource {
 
 			$result = wp_delete_user( $id );
 
-			if ( $result )
+			if ( $result ) {
 				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce' ) );
-			else
+			} else {
 				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce' ), array( 'status' => 500 ) );
-
+			}
 		} else {
 
 			// delete order/coupon/product/webhook
 			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 
-			if ( ! $result )
+			if ( ! $result ) {
 				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), $resource_name ), array( 'status' => 500 ) );
+			}
 
 			if ( $force ) {
 				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), $resource_name ) );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1554,8 +1554,9 @@ class WC_Cart {
 	 * @return bool
 	 */
 	public function show_shipping() {
-		if ( ! wc_shipping_enabled() || ! is_array( $this->cart_contents ) )
+		if ( ! wc_shipping_enabled() || ! is_array( $this->cart_contents ) ) {
 			return false;
+		}
 
 		if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
 			if ( ! WC()->customer->has_calculated_shipping() ) {
@@ -2211,11 +2212,15 @@ class WC_Cart {
 	public function get_taxes_total( $compound = true, $display = true ) {
 		$total = 0;
 		foreach ( $this->taxes as $key => $tax ) {
-			if ( ! $compound && WC_Tax::is_compound( $key ) ) continue;
+			if ( ! $compound && WC_Tax::is_compound( $key ) ) {
+				continue;
+			}
 			$total += $tax;
 		}
 		foreach ( $this->shipping_taxes as $key => $tax ) {
-			if ( ! $compound && WC_Tax::is_compound( $key ) ) continue;
+			if ( ! $compound && WC_Tax::is_compound( $key ) ) {
+				continue;
+			}
 			$total += $tax;
 		}
 		if ( $display ) {

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -380,27 +380,29 @@ class WC_Countries {
 	 * @param bool   $escape (default: false)
 	 */
 	public function country_dropdown_options( $selected_country = '', $selected_state = '', $escape = false ) {
-		if ( $this->countries ) foreach ( $this->countries as $key => $value ) :
-			if ( $states = $this->get_states( $key ) ) :
-				echo '<optgroup label="' . esc_attr( $value ) . '">';
-					foreach ( $states as $state_key => $state_value ) :
-					echo '<option value="' . esc_attr( $key ) . ':' . $state_key . '"';
+		if ( $this->countries ) :
+			foreach ( $this->countries as $key => $value ) :
+				if ( $states = $this->get_states( $key ) ) :
+					echo '<optgroup label="' . esc_attr( $value ) . '">';
+						foreach ( $states as $state_key => $state_value ) :
+						echo '<option value="' . esc_attr( $key ) . ':' . $state_key . '"';
 
-					if ( $selected_country == $key && $selected_state == $state_key ) {
+						if ( $selected_country == $key && $selected_state == $state_key ) {
+							echo ' selected="selected"';
+							}
+
+						echo '>' . $value . ' &mdash; ' . ( $escape ? esc_js( $state_value ) : $state_value ) . '</option>';
+						endforeach;
+					echo '</optgroup>';
+				else :
+					echo '<option';
+					if ( $selected_country == $key && '*' == $selected_state ) {
 						echo ' selected="selected"';
-						}
-
-					echo '>' . $value . ' &mdash; ' . ( $escape ? esc_js( $state_value ) : $state_value ) . '</option>';
-					endforeach;
-				echo '</optgroup>';
-			else :
-				echo '<option';
-				if ( $selected_country == $key && '*' == $selected_state ) {
-					echo ' selected="selected"';
-				}
-				echo ' value="' . esc_attr( $key ) . '">' . ( $escape ? esc_js( $value ) : $value ) . '</option>';
-			endif;
-		endforeach;
+					}
+					echo ' value="' . esc_attr( $key ) . '">' . ( $escape ? esc_js( $value ) : $value ) . '</option>';
+				endif;
+			endforeach;
+		endif;
 	}
 
 	/**

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -506,8 +506,9 @@ class WC_Form_Handler {
 					// Sanitize
 					$quantity = apply_filters( 'woocommerce_stock_amount_cart_item', wc_stock_amount( preg_replace( "/[^0-9\.]/", '', $cart_totals[ $cart_item_key ]['qty'] ) ), $cart_item_key );
 
-					if ( '' === $quantity || $quantity == $values['quantity'] )
+					if ( '' === $quantity || $quantity == $values['quantity'] ) {
 						continue;
+					}
 
 					// Update cart validation
 					$passed_validation 	= apply_filters( 'woocommerce_update_cart_validation', true, $cart_item_key, $values, $quantity );

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -343,8 +343,9 @@ class WC_Query {
 		global $wp_the_query;
 
 		// If this is not a WC Query, do not modify the query
-		if ( empty( $wp_the_query->query_vars['wc_query'] ) || empty( $wp_the_query->query_vars['s'] ) )
+		if ( empty( $wp_the_query->query_vars['wc_query'] ) || empty( $wp_the_query->query_vars['s'] ) ) {
 			return $where;
+		}
 
 		$where = preg_replace(
 			"/post_title\s+LIKE\s*(\'\%[^\%]+\%\')/",

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -162,8 +162,9 @@ class WC_Tax {
 		$non_compound_price = $price / $compound_tax_rate;
 
 		foreach ( $rates as $key => $rate ) {
-			if ( ! isset( $taxes[ $key ] ) )
+			if ( ! isset( $taxes[ $key ] ) ) {
 				$taxes[ $key ] = 0;
+			}
 
 			$the_rate      = $rate['rate'] / 100;
 
@@ -207,10 +208,11 @@ class WC_Tax {
 				$tax_amount = apply_filters( 'woocommerce_price_ex_tax_amount', $tax_amount, $key, $rate, $price );
 
 				// Add rate
-				if ( ! isset( $taxes[ $key ] ) )
+				if ( ! isset( $taxes[ $key ] ) ) {
 					$taxes[ $key ] = $tax_amount;
-				else
+				} else {
 					$taxes[ $key ] += $tax_amount;
+				}
 			}
 
 			$pre_compound_total = array_sum( $taxes );

--- a/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -84,8 +84,9 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 	 * Output for the order received page.
 	 */
 	public function thankyou_page() {
-		if ( $this->instructions )
+		if ( $this->instructions ) {
 			echo wpautop( wptexturize( $this->instructions ) );
+		}
 	}
 
 	/**

--- a/includes/libraries/class-wc-eval-math.php
+++ b/includes/libraries/class-wc-eval-math.php
@@ -55,14 +55,18 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 		public static function evaluate( $expr ) {
 			self::$last_error = null;
 			$expr = trim( $expr );
-			if ( substr( $expr, -1, 1 ) == ';' ) $expr = substr( $expr, 0, strlen( $expr ) -1 ); // strip semicolons at the end
+			if ( substr( $expr, -1, 1 ) == ';' ) {
+				$expr = substr( $expr, 0, strlen( $expr ) -1 ); // strip semicolons at the end
+			}
 			// ===============
 			// is it a variable assignment?
 			if ( preg_match( '/^\s*([a-z]\w*)\s*=\s*(.+)$/', $expr, $matches ) ) {
 				if ( in_array( $matches[1], self::$vb ) ) { // make sure we're not assigning to a constant
 					return self::trigger( "cannot assign to constant '$matches[1]'" );
 				}
-				if ( ( $tmp = self::pfx( self::nfx( $matches[2] ) ) ) === false ) return false; // get the result and make sure it's good
+				if ( ( $tmp = self::pfx( self::nfx( $matches[2] ) ) ) === false ) {
+					return false; // get the result and make sure it's good
+				}
 				self::$v[ $matches[1] ] = $tmp; // if so, stick it in the variable array
 				return self::$v[ $matches[1] ]; // and return the resulting value
 				// ===============
@@ -73,7 +77,9 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 					return self::trigger( "cannot redefine built-in function '$matches[1]()'" );
 				}
 				$args = explode( ",", preg_replace( "/\s+/", "", $matches[2] ) ); // get the arguments
-				if ( ( $stack = self::nfx( $matches[3] ) ) === false ) return false; // see if it can be converted to postfix
+				if ( ( $stack = self::nfx( $matches[3] ) ) === false ) {
+					return false; // see if it can be converted to postfix
+				}
 				$stack_size = count( $stack );
 				for ( $i = 0; $i < $stack_size; $i++ ) { // freeze the state of the non-argument variables
 					$token = $stack[ $i ];
@@ -154,11 +160,13 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 						$arg_count = $stack->pop(); // see how many arguments there were (cleverly stored on the stack, thank you)
 						$output[] = $stack->pop(); // pop the function and push onto the output
 						if ( in_array( $fnn, self::$fb ) ) { // check the argument count
-							if ( $arg_count > 1 )
+							if ( $arg_count > 1 ) {
 								return self::trigger( "too many arguments ($arg_count given, 1 expected)" );
+							}
 						} elseif ( array_key_exists( $fnn, self::$f ) ) {
-							if ( count( self::$f[ $fnn ]['args'] ) != $arg_count )
+							if ( count( self::$f[ $fnn ]['args'] ) != $arg_count ) {
 								return self::trigger( "wrong number of arguments ($arg_count given, " . count( self::$f[ $fnn ]['args'] ) . " expected)" );
+							}
 						} else { // did we somehow push a non-function on the stack? this should never happen
 							return self::trigger( "internal error" );
 						}
@@ -174,8 +182,9 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 						}
 					}
 					// make sure there was a function
-					if ( ! preg_match( "/^([A-Za-z]\w*)\($/", $stack->last( 2 ), $matches ) )
+					if ( ! preg_match( "/^([A-Za-z]\w*)\($/", $stack->last( 2 ), $matches ) ) {
 						return self::trigger( "unexpected ','" );
+					}
 					$stack->push( $stack->pop() + 1 ); // increment the argument count
 					$stack->push( '(' ); // put the ( back on, we'll need to pop back to it again
 					$index++;
@@ -247,8 +256,12 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 			foreach ( $tokens as $token ) { // nice and easy
 				// if the token is a binary operator, pop two values off the stack, do the operation, and push the result back on
 				if ( in_array( $token, array( '+', '-', '*', '/', '^' ) ) ) {
-					if ( is_null( $op2 = $stack->pop() ) ) return self::trigger( "internal error" );
-					if ( is_null( $op1 = $stack->pop() ) ) return self::trigger( "internal error" );
+					if ( is_null( $op2 = $stack->pop() ) ) {
+						return self::trigger( "internal error" );
+					}
+					if ( is_null( $op1 = $stack->pop() ) ) {
+						return self::trigger( "internal error" );
+					}
 					switch ( $token ) {
 						case '+':
 							$stack->push( $op1 + $op2 );
@@ -324,7 +337,9 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 				$file = $debugTrace[1]['file'] ? $debugTrace[1]['file'] : 'n/a';
 				$line = $debugTrace[1]['line'] ? $debugTrace[1]['line'] : 'n/a';
 			}
-			if ( isset( $debugTrace[2] ) ) $func = $debugTrace[2]['function'] ? $debugTrace[2]['function'] : 'n/a';
+			if ( isset( $debugTrace[2] ) ) {
+				$func = $debugTrace[2]['function'] ? $debugTrace[2]['function'] : 'n/a';
+			}
 			echo "\n$file, $func, $line\n";
 		}
 	}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -235,8 +235,9 @@ class WC_Shortcode_Checkout {
 
 			$non_js_checkout = ! empty( $_POST['woocommerce_checkout_update_totals'] ) ? true : false;
 
-			if ( wc_notice_count( 'error' ) == 0 && $non_js_checkout )
+			if ( wc_notice_count( 'error' ) == 0 && $non_js_checkout ) {
 				wc_add_notice( __( 'The order totals have been updated. Please confirm your order by pressing the "Place order" button at the bottom of the page.', 'woocommerce' ) );
+			}
 
 			wc_get_template( 'checkout/form-checkout.php', array( 'checkout' => $checkout ) );
 

--- a/includes/walkers/class-product-cat-list-walker.php
+++ b/includes/walkers/class-product-cat-list-walker.php
@@ -46,8 +46,9 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @param array $args Will only append content if style argument value is 'list'.
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
-		if ( 'list' != $args['style'] )
+		if ( 'list' != $args['style'] ) {
 			return;
+		}
 
 		$indent = str_repeat( "\t", $depth );
 		$output .= "$indent<ul class='children'>\n";
@@ -64,8 +65,9 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @param array $args Will only append content if style argument value is 'list'.
 	 */
 	public function end_lvl( &$output, $depth = 0, $args = array() ) {
-		if ( 'list' != $args['style'] )
+		if ( 'list' != $args['style'] ) {
 			return;
+		}
 
 		$indent = str_repeat( "\t", $depth );
 		$output .= "$indent</ul>\n";

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -303,8 +303,9 @@ function wc_cart_totals_order_total_html() {
 		$tax_string_array = array();
 
 		if ( get_option( 'woocommerce_tax_total_display' ) == 'itemized' ) {
-			foreach ( WC()->cart->get_tax_totals() as $code => $tax )
+			foreach ( WC()->cart->get_tax_totals() as $code => $tax ) {
 				$tax_string_array[] = sprintf( '%s %s', $tax->formatted_amount, $tax->label );
+			}
 		} else {
 			$tax_string_array[] = sprintf( '%s %s', wc_price( WC()->cart->get_taxes_total( true, true ) ), WC()->countries->tax_or_vat() );
 		}

--- a/includes/wc-order-item-functions.php
+++ b/includes/wc-order-item-functions.php
@@ -22,8 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wc_add_order_item( $order_id, $item ) {
 	$order_id = absint( $order_id );
 
-	if ( ! $order_id )
+	if ( ! $order_id ) {
 		return false;
+	}
 
 	$defaults = array(
 		'order_item_name'       => '',

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -215,8 +215,9 @@ function wc_get_featured_product_ids() {
 	$featured_product_ids = get_transient( 'wc_featured_products' );
 
 	// Valid cache found
-	if ( false !== $featured_product_ids )
+	if ( false !== $featured_product_ids ) {
 		return $featured_product_ids;
+	}
 
 	$data_store           = WC_Data_Store::load( 'product' );
 	$featured             = $data_store->get_featured_product_ids();
@@ -492,10 +493,11 @@ function wc_track_product_view() {
 
 	global $post;
 
-	if ( empty( $_COOKIE['woocommerce_recently_viewed'] ) )
+	if ( empty( $_COOKIE['woocommerce_recently_viewed'] ) ) {
 		$viewed_products = array();
-	else
+	} else {
 		$viewed_products = (array) explode( '|', $_COOKIE['woocommerce_recently_viewed'] );
+	}
 
 	if ( ! in_array( $post->ID, $viewed_products ) ) {
 		$viewed_products[] = $post->ID;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -115,11 +115,13 @@ add_action( 'template_redirect', 'wc_prevent_adjacent_posts_rel_link_wp_head' );
 function wc_setup_product_data( $post ) {
 	unset( $GLOBALS['product'] );
 
-	if ( is_int( $post ) )
+	if ( is_int( $post ) ) {
 		$post = get_post( $post );
+	}
 
-	if ( empty( $post->post_type ) || ! in_array( $post->post_type, array( 'product', 'product_variation' ) ) )
+	if ( empty( $post->post_type ) || ! in_array( $post->post_type, array( 'product', 'product_variation' ) ) ) {
 		return;
+	}
 
 	$GLOBALS['product'] = wc_get_product( $post );
 
@@ -514,9 +516,9 @@ if ( ! function_exists( 'woocommerce_page_title' ) ) {
 		if ( is_search() ) {
 			$page_title = sprintf( __( 'Search results: &ldquo;%s&rdquo;', 'woocommerce' ), get_search_query() );
 
-			if ( get_query_var( 'paged' ) )
+			if ( get_query_var( 'paged' ) ) {
 				$page_title .= sprintf( __( '&nbsp;&ndash; Page %s', 'woocommerce' ), get_query_var( 'paged' ) );
-
+			}
 		} elseif ( is_tax() ) {
 
 			$page_title = single_term_title( "", false );
@@ -530,10 +532,11 @@ if ( ! function_exists( 'woocommerce_page_title' ) ) {
 
 		$page_title = apply_filters( 'woocommerce_page_title', $page_title );
 
-		if ( $echo )
+		if ( $echo ) {
 			echo $page_title;
-		else
+		} else {
 			return $page_title;
+		}
 	}
 }
 
@@ -549,10 +552,11 @@ if ( ! function_exists( 'woocommerce_product_loop_start' ) ) {
 		ob_start();
 		$GLOBALS['woocommerce_loop']['loop'] = 0;
 		wc_get_template( 'loop/loop-start.php' );
-		if ( $echo )
+		if ( $echo ) {
 			echo ob_get_clean();
-		else
+		} else {
 			return ob_get_clean();
+		}
 	}
 }
 if ( ! function_exists( 'woocommerce_product_loop_end' ) ) {
@@ -568,10 +572,11 @@ if ( ! function_exists( 'woocommerce_product_loop_end' ) ) {
 
 		wc_get_template( 'loop/loop-end.php' );
 
-		if ( $echo )
+		if ( $echo ) {
 			echo ob_get_clean();
-		else
+		} else {
 			return ob_get_clean();
+		}
 	}
 }
 if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
@@ -596,8 +601,9 @@ if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {
 			<?php
 				echo $category->name;
 
-				if ( $category->count > 0 )
+				if ( $category->count > 0 ) {
 					echo apply_filters( 'woocommerce_subcategory_count_html', ' <mark class="count">(' . $category->count . ')</mark>', $category );
+				}
 			?>
 		</h2>
 		<?php
@@ -1173,8 +1179,9 @@ if ( ! function_exists( 'woocommerce_sort_product_tabs' ) ) {
 		// Re-order tabs by priority
 		if ( ! function_exists( '_sort_priority_callback' ) ) {
 			function _sort_priority_callback( $a, $b ) {
-				if ( $a['priority'] === $b['priority'] )
+				if ( $a['priority'] === $b['priority'] ) {
 					return 0;
+				}
 				return ( $a['priority'] < $b['priority'] ) ? -1 : 1;
 			}
 		}
@@ -1813,7 +1820,9 @@ if ( ! function_exists( 'woocommerce_order_details_table' ) ) {
 	 * @subpackage	Orders
 	 */
 	function woocommerce_order_details_table( $order_id ) {
-		if ( ! $order_id ) return;
+		if ( ! $order_id ) {
+			return;
+		}
 
 		wc_get_template( 'order/order-details.php', array(
 			'order_id' => $order_id,

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -373,8 +373,12 @@ function get_woocommerce_term_meta( $term_id, $key, $single = true ) {
  * @return int
  */
 function wc_reorder_terms( $the_term, $next_id, $taxonomy, $index = 0, $terms = null ) {
-	if ( ! $terms ) $terms = get_terms( $taxonomy, 'menu_order=ASC&hide_empty=0&parent=0' );
-	if ( empty( $terms ) ) return $index;
+	if ( ! $terms ) {
+		$terms = get_terms( $taxonomy, 'menu_order=ASC&hide_empty=0&parent=0' );
+	}
+	if ( empty( $terms ) ) {
+		return $index;
+	}
 
 	$id	= $the_term->term_id;
 
@@ -426,14 +430,17 @@ function wc_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 	$index 		= (int) $index;
 
 	// Meta name
-	if ( taxonomy_is_product_attribute( $taxonomy ) )
+	if ( taxonomy_is_product_attribute( $taxonomy ) ) {
 		$meta_name = 'order_' . esc_attr( $taxonomy );
-	else
+	} else {
 		$meta_name = 'order';
+	}
 
 	update_woocommerce_term_meta( $term_id, $meta_name, $index );
 
-	if ( ! $recursive ) return $index;
+	if ( ! $recursive ) {
+		return $index;
+	}
 
 	$children = get_terms( $taxonomy, "parent=$term_id&menu_order=ASC&hide_empty=0" );
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -61,8 +61,9 @@ function wc_update_200_permalinks() {
 			}
 		}
 
-		if ( get_option( 'woocommerce_prepend_category_to_products' ) == 'yes' )
+		if ( get_option( 'woocommerce_prepend_category_to_products' ) == 'yes' ) {
 			$product_base .= trailingslashit( '%product_cat%' );
+		}
 
 		$permalinks = array(
 			'product_base' 		=> untrailingslashit( $product_base ),
@@ -101,7 +102,7 @@ function wc_update_200_taxrates() {
 	$loop = 0;
 	$tax_rates = get_option( 'woocommerce_tax_rates' );
 
-	if ( $tax_rates )
+	if ( $tax_rates ) {
 		foreach ( $tax_rates as $tax_rate ) {
 
 			foreach ( $tax_rate['countries'] as $country => $states ) {
@@ -133,10 +134,11 @@ function wc_update_200_taxrates() {
 				}
 			}
 		}
+	}
 
 	$local_tax_rates = get_option( 'woocommerce_local_tax_rates' );
 
-	if ( $local_tax_rates )
+	if ( $local_tax_rates ) {
 		foreach ( $local_tax_rates as $tax_rate ) {
 
 			$location_type = ( 'postcode' === $tax_rate['location_type'] ) ? 'postcode' : 'city';
@@ -179,6 +181,7 @@ function wc_update_200_taxrates() {
 
 			$loop++;
 		}
+	}
 
 	update_option( 'woocommerce_tax_rates_backup', $tax_rates );
 	update_option( 'woocommerce_local_tax_rates_backup', $local_tax_rates );
@@ -279,8 +282,9 @@ function wc_update_200_line_items() {
 		if ( ! empty( $order_taxes ) ) {
 			foreach ( $order_taxes as $order_tax ) {
 
-				if ( ! isset( $order_tax['label'] ) || ! isset( $order_tax['cart_tax'] ) || ! isset( $order_tax['shipping_tax'] ) )
+				if ( ! isset( $order_tax['label'] ) || ! isset( $order_tax['cart_tax'] ) || ! isset( $order_tax['shipping_tax'] ) ) {
 					continue;
+				}
 
 				$item_id = wc_add_order_item( $order_tax_row->post_id, array(
 			 		'order_item_name' 		=> $order_tax['label'],

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -17,7 +17,7 @@
 		<exclude name="Generic.Commenting.DocComment.ShortNotCapital" />
 		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />
 		<exclude name="Generic.Commenting.DocComment.SpacingBeforeTags" />
-		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" />
+		<!-- <exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed" /> -->
 		<!-- <exclude name="Generic.Files.EndFileNewline.NotFound" /> -->
 		<exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
 		<exclude name="Generic.Files.LowercasedFilename.NotFound" />

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div class="cart_totals <?php if ( WC()->customer->has_calculated_shipping() ) echo 'calculated_shipping'; ?>">
+<div class="cart_totals <?php echo ( WC()->customer->has_calculated_shipping() ) ? 'calculated_shipping' : ''; ?>">
 
 	<?php do_action( 'woocommerce_before_cart_totals' ); ?>
 

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -38,8 +38,9 @@ if ( 'no' === get_option( 'woocommerce_enable_shipping_calc' ) || ! WC()->cart->
 			<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state" rel="calc_shipping_state">
 				<option value=""><?php _e( 'Select a country&hellip;', 'woocommerce' ); ?></option>
 				<?php
-					foreach ( WC()->countries->get_shipping_countries() as $key => $value )
+					foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
 						echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
+					}
 				?>
 			</select>
 		</p>
@@ -62,8 +63,9 @@ if ( 'no' === get_option( 'woocommerce_enable_shipping_calc' ) || ! WC()->cart->
 						<select name="calc_shipping_state" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
 							<option value=""><?php _e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
 							<?php
-								foreach ( $states as $ckey => $cvalue )
+								foreach ( $states as $ckey => $cvalue ) {
 									echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . __( esc_html( $cvalue ), 'woocommerce' ) . '</option>';
+								}
 							?>
 						</select>
 					</span><?php

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -16,7 +16,9 @@
  * @version 2.3.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
 
 // Load colors
 $bg              = get_option( 'woocommerce_email_background_color' );

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -24,8 +24,9 @@ echo "= " . $email_heading . " =\n\n";
 
 echo sprintf( __( 'Thanks for creating an account on %1$s. Your username is %2$s', 'woocommerce' ), $blogname, '<strong>' . $user_login . '</strong>' ) . "\n\n";
 
-if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated )
+if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) {
 	echo sprintf( __( 'Your password is %s.', 'woocommerce' ), '<strong>' . $user_pass . '</strong>' ) . "\n\n";
+}
 
 echo sprintf( __( 'You can access your account area to view your orders and change your password here: %s.', 'woocommerce' ), wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
 

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -25,11 +25,11 @@ if ( is_user_logged_in() ) {
 }
 
 ?>
-<form class="woocomerce-form woocommerce-form-login login" method="post" <?php if ( $hidden ) echo 'style="display:none;"'; ?>>
+<form class="woocomerce-form woocommerce-form-login login" method="post" <?php echo ( $hidden ) ? 'style="display:none;"' : ''; ?>>
 
 	<?php do_action( 'woocommerce_login_form_start' ); ?>
 
-	<?php if ( $message ) echo wpautop( wptexturize( $message ) ); ?>
+	<?php echo ( $message ) ? wpautop( wptexturize( $message ) ) : ''; ?>
 
 	<p class="form-row form-row-first">
 		<label for="username"><?php _e( 'Username or email', 'woocommerce' ); ?> <span class="required">*</span></label>

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -22,7 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $product;
 
-if ( get_option( 'woocommerce_enable_review_rating' ) === 'no' )
+if ( get_option( 'woocommerce_enable_review_rating' ) === 'no' ) {
 	return;
+}
 
 echo wc_get_rating_html( $product->get_average_rating() );

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -24,8 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $wp_query;
 
-if ( ! woocommerce_products_will_display() )
+if ( ! woocommerce_products_will_display() ) {
 	return;
+}
 ?>
 <p class="woocommerce-result-count">
 	<?php

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -42,7 +42,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 				<label for="username"><?php _e( 'Username or email address', 'woocommerce' ); ?> <span class="required">*</span></label>
-				<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="username" id="username" value="<?php if ( ! empty( $_POST['username'] ) ) echo esc_attr( $_POST['username'] ); ?>" />
+				<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="username" id="username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( $_POST['username'] ) : ''; ?>" />
 			</p>
 			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 				<label for="password"><?php _e( 'Password', 'woocommerce' ); ?> <span class="required">*</span></label>
@@ -82,14 +82,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 					<label for="reg_username"><?php _e( 'Username', 'woocommerce' ); ?> <span class="required">*</span></label>
-					<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="username" id="reg_username" value="<?php if ( ! empty( $_POST['username'] ) ) echo esc_attr( $_POST['username'] ); ?>" />
+					<input type="text" class="woocommerce-Input woocommerce-Input--text input-text" name="username" id="reg_username" value="<?php echo ( ! empty( $_POST['username'] ) ) ? esc_attr( $_POST['username'] ) : ''; ?>" />
 				</p>
 
 			<?php endif; ?>
 
 			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
 				<label for="reg_email"><?php _e( 'Email address', 'woocommerce' ); ?> <span class="required">*</span></label>
-				<input type="email" class="woocommerce-Input woocommerce-Input--text input-text" name="email" id="reg_email" value="<?php if ( ! empty( $_POST['email'] ) ) echo esc_attr( $_POST['email'] ); ?>" />
+				<input type="email" class="woocommerce-Input woocommerce-Input--text input-text" name="email" id="reg_email" value="<?php echo ( ! empty( $_POST['email'] ) ) ? esc_attr( $_POST['email'] ) : ''; ?>" />
 			</p>
 
 			<?php if ( 'no' === get_option( 'woocommerce_registration_generate_password' ) ) : ?>

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -41,7 +41,9 @@ $col    = 1;
 	<?php echo apply_filters( 'woocommerce_my_account_my_address_description', __( 'The following addresses will be used on the checkout page by default.', 'woocommerce' ) ); ?>
 </p>
 
-<?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) echo '<div class="u-columns woocommerce-Addresses col2-set addresses">'; ?>
+<?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
+	<div class="u-columns woocommerce-Addresses col2-set addresses">
+<?php endif; ?>
 
 <?php foreach ( $get_addresses as $name => $title ) : ?>
 
@@ -66,14 +68,17 @@ $col    = 1;
 
 				$formatted_address = WC()->countries->get_formatted_address( $address );
 
-				if ( ! $formatted_address )
+				if ( ! $formatted_address ) {
 					_e( 'You have not set up this type of address yet.', 'woocommerce' );
-				else
+				} else {
 					echo $formatted_address;
+				}
 			?>
 		</address>
 	</div>
 
 <?php endforeach; ?>
 
-<?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) echo '</div>'; ?>
+<?php if ( ! wc_ship_to_billing_address_only() && wc_shipping_enabled() ) : ?>
+	</div>
+<?php endif;

--- a/templates/myaccount/my-downloads.php
+++ b/templates/myaccount/my-downloads.php
@@ -35,8 +35,9 @@ if ( $downloads = WC()->customer->get_downloadable_products() ) : ?>
 				<?php
 					do_action( 'woocommerce_available_download_start', $download );
 
-					if ( is_numeric( $download['downloads_remaining'] ) )
+					if ( is_numeric( $download['downloads_remaining'] ) ) {
 						echo apply_filters( 'woocommerce_available_download_count', '<span class="woocommerce-Count count">' . sprintf( _n( '%s download remaining', '%s downloads remaining', $download['downloads_remaining'], 'woocommerce' ), $download['downloads_remaining'] ) . '</span> ', $download );
+					}
 
 					echo apply_filters( 'woocommerce_available_download_link', '<a href="' . esc_url( $download['download_url'] ) . '">' . $download['download_name'] . '</a>', $download );
 


### PR DESCRIPTION
This PR enables the `Generic.ControlStructures.InlineControlStructure.NotAllowed` test and fixes all PHPCS errors for it.
Inline control structures in WordPress are prohibited.