### PR TITLE
Order note helper functions implementation

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -586,26 +586,19 @@ class WC_Admin_Post_Types {
 
 				if ( $post->comment_count ) {
 
-					// check the status of the post
-					$status = ( 'trash' !== $post->post_status ) ? '' : 'post-trashed';
-
-					remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-
-					$latest_notes = get_comments( array(
-						'post_id'   => $post->ID,
-						'number'    => 1,
-						'status'    => $status,
+					$latest_notes = wc_get_order_notes( array(
+						'order_id' => $post->ID,
+						'limit'    => 1,
+						'orderby'  => 'date_created_gmt',
 					) );
-
-					add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
 
 					$latest_note = current( $latest_notes );
 
-					if ( isset( $latest_note->comment_content ) && 1 == $post->comment_count ) {
-						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( $latest_note->comment_content ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
-					} elseif ( isset( $latest_note->comment_content ) ) {
+					if ( isset( $latest_note->content ) && 1 == $post->comment_count ) {
+						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( $latest_note->content ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
+					} elseif ( isset( $latest_note->content ) ) {
 						/* translators: %d: notes count */
-						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( $latest_note->comment_content . '<br/><small style="display:block">' . sprintf( _n( 'plus %d other note', 'plus %d other notes', ( $post->comment_count - 1 ), 'woocommerce' ), $post->comment_count - 1 ) . '</small>' ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
+						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( $latest_note->content . '<br/><small style="display:block">' . sprintf( _n( 'Plus %d other note', 'Plus %d other notes', ( $post->comment_count - 1 ), 'woocommerce' ), $post->comment_count - 1 ) . '</small>' ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';
 					} else {
 						/* translators: %d: notes count */
 						echo '<span class="note-on tips" data-tip="' . wc_sanitize_tooltip( sprintf( _n( '%d note', '%d notes', $post->comment_count, 'woocommerce' ), $post->comment_count ) ) . '">' . __( 'Yes', 'woocommerce' ) . '</span>';

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -26,18 +26,10 @@ class WC_Meta_Box_Order_Notes {
 		global $post;
 
 		$args = array(
-			'post_id'   => $post->ID,
-			'orderby'   => 'comment_ID',
-			'order'     => 'DESC',
-			'approve'   => 'approve',
-			'type'      => 'order_note',
+			'order_id' => $post->ID,
 		);
 
-		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-
-		$notes = get_comments( $args );
-
-		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
+		$notes = wc_get_order_notes( $args );
 
 		echo '<ul class="order_notes">';
 
@@ -46,20 +38,20 @@ class WC_Meta_Box_Order_Notes {
 			foreach ( $notes as $note ) {
 
 				$note_classes   = array( 'note' );
-				$note_classes[] = get_comment_meta( $note->comment_ID, 'is_customer_note', true ) ? 'customer-note' : '';
-				$note_classes[] = ( __( 'WooCommerce', 'woocommerce' ) === $note->comment_author ) ? 'system-note' : '';
+				$note_classes[] = $note->customer_note ? 'customer-note' : '';
+				$note_classes[] = 'system' === $note->added_by ? 'system-note' : '';
 				$note_classes   = apply_filters( 'woocommerce_order_note_class', array_filter( $note_classes ), $note );
 				?>
-				<li rel="<?php echo absint( $note->comment_ID ); ?>" class="<?php echo esc_attr( implode( ' ', $note_classes ) ); ?>">
+				<li rel="<?php echo absint( $note->id ); ?>" class="<?php echo esc_attr( implode( ' ', $note_classes ) ); ?>">
 					<div class="note_content">
-						<?php echo wpautop( wptexturize( wp_kses_post( $note->comment_content ) ) ); ?>
+						<?php echo wpautop( wptexturize( wp_kses_post( $note->content ) ) ); ?>
 					</div>
 					<p class="meta">
-						<abbr class="exact-date" title="<?php echo $note->comment_date; ?>"><?php printf( __( 'added on %1$s at %2$s', 'woocommerce' ), date_i18n( wc_date_format(), strtotime( $note->comment_date ) ), date_i18n( wc_time_format(), strtotime( $note->comment_date ) ) ); ?></abbr>
+						<abbr class="exact-date" title="<?php echo $note->date_created->date( 'y-m-d h:i:s' ); ?>"><?php printf( __( 'added on %1$s at %2$s', 'woocommerce' ), $note->date_created->date_i18n( wc_date_format() ), $note->date_created->date_i18n( wc_time_format() ) ); ?></abbr>
 						<?php
-						if ( __( 'WooCommerce', 'woocommerce' ) !== $note->comment_author ) :
+						if ( 'system' !== $note->added_by ) :
 							/* translators: %s: note author */
-							printf( ' ' . __( 'by %s', 'woocommerce' ), $note->comment_author );
+							printf( ' ' . __( 'by %s', 'woocommerce' ), $note->added_by );
 						endif;
 						?>
 						<a href="#" class="delete_note" role="button"><?php _e( 'Delete note', 'woocommerce' ); ?></a>

--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -1444,7 +1444,7 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 
 			// Force delete since trashed order notes could not be managed through comments list table
-			$result = wp_delete_comment( $note->comment_ID, true );
+			$result = wc_delete_order_note( $note->comment_ID );
 
 			if ( ! $result ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce' ), 500 );

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -1491,7 +1491,7 @@ class WC_API_Orders extends WC_API_Resource {
 			}
 
 			// Force delete since trashed order notes could not be managed through comments list table
-			$result = wp_delete_comment( $note->comment_ID, true );
+			$result = wc_delete_order_note( $note->comment_ID );
 
 			if ( ! $result ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce' ), 500 );

--- a/includes/api/v1/class-wc-rest-order-notes-controller.php
+++ b/includes/api/v1/class-wc-rest-order-notes-controller.php
@@ -310,7 +310,7 @@ class WC_REST_Order_Notes_V1_Controller extends WC_REST_Controller {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $note, $request );
 
-		$result = wp_delete_comment( $note->comment_ID, true );
+		$result = wc_delete_order_note( $note->comment_ID );
 
 		if ( ! $result ) {
 			return new WP_Error( 'woocommerce_rest_cannot_delete', sprintf( __( 'The %s cannot be deleted.', 'woocommerce' ), 'order_note' ), array( 'status' => 500 ) );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1137,7 +1137,7 @@ class WC_AJAX {
 		$note_id = (int) $_POST['note_id'];
 
 		if ( $note_id > 0 ) {
-			wp_delete_comment( $note_id );
+			wc_delete_order_note( $note_id );
 		}
 		wp_die();
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -884,7 +884,7 @@ function wc_get_order_note( $data ) {
 	return (object) apply_filters( 'woocommerce_get_order_note', array(
 		'id'            => (int) $data->comment_ID,
 		'date_created'  => wc_string_to_datetime( $data->comment_date ),
-		'note'          => $data->comment_content,
+		'content'       => $data->comment_content,
 		'customer_note' => (bool) get_comment_meta( $data->comment_ID, 'is_customer_note', true ),
 		'added_by'      => __( 'WooCommerce', 'woocommerce' ) === $data->comment_author ? 'system' : $data->comment_author,
 	), $data );

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -854,7 +854,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$note_id      = (int) $order->add_order_note( $note_content );
 		$expected     = array(
 			'id'            => $note_id,
-			'note'          => $note_content,
+			'content'       => $note_content,
 			'customer_note' => false,
 			'added_by'      => 'system',
 		);


### PR DESCRIPTION
I not changed the entire REST API because we have plans to remove most of our current legacy versions by 4.0. Starting 4.0 this helpers will be more useful having custom tables for order notes.

I changed `note` to `content` too, because does not make sense have `$note->note`.

Closes #15982