### PR TITLE
Show login form on the "pay for order" step

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -81,44 +81,53 @@ class WC_Shortcode_Checkout {
 		$order_id = absint( $order_id );
 
 		// Handle payment
-		if ( isset( $_GET['pay_for_order'] ) && isset( $_GET['key'] ) && $order_id ) {
+		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) {
 
 			// Pay for existing order
-			$order_key            = $_GET['key'];
-			$order                = wc_get_order( $order_id );
+			$order_key = $_GET['key'];
+			$order     = wc_get_order( $order_id );
 
-			if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
-				echo '<div class="woocommerce-error">' . __( 'Invalid order. If you have an account please log in and try again.', 'woocommerce' ) . ' <a href="' . wc_get_page_permalink( 'myaccount' ) . '" class="wc-forward">' . __( 'My account', 'woocommerce' ) . '</a>' . '</div>';
-				return;
-			}
-
-			if ( $order->get_id() == $order_id && $order->get_order_key() == $order_key ) {
-
-				if ( $order->needs_payment() ) {
-					WC()->customer->set_props( array(
-						'billing_country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
-						'billing_state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
-						'billing_postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
-					) );
-					WC()->customer->save();
-
-					$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-
-					if ( sizeof( $available_gateways ) ) {
-						current( $available_gateways )->set_current();
-					}
-
-					wc_get_template( 'checkout/form-pay.php', array(
-						'order'              => $order,
-						'available_gateways' => $available_gateways,
-						'order_button_text'  => apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) ),
-					) );
-
-				} else {
-					wc_add_notice( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), wc_get_order_status_name( $order->get_status() ) ), 'error' );
-				}
-			} else {
+			// Order or payment link is invalid.
+			if ( ! $order || $order->get_id() !== $order_id || $order->get_order_key() !== $order_key ) {
 				wc_add_notice( __( 'Sorry, this order is invalid and cannot be paid for.', 'woocommerce' ), 'error' );
+
+			// Logged out customer does not have permission to pay for this order.
+			} elseif ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+				echo '<div class="woocommerce-info">' . __( 'Please login to your account below to continue to the payment form.', 'woocommerce' ) . '</div>';
+				woocommerce_login_form( array(
+					'redirect' => $order->get_checkout_payment_url(),
+				) );
+				return;
+
+			// Logged in customer trying to pay for someone else's order.
+			} elseif ( ! current_user_can( 'pay_for_order', $order_id ) ) {
+				wc_add_notice( __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), 'error' );
+
+			// Order does not need to be paid.
+			} elseif ( ! $order->needs_payment() ) {
+				wc_add_notice( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), wc_get_order_status_name( $order->get_status() ) ), 'error' );
+
+			// Show payment form.
+			} else {
+
+				WC()->customer->set_props( array(
+					'billing_country'  => $order->get_billing_country() ? $order->get_billing_country()   : null,
+					'billing_state'    => $order->get_billing_state() ? $order->get_billing_state()       : null,
+					'billing_postcode' => $order->get_billing_postcode() ? $order->get_billing_postcode() : null,
+				) );
+				WC()->customer->save();
+
+				$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+
+				if ( sizeof( $available_gateways ) ) {
+					current( $available_gateways )->set_current();
+				}
+
+				wc_get_template( 'checkout/form-pay.php', array(
+					'order'              => $order,
+					'available_gateways' => $available_gateways,
+					'order_button_text'  => apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) ),
+				) );
 			}
 		} elseif ( $order_id ) {
 
@@ -126,7 +135,7 @@ class WC_Shortcode_Checkout {
 			$order_key            = isset( $_GET['key'] ) ? wc_clean( $_GET['key'] ) : '';
 			$order                = wc_get_order( $order_id );
 
-			if ( $order->get_id() == $order_id && $order->get_order_key() == $order_key ) {
+			if ( $order && $order->get_id() === $order_id && $order->get_order_key() === $order_key ) {
 
 				if ( $order->needs_payment() ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ Yes you can! Join in on our [GitHub repository](http://github.com/woocommerce/wo
 == Changelog ==
 
 = 3.1.0 - 2017-xx-xx =
+* Feature - On the pay for order page, if logged out show a login form rather than an error message.
 * Included WooCommerce endpoints as options nav menu settings on Customize.
 * Dev - Updated Emogrifier to version 1.2.
 * Dev - Sort product data tabs by priority in admin screen.


### PR DESCRIPTION
Closes #14385

To test, create an order pending payment for a USER. If you use the
‘payment’ link on the edit order screen logged out you should see a
login form.

If you create an order and associate no user account, no form should be
shown and you don’t need to login.