### PR TITLE
[3.0] Fix unnecessary bottom margin in #13879

### DIFF
--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -97,14 +97,18 @@ $text_lighter_20 = wc_hex_lighter( $text, 20 );
 
 #body_content td ul.wc-item-meta {
 	font-size: small;
-	margin-left: 0;
-	padding-left: 0;
+	margin: 1em 0 0;
+	padding: 0;
 	list-style: none;
 }
 
 #body_content td ul.wc-item-meta li {
-	margin-left: 0;
-	padding-left: 0;
+	margin: 0.5em 0 0;
+	padding: 0;
+}
+
+#body_content td ul.wc-item-meta li p {
+	margin: 0;
 }
 
 #body_content p {


### PR DESCRIPTION
Thought it might be a good idea to be a little more strict, since most browsers will add a bottom margin to `ul` elements that was throwing the vertical alignment of cell content off-center.

See #13879