### PR TITLE
Importer; create placeholders when importing products with IDs

### DIFF
--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -192,6 +192,8 @@ class WC_Admin_Importers {
 	 * Ajax callback for importing one batch of products from a CSV.
 	 */
 	public function do_ajax_product_import() {
+		global $wpdb;
+
 		check_ajax_referer( 'wc-product-import', 'security' );
 
 		if ( ! current_user_can( 'edit_products' ) || ! isset( $_POST['file'] ) ) {
@@ -226,6 +228,10 @@ class WC_Admin_Importers {
 		update_user_option( get_current_user_id(), 'product_import_error_log', $error_log );
 
 		if ( 100 === $percent_complete ) {
+			// Clear temp meta.
+			$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => '_original_id' ) );
+
+			// Send success.
 			wp_send_json_success( array(
 				'position'   => 'done',
 				'percentage' => 100,

--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<td>
 						<input type="hidden" name="update_existing" value="0" />
 						<input type="checkbox" id="woocommerce-importer-update-existing" name="update_existing" value="1" />
-						<label for="woocommerce-importer-update-existing"><?php esc_html_e( 'If a product being imported matches an existing product ID or SKU, update the existing product data.', 'woocommerce' ); ?></label>
+						<label for="woocommerce-importer-update-existing"><?php esc_html_e( 'If a product being imported matches an existing product by ID or SKU, update the existing product rather than creating a new product or skipping the row.', 'woocommerce' ); ?></label>
 					</td>
 				</tr>
 				<tr class="woocommerce-importer-advanced hidden">

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -38,7 +38,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	public function read( &$product ) {
 		$product->set_defaults();
 
-		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || ! in_array( $post_object->post_type, array( 'product', 'product_variation' )) ) {
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || ! in_array( $post_object->post_type, array( 'product', 'product_variation' ) ) ) {
 			return;
 		}
 

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -197,6 +197,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 				unset( $data['manage_stock'], $data['stock_status'], $data['backorders'] );
 			}
 
+			if ( 'importing' === $object->get_status() ) {
+				$object->set_status( 'publish' );
+				$object->set_slug( '' );
+			}
+
 			$result = $object->set_props( array_diff_key( $data, array_flip( array( 'meta_data', 'raw_image_id', 'raw_gallery_image_ids', 'raw_attributes' ) ) ) );
 
 			if ( is_wp_error( $result ) ) {
@@ -211,10 +216,6 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 			$this->set_image_data( $object, $data );
 			$this->set_meta_data( $object, $data );
-
-			if ( 'importing' === $object->get_status() ) {
-				$object->set_status( 'publish' );
-			}
 
 			$object = apply_filters( 'woocommerce_product_import_pre_insert_product_object', $object, $data );
 			$object->save();


### PR DESCRIPTION
This allows variations to be imported when IDs are used and set.

If you’re not updating via CSV, the default behaviour will be to create new products, but map based on provided IDs.

Fixes #15614