### PR TITLE
Fix product category archives not being cached due to inconsistency

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -155,10 +155,9 @@ class WC_Cache_Helper {
 		if ( ! is_blog_installed() ) {
 			return;
 		}
-		$page_ids        = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
-		$current_page_id = get_queried_object_id();
-
-		if ( isset( $_GET['download_file'] ) || in_array( $current_page_id, $page_ids ) ) {
+		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
+		
+		if ( isset( $_GET['download_file'] ) || is_page( $page_ids ) ) {
 			self::nocache();
 		}
 	}


### PR DESCRIPTION
Wordpress function get_queried_object_id() returns conflicting IDs
for pages and product category archives which in current
implementation results in product category archives possibly not
being cached if their tag ID conflicts with Woocommerce's special
page IDs - cart, checkout, etc.

Let's switch to implementation using is_page() to address this.