### PR TITLE
Output error when exception thrown in wc_get_product

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1779,7 +1779,7 @@ class WC_Admin_Post_Types {
 	public function product_data_visibility() {
 		global $post, $thepostid, $product_object;
 
-		if ( 'product' !== $post->post_type ) {
+		if ( 'product' !== $post->post_type || ! $product_object ) {
 			return;
 		}
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -30,6 +30,10 @@ class WC_Meta_Box_Product_Data {
 		$thepostid      = $post->ID;
 		$product_object = $thepostid ? wc_get_product( $thepostid ) : new WC_Product;
 
+		if ( ! $product_object ) {
+			return;
+		}
+
 		include( 'views/html-product-data-panel.php' );
 	}
 

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -45,7 +45,9 @@ class WC_Product_Factory {
 		try {
 			return new $classname( $product_id, $deprecated );
 		} catch ( Exception $e ) {
-			trigger_error( $e->getMessage(), E_USER_NOTICE );
+			if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+				trigger_error( $e->getMessage(), E_USER_NOTICE );
+			}
 			return false;
 		}
 	}

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -45,6 +45,7 @@ class WC_Product_Factory {
 		try {
 			return new $classname( $product_id, $deprecated );
 		} catch ( Exception $e ) {
+			trigger_error( $e->getMessage(), E_USER_NOTICE );
 			return false;
 		}
 	}

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -180,6 +180,10 @@ class WC_Structured_Data {
 			global $product;
 		}
 
+		if ( ! $product ) {
+			return;
+		}
+
 		$shop_name       = get_bloginfo( 'name' );
 		$shop_url        = home_url();
 		$currency        = get_woocommerce_currency();

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -180,7 +180,7 @@ class WC_Structured_Data {
 			global $product;
 		}
 
-		if ( ! $product ) {
+		if ( ! is_a( $product, 'WC_Product' ) ) {
 			return;
 		}
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -95,7 +95,7 @@ function wc_get_products( $args ) {
  *
  * @param mixed $the_product Post object or post ID of the product.
  * @param array $deprecated Previously used to pass arguments to the factory, e.g. to force a type.
- * @return WC_Product|null
+ * @return WC_Product|false
  */
 function wc_get_product( $the_product = false, $deprecated = array() ) {
 	if ( ! did_action( 'woocommerce_init' ) ) {
@@ -106,10 +106,7 @@ function wc_get_product( $the_product = false, $deprecated = array() ) {
 		wc_deprecated_argument( 'args', '3.0', 'Passing args to wc_get_product is deprecated. If you need to force a type, construct the product class directly.' );
 	}
 
-	$product = WC()->product_factory->get_product( $the_product, $deprecated );
-
-	// Return null on failure for strict backwards compatibility.
-	return $product ? $product : null;
+	return WC()->product_factory->get_product( $the_product, $deprecated );
 }
 
 /**

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -105,7 +105,11 @@ function wc_get_product( $the_product = false, $deprecated = array() ) {
 	if ( ! empty( $deprecated ) ) {
 		wc_deprecated_argument( 'args', '3.0', 'Passing args to wc_get_product is deprecated. If you need to force a type, construct the product class directly.' );
 	}
-	return WC()->product_factory->get_product( $the_product, $deprecated );
+
+	$product = WC()->product_factory->get_product( $the_product, $deprecated );
+
+	// Return null on failure for strict backwards compatibility.
+	return $product ? $product : null;
 }
 
 /**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -836,6 +836,11 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_show_product_images() {
+		global $product;
+		if ( ! $product ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/product-image.php' );
 	}
 }
@@ -880,6 +885,11 @@ if ( ! function_exists( 'woocommerce_template_single_rating' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_template_single_rating() {
+		global $product;
+		if ( ! $product ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/rating.php' );
 	}
 }
@@ -891,6 +901,11 @@ if ( ! function_exists( 'woocommerce_template_single_price' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_template_single_price() {
+		global $product;
+		if ( ! $product ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/price.php' );
 	}
 }
@@ -913,6 +928,11 @@ if ( ! function_exists( 'woocommerce_template_single_meta' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_template_single_meta() {
+		global $product;
+		if ( ! $product ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/meta.php' );
 	}
 }
@@ -935,6 +955,11 @@ if ( ! function_exists( 'woocommerce_show_product_sale_flash' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_show_product_sale_flash() {
+		global $product;
+		if ( ! $product ) {
+			return;
+		}
+
 		wc_get_template( 'single-product/sale-flash.php' );
 	}
 }
@@ -948,6 +973,10 @@ if ( ! function_exists( 'woocommerce_template_single_add_to_cart' ) ) {
 	 */
 	function woocommerce_template_single_add_to_cart() {
 		global $product;
+		if ( ! $product ) {
+			return;
+		}
+
 		do_action( 'woocommerce_' . $product->get_type() . '_add_to_cart' );
 	}
 }
@@ -971,6 +1000,9 @@ if ( ! function_exists( 'woocommerce_grouped_add_to_cart' ) ) {
 	 */
 	function woocommerce_grouped_add_to_cart() {
 		global $product;
+		if ( ! $product ) {
+			return;
+		}
 
 		wc_get_template( 'single-product/add-to-cart/grouped.php', array(
 			'grouped_product'    => $product,
@@ -988,6 +1020,9 @@ if ( ! function_exists( 'woocommerce_variable_add_to_cart' ) ) {
 	 */
 	function woocommerce_variable_add_to_cart() {
 		global $product;
+		if ( ! $product ) {
+			return;
+		}
 
 		// Enqueue variation scripts
 		wp_enqueue_script( 'wc-add-to-cart-variation' );
@@ -1012,8 +1047,7 @@ if ( ! function_exists( 'woocommerce_external_add_to_cart' ) ) {
 	 */
 	function woocommerce_external_add_to_cart() {
 		global $product;
-
-		if ( ! $product->add_to_cart_url() ) {
+		if ( ! $product || ! $product->add_to_cart_url() ) {
 			return;
 		}
 
@@ -1135,7 +1169,7 @@ if ( ! function_exists( 'woocommerce_default_product_tabs' ) ) {
 		}
 
 		// Reviews tab - shows comments
-		if ( comments_open() ) {
+		if ( $product && comments_open() ) {
 			$tabs['reviews'] = array(
 				'title'    => sprintf( __( 'Reviews (%d)', 'woocommerce' ), $product->get_review_count() ),
 				'priority' => 30,
@@ -1319,6 +1353,10 @@ if ( ! function_exists( 'woocommerce_upsell_display' ) ) {
 		$woocommerce_loop['columns'] = apply_filters( 'woocommerce_upsells_columns', isset( $args['columns'] ) ? $args['columns'] : $columns );
 		$orderby                     = apply_filters( 'woocommerce_upsells_orderby', isset( $args['orderby'] ) ? $args['orderby'] : $orderby );
 		$limit                       = apply_filters( 'woocommerce_upsells_total', isset( $args['posts_per_page'] ) ? $args['posts_per_page'] : $limit );
+
+		if ( ! $product ) {
+			return;
+		}
 
 		// Get visble upsells then sort them at random, then limit result set.
 		$upsells = wc_products_array_orderby( array_filter( array_map( 'wc_get_product', $product->get_upsell_ids() ), 'wc_products_array_filter_visible' ), $orderby, $order );
@@ -2480,6 +2518,10 @@ if ( ! function_exists( 'woocommerce_photoswipe' ) ) {
  * @param  WC_Product $product
  */
 function wc_display_product_attributes( $product ) {
+	if ( ! $product ) {
+		return;
+	}
+
 	wc_get_template( 'single-product/product-attributes.php', array(
 		'product'            => $product,
 		'attributes'         => array_filter( $product->get_attributes(), 'wc_attributes_array_filter_visible' ),
@@ -2494,6 +2536,9 @@ function wc_display_product_attributes( $product ) {
  * @return string
  */
 function wc_get_stock_html( $product ) {
+	if ( ! $product ) {
+		return;
+	}
 
 	$html = '';
 	$availability = $product->get_availability();

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -836,8 +836,7 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_show_product_images() {
-		global $product;
-		if ( ! $product ) {
+		if ( ! $GLOBALS['product'] ) {
 			return;
 		}
 
@@ -885,8 +884,7 @@ if ( ! function_exists( 'woocommerce_template_single_rating' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_template_single_rating() {
-		global $product;
-		if ( ! $product ) {
+		if ( ! $GLOBALS['product'] ) {
 			return;
 		}
 
@@ -901,8 +899,7 @@ if ( ! function_exists( 'woocommerce_template_single_price' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_template_single_price() {
-		global $product;
-		if ( ! $product ) {
+		if ( ! $GLOBALS['product'] ) {
 			return;
 		}
 
@@ -928,8 +925,7 @@ if ( ! function_exists( 'woocommerce_template_single_meta' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_template_single_meta() {
-		global $product;
-		if ( ! $product ) {
+		if ( ! $GLOBALS['product'] ) {
 			return;
 		}
 
@@ -955,8 +951,7 @@ if ( ! function_exists( 'woocommerce_show_product_sale_flash' ) ) {
 	 * @subpackage	Product
 	 */
 	function woocommerce_show_product_sale_flash() {
-		global $product;
-		if ( ! $product ) {
+		if ( ! $GLOBALS['product'] ) {
 			return;
 		}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2537,7 +2537,7 @@ function wc_display_product_attributes( $product ) {
  */
 function wc_get_stock_html( $product ) {
 	if ( ! $product ) {
-		return;
+		return '';
 	}
 
 	$html = '';

--- a/tests/framework/class-wc-rest-unit-test-case.php
+++ b/tests/framework/class-wc-rest-unit-test-case.php
@@ -16,6 +16,9 @@
      */
     public function setUp() {
         parent::setUp();
+        if ( ! defined( 'REST_REQUEST' ) ) {
+        	define( 'REST_REQUEST', true );
+        }
         global $wp_rest_server;
         $this->server = $wp_rest_server = new WP_Test_Spy_REST_Server;
         do_action( 'rest_api_init' );


### PR DESCRIPTION
Fixes #13946.

**Don't merge this yet.** I have to fix the unit tests if everything looks good. I wanted to get feedback about the problem and solutions first.

The underlying problem is this:
- If an exception is thrown during `wc_get_product`, it will silently fail and return null.
- If `wc_get_product` returns `null` during `wc_setup_product_data`, `global $product` is `null` and the templates will fail hard.
- Developers will have no info to troubleshoot the problem since `global $product` gets set to `null` silently. The first error they see is going to be something like `Fatal error: Uncaught Error: Call to a member function is_on_sale() on null`.

My solution is to add a notice-level error message when an exception is caught during `WC()->product_factory->get_product`. It's not really possible to keep everything from breaking if the current product is no good, but at least now it can be debugged.