### PR TITLE
Add missing trailing punctuation

### DIFF
--- a/includes/api/class-wc-rest-settings-controller.php
+++ b/includes/api/class-wc-rest-settings-controller.php
@@ -210,7 +210,7 @@ class WC_REST_Settings_Controller extends WC_REST_Controller {
 					),
 				),
 				'description'      => array(
-					'description'  => __( 'A human readable translation wrapped description. Meant to be used in interfaces', 'woocommerce' ),
+					'description'  => __( 'A human readable translation wrapped description. Meant to be used in interfaces.', 'woocommerce' ),
 					'type'         => 'string',
 					'arg_options'  => array(
 						'sanitize_callback' => 'sanitize_text_field',


### PR DESCRIPTION
Trailing punctuation is missing, causing duplication of the same text in translation, although it exists in another file:
https://github.com/woocommerce/woocommerce/blob/master/includes/api/class-wc-rest-settings-options-controller.php#L482