### PR TITLE
#15038 Made WC_Checkout::get_posted_data() public

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -528,7 +528,7 @@ class WC_Checkout {
 	 * @since  3.0.0
 	 * @return array of data.
 	 */
-	protected function get_posted_data() {
+	public function get_posted_data() {
 		$skipped = array();
 		$data    = array(
 			'terms'                              => (int) isset( $_POST['terms'] ),


### PR DESCRIPTION
Having `WC_Checkout::get_posted_data()` public will allow to fetch the posted data, like it was done in WC 2.6 and earlier.