### PR TITLE
Remove race condition

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -273,15 +273,15 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			echo '</form>';
 
 			wc_enqueue_js( "
-				// Submit form on change if standard dropdown.
-				jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . ":not([multiple])' ).change( function() {
-					jQuery( this ).closest( 'form' ).submit();
-				});
-
 				// Update value on change.
 				jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).change( function() {
 					var slug = jQuery( this ).val();
 					jQuery( ':input[name=\"filter_" . esc_js( $taxonomy_filter_name ) . "\"]' ).val( slug );
+
+					// Submit form on change if standard dropdown.
+					if ( ! jQuery( this ).attr( 'multiple' ) ) {
+						jQuery( this ).closest( 'form' ).submit();
+					}
 				});
 
 				// Use Select2 enhancement if possible


### PR DESCRIPTION
The "Submit form on change" and "Update value on change" listeners are both hooked into the same events, so sometimes there is a race condition where the form gets submitted before the value is updated. I've removed this race condition.