### PR TITLE
Use "products" shortcode to list On Sale, Top Rated, Best Selling and Featured products

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -582,7 +582,7 @@ class WC_Query {
 		if ( ! is_array( $meta_query ) ) {
 			$meta_query = array();
 		}
-		$meta_query['price_filter']  = $this->price_filter_meta_query();
+		$meta_query['price_filter'] = $this->price_filter_meta_query();
 		return array_filter( apply_filters( 'woocommerce_product_query_meta_query', $meta_query, $this ) );
 	}
 

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -47,22 +47,22 @@ class WC_Shortcodes {
 			add_shortcode( apply_filters( "{$shortcode}_shortcode_tag", $shortcode ), $function );
 		}
 
-		// Alias for pre 2.1 compatibility
+		// Alias for pre 2.1 compatibility.
 		add_shortcode( 'woocommerce_messages', __CLASS__ . '::shop_messages' );
 	}
 
 	/**
-	 * Shortcode Wrapper.
+	 * Shortcode wrapper.
 	 *
-	 * @param string[] $function
-	 * @param array $atts (default: array())
-	 * @param array $wrapper
+	 * @param string[] $function Callback function name.
+	 * @param array    $atts     Attributes. Default: array().
+	 * @param array    $wrapper  Wrapper attributes.
 	 *
 	 * @return string
 	 */
 	public static function shortcode_wrapper(
 		$function,
-		$atts    = array(),
+		$atts = array(),
 		$wrapper = array(
 			'class'  => 'woocommerce',
 			'before' => null,
@@ -71,18 +71,21 @@ class WC_Shortcodes {
 	) {
 		ob_start();
 
+		// @codingStandardsIgnoreStart
 		echo empty( $wrapper['before'] ) ? '<div class="' . esc_attr( $wrapper['class'] ) . '">' : $wrapper['before'];
 		call_user_func( $function, $atts );
 		echo empty( $wrapper['after'] ) ? '</div>' : $wrapper['after'];
+		// @codingStandardsIgnoreEnd
 
 		return ob_get_clean();
 	}
 
 	/**
 	 * Loop over found products.
-	 * @param  array $query_args
-	 * @param  array $atts
-	 * @param  string $loop_name
+	 *
+	 * @param  array  $query_args Query arguments.
+	 * @param  array  $atts       Attributes.
+	 * @param  string $loop_name  Loop name.
 	 * @return string
 	 */
 	private static function product_loop( $query_args, $atts, $loop_name ) {
@@ -92,7 +95,7 @@ class WC_Shortcodes {
 		$woocommerce_loop['columns'] = $columns;
 		$woocommerce_loop['name']    = $loop_name;
 		$query_args                  = apply_filters( 'woocommerce_shortcode_products_query', $query_args, $atts, $loop_name );
-		$transient_name              = 'wc_loop' . substr( md5( json_encode( $query_args ) . $loop_name ), 28 ) . WC_Cache_Helper::get_transient_version( 'product_query' );
+		$transient_name              = 'wc_loop' . substr( md5( wp_json_encode( $query_args ) . $loop_name ), 28 ) . WC_Cache_Helper::get_transient_version( 'product_query' );
 		$products                    = get_transient( $transient_name );
 
 		if ( false === $products || ! is_a( $products, 'WP_Query' ) ) {
@@ -145,7 +148,7 @@ class WC_Shortcodes {
 	/**
 	 * Checkout page shortcode.
 	 *
-	 * @param mixed $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function checkout( $atts ) {
@@ -155,7 +158,7 @@ class WC_Shortcodes {
 	/**
 	 * Order tracking page shortcode.
 	 *
-	 * @param mixed $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function order_tracking( $atts ) {
@@ -165,7 +168,7 @@ class WC_Shortcodes {
 	/**
 	 * My account page shortcode.
 	 *
-	 * @param mixed $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function my_account( $atts ) {
@@ -175,8 +178,8 @@ class WC_Shortcodes {
 	/**
 	 * Main product listing shortcode.
 	 *
-	 * @param array $atts
-	 * @param str $loop_name
+	 * @param array  $atts      Attributes.
+	 * @param string $loop_name Loop name.
 	 * @return string
 	 */
 	public static function products( $atts, $loop_name = 'products' ) {
@@ -186,18 +189,18 @@ class WC_Shortcodes {
 
 		// Filterable with the shortcode_atts_{$shortcode} filter.
 		$atts = shortcode_atts( array(
-			'orderby'       => '',     // menu_order, title, date, rand, price, popularity, rating, or id
-			'order'         => 'desc', // asc or desc
+			'orderby'       => '',     // menu_order, title, date, rand, price, popularity, rating, or id.
+			'order'         => 'desc', // asc or desc.
 			'limit'         => '4',
-			'per_page'      => '',     // overrides 'limit'
+			'per_page'      => '',     // Overrides 'limit'.
 			'columns'       => '4',
-			'ids'           => '',     // comma separated IDs
-			'skus'          => '',     // comma separated SKUs
-			'category'      => '',     // comma separated category slugs
-			'cat_operator'  => 'IN',   // IN, NOT IN, or AND
-			'attribute'     => '',     // single attribute slug
-			'attr_terms'    => '',     // comma separated term slugs
-			'attr_operator' => 'IN',   // IN, NOT IN, or AND
+			'ids'           => '',     // Comma separated IDs.
+			'skus'          => '',     // Comma separated SKUs.
+			'category'      => '',     // Comma separated category slugs.
+			'cat_operator'  => 'IN',   // IN, NOT IN, or AND.
+			'attribute'     => '',     // Single attribute slug.
+			'attr_terms'    => '',     // Comma separated term slugs.
+			'attr_operator' => 'IN',   // IN, NOT IN, or AND.
 			'on_sale'       => false,
 			'featured'      => false,
 		), $atts, 'products' );
@@ -222,22 +225,28 @@ class WC_Shortcodes {
 			'no_found_rows'       => 1,
 			'orderby'             => empty( $atts['orderby'] ) ? '' : $atts['orderby'],
 			'order'               => empty( $atts['order'] ) ? 'desc' : $atts['order'],
-			'posts_per_page'      => empty( $atts['limit'] ) ? '1' : $atts['limit'],
-			'tax_query'           => WC()->query->get_tax_query(),
-			'meta_query'          => WC()->query->get_meta_query(),
+			'posts_per_page'      => empty( $atts['limit'] ) ? 1 : intval( $atts['limit'] ),
 		) );
+
+		// @codingStandardsIgnoreStart
+		$query_args['tax_query']  = WC()->query->get_tax_query();
+		$query_args['meta_query'] = WC()->query->get_meta_query();
+		// @codingStandardsIgnoreEnd
 
 		// Ordering.
 		if ( 'popularity' === $query_args['orderby'] ) {
 			$query_args['order'] = ( 'DESC' === strtoupper( $query_args['order'] ) ) ? 'DESC' : 'ASC';
 
-			// can remove after get_catalog_ordering_args() is updated.
+			// Can remove after get_catalog_ordering_args() is updated.
+			// @codingStandardsIgnoreStart
 			$query_args['meta_key'] = 'total_sales';
+			// @codingStandardsIgnoreEnd
+
 			$query_args['orderby'] = array(
 				'meta_value_num' => 'DESC',
 				'post_date'      => 'DESC',
 			);
-		} else if ( is_string( $query_args['orderby'] ) && 'ID' === strtoupper( $query_args['orderby'] ) ) {
+		} elseif ( is_string( $query_args['orderby'] ) && 'ID' === strtoupper( $query_args['orderby'] ) ) {
 			$query_args['orderby'] = 'ID';
 			$query_args['order'] = ( 'DESC' === strtoupper( $query_args['order'] ) ) ? 'DESC' : 'ASC';
 		} else {
@@ -247,7 +256,9 @@ class WC_Shortcodes {
 
 			// Add the meta key if ordering by rating.
 			if ( isset( $ordering_args['meta_key'] ) ) {
+				// @codingStandardsIgnoreStart
 				$query_args['meta_key'] = $ordering_args['meta_key'];
+				// @codingStandardsIgnoreEnd
 			}
 		}
 
@@ -297,11 +308,11 @@ class WC_Shortcodes {
 
 		// Allow 'per_page' to override 'limit' for backwards compatibility.
 		if ( ! empty( $atts['per_page'] ) ) {
-			$query_args['posts_per_page'] = $atts['per_page'];
+			$query_args['posts_per_page'] = intval( $atts['per_page'] );
 		}
 
 		// Ensure enough products are shown if IDs or SKUs were entered.
-		if ( $query_args['posts_per_page'] < $min_per_page && '-1' != $query_args['posts_per_page'] ) {
+		if ( $query_args['posts_per_page'] < $min_per_page && -1 !== $query_args['posts_per_page'] ) {
 			$query_args['posts_per_page'] = $min_per_page;
 		}
 
@@ -319,7 +330,7 @@ class WC_Shortcodes {
 	/**
 	 * List products in a category shortcode.
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function product_category( $deprecated ) {
@@ -328,7 +339,7 @@ class WC_Shortcodes {
 			'columns'  => '4',
 			'orderby'  => 'menu_order title',
 			'order'    => 'asc',
-			'category' => '',  // Slugs
+			'category' => '',  // Slugs.
 			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
 		), $deprecated, 'product_category' );
 
@@ -347,7 +358,7 @@ class WC_Shortcodes {
 	/**
 	 * List all (or limited) product categories.
 	 *
-	 * @param array $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function product_categories( $atts ) {
@@ -366,7 +377,7 @@ class WC_Shortcodes {
 		$ids        = array_filter( array_map( 'trim', explode( ',', $atts['ids'] ) ) );
 		$hide_empty = ( true === $atts['hide_empty'] || 'true' === $atts['hide_empty'] || 1 === $atts['hide_empty'] || '1' === $atts['hide_empty'] ) ? 1 : 0;
 
-		// get terms and workaround WP bug with parents/pad counts
+		// Get terms and workaround WP bug with parents/pad counts.
 		$args = array(
 			'orderby'    => $atts['orderby'],
 			'order'      => $atts['order'],
@@ -379,12 +390,14 @@ class WC_Shortcodes {
 		$product_categories = get_terms( 'product_cat', $args );
 
 		if ( '' !== $atts['parent'] ) {
-			$product_categories = wp_list_filter( $product_categories, array( 'parent' => $atts['parent'] ) );
+			$product_categories = wp_list_filter( $product_categories, array(
+				'parent' => $atts['parent'],
+			) );
 		}
 
 		if ( $hide_empty ) {
 			foreach ( $product_categories as $key => $category ) {
-				if ( 0 == $category->count ) {
+				if ( 0 === $category->count ) {
 					unset( $product_categories[ $key ] );
 				}
 			}
@@ -419,7 +432,7 @@ class WC_Shortcodes {
 	/**
 	 * Recent Products shortcode.
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function recent_products( $deprecated ) {
@@ -442,7 +455,7 @@ class WC_Shortcodes {
 	/**
 	 * Display a single product.
 	 *
-	 * @param array $atts
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function product( $deprecated ) {
@@ -462,7 +475,7 @@ class WC_Shortcodes {
 	/**
 	 * Display a single product price + cart button.
 	 *
-	 * @param array $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function product_add_to_cart( $atts ) {
@@ -490,27 +503,29 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$product = is_object( $product_data ) && in_array( $product_data->post_type, array( 'product', 'product_variation' ) ) ? wc_setup_product_data( $product_data ) : false;
+		$product = is_object( $product_data ) && in_array( $product_data->post_type, array( 'product', 'product_variation' ), true ) ? wc_setup_product_data( $product_data ) : false;
 
 		if ( ! $product ) {
 			return '';
 		}
 
-		$styles = empty( $atts['style'] ) ? '' : ' style="' . esc_attr( $atts['style'] ) . '"';
-
 		ob_start();
-		?>
-		<p class="product woocommerce add_to_cart_inline <?php echo esc_attr( $atts['class'] ); ?>"<?php echo $styles; ?>>
 
-			<?php if ( 'true' == $atts['show_price'] ) : ?>
-				<?php echo $product->get_price_html(); ?>
-			<?php endif; ?>
+		echo '<p class="product woocommerce add_to_cart_inline ' . esc_attr( $atts['class'] ) . '" style="' . empty( $atts['style'] ) ? '' :  esc_attr( $atts['style'] ) . '">';
 
-			<?php woocommerce_template_loop_add_to_cart( array( 'quantity' => $atts['quantity'] ) ); ?>
+		if ( 'true' === $atts['show_price'] ) {
+			// @codingStandardsIgnoreStart
+			echo $product->get_price_html();
+			// @codingStandardsIgnoreEnd
+		}
 
-		</p><?php
+		woocommerce_template_loop_add_to_cart( array(
+			'quantity' => $atts['quantity'],
+		) );
 
-		// Restore Product global in case this is shown inside a product post
+		echo '</p>';
+
+		// Restore Product global in case this is shown inside a product post.
 		wc_setup_product_data( $post );
 
 		return ob_get_clean();
@@ -519,7 +534,7 @@ class WC_Shortcodes {
 	/**
 	 * Get the add to cart URL for a product.
 	 *
-	 * @param array $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function product_add_to_cart_url( $atts ) {
@@ -536,7 +551,7 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$product = is_object( $product_data ) && in_array( $product_data->post_type, array( 'product', 'product_variation' ) ) ? wc_setup_product_data( $product_data ) : false;
+		$product = is_object( $product_data ) && in_array( $product_data->post_type, array( 'product', 'product_variation' ), true ) ? wc_setup_product_data( $product_data ) : false;
 
 		if ( ! $product ) {
 			return '';
@@ -550,7 +565,7 @@ class WC_Shortcodes {
 	/**
 	 * List all products on sale.
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function sale_products( $deprecated ) {
@@ -575,7 +590,7 @@ class WC_Shortcodes {
 	/**
 	 * List best selling products on sale.
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function best_selling_products( $deprecated ) {
@@ -598,7 +613,7 @@ class WC_Shortcodes {
 	/**
 	 * List top rated products on sale.
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function top_rated_products( $deprecated ) {
@@ -623,7 +638,7 @@ class WC_Shortcodes {
 	/**
 	 * Output featured products.
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function featured_products( $deprecated ) {
@@ -648,7 +663,7 @@ class WC_Shortcodes {
 	/**
 	 * Show a single product page.
 	 *
-	 * @param array $atts
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function product_page( $atts ) {
@@ -686,16 +701,16 @@ class WC_Shortcodes {
 
 		$preselected_id = '0';
 
-		// check if sku is a variation
+		// Check if sku is a variation.
 		if ( isset( $atts['sku'] ) && $single_product->have_posts() && 'product_variation' === $single_product->post->post_type ) {
 
 			$variation = new WC_Product_Variation( $single_product->post->ID );
 			$attributes = $variation->get_attributes();
 
-			// set preselected id to be used by JS to provide context
+			// Set preselected id to be used by JS to provide context.
 			$preselected_id = $single_product->post->ID;
 
-			// get the parent product object
+			// Get the parent product object.
 			$args = array(
 				'posts_per_page'      => 1,
 				'post_type'           => 'product',
@@ -725,7 +740,9 @@ class WC_Shortcodes {
 
 		// Backup query object so following loops think this is a product page.
 		$previous_wp_query = $wp_query;
-		$wp_query          = $single_product;
+		// @codingStandardsIgnoreStart
+		$wp_query = $single_product;
+		// @codingStandardsIgnoreEnd
 
 		wp_enqueue_script( 'wc-single-product' );
 
@@ -738,8 +755,10 @@ class WC_Shortcodes {
 			<?php
 		}
 
-		// restore $previous_wp_query and reset post data.
+		// Restore $previous_wp_query and reset post data.
+		// @codingStandardsIgnoreStart
 		$wp_query = $previous_wp_query;
+		// @codingStandardsIgnoreEnd
 		wp_reset_postdata();
 
 		return '<div class="woocommerce">' . ob_get_clean() . '</div>';
@@ -760,7 +779,7 @@ class WC_Shortcodes {
 	 * List products with an attribute shortcode.
 	 * Example [product_attribute attribute='color' filter='black'].
 	 *
-	 * @param array $deprecated
+	 * @param array $deprecated Attributes. Deprecated.
 	 * @return string
 	 */
 	public static function product_attribute( $deprecated ) {
@@ -782,19 +801,22 @@ class WC_Shortcodes {
 
 	/**
 	 * List related products.
-	 * @param array $atts
+	 *
+	 * @param array $atts Attributes.
 	 * @return string
 	 */
 	public static function related_products( $atts ) {
+		// @codingStandardsIgnoreStart
 		$atts = shortcode_atts( array(
 			'limit'    => '4',
 			'columns'  => '4',
 			'orderby'  => 'rand',
 		), $atts, 'related_products' );
+		// @codingStandardsIgnoreEnd
 
 		ob_start();
 
-		// Rename arg
+		// Rename arg.
 		$atts['posts_per_page'] = isset( $atts['per_page'] ) ? absint( $atts['per_page'] ) : absint( $atts['limit'] );
 
 		woocommerce_related_products( $atts );

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -203,6 +203,7 @@ class WC_Shortcodes {
 			'attr_operator' => 'IN',   // IN, NOT IN, or AND.
 			'on_sale'       => false,
 			'featured'      => false,
+			'best_selling'  => false,
 		), $atts, 'products' );
 
 		$query_args = self::products_query_args( $atts, $loop_name );
@@ -232,6 +233,11 @@ class WC_Shortcodes {
 		$query_args['tax_query']  = WC()->query->get_tax_query();
 		$query_args['meta_query'] = WC()->query->get_meta_query();
 		// @codingStandardsIgnoreEnd
+
+		// Best selling.
+		if ( ! empty( $atts['best_selling'] ) ) {
+			$query_args['orderby'] = 'popularity';
+		}
 
 		// Ordering.
 		if ( 'popularity' === $query_args['orderby'] ) {
@@ -272,7 +278,8 @@ class WC_Shortcodes {
 			);
 		}
 
-		if ( ! empty( $atts['featured'] ) && $atts['featured'] ) {
+		// Featured products.
+		if ( ! empty( $atts['featured'] ) ) {
 			$query_args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
 				'terms'    => 'featured',
@@ -316,7 +323,8 @@ class WC_Shortcodes {
 			$query_args['posts_per_page'] = $min_per_page;
 		}
 
-		if ( ! empty( $atts['on_sale'] ) && $atts['on_sale'] ) {
+		// On sale products.
+		if ( ! empty( $atts['on_sale'] ) ) {
 			if ( isset( $query_args['post__in'] ) ) {
 				$query_args['post__in'] = array_merge( $query_args['post__in'], wc_get_product_ids_on_sale() );
 			} else {

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -1,17 +1,19 @@
 <?php
+/**
+ * Shortcodes
+ *
+ * @version  3.2.0
+ * @package  WooCommerce/Classes
+ * @category Class
+ * @author   Automattic
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
- * WC_Shortcodes class
- *
- * @class       WC_Shortcodes
- * @version     2.1.0
- * @package     WooCommerce/Classes
- * @category    Class
- * @author      WooThemes
+ * Shortcodes class.
  */
 class WC_Shortcodes {
 
@@ -208,8 +210,8 @@ class WC_Shortcodes {
 	/**
 	 * Take in the shortcode attributes and return query args.
 	 *
-	 * @param array $atts
-	 * @param str $loop_name
+	 * @param  array  $atts      Shortcode attributes.
+	 * @param  string $loop_name Loop name.
 	 * @return array
 	 */
 	public static function products_query_args( $atts, $loop_name ) {
@@ -225,16 +227,11 @@ class WC_Shortcodes {
 			'meta_query'          => WC()->query->get_meta_query(),
 		) );
 
-		/*
-		|-------------------------
-		| Ordering
-		|-------------------------
-		*/
-
+		// Ordering.
 		if ( 'popularity' === $query_args['orderby'] ) {
 			$query_args['order'] = ( 'DESC' === strtoupper( $query_args['order'] ) ) ? 'DESC' : 'ASC';
 
-			// can remove after get_catalog_ordering_args() is updated
+			// can remove after get_catalog_ordering_args() is updated.
 			$query_args['meta_key'] = 'total_sales';
 			$query_args['orderby'] = array(
 				'meta_value_num' => 'DESC',
@@ -254,12 +251,7 @@ class WC_Shortcodes {
 			}
 		}
 
-		/*
-		|-------------------------
-		| Taxonomy Queries
-		|-------------------------
-		*/
-
+		// Taxonomy Queries.
 		if ( ! empty( $atts['category'] ) ) {
 			$query_args['tax_query'][] = array(
 					'taxonomy'     => 'product_cat',
@@ -287,12 +279,7 @@ class WC_Shortcodes {
 			);
 		}
 
-		/*
-		|-------------------------
-		| Meta Queries & post__in
-		|-------------------------
-		*/
-
+		// Meta Queries & post__in.
 		$min_per_page = 0;
 		if ( ! empty( $atts['ids'] ) ) {
 			$min_per_page += count( explode( ',', $atts['ids'] ) );
@@ -337,7 +324,7 @@ class WC_Shortcodes {
 	 */
 	public static function product_category( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page' => '12',
+			'limit'    => '12',
 			'columns'  => '4',
 			'orderby'  => 'menu_order title',
 			'order'    => 'asc',
@@ -437,7 +424,7 @@ class WC_Shortcodes {
 	 */
 	public static function recent_products( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page' => '12',
+			'limit'    => '12',
 			'columns'  => '4',
 			'orderby'  => 'date',
 			'order'    => 'desc',
@@ -568,7 +555,7 @@ class WC_Shortcodes {
 	 */
 	public static function sale_products( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page' => '12',
+			'limit'    => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
 			'order'    => 'asc',
@@ -593,7 +580,7 @@ class WC_Shortcodes {
 	 */
 	public static function best_selling_products( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page' => '12',
+			'limit'    => '12',
 			'columns'  => '4',
 			'category' => '',  // Slugs
 			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
@@ -616,7 +603,7 @@ class WC_Shortcodes {
 	 */
 	public static function top_rated_products( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page' => '12',
+			'limit'    => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
 			'order'    => 'asc',
@@ -641,7 +628,7 @@ class WC_Shortcodes {
 	 */
 	public static function featured_products( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page' => '12',
+			'limit'    => '12',
 			'columns'  => '4',
 			'orderby'  => 'date',
 			'order'    => 'desc',
@@ -778,7 +765,7 @@ class WC_Shortcodes {
 	 */
 	public static function product_attribute( $deprecated ) {
 		$args = shortcode_atts( array(
-			'per_page'  => '12',
+			'limit'     => '12',
 			'columns'   => '4',
 			'orderby'   => 'title',
 			'order'     => 'asc',
@@ -800,7 +787,7 @@ class WC_Shortcodes {
 	 */
 	public static function related_products( $atts ) {
 		$atts = shortcode_atts( array(
-			'per_page' => '4',
+			'limit'    => '4',
 			'columns'  => '4',
 			'orderby'  => 'rand',
 		), $atts, 'related_products' );
@@ -808,7 +795,7 @@ class WC_Shortcodes {
 		ob_start();
 
 		// Rename arg
-		$atts['posts_per_page'] = absint( $atts['per_page'] );
+		$atts['posts_per_page'] = isset( $atts['per_page'] ) ? absint( $atts['per_page'] ) : absint( $atts['limit'] );
 
 		woocommerce_related_products( $atts );
 

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -204,6 +204,7 @@ class WC_Shortcodes {
 			'on_sale'       => false,
 			'featured'      => false,
 			'best_selling'  => false,
+			'top_rated'     => false,
 		), $atts, 'products' );
 
 		$query_args = self::products_query_args( $atts, $loop_name );
@@ -237,6 +238,11 @@ class WC_Shortcodes {
 		// Best selling.
 		if ( ! empty( $atts['best_selling'] ) ) {
 			$query_args['orderby'] = 'popularity';
+		}
+
+		// Top rated.
+		if ( ! empty( $atts['top_rated'] ) ) {
+			$query_args['orderby'] = 'rating';
 		}
 
 		// Ordering.

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -190,7 +190,7 @@ class WC_Shortcodes {
 		// Filterable with the shortcode_atts_{$shortcode} filter.
 		$atts = shortcode_atts( array(
 			'orderby'       => '',     // menu_order, title, date, rand, price, popularity, rating, or id.
-			'order'         => 'desc', // asc or desc.
+			'order'         => 'DESC', // ASC or DESC.
 			'limit'         => '4',
 			'per_page'      => '',     // Overrides 'limit'.
 			'columns'       => '4',
@@ -226,9 +226,12 @@ class WC_Shortcodes {
 			'ignore_sticky_posts' => 1,
 			'no_found_rows'       => 1,
 			'orderby'             => empty( $atts['orderby'] ) ? '' : $atts['orderby'],
-			'order'               => empty( $atts['order'] ) ? 'desc' : $atts['order'],
+			'order'               => empty( $atts['order'] ) ? 'DESC' : strtoupper( $atts['order'] ),
 			'posts_per_page'      => empty( $atts['limit'] ) ? 1 : intval( $atts['limit'] ),
 		) );
+
+		// Validate order options.
+		$query_args['order'] = 'DESC' === $query_args['order'] ? 'DESC' : 'ASC';
 
 		// @codingStandardsIgnoreStart
 		$query_args['tax_query']  = WC()->query->get_tax_query();
@@ -247,8 +250,6 @@ class WC_Shortcodes {
 
 		// Ordering.
 		if ( 'popularity' === $query_args['orderby'] ) {
-			$query_args['order'] = ( 'DESC' === strtoupper( $query_args['order'] ) ) ? 'DESC' : 'ASC';
-
 			// Can remove after get_catalog_ordering_args() is updated.
 			// @codingStandardsIgnoreStart
 			$query_args['meta_key'] = 'total_sales';
@@ -260,7 +261,6 @@ class WC_Shortcodes {
 			);
 		} elseif ( is_string( $query_args['orderby'] ) && 'ID' === strtoupper( $query_args['orderby'] ) ) {
 			$query_args['orderby'] = 'ID';
-			$query_args['order'] = ( 'DESC' === strtoupper( $query_args['order'] ) ) ? 'DESC' : 'ASC';
 		} else {
 			$ordering_args = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
 			$query_args['orderby'] = $ordering_args['orderby'];
@@ -274,7 +274,7 @@ class WC_Shortcodes {
 			}
 		}
 
-		// Taxonomy Queries.
+		// Taxonomy queries.
 		if ( ! empty( $atts['category'] ) ) {
 			$query_args['tax_query'][] = array(
 					'taxonomy'     => 'product_cat',

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -183,24 +183,11 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function products( $atts, $loop_name = 'products' ) {
-		$query_args = self::products_query_args( $atts, $loop_name );
-
-		return self::product_loop( $query_args, $atts, $loop_name );
-	}
-
-	/**
-	 * Take in the shortcode attributes and return query args.
-	 *
-	 * @param  array  $atts      Shortcode attributes.
-	 * @param  string $loop_name Loop name.
-	 * @return array
-	 */
-	public static function products_query_args( $atts, $loop_name ) {
 		// Standard attributes. Filterable with the shortcode_atts_{$shortcode} filter.
 		$atts = shortcode_atts( array(
 			'orderby'       => 'title', // menu_order, title, date, rand, price, popularity, rating, or id.
 			'order'         => 'ASC',   // ASC or DESC.
-			'limit'         => '4',
+			'limit'         => '-1',
 			'per_page'      => '',      // Overrides 'limit'.
 			'columns'       => '4',
 			'ids'           => '',      // Comma separated IDs.
@@ -216,6 +203,19 @@ class WC_Shortcodes {
 			'top_rated'     => false,
 		), $atts, $loop_name );
 
+		$query_args = self::products_query_args( $atts, $loop_name );
+
+		return self::product_loop( $query_args, $atts, $loop_name );
+	}
+
+	/**
+	 * Take in the shortcode attributes and return query args.
+	 *
+	 * @param  array  $atts      Shortcode attributes.
+	 * @param  string $loop_name Loop name.
+	 * @return array
+	 */
+	public static function products_query_args( $atts, $loop_name ) {
 		$query_args = apply_filters( "woocommerce_default_{$loop_name}_query_args", array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -183,30 +183,6 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function products( $atts, $loop_name = 'products' ) {
-		if ( empty( $atts ) ) {
-			return '';
-		}
-
-		// Filterable with the shortcode_atts_{$shortcode} filter.
-		$atts = shortcode_atts( array(
-			'orderby'       => '',     // menu_order, title, date, rand, price, popularity, rating, or id.
-			'order'         => 'DESC', // ASC or DESC.
-			'limit'         => '4',
-			'per_page'      => '',     // Overrides 'limit'.
-			'columns'       => '4',
-			'ids'           => '',     // Comma separated IDs.
-			'skus'          => '',     // Comma separated SKUs.
-			'category'      => '',     // Comma separated category slugs.
-			'cat_operator'  => 'IN',   // IN, NOT IN, or AND.
-			'attribute'     => '',     // Single attribute slug.
-			'attr_terms'    => '',     // Comma separated term slugs.
-			'attr_operator' => 'IN',   // IN, NOT IN, or AND.
-			'on_sale'       => false,
-			'featured'      => false,
-			'best_selling'  => false,
-			'top_rated'     => false,
-		), $atts, 'products' );
-
 		$query_args = self::products_query_args( $atts, $loop_name );
 
 		return self::product_loop( $query_args, $atts, $loop_name );
@@ -220,14 +196,34 @@ class WC_Shortcodes {
 	 * @return array
 	 */
 	public static function products_query_args( $atts, $loop_name ) {
+		// Standard attributes. Filterable with the shortcode_atts_{$shortcode} filter.
+		$atts = shortcode_atts( array(
+			'orderby'       => 'title', // menu_order, title, date, rand, price, popularity, rating, or id.
+			'order'         => 'ASC',   // ASC or DESC.
+			'limit'         => '4',
+			'per_page'      => '',      // Overrides 'limit'.
+			'columns'       => '4',
+			'ids'           => '',      // Comma separated IDs.
+			'skus'          => '',      // Comma separated SKUs.
+			'category'      => '',      // Comma separated category slugs.
+			'cat_operator'  => 'IN',    // IN, NOT IN, or AND.
+			'attribute'     => '',      // Single attribute slug.
+			'attr_terms'    => '',      // Comma separated term slugs.
+			'attr_operator' => 'IN',    // IN, NOT IN, or AND.
+			'on_sale'       => false,
+			'featured'      => false,
+			'best_selling'  => false,
+			'top_rated'     => false,
+		), $atts, $loop_name );
+
 		$query_args = apply_filters( "woocommerce_default_{$loop_name}_query_args", array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'no_found_rows'       => 1,
-			'orderby'             => empty( $atts['orderby'] ) ? '' : $atts['orderby'],
-			'order'               => empty( $atts['order'] ) ? 'DESC' : strtoupper( $atts['order'] ),
-			'posts_per_page'      => empty( $atts['limit'] ) ? 1 : intval( $atts['limit'] ),
+			'orderby'             => $atts['orderby'],
+			'order'               => empty( $atts['order'] ) ? 'ASC' : strtoupper( $atts['order'] ),
+			'posts_per_page'      => empty( $atts['limit'] ) ? -1 : intval( $atts['limit'] ),
 		) );
 
 		// Validate order options.
@@ -277,10 +273,10 @@ class WC_Shortcodes {
 		// Taxonomy queries.
 		if ( ! empty( $atts['category'] ) ) {
 			$query_args['tax_query'][] = array(
-					'taxonomy'     => 'product_cat',
-					'terms'        => array_map( 'sanitize_title', explode( ',', $atts['category'] ) ),
-					'field'        => 'slug',
-					'operator'     => empty( $atts['cat_operator'] ) ? 'IN' : $atts['cat_operator'],
+				'taxonomy' => 'product_cat',
+				'terms'    => array_map( 'sanitize_title', explode( ',', $atts['category'] ) ),
+				'field'    => 'slug',
+				'operator' => empty( $atts['cat_operator'] ) ? 'IN' : $atts['cat_operator'],
 			);
 		}
 

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -175,6 +175,7 @@ class WC_Shortcodes {
 	 * Main products shortcode.
 	 *
 	 * @param array $atts
+	 * @param str $loop_name
 	 * @return string
 	 */
 	public static function wc_products( $atts, $loop_name = 'wc_products' ) {
@@ -208,6 +209,7 @@ class WC_Shortcodes {
 			'order'               => $atts['order'],
 			'posts_per_page'      => $atts['per_page'],
 			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_query'          => WC()->query->get_meta_query(),
 		) );
 
 		/*

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -186,7 +186,8 @@ class WC_Shortcodes {
 		$atts = shortcode_atts( array(
 			'orderby'       => '',      // menu_order, title, date, rand, price, popularity, rating, or id
 			'order'         => 'desc',  // asc or desc
-			'per_page'      => '4',
+			'limit'         => '4',
+			'per_page'      => '',     // overrides 'limit'
 			'columns'       => '4',
 			'ids'           => '',     // comma separated IDs
 			'skus'          => '',     // comma separated SKUs
@@ -206,7 +207,7 @@ class WC_Shortcodes {
 			'no_found_rows'       => 1,
 			'orderby'             => $atts['orderby'], // defaults to 'menu_order title' later on.
 			'order'               => $atts['order'],
-			'posts_per_page'      => $atts['per_page'],
+			'posts_per_page'      => $atts['limit'],
 			'tax_query'           => WC()->query->get_tax_query(),
 			'meta_query'          => WC()->query->get_meta_query(),
 		) );
@@ -287,6 +288,11 @@ class WC_Shortcodes {
 				'value'   => array_map( 'trim', explode( ',', $atts['skus'] ) ),
 				'compare' => 'IN',
 			);
+		}
+
+		// Allow 'per_page' to override 'limit' for backwards compatibility.
+		if ( ! empty( $atts['per_page'] ) ) {
+			$query_args['posts_per_page'] = $atts['per_page'];
 		}
 
 		// Ensure enough products are shown if IDs or SKUs were entered.

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -774,23 +774,6 @@ class WC_Shortcodes {
 	}
 
 	/**
-	 * woocommerce_order_by_rating_post_clauses function.
-	 *
-	 * @param array $args
-	 * @return array
-	 */
-	public static function order_by_rating_post_clauses( $args ) {
-		global $wpdb;
-
-		$args['where']   .= " AND $wpdb->commentmeta.meta_key = 'rating' ";
-		$args['join']    .= "LEFT JOIN $wpdb->comments ON($wpdb->posts.ID               = $wpdb->comments.comment_post_ID) LEFT JOIN $wpdb->commentmeta ON($wpdb->comments.comment_ID = $wpdb->commentmeta.comment_id)";
-		$args['orderby'] = "$wpdb->commentmeta.meta_value DESC";
-		$args['groupby'] = "$wpdb->posts.ID";
-
-		return $args;
-	}
-
-	/**
 	 * List products with an attribute shortcode.
 	 * Example [product_attribute attribute='color' filter='black'].
 	 *

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -177,7 +177,7 @@ class WC_Shortcodes {
 	 * @param array $atts
 	 * @return string
 	 */
-	public static function wc_products( $atts ) {
+	public static function wc_products( $atts, $loop_name = 'wc_products' ) {
 		if ( empty( $atts ) ) {
 			return '';
 		}
@@ -199,7 +199,7 @@ class WC_Shortcodes {
 			'featured'      => false,
 		), $atts, 'wc_products' );
 
-		$query_args = apply_filters( 'woocommerce_default_wc_products_query_args', array(
+		$query_args = apply_filters( "woocommerce_default_{$loop_name}_query_args", array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
@@ -301,7 +301,7 @@ class WC_Shortcodes {
 			}
 		}
 
-		return self::product_loop( $query_args, $atts, 'wc_products' );
+		return self::product_loop( $query_args, $atts, $loop_name );
 	}
 
 	/**
@@ -328,7 +328,7 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'product_category' );
 	}
 
 
@@ -424,7 +424,7 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'recent_products' );
 	}
 
 	/**
@@ -446,7 +446,7 @@ class WC_Shortcodes {
 			'skus'    => '',
 		), $deprecated, 'products' );
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'products' );
 	}
 
 	/**
@@ -466,7 +466,7 @@ class WC_Shortcodes {
 			$args['ids'] = $deprecated['id'];
 		}
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'product' );
 	}
 
 	/**
@@ -579,7 +579,7 @@ class WC_Shortcodes {
 
 		$args['on_sale'] = true;
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'sale_products' );
 	}
 
 	/**
@@ -602,7 +602,7 @@ class WC_Shortcodes {
 
 		$args['orderby'] = 'popularity';
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'best_selling_products' );
 	}
 
 	/**
@@ -627,7 +627,7 @@ class WC_Shortcodes {
 
 		$args['orderby'] = 'rating';
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'top_rated_products' );
 	}
 
 	/**
@@ -652,7 +652,7 @@ class WC_Shortcodes {
 
 		$args['featured'] = 'true';
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'featured_products' );
 	}
 
 	/**
@@ -787,7 +787,7 @@ class WC_Shortcodes {
 		$args['attr_terms'] = $args['filter'];
 		unset( $args['filter'] );
 
-		return self::wc_products( $args );
+		return self::wc_products( $args, 'product_attribute' );
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -835,31 +835,3 @@ class WC_Shortcodes {
 
 		return ob_get_clean();
 	}
-
-	/**
-	 * Adds a tax_query index to the query to filter by category.
-	 *
-	 * @param array $args
-	 * @param string $category
-	 * @param string $operator
-	 * @return array;
-	 * @access private
-	 */
-	private static function _maybe_add_category_args( $args, $category, $operator ) {
-		if ( ! empty( $category ) ) {
-			if ( empty( $args['tax_query'] ) ) {
-				$args['tax_query'] = array();
-			}
-			$args['tax_query'][] = array(
-				array(
-					'taxonomy' => 'product_cat',
-					'terms'    => array_map( 'sanitize_title', explode( ',', $category ) ),
-					'field'    => 'slug',
-					'operator' => $operator,
-				),
-			);
-		}
-
-		return $args;
-	}
-}

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -20,26 +20,25 @@ class WC_Shortcodes {
 	 */
 	public static function init() {
 		$shortcodes = array(
-			'wc_products'                => __CLASS__ . '::wc_products',
-			'product'                    => __CLASS__ . '::product',
+			'products'                   => __CLASS__ . '::products',
 			'product_page'               => __CLASS__ . '::product_page',
-			'product_category'           => __CLASS__ . '::product_category',
 			'product_categories'         => __CLASS__ . '::product_categories',
 			'add_to_cart'                => __CLASS__ . '::product_add_to_cart',
 			'add_to_cart_url'            => __CLASS__ . '::product_add_to_cart_url',
-			'products'                   => __CLASS__ . '::products',
-			'recent_products'            => __CLASS__ . '::recent_products',
-			'sale_products'              => __CLASS__ . '::sale_products',
-			'best_selling_products'      => __CLASS__ . '::best_selling_products',
-			'top_rated_products'         => __CLASS__ . '::top_rated_products',
-			'featured_products'          => __CLASS__ . '::featured_products',
-			'product_attribute'          => __CLASS__ . '::product_attribute',
 			'related_products'           => __CLASS__ . '::related_products',
 			'shop_messages'              => __CLASS__ . '::shop_messages',
 			'woocommerce_order_tracking' => __CLASS__ . '::order_tracking',
 			'woocommerce_cart'           => __CLASS__ . '::cart',
 			'woocommerce_checkout'       => __CLASS__ . '::checkout',
 			'woocommerce_my_account'     => __CLASS__ . '::my_account',
+			'product'                    => __CLASS__ . '::product',
+			'product_category'           => __CLASS__ . '::product_category',
+			'recent_products'            => __CLASS__ . '::recent_products',
+			'sale_products'              => __CLASS__ . '::sale_products',
+			'best_selling_products'      => __CLASS__ . '::best_selling_products',
+			'top_rated_products'         => __CLASS__ . '::top_rated_products',
+			'featured_products'          => __CLASS__ . '::featured_products',
+			'product_attribute'          => __CLASS__ . '::product_attribute',
 		);
 
 		foreach ( $shortcodes as $shortcode => $function ) {
@@ -172,13 +171,13 @@ class WC_Shortcodes {
 	}
 
 	/**
-	 * Main products shortcode.
+	 * Main product listing shortcode.
 	 *
 	 * @param array $atts
 	 * @param str $loop_name
 	 * @return string
 	 */
-	public static function wc_products( $atts, $loop_name = 'wc_products' ) {
+	public static function products( $atts, $loop_name = 'products' ) {
 		if ( empty( $atts ) ) {
 			return '';
 		}
@@ -198,7 +197,7 @@ class WC_Shortcodes {
 			'attr_operator' => 'IN',   // IN, NOT IN, or AND
 			'on_sale'       => false,
 			'featured'      => false,
-		), $atts, 'wc_products' );
+		), $atts, 'products' );
 
 		$query_args = apply_filters( "woocommerce_default_{$loop_name}_query_args", array(
 			'post_type'           => 'product',
@@ -330,7 +329,7 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		return self::wc_products( $args, 'product_category' );
+		return self::products( $args, 'product_category' );
 	}
 
 
@@ -426,29 +425,7 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		return self::wc_products( $args, 'recent_products' );
-	}
-
-	/**
-	 * List multiple products shortcode.
-	 *
-	 * @param array $deprecated
-	 * @return string
-	 */
-	public static function products( $deprecated ) {
-		if ( empty( $deprecated ) ) {
-			return '';
-		}
-
-		$args = shortcode_atts( array(
-			'columns' => '4',
-			'orderby' => 'title',
-			'order'   => 'asc',
-			'ids'     => '',
-			'skus'    => '',
-		), $deprecated, 'products' );
-
-		return self::wc_products( $args, 'products' );
+		return self::products( $args, 'recent_products' );
 	}
 
 	/**
@@ -468,7 +445,7 @@ class WC_Shortcodes {
 			$args['ids'] = $deprecated['id'];
 		}
 
-		return self::wc_products( $args, 'product' );
+		return self::products( $args, 'product' );
 	}
 
 	/**
@@ -581,7 +558,7 @@ class WC_Shortcodes {
 
 		$args['on_sale'] = true;
 
-		return self::wc_products( $args, 'sale_products' );
+		return self::products( $args, 'sale_products' );
 	}
 
 	/**
@@ -604,7 +581,7 @@ class WC_Shortcodes {
 
 		$args['orderby'] = 'popularity';
 
-		return self::wc_products( $args, 'best_selling_products' );
+		return self::products( $args, 'best_selling_products' );
 	}
 
 	/**
@@ -629,7 +606,7 @@ class WC_Shortcodes {
 
 		$args['orderby'] = 'rating';
 
-		return self::wc_products( $args, 'top_rated_products' );
+		return self::products( $args, 'top_rated_products' );
 	}
 
 	/**
@@ -654,7 +631,7 @@ class WC_Shortcodes {
 
 		$args['featured'] = 'true';
 
-		return self::wc_products( $args, 'featured_products' );
+		return self::products( $args, 'featured_products' );
 	}
 
 	/**
@@ -789,7 +766,7 @@ class WC_Shortcodes {
 		$args['attr_terms'] = $args['filter'];
 		unset( $args['filter'] );
 
-		return self::wc_products( $args, 'product_attribute' );
+		return self::products( $args, 'product_attribute' );
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -217,10 +217,11 @@ class WC_Shortcodes {
 		*/
 
 		if ( 'popularity' === $atts['orderby'] ) {
+			// can remove after get_catalog_ordering_args() is updated
 			$query_args['meta_key'] = 'total_sales';
 			$query_args['orderby'] = array(
 				'meta_value_num' => 'DESC',
-				'date' => 'DESC',
+				'post_date'      => 'DESC',
 			);
 		} else {
 			$ordering_args = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
@@ -423,10 +424,6 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		// Force to sorting by date for now.
-		// TODO: revist how recent products are chosen in the new shortcode.
-		$args['orderby'] = 'date';
-
 		return self::wc_products( $args );
 	}
 
@@ -603,8 +600,6 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		// Force to sorting by popularity for now.
-		// TODO: revist how best selling products are chosen in the new shortcode.
 		$args['orderby'] = 'popularity';
 
 		return self::wc_products( $args );
@@ -630,8 +625,6 @@ class WC_Shortcodes {
 		$args['cat_operator'] = $args['operator'];
 		unset( $args['operator'] );
 
-		// Force to sorting by rating for now.
-		// TODO: revist how top rated products are chosen in the new shortcode.
 		$args['orderby'] = 'rating';
 
 		return self::wc_products( $args );
@@ -818,3 +811,5 @@ class WC_Shortcodes {
 
 		return ob_get_clean();
 	}
+
+}

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -203,6 +203,7 @@ class WC_Shortcodes {
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
+			'no_found_rows'       => 1,
 			'orderby'             => $atts['orderby'], // defaults to 'menu_order title' later on.
 			'order'               => $atts['order'],
 			'posts_per_page'      => $atts['per_page'],

--- a/tests/unit-tests/shortcodes/shortcodes.php
+++ b/tests/unit-tests/shortcodes/shortcodes.php
@@ -1,0 +1,357 @@
+<?php
+
+/**
+ * Class WC_Shortcodes.
+ * @package WooCommerce\Tests\Shortcodes
+ */
+class WC_Tests_WC_Shortcodes extends WC_Unit_Test_Case {
+
+	/**
+	 * Test: WC_Shortcodes::products
+	 */
+	public function test_products() {
+
+		// Empty shortcode
+		$this->assertEquals( '', WC_Shortcodes::products( '' ) );
+	}
+
+	/**
+	 * Test: WC_Shortcodes::products_query_args
+	 */
+	public function test_products_query_args_defaults() {
+
+		$default_args = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'no_found_rows'       => 1,
+			'orderby'             => 'menu_order title', // default from WC()->query->get_catalog_ordering_args()
+			'order'               => 'DESC',
+			'posts_per_page'      => '1',
+			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_query'          => WC()->query->get_meta_query(),
+		);
+
+		// All of the default args should be the same
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'ids' => '99',
+			),
+			$default_args
+		) );
+
+		// orderby has been changed
+		$this->assertNotEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'date'
+			),
+			$default_args
+			) );
+	}
+
+	/**
+	 * Test: WC_Shortcodes::products_query_args
+	 */
+	public function test_products_query_args_ordering() {
+
+		// menu_order (falls back on title automatically)
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'menu_order',
+				'order'   => 'desc',
+			),
+			array(
+				'orderby' => 'menu_order title',
+				'order'   => 'DESC',
+			)
+		) );
+
+		// title
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'title',
+				'order'   => 'asc',
+			),
+			array(
+				'orderby' => 'title',
+				'order'   => 'ASC',
+			)
+		) );
+
+		// date (falls back on ID automatically)
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'date',
+				'order'   => 'asc',
+			),
+			array(
+				'orderby' => 'date ID',
+				'order'   => 'ASC',
+			)
+		) );
+
+		// random
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'rand',
+			),
+			array(
+				'orderby' => 'rand',
+			)
+		) );
+
+		// TODO: add price orderby
+
+		// popularity (overrides order)
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'popularity',
+				'order'   => 'asc',
+			),
+			array(
+				'meta_key' => 'total_sales',
+				'orderby'  => array(
+					'meta_value_num' => 'DESC',
+					'post_date'      => 'DESC',
+				),
+			)
+		) );
+
+		// rating
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'rating',
+				'order'   => 'desc',
+			),
+			array(
+				'meta_key' => '_wc_average_rating',
+				'orderby'  => array(
+					'meta_value_num' => 'DESC',
+					'ID'             => 'ASC',
+				),
+			)
+		) );
+
+		// id
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'id',
+				'order'   => 'asc',
+			),
+			array(
+				'orderby' => 'ID',
+				'order'   => 'ASC',
+			)
+		) );
+	}
+
+	/**
+	 * Test: WC_Shortcodes::products_query_args
+	 */
+	public function test_products_query_args_taxonomy() {
+
+		// Visibility tax query will always be present for now
+		$visibility = array(
+			'taxonomy' => 'product_visibility',
+			'field'    => 'term_taxonomy_id',
+			'operator' => 'NOT IN',
+		);
+
+		// visibility
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'orderby' => 'title',
+				'order'   => 'desc',
+			),
+			array(
+				'tax_query' => array( $visibility ),
+			)
+		) );
+
+		// category
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'category'     => '12, 19',
+				'cat_operator' => 'NOT IN',
+			),
+			array(
+				'tax_query' => array(
+					$visibility,
+					array(
+						'taxonomy' => 'product_cat',
+						'terms'    => array( 12, 19 ),
+						'field'    => 'slug',
+						'operator' => 'NOT IN',
+					)
+				),
+		)
+	) );
+
+		// featured
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'featured' => true,
+			),
+			array(
+				'tax_query' => array(
+					$visibility,
+					array(
+						'taxonomy' => 'product_visibility',
+						'terms'    => 'featured',
+						'field'    => 'name',
+						'operator' => 'IN',
+					)
+				),
+		)
+	) );
+
+		// attribute
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'attribute'     => 'color',
+				'attr_terms'    => 'black, white',
+				'attr_operator' => 'AND',
+			),
+			array(
+				'tax_query' => array(
+					$visibility,
+					array(
+						'taxonomy' => 'pa_color',
+						'terms'    => array( 'black', 'white' ),
+						'field'    => 'slug',
+						'operator' => 'AND'
+					)
+				),
+		)
+	) );
+	}
+
+	/**
+	 * Test: WC_Shortcodes::products_query_args
+	 */
+	public function test_products_query_args_misc() {
+
+		// Product SKUs
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'skus' => 'woo1, woo2',
+			),
+			array(
+				'meta_query' => array( array(
+				'key'        => '_sku',
+				'compare'    => 'IN',
+				'value'      => array( 'woo1', 'woo2' ),
+				) )
+		)
+	) );
+
+		// Product IDs
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'ids' => '97, 98',
+			),
+			array(
+				'post__in' => array( '97', '98' ),
+			)
+		) );
+
+		// on_sale
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'on_sale' => true,
+			),
+			array(
+				'post__in' => array_merge( array( 0 ), wc_get_product_ids_on_sale() ),
+				)
+			) );
+
+		// posts_per_page
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'limit' => '19',
+			),
+			array(
+				'posts_per_page' => '19',
+			)
+		) );
+
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'ids'   => '97, 98',
+				'skus'  => 'woo1, woo2',
+				'limit' => '1',
+			),
+			array(
+				'posts_per_page' => '4',
+			)
+		) );
+
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'ids'   => '97, 98',
+				'limit' => '-1',
+			),
+			array(
+				'posts_per_page' => '-1',
+			)
+		) );
+
+		$this->assertEmpty( $this->query_args_array_diff(
+			array(
+				'limit'    => '20',
+				'per_page' => '10'
+			),
+			array(
+				'posts_per_page' => '10',
+			)
+		) );
+	}
+
+	/**
+	 * Helper method for products_query_args array_diff checks.
+	 *
+	 * All of the $results array should be found based on what is
+	 * returned from the shortcodes atts query.
+	 *
+	 * @param array $shortcode_atts (what would have been passed into shortcode)
+	 * @param array $results (the resulting query args)
+	 * @return array
+	 */
+	private function query_args_array_diff( $shortcode_atts, $results ) {
+
+		$query_args = WC_Shortcodes::products_query_args( $shortcode_atts, 'products' );
+
+		return $this->array_diff_assoc_recursive( $results, $query_args );
+	 }
+
+	/**
+	 * Helper method to do a recursive array diff check.
+	 * http://php.net/manual/en/function.array-diff-assoc.php#73972
+	 *
+	 * @param array $array1
+	 * @param array $array2
+	 * @return array
+	 */
+	private function array_diff_assoc_recursive( $array1, $array2 ) {
+
+		foreach( $array1 as $key => $value ) {
+			if ( is_array( $value ) ) {
+				if ( ! isset( $array2[ $key ] ) ) {
+					$difference[ $key ] = $value;
+				} else if ( ! is_array( $array2[ $key ] ) ) {
+					$difference[ $key ] = $value;
+				} else {
+					$new_diff = $this->array_diff_assoc_recursive( $value, $array2[ $key ] );
+					if( $new_diff != FALSE ) {
+						$difference[ $key ] = $new_diff;
+					}
+				}
+			} else if ( ! isset( $array2[ $key ]) || $array2[ $key ] != $value ) {
+				$difference[ $key ] = $value;
+			}
+		}
+
+		return  ! isset( $difference ) ? 0 : $difference;
+	}
+
+}


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce/issues/15979

Still a WIP. Have a couple questions.

1) What is the preferred shortcode name? 

