### PR TITLE
Soft deprecated WC_Cart->coupon_applied_count

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -4,6 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+include_once( 'legacy/class-wc-legacy-cart.php' );
+
 /**
  * WooCommerce cart
  *
@@ -16,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category	Class
  * @author 		WooThemes
  */
-class WC_Cart {
+class WC_Cart extends WC_Legacy_Cart {
 
 	/**
 	 * This stores the chosen shipping methods for the cart item packages.
@@ -38,9 +40,6 @@ class WC_Cart {
 
 	/** @var array Contains an array of coupon code discount taxes. Used for tax incl pricing. */
 	public $coupon_discount_tax_amounts = array();
-
-	/** @var array Contains an array of coupon usage counts after they have been applied. */
-	public $coupon_applied_count = array();
 
 	/** @var array Array of coupons */
 	public $coupons = array();
@@ -2004,20 +2003,6 @@ class WC_Cart {
 	private function increase_coupon_discount_amount( $code, $amount, $tax ) {
 		$this->coupon_discount_amounts[ $code ]     = isset( $this->coupon_discount_amounts[ $code ] ) ? $this->coupon_discount_amounts[ $code ] + $amount : $amount;
 		$this->coupon_discount_tax_amounts[ $code ] = isset( $this->coupon_discount_tax_amounts[ $code ] ) ? $this->coupon_discount_tax_amounts[ $code ] + $tax : $tax;
-	}
-
-	/**
-	 * Store how many times each coupon is applied to cart/items.
-	 *
-	 * @access private
-	 * @param string $code
-	 * @param int    $count
-	 */
-	private function increase_coupon_applied_count( $code, $count = 1 ) {
-		if ( empty( $this->coupon_applied_count[ $code ] ) ) {
-			$this->coupon_applied_count[ $code ] = 0;
-		}
-		$this->coupon_applied_count[ $code ] += $count;
 	}
 
 	/*

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Legacy cart
+ *
+ * Legacy and deprecated functions are here to keep the WC_Cart class clean.
+ * This class will be removed in future versions.
+ *
+ * @version  3.2.0
+ * @package  WooCommerce/Classes
+ * @category Class
+ * @author   Automattic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Legacy cart class.
+ */
+abstract class WC_Legacy_Cart {
+
+	/**
+	 * Contains an array of coupon usage counts after they have been applied.
+	 *
+	 * @var array
+	 */
+	public $coupon_applied_count = array();
+
+	/**
+	 * Store how many times each coupon is applied to cart/items.
+	 *
+	 * @deprecated 3.2.0
+	 * @access private
+	 * @param string $code
+	 * @param int    $count
+	 */
+	protected function increase_coupon_applied_count( $code, $count = 1 ) {
+		if ( empty( $this->coupon_applied_count[ $code ] ) ) {
+			$this->coupon_applied_count[ $code ] = 0;
+		}
+		$this->coupon_applied_count[ $code ] += $count;
+	}
+}


### PR DESCRIPTION
Just as soft deprecated, since has count every time that `WC_Cart->get_discounted_price` is called.
If should really to disallow it, we could always return an empty array.

Not using magic methods to avoid "Indirect modification of overloaded property" notice.

Part of #15500