### PR TITLE
Add variation price data transient name filter

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -154,7 +154,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		 * Transient name for storing prices for this product (note: Max transient length is 45)
 		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
 		 */
-		$transient_name = 'wc_var_prices_' . $product->get_id();
+		$transient_name = apply_filters( 'woocommerce_variation_prices_transient_name', 'wc_var_prices_' . $product->get_id() );
 
 		$price_hash = $this->get_price_hash( $product, $include_taxes );
 


### PR DESCRIPTION
Variation prices get cached, GREAT! Until you attempt to filter the prices, which then when things are dynamically being filtered the transient/cache will mean you never see the filtered version.

This allows the transient name to be filtered so things can still be cached, BUT with unique caches per filtered results.