### PR TITLE
Add woocommerce_order_item_get_formatted_meta_data filter

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -219,7 +219,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			);
 		}
 
-		return $formatted_meta;
+		return apply_filters( 'woocommerce_order_item_get_formatted_meta_data', $formatted_meta, $this );
 	}
 
 	/*


### PR DESCRIPTION
2.6 had woocommerce_order_items_meta_display. 3.0 has no filter to
remove meta from display.

Closes #14372