### PR TITLE
Filter in order details

### DIFF
--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -20,10 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$order = wc_get_order( $order_id );
-
-$show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
-$show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
+$order 					= wc_get_order( $order_id );
+$order_items          	= $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
+$show_purchase_note    	= $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
+$show_customer_details 	= is_user_logged_in() && $order->get_user_id() === get_current_user_id();
 ?>
 
 <section class="woocommerce-order-details">
@@ -41,7 +41,7 @@ $show_customer_details = is_user_logged_in() && $order->get_user_id() === get_cu
 
 		<tbody>
 			<?php
-				foreach ( $order->get_items() as $item_id => $item ) {
+				foreach ( $order_items as $item_id => $item ) {
 					$product = apply_filters( 'woocommerce_order_item_product', $item->get_product(), $item );
 
 					wc_get_template( 'order/order-details-item.php', array(


### PR DESCRIPTION
Added filter to order items so custom products from custom classes can be listed. This kind of filter already exists in wp admin template part 

wp-content\plugins\woocommerce\includes\admin\meta-boxes\views\html-order-items.php

So if you have custom products and related custom order items this way you can show them also on order page. Otherwise, only default products are shown and total price differs from sum of products displayed as not all of them are visible.