### PR TITLE
Add `cart_subtotal` to the shipping package

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1458,8 +1458,8 @@ class WC_Cart {
 		}
 
 		// Get totals for the chosen shipping method
-		$this->shipping_total 		= WC()->shipping->shipping_total;	// Shipping Total
-		$this->shipping_taxes		= WC()->shipping->shipping_taxes;	// Shipping Taxes
+		$this->shipping_total = WC()->shipping->shipping_total; // Shipping Total
+		$this->shipping_taxes = WC()->shipping->shipping_taxes; // Shipping Taxes
 	}
 
 	/**
@@ -1515,6 +1515,7 @@ class WC_Cart {
 						'address'   => WC()->customer->get_shipping_address(),
 						'address_2' => WC()->customer->get_shipping_address_2(),
 					),
+					'cart_subtotal'       => $this->get_displayed_subtotal(),
 				),
 			)
 		);


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/15946

This adds the cart's subtotal to the package. That way when the subtotal changes, the $package_hash changes to the rates are updated - giving the free shipping method the change to add or remove itself based on availability.

I tried adding this onto the package array in a few other places, so it was done conditionally. That way performance doesn't take a hit if there's not even a free shipping method. But it wasn't as easy as it sounds. Has to be done before this point: https://github.com/woocommerce/woocommerce/blob/c16acc6b5104acb0ed082e7df1c63dfd77598459/includes/class-wc-shipping.php#L347

Plus, it's possible other plugins need the hash updated when the cart subtotal/prices change. CSP comes to mind.