### PR TITLE
Only set id for taxonomy-based attributes

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -377,6 +377,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					'is_variation' => 0,
 					'is_taxonomy'  => 0,
 				), (array) $meta_value );
+				$attribute = new WC_Product_Attribute();
 
 				if ( ! empty( $meta_value['is_taxonomy'] ) ) {
 					if ( ! taxonomy_exists( $meta_value['name'] ) ) {
@@ -388,7 +389,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					$options = wc_get_text_attributes( $meta_value['value'] );
 				}
 
-				$attribute = new WC_Product_Attribute();
 				$attribute->set_name( $meta_value['name'] );
 				$attribute->set_options( $options );
 				$attribute->set_position( $meta_value['position'] );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -383,12 +383,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						continue;
 					}
 					$options = wc_get_object_terms( $product->get_id(), $meta_value['name'], 'term_id' );
+					$attribute->set_id( wc_attribute_taxonomy_id_by_name( $meta_value['name'] ) );
 				} else {
 					$options = wc_get_text_attributes( $meta_value['value'] );
 				}
 
 				$attribute = new WC_Product_Attribute();
-				$attribute->set_id( wc_attribute_taxonomy_id_by_name( $meta_value['name'] ) );
 				$attribute->set_name( $meta_value['name'] );
 				$attribute->set_options( $options );
 				$attribute->set_position( $meta_value['position'] );


### PR DESCRIPTION
Closes #14824.

Attributes with a custom attribute that has the same name as a global attribute were wrongly getting the id of the global attribute set on them.