### PR TITLE
Update total orders and items

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -400,10 +400,12 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		// Total orders and discounts also includes those which have been refunded at some point
 		$this->report_data->total_coupons         = number_format( array_sum( wp_list_pluck( $this->report_data->coupons, 'discount_amount' ) ), 2, '.', '' );
 		$this->report_data->total_refunded_orders = absint( count( $this->report_data->full_refunds ) );
-		$this->report_data->total_orders          = absint( array_sum( wp_list_pluck( $this->report_data->order_counts, 'count' ) ) ) - $this->report_data->total_refunded_orders;
 
-		// Item counts
-		$this->report_data->total_items = absint( array_sum( wp_list_pluck( $this->report_data->order_items, 'order_item_count' ) ) ) - $this->report_data->refunded_order_items;
+		// Total orders in this period, even if refunded.
+		$this->report_data->total_orders          = absint( array_sum( wp_list_pluck( $this->report_data->order_counts, 'count' ) ) );
+
+		// Item items ordered in this period, even if refunded.
+		$this->report_data->total_items = absint( array_sum( wp_list_pluck( $this->report_data->order_items, 'order_item_count' ) ) );
 
 		// 3rd party filtering of report data
 		$this->report_data = apply_filters( 'woocommerce_admin_report_data', $this->report_data );


### PR DESCRIPTION
Closes #15532 

This is something that has changed in the past but I feel should show total regardless of amount refunded.

Why? Because it’s not possible to know if the refunded item/order is in the current period, or the past period.

So with issue #15532 the order refunded was in a previous month which threw off this months counts.