### PR TITLE
Fixes incorrect "name" property of the State <select> in the Shopping Cart page.

### DIFF
--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -60,7 +60,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 				} elseif ( is_array( $states ) ) {
 
 					?><span>
-						<select name="calc_shipping_state state_select" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
+						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
 							<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
 							<?php
 								foreach ( $states as $ckey => $cvalue ) {


### PR DESCRIPTION
In the Shopping Cart, click on `Calculate Shipping` and input a country, state and postcode. Upon reloading the page, the other 2 fields are remembered but the `State` field isn't.

This issue was introduced recently (I've tracked it down to [this commit](https://github.com/woocommerce/woocommerce/commit/555f093ac377832dc2bba6edbd123dad903bd713#diff-38bb43c5d8de6b30bc6a2886fd189ca7L63), I wanted to make sure it wasn't like that on putpose). The `<select>` element has a bogus name, so it isn't being processed by the server.