### PR TITLE
Remove redundant / awkward empty password check

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -879,10 +879,6 @@ class WC_Form_Handler {
 					throw new Exception( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . __( 'Username is required.', 'woocommerce' ) );
 				}
 
-				if ( empty( $_POST['password'] ) ) {
-					throw new Exception( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . __( 'Password is required.', 'woocommerce' ) );
-				}
-
 				if ( is_email( $username ) && apply_filters( 'woocommerce_get_username_from_email', true ) ) {
 					$user = get_user_by( 'email', $username );
 


### PR DESCRIPTION
WooCommerce here checks that the password is not empty. This check is redundant, because it is already performed by wp_authenticate_email_password() (which is invoked, eventually, by the call in WC to wp_signon() ). i.e. When you cut these lines, in the absence of other hooks, you will still get an error from WordPress about the missing password. Moreover, the check is harmful, because it prevents extension of the WC login form.

For example, in my use case, I have added a code to the form to be scanned by a smartphone app as a **non-compulsory alternative** to the password. When the code is scanned, a password is no longer required. I could build my own replacement login form that duplicates large chunks of WC, but all I'd be doing is removing this single check. (I want to keep the rest of the form so that I remain compatible with other things that hook in... for example, I can still use a separate OTP-based two-factor plugin that adds a requirement for a TOTP code - that is tested and working).

This extra/redundant check for an empty password on the WooCommerce form prevents my already-working-on-the-standard-wp-login-form code from working here, and there's no way to work around it that isn't hacky/ugly (e.g. direct manipulation of $_POST).