### PR TITLE
Dont set empty strings as tax totals

### DIFF
--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -77,7 +77,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_tax_total( $value ) {
-		$this->set_prop( 'tax_total', wc_format_decimal( $value ) );
+		$this->set_prop( 'tax_total', $value ? wc_format_decimal( $value ) : 0 );
 	}
 
 	/**
@@ -86,7 +86,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_shipping_tax_total( $value ) {
-		$this->set_prop( 'shipping_tax_total', wc_format_decimal( $value ) );
+		$this->set_prop( 'shipping_tax_total', $value ? wc_format_decimal( $value ) : 0 );
 	}
 
 	/**

--- a/tests/unit-tests/order-items/order-item-tax.php
+++ b/tests/unit-tests/order-items/order-item-tax.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Order Item Tax Tests.
+ * @package WooCommerce\Tests\Order_Items
+ * @since 3.0.0
+ */
+class WC_Tests_Order_Item_Tax extends WC_Unit_Test_Case {
+
+	/**
+	 * Test set_tax_total/get_tax_total.
+	 *
+	 * @since 3.0.0
+	 */
+	function test_set_get_tax_totals() {
+
+		$item = new WC_Order_Item_Tax;
+		$this->assertEquals( 0, $item->get_tax_total() );
+
+		$item->set_tax_total( "1.50" );
+		$this->assertEquals( "1.50", $item->get_tax_total() );
+
+		$item->set_tax_total( "" );
+		$this->assertEquals( 0, $item->get_tax_total() );
+
+		$item->set_tax_total( 10.99 );
+		$this->assertEquals( "10.99", $item->get_tax_total() );
+	}
+
+	/**
+	 * Test set_tax_total/get_tax_total.
+	 *
+	 * @since 3.0.0
+	 */
+	function test_set_get_shipping_tax_totals() {
+
+		$item = new WC_Order_Item_Tax;
+		$this->assertEquals( 0, $item->get_shipping_tax_total() );
+
+		$item->set_shipping_tax_total( "1.50" );
+		$this->assertEquals( "1.50", $item->get_shipping_tax_total() );
+
+		$item->set_shipping_tax_total( "" );
+		$this->assertEquals( 0, $item->get_shipping_tax_total() );
+
+		$item->set_shipping_tax_total( 10.99 );
+		$this->assertEquals( "10.99", $item->get_shipping_tax_total() );
+	}
+}


### PR DESCRIPTION
Fixes #13678.

If you have a tax on an item that doesn't apply to the item (e.g. adding a state tax when the customer isn't in that state), it gets rendered as `-` in the admin order screen, and calculating the taxes sets `''` as the tax_total on the tax line item object.

Additionally, it's theoretically possible (but highly unlikely) that `''` could be set as the tax total when the data store reads the metadata into the object.

I've implemented a simple check that treats falsey values passed into `set_tax_total` as` 0`, which should prevent these sorts of situations.