### PR TITLE
Changed action for hidding shop_order columns

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -95,8 +95,8 @@ class WC_Admin_Post_Types {
 		// Disable post type view mode options
 		add_filter( 'view_mode_post_types', array( $this, 'disable_view_mode_options' ) );
 
-		// Update the screen options user meta.
-		add_action( 'admin_init', array( $this, 'adjust_shop_order_columns' ) );
+		// Update the screen options.
+		add_filter( 'default_hidden_columns', array( $this, 'adjust_shop_order_columns' ), 10, 2 );
 
 		// Show blank state
 		add_action( 'manage_posts_extra_tablenav', array( $this, 'maybe_render_blank_state' ) );
@@ -109,14 +109,16 @@ class WC_Admin_Post_Types {
 	/**
 	 * Adjust shop order columns for the user on certain conditions.
 	 */
-	public function adjust_shop_order_columns() {
-		$option_value = get_user_option( 'manageedit-shop_ordercolumnshidden' );
-
-		// If first time editing, disable columns by default. Likewise, CB should never be hidden.
-		if ( false === $option_value || ( is_array( $option_value ) && in_array( 'cb', $option_value ) ) ) {
-			$user = wp_get_current_user();
-			update_user_option( get_current_user_id(), 'manageedit-shop_ordercolumnshidden', array( 0 => 'billing_address' ), true );
+	public function adjust_shop_order_columns( $hidden, $screen ) {
+		if ( isset( $screen->id ) && $screen->id == 'edit-shop_order' ) {
+			if ( 'disabled' == get_option( 'woocommerce_ship_to_countries' ) ) {
+				$hidden[] = 'shipping_address';
+			} else {
+				$hidden[] = 'billing_address';
+			}
 		}
+		
+		return $hidden;
 	}
 
 	/**


### PR DESCRIPTION
For now this is not possible to hide by default columns in orders screen by filter, because WC creates user meta (https://github.com/woocommerce/woocommerce/blob/71d0702523bcc365403dd3b84b945da5218d88b4/includes/admin/class-wc-admin-post-types.php#L112-L120) and `default_hidden_columns` is only used when user meta is not array (https://core.trac.wordpress.org/browser/tags/4.7/src/wp-admin/includes/screen.php#53).

This PR changes behavior from creating meta to using filter. I have also added some conditional for hiding shipping or billing column based on `woocommerce_ship_to_countries` option.