### PR TITLE
Fix PHP 7.1 warnings when manually adding order items

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1078,14 +1078,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		foreach ( $this->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
 			$taxes = $item->get_taxes();
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
-				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + (float) $tax : $tax;
+				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + (float) $tax : (float) $tax;
 			}
 		}
 
 		foreach ( $this->get_shipping_methods() as $item_id => $item ) {
 			$taxes = $item->get_taxes();
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
-				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] + (float) $tax : $tax;
+				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] + (float) $tax : (float) $tax;
 			}
 		}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1078,14 +1078,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		foreach ( $this->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
 			$taxes = $item->get_taxes();
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
-				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + $tax : $tax;
+				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + (float) $tax : $tax;
 			}
 		}
 
 		foreach ( $this->get_shipping_methods() as $item_id => $item ) {
 			$taxes = $item->get_taxes();
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
-				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] + $tax : $tax;
+				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] + (float) $tax : $tax;
 			}
 		}
 


### PR DESCRIPTION
### Explanation

PHP warnings thrown when manually adding items to a taxable order. See stack traces:

<details><summary>PHP Warning:  A non-numeric value encountered in /wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php on line 1081</summary>
<pre>
[13-Apr-2017 23:47:59 UTC] PHP Warning:  A non-numeric value encountered in /wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php on line 1081
[13-Apr-2017 23:47:59 UTC] PHP Stack trace:
[13-Apr-2017 23:47:59 UTC] PHP   1. {main}() /wp-admin/admin-ajax.php:0
[13-Apr-2017 23:47:59 UTC] PHP   2. do_action() /wp-admin/admin-ajax.php:91
[13-Apr-2017 23:47:59 UTC] PHP   3. WP_Hook->do_action() /wp-includes/plugin.php:453
[13-Apr-2017 23:47:59 UTC] PHP   4. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:323
[13-Apr-2017 23:47:59 UTC] PHP   5. WC_AJAX::save_order_items() /wp-includes/class-wp-hook.php:298
[13-Apr-2017 23:47:59 UTC] PHP   6. wc_save_order_items() /wp-content/plugins/woocommerce/includes/class-wc-ajax.php:1054
[13-Apr-2017 23:47:59 UTC] PHP   7. WC_Abstract_Order->update_taxes() /wp-content/plugins/woocommerce/includes/admin/wc-admin-functions.php:295
</pre></details>

<details><summary>PHP Warning:  A non-numeric value encountered in /wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php on line 1088</summary>
<pre>
[13-Apr-2017 23:47:59 UTC] PHP Warning:  A non-numeric value encountered in /wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php on line 1088
[13-Apr-2017 23:47:59 UTC] PHP Stack trace:
[13-Apr-2017 23:47:59 UTC] PHP   1. {main}() /wp-admin/admin-ajax.php:0
[13-Apr-2017 23:47:59 UTC] PHP   2. do_action() /wp-admin/admin-ajax.php:91
[13-Apr-2017 23:47:59 UTC] PHP   3. WP_Hook->do_action() /wp-includes/plugin.php:453
[13-Apr-2017 23:47:59 UTC] PHP   4. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:323
[13-Apr-2017 23:47:59 UTC] PHP   5. WC_AJAX::save_order_items() /wp-includes/class-wp-hook.php:298
[13-Apr-2017 23:47:59 UTC] PHP   6. wc_save_order_items() /wp-content/plugins/woocommerce/includes/class-wc-ajax.php:1054
[13-Apr-2017 23:47:59 UTC] PHP   7. WC_Abstract_Order->update_taxes() /wp-content/plugins/woocommerce/includes/admin/wc-admin-functions.php:295
</pre></details>

### To Replicate
(be sure you're using PHP 7.1)

1. Ensure an order has tax applied
2. Add a product line item
3. Save the items + calculate tax -- both actions will trigger this warning for line 1081

OR

1. Ensure an order has tax applied
1. Add a shipping line item with a cost, but leave tax blank (as we'll calculate it later)
1. Adding the shipping item triggers `update_tax` so you'll see the warning for line 1088
1. Save and calculate taxes -- see the notice again