### PR TITLE
WP_Query expects paged, not page

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -604,6 +604,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			'shipping_tax'   => 'order_shipping_tax',
 			'cart_tax'       => 'order_tax',
 			'total'          => 'order_total',
+			'page'           => 'paged',
 		);
 
 		foreach ( $key_mapping as $query_key => $db_key ) {


### PR DESCRIPTION
Fixes #15930

To test, have enough orders on your account page to trigger pagination.