### PR TITLE
Remove side-effects

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -217,14 +217,16 @@ class WC_Structured_Data {
 
 			if ( $product->is_type( 'variable' ) ) {
 				$prices = $product->get_variation_prices();
+				$lowest = reset( $prices['price'] );
+				$highest = end( $prices['price'] );
 
-				if ( current( $prices['price'] ) === end( $prices['price'] ) ) {
+				if ( $lowest === $highest ) {
 					$markup_offer['price'] = wc_format_decimal( $product->get_price(), wc_get_price_decimals() );
 				} else {
 					$markup_offer['priceSpecification'] = array(
 						'price'         => wc_format_decimal( $product->get_price(), wc_get_price_decimals() ),
-						'minPrice'      => wc_format_decimal( current( $prices['price'] ), wc_get_price_decimals() ),
-						'maxPrice'      => wc_format_decimal( end( $prices['price'] ), wc_get_price_decimals() ),
+						'minPrice'      => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'maxPrice'      => wc_format_decimal( $highest, wc_get_price_decimals() ),
 						'priceCurrency' => $currency,
 					);
 				}


### PR DESCRIPTION
Fixes #15947.

When we do the first `end()` it moves the array pointer to the end of the array, so the next `current()` will get the last array element.

I've refactored to reduce that kind of complexity and prevent these sorts of side-effects.