### PR TITLE
Revert thousand removal in wc_format_decimal, and add more tests

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -246,7 +246,9 @@ function wc_format_refund_total( $amount ) {
 /**
  * Format decimal numbers ready for DB storage.
  *
- * Sanitize, remove locale formatting, and optionally round + trim off zeros.
+ * Sanitize, remove decimals, and optionally round + trim off zeros.
+ *
+ * This function does not remove thousands - this should be done before passing a value to the function.
  *
  * @param  float|string $number Expects either a float or a string with a decimal separator only (no thousands)
  * @param  mixed $dp number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
@@ -258,11 +260,7 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	$decimals = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
 
 	// Remove locale from string.
-	if ( ! is_float( $number ) && strval( floatval( $number ) ) !== $number ) {
-		// Only remove thousands if separator is not same as decimal separator.
-		if ( wc_get_price_thousand_separator() !== wc_get_price_decimal_separator() ) {
-			$number = str_replace( wc_get_price_thousand_separator(), '', $number );
-		}
+	if ( ! is_float( $number ) ) {
 		$number = str_replace( $decimals, '.', $number );
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
 	}

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -210,7 +210,6 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 2.2
 	 */
 	public function test_wc_format_decimal() {
-
 		// given string
 		$this->assertEquals( '9.99', wc_format_decimal( '9.99' ) );
 
@@ -235,14 +234,33 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// trim zeros and round
 		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
-		// given string with thousands
-		$this->assertEquals( '99999.99', wc_format_decimal( '99,999.99' ) );
-
-		// given string with thousands in german format
+		// given string with thousands in german format.
 		update_option( 'woocommerce_price_decimal_sep', ',' );
 		update_option( 'woocommerce_price_thousand_sep', '.' );
 
-		$this->assertEquals( '99999.99', wc_format_decimal( '99.999,99' ) );
+		// given string
+		$this->assertEquals( '9.99', wc_format_decimal( '9.99' ) );
+
+		// float
+		$this->assertEquals( '9.99', wc_format_decimal( 9.99 ) );
+
+		// dp = false, no rounding
+		$this->assertEquals( '9.9999', wc_format_decimal( 9.9999 ) );
+
+		// dp = use default (2)
+		$this->assertEquals( '9.99', wc_format_decimal( 9.9911, '' ) );
+
+		// dp = use default (2) and round
+		$this->assertEquals( '10.00', wc_format_decimal( 9.9999, '' ) );
+
+		// dp = use custom
+		$this->assertEquals( '9.991', wc_format_decimal( 9.9912, 3 ) );
+
+		// trim zeros
+		$this->assertEquals( '9', wc_format_decimal( 9.00, false, true ) );
+
+		// trim zeros and round
+		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
 		update_option( 'woocommerce_price_decimal_sep', '.' );
 		update_option( 'woocommerce_price_thousand_sep', ',' );


### PR DESCRIPTION
Reverts the thousand removal. Since wc_format_decimal has no context, it’s impossible to know if the string is coming from a USER or the DATABASE meaning handling of ‘.’ is incorrect.

Closes #15457