### PR TITLE
Add `status` to the variations REST API

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -169,7 +169,6 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 			'date_on_sale_to'       => wc_rest_prepare_date_response( $object->get_date_on_sale_to(), false ),
 			'date_on_sale_to_gmt'   => wc_rest_prepare_date_response( $object->get_date_on_sale_to() ),
 			'on_sale'               => $object->is_on_sale(),
-			'visible'               => $object->is_visible(),
 			'purchasable'           => $object->is_purchasable(),
 			'virtual'               => $object->is_virtual(),
 			'downloadable'          => $object->is_downloadable(),
@@ -248,12 +247,6 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 		}
 
 		$variation->set_parent_id( absint( $request['product_id'] ) );
-
-		// TODO Fix/Remove in future API version bump. This controls the wrong thing.
-		// https://github.com/woocommerce/woocommerce/issues/15215
-		if ( isset( $request['visible'] ) ) {
-			$variation->set_status( false === $request['visible'] ? 'private' : 'publish' );
-		}
 
 		// Status.
 		if ( isset( $request['status'] ) ) {
@@ -676,12 +669,6 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-				),
-				'visible' => array(
-					'description' => __( 'Variation status. True for published and false for private.', 'woocommerce' ),
-					'type'        => 'boolean',
-					'default'     => true,
-					'context'     => array( 'view', 'edit' ),
 				),
 				'purchasable' => array(
 					'description' => __( 'Shows if the variation can be bought.', 'woocommerce' ),

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -176,6 +176,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 			'downloads'             => $this->get_downloads( $object ),
 			'download_limit'        => '' !== $object->get_download_limit() ? (int) $object->get_download_limit() : -1,
 			'download_expiry'       => '' !== $object->get_download_expiry() ? (int) $object->get_download_expiry() : -1,
+			'status'                => $object->get_status(),
 			'tax_status'            => $object->get_tax_status(),
 			'tax_class'             => $object->get_tax_class(),
 			'manage_stock'          => $object->managing_stock(),
@@ -248,9 +249,15 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 
 		$variation->set_parent_id( absint( $request['product_id'] ) );
 
-		// Status.
+		// TODO Fix/Remove in future API version bump. This controls the wrong thing.
+		// https://github.com/woocommerce/woocommerce/issues/15215
 		if ( isset( $request['visible'] ) ) {
 			$variation->set_status( false === $request['visible'] ? 'private' : 'publish' );
+		}
+
+		// Status.
+		if ( isset( $request['status'] ) ) {
+			$variation->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'draft' );
 		}
 
 		// SKU.
@@ -671,7 +678,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'readonly'    => true,
 				),
 				'visible' => array(
-					'description' => __( "Define if the attribute is visible on the \"Additional information\" tab in the product's page.", 'woocommerce' ),
+					'description' => __( 'Variation status. True for published and false for private.', 'woocommerce' ),
 					'type'        => 'boolean',
 					'default'     => true,
 					'context'     => array( 'view', 'edit' ),
@@ -730,6 +737,13 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'description' => __( 'Number of days until access to downloadable files expires.', 'woocommerce' ),
 					'type'        => 'integer',
 					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'status' => array(
+					'description' => __( 'Variation status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'publish',
+					'enum'        => array_keys( get_post_statuses() ),
 					'context'     => array( 'view', 'edit' ),
 				),
 				'tax_status' => array(

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -169,6 +169,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 10, $variation['regular_price'] );
 		$this->assertEmpty( $variation['sale_price'] );
 		$this->assertEquals( 'small', $variation['attributes'][0]['option'] );
+		$this->assertEquals( 'publish', $variation['status'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
 		$request->set_body_params( array(
@@ -177,6 +178,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 			'description' => 'O_O',
 			'image'       => array( 'position' => 0, 'src' => 'https://cldup.com/Dr1Bczxq4q.png', 'alt' => 'test upload image' ),
 			'attributes'  => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
+			'status'      => 'private',
 		) );
 		$response  = $this->server->dispatch( $request );
 		$variation = $response->get_data();
@@ -189,6 +191,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'medium', $variation['attributes'][0]['option'] );
 		$this->assertContains( 'Dr1Bczxq4q', $variation['image']['src'] );
 		$this->assertContains( 'test upload image', $variation['image']['alt'] );
+		$this->assertEquals( 'private', $variation['status'] );
 		$product->delete( true );
 	}
 
@@ -343,7 +346,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 37, count( $properties ) );
+		$this->assertEquals( 38, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'date_modified', $properties );
@@ -363,6 +366,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'downloads', $properties );
 		$this->assertArrayHasKey( 'download_limit', $properties );
 		$this->assertArrayHasKey( 'download_expiry', $properties );
+		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'tax_status', $properties );
 		$this->assertArrayHasKey( 'tax_class', $properties );
 		$this->assertArrayHasKey( 'manage_stock', $properties );

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -346,7 +346,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 38, count( $properties ) );
+		$this->assertEquals( 37, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'date_modified', $properties );
@@ -359,7 +359,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'date_on_sale_from', $properties );
 		$this->assertArrayHasKey( 'date_on_sale_to', $properties );
 		$this->assertArrayHasKey( 'on_sale', $properties );
-		$this->assertArrayHasKey( 'visible', $properties );
 		$this->assertArrayHasKey( 'purchasable', $properties );
 		$this->assertArrayHasKey( 'virtual', $properties );
 		$this->assertArrayHasKey( 'downloadable', $properties );


### PR DESCRIPTION
This adds a `status` field to a variation's response, which represents post status (published, private, etc). WooCommerce uses 'status' to enable or disable variations without deleting them (see the `enabled` checkbox in `wp-admin`). We need to be able to properly view and update the status in Calypso. This also adds the ability to update the status without relying on the confusing 'visible' prop, which this PR removes (fixes #15215).

Since the variations endpoint calls `parent::prepare_objects_query` we don't need to do anything extra to query for a certain status. This is already supported by the endpoint.

To Test:
* Run `phpunit`.
* Make sure all tests pass.

