### PR TITLE
Ensure stock is marked as reduced by `wc_reduce_stock_levels()`

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -69,10 +69,9 @@ function wc_update_product_stock_status( $product_id, $status ) {
  * @param int $order_id
  */
 function wc_maybe_reduce_stock_levels( $order_id ) {
-	$data_store = WC_Data_Store::load( 'order' );
-	if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', ! $data_store->get_stock_reduced( $order_id ), $order_id ) ) {
+	$order = wc_get_order( $order_id );
+	if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', ! $order->get_data_store()->get_stock_reduced( $order_id ), $order_id ) ) {
 		wc_reduce_stock_levels( $order_id );
-		$data_store->set_stock_reduced( $order_id, true );
 	}
 }
 add_action( 'woocommerce_payment_complete', 'wc_maybe_reduce_stock_levels' );
@@ -83,8 +82,7 @@ add_action( 'woocommerce_payment_complete', 'wc_maybe_reduce_stock_levels' );
  * @param int $order_id
  */
 function wc_reduce_stock_levels( $order_id ) {
-	$order      = wc_get_order( $order_id );
-	$data_store = WC_Data_Store::load( 'order' );
+	$order = wc_get_order( $order_id );
 
 	if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && $order && apply_filters( 'woocommerce_can_reduce_order_stock', true, $order ) && sizeof( $order->get_items() ) > 0 ) {
 		foreach ( $order->get_items() as $item ) {
@@ -114,7 +112,7 @@ function wc_reduce_stock_levels( $order_id ) {
 		}
 
 		// ensure stock is marked as "reduced" in case payment complete or other stock actions are called
-		$data_store->set_stock_reduced( $order_id, true );
+		$order->get_data_store()->set_stock_reduced( $order_id, true );
 
 		do_action( 'woocommerce_reduce_order_stock', $order );
 	}

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -83,7 +83,8 @@ add_action( 'woocommerce_payment_complete', 'wc_maybe_reduce_stock_levels' );
  * @param int $order_id
  */
 function wc_reduce_stock_levels( $order_id ) {
-	$order = wc_get_order( $order_id );
+	$order      = wc_get_order( $order_id );
+	$data_store = WC_Data_Store::load( 'order' );
 
 	if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && $order && apply_filters( 'woocommerce_can_reduce_order_stock', true, $order ) && sizeof( $order->get_items() ) > 0 ) {
 		foreach ( $order->get_items() as $item ) {
@@ -111,6 +112,9 @@ function wc_reduce_stock_levels( $order_id ) {
 				}
 			}
 		}
+
+		// ensure stock is marked as "reduced" in case payment complete or other stock actions are called
+		$data_store->set_stock_reduced( $order_id, true );
 
 		do_action( 'woocommerce_reduce_order_stock', $order );
 	}


### PR DESCRIPTION
Came across this issue due to woo-zd-562799

When PayPal handles an IPN for a transaction, it [looks at the payment response to determine the order status to set](https://github.com/woocommerce/woocommerce/blob/abfedafd46bf07920522f6365dfcbe552231c4b4/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php#L176-L206). In the case of a PayPal eCheck, `WC_Gateway_Paypal_Response::payment_on_hold()` is called to wait for the IPN when the echeck transfer is complete, and the order is marked as "on hold".

When this happens, [the method calls `wc_reduce_stock_levels()`](https://github.com/woocommerce/woocommerce/blob/abfedafd46bf07920522f6365dfcbe552231c4b4/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php#L67-L71) while setting the order to on hold (which imo is exactly expected -- the stock should be reduced here). However, this is where we run into an issue.

When the IPN comes in again for the successful transfer, `WC_Gateway_Paypal_Response::payment_complete()` (`$order->payment_complete()`) is called, [which calls `wc_maybe_reduce_stock_levels()`](https://github.com/woocommerce/woocommerce/blob/bd92f993591e4ef08d67b6bcc8245f4e50af7143/includes/wc-stock-functions.php#L71-L78). Because `wc_reduce_stock_levels()` **never marks stock as reduced**, calling payment complete re-deducts stock from the inventory, resulting in duplicated inventory reductions for the order.

While this issue is likely niche as it requires duplicated PayPal IPNs to be received, it does seem to be an oversight that `wc_reduce_stock_levels()` doesn't actually mark stock as having been reduced for the order when run.