### PR TITLE
wc_attribute_taxonomy_id_by_name should use wc_sanitize_taxonomy_name to prevent breaking special chars

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -111,7 +111,7 @@ function wc_attribute_taxonomy_name_by_id( $attribute_id ) {
  * @return int
  */
 function wc_attribute_taxonomy_id_by_name( $name ) {
-	$name       = str_replace( 'pa_', '', sanitize_title( $name ) );
+	$name       = str_replace( 'pa_', '', wc_sanitize_taxonomy_name( $name ) );
 	$taxonomies = wp_list_pluck( wc_get_attribute_taxonomies(), 'attribute_id', 'attribute_name' );
 
 	return isset( $taxonomies[ $name ] ) ? (int) $taxonomies[ $name ] : 0;


### PR DESCRIPTION
Fixes #14920

@claudiosanches 