### PR TITLE
Allow Polylang provide a translated product

### DIFF
--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -31,7 +31,7 @@ if ( $upsells ) : ?>
 			<?php foreach ( $upsells as $upsell ) : ?>
 
 				<?php
-				 	$post_object = get_post( $upsell->get_id() );
+				 	$post_object = get_post( apply_filters( 'woocommerce_cart_up_sells_post_id', $upsell->get_id(), $upsell ) );
 
 					setup_postdata( $GLOBALS['post'] =& $post_object );
 


### PR DESCRIPTION
Polylang creates duplicate products for translations. single-product/up-sells.php and cart/cross-sells.php do not provide an easy way to change the product id to the translated version. Adding a filter will enable this.