### PR TITLE
Make increase_usage_count work correctly on concurrent checkout

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -711,7 +711,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( $this->get_id() && $this->data_store ) {
 			$new_count = $this->data_store->increase_usage_count( $this, $used_by );
 
-			// Bypass set_prop and remove pending changes since the count gets written by the data store.
+			// Bypass set_prop and remove pending changes since the data store saves the count already.
 			$this->data['usage_count'] = $new_count;
 			if ( isset( $this->changes['usage_count'] ) ) {
 				unset( $this->changes['usage_count'] );
@@ -728,7 +728,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( $this->get_id() && $this->get_usage_count() > 0 && $this->data_store ) {
 			$new_count = $this->data_store->decrease_usage_count( $this, $used_by );
 
-			// Bypass set_prop and remove pending changes since the count gets written by the data store.
+			// Bypass set_prop and remove pending changes since the data store saves the count already.
 			$this->data['usage_count'] = $new_count;
 			if ( isset( $this->changes['usage_count'] ) ) {
 				unset( $this->changes['usage_count'] );

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -711,7 +711,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( $this->get_id() && $this->data_store ) {
 			$new_count = $this->data_store->increase_usage_count( $this, $used_by );
 
-			// Bypass set_prop and remove pending changes to prevent overwriting usage_count on coupon save.
+			// Bypass set_prop and remove pending changes since the count gets written by the data store.
 			$this->data['usage_count'] = $new_count;
 			if ( isset( $this->changes['usage_count'] ) ) {
 				unset( $this->changes['usage_count'] );
@@ -728,7 +728,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( $this->get_id() && $this->get_usage_count() > 0 && $this->data_store ) {
 			$new_count = $this->data_store->decrease_usage_count( $this, $used_by );
 
-			// Bypass set_prop and remove pending changes to prevent overwriting usage_count on coupon save.
+			// Bypass set_prop and remove pending changes since the count gets written by the data store.
 			$this->data['usage_count'] = $new_count;
 			if ( isset( $this->changes['usage_count'] ) ) {
 				unset( $this->changes['usage_count'] );

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -710,7 +710,12 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function increase_usage_count( $used_by = '' ) {
 		if ( $this->get_id() && $this->data_store ) {
 			$new_count = $this->data_store->increase_usage_count( $this, $used_by );
-			$this->set_prop( 'usage_count', $new_count );
+
+			// Bypass set_prop and remove pending changes to prevent overwriting usage_count on coupon save.
+			$this->data['usage_count'] = $new_count;
+			if ( isset( $this->changes['usage_count'] ) ) {
+				unset( $this->changes['usage_count'] );
+			}
 		}
 	}
 
@@ -722,7 +727,12 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function decrease_usage_count( $used_by = '' ) {
 		if ( $this->get_id() && $this->get_usage_count() > 0 && $this->data_store ) {
 			$new_count = $this->data_store->decrease_usage_count( $this, $used_by );
-			$this->set_prop( 'usage_count', $new_count );
+
+			// Bypass set_prop and remove pending changes to prevent overwriting usage_count on coupon save.
+			$this->data['usage_count'] = $new_count;
+			if ( isset( $this->changes['usage_count'] ) ) {
+				unset( $this->changes['usage_count'] );
+			}
 		}
 	}
 

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -709,8 +709,8 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function increase_usage_count( $used_by = '' ) {
 		if ( $this->get_id() && $this->data_store ) {
-			$this->set_prop( 'usage_count', ( $this->get_usage_count( 'edit' ) + 1 ) );
-			$this->data_store->increase_usage_count( $this, $used_by );
+			$new_count = $this->data_store->increase_usage_count( $this, $used_by );
+			$this->set_prop( 'usage_count', $new_count );
 		}
 	}
 
@@ -721,8 +721,8 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function decrease_usage_count( $used_by = '' ) {
 		if ( $this->get_id() && $this->get_usage_count() > 0 && $this->data_store ) {
-			$this->set_prop( 'usage_count', ( $this->get_usage_count( 'edit' ) - 1 ) );
-			$this->data_store->decrease_usage_count( $this, $used_by );
+			$new_count = $this->data_store->decrease_usage_count( $this, $used_by );
+			$this->set_prop( 'usage_count', $new_count );
 		}
 	}
 

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -276,14 +276,12 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		global $wpdb;
 		$id = $coupon->get_id();
 		$operator = ( 'increase' === $operation ) ? '+' : '-';
-		$new_count = ( 'increase' === $operation ) ? ( $coupon->get_usage_count( 'edit' ) + 1 ) : ( $coupon->get_usage_count( 'edit' ) - 1 );
 
-		$updated = $wpdb->query( $wpdb->prepare( "UPDATE $wpdb->postmeta SET meta_value = meta_value {$operator} 1 WHERE meta_key = 'usage_count' AND post_id = %d;", $id ) );
-		if ( ! $updated ) {
-			add_post_meta( $id, 'usage_count', $new_count, true );
-		}
+		add_post_meta( $id, 'usage_count', $coupon->get_usage_count( 'edit' ), true );
+		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->postmeta SET meta_value = meta_value {$operator} 1 WHERE meta_key = 'usage_count' AND post_id = %d;", $id ) );
 
-		return $new_count;
+		// Get the latest value direct from the DB, instead of possibly the WP meta cache.
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = 'usage_count' AND post_id = %d;", $id ) );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -231,7 +231,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * @return int New usage count
 	 */
 	public function increase_usage_count( &$coupon, $used_by = '' ) {
-		$new_count = $this->vary_usage_count_meta( $coupon, 'increase' );
+		$new_count = $this->update_usage_count_meta( $coupon, 'increase' );
 		if ( $used_by ) {
 			add_post_meta( $coupon->get_id(), '_used_by', strtolower( $used_by ) );
 			$coupon->set_used_by( (array) get_post_meta( $coupon->get_id(), '_used_by' ) );
@@ -249,7 +249,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 */
 	public function decrease_usage_count( &$coupon, $used_by = '' ) {
 		global $wpdb;
-		$new_count = $this->vary_usage_count_meta( $coupon, 'decrease' );
+		$new_count = $this->update_usage_count_meta( $coupon, 'decrease' );
 		if ( $used_by ) {
 			/**
 			 * We're doing this the long way because `delete_post_meta( $id, $key, $value )` deletes.
@@ -272,7 +272,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * @param string $operation 'increase' or 'decrease'
 	 * @return int New usage count
 	 */
-	private function vary_usage_count_meta( &$coupon, $operation = 'increase' ) {
+	private function update_usage_count_meta( &$coupon, $operation = 'increase' ) {
 		global $wpdb;
 		$id = $coupon->get_id();
 		$operator = ( 'increase' === $operation ) ? '+' : '-';

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -816,10 +816,10 @@ function wc_update_coupon_usage_counts( $order_id ) {
 
 			switch ( $action ) {
 				case 'reduce' :
-					$coupon->dcr_usage_count( $used_by );
+					$coupon->decrease_usage_count( $used_by );
 				break;
 				case 'increase' :
-					$coupon->inc_usage_count( $used_by );
+					$coupon->increase_usage_count( $used_by );
 				break;
 			}
 		}

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -110,19 +110,19 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, $coupon->get_usage_count() );
 		$this->assertEmpty( $coupon->get_used_by() );
 
-		$coupon->inc_usage_count( 'woo@woo.local' );
+		$coupon->increase_usage_count( 'woo@woo.local' );
 
 		$this->assertEquals( 1, $coupon->get_usage_count() );
 		$this->assertEquals( array( 'woo@woo.local' ), $coupon->get_used_by() );
 
-		$coupon->inc_usage_count( $user_id );
-		$coupon->inc_usage_count( $user_id );
+		$coupon->increase_usage_count( $user_id );
+		$coupon->increase_usage_count( $user_id );
 
 		$data_store = WC_Data_Store::load( 'coupon' );
 		$this->assertEquals( 2, $data_store->get_usage_by_user_id( $coupon, $user_id ) );
 
-		$coupon->dcr_usage_count( 'woo@woo.local' );
-		$coupon->dcr_usage_count( $user_id );
+		$coupon->decrease_usage_count( 'woo@woo.local' );
+		$coupon->decrease_usage_count( $user_id );
 		$this->assertEquals( 1, $coupon->get_usage_count() );
 		$this->assertEquals( array( 1 ), $coupon->get_used_by() );
 	}


### PR DESCRIPTION
Fixes #13505.

Increasing the usage count now does so using a query that works correctly if multiple people check out at the exact same time.

I've also changed some places where we were using the legacy `inc_usage_count`/`dcr_usage_count` to use the new 2.7 methods.