### PR TITLE
[3.0] Tweak meta display value rendering in `wc_display_item_meta`

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2404,7 +2404,7 @@ if ( ! function_exists( 'wc_display_item_meta' ) ) {
 		) );
 
 		foreach ( $item->get_formatted_meta_data() as $meta_id => $meta ) {
-			$value = $args['autop'] ? wp_kses_post( wpautop( make_clickable( $meta->display_value ) ) ) : wp_kses_post( make_clickable( $meta->display_value ) );
+			$value = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( strip_tags( $meta->display_value ) ) ) );
 			$strings[] = '<strong class="wc-item-meta-label">' . wp_kses_post( $meta->display_key ) . ':</strong> ' . $value;
 		}
 


### PR DESCRIPTION
A couple formatting issues I noticed in `wc_display_item_meta`.

The `$meta->display_value` string has already been passed through `wpautop` and `make_clickable` in `WC_Order_Item:: get_formatted_meta_data`.

Therefore, in `wc_display_item_meta`:

- If `$args['autop']` is `true`, we don't need to pass `$meta->display_value` through `wpautop` and `make_clickable` again.
- If `$args['autop']` is `false`, we need to clean up the results of `wpautop` before applying `make_clickable` on `$meta->display_value`.