### PR TITLE
Fixed "Process to checkout" button color in Twenty seventeen dark theme

### DIFF
--- a/assets/css/twenty-seventeen.scss
+++ b/assets/css/twenty-seventeen.scss
@@ -991,12 +991,21 @@ button.pswp__button--zoom:hover {
 	}
 }
 
-.colors-dark.woocommerce-checkout {
+.colors-dark {
+	.checkout-button {
+		border: 2px solid #555;
+
+		&:hover {
+			border-color: #fff;
+		}
+	}
+
 	.wc_payment_method {
 		.payment_box {
 			background: #333;
 		}
 	}
+
 	.select2-container--default {
 		.select2-results {
 			.select2-results__options {
@@ -1006,6 +1015,7 @@ button.pswp__button--zoom:hover {
 				color: #333;
 			}
 		}
+
 		.select2-selection--single {
 			background-color: #333;
 			border: 1px solid #555;


### PR DESCRIPTION
I'll compile the files just after merged, so will make easy to cherry pick to 3.0.

Fixes #14833 
Closes #14834