### PR TITLE
Remove sandbox status forcing in PayPal gateway

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -54,11 +54,6 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 			// Lowercase returned variables.
 			$posted['payment_status'] = strtolower( $posted['payment_status'] );
 
-			// Sandbox fix.
-			if ( ( empty( $posted['pending_reason'] ) || 'authorization' !== $posted['pending_reason'] ) && isset( $posted['test_ipn'] ) && 1 == $posted['test_ipn'] && 'pending' == $posted['payment_status'] ) {
-				$posted['payment_status'] = 'completed';
-			}
-
 			WC_Gateway_Paypal::log( 'Found order #' . $order->get_id() );
 			WC_Gateway_Paypal::log( 'Payment status: ' . $posted['payment_status'] );
 


### PR DESCRIPTION
Closes #15899

@californiakat Should we add
https://stackoverflow.com/questions/4298117/paypal-ipn-always-return-pay
ment-status-pending-on-sandbox to the docs when 3.2 launches?