### PR TITLE
Do not set remaining downloads when is unlimited

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -75,7 +75,9 @@ class WC_Download_Handler {
 		$count     = $download->get_download_count();
 		$remaining = $download->get_downloads_remaining();
 		$download->set_download_count( $count + 1 );
-		$download->set_downloads_remaining( $remaining - 1 );
+		if ( '' !== $remaining ) {
+			$download->set_downloads_remaining( $remaining - 1 );
+		}
 		$download->save();
 
 		self::download( $product->get_file_download_path( $download->get_download_id() ), $download->get_product_id() );


### PR DESCRIPTION
If you try download will throw the follow message:

```
PHP Warning:  A non-numeric value encountered in wp-content/plugins/woocommerce/includes/class-wc-download-handler.php on line 78
```

Still will download without any problem, but if try download more 2 times, will get a message saying that the download is no longer valid.