### PR TITLE
Sleep and Wakeup for WC_Data

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -104,10 +104,24 @@ abstract class WC_Data {
 	 * @param int|object|array $read ID to load from the DB (optional) or already queried data.
 	 */
 	public function __construct( $read = 0 ) {
-
-		$this->data = array_merge( $this->data, $this->extra_data );
-
+		$this->data         = array_merge( $this->data, $this->extra_data );
 		$this->default_data = $this->data;
+	}
+
+	/**
+	 * Only store the object ID to avoid serializing the data object instance.
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+		return array( 'id' );
+	}
+
+	/**
+	 * Re-run the constructor with the object ID.
+	 */
+	public function __wakeup() {
+		$this->__construct( $this->id );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -119,9 +119,16 @@ abstract class WC_Data {
 
 	/**
 	 * Re-run the constructor with the object ID.
+	 *
+	 * If the object no longer exists, remove the ID.
 	 */
 	public function __wakeup() {
-		$this->__construct( $this->id );
+		try {
+			$this->__construct( absint( $this->id ) );
+		} catch ( Exception $e ) {
+			$this->set_id( 0 );
+			$this->set_object_read( true );
+		}
 	}
 
 	/**

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -92,17 +92,8 @@ class WC_Emails {
 	 * Queue transactional email via cron so it's not sent in current request.
 	 */
 	public static function queue_transactional_email() {
-		$filter     = current_filter();
-		$args       = func_get_args();
-
-		// Remove objects and store IDs.
-		if ( 0 === strpos( $filter, 'woocommerce_order_status_' ) ) {
-			$args[1] = $args[1]->get_id();
-		} elseif ( 'woocommerce_low_stock' === $filter || 'woocommerce_no_stock' === $filter ) {
-			$args[0] = $args[0]->get_id();
-		} elseif ( 'woocommerce_product_on_backorder' === $filter ) {
-			$args[0]['product'] = $args[0]['product']->get_id();
-		}
+		$filter = current_filter();
+		$args   = func_get_args();
 
 		wp_schedule_single_event( time() + 5, 'woocommerce_send_queued_transactional_email', array(
 			'filter' => $filter,
@@ -121,16 +112,6 @@ class WC_Emails {
 	public static function send_queued_transactional_email( $filter = '', $args = array() ) {
 		if ( apply_filters( 'woocommerce_allow_send_queued_transactional_email', true, $filter, $args ) ) {
 			self::instance(); // Init self so emails exist.
-
-			// Expand objects from IDs.
-			if ( 0 === strpos( $filter, 'woocommerce_order_status_' ) ) {
-				$args[1] = wc_get_order( $args[1] );
-			} elseif ( 'woocommerce_low_stock' === $filter || 'woocommerce_no_stock' === $filter ) {
-				$args[0] = wc_get_product( $args[0] );
-			} elseif ( 'woocommerce_product_on_backorder' === $filter ) {
-				$args[0]['product'] = wc_get_product( $args[0]['product'] );
-			}
-
 			do_action_ref_array( $filter . '_notification', $args );
 		}
 	}


### PR DESCRIPTION
This handles sleep and wakeup so that when a WC_Data object gets serialised, only the ID is ever stored.

This helps the email cron, and also other times something is serialised.

This should also fix odd errors like @gedex faced with the cron jobs.

cc @justinshreve 