### PR TITLE
[2.7] Unexpected wc_get_price_{in/ex}cluding tax behavior with zero/empty inputs

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -882,8 +882,16 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 		'qty'   => '',
 		'price' => '',
 	) );
-	$price        = (float) max( 0, $args['price'] ? $args['price'] : $product->get_price() );
-	$qty          = (int) $args['qty'] ? $args['qty']               : 1;
+
+	$price = '' !== $args['price'] ? max( 0.0, (float) $args['price'] ) : $product->get_price();
+	$qty   = '' !== $args['qty'] ? max( 0, (int) $args['qty'] ) : 1;
+
+	if ( '' === $price ) {
+		return '';
+	} elseif ( 0 === $qty ) {
+		return 0.0;
+	}
+
 	$line_price   = $price * $qty;
 	$return_price = $line_price;
 
@@ -933,8 +941,15 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 		'qty'   => '',
 		'price' => '',
 	) );
-	$price = (float) max( 0, $args['price'] ? $args['price'] : $product->get_price() );
-	$qty   = (int) $args['qty'] ? $args['qty'] : 1;
+
+	$price = '' !== $args['price'] ? max( 0.0, (float) $args['price'] ) : $product->get_price();
+	$qty   = '' !== $args['qty'] ? max( 0, (int) $args['qty'] ) : 1;
+
+	if ( '' === $price ) {
+		return '';
+	} elseif ( 0 === $qty ) {
+		return 0.0;
+	}
 
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
 		$tax_rates  = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );


### PR DESCRIPTION
(1)

When `wc_get_price_{in/ex}cluding tax` is called with a price input that evaluates to boolean `false` (`0`, `''`, ...), it always falls back to `$product->get_price()`.

As a result, when passing a strictly `0` price input, we get an unexpected / wrong result. I think `0` should be treated as a perfectly valid price input.

This was discovered while rewriting [this line](https://github.com/somewherewarm/woocommerce-product-bundles/blob/master/includes/class-wc-pb-cart.php#L1484) to prevent a notice thrown by WC Subs 2.2, which now calls `wc_get_price_{in/ex}cluding_tax` (the `price` argument fed into the function is populated using `WC_Subscriptions_Product::get_sign_up_fee( $product )`). 

I just noticed that cart prices are getting messed up when the sign-up fee is 0 or empty.

(2)

When `wc_get_price_{in/ex}cluding tax` is called with a strictly empty/undefined price input, then it always falls back to `$product->get_price()`, after casting to float.

However, if `$product->get_price()` returns an empty string, then IMO the expected result should be an empty string, too -- preferably returned by exiting early.

Note that 2.6.x also casts an empty price to a float. So if we want to be 100% consistent with WC 2.6, this can be ignored.

(3)

Similarly, these functions should be able to handle 0 quantities and exit early, returning 0.0.