### PR TITLE
Fix cache issue.

### DIFF
--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -143,5 +143,6 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 */
 	public function clear_cache( &$item ) {
 		wp_cache_delete( 'item-' . $item->get_id(), 'order-items' );
+		wp_cache_delete( 'order-items-' . $item->get_order_id(), 'orders' );
 	}
 }


### PR DESCRIPTION
From discussion with @mikejolley:

The class is not doing its job of invaliding cache after adding a line item.
At any point (action hook), a 3pd can call `get_items` and it will cache the items for that particular order so any subsequent calls to it will return bad data.
Unless you ADD items, `get_items` will return good data.
So adding items in this case is not invalidating, so that's the bug.

Relates to: https://github.com/woocommerce/woocommerce-bookings/issues/1310