### PR TITLE
Fixed undefined customer_user when remove users from order in admin

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -467,7 +467,7 @@ class WC_Meta_Box_Order_Data {
 		}
 
 		// Update customer.
-		$customer_id = absint( $_POST['customer_user'] );
+		$customer_id = isset( $_POST['customer_user'] ) ? absint( $_POST['customer_user'] ) : 0;
 		if ( $customer_id !== $order->get_customer_id() ) {
 			$props['customer_id'] = $customer_id;
 		}


### PR DESCRIPTION
Showing the follow message when remove a customer from and order in admin screen:

```
PHP Notice:  Undefined index: customer_user in wp-content/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php on line 470
```