### PR TITLE
Remove @(deprecated) sign from docblock to prevent false notice in ed…

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -130,7 +130,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Get internal type. Should return string and *should be overridden* by child classes.
 	 *
-	 * The product_type property is @deprecated but is used here for BW compat with child classes which may be defining product_type and not have a get_type method.
+	 * The product_type property is deprecated but is used here for BW compat with child classes which may be defining product_type and not have a get_type method.
 	 *
 	 * @since 2.7.0
 	 * @return string


### PR DESCRIPTION
…itors

False deprecated notice due to the `@deprecated` tag in the docblock referring to property instead of the method.

![image](https://cloud.githubusercontent.com/assets/5774447/23940188/485cb28e-0964-11e7-9e3d-fad9c39a0547.png)
