### PR TITLE
[REST API] Allow set grouped_products

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -994,6 +994,11 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 			$product = $this->save_default_attributes( $product, $request );
 		}
 
+		// Check children for a grouped product.
+		if ( $product->is_type( 'grouped' ) && isset( $request['grouped_products'] ) ) {
+			$product->set_children( $request['grouped_products'] );
+		}
+
 		// Check for featured/gallery images, upload it and set it.
 		if ( isset( $request['images'] ) ) {
 			$product = $this->set_product_images( $product, $request['images'] );
@@ -1925,7 +1930,6 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 						'type'    => 'integer',
 					),
 					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
 				),
 				'menu_order' => array(
 					'description' => __( 'Menu order, used to custom sort products.', 'woocommerce' ),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -994,7 +994,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 			$product = $this->save_default_attributes( $product, $request );
 		}
 
-		// Check children for a grouped product.
+		// Set children for a grouped product.
 		if ( $product->is_type( 'grouped' ) && isset( $request['grouped_products'] ) ) {
 			$product->set_children( $request['grouped_products'] );
 		}


### PR DESCRIPTION
This could go with REST API v3, but I see it as a bug, since there is no way to define grouped products and for sure is "read only" by mistake, so we could include it into 3.0.9.

Fixes #15559