### PR TITLE
Tweak: Filter quantity being added to the cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -888,6 +888,9 @@ class WC_Cart {
 			// Get the product
 			$product_data = wc_get_product( $variation_id ? $variation_id : $product_id );
 
+			// Filter quantity being added to the cart before stock checks
+			$quantity     = apply_filters( 'woocommerce_add_to_cart_quantity', $quantity, $product_id );
+
 			// Sanity check
 			if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {
 				return false;


### PR DESCRIPTION
This stems from changes to `woocommerce_stock_amount` in WC 3.0+, and is needed for Measurement Price Calculator to be able to adjust inventory by a measured amount (ie 200 lbs) rather than by unit.

In previous versions of WC, `woocommerce_stock_amount` was only called in a few situations, so context was typically known. However, `wc_stock_amount()`, and therefore this filter, is called in _far_ more situations in the 3.0 codebase (such as when the product is instantiated), making it impossible to know context from which this filter is called.

As such, while this was an acceptable filter to adjust quantity being added to the cart in previous versions (as we could modify quantity before being added to the cart using a check for `$quantity == $_REQUEST['quantity']` and a flag for `stock_modified` to run it once), it can no longer be used in 3.0 -- it will run on both the _read_ of the quantity remaining, as well as the process of adding to the cart, and it can't be used any longer to modify add to cart quantity, since this caused issues when remaining stock was == stock being added to the cart and our filters were skipped.

As such, we migrated to `woocommerce_order_item_quantity` and `woocommerce_add_cart_item` to modify quantity as items are added to the cart / into the order in 3.0+. This, however, gives us a new issue: now we're not modifying inventory as early as before, so when `WC_Cart::add_to_cart()` is called, the inventory passed in is == the inventory input rather than a filtered value (the measurement entered).

In MPC, this is problematic when inventory drops below the quantity being added to the cart -- the checks for `$product->has_enough_stock()` fail when stock is 0.5m but the quantity added to the cart is "1" for example, even if the measurement input is "0.4m" since we haven't filtered the quantity anymore :) Example: http://cloud.skyver.ge/2H2M3A010B23

This filter will allow us to adjust that quantity again before running checks on inventory + stock in the cart.