### PR TITLE
Add custom message for custom system status tools

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -446,7 +446,9 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				if ( isset( $tools[ $tool ]['callback'] ) ) {
 					$callback = $tools[ $tool ]['callback'];
 					$return = call_user_func( $callback );
-					if ( false === $return ) {
+					if ( is_string( $return ) ) {
+						$message = $return;
+					} elseif ( false === $return ) {
 						$callback_string = is_array( $callback ) ? get_class( $callback[0] ) . '::' . $callback[1] : $callback;
 						$ran = false;
 						$message = sprintf( __( 'There was an error calling %s', 'woocommerce' ), $callback_string );


### PR DESCRIPTION
In WC 2.6, it is possible to display a custom message after a custom system status tool has run with a simple echo. In WC 3.0, this still works while on admin (although it appears above the generic 'Tool ran') but won't while running the tools from the REST API. I suggest to add the possibility to authors of custom system status tools to return a meaningful message.