### PR TITLE
Adds additional param for filter woocommerce_cart_totals_coupon_html

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -285,9 +285,9 @@ function wc_cart_totals_coupon_html( $coupon ) {
 
 	// get rid of empty array elements
 	$value = array_filter( $value );
-	$value = implode( ', ', $value ) . ' <a href="' . esc_url( add_query_arg( 'remove_coupon', urlencode( $coupon->get_code() ), defined( 'WOOCOMMERCE_CHECKOUT' ) ? wc_get_checkout_url() : wc_get_cart_url() ) ) . '" class="woocommerce-remove-coupon" data-coupon="' . esc_attr( $coupon->get_code() ) . '">' . __( '[Remove]', 'woocommerce' ) . '</a>';
+	$output = implode( ', ', $value ) . ' <a href="' . esc_url( add_query_arg( 'remove_coupon', urlencode( $coupon->get_code() ), defined( 'WOOCOMMERCE_CHECKOUT' ) ? wc_get_checkout_url() : wc_get_cart_url() ) ) . '" class="woocommerce-remove-coupon" data-coupon="' . esc_attr( $coupon->get_code() ) . '">' . __( '[Remove]', 'woocommerce' ) . '</a>';
 
-	echo apply_filters( 'woocommerce_cart_totals_coupon_html', $value, $coupon );
+	echo apply_filters( 'woocommerce_cart_totals_coupon_html', $output, $coupon, $value );
 }
 
 /**


### PR DESCRIPTION
To avoid code duplication in own template we've added a third parameter. This gives us the ability to separate the output from the value for easier templating without code duplication.