### PR TITLE
Dont throw exceptions when reading in saved bad downloads

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1155,13 +1155,17 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 
 			// Validate the file extension
 			if ( ! $download_object->is_allowed_filetype() ) {
-				$errors[] = sprintf( __( 'The downloadable file %1$s cannot be used as it does not have an allowed file type. Allowed types include: %2$s', 'woocommerce' ), '<code>' . basename( $download_object->get_file() ) . '</code>', '<code>' . implode( ', ', array_keys( $download_object->get_allowed_mime_types() ) ) . '</code>' );
+				if ( $this->get_object_read() ) {
+					$errors[] = sprintf( __( 'The downloadable file %1$s cannot be used as it does not have an allowed file type. Allowed types include: %2$s', 'woocommerce' ), '<code>' . basename( $download_object->get_file() ) . '</code>', '<code>' . implode( ', ', array_keys( $download_object->get_allowed_mime_types() ) ) . '</code>' );
+				}
 				continue;
 			}
 
 			// Validate the file exists.
 			if ( ! $download_object->file_exists() ) {
-				$errors[] = sprintf( __( 'The downloadable file %s cannot be used as it does not exist on the server.', 'woocommerce' ), '<code>' . $download_object->get_file() . '</code>' );
+				if ( $this->get_object_read() ) {
+					$errors[] = sprintf( __( 'The downloadable file %s cannot be used as it does not exist on the server.', 'woocommerce' ), '<code>' . $download_object->get_file() . '</code>' );
+				}
 				continue;
 			}
 


### PR DESCRIPTION
Fixes #13946.

This way all of the other data still gets read and the product won't break on a bad download.

To test, add the following code somewhere:
```
add_filter( 'woocommerce_downloadable_file_allowed_mime_types', function( $types ) {
	$types['exe'] = 'application/exe';
	return $types;
});
```
Set a download with an `.exe` extension on a product, then remove the code snippet from your codebase.