### PR TITLE
Fixes the shipping address map URL

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -766,6 +766,11 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function get_shipping_address_map_url() {
 		$address = apply_filters( 'woocommerce_shipping_address_map_url_parts', $this->get_address( 'shipping' ), $this );
+		foreach ( array( 'first_name', 'last_name', 'company' ) as $key ) {
+			if ( isset( $address[$key] ) ) {
+				unset( $address[$key] );
+			}
+		}
 		return apply_filters( 'woocommerce_shipping_address_map_url', 'https://maps.google.com/maps?&q=' . urlencode( implode( ', ', $address ) ) . '&z=16', $this );
 	}
 

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -765,12 +765,16 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_shipping_address_map_url() {
-		$address = apply_filters( 'woocommerce_shipping_address_map_url_parts', $this->get_address( 'shipping' ), $this );
+		$address = $this->get_address( 'shipping' );
+
 		foreach ( array( 'first_name', 'last_name', 'company' ) as $key ) {
-			if ( isset( $address[$key] ) ) {
-				unset( $address[$key] );
+			if ( isset( $address[ $key ] ) ) {
+				unset( $address[ $key ] );
 			}
 		}
+
+		$address = apply_filters( 'woocommerce_shipping_address_map_url_parts', $address, $this );
+
 		return apply_filters( 'woocommerce_shipping_address_map_url', 'https://maps.google.com/maps?&q=' . urlencode( implode( ', ', $address ) ) . '&z=16', $this );
 	}
 


### PR DESCRIPTION
Fixes #14398 

This PR removes the first name, last name, and company from the generated Google Maps URL for the shipping address.

@mikejolley @claudiulodro - I see a filter present here, so I attempted using it, and figured I may have put the code in the incorrect file in terms of the current file structure, so I've opted for filtering out these data points directly inside the method instead, as it's a simpler approach, while not directly using the existing filter. I'd particularly appreciate y'all's thoughts on that approach.