### PR TITLE
Use class raw data, don't pass it

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -186,10 +186,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * for rows following this one.
 	 *
 	 * @param  stirng $field
-	 * @param  array $raw_data
 	 * @return int
 	 */
-	public function parse_id_field( $field, $raw_data = array() ) {
+	public function parse_id_field( $field ) {
 		global $wpdb;
 
 		$id = absint( $field );
@@ -208,7 +207,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		// Not updating? Make sure we have a new placeholder for this ID.
 		if ( ! $this->params['update_existing'] ) {
 			// If row has a SKU, make sure placeholder was not made already.
-			if ( isset( $raw_data['sku'] ) && $id = wc_get_product_id_by_sku( $raw_data['sku'] ) ) {
+			if ( isset( $this->raw_data['sku'] ) && $id = wc_get_product_id_by_sku( $this->raw_data['sku'] ) ) {
 				return $id;
 			}
 
@@ -218,8 +217,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			$product->add_meta_data( '_original_id', $id, true );
 
 			// If row has a SKU, make sure placeholder has it too.
-			if ( isset( $raw_data['sku'] ) ) {
-				$product->set_sku( $raw_data['sku'] );
+			if ( isset( $this->raw_data['sku'] ) ) {
+				$product->set_sku( $this->raw_data['sku'] );
 			}
 			$id = $product->save();
 		}
@@ -705,7 +704,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 					$value = wp_check_invalid_utf8( $value, true );
 				}
 
-				$data[ $mapped_keys[ $id ] ] = call_user_func( $parse_functions[ $id ], $value, array_combine( $mapped_keys, $row ) );
+				$data[ $mapped_keys[ $id ] ] = call_user_func( $parse_functions[ $id ], $value );
 			}
 
 			$this->parsed_data[] = apply_filters( 'woocommerce_product_importer_parsed_data', $this->expand_data( $data ), $this );


### PR DESCRIPTION
#16127 caused an issue with fields which don’t require passing args
e.g. esc_url_raw callback. This broke tests.