### PR TITLE
Fix deprecation notice from accessing order props directly

### DIFF
--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -165,8 +165,8 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 			$check_method = false;
 
 			if ( is_object( $order ) ) {
-				if ( $order->shipping_method ) {
-					$check_method = $order->shipping_method;
+				if ( $order->get_shipping_method() ) {
+					$check_method = $order->get_shipping_method();
 				}
 			} elseif ( empty( $chosen_shipping_methods ) || sizeof( $chosen_shipping_methods ) > 1 ) {
 				$check_method = false;


### PR DESCRIPTION
Notice results [from these lines](https://github.com/woocommerce/woocommerce/blob/429e4bfed18bed45b3492a423113246f48b88470/includes/gateways/cod/class-wc-gateway-cod.php#L167-L170)

<details><summary>Stack trace</summary>
<pre>
PHP Notice:  shipping_method was called <strong>incorrectly</strong>. Order properties should not be accessed directly. Backtrace: require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), include('/themes/storefront/template-fullwidth.php'), get_template_part, locate_template, load_template, require('/themes/storefront/content-page.php'), do_action('storefront_page'), WP_Hook->do_action, WP_Hook->apply_filters, storefront_page_content, the_content, apply_filters('the_content'), WP_Hook->apply_filters, do_shortcode, preg_replace_callback, do_shortcode_tag, WC_Shortcodes::checkout, WC_Shortcodes::shortcode_wrapper, WC_Shortcode_Checkout::output, WC_Shortcode_Checkout::order_pay, WC_Payment_Gateways->get_available_payment_gateways, WC_Gateway_COD->is_available, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.0.) in /wp-includes/functions.php on line 4139
PHP Stack trace:
PHP   1. {main}() /index.php:0
PHP   2. require() /index.php:17
PHP   3. require_once() /wp-blog-header.php:19
PHP   4. include() /wp-includes/template-loader.php:74
PHP   5. get_template_part() /wp-content/themes/storefront/template-fullwidth.php:19
PHP   6. locate_template() /wp-includes/general-template.php:167
PHP   7. load_template() /wp-includes/template.php:647
PHP   8. require() /wp-includes/template.php:690
PHP   9. do_action() /wp-content/themes/storefront/content-page.php:19
PHP  10. WP_Hook->do_action() /wp-includes/plugin.php:453
PHP  11. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:323
PHP  12. storefront_page_content() /wp-includes/class-wp-hook.php:298
PHP  13. the_content() /wp-content/themes/storefront/inc/storefront-template-functions.php:339
PHP  14. apply_filters() /wp-includes/post-template.php:240
PHP  15. WP_Hook->apply_filters() /wp-includes/plugin.php:203
PHP  16. do_shortcode() /wp-includes/class-wp-hook.php:298
PHP  17. preg_replace_callback() /wp-includes/shortcodes.php:223
PHP  18. do_shortcode_tag() /wp-includes/shortcodes.php:223
PHP  19. WC_Shortcodes::checkout() /wp-includes/shortcodes.php:345
PHP  20. WC_Shortcodes::shortcode_wrapper() /wp-content/plugins/woocommerce/includes/class-wc-shortcodes.php:150
PHP  21. WC_Shortcode_Checkout::output() /wp-content/plugins/woocommerce/includes/class-wc-shortcodes.php:73
PHP  22. WC_Shortcode_Checkout::order_pay() /wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php:60
PHP  23. WC_Payment_Gateways->get_available_payment_gateways() /wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php:123
PHP  24. WC_Gateway_COD->is_available() /wp-content/plugins/woocommerce/includes/class-wc-payment-gateways.php:154
PHP  25. WC_Abstract_Legacy_Order->__get() /wp-content/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php:169
PHP  26. wc_doing_it_wrong() /wp-content/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php:407
PHP  27. _doing_it_wrong() /wp-content/plugins/woocommerce/includes/wc-deprecated-functions.php:68
PHP  28. trigger_error() /wp-includes/functions.php:4139
</pre></details>