### PR TITLE
Fix: Creating customer triggers password changed

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -101,6 +101,10 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 
 		$customer->set_id( $id );
 		$this->update_user_meta( $customer );
+		
+		// Prevent wp_update_user calls in the same request and customer trigger the 'Notice of Password Changed' email
+		$customer->set_password( '' );
+		
 		wp_update_user( apply_filters( 'woocommerce_update_customer_args', array(
 			'ID'           => $customer->get_id(),
 			'role'         => $customer->get_role(),


### PR DESCRIPTION
Sending POST /wc/v1/customers or POST /wc/v2/customers with the required args triggers the 'Notice of Password Changed' after creating the customer due to update() calls when the password still has a value.