### PR TITLE
Only set default if no value is set in API settings

### DIFF
--- a/includes/api/class-wc-rest-setting-options-controller.php
+++ b/includes/api/class-wc-rest-setting-options-controller.php
@@ -171,8 +171,8 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Controller {
 				$option           = get_option( $option_key[0] );
 				$setting['value'] = isset( $option[ $option_key[1] ] ) ? $option[ $option_key[1] ] : $default;
 			} else {
-				$admin_setting_value = WC_Admin_Settings::get_option( $option_key );
-				$setting['value']    = empty( $admin_setting_value ) ? $default : $admin_setting_value;
+				$admin_setting_value = WC_Admin_Settings::get_option( $option_key, $default );
+				$setting['value']    = $admin_setting_value;
 			}
 
 			if ( 'multi_select_countries' === $setting['type'] ) {


### PR DESCRIPTION
This correctly sets the default only if the option has not been saved, not if the option is empty.

Some options like tax class may be legitimately empty so a default should not apply.

Fixes #15795