### PR TITLE
Included access_expires_gmt to customer downloads endpoint v2

### DIFF
--- a/includes/api/class-wc-rest-customer-downloads-controller.php
+++ b/includes/api/class-wc-rest-customer-downloads-controller.php
@@ -32,14 +32,24 @@ class WC_REST_Customer_Downloads_Controller extends WC_REST_Customer_Downloads_V
 	/**
 	 * Prepare a single download output for response.
 	 *
-	 * @param stdObject $download Download object.
+	 * @param stdClass $download Download object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $download, $request ) {
-		$data = (array) $download;
-		$data['access_expires']      = $data['access_expires'] ? wc_rest_prepare_date_response( $data['access_expires'] ) : 'never';
-		$data['downloads_remaining'] = '' === $data['downloads_remaining'] ? 'unlimited' : $data['downloads_remaining'];
+		$data = array(
+			'download_id'         => $download->download_id,
+			'download_url'        => $download->download_url,
+			'product_id'          => $download->product_id,
+			'product_name'        => $download->product_name,
+			'download_name'       => $download->download_name,
+			'order_id'            => $download->order_id,
+			'order_key'           => $download->order_key,
+			'downloads_remaining' => '' === $download->downloads_remaining ? 'unlimited' : $download->downloads_remaining,
+			'access_expires'      => $download->access_expires ? wc_rest_prepare_date_response( $download->access_expires ) : 'never',
+			'access_expires_gmt'  => $download->access_expires ? wc_rest_prepare_date_response( get_gmt_from_date( $download->access_expires ) ) : 'never',
+			'file'                => $download->file,
+		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
@@ -54,7 +64,7 @@ class WC_REST_Customer_Downloads_Controller extends WC_REST_Customer_Downloads_V
 		 * Filter customer download data returned from the REST API.
 		 *
 		 * @param WP_REST_Response $response  The response object.
-		 * @param stdObject        $download  Download object used to create response.
+		 * @param stdClass         $download  Download object used to create response.
 		 * @param WP_REST_Request  $request   Request object.
 		 */
 		return apply_filters( 'woocommerce_rest_prepare_customer_download', $response, $download, $request );
@@ -71,14 +81,14 @@ class WC_REST_Customer_Downloads_Controller extends WC_REST_Customer_Downloads_V
 			'title'      => 'customer_download',
 			'type'       => 'object',
 			'properties' => array(
-				'download_url' => array(
-					'description' => __( 'Download file URL.', 'woocommerce' ),
+				'download_id' => array(
+					'description' => __( 'Download ID (MD5).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'download_id' => array(
-					'description' => __( 'Download ID (MD5).', 'woocommerce' ),
+				'download_url' => array(
+					'description' => __( 'Download file URL.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
@@ -121,6 +131,12 @@ class WC_REST_Customer_Downloads_Controller extends WC_REST_Customer_Downloads_V
 				),
 				'access_expires' => array(
 					'description' => __( "The date when the download access expires, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'access_expires_gmt' => array(
+					'description' => __( "The date when the download access expires, as GMT.", 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,


### PR DESCRIPTION
Part of #13527 

Improved the schema too moving `download_id` as first item, since we return IDs always as first item.