### PR TITLE
Fix: post_meta function for payment token meta

### DIFF
--- a/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/includes/data-stores/class-wc-payment-token-data-store.php
@@ -159,7 +159,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Payment
 		foreach ( $token->get_extra_data_keys() as $key ) {
 			$function = 'set_' . $key;
 			if ( is_callable( array( $token, $function ) ) ) {
-				$token->{$function}( get_post_meta( $token->get_id(), $key, true ) );
+				$token->{$function}( get_metadata( 'payment_token', $token->get_id(), $key, true ) );
 			}
 		}
 	}
@@ -188,7 +188,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Payment
 			}
 			$function = 'get_' . $key;
 			if ( is_callable( array( $token, $function ) ) ) {
-				if ( update_post_meta( $token->get_id(), $key, $token->{$function}( 'edit' ) ) ) {
+				if ( update_metadata( 'payment_token', $token->get_id(), $key, $token->{$function}( 'edit' ) ) ) {
 					$updated_props[] = $key;
 				}
 			}


### PR DESCRIPTION
**Problem Description**

While testing a Payment Gateway with RC, I found that old Payment Tokens weren't correctly shown in My Account page

I found that `read_extra_data` method in `WC_Payment_Token_Data_Store`, as well as `save_extra_data`, are currenlty using `get_post_meta` and `update_post_meta` to handle Token Meta

I suppose this is a problem, as I can't find any code that switches all Payment token to a custom post type in this new release

Besides, once saving a new Payment token, this is causing meta to be stored in post_meta table, with id of the payment token (possibly interfering with other meta with the same meta_key)


**How to Reproduce the Problem**

A simple test could be done using WooCommerce Stripe plugin (latest version offers support for WC 3.0-rc1)
After installing and configuring it, just
1. Add something to cart
2. Enter all checkout data
3. Enter CC data , asking to save method on customer account
4. Complete checkout

Now you should find a new Payment Token in woocommerce_payment_tokens table, 
http://imgur.com/a/hHXnZ
and all its meta in post_meta table (please, note that in this case token will be correctly shown in My Account page, as meta are retrieved from the same table)
http://imgur.com/a/2cmjU


**Solution**

Fortunately, this is an easy fix :)

I just applied the following changes
`get_post_meta( ... )` ->  `get_metadata( 'payment_token', ... )`
`update_post_meta( ... )` ->  `update_metadata( 'payment_token', ... )`

Hope this helps :)