### PR TITLE
Cleanup: WC_Query

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -334,6 +334,14 @@ class WC_Query {
 	}
 
 	/**
+	 * Search post excerpt.
+	 * @deprecated 3.1.0 - Since WordPress 4.5 not needed anymore.
+	 */
+	public function search_post_excerpt( $where = '' ) {
+		wc_deprecated_function( 'WC_Query::search_post_excerpt', '3.1.0', 'Excerpt added to search query by default since WordPress 4.5.' );
+	}
+
+	/**
 	 * WP SEO meta description.
 	 *
 	 * Hooked into wpseo_ hook already, so no need for function_exist.
@@ -401,6 +409,14 @@ class WC_Query {
 		remove_filter( 'posts_clauses', array( $this, 'order_by_price_desc_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_popularity_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_rating_post_clauses' ) );
+	}
+
+	/**
+	 * Remove the posts_where filter.
+	 * @deprecated 3.1.0 - Nothing to remove anymore because search_post_excerpt() is deprecated.
+	 */
+	public function remove_posts_where() {
+		wc_deprecated_function( 'WC_Query::remove_posts_where', '3.1.0', 'Nothing to remove anymore because search_post_excerpt() is deprecated.' );
 	}
 
 	/**

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -339,6 +339,7 @@ class WC_Query {
 	 */
 	public function search_post_excerpt( $where = '' ) {
 		wc_deprecated_function( 'WC_Query::search_post_excerpt', '3.1.0', 'Excerpt added to search query by default since WordPress 4.5.' );
+		return $where;
 	}
 
 	/**

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -329,35 +329,8 @@ class WC_Query {
 
 		$this->product_query( $q );
 
-		if ( is_search() ) {
-			add_filter( 'posts_where', array( $this, 'search_post_excerpt' ) );
-			add_filter( 'wp', array( $this, 'remove_posts_where' ) );
-		}
-
 		// And remove the pre_get_posts hook
 		$this->remove_product_query();
-	}
-
-	/**
-	 * Search post excerpt.
-	 *
-	 * @access public
-	 * @param string $where (default: '')
-	 * @return string (modified where clause)
-	 */
-	public function search_post_excerpt( $where = '' ) {
-		global $wp_the_query;
-
-		// If this is not a WC Query, do not modify the query
-		if ( empty( $wp_the_query->query_vars['wc_query'] ) || empty( $wp_the_query->query_vars['s'] ) ) {
-			return $where;
-		}
-
-		$where = preg_replace(
-			"/post_title\s+LIKE\s*(\'\%[^\%]+\%\')/",
-			"post_title LIKE $1) OR (post_excerpt LIKE $1", $where );
-
-		return $where;
 	}
 
 	/**
@@ -428,13 +401,6 @@ class WC_Query {
 		remove_filter( 'posts_clauses', array( $this, 'order_by_price_desc_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_popularity_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_rating_post_clauses' ) );
-	}
-
-	/**
-	 * Remove the posts_where filter.
-	 */
-	public function remove_posts_where() {
-		remove_filter( 'posts_where', array( $this, 'search_post_excerpt' ) );
 	}
 
 	/**

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -335,7 +335,7 @@ class WC_Query {
 
 	/**
 	 * Search post excerpt.
-	 * @deprecated 3.2.0 - Bot needed anymore since WordPress 4.5.
+	 * @deprecated 3.2.0 - Not needed anymore since WordPress 4.5.
 	 */
 	public function search_post_excerpt( $where = '' ) {
 		wc_deprecated_function( 'WC_Query::search_post_excerpt', '3.2.0', 'Excerpt added to search query by default since WordPress 4.5.' );

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -335,10 +335,10 @@ class WC_Query {
 
 	/**
 	 * Search post excerpt.
-	 * @deprecated 3.1.0 - Since WordPress 4.5 not needed anymore.
+	 * @deprecated 3.2.0 - Bot needed anymore since WordPress 4.5.
 	 */
 	public function search_post_excerpt( $where = '' ) {
-		wc_deprecated_function( 'WC_Query::search_post_excerpt', '3.1.0', 'Excerpt added to search query by default since WordPress 4.5.' );
+		wc_deprecated_function( 'WC_Query::search_post_excerpt', '3.2.0', 'Excerpt added to search query by default since WordPress 4.5.' );
 		return $where;
 	}
 
@@ -414,10 +414,10 @@ class WC_Query {
 
 	/**
 	 * Remove the posts_where filter.
-	 * @deprecated 3.1.0 - Nothing to remove anymore because search_post_excerpt() is deprecated.
+	 * @deprecated 3.2.0 - Nothing to remove anymore because search_post_excerpt() is deprecated.
 	 */
 	public function remove_posts_where() {
-		wc_deprecated_function( 'WC_Query::remove_posts_where', '3.1.0', 'Nothing to remove anymore because search_post_excerpt() is deprecated.' );
+		wc_deprecated_function( 'WC_Query::remove_posts_where', '3.2.0', 'Nothing to remove anymore because search_post_excerpt() is deprecated.' );
 	}
 
 	/**


### PR DESCRIPTION
Since WP 4.5 `search_post_excerpt()` in `WC_Query()` is not needed anymore because post_excerpt is already added to the wp search query (see https://github.com/WordPress/WordPress/commit/6d8a3f3612c0a3993dc2284f95cddc5a786ee307).
`search_post_excerpt()` just leads to problems with using custom join queries which are rejoining into wp_posts, because added post_excerpt in `search_post_excerpt()` does not use a table prefix -> you get following error:
`[Column 'post_excerpt' in where clause is ambiguous`

We could fix this bug by adding `$wpdb->prefix` to the `preg_replace()`-function in `search_post_excerpt()`, but I think it's ok removing this part of code (WP 4.5 is not so young).

Relevant code changes:
https://github.com/WordPress/WordPress/blob/4.4-branch/wp-includes/query.php#L2196
https://github.com/WordPress/WordPress/blob/4.5-branch/wp-includes/query.php#L2159

Relevant commit:
https://github.com/WordPress/WordPress/commit/6d8a3f3612c0a3993dc2284f95cddc5a786ee307