### PR TITLE
Wrong variable name in \wc_add_order_item

### DIFF
--- a/includes/wc-order-item-functions.php
+++ b/includes/wc-order-item-functions.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param array $item_array
  * @return int|bool Item ID or false
  */
-function wc_add_order_item( $order_id, $item ) {
+function wc_add_order_item( $order_id, $item_array ) {
 	if ( ! $order_id = absint( $order_id ) ) {
 		return false;
 	}


### PR DESCRIPTION
It looks like the intention was to use the variable name `$item_array` but `$item` in the arguments list of  \wc_add_order_item.