### PR TITLE
Dynamic load order items (#14121 fix)

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2277,7 +2277,6 @@ table.wp-list-table {
 			width: 100%;
 			margin: 3px 0 0;
 			padding: 0;
-			display: none;
 
 			td {
 				border: 0;

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -210,9 +210,38 @@ jQuery( function ( $ ) {
 
 	// Show order items on orders page
 	$( document.body ).on( 'click', '.show_order_items', function() {
-		$( this ).closest( 'td' ).find( 'table' ).toggle();
+		var $this       = $( this ),
+			$this_td    = $this.closest( 'td' ),
+			$this_items = $this_td.find( 'table' );
+		
+		if ( $this_items.length > 0 ) {
+			$this_items.toggle();
+			return false;
+		}
+		
+		var id       = $this.closest( 'tr' ).attr( 'id' ),
+			matches  = id.match( /post-(\d+)/ ),
+			order_id = matches[1] || false;
+			
+		if ( order_id !== false ) {
+			$this_td.addClass( 'loading' );
+			
+			$.get( ajaxurl, {
+				'order_id': order_id,
+				'action':   'woocommerce_get_order_items',
+				'nonce':    woocommerce_admin.get_order_items_nonce,
+			}, function( response ) {
+				if ( response.success ) {
+					$this_td.append( response.data.html );
+				}
+			} ).always( function() {
+				$this_td.removeClass( 'loading' );
+			} );
+		}
+
 		return false;
 	});
+
 
 	// Select availability
 	$( 'select.availability' ).change( function() {

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -242,7 +242,6 @@ jQuery( function ( $ ) {
 		return false;
 	});
 
-
 	// Select availability
 	$( 'select.availability' ).change( function() {
 		if ( $( this ).val() === 'all' ) {

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -236,7 +236,17 @@ jQuery( function ( $ ) {
 				'nonce':    woocommerce_admin.get_order_items_nonce,
 			}, function( response ) {
 				if ( response.success ) {
-					$this_td.append( response.data.html );
+					var html        = $( response.data.html ),
+						tiptip_args = {
+							'attribute': 'data-tip',
+							'fadeIn': 50,
+							'fadeOut': 50,
+							'delay': 200
+						};
+
+					html.find( '.woocommerce-help-tip' ).tipTip( tiptip_args );
+
+					$this_td.append( html );
 				}
 			} ).always( function() {
 				$this_td.removeClass( 'loading' );

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -219,6 +219,10 @@ jQuery( function ( $ ) {
 			return false;
 		}
 		
+		if ( $this_td.hasClass( 'loading' ) ) {
+			return false;
+		}
+		
 		var id       = $this.closest( 'tr' ).attr( 'id' ),
 			matches  = id.match( /post-(\d+)/ ),
 			order_id = matches[1] || false;

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -155,6 +155,7 @@ class WC_Admin_Assets {
 				'i18_sale_less_than_regular_error'  => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
 				'decimal_point'                     => $decimal,
 				'mon_decimal_point'                 => wc_get_price_decimal_separator(),
+				'get_order_items_nonce'             =>  wp_create_nonce( 'get-order-items' ),
 			);
 
 			wp_localize_script( 'woocommerce_admin', 'woocommerce_admin', $params );

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -301,6 +301,7 @@ class WC_Admin_Post_Types {
 		$columns['cb']               = $existing_columns['cb'];
 		$columns['order_status']     = '<span class="status_head tips" data-tip="' . esc_attr__( 'Status', 'woocommerce' ) . '">' . esc_attr__( 'Status', 'woocommerce' ) . '</span>';
 		$columns['order_title']      = __( 'Order', 'woocommerce' );
+		$columns['order_items']      = __( 'Purchased', 'woocommerce' );
 		$columns['billing_address']  = __( 'Billing', 'woocommerce' );
 		$columns['shipping_address'] = __( 'Ship to', 'woocommerce' );
 		$columns['customer_message'] = '<span class="notes_head tips" data-tip="' . esc_attr__( 'Customer message', 'woocommerce' ) . '">' . esc_attr__( 'Customer message', 'woocommerce' ) . '</span>';
@@ -538,6 +539,9 @@ class WC_Admin_Post_Types {
 			break;
 			case 'order_date' :
 				printf( '<time datetime="%s">%s</time>', esc_attr( $the_order->get_date_created()->date( 'c' ) ), esc_html( $the_order->get_date_created()->date_i18n( apply_filters( 'woocommerce_admin_order_date_format', __( 'Y-m-d', 'woocommerce' ) ) ) ) );
+			break;
+			case 'order_items' :
+				printf( '<a href="#" class="show_order_items">%s</a>', __('Show/hide items', 'woocommerce') );
 			break;
 			case 'customer_message' :
 				if ( $the_order->get_customer_note() ) {

--- a/includes/admin/views/html-order-items.php
+++ b/includes/admin/views/html-order-items.php
@@ -1,0 +1,22 @@
+<table class="order_items" cellspacing="0">
+	<?php foreach ( $items as $item ):
+		$product        = apply_filters( 'woocommerce_order_item_product', $item->get_product(), $item );
+		$item_meta      = new WC_Order_Item_Meta( $item, $product );
+		$item_meta_html = $item_meta->display( true, true );
+	?>
+		<tr class="<?php echo apply_filters( 'woocommerce_admin_order_item_class', '', $item, $the_order ); ?>">
+			<td class="qty"><?php echo esc_html( $item->get_quantity() ); ?></td>
+			<td class="name">
+				<?php if ( $product ): ?>
+					<?php echo ( wc_product_sku_enabled() && $product->get_sku() ) ? $product->get_sku() . ' - ' : ''; ?><a href="<?php echo get_edit_post_link( $product->get_id() ); ?>"><?php echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ); ?></a>
+				<?php else: ?>
+					<?php echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ); ?>
+				<?php endif;?>
+
+				<?php if ( ! empty( $item_meta_html ) ): ?>
+					<?php echo wc_help_tip( $item_meta_html ); ?>
+				<?php endif;?>
+			</td>
+		</tr>
+	<?php endforeach; ?>
+</table>

--- a/includes/admin/views/html-order-items.php
+++ b/includes/admin/views/html-order-items.php
@@ -1,9 +1,13 @@
 <table class="order_items" cellspacing="0">
-	<?php foreach ( $items as $item ):
-		$product        = apply_filters( 'woocommerce_order_item_product', $item->get_product(), $item );
-		$item_meta      = new WC_Order_Item_Meta( $item, $product );
-		$item_meta_html = $item_meta->display( true, true );
-	?>
+	<?php foreach ( $items as $item ): ?>
+		<?php $product        = apply_filters( 'woocommerce_order_item_product', $item->get_product(), $item );?>
+		<?php $item_meta_html = wc_display_item_meta( $item, array(
+			'before'    => '',
+			'after'     => '',
+			'separator' => ", \n",
+			'echo'      => false,
+			'autop'     => true,
+		) );?>
 		<tr class="<?php echo apply_filters( 'woocommerce_admin_order_item_class', '', $item, $the_order ); ?>">
 			<td class="qty"><?php echo esc_html( $item->get_quantity() ); ?></td>
 			<td class="name">
@@ -18,5 +22,5 @@
 				<?php endif;?>
 			</td>
 		</tr>
-	<?php endforeach; ?>
+	<?php endforeach;?>
 </table>

--- a/includes/admin/views/html-order-items.php
+++ b/includes/admin/views/html-order-items.php
@@ -6,7 +6,6 @@
 			'after'     => '',
 			'separator' => ", \n",
 			'echo'      => false,
-			'autop'     => true,
 		) );?>
 		<tr class="<?php echo apply_filters( 'woocommerce_admin_order_item_class', '', $item, $the_order ); ?>">
 			<td class="qty"><?php echo esc_html( $item->get_quantity() ); ?></td>

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -142,6 +142,7 @@ class WC_AJAX {
 			'shipping_zone_methods_save_changes'               => false,
 			'shipping_zone_methods_save_settings'              => false,
 			'shipping_classes_save_changes'                    => false,
+			'get_order_items'                                  => false,
 		);
 
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
@@ -2344,6 +2345,44 @@ class WC_AJAX {
 
 		wp_send_json_success( array(
 			'shipping_classes' => $wc_shipping->get_shipping_classes(),
+		) );
+	}
+
+	/**
+	 * Get order items table
+	 */
+	public static function get_order_items() {
+		if ( ! isset( $_GET['order_id'], $_GET['nonce'] ) ) {
+			wp_send_json_error( 'missing fields' );
+			exit;
+		}
+		
+		if ( ! wp_verify_nonce( $_GET['nonce'], 'get-order-items' ) ) {
+			wp_send_json_error( 'bad_nonce' );
+			exit;
+		}
+
+		$order_id = absint( $_GET['order_id'] );
+		$order    = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			wp_send_json_error( 'wrong order_id' );
+			exit;
+		}
+
+		$items = $order->get_items();
+		
+		if ( empty( $items ) ) {
+			wp_send_json_error( 'no items in order' );
+			exit;
+		}
+
+		ob_start();
+
+		include 'admin/views/html-order-items.php';
+
+		wp_send_json_success( array(
+			'html' => ob_get_clean(),
 		) );
 	}
 }


### PR DESCRIPTION
#14121 - Things to check/improve:

- [x] replace `WC_Order_Item_Meta` with function
- [ ] add some loading spinner while making request (currently .loading class is added to `td`)
- [ ] getting `order_id` via regexp - is that correct?
- [ ] check strings
- [ ] check code
