### PR TITLE
Updates screen modal.

### DIFF
--- a/includes/admin/class-wc-admin-plugin-updates.php
+++ b/includes/admin/class-wc-admin-plugin-updates.php
@@ -183,9 +183,7 @@ class WC_Admin_Plugin_Updates {
 			( function( $ ) {
 				var $update_box = $( '#woocommerce-update' );
 				var $update_link = $update_box.find('a.update-link').first();
-
 				var update_url = $update_link.attr( 'href' );
-				var old_tb_position = false;
 
 				// Initialize thickbox.
 				$update_link.removeClass( 'update-link' );
@@ -215,7 +213,7 @@ class WC_Admin_Plugin_Updates {
 	/**
 	 * JS for the modal window on the updates screen.
 	 */
-	public function update_screen_modal_js() {
+	protected function update_screen_modal_js() {
 		?>
 		<script>
 			( function( $ ) {

--- a/includes/admin/class-wc-admin-plugin-updates.php
+++ b/includes/admin/class-wc-admin-plugin-updates.php
@@ -139,6 +139,7 @@ class WC_Admin_Plugin_Updates {
 		?>
 		<script>
 			( function( $ ) {
+				// Initialize thickbox.
 				tb_init( '.wc-thickbox' );
 
 				var old_tb_position = false;
@@ -185,7 +186,7 @@ class WC_Admin_Plugin_Updates {
 				var $update_link = $update_box.find('a.update-link').first();
 				var update_url = $update_link.attr( 'href' );
 
-				// Initialize thickbox.
+				// Set up thickbox.
 				$update_link.removeClass( 'update-link' );
 				$update_link.addClass( 'wc-thickbox' );
 				$update_link.attr( 'href', '#TB_inline?height=600&width=550&inlineId=wc_untested_extensions_modal' );

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -101,6 +101,7 @@ class WC_Admin {
 				include( 'class-wc-admin-permalink-settings.php' );
 			break;
 			case 'plugins' :
+			case 'update-core' :
 				include( 'class-wc-admin-plugin-updates.php' );
 			break;
 			case 'users' :

--- a/includes/admin/views/html-notice-untested-extensions-modal.php
+++ b/includes/admin/views/html-notice-untested-extensions-modal.php
@@ -44,5 +44,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</p>
 				</div>
 			<?php endif ?>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
Part of #15478 and #16086.

I think this way should work well and play nicely with other stuff out there that does stuff to the bulk updates screen.

If the user checks the WC checkbox or the "Select All" checkbox, a modal is displayed if there are untested plugins with the new major release:

<img width="1059" alt="screen shot 2017-08-01 at 3 09 39 pm" src="https://user-images.githubusercontent.com/7317227/28849354-854040c4-76cb-11e7-8360-c95720a155ca.png">

If the user clicks "cancel", the WC checkbox unchecks:

<img width="877" alt="screen shot 2017-08-01 at 3 09 54 pm" src="https://user-images.githubusercontent.com/7317227/28849356-88e6b258-76cb-11e7-8315-e5f5517833a5.png">

If they click "accept", the WC checkbox stays checked.