### PR TITLE
Ensure order is not cached before download permissions are generated

### DIFF
--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -350,16 +350,17 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @return array
 	 */
 	public function get_item_downloads() {
-		$files   = array();
-		$product = $this->get_product();
-		$order   = $this->get_order();
+		$files      = array();
+		$product    = $this->get_product();
+		$order      = $this->get_order();
+		$product_id = $this->get_variation_id() ? $this->get_variation_id() : $this->get_product_id();
 
 		if ( $product && $order && $product->is_downloadable() && $order->is_download_permitted() ) {
 			$data_store         = WC_Data_Store::load( 'customer-download' );
 			$customer_downloads = $data_store->get_downloads( array(
 				'user_email' => $order->get_billing_email(),
 				'order_id'   => $order->get_id(),
-				'product_id' => $this->get_variation_id() ? $this->get_variation_id() : $this->get_product_id(),
+				'product_id' => $product_id,
 			) );
 			foreach ( $customer_downloads as $customer_download ) {
 				$download_id = $customer_download->get_download_id();
@@ -367,7 +368,12 @@ class WC_Order_Item_Product extends WC_Order_Item {
 				if ( $product->has_file( $download_id ) ) {
 					$file                                  = $product->get_file( $download_id );
 					$files[ $download_id ]                 = $file->get_data();
-					$files[ $download_id ]['download_url'] = $this->get_item_download_url( $download_id );
+					$files[ $download_id ]['download_url'] = add_query_arg( array(
+						'download_file' => $product_id,
+						'order'         => $order->get_order_key(),
+						'email'         => urlencode( $order->get_billing_email() ),
+						'key'           => $download_id,
+					), trailingslashit( home_url() ) );
 				}
 			}
 		}

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -27,12 +27,6 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	);
 
 	/**
-	 * May store an order to prevent retriving it multiple times.
-	 * @var object
-	 */
-	protected $order;
-
-	/**
 	 * Stores meta in cache for future reads.
 	 * A group must be set to to enable caching.
 	 * @var string
@@ -122,10 +116,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @return int
 	 */
 	public function get_order() {
-		if ( ! $this->order ) {
-		 	$this->order = wc_get_order( $this->get_order_id() );
-		}
-		return $this->order;
+		return wc_get_order( $this->get_order_id() );
 	}
 
 	/*


### PR DESCRIPTION
Fixes an obscure bug @franticpsyx found where the order could be cached before downloads were generated, so they were missing from the first email after ordering.