### PR TITLE
We need to get the order object before we use

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -377,9 +377,9 @@ function wc_get_customer_available_downloads( $customer_id ) {
 
 	if ( $results ) {
 		foreach ( $results as $result ) {
+			$order = wc_get_order( $result->order_id );
+
 			if ( ! $order || $order->get_id() != $result->order_id ) {
-				// new order
-				$order    = wc_get_order( $result->order_id );
 				$_product = null;
 			}
 


### PR DESCRIPTION
On the My Accounts/Downloads page, it will show "no downloads available" This is due to us trying to check the condition of the order object prior to getting the order object. This PR fixes it.