### PR TITLE
Add maybe blank check for API keys & webhooks

### DIFF
--- a/includes/admin/class-wc-admin-api-keys.php
+++ b/includes/admin/class-wc-admin-api-keys.php
@@ -58,18 +58,33 @@ class WC_Admin_API_Keys {
 	 * Table list output.
 	 */
 	private static function table_list_output() {
+
+		global $wpdb;
+
 		echo '<h2>' . __( 'Keys/Apps', 'woocommerce' ) . ' <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=api&section=keys&create-key=1' ) ) . '" class="add-new-h2">' . __( 'Add key', 'woocommerce' ) . '</a></h2>';
 
-		$keys_table_list = new WC_Admin_API_Keys_Table_List();
-		$keys_table_list->prepare_items();
+		// Get the API keys count
+		$count = $wpdb->get_var( "SELECT COUNT(key_id) FROM {$wpdb->prefix}woocommerce_api_keys WHERE 1 = 1;" );
 
-		echo '<input type="hidden" name="page" value="wc-settings" />';
-		echo '<input type="hidden" name="tab" value="api" />';
-		echo '<input type="hidden" name="section" value="keys" />';
+		if ( absint( $count ) && $count > 0 ) {
+			$keys_table_list = new WC_Admin_API_Keys_Table_List();
+			$keys_table_list->prepare_items();
 
-		$keys_table_list->views();
-		$keys_table_list->search_box( __( 'Search key', 'woocommerce' ), 'key' );
-		$keys_table_list->display();
+			echo '<input type="hidden" name="page" value="wc-settings" />';
+			echo '<input type="hidden" name="tab" value="api" />';
+			echo '<input type="hidden" name="section" value="keys" />';
+
+			$keys_table_list->views();
+			$keys_table_list->search_box( __( 'Search key', 'woocommerce' ), 'key' );
+			$keys_table_list->display();
+		} else {
+			echo '<div class="woocommerce-BlankState">';
+			?>
+			<h2 class="woocommerce-BlankState-message"><?php _e( 'The WooCommerce REST API works on a key system to control access. These keys are linked to WordPress users on your website.', 'woocommerce' ); ?></h2>
+			<a class="woocommerce-BlankState-cta button-primary button" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=api&section=keys&create-key=1' ) ); ?>"><?php _e( 'Create your first key!', 'woocommerce' ); ?></a>
+
+			<?php echo '<style type="text/css">#posts-filter .wp-list-table, #posts-filter .tablenav.top, .tablenav.bottom .actions  { display: none; } </style></div>';
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -428,18 +428,33 @@ class WC_Admin_Webhooks {
 	 * Table list output.
 	 */
 	private static function table_list_output() {
+
+		global $wpdb;
+
 		echo '<h2>' . __( 'Webhooks', 'woocommerce' ) . ' <a href="' . esc_url( wp_nonce_url( admin_url( 'admin.php?page=wc-settings&tab=api&section=webhooks&create-webhook=1' ), 'create-webhook' ) ) . '" class="add-new-h2">' . __( 'Add webhook', 'woocommerce' ) . '</a></h2>';
 
-		$webhooks_table_list = new WC_Admin_Webhooks_Table_List();
-		$webhooks_table_list->prepare_items();
+		// Get the webhooks count
+		$count = array_sum( (array) wp_count_posts( 'shop_webhook', 'readable' ) );
 
-		echo '<input type="hidden" name="page" value="wc-settings" />';
-		echo '<input type="hidden" name="tab" value="api" />';
-		echo '<input type="hidden" name="section" value="webhooks" />';
+		if ( absint( $count ) && $count > 0 ) {
+			$webhooks_table_list = new WC_Admin_Webhooks_Table_List();
+			$webhooks_table_list->prepare_items();
 
-		$webhooks_table_list->views();
-		$webhooks_table_list->search_box( __( 'Search webhooks', 'woocommerce' ), 'webhook' );
-		$webhooks_table_list->display();
+			echo '<input type="hidden" name="page" value="wc-settings" />';
+			echo '<input type="hidden" name="tab" value="api" />';
+			echo '<input type="hidden" name="section" value="webhooks" />';
+
+			$webhooks_table_list->views();
+			$webhooks_table_list->search_box( __( 'Search webhooks', 'woocommerce' ), 'webhook' );
+			$webhooks_table_list->display();
+		} else {
+			echo '<div class="woocommerce-BlankState">';
+			?>
+			<h2 class="woocommerce-BlankState-message"><?php _e( 'Webhooks are event notifications sent to a URL of your choice. They are useful for integrating with third-party services and other external API that support them.', 'woocommerce' ); ?></h2>
+			<a class="woocommerce-BlankState-cta button-primary button" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=api&section=webhooks&create-webhook=1' ) ); ?>"><?php _e( 'Create your first webhook!', 'woocommerce' ); ?></a>
+
+			<?php echo '<style type="text/css">#posts-filter .wp-list-table, #posts-filter .tablenav.top, .tablenav.bottom .actions  { display: none; } </style></div>';
+		}
 	}
 
 	/**


### PR DESCRIPTION
For consistency purpose in the way we display empty data (like orders
or coupons), the maybe blank check replaces the default empty table by
a more friendly message explaining the purpose of API keys and webhooks.

Results:

![](http://cld.wthms.co/cEF9+)

The same applies to API keys.