### PR TITLE
Prevent caching on update_cart_action and add_to_cart_action

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -158,7 +158,7 @@ class WC_Cache_Helper {
 		$page_ids        = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
 		$current_page_id = get_queried_object_id();
 
-		if ( isset( $_GET['download_file'] ) || in_array( $current_page_id, $page_ids ) ) {
+		if ( isset( $_GET['download_file'] ) || isset( $_GET['add-to-cart'] ) || in_array( $current_page_id, $page_ids ) ) {
 			self::nocache();
 		}
 	}

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -30,7 +30,7 @@ class WC_Form_Handler {
 		add_action( 'wp_loaded', array( __CLASS__, 'cancel_order' ), 20 );
 		add_action( 'wp_loaded', array( __CLASS__, 'order_again' ), 20 );
 		add_action( 'template_redirect', array( __CLASS__, 'update_cart_action' ), 20 );
-		add_action( 'wp_loaded', array( __CLASS__, 'add_to_cart_action' ), 20 );
+		add_action( 'template_redirect', array( __CLASS__, 'add_to_cart_action' ), 20 );
 
 		// May need $wp global to access query vars.
 		add_action( 'wp', array( __CLASS__, 'pay_action' ), 20 );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -29,7 +29,7 @@ class WC_Form_Handler {
 		add_action( 'wp_loaded', array( __CLASS__, 'process_reset_password' ), 20 );
 		add_action( 'wp_loaded', array( __CLASS__, 'cancel_order' ), 20 );
 		add_action( 'wp_loaded', array( __CLASS__, 'order_again' ), 20 );
-		add_action( 'wp_loaded', array( __CLASS__, 'update_cart_action' ), 20 );
+		add_action( 'template_redirect', array( __CLASS__, 'update_cart_action' ), 20 );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_to_cart_action' ), 20 );
 
 		// May need $wp global to access query vars.


### PR DESCRIPTION
The browser is caching the page because 'update_cart_action' is hooked on' wp_loaded' and is runned before 'prevent_caching' that is hooked on 'wp'. After remove the item, 'update_cart_action' function does a redirect, so prevent_caching is not runned.

The same problem occurs with 'add_to_cart_action.