### PR TITLE
Fix issues with CLI IDs

### DIFF
--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -143,6 +143,7 @@ class WC_CLI_Runner {
 		foreach ( $supported_commands as $command => $endpoint_args ) {
 			$synopsis = array();
 			$arg_regs = array();
+			$ids      = array();
 
 			foreach ( $supported_ids as $id_name => $id_desc ) {
 				if ( strpos( $route, '<' . $id_name . '>' ) !== false ) {
@@ -152,10 +153,10 @@ class WC_CLI_Runner {
 						'description' => $id_desc,
 						'optional'    => false,
 					);
+					$ids[] = $id_name;
 				}
 			}
-
-			if ( in_array( $command, array( 'delete', 'get', 'update' ) ) ) {
+			if ( in_array( $command, array( 'delete', 'get', 'update' ) ) && ! in_array( 'id', $ids )  ) {
 				$synopsis[] = array(
 					'name'		  => 'id',
 					'type'		  => 'positional',
@@ -165,7 +166,7 @@ class WC_CLI_Runner {
 			}
 
 			foreach ( $endpoint_args as $name => $args ) {
-				if ( ! in_array( $name, $positional_args ) ) {
+				if ( ! in_array( $name, $positional_args ) || strpos( $route, '<' . $id_name . '>' ) === false ) {
 					$arg_regs[] = array(
 						'name'		  => $name,
 						'type'		  => 'assoc',


### PR DESCRIPTION
Fixes #15639.

@mikejolley This looks like it should fix the issue reported in that ticket. Additionally, I noticed that some commands are documenting that they accept an ID twice (`i.e. wp wc customer get 1 1`). That should be fixed now as well.

Would you mind doing a few tests to help verify before merging this branch?

We have some tests for the CLI/some commands, but I think we need to make sure to expand coverage and also automatically run tests so we don't miss stuff like this.