### PR TITLE
Use filtered args in get_orders function

### DIFF
--- a/includes/class-wc-order-query.php
+++ b/includes/class-wc-order-query.php
@@ -78,7 +78,7 @@ class WC_Order_Query extends WC_Object_Query {
 	 */
 	public function get_orders() {
 		$args = apply_filters( 'woocommerce_order_query_args', $this->get_query_vars() );
-		$results = WC_Data_Store::load( 'order' )->query( $this->get_query_vars() );
+		$results = WC_Data_Store::load( 'order' )->query( $args );
 		return apply_filters( 'woocommerce_order_query', $results, $args );
 	}
 }


### PR DESCRIPTION
Currently the query arguments are being passed through a filter, only to not be used in the actual query. This PR seeks to rectify this.