### PR TITLE
Improve address labels to help translations

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -53,11 +53,11 @@ class WC_Admin_Profile {
 						'description' => '',
 					),
 					'billing_address_1' => array(
-						'label'       => __( 'Address 1', 'woocommerce' ),
+						'label'       => __( 'Address line 1', 'woocommerce' ),
 						'description' => '',
 					),
 					'billing_address_2' => array(
-						'label'       => __( 'Address 2', 'woocommerce' ),
+						'label'       => __( 'Address line 2', 'woocommerce' ),
 						'description' => '',
 					),
 					'billing_city' => array(
@@ -106,11 +106,11 @@ class WC_Admin_Profile {
 						'description' => '',
 					),
 					'shipping_address_1' => array(
-						'label'       => __( 'Address 1', 'woocommerce' ),
+						'label'       => __( 'Address line 1', 'woocommerce' ),
 						'description' => '',
 					),
 					'shipping_address_2' => array(
-						'label'       => __( 'Address 2', 'woocommerce' ),
+						'label'       => __( 'Address line 2', 'woocommerce' ),
 						'description' => '',
 					),
 					'shipping_city' => array(

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -52,11 +52,11 @@ class WC_Meta_Box_Order_Data {
 				'show'  => false,
 			),
 			'address_1' => array(
-				'label' => __( 'Address 1', 'woocommerce' ),
+				'label' => __( 'Address line 1', 'woocommerce' ),
 				'show'  => false,
 			),
 			'address_2' => array(
-				'label' => __( 'Address 2', 'woocommerce' ),
+				'label' => __( 'Address line 2', 'woocommerce' ),
 				'show'  => false,
 			),
 			'city' => array(
@@ -101,11 +101,11 @@ class WC_Meta_Box_Order_Data {
 				'show'  => false,
 			),
 			'address_1' => array(
-				'label' => __( 'Address 1', 'woocommerce' ),
+				'label' => __( 'Address line 1', 'woocommerce' ),
 				'show'  => false,
 			),
 			'address_2' => array(
-				'label' => __( 'Address 2', 'woocommerce' ),
+				'label' => __( 'Address line 2', 'woocommerce' ),
 				'show'  => false,
 			),
 			'city' => array(

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -216,12 +216,12 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V1_Controller {
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_1' => array(
-							'description' => __( 'Address 1', 'woocommerce' ),
+							'description' => __( 'Address line 1', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_2' => array(
-							'description' => __( 'Address 2', 'woocommerce' ),
+							'description' => __( 'Address line 2', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
@@ -279,12 +279,12 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V1_Controller {
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_1' => array(
-							'description' => __( 'Address 1', 'woocommerce' ),
+							'description' => __( 'Address line 1', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_2' => array(
-							'description' => __( 'Address 2', 'woocommerce' ),
+							'description' => __( 'Address line 2', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -954,12 +954,12 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_1' => array(
-							'description' => __( 'Address 1', 'woocommerce' ),
+							'description' => __( 'Address line 1', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_2' => array(
-							'description' => __( 'Address 2', 'woocommerce' ),
+							'description' => __( 'Address line 2', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
@@ -1017,12 +1017,12 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_1' => array(
-							'description' => __( 'Address 1', 'woocommerce' ),
+							'description' => __( 'Address line 1', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_2' => array(
-							'description' => __( 'Address 2', 'woocommerce' ),
+							'description' => __( 'Address line 2', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -1033,12 +1033,12 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_1' => array(
-							'description' => __( 'Address 1.', 'woocommerce' ),
+							'description' => __( 'Address line 1.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_2' => array(
-							'description' => __( 'Address 2.', 'woocommerce' ),
+							'description' => __( 'Address line 2.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
@@ -1096,12 +1096,12 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_1' => array(
-							'description' => __( 'Address 1.', 'woocommerce' ),
+							'description' => __( 'Address line 1.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'address_2' => array(
-							'description' => __( 'Address 2.', 'woocommerce' ),
+							'description' => __( 'Address line 2.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),


### PR DESCRIPTION
The current form of writing is leading to incorrect translations and incorrect understanding of what this represents.

I found translations like "First Address" and "Second Address".

Not sure why we removed the "line" in this version, but I don't see any reason to remove something that can makes less clear.