### PR TITLE
Change format of product link class.

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -605,7 +605,7 @@ if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {
  * Insert the opening anchor tag for products in the loop.
  */
 function woocommerce_template_loop_product_link_open() {
-	echo '<a href="' . get_the_permalink() . '" class="woocommerce-LoopProduct-link">';
+	echo '<a href="' . get_the_permalink() . '" class="woocommerce-loop-product__link">';
 }
 /**
  * Insert the opening anchor tag for products in the loop.


### PR DESCRIPTION
In this class use capital characters, it's not good formate.

So, I change that and create a new class " woocommerce-loop-product__link ".

The example we use this class for loop product title tag " woocommerce-loop-product__title ".

Thank.