### PR TITLE
Fixed legacy arg mapping for wc_get_orders

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -38,8 +38,8 @@ function wc_get_orders( $args ) {
 	);
 
 	foreach ( $map_legacy as $from => $to ) {
-		if ( isset( $args[ $from ] ) ) {
-			$args[ $to ] = $args[ $from ];
+		if ( isset( $args[ $to ] ) ) {
+			$args[ $from ] = $args[ $to ];
 		}
 	}
 


### PR DESCRIPTION
Currently using any legacy arguments in the `wc_get_orders` method will just result in the arguments being ignored because they're not being mapped properly.