### PR TITLE
Add “site size” areas to system status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -13,14 +13,16 @@ if ( ! class_exists( 'WC_REST_System_Status_Controller', false ) ) {
 	wp_die( 'Cannot load the REST API to access WC_REST_System_Status_Controller.' );
 }
 
-$system_status  = new WC_REST_System_Status_Controller;
-$environment    = $system_status->get_environment_info();
-$database       = $system_status->get_database_info();
-$active_plugins = $system_status->get_active_plugins();
-$theme          = $system_status->get_theme_info();
-$security       = $system_status->get_security_info();
-$settings       = $system_status->get_settings();
-$pages          = $system_status->get_pages();
+$system_status    = new WC_REST_System_Status_Controller;
+$environment      = $system_status->get_environment_info();
+$database         = $system_status->get_database_info();
+$database_size    = $system_status->get_database_table_sizes();
+$post_type_counts = $system_status->get_post_type_counts();
+$active_plugins   = $system_status->get_active_plugins();
+$theme            = $system_status->get_theme_info();
+$security         = $system_status->get_security_info();
+$settings         = $system_status->get_settings();
+$pages            = $system_status->get_pages();
 ?>
 <div class="updated woocommerce-message inline">
 	<p><?php _e( 'Please copy and paste this information in your ticket when contacting support:', 'woocommerce' ); ?> </p>
