### PR TITLE
Introduce wc_get_account_orders_actions function

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -241,6 +241,45 @@ function wc_get_account_payment_methods_types() {
 }
 
 /**
+ * Get account orders actions.
+ *
+ * @since  3.2.0
+ * @param  int|WC_Order $order
+ * @return array
+ */
+function wc_get_account_orders_actions( $order ) {
+	if ( ! is_object( $order ) ) {
+		$order_id = absint( $order );
+		$order    = wc_get_order( $order_id );
+	}
+	
+	$actions = array(
+		'pay'    => array(
+			'url'  => $order->get_checkout_payment_url(),
+			'name' => __( 'Pay', 'woocommerce' ),
+		),
+		'view'   => array(
+			'url'  => $order->get_view_order_url(),
+			'name' => __( 'View', 'woocommerce' ),
+		),
+		'cancel' => array(
+			'url'  => $order->get_cancel_order_url( wc_get_page_permalink( 'myaccount' ) ),
+			'name' => __( 'Cancel', 'woocommerce' ),
+		),
+	);
+
+	if ( ! $order->needs_payment() ) {
+		unset( $actions['pay'] );
+	}
+
+	if ( ! in_array( $order->get_status(), apply_filters( 'woocommerce_valid_order_statuses_for_cancel', array( 'pending', 'failed' ), $order ) ) ) {
+		unset( $actions['cancel'] );
+	}
+	
+	return apply_filters( 'woocommerce_my_account_my_orders_actions', $actions, $order );
+}
+
+/**
  * Returns an array of a user's saved payments list for output on the account tab.
  *
  * @since  2.6

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -69,34 +69,13 @@ if ( $customer_orders ) : ?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php
-									$actions = array(
-										'pay'    => array(
-											'url'  => $order->get_checkout_payment_url(),
-											'name' => __( 'Pay', 'woocommerce' ),
-										),
-										'view'   => array(
-											'url'  => $order->get_view_order_url(),
-											'name' => __( 'View', 'woocommerce' ),
-										),
-										'cancel' => array(
-											'url'  => $order->get_cancel_order_url( wc_get_page_permalink( 'myaccount' ) ),
-											'name' => __( 'Cancel', 'woocommerce' ),
-										),
-									);
-
-									if ( ! $order->needs_payment() ) {
-										unset( $actions['pay'] );
+								$actions = wc_get_account_orders_actions( $order );
+								
+								if ( ! empty( $actions ) ) {
+									foreach ( $actions as $key => $action ) {
+										echo '<a href="' . esc_url( $action['url'] ) . '" class="button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
 									}
-
-									if ( ! in_array( $order->get_status(), apply_filters( 'woocommerce_valid_order_statuses_for_cancel', array( 'pending', 'failed' ), $order ) ) ) {
-										unset( $actions['cancel'] );
-									}
-
-									if ( $actions = apply_filters( 'woocommerce_my_account_my_orders_actions', $actions, $order ) ) {
-										foreach ( $actions as $key => $action ) {
-											echo '<a href="' . esc_url( $action['url'] ) . '" class="button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
-										}
-									}
+								}
 								?>
 							<?php endif; ?>
 						</td>

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -15,7 +15,7 @@
  * @see 	https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.0.0
+ * @version 3.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -65,34 +65,13 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 							<?php elseif ( 'order-actions' === $column_id ) : ?>
 								<?php
-									$actions = array(
-										'pay'    => array(
-											'url'  => $order->get_checkout_payment_url(),
-											'name' => __( 'Pay', 'woocommerce' ),
-										),
-										'view'   => array(
-											'url'  => $order->get_view_order_url(),
-											'name' => __( 'View', 'woocommerce' ),
-										),
-										'cancel' => array(
-											'url'  => $order->get_cancel_order_url( wc_get_page_permalink( 'myaccount' ) ),
-											'name' => __( 'Cancel', 'woocommerce' ),
-										),
-									);
-
-									if ( ! $order->needs_payment() ) {
-										unset( $actions['pay'] );
+								$actions = wc_get_account_orders_actions( $order );
+								
+								if ( ! empty( $actions ) ) {
+									foreach ( $actions as $key => $action ) {
+										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
 									}
-
-									if ( ! in_array( $order->get_status(), apply_filters( 'woocommerce_valid_order_statuses_for_cancel', array( 'pending', 'failed' ), $order ) ) ) {
-										unset( $actions['cancel'] );
-									}
-
-									if ( $actions = apply_filters( 'woocommerce_my_account_my_orders_actions', $actions, $order ) ) {
-										foreach ( $actions as $key => $action ) {
-											echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
-										}
-									}
+								}
 								?>
 							<?php endif; ?>
 						</td>


### PR DESCRIPTION
This function removes a bunch of logic outside of the template making things a little easier to read/customise.

An added benefit to moving this logic outside of the template is that it can be changed without needing to bump the template version.

I've also updated the deprecated `my-orders.php` file for the sake of consistency, but didn't bump up the file version number.