### PR TITLE
Change build_payload from private to public

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -335,7 +335,7 @@ class WC_Webhook {
 	 * @param mixed $resource_id first hook argument, typically the resource ID
 	 * @return mixed payload data
 	 */
-	private function build_payload( $resource_id ) {
+	public function build_payload( $resource_id ) {
 		// build the payload with the same user context as the user who created
 		// the webhook -- this avoids permission errors as background processing
 		// runs with no user context


### PR DESCRIPTION
In the `WC_Webhook` class there is an explicit filter to stop WooCommerce form delivering a payload so it can be delivered using messages queues such as rabbit/zeromq: https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-webhook.php#L182. However, there is no way for a plugin to access the payload that WooCommerce is intending to send.

This PR fixed this issue by making the `build_payload` method public on the `WC_Webhook` class. This way the intended payload is accessible using `$webhook->build_payload`.