### PR TITLE
Fixed titles and items from WC_Admin_Menus::nav_menu_links()

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -238,30 +238,39 @@ class WC_Admin_Menus {
 	 * Output menu links.
 	 */
 	public function nav_menu_links() {
-		$exclude = array( 'view-order', 'add-payment-method', 'order-pay', 'order-received' );
+		// Get items from account menu.
+		$endpoints = wc_get_account_menu_items();
+
+		// Remove dashboard item.
+		if ( isset( $endpoints['dashboard'] ) ) {
+			unset( $endpoints['dashboard'] );
+		}
+
+		// Include missing lost password.
+		$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
+
+		$endpoints = apply_filters( 'woocommerce_custom_nav_menu_items', $endpoints );
+
 		?>
 		<div id="posttype-woocommerce-endpoints" class="posttypediv">
 			<div id="tabs-panel-woocommerce-endpoints" class="tabs-panel tabs-panel-active">
 				<ul id="woocommerce-endpoints-checklist" class="categorychecklist form-no-clear">
 					<?php
 					$i = -1;
-					foreach ( WC()->query->query_vars as $key => $value ) {
-						if ( in_array( $key, $exclude ) ) {
-							continue;
-						}
+					foreach ( $endpoints as $key => $value ) :
 						?>
 						<li>
 							<label class="menu-item-title">
-								<input type="checkbox" class="menu-item-checkbox" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-object-id]" value="<?php echo esc_attr( $i ); ?>" /> <?php echo esc_html( $key ); ?>
+								<input type="checkbox" class="menu-item-checkbox" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-object-id]" value="<?php echo esc_attr( $i ); ?>" /> <?php echo esc_html( $value ); ?>
 							</label>
 							<input type="hidden" class="menu-item-type" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-type]" value="custom" />
-							<input type="hidden" class="menu-item-title" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-title]" value="<?php echo esc_html( $key ); ?>" />
-							<input type="hidden" class="menu-item-url" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-url]" value="<?php echo esc_url( wc_get_endpoint_url( $key, '', wc_get_page_permalink( 'myaccount' ) ) ); ?>" />
+							<input type="hidden" class="menu-item-title" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-title]" value="<?php echo esc_html( $value ); ?>" />
+							<input type="hidden" class="menu-item-url" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-url]" value="<?php echo esc_url( wc_get_account_endpoint_url( $key ) ); ?>" />
 							<input type="hidden" class="menu-item-classes" name="menu-item[<?php echo esc_attr( $i ); ?>][menu-item-classes]" />
 						</li>
 						<?php
-						$i --;
-					}
+						$i--;
+					endforeach;
 					?>
 				</ul>
 			</div>


### PR DESCRIPTION
This remove some not useful links like `remove-payment-method`, allows people to include custom links and fix the titles from the links, e.g `payment-methods` to `Payment methods`.

Part of #13813 