### PR TITLE
Check for an existing display name before updating a user on checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -879,6 +879,12 @@ class WC_Checkout {
 				$customer->set_last_name( $data['billing_last_name'] );
 			}
 
+			$current_user = get_user_by( 'id', $customer_id );
+			// If the display name is an email, update to the user's full name.
+			if ( $current_user && is_email( $current_user->display_name ) ) {
+				$customer->set_display_name( $data['billing_first_name'] . ' ' . $data['billing_last_name'] );
+			}
+
 			foreach ( $data as $key => $value ) {
 				// Use setters where available.
 				if ( is_callable( array( $customer, "set_{$key}" ) ) ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -879,9 +879,8 @@ class WC_Checkout {
 				$customer->set_last_name( $data['billing_last_name'] );
 			}
 
-			$current_user = get_user_by( 'id', $customer_id );
 			// If the display name is an email, update to the user's full name.
-			if ( $current_user && is_email( $current_user->display_name ) ) {
+			if ( is_email( $customer->get_display_name() ) ) {
 				$customer->set_display_name( $data['billing_first_name'] . ' ' . $data['billing_last_name'] );
 			}
 

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -27,6 +27,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		'email'              => '',
 		'first_name'         => '',
 		'last_name'          => '',
+		'display_name'       => '',
 		'role'               => 'customer',
 		'username'           => '',
 		'billing'            => array(
@@ -382,6 +383,17 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
+	 * Return customer's display name.
+	 *
+	 * @since  3.1.0
+	 * @param  string $context
+	 * @return string
+	 */
+	public function get_display_name( $context = 'view' ) {
+		return $this->get_prop( 'display_name', $context );
+	}
+
+	/**
 	 * Return customer's user role.
 	 *
 	 * @since  3.0.0
@@ -718,6 +730,17 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_last_name( $last_name ) {
 		$this->set_prop( 'last_name', $last_name );
+	}
+
+	/**
+	 * Set customer's display name.
+	 *
+	 * @since 3.0.0
+	 * @param string $display_name
+	 * @throws WC_Data_Exception
+	 */
+	public function set_display_name( $display_name ) {
+		$this->set_prop( 'display_name', $display_name );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -36,6 +36,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'last_update',
 		'first_name',
 		'last_name',
+		'display_name',
 		'show_admin_bar_front',
 		'use_ssl',
 		'admin_color',
@@ -148,6 +149,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 			'is_paying_customer' => get_user_meta( $customer_id, 'paying_customer', true ),
 			'email'              => $user_object->user_email,
 			'username'           => $user_object->user_login,
+			'display_name'       => $user_object->display_name,
 			'date_created'       => $user_object->user_registered, // Mysql string in local format.
 			'date_modified'      => get_user_meta( $customer_id, 'last_update', true ),
 			'role'               => ! empty( $user_object->roles[0] ) ? $user_object->roles[0] : 'customer',
@@ -167,7 +169,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		wp_update_user( apply_filters( 'woocommerce_update_customer_args', array(
 			'ID'           => $customer->get_id(),
 			'user_email'   => $customer->get_email(),
-			'display_name' => $customer->get_first_name() . ' ' . $customer->get_last_name(),
+			'display_name' => $customer->get_display_name(),
 		), $customer ) );
 		// Only update password if a new one was set with set_password.
 		if ( $customer->get_password() ) {

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -95,6 +95,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 		$customer->set_password( 'hunter2' );
 		$customer->set_first_name( 'Billy' );
 		$customer->set_last_name( 'Bob' );
+		$customer->set_display_name( 'Billy Bob' );
 		$customer->save();
 		$customer_id = $customer->get_id();
 		$customer_read = new WC_Customer( $customer_id );
@@ -103,6 +104,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 		$this->assertEquals( 'test@woo.local', $customer_read->get_email() );
 		$this->assertEquals( 'Billy', $customer_read->get_first_name() );
 		$this->assertEquals( 'Bob', $customer_read->get_last_name() );
+		$this->assertEquals( 'Billy Bob', $customer_read->get_display_name() );
 		$this->assertEquals( $username, $customer_read->get_username() );
 	}
 
@@ -183,6 +185,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 			'email' => 'test@woo.local',
 			'first_name' => 'Bob',
 			'last_name' => 'tester',
+			'display_name' => 'Bob Tester',
 			'role' => 'customer',
 			'date_created' => $time,
 			'date_modified' => $time,


### PR DESCRIPTION
Fixes #15020

Currently when completing an order, the user's display name is set to "First Name Last Name", which can seem unexpected. This PR adds a check to only update the display name if the existing display name is an email (following the logic in this comment https://github.com/woocommerce/woocommerce/issues/15020#issuecomment-300758499).

**To test**

1. Create a user with their username as the display name
2. Place an order, the display name should still be the username
3. Create another user with the email as their display name (I forced this by adding the email as "nickname")
4. Place an order, the display name should be updated to "First Name Last Name"

Maybe we should add Display Name to the Edit Account form, so that customers can also manage this? Since it is a front-end facing detail in reviews, I think they'd want to control it. Happy to create another issue/PR for this if so 🙂 