### PR TITLE
[3.1] Add action after a product has been imported

### DIFF
--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -219,6 +219,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			$object = apply_filters( 'woocommerce_product_import_pre_insert_product_object', $object, $data );
 			$object->save();
 
+			do_action( 'woocommerce_product_import_inserted_product_object', $object, $data );
+
 			return array(
 				'id'      => $object->get_id(),
 				'updated' => $updating,


### PR DESCRIPTION
Third party plugins may need to take actions after the product id is known. I propose to add an action after the product has been saved to handle this case.