### PR TITLE
[2.7] Add missing 'qty' class to hidden quantity input + discussion

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1041,13 +1041,14 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 		}
 
 		$defaults = array(
-			'input_name'  => 'quantity',
-			'input_value' => '1',
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', -1, $product ),
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
-			'step'        => apply_filters( 'woocommerce_quantity_input_step', 1, $product ),
-			'pattern'     => apply_filters( 'woocommerce_quantity_input_pattern', has_filter( 'woocommerce_stock_amount', 'intval' ) ? '[0-9]*' : '' ),
-			'inputmode'   => apply_filters( 'woocommerce_quantity_input_inputmode', has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'numeric' : '' ),
+			'input_name'    => 'quantity',
+			'input_value'   => '1',
+			'max_value'     => apply_filters( 'woocommerce_quantity_input_max', -1, $product ),
+			'min_value'     => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
+			'step'          => apply_filters( 'woocommerce_quantity_input_step', 1, $product ),
+			'pattern'       => apply_filters( 'woocommerce_quantity_input_pattern', has_filter( 'woocommerce_stock_amount', 'intval' ) ? '[0-9]*' : '' ),
+			'inputmode'     => apply_filters( 'woocommerce_quantity_input_inputmode', has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'numeric' : '' ),
+			'force_visible' => false
 		);
 
 		$args = apply_filters( 'woocommerce_quantity_input_args', wp_parse_args( $args, $defaults ), $product );
@@ -1065,6 +1066,8 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 		if ( 0 < $args['max_value'] && $args['max_value'] < $args['min_value'] ) {
 			$args['max_value'] = $args['min_value'];
 		}
+
+		$args['hide_input'] = ! $args['force_visible'] && $args['max_value'] && $args['min_value'] === $args['max_value'];
 
 		ob_start();
 

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( $max_value && $min_value === $max_value ) {
 	?>
-	<input type="hidden" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
+	<input type="hidden" min="<?php echo esc_attr( $min_value ); ?>" max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
 	<?php
 } else {
 	?>

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -13,7 +13,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     2.5.0
+ * @version     2.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( $max_value && $min_value === $max_value ) {
 	?>
-	<input type="hidden" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
+	<input type="hidden" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
 	<?php
 } else {
 	?>

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -20,9 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( $max_value && $min_value === $max_value ) {
+if ( $hide_input ) {
 	?>
-	<input type="hidden" min="<?php echo esc_attr( $min_value ); ?>" max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
+	<input type="hidden" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
 	<?php
 } else {
 	?>


### PR DESCRIPTION
Commit 846e1ca25c078f9803f955e14617f3646d7777f3 changed the input type in the global quantity to `hidden` when a quantity selector does not need to be visible.

However, some attributes that may be referenced by third-party code are no longer present in the hidden version.

The most notable one is the missing `class` attribute. Its removal can easily cause issues to existing code that references `input.qty` (`qty` is a solid class selector to rely on for targeting qty inputs and has been there for ages).

On a more general note, I would rather see all logic moved inside `woocommerce_quantity_input` and create a new `quantity-input-hidden.php` template to **ensure this will not be a breaking change** for anyone expecting a `div.quantity` class to be present in the returned markup (existing `.quantity input` selectors will still not work, even if this PR gets merged).