### PR TITLE
Change default WordPress auto-draft title for product

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -254,7 +254,10 @@ class WC_Post_Data {
 					$data['post_parent'] = 0;
 				break;
 			}
+		} elseif ( 'product' === $data['post_type'] && 'auto-draft' === $data['post_status'] ) {
+			$data['post_title'] = 'AUTO-DRAFT';
 		}
+
 		return $data;
 	}
 

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -313,7 +313,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					WHERE post_type = 'product_variation'
 					AND post_parent = %d
 				",
-				$previous_name ? $previous_name : __( 'Auto Draft' ),
+				$previous_name ? $previous_name : 'AUTO-DRAFT',
 				$new_name,
 				$product->get_id()
 			 ) );


### PR DESCRIPTION
This helps handle variations title while syncing variations.

Using a translatable string can led to errors, like a auto-draft started by an user with WP admin set up as pt_BR and published by an user in en_GB.

Not to mention that if you are using a translatable string with other textdomain, this always means that something is wrong :nerd_face: 