### PR TITLE
Issue on Single Product zoomed image size

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -163,7 +163,7 @@ jQuery( function( $ ) {
 		$( zoomTarget ).each( function( index, target ) {
 			var image = $( target ).find( 'img' );
 
-			if ( image.attr( 'width' ) > galleryWidth ) {
+			if ( image.data( 'large_image_width' ) > galleryWidth ) {
 				zoomEnabled = true;
 				return false;
 			}

--- a/assets/js/zoom/jquery.zoom.js
+++ b/assets/js/zoom/jquery.zoom.js
@@ -99,7 +99,7 @@
 			if (!settings.url) {
 				var srcElement = source.querySelector('img');
 				if (srcElement) {
-					settings.url = srcElement.getAttribute('data-src') || srcElement.currentSrc || srcElement.src;
+					settings.url = srcElement.getAttribute('data-large_image') || srcElement.currentSrc || srcElement.src;
 				}
 				if (!settings.url) {
 					return;


### PR DESCRIPTION
Hello there,
I've found that when you are hovering the product image this use to zoom not the real full size image, but the single product image size specified in the woocommerce settings.
This works only when the area where this image is shown is smaller than the 'Single product image' size.

Using the correct data the image used for the zooming is the full_size, as it should be, and even if the area have the same dimension of the 'Single product image' size.

I know that jquery.zoom.js is an external library, but I would like to point your attention on this issue and suggest you a possible solution.

------------------
HOW TO REPRODUCE THE ISSUE
-------------------
1) Install WooCommerce and TwentySixteeen theme
2) Set the single product image size to something like 600x450
3) Rebuild the thumbnails
4) Look in the single product page and hover the main image, the one used to zoom is not the real full size image (that can be something like 1200x800)

-------------------
OTHER WAY TO TEST
------------------
1) Install WooCommerce and TwentySixteeen theme
2) Set the single product image size to something like 250x180
3) Rebuild the thumbnails
4) Look in the single product page and hover the main image, the zoom will not appear


I hope I was helpful to you,
have a nice day :) 