### PR TITLE
[3.0] Incorrect use of `wc_format_price_range` in `get_price_html_from_to`

### DIFF
--- a/includes/legacy/abstract-wc-legacy-product.php
+++ b/includes/legacy/abstract-wc-legacy-product.php
@@ -278,8 +278,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @return string
 	 */
 	public function get_price_html_from_to( $from, $to ) {
-		wc_deprecated_function( 'WC_Product::get_price_html_from_to', '3.0', 'wc_format_price_range' );
-		return apply_filters( 'woocommerce_get_price_html_from_to', wc_format_price_range( $from, $to ), $from, $to, $this );
+		wc_deprecated_function( 'WC_Product::get_price_html_from_to', '3.0', 'wc_format_sale_price' );
+		return apply_filters( 'woocommerce_get_price_html_from_to', wc_format_sale_price( $from, $to ), $from, $to, $this );
 	}
 
 	/**


### PR DESCRIPTION
Isn't `wc_format_sale_price` the right method to call for generating strikeout prices?