### PR TITLE
Include date_created_gmt in order notes endpoint

### DIFF
--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -147,12 +147,12 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Order_Notes_V1_Controller {
 					'readonly'    => true,
 				),
 				'note' => array(
-					'description' => __( 'Order note.', 'woocommerce' ),
+					'description' => __( 'Order note content.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'customer_note' => array(
-					'description' => __( 'Shows/define if the note is only for reference or for the customer (the user will be notified).', 'woocommerce' ),
+					'description' => __( 'If true, the note will be shown to customers and they will be notified. If false, the note will be for admin reference only.', 'woocommerce' ),
 					'type'        => 'boolean',
 					'default'     => false,
 					'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -83,6 +83,87 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Order_Notes_V1_Controller {
 	}
 
 	/**
+	 * Prepare a single order note output for response.
+	 *
+	 * @param WP_Comment $note Order note object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $note, $request ) {
+		$data = array(
+			'id'               => (int) $note->comment_ID,
+			'date_created'     => wc_rest_prepare_date_response( $note->comment_date ),
+			'date_created_gmt' => wc_rest_prepare_date_response( $note->comment_date_gmt ),
+			'note'             => $note->comment_content,
+			'customer_note'    => (bool) get_comment_meta( $note->comment_ID, 'is_customer_note', true ),
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $note ) );
+
+		/**
+		 * Filter order note object returned from the REST API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param WP_Comment       $note     Order note object used to create response.
+		 * @param WP_REST_Request  $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_order_note', $response, $note, $request );
+	}
+
+	/**
+	 * Get the Order Notes schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'order_note',
+			'type'       => 'object',
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created' => array(
+					'description' => __( "The date the order note was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created_gmt' => array(
+					'description' => __( "The date the order note was created, as GMT.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'note' => array(
+					'description' => __( 'Order note.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'customer_note' => array(
+					'description' => __( 'Shows/define if the note is only for reference or for the customer (the user will be notified).', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
 	 * Get the query params for collections.
 	 *
 	 * @return array


### PR DESCRIPTION
We forget to update the order notes endpoint.
This change applies only to v2.