### PR TITLE
Change how mapping is posted

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -311,7 +311,8 @@ class WC_Product_CSV_Importer_Controller {
 		}
 
 		if ( ! empty( $_POST['map_to'] ) ) {
-			$mapping = wp_unslash( $_POST['map_to'] );
+			$mapping_from = wp_unslash( $_POST['map_from'] );
+			$mapping_to   = wp_unslash( $_POST['map_to'] );
 		} else {
 			wp_redirect( esc_url_raw( $this->get_next_step_link( 'upload' ) ) );
 			exit;
@@ -319,7 +320,10 @@ class WC_Product_CSV_Importer_Controller {
 
 		wp_localize_script( 'wc-product-import', 'wc_product_import_params', array(
 			'import_nonce'    => wp_create_nonce( 'wc-product-import' ),
-			'mapping'         => $mapping,
+			'mapping'         => array(
+				'from' => $mapping_from,
+				'to'   => $mapping_to,
+			),
 			'file'            => $this->file,
 			'update_existing' => $this->update_existing,
 			'delimiter'       => $this->delimiter,

--- a/includes/admin/importers/views/html-csv-import-mapping.php
+++ b/includes/admin/importers/views/html-csv-import-mapping.php
@@ -30,7 +30,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<?php endif; ?>
 						</td>
 						<td class="wc-importer-mapping-table-field">
-							<select name="map_to[<?php echo esc_attr( $name ); ?>]">
+							<input type="hidden" name="map_from[<?php echo esc_attr( $index ); ?>]" value="<?php echo esc_attr( $name ); ?>" />
+							<select name="map_to[<?php echo esc_attr( $index ); ?>]">
 								<option value=""><?php esc_html_e( 'Do not import', 'woocommerce' ); ?></option>
 								<option value="">--------------</option>
 								<?php foreach ( $this->get_mapping_options( $mapped_value ) as $key => $value ) : ?>

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -44,6 +44,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		$this->params = wp_parse_args( $params, $default_args );
 		$this->file   = $file;
 
+		if ( isset( $this->params['mapping']['from'], $this->params['mapping']['to'] ) ) {
+			$this->params['mapping'] = array_combine( $this->params['mapping']['from'], $this->params['mapping']['to'] );
+		}
+
 		$this->read_file();
 	}
 


### PR DESCRIPTION
I debugged an install where mapping would not post if the key contained brackets. I’m thinking something is filtering it out as invalid on POST.

Fixed by posting them as values in 2 separate arrays.