### PR TITLE
Focus on modal content instead of container

### DIFF
--- a/assets/js/admin/backbone-modal.js
+++ b/assets/js/admin/backbone-modal.js
@@ -79,7 +79,7 @@
 		render: function() {
 			var template = wp.template( this._target );
 
-			this.$el.attr( 'tabindex' , '0' ).append(
+			this.$el.append(
 				template( this._string )
 			);
 
@@ -88,7 +88,8 @@
 			}).append( this.$el );
 
 			this.resizeContent();
-			this.$el.focus();
+			this.$( '.wc-backbone-modal-content' ).attr( 'tabindex' , '0' ).focus();
+
 			$( document.body ).trigger( 'init_tooltips' );
 
 			$( document.body ).trigger( 'wc_backbone_modal_loaded', this._target );


### PR DESCRIPTION
Prevent unwanted jumps in page scroll position when opening a modal. Without this fix, whenever a modal is opened (rendered), the page scrolls to the very bottom, since this is where `this.$el` is - it's the very last element on the page. Instead, add `tabindex` and `focus()` on the content div, so that the page scroll position remains intact.