### PR TITLE
Set order id for items & fix fee title sanitazing on legacy API

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -1070,7 +1070,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$item = new WC_Order_Item_Fee();
 			$item->set_order_id( $order->get_id() );
-			$item->set_name( sanitize_title( $fee['title'] ) );
+			$item->set_name( wc_clean( $fee['title'] ) );
 			$item->set_total( isset( $fee['total'] ) ? floatval( $fee['total'] ) : 0 );
 
 			// if taxable, tax class and total are required
@@ -1102,7 +1102,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$item = new WC_Order_Item_Fee( $fee['id'] );
 
 			if ( isset( $fee['title'] ) ) {
-				$item->set_name( sanitize_title( $fee['title'] ) );
+				$item->set_name( wc_clean( $fee['title'] ) );
 			}
 
 			if ( isset( $fee['tax_class'] ) ) {

--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -1019,6 +1019,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$rate = new WC_Shipping_Rate( $shipping['method_id'], isset( $shipping['method_title'] ) ? $shipping['method_title'] : '', isset( $shipping['total'] ) ? floatval( $shipping['total'] ) : 0, array(), $shipping['method_id'] );
 			$item = new WC_Order_Item_Shipping();
+			$item->set_order_id( $order->get_id() );
 			$item->set_shipping_rate( $rate );
 			$shipping_id = $item->save();
 
@@ -1068,6 +1069,7 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 
 			$item = new WC_Order_Item_Fee();
+			$item->set_order_id( $order->get_id() );
 			$item->set_name( sanitize_title( $fee['title'] ) );
 			$item->set_total( isset( $fee['total'] ) ? floatval( $fee['total'] ) : 0 );
 

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -1120,7 +1120,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$item = new WC_Order_Item_Fee();
 			$item->set_order_id( $order->get_id() );
-			$item->set_name( sanitize_title( $fee['title'] ) );
+			$item->set_name( wc_clean( $fee['title'] ) );
 			$item->set_total( isset( $fee['total'] ) ? floatval( $fee['total'] ) : 0 );
 
 			// if taxable, tax class and total are required
@@ -1152,7 +1152,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$item = new WC_Order_Item_Fee( $fee['id'] );
 
 			if ( isset( $fee['title'] ) ) {
-				$item->set_name( sanitize_title( $fee['title'] ) );
+				$item->set_name( wc_clean( $fee['title'] ) );
 			}
 
 			if ( isset( $fee['tax_class'] ) ) {

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -1069,6 +1069,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			$rate = new WC_Shipping_Rate( $shipping['method_id'], isset( $shipping['method_title'] ) ? $shipping['method_title'] : '', isset( $shipping['total'] ) ? floatval( $shipping['total'] ) : 0, array(), $shipping['method_id'] );
 			$item = new WC_Order_Item_Shipping();
+			$item->set_order_id( $order->get_id() );
 			$item->set_shipping_rate( $rate );
 			$shipping_id = $item->save();
 
@@ -1118,6 +1119,7 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 
 			$item = new WC_Order_Item_Fee();
+			$item->set_order_id( $order->get_id() );
 			$item->set_name( sanitize_title( $fee['title'] ) );
 			$item->set_total( isset( $fee['total'] ) ? floatval( $fee['total'] ) : 0 );
 


### PR DESCRIPTION
This PR addresses a few issues with the legacy API in 2.7:
* Order ID for fees and shipping items was not being set for new items. This resulted in the items being created, but not associated with any order, essentially being "lost" for the user.
* Use `wc_clean` to sanitize fee title instead of `sanitize_title`, as the latter turns the title into a slug and breaks backwards compatibility. Using `wc_clean` is also consistent with the new API, as this is what's used behind the scenes in `WC_Order_Item::set_name()`