### PR TITLE
[REST API] Fixed context from items in schema

### DIFF
--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -369,7 +369,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 				'refunded_by' => array(
 					'description' => __( 'User ID of user who created the refund.', 'woocommerce' ),
 					'type'        => 'integer',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'meta_data' => array(
 					'description' => __( 'Meta data.', 'woocommerce' ),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1921,7 +1921,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 				'variations' => array(
 					'description' => __( 'List of variations IDs.', 'woocommerce' ),
 					'type'        => 'array',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 					'items'       => array(
 						'type'    => 'integer',
 					),

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -1914,7 +1914,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 					'type'        => 'string',
 					'default'     => 'standard',
 					'enum'        => array( 'standard' ),
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'external_url' => array(
 					'description' => __( 'Product external URL. Only for external products.', 'woocommerce' ),


### PR DESCRIPTION
When is only `view` will not return on POST, UPDATE or DELETE.

This is blocking the new REST API docs.