### PR TITLE
Fix metabox logic.

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -12,7 +12,7 @@
 		</label>
 
 		<?php foreach ( self::get_product_type_options() as $key => $option ) :
-			if ( $product_object ) {
+			if ( metadata_exists( 'post', $post->ID, '_' . $key ) ) {
 				$selected_value = is_callable( array( $product_object, "is_$key" ) ) ? $product_object->{"is_$key"}() : 'yes' === get_post_meta( $post->ID, '_' . $key, true );
 			} else {
 				$selected_value = 'yes' === ( isset( $option['default'] ) ? $option['default'] : 'no' );


### PR DESCRIPTION
Fixes #14470.

The current implementation checks for `$product_object` which is [always there](https://github.com/woocommerce/woocommerce/blob/b16d3a091ce6125470d484fd10c4f71ba6c724b0/includes/admin/meta-boxes/class-wc-meta-box-product-data.php#L31), so the `else` never happens. If we check with `metadata_exists`, it will use the default option on new products.