### PR TITLE
Reset ratings count when product is duplicated, ref #14366

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -125,6 +125,9 @@ class WC_Admin_Duplicate_Product {
 		$duplicate->set_status( 'draft' );
 		$duplicate->set_date_created( null );
 		$duplicate->set_slug( '' );
+		$duplicate->set_rating_counts( 0 );
+		$duplicate->set_average_rating( 0 );
+		$duplicate->set_review_count( 0 );
 
 		foreach ( $meta_to_exclude as $meta_key ) {
 			$duplicate->delete_meta_data( $meta_key );


### PR DESCRIPTION
I have modified the function which is used to duplicate the product. So when duplicate product is created I have reset the ratings and reviews count to 0.