### PR TITLE
Avoid deprecated warning when creating an order in unit tests

### DIFF
--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -57,12 +57,15 @@ class WC_Helper_Order {
 		$order 					= wc_create_order( $order_data );
 
 		// Add order products
-		$item_1 = new WC_Order_Item_Product();
-		$item_1->set_props( array(
+		$item = new WC_Order_Item_Product();
+		$item->set_props( array(
 			'product'  => $product,
 			'quantity' => 4,
+			'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 4 ) ),
+			'total' => wc_get_price_excluding_tax( $product, array( 'qty' => 4 ) ),
 		) );
-		$order->add_item( $item_1 );
+		$item->save();
+		$order->add_item( $item );
 
 		// Set billing address
 		$order->set_billing_first_name( 'Jeroen' );

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -57,7 +57,12 @@ class WC_Helper_Order {
 		$order 					= wc_create_order( $order_data );
 
 		// Add order products
-		$order->add_product( $product, 4 );
+		$item_1 = new WC_Order_Item_Product();
+		$item_1->set_props( array(
+			'product'  => $product,
+			'quantity' => 4,
+		) );
+		$order->add_item( $item_1 );
 
 		// Set billing address
 		$order->set_billing_first_name( 'Jeroen' );


### PR DESCRIPTION
Changes WC_Helper_Order::create_order() to use the WC 3.0+ add line item method instead of a deprecated method that was used in WC 2.6.x and earlier.

Avoids these unit tests warnings/errors:

`Unexpected deprecated notice for Action: woocommerce_order_add_product`