### PR TITLE
Change field label and placeholder to minimize user error

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -577,8 +577,9 @@ class WC_Countries {
 				'priority'     => 40,
 			),
 			'address_1' => array(
-				'label'        => __( 'Address', 'woocommerce' ),
-				'placeholder'  => esc_attr__( 'Street address', 'woocommerce' ),
+				'label'        => __( 'Street address', 'woocommerce' ),
+				/* translators: use local order of street name and house number. */
+				'placeholder'  => esc_attr__( 'House number and street name', 'woocommerce' ),
 				'required'     => true,
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line1',


### PR DESCRIPTION
…ators notice

**Status Quo**
Working with several high-volume WooCommerce shops (in the range of several thousand orders per day combined), we've seen that the current placeholder text (and its translations in particular) lead to quite a few users filling in their address data incorrectly. You'd be surprised by the number of people who fail to properly write down their own address (house number missing, house number in wrong place).

**Problem**
This leads to incomplete shipping labels, unsuccessful deliveries, and costly returns (especially for international shipping: 10-40 Euros lost per parcel).

**Solution**
While some of these may stem from misdirected or incomplete browser auto-fills, we've seen (by customizing the language files for German, French, Spanish and Italian) that a more descriptive placeholder text helps reduce user errors on address entry. The goal is basically to make this as fool-proof as possible.

**Why this matters**
At 1000 orders shipped per day, getting the error rate from 5% down to 4% means 10 less parcels coming back every day, which can save hundreds of Euros per day.

**Choice of wording**
- "Address" is not just one field, but rather the sum of all address fields that will end up on a shipping label.
- "Street Address" is what the user needs to input here, hence the new label for the two address fields
- "House number and street name" is the most descriptive placeholder text I can come up with for this field (assuming the U.S. as default), hence the new placeholder text. 
- Translator notice added since many countries will have the house number after the street name.

**References**
- https://en.wikipedia.org/wiki/Address_(geography)