### PR TITLE
Use site locale for customer emails.

### DIFF
--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -27,15 +27,13 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 		$this->id             = 'customer_completed_order';
 		$this->customer_email = true;
 
-		$this->setup_locale();
 		$this->title          = __( 'Completed order', 'woocommerce' );
 		$this->description    = __( 'Order complete emails are sent to customers when their orders are marked completed and usually indicate that their orders have been shipped.', 'woocommerce' );
 
-		$this->heading        = __( 'Your order is complete', 'woocommerce' );
-		$this->subject        = __( 'Your {site_title} order from {order_date} is complete', 'woocommerce' );
-
 		$this->template_html  = 'emails/customer-completed-order.php';
 		$this->template_plain = 'emails/plain/customer-completed-order.php';
+
+		$this->set_email_strings();
 
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_completed_notification', array( $this, 'trigger' ), 10, 2 );
@@ -46,6 +44,15 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 		// Call parent constuctor
 		parent::__construct();
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->heading = __( 'Your order is complete', 'woocommerce' );
+		$this->subject = __( 'Your {site_title} order from {order_date} is complete', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -26,6 +26,8 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 		$this->id             = 'customer_completed_order';
 		$this->customer_email = true;
+
+		$this->setup_locale();
 		$this->title          = __( 'Completed order', 'woocommerce' );
 		$this->description    = __( 'Order complete emails are sent to customers when their orders are marked completed and usually indicate that their orders have been shipped.', 'woocommerce' );
 
@@ -44,6 +46,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 
 		// Call parent constuctor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -39,6 +39,9 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	public function __construct() {
 
 		$this->id             = 'customer_invoice';
+		$this->customer_email = true;
+
+		$this->setup_locale();
 		$this->title          = __( 'Customer invoice', 'woocommerce' );
 		$this->description    = __( 'Customer invoice emails can be sent to customers containing their order information and payment links.', 'woocommerce' );
 
@@ -54,10 +57,10 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		// Call parent constructor
 		parent::__construct();
 
-		$this->customer_email = true;
 		$this->manual         = true;
 		$this->heading_paid   = $this->get_option( 'heading_paid', $this->heading_paid );
 		$this->subject_paid   = $this->get_option( 'subject_paid', $this->subject_paid );
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -41,18 +41,12 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		$this->id             = 'customer_invoice';
 		$this->customer_email = true;
 
-		$this->setup_locale();
 		$this->title          = __( 'Customer invoice', 'woocommerce' );
 		$this->description    = __( 'Customer invoice emails can be sent to customers containing their order information and payment links.', 'woocommerce' );
-
 		$this->template_html  = 'emails/customer-invoice.php';
 		$this->template_plain = 'emails/plain/customer-invoice.php';
 
-		$this->subject        = __( 'Invoice for order {order_number} from {order_date}', 'woocommerce' );
-		$this->heading        = __( 'Invoice for order {order_number}', 'woocommerce' );
-
-		$this->subject_paid   = __( 'Your {site_title} order from {order_date}', 'woocommerce' );
-		$this->heading_paid   = __( 'Order {order_number} details', 'woocommerce' );
+		$this->set_email_strings();
 
 		// Call parent constructor
 		parent::__construct();
@@ -60,6 +54,17 @@ class WC_Email_Customer_Invoice extends WC_Email {
 		$this->manual         = true;
 		$this->heading_paid   = $this->get_option( 'heading_paid', $this->heading_paid );
 		$this->subject_paid   = $this->get_option( 'subject_paid', $this->subject_paid );
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->subject      = __( 'Invoice for order {order_number} from {order_date}', 'woocommerce' );
+		$this->heading      = __( 'Invoice for order {order_number}', 'woocommerce' );
+		$this->subject_paid = __( 'Your {site_title} order from {order_date}', 'woocommerce' );
+		$this->heading_paid = __( 'Order {order_number} details', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -55,18 +55,25 @@ class WC_Email_Customer_New_Account extends WC_Email {
 		$this->id             = 'customer_new_account';
 		$this->customer_email = true;
 
-		$this->setup_locale();
 		$this->title          = __( 'New account', 'woocommerce' );
 		$this->description    = __( 'Customer "new account" emails are sent to the customer when a customer signs up via checkout or account pages.', 'woocommerce' );
 
 		$this->template_html  = 'emails/customer-new-account.php';
 		$this->template_plain = 'emails/plain/customer-new-account.php';
 
-		$this->subject        = __( 'Your account on {site_title}', 'woocommerce' );
-		$this->heading        = __( 'Welcome to {site_title}', 'woocommerce' );
+		$this->set_email_strings();
 
 		// Call parent constructor
 		parent::__construct();
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->subject = __( 'Your account on {site_title}', 'woocommerce' );
+		$this->heading = __( 'Welcome to {site_title}', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -54,6 +54,8 @@ class WC_Email_Customer_New_Account extends WC_Email {
 
 		$this->id             = 'customer_new_account';
 		$this->customer_email = true;
+
+		$this->setup_locale();
 		$this->title          = __( 'New account', 'woocommerce' );
 		$this->description    = __( 'Customer "new account" emails are sent to the customer when a customer signs up via checkout or account pages.', 'woocommerce' );
 
@@ -65,6 +67,7 @@ class WC_Email_Customer_New_Account extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -33,6 +33,8 @@ class WC_Email_Customer_Note extends WC_Email {
 
 		$this->id             = 'customer_note';
 		$this->customer_email = true;
+
+		$this->setup_locale();
 		$this->title          = __( 'Customer note', 'woocommerce' );
 		$this->description    = __( 'Customer note emails are sent when you add a note to an order.', 'woocommerce' );
 
@@ -47,6 +49,7 @@ class WC_Email_Customer_Note extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -34,21 +34,28 @@ class WC_Email_Customer_Note extends WC_Email {
 		$this->id             = 'customer_note';
 		$this->customer_email = true;
 
-		$this->setup_locale();
 		$this->title          = __( 'Customer note', 'woocommerce' );
 		$this->description    = __( 'Customer note emails are sent when you add a note to an order.', 'woocommerce' );
 
 		$this->template_html  = 'emails/customer-note.php';
 		$this->template_plain = 'emails/plain/customer-note.php';
 
-		$this->subject        = __( 'Note added to your {site_title} order from {order_date}', 'woocommerce' );
-		$this->heading        = __( 'A note has been added to your order', 'woocommerce' );
+		$this->set_email_strings();
 
 		// Triggers
 		add_action( 'woocommerce_new_customer_note_notification', array( $this, 'trigger' ) );
 
 		// Call parent constructor
 		parent::__construct();
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->subject = __( 'Note added to your {site_title} order from {order_date}', 'woocommerce' );
+		$this->heading = __( 'A note has been added to your order', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -26,13 +26,12 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 		$this->id               = 'customer_on_hold_order';
 		$this->customer_email   = true;
 
-		$this->setup_locale();
 		$this->title            = __( 'Order on-hold', 'woocommerce' );
 		$this->description      = __( 'This is an order notification sent to customers containing order details after an order is placed on-hold.', 'woocommerce' );
-		$this->heading          = __( 'Thank you for your order', 'woocommerce' );
-		$this->subject          = __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
 		$this->template_html    = 'emails/customer-on-hold-order.php';
 		$this->template_plain   = 'emails/plain/customer-on-hold-order.php';
+
+		$this->set_email_strings();
 
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
@@ -40,6 +39,15 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->heading = __( 'Thank you for your order', 'woocommerce' );
+		$this->subject = __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -25,6 +25,8 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 	public function __construct() {
 		$this->id               = 'customer_on_hold_order';
 		$this->customer_email   = true;
+
+		$this->setup_locale();
 		$this->title            = __( 'Order on-hold', 'woocommerce' );
 		$this->description      = __( 'This is an order notification sent to customers containing order details after an order is placed on-hold.', 'woocommerce' );
 		$this->heading          = __( 'Thank you for your order', 'woocommerce' );
@@ -38,6 +40,7 @@ class WC_Email_Customer_On_Hold_Order extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -39,7 +39,6 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
-		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -26,13 +26,12 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 		$this->id               = 'customer_processing_order';
 		$this->customer_email   = true;
 
-		$this->setup_locale();
 		$this->title            = __( 'Processing order', 'woocommerce' );
 		$this->description      = __( 'This is an order notification sent to customers containing order details after payment.', 'woocommerce' );
-		$this->heading          = __( 'Thank you for your order', 'woocommerce' );
-		$this->subject          = __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
 		$this->template_html    = 'emails/customer-processing-order.php';
 		$this->template_plain   = 'emails/plain/customer-processing-order.php';
+
+		$this->set_email_strings();
 
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_on-hold_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
@@ -40,6 +39,16 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+		$this->restore_locale();
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->heading = __( 'Thank you for your order', 'woocommerce' );
+		$this->subject = __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -25,6 +25,8 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 	public function __construct() {
 		$this->id               = 'customer_processing_order';
 		$this->customer_email   = true;
+
+		$this->setup_locale();
 		$this->title            = __( 'Processing order', 'woocommerce' );
 		$this->description      = __( 'This is an order notification sent to customers containing order details after payment.', 'woocommerce' );
 		$this->heading          = __( 'Thank you for your order', 'woocommerce' );
@@ -38,6 +40,7 @@ class WC_Email_Customer_Processing_Order extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -38,7 +38,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 	 */
 	public function __construct() {
 		$this->customer_email = true;
-		$this->setup_locale();
+
 		$this->set_email_strings();
 
 		// Triggers for this email
@@ -47,7 +47,6 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 
 		// Call parent constuctor
 		parent::__construct();
-		$this->restore_locale();
 	}
 
 	/**
@@ -56,11 +55,13 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 	 * @param bool $partial_refund
 	 */
 	public function set_email_strings( $partial_refund = false ) {
+		$this->setup_locale();
 		$this->subject_partial     = $this->get_option( 'subject_partial', __( 'Your {site_title} order from {order_date} has been partially refunded', 'woocommerce' ) );
 		$this->subject_full        = $this->get_option( 'subject_full', __( 'Your {site_title} order from {order_date} has been refunded', 'woocommerce' ) );
 
 		$this->heading_full        = $this->get_option( 'heading_full', __( 'Your order has been fully refunded', 'woocommerce' ) );
 		$this->heading_partial     = $this->get_option( 'heading_partial', __( 'Your order has been partially refunded', 'woocommerce' ) );
+		$this->restore_locale();
 
 		$this->template_html  = 'emails/customer-refunded-order.php';
 		$this->template_plain = 'emails/plain/customer-refunded-order.php';

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -37,8 +37,9 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->set_email_strings();
 		$this->customer_email = true;
+		$this->setup_locale();
+		$this->set_email_strings();
 
 		// Triggers for this email
 		add_action( 'woocommerce_order_fully_refunded_notification', array( $this, 'trigger_full' ), 10, 2 );
@@ -46,6 +47,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 
 		// Call parent constuctor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -46,9 +46,11 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	public function __construct() {
 
 		$this->id               = 'customer_reset_password';
+		$this->customer_email   = true;
+
+		$this->setup_locale();
 		$this->title            = __( 'Reset password', 'woocommerce' );
 		$this->description      = __( 'Customer "reset password" emails are sent when customers reset their passwords.', 'woocommerce' );
-		$this->customer_email   = true;
 
 		$this->template_html    = 'emails/customer-reset-password.php';
 		$this->template_plain   = 'emails/plain/customer-reset-password.php';
@@ -61,6 +63,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 
 		// Call parent constructor
 		parent::__construct();
+		$this->restore_locale();
 	}
 
 	/**

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -48,21 +48,28 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 		$this->id               = 'customer_reset_password';
 		$this->customer_email   = true;
 
-		$this->setup_locale();
 		$this->title            = __( 'Reset password', 'woocommerce' );
 		$this->description      = __( 'Customer "reset password" emails are sent when customers reset their passwords.', 'woocommerce' );
 
 		$this->template_html    = 'emails/customer-reset-password.php';
 		$this->template_plain   = 'emails/plain/customer-reset-password.php';
 
-		$this->subject          = __( 'Password reset for {site_title}', 'woocommerce' );
-		$this->heading          = __( 'Password reset instructions', 'woocommerce' );
+		$this->set_email_strings();
 
 		// Trigger
 		add_action( 'woocommerce_reset_password_notification', array( $this, 'trigger' ), 10, 2 );
 
 		// Call parent constructor
 		parent::__construct();
+	}
+
+	/**
+	 * Set email strings.
+	 */
+	public function set_email_strings() {
+		$this->setup_locale();
+		$this->subject = __( 'Password reset for {site_title}', 'woocommerce' );
+		$this->heading = __( 'Password reset instructions', 'woocommerce' );
 		$this->restore_locale();
 	}
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -255,7 +255,7 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Restore the locale to the default locale. Use after finished with setup_locale.
 	 */
-	public function restore_locale( $email ) {
+	public function restore_locale() {
 		if ( function_exists( 'restore_previous_locale' ) && $this->is_customer_email() ) {
 			restore_previous_locale();
 		}

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -243,12 +243,18 @@ class WC_Email extends WC_Settings_API {
 		return str_replace( apply_filters( 'woocommerce_email_format_string_find', $this->find, $this ), apply_filters( 'woocommerce_email_format_string_replace', $this->replace, $this ), $string );
 	}
 
+	/**
+	 * Set the locale to the store locale for customer emails to make sure emails are in the store language.
+	 */
 	public function setup_locale() {
 		if ( function_exists( 'switch_to_locale' ) && $this->is_customer_email() ) {
 			switch_to_locale( get_locale() );
 		}
 	}
 
+	/**
+	 * Restore the locale to the default locale. Use after finished with setup_locale.
+	 */
 	public function restore_locale( $email ) {
 		if ( function_exists( 'restore_previous_locale' ) && $this->is_customer_email() ) {
 			restore_previous_locale();

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -243,6 +243,18 @@ class WC_Email extends WC_Settings_API {
 		return str_replace( apply_filters( 'woocommerce_email_format_string_find', $this->find, $this ), apply_filters( 'woocommerce_email_format_string_replace', $this->replace, $this ), $string );
 	}
 
+	public function setup_locale() {
+		if ( function_exists( 'switch_to_locale' ) && $this->is_customer_email() ) {
+			switch_to_locale( get_locale() );
+		}
+	}
+
+	public function restore_locale( $email ) {
+		if ( function_exists( 'restore_previous_locale' ) && $this->is_customer_email() ) {
+			restore_previous_locale();
+		}
+	}
+
 	/**
 	 * Get email subject.
 	 *
@@ -388,6 +400,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_content() {
+		$this->setup_locale();
 		$this->sending = true;
 
 		if ( 'plain' === $this->get_email_type() ) {
@@ -395,6 +408,7 @@ class WC_Email extends WC_Settings_API {
 		} else {
 			$email_content = $this->get_content_html();
 		}
+		$this->restore_locale();
 
 		return wordwrap( $email_content, 70 );
 	}


### PR DESCRIPTION
Closes #14763.

To test: 
- Set site language to a different language than the admin user's language.
- Change some order statuses.
- Check MailCatcher at `http://vvv.dev:1080/`
- Observe admin emails are in admin user language and customer emails are in site language.