### PR TITLE
Fixed typos.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
 env:
   - WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
 
-# Additonal tests against stable PHP (min recommended version is 5.6) and past supported versions of WP.
+# Additional tests against stable PHP (min recommended version is 5.6) and past supported versions of WP.
 matrix:
   include:
   - php: 5.6

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1377,7 +1377,7 @@
 * Fix - Use wc_get_order in simplify-commerce.
 * Fix - Use 'no' instead of boolean to disable PayPal gateway.
 * Fix - Do not escape redirect url in form handler - fixes malformed URLs.
-* Fix - Prevented non-existant pages from breaking cache helper.
+* Fix - Prevented non-existent pages from breaking cache helper.
 * Fix - Prevent sale prices showing errors in admin wrongly.
 * Fix - Prevent order statuses affecting other queries.
 * Fix - Removed deprecated get_page() functions.

--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -360,7 +360,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	}
 
 	/**
-	 * Core credit card form which gateways can used if needed. Deprecated - inheirt WC_Payment_Gateway_CC instead.
+	 * Core credit card form which gateways can used if needed. Deprecated - inherit WC_Payment_Gateway_CC instead.
 	 * @param  array $args
 	 * @param  array $fields
 	 */

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1587,7 +1587,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	}
 
 	/**
-	 * Returns whether or not the product has additonal options that need
+	 * Returns whether or not the product has additional options that need
 	 * selecting before adding to cart.
 	 *
 	 * @since  3.0.0

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -322,7 +322,7 @@ class WC_Admin_Post_Types {
 	}
 
 	/**
-	 * Ouput custom columns for products.
+	 * Output custom columns for products.
 	 *
 	 * @param string $column
 	 */

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -202,11 +202,11 @@ class WC_Admin_Setup_Wizard {
 	 * Output the steps.
 	 */
 	public function setup_wizard_steps() {
-		$ouput_steps = $this->steps;
-		array_shift( $ouput_steps );
+		$output_steps = $this->steps;
+		array_shift( $output_steps );
 		?>
 		<ol class="wc-setup-steps">
-			<?php foreach ( $ouput_steps as $step_key => $step ) : ?>
+			<?php foreach ( $output_steps as $step_key => $step ) : ?>
 				<li class="<?php
 					if ( $step_key === $this->step ) {
 						echo 'active';

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1017,7 +1017,7 @@ class WC_Helper {
 			return;
 		}
 
-		self::log( 'Auto-activated a subscripton for ' . $filename );
+		self::log( 'Auto-activated a subscription for ' . $filename );
 		self::_flush_subscriptions_cache();
 	}
 
@@ -1073,7 +1073,7 @@ class WC_Helper {
 		}
 
 		if ( $deactivated ) {
-			self::log( sprintf( 'Auto-deactivated %d subscripton(s) for %s', $deactivated, $filename ) );
+			self::log( sprintf( 'Auto-deactivated %d subscription(s) for %s', $deactivated, $filename ) );
 			self::_flush_subscriptions_cache();
 		}
 	}

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -110,7 +110,7 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 	}
 
 	/**
-	 * A list of avaiable tools for use in the system status section.
+	 * A list of available tools for use in the system status section.
 	 * 'button' becomes 'action' in the API.
 	 *
 	 * @return array

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -351,7 +351,7 @@ class WC_Checkout {
 	public function create_order_line_items( &$order, $cart ) {
 		foreach ( $cart->get_cart() as $cart_item_key => $values ) {
 			/**
-			 * Filter hook to get inital item object.
+			 * Filter hook to get initial item object.
 			 * @since 3.1.0
 			 */
 			$item                       = apply_filters( 'woocommerce_checkout_create_order_line_item_object', new WC_Order_Item_Product(), $cart_item_key, $values, $order );

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -23,7 +23,7 @@ class WC_Data_Store {
 	 * Format of object name => class name.
 	 * Example: 'product' => 'WC_Product_Data_Store_CPT'
 	 * You can also pass something like product_<type> for product stores and
-	 * that type will be used first when avaiable, if a store is requested like
+	 * that type will be used first when available, if a store is requested like
 	 * this and doesn't exist, then the store would fall back to 'product'.
 	 * Ran through `woocommerce_data_stores`.
 	 */

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -35,7 +35,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 
 	/**
 	 * Meta type. This should match up with
-	 * the types avaiable at https://codex.wordpress.org/Function_Reference/add_metadata.
+	 * the types available at https://codex.wordpress.org/Function_Reference/add_metadata.
 	 * WP defines 'post', 'user', 'comment', and 'term'.
 	 */
 	protected $meta_type = 'order_item';

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -489,7 +489,7 @@ class WC_Product_Variable extends WC_Product {
 	}
 
 	/**
-	 * Returns whether or not the product has additonal options that need
+	 * Returns whether or not the product has additional options that need
 	 * selecting before adding to cart.
 	 *
 	 * @since  3.0.0

--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_CLI_Runner {
 	/**
-	 * Endpoints to disable (meaning they will not be avaiable as CLI commands).
+	 * Endpoints to disable (meaning they will not be available as CLI commands).
 	 * Some of these can either be done via WP already, or are offered with
 	 * some other changes (like tools).
 	 */
@@ -86,7 +86,7 @@ class WC_CLI_Runner {
 
 	/**
 	 * Generates command information and tells WP CLI about all
-	 * commands avaiable from a route.
+	 * commands available from a route.
 	 *
 	 * @param string $rest_command
 	 * @param string $route

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -14,7 +14,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 
 	/**
 	 * Meta type. This should match up with
-	 * the types avaiable at https://codex.wordpress.org/Function_Reference/add_metadata.
+	 * the types available at https://codex.wordpress.org/Function_Reference/add_metadata.
 	 * WP defines 'post', 'user', 'comment', and 'term'.
 	 */
 	protected $meta_type = 'order_item';

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -360,7 +360,7 @@ class WC_Data_Store_WP {
 		}
 
 		// Meta dates are stored as timestamps in the db.
-		// Check against begining/end-of-day timestamps when using 'day' precision.
+		// Check against beginning/end-of-day timestamps when using 'day' precision.
 		if ( 'day' === $precision ) {
 			$start_timestamp = strtotime( gmdate( 'm/d/Y 00:00:00', $dates[0]->getTimestamp() ) );
 			$end_timestamp = '...' !== $operator ? ( $start_timestamp + DAY_IN_SECONDS ) : strtotime( gmdate( 'm/d/Y 00:00:00', $dates[1]->getTimestamp() ) );

--- a/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/includes/data-stores/class-wc-payment-token-data-store.php
@@ -207,7 +207,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Payment
 	}
 
 	/**
-	 * Returns an array of objects (stdObject) matching specific token critera.
+	 * Returns an array of objects (stdObject) matching specific token criteria.
 	 * Accepts token_id, user_id, gateway_id, and type.
 	 * Each object should contain the fields token_id, gateway_id, token, user_id, type, is_default.
 	 *

--- a/includes/interfaces/class-wc-payment-token-data-store-interface.php
+++ b/includes/interfaces/class-wc-payment-token-data-store-interface.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 interface WC_Payment_Token_Data_Store_Interface {
 	/**
-	 * Returns an array of objects (stdObject) matching specific token critera.
+	 * Returns an array of objects (stdObject) matching specific token criteria.
 	 * Accepts token_id, user_id, gateway_id, and type.
 	 * Each object should contain the fields token_id, gateway_id, token, user_id, type, is_default.
 	 * @param array $args

--- a/includes/theme-support/class-wc-twenty-seventeen.php
+++ b/includes/theme-support/class-wc-twenty-seventeen.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Twenty Seventeen suport.
+ * Twenty Seventeen support.
  *
  * @class   WC_Twenty_Seventeen
  * @since   2.6.9

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -206,7 +206,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
 
-		// non-existant customer
+		// non-existent customer
 		$request = new WP_REST_Request( 'POST', '/wc/v2/orders' );
 		$request->set_body_params( array(
 			'payment_method'       => 'bacs',

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -411,7 +411,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_price_thousand_separator() {
 		$separator = get_option( 'woocommerce_price_thousand_sep' );
 
-		// defualt value
+		// default value
 		$this->assertEquals( ',', wc_get_price_thousand_separator() );
 
 		update_option( 'woocommerce_price_thousand_sep', '.' );
@@ -431,7 +431,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_price_decimal_separator() {
 		$separator = get_option( 'woocommerce_price_decimal_sep' );
 
-		// defualt value
+		// default value
 		$this->assertEquals( '.', wc_get_price_decimal_separator() );
 
 		update_option( 'woocommerce_price_decimal_sep', ',' );
@@ -451,7 +451,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_price_decimals() {
 		$decimals = get_option( 'woocommerce_price_num_decimals' );
 
-		// defualt value
+		// default value
 		$this->assertEquals( 2, wc_get_price_decimals() );
 
 		update_option( 'woocommerce_price_num_decimals', '1' );

--- a/tests/unit-tests/settings/register-wp-admin-settings.php
+++ b/tests/unit-tests/settings/register-wp-admin-settings.php
@@ -3,7 +3,7 @@
 /**
  * Settings API: WP-Admin Helper Tests
  * Tests the helper class that makes settings (currently present in wp-admin)
- * avaiable to the REST API.
+ * available to the REST API.
  *
  * @package WooCommerce\Tests\Settings
  * @since 3.0.0


### PR DESCRIPTION
These typos are caught by [`misspell`](https://github.com/client9/misspell) program (could be handy to integrate with CI in the future).

```
find . -type f | grep -v assets | grep -v dummy-data | grep -v i18n | grep -v node_modules | grep -v .git | grep -v apigen |  xargs misspell -w
```

Some results are excluded because of 3rd party ownership and non-english sentences.