### PR TITLE
[WIP] Display downloads in their own table, universally.

### DIFF
--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -366,9 +366,11 @@ class WC_Order_Item_Product extends WC_Order_Item {
 				$download_id = $customer_download->get_download_id();
 
 				if ( $product->has_file( $download_id ) ) {
-					$file                                  = $product->get_file( $download_id );
-					$files[ $download_id ]                 = $file->get_data();
-					$files[ $download_id ]['download_url'] = add_query_arg( array(
+					$file                                         = $product->get_file( $download_id );
+					$files[ $download_id ]                        = $file->get_data();
+					$files[ $download_id ]['downloads_remaining'] = $customer_download->get_downloads_remaining();
+					$files[ $download_id ]['access_expires']      = $customer_download->get_access_expires();
+					$files[ $download_id ]['download_url']        = add_query_arg( array(
 						'download_file' => $product_id,
 						'order'         => $order->get_order_key(),
 						'email'         => urlencode( $order->get_billing_email() ),

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -826,13 +826,35 @@ class WC_Order extends WC_Abstract_Order {
 	}
 
 	/**
-	 * Returns true if the order has a shipping address.
+	 * Get downloadable items for the order.
 	 *
-	 * @since  3.0.4
-	 * @return boolean
+	 * @return array
 	 */
-	public function has_shipping_address() {
-		return $this->get_shipping_address_1() || $this->get_shipping_address_2();
+	public function get_downloadable_items() {
+		$downloads = array();
+
+		foreach ( $this->get_items() as $item ) {
+			if ( is_object( $item ) && $item->is_type( 'line_item' ) && ( $item_downloads = $item->get_item_downloads() ) ) {
+				$product = $item->get_product();
+
+				foreach ( $item_downloads as $file ) {
+					$downloads[] = array(
+						'download_url'          => $file['download_url'],
+						'download_id'           => $file['id'],
+						'product_id'            => $product->get_id(),
+						'product_name'          => $product->get_name(),
+						'download_name'         => $file['name'],
+						'order_id'              => $this->get_id(),
+						'order_key'             => $this->get_order_key(),
+						'downloads_remaining'   => $file['downloads_remaining'],
+						'access_expires'        => $file['access_expires']
+					);
+
+				}
+			}
+		}
+
+		return $downloads;
 	}
 
 	/*
@@ -1259,7 +1281,7 @@ class WC_Order extends WC_Abstract_Order {
 	}
 
 	/**
-	 * Checks if product download is permitted.
+	 * Checks if order download is permitted.
 	 *
 	 * @return bool
 	 */
@@ -1290,6 +1312,16 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		return apply_filters( 'woocommerce_order_needs_shipping_address', $needs_address, $hide, $this );
+	}
+
+	/**
+	 * Returns true if the order has a shipping address.
+	 *
+	 * @since  3.0.4
+	 * @return boolean
+	 */
+	public function has_shipping_address() {
+		return $this->get_shipping_address_1() || $this->get_shipping_address_2();
 	}
 
 	/**

--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -202,7 +202,7 @@ function wc_get_account_downloads_columns() {
 		'download-product'   => __( 'Product', 'woocommerce' ),
 		'download-remaining' => __( 'Downloads remaining', 'woocommerce' ),
 		'download-expires'   => __( 'Expires', 'woocommerce' ),
-		'download-file'      => __( 'File', 'woocommerce' ),
+		'download-file'      => __( 'Download', 'woocommerce' ),
 		'download-actions'   => '&nbsp;',
 	) );
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1868,6 +1868,24 @@ if ( ! function_exists( 'woocommerce_order_details_table' ) ) {
 	}
 }
 
+if ( ! function_exists( 'woocommerce_order_downloads_table' ) ) {
+
+	/**
+	 * Displays order downloads in a table.
+	 *
+	 * @param array $downloads
+	 * @subpackage	Orders
+	 */
+	function woocommerce_order_downloads_table( $downloads ) {
+		if ( ! $downloads ) {
+			return;
+		}
+
+		wc_get_template( 'order/order-downloads.php', array(
+			'downloads' => $downloads,
+		) );
+	}
+}
 
 if ( ! function_exists( 'woocommerce_order_again_button' ) ) {
 

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -250,6 +250,13 @@ add_action( 'woocommerce_thankyou', 'woocommerce_order_details_table', 10 );
 add_action( 'woocommerce_order_details_after_order_table', 'woocommerce_order_again_button' );
 
 /**
+ * Order downloads.
+ *
+ * @see woocommerce_order_downloads_table()
+ */
+add_action( 'woocommerce_available_downloads', 'woocommerce_order_downloads_table', 10 );
+
+/**
  * Auth.
  *
  * @see woocommerce_output_auth_header()

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -411,7 +411,7 @@ function wc_get_customer_available_downloads( $customer_id ) {
 			// Download name will be 'Product Name' for products with a single downloadable file, and 'Product Name - File X' for products with multiple files.
 			$download_name = apply_filters(
 				'woocommerce_downloadable_product_name',
-				$_product->get_name() . ' &ndash; ' . $download_file['name'],
+				$download_file['name'],
 				$_product,
 				$result->download_id,
 				$file_number

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -31,66 +31,9 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 
 	<?php do_action( 'woocommerce_before_available_downloads' ); ?>
 
-	<table class="woocommerce-MyAccount-downloads shop_table shop_table_responsive">
-		<thead>
-			<tr>
-				<?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
-					<th class="<?php echo esc_attr( $column_id ); ?>"><span class="nobr"><?php echo esc_html( $column_name ); ?></span></th>
-				<?php endforeach; ?>
-			</tr>
-		</thead>
-		<?php foreach ( $downloads as $download ) : ?>
-			<tr>
-				<?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
-					<td class="<?php echo esc_attr( $column_id ); ?>" data-title="<?php echo esc_attr( $column_name ); ?>">
-						<?php
-							if ( has_action( 'woocommerce_account_downloads_column_' . $column_id ) ) {
-								do_action( 'woocommerce_account_downloads_column_' . $column_id, $download );
-							} else {
-								switch ( $column_id ) {
-									case 'download-product' : ?>
-										<a href="<?php echo esc_url( get_permalink( $download['product_id'] ) ); ?>">
-											<?php echo esc_html( $download['product_name'] ); ?>
-										</a>
-										<?php break;
-									case 'download-file' : ?>
-										<a href="<?php echo esc_url( $download['download_url'] ); ?>" class="woocommerce-MyAccount-downloads-file button alt">
-											<?php echo esc_html( $download['file']['name'] ); ?>
-										</a>
-										<?php break;
-									case 'download-remaining' :
-										echo is_numeric( $download['downloads_remaining'] ) ? esc_html( $download['downloads_remaining'] ) : __( '&infin;', 'woocommerce' );
-										break;
-									case 'download-expires' : ?>
-										<?php if ( ! empty( $download['access_expires'] ) ) : ?>
-											<time datetime="<?php echo date( 'Y-m-d', strtotime( $download['access_expires'] ) ); ?>" title="<?php echo esc_attr( strtotime( $download['access_expires'] ) ); ?>"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $download['access_expires'] ) ); ?></time>
-										<?php else : ?>
-											<?php _e( 'Never', 'woocommerce' ); ?>
-										<?php endif; ?>
-										<?php break;
-									case 'download-actions' : ?>
-										<?php
-											$actions = array(
-												'download'  => array(
-													'url'  => $download['download_url'],
-													'name' => __( 'Download', 'woocommerce' ),
-												),
-											);
-											if ( $actions = apply_filters( 'woocommerce_account_download_actions', $actions, $download ) ) {
-												foreach ( $actions as $key => $action ) {
-													echo '<a href="' . esc_url( $action['url'] ) . '" class="button woocommerce-Button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
-												}
-											}
-										?>
-										<?php break;
-								}
-							}
-						?>
-					</td>
-				<?php endforeach; ?>
-			</tr>
-		<?php endforeach; ?>
-	</table>
+	<!-- TODO: Deprecate the before/after hooks around this one? -->
+	<?php do_action( 'woocommerce_available_downloads', $downloads ); ?>
+
 	<?php do_action( 'woocommerce_after_available_downloads' ); ?>
 <?php else : ?>
 	<div class="woocommerce-Message woocommerce-Message--info woocommerce-info">

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -15,7 +15,7 @@
  * @see 	https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.0.0
+ * @version 3.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -54,7 +54,7 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 										</a>
 										<?php break;
 									case 'download-file' : ?>
-										<a href="<?php echo esc_url( $download['download_url'] ); ?>" class="woocommerce-MyAccount-downloads-file">
+										<a href="<?php echo esc_url( $download['download_url'] ); ?>" class="woocommerce-MyAccount-downloads-file button alt">
 											<?php echo esc_html( $download['file']['name'] ); ?>
 										</a>
 										<?php break;

--- a/templates/myaccount/my-downloads.php
+++ b/templates/myaccount/my-downloads.php
@@ -16,7 +16,7 @@
  * @author      WooThemes
  * @package     WooCommerce/Templates
  * @version     2.0.0
- * @depreacated 2.6.0
+ * @deprecated 2.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -37,7 +37,6 @@ if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 			do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order );
 
 			wc_display_item_meta( $item );
-			wc_display_item_downloads( $item );
 
 			do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order );
 		?>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -24,6 +24,8 @@ $order = wc_get_order( $order_id );
 
 $show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
 $show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
+$downloads             = $order->get_downloadable_items();
+$has_downloads         = $order->has_downloadable_item();
 ?>
 
 <section class="woocommerce-order-details">
@@ -73,6 +75,13 @@ $show_customer_details = is_user_logged_in() && $order->get_user_id() === get_cu
 	</table>
 
 	<?php do_action( 'woocommerce_order_details_after_order_table', $order ); ?>
+
+		<?php if ( $has_downloads ) : ?>
+			<section class="woocommerce-order-downloads">
+				<h2 class="woocommerce-order-downloads__title"><?php _e( 'Order downloads', 'woocommerce' ); ?></h2>
+				<?php wc_get_template( 'order/order-downloads.php', array( 'downloads' => $downloads ) ); ?>
+			</section>
+		<?php endif; ?>
 
 	<?php if ( $show_customer_details ) : ?>
 		<?php wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) ); ?>

--- a/templates/order/order-downloads.php
+++ b/templates/order/order-downloads.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Order Downloads
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-downloads.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<table class="woocommerce-table woocommerce-table--order-downloads shop_table order_details">
+
+  <thead>
+    <tr>
+      <?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
+        <th class="<?php echo esc_attr( $column_id ); ?>"><span class="nobr"><?php echo esc_html( $column_name ); ?></span></th>
+      <?php endforeach; ?>
+    </tr>
+  </thead>
+
+  <?php foreach ( $downloads as $download ) : ?>
+    <tr>
+      <?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
+        <td class="<?php echo esc_attr( $column_id ); ?>" data-title="<?php echo esc_attr( $column_name ); ?>">
+          <?php
+            if ( has_action( 'woocommerce_account_downloads_column_' . $column_id ) ) {
+              do_action( 'woocommerce_account_downloads_column_' . $column_id, $download );
+            } else {
+              switch ( $column_id ) {
+                case 'download-product' : ?>
+                  <a href="<?php echo esc_url( get_permalink( $download['product_id'] ) ); ?>">
+                    <?php echo esc_html( $download['product_name'] ); ?>
+                  </a>
+                  <?php break;
+                case 'download-file' : ?>
+                  <a href="<?php echo esc_url( $download['download_url'] ); ?>" class="woocommerce-MyAccount-downloads-file button alt">
+                    <?php echo esc_html( $download['download_name'] ); ?>
+                  </a>
+                  <?php break;
+                case 'download-remaining' :
+                  echo is_numeric( $download['downloads_remaining'] ) ? esc_html( $download['downloads_remaining'] ) : __( '&infin;', 'woocommerce' );
+                  break;
+                case 'download-expires' : ?>
+                  <?php if ( ! empty( $download['access_expires'] ) ) : ?>
+                    <time datetime="<?php echo date( 'Y-m-d', strtotime( $download['access_expires'] ) ); ?>" title="<?php echo esc_attr( strtotime( $download['access_expires'] ) ); ?>"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $download['access_expires'] ) ); ?></time>
+                  <?php else : ?>
+                    <?php _e( 'Never', 'woocommerce' ); ?>
+                  <?php endif; ?>
+                  <?php break;
+              }
+            }
+          ?>
+        </td>
+      <?php endforeach; ?>
+    </tr>
+  <?php endforeach; ?>
+</table>


### PR DESCRIPTION
Taking a stab at https://github.com/woocommerce/woocommerce/issues/15563. This isn't complete, just pushing up in case it will help somebody else get started on this.

@mikejolley - what are your thoughts on introducing a new template, order-downloads.php? This table needs to be displayed in at least three places, so seemed fitting to copy the same structure that the order details table uses.

_____
Things to do still:

- Check `$has_downloads` conditionals.
- Add "download icon" to the button with CSS in the new table.
- Add this table to emails.
	- Leave out 'downloads remaining'.
- Thankyou page should have order downloads at the top.
- Look into what all needs to be deprecated.
	- `woocommerce_available_downloads` before/after hooks
	- `wc_display_item_downloads()`
	- MyAccount namespacing and `wc_get_account_downloads_columns()`
- Test.


`get_item_downloads()`, `get_downloadable_items`, `get_downloadable_products`, and `wc_get_customer_available_downloads() ` could prolly have some parts abstracted and/or standardized as well. Two different functions and processes that feed the same template could lead to some bugs down the road.