### PR TITLE
[REST API] Fixed shipping zones schema

### DIFF
--- a/includes/api/class-wc-rest-shipping-zones-controller.php
+++ b/includes/api/class-wc-rest-shipping-zones-controller.php
@@ -36,7 +36,13 @@ class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_Controlle
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'create_item' ),
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
+					'name' => array(
+						'required' => true,
+						'type'     => 'string',
+						'description' => __( 'Shipping zone name.', 'woocommerce' ),
+					),
+				) ),
 			),
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
@@ -275,7 +281,6 @@ class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_Controlle
 					'description' => __( 'Shipping zone name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
-					'required'    => true,
 					'arg_options' => array(
 						'sanitize_callback' => 'sanitize_text_field',
 					),
@@ -284,10 +289,6 @@ class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_Controlle
 					'description' => __( 'Shipping zone order.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
-					'required'    => false,
-					'arg_options' => array(
-						'sanitize_callback' => 'absint',
-					),
 				),
 			),
 		);

--- a/includes/api/class-wc-rest-shipping-zones-controller.php
+++ b/includes/api/class-wc-rest-shipping-zones-controller.php
@@ -38,8 +38,8 @@ class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_Controlle
 				'permission_callback' => array( $this, 'create_item_permissions_check' ),
 				'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
 					'name' => array(
-						'required' => true,
-						'type'     => 'string',
+						'required'    => true,
+						'type'        => 'string',
 						'description' => __( 'Shipping zone name.', 'woocommerce' ),
 					),
 				) ),

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -176,9 +176,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertTrue( $properties['id']['readonly'] );
 		$this->assertArrayHasKey( 'name', $properties );
-		$this->assertTrue( $properties['name']['required'] );
 		$this->assertArrayHasKey( 'order', $properties );
-		$this->assertFalse( $properties['order']['required'] );
 	}
 
 	/**


### PR DESCRIPTION
`name` is only required while creating a new zone.
`order` do request to define `required` and is already sanitized by `integer` type.