### PR TITLE
Added update Meta Data cache after each change to meta_data array

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -347,6 +347,8 @@ abstract class WC_Data {
 			'key'   => $key,
 			'value' => $value,
 		);
+
+		$this->update_meta_data_cache();
 	}
 
 	/**
@@ -365,6 +367,8 @@ abstract class WC_Data {
 				'key'   => $key,
 				'value' => $value,
 			);
+
+			$this->update_meta_data_cache();
 		} else {
 			$this->add_meta_data( $key, $value, true );
 		}
@@ -382,6 +386,8 @@ abstract class WC_Data {
 			foreach ( $array_keys as $array_key ) {
 				$this->meta_data[ $array_key ]->value = null;
 			}
+
+			$this->update_meta_data_cache();
 		}
 	}
 
@@ -487,6 +493,18 @@ abstract class WC_Data {
 
 		if ( ! empty( $this->cache_group ) ) {
 			WC_Cache_Helper::incr_cache_prefix( $this->cache_group );
+		}
+	}
+
+	/**
+	 * Update Meta Data cache
+	 *
+	 * @since 3.1.0
+	 */
+	public function update_meta_data_cache(){
+		if ( ! empty( $this->cache_group ) ) {
+			$cache_key = WC_Cache_Helper::get_cache_prefix( $this->cache_group ) . 'object_meta_' . $this->get_id();
+			wp_cache_set( $cache_key, $this->meta_data, $this->cache_group );
 		}
 	}
 


### PR DESCRIPTION
**tl;dr**
meta_data cache, set in _includes/abstracts/_**abstract-wc-data.php**:441needs to be updated each time a method changes meta array

I added `update_meta_data_cache()` method to `WC_data` class, to perform this operation

# Problem Description

It seems that if we use any of the `WC_Data`'s method to update meta_data array, and then we get a new instance of the same `WC_Data `object, changes to meta data array are lost

Let's make a proper example, considering a Product (`WC_Product` extends `WC_Data`)
If I get the product object, using `wc_get_product()` function, and I add some meta data to it, using `add_meta_data()` method, everything seems to work just fine

Anyway, if then I get the same product, calling `wc_get_product()` again, my changes to meta data are lost

This could be totally ok, by the way, so please ignore this request if this was intended; anyway I think that product instances should match each other, especially when talking about meta data, that could be stored into DB in a second moment

# How to recreate the problem

Using latest WooCommerce commit, simply follow these steps

1. Add the following code to **functions.php** file of your theme or child
```
function test1(){
    $product = wc_get_product(70);
    $product->add_meta_data( 'test_key', 'test_value' );
}
add_action( 'init', 'test1' );

function test2(){
	$product = wc_get_product(70);
	var_dump( $product->get_meta( 'test_key', true ) );die();
}
add_action( 'init', 'test2', 20 );
```
2. Visit any page of the site

My code just performs two different actions on `init` hook:
- first (priority 10) set a meta for the product with id 70 (change that to any product ID actually present in your DB)
- then (priority 20) retrieves back the product with id 70, and print value for the meta added before

This code should just print an empty string, to demonstrate that my meta is lost

# Why this is happening

I think that the problem is related to the fact that cache for `meta_data` is set on the first call of `read_meta_data()` method, using values read from DB, but it never gets updated

Once cache is set, each subsequent call to `read_meta_data()` will just return the meta cache, that could, at this point, contain outdated informations

# Possible solution to the problem

An easy fix would be to update cached values each time something changes into `meta_data` array

I added the `update_meta_data_cache()` method to `WC_Data` class, in order to perform this operation, and I simply call it each time a change is performed over `meta_data` property
This means in the following methods:
- `add_meta_data()`
- `update_meta_data()`
- `delete_meta_data()`