### PR TITLE
Incorrect sale dates set when bulk editing variations ref #14227

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1844,7 +1844,7 @@ class WC_AJAX {
 			}
 
 			if ( 'false' !== $data['date_to'] ) {
-				$variation->set_date_on_sale_from( wc_clean( $data['date_to'] ) );
+				$variation->set_date_on_sale_to( wc_clean( $data['date_to'] ) );
 			}
 
 			$variation->save();


### PR DESCRIPTION
@mikejolley 

I have pushed code for Incorrect sale dates set when bulking editing variations ref #14227 . There is issue in function set_date_on_sale_from. This function replace with set_date_on_sale_to.

Thanks