### PR TITLE
Add/allow coupons to change price data

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1911,15 +1911,22 @@ class WC_Cart {
 		}
 
 		$undiscounted_price = $price;
-
 		if ( ! empty( $this->coupons ) ) {
 			$product = $values['data'];
 
 			foreach ( $this->coupons as $code => $coupon ) {
 				if ( $coupon->is_valid() && ( $coupon->is_valid_for_product( $product, $values ) || $coupon->is_valid_for_cart() ) ) {
 					$discount_amount = $coupon->get_discount_amount( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ? $price : $undiscounted_price, $values, true );
-					$discount_amount = min( $price, $discount_amount );
-					$price           = max( $price - $discount_amount, 0 );
+
+					$discount_calculation = apply_filters( 'woocommerce_coupon_discount_amount_calculation', array(), $coupon, $discount_amount, $price );
+
+					if ( ! isset( $discount_calculation['discount_amount'] ) || ! isset( $discount_calculation['price'] ) ) {
+						$discount_amount = min( $price, $discount_amount );
+						$price           = max( $price - $discount_amount, 0 );
+					} else {
+						$discount_amount = $discount_calculation['discount_amount'];
+						$price           = $discount_calculation['price'];
+					}
 
 					// Store the totals for DISPLAY in the cart.
 					if ( $add_totals ) {


### PR DESCRIPTION
Allow prices for coupons to be calculated by adding additional filters for it. This will allow for hacky approach to calculate shipping costs for coupons as well (see https://github.com/woocommerce/woocommerce-store-credit/pull/21 as an example).