### PR TITLE
Allow other product types to use the sale schedule inputs.

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -245,10 +245,13 @@ jQuery( function( $ ) {
 			numberOfMonths: 1,
 			showButtonPanel: true,
 			onSelect: function( selectedDate ) {
-				var option   = $( this ).is( '#_sale_price_dates_from, .sale_price_dates_from' ) ? 'minDate' : 'maxDate';
-				var instance = $( this ).data( 'datepicker' );
-				var date     = $.datepicker.parseDate( instance.settings.dateFormat || $.datepicker._defaults.dateFormat, selectedDate, instance.settings );
+				var option   = $( this ).next().is('.hasDatepicker') ? 'minDate' : 'maxDate',
+					instance = $( this ).data( 'datepicker' ),
+					dates    = $( this ).closest( '.sale_price_dates_fields' ).find( 'input' ),
+					date     = $.datepicker.parseDate( instance.settings.dateFormat || $.datepicker._defaults.dateFormat, selectedDate, instance.settings );
+
 				dates.not( this ).datepicker( 'option', option, date );
+				$( this ).change();
 			}
 		});
 	});


### PR DESCRIPTION
Problem:

Simple product allow to schedule a product sale, but the datepicker
works only if there is one group of sale inputs.

This is because only the simple&external product type is allowed to show the general data tab.

As referenced within the includes/admin/meta-boxes/views/html-product-data-general.php
the div container has the class attribute values "show_if_simple show_if_external".

This make impossible to use the price fields for custom product types.

Workaround:

When I register a new product type and I want to use the general data tab, simply, I cannot.
But, I can create an additional data tab and put my custom code there but if I want to use the price and sale input what I need to do
is to get a copy of the code from html-product-data-general.php and put it on my own view.

Surprise, is not possible to send the data from the datepicker to the input field, also, the recalculate value for the minDate and maxDate
doesn't work as expected.

Solution:

Instead of use the .sale_price_dates_from (that is removed when the datePicker is initialized, and instead of using the id attribute
that must be unique and may create issues, using a combination of .next() and .is() function allow us to determine if the options must be the min or max value.

The code is a copy of the same closure found within the meta-boxes-variation.js.