### PR TITLE
Fix for Custom Post Type as a Product

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -798,8 +798,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	protected function get_items_key( $item ) {
-		
-		if ( is_a( $item, 'WC_Order_Item_Fee' ) ) {
+		if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
+			return 'line_items';
+		} elseif ( is_a( $item, 'WC_Order_Item_Fee' ) ) {
 			return 'fee_lines';
 		} elseif ( is_a( $item, 'WC_Order_Item_Shipping' ) ) {
 			return 'shipping_lines';
@@ -808,7 +809,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		} elseif ( is_a( $item, 'WC_Order_Item_Coupon' ) ) {
 			return 'coupon_lines';
 		} else {
-			return 'line_items';
+			return apply_filters( 'woocommerce_items_type_key', '', $item );
 		}
 	}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -798,9 +798,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	protected function get_items_key( $item ) {
-		if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
-			return 'line_items';
-		} elseif ( is_a( $item, 'WC_Order_Item_Fee' ) ) {
+		
+		if ( is_a( $item, 'WC_Order_Item_Fee' ) ) {
 			return 'fee_lines';
 		} elseif ( is_a( $item, 'WC_Order_Item_Shipping' ) ) {
 			return 'shipping_lines';
@@ -809,7 +808,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		} elseif ( is_a( $item, 'WC_Order_Item_Coupon' ) ) {
 			return 'coupon_lines';
 		} else {
-			return '';
+			return 'line_items';
 		}
 	}
 

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -349,7 +349,7 @@ class WC_Checkout {
 	public function create_order_line_items( &$order, $cart ) {
 		foreach ( $cart->get_cart() as $cart_item_key => $values ) {
 			$product                    = $values['data'];
-			$item                       = apply_filters( 'woocommerce_order_line_item', new WC_Order_Item_Product());
+			$item                       = apply_filters( 'woocommerce_order_line_item', new WC_Order_Item_Product(), $product);
 			$item->legacy_values        = $values; // @deprecated For legacy actions.
 			$item->legacy_cart_item_key = $cart_item_key; // @deprecated For legacy actions.
 			$item->set_props( array(

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -349,7 +349,7 @@ class WC_Checkout {
 	public function create_order_line_items( &$order, $cart ) {
 		foreach ( $cart->get_cart() as $cart_item_key => $values ) {
 			$product                    = $values['data'];
-			$item                       = new WC_Order_Item_Product();
+			$item                       = apply_filters( 'woocommerce_order_line_item', new WC_Order_Item_Product());
 			$item->legacy_values        = $values; // @deprecated For legacy actions.
 			$item->legacy_cart_item_key = $cart_item_key; // @deprecated For legacy actions.
 			$item->set_props( array(

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -349,7 +349,7 @@ class WC_Checkout {
 	public function create_order_line_items( &$order, $cart ) {
 		foreach ( $cart->get_cart() as $cart_item_key => $values ) {
 			$product                    = $values['data'];
-			$item                       = apply_filters( 'woocommerce_order_line_item', new WC_Order_Item_Product(), $product);
+			$item                       = apply_filters( 'woocommerce_order_line_item_object', new WC_Order_Item_Product(), $values );
 			$item->legacy_values        = $values; // @deprecated For legacy actions.
 			$item->legacy_cart_item_key = $cart_item_key; // @deprecated For legacy actions.
 			$item->set_props( array(

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -79,6 +79,7 @@ class WC_Order_Factory {
 				case 'line_item' :
 				case 'product' :
 					$classname = 'WC_Order_Item_Product';
+					$classname = apply_filters( 'woocommerce_get_order_item_classname', $classname, $item_type, $id );
 				break;
 				case 'coupon' :
 					$classname = 'WC_Order_Item_Coupon';


### PR DESCRIPTION
Fix for the problem that is discussed here - https://github.com/woocommerce/woocommerce/issues/14302

As I also wrote there:

`WC_Order_Factory -> get_order_item` never goes to its default case and thus never applies the `woocommerce_get_order_item_classname` filter because  the operation bails before that in `WC_Abstract_Order -> add_item`(`WC_Abstract_Order -> get_items_key` returns nothng on a custom classname).


The only thing that I'm concerned is if the change in `WC_Abstract_Order -> get_items_key` is correct.