### PR TITLE
Avoid filters during construct

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -103,11 +103,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->set_object_read( true );
 		}
 
-		// Set default status if none were read.
-		if ( ! $this->get_status() ) {
-			$this->set_status( apply_filters( 'woocommerce_default_order_status', 'pending' ) );
-		}
-
 		$this->data_store = WC_Data_Store::load( $this->data_store_name );
 
 		if ( $this->get_id() > 0 ) {
@@ -283,7 +278,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	public function get_status( $context = 'view' ) {
-		return $this->get_prop( 'status', $context );
+		$status = $this->get_prop( 'status', $context );
+
+		if ( empty( $status ) && 'view' === $context ) {
+			// In view context, return the default status if no status has been set.
+			$status = apply_filters( 'woocommerce_default_order_status', 'pending' );
+		}
+		return $status;
 	}
 
 	/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -732,7 +732,7 @@ class WC_Order extends WC_Abstract_Order {
 
 		if ( 'view' === $context && ! $date_paid && version_compare( $this->get_version( 'edit' ), '2.7', '<' ) && $this->has_status( apply_filters( 'woocommerce_payment_complete_order_status', $this->needs_processing() ? 'processing' : 'completed', $this->get_id() ) ) ) {
 			// In view context, return a date if missing.
-			$date_paid = $this->get_date_created( 'edit' )
+			$date_paid = $this->get_date_created( 'edit' );
 		}
 		return $date_paid;
 	}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -253,11 +253,10 @@ class WC_Order extends WC_Abstract_Order {
 	 * `payment_complete` method.
 	 *
 	 * @since 2.7.0
-	 * @param $date_paid What to set date paid to. Defaults to current time.
 	 */
-	public function maybe_set_date_paid( $date_paid = '' ) {
-		if ( ! $this->get_date_paid( 'edit' ) && $this->has_status( array( 'processing', 'completed' ) ) ) {
-			$this->set_date_paid( $date_paid ? $date_paid : current_time( 'timestamp' ) );
+	public function maybe_set_date_paid() {
+		if ( ! $this->get_date_paid( 'edit' ) && $this->has_status( apply_filters( 'woocommerce_payment_complete_order_status', $this->needs_processing() ? 'processing' : 'completed', $this->get_id() ) ) ) {
+			$this->set_date_paid( current_time( 'timestamp' ) );
 		}
 	}
 
@@ -729,7 +728,13 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return int
 	 */
 	public function get_date_paid( $context = 'view' ) {
-		return $this->get_prop( 'date_paid', $context );
+		$date_paid = $this->get_prop( 'date_paid', $context );
+
+		if ( 'view' === $context && ! $date_paid && version_compare( $this->get_version( 'edit' ), '2.7', '<' ) && $this->has_status( apply_filters( 'woocommerce_payment_complete_order_status', $this->needs_processing() ? 'processing' : 'completed', $this->get_id() ) ) ) {
+			// In view context, return a date if missing.
+			$date_paid = $this->get_date_created( 'edit' )
+		}
+		return $date_paid;
 	}
 
 	/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1297,7 +1297,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @since 2.7.0
 	 * @return bool
 	 */
-	protected function needs_processing() {
+	public function needs_processing() {
 		$needs_processing = false;
 
 		if ( sizeof( $this->get_items() ) > 0 ) {

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -100,21 +100,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		/**
 		 * In older versions, discounts may have been stored differently.
 		 * Update them now so if the object is saved, the correct values are
-		 * stored.
-		 * @todo When/if meta is flattened, handle this in the migration script.
+		 * stored. @todo When meta is flattened, handle this during migration.
 		 */
-		if ( ! $order->get_version( 'edit' ) || version_compare( $order->get_version( 'edit' ), '2.3.7', '<' ) ) {
-			if ( $order->get_prices_include_tax( 'edit' ) ) {
-				$order->set_discount_total( (double) get_post_meta( $order->get_id(), '_cart_discount', true ) - (double) get_post_meta( $order->get_id(), '_cart_discount_tax', true ) );
-			}
-		}
-
-		/**
-		 * In older versions, paid date may not have been set.
-		 * @todo When/if meta is flattened, handle this in the migration script.
-		 */
-		if ( ! $order->get_version( 'edit' ) || version_compare( $order->get_version( 'edit' ), '2.7', '<' ) ) {
-			$order->maybe_set_date_paid( $order->get_date_created( 'edit' ) );
+		if ( version_compare( $order->get_version( 'edit' ), '2.3.7', '<' ) && $order->get_prices_include_tax( 'edit' ) ) {
+			$order->set_discount_total( (double) get_post_meta( $order->get_id(), '_cart_discount', true ) - (double) get_post_meta( $order->get_id(), '_cart_discount_tax', true ) );
 		}
 	}
 
@@ -248,6 +237,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		);
 
 		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
+
 		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $order->{"get_$prop"}( 'edit' );
 

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -131,7 +131,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * @param WC_Order $order
 	 */
 	public function update( &$order ) {
+		// Before updating, ensure date paid is set if missing.
+		if ( ! $order->get_date_paid( 'edit' ) && version_compare( $order->get_version( 'edit' ), '2.7', '<' ) && $order->has_status( apply_filters( 'woocommerce_payment_complete_order_status', $order->needs_processing() ? 'processing' : 'completed', $order->get_id() ) ) ) {
+			$order->set_date_paid( $order->get_date_created( 'edit' ) );
+		}
+
+		// Update the order.
 		parent::update( $order );
+
 		do_action( 'woocommerce_update_order', $order->get_id() );
 	}
 


### PR DESCRIPTION
This is an alternative fix for #13496 which avoids filters during construct.

The date paid getter instead returns the correct value in view context, and handles the data when saved.

The status filter is also moved to the getter. It was already handled during save.

@bor0 @thenbrent Can I get your 👁 on this?

Closes #13496