### PR TITLE
Fix typo in '@oaram' to '@param'

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -369,8 +369,9 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 	/**
 	 * Search customers and return customer IDs.
 	 *
-	 * @param  string $term
-	 * @oaram  int|string $limit @since 3.0.7
+	 * @param  string     $term
+	 * @param  int|string $limit @since 3.0.7
+	 *
 	 * @return array
 	 */
 	public function search_customers( $term, $limit = '' ) {


### PR DESCRIPTION
@mikejolley , @claudiosanches Fixed typo in `@oaram` to `@param`.