### PR TITLE
Fix term exclusion in term count queries

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -552,21 +552,24 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 
 	// Main query.
 	$count_query = "
-		SELECT COUNT( DISTINCT posts.ID ) FROM {$wpdb->posts} as posts
-		LEFT JOIN {$wpdb->term_relationships} AS rel ON posts.ID=rel.object_ID
-		LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id )
+		SELECT COUNT( DISTINCT ID ) FROM wp_posts
 		WHERE post_status = 'publish'
 		AND post_type = 'product'
 	";
 
 	$product_visibility_term_ids = wc_get_product_visibility_term_ids();
+	$exclude_term_ids            = array();
 
 	if ( $product_visibility_term_ids['exclude-from-catalog'] ) {
-		$count_query .= " AND term_taxonomy_id !=" . $product_visibility_term_ids['exclude-from-catalog'];
+		$exclude_term_ids[] = $product_visibility_term_ids['exclude-from-catalog'];
 	}
 
 	if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && $product_visibility_term_ids['outofstock'] ) {
-		$count_query .= " AND term_taxonomy_id !=" . $product_visibility_term_ids['outofstock'];
+		$exclude_term_ids[] = $product_visibility_term_ids['outofstock'];
+	}
+
+	if ( $exclude_term_ids ) {
+		$count_query .= " AND ID NOT IN ( SELECT object_ID FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN (" . implode( ',', array_map( 'absint', $exclude_term_ids ) ) . " ) ) ";
 	}
 
 	// Pre-process term taxonomy ids.
@@ -610,7 +613,7 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 		}
 
 		// Generate term query
-		$term_query = ' AND term_id IN ( ' . implode( ',', $terms_to_count ) . ' )';
+		$term_query = " AND ID IN ( SELECT object_ID FROM {$wpdb->term_relationships} LEFT JOIN {$wpdb->term_taxonomy} AS tax USING( term_taxonomy_id ) WHERE term_id IN (" . implode( ',', array_map( 'absint', $terms_to_count ) ) . " ) ) ";
 
 		// Get the count
 		$count = $wpdb->get_var( $count_query . $term_query );

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -552,7 +552,7 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 
 	// Main query.
 	$count_query = "
-		SELECT COUNT( DISTINCT ID ) FROM wp_posts
+		SELECT COUNT( DISTINCT ID ) FROM {$wpdb->posts}
 		WHERE post_status = 'publish'
 		AND post_type = 'product'
 	";


### PR DESCRIPTION
Closes #14662

To test, change some products to out of stock, set product > display to show subcategories in the shop and category screens, and compare the counts before and after patch.

(after patch, system status > tools > recount terms is needed).