### PR TITLE
Fix :before element appearing on orders pages on mobile issue

### DIFF
--- a/assets/css/woocommerce-smallscreen.scss
+++ b/assets/css/woocommerce-smallscreen.scss
@@ -40,8 +40,12 @@
 				display: block;
 				text-align: right !important; // Important to overwrite order status inline styling
 
-				&.order-actions {
+				&.woocommerce-orders-table__cell-order-actions {
 					text-align: left !important; // This must always align left on handheld
+
+					&::before {
+						display: none;
+					}
 				}
 
 				&::before {


### PR DESCRIPTION
@mikejolley 

I have fixed :before element appearing on orders pages on the mobile issue and also I have set the "View" order text on the left side as it was in < 3.0 versions. Please let me know your suggestion if any changes required.

#14581 

Thanks,