### PR TITLE
Fix for #15294

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -260,7 +260,7 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	// Remove locale from string.
 	if ( ! is_float( $number ) && $number !== strval( floatval( $number ) ) ) {
 		// Only remove thousands if separator is not same as decimal separator.
-		if( ! in_array( wc_get_price_thousand_separator(), $decimals ) ) {
+		if( wc_get_price_thousand_separator() !== wc_get_price_decimal_separator() ) {
 			$number = str_replace( wc_get_price_thousand_separator(), '', $number );
 		}
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -258,8 +258,12 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	$decimals = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
 
 	// Remove locale from string.
-	if ( ! is_float( $number ) ) {
-		$number = str_replace( wc_get_price_thousand_separator(), '', $number );
+	if ( ! is_float( $number ) && $number !== strval( floatval( $number ) ) ) {
+		// Only remove thousands if separator is not same as decimal separator.
+		if( ! in_array( wc_get_price_thousand_separator(), $decimals ) ) {
+			$number = str_replace( wc_get_price_thousand_separator(), '', $number );
+		}
+
 		$number = str_replace( $decimals, '.', $number );
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
 	}

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -6,6 +6,23 @@
  * @since 2.2
  */
 class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
+	/**
+	 * Change decimal separator to german style for testing.
+	 * @param string $value
+	 * @return string
+	 */
+	function change_decimal_separator_de( $value ) {
+		return ',';
+	}
+
+	/**
+	 * Change thousand separator to german style for testing.
+	 * @param string $value
+	 * @return string
+	 */
+	function change_thousand_separator_de( $value ) {
+		return '.';
+	}
 
 	/**
 	 * Test wc_sanitize_taxonomy_name().
@@ -237,7 +254,14 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
 		// given string with thousands
-		$this->assertEquals( '99999.99', wc_format_decimal( '9,9999.99' ) );
+		$this->assertEquals( '99999.99', wc_format_decimal( '99,999.99' ) );
+
+		// given string with thousands in german format
+		add_filter( 'wc_get_price_decimal_separator', array( $this, 'change_decimal_separator_de' ) );
+		add_filter( 'wc_get_price_thousand_separator', array( $this, 'change_thousand_separator_de' ) );
+		$this->assertEquals( '99999.99', wc_format_decimal( '99.999,99' ) );
+		remove_filter( 'wc_get_price_decimal_separator', array( $this, 'change_decimal_separator_de' ) );
+		remove_filter( 'woocommerce_price_trim_zeros', array( $this, 'change_thousand_separator_de' ) );
 	}
 
 	/**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -7,12 +7,20 @@
  */
 class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	/**
-	 * Change decimal separator to german style for testing.
+	 * Replace the decimal separators with thousand and thousand seperators with decimal separator for testing.
 	 * @param string $value
 	 * @return string
 	 */
-	function change_decimal_separator_de( $value ) {
-		return ',';
+	function replace_decimal_thousand_separators( $value ) {
+		if( '.' === $value ) {
+			return ',';
+		}
+
+		if( ',' === $value ) {
+			return '.';
+		}
+
+		return $value;
 	}
 
 	/**
@@ -257,11 +265,11 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( '99999.99', wc_format_decimal( '99,999.99' ) );
 
 		// given string with thousands in german format
-		add_filter( 'wc_get_price_decimal_separator', array( $this, 'change_decimal_separator_de' ) );
-		add_filter( 'wc_get_price_thousand_separator', array( $this, 'change_thousand_separator_de' ) );
+		add_filter( 'wc_get_price_decimal_separator', array( $this, 'replace_decimal_thousand_separators' ) );
+		add_filter( 'wc_get_price_thousand_separator', array( $this, 'replace_decimal_thousand_separators' ) );
 		$this->assertEquals( '99999.99', wc_format_decimal( '99.999,99' ) );
-		remove_filter( 'wc_get_price_decimal_separator', array( $this, 'change_decimal_separator_de' ) );
-		remove_filter( 'woocommerce_price_trim_zeros', array( $this, 'change_thousand_separator_de' ) );
+		remove_filter( 'wc_get_price_decimal_separator', array( $this, 'replace_decimal_thousand_separators' ) );
+		remove_filter( 'wc_get_price_thousand_separator', array( $this, 'replace_decimal_thousand_separators' ) );
 	}
 
 	/**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -11,7 +11,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @param string $value
 	 * @return string
 	 */
-	function replace_decimal_thousand_separators( $value ) {
+	function interchange_decimal_thousand_separators( $value ) {
 		if( '.' === $value ) {
 			return ',';
 		}
@@ -265,11 +265,11 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( '99999.99', wc_format_decimal( '99,999.99' ) );
 
 		// given string with thousands in german format
-		add_filter( 'wc_get_price_decimal_separator', array( $this, 'replace_decimal_thousand_separators' ) );
-		add_filter( 'wc_get_price_thousand_separator', array( $this, 'replace_decimal_thousand_separators' ) );
+		add_filter( 'wc_get_price_decimal_separator', array( $this, 'interchange_decimal_thousand_separators' ) );
+		add_filter( 'wc_get_price_thousand_separator', array( $this, 'interchange_decimal_thousand_separators' ) );
 		$this->assertEquals( '99999.99', wc_format_decimal( '99.999,99' ) );
-		remove_filter( 'wc_get_price_decimal_separator', array( $this, 'replace_decimal_thousand_separators' ) );
-		remove_filter( 'wc_get_price_thousand_separator', array( $this, 'replace_decimal_thousand_separators' ) );
+		remove_filter( 'wc_get_price_decimal_separator', array( $this, 'interchange_decimal_thousand_separators' ) );
+		remove_filter( 'wc_get_price_thousand_separator', array( $this, 'interchange_decimal_thousand_separators' ) );
 	}
 
 	/**


### PR DESCRIPTION
Second version. Removed the server thousands.
`if ( ! is_float( $number ) && $number !== strval( floatval( $number ) ) ) {` is for checking the format type of the $number, if already float format, then skip replacing separators.

`if( wc_get_price_thousand_separator() !== wc_get_price_decimal_separator() ) {` is just for hardening the thousands separator replacement. If thousand separator is same as decimal separator, then skip.