### PR TITLE
Adds small fix to sale problems

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1410,7 +1410,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return bool
 	 */
 	public function is_on_sale( $context = 'view' ) {
-		if ( '' !== (string) $this->get_sale_price( $context ) && $this->get_regular_price( $context ) > $this->get_sale_price( $context ) ) {
+		if ( '' !== (string) $this->get_sale_price( $context ) && '0' !== (string) $this->get_sale_price( $context )  && $this->get_regular_price( $context ) > $this->get_sale_price( $context ) ) {
 			$on_sale = true;
 
 			if ( $this->get_date_on_sale_from( $context ) && $this->get_date_on_sale_from( $context )->getTimestamp() > time() ) {


### PR DESCRIPTION
Sometimes when importing and/or creating products is_on_sale() returns true even when there is no sale price. Adding a check for if the string is 0 fixes this problem.