### PR TITLE
Support floats for the custom sort function

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -151,12 +151,13 @@ function wc_get_product_terms( $product_id, $taxonomy, $args = array() ) {
  * @return int
  */
 function _wc_get_product_terms_name_num_usort_callback( $a, $b ) {
-    $a_name = (int) $a->name;
-    $b_name = (int) $b->name;
+	$a_name = (float) $a->name;
+	$b_name = (float) $b->name;
 
-	if ( $a_name === $b_name ) {
+	if ( abs( $a_name - $b_name ) < 0.001 ) {
 		return 0;
 	}
+
 	return ( $a_name < $b_name ) ? -1 : 1;
 }
 


### PR DESCRIPTION
Use the following test:
```php
<?php
class Test {
        public $name;

        public function __construct( $value ) {
                $this->name = $value;
        }
}

$objects = [
        new Test( 5.5 ),
        new Test( 7.8 ),
        new Test( 7.5 ),
        new Test( 7.4 ),
        new Test( 7.3 )
];

usort( $objects, '_wc_get_product_terms_name_num_usort_callback' );

foreach ( $objects as $object ) {
        echo $object->name . "\n";
}
```

Before this fix:
```
5.5
7.8
7.5
7.4
7.3
```

After this fix:
```
5.5
7.3
7.4
7.5
7.8
```