### PR TITLE
added filters on zoom / flexslider / photoswipe enabling

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -474,16 +474,16 @@ class WC_Frontend_Scripts {
 						'animationSpeed' => 500,
 						'animationLoop'  => false, // Breaks photoswipe pagination if true.
 					) ),
-					'zoom_enabled'       => get_theme_support( 'wc-product-gallery-zoom' ),
-					'photoswipe_enabled' => get_theme_support( 'wc-product-gallery-lightbox' ),
-					'photoswipe_options' => apply_filters( 'woocommerce_single_product_photoswipe_options', array(
+					'zoom_enabled'       => apply_filters( 'woocommerce_single_product_zoom_enabled', get_theme_support( 'wc-product-gallery-zoom' ) ),
+					'photoswipe_enabled' => apply_filters( 'woocommerce_single_product_photoswipe_enabled', get_theme_support( 'wc-product-gallery-lightbox' ) ),
+   					'photoswipe_options' => apply_filters( 'woocommerce_single_product_photoswipe_options', array(
 						'shareEl'               => false,
 						'closeOnScroll'         => false,
 						'history'               => false,
 						'hideAnimationDuration' => 0,
 						'showAnimationDuration' => 0
 					) ),
-					'flexslider_enabled' => get_theme_support( 'wc-product-gallery-slider' ),
+					'flexslider_enabled' => apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) ),
 				);
 			break;
 			case 'wc-checkout' :


### PR DESCRIPTION
Added some filters to enable new features on some posts only (or disable them).

Tried with a child theme of TwentySeventeen and with a top-ten theme from ThemeForest. It seems to work in this way, for instance:

```php
add_filter( 'woocommerce_single_product_photoswipe_enabled', 'test_woocommerce_single_product_zoom_enabled' );
function test_woocommerce_single_product_zoom_enabled( $return ){
	global $post;

	if ( $post && $post->ID == 5 )
		$return = false;

	return $return;
}
```

The file already contains other filters, so it should be a consistent change.