### PR TITLE
Fixed support for WordPress 4.7 user site locale

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -456,7 +456,8 @@ final class WooCommerce {
 	 *      - WP_LANG_DIR/plugins/woocommerce-LOCALE.mo
 	 */
 	public function load_plugin_textdomain() {
-		$locale = apply_filters( 'plugin_locale', get_locale(), 'woocommerce' );
+		$locale = is_admin() && function_exists( 'get_user_locale' ) ? get_user_locale() : get_locale();
+		$locale = apply_filters( 'plugin_locale', $locale, 'woocommerce' );
 
 		load_textdomain( 'woocommerce', WP_LANG_DIR . '/woocommerce/woocommerce-' . $locale . '.mo' );
 		load_plugin_textdomain( 'woocommerce', false, plugin_basename( dirname( __FILE__ ) ) . '/i18n/languages' );


### PR DESCRIPTION
Fix required only for our custom language pack location.

@mikejolley this should be included into a patch release, since this is fixing something to better support WordPress 4.7 and there is no impact for most of the users.

Closes #14361