### PR TITLE
Change thumbnail regeneration plugin

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -177,7 +177,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 				array(
 					'title' => __( 'Product images', 'woocommerce' ),
 					'type' 	=> 'title',
-					'desc' 	=> sprintf( __( 'These settings affect the display and dimensions of images in your catalog - the display on the front-end will still be affected by CSS styles. After changing these settings you may need to <a target="_blank" href="%s">regenerate your thumbnails</a>.', 'woocommerce' ), 'https://wordpress.org/plugins/regenerate-thumbnails/' ),
+					'desc' 	=> sprintf( __( 'These settings affect the display and dimensions of images in your catalog - the display on the front-end will still be affected by CSS styles. After changing these settings you may need to <a target="_blank" href="%s">regenerate your thumbnails</a>.', 'woocommerce' ), 'https://wordpress.org/plugins/force-regenerate-thumbnails/' ),
 					'id' 	=> 'image_options',
 				),
 


### PR DESCRIPTION
* Switch to a better alternative - [Force Regenerate Thumbnails](https://wordpress.org/plugins/force-regenerate-thumbnails/);
* Allows regeneration via AJAX;
* Adds bulk-action option for image regeneration under _Media > All Media_
* Deletes old, unused image sizes;