### PR TITLE
Get posts in ID ascending order in exporter.

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -129,7 +129,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 			'limit'    => $this->get_limit(),
 			'page'     => $this->get_page(),
 			'orderby'  => array(
-				'ID'   => 'DESC',
+				'ID'   => 'ASC',
 			),
 			'return'   => 'objects',
 			'paginate' => true,


### PR DESCRIPTION
If we get posts in ID ascending order for the exporter, variations will always be after the parent variable product in the exported CSV. This will prevent potential problems when importing, since a variation's parent will always be imported before the children.