### PR TITLE
Fix help tip display with shipping zone modals

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -4381,6 +4381,7 @@ img.tips {
 
 #tiptip_holder {
 	display: none;
+	z-index: 8675309;
 	position: absolute;
 	top: 0;
 	/*rtl:ignore*/


### PR DESCRIPTION
Do some Tommy Tutone magic here so this:

![tooltip-before](https://cloud.githubusercontent.com/assets/4983547/25294784/d5134afa-26ae-11e7-9827-74dbb7171d1c.png)

becomes this:

![tooltip-after](https://cloud.githubusercontent.com/assets/4983547/25294799/e0c68a9c-26ae-11e7-8fb9-3895e62f45c4.png)
