### PR TITLE
Fix 'base location' not being returned via the settings API.

### DIFF
--- a/includes/api/class-wc-rest-setting-options-controller.php
+++ b/includes/api/class-wc-rest-setting-options-controller.php
@@ -178,12 +178,42 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Controller {
 			if ( 'multi_select_countries' === $setting['type'] ) {
 				$setting['options'] = WC()->countries->get_countries();
 				$setting['type']    = 'multiselect';
+			} elseif ( 'single_select_country' === $setting['type'] ) {
+				$setting['type']    = 'select';
+				$setting['options'] = $this->get_countries_and_states();
 			}
 
 			$filtered_settings[] = $setting;
 		}
 
 		return $filtered_settings;
+	}
+
+	/**
+	 * Returns a list of countries and states for use in the base location setting.
+	 *
+	 * @since  3.0.7
+	 * @return array Array of states and countries.
+	 */
+	private function get_countries_and_states() {
+		$countries = WC()->countries->get_countries();
+		if ( ! $countries ) {
+			return array();
+		}
+
+		$output = array();
+
+		foreach ( $countries as $key => $value ) {
+			if ( $states = WC()->countries->get_states( $key ) ) {
+				foreach ( $states as $state_key => $state_value ) {
+					$output[ $key . ':' . $state_key ] = $value . ' - ' . $state_value;
+				}
+			} else {
+				$output[ $key ] = $value;
+			}
+		}
+
+		return $output;
 	}
 
 	/**

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -735,4 +735,21 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( array( 'width' => 200, 'height' => 100, 'crop' => false ), $setting['value'] );
 	}
 
+	/**
+	 * Test to make sure the 'base location' setting is present in the response.
+	 * That it is returned as 'select' and not 'single_select_country',
+	 * and that both state and country options are returned.
+	 *
+	 * @since 3.0.7
+	 */
+	public function test_woocommerce_default_country() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/general/woocommerce_default_country' ) );
+		$setting  = $response->get_data();
+
+		$this->assertEquals( 'select', $setting['type'] );
+		$this->assertArrayHasKey( 'GB', $setting['options'] );
+		$this->assertArrayHasKey( 'US:OR', $setting['options'] );
+	}
+
 }


### PR DESCRIPTION
This PR makes sure that the 'base location' setting is returned to the `/settings/general` endpoint correctly.

The setting uses a special setting type that the API didn't handle properly, so no setting was returned before. This PR adds that handling.

Since this is a bug, I put it in the 3.0.7 milestone, but feel free to adjust.

To test:
* Run `phpunit` and make sure all tests pass.
* Make a `GET` request to `https://:siteUrl/wp-json/wc/v2/settings/general` and make sure that `woocommerce_default_country` setting is present.