### PR TITLE
Remove cart dependency from WC_Coupon

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -767,13 +767,14 @@ class WC_Coupon extends WC_Legacy_Coupon {
 				// 'data'         => $raw_item->get_product(),
 				// );
 			} elseif ( is_a( $raw_item, 'WC_Order_Item_Product' ) ) {
-				$item = array(
+				$product = $raw_item->get_product();
+				$item    = array(
 					'key'          => $raw_item->get_id(),
 					'product_id'   => $raw_item->get_product_id(),
 					'variation_id' => $raw_item->get_variation_id(),
-					'variation'    => 0 < $raw_item->get_variation_id() ? $raw_item->get_variation_attributes() : array(),
+					'variation'    => 0 < $raw_item->get_variation_id() ? $product->get_variation_attributes() : array(),
 					'quantity'     => $raw_item->get_quantity(),
-					'data'         => $raw_item->get_product(),
+					'data'         => $product,
 				);
 			} else {
 				$item = array(

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -480,7 +480,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function get_items_total_ex_tax() {
 		// Fallback for backwards compatibility.
 		if ( is_null( $this->items_total_ex_tax ) ) {
-			$this->set_items_total( WC()->cart->subtotal_ex_tax );
+			$this->set_items_total_ex_tax( WC()->cart->subtotal_ex_tax );
 		}
 
 		return $this->items_total_ex_tax;
@@ -496,9 +496,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
 
 		if ( 'incl' === $tax_display_cart ) {
-			return wc_format_decimal( $this->items_total );
+			return wc_format_decimal( $this->get_items_total() );
 		} elseif ( 'excl' === $tax_display_cart ) {
-			return wc_format_decimal( $this->items_total_ex_tax );
+			return wc_format_decimal( $this->get_items_total_ex_tax() );
 		}
 	}
 

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -74,6 +74,28 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	protected $cache_group = 'coupons';
 
 	/**
+	 * Cart or order items.
+	 *
+	 * @since 2.3.0
+	 * @var   array
+	 */
+	protected $items = array();
+
+	/**
+	 * Items total.
+	 *
+	 * @var float|null
+	 */
+	protected $items_total = null;
+
+	/**
+	 * Items total excluding tax.
+	 *
+	 * @var float|null
+	 */
+	protected $items_total_ex_tax = null;
+
+	/**
 	 * Coupon constructor. Loads coupon data.
 	 * @param mixed $data Coupon data, object, ID or code.
 	 */
@@ -368,7 +390,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 
 		if ( $this->is_type( array( 'percent' ) ) ) {
 			$discount = (float) $this->get_amount() * ( $discounting_amount / 100 );
-		} elseif ( $this->is_type( 'fixed_cart' ) && ! is_null( $cart_item ) && WC()->cart->subtotal_ex_tax ) {
+		} elseif ( $this->is_type( 'fixed_cart' ) && ! is_null( $cart_item ) && $this->get_items_total_ex_tax() ) {
 			/**
 			 * This is the most complex discount - we need to divide the discount between rows based on their price in.
 			 * proportion to the subtotal. This is so rows with different tax rates get a fair discount, and so rows.
@@ -379,9 +401,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			 * Uses price inc tax if prices include tax to work around https://github.com/woocommerce/woocommerce/issues/7669 and https://github.com/woocommerce/woocommerce/issues/8074.
 			 */
 			if ( wc_prices_include_tax() ) {
-				$discount_percent = ( wc_get_price_including_tax( $cart_item['data'] ) * $cart_item_qty ) / WC()->cart->subtotal;
+				$discount_percent = ( wc_get_price_including_tax( $cart_item['data'] ) * $cart_item_qty ) / $this->get_items_total();
 			} else {
-				$discount_percent = ( wc_get_price_excluding_tax( $cart_item['data'] ) * $cart_item_qty ) / WC()->cart->subtotal_ex_tax;
+				$discount_percent = ( wc_get_price_excluding_tax( $cart_item['data'] ) * $cart_item_qty ) / $this->get_items_total_ex_tax();
 			}
 			$discount = ( (float) $this->get_amount() * $discount_percent ) / $cart_item_qty;
 
@@ -413,6 +435,71 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$discount = round( $discount, wc_get_rounding_precision() );
 
 		return apply_filters( 'woocommerce_coupon_get_discount_amount', $discount, $discounting_amount, $cart_item, $single, $this );
+	}
+
+	/**
+	 * Get items.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	public function get_items() {
+		// Fallback for backwards compatibility.
+		if ( ! $this->items ) {
+			if ( ! WC()->cart->is_empty() ) {
+				$this->set_items( WC()->cart->get_cart() );
+			} else {
+				return array();
+			}
+		}
+
+		return $this->items;
+	}
+
+	/**
+	 * Get items total.
+	 *
+	 * @since  3.2.0
+	 * @return float
+	 */
+	public function get_items_total() {
+		// Fallback for backwards compatibility.
+		if ( is_null( $this->items_total ) ) {
+			$this->set_items_total( WC()->cart->subtotal );
+		}
+
+		return $this->items_total;
+	}
+
+	/**
+	 * Get items total excluding tax.
+	 *
+	 * @since  3.2.0
+	 * @return float
+	 */
+	public function get_items_total_ex_tax() {
+		// Fallback for backwards compatibility.
+		if ( is_null( $this->items_total_ex_tax ) ) {
+			$this->set_items_total( WC()->cart->subtotal_ex_tax );
+		}
+
+		return $this->items_total_ex_tax;
+	}
+
+	/**
+	 * Get items displayed total.
+	 *
+	 * @since  3.2.0
+	 * @return string
+	 */
+	public function get_items_displayed_total() {
+		$tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
+
+		if ( 'incl' === $tax_display_cart ) {
+			return wc_format_decimal( $this->items_total );
+		} elseif ( 'excl' === $tax_display_cart ) {
+			return wc_format_decimal( $this->items_total_ex_tax );
+		}
 	}
 
 	/*
@@ -658,6 +745,71 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$this->set_prop( 'used_by', array_filter( $used_by ) );
 	}
 
+	/**
+	 * Set items.
+	 *
+	 * @since 3.2.0
+	 * @param array $items List of items.
+	 */
+	public function set_items( $raw_items ) {
+		$this->items = array();
+
+		foreach ( $raw_items as $raw_item ) {
+			$item = array();
+
+			if ( is_a( $raw_item, 'WC_Cart_Item' ) ) {
+				// $item = array(
+				// 'key'          => $raw_item->get_id(),
+				// 'product_id'   => $raw_item->get_product_id(),
+				// 'variation_id' => $raw_item->variation_id,
+				// 'variation'    => $raw_item->get_variation(),
+				// 'quantity'     => $raw_item->get_quantity(),
+				// 'data'         => $raw_item->get_product(),
+				// );
+			} elseif ( is_a( $raw_item, 'WC_Order_Item_Product' ) ) {
+				$item = array(
+					'key'          => $raw_item->get_id(),
+					'product_id'   => $raw_item->get_product_id(),
+					'variation_id' => $raw_item->get_variation_id(),
+					'variation'    => 0 < $raw_item->get_variation_id() ? $raw_item->get_variation_attributes() : array(),
+					'quantity'     => $raw_item->get_quantity(),
+					'data'         => $raw_item->get_product(),
+				);
+			} else {
+				$item = array(
+					'key'          => $raw_item['key'],
+					'product_id'   => $raw_item['product_id'],
+					'variation_id' => $raw_item['variation_id'],
+					'variation'    => $raw_item['variation'],
+					'quantity'     => $raw_item['quantity'],
+					'data'         => $raw_item['data'],
+				);
+			}
+
+			$this->items[ $item['key'] ] = $item;
+		}
+	}
+
+	/**
+	 * Set items total.
+	 *
+	 * @since 3.2.0
+	 * @param float $total Items total.
+	 */
+	public function set_items_total( $total ) {
+		$this->items_total = $total;
+	}
+
+	/**
+	 * Set items total excluding tax.
+	 *
+	 * @since 3.2.0
+	 * @param float Items total excluding tax.
+	 */
+	public function set_items_total_ex_tax( $total ) {
+		$this->items_total_ex_tax = $total;
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Other Actions
@@ -820,7 +972,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws Exception
 	 */
 	private function validate_minimum_amount() {
-		if ( $this->get_minimum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_minimum_amount', $this->get_minimum_amount() > WC()->cart->get_displayed_subtotal(), $this ) ) {
+		if ( $this->get_minimum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_minimum_amount', $this->get_minimum_amount() > $this->get_items_displayed_total(), $this ) ) {
 			throw new Exception( self::E_WC_COUPON_MIN_SPEND_LIMIT_NOT_MET );
 		}
 	}
@@ -831,7 +983,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws Exception
 	 */
 	private function validate_maximum_amount() {
-		if ( $this->get_maximum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_maximum_amount', $this->get_maximum_amount() < WC()->cart->get_displayed_subtotal(), $this ) ) {
+		if ( $this->get_maximum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_maximum_amount', $this->get_maximum_amount() < $this->get_items_displayed_total(), $this ) ) {
 			throw new Exception( self::E_WC_COUPON_MAX_SPEND_LIMIT_MET );
 		}
 	}
@@ -844,11 +996,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	private function validate_product_ids() {
 		if ( sizeof( $this->get_product_ids() ) > 0 ) {
 			$valid_for_cart = false;
-			if ( ! WC()->cart->is_empty() ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					if ( in_array( $cart_item['product_id'], $this->get_product_ids() ) || in_array( $cart_item['variation_id'], $this->get_product_ids() ) || in_array( $cart_item['data']->get_parent_id(), $this->get_product_ids() ) ) {
-						$valid_for_cart = true;
-					}
+			foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+				if ( in_array( $cart_item['product_id'], $this->get_product_ids() ) || in_array( $cart_item['variation_id'], $this->get_product_ids() ) || in_array( $cart_item['data']->get_parent_id(), $this->get_product_ids() ) ) {
+					$valid_for_cart = true;
 				}
 			}
 			if ( ! $valid_for_cart ) {
@@ -865,17 +1015,15 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	private function validate_product_categories() {
 		if ( sizeof( $this->get_product_categories() ) > 0 ) {
 			$valid_for_cart = false;
-			if ( ! WC()->cart->is_empty() ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					if ( $this->get_exclude_sale_items() && $cart_item['data'] && $cart_item['data']->is_on_sale() ) {
-						continue;
-					}
-					$product_cats = wc_get_product_cat_ids( $cart_item['product_id'] );
+			foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+				if ( $this->get_exclude_sale_items() && $cart_item['data'] && $cart_item['data']->is_on_sale() ) {
+					continue;
+				}
+				$product_cats = wc_get_product_cat_ids( $cart_item['product_id'] );
 
-					// If we find an item with a cat in our allowed cat list, the coupon is valid
-					if ( sizeof( array_intersect( $product_cats, $this->get_product_categories() ) ) > 0 ) {
-						$valid_for_cart = true;
-					}
+				// If we find an item with a cat in our allowed cat list, the coupon is valid
+				if ( sizeof( array_intersect( $product_cats, $this->get_product_categories() ) ) > 0 ) {
+					$valid_for_cart = true;
 				}
 			}
 			if ( ! $valid_for_cart ) {
@@ -893,13 +1041,11 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		if ( $this->get_exclude_sale_items() ) {
 			$valid_for_cart = false;
 
-			if ( ! WC()->cart->is_empty() ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					$product = $cart_item['data'];
+			foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+				$product = $cart_item['data'];
 
-					if ( ! $product->is_on_sale() ) {
-						$valid_for_cart = true;
-					}
+				if ( ! $product->is_on_sale() ) {
+					$valid_for_cart = true;
 				}
 			}
 			if ( ! $valid_for_cart ) {
@@ -912,10 +1058,10 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * All exclusion rules must pass at the same time for a product coupon to be valid.
 	 */
 	private function validate_excluded_items() {
-		if ( ! WC()->cart->is_empty() && $this->is_type( wc_get_product_coupon_types() ) ) {
+		if ( ! $this->get_items() && $this->is_type( wc_get_product_coupon_types() ) ) {
 			$valid = false;
 
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+			foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
 				if ( $this->is_valid_for_product( $cart_item['data'], $cart_item ) ) {
 					$valid = true;
 					break;
@@ -947,11 +1093,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		// Exclude Products
 		if ( sizeof( $this->get_excluded_product_ids() ) > 0 ) {
 			$valid_for_cart = true;
-			if ( ! WC()->cart->is_empty() ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					if ( in_array( $cart_item['product_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['variation_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['data']->get_parent_id(), $this->get_excluded_product_ids() ) ) {
-						$valid_for_cart = false;
-					}
+			foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+				if ( in_array( $cart_item['product_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['variation_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['data']->get_parent_id(), $this->get_excluded_product_ids() ) ) {
+					$valid_for_cart = false;
 				}
 			}
 			if ( ! $valid_for_cart ) {
@@ -968,16 +1112,14 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	private function validate_cart_excluded_product_categories() {
 		if ( sizeof( $this->get_excluded_product_categories() ) > 0 ) {
 			$valid_for_cart = true;
-			if ( ! WC()->cart->is_empty() ) {
-				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					if ( $this->get_exclude_sale_items() && $cart_item['data'] && $cart_item['data']->is_on_sale() ) {
-						continue;
-					}
-					$product_cats = wc_get_product_cat_ids( $cart_item['product_id'] );
+			foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+				if ( $this->get_exclude_sale_items() && $cart_item['data'] && $cart_item['data']->is_on_sale() ) {
+					continue;
+				}
+				$product_cats = wc_get_product_cat_ids( $cart_item['product_id'] );
 
-					if ( sizeof( array_intersect( $product_cats, $this->get_excluded_product_categories() ) ) > 0 ) {
-						$valid_for_cart = false;
-					}
+				if ( sizeof( array_intersect( $product_cats, $this->get_excluded_product_categories() ) ) > 0 ) {
+					$valid_for_cart = false;
 				}
 			}
 			if ( ! $valid_for_cart ) {
@@ -1167,11 +1309,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			case self::E_WC_COUPON_EXCLUDED_PRODUCTS:
 				// Store excluded products that are in cart in $products
 				$products = array();
-				if ( ! WC()->cart->is_empty() ) {
-					foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-						if ( in_array( $cart_item['product_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['variation_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['data']->get_parent_id(), $this->get_excluded_product_ids() ) ) {
-							$products[] = $cart_item['data']->get_name();
-						}
+				foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+					if ( in_array( $cart_item['product_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['variation_id'], $this->get_excluded_product_ids() ) || in_array( $cart_item['data']->get_parent_id(), $this->get_excluded_product_ids() ) ) {
+						$products[] = $cart_item['data']->get_name();
 					}
 				}
 
@@ -1181,16 +1321,14 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			case self::E_WC_COUPON_EXCLUDED_CATEGORIES:
 				// Store excluded categories that are in cart in $categories
 				$categories = array();
-				if ( ! WC()->cart->is_empty() ) {
-					foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-						$product_cats = wc_get_product_cat_ids( $cart_item['product_id'] );
+				foreach ( $this->get_items() as $cart_item_key => $cart_item ) {
+					$product_cats = wc_get_product_cat_ids( $cart_item['product_id'] );
 
-						if ( sizeof( $intersect = array_intersect( $product_cats, $this->get_excluded_product_categories() ) ) > 0 ) {
+					if ( sizeof( $intersect = array_intersect( $product_cats, $this->get_excluded_product_categories() ) ) > 0 ) {
 
-							foreach ( $intersect as $cat_id ) {
-								$cat = get_term( $cat_id, 'product_cat' );
-								$categories[] = $cat->name;
-							}
+						foreach ( $intersect as $cat_id ) {
+							$cat = get_term( $cat_id, 'product_cat' );
+							$categories[] = $cat->name;
 						}
 					}
 				}

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -179,10 +179,10 @@ class WC_Discounts {
 		$items_to_apply = $this->get_items_to_apply_coupon( $coupon );
 
 		// Set items to valid coupon.
-		$items = array();
+		$items_to_validate = array();
 		foreach ( $items_to_apply as $item ) {
 			$is_variable = $item->product->is_type( 'variation' );
-			$items[ $item->key ] = array(
+			$items_to_validate[ $item->key ] = array(
 				'key'          => $item->key,
 				'product_id'   => $is_variable ? $item->product->get_parent_id() : $item->product->get_id(),
 				'variation_id' => $is_variable ? $item->product->get_id() : 0,
@@ -191,9 +191,8 @@ class WC_Discounts {
 				'data'         => $item->product,
 			);
 		}
-		$coupon->set_items( $items );
 
-		if ( ! $coupon->is_valid() ) {
+		if ( ! $coupon->is_valid( $items_to_validate ) ) {
 			return new WP_Error( 'invalid_coupon', $coupon->get_error_message() );
 		}
 

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -58,16 +58,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts->set_items( WC()->cart->get_cart() );
 
 		// Test applying multiple coupons and getting totals.
-		$coupon = new WC_Coupon;
-		$coupon->set_code( 'test' );
+		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
 		$coupon->set_amount( 50 );
 		$coupon->set_discount_type( 'percent' );
 		$discounts->apply_coupon( $coupon );
 
 		$this->assertEquals( array( 'test' => 5 ), $discounts->get_applied_coupons() );
 
-		$coupon2 = new WC_Coupon;
-		$coupon2->set_code( 'test2' );
+		$coupon2 = WC_Helper_Coupon::create_coupon( 'test2' );
 		$coupon2->set_amount( 50 );
 		$coupon2->set_discount_type( 'percent' );
 		$discounts->apply_coupon( $coupon2 );
@@ -94,6 +92,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		// Cleanup.
 		WC()->cart->empty_cart();
 		$product->delete( true );
+		$coupon->delete( true );
+		$coupon2->delete( true );
 	}
 
 	/**
@@ -108,8 +108,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$product->save();
 		WC()->cart->empty_cart();
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
-		$coupon = new WC_Coupon;
-		$coupon->set_code( 'test' );
+
+		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
 		$coupon->set_amount( 10 );
 
 		// Apply a percent discount.
@@ -133,6 +133,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		// Cleanup.
 		WC()->cart->empty_cart();
 		$product->delete( true );
+		$coupon->delete( true );
 	}
 
 	/**
@@ -160,14 +161,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 10,
 						'qty'   => 1,
-					)
+					),
 				),
 				'coupons' => array(
 					array(
 						'code'          => 'test',
 						'discount_type' => 'percent',
 						'amount'        => '20',
-					)
+					),
 				),
 				'expected_total_discount' => 2,
 			),
@@ -177,35 +178,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 10,
 						'qty'   => 2,
-					)
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '10',
-					)
-				),
-				'expected_total_discount' => 10,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 1,
 					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					)
 				),
 				'coupons' => array(
 					array(
 						'code'          => 'test',
 						'discount_type' => 'fixed_cart',
 						'amount'        => '10',
-					)
+					),
 				),
 				'expected_total_discount' => 10,
 			),
@@ -220,17 +200,38 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'price' => 10,
 						'qty'   => 1,
 					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					)
 				),
 				'coupons' => array(
 					array(
 						'code'          => 'test',
 						'discount_type' => 'fixed_cart',
 						'amount'        => '10',
-					)
+					),
+				),
+				'expected_total_discount' => 10,
+			),
+			array(
+				'prices_include_tax' => false,
+				'cart' => array(
+					array(
+						'price' => 10,
+						'qty'   => 1,
+					),
+					array(
+						'price' => 10,
+						'qty'   => 1,
+					),
+					array(
+						'price' => 10,
+						'qty'   => 1,
+					),
+				),
+				'coupons' => array(
+					array(
+						'code'          => 'test',
+						'discount_type' => 'fixed_cart',
+						'amount'        => '10',
+					),
 				),
 				'expected_total_discount' => 10,
 			),
@@ -248,14 +249,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 10,
 						'qty'   => 2,
-					)
+					),
 				),
 				'coupons' => array(
 					array(
 						'code'          => 'test',
 						'discount_type' => 'fixed_cart',
 						'amount'        => '10',
-					)
+					),
 				),
 				'expected_total_discount' => 10,
 			),
@@ -305,14 +306,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 10,
 						'qty'   => 1,
-					)
+					),
 				),
 				'coupons' => array(
 					array(
 						'code'          => 'test',
 						'discount_type' => 'fixed_cart',
 						'amount'        => '10',
-					)
+					),
 				),
 				'expected_total_discount' => 10,
 			),
@@ -330,14 +331,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 1,
 						'qty'   => 1,
-					)
+					),
 				),
 				'coupons' => array(
 					array(
 						'code'          => 'test',
 						'discount_type' => 'fixed_cart',
 						'amount'        => '1',
-					)
+					),
 				),
 				'expected_total_discount' => 1,
 			),
@@ -347,7 +348,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 10,
 						'qty'   => 2,
-					)
+					),
 				),
 				'coupons' => array(
 					array(
@@ -355,7 +356,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'discount_type'          => 'percent',
 						'amount'                 => '10',
 						'limit_usage_to_x_items' => 1,
-					)
+					),
 				),
 				'expected_total_discount' => 1,
 			),
@@ -369,7 +370,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					array(
 						'price' => 10,
 						'qty'   => 2,
-					)
+					),
 				),
 				'coupons' => array(
 					array(
@@ -377,11 +378,13 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'discount_type'          => 'percent',
 						'amount'                 => '10',
 						'limit_usage_to_x_items' => 1,
-					)
+					),
 				),
 				'expected_total_discount' => 1,
 			),
 		);
+
+		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
 
 		foreach ( $tests as $test_index => $test ) {
 			$discounts = new WC_Discounts();
@@ -399,7 +402,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			$discounts->set_items( WC()->cart->get_cart() );
 
 			foreach ( $test['coupons'] as $coupon_props ) {
-				$coupon = new WC_Coupon;
 				$coupon->set_props( $coupon_props );
 				$discounts->apply_coupon( $coupon );
 			}
@@ -416,5 +418,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 		update_option( 'woocommerce_calc_taxes', 'no' );
+		$coupon->delete( true );
 	}
 }


### PR DESCRIPTION
Now is possible to properly validate a coupon inside `WC_Discounts` class,