### PR TITLE
Remove some product internal meta keys

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -51,6 +51,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		'_wc_average_rating',
 		'_wc_review_count',
 		'_variation_description',
+		'_thumbnail_id',
+		'_file_paths',
+		'_product_image_gallery',
+		'_product_version',
 	);
 
 	/**


### PR DESCRIPTION
Removed it since it's returning on REST API as `meta_data` and can be a problem if people start manipulate this items without CRUD.