### PR TITLE
Compare page IDs rather than URIs in the cache helper

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -20,7 +20,7 @@ class WC_Cache_Helper {
 	 */
 	public static function init() {
 		add_action( 'template_redirect', array( __CLASS__, 'geolocation_ajax_redirect' ) );
-		add_action( 'before_woocommerce_init', array( __CLASS__, 'prevent_caching' ) );
+		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
 	}
@@ -149,44 +149,17 @@ class WC_Cache_Helper {
 	}
 
 	/**
-	 * Get the page name/id for a WC page.
-	 * @param  string $wc_page
-	 * @return array
-	 */
-	private static function get_page_uris( $wc_page ) {
-		$wc_page_uris = array();
-
-		if ( ( $page_id = wc_get_page_id( $wc_page ) ) && $page_id > 0 && ( $page = get_post( $page_id ) ) ) {
-			$wc_page_uris[] = 'p=' . $page_id;
-			$wc_page_uris[] = '/' . $page->post_name . '/';
-		}
-
-		return $wc_page_uris;
-	}
-
-	/**
 	 * Prevent caching on dynamic pages.
 	 */
 	public static function prevent_caching() {
-
 		if ( ! is_blog_installed() ) {
 			return;
 		}
+		$page_ids        = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
+		$current_page_id = get_queried_object_id();
 
-		if ( false === ( $wc_page_uris = get_transient( 'woocommerce_cache_excluded_uris' ) ) ) {
-			$wc_page_uris   = array_filter( array_merge( self::get_page_uris( 'cart' ), self::get_page_uris( 'checkout' ), self::get_page_uris( 'myaccount' ) ) );
-	    	set_transient( 'woocommerce_cache_excluded_uris', $wc_page_uris );
-		}
-
-		if ( isset( $_GET['download_file'] ) ) {
+		if ( isset( $_GET['download_file'] ) || in_array( $current_page_id, $page_ids ) ) {
 			self::nocache();
-		} elseif ( is_array( $wc_page_uris ) ) {
-			foreach ( $wc_page_uris as $uri ) {
-				if ( stristr( trailingslashit( $_SERVER['REQUEST_URI'] ), $uri ) ) {
-					self::nocache();
-					break;
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
Updates page caching code to compare the current page ID instead of the current URL.

Should be more reliable and quicker.