### PR TITLE
Fix: Grouped Product Pages Show Incorrect Name / Permalink

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -10,10 +10,10 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     3.0.6
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @author      WooThemes
+ * @package     WooCommerce/Templates
+ * @version     3.0.7
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -67,7 +67,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 						</td>
 						<td class="label">
 							<label for="product-<?php echo $grouped_product->get_id(); ?>">
-								<?php echo $grouped_product->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', get_permalink(), $grouped_product->get_id() ) ) . '">' . get_the_title() . '</a>' : get_the_title(); ?>
+								<?php echo $grouped_product->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', get_permalink( $grouped_product->get_id() ), $grouped_product->get_id() ) ) . '">' . $grouped_product->get_name() . '</a>' : $grouped_product->get_name(); ?>
 							</label>
 						</td>
 						<?php do_action( 'woocommerce_grouped_product_list_before_price', $grouped_product ); ?>


### PR DESCRIPTION
Grouped product pages show only the parent (group) product's name, and more importantly, permalinks in the add to cart template.

### To Replicate

1. Create several products
2. Add these products to a group
3. View the grouped product
4. Notice all products in the group have the parent name + permalink instead of the name / link for the item in the group

![screen shot 2017-05-10 at 4 06 22 am](https://cloud.githubusercontent.com/assets/4983547/25889032/71e54d34-3536-11e7-9eae-ff4c37ed6b8f.png)

This is due to using loop functions like `get_the_title()`, which are using the global post object, instead of getting the name specifically of the group product to output via `$product->get_name()`. After updating the permalink / name:

![screen shot 2017-05-10 at 4 12 17 am](https://cloud.githubusercontent.com/assets/4983547/25889226/134e6084-3537-11e7-9006-5673635d21f2.png)

**Note** I did not bump the template version as I wasn't sure when this would go in.