### PR TITLE
Improve apply coupon handling

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1733,8 +1733,14 @@ class WC_Cart {
 		// Sanitize coupon code.
 		$coupon_code = wc_format_coupon_code( $coupon_code );
 
-		// Get the coupon.
-		$the_coupon = new WC_Coupon( $coupon_code );
+		// Only allow coupons by code, not by id.
+		$coupon_id = wc_get_coupon_id_by_code( $coupon_code );
+		if ( $coupon_id ) {
+			$the_coupon = new WC_Coupon( $coupon_id );
+		} else {
+			$the_coupon = new WC_Coupon;
+			$the_coupon->set_code( $coupon_code );
+		}
 
 		// Check it can be used with cart.
 		if ( ! $the_coupon->is_valid() ) {

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -85,11 +85,16 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		} elseif ( $coupon = apply_filters( 'woocommerce_get_shop_coupon_data', false, $data ) ) {
 			$this->read_manual_coupon( $data, $coupon );
 			return;
-		} elseif ( is_numeric( $data ) && 'shop_coupon' === get_post_type( $data ) ) {
-			$this->set_id( $data );
 		} elseif ( ! empty( $data ) ) {
-			$this->set_id( wc_get_coupon_id_by_code( $data ) );
-			$this->set_code( $data );
+			$id = wc_get_coupon_id_by_code( $data );
+			if ( $id ) {
+				$this->set_id( $id );
+				$this->set_code( $data );
+			} elseif ( is_numeric( $data ) && 'shop_coupon' === get_post_type( $data ) ) {
+				$this->set_id( $data );
+			} else {
+				$this->set_code( $data );
+			}
 		} else {
 			$this->set_object_read( true );
 		}


### PR DESCRIPTION
Fixes #15725 
Also fixes a bug: you can put a coupon's post id into the coupon box to get the coupon.

I'm not satisfied with this solution, but I'm not sure if it's possible to have a perfect solution for this in a fully backwards-compatible way. How would you know if `new WC_Coupon( '359' )` is supposed to be a post id or a coupon code with 100% accuracy?

What the change to the WC_Coupon constructor does is it checks for the coupon by code before checking for the coupon by id. Previously, it checked by id before checking by code. 

The problem is that we now have the opposite issue. If you have a coupon with code '359' and a coupon with id '359', `new WC_Coupon( '359' )` will get the coupon with code '359'. This moves the problems from the cart to the admin area:

<img width="602" alt="screen shot 2017-06-21 at 2 44 31 pm" src="https://user-images.githubusercontent.com/7317227/27408173-3f25df0a-5690-11e7-886b-016dbf68db0b.png">

Thoughts?

(Probably don't merge this yet unless we're cool with that ^)
