### PR TITLE
Fix “risky” rest api tests

### DIFF
--- a/tests/unit-tests/api/functions.php
+++ b/tests/unit-tests/api/functions.php
@@ -73,7 +73,7 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_rest_check_post_permissions() {
-		$this->isFalse( wc_rest_check_post_permissions( 'shop_order' ) );
+		$this->assertFalse( wc_rest_check_post_permissions( 'shop_order' ) );
 	}
 
 	/**
@@ -82,7 +82,7 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_rest_check_user_permissions() {
-		$this->isFalse( wc_rest_check_user_permissions() );
+		$this->assertFalse( wc_rest_check_user_permissions() );
 	}
 
 	/**
@@ -91,7 +91,7 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_rest_check_product_term_permissions() {
-		$this->isFalse( wc_rest_check_product_term_permissions( 'product_cat' ) );
+		$this->assertFalse( wc_rest_check_product_term_permissions( 'product_cat' ) );
 	}
 
 	/**
@@ -100,6 +100,6 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_rest_check_manager_permissions() {
-		$this->isFalse( wc_rest_check_manager_permissions( 'reports' ) );
+		$this->assertFalse( wc_rest_check_manager_permissions( 'reports' ) );
 	}
 }


### PR DESCRIPTION
I think this is right? Still learning about tests xD

Removes these notices:
```
WC_Tests_API_Functions::test_wc_rest_check_post_permissions
This test did not perform any assertions

WC_Tests_API_Functions::test_wc_rest_check_user_permissions
This test did not perform any assertions

WC_Tests_API_Functions::test_wc_rest_check_product_term_permissions
This test did not perform any assertions

WC_Tests_API_Functions::test_wc_rest_check_manager_permissions
This test did not perform any assertions
```