### PR TITLE
Add the "Terms and conditions" page to the api system status pages property

### DIFF
--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -888,6 +888,10 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				'option'    => 'woocommerce_myaccount_page_id',
 				'shortcode' => '[' . apply_filters( 'woocommerce_my_account_shortcode_tag', 'woocommerce_my_account' ) . ']',
 			),
+			_x( 'Terms and conditions', 'Page setting', 'woocommerce' ) => array(
+				'option'    => 'woocommerce_terms_page_id',
+				'shortcode' => '',
+			),
 		);
 
 		$pages_output = array();

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -184,7 +184,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/system_status' ) );
 		$data     = $response->get_data();
 		$pages    = $data['pages'];
-		$this->assertEquals( 4, count( $pages ) );
+		$this->assertEquals( 5, count( $pages ) );
 	}
 
 	/**


### PR DESCRIPTION
Simply adds the "Terms and conditions" page to the system status pages property.

The option is treated like other pages in the [dashboard](https://cl.ly/1o323z3x0K3L).

Similarly the response output returns the same as other pages e.g.

```
        {
            "page_name": "Terms and conditions",
            "page_id": "1035",
            "page_set": true,
            "page_exists": true,
            "page_visible": true,
            "shortcode": "",
            "shortcode_required": false,
            "shortcode_present": false
        }
```

I've also updated the unit tests to check for the extra page.

I wasn't sure if this is considered a feature request so didn't submit it to https://github.com/woocommerce/wc-api-dev. Let me know if it needs to go somewhere else.

Thanks.
