### PR TITLE
Set default email sending method to not defer

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -88,7 +88,7 @@ class WC_Emails {
 			'woocommerce_created_customer',
 		) );
 
-		if ( apply_filters( 'woocommerce_defer_transactional_emails', true ) ) {
+		if ( apply_filters( 'woocommerce_defer_transactional_emails', false ) ) {
 			self::$background_emailer = new WC_Background_Emailer();
 
 			foreach ( $email_actions as $action ) {

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -139,9 +139,15 @@ class WC_Emails {
 	 * @param array $args Email args (default: []).
 	 */
 	public static function send_transactional_email( $args = array() ) {
-		$args = func_get_args();
-		self::instance(); // Init self so emails exist.
-		do_action_ref_array( current_filter() . '_notification', $args );
+		try {
+			$args = func_get_args();
+			self::instance(); // Init self so emails exist.
+			do_action_ref_array( current_filter() . '_notification', $args );
+		} catch ( Exception $e ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				trigger_error( 'Transactional email triggered fatal error for callback ' . current_filter(), E_USER_WARNING );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Despite best efforts, and it working on multiple test installs (even Godaddy!) the deferred email sending us causing an influx of tickets and issues due to emails “not sending”. Whilst there is a snippet to disable it, and while I’d still like to debug and encourage using this for the performance benefits, for our own sanity this PR turns it off by default. 

This feature can be turned on again using the `woocommerce_defer_transactional_emails` filter.

Hopefully we can work with @maxrice and @bekarice on a more robust background processor (which we will need for imports) and this can come back in a future release after more testing.