### PR TITLE
Adds a fallback to queue_transactional_email if background sending is disabled.

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -102,13 +102,18 @@ class WC_Emails {
 	}
 
 	/**
-	 * Queue transactional email so it's not sent in current request.
+	 * Queues transactional email so it's not sent in current request if enabled,
+	 * otherwise falls back to send now.
 	 */
 	public static function queue_transactional_email() {
-		self::$background_emailer->push_to_queue( array(
-			'filter' => current_filter(),
-			'args'   => func_get_args(),
-		) );
+		if ( is_a( self::$background_emailer, 'WC_Background_Emailer' ) ) {
+			self::$background_emailer->push_to_queue( array(
+				'filter' => current_filter(),
+				'args'   => func_get_args(),
+			) );
+		} else {
+			call_user_func_array( array( __CLASS__, 'send_transactional_email' ), func_get_args() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #14476

After turning off deferred emails by default it seems Subscriptions was
using the ‘default’ value in a filter to check if deferred emails were
enabled or not to hook in these methods.

https://github.com/woocommerce/woocommerce-subscriptions/blob/f87a11cdf0
9bb59aa66f4e86d37592f74193937f/includes/class-wc-subscriptions-email.php
#L339

@thenbrent

This code change adds a fallback so if this method was hooked in
anywhere, and the background emailer was not init or disabled, it will
fallback to regular send-now.