### PR TITLE
[3.0] Fix order item meta style in e-mails.

### DIFF
--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -96,7 +96,7 @@ $text_lighter_20 = wc_hex_lighter( $text, 20 );
 }
 
 #body_content td ul.wc-item-meta {
-	font-size: 0.875em;
+	font-size: small;
 	margin-left: 0;
 	padding-left: 0;
 	list-style: none;

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -10,7 +10,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
+ * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates/Emails
  * @version 2.3.0
@@ -93,6 +93,18 @@ $text_lighter_20 = wc_hex_lighter( $text, 20 );
 
 #body_content table td th {
 	padding: 12px;
+}
+
+#body_content td ul.wc-item-meta {
+	font-size: 0.875em;
+	margin-left: 0;
+	padding-left: 0;
+	list-style: none;
+}
+
+#body_content td ul.wc-item-meta li {
+	margin-left: 0;
+	padding-left: 0;
 }
 
 #body_content p {


### PR DESCRIPTION
In 3.0, the order item meta list in e-mails is generated using `wc_display_item_meta`. 
However, I noticed that no styles have been defined for the new list in the `email-styles.php` template.

Item meta lists in e-mails look like they could use some styling in 3.0 (at least in comparison to 2.6):

https://cl.ly/3A2f1M081G0k

This PR adds some basic styling to make them look consistent with FE order templates:

https://cl.ly/321H3a3n0M0c