### PR TITLE
[3.0.3] Fix Undefined property notice in `WC_Order_Item::offsetGet`

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -303,7 +303,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			$return = array();
 
 			foreach ( $this->meta_data as $meta ) {
-				$return[ $meta->id ] = $meta;
+				$return[ $meta->key ] = $meta;
 			}
 
 			return $return;


### PR DESCRIPTION
This could be the culprit for a number of plugin-related issues.

Found it while doing some tests with the Shipstation Integration extension.