### PR TITLE
Comment exclusion queries optimisation

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -246,6 +246,7 @@ class WC_Admin_Dashboard {
 	 */
 	public function recent_reviews() {
 		global $wpdb;
+
 		$query_from = apply_filters( 'woocommerce_report_recent_reviews_query_from', "FROM {$wpdb->comments} comments
 			LEFT JOIN {$wpdb->posts} posts ON (comments.comment_post_ID = posts.ID)
 			WHERE comments.comment_approved = '1'
@@ -256,8 +257,9 @@ class WC_Admin_Dashboard {
 			ORDER BY comments.comment_date_gmt DESC
 			LIMIT 5
 		" );
+
 		$comments = $wpdb->get_results( "
-			SELECT posts.ID, posts.post_title, comments.comment_author, comments.comment_ID, SUBSTRING(comments.comment_content,1,100) AS comment_excerpt
+			SELECT posts.ID, posts.post_title, comments.comment_author, comments.comment_ID, comments.comment_content
 			{$query_from};
 		" );
 
@@ -276,7 +278,7 @@ class WC_Admin_Dashboard {
 
 				/* translators: %s: review author */
 				echo '<h4 class="meta"><a href="' . get_permalink( $comment->ID ) . '#comment-' . absint( $comment->comment_ID ) . '">' . esc_html( apply_filters( 'woocommerce_admin_dashboard_recent_reviews', $comment->post_title, $comment ) ) . '</a> ' . sprintf( __( 'reviewed by %s', 'woocommerce' ), esc_html( $comment->comment_author ) ) . '</h4>';
-				echo '<blockquote>' . wp_kses_data( $comment->comment_excerpt ) . ' [...]</blockquote></li>';
+				echo '<blockquote>' . wp_kses_data( $comment->comment_content ) . '</blockquote></li>';
 
 			}
 			echo '</ul>';

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -586,11 +586,15 @@ class WC_Admin_Post_Types {
 					// check the status of the post
 					$status = ( 'trash' !== $post->post_status ) ? '' : 'post-trashed';
 
+					remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+
 					$latest_notes = get_comments( array(
 						'post_id'   => $post->ID,
 						'number'    => 1,
 						'status'    => $status,
 					) );
+
+					add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
 
 					$latest_note = current( $latest_notes );
 

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -31,12 +31,10 @@ class WC_Comments {
 
 		// Secure order notes
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_order_comments' ), 10, 1 );
-		add_action( 'comment_feed_join', array( __CLASS__, 'exclude_order_comments_from_feed_join' ) );
 		add_action( 'comment_feed_where', array( __CLASS__, 'exclude_order_comments_from_feed_where' ) );
 
 		// Secure webhook comments
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_webhook_comments' ), 10, 1 );
-		add_action( 'comment_feed_join', array( __CLASS__, 'exclude_webhook_comments_from_feed_join' ) );
 		add_action( 'comment_feed_where', array( __CLASS__, 'exclude_webhook_comments_from_feed_where' ) );
 
 		// Count comments
@@ -65,59 +63,25 @@ class WC_Comments {
 	 * @return array
 	 */
 	public static function exclude_order_comments( $clauses ) {
-		global $wpdb, $typenow;
-
-		if ( is_admin() && in_array( $typenow, wc_get_order_types() ) && current_user_can( 'manage_woocommerce' ) ) {
-			return $clauses; // Don't hide when viewing orders in admin
-		}
-
-		if ( ! $clauses['join'] ) {
-			$clauses['join'] = '';
-		}
-
-		if ( ! stristr( $clauses['join'], "JOIN $wpdb->posts ON" ) ) {
-			$clauses['join'] .= " LEFT JOIN $wpdb->posts ON comment_post_ID = $wpdb->posts.ID ";
-		}
-
-		if ( $clauses['where'] ) {
-			$clauses['where'] .= ' AND ';
-		}
-
-		$clauses['where'] .= " $wpdb->posts.post_type NOT IN ('" . implode( "','", wc_get_order_types() ) . "') ";
-
+		$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " comment_type != 'order_note' ";
 		return $clauses;
 	}
 
 	/**
-	 * Exclude order comments from queries and RSS.
-	 * @param  string $join
-	 * @return string
+	 * @deprecated 3.1
 	 */
 	public static function exclude_order_comments_from_feed_join( $join ) {
-		global $wpdb;
-
-		if ( ! stristr( $join, "JOIN $wpdb->posts ON" ) ) {
-			$join = " LEFT JOIN $wpdb->posts ON $wpdb->comments.comment_post_ID = $wpdb->posts.ID ";
-		}
-
-		return $join;
+		wc_deprecated_function( 'WC_Comments::exclude_order_comments_from_feed_join', '3.1' );
 	}
 
 	/**
 	 * Exclude order comments from queries and RSS.
+	 *
 	 * @param  string $where
 	 * @return string
 	 */
 	public static function exclude_order_comments_from_feed_where( $where ) {
-		global $wpdb;
-
-		if ( $where ) {
-			$where .= ' AND ';
-		}
-
-		$where .= " $wpdb->posts.post_type NOT IN ('" . implode( "','", wc_get_order_types() ) . "') ";
-
-		return $where;
+		return ( $where ? ' AND ' : '' ) . " comment_type != 'order_note' ";
 	}
 
 	/**
@@ -127,39 +91,15 @@ class WC_Comments {
 	 * @return array
 	 */
 	public static function exclude_webhook_comments( $clauses ) {
-		global $wpdb;
-
-		if ( ! $clauses['join'] ) {
-			$clauses['join'] = '';
-		}
-
-		if ( ! strstr( $clauses['join'], "JOIN $wpdb->posts" ) ) {
-			$clauses['join'] .= " LEFT JOIN $wpdb->posts ON comment_post_ID = $wpdb->posts.ID ";
-		}
-
-		if ( $clauses['where'] ) {
-			$clauses['where'] .= ' AND ';
-		}
-
-		$clauses['where'] .= " $wpdb->posts.post_type <> 'shop_webhook' ";
-
+		$clauses['where'] .= ( $clauses['where'] ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
 		return $clauses;
 	}
 
 	/**
-	 * Exclude webhook comments from queries and RSS.
-	 * @since  2.2
-	 * @param  string $join
-	 * @return string
+	 * @deprecated 3.1
 	 */
 	public static function exclude_webhook_comments_from_feed_join( $join ) {
-		global $wpdb;
-
-		if ( ! strstr( $join, $wpdb->posts ) ) {
-			$join = " LEFT JOIN $wpdb->posts ON $wpdb->comments.comment_post_ID = $wpdb->posts.ID ";
-		}
-
-		return $join;
+		wc_deprecated_function( 'WC_Comments::exclude_webhook_comments_from_feed_join', '3.1' );
 	}
 
 	/**
@@ -169,15 +109,7 @@ class WC_Comments {
 	 * @return string
 	 */
 	public static function exclude_webhook_comments_from_feed_where( $where ) {
-		global $wpdb;
-
-		if ( $where ) {
-			$where .= ' AND ';
-		}
-
-		$where .= " $wpdb->posts.post_type <> 'shop_webhook' ";
-
-		return $where;
+		return ( $where ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -81,6 +81,7 @@ class WC_Install {
 		),
 		'3.1.0' => array(
 			'wc_update_310_downloadable_products',
+			'wc_update_310_old_comments',
 			'wc_update_310_db_version',
 		),
 	);

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1113,6 +1113,15 @@ function wc_update_310_downloadable_products() {
 }
 
 /**
+ * Find old order notes and ensure they have the correct type for exclusion.
+ */
+function wc_update_310_old_comments() {
+	global $wpdb;
+
+	$wpdb->query( "UPDATE $wpdb->comments comments LEFT JOIN $wpdb->posts as posts ON comments.comment_post_ID = posts.ID SET comment_type = 'order_note' WHERE posts.post_type = 'shop_order' AND comment_type = '';" );
+}
+
+/**
  * Update DB Version.
  */
 function wc_update_310_db_version() {


### PR DESCRIPTION
Rather than use the post table + post types, this does exclusion based on comment type which has been set since WC 1.6.