### PR TITLE
Add search_customers() filter

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -379,7 +379,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 			'search_columns' => array( 'user_login', 'user_url', 'user_email', 'user_nicename', 'display_name' ),
 			'fields'         => 'ID',
 			'number'         => $limit,
-		), $term, $limit, 'main_query' );
+		), $term, $limit, 'main_query' ) );
 
 		$query2 = new WP_User_Query( apply_filters( 'woocommerce_customer_search_customers', array(
 			'fields'         => 'ID',
@@ -397,7 +397,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 					'compare' => 'LIKE',
 				),
 			),
-		), $term, $limit, 'meta_query' );
+		), $term, $limit, 'meta_query' ) );
 
 		$results = wp_parse_id_list( array_merge( $query->get_results(), $query2->get_results() ) );
 

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -374,14 +374,14 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 	 * @return array
 	 */
 	public function search_customers( $term, $limit = '' ) {
-		$query = new WP_User_Query( array(
+		$query = new WP_User_Query( apply_filters( 'woocommerce_customer_search_customers', array(
 			'search'         => '*' . esc_attr( $term ) . '*',
 			'search_columns' => array( 'user_login', 'user_url', 'user_email', 'user_nicename', 'display_name' ),
 			'fields'         => 'ID',
 			'number'         => $limit,
-		) );
+		), $term, $limit, 'main_query' );
 
-		$query2 = new WP_User_Query( array(
+		$query2 = new WP_User_Query( apply_filters( 'woocommerce_customer_search_customers', array(
 			'fields'         => 'ID',
 			'number'         => $limit,
 			'meta_query'     => array(
@@ -397,7 +397,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 					'compare' => 'LIKE',
 				),
 			),
-		) );
+		), $term, $limit, 'meta_query' );
 
 		$results = wp_parse_id_list( array_merge( $query->get_results(), $query2->get_results() ) );
 


### PR DESCRIPTION
Includes each of the parameters passed to the method, as well as a context parameter for each query.

Our specific use case for this is for a custom wholesale ordering system, where we're wanting to limit the search to a specific role - so customizing the arguments here would be really helpful.

Ironically, proposed the same thing three years ago and the committed filter no longer exists: https://github.com/woocommerce/woocommerce/commit/e91ca49b6d3ba037eb6898e7c1159d2244712ecd