### PR TITLE
Only show thumbs if there is a main post thumbnail

### DIFF
--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -24,7 +24,7 @@ global $post, $product;
 
 $attachment_ids = $product->get_gallery_image_ids();
 
-if ( $attachment_ids ) {
+if ( $attachment_ids && has_post_thumbnail() ) {
 	foreach ( $attachment_ids as $attachment_id ) {
 		$full_size_image  = wp_get_attachment_image_src( $attachment_id, 'full' );
 		$thumbnail        = wp_get_attachment_image_src( $attachment_id, 'shop_thumbnail' );


### PR DESCRIPTION
Closes #13573 

This is kind of a hacky non-solution to prevent breakage, but is all we should do until we resolve properly as part of https://github.com/woocommerce/woocommerce/issues/13071