### PR TITLE
Fix missing return statement

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -200,8 +200,8 @@ abstract class WC_Data {
 			} else {
 				$this->data_store->create( $this );
 			}
-			return $this->get_id();
 		}
+		return $this->get_id();
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1280,6 +1280,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * Save data (either create or update depending on if we are working on an existing product).
 	 *
 	 * @since 3.0.0
+	 * @return int
 	 */
 	public function save() {
 		$this->validate_props();
@@ -1296,8 +1297,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			if ( $this->get_parent_id() ) {
 				wc_deferred_product_sync( $this->get_parent_id() );
 			}
-			return $this->get_id();
 		}
+		return $this->get_id();
 	}
 
 	/*

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -89,7 +89,6 @@ abstract class WC_Settings_API {
 	 * on the gateway's settings screen.
 	 *
 	 * @since  1.0.0
-	 * @return string
 	 */
 	public function init_form_fields() {}
 

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -118,10 +118,8 @@ abstract class WC_Widget extends WP_Widget {
 	/**
 	 * Output the html at the start of a widget.
 	 *
-	 * @param  array $args
+	 * @param array $args
 	 * @param array $instance
-	 *
-	 * @return string
 	 */
 	public function widget_start( $args, $instance ) {
 		echo $args['before_widget'];
@@ -135,7 +133,6 @@ abstract class WC_Widget extends WP_Widget {
 	 * Output the html at the end of a widget.
 	 *
 	 * @param  array $args
-	 * @return string
 	 */
 	public function widget_end( $args ) {
 		echo $args['after_widget'];

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -110,7 +110,6 @@ class WC_Admin_Settings {
 
 	/**
 	 * Output messages + errors.
-	 * @return string
 	 */
 	public static function show_messages() {
 		if ( sizeof( self::$errors ) > 0 ) {

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -176,8 +176,6 @@ class WC_Admin {
 
 	/**
 	 * Preview email template.
-	 *
-	 * @return string
 	 */
 	public function preview_emails() {
 

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -616,8 +616,6 @@ class WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {}
 

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -359,8 +359,6 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {
 		global $wp_locale;

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -272,8 +272,6 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {
 		global $wp_locale;

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -607,8 +607,6 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {
 		global $wp_locale;

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -387,8 +387,6 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {
 		global $wp_locale;

--- a/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -67,8 +67,6 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {
 		global $wpdb;

--- a/includes/admin/reports/class-wc-report-taxes-by-date.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-date.php
@@ -67,8 +67,6 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 
 	/**
 	 * Get the main chart.
-	 *
-	 * @return string
 	 */
 	public function get_main_chart() {
 		$query_data = array(

--- a/includes/api/legacy/v1/class-wc-api-authentication.php
+++ b/includes/api/legacy/v1/class-wc-api-authentication.php
@@ -19,7 +19,6 @@ class WC_API_Authentication {
 	 * Setup class
 	 *
 	 * @since 2.1
-	 * @return WC_API_Authentication
 	 */
 	public function __construct() {
 

--- a/includes/api/legacy/v1/class-wc-api-customers.php
+++ b/includes/api/legacy/v1/class-wc-api-customers.php
@@ -31,7 +31,6 @@ class WC_API_Customers extends WC_API_Resource {
 	 *
 	 * @since 2.1
 	 * @param WC_API_Server $server
-	 * @return WC_API_Customers
 	 */
 	public function __construct( WC_API_Server $server ) {
 

--- a/includes/api/legacy/v1/class-wc-api-resource.php
+++ b/includes/api/legacy/v1/class-wc-api-resource.php
@@ -28,7 +28,6 @@ class WC_API_Resource {
 	 *
 	 * @since 2.1
 	 * @param WC_API_Server $server
-	 * @return WC_API_Resource
 	 */
 	public function __construct( WC_API_Server $server ) {
 

--- a/includes/api/legacy/v1/class-wc-api-server.php
+++ b/includes/api/legacy/v1/class-wc-api-server.php
@@ -112,7 +112,6 @@ class WC_API_Server {
 	 *
 	 * @since 2.1
 	 * @param $path
-	 * @return WC_API_Server
 	 */
 	public function __construct( $path ) {
 

--- a/includes/api/legacy/v2/class-wc-api-authentication.php
+++ b/includes/api/legacy/v2/class-wc-api-authentication.php
@@ -19,7 +19,6 @@ class WC_API_Authentication {
 	 * Setup class
 	 *
 	 * @since 2.1
-	 * @return WC_API_Authentication
 	 */
 	public function __construct() {
 

--- a/includes/api/legacy/v2/class-wc-api-customers.php
+++ b/includes/api/legacy/v2/class-wc-api-customers.php
@@ -30,7 +30,6 @@ class WC_API_Customers extends WC_API_Resource {
 	 *
 	 * @since 2.1
 	 * @param WC_API_Server $server
-	 * @return WC_API_Customers
 	 */
 	public function __construct( WC_API_Server $server ) {
 

--- a/includes/api/legacy/v2/class-wc-api-resource.php
+++ b/includes/api/legacy/v2/class-wc-api-resource.php
@@ -27,7 +27,6 @@ class WC_API_Resource {
 	 *
 	 * @since 2.1
 	 * @param WC_API_Server $server
-	 * @return WC_API_Resource
 	 */
 	public function __construct( WC_API_Server $server ) {
 

--- a/includes/api/legacy/v2/class-wc-api-server.php
+++ b/includes/api/legacy/v2/class-wc-api-server.php
@@ -111,7 +111,6 @@ class WC_API_Server {
 	 *
 	 * @since 2.1
 	 * @param $path
-	 * @return WC_API_Server
 	 */
 	public function __construct( $path ) {
 

--- a/includes/api/legacy/v3/class-wc-api-authentication.php
+++ b/includes/api/legacy/v3/class-wc-api-authentication.php
@@ -19,7 +19,6 @@ class WC_API_Authentication {
 	 * Setup class
 	 *
 	 * @since 2.1
-	 * @return WC_API_Authentication
 	 */
 	public function __construct() {
 

--- a/includes/api/legacy/v3/class-wc-api-customers.php
+++ b/includes/api/legacy/v3/class-wc-api-customers.php
@@ -30,7 +30,6 @@ class WC_API_Customers extends WC_API_Resource {
 	 *
 	 * @since 2.1
 	 * @param WC_API_Server $server
-	 * @return WC_API_Customers
 	 */
 	public function __construct( WC_API_Server $server ) {
 

--- a/includes/api/legacy/v3/class-wc-api-resource.php
+++ b/includes/api/legacy/v3/class-wc-api-resource.php
@@ -27,7 +27,6 @@ class WC_API_Resource {
 	 *
 	 * @since 2.1
 	 * @param WC_API_Server $server
-	 * @return WC_API_Resource
 	 */
 	public function __construct( WC_API_Server $server ) {
 

--- a/includes/api/legacy/v3/class-wc-api-server.php
+++ b/includes/api/legacy/v3/class-wc-api-server.php
@@ -111,7 +111,6 @@ class WC_API_Server {
 	 *
 	 * @since 2.1
 	 * @param $path
-	 * @return WC_API_Server
 	 */
 	public function __construct( $path ) {
 

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -375,9 +375,8 @@ class WC_Emails {
 	 * Add order meta to email templates.
 	 *
 	 * @param mixed $order
-	 * @param bool $sent_to_admin (default: false)
-	 * @param bool $plain_text (default: false)
-	 * @return string
+	 * @param bool  $sent_to_admin (default: false)
+	 * @param bool  $plain_text    (default: false)
 	 */
 	public function order_meta( $order, $sent_to_admin = false, $plain_text = false ) {
 		$fields = apply_filters( 'woocommerce_email_order_meta_fields', array(), $sent_to_admin, $order );

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -916,7 +916,6 @@ class WC_Tax {
 	 *
 	 * @param  int $tax_rate_id
 	 * @param  string $postcodes String of postcodes separated by ; characters
-	 * @return string
 	 */
 	public static function _update_tax_rate_postcodes( $tax_rate_id, $postcodes ) {
 		if ( ! is_array( $postcodes ) ) {
@@ -939,7 +938,6 @@ class WC_Tax {
 	 *
 	 * @param  int $tax_rate_id
 	 * @param  string $cities
-	 * @return string
 	 */
 	public static function _update_tax_rate_cities( $tax_rate_id, $cities ) {
 		if ( ! is_array( $cities ) ) {
@@ -961,8 +959,6 @@ class WC_Tax {
 	 * @param int $tax_rate_id
 	 * @param array $values
 	 * @param string $type
-	 *
-	 * @return string
 	 */
 	private static function _update_tax_rate_locations( $tax_rate_id, $values, $type ) {
 		global $wpdb;

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -85,7 +85,6 @@ class WC_Data_Store_WP {
 	 * @since  3.0.0
 	 * @param  WC_Data
 	 * @param  stdClass (containing at least ->id)
-	 * @return array
 	 */
 	public function delete_meta( &$object, $meta ) {
 		delete_metadata_by_mid( $this->meta_type, $meta->id );

--- a/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
+++ b/includes/gateways/simplify-commerce/class-wc-addons-gateway-simplify-commerce.php
@@ -393,7 +393,6 @@ class WC_Addons_Gateway_Simplify_Commerce extends WC_Gateway_Simplify_Commerce {
 	 * @since  2.4
 	 * @param  string $payment_method_id The ID of the payment method to validate
 	 * @param  array $payment_meta associative array of meta data required for automatic payments
-	 * @return array
 	 * @throws Exception
 	 */
 	public function validate_subscription_payment_meta( $payment_method_id, $payment_meta ) {

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -293,7 +293,6 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @param WC_Product $product Product instance.
 	 * @param array      $data    Item data.
 	 *
-	 * @return WC_Product|WP_Error
 	 * @throws Exception
 	 */
 	protected function set_product_data( &$product, $data ) {

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -54,8 +54,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 	/**
 	 * Read file.
-	 *
-	 * @return array
 	 */
 	protected function read_file() {
 		if ( false !== ( $handle = fopen( $this->file, 'r' ) ) ) {
@@ -107,8 +105,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 	/**
 	 * Set file mapped keys.
-	 *
-	 * @return array
 	 */
 	protected function set_mapped_keys() {
 		$mapping = $this->params['mapping'];
@@ -669,8 +665,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 	/**
 	 * Map and format raw data to known fields.
-	 *
-	 * @return array
 	 */
 	protected function set_parsed_data() {
 		$parse_functions = $this->get_formating_callback();

--- a/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
+++ b/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
@@ -216,7 +216,6 @@ class WC_Shipping_Legacy_Free_Shipping extends WC_Shipping_Method {
 
 	/**
 	 * calculate_shipping function.
-	 * @return array
 	 */
 	public function calculate_shipping( $package = array() ) {
 		$args = array(

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -191,7 +191,6 @@ add_action( 'get_header', 'wc_clear_cart_after_payment' );
  * Get the subtotal.
  *
  * @access public
- * @return string
  */
 function wc_cart_totals_subtotal_html() {
 	echo WC()->cart->get_cart_subtotal();

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -995,8 +995,6 @@ function wc_update_300_webhooks() {
 /**
  * Add an index to the field comment_type to improve the response time of the query
  * used by WC_Comments::wp_count_comments() to get the number of comments by type.
- *
- * @return null
  */
 function wc_update_300_comment_type_index() {
 	global $wpdb;


### PR DESCRIPTION
Hi @mikejolley ,

As per phpstorm IDE, I got missing return statement errors. There are a many methods which are not return anythings but still have `@return` tag in PHPDOC so I have removed those. 

Please review it.

Thanks