### PR TITLE
[3.0] Allow multiple and dynamically loaded product galleries

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -10,6 +10,7 @@
 		this.$singleVariationWrap = $form.find( '.single_variation_wrap' );
 		this.$resetVariations     = $form.find( '.reset_variations' );
 		this.$product             = $form.closest( '.product' );
+		this.$product_gallery     = this.$product.find( '.woocommerce-product-gallery' );
 		this.variationData        = $form.data( 'product_variations' );
 		this.useAjax              = false === this.variationData;
 		this.xhr                  = false;
@@ -527,7 +528,9 @@
 	 * Reset the slide position if the variation has a different image than the current one
 	 */
 	$.fn.wc_maybe_trigger_slide_position_reset = function( variation ) {
-		var $form = $( this ),
+		var $form                = $( this ),
+			$product             = $form.closest( '.product' ),
+			$product_gallery     = $product.find( '.woocommerce-product-gallery' ),
 			reset_slide_position = false,
 			new_image_id = ( variation && variation.image_id ) ? variation.image_id : '';
 
@@ -538,7 +541,7 @@
 		$form.attr( 'current-image', new_image_id );
 
 		if ( reset_slide_position ) {
-			$( 'body' ).trigger( 'woocommerce_gallery_reset_slide_position' );
+			$product_gallery.trigger( 'woocommerce_gallery_reset_slide_position' );
 		}
 	};
 
@@ -548,6 +551,7 @@
 	$.fn.wc_variations_image_update = function( variation ) {
 		var $form             = this,
 			$product          = $form.closest( '.product' ),
+			$product_gallery  = $product.find( '.woocommerce-product-gallery' ),
 			$gallery_img      = $product.find( '.flex-control-nav li:eq(0) img' ),
 			$gallery_wrapper  = $product.find( '.woocommerce-product-gallery__wrapper ' ),
 			$product_img_wrap = $gallery_wrapper.find( '.woocommerce-product-gallery__image, .woocommerce-product-gallery__image--placeholder' ).eq( 0 ),
@@ -583,7 +587,7 @@
 		}
 
 		window.setTimeout( function() {
-			$( 'body' ).trigger( 'woocommerce_init_gallery' );
+			$product_gallery.trigger( 'woocommerce_gallery_init_zoom' );
 			$form.wc_maybe_trigger_slide_position_reset( variation );
 			$( window ).trigger( 'resize' );
 		}, 10 );

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -10,7 +10,6 @@
 		this.$singleVariationWrap = $form.find( '.single_variation_wrap' );
 		this.$resetVariations     = $form.find( '.reset_variations' );
 		this.$product             = $form.closest( '.product' );
-		this.$product_gallery     = this.$product.find( '.woocommerce-product-gallery' );
 		this.variationData        = $form.data( 'product_variations' );
 		this.useAjax              = false === this.variationData;
 		this.xhr                  = false;
@@ -22,10 +21,10 @@
 		this.$attributeFields.unbind( 'change ' );
 
 		// Methods.
-		this.getChosenAttributes = this.getChosenAttributes.bind( this );
+		this.getChosenAttributes    = this.getChosenAttributes.bind( this );
 		this.findMatchingVariations = this.findMatchingVariations.bind( this );
-		this.isMatch = this.isMatch.bind( this );
-		this.toggleResetLink = this.toggleResetLink.bind( this );
+		this.isMatch                = this.isMatch.bind( this );
+		this.toggleResetLink        = this.toggleResetLink.bind( this );
 
 		// Events.
 		$form.on( 'click', '.reset_variations', { variationForm: this }, this.onReset );
