### PR TITLE
Adding in proper error handling from 'lostpassword_post'

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -246,8 +246,14 @@ class WC_Shortcode_My_Account {
 		if ( ! $user_data && is_email( $login ) && apply_filters( 'woocommerce_get_username_from_email', true ) ) {
 			$user_data = get_user_by( 'email', $login );
 		}
+		
+		$errors = new WP_Error();
+        do_action( 'lostpassword_post', $errors );
 
-		do_action( 'lostpassword_post' );
+        if ( $errors->get_error_code() ) {
+			wc_add_notice( $allow->get_error_message(), 'error' );
+			return false;
+		}
 
 		if ( ! $user_data ) {
 			wc_add_notice( __( 'Invalid username or email.', 'woocommerce' ), 'error' );


### PR DESCRIPTION
Since WP version 4.4.0 the 'lostpassword_post' hook has had the ability to handle error messages from the WP_Error class.  This allows errors to to occur BEFORE the username or email address are validated against the WP.

wp-login.php
        /**
         * Fires before errors are returned from a password reset request.
         *
         * @since 2.1.0
         * @since 4.4.0 Added the `$errors` parameter.
         *
         * @param WP_Error $errors A WP_Error object containing any errors generated
         *                         by using invalid credentials.
         */
        do_action( 'lostpassword_post', $errors );

        if ( $errors->get_error_code() )
                return $errors;

Proposal is to have this same process be respected by WooCommerce Lost Password process.