### PR TITLE
Fix shortcodes formatted with <p> and improved wc_format_content()

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -51,6 +51,7 @@ add_filter( 'woocommerce_short_description', 'wpautop' );
 add_filter( 'woocommerce_short_description', 'shortcode_unautop' );
 add_filter( 'woocommerce_short_description', 'prepend_attachment' );
 add_filter( 'woocommerce_short_description', 'do_shortcode', 11 ); // AFTER wpautop()
+add_filter( 'woocommerce_short_description', 'wc_format_product_short_description', 9999999 );
 
 /**
  * Define a constant if it is not already defined.

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -847,7 +847,7 @@ function wc_trim_string( $string, $chars = 200, $suffix = '...' ) {
  * @return string
  */
 function wc_format_content( $raw_string ) {
-	return apply_filters( 'woocommerce_format_content', wpautop( do_shortcode( wp_kses_post( $raw_string ) ) ), $raw_string );
+	return apply_filters( 'woocommerce_format_content', apply_filters( 'woocommerce_short_description', $raw_string ), $raw_string );
 }
 
 /**
@@ -868,8 +868,6 @@ function wc_format_product_short_description( $content ) {
 
 	return $content;
 }
-
-add_filter( 'woocommerce_short_description', 'wc_format_product_short_description', 9999999 );
 
 /**
  * Formats curency symbols when saved in settings.


### PR DESCRIPTION
This fix the shortcode issue, stop extra sanitization and allow use smilies, attachments, embeds and Jetpack markdown.

Closes #14135