### PR TITLE
Order query unit tests and fixes.

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -612,7 +612,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					$status = wc_is_order_status( 'wc-' . $status ) ? 'wc-' . $status : $status;
 				}
 			} else {
-				$query_vars['post_status'] = ( ! wc_is_order_status( $query_vars['post_status'] ) && wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
+				$query_vars['post_status'] = wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
 			}
 		}
 

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -584,15 +584,35 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 */
 	protected function get_wp_query_args( $query_vars ) {
 
+		// Map query vars to ones that get_wp_query_args or WP_Query recognize.
 		$key_mapping = array(
-			'customer_id' => 'customer_user',
-			'status' => 'post_status',
+			'customer_id'    => 'customer_user',
+			'status'         => 'post_status',
+			'currency'       => 'order_currency',
+			'version'        => 'order_version',
+			'discount_total' => 'cart_discount',
+			'discount_tax'   => 'cart_discount_tax',
+			'shipping_total' => 'order_shipping',
+			'shipping_tax'   => 'order_shipping_tax',
+			'cart_tax'       => 'order_tax',
+			'total'          => 'order_total',
 		);
 
 		foreach ( $key_mapping as $query_key => $db_key ) {
 			if ( isset( $query_vars[ $query_key ] ) ) {
 				$query_vars[ $db_key ] = $query_vars[ $query_key ];
 				unset( $query_vars[ $query_key ] );
+			}
+		}
+
+		// Add the 'wc-' prefix to status if needed.
+		if ( ! empty( $query_vars['post_status'] ) ) {
+			if ( is_array( $query_vars['post_status'] ) ) {
+				foreach ( $query_vars['post_status'] as &$status ) {
+					$status = wc_is_order_status( 'wc-' . $status ) ? 'wc-' . $status : $status;
+				}
+			} else {
+				$query_vars['post_status'] = ( ! wc_is_order_status( $query_vars['post_status'] ) && wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
 			}
 		}
 

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -188,7 +188,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the before and after date parameters for wc_get_orders.
+	 * Test the legacy before and after date parameters for wc_get_orders.
 	 *
 	 * @since 3.0
 	 */
@@ -241,6 +241,11 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order3->delete();
 	}
 
+	/**
+	 * Test the status parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_status_param() {
 		$order1 = WC_Helper_Order::create_order();
 		$order1->set_status( 'pending' );
@@ -249,15 +254,20 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_status( 'completed' );
 		$order2->save();
 
-		$orders   = wc_get_orders( array( 'status' => 'wc-pending', 'return' => 'ids' ) );
+		$orders   = wc_get_orders( array( 'status' => 'pending', 'return' => 'ids' ) );
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders   = wc_get_orders( array( 'status' => 'wc-completed', 'return' => 'ids' ) );
+		$orders   = wc_get_orders( array( 'status' => 'completed', 'return' => 'ids' ) );
 		$expected = array( $order2->get_id() );
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the type parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_type_param() {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
@@ -273,20 +283,34 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the version parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_version_param() {
-		$order  = WC_Helper_Order::create_order();
+		$order = WC_Helper_Order::create_order();
 		$order->save();
 
 		$orders = wc_get_orders( array( 'version' => WC_VERSION, 'return' => 'ids' ) );
 		$expected = array( $order->get_id() );
 		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'version' => '2.1.0', 'return' => 'ids' ) );
+		$expected = array();
+		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the created_via parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_created_via_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->set_created_via( 'rest-api' );
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->set_created_via( 'checkout' );
 		$order2->save();
 
@@ -299,14 +323,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the parent parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_parent_param() {
-		$parent  = WC_Helper_Order::create_order();
+		$parent = WC_Helper_Order::create_order();
 		$parent->save();
 
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->set_parent_id( $parent->get_id() );
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
 		$orders = wc_get_orders( array( 'parent' => $parent->get_id(), 'return' => 'ids' ) );
@@ -314,14 +343,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the parent_exclude parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_parent_exclude_param() {
-		$parent  = WC_Helper_Order::create_order();
+		$parent = WC_Helper_Order::create_order();
 		$parent->save();
 
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->set_parent_id( $parent->get_id() );
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
 		$orders = wc_get_orders( array( 'parent_exclude' => array( $parent->get_id() ), 'return' => 'ids' ) );
@@ -330,10 +364,15 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the exclude parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_exclude_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
 		$orders = wc_get_orders( array( 'exclude' => array( $order1->get_id() ), 'return' => 'ids' ) );
@@ -341,46 +380,66 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the limit parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_limit_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
 		$orders = wc_get_orders( array( 'limit' => 1 ) );
 		$this->assertEquals( 1, count( $orders ) );
 	}
 
+	/**
+	 * Test the paged parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_paged_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders( array( 'paged' => 1, 'limit' => 1, 'return' => 'ids' ) );
+		$orders = wc_get_orders( array( 'paged' => 1, 'orderby' => 'ID', 'order' => 'ASC', 'limit' => 1, 'return' => 'ids' ) );
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders( array( 'paged' => 2, 'limit' => 1, 'return' => 'ids' ) );
+		$orders = wc_get_orders( array( 'paged' => 2, 'orderby' => 'ID', 'order' => 'ASC', 'limit' => 1, 'return' => 'ids' ) );
 		$expected = array( $order2->get_id() );
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the offset parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_offset_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders( array( 'offset' => 1, 'return' => 'ids' ) );
+		$orders = wc_get_orders( array( 'offset' => 1, 'orderby' => 'ID', 'order' => 'ASC', 'return' => 'ids' ) );
 		$expected = array( $order2->get_id() );
 		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the paginate parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_paginate_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
 		$orders = wc_get_orders( array( 'paginate' => true ) );
@@ -389,31 +448,364 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, $orders->max_num_pages );
 	}
 
+	/**
+	 * Test the order parameters for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_order_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders( array( 'orderby' => 'id', 'return' => 'ids' ) );
+		$orders = wc_get_orders( array( 'orderby' => 'ID', 'order' => 'DESC', 'return' => 'ids' ) );
 		$expected = array( $order2->get_id(), $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders( array( 'orderby' => 'id', 'order' => 'ASC', 'return' => 'ids' ) );
+		$orders = wc_get_orders( array( 'orderby' => 'ID', 'order' => 'ASC', 'return' => 'ids' ) );
 		$expected = array( $order1->get_id(), $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
 	}
 
+	/**
+	 * Test the currency parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
 	public function test_wc_get_order_currency_param() {
-		$order1  = WC_Helper_Order::create_order();
+		$order1 = WC_Helper_Order::create_order();
 		$order1->set_currency( 'BRL' );
 		$order1->save();
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->set_currency( 'USD' );
 		$order2->save();
 
 		$orders = wc_get_orders( array( 'currency' => 'BRL', 'return' => 'ids' ) );
 		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
 
 		$orders = wc_get_orders( array( 'currency' => 'USD', 'return' => 'ids' ) );
 		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the prices_include_tax parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_wc_get_order_prices_include_tax_param() {
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_prices_include_tax( true );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_prices_include_tax( false );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'prices_include_tax' => 'yes', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'prices_include_tax' => 'no', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the payment_method parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_wc_get_order_payment_method_param() {
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_payment_method( 'cheque' );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_payment_method( 'cod' );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'payment_method' => 'cheque', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'payment_method' => 'cod', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the payment_method_title parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_get_order_payment_method_title_param() {
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_payment_method_title( 'Check payments' );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_payment_method_title( 'PayPal' );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'payment_method_title' => 'Check payments', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'payment_method_title' => 'PayPal', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the price parameters for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_wc_get_order_price_price_params() {
+		$order1 = new WC_Order();
+		$order1->set_discount_total( 5.50 );
+		$order1->set_discount_tax( 0.50 );
+		$order1->set_shipping_total( 3.99 );
+		$order1->set_shipping_tax( 0.25);
+		$order1->set_cart_tax( 0.10 );
+		$order1->set_total( 10.34 );
+		$order1->save();
+		$order2 = new WC_Order();
+		$order2->set_discount_total( 2.50 );
+		$order2->set_discount_tax( 0.20 );
+		$order2->set_shipping_total( 2.99 );
+		$order2->set_shipping_tax( 0.15);
+		$order2->set_cart_tax( 0.05 );
+		$order2->set_total( 5.89 );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'discount_total' => 5.50, 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'discount_tax' => 0.20, 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_total' => 3.99, 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_tax' => 0.15, 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'cart_tax' => 0.10, 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'total' => 5.89, 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the customer parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_wc_get_order_customer_param() {
+		$customer1 = WC_Helper_Customer::create_customer( 'customer1', 'password', 'test1@test.com' );
+		$customer1->set_billing_email( 'customer1@test.com' );
+		$customer1->save();
+
+		$customer2 = WC_Helper_Customer::create_customer( 'customer2', 'password', 'test2@test.com' );
+		$customer2->set_billing_email( 'customer2@test.com' );
+		$customer2->save();
+
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_customer_id( $customer1->get_id() );
+		$order1->set_billing_email( $customer1->get_billing_email() );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_customer_id( $customer2->get_id() );
+		$order2->set_billing_email( $customer2->get_billing_email() );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'customer' => $customer1->get_billing_email(), 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'customer' => $customer2->get_id(), 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the customer_id parameter for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_wc_get_order_customer_id_param() {
+		$customer1 = WC_Helper_Customer::create_customer( 'customer1', 'password', 'test1@test.com' );
+		$customer1->set_billing_email( 'customer1@test.com' );
+		$customer1->save();
+
+		$customer2 = WC_Helper_Customer::create_customer( 'customer2', 'password', 'test2@test.com' );
+		$customer2->set_billing_email( 'customer2@test.com' );
+		$customer2->save();
+
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_customer_id( $customer1->get_id() );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_customer_id( $customer2->get_id() );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'customer_id' => $customer1->get_id(), 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'customer_id' => $customer2->get_id(), 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
+	 * Test the address parameters for wc_get_orders.
+	 *
+	 * @since 3.1
+	 */
+	public function test_wc_get_order_address_params() {
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_props( array(
+			'billing_email' => 'test1@test.com',
+			'billing_first_name' => 'Bill',
+			'billing_last_name' => 'Powers',
+			'billing_company' => 'TestCo.',
+			'billing_address_1' => '1234 Cool St.',
+			'billing_address_2' => 'Apt 2',
+			'billing_city' => 'Portland',
+			'billing_state' => 'OR',
+			'billing_postcode' => '97266',
+			'billing_country' => 'USA',
+			'billing_phone' => '503-123-4567',
+			'shipping_first_name' => 'Jane',
+			'shipping_last_name' => 'Powers',
+			'shipping_company' => '',
+			'shipping_address_1' => '4321 Cool St.',
+			'shipping_address_2' => 'Apt 1',
+			'shipping_city' => 'Milwaukie',
+			'shipping_state' => 'OR',
+			'shipping_postcode' => '97222',
+			'shipping_country' => 'USA',
+		) );
+		$order1->save();
+		$order1_id = $order1->get_id();
+
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_props( array(
+			'billing_email' => 'test2@test.com',
+			'billing_first_name' => 'Joe',
+			'billing_last_name' => 'Thunder',
+			'billing_company' => 'ThunderCo.',
+			'billing_address_1' => '1234 Thunder St.',
+			'billing_address_2' => '',
+			'billing_city' => 'Vancouver',
+			'billing_state' => 'WA',
+			'billing_postcode' => '97267',
+			'billing_country' => 'USA',
+			'billing_phone' => '503-333-3333',
+			'shipping_first_name' => 'Joseph',
+			'shipping_last_name' => 'Thunder',
+			'shipping_company' => 'Thunder Inc',
+			'shipping_address_1' => '1 Thunder Blvd',
+			'shipping_address_2' => '',
+			'shipping_city' => 'Vancouver',
+			'shipping_state' => 'WA',
+			'shipping_postcode' => '97233',
+			'shipping_country' => 'USA',
+		) );
+		$order2->save();
+		$order2_id = $order2->get_id();
+
+		$orders = wc_get_orders( array( 'billing_email' => 'test1@test.com', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_first_name' => 'Joe', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_last_name' => 'Powers', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_company' => 'ThunderCo.', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_address_1' => '1234 Cool St.', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_address_2' => 'Apt 2', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_city' => 'Vancouver', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_state' => 'OR', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_postcode' => '97267', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_country' => 'USA', 'orderby' => 'ID', 'order' => 'ASC', 'return' => 'ids' ) );
+		$expected = array( $order1_id, $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_phone' => '503-333-3333', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_first_name' => 'Jane', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_last_name' => 'Thunder', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_company' => 'Thunder Inc', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_address_1' => '1 Thunder Blvd', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_address_2' => 'Apt 1', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_city' => 'Vancouver', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_state' => 'OR', 'return' => 'ids' ) );
+		$expected = array( $order1_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_postcode' => '97233', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'shipping_country' => 'USA', 'orderby' => 'ID', 'order' => 'ASC', 'return' => 'ids' ) );
+		$expected = array( $order1_id, $order2_id );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'billing_first_name' => 'Joe', 'billing_last_name' => 'Thunder', 'return' => 'ids' ) );
+		$expected = array( $order2_id );
+		$this->assertEquals( $expected, $orders );
 	}
 }

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -240,4 +240,180 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->delete();
 		$order3->delete();
 	}
