### PR TITLE
Background Emailer instead of just CRON

### DIFF
--- a/includes/class-wc-background-emailer.php
+++ b/includes/class-wc-background-emailer.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Background Emailer
+ *
+ * Uses https://github.com/A5hleyRich/wp-background-processing to handle emails
+ * in the background.
+ *
+ * @class    WC_Background_Emailer
+ * @version  3.0.0
+ * @package  WooCommerce/Classes
+ * @category Class
+ * @author   WooThemes
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WP_Async_Request', false ) ) {
+	include_once( dirname( __FILE__ ) . '/libraries/wp-async-request.php' );
+}
+
+if ( ! class_exists( 'WP_Background_Process', false ) ) {
+	include_once( dirname( __FILE__ ) . '/libraries/wp-background-process.php' );
+}
+
+/**
+ * WC_Background_Emailer Class.
+ */
+class WC_Background_Emailer extends WP_Background_Process {
+
+	/**
+	 * @var string
+	 */
+	protected $action = 'wc_emailer';
+
+	/**
+	 * Initiate new background process
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'shutdown', array( $this, 'dispatch_queue' ) );
+	}
+
+	/**
+	 * Schedule fallback event.
+	 */
+	protected function schedule_event() {
+		if ( ! wp_next_scheduled( $this->cron_hook_identifier ) ) {
+			wp_schedule_event( time() + 10, $this->cron_interval_identifier, $this->cron_hook_identifier );
+		}
+	}
+
+	/**
+	 * Task
+	 *
+	 * Override this method to perform any actions required on each
+	 * queue item. Return the modified item for further processing
+	 * in the next pass through. Or, return false to remove the
+	 * item from the queue.
+	 *
+	 * @param string $callback Update callback function
+	 * @return mixed
+	 */
+	protected function task( $callback ) {
+		if ( isset( $callback['filter'], $callback['args'] ) ) {
+			WC_Emails::send_queued_transactional_email( $callback['filter'], $callback['args'] );
+		}
+		return false;
+	}
+
+	/**
+	 * Save and run queue.
+	 */
+	public function dispatch_queue() {
+		if ( ! empty( $this->data ) ) {
+			$this->save()->dispatch();
+		}
+	}
+}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -181,7 +181,6 @@ final class WooCommerce {
 		add_action( 'init', array( $this, 'init' ), 0 );
 		add_action( 'init', array( 'WC_Shortcodes', 'init' ) );
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
-		add_action( 'woocommerce_send_queued_transactional_email', array( 'WC_Emails', 'send_queued_transactional_email' ), 10, 2 );
 		add_action( 'init', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 	}
@@ -319,6 +318,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-https.php' ); // https Helper
 		include_once( WC_ABSPATH . 'includes/class-wc-deprecated-action-hooks.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-deprecated-filter-hooks.php' );
+		include_once( WC_ABSPATH . 'includes/class-wc-background-emailer.php' );
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.


### PR DESCRIPTION
This is a larger PR and may not be suitable for a fix release, but that needs deciding. If we don’t ship a fix, we need to just allow cron sending to be disabled, or revert it.

This PR:

- Adds a woocommerce_defer_transactional_emails filter to switch off defered emails (should do this for 3.0.1)
- Uses the existing background processing class for a WC_Background_Emailer
- Rather than schedule a cron event, emails get pushed to the queue. They are then sent async, or fall back to cron based handling. This works like our updater.

Closes #13963 - these should not run multiple times.