### PR TITLE
[REST API] Fixed links of settings endpoint

### DIFF
--- a/includes/api/class-wc-rest-settings-controller.php
+++ b/includes/api/class-wc-rest-settings-controller.php
@@ -97,9 +97,8 @@ class WC_REST_Settings_Controller extends WC_REST_Controller {
 	protected function prepare_links( $group_id ) {
 		$base  = '/' . $this->namespace . '/' . $this->rest_base;
 		$links = array(
-			'item' => array(
-				'href'       => rest_url( trailingslashit( $base ) . $group_id ),
-				'embeddable' => true,
+			'options' => array(
+				'href' => rest_url( trailingslashit( $base ) . $group_id ),
 			),
 		);
 

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -52,10 +52,9 @@ class Settings extends WC_REST_Unit_Test_Case {
 			'description' => 'My awesome test settings.',
 			'sub_groups'  => array( 'sub-test' ),
 			'_links'      => array(
-				'item' => array(
+				'options' => array(
 					array(
-						'href'       => rest_url( '/wc/v2/settings/test' ),
-						'embeddable' => true,
+						'href' => rest_url( '/wc/v2/settings/test' ),
 					),
 				),
 			),
@@ -68,10 +67,9 @@ class Settings extends WC_REST_Unit_Test_Case {
 			'description' => '',
 			'sub_groups'  => array(),
 			'_links'      => array(
-				'item' => array(
+				'options' => array(
 					array(
-						'href'       => rest_url( '/wc/v2/settings/sub-test' ),
-						'embeddable' => true,
+						'href' => rest_url( '/wc/v2/settings/sub-test' ),
 					),
 				),
 			),


### PR DESCRIPTION
Do not allow embed and updated the key to reflect the items from the endpoint response