### PR TITLE
Don't return deleted meta in get_meta_data()

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -275,14 +275,16 @@ abstract class WC_Data {
 	 */
 	public function get_meta( $key = '', $single = true, $context = 'view' ) {
 		$this->maybe_read_meta_data();
-		$array_keys = array_keys( wp_list_pluck( $this->get_meta_data(), 'key' ), $key );
+		$meta_data  = $this->get_meta_data();
+		$array_keys = array_keys( wp_list_pluck( $meta_data, 'key' ), $key );
 		$value      = $single ? '' : array();
 
 		if ( ! empty( $array_keys ) ) {
+			// We don't use the $this->meta_data property directly here because we don't want meta with a null value (i.e. meta which has been deleted via $this->delete_meta_data())
 			if ( $single ) {
-				$value = $this->meta_data[ current( $array_keys ) ]->value;
+				$value = $meta_data[ current( $array_keys ) ]->value;
 			} else {
-				$value = array_intersect_key( $this->meta_data, array_flip( $array_keys ) );
+				$value = array_intersect_key( $meta_data, array_flip( $array_keys ) );
 			}
 
 			if ( 'view' === $context ) {


### PR DESCRIPTION
I'm not sure whether its intentional or not, but `WC_Data::get_meta_data()` will return meta data that has been previously deleted on the object (but not saved) by a call to `WC_Data::delete_meta_data()`. This has a few issues:

1. its behaviour differs to `WC_Data::get_meta()`, which will _not_ return that meta data, because it passes meta through `WC_Data::filter_null_meta()` before returning it
1. calls to `WC_Data::add_meta_data()` and `WC_Data::update_meta_data()` without a `$meta_id` effectively duplicate meta data until the next `save()` request, because they call `WC_Data::delete_meta_data()` before adding the item, but if something else calls `WC_Data::get_meta_data()` to access the new value of the meta, they will receive `null` as set as the value of the existing meta item.

Because of these issues, I thought it was worth submitting a PR to address it just in case it's not intended.

This patch changes `WC_Data:: get_meta()` to use `$this-> get_meta()`, rather than accessing `$this->meta_data` directly, to ensure the meta values are passed through the `WC_Data::filter_null_meta()` method.