### PR TITLE
Add required filters to allow custom order item types

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -652,13 +652,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string group
 	 */
 	protected function type_to_group( $type ) {
-		$type_to_group = array(
+		$type_to_group = apply_filters( 'woocommerce_order_type_to_group', array(
 			'line_item' => 'line_items',
 			'tax'       => 'tax_lines',
 			'shipping'  => 'shipping_lines',
 			'fee'       => 'fee_lines',
 			'coupon'    => 'coupon_lines',
-		);
+		) );
 		return isset( $type_to_group[ $type ] ) ? $type_to_group[ $type ] : '';
 	}
 

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -101,7 +101,7 @@ class WC_Order_Factory {
 					$classname = 'WC_Order_Item_Tax';
 				break;
 				default :
-					$classname = apply_filters( 'woocommerce_get_order_item_classname', $classname, $item_type, $item_id );
+					$classname = apply_filters( 'woocommerce_get_order_item_classname', $classname, $item_type, $id );
 				break;
 			}
 

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -100,8 +100,12 @@ class WC_Order_Factory {
 				case 'tax' :
 					$classname = 'WC_Order_Item_Tax';
 				break;
+				default :
+					$classname = apply_filters( 'woocommerce_get_order_item_classname', $classname, $item_type, $item_id );
+				break;
 			}
-			if ( $classname ) {
+
+			if ( class_exists( $classname ) ) {
 				try {
 					// Try to get from cache, otherwise create a new object,
 					$item = wp_cache_get( 'object-' . $id, 'order-items' );

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -105,7 +105,7 @@ class WC_Order_Factory {
 				break;
 			}
 
-			if ( class_exists( $classname ) ) {
+			if ( $classname && class_exists( $classname ) ) {
 				try {
 					// Try to get from cache, otherwise create a new object,
 					$item = wp_cache_get( 'object-' . $id, 'order-items' );


### PR DESCRIPTION
Pre 3.0 it was possible to add your own custom order item types. 

With the new CRUD in place these changes are required to allow it again. I've successfully tested the working of adding a custom order item with one of my plugins, and was unable to do it without them.