### PR TITLE
Prevent infinite loops during save_post

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -128,14 +128,34 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 */
 	public function update( &$coupon ) {
 		$coupon->save_meta_data();
-		$post_data = array(
-			'ID'           => $coupon->get_id(),
-			'post_title'   => $coupon->get_code(),
-			'post_excerpt' => $coupon->get_description(),
-		);
-		wp_update_post( $post_data );
-		$coupon->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
+		$changes = $coupon->get_changes();
 
+		if ( array_intersect( array( 'code', 'description', 'date_created', 'date_modified' ), array_keys( $coupon ) ) ) {
+			$post_data = array(
+				'post_title'        => $coupon->get_code(),
+				'post_excerpt'      => $coupon->get_description(),
+				'post_date'         => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created( 'edit' )->getOffsetTimestamp() ),
+				'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created( 'edit' )->getTimestamp() ),
+				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $coupon->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),
+				'post_modified_gmt' => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $coupon->get_date_modified( 'edit' )->getTimestamp() )       : current_time( 'mysql', 1 ),
+			);
+
+			/**
+			 * When updating this object, to prevent infinite loops, use $wpdb
+			 * to update data, since wp_update_post spawns more calls to the
+			 * save_post action.
+			 *
+			 * This ensures hooks are fired by either WP itself (admin screen save),
+			 * or an update purely from CRUD.
+			 */
+			if ( doing_action( 'save_post' ) ) {
+				$GLOBALS['wpdb']->update( $GLOBALS['wpdb']->posts, $post_data, array( 'ID' => $coupon->get_id() ) );
+				clean_post_cache( $coupon->get_id() );
+			} else {
+				wp_update_post( array_merge( array( 'ID' => $coupon->get_id() ), $post_data ) );
+			}
+			$coupon->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
+		}
 		$this->update_post_meta( $coupon );
 		$coupon->apply_changes();
 		do_action( 'woocommerce_update_coupon', $coupon->get_id() );

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -61,9 +61,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			'post_type'     => 'shop_coupon',
 			'post_status'   => 'publish',
 			'post_author'   => get_current_user_id(),
-			'post_title'    => $coupon->get_code(),
+			'post_title'    => $coupon->get_code( 'edit' ),
 			'post_content'  => '',
-			'post_excerpt'  => $coupon->get_description(),
+			'post_excerpt'  => $coupon->get_description( 'edit' ),
 			'post_date'     => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created()->getOffsetTimestamp() ),
 			'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created()->getTimestamp() ),
 		) ), true );
@@ -130,10 +130,10 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$coupon->save_meta_data();
 		$changes = $coupon->get_changes();
 
-		if ( array_intersect( array( 'code', 'description', 'date_created', 'date_modified' ), array_keys( $coupon ) ) ) {
+		if ( array_intersect( array( 'code', 'description', 'date_created', 'date_modified' ), array_keys( $changes ) ) ) {
 			$post_data = array(
-				'post_title'        => $coupon->get_code(),
-				'post_excerpt'      => $coupon->get_description(),
+				'post_title'        => $coupon->get_code( 'edit' ),
+				'post_excerpt'      => $coupon->get_description( 'edit' ),
 				'post_date'         => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created( 'edit' )->getOffsetTimestamp() ),
 				'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $coupon->get_date_created( 'edit' )->getTimestamp() ),
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $coupon->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -190,12 +190,15 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 
 			/**
-			 * When updating this object, to prevent infinite loops, use WPDB when doing an update during save_post action.
+			 * When updating this object, to prevent infinite loops, use $wpdb
+			 * to update data, since wp_update_post spawns more calls to the
+			 * save_post action.
 			 *
-			 * This ensures hooks are fired by either WP itself (admin screen save), or an update purely from CRUD.
+			 * This ensures hooks are fired by either WP itself (admin screen save),
+			 * or an update purely from CRUD.
 			 */
 			if ( doing_action( 'save_post' ) ) {
-				$GLOBALS['wpdb']->update( $wpdb->posts, $post_data, array( 'ID' => $product->get_id() ) );
+				$GLOBALS['wpdb']->update( $GLOBALS['wpdb']->posts, $post_data, array( 'ID' => $product->get_id() ) );
 				clean_post_cache( $product->get_id() );
 			} else {
 				wp_update_post( array_merge( array( 'ID' => $product->get_id() ), $post_data ) );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -168,7 +168,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Only update the post when the post data changes.
 		if ( array_intersect( array( 'description', 'short_description', 'name', 'parent_id', 'reviews_allowed', 'status', 'menu_order', 'date_created', 'date_modified', 'slug' ), array_keys( $changes ) ) ) {
 			$post_data = array(
-				'ID'             => $product->get_id(),
 				'post_content'   => $product->get_description( 'edit' ),
 				'post_excerpt'   => $product->get_short_description( 'edit' ),
 				'post_title'     => $product->get_name( 'edit' ),
@@ -189,7 +188,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				$post_data['post_modified']     = current_time( 'mysql' );
 				$post_data['post_modified_gmt'] = current_time( 'mysql', 1 );
 			}
-			wp_update_post( $post_data );
+
+			/**
+			 * When updating this object, to prevent infinite loops, use WPDB when doing an update during save_post action.
+			 *
+			 * This ensures hooks are fired by either WP itself (admin screen save), or an update purely from CRUD.
+			 */
+			if ( doing_action( 'save_post' ) ) {
+				$GLOBALS['wpdb']->update( $wpdb->posts, $post_data, array( 'ID' => $product->get_id() ) );
+				clean_post_cache( $product->get_id() );
+			} else {
+				wp_update_post( array_merge( array( 'ID' => $product->get_id() ), $post_data ) );
+			}
 			$product->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
 		}
 


### PR DESCRIPTION
In WP Admin, WooCommerce uses the `save_post` hook to save extra data for products, coupons and orders. To prevent these hooks running multiple times in case of further `save_post` events (triggered by `wp_update_post` usage), WC has some preventative code in place: https://github.com/woocommerce/woocommerce/blob/31cd2dcb904868658dcb4febd70e1081c3564a51/includes/admin/class-wc-admin-meta-boxes.php#L186

However, it is not reasonable to expect developers to add the same safe guards to their own code, so there is risk of infinite loops **especially** with 3.0 and the CRUD system which uses `wp_update_post` in the data-store classes.

Using `wp_update_post` does have benefits - it fires a variety of actions and filters developers can listen out for, so preventing this completely when saving an object via CRUD could be a bad idea.

With this in mind, I’ve come up with a solution which does both, depending on whether or not the update event is **during** a `save_post` action. I’ve done this with  the`doing_action()` function.

There is very little code duplication since both the `$wpdb->update` and `wp_update_post` take similar args.

Calling on @thenbrent @maxrice @franticpsyx @bekarice  for feedback on this one. It is a fix, and will stop those random error 500/infinite loops that are cropping up due to plugin conflicts, but I’m cautious because I don’t want to break anything :)

Let me know your thoughts and if you feel it’s safe for a patch release.  

Possibly related to #14377