### PR TITLE
CSV Importer: Add an action before a row is parsed

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -622,6 +622,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			}
 			$data = array();
 
+			do_action( 'woocommerce_product_importer_before_parsed_data', $row, $mapped_keys );
+
 			foreach ( $row as $id => $value ) {
 				// Skip ignored columns.
 				if ( empty( $mapped_keys[ $id ] ) ) {


### PR DESCRIPTION
This would allow third party plugins to take actions before a row is parsed. This is a complement to #15700 and is useful for example to setup filters before inserting new terms in methods such as `parse_tags_field`. 