@@ -530,7 +529,7 @@
 	$.fn.wc_maybe_trigger_slide_position_reset = function( variation ) {
 		var $form                = $( this ),
 			$product             = $form.closest( '.product' ),
-			$product_gallery     = $product.find( '.woocommerce-product-gallery' ),
+			$product_gallery     = $product.find( '.images' ),
 			reset_slide_position = false,
 			new_image_id = ( variation && variation.image_id ) ? variation.image_id : '';
 
@@ -551,10 +550,9 @@
 	$.fn.wc_variations_image_update = function( variation ) {
 		var $form             = this,
 			$product          = $form.closest( '.product' ),
-			$product_gallery  = $product.find( '.woocommerce-product-gallery' ),
+			$product_gallery  = $product.find( '.images' ),
 			$gallery_img      = $product.find( '.flex-control-nav li:eq(0) img' ),
-			$gallery_wrapper  = $product.find( '.woocommerce-product-gallery__wrapper ' ),
-			$product_img_wrap = $gallery_wrapper.find( '.woocommerce-product-gallery__image, .woocommerce-product-gallery__image--placeholder' ).eq( 0 ),
+			$product_img_wrap = $product_gallery.find( '.woocommerce-product-gallery__image, .woocommerce-product-gallery__image--placeholder' ).eq( 0 ),
 			$product_img      = $product_img_wrap.find( '.wp-post-image' );
 
 		if ( variation && variation.image && variation.image.src && variation.image.src.length > 1 ) {
@@ -565,9 +563,9 @@
 			$product_img.wc_set_variation_attr( 'sizes', variation.image.sizes );
 			$product_img.wc_set_variation_attr( 'title', variation.image.title );
 			$product_img.wc_set_variation_attr( 'alt', variation.image.alt );
-			$product_img.wc_set_variation_attr( 'data-large-image', variation.image.full_src );
-			$product_img.wc_set_variation_attr( 'data-large-image-width', variation.image.full_src_w );
-			$product_img.wc_set_variation_attr( 'data-large-image-height', variation.image.full_src_h );
+			$product_img.wc_set_variation_attr( 'data-large_image', variation.image.full_src );
+			$product_img.wc_set_variation_attr( 'data-large_image_width', variation.image.full_src_w );
+			$product_img.wc_set_variation_attr( 'data-large_image_height', variation.image.full_src_h );
 			$product_img_wrap.wc_set_variation_attr( 'data-thumb', variation.image.src );
 			$gallery_img.wc_set_variation_attr( 'src', variation.image.src );
 		} else {
@@ -578,11 +576,10 @@
 			$product_img.wc_reset_variation_attr( 'sizes' );
 			$product_img.wc_reset_variation_attr( 'title' );
 			$product_img.wc_reset_variation_attr( 'alt' );
-			$product_img.wc_reset_variation_attr( 'data-large-image' );
-			$product_img.wc_reset_variation_attr( 'data-large-image-width' );
-			$product_img.wc_reset_variation_attr( 'data-large-image-height' );
+			$product_img.wc_reset_variation_attr( 'data-large_image' );
+			$product_img.wc_reset_variation_attr( 'data-large_image_width' );
+			$product_img.wc_reset_variation_attr( 'data-large_image_height' );
 			$product_img_wrap.wc_reset_variation_attr( 'data-thumb' );
-			$product_img.wc_reset_variation_attr( 'large-image' );
 			$gallery_img.wc_reset_variation_attr( 'src' );
 		}
 

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -195,9 +195,9 @@ jQuery( function( $ ) {
 			if ( $slides.length > 0 ) {
 				$slides.each( function( i, el ) {
 					var img = $( el ).find( 'img' ),
-						large_image_src = img.data( 'large_image' ),
-						large_image_w   = img.data( 'large_image_width' ),
-						large_image_h   = img.data( 'large_image_height' ),
+						large_image_src = img.attr( 'data-large_image' ),
+						large_image_w   = img.attr( 'data-large_image_width' ),
+						large_image_h   = img.attr( 'data-large_image_height' ),
 						item            = {
 							src: large_image_src,
 							w:   large_image_w,

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -81,7 +81,7 @@ jQuery( function( $ ) {
 		this.$images = $( '.woocommerce-product-gallery__image', $el );
 
 		// Make this object available.
-		$el.data['product_gallery'] = this;
+		$el.data( 'product_gallery', this );
 
 		// Pick functionality to initialize...
 		this.flexslider_enabled = $.isFunction( $.fn.flexslider ) && wc_single_product_params.flexslider_enabled;

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -103,6 +103,9 @@ jQuery( function( $ ) {
 			this.init_flexslider();
 			this.init_zoom();
 			this.init_photoswipe();
+
+			$el.on( 'woocommerce_gallery_init_zoom', this.init_zoom );
+			$el.on( 'woocommerce_gallery_reset_slide_position', this.reset_slide_position );
 		};
 
 		/**
@@ -141,9 +144,6 @@ jQuery( function( $ ) {
 				}
 			} );
 
-			$el.on( 'woocommerce_gallery_reset_slide_position', this.reset_slide_position );
-
-			$el.on( 'woocommerce_gallery_init_zoom', this.init_zoom );
 		};
 
 		/**
@@ -181,6 +181,11 @@ jQuery( function( $ ) {
 		};
 
 		this.reset_slide_position = function() {
+
+			if ( ! gallery.flexslider_enabled ) {
+				return;
+			}
+
 			$el.flexslider( 0 );
 		};
 

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -158,7 +158,7 @@ jQuery( function( $ ) {
 			var zoom_target = gallery.$images,
 				enable_zoom = false;
 
-			if ( ! wc_single_product_params.flexslider_enabled ) {
+			if ( ! gallery.flexslider_enabled ) {
 				zoom_target = zoom_target.first();
 			}
 

--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -227,10 +227,10 @@ jQuery( function( $ ) {
 
 			if ( this.zoom_enabled && this.$images.length > 0 ) {
 				$el.prepend( '<a href="#" class="woocommerce-product-gallery__trigger">🔍</a>' );
-				$el.on( 'click', '.woocommerce-product-gallery__trigger', { gallery: this }, this.trigger_photoswipe );
+				$el.on( 'click', '.woocommerce-product-gallery__trigger', this.trigger_photoswipe );
 			}
 
-			$el.on( 'click', '.woocommerce-product-gallery__image a', { gallery: this }, this.trigger_photoswipe );
+			$el.on( 'click', '.woocommerce-product-gallery__image a', this.trigger_photoswipe );
 		};
 
 		/**
@@ -238,17 +238,21 @@ jQuery( function( $ ) {
 		 */
 		this.trigger_photoswipe = function( e ) {
 
+			if ( ! gallery.photoswipe_enabled ) {
+				return;
+			}
+
 			e.preventDefault();
 
 			var pswpElement = $( '.pswp' )[0],
-				items  = e.data.gallery.get_gallery_items(),
+				items  = gallery.get_gallery_items(),
 				target = $( e.target ),
 				clicked;
 
 			if ( ! target.is( '.woocommerce-product-gallery__trigger' ) ) {
 				clicked = e.target.closest( '.woocommerce-product-gallery__image' );
 			} else {
-				clicked = e.data.gallery.$el.find( '.flex-active-slide' );
+				clicked = gallery.$el.find( '.flex-active-slide' );
 			}
 
 			var options = {
@@ -261,8 +265,8 @@ jQuery( function( $ ) {
 			};
 
 			// Initializes and opens PhotoSwipe.
-			var gallery = new PhotoSwipe( pswpElement, PhotoSwipeUI_Default, items, options );
-			gallery.init();
+			var photoswipe = new PhotoSwipe( pswpElement, PhotoSwipeUI_Default, items, options );
+			photoswipe.init();
 		};
 
 		this.init();

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -38,10 +38,10 @@ $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_cl
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
 		$attributes = array(
-			'title'                   => $image_title,
-			'data-large-image'        => $full_size_image[0],
-			'data-large-image-width'  => $full_size_image[1],
-			'data-large-image-height' => $full_size_image[2],
+			'title'             => $image_title,
+			'data-large_image'        => $full_size_image[0],
+			'data-large_image_width'  => $full_size_image[1],
+			'data-large_image_height' => $full_size_image[2],
 		);
 
 		if ( has_post_thumbnail() ) {

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -33,9 +33,9 @@ if ( $attachment_ids && has_post_thumbnail() ) {
 
 		$attributes = array(
 			'title'                   => $image_title,
-			'data-large-image'        => $full_size_image[0],
-			'data-large-image-width'  => $full_size_image[1],
-			'data-large-image-height' => $full_size_image[2],
+			'data-large_image'        => $full_size_image[0],
+			'data-large_image_width'  => $full_size_image[1],
+			'data-large_image_height' => $full_size_image[2],
 		);
 
 		$html  = '<figure data-thumb="' . esc_url( $thumbnail[0] ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_size_image[0] ) . '">';


### PR DESCRIPTION
Current galleries JS assumes a single `.woocommerce-product-gallery` element per page and cannot be used to re-initialize dynamically loaded gallery markup.

This PR makes it possible to call `wc_product_gallery` on any jQuery object to create a WC product gallery.

Useful for plugins such as WC Quick View, Bundles, Composites, One Page Checkout, to name a few.

Review needed @mikejolley -- also please test with multiple galleries on single page.