### PR TITLE
Fixed "singular" and "plural" parameters of WP_List_Table instances

### DIFF
--- a/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -23,8 +23,8 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 	 */
 	public function __construct() {
 		parent::__construct( array(
-			'singular' => __( 'key', 'woocommerce' ),
-			'plural'   => __( 'keys', 'woocommerce' ),
+			'singular' => 'key',
+			'plural'   => 'keys',
 			'ajax'     => false,
 		) );
 	}

--- a/includes/admin/class-wc-admin-log-table-list.php
+++ b/includes/admin/class-wc-admin-log-table-list.php
@@ -23,8 +23,8 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	 */
 	public function __construct() {
 		parent::__construct( array(
-			'singular' => __( 'log',  'woocommerce' ),
-			'plural'   => __( 'logs', 'woocommerce' ),
+			'singular' => 'log',
+			'plural'   => 'logs',
 			'ajax'     => false,
 		) );
 	}

--- a/includes/admin/class-wc-admin-webhooks-table-list.php
+++ b/includes/admin/class-wc-admin-webhooks-table-list.php
@@ -23,8 +23,8 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 	 */
 	public function __construct() {
 		parent::__construct( array(
-			'singular' => __( 'webhook', 'woocommerce' ),
-			'plural'   => __( 'webhooks', 'woocommerce' ),
+			'singular' => 'webhook',
+			'plural'   => 'webhooks',
 			'ajax'     => false,
 		) );
 	}

--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -24,8 +24,8 @@ class WC_Report_Customer_List extends WP_List_Table {
 	public function __construct() {
 
 		parent::__construct( array(
-			'singular'  => __( 'Customer', 'woocommerce' ),
-			'plural'    => __( 'Customers', 'woocommerce' ),
+			'singular'  => 'customer',
+			'plural'    => 'customers',
 			'ajax'      => false,
 		) );
 	}

--- a/includes/admin/reports/class-wc-report-stock.php
+++ b/includes/admin/reports/class-wc-report-stock.php
@@ -31,8 +31,8 @@ class WC_Report_Stock extends WP_List_Table {
 	public function __construct() {
 
 		parent::__construct( array(
-			'singular'  => __( 'Stock', 'woocommerce' ),
-			'plural'    => __( 'Stock', 'woocommerce' ),
+			'singular'  => 'stock',
+			'plural'    => 'stock',
 			'ajax'      => false,
 		) );
 	}


### PR DESCRIPTION
Both should be slugs and not translatable.

Not even in WordPress core this strings are translatable:

- https://github.com/WordPress/WordPress/blob/b84023ea338b01a5c688b0739574820f9ea12ae2/wp-admin/includes/class-wp-terms-list-table.php#L43-L44
- https://github.com/WordPress/WordPress/blob/e4d7dd2b8a359807f73e460cdb1415e40cd8b029/wp-admin/includes/class-wp-ms-themes-list-table.php#L42
- https://github.com/WordPress/WordPress/blob/6a2b38ca6c066be5885f9e3913a29c7ffbac4b75/wp-admin/includes/class-wp-ms-sites-list-table.php#L48

Note the description of the parameters in https://developer.wordpress.org/reference/classes/wp_list_table/

```
     *     @type string $plural   Plural value used for labels and the objects being listed.
     *                            This affects things such as CSS class-names and nonces used
     *                            in the list table, e.g. 'posts'. Default empty.
     *     @type string $singular Singular label for an object being listed, e.g. 'post'.
     *                            Default empty
```

Fixes #13954
