### PR TITLE
[3.0.3] Fix PHP 7.1 `wc_get_weight` warning

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -165,6 +165,7 @@ function wc_get_dimension( $dimension, $to_unit, $from_unit = '' ) {
  * @return float
  */
 function wc_get_weight( $weight, $to_unit, $from_unit = '' ) {
+	$weight  = (float) $weight;
 	$to_unit = strtolower( $to_unit );
 
 	if ( empty( $from_unit ) ) {


### PR DESCRIPTION
Fixes a `A non-numeric value encountered` warning with PHP 7.1.

Note that this will always cause the function to return a `float` type weight. I am not sure if this might have any undesirable consequences, e.g. when the weight is empty.

ref: https://github.com/woocommerce/woocommerce/issues/12748