### PR TITLE
Added context to string in result-count.php to make GlotPress catch

### DIFF
--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -15,7 +15,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     2.0.0
+ * @version     3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -40,7 +40,7 @@ if ( ! woocommerce_products_will_display() )
 		printf( _n( 'Showing the single result', 'Showing all %d results', $total, 'woocommerce' ), $total );
 	} else {
 		/* translators: 1: first result 2: last result 3: total results */
-		printf( _n( 'Showing the single result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, 'woocommerce' ), $first, $last, $total );
+		printf( _nx( 'Showing the single result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, 'with first and last result', 'woocommerce' ), $first, $last, $total );
 	}
 	?>
 </p>


### PR DESCRIPTION
Missing this string on GlotPress, since the first part is equal from the previous translatable string.

Reported by @f4w-pwharton in https://github.com/woocommerce/woocommerce/commit/4375618438b86f9d49629d8d79a9537af83de6b3#commitcomment-21633879