### PR TITLE
Array filter before saving

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -189,7 +189,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		// Add/save items.
 		foreach ( $this->items as $item_group => $items ) {
 			if ( is_array( $items ) ) {
-				foreach ( $items as $item_key => $item ) {
+				foreach ( array_filter( $items ) as $item_key => $item ) {
 					$item->set_order_id( $this->get_id() );
 					$item_id = $item->save();
 


### PR DESCRIPTION
Fixes new issue at https://wordpress.org/support/topic/call-to-a-member-function-is_type-class-wc-order-php-on-line-1305/