### PR TITLE
Remove factory cache

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -469,7 +469,6 @@ abstract class WC_Data {
 
 		if ( ! empty( $this->cache_group ) ) {
 			WC_Cache_Helper::incr_cache_prefix( $this->cache_group );
-			wp_cache_delete( 'object-' . $this->get_id(), $this->cache_group );
 		}
 	}
 

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -44,15 +44,7 @@ class WC_Order_Factory {
 		}
 
 		try {
-			// Try to get from cache, otherwise create a new object,
-			$order = wp_cache_get( 'object-' . $order_id, 'orders' );
-
-			if ( ! is_a( $order, 'WC_Order' ) ) {
-				$order = new $classname( $order_id );
-				wp_cache_set( 'object-' . $order_id, $order, 'orders' );
-			}
-
-			return $order;
+			return new $classname( $order_id );
 		} catch ( Exception $e ) {
 			return false;
 		}
@@ -107,15 +99,7 @@ class WC_Order_Factory {
 
 			if ( $classname && class_exists( $classname ) ) {
 				try {
-					// Try to get from cache, otherwise create a new object,
-					$item = wp_cache_get( 'object-' . $id, 'order-items' );
-
-					if ( ! is_a( $item, 'WC_Order_Item' ) ) {
-						$item = new $classname( $id );
-						wp_cache_set( 'object-' . $id, $item, 'order-items' );
-					}
-
-					return $item;
+					return new $classname( $id );
 				} catch ( Exception $e ) {
 					return false;
 				}

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -43,15 +43,7 @@ class WC_Product_Factory {
 		$classname = $this->get_product_classname( $product_id, $product_type );
 
 		try {
-			// Try to get from cache, otherwise create a new object,
-			$product = wp_cache_get( 'product-' . $product_id, 'products' );
-
-			if ( ! is_a( $product, 'WC_Product' ) ) {
-				$product = new $classname( $product_id, $deprecated );
-				wp_cache_set( 'product-' . $product_id, $product, 'products' );
-			}
-
-			return $product;
+			return new $classname( $product_id, $deprecated );
 		} catch ( Exception $e ) {
 			return false;
 		}

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -263,7 +263,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected function clear_caches( &$order ) {
 		clean_post_cache( $order->get_id() );
 		wc_delete_shop_order_transients( $order );
-		wp_cache_delete( 'object-' . $order->get_id(), 'orders' );
+		wp_cache_delete( 'items-' . $order->get_id(), 'orders' );
 	}
 
 	/**
@@ -276,8 +276,16 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function read_items( $order, $type ) {
 		global $wpdb;
 
-		$get_items_sql = $wpdb->prepare( "SELECT order_item_type, order_item_id, order_id, order_item_name FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d AND order_item_type = %s ORDER BY order_item_id;", $order->get_id(), $type );
-		$items         = $wpdb->get_results( $get_items_sql );
+		// Get from cache if available.
+		$items = wp_cache_get( 'items-' . $order->get_id(), 'orders' );
+
+		if ( false === $items ) {
+			$get_items_sql = $wpdb->prepare( "SELECT order_item_type, order_item_id, order_id, order_item_name FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d ORDER BY order_item_id;", $order->get_id() );
+			$items         = $wpdb->get_results( $get_items_sql );
+			wp_cache_set( 'items-' . $order->get_id(), $items, 'order-items' );
+		}
+
+		$items = wp_list_filter( $items, array( 'order_item_type' => $type ) );
 
 		if ( ! empty( $items ) ) {
 			$items = array_map( array( 'WC_Order_Factory', 'get_order_item' ), array_combine( wp_list_pluck( $items, 'order_item_id' ), $items ) );
@@ -303,6 +311,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			$wpdb->query( $wpdb->prepare( "DELETE FROM itemmeta USING {$wpdb->prefix}woocommerce_order_itemmeta itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items items WHERE itemmeta.order_item_id = items.order_item_id and items.order_id = %d", $order->get_id() ) );
 			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() ) );
 		}
+		$this->clear_caches( $order );
 	}
 
 	/**

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -263,7 +263,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	protected function clear_caches( &$order ) {
 		clean_post_cache( $order->get_id() );
 		wc_delete_shop_order_transients( $order );
-		wp_cache_delete( 'items-' . $order->get_id(), 'orders' );
+		wp_cache_delete( 'order-items-' . $order->get_id(), 'orders' );
 	}
 
 	/**
@@ -277,12 +277,15 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		global $wpdb;
 
 		// Get from cache if available.
-		$items = wp_cache_get( 'items-' . $order->get_id(), 'orders' );
+		$items = wp_cache_get( 'order-items-' . $order->get_id(), 'orders' );
 
 		if ( false === $items ) {
 			$get_items_sql = $wpdb->prepare( "SELECT order_item_type, order_item_id, order_id, order_item_name FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d ORDER BY order_item_id;", $order->get_id() );
 			$items         = $wpdb->get_results( $get_items_sql );
-			wp_cache_set( 'items-' . $order->get_id(), $items, 'order-items' );
+			foreach ( $items as $item ) {
+				wp_cache_set( 'item-' . $item->order_item_id, $item, 'order-items' );
+			}
+			wp_cache_set( 'order-items-' . $order->get_id(), $items, 'orders' );
 		}
 
 		$items = wp_list_filter( $items, array( 'order_item_type' => $type ) );

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -101,7 +101,13 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 
 		$item->set_defaults();
 
-		$data = $wpdb->get_row( $wpdb->prepare( "SELECT order_id, order_item_name, order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item->get_id() ) );
+		// Get from cache if available.
+		$data = wp_cache_get( 'data-' . $item->get_id(), 'order-items' );
+
+		if ( false === $data ) {
+			$data = $wpdb->get_row( $wpdb->prepare( "SELECT order_id, order_item_name, order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item->get_id() ) );
+			wp_cache_set( 'data-' . $item->get_id(), $data, 'order-items' );
+		}
 
 		if ( ! $data ) {
 			throw new Exception( __( 'Invalid order item.', 'woocommerce' ) );
@@ -128,6 +134,6 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 * Clear meta cachce.
 	 */
 	public function clear_cache( &$item ) {
-		wp_cache_delete( 'object-' . $item->get_id(), 'order-items' );
+		wp_cache_delete( 'data-' . $item->get_id(), 'order-items' );
 	}
 }

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -102,11 +102,11 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 		$item->set_defaults();
 
 		// Get from cache if available.
-		$data = wp_cache_get( 'data-' . $item->get_id(), 'order-items' );
+		$data = wp_cache_get( 'item-' . $item->get_id(), 'order-items' );
 
 		if ( false === $data ) {
-			$data = $wpdb->get_row( $wpdb->prepare( "SELECT order_id, order_item_name, order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item->get_id() ) );
-			wp_cache_set( 'data-' . $item->get_id(), $data, 'order-items' );
+			$data = $wpdb->get_row( $wpdb->prepare( "SELECT order_id, order_item_name FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item->get_id() ) );
+			wp_cache_set( 'item-' . $item->get_id(), $data, 'order-items' );
 		}
 
 		if ( ! $data ) {
@@ -116,7 +116,6 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 		$item->set_props( array(
 			'order_id' => $data->order_id,
 			'name'     => $data->order_item_name,
-			'type'     => $data->order_item_type,
 		) );
 		$item->read_meta_data();
 	}
@@ -134,6 +133,6 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 * Clear meta cachce.
 	 */
 	public function clear_cache( &$item ) {
-		wp_cache_delete( 'data-' . $item->get_id(), 'order-items' );
+		wp_cache_delete( 'item-' . $item->get_id(), 'order-items' );
 	}
 }

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -695,7 +695,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 */
 	protected function clear_caches( &$product ) {
 		wc_delete_product_transients( $product->get_id() );
-		wp_cache_delete( 'object-' . $product->get_id(), 'products' );
 	}
 
 	/*


### PR DESCRIPTION
@prettyboymp pointed out that the change in https://github.com/woocommerce/woocommerce/pull/13690#issuecomment-288220419 would make the factory caching unhelpful, since it would read after unserialization.

This PR removes said cache, and adds caching instead within the data stores doing direct wpdb queries; that is specifically order items.

Do not merge until after feedback.

cc @franticpsyx who was interested in the cache also.