### PR TITLE
Fix typo

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -91,7 +91,7 @@ abstract class WC_Data {
 	protected $cache_group = '';
 
 	/**
-	 * Stores additonal meta data.
+	 * Stores additional meta data.
 	 *
 	 * @since 3.0.0
 	 * @var array
@@ -168,7 +168,7 @@ abstract class WC_Data {
 	}
 
 	/**
-	 * Save should create or update based on object existance.
+	 * Save should create or update based on object existence.
 	 *
 	 * @since  2.6.0
 	 * @return int

--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract Rest Controler Class
+ * Abstract Rest Controller Class
  *
  * @author   WooThemes
  * @category API

--- a/includes/abstracts/abstract-wc-rest-crud-controller.php
+++ b/includes/abstracts/abstract-wc-rest-crud-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Abstract Rest CRUD Controler Class
+ * Abstract Rest CRUD Controller Class
  *
  * @author   Automattic
  * @category API

--- a/includes/abstracts/abstract-wc-rest-posts-controller.php
+++ b/includes/abstracts/abstract-wc-rest-posts-controller.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract Rest Posts Controler Class
+ * Abstract Rest Posts Controller Class
  *
  * @author   WooThemes
  * @category API

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Abstract Rest Terms Controler Class
+ * Abstract Rest Terms Controller Class
  *
  * @author   WooThemes
  * @category API

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -618,7 +618,7 @@ class WC_Admin_Settings {
 	}
 
 	/**
-	 * Helper function to get the formated description and tip HTML for a
+	 * Helper function to get the formatted description and tip HTML for a
 	 * given form field. Plugins can call this when implementing their own custom
 	 * settings types.
 	 *

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -105,14 +105,14 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 		$total_coupons  = absint( $this->get_order_report_data( $total_coupons_query ) );
 
 		$legend[] = array(
-			/* translators: %s: discount ammount */
+			/* translators: %s: discount amount */
 			'title' => sprintf( __( '%s discounts in total', 'woocommerce' ), '<strong>' . wc_price( $total_discount ) . '</strong>' ),
 			'color' => $this->chart_colours['discount_amount'],
 			'highlight_series' => 1,
 		);
 
 		$legend[] = array(
-			/* translators: %s: coupons ammount */
+			/* translators: %s: coupons amount */
 			'title' => sprintf( __( '%s coupons used in total', 'woocommerce' ), '<strong>' . $total_coupons . '</strong>' ),
 			'color' => $this->chart_colours['coupon_count'],
 			'highlight_series' => 0,

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -37,7 +37,7 @@ class WC_Report_Customers extends WC_Admin_Report {
 		$legend   = array();
 
 		$legend[] = array(
-			/* translators: %s: signups ammount */
+			/* translators: %s: signups amount */
 			'title' => sprintf( __( '%s signups in this period', 'woocommerce' ), '<strong>' . sizeof( $this->customers ) . '</strong>' ),
 			'color' => $this->chart_colours['signups'],
 			'highlight_series' => 2,

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -309,7 +309,7 @@ class WC_Order extends WC_Abstract_Order {
 				$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['to'] ) );
 			}
 
-			// Note the transition occured
+			// Note the transition occurred
 			$this->add_order_note( trim( $this->status_transition['note'] . ' ' . $transition_note ), 0, $this->status_transition['manual'] );
 
 			// This has ran, so reset status transition variable

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -3,7 +3,7 @@
  * WooCommerce Tracker
  *
  * The WooCommerce tracker class adds functionality to track WooCommerce usage based on if the customer opted in.
- * No personal infomation is tracked, only general WooCommerce settings, general product, order and user counts and admin email for discount code.
+ * No personal information is tracked, only general WooCommerce settings, general product, order and user counts and admin email for discount code.
  *
  * @class 		WC_Tracker
  * @version		2.3.0
@@ -37,7 +37,7 @@ class WC_Tracker {
 	 * @param boolean $override
 	 */
 	public static function send_tracking_data( $override = false ) {
-		// Dont trigger this on AJAX Requests
+		// Don't trigger this on AJAX Requests
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
 		}
@@ -49,7 +49,7 @@ class WC_Tracker {
 				return;
 			}
 		} else {
-			// Make sure there is at least a 1 hour delay between override sends, we dont want duplicate calls due to double clicking links.
+			// Make sure there is at least a 1 hour delay between override sends, we don't want duplicate calls due to double clicking links.
 			$last_send = self::get_last_send_time();
 			if ( $last_send && $last_send > strtotime( '-1 hours' ) ) {
 				return;

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1128,7 +1128,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'order'          => $args['order'],
 			'tax_query'      => array(),
 		);
-		// Do not load unneccessary post data if the user only wants IDs.
+		// Do not load unnecessary post data if the user only wants IDs.
 		if ( 'ids' === $args['return'] ) {
 			$wp_query_args['fields'] = 'ids';
 		}

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -283,7 +283,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	}
 
 	/**
-	 * Handle a reveral.
+	 * Handle a reversal.
 	 * @param WC_Order $order
 	 * @param array $posted
 	 */
@@ -297,7 +297,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	}
 
 	/**
-	 * Handle a cancelled reveral.
+	 * Handle a cancelled reversal.
 	 * @param WC_Order $order
 	 * @param array $posted
 	 */

