### PR TITLE
Comment feed where clauses should be appended

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -97,7 +97,7 @@ class WC_Comments {
 	 * @return string
 	 */
 	public static function exclude_order_comments_from_feed_where( $where ) {
-		return ( $where ? ' AND ' : '' ) . " comment_type != 'order_note' ";
+		return $where . ( $where ? ' AND ' : '' ) . " comment_type != 'order_note' ";
 	}
 
 	/**
@@ -125,7 +125,7 @@ class WC_Comments {
 	 * @return string
 	 */
 	public static function exclude_webhook_comments_from_feed_where( $where ) {
-		return ( $where ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
+		return $where . ( $where ? ' AND ' : '' ) . " comment_type != 'webhook_delivery' ";
 	}
 
 	/**


### PR DESCRIPTION
Applies to both exclude_order_comments_from_feed_where and
exclude_webhook_comments_from_feed_where

They need to append the additonal where clause to avoid SQL errors on
the feed URL.