### PR TITLE
Add a filter to arguments passed to wc_get_products during prepare_data_to_export()

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -124,7 +124,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 */
 	public function prepare_data_to_export() {
 		$columns  = $this->get_column_names();
-		$products = wc_get_products( array(
+		$args = apply_filters( "woocommerce_product_export_{$this->export_type}_query_args", array(
 			'status'   => array( 'private', 'publish' ),
 			'type'     => $this->product_types_to_export,
 			'limit'    => $this->get_limit(),
@@ -135,6 +135,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 			'return'   => 'objects',
 			'paginate' => true,
 		) );
+		$products = wc_get_products( $args );
 
 		$this->total_rows = $products->total;
 		$this->row_data   = array();


### PR DESCRIPTION
This PR adds a filter to WC_Product_CSV_Exporter::prepare_data_to_export to change the arguments added to wc_get_products.

Use case: A user or plugin wants to change the which products are exported, such as additional post status.

I don't know about the name of this filter, and also am wondering if it should use a context pattern instead. Alternative:
```
$args = apply_filters( 'woocommerce_product_export_query_args', array(...), $this->export_type);
```