### PR TITLE
Update test and add flag to importer

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -31,13 +31,14 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 */
 	public function __construct( $file, $params = array() ) {
 		$default_args = array(
-			'start_pos'       => 0, // File pointer start.
-			'end_pos'         => -1, // File pointer end.
-			'lines'           => -1, // Max lines to read.
-			'mapping'         => array(), // Column mapping. csv_heading => schema_heading.
-			'parse'           => false, // Whether to sanitize and format data.
-			'update_existing' => false, // Whether to update existing items.
-			'delimiter'       => ',', // CSV delimiter.
+			'start_pos'        => 0, // File pointer start.
+			'end_pos'          => -1, // File pointer end.
+			'lines'            => -1, // Max lines to read.
+			'mapping'          => array(), // Column mapping. csv_heading => schema_heading.
+			'parse'            => false, // Whether to sanitize and format data.
+			'update_existing'  => false, // Whether to update existing items.
+			'delimiter'        => ',', // CSV delimiter.
+			'prevent_timeouts' => true, // Check memory and time usage and abort if reaching limit.
 		);
 
 		$this->params = wp_parse_args( $params, $default_args );
@@ -711,7 +712,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 			$index ++;
 
-			if ( $this->time_exceeded() || $this->memory_exceeded() ) {
+			if ( $this->params['prevent_timeouts'] && ( $this->time_exceeded() || $this->memory_exceeded() ) ) {
 				$this->file_position = $this->file_positions[ $index ];
 				break;
 			}

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -539,10 +539,10 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( array(
 			'id'          => 'subject',
 			'label'       => 'Subject',
-			'description' => 'This controls the email subject line. Leave blank to use the default subject: <code>[{site_title}] New customer order ({order_number}) - {order_date}</code>.',
+			'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
 			'type'        => 'text',
 			'default'     => '',
-			'tip'         => 'This controls the email subject line. Leave blank to use the default subject: <code>[{site_title}] New customer order ({order_number}) - {order_date}</code>.',
+			'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
 			'value'       => '',
 		), $setting );
 
@@ -557,10 +557,10 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( array(
 			'id'          => 'subject',
 			'label'       => 'Subject',
-			'description' => 'This controls the email subject line. Leave blank to use the default subject: <code>[{site_title}] New customer order ({order_number}) - {order_date}</code>.',
+			'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
 			'type'        => 'text',
 			'default'     => '',
-			'tip'         => 'This controls the email subject line. Leave blank to use the default subject: <code>[{site_title}] New customer order ({order_number}) - {order_date}</code>.',
+			'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
 			'value'       => 'This is my subject',
 		), $setting );
 

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -84,8 +84,9 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 */
 	public function test_import() {
 		$args = array(
-			'mapping' => $this->get_csv_mapped_items(),
-			'parse'   => true,
+			'mapping'          => $this->get_csv_mapped_items(),
+			'parse'            => true,
+			'prevent_timeouts' => false,
 		);
 
 		$importer = new WC_Product_CSV_Importer( $this->csv_file, $args );


### PR DESCRIPTION
The new importer flag enables us to turn the memory/time checks off, which should stop the importer tests from failing due to memory/time limits reached.