### PR TITLE
Use correct attribute type label in attributes admin screen

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -384,7 +384,7 @@ class WC_Admin_Attributes {
 													<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ) ); ?>"><?php _e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php _e( 'Delete', 'woocommerce' ); ?></a></span></div>
 												</td>
 												<td><?php echo esc_html( $tax->attribute_name ); ?></td>
-												<td><?php echo esc_html( ucfirst( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? __( '(Public)', 'woocommerce' ) : ''; ?></td>
+												<td><?php echo esc_html( wc_get_attribute_type_label( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? __( '(Public)', 'woocommerce' ) : ''; ?></td>
 												<td><?php
 													switch ( $tax->attribute_orderby ) {
 														case 'name' :

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -198,6 +198,19 @@ function wc_get_attribute_types() {
 }
 
 /**
+ * Get attribute type label.
+ *
+ * @since  3.0.0
+ * @param  string $type Attribute type slug.
+ * @return string
+ */
+function wc_get_attribute_type_label( $type ) {
+	$types = wc_get_attribute_types();
+
+	return isset( $types[ $type ] ) ? $types[ $type ] : ucfirst( $type );
+}
+
+/**
  * Check if attribute name is reserved.
  * https://codex.wordpress.org/Function_Reference/register_taxonomy#Reserved_Terms.
  *


### PR DESCRIPTION
This allow use a translatable label for attribute type instead of forcing English for everybody.

Reported in #13831