### PR TITLE
Tests for #13533

### DIFF
--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Test meta for https://github.com/woocommerce/woocommerce/issues/13533.
+ *
+ * @package WooCommerce\Tests\CRUD
+ */
+class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
+
+	private $item_id  = 0;
+	private $order_id = 0;
+
+	/**
+	 * A callback for the hooks triggered by eg_disappearing_order_meta() and
+	 * eg_disappearing_item_meta() that saves additional meta data on the
+	 * object via by pre-CRUD and CRUD methods.
+	 */
+	function add_different_object_meta( $object_id ) {
+
+		// Get a new instance of the item or order object
+		$object = ( $this->item_id == $object_id ) ? WC_Order_Factory::get_order_item( $object_id ) : wc_get_order( $object_id );
+		$object->add_meta_data( 'random_other', 'This might disappear :cry:.' );
+		$object->save(); // 'random_other' will be saved correctly, 'random' will also be saved
+
+		// Now set some meta data for it using the pre-CRUD approach
+		if ( $this->item_id == $object_id ) {
+			wc_update_order_item_meta( $object_id, 'random_other_pre_crud', 'This might disappear too :sob:.' );
+		} else {
+			update_post_meta( $object_id, 'random_other_pre_crud', 'This might disappear too :sob:.' );
+		}
+	}
+
+	/**
+	 * Instantiate an instance of an order line item, save meta on that item, then trigger a hook which only passes the
+	 * item's ID to callbacks. Afterwards, save the existing item without that other meta here and log the result to
+	 * show that data has been removed.
+	 */
+	function test_disappearing_item_meta() {
+		// Setup for testing by making an item.
+		$item = new WC_Order_Item_Product();
+		$this->item_id = $item->save();
+
+		$item = WC_Order_Factory::get_order_item( $this->item_id );
+
+		// First make sure we're starting from a clean slate
+		$item->delete_meta_data( 'random' );
+		$item->delete_meta_data( 'random_other' );
+		$item->delete_meta_data( 'random_other_pre_crud' );
+		$item->save();
+
+		// Now add one piece of meta
+		$item->add_meta_data( 'random', (string) rand( 0, 0xffffff ) );
+		$item->save(); // 'random' will be saved correctly
+
+		// Run callback that passes just the item's ID to mimic this kind of normal behaviour in WP/WC
+		$this->add_different_object_meta( $this->item_id );
+
+		// Resave our current item that has our meta data, but not the other piece of meta data
+		$item->save();
+
+		// Get a new instance that should have both 'random' and 'random_other' set on it
+		$new_item = WC_Order_Factory::get_order_item( $this->item_id );
+
+		// The original $item should have 1 item of meta - random.
+		$this->assertCount( 1, $item->get_meta_data() );
+		$this->assertTrue( in_array( 'random', wp_list_pluck( $item->get_meta_data(), 'key' ) ) );
+
+		// The new $item should have 3 items of meta since it's freshly loaded.
+		$this->assertCount( 3, $new_item->get_meta_data() );
+		$this->assertTrue( in_array( 'random', wp_list_pluck( $new_item->get_meta_data(), 'key' ) ) );
+		$this->assertTrue( in_array( 'random_other', wp_list_pluck( $new_item->get_meta_data(), 'key' ) ) );
+		$this->assertTrue( in_array( 'random_other_pre_crud', wp_list_pluck( $new_item->get_meta_data(), 'key' ) ) );
+	}
+
+	/**
+	 * Instantiate an instance of an order, save meta on that order, then trigger a hook which only passes the order's ID to
+	 * callbacks. Afterwards, save the existing order without that other meta here and log the result to show that data
+	 * has been removed.
+	 */
+	function test_disappearing_order_meta() {
+		// Setup for testing by making an item.
+		$order = new WC_Order();
+		$this->order_id = $order->save();
+
+		$order = wc_get_order( $this->order_id );
+
+		// First make sure we're starting from a clean slate
+		$order->delete_meta_data( 'random' );
+		$order->delete_meta_data( 'random_other' );
+		$order->delete_meta_data( 'random_other_pre_crud' );
+		$order->save();
+
+		// Now add one piece of meta
+		$order->add_meta_data( 'random', (string) rand( 0, 0xffffff ) );
+		$order->save(); // 'random' will be saved correctly
+
+		// Run callback that passes just the item's ID to mimic this kind of normal behaviour in WP/WC
+		$this->add_different_object_meta( $this->order_id );
+
+		// Resave our current item that has our meta data, but not the other piece of meta data
+		$order->save();
+
+		// Get a new instance of the same order. It should have both 'random' and 'random_other' set on it
+		$new_order = wc_get_order( $this->order_id );
+
+		// The original $order should have 1 item of meta - random.
+		$this->assertCount( 1, $order->get_meta_data() );
+		$this->assertTrue( in_array( 'random', wp_list_pluck( $order->get_meta_data(), 'key' ) ) );
+
+		// The new $order should have 3 items of meta since it's freshly loaded.
+		$this->assertCount( 3, $new_order->get_meta_data() );
+		$this->assertTrue( in_array( 'random', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
+		$this->assertTrue( in_array( 'random_other', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
+		$this->assertTrue( in_array( 'random_other_pre_crud', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
+	}
+}


### PR DESCRIPTION
Closes #13533 

Adds test to protect against #13533 and shows that the reported issue does not actually occur. I suspect a logic bug in the original gist.

Data is not overwritten, as tests show, for both orders and items.