### PR TITLE
Dont set everything up if 'woocommerce_admin' doesn't exist

### DIFF
--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -1,6 +1,10 @@
 /* global woocommerce_admin */
 jQuery( function ( $ ) {
 
+	if ( 'undefined' === typeof woocommerce_admin ) {
+		return;
+	}
+
 	// Add buttons to product screen.
 	var $product_screen = $( '.edit-php.post-type-product' ),
 		$title_action   = $product_screen.find( '.page-title-action:first' ),


### PR DESCRIPTION
Fixes #15848 

Let's just stop the whole show instead of trying to make it go on without an important player.

(JS needs to be recompiled before release anyways so I didn't recompile it for this PR)