### PR TITLE
Introduce wc_is_product_post_type function

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -770,7 +770,7 @@ class WC_Admin_Post_Types {
 	 * @return array
 	 */
 	public function row_actions( $actions, $post ) {
-		if ( 'product' === $post->post_type ) {
+		if ( wc_is_product_post_type( $post ) ) {
 			return array_merge( array( 'id' => 'ID: ' . $post->ID ), $actions );
 		}
 

--- a/includes/api/v1/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/v1/class-wc-rest-product-reviews-controller.php
@@ -205,7 +205,7 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	public function get_items( $request ) {
 		$product_id = (int) $request['product_id'];
 
-		if ( 'product' !== get_post_type( $product_id ) ) {
+		if ( ! wc_is_product_post_type( $product_id ) ) {
 			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
@@ -230,7 +230,7 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 		$id         = (int) $request['id'];
 		$product_id = (int) $request['product_id'];
 
-		if ( 'product' !== get_post_type( $product_id ) ) {
+		if ( ! wc_is_product_post_type( $product_id ) ) {
 			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
@@ -256,7 +256,7 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 	public function create_item( $request ) {
 		$product_id = (int) $request['product_id'];
 
-		if ( 'product' !== get_post_type( $product_id ) ) {
+		if ( ! wc_is_product_post_type( $product_id ) ) {
 			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
@@ -311,7 +311,7 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 		$product_review_id = (int) $request['id'];
 		$product_id        = (int) $request['product_id'];
 
-		if ( 'product' !== get_post_type( $product_id ) ) {
+		if ( ! wc_is_product_post_type( $product_id ) ) {
 			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -142,7 +142,7 @@ class WC_Breadcrumb {
 			$post = get_post( $post_id );
 		}
 
-		if ( 'product' === get_post_type( $post ) ) {
+		if ( wc_is_product_post_type( $post ) ) {
 			$this->prepend_shop_page();
 			if ( $terms = wc_get_product_terms( $post->ID, 'product_cat', array( 'orderby' => 'parent', 'order' => 'DESC' ) ) ) {
 				$main_term = apply_filters( 'woocommerce_breadcrumb_main_term', $terms[0], $terms );

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -61,7 +61,7 @@ class WC_Comments {
 	 * @return bool
 	 */
 	public static function comments_open( $open, $post_id ) {
-		if ( 'product' === get_post_type( $post_id ) && ! post_type_supports( 'product', 'comments' ) ) {
+		if ( wc_is_product_post_type( $post_id ) && ! post_type_supports( 'product', 'comments' ) ) {
 			$open = false;
 		}
 		return $open;
@@ -148,7 +148,7 @@ class WC_Comments {
 	 * @param int $comment_id
 	 */
 	public static function add_comment_rating( $comment_id ) {
-		if ( isset( $_POST['rating'] ) && 'product' === get_post_type( $_POST['comment_post_ID'] ) ) {
+		if ( isset( $_POST['rating'] ) && wc_is_product_post_type( $_POST['comment_post_ID'] ) ) {
 			if ( ! $_POST['rating'] || $_POST['rating'] > 5 || $_POST['rating'] < 0 ) {
 				return;
 			}
@@ -170,7 +170,7 @@ class WC_Comments {
 	public static function comment_moderation_recipients( $emails, $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( $comment && 'product' === get_post_type( $comment->comment_post_ID ) ) {
+		if ( $comment && ! wc_is_product_post_type( $comment->comment_post_ID ) ) {
 			$emails = array( get_option( 'admin_email' ) );
 		}
 
@@ -183,7 +183,7 @@ class WC_Comments {
 	 */
 	public static function clear_transients( $post_id ) {
 
-		if ( 'product' === get_post_type( $post_id ) ) {
+		if ( wc_is_product_post_type( $post_id ) ) {
 			$product = wc_get_product( $post_id );
 			self::get_rating_counts_for_product( $product );
 			self::get_average_rating_for_product( $product );
@@ -280,7 +280,7 @@ class WC_Comments {
 	public static function add_comment_purchase_verification( $comment_id ) {
 		$comment  = get_comment( $comment_id );
 		$verified = false;
-		if ( 'product' === get_post_type( $comment->comment_post_ID ) ) {
+		if ( wc_is_product_post_type( $comment->comment_post_ID ) ) {
 			$verified = wc_customer_bought_product( $comment->comment_author_email, $comment->user_id, $comment->comment_post_ID );
 			add_comment_meta( $comment_id, 'verified', (int) $verified, true );
 		}

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -70,7 +70,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_product_id( $value ) {
-		if ( $value > 0 && 'product' !== get_post_type( absint( $value ) ) ) {
+		if ( $value > 0 && ! wc_is_product_post_type( $value ) ) {
 			$this->error( 'order_item_product_invalid_product_id', __( 'Invalid product ID', 'woocommerce' ) );
 		}
 		$this->set_prop( 'product_id', absint( $value ) );

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -102,7 +102,7 @@ class WC_Product_Factory {
 	 * @return int|bool false on failure
 	 */
 	private function get_product_id( $product ) {
-		if ( false === $product && isset( $GLOBALS['post'], $GLOBALS['post']->ID ) && 'product' === get_post_type( $GLOBALS['post']->ID ) ) {
+		if ( false === $product && isset( $GLOBALS['post'], $GLOBALS['post']->ID ) && wc_is_product_post_type( $GLOBALS['post'] ) ) {
 			return $GLOBALS['post']->ID;
 		} elseif ( is_numeric( $product ) ) {
 			return $product;

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -130,7 +130,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function read( &$product ) {
 		$product->set_defaults();
 
-		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || 'product' !== $post_object->post_type ) {
+		if ( ! $product->get_id() || ! ( $post_object = get_post( $product->get_id() ) ) || ! wc_is_product_post_type( $product ) ) {
 			throw new Exception( __( 'Invalid product.', 'woocommerce' ) );
 		}
 

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -54,7 +54,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		) );
 
 		// The post parent is not a valid variable product so we should prevent this.
-		if ( $product->get_parent_id( 'edit' ) && 'product' !== get_post_type( $product->get_parent_id( 'edit' ) ) ) {
+		if ( $product->get_parent_id( 'edit' ) && ! wc_is_product_post_type( $product->get_parent_id( 'edit' ) ) ) {
 			$product->set_parent_id( 0 );
 		}
 
@@ -96,7 +96,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		// The post parent is not a valid variable product so we should prevent this.
-		if ( $product->get_parent_id( 'edit' ) && 'product' !== get_post_type( $product->get_parent_id( 'edit' ) ) ) {
+		if ( $product->get_parent_id( 'edit' ) && ! wc_is_product_post_type( $product->get_parent_id( 'edit' ) ) ) {
 			$product->set_parent_id( 0 );
 		}
 
@@ -150,7 +150,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		// The post parent is not a valid variable product so we should prevent this.
-		if ( $product->get_parent_id( 'edit' ) && 'product' !== get_post_type( $product->get_parent_id( 'edit' ) ) ) {
+		if ( $product->get_parent_id( 'edit' ) && ! wc_is_product_post_type( $product->get_parent_id( 'edit' ) ) ) {
 			$product->set_parent_id( 0 );
 		}
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -877,7 +877,7 @@ add_filter( 'rewrite_rules_array', 'wc_fix_rewrite_rules' );
  */
 function wc_fix_product_attachment_link( $link, $post_id ) {
 	$post = get_post( $post_id );
-	if ( 'product' === get_post_type( $post->post_parent ) ) {
+	if ( wc_is_product_post_type( $post->post_parent ) ) {
 		$permalinks = wc_get_permalink_structure();
 		if ( preg_match( '/\/(.+)(\/%product_cat%)$/', $permalinks['product_rewrite_slug'], $matches ) ) {
 			$link = home_url( '/?attachment_id=' . $post->ID );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1184,13 +1184,16 @@ function wc_deferred_product_sync( $product_id ) {
 }
 
 /**
- * Determine if the provided post object is the product post type.
+ * Determine if the provided post object or post ID is the product post type.
  * 
  * @since  3.2.0
- * @param  object $post_object
+ * @param  object|int $post_object
  * @return bool
  */
 function wc_is_product_post_type( $post_object ) {
+	if ( is_int( $post_object ) ) {
+		$post_object = get_post( $post_object );
+	}
 	$valid_type = $post_object && 'product' == $post_object->post_type;
 	
 	return apply_filters( 'woocommerce_is_product_post_type', $valid_type, $post_object );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1182,3 +1182,16 @@ function wc_deferred_product_sync( $product_id ) {
 
 	$wc_deferred_product_sync[] = $product_id;
 }
+
+/**
+ * Determine if the provided post object is the product post type.
+ * 
+ * @since  3.2.0
+ * @param  object $post_object
+ * @return bool
+ */
+function wc_is_product_post_type( $post_object ) {
+	$valid_type = $post_object && 'product' == $post_object->post_type;
+	
+	return apply_filters( 'woocommerce_is_product_post_type', $valid_type, $post_object );
+}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -238,7 +238,7 @@ function wc_get_featured_product_ids() {
  */
 function wc_product_post_type_link( $permalink, $post ) {
 	// Abort if post is not a product.
-	if ( 'product' !== $post->post_type ) {
+	if ( ! wc_is_product_post_type( $post ) ) {
 		return $permalink;
 	}
 


### PR DESCRIPTION
Due to the changes made with 3.0, it's broken custom functionality for a client's website where there is a custom post type which can be added into the cart/checkout and take advantage of all that WooCommerce can offer.

Specifically the hard-coded `product` post type on this line has broken this custom functionality, as it throws the exception whenever that post type loads:  https://github.com/woocommerce/woocommerce/commit/478e5f87e5f0790be8073d9104d85762c499f29f#diff-dfe1f5ea8a99b6978fadb1301dc0d750

I've hacked the file for now, but ideally I would prefer if I could simply filter the post type, hence this pull request.

It introduces a new `wc_is_product_post_type` function whilst also replacing a bunch of instances where `get_post_type()` or `$object->post_type` is used.