### PR TITLE
Remove escape to fix saving of Special characters in attributes

### DIFF
--- a/includes/class-wc-product-attribute.php
+++ b/includes/class-wc-product-attribute.php
@@ -74,7 +74,7 @@ class WC_Product_Attribute implements ArrayAccess {
 				$term = get_term_by( 'id', $option, $this->get_name() );
 			} else {
 				// Term names get escaped in WP. See sanitize_term_field.
-				$term = get_term_by( 'name', esc_attr( $option ), $this->get_name() );
+				$term = get_term_by( 'name', $option, $this->get_name() );
 
 				if ( ! $term || is_wp_error( $term ) ) {
 					$new_term = wp_insert_term( $option, $this->get_name() );


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/commit/7f8add52a76bd68536d8c4c1c94eea8482b293c5 caused a regression with quote characters.

The escape encodes quote characters which then causes it to not match the term name, so nothing gets saved.

Oddly, I can no longer replicate #15238 after changing this back. The term name is stored with an encoded quote character, yet it still matches after post..

Fixes #15561