### PR TITLE
Removes the use of strip_tags() when outputting order item meta

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2456,7 +2456,7 @@ if ( ! function_exists( 'wc_display_item_meta' ) ) {
 		) );
 
 		foreach ( $item->get_formatted_meta_data() as $meta_id => $meta ) {
-			$value = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( strip_tags( $meta->display_value ) ) ) );
+			$value = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( $meta->display_value ) ) );
 			$strings[] = '<strong class="wc-item-meta-label">' . wp_kses_post( $meta->display_key ) . ':</strong> ' . $value;
 		}
 


### PR DESCRIPTION
When debugging an extension issue with Product Add-ons, it looks like we're being quite strict when outputting order item meta.

We allow for formatting using `wp_kses_post`, yet we then run `strip_tags` as well, which negates the ability to format and adjust the order item meta.

This results in Product Add-ons not being able to display a hyperlink to an uploaded file, because we're removing the links anyway, yet are allowing developers to reformat the order item meta.

This PR removes the use of `strip_tags`, in favour of the (already very powerful) `wp_kses_post`.

cc @mikejolley 