### PR TITLE
Increase rounding precision to 6

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1397,13 +1397,13 @@ function wc_shipping_zone_method_order_uasort_comparison( $a, $b ) {
 
 /**
  * Get rounding precision for internal WC calculations.
- * Will increase the precision of wc_get_price_decimals by 2 decimals, unless WC_ROUNDING_PRECISION is set to a higher number.
+ * Will increase the precision of wc_get_price_decimals by 4 decimals, unless WC_ROUNDING_PRECISION is set to a higher number.
  *
  * @since 2.6.3
  * @return int
  */
 function wc_get_rounding_precision() {
-	$precision = wc_get_price_decimals() + 2;
+	$precision = wc_get_price_decimals() + 4;
 	if ( absint( WC_ROUNDING_PRECISION ) > $precision ) {
 		$precision = absint( WC_ROUNDING_PRECISION );
 	}

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -422,7 +422,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	 * Test the rounding method.
 	 */
 	public function test_round() {
-		$this->assertEquals( WC_Tax::round( '2.123456789999' ), '2.123568' );
+		$this->assertEquals( WC_Tax::round( '2.123456789999' ), '2.123457' );
 	}
 
 	/**

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -272,7 +272,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		 * Next tax would be calced on 100 - 7.8341 = 92.1659.
 		 * 92.1659 - ( 92.1659 / 1.05 ) = 4.38885.
 		 */
-		$this->assertEquals( $calced_tax, array( $tax_rate_1_id => 4.3889, $tax_rate_2_id => 7.8341 ) );
+		$this->assertEquals( $calced_tax, array( $tax_rate_1_id => 4.388852, $tax_rate_2_id => 7.834101 ) );
 
 		WC_Tax::_delete_tax_rate( $tax_rate_1_id );
 		WC_Tax::_delete_tax_rate( $tax_rate_2_id );
@@ -422,7 +422,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	 * Test the rounding method.
 	 */
 	public function test_round() {
-		$this->assertEquals( WC_Tax::round( '2.1234567' ), '2.1235' );
+		$this->assertEquals( WC_Tax::round( '2.123456789999' ), '2.123568' );
 	}
 
 	/**

--- a/tests/unit-tests/util/main-class.php
+++ b/tests/unit-tests/util/main-class.php
@@ -46,7 +46,7 @@ class WC_Tests_Main_Class extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $this->wc->version, WC_VERSION );
 		$this->assertEquals( WC_VERSION, WOOCOMMERCE_VERSION );
-		$this->assertEquals( 4, WC_ROUNDING_PRECISION );
+		$this->assertEquals( 6, WC_ROUNDING_PRECISION );
 		$this->assertContains( WC_TAX_ROUNDING_MODE, array( 2, 1 ) );
 		$this->assertEquals( '|', WC_DELIMITER );
 		$this->assertNotEquals( WC_LOG_DIR, '' );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -197,7 +197,7 @@ final class WooCommerce {
 		$this->define( 'WC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 		$this->define( 'WC_VERSION', $this->version );
 		$this->define( 'WOOCOMMERCE_VERSION', $this->version );
-		$this->define( 'WC_ROUNDING_PRECISION', 4 );
+		$this->define( 'WC_ROUNDING_PRECISION', 6 );
 		$this->define( 'WC_DISCOUNT_ROUNDING_MODE', 2 );
 		$this->define( 'WC_TAX_ROUNDING_MODE', 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1 );
 		$this->define( 'WC_DELIMITER', '|' );


### PR DESCRIPTION
Ref: #13802 

Rounding precision is by default 4. To make fixed cart discounts more accurate, this can be increased to 6.

Increase default to 6 and update unit tests. This needs thorough testing before including in core, so marked for a future release.