### PR TITLE
[REST API] Adds missing "id" in shipping zone methods endpoint

### DIFF
--- a/includes/api/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-methods-controller.php
@@ -53,7 +53,7 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 			'schema' => array( $this, 'get_public_item_schema' ),
 		) );
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<zone_id>[\d]+)/methods/(?P<instance_id>[\d-]+)', array(
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<zone_id>[\d]+)/methods/(?P<instance_id>[\d]+)', array(
 			'args' => array(
 				'zone_id' => array(
 					'description' => __( 'Unique ID for the zone.', 'woocommerce' ),
@@ -346,6 +346,7 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$method = array(
+			'id'                 => $item->instance_id,
 			'instance_id'        => $item->instance_id,
 			'title'              => $item->instance_settings['title'],
 			'order'              => $item->method_order,
@@ -430,6 +431,12 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zones_Co
 			'title'      => 'shipping_zone_method',
 			'type'       => 'object',
 			'properties' => array(
+				'id' => array(
+					'description' => __( 'Shipping method instance ID.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'instance_id' => array(
 					'description' => __( 'Shipping method instance ID.', 'woocommerce' ),
 					'type'        => 'integer',

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -66,7 +66,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<id>[\d-]+)', $routes );
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<id>[\d]+)/locations', $routes );
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<zone_id>[\d]+)/methods', $routes );
-		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<zone_id>[\d]+)/methods/(?P<instance_id>[\d-]+)', $routes );
+		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<zone_id>[\d]+)/methods/(?P<instance_id>[\d]+)', $routes );
 	}
 
 	/**
@@ -565,6 +565,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods' ) );
 		$data     = $response->get_data();
 		$expected = array(
+			'id'                 => $instance_id,
 			'instance_id'        => $instance_id,
 			'title'              => $method->instance_settings['title'],
 			'order'              => $method->method_order,


### PR DESCRIPTION
This missing "id" will break CLI.

Added as duplicated with `instance_id` to keep backwards compatibility.

Fixes #14831