### PR TITLE
Add filter woocommerce_skip_formatted_meta to change allowed order me…

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -37,7 +37,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * A group must be set to to enable caching.
 	 * @var string
 	 */
-	protected $cache_group = 'order-items';
+	protected $cache_group = 'order_itemmeta';
 
 	/**
 	 * Meta type. This should match up with
@@ -187,7 +187,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		$product = is_callable( array( $this, 'get_product' ) ) ? $this->get_product() : false;
 
 		foreach ( $meta_data as $meta ) {
-			if ( "" === $meta->value || is_serialized( $meta->value ) || ( $hideprefix_length && substr( $meta->key, 0, $hideprefix_length ) === $hideprefix ) ) {
+			if ( apply_filters( 'woocommerce_skip_formatted_meta', ( "" === $meta->value || is_serialized( $meta->value ) || ( $hideprefix_length && substr( $meta->key, 0, $hideprefix_length ) === $hideprefix ) ), $meta ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
In WooCommerce 2.6 the order itemmeta that start with _ (underscore) are hidden in admin, but If a developer have WP_DEBUG set to true this meta are shown, look this: 

![selection_281](https://cloud.githubusercontent.com/assets/14902963/23706859/39d9b382-0410-11e7-8182-3e6f358dac2a.png)

In WooCommerce 2.7-RC1 this meta are hidden in all cases. I think a filter to show them would be useful in development because in this moment the only way to check if this meta exists or have the correct value is to search it in database or open the template wp-content/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php and hack it at line 2 

![selection_282](https://cloud.githubusercontent.com/assets/14902963/23706981/c6a8ff66-0410-11e7-9daf-fcc69172ec60.png)

Let me know if you think this is a good idea. 
If you don't like the hook solution, please if possible to force the plugin to show the hidden meta if WP_DEBUG is set to TRUE ?

Thanks. 
Have a nice day 
AG