### PR TITLE
Don't output the shipping calculator markup on the Checkout page

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -221,7 +221,7 @@ function wc_cart_totals_shipping_html() {
 			'package'                  => $package,
 			'available_methods'        => $package['rates'],
 			'show_package_details'     => sizeof( $packages ) > 1,
-			'show_shipping_calculator' => $first,
+			'show_shipping_calculator' => is_cart() && $first,
 			'package_details'          => implode( ', ', $product_names ),
 			// @codingStandardsIgnoreStart
 			'package_name'             => apply_filters( 'woocommerce_shipping_package_name', sprintf( _nx( 'Shipping', 'Shipping %d', ( $i + 1 ), 'shipping packages', 'woocommerce' ), ( $i + 1 ) ), $i, $package ),


### PR DESCRIPTION
Since https://github.com/woocommerce/woocommerce/commit/cffe326e0e479713969396071936b77a45217684 the shipping calculator also shows on the Checkout page. I don't think there's a reason it would be needed there, but if so the JS would need to be updated to handle the form.

This PR just restores the `is_cart()` check to limit it to the cart page.