### PR TITLE
Make get item consistent

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -802,7 +802,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		// The item was not found in memory, we load in memory all the items related to this order
 		$types = $this->data_store->get_order_item_types( $this );
 		foreach ( $types as $type ) {
-			if ( !( $group = $this->type_to_group( $type ) )  && ! empty( $this->items[ $group ] ) ) {
+			if ( !( $group = $this->type_to_group( $type ) )  || ! empty( $this->items[ $group ] ) ) {
 				continue;
 			}
 			$this->items[ $group ] = $this->data_store->read_items( $this, $type );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -791,7 +791,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	public function get_item( $item_id ) {
 		foreach ( $this->items as $items ) {
 			if ( ! empty( $items[ $item_id ] ) ) {
-				return $items[ $item_id ];
+				$items = apply_filters( 'woocommerce_order_get_items', array( $item_id => $items[ $item_id ] ), $this );
+				return empty( $items[ $item_id ] ) ? false : $items[ $item_id ];
 			}
 		}
 
@@ -805,7 +806,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( $group ) {
 			$this->items[ $group ] = $this->data_store->read_items( $this, $type );
 			if ( ! empty( $this->items[ $group ][ $item_id ] ) ) {
-				return $this->items[ $group ][ $item_id ];
+				$items = apply_filters( 'woocommerce_order_get_items', array( $item_id => $this->items[ $group ][ $item_id ] ), $this );
+				return empty( $items[ $item_id ] ) ? false : $items[ $item_id ];
 			}
 		}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -800,11 +800,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		// The item was not found in memory, we load in memory all the items related to this order
-		$types = $this->data_store->get_order_item_types( $this );
-		foreach ( $types as $type ) {
-			if ( ! ( $group = $this->type_to_group( $type ) )  || ! empty( $this->items[ $group ] ) ) {
-				continue;
-			}
+		$type  = $this->data_store->get_order_item_type( $this, $item_id );
+		$group = $type ? $this->type_to_group( $type ) : false;
+		if ( $group ) {
 			$this->items[ $group ] = $this->data_store->read_items( $this, $type );
 			if ( ! empty( $this->items[ $group ][ $item_id ] ) ) {
 				return $this->items[ $group ][ $item_id ];

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -789,29 +789,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return WC_Order_Item
 	 */
 	public function get_item( $item_id ) {
-		foreach ( $this->items as $items ) {
-			if ( ! empty( $items[ $item_id ] ) ) {
-				$items = apply_filters( 'woocommerce_order_get_items', array( $item_id => $items[ $item_id ] ), $this );
-				return empty( $items[ $item_id ] ) ? false : $items[ $item_id ];
-			}
-		}
-
-		if ( ! $this->get_id() ) {
+		$type = $this->data_store->get_order_item_type( $this, $item_id );
+		if ( ! $type ) {
 			return false;
 		}
 
-		// The item was not found in memory, we load in memory all the items related to this order
-		$type  = $this->data_store->get_order_item_type( $this, $item_id );
-		$group = $type ? $this->type_to_group( $type ) : false;
-		if ( $group ) {
-			$this->items[ $group ] = $this->data_store->read_items( $this, $type );
-			if ( ! empty( $this->items[ $group ][ $item_id ] ) ) {
-				$items = apply_filters( 'woocommerce_order_get_items', array( $item_id => $this->items[ $group ][ $item_id ] ), $this );
-				return empty( $items[ $item_id ] ) ? false : $items[ $item_id ];
-			}
-		}
-
-		return false;
+		$items = $this->get_items( $type );
+		return ! empty( $items[ $item_id ] ) ? $items[ $item_id ] : false;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -780,7 +780,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Get an order item object, based on it's type.
+	 * Get an order item object, based on it's ID. The item must belong to the current
+	 * order. If the item cannot be found or it doens't belong to current order
+	 * FALSE will be returned.
 	 *
 	 * @since  3.0.0
 	 * @param  int $item_id

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -787,7 +787,29 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return WC_Order_Item
 	 */
 	public function get_item( $item_id ) {
-		return WC_Order_Factory::get_order_item( $item_id );
+		foreach ( $this->items as $items ) {
+			if ( ! empty( $items[ $item_id ] ) ) {
+				return $items[ $item_id ];
+			}
+		}
+
+		if ( ! $this->get_id() ) {
+			return false;
+		}
+
+		// The item was not found in memory, we load in memory all the items related to this order
+		$types = $this->data_store->get_order_item_types( $this );
+		foreach ( $types as $type ) {
+			if ( !( $group = $this->type_to_group( $type ) )  && ! empty( $this->items[ $group ] ) ) {
+				continue;
+			}
+			$this->items[ $group ] = $this->data_store->read_items( $this, $type );
+			if ( ! empty( $this->items[$group][ $item_id ] ) ) {
+				return $this->items[$group][ $item_id ];
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -802,12 +802,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		// The item was not found in memory, we load in memory all the items related to this order
 		$types = $this->data_store->get_order_item_types( $this );
 		foreach ( $types as $type ) {
-			if ( !( $group = $this->type_to_group( $type ) )  || ! empty( $this->items[ $group ] ) ) {
+			if ( ! ( $group = $this->type_to_group( $type ) )  || ! empty( $this->items[ $group ] ) ) {
 				continue;
 			}
 			$this->items[ $group ] = $this->data_store->read_items( $this, $type );
-			if ( ! empty( $this->items[$group][ $item_id ] ) ) {
-				return $this->items[$group][ $item_id ];
+			if ( ! empty( $this->items[ $group ][ $item_id ] ) ) {
+				return $this->items[ $group ][ $item_id ];
 			}
 		}
 

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -50,7 +50,6 @@ class WC_Order_Factory {
 		}
 	}
 
-
 	/**
 	 * Get order item.
 	 * @param int

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -50,6 +50,7 @@ class WC_Order_Factory {
 		}
 	}
 
+
 	/**
 	 * Get order item.
 	 * @param int

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -354,15 +354,20 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	}
 
 	/**
-	 * Get all the order items type in a given order
+	 * Return the order type of a given item which belongs to WC_Order
 	 *
 	 * @param WC_Order $order	Order Object
+	 * @param int	$order_id
 	 *
-	 * @return Array	A list with all order_item_type
+	 * @return string Order Item type
 	 */
-	public function get_order_item_types( WC_Order $order ) {
+	public function get_order_item_type( WC_Order $order, $order_item_id ) {
 		global $wpdb;
-		$query = $wpdb->prepare( "SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() );
-		return wp_list_pluck( $wpdb->get_results( $query ), 'order_item_type' );
+		$query = $wpdb->prepare(
+			"SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d and order_item_id",
+			$order->get_id(),
+			$order_item_id
+		);
+		return $wpdb->get_var( $query );
 	}
 }

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -352,4 +352,17 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function update_payment_token_ids( $order, $token_ids ) {
 		update_post_meta( $order->get_id(), '_payment_tokens', $token_ids );
 	}
+
+	/**
+	 * Get all the order items type in a given order
+	 *
+	 * @param WC_Order $order	Order Object
+	 *
+	 * @return Array	A list with all order_item_type
+	 */
+	public function get_order_item_types( WC_Order $order ) {
+		global $wpdb;
+		$query   = $wpdb->prepare( "SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() );
+		return wp_list_pluck( $wpdb->get_results( $query ), 'order_item_type' );
+	}
 }

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -362,7 +362,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	public function get_order_item_types( WC_Order $order ) {
 		global $wpdb;
-		$query   = $wpdb->prepare( "SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() );
+		$query = $wpdb->prepare( "SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order->get_id() );
 		return wp_list_pluck( $wpdb->get_results( $query ), 'order_item_type' );
 	}
 }

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -364,7 +364,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function get_order_item_type( WC_Order $order, $order_item_id ) {
 		global $wpdb;
 		$query = $wpdb->prepare(
-			"SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d and order_item_id",
+			"SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d and order_item_id = %d",
 			$order->get_id(),
 			$order_item_id
 		);

--- a/tests/unit-tests/order/crud.php
+++ b/tests/unit-tests/order/crud.php
@@ -456,10 +456,10 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 			'product'  => WC_Helper_Product::create_simple_product(),
 			'quantity' => 4,
 		) );
-		$item->save();
-		$object->add_item( $item->get_id() );
+		$object->add_item( $item );
 		$object->save();
 		$this->assertTrue( $object->get_item( $item->get_id() ) instanceOf WC_Order_Item_Product );
+		$this->assertEquals( spl_object_hash( $item ), spl_object_hash( $object->get_item( $item->get_id() ) ) );
 
 		$object = new WC_Order();
 		$item   = new WC_Order_Item_Coupon();
@@ -472,6 +472,50 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object->add_item( $item );
 		$object->save();
 		$this->assertTrue( $object->get_item( $item_id ) instanceOf WC_Order_Item_Coupon );
+
+		$object = new WC_Order( $object->get_id() );
+		$this->assertTrue( $object->get_item( $item_id ) instanceOf WC_Order_Item_Coupon );
+	}
+
+	/**
+	 *	Make sure that items returned by get_item is tied to the order,
+	 *  and that is saved when the order is saved.
+	 */
+	public function test_get_item_object_is_updated_with_order_save() {
+		$object = new WC_Order();
+		$item   = new WC_Order_Item_Product();
+		$item->set_props( array(
+			'product'  => WC_Helper_Product::create_simple_product(),
+			'quantity' => 4,
+		) );
+		$object->add_item( $item );
+		$object->save();
+
+		$object = new WC_Order( $object->get_id() );
+		$item = $object->get_item( $item->get_id() );
+		$item->set_quantity( 6 );
+		$object->save();
+
+		$object = new WC_Order( $object->get_id() );
+		$this->assertEquals(6, $object->get_item( $item->get_id() )->get_quantity() );
+	}
+
+	/**
+	 * Makes sure that get_item only returns items related to the order
+	 */
+	public function test_get_item_from_another_order() {
+		$object = new WC_Order();
+		$item   = new WC_Order_Item_Product();
+		$item->set_props( array(
+			'product'  => WC_Helper_Product::create_simple_product(),
+			'quantity' => 4,
+		) );
+		$item->save();
+		$this->assertFalse( $object->get_item( $item->get_id() ) );
+
+		$object->save();
+		$this->assertFalse( $object->get_item( $item->get_id() ) );
+
 	}
 
 	/**

--- a/tests/unit-tests/order/crud.php
+++ b/tests/unit-tests/order/crud.php
@@ -509,6 +509,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$item->set_props( array(
 			'product'  => WC_Helper_Product::create_simple_product(),
 			'quantity' => 4,
+			'order_id' => 999,
 		) );
 		$item->save();
 		$this->assertFalse( $object->get_item( $item->get_id() ) );


### PR DESCRIPTION
Right now `get_item()` is loading items from the database directly. It doesn't
take advantage of our cache and it doesn't check if the item is already loaded in memory.

There is also another bug (or feature?) that it will let you load any item, even if the item is not related to the current order. I believe this is a bug, if somebody really wants to load any item regardless of the order they should use `WC_Order_Factory::get_order_item`.

Another bug is that items loaded with get_item() are not related to the order object, therefore any calls to `Order::save()` won't persist the changes made to the item.

This commits makes sure the item returned by get_item is loaded similarly like get_items() does, taking advantage of the cache and the $items protected property (chances are the item is already in memory, ready to be used).

If a given item is not found false will be returned. If item exists but it is not related to the current object it will return false as well (If this behaviour is wanted, I can easily change it load the item anyways instead of returning `FALSE`).
