### PR TITLE
Fix param documentation for WC_Product::is_type

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1332,7 +1332,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 *
 	 * Backwards compat with downloadable/virtual.
 	 *
-	 * @param string $type Array or string of types
+	 * @param string|array $type Array or string of types
 	 * @return bool
 	 */
 	public function is_type( $type ) {


### PR DESCRIPTION
WC_Product::is_type accepts both strings and arrays