### PR TITLE
Removed extra variation description extra sanitization

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -384,7 +384,7 @@ class WC_Meta_Box_Product_Data {
 					'downloadable'      => isset( $_POST['variable_is_downloadable'][ $i ] ),
 					'date_on_sale_from' => wc_clean( $_POST['variable_sale_price_dates_from'][ $i ] ),
 					'date_on_sale_to'   => wc_clean( $_POST['variable_sale_price_dates_to'][ $i ] ),
-					'description'       => wp_kses_post( wc_sanitize_textarea( $_POST['variable_description'][ $i ] ) ),
+					'description'       => wp_kses_post( $_POST['variable_description'][ $i ] ),
 					'download_limit'    => wc_clean( $_POST['variable_download_limit'][ $i ] ),
 					'download_expiry'   => wc_clean( $_POST['variable_download_expiry'][ $i ] ),
 					'downloads'         => self::prepare_downloads(


### PR DESCRIPTION
`wp_kses_post()` should be enough and it's the same we did until 2.6.14, not to mention that if are applying `wc_clean()` to all lines we should not need `wp_kses_post()` anymore.

![screenshot from 2017-04-06 13-23-30](https://cloud.githubusercontent.com/assets/1264099/24764900/3e6b35ba-1acc-11e7-8fb8-7f146b8e9f8d.png)

cc @DanielSantoro 