### PR TITLE
leave objects alone rather than slashing in the meta api

### DIFF
--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -100,7 +100,7 @@ class WC_Data_Store_WP {
 	 * @return int meta ID
 	 */
 	public function add_meta( &$object, $meta ) {
-		return add_metadata( $this->meta_type, $object->get_id(), $meta->key, wp_slash( $meta->value ), false );
+		return add_metadata( $this->meta_type, $object->get_id(), $meta->key, is_string( $meta->value ) ? wp_slash( $meta->value ) : $meta->value, false );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -75,7 +75,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @return bool
 	 */
 	public function update_metadata( $item_id, $meta_key, $meta_value, $prev_value = '' ) {
-		return update_metadata( 'order_item', $item_id, $meta_key, wp_slash( $meta_value ), $prev_value );
+		return update_metadata( 'order_item', $item_id, $meta_key, is_string( $meta_value ) ? wp_slash( $meta_value ) : $meta_value, $prev_value );
 	}
 
 	/**
@@ -89,7 +89,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @return int    New row ID or 0
 	 */
 	public function add_metadata( $item_id, $meta_key, $meta_value, $unique = false ) {
-		return add_metadata( 'order_item', $item_id, $meta_key, wp_slash( $meta_value ), $unique );
+		return add_metadata( 'order_item', $item_id, $meta_key, is_string( $meta_value ) ? wp_slash( $meta_value ) : $meta_value, $unique );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @return bool
 	 */
 	public function delete_metadata( $item_id, $meta_key, $meta_value = '', $delete_all = false ) {
-		return delete_metadata( 'order_item', $item_id, $meta_key, wp_slash( $meta_value ), $delete_all );
+		return delete_metadata( 'order_item', $item_id, $meta_key, is_string( $meta_value ) ? wp_slash( $meta_value ) : $meta_value, $delete_all );
 	}
 
 	/**

--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -132,4 +132,29 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 		$product = wc_get_product( $object->get_id() );
 		$this->assertEquals( 'val2', $product->get_meta( '_some_meta_key', true ) );
 	}
+
+	/**
+	 * Tests setting objects and strings in meta to ensure slashing/unslashing works.
+	 */
+	function test_strings_in_meta() {
+		// Create objects.
+		$object = new WC_Product;
+		$object_to_store = new stdClass();
+		$object_to_store->prop1 = 'prop_value';
+		$object_to_store->prop2 = 'prop_value_with_\\\"quotes"';
+
+		$object->add_meta_data( 'Test Object', $object_to_store );
+		$object->add_meta_data( 'Test meta with slash', 'Test\slashes' );
+		$object_id = $object->save();
+
+		// Get object and check it.
+		$object = wc_get_product( $object_id );
+		$value = $object->get_meta( 'Test Object', true );
+
+		$this->assertEquals( $object_to_store, $object->get_meta( 'Test Object', true ) );
+		$this->assertEquals( 'Test\slashes', $object->get_meta( 'Test meta with slash', true ) );
+
+		// clean
+		$object->delete();
+	}
 }


### PR DESCRIPTION
Has tests. Prevents notices when you pass an object to add_meta_data.