### PR TITLE
Revert pull request #14706 with changes to Abstract_WC_Order::get_item() to avoid critical fatal errors

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -782,22 +782,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Get an order item object, based on it's ID. The item must belong to the current
-	 * order. If the item cannot be found or it doens't belong to current order
-	 * FALSE will be returned.
+	 * Get an order item object, based on it's type.
 	 *
 	 * @since  3.0.0
 	 * @param  int $item_id
 	 * @return WC_Order_Item
 	 */
 	public function get_item( $item_id ) {
-		$type = $this->data_store->get_order_item_type( $this, $item_id );
-		if ( ! $type ) {
-			return false;
-		}
-
-		$items = $this->get_items( $type );
-		return ! empty( $items[ $item_id ] ) ? $items[ $item_id ] : false;
+		return WC_Order_Factory::get_order_item( $item_id );
 	}
 
 	/**

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -358,22 +358,4 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	public function update_payment_token_ids( $order, $token_ids ) {
 		update_post_meta( $order->get_id(), '_payment_tokens', $token_ids );
 	}
-
-	/**
-	 * Return the order type of a given item which belongs to WC_Order
-	 *
-	 * @param WC_Order $order	Order Object
-	 * @param int	$order_id
-	 *
-	 * @return string Order Item type
-	 */
-	public function get_order_item_type( WC_Order $order, $order_item_id ) {
-		global $wpdb;
-		$query = $wpdb->prepare(
-			"SELECT DISTINCT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d and order_item_id = %d",
-			$order->get_id(),
-			$order_item_id
-		);
-		return $wpdb->get_var( $query );
-	}
 }

--- a/tests/unit-tests/order/crud.php
+++ b/tests/unit-tests/order/crud.php
@@ -479,10 +479,10 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 			'product'  => WC_Helper_Product::create_simple_product(),
 			'quantity' => 4,
 		) );
-		$object->add_item( $item );
+		$item->save();
+		$object->add_item( $item->get_id() );
 		$object->save();
 		$this->assertTrue( $object->get_item( $item->get_id() ) instanceOf WC_Order_Item_Product );
-		$this->assertEquals( spl_object_hash( $item ), spl_object_hash( $object->get_item( $item->get_id() ) ) );
 
 		$object = new WC_Order();
 		$item   = new WC_Order_Item_Coupon();
@@ -495,51 +495,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object->add_item( $item );
 		$object->save();
 		$this->assertTrue( $object->get_item( $item_id ) instanceOf WC_Order_Item_Coupon );
-
-		$object = new WC_Order( $object->get_id() );
-		$this->assertTrue( $object->get_item( $item_id ) instanceOf WC_Order_Item_Coupon );
-	}
-
-	/**
-	 *	Make sure that items returned by get_item is tied to the order,
-	 *  and that is saved when the order is saved.
-	 */
-	public function test_get_item_object_is_updated_with_order_save() {
-		$object = new WC_Order();
-		$item   = new WC_Order_Item_Product();
-		$item->set_props( array(
-			'product'  => WC_Helper_Product::create_simple_product(),
-			'quantity' => 4,
-		) );
-		$object->add_item( $item );
-		$object->save();
-
-		$object = new WC_Order( $object->get_id() );
-		$item = $object->get_item( $item->get_id() );
-		$item->set_quantity( 6 );
-		$object->save();
-
-		$object = new WC_Order( $object->get_id() );
-		$this->assertEquals(6, $object->get_item( $item->get_id() )->get_quantity() );
-	}
-
-	/**
-	 * Makes sure that get_item only returns items related to the order
-	 */
-	public function test_get_item_from_another_order() {
-		$object = new WC_Order();
-		$item   = new WC_Order_Item_Product();
-		$item->set_props( array(
-			'product'  => WC_Helper_Product::create_simple_product(),
-			'quantity' => 4,
-			'order_id' => 999,
-		) );
-		$item->save();
-		$this->assertFalse( $object->get_item( $item->get_id() ) );
-
-		$object->save();
-		$this->assertFalse( $object->get_item( $item->get_id() ) );
-
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit 56ffa3d2aae38612daf1a69cd9c005cb4a8785c1, reversing changes made in PR #14706.

The reason I think this needs to be reverted is because it introduces high potential for fatal errors when some code is interacting with order items via the functional APIs (i.e. calling `wc_{add|update|delete}_order_item()`) and other code is using the object oriented APIs (i.e. calling `Abstract_WC_Order::{add|remove}_item()`). These two APIs are still disjointed in how they cache data, making it very easy to get unexpected, invalid results with the patches added in #14706.

For an example, see https://github.com/Prospress/woocommerce-subscriptions/issues/2210. The tl;dr of that issue - the patch from #14706 prevents renewal payments being processed by Subscriptions (⁉️) because it's continuing to use the old `wc_add_order_item()` API, then expecting to be able to get that item using `Abstract_WC_Order::get_item()` (which worked fine in 3.0, even if it isn't the best way to do it and will be changed once we get time to cleanup some of the hacks we added to keep Subscriptions working with 3.0).

I thought #15836 could fix this issue without reintroducing the issues fixed with #14706, but it only fixes it for subscriptions with no more than one of the same line item (e.g. only one tax, or one product or one shipping line item). To fix it in all cases would require a more substantial patch because `WC_Abstract_Order::get_items()` will also cache the line items on the instance of the object, as well as in the WP object cache (⁉️), so that cache would also need to be invalidated.

The issues being addressed in PR #14706 are still valid, but I think the better fix would require rethinking the entire order items API and possibly deprecating the functional APIs. The duplication of identical data with separate data stores/caches seems to consistently cause issues.

For now though, **I hope this patch can be included in v3.1 so that stores don't find all their renewal payments stop after updating to 3.1**.

--- 

**Side note**: in reviewing this change more closely, I also realised the `Abstract_WC_Order_Data_Store_CPT::get_order_item_type()` method it introduced was unnecessary, as the existing `WC_Order_Item_Data_Store->get_order_item_type( $item_id )` method could have been used instead (the SQL is different, but will result in identical results for all valid queries because `$item_id` will be unique, so its redundant to also check for `$order_id`, unless an invalid `$order_id` and `$item_id` combination is provided, in which case empty data will be returned).