### PR TITLE
WIP - meta_input usage

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -223,7 +223,8 @@ class WC_Post_Data {
 	}
 
 	/**
-	 * Ensure floats are correctly converted to strings based on PHP locale.
+	 * Ensure floats are correctly converted to strings based on PHP locale,
+	 * and handles null meta.
 	 *
 	 * @param  null $check
 	 * @param  int $object_id
@@ -238,15 +239,14 @@ class WC_Post_Data {
 			wp_cache_delete( 'product-' . $object_id, 'products' );
 		}
 
+		// Convert floats to string and update.
 		if ( ! empty( $meta_value ) && is_float( $meta_value ) && in_array( get_post_type( $object_id ), array_merge( wc_get_order_types(), array( 'shop_coupon', 'product', 'product_variation' ) ) ) ) {
+			update_metadata( 'post', $object_id, $meta_key, wc_float_to_string( $meta_value ), $prev_value );
+			return true;
 
-			// Convert float to string
-			$meta_value = wc_float_to_string( $meta_value );
-
-			// Update meta value with new string
-			update_metadata( 'post', $object_id, $meta_key, $meta_value, $prev_value );
-
-			// Return
+		// Delete rather than set NULL value meta.
+		} elseif ( is_null( $meta_value ) ) {
+			delete_metadata( 'post', $object_id, $meta_key, $prev_value );
 			return true;
 		}
 		return $check;

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -27,19 +27,20 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @var array
 	 */
 	protected $parent_data = array(
-		'title'             => '',
-		'sku'               => '',
-		'manage_stock'      => '',
-		'backorders'        => '',
-		'stock_quantity'    => '',
-		'weight'            => '',
-		'length'            => '',
-		'width'             => '',
-		'height'            => '',
-		'tax_class'         => '',
-		'shipping_class_id' => '',
-		'image_id'          => '',
-		'purchase_note'     => '',
+		'title'              => '',
+		'sku'                => '',
+		'manage_stock'       => '',
+		'backorders'         => '',
+		'stock_quantity'     => '',
+		'weight'             => '',
+		'length'             => '',
+		'width'              => '',
+		'height'             => '',
+		'tax_class'          => '',
+		'shipping_class_id'  => '',
+		'image_id'           => '',
+		'purchase_note'      => '',
+		'catalog_visibility' => '',
 	);
 
 	/**

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -391,7 +391,15 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$variation->set_width( 10 );
 		$variation->save();
 
+		$taxonomy_obj = get_taxonomy( 'product_type' );
+		var_dump($taxonomy_obj);
+		var_dump( current_user_can( $taxonomy_obj->cap->assign_terms ) );
+
+		var_dump($product->get_type());
+
 		$product = wc_get_product( $product->get_id() );
+
+		var_dump($product->get_type());
 
 		$store = new WC_Product_Variable_Data_Store_CPT();
 


### PR DESCRIPTION
This is an experimental branch using meta_input, tax_input, and _thumbnail_id fields in wp_insert_post so data exists when core WP hooks are fired.

Ref #15262