### PR TITLE
Fix Fatal Error: undefined function

### DIFF
--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -127,7 +127,7 @@ class WC_Embed {
 				<?php
 					/* translators: %s: average rating */
 					printf(
-						esc_html_( 'Rated %s out of 5', 'woocommerce' ),
+						esc_html__( 'Rated %s out of 5', 'woocommerce' ),
 						esc_html( $_product->get_average_rating() )
 					);
 				?>


### PR DESCRIPTION
Spotted on a merchant site in support:

<pre>
[12-May-2017 06:50:05 UTC] PHP Fatal error:  Call to undefined function esc_html_() in /home/summitma/public_html/wp-content/plugins/woocommerce/includes/class-wc-embed.php on line 130
</pre>