### PR TITLE
Fix typo in WooCommerce plugin

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -644,7 +644,7 @@ abstract class WC_Data {
 	}
 
 	/**
-	 * Sets a date prop whilst handling formatting and datatime objects.
+	 * Sets a date prop whilst handling formatting and datetime objects.
 	 *
 	 * @since 3.0.0
 	 * @param string $prop Name of prop to set.

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -616,7 +616,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Sets order tax (sum of cart and shipping tax). Used internaly only.
+	 * Sets order tax (sum of cart and shipping tax). Used internally only.
 	 *
 	 * @param string $value
 	 * @throws WC_Data_Exception

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -130,7 +130,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Get internal type. Should return string and *should be overridden* by child classes.
 	 *
-	 * The product_type property is deprecated but is used here for BW compat with child classes which may be defining product_type and not have a get_type method.
+	 * The product_type property is deprecated but is used here for BW compatibility with child classes which may be defining product_type and not have a get_type method.
 	 *
 	 * @since 3.0.0
 	 * @return string
@@ -1331,7 +1331,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Checks the product type.
 	 *
-	 * Backwards compat with downloadable/virtual.
+	 * Backwards compatibility with downloadable/virtual.
 	 *
 	 * @param string|array $type Array or string of types
 	 * @return bool

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -452,7 +452,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	}
 
 	/**
-	 * Get upsel IDs.
+	 * Get upsell IDs.
 	 *
 	 * @since 3.0.0
 	 * @param  string $context

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -326,7 +326,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 
 		$response = rest_ensure_response( $response );
 
-		// Store pagation values for headers then unset for count query.
+		// Store pagination values for headers then unset for count query.
 		$per_page = (int) $prepared_args['number'];
 		$page = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
 

--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -133,7 +133,7 @@ class WC_Admin_Reports {
 		}
 
 		$reports = apply_filters( 'woocommerce_admin_reports', $reports );
-		$reports = apply_filters( 'woocommerce_reports_charts', $reports ); // Backwards compat
+		$reports = apply_filters( 'woocommerce_reports_charts', $reports ); // Backwards compatibility.
 
 		foreach ( $reports as $key => $report_group ) {
 			if ( isset( $reports[ $key ]['charts'] ) ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Setup_Wizard {
 
-	/** @var string Currenct Step */
+	/** @var string Current Step */
 	private $step   = '';
 
 	/** @var array Steps for the setup wizard */

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -374,7 +374,7 @@ class WC_Helper {
 					), admin_url( 'admin.php' ) );
 
 					/* translators: %1$s: product name, %2$s: deactivate url */
