### PR TITLE
Adding product_variation to permitted post types

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -130,7 +130,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function read( &$product ) {
 		$product->set_defaults();
 
-		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || 'product' !== $post_object->post_type ) {
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || ! ('product' === $post_object->post_type || 'product_variation' === $post_object->post_type ) ) {
 			throw new Exception( __( 'Invalid product.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
A custom plugin on a client site passes product_variations through this class. I think, though I am open to correction, that also allowing the 'product_variation' post type will solve my problem while also being in line with the goals of the project.