### PR TITLE
Fix shop page when using shop base and UTF8 shop page slug

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -290,7 +290,7 @@ class WC_Post_types {
 					'rewrite'             => $permalinks['product_rewrite_slug'] ? array( 'slug' => $permalinks['product_rewrite_slug'], 'with_front' => false, 'feeds' => true ) : false,
 					'query_var'           => true,
 					'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'publicize', 'wpcom-markdown' ),
-					'has_archive'         => ( $shop_page_id = wc_get_page_id( 'shop' ) ) && get_post( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop',
+					'has_archive'         => ( $shop_page_id = wc_get_page_id( 'shop' ) ) && get_post( $shop_page_id ) ? urldecode( get_page_uri( $shop_page_id ) ) : 'shop',
 					'show_in_nav_menus'   => true,
 					'show_in_rest'        => true,
 				)


### PR DESCRIPTION
To test, set shop page slug and name to `חנות` then set permalinks to
shop base.

Repeat that before and after patch.

Shop page 404 errors before patch.

Fixes #15111