### PR TITLE
[Importer] Use English mapping by default when current site language is not English

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -399,21 +399,18 @@ class WC_Product_CSV_Importer_Controller {
 			__( 'Button text', 'woocommerce' )                             => 'button_text',
 		) );
 
-		$special_columns = array_map(
-			array( $this, 'sanitize_special_column_name_regex' ),
-			apply_filters( 'woocommerce_csv_product_import_mapping_special_columns',
-				array(
-					'attributes:name'     => __( 'Attribute %d name', 'woocommerce' ),
-					'attributes:value'    => __( 'Attribute %d value(s)', 'woocommerce' ),
-					'attributes:visible'  => __( 'Attribute %d visible', 'woocommerce' ),
-					'attributes:taxonomy' => __( 'Attribute %d global', 'woocommerce' ),
-					'attributes:default'  => __( 'Attribute %d default', 'woocommerce' ),
-					'downloads:name'      => __( 'Download %d name', 'woocommerce' ),
-					'downloads:url'       => __( 'Download %d URL', 'woocommerce' ),
-					'meta:'               => __( 'Meta: %s', 'woocommerce' ),
-				)
+		$special_columns = $this->get_special_columns( apply_filters( 'woocommerce_csv_product_import_mapping_special_columns',
+			array(
+				__( 'Attribute %d name', 'woocommerce' )     => 'attributes:name',
+				__( 'Attribute %d value(s)', 'woocommerce' ) => 'attributes:value',
+				__( 'Attribute %d visible', 'woocommerce' )  => 'attributes:visible',
+				__( 'Attribute %d global', 'woocommerce' )   => 'attributes:taxonomy',
+				__( 'Attribute %d default', 'woocommerce' )  => 'attributes:default',
+				__( 'Download %d name', 'woocommerce' )      => 'downloads:name',
+				__( 'Download %d URL', 'woocommerce' )       => 'downloads:url',
+				__( 'Meta: %s', 'woocommerce' )              => 'meta:',
 			)
-		);
+		) );
 
 		$headers = array();
 		foreach ( $raw_headers as $key => $field ) {
@@ -423,7 +420,7 @@ class WC_Product_CSV_Importer_Controller {
 			if ( isset( $default_columns[ $field ] ) ) {
 				$headers[ $index ] = $default_columns[ $field ];
 			} else {
-				foreach ( $special_columns as $special_key => $regex ) {
+				foreach ( $special_columns as $regex => $special_key ) {
 					if ( preg_match( $regex, $field, $matches ) ) {
 						$headers[ $index ] = $special_key . $matches[1];
 						break;
@@ -443,6 +440,24 @@ class WC_Product_CSV_Importer_Controller {
 	 */
 	protected function sanitize_special_column_name_regex( $value ) {
 		return '/' . str_replace( array( '%d', '%s' ), '(.*)', quotemeta( $value ) ) . '/';
+	}
+
+	/**
+	 * Get special columns.
+	 *
+	 * @param  array $columns Raw special columns.
+	 * @return array
+	 */
+	protected function get_special_columns( $columns ) {
+		$formatted = array();
+
+		foreach ( $columns as $key => $value ) {
+			$regex = $this->sanitize_special_column_name_regex( $key );
+
+			$formatted[ $regex ] = $value;
+		}
+
+		return $formatted;
 	}
 
 	/**

--- a/includes/admin/importers/mappings/default.php
+++ b/includes/admin/importers/mappings/default.php
@@ -1,0 +1,105 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Importer current locale.
+ *
+ * @since 3.1.0
+ * @return string
+ */
+function wc_importer_current_locale() {
+	$locale = get_locale();
+	if ( function_exists( 'get_user_locale' ) ) {
+		$locale = get_user_locale();
+	}
+
+	return $locale;
+}
+
+/**
+ * Add English mapping placeholders when not using English as current language.
+ *
+ * @since 3.1.0
+ * @param array $mappings
+ * @return array
+ */
+function wc_importer_default_english_mappings( $mappings ) {
+	if ( 'en_US' === wc_importer_current_locale() ) {
+		return $mappings;
+	}
+
+	$weight_unit      = get_option( 'woocommerce_weight_unit' );
+	$dimension_unit   = get_option( 'woocommerce_dimension_unit' );
+	$default_mappings = array(
+		'ID'                                      => 'id',
+		'Type'                                    => 'type',
+		'SKU'                                     => 'sku',
+		'Name'                                    => 'name',
+		'Published'                               => 'published',
+		'Is featured?'                            => 'featured',
+		'Visibility in catalog'                   => 'catalog_visibility',
+		'Short description'                       => 'short_description',
+		'Description'                             => 'description',
+		'Date sale price starts'                  => 'date_on_sale_from',
+		'Date sale price ends'                    => 'date_on_sale_to',
+		'Tax status'                              => 'tax_status',
+		'Tax class'                               => 'tax_class',
+		'In stock?'                               => 'stock_status',
+		'Stock'                                   => 'stock_quantity',
+		'Backorders allowed?'                     => 'backorders',
+		'Sold individually?'                      => 'sold_individually',
+		sprintf( 'Weight (%s)', $weight_unit )    => 'weight',
+		sprintf( 'Length (%s)', $dimension_unit ) => 'length',
+		sprintf( 'Width (%s)', $dimension_unit )  => 'width',
+		sprintf( 'Height (%s)', $dimension_unit ) => 'height',
+		'Allow customer reviews?'                 => 'reviews_allowed',
+		'Purchase note'                           => 'purchase_note',
+		'Sale price'                              => 'sale_price',
+		'Regular price'                           => 'regular_price',
+		'Categories'                              => 'category_ids',
+		'Tags'                                    => 'tag_ids',
+		'Shipping class'                          => 'shipping_class_id',
+		'Images'                                  => 'images',
+		'Download limit'                          => 'download_limit',
+		'Download expiry days'                    => 'download_expiry',
+		'Parent'                                  => 'parent_id',
+		'Upsells'                                 => 'upsell_ids',
+		'Cross-sells'                             => 'cross_sell_ids',
+		'Grouped products'                        => 'grouped_products',
+		'External URL'                            => 'product_url',
+		'Button text'                             => 'button_text',
+	);
+
+	return array_merge( $mappings, $default_mappings );
+}
+add_filter( 'woocommerce_csv_product_import_mapping_default_columns', 'wc_importer_default_english_mappings', 100 );
+
+/**
+ * Add English special mapping placeholders when not using English as current language.
+ *
+ * @since 3.1.0
+ * @param array $mappings
+ * @return array
+ */
+function wc_importer_default_special_english_mappings( $mappings ) {
+	if ( 'en_US' === wc_importer_current_locale() ) {
+		return $mappings;
+	}
+
+	$default_mappings = array(
+		'Attribute %d name'     => 'attributes:name',
+		'Attribute %d value(s)' => 'attributes:value',
+		'Attribute %d visible'  => 'attributes:visible',
+		'Attribute %d global'   => 'attributes:taxonomy',
+		'Attribute %d default'  => 'attributes:default',
+		'Download %d name'      => 'downloads:name',
+		'Download %d URL'       => 'downloads:url',
+		'Meta: %s'              => 'meta:',
+	);
+
+	return array_merge( $mappings, $generic_mappings );
+}
+add_filter( 'woocommerce_csv_product_import_mapping_special_columns', 'wc_importer_default_special_english_mappings', 100 );

--- a/includes/admin/importers/mappings/mappings.php
+++ b/includes/admin/importers/mappings/mappings.php
@@ -7,5 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+include( dirname( __FILE__ ) . '/default.php' );
 include( dirname( __FILE__ ) . '/generic.php' );
 include( dirname( __FILE__ ) . '/wordpress.php' );


### PR DESCRIPTION
This helps in at least in the follow two scenarios:

- Using the `dummy-data.csv` in a non-English installation (most common case for sure).
- Multiple store managers using different languages, so they can work with a single English csv file.