### PR TITLE
[3.0] Clone each meta stdClass object when cloning a WC_Data object

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -140,6 +140,7 @@ abstract class WC_Data {
 		$this->maybe_read_meta_data();
 		if ( ! empty( $this->meta_data ) ) {
 			foreach ( $this->meta_data as $array_key => $meta ) {
+				$this->meta_data[ $array_key ] = clone $meta;
 				if ( ! empty( $meta->id ) ) {
 					unset( $this->meta_data[ $array_key ]->id );
 				}


### PR DESCRIPTION
Currently, when a `WC_Data` object is cloned, the `id` properties of all meta objects on the clone are removed to ensure that the object is properly "duplicated".

However, the `stdClass` objects on the clone are actually the same objects that exist on the original, so when their `id` props are deleted, the change also affects the original `WC_Data` object.

By cloning each meta object, we ensure that the change will not affect the meta objects stored in the original `WC_Data` object.

Hope this makes sense :)