### PR TITLE
Coding improvements for datepicker range

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -123,10 +123,10 @@ jQuery( function( $ ) {
 				dateFormat:      'yy-mm-dd',
 				numberOfMonths:  1,
 				showButtonPanel: true,
-				onSelect:        function( selectedDate, instance ) {
+				onSelect:        function() {
 					var option = $( this ).is( '.sale_price_dates_from' ) ? 'minDate' : 'maxDate',
 						dates  = $( this ).closest( '.sale_price_dates_fields' ).find( 'input' ),
-						date   = $.datepicker.parseDate( instance.settings.dateFormat || $.datepicker._defaults.dateFormat, selectedDate, instance.settings );
+                        date   = $( this ).datepicker( 'getDate' );
 
 					dates.not( this ).datepicker( 'option', option, date );
 					$( this ).change();

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -126,7 +126,7 @@ jQuery( function( $ ) {
 				onSelect:        function() {
 					var option = $( this ).is( '.sale_price_dates_from' ) ? 'minDate' : 'maxDate',
 						dates  = $( this ).closest( '.sale_price_dates_fields' ).find( 'input' ),
-                        date   = $( this ).datepicker( 'getDate' );
+						date   = $( this ).datepicker( 'getDate' );
 
 					dates.not( this ).datepicker( 'option', option, date );
 					$( this ).change();

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -244,7 +244,7 @@ jQuery( function( $ ) {
 			dateFormat: 'yy-mm-dd',
 			numberOfMonths: 1,
 			showButtonPanel: true,
-			onSelect: function( selectedDate ) {
+			onSelect: function() {
 				var option = $( this ).is( '#_sale_price_dates_from, .sale_price_dates_from' ) ? 'minDate' : 'maxDate',
 					date   = $( this ).datepicker( 'getDate' );
 

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -245,9 +245,9 @@ jQuery( function( $ ) {
 			numberOfMonths: 1,
 			showButtonPanel: true,
 			onSelect: function( selectedDate ) {
-				var option   = $( this ).is( '#_sale_price_dates_from, .sale_price_dates_from' ) ? 'minDate' : 'maxDate';
-				var instance = $( this ).data( 'datepicker' );
-				var date     = $.datepicker.parseDate( instance.settings.dateFormat || $.datepicker._defaults.dateFormat, selectedDate, instance.settings );
+				var option = $( this ).is( '#_sale_price_dates_from, .sale_price_dates_from' ) ? 'minDate' : 'maxDate',
+					date   = $( this ).datepicker( 'getDate' );
+
 				dates.not( this ).datepicker( 'option', option, date );
 			}
 		});

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -117,7 +117,7 @@ jQuery(function( $ ) {
 		buttonImageOnly: true,
 		onSelect: function() {
 			var option = $( this ).is( '.from' ) ? 'minDate' : 'maxDate',
-                date   = $( this ).datepicker( 'getDate' );
+				date   = $( this ).datepicker( 'getDate' );
 
 			dates.not( this ).datepicker( 'option', option, date );
 		}

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -115,10 +115,9 @@ jQuery(function( $ ) {
 		showButtonPanel: true,
 		showOn: 'focus',
 		buttonImageOnly: true,
-		onSelect: function( selectedDate ) {
+		onSelect: function() {
 			var option = $( this ).is( '.from' ) ? 'minDate' : 'maxDate',
-				instance = $( this ).data( 'datepicker' ),
-				date = $.datepicker.parseDate( instance.settings.dateFormat || $.datepicker._defaults.dateFormat, selectedDate, instance.settings );
+                date   = $( this ).datepicker( 'getDate' );
 
 			dates.not( this ).datepicker( 'option', option, date );
 		}


### PR DESCRIPTION
No need to parse the date. Just use getDate-function of the datepicker.

## Using localized date formats
BTW: For using localized date formats you just need to:
1. Remove the name attribute from the datepicker text field
2. Add an input hidden field with the removed name attribute after the datepicker text field
3. Remove `dateFormat: 'yy-mm-dd',` option from datepicker
4. Add following code after `dates.not( this ).datepicker( 'option', option, date );`:
```
var dateFormatted = jQuery.datepicker.formatDate( 'yy-mm-dd', date );
$( this ).siblings( 'input[type="hidden"]' ).val( dateFormatted );
```

If interested I can add an additional patch for that. This would enhance the regional ux.