### PR TITLE
[REST API] Ignore 0 category while querying products

### DIFF
--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -151,6 +151,10 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 
 		// Set tax_query for each passed arg.
 		foreach ( $taxonomies as $taxonomy => $key ) {
+			if ( ! empty( $request[ $key ] ) && is_array( $request[ $key ] ) ) {
+				$request[ $key ] = array_filter( $request[ $key ] );
+			}
+
 			if ( ! empty( $request[ $key ] ) ) {
 				$tax_query[] = array(
 					'taxonomy' => $taxonomy,


### PR DESCRIPTION
This reintroduce a bug to make compatibility with 2.6.

Ref #13839