### PR TITLE
Variation attributes are displaying below product title

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -373,9 +373,7 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
 				if ( ! is_wp_error( $term ) && ! empty( $term->name ) ) {
 					$value = $term->name;
 				}
-			} else {
-				$value = ucwords( str_replace( '-', ' ', $value ) );
-			}
+			} 
 
 			if ( $include_names ) {
 				if ( $flat ) {


### PR DESCRIPTION
@mikejolley 

I have a pull request for Variation attributes are displaying below product title if dash is in value. In this issue, I have removed https://github.com/woocommerce/woocommerce/blob/aab401c8f8eb67d586214129ed00edbcb6842d69/includes/wc-product-functions.php#L379-L381 as per your suggestion. Please test it and let me know any changes.

Thanks,