### PR TITLE
Catch/log fatal errors

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -176,6 +176,7 @@ final class WooCommerce {
 	 */
 	private function init_hooks() {
 		register_activation_hook( __FILE__, array( 'WC_Install', 'install' ) );
+		register_shutdown_function( array( $this, 'log_errors' ) );
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
 		add_action( 'init', array( $this, 'init' ), 0 );
@@ -183,6 +184,22 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
+	}
+
+	/**
+	 * Ensures fatal errors are logged so they can be picked up in the status report.
+	 *
+	 * @since 3.2.0
+	 */
+	public function log_errors() {
+		$error = error_get_last();
+		if ( E_ERROR === $error['type'] ) {
+			$logger = wc_get_logger();
+			$logger->critical(
+				$error['message'] . PHP_EOL,
+				array( 'source' => 'fatal-errors' )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Adds a shutdown hook to log fatal errors so support can access them in our ‘logs’ section.

@WPprodigy 