### PR TITLE
woocommerce_shortcode_products_query params

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -397,7 +397,7 @@ class WC_Shortcodes {
 
 		ob_start();
 
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts ) );
+		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts, null ) );
 
 		if ( $products->have_posts() ) : ?>
 


### PR DESCRIPTION
The `woocommerce_shortcode_products_query` filter is used earlier on in this file but with 3 params. The third being `$loop_name`. It's not relevant here, so set to `null`, but needs to be included to avoid errors when adding a filter.