### PR TITLE
Add new filter woocommerce_logger_log_message

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -129,6 +129,7 @@ class WC_Logger implements WC_Logger_Interface {
 
 		if ( $this->should_handle( $level ) ) {
 			$timestamp = current_time( 'timestamp' );
+			$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
 
 			foreach ( $this->handlers as $handler ) {
 				$handler->handle( $timestamp, $level, $message, $context );


### PR DESCRIPTION
It replicates the filter for the deprecated add logger function in the equivalent log function.