### PR TITLE
solve issue Calling the order key URL of a deleted order causes an exception ref #14239

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -189,7 +189,7 @@ class WC_Shortcode_Checkout {
 
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );
-			if ( $order->get_order_key() != $order_key ) {
+			if ( is_object( $order ) && $order->get_order_key() != $order_key ) {
 				$order = false;
 			}
 		}

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -162,7 +162,7 @@ function wc_clear_cart_after_payment() {
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );
 
-			if ( $order->get_order_key() === $order_key ) {
+			if ( is_object( $order ) && $order->get_order_key() === $order_key ) {
 				WC()->cart->empty_cart();
 			}
 		}


### PR DESCRIPTION
@mikejolley 

I have pushed code for Calling the order key URL of a deleted order causes an exception ref #14239. I feel if set is_object condition for $order then this error will be solved.

Thanks,