### PR TITLE
issue solved Pass more params to woocommerce_duplicate_product_exclude_children filter

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -140,7 +140,7 @@ class WC_Admin_Duplicate_Product {
 		$duplicate->save();
 
 		// Duplicate children of a variable product.
-		if ( ! apply_filters( 'woocommerce_duplicate_product_exclude_children', false ) && $product->is_type( 'variable' ) ) {
+		if ( ! apply_filters( 'woocommerce_duplicate_product_exclude_children', false, $product ) && $product->is_type( 'variable' ) ) {
 			foreach ( $product->get_children() as $child_id ) {
 				$child           = wc_get_product( $child_id );
 				$child_duplicate = clone $child;


### PR DESCRIPTION
@mikejolley ,
@gedex 

 I have passed the $product to the filter as a second param for issue #15772.

Please review it and let me know if any changes.

Thanks,
Dixita Dusara