-					$message = sprintf( __( 'Subscription for %1$s deactivated successfully. You will no longer receive updates for this product. <a href="%2$s">Click here</a> if you wish to deactive the plugin as well.', 'woocommerce' ),
+					$message = sprintf( __( 'Subscription for %1$s deactivated successfully. You will no longer receive updates for this product. <a href="%2$s">Click here</a> if you wish to deactivate the plugin as well.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>', esc_url( $deactivate_plugin_url ) );
 				}
 
@@ -835,7 +835,7 @@ class WC_Helper {
 		$plugins = get_plugins();
 		$woo_plugins = array();
 
-		// Back-compat for woothemes_queue_update().
+		// Backwards compatibility for woothemes_queue_update().
 		$_compat = array();
 		if ( ! empty( $GLOBALS['woothemes_queued_updates'] ) ) {
 			foreach ( $GLOBALS['woothemes_queued_updates'] as $_compat_plugin ) {
@@ -880,7 +880,7 @@ class WC_Helper {
 		foreach ( $themes as $theme ) {
 			$header = $theme->get( 'Woo' );
 
-			// Back-compat for theme_info.txt
+			// Backwards compatibility for theme_info.txt
 			if ( ! $header ) {
 				$txt = $theme->get_stylesheet_directory() . '/theme_info.txt';
 				if ( is_readable( $txt ) ) {

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -32,7 +32,7 @@ class WC_Meta_Box_Product_Images {
 					if ( metadata_exists( 'post', $post->ID, '_product_image_gallery' ) ) {
 						$product_image_gallery = get_post_meta( $post->ID, '_product_image_gallery', true );
 					} else {
-						// Backwards compat
+						// Backwards compatibility.
 						$attachment_ids = get_posts( 'post_parent=' . $post->ID . '&numberposts=-1&post_type=attachment&orderby=menu_order&order=ASC&post_mime_type=image&fields=ids&meta_key=_woocommerce_exclude_image&meta_value=0' );
 						$attachment_ids = array_diff( $attachment_ids, array( get_post_thumbnail_id() ) );
 						$product_image_gallery = implode( ',', $attachment_ids );

--- a/includes/api/class-wc-rest-authentication.php
+++ b/includes/api/class-wc-rest-authentication.php
@@ -92,7 +92,7 @@ class WC_REST_Authentication {
 	 * @return WP_Error|null|bool
 	 */
 	public function check_authentication_error( $error ) {
-		// Passthrough other errors.
+		// Pass through other errors.
 		if ( ! empty( $error ) ) {
 			return $error;
 		}
@@ -103,7 +103,7 @@ class WC_REST_Authentication {
 	/**
 	 * Set authentication error.
 	 *
-	 * @param WP_Error $error Authication error data.
+	 * @param WP_Error $error Authentication error data.
 	 */
 	protected function set_error( $error ) {
 		// Reset user.

--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -240,7 +240,7 @@ class WC_REST_Coupons_Controller extends WC_REST_Legacy_Coupons_Controller {
 	}
 
 	/**
-	 * Only reutrn writeable props from schema.
+	 * Only return writable props from schema.
 	 *
 	 * @param  array $schema
 	 * @return bool

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -394,7 +394,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 	}
 
 	/**
-	 * Only reutrn writeable props from schema.
+	 * Only return writable props from schema.
 	 *
 	 * @param  array $schema
 	 * @return bool

--- a/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
@@ -215,7 +215,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 		 * The dynamic portion of the hook name, $this->post_type, refers to post_type of the post being
 		 * prepared for the response.
 		 *
-		 * @param WC_Order           $order      The prder object.
+		 * @param WC_Order           $order      The Order object.
 		 * @param WP_REST_Request    $request    Request object.
 		 */
 		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}", $order, $request );

--- a/includes/api/legacy/v1/class-wc-api-authentication.php
+++ b/includes/api/legacy/v1/class-wc-api-authentication.php
@@ -293,7 +293,7 @@ class WC_API_Authentication {
 	 *
 	 * @since 2.1
 	 * @see rawurlencode()
-	 * @param array $parameters un-normalized pararmeters
+	 * @param array $parameters un-normalized parameters
 	 * @return array normalized parameters
 	 */
 	private function normalize_parameters( $parameters ) {

--- a/includes/api/legacy/v2/class-wc-api-authentication.php
+++ b/includes/api/legacy/v2/class-wc-api-authentication.php
@@ -291,7 +291,7 @@ class WC_API_Authentication {
 	 *
 	 * @since 2.1
 	 * @see rawurlencode()
-	 * @param array $parameters un-normalized pararmeters
+	 * @param array $parameters un-normalized parameters
 	 * @return array normalized parameters
 	 */
 	private function normalize_parameters( $parameters ) {

--- a/includes/api/legacy/v2/class-wc-api-customers.php
+++ b/includes/api/legacy/v2/class-wc-api-customers.php
@@ -608,7 +608,7 @@ class WC_API_Customers extends WC_API_Resource {
 			$query_args['order'] = $args['order'];
 		}
 
-		// Orderby
+		// Order by
 		if ( ! empty( $args['orderby'] ) ) {
 			$query_args['orderby'] = $args['orderby'];
 

--- a/includes/api/legacy/v3/class-wc-api-authentication.php
+++ b/includes/api/legacy/v3/class-wc-api-authentication.php
@@ -290,7 +290,7 @@ class WC_API_Authentication {
 	 *
 	 * @since 2.1
 	 * @see rawurlencode()
-	 * @param array $parameters un-normalized pararmeters
+	 * @param array $parameters un-normalized parameters
 	 * @return array normalized parameters
 	 */
 	private function normalize_parameters( $parameters ) {

--- a/includes/api/legacy/v3/class-wc-api-customers.php
+++ b/includes/api/legacy/v3/class-wc-api-customers.php
@@ -598,7 +598,7 @@ class WC_API_Customers extends WC_API_Resource {
 			$query_args['order'] = $args['order'];
 		}
 
-		// Orderby
+		// Order by
 		if ( ! empty( $args['orderby'] ) ) {
 			$query_args['orderby'] = $args['orderby'];
 

--- a/includes/api/legacy/v3/class-wc-api-taxes.php
+++ b/includes/api/legacy/v3/class-wc-api-taxes.php
@@ -297,7 +297,7 @@ class WC_API_Taxes extends WC_API_Resource {
 					continue;
 				}
 
-				// Fix compund and shipping values
+				// Fix compound and shipping values
 				if ( in_array( $key, array( 'compound', 'shipping' ) ) ) {
 					$value = $value ? 1 : 0;
 				}

--- a/includes/api/v1/class-wc-rest-coupons-controller.php
+++ b/includes/api/v1/class-wc-rest-coupons-controller.php
@@ -219,7 +219,7 @@ class WC_REST_Coupons_V1_Controller extends WC_REST_Posts_Controller {
 	}
 
 	/**
-	 * Only reutrn writeable props from schema.
+	 * Only return writable props from schema.
 	 * @param  array $schema
 	 * @return bool
 	 */

--- a/includes/api/v1/class-wc-rest-customers-controller.php
+++ b/includes/api/v1/class-wc-rest-customers-controller.php
@@ -279,7 +279,7 @@ class WC_REST_Customers_V1_Controller extends WC_REST_Controller {
 
 		$response = rest_ensure_response( $users );
 
-		// Store pagation values for headers then unset for count query.
+		// Store pagination values for headers then unset for count query.
 		$per_page = (int) $prepared_args['number'];
 		$page = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
 

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -513,7 +513,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 	}
 
 	/**
-	 * Only reutrn writeable props from schema.
+	 * Only return writable props from schema.
 	 * @param  array $schema
 	 * @return bool
 	 */

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -496,7 +496,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 		 * The dynamic portion of the hook name, $this->post_type, refers to post_type of the post being
 		 * prepared for the response.
 		 *
-		 * @param WC_Order           $order      The prder object.
+		 * @param WC_Order           $order      The order object.
 		 * @param WP_REST_Request    $request    Request object.
 		 */
 		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}", $order, $request );

--- a/includes/api/v1/class-wc-rest-taxes-controller.php
+++ b/includes/api/v1/class-wc-rest-taxes-controller.php
@@ -252,14 +252,14 @@ class WC_REST_Taxes_V1_Controller extends WC_REST_Controller {
 
 		$response = rest_ensure_response( $taxes );
 
-		// Store pagation values for headers then unset for count query.
+		// Store pagination values for headers then unset for count query.
 		$per_page = (int) $prepared_args['number'];
 		$page = ceil( ( ( (int) $prepared_args['offset'] ) / $per_page ) + 1 );
 
 		// Query only for ids.
 		$wpdb->get_results( str_replace( 'SELECT *', 'SELECT tax_rate_id', $query ) );
 
-		// Calcule totals.
+		// Calculate totals.
 		$total_taxes = (int) $wpdb->num_rows;
 		$response->header( 'X-WP-Total', (int) $total_taxes );
 		$max_pages = ceil( $total_taxes / $per_page );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -592,7 +592,7 @@ class WC_AJAX {
 		$variation_object->set_parent_id( $product_id );
 		$variation_id     = $variation_object->save();
 		$variation        = get_post( $variation_id );
-		$variation_data   = array_merge( array_map( 'maybe_unserialize', get_post_custom( $variation_id ) ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compat.
+		$variation_data   = array_merge( array_map( 'maybe_unserialize', get_post_custom( $variation_id ) ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
 		include( 'admin/meta-boxes/views/html-variation-admin.php' );
 		wp_die();
 	}
@@ -1040,7 +1040,7 @@ class WC_AJAX {
 		// Save order items first
 		wc_save_order_items( $order_id, $items );
 
-		// Grab the order and recalc taxes
+		// Grab the order and recalculate taxes
 		$order = wc_get_order( $order_id );
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
@@ -1654,7 +1654,7 @@ class WC_AJAX {
 			foreach ( $variations as $variation_object ) {
 				$variation_id   = $variation_object->get_id();
 				$variation      = get_post( $variation_id );
-				$variation_data = array_merge( array_map( 'maybe_unserialize', get_post_custom( $variation_id ) ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compat.
+				$variation_data = array_merge( array_map( 'maybe_unserialize', get_post_custom( $variation_id ) ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
 				include( 'admin/meta-boxes/views/html-variation-admin.php' );
 				$loop++;
 			}

--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -379,7 +379,7 @@ class WC_Auth {
 		} catch ( Exception $e ) {
 			$this->maybe_delete_key( $consumer_data );
 
-			/* translators: %s: error messase */
+			/* translators: %s: error message */
 			wp_die( sprintf( __( 'Error: %s.', 'woocommerce' ), $e->getMessage() ), __( 'Access denied', 'woocommerce' ), array( 'response' => 401 ) );
 		}
 	}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1339,7 +1339,7 @@ class WC_Cart {
 
 			/**
 			 * Store costs + taxes for lines. For tax inclusive prices, we do some extra rounding logic so the stored
-			 * values "add up" when viewing the order in admin. This does have the disadvatage of not being able to
+			 * values "add up" when viewing the order in admin. This does have the disadvantage of not being able to
 			 * recalculate the tax total/subtotal accurately in the future, but it does ensure the data looks correct.
 			 *
 			 * Tax exclusive prices are not affected.

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -316,7 +316,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Get minium spend amount.
+	 * Get minimum spend amount.
 	 * @since  3.0.0
 	 * @param  string $context
 	 * @return float

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -665,7 +665,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	*/
 
 	/**
-	 * Developers can programically return coupons. This function will read those values into our WC_Coupon class.
+	 * Developers can programmatically return coupons. This function will read those values into our WC_Coupon class.
 	 * @since  3.0.0
 	 * @param  string $code  Coupon code
 	 * @param  array $coupon Array of coupon properties
@@ -929,7 +929,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Cart discounts cannot be added if non-eligble product is found in cart.
+	 * Cart discounts cannot be added if non-eligible product is found in cart.
 	 */
 	private function validate_cart_excluded_items() {
 		if ( ! $this->is_type( wc_get_product_coupon_types() ) ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -40,7 +40,7 @@ class WC_Form_Handler {
 	}
 
 	/**
-	 * Remove key and login from querystring, set cookie, and redirect to account page to show the form.
+	 * Remove key and login from query string, set cookie, and redirect to account page to show the form.
 	 */
 	public static function redirect_reset_password_link() {
 		if ( is_account_page() && ! empty( $_GET['key'] ) && ! empty( $_GET['login'] ) ) {

--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -131,7 +131,7 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	| Array Access Methods
 	|--------------------------------------------------------------------------
 	|
-	| For backwards compat with legacy arrays.
+	| For backwards compatibility with legacy arrays.
 	|
 	*/
 

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -188,7 +188,7 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	| Array Access Methods
 	|--------------------------------------------------------------------------
 	|
-	| For backwards compat with legacy arrays.
+	| For backwards compatibility with legacy arrays.
 	|
 	*/
 

--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -37,7 +37,7 @@ class WC_Order_Item_Meta {
 	public function __construct( $item = array(), $product = null ) {
 		wc_deprecated_function( 'WC_Order_Item_Meta::__construct', '3.1', 'WC_Order_Item_Product' );
 
-		// Backwards (pre 2.4) compat
+		// Backwards (pre 2.4) compatibility
 		if ( ! isset( $item['item_meta'] ) ) {
 			$this->legacy = true;
 			$this->meta   = array_filter( (array) $item );

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -397,7 +397,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	| Array Access Methods
 	|--------------------------------------------------------------------------
 	|
-	| For backwards compat with legacy arrays.
+	| For backwards compatibility with legacy arrays.
 	|
 	*/
 

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -205,7 +205,7 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	| Array Access Methods
 	|--------------------------------------------------------------------------
 	|
-	| For backwards compat with legacy arrays.
+	| For backwards compatibility with legacy arrays.
 	|
 	*/
 

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -215,7 +215,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	| Array Access Methods
 	|--------------------------------------------------------------------------
 	|
-	| For backwards compat with legacy arrays.
+	| For backwards compatibility with legacy arrays.
 	|
 	*/
 

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -219,7 +219,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	| Array Access Methods
 	|--------------------------------------------------------------------------
 	|
-	| For backwards compat with legacy arrays.
+	| For backwards compatibility with legacy arrays.
 	|
 	*/
 

--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -122,7 +122,7 @@ class WC_Product_External extends WC_Product {
 	}
 
 	/**
-	 * xternal products cannot be backordered.
+	 * External products cannot be backordered.
 	 *
 	 * @since 3.0.0
 	 * @param string $backorders Options: 'yes', 'no' or 'notify'.

--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -162,7 +162,7 @@ class WC_Product_Grouped extends WC_Product {
 	 * upwards (from child to parent) when the variation is saved.
 	 *
 	 * @param WC_Product|int $product Product object or ID for which you wish to sync.
-	 * @param bool $save If true, the prouduct object will be saved to the DB before returning it.
+	 * @param bool $save If true, the product object will be saved to the DB before returning it.
 	 * @return WC_Product Synced product object.
 	 */
 	public static function sync( $product, $save = true ) {

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -538,7 +538,7 @@ class WC_Product_Variable extends WC_Product {
 	 * Sync parent stock status with the status of all children and save.
 	 *
 	 * @param WC_Product|int $product Product object or ID for which you wish to sync.
-	 * @param bool $save If true, the prouduct object will be saved to the DB before returning it.
+	 * @param bool $save If true, the product object will be saved to the DB before returning it.
 	 * @return WC_Product Synced product object.
 	 */
 	public static function sync_stock_status( $product, $save = true ) {

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -516,7 +516,7 @@ class WC_Query {
 	}
 
 	/**
-	 * WP Core doens't let us change the sort direction for invidual orderby params - https://core.trac.wordpress.org/ticket/17065.
+	 * WP Core doens't let us change the sort direction for individual orderby params - https://core.trac.wordpress.org/ticket/17065.
 	 *
 	 * This lets us sort by meta value desc, and have a second orderby param.
 	 *

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -82,7 +82,7 @@ class WC_Shipping_Zones {
 	 *
 	 * @param $instance_id
 	 *
-	 * @return bool|WC_Shipping_Meethod
+	 * @return bool|WC_Shipping_Method
 	 */
 	public static function get_shipping_method( $instance_id ) {
 		$data_store          = WC_Data_Store::load( 'shipping-zone' );

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -558,7 +558,7 @@ class WC_Tax {
 				// This will be per order shipping - loop through the order and find the highest tax class rate
 				$cart_tax_classes = WC()->cart->get_cart_item_tax_classes();
 
-				// If multiple classes are found, use the first one found unless a standard rate item is found. This will be the first listed in the 'additonal tax class' section.
+				// If multiple classes are found, use the first one found unless a standard rate item is found. This will be the first listed in the 'additional tax class' section.
 				if ( sizeof( $cart_tax_classes ) > 1 && ! in_array( '', $cart_tax_classes ) ) {
 					$tax_classes = self::get_tax_class_slugs();
 

--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -94,7 +94,7 @@ class WC_CLI_REST_Command {
 	}
 
 	/**
-	 * Peturns an ID of supported ID arguments (things like product_id, order_id, etc) that we should look for in addition to id.
+	 * Returns an ID of supported ID arguments (things like product_id, order_id, etc) that we should look for in addition to id.
 	 *
 	 * @return array
 	 */

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -137,7 +137,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	public function save_item_data( &$item ) {}
 
 	/**
-	 * Clear meta cachce.
+	 * Clear meta cache.
 	 *
 	 * @param WC_Order_Item $item
 	 */

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -227,7 +227,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 
 	/**
 	 * Create unique cache key based on the tax location (affects displayed/cached prices), product version and active price filters.
-	 * DEVELOPERS should filter this hash if offering conditonal pricing to keep it unique.
+	 * DEVELOPERS should filter this hash if offering conditional pricing to keep it unique.
 	 *
 	 * @since  3.0.0
 	 * @param  WC_Product

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -36,7 +36,7 @@ class WC_Email_Customer_Completed_Order extends WC_Email {
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_completed_notification', array( $this, 'trigger' ), 10, 2 );
 
-		// Call parent constuctor
+		// Call parent constructor
 		parent::__construct();
 	}
 

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -48,7 +48,7 @@ class WC_Email_Customer_Refunded_Order extends WC_Email {
 		add_action( 'woocommerce_order_fully_refunded_notification', array( $this, 'trigger_full' ), 10, 2 );
 		add_action( 'woocommerce_order_partially_refunded_notification', array( $this, 'trigger_partial' ), 10, 2 );
 
-		// Call parent constuctor
+		// Call parent constructor.
 		parent::__construct();
 	}
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -49,7 +49,7 @@ class WC_Email extends WC_Settings_API {
 	 * Default heading.
 	 *
 	 * Supported for backwards compatibility but we recommend overloading the
-	 * get_default_x methods instead so localication can be done when needed.
+	 * get_default_x methods instead so localization can be done when needed.
 	 *
 	 * @var string
 	 */
@@ -59,7 +59,7 @@ class WC_Email extends WC_Settings_API {
 	 * Default subject.
 	 *
 	 * Supported for backwards compatibility but we recommend overloading the
-	 * get_default_x methods instead so localication can be done when needed.
+	 * get_default_x methods instead so localization can be done when needed.
 	 *
 	 * @var string
 	 */

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -36,7 +36,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	protected $enable_meta_export = false;
 
 	/**
-	 * Which product types are beign exported.
+	 * Which product types are being exported.
 	 * @var array
 	 */
 	protected $product_types_to_export = array();

--- a/includes/gateways/simplify-commerce/includes/Simplify/Constants.php
+++ b/includes/gateways/simplify-commerce/includes/Simplify/Constants.php
@@ -52,7 +52,7 @@ class Simplify_Constants
 	const API_BASE_SANDBOX_URL = 'https://sandbox.simplify.com/v1/api';
 
 	/**
-	 * @var string OAUTH_BASE_URL URL for the oauth enpoint
+	 * @var string OAUTH_BASE_URL URL for the oauth endpoint
 	 */
 	const OAUTH_BASE_URL = 'https://www.simplify.com/commerce/oauth';
 }

--- a/includes/gateways/simplify-commerce/includes/Simplify/Event.php
+++ b/includes/gateways/simplify-commerce/includes/Simplify/Event.php
@@ -36,7 +36,7 @@ class Simplify_Event extends Simplify_Object {
 	/**
 	 * Creates an Event object
 	 * @param     array $hash A map of parameters; valid keys are:
-	 *     <dt><code>paylod</code></dt>    <dd>The raw JWS payload. </dd> <strong>required</strong>
+	 *     <dt><code>payload</code></dt>    <dd>The raw JWS payload. </dd> <strong>required</strong>
 	 *     <dt><code>url</code></dt>    <dd>The URL for the webhook.  If present it must match the URL registered for the webhook.</dd>
 	 * @param  $authentication Object that contains the API public and private keys.  If null the values of the static
 	 *         Simplify::$publicKey and Simplify::$privateKey will be used.
@@ -53,7 +53,7 @@ class Simplify_Event extends Simplify_Object {
 		$jsonObject = $paymentsApi->jwsDecode($hash, $authentication);
 
 		if ($jsonObject['event'] == null) {
-			throw new InvalidArgumentException("Incorect data in webhook event");
+			throw new InvalidArgumentException("Incorrect data in webhook event");
 		}
 
 		return  $paymentsApi->convertFromHashToObject($jsonObject['event'], self::getClazz());

--- a/includes/gateways/simplify-commerce/includes/Simplify/Http.php
+++ b/includes/gateways/simplify-commerce/includes/Simplify/Http.php
@@ -394,7 +394,7 @@ class Simplify_HTTP
 					break;
 			case 3: $s = $s . "=";
 					break;
-			default: throw new InvalidArgumentException('incorrecly formatted JWS payload');
+			default: throw new InvalidArgumentException('incorrectly formatted JWS payload');
 		}
 		return base64_decode(str_replace(array('-', '_'), array('+', '/'), $s));
 	}

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -471,7 +471,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 			// Check if attribute handle variations.
 			if ( isset( $parent_attributes[ $attribute_name ] ) && ! $parent_attributes[ $attribute_name ]->get_variation() ) {
-				// Re-create the attribute to CRUD save and genarate again.
+				// Re-create the attribute to CRUD save and generate again.
 				$parent_attributes[ $attribute_name ] = clone $parent_attributes[ $attribute_name ];
 				$parent_attributes[ $attribute_name ]->set_variation( 1 );
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -228,7 +228,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
-	 * Parse reletive comma-delineated field and return product ID.
+	 * Parse relative comma-delineated field and return product ID.
 	 *
 	 * @param string $field Field value.
 	 * @return array

--- a/includes/legacy/abstract-wc-legacy-order.php
+++ b/includes/legacy/abstract-wc-legacy-order.php
@@ -158,7 +158,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 			}
 		}
 
-		// Handly qty if set
+		// Handle qty if set.
 		if ( isset( $args['qty'] ) ) {
 			if ( $product->backorders_require_notification() && $product->is_on_backorder( $args['qty'] ) ) {
 				$item->add_meta_data( apply_filters( 'woocommerce_backordered_item_meta_name', __( 'Backordered', 'woocommerce' ) ), $args['qty'] - max( 0, $product->get_stock_quantity() ), true );

--- a/includes/legacy/abstract-wc-legacy-product.php
+++ b/includes/legacy/abstract-wc-legacy-product.php
@@ -681,7 +681,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	}
 
 	/**
-	 * @deprected 3.0.0 Sync is taken care of during save - no need to call this directly.
+	 * @deprecated 3.0.0 Sync is taken care of during save - no need to call this directly.
 	 */
 	public function grouped_product_sync() {
 		wc_deprecated_function( 'WC_Product::grouped_product_sync', '3.0' );

--- a/includes/libraries/class-wc-eval-math.php
+++ b/includes/libraries/class-wc-eval-math.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 					return self::trigger( "illegal character '_'" ); // but not in the input expression
 					// ===============
 				} elseif ( ( in_array( $op, $ops ) or $ex ) and $expecting_op ) { // are we putting an operator on the stack?
-					if ( $ex ) { // are we expecting an operator but have a number/variable/function/opening parethesis?
+					if ( $ex ) { // are we expecting an operator but have a number/variable/function/opening parenthesis?
 						$op = '*';
 						$index--; // it's an implicit multiplication
 					}

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -283,7 +283,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Rotate log files.
 	 *
-	 * Logs are rotatated by prepending '.x' to the '.log' suffix.
+	 * Logs are rotated by prepending '.x' to the '.log' suffix.
 	 * The current log plus 10 historical logs are maintained.
 	 * For example:
 	 *     base.9.log -> [ REMOVED ]

--- a/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Flat Rate Shipping Method.
  *
- * This class is here for backwards commpatility for methods existing before zones existed.
+ * This class is here for backwards compatibility for methods existing before zones existed.
  *
  * @deprecated  2.6.0
  * @version		2.4.0

--- a/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
+++ b/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Free Shipping Method.
  *
- * This class is here for backwards commpatility for methods existing before zones existed.
+ * This class is here for backwards compatibility for methods existing before zones existed.
  *
  * @deprecated  2.6.0
  * @version 2.4.0

--- a/includes/shipping/legacy-international-delivery/class-wc-shipping-legacy-international-delivery.php
+++ b/includes/shipping/legacy-international-delivery/class-wc-shipping-legacy-international-delivery.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * International Delivery - Based on the Flat Rate Shipping Method.
  *
- * This class is here for backwards commpatility for methods existing before zones existed.
+ * This class is here for backwards compatibility for methods existing before zones existed.
  *
  * @deprecated  2.6.0
  * @version		2.4.0

--- a/includes/shipping/legacy-local-delivery/class-wc-shipping-legacy-local-delivery.php
+++ b/includes/shipping/legacy-local-delivery/class-wc-shipping-legacy-local-delivery.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Local Delivery Shipping Method.
  *
- * This class is here for backwards commpatility for methods existing before zones existed.
+ * This class is here for backwards compatibility for methods existing before zones existed.
  *
  * @deprecated  2.6.0
  * @version		2.3.0

--- a/includes/shipping/legacy-local-pickup/class-wc-shipping-legacy-local-pickup.php
+++ b/includes/shipping/legacy-local-pickup/class-wc-shipping-legacy-local-pickup.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Local Pickup Shipping Method.
  *
- * This class is here for backwards commpatility for methods existing before zones existed.
+ * This class is here for backwards compatibility for methods existing before zones existed.
  *
  * @deprecated  2.6.0
  * @version		2.3.0

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -39,7 +39,7 @@ class WC_Shortcode_Checkout {
 			return;
 		}
 
-		// Backwards compat with old pay and thanks link arguments
+		// Backwards compatibility with old pay and thanks link arguments
 		if ( isset( $_GET['order'] ) && isset( $_GET['key'] ) ) {
 			wc_deprecated_argument( __CLASS__ . '->' . __FUNCTION__, '2.1', '"order" is no longer used to pass an order ID. Use the order-pay or order-received endpoint instead.' );
 

--- a/includes/vendor/abstract-wp-rest-controller.php
+++ b/includes/vendor/abstract-wp-rest-controller.php
@@ -27,7 +27,7 @@ abstract class WP_REST_Controller {
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {
-		wc_doing_it_wrong( 'WP_REST_Controller::register_routes', __( 'The register_routes() method must be overriden', 'woocommerce' ), 'WPAPI-2.0' );
+		wc_doing_it_wrong( 'WP_REST_Controller::register_routes', __( 'The register_routes() method must be overridden', 'woocommerce' ), 'WPAPI-2.0' );
 	}
 
 	/**

--- a/includes/vendor/wp-rest-functions.php
+++ b/includes/vendor/wp-rest-functions.php
@@ -139,7 +139,7 @@ if ( ! function_exists( 'register_rest_field' ) ) {
 
 if ( ! function_exists( 'register_api_field' ) ) {
 	/**
-	 * Backwards compat shim
+	 * Backwards compatibility shim
 	 *
 	 * @param array|string $object_type
 	 * @param string $attributes

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -223,7 +223,7 @@ function wc_get_order_types( $for = '' ) {
 /**
  * Get an order type by post type name.
  * @param  string post type name
- * @return bool|array of datails about the order type
+ * @return bool|array of details about the order type
  */
 function wc_get_order_type( $type ) {
 	global $wc_order_types;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1329,7 +1329,7 @@ if ( ! function_exists( 'woocommerce_related_products' ) ) {
 
 		$args = wp_parse_args( $args, $defaults );
 
-		// Get visble related products then sort them at random.
+		// Get visible related products then sort them at random.
 		$args['related_products'] = array_filter( array_map( 'wc_get_product', wc_get_related_products( $product->get_id(), $args['posts_per_page'], $product->get_upsell_ids() ) ), 'wc_products_array_filter_visible' );
 
 		// Handle orderby.
@@ -1371,7 +1371,7 @@ if ( ! function_exists( 'woocommerce_upsell_display' ) ) {
 		$orderby                     = apply_filters( 'woocommerce_upsells_orderby', isset( $args['orderby'] ) ? $args['orderby'] : $orderby );
 		$limit                       = apply_filters( 'woocommerce_upsells_total', isset( $args['posts_per_page'] ) ? $args['posts_per_page'] : $limit );
 
-		// Get visble upsells then sort them at random, then limit result set.
+		// Get visible upsells then sort them at random, then limit result set.
 		$upsells = wc_products_array_orderby( array_filter( array_map( 'wc_get_product', $product->get_upsell_ids() ), 'wc_products_array_filter_visible' ), $orderby, $order );
 		$upsells = $limit > 0 ? array_slice( $upsells, 0, $limit ) : $upsells;
 

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Prevent any user who cannot 'edit_posts' (subscribers, customers etc) from seeing the admin bar.
  *
- * Note: get_option( 'woocommerce_lock_down_admin', true ) is a deprecated option here for backwards compat. Defaults to true.
+ * Note: get_option( 'woocommerce_lock_down_admin', true ) is a deprecated option here for backwards compatibility. Defaults to true.
  *
  * @access public
  * @param bool $show_admin_bar
@@ -320,7 +320,7 @@ function wc_modify_editable_roles( $roles ) {
 add_filter( 'editable_roles', 'wc_modify_editable_roles' );
 
 /**
- * Modify capabiltiies to prevent non-admin users editing admin users.
+ * Modify capabilities to prevent non-admin users editing admin users.
  *
  * $args[0] will be the user being edited in this case.
  *

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -62,7 +62,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 			$link = add_query_arg( 'max_price', wc_clean( $_GET['max_price'] ), $link );
 		}
 
-		// Orderby
+		// Order by
 		if ( isset( $_GET['orderby'] ) ) {
 			$link = add_query_arg( 'orderby', wc_clean( $_GET['orderby'] ), $link );
 		}

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -331,7 +331,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			$link = add_query_arg( 'max_price', wc_clean( $_GET['max_price'] ), $link );
 		}
 
-		// Orderby
+		// Order by
 		if ( isset( $_GET['orderby'] ) ) {
 			$link = add_query_arg( 'orderby', wc_clean( $_GET['orderby'] ), $link );
 		}

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -56,7 +56,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			$link = add_query_arg( 'max_price', wc_clean( $_GET['max_price'] ), $link );
 		}
 
-		// Orderby
+		// Order by
 		if ( isset( $_GET['orderby'] ) ) {
 			$link = add_query_arg( 'orderby', wc_clean( $_GET['orderby'] ), $link );
 		}


### PR DESCRIPTION
Hi @mikejolley , I have review the WooCommerce plugin and I have found that there are a lots of typo errors, short names in Phpdoc and few strings. so I have fixed all typos in this PR. 

Please review it and let me know if any change in it. 