### PR TITLE
Improves cash on delivery logic when dealing with multiple methods

### DIFF
--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -150,48 +150,17 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 			return false;
 		}
 
-		// Check methods
+		// Only apply if all packages are being shipped via chosen method, or order is virtual.
 		if ( ! empty( $this->enable_for_methods ) && $needs_shipping ) {
-
-			// Only apply if all packages are being shipped via chosen methods, or order is virtual
-			$chosen_shipping_methods_session = WC()->session->get( 'chosen_shipping_methods' );
-
-			if ( isset( $chosen_shipping_methods_session ) ) {
-				$chosen_shipping_methods = array_unique( $chosen_shipping_methods_session );
-			} else {
-				$chosen_shipping_methods = array();
-			}
-
-			$check_method = false;
+			$chosen_shipping_methods = array();
 
 			if ( is_object( $order ) ) {
-				if ( $order->get_shipping_method() ) {
-					$check_method = $order->get_shipping_method();
-				}
-			} elseif ( empty( $chosen_shipping_methods ) || sizeof( $chosen_shipping_methods ) > 1 ) {
-				$check_method = false;
-			} elseif ( sizeof( $chosen_shipping_methods ) == 1 ) {
-				$check_method = $chosen_shipping_methods[0];
+				$chosen_shipping_methods = array_unique( array_map( 'wc_get_string_before_colon', $order->get_shipping_methods() ) );
+			} elseif ( $chosen_shipping_methods_session = WC()->session->get( 'chosen_shipping_methods' ) ) {
+				$chosen_shipping_methods = array_unique( array_map( 'wc_get_string_before_colon', $chosen_shipping_methods_session ) );
 			}
 
-			if ( ! $check_method ) {
-				return false;
-			}
-
-			if ( strstr( $check_method, ':' ) ) {
-				$check_method = current( explode( ':', $check_method ) );
-			}
-
-			$found = false;
-
-			foreach ( $this->enable_for_methods as $method_id ) {
-				if ( $check_method === $method_id ) {
-					$found = true;
-					break;
-				}
-			}
-
-			if ( ! $found ) {
+			if ( 0 < count( array_diff( $chosen_shipping_methods, $this->enable_for_methods ) ) ) {
 				return false;
 			}
 		}

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1139,3 +1139,17 @@ function wc_do_oembeds( $content ) {
 
 	return $content;
 }
+
+/**
+ * Get part of a string before :.
+ *
+ * Used for example in shipping methods ids where they take the format
+ * method_id:instance_id
+ *
+ * @since  3.2.0
+ * @param  string $string
+ * @return string
+ */
+function wc_get_string_before_colon( $string ) {
+	return trim( current( explode( ':', (string) $string ) ) );
+}


### PR DESCRIPTION
If an order has multiple shipping methods, check all against the
allowed methods using a simple array_diff.