### PR TITLE
Require T&Cs be a different page than checkout

### DIFF
--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -361,14 +361,12 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 		$wc_payment_gateways = WC_Payment_Gateways::instance();
 
 		if ( ! $current_section ) {
-			$settings = $this->get_settings();
-
 			// Prevent the T&Cs and checkout page from being set to the same page.
 			if ( isset( $_POST[ 'woocommerce_terms_page_id' ], $_POST[ 'woocommerce_checkout_page_id' ] ) && $_POST[ 'woocommerce_terms_page_id' ] === $_POST[ 'woocommerce_checkout_page_id' ] ) {
 				$_POST[ 'woocommerce_terms_page_id' ] = '';
 			}
 
-			WC_Admin_Settings::save_fields( $settings );
+			WC_Admin_Settings::save_fields( $this->get_settings() );
 			$wc_payment_gateways->process_admin_options();
 
 		} else {

--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -167,6 +167,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 					'class'    => 'wc-enhanced-select-nostd',
 					'css'      => 'min-width:300px;',
 					'type'     => 'single_select_page',
+					'args'     => array( 'exclude' => wc_get_page_id( 'checkout' ) ),
 					'desc_tip' => true,
 					'autoload' => false,
 				),
@@ -360,7 +361,14 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 		$wc_payment_gateways = WC_Payment_Gateways::instance();
 
 		if ( ! $current_section ) {
-			WC_Admin_Settings::save_fields( $this->get_settings() );
+			$settings = $this->get_settings();
+
+			// Prevent the T&Cs and checkout page from being set to the same page.
+			if ( isset( $_POST[ 'woocommerce_terms_page_id' ], $_POST[ 'woocommerce_checkout_page_id' ] ) && $_POST[ 'woocommerce_terms_page_id' ] === $_POST[ 'woocommerce_checkout_page_id' ] ) {
+				$_POST[ 'woocommerce_terms_page_id' ] = '';
+			}
+
+			WC_Admin_Settings::save_fields( $settings );
 			$wc_payment_gateways->process_admin_options();
 
 		} else {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/15949

The `exclude` arg comes from WP core: https://codex.wordpress.org/Function_Reference/wp_dropdown_pages#Parameters. This isn't enough though, as you could still save the same page for both checkout and T&C if you do it at the same time.

I tried to make a cleaner solution that would take care of this for all fields using exclude. I added the following case here: https://github.com/woocommerce/woocommerce/blob/c16acc6b5104acb0ed082e7df1c63dfd77598459/includes/admin/class-wc-admin-settings.php#L736

```
case 'single_select_page':
	// Don't allow an excluded page to be saved.
	if ( ! empty( $option['args'] ) && array_key_exists( 'exclude', $option['args'] ) ) {
		$excluded_ids = explode( ',', preg_replace( '/[^0-9,]/', '', $option['args']['exclude'] ) );

		if ( array_search( $raw_value, $excluded_ids ) ) {
			$raw_value = '';
		}
	}
	$value = wc_clean( $raw_value );
	break;
```

But that didn't help, since wc_get_page_id() will still be returning -1 for the checkout page if we're saving both fields at once. And it didn't feel useful enough to leave in place.