### PR TITLE
Change the "Rest of the World" zone name to "Locations not covered by your other zones" everywhere

### DIFF
--- a/includes/api/class-wc-rest-shipping-zone-locations-controller.php
+++ b/includes/api/class-wc-rest-shipping-zone-locations-controller.php
@@ -87,7 +87,7 @@ class WC_REST_Shipping_Zone_Locations_Controller extends WC_REST_Shipping_Zones_
 		}
 
 		if ( 0 === $zone->get_id() ) {
-			return new WP_Error( "woocommerce_rest_shipping_zone_locations_invalid_zone", __( 'The "rest of the world" zone cannot be updated.', 'woocommerce' ), array( 'status' => 403 ) );
+			return new WP_Error( "woocommerce_rest_shipping_zone_locations_invalid_zone", __( 'The "locations not covered by your other zones" zone cannot be updated.', 'woocommerce' ), array( 'status' => 403 ) );
 		}
 
 		$raw_locations = $request->get_json_params();

--- a/includes/api/class-wc-rest-shipping-zones-controller.php
+++ b/includes/api/class-wc-rest-shipping-zones-controller.php
@@ -167,7 +167,7 @@ class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_Controlle
 		}
 
 		if ( 0 === $zone->get_id() ) {
-			return new WP_Error( "woocommerce_rest_shipping_zone_invalid_zone", __( 'The "rest of the world" zone cannot be updated.', 'woocommerce' ), array( 'status' => 403 ) );
+			return new WP_Error( "woocommerce_rest_shipping_zone_invalid_zone", __( 'The "locations not covered by your other zones" zone cannot be updated.', 'woocommerce' ), array( 'status' => 403 ) );
 		}
 
 		$zone_changed = false;

--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -64,7 +64,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 		global $wpdb;
 		if ( 0 === $zone->get_id() || "0" === $zone->get_id() ) {
 			$this->read_zone_locations( $zone );
-			$zone->set_zone_name( __( 'Rest of the World', 'woocommerce' ) );
+			$zone->set_zone_name( __( 'Locations not covered by your other zones', 'woocommerce' ) );
 			$zone->read_meta_data();
 			$zone->set_object_read( true );
 			do_action( 'woocommerce_shipping_zone_loaded', $zone );

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -84,7 +84,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( count( $data ), 1 );
 		$this->assertContains( array(
 			'id'     => 0,
-			'name'   => 'Rest of the World',
+			'name'   => 'Locations not covered by your other zones',
 			'order'  => 0,
 			'_links' => array(
 				'self'       => array(


### PR DESCRIPTION
This addresses https://github.com/woocommerce/woocommerce/issues/15031 . The issue was supposed to be fixed in https://github.com/woocommerce/woocommerce/commit/eddcb16e00ac5977f358367772fd9ab8e34e3526 , but that only changed the name ot the `Rest of the World` zone in the zones list. The zone name as presented in the UI and returned by the API was still `Rest of the World`. See screenshot:
![rest-of-the-world](https://user-images.githubusercontent.com/1715800/27959337-f48e8258-631e-11e7-8977-6e1c8fcb518e.png)

This PR changes the `Rest of the World` name everywhere to `Locations not covered by your other zones`.

To test:
* Go to `Settings -> Shipping` and go edit the `Locations not covered by your other zones` zone.
* See that in the breadcrumbs, the `Locations not covered by your other zones` name is displayed.
* (Optional) Do an API request for `GET /wc/v2/shipping/zones`, confirm that the `id=0` zone has the correct name.