### PR TITLE
Update product rating counts after adding a rating

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -205,6 +205,11 @@ class WC_Comments {
 				return;
 			}
 			add_comment_meta( $comment_id, 'rating', (int) esc_attr( $_POST['rating'] ), true );
+
+			$post_id = isset( $_POST['comment_post_ID'] ) ? (int) $_POST['comment_post_ID'] : 0;
+			if ( $post_id ) {
+				self::clear_transients( $post_id );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #13829.

The problem is that there needs to be a recount and recalculation after the comment meta is added. I think this is the best way to do it.