### PR TITLE
Use parent settings for determining if variations are sold individually.

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -280,6 +280,9 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			'shipping_class_id' => absint( current( $this->get_term_ids( $product->get_parent_id(), 'product_shipping_class' ) ) ),
 			'image_id'          => get_post_thumbnail_id( $product->get_parent_id() ),
 		) );
+
+		// Use the parent sold_individually settings since variations don't have a user-facing way to set sold_individually.
+		$product->set_sold_individually( get_post_meta( $product->get_parent_id(), '_sold_individually', true ) );
 	}
 
 	/**

--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -21,7 +21,9 @@ global $product;
 		do_action( 'woocommerce_before_add_to_cart_quantity' );
 
 		woocommerce_quantity_input( array(
-			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : 1,
+			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : $product->get_min_purchase_quantity(),
 		) );
 
 		/**

--- a/tests/unit-tests/product/product-variation.php
+++ b/tests/unit-tests/product/product-variation.php
@@ -16,26 +16,13 @@ class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
 		// Create a variable product with sold individually.
 		$product = new WC_Product_Variable;
 		$product->set_sold_individually( true );
-
-		$attribute = new WC_Product_Attribute();
-		$attribute->set_id( 0 );
-		$attribute->set_name( 'color' );
-		$attribute->set_options( explode( WC_DELIMITER, 'green | red' ) );
-		$attribute->set_visible( true );
-		$attribute->set_variation( true );
-
-		$product->set_attributes( array( $attribute ) );
 		$product->save();
 
-		// Create a new variation with the color 'green'.
 		$variation = new WC_Product_Variation;
 		$variation->set_parent_id( $product->get_id() );
-		$variation->set_attributes( array( 'color' => 'green' ) );
-		$variation->set_status( 'private' );
 		$variation->save();
 
 		$variation = wc_get_product( $variation->get_id() );
 		$this->assertTrue( $variation->is_sold_individually() );
 	}
-
 }

--- a/tests/unit-tests/product/product-variation.php
+++ b/tests/unit-tests/product/product-variation.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Class Product_Variation.
+ * @package WooCommerce\Tests\Product
+ * @since 3.0
+ */
+class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
+
+	/**
+	 * Test is_sold_individually().
+	 *
+	 * @since 2.3
+	 */
+	public function test_is_sold_individually() {
+		// Create a variable product with sold individually.
+		$product = new WC_Product_Variable;
+		$product->set_sold_individually( true );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( 'color' );
+		$attribute->set_options( explode( WC_DELIMITER, 'green | red' ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+
+		$product->set_attributes( array( $attribute ) );
+		$product->save();
+
+		// Create a new variation with the color 'green'.
+		$variation = new WC_Product_Variation;
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_attributes( array( 'color' => 'green' ) );
+		$variation->set_status( 'private' );
+		$variation->save();
+
+		$variation = wc_get_product( $variation->get_id() );
+		$this->assertTrue( $variation->is_sold_individually() );
+	}
+
+}


### PR DESCRIPTION
Fixes #13933.

The "Sold individually" checkbox saves to the parent product, and nothing passes that information along to variations. This change makes variations use the parent's "Sold individually" settings when read.