### PR TITLE
Change parent_data from array to object referencing the parent

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -24,22 +24,9 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 	/**
 	 * Parent data.
-	 * @var array
+	 * @var object
 	 */
-	protected $parent_data = array(
-		'title'             => '',
-		'sku'               => '',
-		'manage_stock'      => '',
-		'backorders'        => '',
-		'stock_quantity'    => '',
-		'weight'            => '',
-		'length'            => '',
-		'width'             => '',
-		'height'            => '',
-		'tax_class'         => '',
-		'shipping_class_id' => '',
-		'image_id'          => '',
-	);
+	protected $parent_data;
 
 	/**
 	 * Prefix for action and filter hooks on data.
@@ -74,7 +61,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @return string
 	 */
 	public function get_title() {
-		return apply_filters( 'woocommerce_product_title', $this->parent_data['title'], $this );
+		return apply_filters( 'woocommerce_product_title', $this->parent_data->get_title(), $this );
 	}
 
 	/**
@@ -135,7 +122,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['sku'];
+			$value = $this->parent_data->get_sku( $context );
 		}
 		return $value;
 	}
@@ -151,7 +138,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['weight'];
+			$value = $this->parent_data->get_weight( $context );
 		}
 		return $value;
 	}
@@ -167,7 +154,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['length'];
+			$value = $this->parent_data->get_length( $context );
 		}
 		return $value;
 	}
@@ -183,7 +170,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['width'];
+			$value = $this->parent_data->get_width( $context );
 		}
 		return $value;
 	}
@@ -199,7 +186,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['height'];
+			$value = $this->parent_data->get_height( $context );
 		}
 		return $value;
 	}
@@ -215,7 +202,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && 'parent' === $value ) {
-			$value = $this->parent_data['tax_class'];
+			$value = $this->parent_data->get_tax_class( $context );
 		}
 		return $value;
 	}
@@ -231,7 +218,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		$value = $this->get_prop( 'manage_stock', $context );
 
 		// Inherit value from parent.
-		if ( 'view' === $context && false === $value && true === wc_string_to_bool( $this->parent_data['manage_stock'] ) ) {
+		if ( 'view' === $context && false === $value && true === wc_string_to_bool( $this->parent_data->get_manage_stock( $context ) ) ) {
 			$value = 'parent';
 		}
 		return $value;
@@ -248,7 +235,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && 'parent' === $this->get_manage_stock() ) {
-			$value = $this->parent_data['stock_quantity'];
+			$value = $this->parent_data->get_stock_quantity( $context );
 		}
 		return $value;
 	}
@@ -265,7 +252,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && 'parent' === $this->get_manage_stock() ) {
-			$value = $this->parent_data['backorders'];
+			$value = $this->parent_data->get_backorders( $context );
 		}
 		return $value;
 	}
@@ -281,7 +268,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		$image_id = $this->get_prop( 'image_id', $context );
 
 		if ( 'view' === $context && ! $image_id ) {
-			$image_id = $this->parent_data['image_id'];
+			$image_id = $this->parent_data->get_image_id( $context );
 		}
 
 		return $image_id;
@@ -298,7 +285,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		$shipping_class_id = $this->get_prop( 'shipping_class_id', $context );
 
 		if ( 'view' === $context && ! $shipping_class_id ) {
-			$shipping_class_id = $this->parent_data['shipping_class_id'];
+			$shipping_class_id = $this->parent_data->get_shipping_class_id( $context );
 		}
 
 		return $shipping_class_id;

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -259,26 +259,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->set_price( $product->get_regular_price( 'edit' ) );
 		}
 
-		$parent_object = get_post( $product->get_parent_id() );
-		$product->set_parent_data( array(
-			'title'             => $parent_object->post_title,
-			'sku'               => get_post_meta( $product->get_parent_id(), '_sku', true ),
-			'manage_stock'      => get_post_meta( $product->get_parent_id(), '_manage_stock', true ),
-			'backorders'        => get_post_meta( $product->get_parent_id(), '_backorders', true ),
-			'stock_quantity'    => get_post_meta( $product->get_parent_id(), '_stock', true ),
-			'weight'            => get_post_meta( $product->get_parent_id(), '_weight', true ),
-			'length'            => get_post_meta( $product->get_parent_id(), '_length', true ),
-			'width'             => get_post_meta( $product->get_parent_id(), '_width', true ),
-			'height'            => get_post_meta( $product->get_parent_id(), '_height', true ),
-			'tax_class'         => get_post_meta( $product->get_parent_id(), '_tax_class', true ),
-			'shipping_class_id' => absint( current( $this->get_term_ids( $product->get_parent_id(), 'product_shipping_class' ) ) ),
-			'image_id'          => get_post_thumbnail_id( $product->get_parent_id() ),
-		) );
-
+		$parent = wc_get_product( $product->get_parent_id() );
+		$product->set_parent_data( $parent );
 		// Pull data from the parent when there is no user-facing way to set props.
-		$product->set_sold_individually( get_post_meta( $product->get_parent_id(), '_sold_individually', true ) );
-		$product->set_tax_status( get_post_meta( $product->get_parent_id(), '_tax_status', true ) );
-		$product->set_cross_sell_ids( get_post_meta( $product->get_parent_id(), '_crosssell_ids', true ) );
+		$product->set_sold_individually( $parent->get_sold_individually() );
+		$product->set_tax_status( $parent->get_tax_status() );
+		$product->set_cross_sell_ids( $parent->get_cross_sell_ids() );
 	}
 
 	/**


### PR DESCRIPTION
Working on updating my plugin to deal with WooCommerce 3.0 I uncovered a weird issue that I initially thought was related to my code, but it wasn't. The WC_Data->set_props() and WC_Data->set_prop() functions do a good job but they are only useful for storing data in the WC_Data->data[] array.  So any data loaded into WC_Product_Variation->parent_data does not get any special treatment.

For example: The 'stock_quantity' field in parent_data does not get sent through set_stock_quantity() -> wc_stock_amount() -> apply_filters( 'woocommerce_stock_amount' ) -> intval

To demonstrate the results of this issue:
1. Create a Variable product that stock is managed by the parent item.  
2. View product and see that the quantity is showed as stored in the DB and not properly formatted   (10.0000 vs 10)

This was just a simple throw together method to resolve the issue. I'm not sure if you would want to deprecate using $parent_data and switch it to a different variable/functions in case anyone had started using it in the short time it has been available. 