### PR TITLE
Improved meta data cache

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -327,6 +327,7 @@ abstract class WC_Data {
 					);
 				}
 			}
+			$this->update_meta_data_cache();
 		}
 	}
 
@@ -347,6 +348,7 @@ abstract class WC_Data {
 			'key'   => $key,
 			'value' => $value,
 		);
+		$this->update_meta_data_cache();
 	}
 
 	/**
@@ -455,10 +457,20 @@ abstract class WC_Data {
 					);
 				}
 
-				if ( ! empty( $this->cache_group ) ) {
-					wp_cache_set( $cache_key, $this->meta_data, $this->cache_group );
-				}
+				$this->update_meta_data_cache();
 			}
+		}
+	}
+
+	/**
+	 * Saves the meta_data Array in the object global cache. It should be called
+	 * everytime a new entry is added to meta_data. Updates are reflected automatically
+	 * in the global cache because objects are always by reference.
+	 */
+	protected function update_meta_data_cache() {
+		if ( ! empty( $this->cache_group ) ) {
+			$cache_key = WC_Cache_Helper::get_cache_prefix( $this->cache_group ) . 'object_meta_' . $this->get_id();
+			wp_cache_set( $cache_key, $this->meta_data, $this->cache_group );
 		}
 	}
 

--- a/tests/framework/class-wc-mock-wc-data.php
+++ b/tests/framework/class-wc-mock-wc-data.php
@@ -224,3 +224,11 @@ class WC_Mock_WC_Data extends WC_Data {
 		return $this->get_id();
 	}
 }
+
+/**
+ * A child class of WC_Mock_WC_Data but it has the meta data
+ * cache enabled.
+ */
+class WC_Mock_WC_Data_With_Cache extends WC_Mock_WC_Data {
+	protected $cache_group = __CLASS__;
+}

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -257,6 +257,22 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	}
 
 
+	function test_metadata_global_cache() {
+		$object    = $this->create_test_post();
+		$object_id = $object->get_id();
+		$object->add_meta_data( 'test_meta_key', 'val1', true );
+		$object->save();
+
+		$object = new WC_Mock_WC_Data_With_Cache( $object_id );
+		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
+		$object->add_meta_data( 'test_meta_key', 'val2', true );
+		$this->assertEquals( 'val2', $object->get_meta( 'test_meta_key' ) );
+
+		$object = new WC_Mock_WC_Data_With_Cache( $object_id );
+		$this->assertEquals( 'val2', $object->get_meta( 'test_meta_key' ) );
+	}
+
+
 	/**
 	 * Test saving metadata.. (Actually making sure changes are written to DB)
 	 */


### PR DESCRIPTION
Meta data cache is shared among all instances. That is because each meta data internally is an object (and objects are always referenced in PHP 5 and onwards). That's a fantastic feature and it reduces possible races conditions (at least in the same request).

There is one corner case which is not covered though, new data added to the meta data array are not updating the global cache, which leads to inconsistencies. For instance when `update_meta_data` is called, internally it will eliminate any previous value before adding a new value if no $meta_id is passed.

```php
$sub1 = wcs_get_subscription( 1317 );
$sub1->add_meta_data( '_stripe_customer_id', 'something else', true );

$sub2 = wcs_get_subscription( 1317 );
$value = $sub2->get_meta( '_stripe_customer_id' );
var_dump($value); // string(0) ""
```

What happens there is that `add_meta_data` removes the value `_stripe_customer_id` (which is updated in the global cache, because "removing" means set its value to NULL), but the new entry `something else` is not added, therefore in the second instance the value is empty, instead of `something else`.

This commit synchronizes any new value added to the meta_data to the global cache as well.