### PR TITLE
Apply woocommerce_variable_price_html filter once

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -143,12 +143,14 @@ class WC_Product_Variable extends WC_Product {
 			$max_reg_price = end( $prices['regular_price'] );
 
 			if ( $min_price !== $max_price ) {
-				$price = apply_filters( 'woocommerce_variable_price_html', wc_format_price_range( $min_price, $max_price ) . $this->get_price_suffix(), $this );
+				$price = wc_format_price_range( $min_price, $max_price ) . $this->get_price_suffix();
 			} elseif ( $this->is_on_sale() && $min_reg_price === $max_reg_price ) {
-				$price = apply_filters( 'woocommerce_variable_price_html', wc_format_sale_price( wc_price( $max_reg_price ), wc_price( $min_price ) ) . $this->get_price_suffix(), $this );
+				$price = wc_format_sale_price( wc_price( $max_reg_price ), wc_price( $min_price ) ) . $this->get_price_suffix();
 			} else {
-				$price = apply_filters( 'woocommerce_variable_price_html', wc_price( $min_price ) . $this->get_price_suffix(), $this );
+				$price = wc_price( $min_price ) . $this->get_price_suffix();
 			}
+
+			$price = apply_filters( 'woocommerce_variable_price_html', $price, $this );
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -143,14 +143,14 @@ class WC_Product_Variable extends WC_Product {
 			$max_reg_price = end( $prices['regular_price'] );
 
 			if ( $min_price !== $max_price ) {
-				$price = wc_format_price_range( $min_price, $max_price ) . $this->get_price_suffix();
+				$price = wc_format_price_range( $min_price, $max_price );
 			} elseif ( $this->is_on_sale() && $min_reg_price === $max_reg_price ) {
-				$price = wc_format_sale_price( wc_price( $max_reg_price ), wc_price( $min_price ) ) . $this->get_price_suffix();
+				$price = wc_format_sale_price( wc_price( $max_reg_price ), wc_price( $min_price ) );
 			} else {
-				$price = wc_price( $min_price ) . $this->get_price_suffix();
+				$price = wc_price( $min_price );
 			}
 
-			$price = apply_filters( 'woocommerce_variable_price_html', $price, $this );
+			$price = apply_filters( 'woocommerce_variable_price_html', $price . $this->get_price_suffix(), $this );
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );


### PR DESCRIPTION
To save a bit of duplicate code. As far as I could tell, there was no reason to have 3 separate instances calling it, or 3 separate calls to `$this->get_price_suffix()`. It was introduced with #14752, but that was just a revert so I didn't see any info there to explain why it should be called separately there either.