Went with `wc_products` for now, but could easily just use `products` while still maintaining backwards compat.

2) What are your thoughts on a `show_hidden` attribute?

Essentially enabling you to show products through the shortcode that are hidden by default in the catalog. I can see this being useful for private/hidden pages and membership type sites. Also useful if you really want to display a product in a special place, even when it's out of stock.

I started to implement this, but the content-product.php template wasn't playing nice. The `woocommerce_product_is_visible` filter could maybe be a workaround though.

3) Could we switch to `number` instead of `per_page` moving forward? per page has always caused confusion with users. They look for/want pagination. Then again, may be a non-issue once we are all-in w/ Gutenburg.

4) Can I update [get_catalog_ordering_args()](https://github.com/woocommerce/woocommerce/blob/cb0abd5483aedd2825712d1134a28cf395d1bee6/includes/class-wc-query.php#L489) in this branch to use an array of orderby args for the popularity option?

It wasn't available at the time, but it's been in WP core [for a while now](https://make.wordpress.org/core/2014/08/29/a-more-powerful-order-by-in-wordpress-4-0/). I also ran into a weird db issue when I had multiple shortcodes on one page when using get_catalog_ordering_args for popularity. Using this solved it:

```
$query_args['meta_key'] = 'total_sales';
$query_args['orderby'] = array(
	'meta_value_num' => 'DESC',
	'post_date'      => 'DESC',
);
```