### PR TITLE
[3.1] Fix GROUP BY clause in `wc_terms_clauses`

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -534,9 +534,6 @@ function wc_terms_clauses( $clauses, $taxonomies, $args ) {
 		$clauses['join'] .= " LEFT JOIN {$wpdb->termmeta} AS tm ON (t.term_id = tm.term_id AND tm.meta_key = '" . esc_sql( $meta_name ) . "') ";
 	}
 
-	// Grouping.
-	$clauses['where'] .= ' GROUP BY t.term_id ';
-
 	// Default to ASC.
 	if ( ! isset( $args['menu_order'] ) || ! in_array( strtoupper( $args['menu_order'] ), array( 'ASC', 'DESC' ) ) ) {
 		$args['menu_order'] = 'ASC';
@@ -549,6 +546,9 @@ function wc_terms_clauses( $clauses, $taxonomies, $args ) {
 	} else {
 		$clauses['orderby'] = $order;
 	}
+
+	// Grouping.
+	$clauses['orderby'] = ' GROUP BY t.term_id ' . $clauses['orderby'];
 
 	return $clauses;
 }


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/commit/eae2fb64c87933aabded1ab35190b3110ab19e06 introduced an issue when the WHERE clause is modified by other plugins than WooCommerce. The GROUP BY clause can appear in the middle of the WHERE clause with something like:
WHERE ... GROUP BY ... AND ...
The resulting query gives completely unexpected results.
I propose to move the new GROUP BY clause just before the ORDER BY clause.