### PR TITLE
WC_Totals class

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -140,7 +140,7 @@ class WC_Discounts {
 	 * @todo is_valid_for_product accepts values - how can we deal with that?
 	 *
 	 * @since  3.2.0
-	 * @param  WC_Coupon $coupon
+	 * @param  WC_Coupon $coupon Coupon object being applied to the items.
 	 * @return bool True if applied.
 	 */
 	public function apply_coupon( $coupon ) {

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -78,10 +78,11 @@ class WC_Discounts {
 	 * Get all discount totals with precision.
 	 *
 	 * @since  3.2.0
+	 * @param  bool $in_cents Should the totals be returned in cents, or without precision.
 	 * @return array
 	 */
-	public function get_discounts() {
-		return $this->discounts;
+	public function get_discounts( $in_cents = false ) {
+		return $in_cents ? $this->discounts : array_map( array( $this, 'remove_precision' ), $this->discounts );
 	}
 
 	/**
@@ -173,13 +174,39 @@ class WC_Discounts {
 	}
 
 	/**
-	 * Remove precision from a price.
+	 * Add precision (deep) to a price.
 	 *
-	 * @param  int $value Value to remove precision from.
+	 * @since  3.2.0
+	 * @param  int|array $value Value to remove precision from.
+	 * @return float
+	 */
+	protected function add_precision( $value ) {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $subvalue ) {
+				$value[ $key ] = $this->add_precision( $subvalue );
+			}
+		} else {
+			$value = $value * $this->precision;
+		}
+		return $value;
+	}
+
+	/**
+	 * Remove precision (deep) from a price.
+	 *
+	 * @since  3.2.0
+	 * @param  int|array $value Value to remove precision from.
 	 * @return float
 	 */
 	protected function remove_precision( $value ) {
-		return wc_format_decimal( $value / $this->precision, wc_get_price_decimals() );
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $subvalue ) {
+				$value[ $key ] = $this->remove_precision( $subvalue );
+			}
+		} else {
+			$value = wc_format_decimal( $value / $this->precision, wc_get_price_decimals() );
+		}
+		return $value;
 	}
 
 	/**

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -45,6 +45,8 @@ class WC_Discounts {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param array $items Items to discount.
 	 */
 	public function __construct( $items ) {
 		$this->precision = pow( 10, wc_get_price_decimals() );
@@ -65,6 +67,7 @@ class WC_Discounts {
 	 * Get discount by key without precision.
 	 *
 	 * @since  3.2.0
+	 * @param  string $key name of discount row to return.
 	 * @return array
 	 */
 	public function get_discount( $key ) {
@@ -85,7 +88,7 @@ class WC_Discounts {
 	 * Get discounted price of an item without precision.
 	 *
 	 * @since  3.2.0
-	 * @param  object $item
+	 * @param  object $item Get data for this item.
 	 * @return float
 	 */
 	public function get_discounted_price( $item ) {
@@ -96,7 +99,7 @@ class WC_Discounts {
 	 * Get discounted price of an item to precision (in cents).
 	 *
 	 * @since  3.2.0
-	 * @param  object $item
+	 * @param  object $item Get data for this item.
 	 * @return float
 	 */
 	public function get_discounted_price_in_cents( $item ) {
@@ -172,7 +175,7 @@ class WC_Discounts {
 	/**
 	 * Remove precision from a price.
 	 *
-	 * @param  int $value
+	 * @param  int $value Value to remove precision from.
 	 * @return float
 	 */
 	protected function remove_precision( $value ) {
@@ -182,13 +185,13 @@ class WC_Discounts {
 	/**
 	 * Sort by price.
 	 *
-	 * @param  array $a
-	 * @param  array $b
+	 * @param  array $a First element.
+	 * @param  array $b Second element.
 	 * @return int
 	 */
 	protected function sort_by_price( $a, $b ) {
 		$price_1 = $a->price * $a->quantity;
-		$price_2 = $b->price * $b->quantity;;
+		$price_2 = $b->price * $b->quantity;
 		if ( $price_1 === $price_2 ) {
 			return 0;
 		}
@@ -199,7 +202,7 @@ class WC_Discounts {
 	 * Filter out all products which have been fully discounted to 0.
 	 * Used as array_filter callback.
 	 *
-	 * @param  object $item
+	 * @param  object $item Get data for this item.
 	 * @return bool
 	 */
 	protected function filter_products_with_price( $item ) {
@@ -209,7 +212,7 @@ class WC_Discounts {
 	/**
 	 * Get items which the coupon should be applied to.
 	 *
-	 * @param  object $coupon
+	 * @param  object $coupon Coupon object.
 	 * @return array
 	 */
 	protected function get_items_to_apply_coupon( $coupon ) {
@@ -249,9 +252,9 @@ class WC_Discounts {
 	 * Apply a discount amount to an item and ensure it does not go negative.
 	 *
 	 * @since  3.2.0
-	 * @param  object $item
-	 * @param  int $discount
-	 * @return int Amount discounted.
+	 * @param  object $item Get data for this item.
+	 * @param  int    $discount Amount of discount.
+	 * @return int    Amount discounted.
 	 */
 	protected function add_item_discount( &$item, $discount ) {
 		$discounted_price              = $this->get_discounted_price_in_cents( $item );
@@ -264,9 +267,9 @@ class WC_Discounts {
 	 * Apply percent discount to items.
 	 *
 	 * @since  3.2.0
-	 * @param array $items_to_apply Array of items to apply the coupon to.
-	 * @param  int $amount
-	 * @return int total discounted in cents
+	 * @param  array $items_to_apply Array of items to apply the coupon to.
+	 * @param  int   $amount Amount of discount.
+	 * @return int   total discounted in cents
 	 */
 	protected function apply_percentage_discount( $items_to_apply, $amount ) {
 		$total_discounted = 0;
@@ -283,7 +286,7 @@ class WC_Discounts {
 	 *
 	 * @since  3.2.0
 	 * @param  array $items_to_apply Array of items to apply the coupon to.
-	 * @param  int $amount
+	 * @param  int   $discount Amount of discout.
 	 * @return int total discounted in cents
 	 */
 	protected function apply_fixed_product_discount( $items_to_apply, $discount ) {
@@ -301,7 +304,7 @@ class WC_Discounts {
 	 *
 	 * @since  3.2.0
 	 * @param  array $items_to_apply Array of items to apply the coupon to.
-	 * @param  int $cart_discount
+	 * @param  int   $cart_discount Fixed discount amount to apply.
 	 * @return int total discounted in cents
 	 */
 	protected function apply_fixed_cart_discount( $items_to_apply, $cart_discount ) {
@@ -325,12 +328,11 @@ class WC_Discounts {
 			if ( $amount_discounted > 0 && $amount_discounted < $cart_discount ) {
 				$amount_discounted += $this->apply_fixed_cart_discount( $items_to_apply, $cart_discount - $amount_discounted );
 			}
-
-		/**
-		 * Deal with remaining fractional discounts by splitting it over items
-		 * until the amount is expired, discounting 1 cent at a time.
-		 */
-	 	} elseif ( $cart_discount > 0 ) {
+		} elseif ( $cart_discount > 0 ) {
+			/**
+			 * Deal with remaining fractional discounts by splitting it over items
+			 * until the amount is expired, discounting 1 cent at a time.
+			 */
 			foreach ( $items_to_apply as $item ) {
 				for ( $i = 0; $i < $item->quantity; $i ++ ) {
 					$amount_discounted += $this->add_item_discount( $item, 1 );

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -48,7 +48,7 @@ class WC_Discounts {
 	 *
 	 * @param array $items Items to discount.
 	 */
-	public function __construct( $items ) {
+	public function __construct( $items = array() ) {
 		$this->precision = pow( 10, wc_get_price_decimals() );
 		$this->set_items( $items );
 	}

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -26,12 +26,6 @@ class WC_Shipping {
 	/** @var array|null Stores methods loaded into woocommerce. */
 	public $shipping_methods         = null;
 
-	/** @var float Stores the cost of shipping */
-	public $shipping_total 			 = 0;
-
-	/** @var array Stores an array of shipping taxes. */
-	public $shipping_taxes			 = array();
-
 	/** @var array Stores the shipping classes. */
 	public $shipping_classes		 = array();
 
@@ -237,18 +231,17 @@ class WC_Shipping {
 	/**
 	 * Calculate shipping for (multiple) packages of cart items.
 	 *
-	 * @param array $packages multi-dimensional array of cart items to calc shipping for
+	 * @param array $packages multi-dimensional array of cart items to calc shipping for.
+	 * @return array Array of calculated packages.
 	 */
 	public function calculate_shipping( $packages = array() ) {
-		$this->shipping_total = 0;
-		$this->shipping_taxes = array();
-		$this->packages       = array();
+		$this->packages = array();
 
 		if ( ! $this->enabled || empty( $packages ) ) {
-			return;
+			return array();
 		}
 
-		// Calculate costs for passed packages
+		// Calculate costs for passed packages.
 		foreach ( $packages as $package_key => $package ) {
 			$this->packages[ $package_key ] = $this->calculate_shipping_for_package( $package, $package_key );
 		}
@@ -264,58 +257,9 @@ class WC_Shipping {
 		 *
 		 * @param array $packages The array of packages after shipping costs are calculated.
 		 */
-		$this->packages = apply_filters( 'woocommerce_shipping_packages', $this->packages );
+		$this->packages = array_filter( (array) apply_filters( 'woocommerce_shipping_packages', $this->packages ) );
 
-		if ( ! is_array( $this->packages ) || empty( $this->packages ) ) {
-			return;
-		}
-
-		// Get all chosen methods
-		$chosen_methods = WC()->session->get( 'chosen_shipping_methods' );
-		$method_counts  = WC()->session->get( 'shipping_method_counts' );
-
-		// Get chosen methods for each package
-		foreach ( $this->packages as $i => $package ) {
-			$chosen_method    = false;
-			$method_count     = false;
-
-			if ( ! empty( $chosen_methods[ $i ] ) ) {
-				$chosen_method = $chosen_methods[ $i ];
-			}
-
-			if ( ! empty( $method_counts[ $i ] ) ) {
-				$method_count = absint( $method_counts[ $i ] );
-			}
-
-			if ( sizeof( $package['rates'] ) > 0 ) {
-
-				// If not set, not available, or available methods have changed, set to the DEFAULT option
-				if ( empty( $chosen_method ) || ! isset( $package['rates'][ $chosen_method ] ) || sizeof( $package['rates'] ) !== $method_count ) {
-					$chosen_method        = apply_filters( 'woocommerce_shipping_chosen_method', $this->get_default_method( $package['rates'], false ), $package['rates'], $chosen_method );
-					$chosen_methods[ $i ] = $chosen_method;
-					$method_counts[ $i ]  = sizeof( $package['rates'] );
-					do_action( 'woocommerce_shipping_method_chosen', $chosen_method );
-				}
-
-				// Store total costs
-				if ( $chosen_method && isset( $package['rates'][ $chosen_method ] ) ) {
-					$rate = $package['rates'][ $chosen_method ];
-
-					// Merge cost and taxes - label and ID will be the same
-					$this->shipping_total += $rate->cost;
-
-					if ( ! empty( $rate->taxes ) && is_array( $rate->taxes ) ) {
-						foreach ( array_keys( $this->shipping_taxes + $rate->taxes ) as $key ) {
-							$this->shipping_taxes[ $key ] = ( isset( $rate->taxes[ $key ] ) ? $rate->taxes[ $key ] : 0 ) + ( isset( $this->shipping_taxes[ $key ] ) ? $this->shipping_taxes[ $key ] : 0 );
-						}
-					}
-				}
-			}
-		}
-
-		// Save all chosen methods (array)
-		WC()->session->set( 'chosen_shipping_methods', $chosen_methods );
-		WC()->session->set( 'shipping_method_counts', $method_counts );
+		return $this->packages;
 	}
 
 	/**
@@ -396,8 +340,6 @@ class WC_Shipping {
 	 */
 	public function reset_shipping() {
 		unset( WC()->session->chosen_shipping_methods );
-		$this->shipping_total = 0;
-		$this->shipping_taxes = array();
 		$this->packages = array();
 	}
 

--- a/includes/class-wc-totals.php
+++ b/includes/class-wc-totals.php
@@ -1,14 +1,26 @@
 <?php
+/**
+ * Order/cart totals calculation class.
+ *
+ * Methods are private and class is final to keep this as an internal API.
+ * May be opened in the future once structure is stable.
+ *
+ * @author  Automattic
+ * @package WooCommerce/Classes
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Order/cart totals calculation class.
+ * WC_Totals class.
  *
- * @author  Automattic
- * @package WooCommerce/Classes
- * @version 3.2.0
+ * @todo consider extending this for cart vs orders if lots of conditonal logic is needed.
+ * @todo Instead of setting cart totals from here, do it from a subclass.
+ * @todo woocommerce_tax_round_at_subtotal option - how should we handle this with precision?
+ * @todo woocommerce_calculate_totals action for carts.
+ * @todo woocommerce_calculated_total filter for carts.
  * @since   3.2.0
  */
 class WC_Totals {
@@ -19,7 +31,7 @@ class WC_Totals {
 	 * @since 3.2.0
 	 * @var array
 	 */
-	protected $object;
+	private $object;
 
 	/**
 	 * Line items to calculate.
@@ -27,37 +39,23 @@ class WC_Totals {
 	 * @since 3.2.0
 	 * @var array
 	 */
-	protected $items = array(); // @todo ?
+	private $items = array();
 
 	/**
-	 * Discount amounts in cents after calculation.
+	 * Fees to calculate.
 	 *
 	 * @since 3.2.0
 	 * @var array
 	 */
-	protected $discounts = array();
+	private $fees = array();
 
 	/**
-	 * Stores totals.
+	 * Discount amounts in cents after calculation for the cart.
 	 *
 	 * @since 3.2.0
 	 * @var array
 	 */
-	protected $totals = array(
-		'fees_total'         => 0,
-		'fees_total_tax'     => 0,
-		'items_subtotal'     => 0,
-		'items_subtotal_tax' => 0,
-		'items_total'        => 0,
-		'items_total_tax'    => 0,
-		'total'              => 0,
-		'taxes'              => array(),
-		'tax_total'          => 0,
-		'shipping_total'     => 0,
-		'shipping_tax_total' => 0,
-		'discounts_total'     => 0,
-		'discounts_tax_total' => 0,
-	);
+	private $discount_totals = array();
 
 	/**
 	 * Precision so we can work in cents.
@@ -65,12 +63,35 @@ class WC_Totals {
 	 * @since 3.2.0
 	 * @var int
 	 */
-	protected $precision = 1;
+	private $precision = 1;
+
+	/**
+	 * Stores totals.
+	 *
+	 * @since 3.2.0
+	 * @var array
+	 */
+	private $totals = array(
+		'fees_total'          => 0,
+		'fees_total_tax'      => 0,
+		'items_subtotal'      => 0,
+		'items_subtotal_tax'  => 0,
+		'items_total'         => 0,
+		'items_total_tax'     => 0,
+		'total'               => 0,
+		'taxes'               => array(),
+		'tax_total'           => 0,
+		'shipping_total'      => 0,
+		'shipping_tax_total'  => 0,
+		'discounts_total'     => 0,
+		'discounts_tax_total' => 0,
+	);
 
 	/**
 	 * Sets up the items provided, and calculate totals.
 	 *
 	 * @since 3.2.0
+	 * @param object $cart Cart or order object to calculate totals for.
 	 */
 	public function __construct( &$cart = null ) {
 		$this->precision = pow( 10, wc_get_price_decimals() );
@@ -80,11 +101,12 @@ class WC_Totals {
 	}
 
 	/**
-	 * Handles a cart or order object passed in for calculation. Normalises data.
+	 * Handles a cart or order object passed in for calculation. Normalises data
+	 * into the same format for use by this class.
 	 *
 	 * @since 3.2.0
 	 */
-	protected function set_items() {
+	private function set_items() {
 		if ( is_a( $this->object, 'WC_Cart' ) ) {
 			foreach ( $this->object->get_cart() as $cart_item_key => $cart_item ) {
 				$item                          = $this->get_default_item_props();
@@ -98,13 +120,13 @@ class WC_Totals {
 	}
 
 	/**
-	 * Remove precision from a price.
+	 * Remove precision (deep) from a price.
 	 *
 	 * @since  3.2.0
-	 * @param  int $value
+	 * @param  int|array $value Value to remove precision from.
 	 * @return float
 	 */
-	protected function remove_precision( $value ) {
+	private function remove_precision( $value ) {
 		if ( is_array( $value ) ) {
 			foreach ( $value as $key => $subvalue ) {
 				$value[ $key ] = $this->remove_precision( $subvalue );
@@ -121,8 +143,12 @@ class WC_Totals {
 	 * @since  3.2.0
 	 * @return array
 	 */
-	protected function get_default_item_props() {
+	private function get_default_item_props() {
 		return (object) array(
+			'key'                => '',
+			'quantity'           => 0,
+			'price'              => 0,
+			'product'            => false,
 			'price_includes_tax' => wc_prices_include_tax(),
 			'subtotal'           => 0,
 			'subtotal_tax'       => 0,
@@ -135,22 +161,37 @@ class WC_Totals {
 	}
 
 	/**
+	 * Get default blank set of props used per fee.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	private function get_default_fee_props() {
+		return (object) array(
+			'total_tax' => 0,
+			'taxes'     => array(),
+		);
+	}
+
+	/**
 	 * Only ran if woocommerce_adjust_non_base_location_prices is true.
 	 *
 	 * If the customer is outside of the base location, this removes the base
 	 * taxes. This is off by default unless the filter is used.
 	 *
 	 * @since 3.2.0
+	 * @param object $item Item to adjust the prices of.
+	 * @return object
 	 */
-	protected function adjust_non_base_location_price( $item ) {
+	private function adjust_non_base_location_price( $item ) {
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $item->product->tax_class );
 		$item_tax_rates = $this->get_item_tax_rates( $item );
 
 		if ( $item_tax_rates !== $base_tax_rates ) {
-			// Work out a new base price without the shop's base tax
+			// Work out a new base price without the shop's base tax.
 			$taxes                    = WC_Tax::calc_tax( $item->price, $base_tax_rates, true, true );
 
-			// Now we have a new item price (excluding TAX)
+			// Now we have a new item price (excluding TAX).
 			$item->price              = $item->price - array_sum( $taxes );
 			$item->price_includes_tax = false;
 		}
@@ -161,20 +202,20 @@ class WC_Totals {
 	 * Get discounted price of an item with precision (in cents).
 	 *
 	 * @since  3.2.0
-	 * @param  object $item
+	 * @param  object $item Item to get the price of.
 	 * @return int
 	 */
-	protected function get_discounted_price_in_cents( $item ) {
-		return $item->price - $this->totals['discounts'][ $item->key ];
+	private function get_discounted_price_in_cents( $item ) {
+		return $item->price - $this->discount_totals[ $item->key ];
 	}
 
 	/**
 	 * Get tax rates for an item. Caches rates in class to avoid multiple look ups.
 	 *
-	 * @param  object $item
+	 * @param  object $item Item to get tax rates for.
 	 * @return array of taxes
 	 */
-	protected function get_item_tax_rates( $item ) {
+	private function get_item_tax_rates( $item ) {
 		$tax_class = $item->product->get_tax_class();
 		return isset( $this->item_tax_rates[ $tax_class ] ) ? $this->item_tax_rates[ $tax_class ] : $this->item_tax_rates[ $tax_class ] = WC_Tax::get_rates( $item->product->get_tax_class() );
 	}
@@ -185,7 +226,7 @@ class WC_Totals {
 	 * @since  3.2.0
 	 * @return array
 	 */
-	protected function get_coupons() {
+	private function get_coupons() {
 		if ( is_a( $this->object, 'WC_Cart' ) ) {
 			return $this->object->get_coupons();
 		}
@@ -197,18 +238,18 @@ class WC_Totals {
 	 * @since  3.2.0
 	 * @return array
 	 */
-	protected function get_shipping() {
+	private function get_shipping() {
 		// @todo get this somehow. Where does calc occur?
 		return array();
 	}
 
-	protected function get_discounts() {
+	/**
+	 * Get discounts.
+	 *
+	 * @return array
+	 */
+	private function get_discounts() {
 		// @todo fee style API for discounts in cart/checkout.
-		return array();
-	}
-
-	protected function get_fees() {
-		// @todo where should fee api be located? New class?
 		return array();
 	}
 
@@ -217,7 +258,7 @@ class WC_Totals {
 	 *
 	 * @since  3.2.0
 	 * @param  string $key Total to get.
-	 * @param  bool $in_cents
+	 * @param  bool   $in_cents Should the totals be returned in cents, or without precision.
 	 * @return int|float
 	 */
 	public function get_total( $key = 'total', $in_cents = false ) {
@@ -229,10 +270,10 @@ class WC_Totals {
 	 * Set a single total.
 	 *
 	 * @since  3.2.0
-	 * @param string $key
-	 * @param int $total
+	 * @param string $key Total name you want to set.
+	 * @param int    $total Total to set.
 	 */
-	protected function set_total( $key = 'total', $total ) {
+	private function set_total( $key = 'total', $total ) {
 		$this->totals[ $key ] = $total;
 	}
 
@@ -240,7 +281,7 @@ class WC_Totals {
 	 * Get all totals with or without precision (in cents).
 	 *
 	 * @since  3.2.0
-	 * @param  $in_cents bool
+	 * @param  bool $in_cents Should the totals be returned in cents, or without precision.
 	 * @return array.
 	 */
 	public function get_totals( $in_cents = false ) {
@@ -255,22 +296,29 @@ class WC_Totals {
 	 * @since  3.2.0
 	 * @return array
 	 */
-	protected function get_merged_taxes() {
+	private function get_merged_taxes() {
 		$taxes = array();
+
+		foreach ( array_merge( $this->items, $this->fees, $this->get_shipping() ) as $item ) {
+			foreach ( $item->taxes as $rate_id => $rate ) {
+				$taxes[ $rate_id ] = array( 'tax_total' => 0, 'shipping_tax_total' => 0 );
+			}
+		}
+
 		foreach ( $this->items as $item ) {
 			foreach ( $item->taxes as $rate_id => $rate ) {
-				if ( ! isset( $taxes[ $rate_id ] ) ) {
-					$taxes[ $rate_id ] = array( 'tax_total' => 0, 'shipping_tax_total' => 0 );
-				}
+				$taxes[ $rate_id ]['tax_total'] = $taxes[ $rate_id ]['tax_total'] + $rate;
+			}
+		}
+
+		foreach ( $this->fees as $fee ) {
+			foreach ( $fee->taxes as $rate_id => $rate ) {
 				$taxes[ $rate_id ]['tax_total'] = $taxes[ $rate_id ]['tax_total'] + $rate;
 			}
 		}
 
 		foreach ( $this->get_shipping() as $item ) {
 			foreach ( $item->taxes as $rate_id => $rate ) {
-				if ( ! isset( $taxes[ $rate_id ] ) ) {
-					$taxes[ $rate_id ] = array( 'tax_total' => 0, 'shipping_tax_total' => 0 );
-				}
 				$taxes[ $rate_id ]['shipping_tax_total'] = $taxes[ $rate_id ]['shipping_tax_total'] + $rate;
 			}
 		}
@@ -284,11 +332,11 @@ class WC_Totals {
 	*/
 
 	/**
-	 * Run all calculations methods on the given items.
+	 * Run all calculations methods on the given items in sequence.
 	 *
 	 * @since 3.2.0
 	 */
-	protected function calculate() {
+	private function calculate() {
 		$this->calculate_item_subtotals();
 		$this->calculate_discounts();
 		$this->calculate_item_totals();
@@ -311,7 +359,7 @@ class WC_Totals {
 	 *
 	 * @since 3.2.0
 	 */
-	protected function calculate_item_subtotals() {
+	private function calculate_item_subtotals() {
 		foreach ( $this->items as $item ) {
 			if ( $item->price_includes_tax && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
 				$item           = $this->adjust_non_base_location_price( $item );
@@ -336,23 +384,21 @@ class WC_Totals {
 	/**
 	 * Calculate all discount and coupon amounts.
 	 *
+	 * @todo Manual discounts.
+	 *
 	 * @since 3.2.0
 	 * @uses  WC_Discounts class.
 	 */
-	protected function calculate_discounts() {
+	private function calculate_discounts() {
 		$discounts = new WC_Discounts( $this->items );
 
 		foreach ( $this->get_coupons() as $coupon ) {
 			$discounts->apply_coupon( $coupon );
 		}
 
-		foreach ( $this->get_discounts() as $discount ) {
-			//$discounts->apply_discount( $coupon ); @todo
-		}
-
-		$this->totals['discounts']       = $discounts->get_discounts();
-		$this->totals['discounts_total'] = array_sum( $this->totals['discounts'] );
-	//	$this->totals['discounts_tax_total'] = $value;
+		$this->discount_totals           = $discounts->get_discounts();
+		$this->totals['discounts_total'] = array_sum( $this->discount_totals );
+		// @todo $this->totals['discounts_tax_total'] = $value;
 
 		/*$this->set_coupon_totals( wp_list_pluck( $this->coupons, 'total' ) );
 		//$this->set_coupon_tax_totals( wp_list_pluck( $this->coupons, 'total_tax' ) );
@@ -360,11 +406,11 @@ class WC_Totals {
 	}
 
 	/**
-	 * Totals are costs after discounts.
+	 * Totals are costs after discounts. @todo move cart specific setters to subclass?
 	 *
 	 * @since 3.2.0
 	 */
-	protected function calculate_item_totals() {
+	private function calculate_item_totals() {
 		foreach ( $this->items as $item ) {
 			$item->total     = $this->get_discounted_price_in_cents( $item );
 			$item->total_tax = 0;
@@ -382,20 +428,45 @@ class WC_Totals {
 		}
 		$this->set_total( 'items_total', array_sum( array_values( wp_list_pluck( $this->items, 'total' ) ) ) );
 		$this->set_total( 'items_total_tax', array_sum( array_values( wp_list_pluck( $this->items, 'total_tax' ) ) ) );
+
+		$this->object->subtotal = array_sum( wp_list_pluck( $this->items, 'total' ) ) + array_sum( wp_list_pluck( $this->items, 'total_tax' ) );
+		$this->object->subtotal_ex_tax = array_sum( wp_list_pluck( $this->items, 'total' ) );
 	}
 
 	/**
-	 * Calculate any fees taxes.
+	 * Triggers the cart fees API, grabs the list of fees, and calculates taxes.
+	 *
+	 * Note: This class sets the totals for the 'object' as they are calculated. This is so that APIs like the fees API can see these totals if needed.
 	 *
 	 * @since 3.2.0
+	 * @todo logic is unqiue to carts.
 	 */
-	protected function calculate_fee_totals() {
-		foreach ( $this->get_fees() as $fee_key => $fee ) {
-			if ( wc_tax_enabled() && $fee->taxable ) {
-				$fee->taxes     = WC_Tax::calc_tax( $fee->total, $tax_rates, false );
+	private function calculate_fee_totals() {
+		$this->object->calculate_fees();
+
+		foreach ( $this->object->get_fees() as $fee_key => $fee_object ) {
+			$fee         = $this->get_default_fee_props();
+			$fee->object = $fee_object;
+			$fee->total  = $fee->object->amount * $this->precision;
+
+			if ( wc_tax_enabled() && $fee->object->taxable ) {
+				$fee->taxes     = WC_Tax::calc_tax( $fee->total, WC_Tax::get_rates( $fee->object->tax_class ), false );
 				$fee->total_tax = array_sum( $fee->taxes );
 			}
+
+			$this->fees[ $fee_key ] = $fee;
 		}
+
+		// Store totals to self.
+		$this->set_total( 'fees_total', array_sum( wp_list_pluck( $this->fees, 'total' ) ) );
+		$this->set_total( 'fees_total_tax', array_sum( wp_list_pluck( $this->fees, 'total_tax' ) ) );
+
+		// Transfer totals to the cart.
+		foreach ( $this->fees as $fee_key => $fee ) {
+			$this->object->fees[ $fee_key ]->tax      = $this->remove_precision( $fee->total_tax );
+			$this->object->fees[ $fee_key ]->tax_data = $this->remove_precision( $fee->taxes );
+		}
+		$this->object->fee_total = $this->remove_precision( array_sum( wp_list_pluck( $this->fees, 'total' ) ) );
 	}
 
 	/**
@@ -403,7 +474,7 @@ class WC_Totals {
 	 *
 	 * @since 3.2.0
 	 */
-	protected function calculate_shipping_totals() {
+	private function calculate_shipping_totals() {
 		//$this->set_shipping_total( array_sum( array_values( wp_list_pluck( $this->shipping, 'total' ) ) ) );
 	}
 
@@ -412,20 +483,10 @@ class WC_Totals {
 	 *
 	 * @since 3.2.0
 	 */
-	protected function calculate_totals() {
+	private function calculate_totals() {
 		$this->set_total( 'taxes', $this->get_merged_taxes() );
 		$this->set_total( 'tax_total', array_sum( wp_list_pluck( $this->get_total( 'taxes', true ), 'tax_total' ) ) );
 		$this->set_total( 'shipping_tax_total', array_sum( wp_list_pluck( $this->get_total( 'taxes', true ), 'shipping_tax_total' ) ) );
-
-		//$this->set_fees_total( array_sum( array_values( wp_list_pluck( $this->fees, 'total' ) ) ) );
-		//$this->set_fees_total_tax( array_sum( array_values( wp_list_pluck( $this->fees, 'total_tax' ) ) ) );
-
-
 		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + $this->get_total( 'tax_total', true ) + $this->get_total( 'shipping_tax_total', true ) ) );
-
-
-		// @todo woocommerce_tax_round_at_subtotal option - how should we handle this with precision?
-		// @todo woocommerce_calculate_totals action for carts.
-		// @todo woocommerce_calculated_total filter for carts.
 	}
 }

--- a/includes/class-wc-totals.php
+++ b/includes/class-wc-totals.php
@@ -408,7 +408,7 @@ class WC_Totals {
 			$discounts->apply_coupon( $coupon );
 		}
 
-		$this->discount_totals           = $discounts->get_discounts();
+		$this->discount_totals           = $discounts->get_discounts( true );
 		$this->totals['discounts_total'] = array_sum( $this->discount_totals );
 
 		// See how much tax was 'discounted'.

--- a/includes/class-wc-totals.php
+++ b/includes/class-wc-totals.php
@@ -1,0 +1,663 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Order/cart totals calculation class.
+ *
+ * @author  Automattic
+ * @package WooCommerce/Classes
+ * @version 3.2.0
+ * @since   3.2.0
+ */
+class WC_Totals {
+
+	/**
+	 * Line items to calculate.
+	 *
+	 * @var array
+	 */
+	protected $items          = array();
+
+	/**
+	 * Coupons to calculate.
+	 *
+	 * @var array
+	 */
+	protected $coupons        = array();
+
+	/**
+	 * Fees to calculate.
+	 *
+	 * @var array
+	 */
+	protected $fees           = array();
+
+	/**
+	 * Shipping to calculate.
+	 *
+	 * @var array
+	 */
+	protected $shipping_lines = array();
+
+	/**
+	 * Stores totals.
+	 *
+	 * @var array
+	 */
+	protected $totals         = null;
+
+	/**
+	 * Precision so we can work in cents.
+	 *
+	 * @var int
+	 */
+	protected $precision = 1;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->precision = pow( 10, wc_get_price_decimals() );
+		$this->set_totals( $this->get_default_totals() );
+	}
+
+	/**
+	 * Remove precision from a price.
+	 *
+	 * @param  int $value
+	 * @return float
+	 */
+	protected function remove_precision( $value ) {
+		return wc_format_decimal( $value / $this->precision, wc_get_price_decimals() );
+	}
+
+	/**
+	 * Get default totals.
+	 * @return array
+	 */
+	protected function get_default_totals() {
+		return array(
+			'fees_total'         => 0,
+			'fees_total_tax'     => 0,
+			'items_subtotal'     => 0,
+			'items_subtotal_tax' => 0,
+			'items_total'        => 0,
+			'items_total_tax'    => 0,
+			'item_totals'        => array(),
+			'total'              => 0,
+			'taxes'              => array(),
+			'tax_total'          => 0,
+			'shipping_total'     => 0,
+			'shipping_tax_total' => 0,
+		);
+	}
+
+	/**
+	 * Get default blank set of props used per item.
+	 * @return array
+	 */
+	protected function get_default_item_props() {
+		return (object) array(
+			'price_includes_tax' => wc_prices_include_tax(),
+			'subtotal'           => 0,
+			'subtotal_tax'       => 0,
+			'subtotal_taxes'     => array(),
+			'total'              => 0,
+			'total_tax'          => 0,
+			'taxes'              => array(),
+			'discounted_price'   => 0,
+		);
+	}
+
+	/**
+	 * Get default blank set of props used per coupon.
+	 * @return array
+	 */
+	protected function get_default_coupon_props() {
+		return (object) array(
+			'count'     => 0,
+			'total'     => 0,
+			'total_tax' => 0,
+		);
+	}
+
+	/**
+	 * Get default blank set of props used per fee.
+	 * @return array
+	 */
+	protected function get_default_fee_props() {
+		return (object) array(
+			'total_tax' => 0,
+			'taxes'     => array(),
+		);
+	}
+
+	/**
+	 * Get default blank set of props used per shipping row.
+	 * @return array
+	 */
+	protected function get_default_shipping_props() {
+		return (object) array(
+			'total'     => 0,
+			'total_tax' => 0,
+			'taxes'     => array(),
+		);
+	}
+
+	/**
+	 * Sort items by the subtotal.
+	 *
+	 * @param  object $a
+	 * @param  object $b
+	 * @return int
+	 */
+	protected function sort_items_callback( $a, $b ) {
+		$b->subtotal = isset( $a->subtotal ) ? $a->subtotal : 0;
+		$b->subtotal = isset( $b->subtotal ) ? $b->subtotal : 0;
+		return $b->subtotal === $b->subtotal ? 0 : ( $b->subtotal < $b->subtotal ? 1 : -1 );
+	}
+
+	/**
+	 * Only ran if woocommerce_adjust_non_base_location_prices is true.
+	 *
+	 * If the customer is outside of the base location, this removes the base
+	 * taxes. This is off by default unless the filter is used.
+	 */
+	protected function adjust_non_base_location_price( $item ) {
+		$base_tax_rates = WC_Tax::get_base_tax_rates( $item->product->tax_class );
+		$item_tax_rates = $this->get_item_tax_rates( $item );
+
+		if ( $item_tax_rates !== $base_tax_rates ) {
+			// Work out a new base price without the shop's base tax
+			$taxes                    = WC_Tax::calc_tax( $item->price, $base_tax_rates, true, true );
+
+			// Now we have a new item price (excluding TAX)
+			$item->price              = $item->price - array_sum( $taxes );
+			$item->price_includes_tax = false;
+		}
+		return $item;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Calculation methods.
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Run all calculations methods on the given items.
+	 */
+	public function calculate() {
+		$this->calculate_item_subtotals();
+		$this->calculate_item_totals();
+		$this->calculate_fee_totals();
+		$this->calculate_shipping_totals();
+		$this->calculate_totals();
+	}
+
+	/**
+	 * Subtotals are costs before discounts.
+	 *
+	 * To prevent rounding issues we need to work with the inclusive price where possible.
+	 * otherwise we'll see errors such as when working with a 9.99 inc price, 20% VAT which would.
+	 * be 8.325 leading to totals being 1p off.
+	 *
+	 * Pre tax coupons come off the price the customer thinks they are paying - tax is calculated.
+	 * afterwards.
+	 *
+	 * e.g. $100 bike with $10 coupon = customer pays $90 and tax worked backwards from that.
+	 */
+	protected function calculate_item_subtotals() {
+		foreach ( $this->items as $item ) {
+			$item->subtotal     = $item->price * $item->quantity;
+			$item->subtotal_tax = 0;
+
+			if ( $item->price_includes_tax && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
+				$item           = $this->adjust_non_base_location_price( $item );
+				$item->subtotal = $item->price * $item->quantity;
+			}
+
+			if ( $this->wc_tax_enabled() && $item->product->is_taxable() ) {
+				$item->subtotal_taxes = WC_Tax::calc_tax( $item->subtotal, $this->get_item_tax_rates( $item ), $item->price_includes_tax );
+				$item->subtotal_tax      = array_sum( $item->subtotal_taxes );
+
+				if ( $item->price_includes_tax ) {
+					$item->subtotal = $item->subtotal - $item->subtotal_tax;
+				}
+			}
+		}
+		uasort( $this->items, array( $this, 'sort_items_callback' ) );
+		$this->set_items_subtotal( array_sum( array_values( wp_list_pluck( $this->items, 'subtotal' ) ) ) );
+		$this->set_items_subtotal_tax( array_sum( array_values( wp_list_pluck( $this->items, 'subtotal_tax' ) ) ) );
+	}
+
+	/**
+	 * Totals are costs after discounts.
+	 */
+	public function calculate_item_totals() {
+		foreach ( $this->items as $item ) {
+
+
+
+			// ! @todo
+			//$item->discounted_price = $this->get_discounted_price( $item );
+
+
+
+
+
+
+			$item->total            = $item->discounted_price * $item->quantity;
+			$item->total_tax        = 0;
+
+			if ( $this->wc_tax_enabled() && $item->product->is_taxable() ) {
+				$item->taxes     = WC_Tax::calc_tax( $item->total, $this->get_item_tax_rates( $item ), $item->price_includes_tax );
+				$item->total_tax = array_sum( $item->taxes );
+
+				if ( $item->price_includes_tax ) {
+					$item->total = $item->total - $item->total_tax;
+				} else {
+					$item->total = $item->total;
+				}
+			}
+		}
+		$this->set_items_total( array_sum( array_values( wp_list_pluck( $this->items, 'total' ) ) ) );
+		$this->set_items_total_tax( array_sum( array_values( wp_list_pluck( $this->items, 'total_tax' ) ) ) );
+		//$this->set_coupon_totals( wp_list_pluck( $this->coupons, 'total' ) );
+		//$this->set_coupon_tax_totals( wp_list_pluck( $this->coupons, 'total_tax' ) );
+		//$this->set_coupon_counts( wp_list_pluck( $this->coupons, 'count' ) );
+		//$this->set_item_totals( $this->items );
+	}
+
+	/**
+	 * Calculate any fees taxes.
+	 */
+	protected function calculate_fee_totals() {
+		if ( ! empty( $this->fees ) ) {
+			foreach ( $this->fees as $fee_key => $fee ) {
+				if ( $this->wc_tax_enabled() && $fee->taxable ) {
+					$fee->taxes     = WC_Tax::calc_tax( $fee->total, $tax_rates, false );
+					$fee->total_tax = array_sum( $fee->taxes );
+				}
+			}
+		}
+		$this->set_fees_total( array_sum( array_values( wp_list_pluck( $this->fees, 'total' ) ) ) );
+		$this->set_fees_total_tax( array_sum( array_values( wp_list_pluck( $this->fees, 'total_tax' ) ) ) );
+	}
+
+	/**
+	 * Calculate any shipping taxes.
+	 */
+	protected function calculate_shipping_totals() {
+
+	}
+
+	/**
+	 * Main cart totals.
+	 */
+	public function calculate_totals() {
+
+		$this->set_shipping_total( array_sum( array_values( wp_list_pluck( $this->shipping_lines, 'total' ) ) ) );
+		$this->set_taxes( $this->get_merged_taxes() );
+
+		// Total up/round taxes and shipping taxes
+		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+			$this->set_tax_total( WC_Tax::get_tax_total( wc_list_pluck( $this->get_taxes(), 'get_tax_total' ) ) );
+			$this->set_shipping_tax_total( WC_Tax::get_tax_total( wc_list_pluck( $this->get_taxes(), 'get_shipping_tax_total' ) ) );
+		} else {
+			$this->set_tax_total( array_sum( wc_list_pluck( $this->get_taxes(), 'get_tax_total' ) ) );
+			$this->set_shipping_tax_total( array_sum( wc_list_pluck( $this->get_taxes(), 'get_shipping_tax_total' ) ) );
+		}
+
+		// Allow plugins to hook and alter totals before final total is calculated
+		do_action( 'woocommerce_calculate_totals', WC()->cart );
+
+		// Grand Total - Discounted product prices, discounted tax, shipping cost + tax
+		$this->set_total( apply_filters( 'woocommerce_calculated_total', round( $this->get_items_total() + $this->get_fees_total() + $this->get_shipping_total() + $this->get_tax_total() + $this->get_shipping_tax_total(), wc_get_price_decimals() ), WC()->cart ) );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters.
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Set all totals.
+	 * @param array $value
+	 */
+	public function set_totals( $value ) {
+		$value = wp_parse_args( $value, $this->get_default_totals() );
+		$this->totals = $value;
+	}
+
+	/**
+	 * Set cart/order items which will be discounted.
+	 *
+	 * @since 3.2.0
+	 * @param array $raw_items List of raw cart or order items.
+	 */
+	public function set_items( $raw_items ) {
+		$this->items           = array();
+
+		if ( ! empty( $raw_items ) && is_array( $raw_items ) ) {
+			foreach ( $raw_items as $raw_item ) {
+				$item = (object) array(
+					'price'    => 0, // Line price without discounts, in cents.
+					'quantity' => 0, // Line qty.
+					'product'  => false,
+				);
+				if ( is_a( $raw_item, 'WC_Cart_Item' ) ) {
+					//$item->quantity   = $raw_item->get_quantity();
+					//$item->price      = $raw_item->get_price() * $raw_item->get_quantity();
+					//$item->is_taxable = $raw_item->is_taxable();
+					//$item->tax_class  = $raw_item->get_tax_class();
+					// @todo
+				} elseif ( is_a( $raw_item, 'WC_Order_Item_Product' ) ) {
+					$item->key      = $raw_item->get_id();
+					$item->quantity = $raw_item->get_quantity();
+					$item->price    = $raw_item->get_subtotal() * $this->precision;
+					$item->product  = $raw_item->get_product();
+				} else {
+					$item->key      = $raw_item['key'];
+					$item->quantity = $raw_item['quantity'];
+					$item->price    = $raw_item['data']->get_price() * $this->precision * $raw_item['quantity'];
+					$item->product  = $raw_item['data'];
+				}
+				$this->items[ $item->key ]     = $item;
+			}
+		}
+	}
+
+	/**
+	 * Set coupons.
+	 * @param array $coupons
+	 */
+	public function set_coupons( $coupons ) {
+		foreach ( $coupons as $code => $coupon_object ) {
+			$coupon                 = $this->get_default_coupon_props();
+			$coupon->coupon         = $coupon_object;
+			$this->coupons[ $code ] = $coupon;
+		}
+	}
+
+	/**
+	 * Set fees.
+	 * @param array $fees
+	 */
+	public function set_fees( $fees ) {
+		foreach ( $fees as $fee_key => $fee_object ) {
+			$fee                    = $this->get_default_fee_props();
+			$fee->total             = $fee_object->amount;
+			$fee->taxable           = $fee_object->taxable;
+			$fee->tax_class         = $fee_object->tax_class;
+			$this->fees[ $fee_key ] = $fee;
+		}
+	}
+
+	/**
+	 * Set shipping lines.
+	 * @param array
+	 */
+	public function set_shipping( $shipping_objects ) {
+		$this->shipping_lines = array();
+
+		if ( is_array( $shipping_objects ) ) {
+			foreach ( $shipping_objects as $key => $shipping_object ) {
+				$shipping                     = $this->get_default_shipping_props();
+				$shipping->total              = $shipping_object->cost;
+				$shipping->taxes              = $shipping_object->taxes;
+				$shipping->total_tax          = array_sum( $shipping_object->taxes );
+				$this->shipping_lines[ $key ] = $shipping;
+			}
+		}
+	}
+
+	/**
+	 * Set taxes.
+	 * @param array $value
+	 */
+	protected function set_taxes( $value ) {
+		$this->totals['taxes'] = $value;
+	}
+
+	/**
+	 * Set tax total.
+	 * @param float $value
+	 */
+	protected function set_tax_total( $value ) {
+		$this->totals['tax_total'] = $value;
+	}
+
+	/**
+	 * Set shipping total.
+	 * @param float $value
+	 */
+	protected function set_shipping_total( $value ) {
+		$this->totals['shipping_total'] = $value;
+	}
+
+	/**
+	 * Set shipping tax total.
+	 * @param float $value
+	 */
+	protected function set_shipping_tax_total( $value ) {
+		$this->totals['shipping_tax_total'] = $value;
+	}
+
+	/**
+	 * Set item totals.
+	 * @param array $value
+	 */
+	protected function set_item_totals( $value ) {
+		$this->totals['item_totals'] = $value;
+	}
+
+	/**
+	 * Set items subtotal.
+	 * @param float $value
+	 */
+	protected function set_items_subtotal( $value ) {
+		$this->totals['items_subtotal'] = $value;
+	}
+
+	/**
+	 * Set items subtotal tax.
+	 * @param float $value
+	 */
+	protected function set_items_subtotal_tax( $value ) {
+		$this->totals['items_subtotal_tax'] = $value;
+	}
+
+	/**
+	 * Set items total.
+	 * @param float $value
+	 */
+	protected function set_items_total( $value ) {
+		$this->totals['items_total'] = $value;
+	}
+
+	/**
+	 * Set items total tax.
+	 * @param float $value
+	 */
+	protected function set_items_total_tax( $value ) {
+		$this->totals['items_total_tax'] = $value;
+	}
+
+	/**
+	 * Set fees total.
+	 * @param float $value
+	 */
+	protected function set_fees_total( $value ) {
+		$this->totals['fees_total'] = $value;
+	}
+
+	/**
+	 * Set fees total tax.
+	 * @param float $value
+	 */
+	protected function set_fees_total_tax( $value ) {
+		$this->totals['fees_total_tax'] = $value;
+	}
+
+	/**
+	 * Set total.
+	 * @param float $value
+	 */
+	protected function set_total( $value ) {
+		$this->totals['total'] = max( 0, $value );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Getters.
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Get all totals.
+	 * @return array.
+	 */
+	public function get_totals() {
+		return $this->totals;
+	}
+
+	/**
+	 * Get shipping and item taxes.
+	 * @return array
+	 */
+	public function get_taxes() {
+		return $this->totals['taxes'];
+	}
+
+	/**
+	 * Get tax total.
+	 * @return float
+	 */
+	public function get_tax_total() {
+		return $this->totals['tax_total'];
+	}
+
+	/**
+	 * Get shipping total.
+	 * @return float
+	 */
+	public function get_shipping_total() {
+		return $this->totals['shipping_total'];
+	}
+
+	/**
+	 * Get shipping tax total.
+	 * @return float
+	 */
+	public function get_shipping_tax_total() {
+		return $this->totals['shipping_tax_total'];
+	}
+
+	/**
+	 * Get the items subtotal.
+	 * @return float
+	 */
+	public function get_items_subtotal() {
+		return $this->totals['items_subtotal'];
+	}
+
+	/**
+	 * Get the items subtotal tax.
+	 * @return float
+	 */
+	public function get_items_subtotal_tax() {
+		return $this->totals['items_subtotal_tax'];
+	}
+
+	/**
+	 * Get the items total.
+	 * @return float
+	 */
+	public function get_items_total() {
+		return $this->totals['items_total'];
+	}
+
+	/**
+	 * Get the items total tax.
+	 * @return float
+	 */
+	public function get_items_total_tax() {
+		return $this->totals['items_total_tax'];
+	}
+
+	/**
+	 * Get the total fees amount.
+	 * @return float
+	 */
+	public function get_fees_total() {
+		return $this->totals['fees_total'];
+	}
+
+	/**
+	 * Get the total fee tax amount.
+	 * @return float
+	 */
+	public function get_fees_total_tax() {
+		return $this->totals['fees_total_tax'];
+	}
+
+	/**
+	 * Get the total.
+	 * @return float
+	 */
+	public function get_total() {
+		return $this->totals['total'];
+	}
+
+	/**
+	 * Returns an array of item totals.
+	 * @return array
+	 */
+	public function get_item_totals() {
+		return $this->totals['item_totals'];
+	}
+
+	/**
+	 * Get tax rates for an item. Caches rates in class to avoid multiple look ups.
+	 * @param  object $item
+	 * @return array of taxes
+	 */
+	protected function get_item_tax_rates( $item ) {
+		$tax_class = $item->product->get_tax_class();
+		return isset( $this->item_tax_rates[ $tax_class ] ) ? $this->item_tax_rates[ $tax_class ] : $this->item_tax_rates[ $tax_class ] = WC_Tax::get_rates( $item->product->get_tax_class() );
+	}
+
+	/**
+	 * Get all tax rows for a set of items and shipping methods.
+	 * @return array
+	 */
+	protected function get_merged_taxes() {
+		$taxes = array();
+
+		foreach ( $this->items as $item ) {
+			foreach ( $item->taxes as $rate_id => $rate ) {
+				if ( ! isset( $taxes[ $rate_id ] ) ) {
+					$taxes[ $rate_id ] = new WC_Item_Tax();
+				}
+				$taxes[ $rate_id ]->set_rate( $rate_id );
+				$taxes[ $rate_id ]->set_tax_total( $taxes[ $rate_id ]->get_tax_total() + $rate );
+			}
+		}
+
+		foreach ( $this->shipping_lines as $item ) {
+			foreach ( $item->taxes as $rate_id => $rate ) {
+				if ( ! isset( $taxes[ $rate_id ] ) ) {
+					$taxes[ $rate_id ] = new WC_Item_Tax();
+				}
+				$taxes[ $rate_id ]->set_rate( $rate_id );
+				$taxes[ $rate_id ]->set_shipping_tax_total( $taxes[ $rate_id ]->get_shipping_tax_total() + $rate );
+			}
+		}
+
+		return $taxes;
+	}
+}

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -334,6 +334,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-deprecated-filter-hooks.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-background-emailer.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-discounts.php' );
+		include_once( WC_ABSPATH . 'includes/class-wc-totals.php' );
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -388,3 +388,69 @@ function wc_get_chosen_shipping_method_ids() {
 	}
 	return $method_ids;
 }
+
+/**
+ * Get chosen method for package from session.
+ *
+ * @since  3.2.0
+ * @param  int $key
+ * @param  array $package
+ * @return string|bool
+ */
+function wc_get_chosen_shipping_method_for_package( $key, $package ) {
+	$chosen_methods = WC()->session->get( 'chosen_shipping_methods' );
+	$chosen_method  = isset( $chosen_methods[ $key ] ) ? $chosen_methods[ $key ] : false;
+	$changed        = wc_shipping_methods_have_changed( $key, $package );
+	// If not set, not available, or available methods have changed, set to the DEFAULT option
+	if ( ! $chosen_method || $changed || ! isset( $package['rates'][ $chosen_method ] ) ) {
+		$chosen_method          = wc_get_default_shipping_method_for_package( $key, $package, $chosen_method );
+		$chosen_methods[ $key ] = $chosen_method;
+		WC()->session->set( 'chosen_shipping_methods', $chosen_methods );
+		do_action( 'woocommerce_shipping_method_chosen', $chosen_method );
+	}
+	return $chosen_method;
+}
+/**
+ * Choose the default method for a package.
+ *
+ * @since  3.2.0
+ * @param  string $key
+ * @param  array $package
+ * @return string
+ */
+function wc_get_default_shipping_method_for_package( $key, $package, $chosen_method ) {
+	$rate_keys = array_keys( $package['rates'] );
+	$default   = current( $rate_keys );
+	$coupons   = WC()->cart->get_coupons();
+	foreach ( $coupons as $coupon ) {
+		if ( $coupon->get_free_shipping() ) {
+			foreach ( $rate_keys as $rate_key ) {
+				if ( 0 === stripos( $rate_key, 'free_shipping' ) ) {
+					$default = $rate_key;
+					break;
+				}
+			}
+			break;
+		}
+	}
+	return apply_filters( 'woocommerce_shipping_chosen_method', $default, $package['rates'], $chosen_method );
+}
+/**
+ * See if the methods have changed since the last request.
+ *
+ * @since  3.2.0
+ * @param  int $key
+ * @param  array $package
+ * @return bool
+ */
+function wc_shipping_methods_have_changed( $key, $package ) {
+	// Lookup previous methods from session.
+	$previous_shipping_methods = WC()->session->get( 'previous_shipping_methods' );
+	// Get new and old rates.
+	$new_rates  = array_keys( $package['rates'] );
+	$prev_rates = isset( $previous_shipping_methods[ $key ] ) ? $previous_shipping_methods[ $key ] : false;
+	// Update session.
+	$previous_shipping_methods[ $key ] = $new_rates;
+	WC()->session->set( 'previous_shipping_methods', $previous_shipping_methods );
+	return $new_rates != $prev_rates;
+}

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -6,8 +6,9 @@
  */
 class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
-	protected function get_items_for_discounts_class( $items ) {
-		$items = array();
+	protected function get_items_for_discounts_class() {
+		$items     = array();
+		$precision = pow( 10, wc_get_price_decimals() );
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$item                          = (object) array(
 				'key'                => '',
@@ -25,7 +26,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			);
 			$item->key                     = $cart_item_key;
 			$item->quantity                = $cart_item['quantity'];
-			$item->price                   = $this->add_precision( $cart_item['data']->get_price() ) * $cart_item['quantity'];
+			$item->price                   = $cart_item['data']->get_price() * $precision * $cart_item['quantity'];
 			$item->product                 = $cart_item['data'];
 			$items[ $cart_item_key ] = $item;
 		}

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -3,11 +3,34 @@
 /**
  * Test for the discounts class.
  * @package WooCommerce\Tests\Discounts
- * @todo update tests for new 'items' stucture, or handle other data.
  */
-return;
-
 class WC_Tests_Discounts extends WC_Unit_Test_Case {
+
+	protected function get_items_for_discounts_class( $items ) {
+		$items = array();
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+			$item                          = (object) array(
+				'key'                => '',
+				'quantity'           => 0,
+				'price'              => 0,
+				'product'            => false,
+				'price_includes_tax' => wc_prices_include_tax(),
+				'subtotal'           => 0,
+				'subtotal_tax'       => 0,
+				'subtotal_taxes'     => array(),
+				'total'              => 0,
+				'total_tax'          => 0,
+				'taxes'              => array(),
+				'discounted_price'   => 0,
+			);
+			$item->key                     = $cart_item_key;
+			$item->quantity                = $cart_item['quantity'];
+			$item->price                   = $this->add_precision( $cart_item['data']->get_price() ) * $cart_item['quantity'];
+			$item->product                 = $cart_item['data'];
+			$items[ $cart_item_key ] = $item;
+		}
+		return $items;
+	}
 
 	/**
 	 * Test get and set items.
@@ -27,12 +50,12 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
 		// Test setting items to the cart.
 		$discounts = new WC_Discounts();
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$this->assertEquals( 1, count( $discounts->get_items() ) );
 
 		// Test setting items to an order.
 		$discounts = new WC_Discounts();
-		$discounts->set_items( $order->get_items() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$this->assertEquals( 1, count( $discounts->get_items() ) );
 
 		// Empty array of items.
@@ -58,7 +81,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts = new WC_Discounts();
 		$product   = WC_Helper_Product::create_simple_product();
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 
 		// Test applying multiple coupons and getting totals.
 		$coupon = new WC_Coupon;
@@ -85,12 +108,12 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		WC()->cart->add_to_cart( $product->get_id(), 2 );
 		$coupon->set_discount_type( 'fixed_product' );
 		$coupon->set_amount( 2 );
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( array( 'test' => 4 ), $discounts->get_applied_coupons() );
 
 		$coupon->set_discount_type( 'fixed_cart' );
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( array( 'test' => 2 ), $discounts->get_applied_coupons() );
 
@@ -117,19 +140,19 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
 		// Apply a percent discount.
 		$coupon->set_discount_type( 'percent' );
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( 9, $discounts->get_discounted_price( current( $discounts->get_items() ) ) );
 
 		// Apply a fixed cart coupon.
 		$coupon->set_discount_type( 'fixed_cart' );
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( 0, $discounts->get_discounted_price( current( $discounts->get_items() ) ) );
 
 		// Apply a fixed product coupon.
 		$coupon->set_discount_type( 'fixed_product' );
-		$discounts->set_items( WC()->cart->get_cart() );
+		$discounts->set_items( $this->get_items_for_discounts_class() );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( 0, $discounts->get_discounted_price( current( $discounts->get_items() ) ) );
 
@@ -399,7 +422,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 				$products[] = $product;
 			}
 
-			$discounts->set_items( WC()->cart->get_cart() );
+			$discounts->set_items( $this->get_items_for_discounts_class() );
 
 			foreach ( $test['coupons'] as $coupon_props ) {
 				$coupon = new WC_Coupon;

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -3,7 +3,10 @@
 /**
  * Test for the discounts class.
  * @package WooCommerce\Tests\Discounts
+ * @todo update tests for new 'items' stucture, or handle other data.
  */
+return;
+
 class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
 	/**

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -1,18 +1,28 @@
 <?php
-
 /**
  * Tests for the totals class.
+ *
  * @package WooCommerce\Tests\Discounts
+ */
+
+/**
+ * WC_Tests_Totals
  */
 class WC_Tests_Totals extends WC_Unit_Test_Case {
 
-	// Totals class for getter tests.
+	/**
+	 * Totals class for getter tests.
+	 *
+	 * @var object
+	 */
 	protected $totals;
 
-	// ID tracking for cleanup.
-	protected $products = array();
-	protected $coupons = array();
-	protected $tax_rate_ids = array();
+	/**
+	 * ID tracking for cleanup.
+	 *
+	 * @var array
+	 */
+	protected $ids = array();
 
 	/**
 	 * Setup the cart for totals calculation.
@@ -44,10 +54,10 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		$coupon->set_discount_type( 'percent' );
 		$coupon->save();
 
-		$this->tax_rate_ids[] = $tax_rate_id;
-		$this->products[]     = $product;
-		$this->products[]     = $product2;
-		$this->coupons[]      = $coupon;
+		$this->ids['tax_rate_ids'][] = $tax_rate_id;
+		$this->ids['products'][]     = $product;
+		$this->ids['products'][]     = $product2;
+		$this->ids['coupons'][]      = $coupon;
 
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 		WC()->cart->add_to_cart( $product2->get_id(), 2 );
@@ -63,9 +73,9 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	 * Add fees when the fees API is called.
 	 */
 	public function add_cart_fees_callback() {
-		WC()->cart->add_fee( "test fee", 10, true );
-		WC()->cart->add_fee( "test fee 2", 20, true );
-		WC()->cart->add_fee( "test fee non-taxable", 10, false );
+		WC()->cart->add_fee( 'test fee', 10, true );
+		WC()->cart->add_fee( 'test fee 2', 20, true );
+		WC()->cart->add_fee( 'test fee non-taxable', 10, false );
 	}
 
 	/**
@@ -78,15 +88,15 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		remove_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_cart_fees_callback' ) );
 
-		foreach ( $this->products as $product ) {
+		foreach ( $this->ids['products'] as $product ) {
 			$product->delete( true );
 		}
 
-		foreach ( $this->coupons as $coupon ) {
+		foreach ( $this->ids['coupons'] as $coupon ) {
 			$coupon->delete( true );
 		}
 
-		foreach ( $this->tax_rate_ids as $tax_rate_id ) {
+		foreach ( $this->ids['tax_rate_ids'] as $tax_rate_id ) {
 			WC_Tax::_delete_tax_rate( $tax_rate_id );
 		}
 	}
@@ -102,18 +112,18 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 			'items_subtotal_tax'  => 6.00,
 			'items_total'         => 27.00,
 			'items_total_tax'     => 5.40,
-			'total'               => 78.40,
+			'total'               => 90.40,
 			'taxes'               => array(
 				1 => array(
 					'tax_total'          => 11.40,
-					'shipping_tax_total' => 0.00,
-				)
+					'shipping_tax_total' => 2.00,
+				),
 			),
 			'tax_total'           => 11.40,
-			'shipping_total'      => 0, // @todo ?
-			'shipping_tax_total'  => 0, // @todo ?
+			'shipping_total'      => 10,
+			'shipping_tax_total'  => 2,
 			'discounts_total'     => 3.00,
-			'discounts_tax_total' => 0, // @todo ?
+			'discounts_tax_total' => 0.60,
 		), $this->totals->get_totals() );
 	}
 }

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Tests for the totals class.
+ * @package WooCommerce\Tests\Discounts
+ */
+class WC_Tests_Totals extends WC_Unit_Test_Case {
+
+	// Totals class for getter tests.
+	protected $totals;
+
+	// ID tracking for cleanup.
+	protected $products = array();
+	protected $coupons = array();
+	protected $tax_rate_ids = array();
+
+	/**
+	 * Setup the cart for totals calculation.
+	 */
+	public function setUp() {
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '20.0000',
+			'tax_rate_name'     => 'VAT',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$product  = WC_Helper_Product::create_simple_product();
+		$product2 = WC_Helper_Product::create_simple_product();
+
+		$coupon = new WC_Coupon;
+		$coupon->set_code( 'test-coupon-10' );
+		$coupon->set_amount( 10 );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->save();
+
+		$this->tax_rate_ids[] = $tax_rate_id;
+		$this->products[]     = $product;
+		$this->products[]     = $product2;
+		$this->coupons[]      = $coupon;
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->add_to_cart( $product2->get_id(), 2 );
+		WC()->cart->add_fee( "test fee", 10, true );
+		WC()->cart->add_fee( "test fee 2", 20, true );
+		WC()->cart->add_fee( "test fee non-taxable", 10, false );
+		WC()->cart->add_discount( 'test-coupon-10' );
+
+		// @todo manual discounts
+		$this->totals = new WC_Totals( WC()->cart );
+	}
+
+	/**
+	 * Clean up after test.
+	 */
+	public function tearDown() {
+		WC()->cart->empty_cart();
+		update_option( 'woocommerce_calc_taxes', 'no' );
+
+		foreach ( $this->products as $product ) {
+			$product->delete( true );
+		}
+
+		foreach ( $this->coupons as $coupon ) {
+			$coupon->delete( true );
+		}
+
+		foreach ( $this->tax_rate_ids as $tax_rate_id ) {
+			WC_Tax::_delete_tax_rate( $tax_rate_id );
+		}
+	}
+
+	/**
+	 * Test get and set items.
+	 */
+	public function test_get_totals() {
+		$this->assertEquals( array(), $this->totals->get_totals() );
+	}
+
+	/**
+	 * Test get and set items.
+	 */
+	public function test_get_taxes() {
+
+	}
+
+	/**
+	 * Test get and set items.
+	 */
+	public function test_get_tax_total() {
+
+	}
+
+	//... @todo test all public methods
+}

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -51,7 +51,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		WC()->cart->add_fee( "test fee", 10, true );
 		WC()->cart->add_fee( "test fee 2", 20, true );
 		WC()->cart->add_fee( "test fee non-taxable", 10, false );
-		WC()->cart->add_discount( 'test-coupon-10' );
+		WC()->cart->add_discount( $coupon->get_code() );
 
 		// @todo manual discounts
 		$this->totals = new WC_Totals( WC()->cart );
@@ -81,22 +81,20 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	 * Test get and set items.
 	 */
 	public function test_get_totals() {
-		$this->assertEquals( array(), $this->totals->get_totals() );
+		$this->assertEquals( array(
+			'fees_total'          => 40.00,
+			'fees_total_tax'      => 6.00,
+			'items_subtotal'      => 30.00,
+			'items_subtotal_tax'  => 6.00,
+			'items_total'         => 27.00,
+			'items_total_tax'     => 5.40,
+			'total'               => 72.40,
+			'taxes'               => array(), // @todo ?
+			'tax_total'           => 11.40,
+			'shipping_total'      => 0, // @todo ?
+			'shipping_tax_total'  => 0, // @todo ?
+			'discounts_total'     => 3.00,
+			'discounts_tax_total' => 0, // @todo ?
+		), $this->totals->get_totals() );
 	}
-
-	/**
-	 * Test get and set items.
-	 */
-	public function test_get_taxes() {
-
-	}
-
-	/**
-	 * Test get and set items.
-	 */
-	public function test_get_tax_total() {
-
-	}
-
-	//... @todo test all public methods
 }

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -65,7 +65,6 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 
 		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_cart_fees_callback' ) );
 
-		// @todo manual discounts
 		$this->totals = new WC_Totals( WC()->cart );
 	}
 

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -113,7 +113,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 			'items_total_tax'     => 5.40,
 			'total'               => 90.40,
 			'taxes'               => array(
-				1 => array(
+				$this->ids['tax_rate_ids'][0] => array(
 					'tax_total'          => 11.40,
 					'shipping_tax_total' => 2.00,
 				),


### PR DESCRIPTION
This PR implements an early version of the WC_Totals class, adapted from https://github.com/woocommerce/woocommerce/pull/11889/files

This class links carts/orders with discounts and handles calculations.

The idea is that it gets given either a cart or order, then does the calculations and updates the values on the cart/order as things get calculated. Carts and orders are passed by reference.

There are todo items left to do - mostly for implementing legacy filters and clean up. Those should be done before integration into the cart.

Side note; getting this working did involve some changes to the WC_Shipping and WC_Cart classes since those were badly written. Changes should be BW compatible anyhow - we just need to make them less dependent on each other.