### PR TITLE
Allow filtering of unset properties

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -634,10 +634,10 @@ abstract class WC_Data {
 
 		if ( array_key_exists( $prop, $this->data ) ) {
 			$value = array_key_exists( $prop, $this->changes ) ? $this->changes[ $prop ] : $this->data[ $prop ];
-
-			if ( 'view' === $context ) {
-				$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this );
-			}
+		}
+		
+		if ( 'view' === $context ) {
+			$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this );
 		}
 
 		return $value;


### PR DESCRIPTION
If a property is not set it's not filtered right now.

Example:
1. Create a variable product with two variations
2. Do not set default attributes
3. Try to filter the default attributes, the filter is not applied.