### PR TITLE
Prevent fatal error on order page

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -137,7 +137,7 @@ function wc_attribute_label( $name, $product = '' ) {
 			$product = wc_get_product( $product->get_parent_id() );
 		}
 		// Attempt to get label from product, as entered by the user.
-		if ( ( $attributes = $product->get_attributes() ) && isset( $attributes[ sanitize_title( $name ) ] ) ) {
+		if ( false !== $product && ( $attributes = $product->get_attributes() ) && isset( $attributes[ sanitize_title( $name ) ] ) ) {
 			$label = $attributes[ sanitize_title( $name ) ]->get_name();
 		} else {
 			$label = $name;


### PR DESCRIPTION
Prevents a fatal error on order pages when variable products are purchased.

From:
![](http://cld.wthms.co/BgbX7d+)
**Image Link**: http://cld.wthms.co/BgbX7d+

To:
![](http://cld.wthms.co/NHFhvD+)
**Image Link**: http://cld.wthms.co/NHFhvD+

The product, in this case, didn't exist anymore, so `wc_get_product()` was returning `false`, and cause the fatal error later.

Reported in 596481-zd-woothemes