### PR TITLE
fixes #15283

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -260,7 +260,7 @@ class WC_Structured_Data {
 		$markup['description']   = get_comment_text( $comment->comment_ID );
 		$markup['itemReviewed']  = array(
 			'@type' => 'Product',
-			'name'  => get_the_title( $comment->post_ID ),
+			'name'  => get_the_title( $comment->comment_post_ID ),
 		);
 		if ( $rating = get_comment_meta( $comment->comment_ID, 'rating', true ) ) {
 			$markup['reviewRating']  = array(


### PR DESCRIPTION
fixes #15283 Notice: Undefined property: stdClass::$post_ID in wp-content/plugins/woocommerce/includes/class-wc-structured-data.php on line 262 
when calling wp_list_comments with $options['callback'] = 'woocommerce_comments'