### PR TITLE
Fatal error calling wc_get_payment_gateway_by_order for a refund #14973

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -582,9 +582,10 @@ function wc_get_payment_gateway_by_order( $order ) {
 	if ( ! is_object( $order ) ) {
 		$order_id = absint( $order );
 		$order    = wc_get_order( $order_id );
-	}
-
-	return isset( $payment_gateways[ $order->get_payment_method() ] ) ? $payment_gateways[ $order->get_payment_method() ] : false;
+		return isset( $payment_gateways[ $order->get_payment_method() ] ) ? $payment_gateways[ $order->get_payment_method() ] : false;
+	} else {
+		return false;
+	}	
 }
 
 /**


### PR DESCRIPTION
@mikejolley 

I have tried to solved Fatal error calling wc_get_payment_gateway_by_order for a refund ref #14973.

I feel if order return empty then get_payment_method() not found and it cause of generate a fatal error.

Please check and let me know if any changes.

Thanks,