### PR TITLE
Add locking mechinism class

### DIFF
--- a/includes/class-wc-database-locks.php
+++ b/includes/class-wc-database-locks.php
@@ -36,14 +36,12 @@ class WC_Database_Locks {
 	/**
 	 * Get an existing lock.
 	 *
-	 * @return object|false
+	 * @param  string $lock_name
+	 * @return object|null
 	 */
 	public static function get_lock( $lock_name ) {
 		global $wpdb;
-
-		$lock = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_locks WHERE name = %s;", $lock_name ) );
-
-		return $lock ? $lock : false;
+		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_locks WHERE name = %s;", $lock_name ) );
 	}
 
 	/**

--- a/includes/class-wc-database-locks.php
+++ b/includes/class-wc-database-locks.php
@@ -1,0 +1,129 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Allows the DB to be locked to avoid concurrent events doing the same thing.
+ *
+ * @since    3.2.0
+ * @package  WooCommerce/Classes
+ * @category Class
+ * @author   Automattic
+ */
+class WC_Database_Locks {
+
+	/**
+	 * Request ID.
+	 * @var string
+	 */
+	private static $request_id = '';
+
+	/**
+	 * Get ID of this request.
+	 *
+	 * @return string
+	 */
+	public static function get_request_id() {
+		if ( ! self::$request_id ) {
+			self::$request_id = uniqid( mt_rand(), true );
+			add_action( 'shutdown', __CLASS__, 'release_all_locks' );
+		}
+		return self::$request_id;
+	}
+
+	/**
+	 * Get an existing lock.
+	 *
+	 * @return object|false
+	 */
+	public static function get_lock( $lock_name ) {
+		global $wpdb;
+		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_locks WHERE name = %s;", $lock_name ) );
+	}
+
+	/**
+	 * Create a lock.
+	 *
+	 * @param  string $lock_name The name of this unique lock.
+	 * @param  int $release_timeout The duration in seconds to respect an existing lock. Default: 1 hour.
+	 * @return bool False if a lock couldn't be created or if the lock is still valid. True otherwise.
+	 */
+	public static function create_lock( $lock_name, $release_timeout = 3600 ) {
+		global $wpdb;
+
+		if ( ! $release_timeout ) {
+			$release_timeout = HOUR_IN_SECONDS;
+		}
+
+		$lock_result = $wpdb->query( $wpdb->prepare( "INSERT IGNORE INTO {$wpdb->prefix}woocommerce_locks ( `name`, `request_id`, `timestamp` ) VALUES ( %s, %s, 'no' );", $lock_name, self::get_request_id(), time() ) );
+
+		if ( ! $lock_result ) {
+			$lock_result = self::get_lock( $lock_name );
+
+			// If a lock couldn't be created, and there isn't a lock, bail.
+			if ( ! $lock_result ) {
+				return false;
+			}
+
+			// Check to see if the lock is still valid. If it is, bail.
+			if ( $lock_result->timestamp > ( time() - $release_timeout ) ) {
+				return false;
+			}
+
+			// Lock is expired.
+			self::release_lock( $lock_name );
+
+			return self::create_lock( $lock_name, $release_timeout );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Aquire a lock, waiting for a set duration if needed.
+	 *
+	 * @param  string $lock_name The name of this unique lock.
+	 * @param  int $max_wait_timeout The duration in seconds to wait for the lock to be freed.
+	 * @return bool False if a lock couldn't be created or if the lock is still valid. True otherwise.
+	 */
+	public static function aquire_lock( $lock_name, $max_wait_timeout = 10 ) {
+		global $wpdb;
+
+		$start = time();
+
+		while ( $start > ( time() - $max_wait_timeout ) ) {
+			$locked = self::create_lock( $lock_name );
+
+			if ( $locked ) {
+				return true;
+			}
+
+			sleep( 1 );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Release a lock.
+	 *
+	 * @param  string $lock_name The name of this unique lock.
+	 * @return bool True if the lock was successfully released. False on failure.
+	 */
+	public static function release_lock( $lock_name ) {
+		global $wpdb;
+		return $wpdb->delete( "{$wpdb->prefix}woocommerce_locks", array( 'name' => $lock_name ) );
+	}
+
+	/**
+	 * Release all locks for a request.
+	 */
+	public static function release_all_locks() {
+		global $wpdb;
+		if ( self::$request_id ) {
+			$wpdb->delete( "{$wpdb->prefix}woocommerce_locks", array( 'request_id' => self::$request_id ) );
+		}
+	}
+}

--- a/includes/class-wc-database-locks.php
+++ b/includes/class-wc-database-locks.php
@@ -28,7 +28,7 @@ class WC_Database_Locks {
 	public static function get_request_id() {
 		if ( ! self::$request_id ) {
 			self::$request_id = uniqid( wp_rand(), true );
-			add_action( 'shutdown', __CLASS__, 'release_all_locks' );
+			add_action( 'shutdown', array( __CLASS__, 'release_all_locks' ) );
 		}
 		return self::$request_id;
 	}
@@ -101,7 +101,7 @@ class WC_Database_Locks {
 				return true;
 			}
 
-			sleep( 1 );
+			usleep( rand( 0, 1000000 ) );
 		}
 
 		return false;

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -626,8 +626,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_log (
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_locks (
   name char(32) NOT NULL,
-  request_id char(32) NOT NULL,
-  timestamp datetime NOT NULL,
+  request_id char(100) NOT NULL,
+  expires datetime NOT NULL,
   PRIMARY KEY (name)
 ) $collate;
 		";

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -624,6 +624,12 @@ CREATE TABLE {$wpdb->prefix}woocommerce_log (
   PRIMARY KEY (log_id),
   KEY level (level)
 ) $collate;
+CREATE TABLE {$wpdb->prefix}woocommerce_locks (
+  name char(32) NOT NULL,
+  request_id char(32) NOT NULL,
+  timestamp datetime NOT NULL,
+  PRIMARY KEY (name)
+) $collate;
 		";
 
 		/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -134,6 +134,8 @@ class WC_Order extends WC_Abstract_Order {
 				}
 
 				WC_Database_Locks::release_lock( $lock_name );
+			} else {
+				return false;
 			}
 		} catch ( Exception $e ) {
 			return false;

--- a/tests/unit-tests/locks/locks.php
+++ b/tests/unit-tests/locks/locks.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Database Locks.
+ * @package WooCommerce\Tests\Locks
+ */
+class WC_Tests_Locks extends WC_Unit_Test_Case {
+
+	/**
+	 * test_get_request_id.
+	 */
+	function test_get_request_id() {
+		$request_id = WC_Database_Locks::get_request_id();
+
+		$this->assertEquals( $request_id, WC_Database_Locks::get_request_id() );
+		$this->assertTrue( has_action( 'shutdown', array( 'WC_Database_Locks', 'release_all_locks' ) ) );
+	}
+
+	/**
+	 * test_create_lock.
+	 */
+	function test_create_lock() {
+		// Create a new lock twice.
+		$this->assertTrue( WC_Database_Locks::create_lock( 'test_lock' ) );
+		$this->assertFalse( WC_Database_Locks::create_lock( 'test_lock' ) );
+
+		// Lock which expires in 1 second.
+		$this->assertTrue( WC_Database_Locks::create_lock( 'test_lock_2', 1 ) );
+		sleep( 1 );
+		$this->assertTrue( WC_Database_Locks::create_lock( 'test_lock_2', 1 ) );
+	}
+
+	/**
+	 * test_aquire_lock.
+	 */
+	function test_aquire_lock() {
+		// Create lock which expires in 5 seconds.
+		WC_Database_Locks::create_lock( 'test_lock', 5 );
+
+		$lock_aquired = false;
+
+		if ( $lock = WC_Database_Locks::aquire_lock( 'test_lock' ) ) {
+			$lock_aquired = true;
+		}
+
+		$this->assertTrue( $lock_aquired );
+
+		// Create lock which expires in 10 seconds but only wait 5 to aquire.
+		WC_Database_Locks::create_lock( 'test_lock', 10 );
+
+		$lock_aquired = false;
+
+		if ( $lock = WC_Database_Locks::aquire_lock( 'test_lock', 5 ) ) {
+			$lock_aquired = true;
+		}
+
+		$this->assertFalse( $lock_aquired );
+	}
+
+	/**
+	 * test_release_lock.
+	 */
+	function test_release_lock() {
+		WC_Database_Locks::create_lock( 'lock_to_release' );
+		$this->assertTrue( WC_Database_Locks::get_lock( 'lock_to_release' ) );
+		$this->assertTrue( WC_Database_Locks::release_lock( 'lock_to_release' ) );
+		$this->assertFalse( WC_Database_Locks::get_lock( 'lock_to_release' ) );
+	}
+
+	/**
+	 * test_release_all_locks.
+	 */
+	function test_release_all_locks() {
+		$this->assertTrue( WC_Database_Locks::create_lock( 'release_all_locks_1' ) );
+		$this->assertTrue( WC_Database_Locks::create_lock( 'release_all_locks_2' ) );
+		$this->assertTrue( WC_Database_Locks::create_lock( 'release_all_locks_3' ) );
+
+		WC_Database_Locks::release_all_locks();
+
+		$this->assertFalse( WC_Database_Locks::get_lock( 'release_all_locks_1' ) );
+		$this->assertFalse( WC_Database_Locks::get_lock( 'release_all_locks_2' ) );
+		$this->assertFalse( WC_Database_Locks::get_lock( 'release_all_locks_3' ) );
+	}
+
+	/**
+	 * test_get_lock.
+	 */
+	function test_get_lock() {
+		$this->assertTrue( WC_Database_Locks::create_lock( 'test_lock' ) );
+		$this->assertTrue( WC_Database_Locks::get_lock( 'test_lock' ) );
+		$this->assertFalse( WC_Database_Locks::get_lock( 'this_lock_does_not_exist' ) );
+	}
+}

--- a/tests/unit-tests/locks/locks.php
+++ b/tests/unit-tests/locks/locks.php
@@ -61,24 +61,24 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 	function test_release_lock() {
 		WC_Database_Locks::create_lock( 'lock_to_release' );
 
-		$this->assertNotFalse( WC_Database_Locks::get_lock( 'lock_to_release' ) );
+		$this->assertNotNull( WC_Database_Locks::get_lock( 'lock_to_release' ) );
 		$this->assertTrue( WC_Database_Locks::release_lock( 'lock_to_release' ) );
-		$this->assertFalse( WC_Database_Locks::get_lock( 'lock_to_release' ) );
+		$this->assertNull( WC_Database_Locks::get_lock( 'lock_to_release' ) );
 	}
 
 	/**
 	 * test_release_all_locks.
 	 */
 	function test_release_all_locks() {
-		$this->assertNotFalse( WC_Database_Locks::create_lock( 'release_all_locks_1' ) );
-		$this->assertNotFalse( WC_Database_Locks::create_lock( 'release_all_locks_2' ) );
-		$this->assertNotFalse( WC_Database_Locks::create_lock( 'release_all_locks_3' ) );
+		$this->assertNotNull( WC_Database_Locks::create_lock( 'release_all_locks_1' ) );
+		$this->assertNotNull( WC_Database_Locks::create_lock( 'release_all_locks_2' ) );
+		$this->assertNotNull( WC_Database_Locks::create_lock( 'release_all_locks_3' ) );
 
 		WC_Database_Locks::release_all_locks();
 
-		$this->assertFalse( WC_Database_Locks::get_lock( 'release_all_locks_1' ) );
-		$this->assertFalse( WC_Database_Locks::get_lock( 'release_all_locks_2' ) );
-		$this->assertFalse( WC_Database_Locks::get_lock( 'release_all_locks_3' ) );
+		$this->assertNull( WC_Database_Locks::get_lock( 'release_all_locks_1' ) );
+		$this->assertNull( WC_Database_Locks::get_lock( 'release_all_locks_2' ) );
+		$this->assertNull( WC_Database_Locks::get_lock( 'release_all_locks_3' ) );
 	}
 
 	/**
@@ -86,7 +86,7 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 	 */
 	function test_get_lock() {
 		$this->assertTrue( WC_Database_Locks::create_lock( 'test_lock' ) );
-		$this->assertNotFalse( WC_Database_Locks::get_lock( 'test_lock' ) );
-		$this->assertFalse( WC_Database_Locks::get_lock( 'this_lock_does_not_exist' ) );
+		$this->assertNotNull( WC_Database_Locks::get_lock( 'test_lock' ) );
+		$this->assertNull( WC_Database_Locks::get_lock( 'this_lock_does_not_exist' ) );
 	}
 }

--- a/tests/unit-tests/locks/locks.php
+++ b/tests/unit-tests/locks/locks.php
@@ -12,7 +12,6 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 		$request_id = WC_Database_Locks::get_request_id();
 
 		$this->assertEquals( $request_id, WC_Database_Locks::get_request_id() );
-		$this->assertTrue( has_action( 'shutdown', array( 'WC_Database_Locks', 'release_all_locks' ) ) );
 	}
 
 	/**
@@ -33,23 +32,23 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 	 * test_aquire_lock.
 	 */
 	function test_aquire_lock() {
-		// Create lock which expires in 5 seconds.
-		WC_Database_Locks::create_lock( 'test_lock', 5 );
+		// Create lock which expires in 1 second.
+		WC_Database_Locks::create_lock( 'test_aquire_lock', 1 );
 
 		$lock_aquired = false;
 
-		if ( $lock = WC_Database_Locks::aquire_lock( 'test_lock' ) ) {
+		if ( $lock = WC_Database_Locks::aquire_lock( 'test_aquire_lock' ) ) {
 			$lock_aquired = true;
 		}
 
 		$this->assertTrue( $lock_aquired );
 
-		// Create lock which expires in 10 seconds but only wait 5 to aquire.
-		WC_Database_Locks::create_lock( 'test_lock', 10 );
+		// Create lock which expires in 5 seconds but only wait 2 to aquire.
+		WC_Database_Locks::create_lock( 'test_aquire_lock_2', 5 );
 
 		$lock_aquired = false;
 
-		if ( $lock = WC_Database_Locks::aquire_lock( 'test_lock', 5 ) ) {
+		if ( $lock = WC_Database_Locks::aquire_lock( 'test_aquire_lock_2', 2 ) ) {
 			$lock_aquired = true;
 		}
 
@@ -61,7 +60,8 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 	 */
 	function test_release_lock() {
 		WC_Database_Locks::create_lock( 'lock_to_release' );
-		$this->assertTrue( WC_Database_Locks::get_lock( 'lock_to_release' ) );
+
+		$this->assertNotFalse( WC_Database_Locks::get_lock( 'lock_to_release' ) );
 		$this->assertTrue( WC_Database_Locks::release_lock( 'lock_to_release' ) );
 		$this->assertFalse( WC_Database_Locks::get_lock( 'lock_to_release' ) );
 	}
@@ -70,9 +70,9 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 	 * test_release_all_locks.
 	 */
 	function test_release_all_locks() {
-		$this->assertTrue( WC_Database_Locks::create_lock( 'release_all_locks_1' ) );
-		$this->assertTrue( WC_Database_Locks::create_lock( 'release_all_locks_2' ) );
-		$this->assertTrue( WC_Database_Locks::create_lock( 'release_all_locks_3' ) );
+		$this->assertNotFalse( WC_Database_Locks::create_lock( 'release_all_locks_1' ) );
+		$this->assertNotFalse( WC_Database_Locks::create_lock( 'release_all_locks_2' ) );
+		$this->assertNotFalse( WC_Database_Locks::create_lock( 'release_all_locks_3' ) );
 
 		WC_Database_Locks::release_all_locks();
 
@@ -86,7 +86,7 @@ class WC_Tests_Locks extends WC_Unit_Test_Case {
 	 */
 	function test_get_lock() {
 		$this->assertTrue( WC_Database_Locks::create_lock( 'test_lock' ) );
-		$this->assertTrue( WC_Database_Locks::get_lock( 'test_lock' ) );
+		$this->assertNotFalse( WC_Database_Locks::get_lock( 'test_lock' ) );
 		$this->assertFalse( WC_Database_Locks::get_lock( 'this_lock_does_not_exist' ) );
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -61,6 +61,7 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_sessions" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_payment_tokens" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_payment_tokenmeta" );
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_locks" );
 
 	// Delete options.
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'woocommerce\_%';" );

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -297,6 +297,7 @@ final class WooCommerce {
 		 */
 		include_once( WC_ABSPATH . 'includes/wc-core-functions.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-datetime.php' );
+		include_once( WC_ABSPATH . 'includes/class-wc-database-locks.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-post-types.php' ); // Registers post types
 		include_once( WC_ABSPATH . 'includes/class-wc-install.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-geolocation.php' );


### PR DESCRIPTION
Part of #15780 

Implements a class to handle locking, and includes tests.

This could in theory be used to lock something so other concurrent requests cannot update the same thing until it’s finished.

Getting feedback before moving to implementation.