### PR TITLE
Validate the parent order ID by calling wc_get_order()

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -452,7 +452,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_parent_id( $value ) {
-		if ( $value && ! get_post( $value ) ) {
+		if ( $value && ! wc_get_order( $value ) ) {
 			$this->error( 'order_invalid_parent_id', __( 'Invalid parent ID', 'woocommerce' ) );
 		}
 		$this->set_prop( 'parent_id', absint( $value ) );


### PR DESCRIPTION
fixes #13506 