@@ -302,57 +304,100 @@ $pages          = $system_status->get_pages();
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">
-	<thead>
-		<tr>
-			<th colspan="3" data-export-label="Database"><h2><?php _e( 'Database', 'woocommerce' ); ?></h2></th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td data-export-label="WC Database Version"><?php _e( 'WC database version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce version.', 'woocommerce' ) ); ?></td>
-			<td><?php echo esc_html( $database['wc_database_version'] ); ?></td>
-		</tr>
-		<tr>
-			<td data-export-label="WC Database Prefix"><?php _e( 'Database prefix', 'woocommerce' ); ?></td>
-			<td class="help">&nbsp;</td>
-			<td><?php
-				if ( strlen( $database['database_prefix'] ) > 20 ) {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend using a prefix with less than 20 characters. See: %2$s', 'woocommerce' ), esc_html( $database['database_prefix'] ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . __( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
-				} else {
-					echo '<mark class="yes">' . esc_html( $database['database_prefix'] ) . '</mark>';
-				}
-				?>
-			</td>
-		</tr>
-		<?php
-		foreach ( $database['database_tables'] as $table => $table_exists ) {
+    <thead>
+    <tr>
+        <th colspan="3" data-export-label="Database"><h2><?php _e( 'Database', 'woocommerce' ); ?></h2></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td data-export-label="WC Database Version"><?php _e( 'WC database version', 'woocommerce' ); ?>:</td>
+        <td class="help"><?php echo wc_help_tip( __( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce version.', 'woocommerce' ) ); ?></td>
+        <td><?php echo esc_html( $database['wc_database_version'] ); ?></td>
+    </tr>
+    <tr>
+        <td data-export-label="WC Database Prefix"><?php _e( 'Database prefix', 'woocommerce' ); ?></td>
+        <td class="help">&nbsp;</td>
+        <td><?php
+			if ( strlen( $database['database_prefix'] ) > 20 ) {
+				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend using a prefix with less than 20 characters. See: %2$s', 'woocommerce' ), esc_html( $database['database_prefix'] ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . __( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
+			} else {
+				echo '<mark class="yes">' . esc_html( $database['database_prefix'] ) . '</mark>';
+			}
 			?>
-			<tr>
-				<td><?php echo esc_html( $table ); ?></td>
-				<td class="help">&nbsp;</td>
-				<td><?php echo ! $table_exists ? '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Table does not exist', 'woocommerce' ) . '</mark>' : '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>'; ?></td>
-			</tr>
-			<?php
-		}
-
-		if ( $settings['geolocation_enabled'] ) {
-			?>
-			<tr>
-				<td data-export-label="MaxMind GeoIP Database"><?php _e( 'MaxMind GeoIP database', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The GeoIP database from MaxMind is used to geolocate customers.', 'woocommerce' ) ); ?></td>
-				<td><?php
-					if ( file_exists( $database['maxmind_geoip_database'] ) ) {
-						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> <code class="private">' . esc_html( $database['maxmind_geoip_database'] ) . '</code></mark> ';
-					} else {
-						printf( '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'The MaxMind GeoIP Database does not exist - Geolocation will not function. You can download and install it manually from %1$s to the path: %2$s. Scroll down to "Downloads" and download the "Binary / gzip" file next to "GeoLite Country". Please remember to uncompress GeoIP.dat.gz and upload the GeoIP.dat file only.', 'woocommerce' ), make_clickable( 'http://dev.maxmind.com/geoip/legacy/geolite/' ), '<code class="private">' . $database['maxmind_geoip_database'] . '</code>' ) . '</mark>', WC_LOG_DIR );
-					}
-				?></td>
-			</tr>
-			<?php
-		}
+        </td>
+    </tr>
+	<?php
+	foreach ( $database['database_tables'] as $table => $table_exists ) {
 		?>
-	</tbody>
+        <tr>
+            <td><?php echo esc_html( $table ); ?></td>
+            <td class="help">&nbsp;</td>
+            <td><?php echo ! $table_exists ? '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Table does not exist', 'woocommerce' ) . '</mark>' : '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>'; ?></td>
+        </tr>
+		<?php
+	}
+
+	if ( $settings['geolocation_enabled'] ) {
+		?>
+        <tr>
+            <td data-export-label="MaxMind GeoIP Database"><?php _e( 'MaxMind GeoIP database', 'woocommerce' ); ?>:</td>
+            <td class="help"><?php echo wc_help_tip( __( 'The GeoIP database from MaxMind is used to geolocate customers.', 'woocommerce' ) ); ?></td>
+            <td><?php
+				if ( file_exists( $database['maxmind_geoip_database'] ) ) {
+					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> <code class="private">' . esc_html( $database['maxmind_geoip_database'] ) . '</code></mark> ';
+				} else {
+					printf( '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'The MaxMind GeoIP Database does not exist - Geolocation will not function. You can download and install it manually from %1$s to the path: %2$s. Scroll down to "Downloads" and download the "Binary / gzip" file next to "GeoLite Country". Please remember to uncompress GeoIP.dat.gz and upload the GeoIP.dat file only.', 'woocommerce' ), make_clickable( 'http://dev.maxmind.com/geoip/legacy/geolite/' ), '<code class="private">' . $database['maxmind_geoip_database'] . '</code>' ) . '</mark>', WC_LOG_DIR );
+				}
+				?></td>
+        </tr>
+		<?php
+	}
+	?>
+    </tbody>
+</table>
+<table class="wc_status_table widefat" cellspacing="0">
+    <thead>
+    <tr>
+        <th colspan="3" data-export-label="Database Table Sizes"><h2><?php _e( 'Database Table Sizes', 'woocommerce' ); ?></h2></th>
+    </tr>
+    </thead>
+    <tbody>
+	<?php
+	foreach ( $database_size as $table ) {
+		?>
+        <tr>
+            <td><?php echo esc_html( $table->name ); ?></td>
+            <td class="help">&nbsp;</td>
+            <td>
+	            <?php _e( 'Data: ', 'woocommerce' ); ?><?php echo wc_format_decimal( $table->data, 2 ); ?>MB,
+	            <?php _e( 'Index: ', 'woocommerce' ); ?><?php echo wc_format_decimal( $table->index, 2 ); ?>MB
+            </td>
+        </tr>
+		<?php
+	}
+	?>
+    </tbody>
+</table>
+<table class="wc_status_table widefat" cellspacing="0">
+    <thead>
+    <tr>
+        <th colspan="3" data-export-label="Post Type Counts"><h2><?php _e( 'Post Type Counts', 'woocommerce' ); ?></h2></th>
+    </tr>
+    </thead>
+    <tbody>
+	<?php
+	foreach ( $post_type_counts as $post_type ) {
+		?>
+        <tr>
+            <td><?php echo esc_html( $post_type->type ); ?></td>
+            <td class="help">&nbsp;</td>
+            <td><?php echo absint( $post_type->count ); ?></td>
+        </tr>
+		<?php
+	}
+	?>
+    </tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">
 	<thead>

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -636,8 +636,18 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 	public function get_database_info() {
 		global $wpdb;
 
+		$database_table_sizes = $wpdb->get_results( $wpdb->prepare( "
+			SELECT 
+			    table_name AS 'name', 
+			    round( ( data_length / 1024 / 1024 ), 2 ) 'data',
+			    round( ( index_length / 1024 / 1024 ), 2 ) 'index'
+			FROM information_schema.TABLES 
+			WHERE table_schema = %s
+			ORDER BY name ASC;
+		", DB_NAME ) );
+
 		// WC Core tables to check existence of
-		$tables = apply_filters( 'woocommerce_database_tables', array(
+		$core_tables = apply_filters( 'woocommerce_database_tables', array(
 			'woocommerce_sessions',
 			'woocommerce_api_keys',
 			'woocommerce_attribute_taxonomies',
@@ -651,14 +661,48 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			'woocommerce_shipping_zone_methods',
 			'woocommerce_payment_tokens',
 			'woocommerce_payment_tokenmeta',
+			'woocommerce_log',
 		) );
 
 		if ( get_option( 'db_version' ) < 34370 ) {
-			$tables[] = 'woocommerce_termmeta';
+			$core_tables[] = 'woocommerce_termmeta';
 		}
-		$table_exists = array();
-		foreach ( $tables as $table ) {
-			$table_exists[ $table ] = ( $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s;", $wpdb->prefix . $table ) ) === $wpdb->prefix . $table );
+
+		/**
+		 * Adding the prefix to the tables array, for backwards compatibility.
+		 *
+		 * If we changed the tables above to include the prefix, then any filters against that table could break.
+		 */
+		$core_tables = array_map( function( $table ) {
+			global $wpdb;
+			return $wpdb->prefix . $table;
+		}, $core_tables );
+
+		/**
+		 * Organize WooCommerce and non-WooCommerce tables separately for display purposes later.
+		 *
+		 * To ensure we include all WC tables, even if they do not exist, pre-populate the WC array with all the tables.
+		 */
+		$tables = array(
+			'woocommerce' => array_fill_keys( $core_tables, false ),
+			'other' => array()
+		);
+
+		$database_size = array(
+			'data' => 0,
+			'index' => 0
+		);
+
+		foreach ( $database_table_sizes as $table ) {
+			$table_type = in_array( $table->name, $core_tables ) ? 'woocommerce' : 'other';
+
+			$tables[ $table_type ][ $table->name ] = array(
+				'data'  => $table->data,
+				'index' => $table->index
+			);
+
+			$database_size[ 'data' ] += $table->data;
+			$database_size[ 'index' ] += $table->index;
 		}
 
 		// Return all database info. Described by JSON Schema.
@@ -666,24 +710,9 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			'wc_database_version'    => get_option( 'woocommerce_db_version' ),
 			'database_prefix'        => $wpdb->prefix,
 			'maxmind_geoip_database' => WC_Geolocation::get_local_database_path(),
-			'database_tables'        => $table_exists,
+			'database_tables'        => $tables,
+			'database_size'          => $database_size,
 		);
-	}
-
-	public function get_database_table_sizes() {
-		global $wpdb;
-
-		$database_table_sizes = $wpdb->get_results( $wpdb->prepare( "
-			SELECT 
-			    table_name AS 'name', 
-			    round( ( data_length / 1024 / 1024 ), 2 ) 'data',
-			    round( ( index_length / 1024 / 1024 ), 2 ) 'index'
-			FROM information_schema.TABLES 
-			WHERE table_schema = %s
-			ORDER BY name ASC;
-		", DB_NAME ) );
-
-		return is_array( $database_table_sizes ) ? $database_table_sizes : array();
 	}
 
 	/**

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -670,6 +670,35 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		);
 	}
 
+	public function get_database_table_sizes() {
+		global $wpdb;
+
+		$database_table_sizes = $wpdb->get_results( $wpdb->prepare( "
+			SELECT 
+			    table_name AS 'name', 
+			    round( ( data_length / 1024 / 1024 ), 2 ) 'data',
+			    round( ( index_length / 1024 / 1024 ), 2 ) 'index'
+			FROM information_schema.TABLES 
+			WHERE table_schema = %s
+			ORDER BY name ASC;
+		", DB_NAME ) );
+
+		return is_array( $database_table_sizes ) ? $database_table_sizes : array();
+	}
+
+	/**
+	 * Get array of counts of objects. Orders, products, etc.
+	 *
+	 * @return array
+	 */
+	public function get_post_type_counts() {
+		global $wpdb;
+
+		$post_type_counts = $wpdb->get_results( "SELECT post_type AS 'type', count(1) AS 'count' FROM {$wpdb->posts} GROUP BY post_type;" );
+
+		return is_array( $post_type_counts ) ? $post_type_counts : array();
+	}
+
 	/**
 	 * Get a list of plugins active on the site.
 	 *


### PR DESCRIPTION
The size of the site very much impacts the status of the site. This type of information would be extremely helpful when supporting a site.

1) post counts - can reveal high volumes of specific kinds of post types both within WC (orders, products, etc) or outside (revisions, attachments, third party ones, etc)

2) table sizes - a site with a 5MB postmeta table is very different than a site with a 5GB postmeta table, which is different than a site with a 50GB postmeta table, and require different kinds of support and focus.