### PR TITLE
Fixed missing reviews in product_page shortcode with SKU

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -731,6 +731,9 @@ class WC_Shortcodes {
 		<?php
 		}
 
+		// For "is_single" to always make load comments_template() for reviews.
+		$single_product->is_single = true;
+
 		ob_start();
 
 		global $wp_query;


### PR DESCRIPTION
When quering with SKU, WP_Query does not set `is_single` as true and this
makes fail the check inside `comments_template()`.

Closes #16128