### PR TITLE
Fix child_has_dimensions

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -264,7 +264,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	public function child_has_weight( $product ) {
 		global $wpdb;
 		$children = $product->get_visible_children();
-		return $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_weight' AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+		return $children ? (bool) $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key = '_weight' AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
 	}
 
 	/**
@@ -277,7 +277,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	public function child_has_dimensions( $product ) {
 		global $wpdb;
 		$children = $product->get_visible_children();
-		return $children ? $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key IN ( '_length', '_width', '_height' ) AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+		return $children ? (bool) $wpdb->get_var( "SELECT 1 FROM $wpdb->postmeta WHERE meta_key IN ( '_length', '_width', '_height' ) AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
 	}
 
 	/**

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -350,6 +350,37 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( 'green', $_attribute['color'] );
 	}
 
+	function test_variable_child_has_dimensions() {
+		$product = new WC_Product_Variable;
+		$product->save();
+
+		$variation = new WC_Product_variation;
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_width( 10 );
+		$variation->save();
+
+		$product = wc_get_product( $product->get_id() );
+
+		$store = new WC_Product_Variable_Data_Store_CPT();
+
+		$this->assertTrue( $store->child_has_dimensions( $product ) );
+	}
+
+	function test_variable_child_has_dimensions_no_dimensions() {
+		$product = new WC_Product_Variable;
+		$product->save();
+
+		$variation = new WC_Product_variation;
+		$variation->set_parent_id( $product->get_id() );
+		$variation->save();
+
+		$product = wc_get_product( $product->get_id() );
+
+		$store = new WC_Product_Variable_Data_Store_CPT();
+
+		$this->assertFalse( $store->child_has_dimensions( $product ) );
+	}
+
 	function test_get_on_sale_products() {
 		$product_store = new WC_Product_Data_Store_CPT();
 


### PR DESCRIPTION
Fixes #13771.

The previous implementation would return a 1 if the meta keys just existed, as opposed to existing and having a real measurement. 

I'm also casting the result to a bool now, because a 1 isn't technically a boolean so it would fail `===` checks.