### PR TITLE
Only delete if the object has an ID

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -164,6 +164,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			'force_delete' => false,
 		) );
 
+		if ( ! $id ) {
+			return;
+		}
+
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $id );
 			$order->set_id( 0 );

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -179,12 +179,16 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 
 		$id = $coupon->get_id();
 
+		if ( ! $id ) {
+			return;
+		}
+
 		if ( $args['force_delete'] ) {
-			wp_delete_post( $coupon->get_id() );
+			wp_delete_post( $id );
 			$coupon->set_id( 0 );
 			do_action( 'woocommerce_delete_coupon', $id );
 		} else {
-			wp_trash_post( $coupon->get_id() );
+			wp_trash_post( $id );
 			do_action( 'woocommerce_trash_coupon', $id );
 		}
 	}

--- a/includes/data-stores/class-wc-order-refund-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-refund-data-store-cpt.php
@@ -41,6 +41,10 @@ class WC_Order_Refund_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT im
 	public function delete( &$order, $args = array() ) {
 		$id = $order->get_id();
 
+		if ( ! $id ) {
+			return;
+		}
+
 		wp_delete_post( $id );
 		$order->set_id( 0 );
 		do_action( 'woocommerce_delete_order_refund', $id );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -234,12 +234,16 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'force_delete' => false,
 		) );
 
+		if ( ! $id ) {
+			return;
+		}
+
 		if ( $args['force_delete'] ) {
-			wp_delete_post( $product->get_id() );
+			wp_delete_post( $id );
 			$product->set_id( 0 );
 			do_action( 'woocommerce_delete_' . $post_type, $id );
 		} else {
-			wp_trash_post( $product->get_id() );
+			wp_trash_post( $id );
 			$product->set_status( 'trash' );
 			do_action( 'woocommerce_trash_' . $post_type, $id );
 		}


### PR DESCRIPTION
Since wp_delete_post will inherit global if an ID is not passed.

Fixes #15356