### PR TITLE
Cart item BW compat for discounts class

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -259,13 +259,11 @@ class WC_Discounts {
 			$limit_usage_qty = $coupon->get_limit_usage_to_x_items();
 		}
 
-		$cart_items = $this->get_cart_items_backwards_compatibility();
-
 		foreach ( $this->items as $item ) {
 			if ( 0 === $this->get_discounted_price_in_cents( $item ) ) {
 				continue;
 			}
-			if ( ! $coupon->is_valid_for_product( $item->product, $cart_items[ $item->key ] ) && ! $coupon->is_valid_for_cart() ) { // @todo is this enough?
+			if ( ! $coupon->is_valid_for_product( $item->product, $item->cart_item ) && ! $coupon->is_valid_for_cart() ) {
 				continue;
 			}
 			if ( $limit_usage_qty && $applied_count > $limit_usage_qty ) {
@@ -606,9 +604,8 @@ class WC_Discounts {
 		if ( ! $this->items && $coupon->is_type( wc_get_product_coupon_types() ) ) {
 			$valid = false;
 
-			$cart_items = $this->get_cart_items_backwards_compatibility();
 			foreach ( $this->items as $item ) {
-				if ( $item->product && $coupon->is_valid_for_product( $item->product, $cart_items[ $item->key ] ) ) {
+				if ( $item->product && $coupon->is_valid_for_product( $item->product, $item->cart_item ) ) {
 					$valid = true;
 					break;
 				}
@@ -760,28 +757,5 @@ class WC_Discounts {
 			) );
 		}
 		return true;
-	}
-
-	/**
-	 * Backwards compatibility method to get cart items.
-	 *
-	 * @return array
-	 */
-	protected function get_cart_items_backwards_compatibility() {
-		$items = array();
-
-		foreach ( $this->items as $item ) {
-			$is_variable = $item->product->is_type( 'variation' );
-			$items[ $item->key ] = array(
-				'key'          => $item->key,
-				'product_id'   => $is_variable ? $item->product->get_parent_id() : $item->product->get_id(),
-				'variation_id' => $is_variable ? $item->product->get_id() : 0,
-				'variation'    => $is_variable ? $item->product->get_variation_attributes() : array(),
-				'quantity'     => $item->quantity,
-				'data'         => $item->product,
-			);
-		}
-
-		return $items;
 	}
 }

--- a/includes/class-wc-totals.php
+++ b/includes/class-wc-totals.php
@@ -112,6 +112,13 @@ class WC_Totals {
 	 * Handles a cart or order object passed in for calculation. Normalises data
 	 * into the same format for use by this class.
 	 *
+	 * Each item is made up of the following props, in addition to those returned by get_default_item_props() for totals.
+	 * 	- key: An identifier for the item (cart item key or line item ID).
+	 *  - cart_item: For carts, the cart item from the cart which may include custom data.
+	 *  - quantity: The qty for this line.
+	 *  - price: The line price in cents.
+	 *  - product: The product object this cart item is for.
+	 *
 	 * @since 3.2.0
 	 */
 	private function set_items() {
@@ -119,6 +126,7 @@ class WC_Totals {
 			foreach ( $this->object->get_cart() as $cart_item_key => $cart_item ) {
 				$item                          = $this->get_default_item_props();
 				$item->key                     = $cart_item_key;
+				$item->cart_item               = $cart_item;
 				$item->quantity                = $cart_item['quantity'];
 				$item->price                   = $this->add_precision( $cart_item['data']->get_price() ) * $cart_item['quantity'];
 				$item->product                 = $cart_item['data'];

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -25,6 +25,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 				'discounted_price'   => 0,
 			);
 			$item->key                     = $cart_item_key;
+			$item->cart_item               = $cart_item;
 			$item->quantity                = $cart_item['quantity'];
 			$item->price                   = $cart_item['data']->get_price() * $precision * $cart_item['quantity'];
 			$item->product                 = $cart_item['data'];


### PR DESCRIPTION
Generating a ‘cart item’ loses all the custom data that may have been set.

It’s best to pass this through.