### PR TITLE
Export metadata along with custom columns

### DIFF
--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -122,7 +122,7 @@ abstract class WC_CSV_Exporter {
 			return true;
 		}
 
-		if ( in_array( $column_id, $columns_to_export ) ) {
+		if ( in_array( $column_id, $columns_to_export ) || 'meta' === $column_id ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/15920

`WC_Product_CSV_Exporter->prepare_meta_for_export()` will prevent meta from being exported if it's not meant to be.