### PR TITLE
Add a new hook for product abstract  after save.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1297,7 +1297,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			if ( $this->get_parent_id() ) {
 				wc_deferred_product_sync( $this->get_parent_id() );
 			}
-
 			return $this->get_id();
 		}
 	}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1291,10 +1291,13 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 				$this->data_store->update( $this );
 			} else {
 				$this->data_store->create( $this );
+				// Trigger action after creating a product type in it's data store.
+				do_action( 'woocommerce_after_' . $this->object_type . '_object_created', $this, $this->data_store );
 			}
 			if ( $this->get_parent_id() ) {
 				wc_deferred_product_sync( $this->get_parent_id() );
 			}
+
 			return $this->get_id();
 		}
 	}


### PR DESCRIPTION
In certain cases, we need to be able to make certain based on a product ID after it is created. Specifically for WP related functions that require an ID.