### PR TITLE
[3.1] Add woocommerce_add_to_cart_sold_individually_found_in_cart hook

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -904,10 +904,10 @@ class WC_Cart {
 
 			// Force quantity to 1 if sold individually and check for existing item in cart
 			if ( $product_data->is_sold_individually() ) {
-				$quantity         = apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', 1, $quantity, $product_id, $variation_id, $cart_item_data );
-				$in_cart_quantity = $cart_item_key ? $this->cart_contents[ $cart_item_key ]['quantity'] : 0;
+				$quantity      = apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', 1, $quantity, $product_id, $variation_id, $cart_item_data );
+				$found_in_cart = apply_filters( 'woocommerce_add_to_cart_sold_individually_found_in_cart', $cart_item_key && $this->cart_contents[ $cart_item_key ]['quantity'] > 0, $product_id, $variation_id, $cart_item_data, $cart_id );
 
-				if ( $in_cart_quantity > 0 ) {
+				if ( $found_in_cart ) {
 					/* translators: %s: product name */
 					throw new Exception( sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', wc_get_cart_url(), __( 'View cart', 'woocommerce' ), sprintf( __( 'You cannot add another "%s" to your cart.', 'woocommerce' ), $product_data->get_name() ) ) );
 				}


### PR DESCRIPTION
Currently **Sold Individually** works by comparing cart item keys (hashes).

This has a number of implications for extensions, e.g.:

A Simple product with Add-Ons that is Sold Individually can be added to the cart multiple times if you choose different add-ons options.

As a result, **Sold Individually** works rather unpredictably when 3p code adds custom data to cart items, since most users expect it to work based on **product ID**.

This is something we have seen in tickets since a long time ago -- probably already since v2.0. It has been discussed many times in ZD and Slack but somehow always gets missed :)

The PR **does NOT change the logic to work based on product IDs**, but adds a filter that can be used to modify the default behavior, e.g. using a snippet.

For backwards compatibility, leaving the existing logic alone might be the best option, IMO. This will make it easy for third parties to provide a workaround or "fix" for the default behavior, which works fine when leaving plugins/extensions out of the picture.