### PR TITLE
Pass context information to formatted order item meta data filters - Part 2

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -135,7 +135,7 @@ class WC_Order_Item_Meta {
 				$formatted_meta[ $meta_id ] = array(
 					'key'   => $meta->key,
 					'label' => wc_attribute_label( $attribute_key, $this->product ),
-					'value' => apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ),
+					'value' => apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value, $meta, $this->item ),
 				);
 			}
 		}


### PR DESCRIPTION
Add extra data to the second occurrence of the 'woocommerce_order_item_display_meta_value' hook so it matches the change done in https://github.com/woocommerce/woocommerce/pull/15551