+
+	public function test_wc_get_order_status_param() {
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_status( 'pending' );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_status( 'completed' );
+		$order2->save();
+
+		$orders   = wc_get_orders( array( 'status' => 'wc-pending', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders   = wc_get_orders( array( 'status' => 'wc-completed', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_type_param() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+		$refund = new WC_Order_Refund();
+		$refund->save();
+
+		$orders = wc_get_orders( array( 'type' => 'shop_order_refund', 'return' => 'ids' ) );
+		$expected = array( $refund->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'type' => 'shop_order', 'return' => 'ids' ) );
+		$expected = array( $order->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_version_param() {
+		$order  = WC_Helper_Order::create_order();
+		$order->save();
+
+		$orders = wc_get_orders( array( 'version' => WC_VERSION, 'return' => 'ids' ) );
+		$expected = array( $order->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_created_via_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->set_created_via( 'rest-api' );
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->set_created_via( 'checkout' );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'created_via' => 'rest-api', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'created_via' => 'checkout', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_parent_param() {
+		$parent  = WC_Helper_Order::create_order();
+		$parent->save();
+
+		$order1  = WC_Helper_Order::create_order();
+		$order1->set_parent_id( $parent->get_id() );
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'parent' => $parent->get_id(), 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_parent_exclude_param() {
+		$parent  = WC_Helper_Order::create_order();
+		$parent->save();
+
+		$order1  = WC_Helper_Order::create_order();
+		$order1->set_parent_id( $parent->get_id() );
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'parent_exclude' => array( $parent->get_id() ), 'return' => 'ids' ) );
+		sort( $orders );
+		$expected = array( $parent->get_id(), $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_exclude_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'exclude' => array( $order1->get_id() ), 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_limit_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'limit' => 1 ) );
+		$this->assertEquals( 1, count( $orders ) );
+	}
+
+	public function test_wc_get_order_paged_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'paged' => 1, 'limit' => 1, 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		$orders = wc_get_orders( array( 'paged' => 2, 'limit' => 1, 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_offset_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'offset' => 1, 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	public function test_wc_get_order_paginate_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'paginate' => true ) );
+		$this->assertEquals( 2, $orders->total );
+		$this->assertEquals( 2, count( $orders->orders ) );
+		$this->assertEquals( 1, $orders->max_num_pages );
+	}
+
+	public function test_wc_get_order_order_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'orderby' => 'id', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id(), $order1->get_id() );
+
+		$orders = wc_get_orders( array( 'orderby' => 'id', 'order' => 'ASC', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id(), $order2->get_id() );
+	}
+
+	public function test_wc_get_order_currency_param() {
+		$order1  = WC_Helper_Order::create_order();
+		$order1->set_currency( 'BRL' );
+		$order1->save();
+		$order2  = WC_Helper_Order::create_order();
+		$order2->set_currency( 'USD' );
+		$order2->save();
+
+		$orders = wc_get_orders( array( 'currency' => 'BRL', 'return' => 'ids' ) );
+		$expected = array( $order1->get_id() );
+
+		$orders = wc_get_orders( array( 'currency' => 'USD', 'return' => 'ids' ) );
+		$expected = array( $order2->get_id() );
+	}
 }


### PR DESCRIPTION
Closes #15187.

These are the unit tests for all of the supported `wc_get_orders` and `WC_Order_Query` parameters. Unit testing uncovered a few query vars that needed mapping, so I've included that in this PR.

Also, I've modified the 'status' query to accept 'pending', 'processing', etc. instead of 'wc-pending', 'wc-processing', etc. as was discussed in the dev chat.