### PR TITLE
Introduce wc_get_account_formatted_address function

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -241,6 +241,36 @@ function wc_get_account_payment_methods_types() {
 }
 
 /**
+ * Get account formatted address.
+ *
+ * @since  3.2.0
+ * @param  string $name
+ * @return string
+ */
+function wc_get_account_formatted_address( $name ) {
+	$customer_id = get_current_user_id();
+	$meta_keys   = [
+		'first_name',
+		'last_name',
+		'company',
+		'address_1',
+		'address_2',
+		'city',
+		'postcode',
+		'country',
+	];
+	
+	$meta = [];
+	foreach ( $meta_keys as $key ) {
+		$meta[ $key ] = get_user_meta( $customer_id, $name . '_' . $key, true );
+	}
+	
+	$address = apply_filters( 'woocommerce_my_account_my_address_formatted_address', $meta, $customer_id, $name );
+	
+	return WC()->countries->get_formatted_address( $address );
+}
+
+/**
  * Returns an array of a user's saved payments list for output on the account tab.
  *
  * @since  2.6

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -54,25 +54,8 @@ $col    = 1;
 		</header>
 		<address>
 			<?php
-				$address = apply_filters( 'woocommerce_my_account_my_address_formatted_address', array(
-					'first_name'  => get_user_meta( $customer_id, $name . '_first_name', true ),
-					'last_name'   => get_user_meta( $customer_id, $name . '_last_name', true ),
-					'company'     => get_user_meta( $customer_id, $name . '_company', true ),
-					'address_1'   => get_user_meta( $customer_id, $name . '_address_1', true ),
-					'address_2'   => get_user_meta( $customer_id, $name . '_address_2', true ),
-					'city'        => get_user_meta( $customer_id, $name . '_city', true ),
-					'state'       => get_user_meta( $customer_id, $name . '_state', true ),
-					'postcode'    => get_user_meta( $customer_id, $name . '_postcode', true ),
-					'country'     => get_user_meta( $customer_id, $name . '_country', true ),
-				), $customer_id, $name );
-
-				$formatted_address = WC()->countries->get_formatted_address( $address );
-
-				if ( ! $formatted_address ) {
-					_e( 'You have not set up this type of address yet.', 'woocommerce' );
-				} else {
-					echo $formatted_address;
-				}
+			$address = wc_get_account_formatted_address( $name );
+			echo $address ? $address : __( 'You have not set up this type of address yet.', 'woocommerce' );
 			?>
 		</address>
 	</div>


### PR DESCRIPTION
This function removes a bunch of logic outside of the template making things a little easier to read.

An added benefit to moving this logic outside of the template is that it can be changed without needing to bump the template version.