### PR TITLE
#15103 Variation default value of '0' fails to save on product.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1066,7 +1066,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param array $default_attributes List of default attributes.
 	 */
 	public function set_default_attributes( $default_attributes ) {
-		$this->set_prop( 'default_attributes', array_filter( (array) $default_attributes ) );
+		$this->set_prop( 'default_attributes',
+			array_filter( (array) $default_attributes, 'wc_array_filter_default_attributes' ) );
 	}
 
 	/**

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -332,3 +332,15 @@ function wc_is_attribute_in_product_name( $attribute, $name ) {
 	$is_in_name = stristr( $name, ' ' . $attribute . ',' ) || 0 === stripos( strrev( $name ), strrev( ' ' . $attribute ) );
 	return apply_filters( 'woocommerce_is_attribute_in_product_name', $is_in_name, $attribute, $name );
 }
+
+/**
+ * Callback for array filter to get default attributes.  Will allow for '0' string values, but regard all other
+ * class PHP FALSE equivalents normally.
+ *
+ * @since 3.1.0
+ * @param mixed $attribute  Attribute being considered for exclusion from parent array.
+ * @return bool
+ */
+function wc_array_filter_default_attributes( $attribute ) {
+	return ( ! empty( $attribute ) || $attribute === '0' );
+}


### PR DESCRIPTION
The WC_Product::set_default_attributes function uses an array_filter (using the default callback for filtration) to remove null and false values from the defaults array for a given product.  The issue here is that, in the above use case, the array_filter will evaluate '0' as 0 and therefore as false. Ultimately, array_filter then prevents the value from being recorded.

I've added a new filter callback to includes/wc-attribute-functions which will disregard all FALSE PHP equivalents except for '0' (as a string).  Also, I've updated the filter_array call in WC_Product::set_default_attributes so that it uses this new callback, instead of the PHP default. Finally, I've added a phpunit test to assert that, when storing default variations / attributes on a product, the false/true PHP synonyms are evaluating and storing like one would normally expect, with the exception that (string) '0' evaluates as true in this special case.

This solution could potentially be broadened to facilitate similar rules elsewhere, perhaps.  For now this solution is designed only to fix the indicated issue, specifically.