### PR TITLE
Fix saving meta when using `save_post`.

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -113,6 +113,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @param WC_Order $order
 	 */
 	public function update( &$order ) {
+		$order->save_meta_data();
 		$order->set_version( WC_VERSION );
 
 		$changes = $order->get_changes();
@@ -129,9 +130,9 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),
 				'post_modified_gmt' => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getTimestamp() ) : current_time( 'mysql', 1 ),
 			) );
+			$order->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
 		}
 		$this->update_post_meta( $order );
-		$order->save_meta_data();
 		$order->apply_changes();
 		$this->clear_caches( $order );
 	}

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -127,14 +127,16 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * @param WC_Coupon
 	 */
 	public function update( &$coupon ) {
+		$coupon->save_meta_data();
 		$post_data = array(
 			'ID'           => $coupon->get_id(),
 			'post_title'   => $coupon->get_code(),
 			'post_excerpt' => $coupon->get_description(),
 		);
 		wp_update_post( $post_data );
+		$coupon->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
+
 		$this->update_post_meta( $coupon );
-		$coupon->save_meta_data();
 		$coupon->apply_changes();
 		do_action( 'woocommerce_update_coupon', $coupon->get_id() );
 	}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -162,6 +162,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @param WC_Product
 	 */
 	public function update( &$product ) {
+		$product->save_meta_data();
 		$changes = $product->get_changes();
 
 		// Only update the post when the post data changes.
@@ -189,6 +190,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				$post_data['post_modified_gmt'] = current_time( 'mysql', 1 );
 			}
 			wp_update_post( $post_data );
+			$product->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
 		}
 
 		$this->update_post_meta( $product );
@@ -198,7 +200,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$this->update_version_and_type( $product );
 		$this->handle_updated_props( $product );
 
-		$product->save_meta_data();
 		$product->apply_changes();
 
 		$this->clear_caches( $product );

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -136,6 +136,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 * @param WC_Product
 	 */
 	public function update( &$product ) {
+		$product->save_meta_data();
 		$changes = $product->get_changes();
 		$title   = $this->generate_product_title( $product );
 
@@ -153,6 +154,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $product->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),
 				'post_modified_gmt' => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $product->get_date_modified( 'edit' )->getTimestamp() ) : current_time( 'mysql', 1 ),
 			) );
+			$product->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
 		}
 
 		$this->update_post_meta( $product );
@@ -160,7 +162,6 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$this->update_attributes( $product );
 		$this->handle_updated_props( $product );
 
-		$product->save_meta_data();
 		$product->apply_changes();
 
 		$this->update_version_and_type( $product );

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -326,4 +326,12 @@ class WC_Helper_Product {
 
 		return wp_insert_comment( $data );
 	}
+
+	/**
+	 * A helper function for hooking into save_post during the test_product_meta_save_post test.
+	 * @since 3.0.1
+	 */
+	public static function save_post_test_update_meta_data_direct( $id ) {
+		update_post_meta( $id, '_test2', 'world' );
+	}
 }

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -460,7 +460,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Test to make sure meta can still be set while hooked using save_post.
 	 * https://github.com/woocommerce/woocommerce/issues/13960
-	 * @since 3.0.01
+	 * @since 3.0.1
 	 */
 	function test_product_meta_save_post() {
 		$product = new WC_Product;


### PR DESCRIPTION
Fixes #13960. Here is the general flow of the bug:

* `WC_Meta_Box_Product_Data::save()` calls `woocommerce_admin_process_product_object` and passes the `$product` object in.
* NYP (or another plugin) hooks to `woocommerce_admin_process_product_object` and sets some meta with `$product->update_meta_data()`. 
* `WC_Meta_Box_Product_Data::save()`  calls `$product->save()`. Our meta is currently unsaved in the database at this time, but is present on the `$product` object.  
* Down the chain from `$product->save()` is the product data store `update` method, which calls  `wp_update_post` and runs certain hooks like `save_post`.
* Subscriptions (or another plugin) hooks in `save_post` and does direct `update_post_meta` calls.
* Back in the product data store, after `wp_update_post`, we run CRUD `update_post_meta` and `save_post_meta`. The data store and CRUD object don't know about the direct meta changes and `save_meta_data` wipe out the changes thinking the value Is still the old value (`save_meta_data` loops through an array of meta and calls `data_store->update_meta` -- so the old value is getting set here).

Tl;dr Order of operations + a mix of CRUD and direct meta updates causes issues.

--

To fix, I've moved `save_meta_data` earlier in the update routine and then re pull the meta cache after `save_post` gets called. I've done this for the data stores that use those internal WP functions.

Our meta handling could probably be made smarter -- but I think that requires a bit more thought, especially when direct calls can still be made.

--

To Test:

* Make sure `phpunit` tests all pass.
* Install Name Your Price and Subscriptions. Activate both.
* On a subscriptions product, try to updating a value like subscription trial length and the NYP price fields. Make sure both save (without this branch, only NYP will save).
* Spot check updating coupons, products, and an order detail since there are some similar changes there as well.