### PR TITLE
Be more selective about when to create shipping data.

### DIFF
--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -183,10 +183,12 @@ class WC_Data_Store_WP {
 	protected function get_props_to_update( $object, $meta_key_to_props, $meta_type = 'post' ) {
 		$props_to_update = array();
 		$changed_props   = $object->get_changes();
+		$object_class = get_class( $object );
+		$default = new $object_class;
 
-		// Props should be updated if they are a part of the $changed array or don't exist yet.
+		// Props should be updated if they are a part of the $changed array or something meaningful was set.
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			if ( array_key_exists( $prop, $changed_props ) || ! metadata_exists( $meta_type, $object->get_id(), $meta_key ) ) {
+			if ( array_key_exists( $prop, $changed_props ) || $default->{"get_$prop"}( 'edit' ) !== $object->{"get_$prop"}( 'edit' )  ) {
 				$props_to_update[ $meta_key ] = $prop;
 			}
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -215,6 +215,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'_billing_email'      => 'billing_email',
 				'_billing_phone'      => 'billing_phone',
 			),
+			'shipping' => array(),
 		);
 
 		$shipping_props = array(
@@ -232,8 +233,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		if ( wc_shipping_enabled() ) {
 			$address_props['shipping'] = $shipping_props;
 		} else {
-			$address_props['shipping'] = array();
-
 			// If shipping is disabled, only update the fields that have set info or already exist.
 			foreach ( $shipping_props as $meta_key => $prop ) {
 				if ( $order->{"get_$prop"}( 'edit' ) || metadata_exists( 'post', $id, $meta_key ) ) {

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -215,7 +215,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'_billing_email'      => 'billing_email',
 				'_billing_phone'      => 'billing_phone',
 			),
-			'shipping' => array(
+		);
+
+		$shipping_props = array(
 				'_shipping_first_name' => 'shipping_first_name',
 				'_shipping_last_name'  => 'shipping_last_name',
 				'_shipping_company'    => 'shipping_company',
@@ -225,8 +227,20 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'_shipping_state'      => 'shipping_state',
 				'_shipping_postcode'   => 'shipping_postcode',
 				'_shipping_country'    => 'shipping_country',
-			),
-		);
+			);
+
+		if ( wc_shipping_enabled() ) {
+			$address_props['shipping'] = $shipping_props;
+		} else {
+			$address_props['shipping'] = array();
+
+			// If shipping is disabled, only update the fields that have set info or already exist.
+			foreach ( $shipping_props as $meta_key => $prop ) {
+				if ( $order->{"get_$prop"}( 'edit' ) || metadata_exists( 'post', $id, $meta_key ) ) {
+					$address_props['shipping'][ $meta_key ] = $prop;
+				}
+			}
+		}
 
 		foreach ( $address_props as $props_key => $props ) {
 			$props_to_update = $this->get_props_to_update( $order, $props );

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -215,10 +215,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'_billing_email'      => 'billing_email',
 				'_billing_phone'      => 'billing_phone',
 			),
-			'shipping' => array(),
-		);
-
-		$shipping_props = array(
+			'shipping' => array(
 				'_shipping_first_name' => 'shipping_first_name',
 				'_shipping_last_name'  => 'shipping_last_name',
 				'_shipping_company'    => 'shipping_company',
@@ -228,18 +225,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'_shipping_state'      => 'shipping_state',
 				'_shipping_postcode'   => 'shipping_postcode',
 				'_shipping_country'    => 'shipping_country',
-			);
-
-		if ( wc_shipping_enabled() ) {
-			$address_props['shipping'] = $shipping_props;
-		} else {
-			// If shipping is disabled, only update the fields that have set info or already exist.
-			foreach ( $shipping_props as $meta_key => $prop ) {
-				if ( $order->{"get_$prop"}( 'edit' ) || metadata_exists( 'post', $id, $meta_key ) ) {
-					$address_props['shipping'][ $meta_key ] = $prop;
-				}
-			}
-		}
+			),
+		);
 
 		foreach ( $address_props as $props_key => $props ) {
 			$props_to_update = $this->get_props_to_update( $order, $props );

--- a/tests/unit-tests/order/data-store.php
+++ b/tests/unit-tests/order/data-store.php
@@ -7,47 +7,39 @@
 class WC_Tests_Orders_Data_Store extends WC_Unit_Test_Case {
 
 	/**
-	 * Test: Saving creates shipping data if shipping enabled.
+	 * Test: New saved objects create shipping data.
 	 */
-	function test_shipping_saving_shipping_enabled() {
-		add_filter( 'wc_shipping_enabled', '__return_true' );
+	function test_shipping_meta_saving_new_data() {
 
+		// Should be able to create data on a fresh object.
 		$order = new WC_Order;
-		$order->save();
-
-		// Should create empty data if shipping is enabled.
-		$this->assertTrue( metadata_exists( 'post', $order->get_id(), '_shipping_first_name' ) );
-
 		$order->set_shipping_first_name( 'test' );
 		$order->save();
-
-		// Should be able to update data if shipping is enabled.
 		$this->assertEquals( 'test', get_post_meta( $order->get_id(), '_shipping_first_name', true ) );
+
+		// Default data doesn't get saved to the DB.
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_shipping_last_name' ) );
 	}
 
 	/**
-	 * Test: Saving doesn't always create shipping data if shipping disabled.
+	 * Test: Existing saved objects update properly.
 	 */
-	function test_shipping_saving_shipping_disabled() {
-		add_filter( 'wc_shipping_enabled', '__return_false' );
+	function test_shipping_meta_saving() {
 
+		// Should not create DB data if no title set.
 		$order = new WC_Order;
 		$order->save();
-
-		// Should not create empty data if shipping disabled.
 		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_shipping_first_name' ) );
 
+		// Should be able to update data.
 		$order->set_shipping_first_name( 'test' );
 		$order->save();
-
-		// Should save shipping data when manually set even if shipping disabled.
 		$this->assertEquals( 'test', get_post_meta( $order->get_id(), '_shipping_first_name', true ) );
-
 		$order->set_shipping_first_name( '' );
 		$order->save();
-
-		// Should save empty shipping data if shipping metadata already exists.
 		$this->assertEquals( '', get_post_meta( $order->get_id(), '_shipping_first_name', true ) );
-	}
 
+		// Default data doesn't get saved to the DB.
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_shipping_last_name' ) );
+	}
 }

--- a/tests/unit-tests/order/data-store.php
+++ b/tests/unit-tests/order/data-store.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Orders Data Store.
+ * @package WooCommerce\Tests\data-store
+ */
+class WC_Tests_Orders_Data_Store extends WC_Unit_Test_Case {
+
+	/**
+	 * Test: Saving creates shipping data if shipping enabled.
+	 */
+	function test_shipping_saving_shipping_enabled() {
+		add_filter( 'wc_shipping_enabled', '__return_true' );
+
+		$order = new WC_Order;
+		$order->save();
+
+		// Should create empty data if shipping is enabled.
+		$this->assertTrue( metadata_exists( 'post', $order->get_id(), '_shipping_first_name' ) );
+
+		$order->set_shipping_first_name( 'test' );
+		$order->save();
+
+		// Should be able to update data if shipping is enabled.
+		$this->assertEquals( 'test', get_post_meta( $order->get_id(), '_shipping_first_name', true ) );
+	}
+
+	/**
+	 * Test: Saving doesn't always create shipping data if shipping disabled.
+	 */
+	function test_shipping_saving_shipping_disabled() {
+		add_filter( 'wc_shipping_enabled', '__return_false' );
+
+		$order = new WC_Order;
+		$order->save();
+
+		// Should not create empty data if shipping disabled.
+		$this->assertFalse( metadata_exists( 'post', $order->get_id(), '_shipping_first_name' ) );
+
+		$order->set_shipping_first_name( 'test' );
+		$order->save();
+
+		// Should save shipping data when manually set even if shipping disabled.
+		$this->assertEquals( 'test', get_post_meta( $order->get_id(), '_shipping_first_name', true ) );
+
+		$order->set_shipping_first_name( '' );
+		$order->save();
+
+		// Should save empty shipping data if shipping metadata already exists.
+		$this->assertEquals( '', get_post_meta( $order->get_id(), '_shipping_first_name', true ) );
+	}
+
+}


### PR DESCRIPTION
Closes #13677.

```php
foreach ( $shipping_props as $meta_key => $prop ) {
    if ( $order->{"get_$prop"}( 'edit' ) || metadata_exists( 'post', $id, $meta_key ) ) {
        $address_props['shipping'][ $meta_key ] = $prop;
    }
}
```

I think something similar to this ^ could be a good thing to implement for general metadata saving, so we're only hitting the db when there is something meaningful to insert or something already there. Could be a good performance boost.