### PR TITLE
Fix non numeric warning for orders.

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1194,7 +1194,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( $inc_tax ) {
 				$subtotal = ( $item->get_subtotal() + $item->get_subtotal_tax() ) / max( 1, $item->get_quantity() );
 			} else {
-				$subtotal = ( intval( $item->get_subtotal() ) / max( 1, $item->get_quantity() ) );
+				$subtotal = ( floatval( $item->get_subtotal() ) / max( 1, $item->get_quantity() ) );
 			}
 
 			$subtotal = $round ? number_format( (float) $subtotal, wc_get_price_decimals(), '.', '' ) : $subtotal;
@@ -1242,7 +1242,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( $inc_tax ) {
 				$total = ( $item->get_total() + $item->get_total_tax() ) / max( 1, $item->get_quantity() );
 			} else {
-				$total = intval( $item->get_total() ) / max( 1, $item->get_quantity() );
+				$total = floatval( $item->get_total() ) / max( 1, $item->get_quantity() );
 			}
 
 			$total = $round ? round( $total, wc_get_price_decimals() ) : $total;

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1194,7 +1194,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( $inc_tax ) {
 				$subtotal = ( $item->get_subtotal() + $item->get_subtotal_tax() ) / max( 1, $item->get_quantity() );
 			} else {
-				$subtotal = ( $item->get_subtotal() / max( 1, $item->get_quantity() ) );
+				$subtotal = ( intval( $item->get_subtotal() ) / max( 1, $item->get_quantity() ) );
 			}
 
 			$subtotal = $round ? number_format( (float) $subtotal, wc_get_price_decimals(), '.', '' ) : $subtotal;
@@ -1242,7 +1242,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( $inc_tax ) {
 				$total = ( $item->get_total() + $item->get_total_tax() ) / max( 1, $item->get_quantity() );
 			} else {
-				$total = $item->get_total() / max( 1, $item->get_quantity() );
+				$total = intval( $item->get_total() ) / max( 1, $item->get_quantity() );
 			}
 
 			$total = $round ? round( $total, wc_get_price_decimals() ) : $total;

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -96,7 +96,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_subtotal( $value ) {
-		$this->set_prop( 'subtotal', wc_format_decimal( $value ) );
+		$this->set_prop( 'subtotal', intval( wc_format_decimal( $value ) ) );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_total( $value ) {
-		$this->set_prop( 'total', wc_format_decimal( $value ) );
+		$this->set_prop( 'total', intval( wc_format_decimal( $value ) ) );
 
 		// Subtotal cannot be less than total
 		if ( ! $this->get_subtotal() || $this->get_subtotal() < $this->get_total() ) {

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -96,7 +96,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_subtotal( $value ) {
-		$this->set_prop( 'subtotal', intval( wc_format_decimal( $value ) ) );
+		$this->set_prop( 'subtotal', floatval( wc_format_decimal( $value ) ) );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_total( $value ) {
-		$this->set_prop( 'total', intval( wc_format_decimal( $value ) ) );
+		$this->set_prop( 'total', floatval( wc_format_decimal( $value ) ) );
 
 		// Subtotal cannot be less than total
 		if ( ! $this->get_subtotal() || $this->get_subtotal() < $this->get_total() ) {


### PR DESCRIPTION
Fixes #14845.

The changes in `includes/abstracts/abstract-wc-order.php` are made for existing data in DB that has empty strings to be treated as integers.

The code changes in `includes/class-wc-order-item-product.php` will change the way orders save stuff in the database.

Before:
```
mysql> select * from wp_woocommerce_order_itemmeta where order_item_id = 468;
+---------+---------------+--------------------+-----------------------------------------------+
| meta_id | order_item_id | meta_key           | meta_value                                    |
+---------+---------------+--------------------+-----------------------------------------------+
|    3244 |           468 | _product_id        | 808                                           |
|    3245 |           468 | _variation_id      | 0                                             |
|    3246 |           468 | _qty               | 1                                             |
|    3247 |           468 | _tax_class         |                                               |
|    3248 |           468 | _line_subtotal     |                                               |
|    3249 |           468 | _line_subtotal_tax | 0                                             |
|    3250 |           468 | _line_total        |                                               |
|    3251 |           468 | _line_tax          | 0                                             |
|    3252 |           468 | _line_tax_data     | a:2:{s:8:"subtotal";a:0:{}s:5:"total";a:0:{}} |
+---------+---------------+--------------------+-----------------------------------------------+
```

After:
```
mysql> select * from wp_woocommerce_order_itemmeta where order_item_id = 469;
+---------+---------------+--------------------+-----------------------------------------------+
| meta_id | order_item_id | meta_key           | meta_value                                    |
+---------+---------------+--------------------+-----------------------------------------------+
|    3253 |           469 | _product_id        | 808                                           |
|    3254 |           469 | _variation_id      | 0                                             |
|    3255 |           469 | _qty               | 1                                             |
|    3256 |           469 | _tax_class         |                                               |
|    3257 |           469 | _line_subtotal     | 0                                             |
|    3258 |           469 | _line_subtotal_tax | 0                                             |
|    3259 |           469 | _line_total        | 0                                             |
|    3260 |           469 | _line_tax          | 0                                             |
|    3261 |           469 | _line_tax_data     | a:2:{s:8:"subtotal";a:0:{}s:5:"total";a:0:{}} |
+---------+---------------+--------------------+-----------------------------------------------+
```

Thus, it is now consistent with [this](https://github.com/woocommerce/woocommerce/blob/8f63211f1cc674bc561deaf0bb33e5b814992a70/includes/class-wc-order-item-product.php#L22-L35).