### PR TITLE
Add filter to skip metas from being exported

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -531,9 +531,11 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 			$meta_data = $product->get_meta_data();
 
 			if ( count( $meta_data ) ) {
+				$metas_to_skip = apply_filters( 'woocommerce_product_export_skip_custom_meta', array(), $product, $meta_data );
+
 				$i = 1;
 				foreach ( $meta_data as $meta ) {
-					if ( ! is_scalar( $meta->value ) ) {
+					if ( ! is_scalar( $meta->value ) || in_array( $meta->key, $metas_to_skip ) ) {
 						continue;
 					}
 					$column_key                        = 'meta:' . esc_attr( $meta->key );


### PR DESCRIPTION
If my plugin has added custom export columns, it's strange seeing both my custom column and the default meta export column showing up for each.

This can result in many columns containing the same data, and it's confusing for the customer because they don't know which column they should edit - or they may forget to edit one causing their new value to be overwritten by the old value.

So here is a filter to help solve this problem. Would be used like so:

```
add_filter( 'woocommerce_product_export_skip_custom_meta', 'skip_custom_meta_on_export' );

public function skip_custom_meta_on_export( $metas_to_skip ) {
	$new_metas = array( 'product-fee-name', 'product-fee-amount', 'product-fee-multiplier' );
	return array_merge( $new_metas, $metas_to_skip );
}
```