### PR TITLE
Fix: Re-add date for wc_create_refund()

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -540,6 +540,12 @@ function wc_create_refund( $args = array() ) {
 		$refund->calculate_totals( false );
 		$refund->set_total( $args['amount'] * -1 );
 
+		// this should remain after update_taxes(), as this will save the order, and write the current date to the db
+		// so we must wait until the order is persisted to set the date
+		if ( isset( $args['date_created'] ) ) {
+			$refund->set_date_created( $args['date_created'] );
+		}
+
 		/**
 		 * Action hook to adjust refund before save.
 		 * @since 3.0.0


### PR DESCRIPTION
Previous versions of WooCommerce accepted a `date` parameter for `wc_create_refund()` ([see WC 2.6](https://github.com/woocommerce/woocommerce/blob/2.6.0/includes/wc-order-functions.php#L796-L804)). This parameter is [no longer accepted in WC 3.0](https://github.com/woocommerce/woocommerce/blob/34a7f9b3dd9b711acbff8dce79ade4e4daba137e/includes/wc-order-functions.php#L467-L475), but it's required by plugins like Order CSV Import that programmatically create refunds so they can set the refunded date for reporting accuracy.

As this is already broken, this PR proposes changing the param to `date_created` to be more descriptive, and re-adding support for setting refund dates. 

There are a couple important things to note:

1. Adding this to the "default" args is not required. This is because of the second point below; it will be set regardless when saving the refund. However, happy to add the default if you think it makes it clearer for devs that it's accepted.
2. The `$refund->set_date_created()` method **must be called** after `$refund->update_taxes()` and `$refund->calculate_totals();` -- this is because:
   - both of these methods call the `$refund->save()` function
   - however, since the refund hasn't been persisted to the DB yet (as one of these calling save is what does it initially), the refund doesn't "exist" yet / doesn't have an ID upon the first `save()` call
   - since there's no ID, the save method then calls `create()` on the data store the first time as a result; the refund is now persisted to the DB, and in doing so, the `create()` method will always set the post date / refund date to the site's current time when writing it

So since the methods before my proposed addition of `$refund->set_date_created()` call `$refund->save()`, they effectively set the default created date, so an `isset()` check for the parameter is really the only thing that's needed, but not sure if it's clear then that it's accepted as an arg 😸  And this is also why setting the date must happen later before the final call to save the refund, but after the initial method that calls `save()` has run.

cc @mikejolley 