### PR TITLE
Allow Polylang provide a translated product

### DIFF
--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -31,7 +31,7 @@ if ( $cross_sells ) : ?>
 			<?php foreach ( $cross_sells as $cross_sell ) : ?>
 
 				<?php
-				 	$post_object = get_post( $cross_sell->get_id() );
+				 	$post_object = get_post( apply_filters( 'woocommerce_cart_cross_sells_post_id', $cross_sell->get_id(), $cross_sell ) );
 
 					setup_postdata( $GLOBALS['post'] =& $post_object );
 


### PR DESCRIPTION
Polylang creates duplicate products for translations. single-product/up-sells.php and cart/cross-sells.php do not provide an easy way to change the product id to the translated version. Adding a filter will enable this.

Sample code:
add_filter( 'woocommerce_cart_up_sells_post_id', 'dsh_polylang_translate_product_id' );
add_filter( 'woocommerce_cart_cross_sells_post_id', 'dsh_polylang_translate_product_id' );
function dsh_polylang_translate_product_id( $related_product_id ) {
    error_log( 'Cross Sell: '.$related_product_id );
    if ( function_exists( 'pll_get_post' ) ) {
        return pll_get_post( $related_product_id );
    }

    return $related_product_id;
}