### PR TITLE
Updates product title in product loop commenting

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -577,7 +577,7 @@ if ( ! function_exists( 'woocommerce_product_loop_end' ) ) {
 if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 
 	/**
-	 * Show the product title in the product loop. By default this is an H3.
+	 * Show the product title in the product loop. By default this is an H2.
 	 */
 	function woocommerce_template_loop_product_title() {
 		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>';


### PR DESCRIPTION
Commenting in `includes/wc-template-functions.php` indicated the product title in the product loop was enclosed in an `<h3>`, when the code was actually printing an `<h2>`.

cc @mattyza 