### PR TITLE
Add store street address, city and postal code to settings

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -308,10 +308,19 @@ class WC_Admin_Setup_Wizard {
 	 * Location and Tax settings.
 	 */
 	public function wc_setup_location() {
-		$user_location  = WC_Geolocation::geolocate_ip();
-		$country        = ! empty( $user_location['country'] ) ? $user_location['country'] : 'US';
-		$state          = ! empty( $user_location['state'] ) ? $user_location['state'] : '*';
-		$state          = 'US' === $country && '*' === $state ? 'AL' : $state;
+		$address        = WC()->countries->get_base_address();
+		$address_2      = WC()->countries->get_base_address_2();
+		$city           = WC()->countries->get_base_city();
+		$state          = WC()->countries->get_base_state();
+		$country        = WC()->countries->get_base_country();
+		$postcode       = WC()->countries->get_base_postcode();
+
+		if ( empty( $country ) ) {
+			$user_location  = WC_Geolocation::geolocate_ip();
+			$country        = ! empty( $user_location['country'] ) ? $user_location['country'] : 'US';
+			$state          = ! empty( $user_location['state'] ) ? $user_location['state'] : '*';
+			$state          = 'US' === $country && '*' === $state ? 'AL' : $state;
+		}
 
 		// Defaults
 		$currency       = get_option( 'woocommerce_currency', 'GBP' );
@@ -324,11 +333,40 @@ class WC_Admin_Setup_Wizard {
 		<form method="post">
 			<table class="form-table">
 				<tr>
-					<th scope="row"><label for="store_location"><?php esc_html_e( 'Where is your store based?', 'woocommerce' ); ?></label></th>
+					<tr>
+						<th scope="row"><label for="store_address"><?php esc_html_e( 'Where is your store based?', 'woocommerce' ); ?></label></th>
+						<td>
+							<input type="text" id="store_address" name="store_address" value="<?php echo esc_attr( $address ); ?>" />
+							<span class="description"> <?php esc_html_e( 'Address line 1', 'woocommerce' ); ?></span>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">&nbsp;</th>
+						<td>
+							<input type="text" id="store_address_2" name="store_address_2" value="<?php echo esc_attr( $address_2 ); ?>" />
+							<span class="description"> <?php esc_html_e( 'Address line 2', 'woocommerce' ); ?></span>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">&nbsp;</th>
+						<td>
+							<input type="text" id="store_city" name="store_city" value="<?php echo esc_attr( $city ); ?>" />
+							<span class="description"> <?php esc_html_e( 'City', 'woocommerce' ); ?></span>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">&nbsp;</th>
+						<td>
+							<select id="store_location" name="store_location" style="width:100%;" required data-placeholder="<?php esc_attr_e( 'Choose a country&hellip;', 'woocommerce' ); ?>" class="wc-enhanced-select">
+								<?php WC()->countries->country_dropdown_options( $country, $state ); ?>
+							</select>
+							<span class="description"> <?php esc_html_e( 'Country / State', 'woocommerce' ); ?></span>
+						</td>
+					</tr>
+					<th scope="row">&nbsp;</th>
 					<td>
-					<select id="store_location" name="store_location" style="width:100%;" required data-placeholder="<?php esc_attr_e( 'Choose a country&hellip;', 'woocommerce' ); ?>" class="wc-enhanced-select">
-							<?php WC()->countries->country_dropdown_options( $country, $state ); ?>
-						</select>
+						<input type="text" id="store_postcode" name="store_postcode" value="<?php echo esc_attr( $postcode ); ?>" />
+						<span class="description"> <?php esc_html_e( 'Postcode / ZIP', 'woocommerce' ); ?></span>
 					</td>
 				</tr>
 				<tr>
@@ -423,14 +461,24 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_location_save() {
 		check_admin_referer( 'wc-setup' );
 
+		$address        = sanitize_text_field( $_POST['store_address'] );
+		$address_2      = sanitize_text_field( $_POST['store_address_2'] );
+		$city           = sanitize_text_field( $_POST['store_city'] );
 		$store_location = sanitize_text_field( $_POST['store_location'] );
+		$postcode       = sanitize_text_field( $_POST['store_postcode'] );
+
 		$currency_code  = sanitize_text_field( $_POST['currency_code'] );
 		$currency_pos   = sanitize_text_field( $_POST['currency_pos'] );
 		$decimal_sep    = sanitize_text_field( $_POST['decimal_sep'] );
 		$num_decimals   = sanitize_text_field( $_POST['num_decimals'] );
 		$thousand_sep   = sanitize_text_field( $_POST['thousand_sep'] );
 
+		update_option( 'woocommerce_store_address', $address );
+		update_option( 'woocommerce_store_address_2', $address_2 );
+		update_option( 'woocommerce_store_city', $city );
 		update_option( 'woocommerce_default_country', $store_location );
+		update_option( 'woocommerce_store_postcode', $postcode );
+
 		update_option( 'woocommerce_currency', $currency_code );
 		update_option( 'woocommerce_currency_pos', $currency_pos );
 		update_option( 'woocommerce_price_decimal_sep', $decimal_sep );

--- a/includes/admin/settings/class-wc-settings-general.php
+++ b/includes/admin/settings/class-wc-settings-general.php
@@ -47,17 +47,66 @@ class WC_Settings_General extends WC_Settings_Page {
 
 		$settings = apply_filters( 'woocommerce_general_settings', array(
 
-			array( 'title' => __( 'General options', 'woocommerce' ), 'type' => 'title', 'desc' => '', 'id' => 'general_options' ),
+			array(
+				'title'    => __( 'Store Address', 'woocommerce' ),
+				'type'     => 'title',
+				'desc'     => __( 'This is where your business is located. Tax rates and shipping rates will use this address.', 'woocommerce' ),
+				'id'       => 'store_address'
+			),
 
 			array(
-				'title'    => __( 'Base location', 'woocommerce' ),
-				'desc'     => __( 'This is the base location for your business. Tax rates will be based on this country.', 'woocommerce' ),
+				'title'    => __( 'Street address', 'woocommerce' ),
+				'desc'     => __( 'The street address for your business location.', 'woocommerce' ),
+				'id'       => 'woocommerce_store_address',
+				'css'      => 'min-width:350px;',
+				'default'  => '',
+				'type'     => 'text',
+				'desc_tip' => true,
+			),
+
+			array(
+				'title'    => __( 'Street address 2', 'woocommerce' ),
+				'desc'     => __( 'An additional, optional address line for your business location.', 'woocommerce' ),
+				'id'       => 'woocommerce_store_address_2',
+				'css'      => 'min-width:350px;',
+				'default'  => '',
+				'type'     => 'text',
+				'desc_tip' => true,
+			),
+
+			array(
+				'title'    => __( 'City', 'woocommerce' ),
+				'desc'     => __( 'The city in which your business is located.', 'woocommerce' ),
+				'id'       => 'woocommerce_store_city',
+				'css'      => 'min-width:350px;',
+				'default'  => '',
+				'type'     => 'text',
+				'desc_tip' => true,
+			),
+
+			array(
+				'title'    => __( 'Country / State', 'woocommerce' ),
+				'desc'     => __( 'The country and state or province, if any, in which your business is located.', 'woocommerce' ),
 				'id'       => 'woocommerce_default_country',
 				'css'      => 'min-width:350px;',
 				'default'  => 'GB',
 				'type'     => 'single_select_country',
 				'desc_tip' => true,
 			),
+
+			array(
+				'title'    => __( 'Postal Code', 'woocommerce' ),
+				'desc'     => __( 'The postal code, if any, in which your business is located.', 'woocommerce' ),
+				'id'       => 'woocommerce_store_postcode',
+				'css'      => 'min-width:50px;',
+				'default'  => '',
+				'type'     => 'text',
+				'desc_tip' => true,
+			),
+
+			array( 'type' => 'sectionend', 'id' => 'store_address' ),
+
+			array( 'title' => __( 'General options', 'woocommerce' ), 'type' => 'title', 'desc' => '', 'id' => 'general_options' ),
 
 			array(
 				'title'    => __( 'Selling location(s)', 'woocommerce' ),

--- a/includes/admin/settings/class-wc-settings-general.php
+++ b/includes/admin/settings/class-wc-settings-general.php
@@ -55,7 +55,7 @@ class WC_Settings_General extends WC_Settings_Page {
 			),
 
 			array(
-				'title'    => __( 'Street address', 'woocommerce' ),
+				'title'    => __( 'Address line 1', 'woocommerce' ),
 				'desc'     => __( 'The street address for your business location.', 'woocommerce' ),
 				'id'       => 'woocommerce_store_address',
 				'css'      => 'min-width:350px;',
@@ -65,7 +65,7 @@ class WC_Settings_General extends WC_Settings_Page {
 			),
 
 			array(
-				'title'    => __( 'Street address 2', 'woocommerce' ),
+				'title'    => __( 'Address line 2', 'woocommerce' ),
 				'desc'     => __( 'An additional, optional address line for your business location.', 'woocommerce' ),
 				'id'       => 'woocommerce_store_address_2',
 				'css'      => 'min-width:350px;',
@@ -95,7 +95,7 @@ class WC_Settings_General extends WC_Settings_Page {
 			),
 
 			array(
-				'title'    => __( 'Postal Code', 'woocommerce' ),
+				'title'    => __( 'Postcode / ZIP', 'woocommerce' ),
 				'desc'     => __( 'The postal code, if any, in which your business is located.', 'woocommerce' ),
 				'id'       => 'woocommerce_store_postcode',
 				'css'      => 'min-width:50px;',

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -152,6 +152,26 @@ class WC_Countries {
 	}
 
 	/**
+	 * Get the base address (first line) for the store.
+	 * @since 3.1.1
+	 * @return string
+	 */
+	public function get_base_address() {
+		$base_address = get_option( 'woocommerce_store_address', '' );
+		return apply_filters( 'woocommerce_countries_base_address', $base_address );
+	}
+
+	/**
+	 * Get the base address (second line) for the store.
+	 * @since 3.1.1
+	 * @return string
+	 */
+	public function get_base_address_2() {
+		$base_address_2 = get_option( 'woocommerce_store_address_2', '' );
+		return apply_filters( 'woocommerce_countries_base_address_2', $base_address_2 );
+	}
+
+	/**
 	 * Get the base country for the store.
 	 * @return string
 	 */
@@ -171,18 +191,22 @@ class WC_Countries {
 
 	/**
 	 * Get the base city for the store.
+	 * @version 3.1.1
 	 * @return string
 	 */
 	public function get_base_city() {
-		return apply_filters( 'woocommerce_countries_base_city', '' );
+		$base_city = get_option( 'woocommerce_store_city', '' );
+		return apply_filters( 'woocommerce_countries_base_city', $base_city );
 	}
 
 	/**
 	 * Get the base postcode for the store.
+	 * @since 3.1.1
 	 * @return string
 	 */
 	public function get_base_postcode() {
-		return apply_filters( 'woocommerce_countries_base_postcode', '' );
+		$base_postcode = get_option( 'woocommerce_store_postcode', '' );
+		return apply_filters( 'woocommerce_countries_base_postcode', $base_postcode );
 	}
 
 	/**

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -752,4 +752,131 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'US:OR', $setting['options'] );
 	}
 
+	/**
+	 * Test to make sure the store address setting can be fetched and updated.
+	 *
+	 * @since 3.1.1
+	 */
+	public function test_woocommerce_store_address() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/general/woocommerce_store_address' ) );
+		$setting  = $response->get_data();
+		$this->assertEquals( 'text', $setting['type'] );
+
+		// Repalce the old value with something uniquely new
+		$old_value = $setting['value'];
+		$new_value = $old_value . ' ' . rand( 1000, 9999 );
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address' );
+		$request->set_body_params( array(
+			'value' => $new_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $new_value, $setting['value'] );
+
+		// Put the original value back
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address' );
+		$request->set_body_params( array(
+			'value' => $old_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $old_value, $setting['value'] );
+	}
+
+	/**
+	 * Test to make sure the store address 2 (line 2) setting can be fetched and updated.
+	 *
+	 * @since 3.1.1
+	 */
+	public function test_woocommerce_store_address_2() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/general/woocommerce_store_address_2' ) );
+		$setting  = $response->get_data();
+		$this->assertEquals( 'text', $setting['type'] );
+
+		// Repalce the old value with something uniquely new
+		$old_value = $setting['value'];
+		$new_value = $old_value . ' ' . rand( 1000, 9999 );
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address_2' );
+		$request->set_body_params( array(
+			'value' => $new_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $new_value, $setting['value'] );
+
+		// Put the original value back
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address_2' );
+		$request->set_body_params( array(
+			'value' => $old_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $old_value, $setting['value'] );
+	}
+
+	/**
+	 * Test to make sure the store city setting can be fetched and updated.
+	 *
+	 * @since 3.1.1
+	 */
+	public function test_woocommerce_store_city() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/general/woocommerce_store_city' ) );
+		$setting  = $response->get_data();
+		$this->assertEquals( 'text', $setting['type'] );
+
+		// Repalce the old value with something uniquely new
+		$old_value = $setting['value'];
+		$new_value = $old_value . ' ' . rand( 1000, 9999 );
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_city' );
+		$request->set_body_params( array(
+			'value' => $new_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $new_value, $setting['value'] );
+
+		// Put the original value back
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_city' );
+		$request->set_body_params( array(
+			'value' => $old_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $old_value, $setting['value'] );
+	}
+
+	/**
+	 * Test to make sure the store postcode setting can be fetched and updated.
+	 *
+	 * @since 3.1.1
+	 */
+	public function test_woocommerce_store_postcode() {
+		wp_set_current_user( $this->user );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/general/woocommerce_store_postcode' ) );
+		$setting  = $response->get_data();
+		$this->assertEquals( 'text', $setting['type'] );
+
+		// Repalce the old value with something uniquely new
+		$old_value = $setting['value'];
+		$new_value = $old_value . ' ' . rand( 1000, 9999 );
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_postcode' );
+		$request->set_body_params( array(
+			'value' => $new_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $new_value, $setting['value'] );
+
+		// Put the original value back
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_postcode' );
+		$request->set_body_params( array(
+			'value' => $old_value,
+		) );
+		$response = $this->server->dispatch( $request );
+		$setting  = $response->get_data();
+		$this->assertEquals( $old_value, $setting['value'] );
+	}
 }


### PR DESCRIPTION
Fixes #15602

Ready for review

To test:
- Launch the Setup Wizard
- Verify you can set a street address, city and postcode for the store's (base) location
- Verify the Country/State selector still works too

- Go to wp-admin > WooCommerce > Settings > General
- Verify you can set a street address, city and postcode for the store's (base) location
- Verify the Country/State selector still works too

- Verify the GETting REST API at `/wp-json/wc/v2/settings/general` includes the new settings and their values

`woocommerce_store_address`
`woocommerce_store_address_2`
`woocommerce_store_city`
`woocommerce_store_postcode`

- Verify the REST API GET response continues to include `woocommerce_default_country` and its value
- Verify POSTing to `/wp-json/wc/v2/settings/general/woocommerce_store_address` accepts changes (remember to pass the new value under the `value` key in `form-data`)
- Verify POSTing to `/wp-json/wc/v2/settings/general/woocommerce_store_address_2` accepts changes
- Verify POSTing to `/wp-json/wc/v2/settings/general/woocommerce_store_city` accepts changes
- Verify POSTing to `/wp-json/wc/v2/settings/general/woocommerce_store_postcode` accepts changes

- Verify phpunit tests pass