### PR TITLE
Add enclosure and escape arguments to importer. Introduce filter to change importer arguments

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -68,7 +68,7 @@ class WC_Product_CSV_Importer_Controller {
 	 */
 	public static function get_importer( $file, $args = array() ) {
 		$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
-		$args = apply_filters('woocommerce_product_csv_importer_args', $args, $importer_class);
+		$args = apply_filters( 'woocommerce_product_csv_importer_args', $args, $importer_class );
 		return new $importer_class( $file, $args );
 	}
 

--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -68,6 +68,7 @@ class WC_Product_CSV_Importer_Controller {
 	 */
 	public static function get_importer( $file, $args = array() ) {
 		$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
+		$args = apply_filters('woocommerce_product_csv_importer_args', $args, $importer_class);
 		return new $importer_class( $file, $args );
 	}
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -39,8 +39,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'update_existing'  => false, // Whether to update existing items.
 			'delimiter'        => ',', // CSV delimiter.
 			'prevent_timeouts' => true, // Check memory and time usage and abort if reaching limit.
-			'enclosure'        => '"', //The enclousure argument passed to fgetcsv.
-			'escape'           => '\\', //The escape argument passed to fgetcsv.
+			'enclosure'        => '"', // The character used to wrap text in the CSV.
+			'escape'           => '\\',
 		);
 
 		$this->params = wp_parse_args( $params, $default_args );

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -39,6 +39,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'update_existing'  => false, // Whether to update existing items.
 			'delimiter'        => ',', // CSV delimiter.
 			'prevent_timeouts' => true, // Check memory and time usage and abort if reaching limit.
+			'enclosure'        => '"', //The enclousure argument passed to fgetcsv.
+			'escape'           => '\\', //The escape argument passed to fgetcsv.
 		);
 
 		$this->params = wp_parse_args( $params, $default_args );
@@ -58,7 +60,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 */
 	protected function read_file() {
 		if ( false !== ( $handle = fopen( $this->file, 'r' ) ) ) {
-			$this->raw_keys = fgetcsv( $handle, 0, $this->params['delimiter'] );
+			$this->raw_keys = fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] );
 
 			// Remove BOM signature from the first item.
 			if ( isset( $this->raw_keys[0] ) ) {
@@ -69,7 +71,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				fseek( $handle, (int) $this->params['start_pos'] );
 			}
 
-			while ( false !== ( $row = fgetcsv( $handle, 0, $this->params['delimiter'] ) ) ) {
+			while ( false !== ( $row = fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ) ) ) {
 				$this->raw_data[]                                 = $row;
 				$this->file_positions[ count( $this->raw_data ) ] = ftell( $handle );
 


### PR DESCRIPTION
This PR is twofold. The first change introduces a new filter to change arguments passed to `WC_Product_CSV_Importer_Controller::get_importer()`. The second change introduces `enclosure` and `escape` arguments to `WC_Product_CSV_Importer` which get passed to `fgetcsv`.

Use case:  
A client is using a legacy inventory tracking system that has trouble outputting text and escaping correctly. We decided that the easiest way to create the import CSV file is to have the legacy system use backticks instead of quotes as the enclosure. I can then use `woocommerce_product_csv_importer_args` to change the enclosure arg to the backtick.

Possible workaround: I could create an additional separate system that converts the CSV from the legacy system into one WooCommerce expects, or I could write my own importer class, perhaps extending the base one and updating `read_file`.

Use case:
A user wants to change the arguments passed to an arbitrary importer class, whether that is a WooCommerce core class or provided by another plugin. The user can use `woocommerce_product_csv_importer_args` to filter and change the arguments passed to it.

Possible workaround: A user can create their own importer class and use `woocommerce_product_csv_importer_class` to change which class is used.