### PR TITLE
Private and variable product fixes

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1581,6 +1581,17 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		return $this->is_downloadable() && $this->get_file( $download_id );
 	}
 
+	/**
+	 * Returns whether or not the product has additonal options that need
+	 * selecting before adding to cart.
+	 *
+	 * @since  3.0.0
+	 * @return boolean
+	 */
+	public function has_options() {
+		return false;
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Non-CRUD Getters

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -470,6 +470,17 @@ class WC_Product_Variable extends WC_Product {
 		return parent::has_weight() || $this->child_has_weight();
 	}
 
+	/**
+	 * Returns whether or not the product has additonal options that need
+	 * selecting before adding to cart.
+	 *
+	 * @since  3.0.0
+	 * @return boolean
+	 */
+	public function has_options() {
+		return true;
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Sync with child variations.

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1239,10 +1239,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$search_fields = array_map( 'wc_clean', apply_filters( 'woocommerce_product_search_fields', array(
 			'_sku',
 		) ) );
-		$like_term  = '%' . $wpdb->esc_like( $term ) . '%';
-		$post_types = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
-		$type_join  = '';
-		$type_where = '';
+		$like_term     = '%' . $wpdb->esc_like( $term ) . '%';
+		$post_types    = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
+		$post_statuses = current_user_can( 'edit_private_products' ) ? array( 'private', 'publish' ) : array( 'publish' );
+		$type_join     = '';
+		$type_where    = '';
 
 		if ( $type ) {
 			if ( in_array( $type, array( 'virtual', 'downloadable' ) ) ) {
@@ -1264,7 +1265,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					)
 				)
 				AND posts.post_type IN ('" . implode( "','", $post_types ) . "')
-				AND posts.post_status = 'publish'
+				AND posts.post_status IN ('" . implode( "','", $post_statuses ) . "')
 				$type_where
 				ORDER BY posts.post_parent ASC, posts.post_title ASC
 				",

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -30,14 +30,14 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				$quantites_required = false;
 
 				foreach ( $grouped_products as $grouped_product ) {
-					$post_object = get_post( $grouped_product->get_id() );
-					$quantites_required = $quantites_required || $grouped_product->is_purchasable();
+					$post_object        = get_post( $grouped_product->get_id() );
+					$quantites_required = $quantites_required || ( $grouped_product->is_purchasable() && ! $grouped_product->has_options() );
 
 					setup_postdata( $GLOBALS['post'] =& $post_object );
 					?>
 					<tr id="product-<?php the_ID(); ?>" <?php post_class(); ?>>
 						<td>
-							<?php if ( ! $grouped_product->is_purchasable() ) : ?>
+							<?php if ( ! $grouped_product->is_purchasable() || $grouped_product->has_options() ) : ?>
 								<?php woocommerce_template_loop_add_to_cart(); ?>
 
 							<?php elseif ( $grouped_product->is_sold_individually() ) : ?>


### PR DESCRIPTION
Variable products have options and thus should not be added to the cart directly with grouped products.

Fixes #13875 

If you can view private products, you should be able to search them.

Fixes #13877