### PR TITLE
Fetch only guest orders: Allow passing a `customer=0` filter on the order request

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -353,7 +353,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 			$args['post_status'] = 'any';
 		}
 
-		if ( ! empty( $request['customer'] ) ) {
+		if ( isset( $request['customer'] ) ) {
 			if ( ! empty( $args['meta_query'] ) ) {
 				$args['meta_query'] = array();
 			}

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -407,7 +407,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 			$args['post_status'] = 'any';
 		}
 
-		if ( ! empty( $request['customer'] ) ) {
+		if ( isset( $request['customer'] ) ) {
 			if ( ! empty( $args['meta_query'] ) ) {
 				$args['meta_query'] = array();
 			}


### PR DESCRIPTION
Issue: the `customer` filter for retrieving orders should allow passing a `0` to get all the guest checkouts. Since the check is done with `if (! empty(...))` that automatically discards the filter and the request will retrieve all orders for all customers.

Solution: Use `isset` to rather check for the presence of the `customer` filter which will allow fetching only guest checkouts if the `customer` filter is set to `0`.