### PR TITLE
wc_update_300_grouped_products update routine needs to unset the post_parent on grouped products

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1020,7 +1020,18 @@ function wc_update_300_grouped_products() {
 				'post_type'      => 'product',
 				'fields'         => 'ids',
 			) );
-			add_post_meta( $parent_id, '_children', $children_ids, true );
+			update_post_meta( $parent_id, '_children', $children_ids );
+
+			// Update children to remove the parent.
+			$wpdb->update(
+				$wpdb->posts,
+				array(
+					'post_parent' => 0,
+				),
+				array(
+					'post_parent' => $parent_id,
+				)
+			);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #14507