### PR TITLE
Tweak/rounding precision totals

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1106,104 +1106,31 @@ class WC_Cart {
 		$cart           = $this->get_cart();
 
 		/**
-		 * Calculate subtotals for items. This is done first so that discount logic can use the values.
+		 * Calculate subtotals for items. This is done first so that discount logic can use the values. Subtotals are amounts before discount.
 		 */
 		foreach ( $cart as $cart_item_key => $values ) {
-			$product           = $values['data'];
-			$line_price        = $product->get_price() * $values['quantity'];
-			$line_subtotal     = 0;
-			$line_subtotal_tax = 0;
+			$product = $values['data'];
 
-			/**
-			 * No tax to calculate.
-			 */
-			if ( ! $product->is_taxable() ) {
-
-				// Subtotal is the undiscounted price
-				$this->subtotal += $line_price;
-				$this->subtotal_ex_tax += $line_price;
-
-			/**
-			 * Prices include tax.
-			 *
-			 * To prevent rounding issues we need to work with the inclusive price where possible.
-			 * otherwise we'll see errors such as when working with a 9.99 inc price, 20% VAT which would.
-			 * be 8.325 leading to totals being 1p off.
-			 *
-			 * Pre tax coupons come off the price the customer thinks they are paying - tax is calculated.
-			 * afterwards.
-			 *
-			 * e.g. $100 bike with $10 coupon = customer pays $90 and tax worked backwards from that.
-			 */
-			} elseif ( $this->prices_include_tax ) {
-
-				// Get base tax rates
-				if ( empty( $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] ) ) {
-					$shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
-				}
-
-				// Get item tax rates
-				if ( empty( $tax_rates[ $product->get_tax_class() ] ) ) {
-					$tax_rates[ $product->get_tax_class() ] = WC_Tax::get_rates( $product->get_tax_class() );
-				}
-
-				$base_tax_rates = $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ];
-				$item_tax_rates = $tax_rates[ $product->get_tax_class() ];
-
-				/**
-				 * ADJUST TAX - Calculations when base tax is not equal to the item tax.
-				 *
-					 * The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations.
-					 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
-					 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
-					 */
-				if ( $item_tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
-
-					// Work out a new base price without the shop's base tax
-					$taxes                 = WC_Tax::calc_tax( $line_price, $base_tax_rates, true, true );
-
-					// Now we have a new item price (excluding TAX)
-					$line_subtotal         = $line_price - array_sum( $taxes );
-
-					// Now add modified taxes
-					$tax_result            = WC_Tax::calc_tax( $line_subtotal, $item_tax_rates );
-					$line_subtotal_tax     = array_sum( $tax_result );
-
-				/**
-				 * Regular tax calculation (customer inside base and the tax class is unmodified.
-				 */
-				} else {
-
-					// Calc tax normally
-					$taxes                 = WC_Tax::calc_tax( $line_price, $item_tax_rates, true );
-					$line_subtotal_tax     = array_sum( $taxes );
-					$line_subtotal         = $line_price - array_sum( $taxes );
-				}
-
-			/**
-			 * Prices exclude tax.
-			 *
-			 * This calculation is simpler - work with the base, untaxed price.
-			 */
-			} else {
-
-				// Get item tax rates
-				if ( empty( $tax_rates[ $product->get_tax_class() ] ) ) {
-					$tax_rates[ $product->get_tax_class() ] = WC_Tax::get_rates( $product->get_tax_class() );
-				}
-
-				$item_tax_rates        = $tax_rates[ $product->get_tax_class() ];
-
-				// Base tax for line before discount - we will store this in the order data
-				$taxes                 = WC_Tax::calc_tax( $line_price, $item_tax_rates );
-				$line_subtotal_tax     = array_sum( $taxes );
-
-				$line_subtotal         = $line_price;
+			// Get base tax rates
+			if ( empty( $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] ) ) {
+				$shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 			}
 
