### PR TITLE
Type cast ->get_weight() on WC_Cart::get_cart_contents_weight calcula…

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -358,7 +358,7 @@ class WC_Cart {
 		$weight = 0;
 
 		foreach ( $this->get_cart() as $cart_item_key => $values ) {
-			$weight += $values['data']->get_weight() * $values['quantity'];
+			$weight += (float) $values['data']->get_weight() * $values['quantity'];
 		}
 
 		return apply_filters( 'woocommerce_cart_contents_weight', $weight );


### PR DESCRIPTION
…tion

Prevents the following warning on PHP 7.1
```
Warning:  A non-numeric value encountered in wordpress/wp-content/plugins/woocommerce/includes/class-wc-cart.php on line 359
```

`$product->ge_weight()` returns a string, and in PHP 7.1 new E_WARNING errors have been added when strings are used when numbers are expected. 
(Source: http://php.net/manual/en/migration71.other-changes.php )