### PR TITLE
Fix variation description formatting in frontend and REST API v2

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -158,7 +158,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 			'date_created_gmt'      => wc_rest_prepare_date_response( $object->get_date_created() ),
 			'date_modified'         => wc_rest_prepare_date_response( $object->get_date_modified(), false ),
 			'date_modified_gmt'     => wc_rest_prepare_date_response( $object->get_date_modified() ),
-			'description'           => $object->get_description(),
+			'description'           => wc_format_content( $object->get_description() ),
 			'permalink'             => $object->get_permalink(),
 			'sku'                   => $object->get_sku(),
 			'price'                 => $object->get_price(),

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -294,7 +294,7 @@ class WC_Product_Variable extends WC_Product {
 			'is_downloadable'       => $variation->is_downloadable(),
 			'is_virtual'            => $variation->is_virtual(),
 			'is_sold_individually'  => $variation->is_sold_individually() ? 'yes' : 'no',
-			'variation_description' => $variation->get_description(),
+			'variation_description' => wc_format_content( $variation->get_description() ),
 		) ), $this, $variation );
 	}
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -847,7 +847,7 @@ function wc_trim_string( $string, $chars = 200, $suffix = '...' ) {
  * @return string
  */
 function wc_format_content( $raw_string ) {
-	return apply_filters( 'woocommerce_format_content', do_shortcode( shortcode_unautop( wpautop( $raw_string ) ) ), $raw_string );
+	return apply_filters( 'woocommerce_format_content', wpautop( do_shortcode( wp_kses_post( $raw_string ) ) ), $raw_string );
 }
 
 /**

--- a/templates/single-product/add-to-cart/variation.php
+++ b/templates/single-product/add-to-cart/variation.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <script type="text/template" id="tmpl-variation-template">
 	<div class="woocommerce-variation-description">
-		{{{ data.variation.description }}}
+		{{{ data.variation.variation_description }}}
 	</div>
 
 	<div class="woocommerce-variation-price">


### PR DESCRIPTION
Fixes #13949 

And fix a backwards compatibility in `templates/single-product/add-to-cart/variation.php ` since the template version has not been updated.