### PR TITLE
Fix #14967 - 

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -605,7 +605,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_payment_tokenmeta (
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_log (
   log_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  timestamp datetime NOT NULL,
+  timestamp datetime(6) NOT NULL DEFAULT NOW(5),
   level smallint(4) NOT NULL,
   source varchar(200) NOT NULL,
   message longtext NOT NULL,

--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -39,13 +39,12 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 			$source = $this->get_log_source();
 		}
 
-		return $this->add( $timestamp, $level, $message, $source, $context );
+		return $this->add( $level, $message, $source, $context );
 	}
 
 	/**
 	 * Add a log entry to chosen file.
 	 *
-	 * @param int $timestamp Log timestamp.
 	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug
 	 * @param string $message Log message.
 	 * @param string $source Log source. Useful for filtering and sorting.
@@ -55,18 +54,16 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 	 *
 	 * @return bool True if write was successful.
 	 */
-	protected static function add( $timestamp, $level, $message, $source, $context ) {
+	protected static function add($level, $message, $source, $context ) {
 		global $wpdb;
 
 		$insert = array(
-			'timestamp' => date( 'Y-m-d H:i:s', $timestamp ),
 			'level' => WC_Log_Levels::get_level_severity( $level ),
 			'message' => $message,
 			'source' => $source,
 		);
 
 		$format = array(
-			'%s',
 			'%d',
 			'%s',
 			'%s',


### PR DESCRIPTION
Allows logs to be stored by microseconds by moving the responsibility of the timestamp to the database.

Fixes #14967 