### PR TITLE
New feature: set the periodicity for cancelling pending-payment orders

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -264,6 +264,20 @@ class WC_Settings_Products extends WC_Settings_Page {
 				),
 
 				array(
+					'title'             => __( 'Hold Stock Check Periodicity (minutes)', 'woocommerce' ),
+					'desc'              => __( 'Time in minutes between held stock checks. Must be less or equal to the Hold Stock setting', 'woocommerce' ),
+					'id'                => 'woocommerce_hold_stock_check_periodicity',
+					'type'              => 'number',
+					'custom_attributes' => array(
+						'min'  => 0,
+						'step' => 1
+					),
+					'css'               => 'width: 80px;',
+					'default'           => '60',
+					'autoload'          => false
+				),
+
+				array(
 					'title'         => __( 'Notifications', 'woocommerce' ),
 					'desc'          => __( 'Enable low stock notifications', 'woocommerce' ),
 					'id'            => 'woocommerce_notify_low_stock',

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -304,9 +304,10 @@ class WC_Install {
 		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . get_option( 'gmt_offset' ) . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
 
 		$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
+		$hold_stock_check_periodicity = get_option( 'woocommerce_hold_stock_check_periodicity', $held_duration );
 
-		if ( '' != $held_duration ) {
-			wp_schedule_single_event( time() + ( absint( $held_duration ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+		if ( '' != $hold_stock_check_periodicity ) {
+			wp_schedule_single_event( time() + ( absint( $hold_stock_check_periodicity ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 		}
 
 		wp_schedule_event( time(), 'twicedaily', 'woocommerce_cleanup_sessions' );

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -943,14 +943,36 @@ function wc_format_option_price_num_decimals( $value, $option, $raw_value ) {
 add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_price_num_decimals', 'wc_format_option_price_num_decimals', 10, 3 );
 
 /**
- * Formats hold stock option and sets cron event up.
+ * Formats hold stock option
  * @param  string $value
  * @param  array $option
  * @param  string $raw_value
  * @return string
  */
 function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
+	return ! empty( $raw_value ) ? absint( $raw_value ) : ''; // Allow > 0 or set to ''
+}
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_hold_stock_minutes', 'wc_format_option_hold_stock_minutes', 10, 3 );
+
+/**
+ * Formats hold stock check periodicity option and sets cron event up.
+ * @param  string $value
+ * @param  array $option
+ * @param  string $raw_value
+ * @return string
+ */
+function wc_format_option_hold_stock_check_periodicity( $value, $option, $raw_value ) {
 	$value = ! empty( $raw_value ) ? absint( $raw_value ) : ''; // Allow > 0 or set to ''
+
+	$hold_stock_minutes = get_option( 'woocommerce_hold_stock_minutes' );
+
+	if ( empty( $hold_stock_minutes ) ) {
+		$value = '';
+	}
+
+	if ( ! empty( $hold_stock_minutes ) && ( empty( $value ) || $value > $hold_stock_minutes ) ) {
+		$value = $hold_stock_minutes;
+	}
 
 	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 
@@ -960,7 +982,8 @@ function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
 
 	return $value;
 }
-add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_hold_stock_minutes', 'wc_format_option_hold_stock_minutes', 10, 3 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_hold_stock_check_periodicity', 'wc_format_option_hold_stock_check_periodicity', 10, 3 );
+
 
 /**
  * Sanitize terms from an attribute text based.

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -839,6 +839,9 @@ function wc_cancel_unpaid_orders() {
 		return;
 	}
 
+	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	wp_schedule_single_event( time() + ( absint( $periodicity ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+
 	$data_store    = WC_Data_Store::load( 'order' );
 	$unpaid_orders = $data_store->get_unpaid_orders( strtotime( '-' . absint( $held_duration ) . ' MINUTES', current_time( 'timestamp' ) ) );
 
@@ -851,8 +854,6 @@ function wc_cancel_unpaid_orders() {
 			}
 		}
 	}
-	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
-	wp_schedule_single_event( time() + ( absint( $periodicity ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 }
 add_action( 'woocommerce_cancel_unpaid_orders', 'wc_cancel_unpaid_orders' );
 


### PR DESCRIPTION
As it has not to be the same than the hold-stock time, especially if hold-stock time is very long.

This solution was implemented as, in our case, the hold-stock time is configured to 2 weeks. The scheduled task execution takes too long when cancelling 2 weeks of pending payments, so the php_execution_time is exceeded and isn't scheduled again, as the process is aborted.

With this new option, we can set the periodicity to an hour, so every hour we cancel pending-cancel orders that are older than 2 weeks. 