### PR TITLE
Integrate WC_Order_Query

### DIFF
--- a/includes/abstracts/abstract-wc-object-query.php
+++ b/includes/abstracts/abstract-wc-object-query.php
@@ -71,8 +71,8 @@ abstract class WC_Object_Query {
 			'parent_exclude' => '',
 			'exclude'        => '',
 
-			'limit'          => -1,
-			'page'           => '',
+			'limit'          => get_option( 'posts_per_page' ),
+			'page'           => 1,
 			'offset'         => '',
 			'paginate'       => false,
 

--- a/includes/class-wc-order-query.php
+++ b/includes/class-wc-order-query.php
@@ -37,6 +37,7 @@ class WC_Order_Query extends WC_Object_Query {
 				'cart_tax'              => '',
 				'total'                 => '',
 				'total_tax'             => '',
+				'customer'              => '',
 				'customer_id'           => '',
 				'order_key'             => '',
 				'billing_first_name'    => '',

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -318,14 +318,21 @@ class WC_Data_Store_WP {
 			}
 
 			foreach ( $comparisons as $index => $comparison ) {
-				$query_arg[ $comparison ] = array(
-					'year'  => $dates[ $index ]->date( 'Y' ),
-					'month' => $dates[ $index ]->date( 'n' ),
-					'day'   => $dates[ $index ]->date( 'j' ),
-				);
-				if ( 'second' === $precision ) {
-					$query_arg[ $comparison ]['minute'] = $dates[ $index ]->date( 'i' );
-					$query_arg[ $comparison ]['second'] = $dates[ $index ]->date( 's' );
+				/**
+				 * WordPress doesn't generate the correct SQL for inclusive day queries with both a 'before' and
+				 * 'after' string query, so we have to use the array format in 'day' precision.
+				 * @see https://core.trac.wordpress.org/ticket/29908
+				 */
+				if ( 'day' === $precision ) {
+					$query_arg[ $comparison ]['year']  = $dates[ $index ]->date( 'Y' );
+					$query_arg[ $comparison ]['month'] = $dates[ $index ]->date( 'n' );
+					$query_arg[ $comparison ]['day']   = $dates[ $index ]->date( 'j' );
+				/**
+				 * WordPress doesn't support 'hour'/'second'/'minute' in array format 'before'/'after' queries,
+				 * so we have to use a string query.
+				 */
+				} else {
+					$query_arg[ $comparison ] = gmdate( 'm/d/Y H:i:s', $dates[ $index ]->getTimestamp() );
 				}
 			}
 
@@ -334,11 +341,11 @@ class WC_Data_Store_WP {
 				$query_arg['month'] = $dates[0]->date( 'n' );
 				$query_arg['day']   = $dates[0]->date( 'j' );
 				if ( 'second' === $precision ) {
+					$query_arg['hour']   = $dates[0]->date( 'H' );
 					$query_arg['minute'] = $dates[0]->date( 'i' );
 					$query_arg['second'] = $dates[0]->date( 's' );
 				}
 			}
-
 			$wp_query_args['date_query'][] = $query_arg;
 			return $wp_query_args;
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -354,74 +354,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	/**
 	 * Get all orders matching the passed in args.
 	 *
+	 * @deprecated 3.1.0 - Use wc_get_orders instead.
 	 * @see    wc_get_orders()
 	 * @param  array $args
 	 * @return array of orders
 	 */
 	public function get_orders( $args = array() ) {
-		/**
-		 * Generate WP_Query args. This logic will change if orders are moved to
-		 * custom tables in the future.
-		 */
-		$wp_query_args = array(
-			'post_type'      => $args['type'] ? $args['type'] : 'shop_order',
-			'post_status'    => $args['status'],
-			'posts_per_page' => $args['limit'],
-			'meta_query'     => array(),
-			'fields'         => 'ids',
-			'orderby'        => $args['orderby'],
-			'order'          => $args['order'],
-		);
-
-		if ( ! is_null( $args['parent'] ) ) {
-			$wp_query_args['post_parent'] = absint( $args['parent'] );
-		}
-
-		if ( ! is_null( $args['offset'] ) ) {
-			$wp_query_args['offset'] = absint( $args['offset'] );
-		} else {
-			$wp_query_args['paged'] = absint( $args['page'] );
-		}
-
-		if ( isset( $args['customer'] ) && '' !== $args['customer'] ) {
-			$values = is_array( $args['customer'] ) ? $args['customer'] : array( $args['customer'] );
-			$wp_query_args['meta_query'][] = $this->get_orders_generate_customer_meta_query( $values );
-		}
-
-		if ( ! empty( $args['exclude'] ) ) {
-			$wp_query_args['post__not_in'] = array_map( 'absint', $args['exclude'] );
-		}
-
-		if ( ! $args['paginate'] ) {
-			$wp_query_args['no_found_rows'] = true;
-		}
-
-		if ( ! empty( $args['date_before'] ) ) {
-			$wp_query_args['date_query']['before'] = $args['date_before'];
-		}
-
-		if ( ! empty( $args['date_after'] ) ) {
-			$wp_query_args['date_query']['after'] = $args['date_after'];
-		}
-
-		// Get results.
-		$orders = new WP_Query( apply_filters( 'woocommerce_order_data_store_cpt_get_orders_query', $wp_query_args, $args, $this ) );
-
-		if ( 'objects' === $args['return'] ) {
-			$return = array_map( 'wc_get_order', $orders->posts );
-		} else {
-			$return = $orders->posts;
-		}
-
-		if ( $args['paginate'] ) {
-			return (object) array(
-				'orders'        => $return,
-				'total'         => $orders->found_posts,
-				'max_num_pages' => $orders->max_num_pages,
-			);
-		} else {
-			return $return;
-		}
+		wc_deprecated_function( 'WC_Order_Data_Store_CPT::get_orders', '3.1.0', 'Use wc_get_orders instead.' );
+		return wc_get_orders( $args );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -684,6 +684,11 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
+		if ( isset( $query_vars['customer'] ) && '' !== $query_vars['customer'] ) {
+			$values = is_array( $query_vars['customer'] ) ? $query_vars['customer'] : array( $query_vars['customer'] );
+			$wp_query_args['meta_query'][] = $this->get_orders_generate_customer_meta_query( $values );
+		}
+
 		if ( ! isset( $query_vars['paginate'] ) || ! $query_vars['paginate'] ) {
 			$wp_query_args['no_found_rows'] = true;
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -624,7 +624,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
-		if ( isset( $query_vars['customer'] ) && ! empty( $query_vars['customer'] ) ) {
+		if ( isset( $query_vars['customer'] ) && '' !== $query_vars['customer'] && array() !== $query_vars['customer'] ) {
 			$values = is_array( $query_vars['customer'] ) ? $query_vars['customer'] : array( $query_vars['customer'] );
 			$wp_query_args['meta_query'][] = $this->get_orders_generate_customer_meta_query( $values );
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -624,7 +624,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
-		if ( isset( $query_vars['customer'] ) && '' !== $query_vars['customer'] ) {
+		if ( isset( $query_vars['customer'] ) && ! empty( $query_vars['customer'] ) ) {
 			$values = is_array( $query_vars['customer'] ) ? $query_vars['customer'] : array( $query_vars['customer'] );
 			$wp_query_args['meta_query'][] = $this->get_orders_generate_customer_meta_query( $values );
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -633,7 +633,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$wp_query_args['no_found_rows'] = true;
 		}
 
-		return apply_filters( 'woocommerce_get_order_wp_query_args', $wp_query_args, $query_vars );
+		return apply_filters( 'woocommerce_order_data_store_cpt_get_orders_query', $wp_query_args, $query_vars, $this );
 	}
 
 	/**

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -51,7 +51,7 @@ function wc_get_orders( $args ) {
 		$datetime    = wc_string_to_datetime( $args['date_before'] );
 		$date_before = strpos( $args['date_before'], ':' ) ? $datetime->getOffsetTimestamp() : $datetime->date( 'Y-m-d' );
 	}
-	if ( ! empty ( $args['date_after'] ) ) {
+	if ( ! empty( $args['date_after'] ) ) {
 		$datetime   = wc_string_to_datetime( $args['date_after'] );
 		$date_after = strpos( $args['date_after'], ':' ) ? $datetime->getOffsetTimestamp() : $datetime->date( 'Y-m-d' );
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -109,8 +109,22 @@ function wc_get_orders( $args ) {
 	}
 
 	// Map legacy date args to modern date args.
-	$date_before = ! empty( $args['date_before'] ) ? strtotime( $args['date_before'] ) : false;
-	$date_after = ! empty( $args['date_after'] ) ? strtotime( $args['date_after'] ) : false;
+	$date_before = false;
+	$date_after = false;
+
+	if ( ! empty( $args['date_before'] ) ) {
+		$date_before = strtotime( $args['date_before'] );
+		if ( $date_before && ! strpos( $args['date_before'], ':' ) ) {
+			$date_before = date( 'Y-m-d', $date_before );
+		}
+	}
+	if ( ! empty ( $args['date_after'] ) ) {
+		$date_after = strtotime( $args['date_after'] );
+		if ( $date_after && ! strpos( $args['date_after'], ':' ) ) {
+			$date_after = date( 'Y-m-d', $date_after );
+		}
+	}
+
 	if ( $date_before && $date_after ) {
 		$args['date_created'] = $date_before . '...' . $date_after;
 	} elseif ( $date_before ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -45,14 +45,14 @@ function wc_get_orders( $args ) {
 
 	// Map legacy date args to modern date args.
 	$date_before = false;
-	$date_after = false;
+	$date_after  = false;
 
 	if ( ! empty( $args['date_before'] ) ) {
-		$datetime = wc_string_to_datetime( $args['date_before'] );
+		$datetime    = wc_string_to_datetime( $args['date_before'] );
 		$date_before = strpos( $args['date_before'], ':' ) ? $datetime->getOffsetTimestamp() : $datetime->date( 'Y-m-d' );
 	}
 	if ( ! empty ( $args['date_after'] ) ) {
-		$datetime = wc_string_to_datetime( $args['date_after'] );
+		$datetime   = wc_string_to_datetime( $args['date_after'] );
 		$date_after = strpos( $args['date_after'], ':' ) ? $datetime->getOffsetTimestamp() : $datetime->date( 'Y-m-d' );
 	}
 

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -18,72 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This function should be used for order retrieval so that when we move to
  * custom tables, functions still work.
  *
- * Args:
- * 		'name'
- *		'parent' int post/order parent
- *		'parent_exclude'
- *		'exclude' array Order IDs to exclude from the query.
- *		'limit' int Maximum of orders to retrieve.
- *		'page' int Page of orders to retrieve. Ignored when using the 'offset' arg.
- *		'offset' int Offset of orders to retrieve.
- *		'paginate' bool If true, the return value will be an array with values:
- *          'orders'        => array of data (return value above),
- *          'total'         => total number of orders matching the query
- *          'max_num_pages' => max number of pages found
- *		'order' string ASC or DESC.
- *		'orderby' string Order by date, title, id, modified, rand etc.
- *		'return' string Type of data to return. Allowed values:
- *          ids array of order ids
- *          objects array of order objects (default)
- *
- *		'status' array|string List of order statuses to find
- *		'type' array|string Order type, e.g. shop_order or shop_order_refund
- *		'currency'
- *		'version'
- *		'prices_include_tax'
- *		'date_created'
- *		'date_modified'
- *		'date_completed'
- *		'date_paid'
- *		'discount_total'
- *		'discount_tax'
- *		'shipping_total'
- *		'shipping_tax'
- *		'cart_tax'
- *		'total'
- *		'total_tax'
- *		'customer_id'
- *      'customer' int|string|array User ID or billing email to limit orders to a
- *          particular user. Accepts array of values. Array of values is OR'ed. If array of array is passed, each array will be AND'ed.
- *          e.g. test@test.com, 1, array( 1, 2, 3 ), array( array( 1, 'test@test.com' ), 2, 3 )
- *		'order_key'
- *		'billing_first_name'
- *		'billing_last_name'
- *		'billing_company'
- *		'billing_address_1'
- *		'billing_address_2'
- *		'billing_city'
- *		'billing_state'
- *		'billing_postcode'
- *		'billing_country'
- *		'billing_email'
- *		'billing_phone'
- *		'shipping_first_name'
- *		'shipping_last_name'
- *		'shipping_company'
- *		'shipping_address_1'
- *		'shipping_address_2'
- *		'shipping_city'
- *		'shipping_state'
- *		'shipping_postcode'
- *		'shipping_country'
- *		'payment_method'
- *		'payment_method_title'
- *		'transaction_id'
- *		'customer_ip_address'
- *		'customer_user_agent'
- *		'created_via'
- *		'customer_note'
+ * Args and usage: @todo link to wiki page.
  *
  * @since  2.6.0
  * @param  array $args Array of args (above)
@@ -113,16 +48,12 @@ function wc_get_orders( $args ) {
 	$date_after = false;
 
 	if ( ! empty( $args['date_before'] ) ) {
-		$date_before = strtotime( $args['date_before'] );
-		if ( $date_before && ! strpos( $args['date_before'], ':' ) ) {
-			$date_before = date( 'Y-m-d', $date_before );
-		}
+		$datetime = wc_string_to_datetime( $args['date_before'] );
+		$date_before = strpos( $args['date_before'], ':' ) ? $datetime->getOffsetTimestamp() : $datetime->date( 'Y-m-d' );
 	}
 	if ( ! empty ( $args['date_after'] ) ) {
-		$date_after = strtotime( $args['date_after'] );
-		if ( $date_after && ! strpos( $args['date_after'], ':' ) ) {
-			$date_after = date( 'Y-m-d', $date_after );
-		}
+		$datetime = wc_string_to_datetime( $args['date_after'] );
+		$date_after = strpos( $args['date_after'], ':' ) ? $datetime->getOffsetTimestamp() : $datetime->date( 'Y-m-d' );
 	}
 
 	if ( $date_before && $date_after ) {


### PR DESCRIPTION
Closes #14795.

I've deprecated `WC_Order_Data_Store_CPT::get_orders` on the off chance that someone is using it for something already.

This PR also includes a tweak to `parse_date_for_wp_query` that works around some WordPress limitations.