### PR TITLE
Fixed oauth signature replacing spaces by plus sign

### DIFF
--- a/includes/api/class-wc-rest-authentication.php
+++ b/includes/api/class-wc-rest-authentication.php
@@ -333,7 +333,7 @@ class WC_REST_Authentication {
 		$base_request_uri = rawurlencode( get_home_url( null, $request_path ) );
 
 		// Get the signature provided by the consumer and remove it from the parameters prior to checking the signature.
-		$consumer_signature = rawurldecode( $params['oauth_signature'] );
+		$consumer_signature = rawurldecode( str_replace( ' ', '+', $params['oauth_signature'] ) );
 		unset( $params['oauth_signature'] );
 
 		// Sort parameters.

--- a/includes/api/legacy/v1/class-wc-api-authentication.php
+++ b/includes/api/legacy/v1/class-wc-api-authentication.php
@@ -232,7 +232,7 @@ class WC_API_Authentication {
 		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . WC()->api->server->path );
 
 		// Get the signature provided by the consumer and remove it from the parameters prior to checking the signature
-		$consumer_signature = rawurldecode( $params['oauth_signature'] );
+		$consumer_signature = rawurldecode( str_replace( ' ', '+', $params['oauth_signature'] ) );
 		unset( $params['oauth_signature'] );
 
 		// Remove filters and convert them from array to strings to void normalize issues

--- a/includes/api/legacy/v2/class-wc-api-authentication.php
+++ b/includes/api/legacy/v2/class-wc-api-authentication.php
@@ -231,7 +231,7 @@ class WC_API_Authentication {
 		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . WC()->api->server->path );
 
 		// Get the signature provided by the consumer and remove it from the parameters prior to checking the signature
-		$consumer_signature = rawurldecode( $params['oauth_signature'] );
+		$consumer_signature = rawurldecode( str_replace( ' ', '+', $params['oauth_signature'] ) );
 		unset( $params['oauth_signature'] );
 
 		// Remove filters and convert them from array to strings to void normalize issues

--- a/includes/api/legacy/v3/class-wc-api-authentication.php
+++ b/includes/api/legacy/v3/class-wc-api-authentication.php
@@ -233,7 +233,7 @@ class WC_API_Authentication {
 		$base_request_uri = rawurlencode( untrailingslashit( get_woocommerce_api_url( '' ) ) . $server_path );
 
 		// Get the signature provided by the consumer and remove it from the parameters prior to checking the signature
-		$consumer_signature = rawurldecode( $params['oauth_signature'] );
+		$consumer_signature = rawurldecode( str_replace( ' ', '+', $params['oauth_signature'] ) );
 		unset( $params['oauth_signature'] );
 
 		// Sort parameters


### PR DESCRIPTION
oAuth signatures are encoded by base64, that can generate plus signs.
See RFC 4648 <http://www.rfc-editor.org/rfc/rfc4648.txt>

By default plus signs in query params are replaced into spaces while
trying to access by super globals like $_GET and $_POST

Closes #13615