### PR TITLE
Introduced the woocommerce_allow_structured_data_in_emails filter

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -132,7 +132,10 @@ class WC_Structured_Data {
 		if ( $plain_text ) {
 			return;
 		}
-		$this->output_structured_data();
+
+		if ( apply_filters( 'woocommerce_allow_structured_data_in_emails', false ) ) {
+			$this->output_structured_data();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Disable structured data by default in emails since not email gateway/scanner/server allows send scripts in the email body.

For those how wants to enable just need to use:

```php
add_filter( 'woocommerce_allow_structured_data_in_emails', '__return_true` );
```

Closes #13930