### PR TITLE
Adjust variation name logic

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -245,7 +245,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$title_base                = get_post_field( 'post_title', $product->get_parent_id() );
 		$title_suffix              = $should_include_attributes ? wc_get_formatted_variation( $product, true, false ) : '';
 
-		return apply_filters( 'woocommerce_product_variation_title', rtrim( $title_base . $separator . $title_suffix, $separator ), $product, $title_base, $title_suffix );
+		return apply_filters( 'woocommerce_product_variation_title', $title_suffix ? $title_base . $separator . $title_suffix : $title_base, $product, $title_base, $title_suffix );
 	}
 
 	/**

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -376,8 +376,6 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
 				if ( ! is_wp_error( $term ) && ! empty( $term->name ) ) {
 					$value = $term->name;
 				}
-			} else {
-				$value = ucwords( str_replace( '-', ' ', $value ) );
 			}
 
 			if ( $include_names ) {

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -449,17 +449,17 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 		$one_attribute_variation = new WC_Product_Variation;
 		$one_attribute_variation->set_parent_id( $product->get_id() );
-		$one_attribute_variation->set_attributes( array( 'color' => 'green' ) );
+		$one_attribute_variation->set_attributes( array( 'color' => 'Green' ) );
 		$one_attribute_variation->save();
 
 		$two_attribute_variation = new WC_Product_Variation;
 		$two_attribute_variation->set_parent_id( $product->get_id() );
-		$two_attribute_variation->set_attributes( array( 'color' => 'green', 'size' => 'large' ) );
+		$two_attribute_variation->set_attributes( array( 'color' => 'Green', 'size' => 'Large' ) );
 		$two_attribute_variation->save();
 
 		$multiword_attribute_variation = new WC_Product_Variation;
 		$multiword_attribute_variation->set_parent_id( $product->get_id() );
-		$multiword_attribute_variation->set_attributes( array( 'color' => 'green', 'mounting-plate' => 'galaxy-s6', 'support' => 'one-year' ) );
+		$multiword_attribute_variation->set_attributes( array( 'color' => 'Green', 'mounting-plate' => 'galaxy-s6', 'support' => 'one-year' ) );
 		$multiword_attribute_variation->save();
 
 		// Check the one attribute variation title.


### PR DESCRIPTION
Changing the hyphen was not needed. We just need to stop adjusting text-based values.

I also found an issue with rtrim if you filter the separator, because rtrim filters out all chars, not the whole string.

Closes #15763