### PR TITLE
Include WooCommerce endpoints to customize nav menu setting

### DIFF
--- a/includes/admin/class-wc-admin-customize.php
+++ b/includes/admin/class-wc-admin-customize.php
@@ -5,7 +5,7 @@
  * @author   WooCommerce
  * @category Admin
  * @package  WooCommerce/Admin/Customize
- * @version  3.0.0
+ * @version  3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -32,7 +32,7 @@ class WC_Admin_Customize {
 	 * Register customize new nav menu item types.
 	 * This will register WooCommerce account endpoints as a nav menu item type.
 	 *
-	 * @since  3.0.0
+	 * @since  3.1.0
 	 * @param  array $item_types Menu item types.
 	 * @return array
 	 */
@@ -50,7 +50,7 @@ class WC_Admin_Customize {
 	/**
 	 * Register account endpoints to customize nav menu items.
 	 *
-	 * @since  3.0.0
+	 * @since  3.1.0
 	 * @param  array   $items  List of nav menu items.
 	 * @param  string  $type   Nav menu type.
 	 * @param  string  $object Nav menu object.

--- a/includes/admin/class-wc-admin-customize.php
+++ b/includes/admin/class-wc-admin-customize.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Setup customize items.
+ *
+ * @author   WooCommerce
+ * @category Admin
+ * @package  WooCommerce/Admin/Customize
+ * @version  3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Admin_Customize', false ) ) :
+
+/**
+ * WC_Admin_Customize Class.
+ */
+class WC_Admin_Customize {
+
+	/**
+	 * Initialize customize actions.
+	 */
+	public function __construct() {
+		// Include custom items to customizer nav menu settings.
+		add_filter( 'customize_nav_menu_available_item_types', array( $this, 'register_customize_nav_menu_item_types' ) );
+		add_filter( 'customize_nav_menu_available_items', array( $this, 'register_customize_nav_menu_items' ), 10, 4 );
+	}
+
+	/**
+	 * Register customize new nav menu item types.
+	 * This will register WooCommerce account endpoints as a nav menu item type.
+	 *
+	 * @since  3.0.0
+	 * @param  array $item_types Menu item types.
+	 * @return array
+	 */
+	public function register_customize_nav_menu_item_types( $item_types  ) {
+		$item_types[] = array(
+			'title'      => __( 'WooCommerce endpoints', 'woocommerce' ),
+			'type_label' => __( 'WooCommerce endpoint', 'woocommerce' ),
+			'type'       => 'woocommerce_nav',
+			'object'     => 'woocommerce_endpoint'
+		);
+
+		return $item_types;
+	}
+
+	/**
+	 * Register account endpoints to customize nav menu items.
+	 *
+	 * @since  3.0.0
+	 * @param  array   $items  List of nav menu items.
+	 * @param  string  $type   Nav menu type.
+	 * @param  string  $object Nav menu object.
+	 * @param  integer $page   Page number.
+	 * @return array
+	 */
+	public function register_customize_nav_menu_items( $items = array(), $type = '', $object = '', $page = 0 ) {
+		if ( 'woocommerce_endpoint' !== $object ) {
+			return $items;
+		}
+
+		// Don't allow pagination since all items are loaded at once.
+		if ( 0 < $page ) {
+			return $items;
+		}
+
+		// Get items from account menu.
+		$endpoints = wc_get_account_menu_items();
+
+		// Remove dashboard item.
+		if ( isset( $endpoints['dashboard'] ) ) {
+			unset( $endpoints['dashboard'] );
+		}
+
+		// Include missing lost password.
+		$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
+
+		$endpoints = apply_filters( 'woocommerce_custom_nav_menu_items', $endpoints );
+
+		foreach ( $endpoints as $endpoint => $title ) {
+			$items[] = array(
+				'id'         => $endpoint,
+				'title'      => $title,
+				'type_label' => __( 'Custom Link', 'woocommerce' ),
+				'url'        => esc_url_raw( wc_get_account_endpoint_url( $endpoint ) ),
+			);
+		}
+
+		return $items;
+	}
+}
+
+endif;
+
+return new WC_Admin_Customize();

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -48,6 +48,7 @@ class WC_Admin {
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-post-types.php' );
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-taxonomies.php' );
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-menus.php' );
+		include_once( dirname( __FILE__ ) . '/class-wc-admin-customize.php' );
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-notices.php' );
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-assets.php' );
 		include_once( dirname( __FILE__ ) . '/class-wc-admin-api-keys.php' );


### PR DESCRIPTION
This PR properly includes the "WooCommerce endpoints" back to the customize nav menu setting, previous removed by #13814.

Part of #13813