### PR TITLE
Set session data only if the value is empty in customer object. Prevents session data overwriting customer data on login.

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -95,7 +95,10 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 					$session_key = str_replace( 'billing_', '', $session_key );
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
-					$customer->{"set_{$function_key}"}( $data[ $session_key ] );
+					// Only set from session if data is already missing.
+					if ( ! $customer->{"get_{$function_key}"}() ) {
+						$customer->{"set_{$function_key}"}( $data[ $session_key ] );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #13906