### PR TITLE
Integrate Totals class with Cart

### DIFF
--- a/includes/class-wc-cart-item.php
+++ b/includes/class-wc-cart-item.php
@@ -51,7 +51,7 @@ class WC_Cart_Item implements ArrayAccess {
 	}
 
 	/**
-	 * Gets price of the product.
+	 * Gets weight of the product.
 	 * @return float
 	 */
 	public function get_weight() {
@@ -59,7 +59,7 @@ class WC_Cart_Item implements ArrayAccess {
 	}
 
 	/**
-	 * Gets price of the product.
+	 * Gets tax class of the product.
 	 * @return float
 	 */
 	public function get_tax_class() {

--- a/includes/class-wc-totals.php
+++ b/includes/class-wc-totals.php
@@ -448,8 +448,8 @@ class WC_Totals {
 		$this->set_total( 'items_total', array_sum( array_values( wp_list_pluck( $this->items, 'total' ) ) ) );
 		$this->set_total( 'items_total_tax', array_sum( array_values( wp_list_pluck( $this->items, 'total_tax' ) ) ) );
 
-		$this->object->subtotal = array_sum( wp_list_pluck( $this->items, 'total' ) ) + array_sum( wp_list_pluck( $this->items, 'total_tax' ) );
-		$this->object->subtotal_ex_tax = array_sum( wp_list_pluck( $this->items, 'total' ) );
+		$this->object->subtotal = $this->get_total( 'items_total' ) + $this->get_total( 'items_total_tax' );
+		$this->object->subtotal_ex_tax = $this->get_total( 'items_total' );
 	}
 
 	/**
@@ -519,5 +519,10 @@ class WC_Totals {
 		$this->set_total( 'tax_total', array_sum( wp_list_pluck( $this->get_total( 'taxes', true ), 'tax_total' ) ) );
 		$this->set_total( 'shipping_tax_total', array_sum( wp_list_pluck( $this->get_total( 'taxes', true ), 'shipping_tax_total' ) ) );
 		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + $this->get_total( 'tax_total', true ) + $this->get_total( 'shipping_tax_total', true ) ) );
+
+		$this->object->total = $this->get_total( 'total' );
+		$this->object->tax_total = $this->get_total( 'tax_total' );
+		$this->object->shipping_total = $this->get_total( 'shipping_total' );
+		$this->object->shipping_tax_total = $this->get_total( 'shipping_tax_total' );
 	}
 }

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -28,6 +28,8 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	 * Setup the cart for totals calculation.
 	 */
 	public function setUp() {
+		$this->ids = array();
+
 		$tax_rate = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
@@ -93,6 +95,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 
 		foreach ( $this->ids['coupons'] as $coupon ) {
 			$coupon->delete( true );
+			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
 		}
 
 		foreach ( $this->ids['tax_rate_ids'] as $tax_rate_id ) {
@@ -124,5 +127,24 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 			'discounts_total'     => 3.00,
 			'discounts_tax_total' => 0.60,
 		), $this->totals->get_totals() );
+	}
+
+	/**
+	 * Test that cart totals get updated.
+	 */
+	public function test_cart_totals() {
+		$cart = WC()->cart;
+
+		$this->assertEquals( 40.00, $cart->fee_total );
+		$this->assertEquals( 27.00, $cart->cart_contents_total );
+		$this->assertEquals( 90.40, $cart->total );
+		$this->assertEquals( 32.40, $cart->subtotal );
+		$this->assertEquals( 27.00, $cart->subtotal_ex_tax );
+		$this->assertEquals( 11.40, $cart->tax_total );
+		$this->assertEquals( 3.00, $cart->discount_cart );
+		$this->assertEquals( 0.60, $cart->discount_cart_tax );
+		$this->assertEquals( 40.00, $cart->fee_total );
+		$this->assertEquals( 10, $cart->shipping_total );
+		$this->assertEquals( 2, $cart->shipping_tax_total );
 	}
 }


### PR DESCRIPTION
There is still work to do in the Cart and Totals classes, but WC_Totals should be correctly setting the totals in the Cart now (I think).

I believe the next step after this PR is merged is remove/refactor(?) the calculation methods from WC_Cart and just use the ones from WC_Totals.

We'll probably also want to [do this](https://github.com/woocommerce/woocommerce/compare/feature/discounts-class...feature/discounts-class-cart-total?expand=1#diff-a1af0135d854b1fc52e9257517db4f42R428) before we integrate WC_Totals everywhere.

I'm not super familiar with this feature yet, so let me know if I've made some incorrect assumptions about how the cart works.