-			// Add to main subtotal
-			$this->subtotal        += $line_subtotal + $line_subtotal_tax;
-			$this->subtotal_ex_tax += $line_subtotal;
+			// Get item tax rates
+			if ( empty( $tax_rates[ $product->get_tax_class() ] ) ) {
+				$tax_rates[ $product->get_tax_class() ] = WC_Tax::get_rates( $product->get_tax_class() );
+			}
+
+			if ( ! $product->is_taxable() ) {
+				$line_costs = $this->get_line_costs_for_prices_excluding_tax( $values, false, true );
+			} elseif ( $this->prices_include_tax ) {
+				$line_costs = $this->get_line_costs_for_prices_including_tax( $values, $tax_rates[ $product->get_tax_class() ], $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ], true );
+			} else {
+				$line_costs = $this->get_line_costs_for_prices_excluding_tax( $values, $tax_rates[ $product->get_tax_class() ], true );
+			}
+
+			$this->subtotal        += $line_costs->subtotal + $line_costs->subtotal_tax;
+			$this->subtotal_ex_tax += $line_costs->subtotal;
 		}
 
 		// Order cart items by price so coupon logic is 'fair' for customers and not based on order added to cart.
@@ -1213,132 +1140,35 @@ class WC_Cart {
 		 * Calculate totals for items.
 		 */
 		foreach ( $cart as $cart_item_key => $values ) {
-
 			$product = $values['data'];
 
-			// Prices
-			$base_price = $product->get_price();
-			$line_price = $product->get_price() * $values['quantity'];
-
-			// Tax data
-			$taxes = array();
-			$discounted_taxes = array();
-
-			/**
-			 * No tax to calculate.
-			 */
 			if ( ! $product->is_taxable() ) {
-
-				// Discounted Price (price with any pre-tax discounts applied)
-				$discounted_price      = $this->get_discounted_price( $values, $base_price, true );
-				$line_subtotal_tax     = 0;
-				$line_subtotal         = $line_price;
-				$line_tax              = 0;
-				$line_total            = round( $discounted_price * $values['quantity'], wc_get_rounding_precision() );
-
-			/**
-			 * Prices include tax.
-			 */
+				$line_costs = $this->get_line_costs_for_prices_excluding_tax( $values );
 			} elseif ( $this->prices_include_tax ) {
-
-				$base_tax_rates = $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ];
-				$item_tax_rates = $tax_rates[ $product->get_tax_class() ];
-
-				/**
-				 * ADJUST TAX - Calculations when base tax is not equal to the item tax.
-				 *
-					 * The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations.
-					 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
-					 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
-					 */
-				if ( $item_tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
-
-					// Work out a new base price without the shop's base tax
-					$taxes             = WC_Tax::calc_tax( $line_price, $base_tax_rates, true, true );
-
-					// Now we have a new item price (excluding TAX)
-					$line_subtotal     = round( $line_price - array_sum( $taxes ), wc_get_rounding_precision() );
-					$taxes             = WC_Tax::calc_tax( $line_subtotal, $item_tax_rates );
-					$line_subtotal_tax = array_sum( $taxes );
-
-					// Adjusted price (this is the price including the new tax rate)
-					$adjusted_price    = ( $line_subtotal + $line_subtotal_tax ) / $values['quantity'];
-
-					// Apply discounts and get the discounted price FOR A SINGLE ITEM
-					$discounted_price  = $this->get_discounted_price( $values, $adjusted_price, true );
-
-					// Convert back to line price
-					$discounted_line_price = round( $discounted_price * $values['quantity'], wc_get_rounding_precision() );
-
-					// Now use rounded line price to get taxes.
-					$discounted_taxes  = WC_Tax::calc_tax( $discounted_line_price, $item_tax_rates, true );
-					$line_tax          = wc_round_tax_total( array_sum( $discounted_taxes ) );
-					$line_total        = $discounted_line_price - $line_tax;
-
-				/**
-				 * Regular tax calculation (customer inside base and the tax class is unmodified.
-				 */
-				} else {
-
-					// Work out a new base price without the item tax
-					$taxes             = WC_Tax::calc_tax( $line_price, $item_tax_rates, true );
-
-					// Now we have a new item price (excluding TAX)
-					$line_subtotal     = $line_price - array_sum( $taxes );
-					$line_subtotal_tax = array_sum( $taxes );
-
-					// Calc prices and tax (discounted)
-					$discounted_price = $this->get_discounted_price( $values, $base_price, true );
-
-					// Convert back to line price
-					$discounted_line_price = round( $discounted_price * $values['quantity'], wc_get_rounding_precision() );
-
-					// Now use rounded line price to get taxes.
-					$discounted_taxes  = WC_Tax::calc_tax( $discounted_line_price, $item_tax_rates, true );
-					$line_tax          = wc_round_tax_total( array_sum( $discounted_taxes ) );
-					$line_total        = $discounted_line_price - $line_tax;
-				}
-
-				// Tax rows - merge the totals we just got
-				foreach ( array_keys( $this->taxes + $discounted_taxes ) as $key ) {
-					$this->taxes[ $key ] = ( isset( $discounted_taxes[ $key ] ) ? wc_round_tax_total( $discounted_taxes[ $key ] ) : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
-				}
-
-			/**
-			 * Prices exclude tax.
-			 */
+				$line_costs = $this->get_line_costs_for_prices_including_tax( $values, $tax_rates[ $product->get_tax_class() ], $shop_tax_rates[ $product->get_tax_class( 'unfiltered' ) ] );
 			} else {
-
-				$item_tax_rates        = $tax_rates[ $product->get_tax_class() ];
-
-				// Work out a new base price without the shop's base tax
-				$taxes                 = WC_Tax::calc_tax( $line_price, $item_tax_rates );
-
-				// Now we have the item price (excluding TAX)
-				$line_subtotal         = $line_price;
-				$line_subtotal_tax     = array_sum( $taxes );
-
-				// Now calc product rates
-				$discounted_price      = $this->get_discounted_price( $values, $base_price, true );
-				$discounted_taxes      = WC_Tax::calc_tax( $discounted_price * $values['quantity'], $item_tax_rates );
-				$discounted_tax_amount = array_sum( $discounted_taxes );
-				$line_tax              = wc_round_tax_total( $discounted_tax_amount );
-				$line_total            = round( $discounted_price * $values['quantity'], wc_get_rounding_precision() );
-
-				// Tax rows - merge the totals we just got
-				foreach ( array_keys( $this->taxes + $discounted_taxes ) as $key ) {
-					$this->taxes[ $key ] = ( isset( $discounted_taxes[ $key ] ) ? wc_round_tax_total( $discounted_taxes[ $key ] ) : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
-				}
+				$line_costs = $this->get_line_costs_for_prices_excluding_tax( $values, $tax_rates[ $product->get_tax_class() ] );
 			}
 
 			// Cart contents total is based on discounted prices and is used for the final total calculation
-			$this->cart_contents_total += $line_total;
+			$this->cart_contents_total += $line_costs->total;
 
-			$this->cart_contents[ $cart_item_key ]['line_total']        = $line_total;
-			$this->cart_contents[ $cart_item_key ]['line_subtotal']     = $line_subtotal;
-			$this->cart_contents[ $cart_item_key ]['line_tax']          = $line_tax;
-			$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $line_subtotal_tax;
-			$this->cart_contents[ $cart_item_key ]['line_tax_data']     = array( 'total' => $discounted_taxes, 'subtotal' => $taxes );
+			// Tax rows - merge the totals we just got
+			foreach ( array_keys( $this->taxes + $line_costs->total_taxes ) as $key ) {
+				if ( ! isset( $line_costs->total_taxes[ $key ] ) ) {
+					continue;
+				}
+				if ( ! isset( $this->taxes[ $key ] ) ) {
+					$this->taxes[ $key ] = 0;
+				}
+				$this->taxes[ $key ] += $line_costs->total_taxes[ $key ];
+			}
+
+			$this->cart_contents[ $cart_item_key ]['line_total']        = $line_costs->total;
+			$this->cart_contents[ $cart_item_key ]['line_subtotal']     = $line_costs->subtotal;
+			$this->cart_contents[ $cart_item_key ]['line_tax']          = $line_costs->total_tax;
+			$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $line_costs->subtotal_tax;
+			$this->cart_contents[ $cart_item_key ]['line_tax_data']     = array( 'total' => $line_costs->total_taxes, 'subtotal' => $line_costs->subtotal_taxes );
 		}
 
 		// Only calculate the grand total + shipping if on the cart/checkout
@@ -1386,6 +1216,115 @@ class WC_Cart {
 		do_action( 'woocommerce_after_calculate_totals', $this );
 
 		$this->set_session();
+	}
+
+	/**
+	 * Get line costs when prices include tax.
+	 *
+	 * @since  3.1.0
+	 * @param  array $cart_item
+	 * @param  array $item_tax_rates
+	 * @param  array $base_tax_rates
+	 * @param  bool  $subtotal_only
+	 * @return object
+	 */
+	private function get_line_costs_for_prices_including_tax( $cart_item, $item_tax_rates, $base_tax_rates, $subtotal_only = false ) {
+		$product              = $cart_item['data'];
+		$quantity             = $cart_item['quantity'];
+		$line_costs           = new stdClass();
+		$line_costs->subtotal = round( $product->get_price() * $quantity, wc_get_rounding_precision() );
+
+		/**
+		 * ADJUST TAX - Calculations when base tax is not equal to the item tax.
+		 *
+		 * The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations.
+		 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
+		 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
+		 */
+		if ( $item_tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
+			// Work out a new base price without the shop's base tax.
+			$taxes                      = WC_Tax::calc_tax( $line_costs->subtotal, $base_tax_rates, true, true );
+
+			// Now we have a new item price (excluding TAX).
+			$line_costs->subtotal       = round( $line_costs->subtotal - array_sum( $taxes ), wc_get_rounding_precision() );
+			$line_costs->subtotal_taxes = WC_Tax::calc_tax( $line_costs->subtotal, $item_tax_rates );
+			$line_costs->subtotal_tax   = round( array_sum( $line_costs->subtotal_taxes ), wc_get_rounding_precision() );
+
+			if ( $subtotal_only ) {
+				return $line_costs;
+			}
+
+			// Adjusted price (this is the price including the new tax rate).
+			$adjusted_price             = round( ( $line_costs->subtotal + $line_costs->subtotal_tax ) / $values['quantity'], wc_get_rounding_precision() );
+
+			// Apply discounts and get the discounted price FOR A SINGLE ITEM.
+			$discounted_price           = $this->get_discounted_price( $values, $adjusted_price, true );
+
+			// Round discounted line price to the DP setting rather than precision - this is the price being charged.
+			$discounted_line            = round( $discounted_price * $quantity, wc_get_rounding_precision() );
+
+			// Convert back to line price and get total taxes.
+			$line_costs->total_taxes    = WC_Tax::calc_tax( $discounted_line, $item_tax_rates, true );
+			$line_costs->total_tax      = round( array_sum( $line_costs->total_taxes ), wc_get_rounding_precision() );
+			$line_costs->total          = round( $discounted_line - $line_costs->total_tax, wc_get_rounding_precision() );
+		} else {
+			$line_costs->subtotal_taxes = WC_Tax::calc_tax( $line_costs->subtotal, $base_tax_rates, true );
+			$line_costs->subtotal_tax   = round( array_sum( $line_costs->subtotal_taxes ), wc_get_rounding_precision() );
+			$line_costs->subtotal       = round( $line_costs->subtotal - $line_costs->subtotal_tax, wc_get_rounding_precision() );
+
+			if ( $subtotal_only ) {
+				return $line_costs;
+			}
+
+			$discounted_price           = $this->get_discounted_price( $cart_item, $product->get_price(), true );
+			$discounted_line            = round( $discounted_price * $quantity, wc_get_rounding_precision() );
+
+			$line_costs->total_taxes    = WC_Tax::calc_tax( $discounted_line, $item_tax_rates, true );
+			$line_costs->total_tax      = round( array_sum( $line_costs->total_taxes ), wc_get_rounding_precision() );
+			$line_costs->total          = round( $discounted_line - $line_costs->total_tax, wc_get_rounding_precision() );
+		}
+
+		return $line_costs;
+	}
+
+	/**
+	 * Get line costs when prices exclude tax.
+	 *
+	 * @since  3.1.0
+	 * @param  array $cart_item
+	 * @param  array $item_tax_rates
+	 * @param  bool  $subtotal_only
+	 * @return object
+	 */
+	private function get_line_costs_for_prices_excluding_tax( $cart_item, $item_tax_rates = false, $subtotal_only = false ) {
+		$product                    = $cart_item['data'];
+		$quantity                   = $cart_item['quantity'];
+		$line_costs                 = new stdClass();
+		$line_costs->subtotal       = round( $product->get_price() * $quantity, wc_get_rounding_precision() );
+		$line_costs->subtotal_taxes = array();
+		$line_costs->subtotal_tax   = 0;
+
+		if ( $product->is_taxable() && $item_tax_rates ) {
+			$line_costs->subtotal_taxes = WC_Tax::calc_tax( $line_costs->subtotal, $item_tax_rates );
+			$line_costs->subtotal_tax   = round( array_sum( $line_costs->subtotal_taxes ), wc_get_rounding_precision() );
+		}
+
+		if ( $subtotal_only ) {
+			return $line_costs;
+		}
+
+		$discounted_price        = $this->get_discounted_price( $cart_item, $product->get_price(), true );
+		$discounted_line         = round( $discounted_price * $quantity, wc_get_rounding_precision() );
+		$line_costs->total       = round( $discounted_line, wc_get_rounding_precision() );
+		$line_costs->total_taxes = array();
+		$line_costs->total_tax   = 0;
+
+		if ( $product->is_taxable() && $item_tax_rates ) {
+			$line_costs->total_taxes    = WC_Tax::calc_tax( $line_costs->total, $item_tax_rates );
+			$line_costs->total_tax      = round( array_sum( $line_costs->total_taxes ), wc_get_rounding_precision() );
+		}
+
+		return $line_costs;
 	}
 
 	/**

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -81,7 +81,7 @@ class WC_Tax {
 		}
 
 		// Round to precision
-		if ( ! self::$round_at_subtotal && ! $suppress_rounding ) {
+		if ( ! $suppress_rounding ) {
 			$taxes = array_map( 'round', $taxes ); // Round to precision
 		}
 
@@ -694,7 +694,7 @@ class WC_Tax {
 	 * @return  float
 	 */
 	public static function get_tax_total( $taxes ) {
-		return array_sum( array_map( 'wc_round_tax_total', $taxes ) );
+		return array_sum( array_map( array( __CLASS__, 'round' ), $taxes ) );
 	}
 
 	/**

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -694,7 +694,7 @@ class WC_Tax {
 	 * @return  float
 	 */
 	public static function get_tax_total( $taxes ) {
-		return array_sum( array_map( array( __CLASS__, 'round' ), $taxes ) );
+		return array_sum( array_map( 'wc_round_tax_total', $taxes ) );
 	}
 
 	/**

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -356,7 +356,10 @@ function wc_cart_totals_shipping_method_label( $method ) {
  * @param  int $precision
  * @return float
  */
-function wc_cart_round_discount( $value, $precision ) {
+function wc_cart_round_discount( $value, $precision = 0 ) {
+	if ( ! $precision ) {
+		$precision = wc_get_price_decimals();
+	}
 	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
 		return round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE );
 	} else {

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -55,7 +55,15 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 		WC()->cart->remove_coupons();
 
-		# Test case 2 #10573
+		/**
+		 * Test case 2 #10573 modified.
+		 *
+		 * User wanted line to be 24.51, however, mathmatically without rounding
+		 * before save this is not possible.
+		 *
+		 * Actualy values are 24.5045 and 2.4505 tax. This gives 26.955.
+		 * 29.95 with 10% off is 26.955, so this actually matches up.
+		 */
 		update_post_meta( $product->get_id(), '_regular_price', '29.95' );
 		update_post_meta( $product->get_id(), '_price', '29.95' );
 		update_post_meta( $coupon->get_id(), 'discount_type', 'percent' );
@@ -81,7 +89,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 		WC()->cart->calculate_totals();
 		$cart_item = current( WC()->cart->get_cart() );
-		$this->assertEquals( '24.51', number_format( $cart_item['line_total'], 2, '.', '' ) );
+		$this->assertEquals( '24.50', number_format( $cart_item['line_total'], 2, '.', '' ) );
 
 		// Cleanup
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -426,15 +426,14 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Get tax totals.
+	 * Test the get_tax_total method which rounds each row to get a grand total.
 	 */
 	public function test_get_tax_total() {
 		$to_total = array(
 			'1' => '1.665',
 			'2' => '2',
 		);
-
-		$this->assertEquals( WC_Tax::get_tax_total( $to_total ), '3.665' );
+		$this->assertEquals( '3.67', WC_Tax::get_tax_total( $to_total ) );
 	}
 
 	/**

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -433,7 +433,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 			'1' => '1.665',
 			'2' => '2',
 		);
-		$this->assertEquals( '3.67', WC_Tax::get_tax_total( $to_total ) );
+		$this->assertEquals( '3.665', WC_Tax::get_tax_total( $to_total ) );
 	}
 
 	/**


### PR DESCRIPTION
For #14458

Does extra rounding on taxes after calculation/totalling to reduce likelihood of rounding errors.

Also removes the quasi-rounding for tax inclusive prices since it’s not needed if the above works as it should.

Unit tests and my own tests pass. 1 unit test modified to reflect the rounding function used.

Todo:

- [ ] Tests covering prices inc tax, display inc tax
- [ ] Tests covering prices inc tax, display ex tax
- [ ] Tests covering prices ex tax, display inc tax
- [ ] Tests covering prices ex tax, display ex tax
- [ ] Handle euro_5cent_rounding example throughout (need to round early)