### PR TITLE
Fix tax class handling in the cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1138,8 +1138,8 @@ class WC_Cart {
 			} elseif ( $this->prices_include_tax ) {
 
 				// Get base tax rates
-				if ( empty( $shop_tax_rates[ $product->get_tax_class( true ) ] ) ) {
-					$shop_tax_rates[ $product->get_tax_class( true ) ] = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );
+				if ( empty( $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] ) ) {
+					$shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 				}
 
 				// Get item tax rates
@@ -1147,7 +1147,7 @@ class WC_Cart {
 					$tax_rates[ $product->get_tax_class() ] = WC_Tax::get_rates( $product->get_tax_class() );
 				}
 
-				$base_tax_rates = $shop_tax_rates[ $product->get_tax_class( true ) ];
+				$base_tax_rates = $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ];
 				$item_tax_rates = $tax_rates[ $product->get_tax_class() ];
 
 				/**
@@ -1241,7 +1241,7 @@ class WC_Cart {
 			 */
 			} elseif ( $this->prices_include_tax ) {
 
-				$base_tax_rates = $shop_tax_rates[ $product->get_tax_class( true ) ];
+				$base_tax_rates = $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ];
 				$item_tax_rates = $tax_rates[ $product->get_tax_class() ];
 
 				/**

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -135,7 +135,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['sku'];
+			$value = apply_filters( $this->get_hook_prefix() . 'sku', $this->parent_data['sku'], $this );
 		}
 		return $value;
 	}
@@ -151,7 +151,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['weight'];
+			$value = apply_filters( $this->get_hook_prefix() . 'weight', $this->parent_data['weight'], $this );
 		}
 		return $value;
 	}
@@ -167,7 +167,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['length'];
+			$value = apply_filters( $this->get_hook_prefix() . 'length', $this->parent_data['length'], $this );
 		}
 		return $value;
 	}
@@ -183,7 +183,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['width'];
+			$value = apply_filters( $this->get_hook_prefix() . 'width', $this->parent_data['width'], $this );
 		}
 		return $value;
 	}
@@ -199,7 +199,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && empty( $value ) ) {
-			$value = $this->parent_data['height'];
+			$value = apply_filters( $this->get_hook_prefix() . 'height', $this->parent_data['height'], $this );
 		}
 		return $value;
 	}
@@ -257,7 +257,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && 'parent' === $this->get_manage_stock() ) {
-			$value = $this->parent_data['stock_quantity'];
+			$value = apply_filters( $this->get_hook_prefix() . 'stock_quantity', $this->parent_data['stock_quantity'], $this );
 		}
 		return $value;
 	}
@@ -274,7 +274,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		// Inherit value from parent.
 		if ( 'view' === $context && 'parent' === $this->get_manage_stock() ) {
-			$value = $this->parent_data['backorders'];
+			$value = apply_filters( $this->get_hook_prefix() . 'backorders', $this->parent_data['backorders'], $this );
 		}
 		return $value;
 	}
@@ -290,7 +290,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		$image_id = $this->get_prop( 'image_id', $context );
 
 		if ( 'view' === $context && ! $image_id ) {
-			$image_id = $this->parent_data['image_id'];
+			$value = apply_filters( $this->get_hook_prefix() . 'image_id', $this->parent_data['image_id'], $this );
 		}
 
 		return $image_id;
@@ -307,7 +307,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 		$shipping_class_id = $this->get_prop( 'shipping_class_id', $context );
 
 		if ( 'view' === $context && ! $shipping_class_id ) {
-			$shipping_class_id = $this->parent_data['shipping_class_id'];
+			$value = apply_filters( $this->get_hook_prefix() . 'shipping_class_id', $this->parent_data['shipping_class_id'], $this );
 		}
 
 		return $shipping_class_id;

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -207,15 +207,24 @@ class WC_Product_Variation extends WC_Product_Simple {
 	/**
 	 * Returns the tax class.
 	 *
-	 * @param  string $context
+	 * Does not use get_prop so it can handle 'parent' Inheritance correctly.
+	 *
+	 * @param  string $context view, edit, or unfiltered
 	 * @return string
 	 */
 	public function get_tax_class( $context = 'view' ) {
-		$value = $this->get_prop( 'tax_class', $context );
+		$value = null;
 
-		// Inherit value from parent.
-		if ( 'view' === $context && 'parent' === $value ) {
-			$value = $this->parent_data['tax_class'];
+		if ( array_key_exists( 'tax_class', $this->data ) ) {
+			$value = array_key_exists( 'tax_class', $this->changes ) ? $this->changes['tax_class'] : $this->data['tax_class'];
+
+			if ( 'edit' !== $context && 'parent' === $value ) {
+				$value = $this->parent_data['tax_class'];
+			}
+
+			if ( 'view' === $context ) {
+				$value = apply_filters( $this->get_hook_prefix() . 'tax_class', $value, $this );
+			}
 		}
 		return $value;
 	}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -908,7 +908,7 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 			$return_price = round( $line_price + $tax_amount, wc_get_price_decimals() );
 		} else {
 			$tax_rates      = WC_Tax::get_rates( $product->get_tax_class() );
-			$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );
+			$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 
 			/**
 			 * If the customer is excempt from VAT, remove the taxes here.
@@ -957,7 +957,7 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 	}
 
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
-		$tax_rates  = WC_Tax::get_base_tax_rates( $product->get_tax_class( true ) );
+		$tax_rates  = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$taxes      = WC_Tax::calc_tax( $price * $qty, $tax_rates, true );
 		$price      = WC_Tax::round( $price * $qty - array_sum( $taxes ) );
 	} else {


### PR DESCRIPTION
3.0.2 fixed inheriting tax class from the parent. however, some code in the cart classes were passing invalid context.

The intention in that code is to get an unfiltered, unmodified tax class so the original price and tax is known. However, since it was not passing a recognised context, ‘parent’ was not replaced with the tax class of the parent and thus ‘parent’ tax class was used which is not valid. This lead to taxes being applied on top of defined prices when using tax inclusive prices.

Closes #14321
Closes #14331