### PR TITLE
Automatic Shipping Zone Creation In Setup Wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -536,7 +536,8 @@ class WC_Admin_Setup_Wizard {
 
 			/*
 			 * If this is the initial shipping setup, create a shipping
-			 * zone containing the country the store is located in.
+			 * zone containing the country the store is located in, with
+			 * a "free shipping" method preconfigured.
 			 */
 			if ( false === $current_shipping ) {
 				$default_country = get_option( 'woocommerce_default_country' );
@@ -546,6 +547,7 @@ class WC_Admin_Setup_Wizard {
 				$zone->set_zone_order( 0 );
 				$zone->add_location( $location['country'], 'country' );
 				$zone->set_zone_name( $zone->get_formatted_location() );
+				$zone->add_shipping_method( 'free_shipping' );
 				$zone->save();
 			}
 		} else {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -526,24 +526,28 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_shipping_taxes_save() {
 		check_admin_referer( 'wc-setup' );
 
-		$enable_shipping = isset( $_POST['woocommerce_calc_shipping'] );
-		$enable_taxes    = isset( $_POST['woocommerce_calc_taxes'] );
+		$enable_shipping  = isset( $_POST['woocommerce_calc_shipping'] );
+		$enable_taxes     = isset( $_POST['woocommerce_calc_taxes'] );
+		$current_shipping = get_option( 'woocommerce_ship_to_countries' );
 
 		if ( $enable_shipping ) {
 			update_option( 'woocommerce_ship_to_countries', '' );
 			WC_Admin_Notices::add_notice( 'no_shipping_methods' );
 
 			/*
-			 * Create a shipping zone containing the country the store is located in.
+			 * If this is the initial shipping setup, create a shipping
+			 * zone containing the country the store is located in.
 			 */
-			$default_country = get_option( 'woocommerce_default_country' );
-			$location        = wc_format_country_state_string( $default_country );
+			if ( false === $current_shipping ) {
+				$default_country = get_option( 'woocommerce_default_country' );
+				$location        = wc_format_country_state_string( $default_country );
 
-			$zone = new WC_Shipping_Zone( null );
-			$zone->set_zone_order( 0 );
-			$zone->add_location( $location['country'], 'country' );
-			$zone->set_zone_name( $zone->get_formatted_location() );
-			$zone->save();
+				$zone = new WC_Shipping_Zone( null );
+				$zone->set_zone_order( 0 );
+				$zone->add_location( $location['country'], 'country' );
+				$zone->set_zone_name( $zone->get_formatted_location() );
+				$zone->save();
+			}
 		} else {
 			update_option( 'woocommerce_ship_to_countries', 'disabled' );
 		}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -532,6 +532,18 @@ class WC_Admin_Setup_Wizard {
 		if ( $enable_shipping ) {
 			update_option( 'woocommerce_ship_to_countries', '' );
 			WC_Admin_Notices::add_notice( 'no_shipping_methods' );
+
+			/*
+			 * Create a shipping zone containing the country the store is located in.
+			 */
+			$default_country = get_option( 'woocommerce_default_country' );
+			$location        = wc_format_country_state_string( $default_country );
+
+			$zone = new WC_Shipping_Zone( null );
+			$zone->set_zone_order( 0 );
+			$zone->add_location( $location['country'], 'country' );
+			$zone->set_zone_name( $zone->get_formatted_location() );
+			$zone->save();
 		} else {
 			update_option( 'woocommerce_ship_to_countries', 'disabled' );
 		}


### PR DESCRIPTION
This PR seeks to create a shipping zone containing the store’s country and a "free shipping" method when enabling shipping calculation from the setup wizard (and only if it's the first run).

<img width="747" alt="screen shot 2017-04-20 at 10 56 44 pm" src="https://cloud.githubusercontent.com/assets/63922/25263580/d4bfe496-261d-11e7-8a24-342ceacb5de4.png">

<img width="744" alt="screen shot 2017-04-20 at 10 59 22 pm" src="https://cloud.githubusercontent.com/assets/63922/25263582/d84edc52-261d-11e7-8e61-8eb4f1b8f366.png">

![screen shot 2017-04-21 at 8 46 27 am](https://cloud.githubusercontent.com/assets/63922/25282880/0ec003dc-266f-11e7-9f25-6c1ce5d19fdd.png)


(cc: @kellychoffman)