### PR TITLE
reset review and ratting null when create duplicate product ref #14366

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -670,8 +670,11 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param  string $context
 	 * @return int
 	 */
-	public function get_review_count( $context = 'view' ) {
-		return $this->get_prop( 'review_count', $context );
+	public function get_review_count( $context = 'view' ) { 
+		$get_review_by_ID =  get_comments('post_id='.$this->id);
+		   if( !empty( $get_review_by_ID )) {
+			return $this->get_prop( 'review_count', $context );
+		   }
 	}
 
 	/*

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -122,6 +122,13 @@ class WC_Admin_Duplicate_Product {
 			$duplicate->set_sku( wc_product_generate_unique_sku( 0, $product->get_sku( 'edit' ) ) );
 		}
 		$duplicate->set_status( 'draft' );
+		
+		$duplicate->set_date_created( null );
+		$duplicate->set_slug( '' );
+        $duplicate->set_rating_counts( 0 );
+ 		$duplicate->set_average_rating( 0 );
+ 		$duplicate->set_review_count( 0 );
+		
 
 		foreach ( $meta_to_exclude as $meta_key ) {
 			$duplicate->delete_meta_data( $meta_key );


### PR DESCRIPTION
@mikejolley 

I have pushed ref #14366  Reset reviews and ratting when create duplicate product. If  we have already duplicate product so it is required to change the  review and ratting.