### PR TITLE
Fix PHP deprecation notice

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -1243,7 +1243,7 @@ class WC_Admin_Post_Types {
 		$stock_status = ! empty( $_REQUEST['_stock_status'] ) ? wc_clean( $_REQUEST['_stock_status'] ) : $stock_status;
 
 		if ( ! empty( $_REQUEST['_manage_stock'] ) ) {
-			$manage_stock = 'yes' === wc_clean( $_REQUEST['_manage_stock'] ) && 'grouped' !== $product->product_type ? 'yes' : 'no';
+			$manage_stock = 'yes' === wc_clean( $_REQUEST['_manage_stock'] ) && 'grouped' !== $product->get_type() ? 'yes' : 'no';
 		} else {
 			$manage_stock = $was_managing_stock;
 		}


### PR DESCRIPTION
Occurs when updating "Manage stock" via bulk edit.

<details><summary>Stack trace</summary>
<pre>
PHP Notice:  product_type was called <strong>incorrectly</strong>. Product properties should not be accessed directly. Backtrace: bulk_edit_posts, wp_update_post, wp_insert_post, do_action('save_post'), WP_Hook->do_action, WP_Hook->apply_filters, WC_Admin_Post_Types->bulk_and_quick_edit_hook, do_action('woocommerce_product_bulk_and_quick_edit'), WP_Hook->do_action, WP_Hook->apply_filters, WC_Admin_Post_Types->bulk_and_quick_edit_save_post, WC_Admin_Post_Types->bulk_edit_save, WC_Abstract_Legacy_Product->__get, wc_doing_it_wrong Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.0.) in /wp-includes/functions.php on line 4139
PHP Stack trace:
PHP   1. {main}() /wp-admin/edit.php:0
PHP   2. bulk_edit_posts() /wp-admin/edit.php:155
PHP   3. wp_update_post() /wp-admin/includes/post.php:568
PHP   4. wp_insert_post() /wp-includes/post.php:3583
PHP   5. do_action() /wp-includes/post.php:3510
PHP   6. WP_Hook->do_action() /wp-includes/plugin.php:453
PHP   7. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:323
PHP   8. WC_Admin_Post_Types->bulk_and_quick_edit_hook() /wp-includes/class-wp-hook.php:300
PHP   9. do_action() /wp-content/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php:872
PHP  10. WP_Hook->do_action() /wp-includes/plugin.php:453
PHP  11. WP_Hook->apply_filters() /wp-includes/class-wp-hook.php:323
PHP  12. WC_Admin_Post_Types->bulk_and_quick_edit_save_post() /wp-includes/class-wp-hook.php:298
PHP  13. WC_Admin_Post_Types->bulk_edit_save() /wp-content/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php:921
PHP  14. WC_Abstract_Legacy_Product->__get() /wp-content/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php:1250
PHP  15. wc_doing_it_wrong() /wp-content/plugins/woocommerce/includes/legacy/abstract-wc-legacy-product.php:72
PHP  16. _doing_it_wrong() /wp-content/plugins/woocommerce/includes/wc-deprecated-functions.php:68
PHP  17. trigger_error() /wp-includes/functions.php:4139
</pre></details>