### PR TITLE
Fix direct property access for coupon amount.

### DIFF
--- a/includes/legacy/class-wc-legacy-coupon.php
+++ b/includes/legacy/class-wc-legacy-coupon.php
@@ -30,6 +30,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 			'type',
 			'discount_type',
 			'amount',
+			'coupon_amount',
 			'code',
 			'individual_use',
 			'product_ids',
@@ -82,6 +83,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 				$value = $this->get_discount_type();
 			break;
 			case 'amount' :
+			case 'coupon_amount' :
 				$value = $this->get_amount();
 			break;
 			case 'code' :

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -39,6 +39,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 			'type',
 			'discount_type',
 			'amount',
+			'coupon_amount',
 			'code',
 			'individual_use',
 			'product_ids',
@@ -68,6 +69,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 		$this->assertEquals( $coupon->get_discount_type(), $coupon->type );
 		$this->assertEquals( $coupon->get_discount_type(), $coupon->discount_type );
 		$this->assertEquals( $coupon->get_amount(), $coupon->amount );
+		$this->assertEquals( $coupon->get_amount(), $coupon->coupon_amount );
 		$this->assertEquals( $coupon->get_code(), $coupon->code );
 		$this->assertEquals( $coupon->get_individual_use(), ( 'yes' === $coupon->individual_use ? true : false ) );
 		$this->assertEquals( $coupon->get_product_ids(), $coupon->product_ids );


### PR DESCRIPTION
In 2.6, you could access the amount via $coupon->coupon_amount. Our legacy code incorrectly handles $coupon->amount instead. https://github.com/woocommerce/woocommerce/blob/77785833409869b33428fd0ce2c131ee3018df45/includes/class-wc-coupon.php#L102

This PR handles both since the RCs and betas allowed `->amount` and I don't want to break anything that may be accessing it that way..

To Test:
* `phpunit --filter=test_coupon_backwards_compat_props_use_correct_getters`