### PR TITLE
[REST API] Fixed all products v1 query parameters.

### DIFF
--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -152,8 +152,6 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 		// Set tax_query for each passed arg.
 		foreach ( $taxonomies as $taxonomy => $key ) {
 			if ( ! empty( $request[ $key ] ) ) {
-				$terms = explode( ',', $request[ $key ] );
-
 				$tax_query[] = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'term_id',


### PR DESCRIPTION
Fixed the follow error:

```
PHP Warning: explode() expects parameter 2 to be string, array given in includes/api/v1/class-wc-rest-products-controller.php on line 156
```

Error caused since terms are sanitized by wp_parse_id_list() that already creates an array.

And fixed other minor issues with all custom query parameters.

Closes #13790