--- a/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-gateway-simplify-commerce.php
@@ -339,7 +339,7 @@ class WC_Gateway_Simplify_Commerce extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Actualy saves a customer token to the database.
+	 * Actually saves a customer token to the database.
 	 *
 	 * @param  WC_Payment_Token   $customer_token Payment Token
 	 * @param  string             $cart_token     CC Token

--- a/includes/libraries/class-wc-eval-math.php
+++ b/includes/libraries/class-wc-eval-math.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 				} elseif ( in_array( $op, $ops ) and ! $expecting_op ) {
 					return self::trigger( "unexpected operator '$op'" );
 				} else { // I don't even want to know what you did to get here
-					return self::trigger( "an unexpected error occured" );
+					return self::trigger( "an unexpected error occurred" );
 				}
 				if ( strlen( $expr ) == $index ) {
 					if ( in_array( $op, $ops ) ) { // did we end with an operator? bad.

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -78,7 +78,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	 *
 	 *     @type string $source Optional. Determines log file to write to. Default 'log'.
 	 *     @type bool $_legacy Optional. Default false. True to use outdated log format
-	 *         orignally used in deprecated WC_Logger::add calls.
+	 *         originally used in deprecated WC_Logger::add calls.
 	 * }
 	 *
 	 * @return bool False if value was not handled and true if value was handled.

--- a/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -273,7 +273,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	 *
 	 * @deprecated 2.4.0
 	 *
-	 * Additonal rates defined like this:
+	 * Additional rates defined like this:
 	 * 	Option Name | Additional Cost [+- Percents%] | Per Cost Type (order, class, or item).
 	 */
 	public function calculate_extra_shipping( $method, $rate ) {

--- a/includes/wc-coupon-functions.php
+++ b/includes/wc-coupon-functions.php
@@ -87,7 +87,7 @@ function wc_get_coupon_code_by_id( $id ) {
  *
  * @since 3.0.0
  * @param string $code
- * @param int $exclude Used to exclude an ID from the check if you're checking existance.
+ * @param int $exclude Used to exclude an ID from the check if you're checking existence.
  * @return int
  */
 function wc_get_coupon_id_by_code( $code, $exclude = 0 ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -166,7 +166,7 @@ function wc_get_order_id_by_order_key( $order_key ) {
 /**
  * Get all registered order types.
  *
- * $for optionally define what you are getting order types for so only relevent types are returned.
+ * $for optionally define what you are getting order types for so only relevant types are returned.
  *
  * e.g. for 'order-meta-boxes', 'order-count'
  *

--- a/includes/widgets/class-wc-widget-product-tag-cloud.php
+++ b/includes/widgets/class-wc-widget-product-tag-cloud.php
@@ -75,7 +75,7 @@ class WC_Widget_Product_Tag_Cloud extends WC_Widget {
 	}
 
 	/**
-	 * Retuns topic count text.
+	 * Returns topic count text.
 	 *
 	 * @since 2.6.0
 	 * @param int $count

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -91,7 +91,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 	}
 
 	/**
-	 * Count products after other filters have occured by adjusting the main query.
+	 * Count products after other filters have occurred by adjusting the main query.
 	 * @param  int $rating
 	 * @return int
 	 */

--- a/tests/unit-tests/api/payment-gateways.php
+++ b/tests/unit-tests/api/payment-gateways.php
@@ -264,7 +264,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Loads a particualr gateway's settings so we can correctly test API output.
+	 * Loads a particular gateway's settings so we can correctly test API output.
 	 *
 	 * @since 3.0.0
 	 * @param string $gateway_class Name of WC_Payment_Gateway class.

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -180,7 +180,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertContains( 'Dr1Bczxq4q', $data['images'][0]['src'] );
 		$this->assertContains( 'test upload image', $data['images'][0]['alt'] );
 
-		// test variable product (varations are tested in product-variations.php)
+		// test variable product (variations are tested in product-variations.php)
 		$product  = WC_Helper_Product::create_variation_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
 		$data     = $response->get_data();


### PR DESCRIPTION
This fixes all typos found by [codespell](https://github.com/lucasdemarchi/codespell). Codespell also fixes all scanned typo, with `-w` arg. I double check the diff and most changes are typos in comment and unlikely to break if it's not a comment.

Maybe in the future this can be integrated with our CI build to prevent typos being pushed. 