### PR TITLE
Utilise $product method to get thumbnail

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -768,18 +768,11 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	 * @return string
 	 */
 	function woocommerce_get_product_thumbnail( $size = 'shop_catalog', $deprecated1 = 0, $deprecated2 = 0 ) {
-		global $post;
+		global $product;
+
 		$image_size = apply_filters( 'single_product_archive_thumbnail_size', $size );
 
-		if ( has_post_thumbnail() ) {
-			$props = wc_get_product_attachment_props( get_post_thumbnail_id(), $post );
-			return get_the_post_thumbnail( $post->ID, $image_size, array(
-				'title'	 => $props['title'],
-				'alt'    => $props['alt'],
-			) );
-		} elseif ( wc_placeholder_img_src() ) {
-			return wc_placeholder_img( $image_size );
-		}
+		return $product->get_image( $image_size );
 	}
 }
 


### PR DESCRIPTION
Is there any reason this function isn't using the `get_image()` method? It seems if we're accessing the `$post->ID`, then we should have access to the `$product` object too?

The reason being, the `get_image()` method also checks for the parent featured image, so is more robust. It may also be worth considering a filter in the `get_image()` method.