### PR TITLE
Make sure the meta data cache is not shared among instances

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -436,28 +436,23 @@ abstract class WC_Data {
 
 		if ( ! $force_read ) {
 			if ( ! empty( $this->cache_group ) ) {
-				$cached_meta = wp_cache_get( $cache_key, $this->cache_group );
-				if ( false !== $cached_meta ) {
-					$this->meta_data = $cached_meta;
-					$cache_loaded    = true;
-				}
+				$cached_meta  = wp_cache_get( $cache_key, $this->cache_group );
+				$cache_loaded = ! empty( $cached_meta );
 			}
 		}
 
-		if ( ! $cache_loaded ) {
-			$raw_meta_data   = $this->data_store->read_meta( $this );
-			if ( $raw_meta_data ) {
-				foreach ( $raw_meta_data as $meta ) {
-					$this->meta_data[] = (object) array(
-						'id'    => (int) $meta->meta_id,
-						'key'   => $meta->meta_key,
-						'value' => maybe_unserialize( $meta->meta_value ),
-					);
-				}
+		$raw_meta_data = $cache_loaded ? $cached_meta : $this->data_store->read_meta( $this );
+		if ( $raw_meta_data ) {
+			foreach ( $raw_meta_data as $meta ) {
+				$this->meta_data[] = (object) array(
+					'id'    => (int) $meta->meta_id,
+					'key'   => $meta->meta_key,
+					'value' => maybe_unserialize( $meta->meta_value ),
+				);
+			}
 
-				if ( ! empty( $this->cache_group ) ) {
-					wp_cache_set( $cache_key, $this->meta_data, $this->cache_group );
-				}
+			if ( ! $cache_loaded && ! empty( $this->cache_group ) ) {
+				wp_cache_set( $cache_key, $raw_meta_data, $this->cache_group );
 			}
 		}
 	}

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -116,6 +116,45 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that the meta data cache is not shared among instances.
+	 */
+	function test_get_meta_data_shared_bug() {
+		$object  = new WC_Order;
+		$object->add_meta_data( 'test_meta_key', 'val1', true );
+		$object->add_meta_data( 'test_multi_meta_key', 'val2' );
+		$object->add_meta_data( 'test_multi_meta_key', 'val3' );
+		$object->save();
+
+		$order = new WC_Order( $object->get_id() );
+		$metas = $order->get_meta_data();
+		$metas[0]->value = 'wrong value';
+
+		$order = new WC_Order( $object->get_id() );
+		$metas = $order->get_meta_data();
+		$this->assertNotEquals( 'wrong value', $metas[0]->value );
+	}
+
+	/**
+	 * Tests the cache invalidation after an order is saved
+	 */
+	function test_get_meta_data_cache_invalidation() {
+		$object  = new WC_Order;
+		$object->add_meta_data( 'test_meta_key', 'val1', true );
+		$object->add_meta_data( 'test_multi_meta_key', 'val2' );
+		$object->add_meta_data( 'test_multi_meta_key', 'val3' );
+		$object->save();
+
+		$order = new WC_Order( $object->get_id() );
+		$metas = $order->get_meta_data();
+		$metas[0]->value = 'updated value';
+		$order->save();
+
+		$order = new WC_Order( $object->get_id() );
+		$metas = $order->get_meta_data();
+		$this->assertEquals( 'updated value', $metas[0]->value );
+	}
+
+	/**
 	 * Test getting meta by ID.
 	 */
 	function test_get_meta() {


### PR DESCRIPTION
See #14620 for more context. In there I thought this was the desired behaviour and I enhanced it. After talking with @mikejolley he explained to me that it was not by designed.

This commit makes sure the meta data cache is not shared among instances