### PR TITLE
Store status_transition in a local variable and reset it before firing hooks in order to avoid infinite loops

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -303,25 +303,27 @@ class WC_Order extends WC_Abstract_Order {
 	 * Handle the status transition.
 	 */
 	protected function status_transition() {
-		if ( $this->status_transition ) {
-			do_action( 'woocommerce_order_status_' . $this->status_transition['to'], $this->get_id(), $this );
+		$status_transition = $this->status_transition;
 
-			if ( ! empty( $this->status_transition['from'] ) ) {
+		// Reset status transition variable
+		$this->status_transition = false;
+
+		if ( $status_transition ) {
+			do_action( 'woocommerce_order_status_' . $status_transition['to'], $this->get_id(), $this );
+
+			if ( ! empty( $status_transition['from'] ) ) {
 				/* translators: 1: old order status 2: new order status */
-				$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['from'] ), wc_get_order_status_name( $this->status_transition['to'] ) );
+				$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['from'] ), wc_get_order_status_name( $status_transition['to'] ) );
 
-				do_action( 'woocommerce_order_status_' . $this->status_transition['from'] . '_to_' . $this->status_transition['to'], $this->get_id(), $this );
-				do_action( 'woocommerce_order_status_changed', $this->get_id(), $this->status_transition['from'], $this->status_transition['to'], $this );
+				do_action( 'woocommerce_order_status_' . $status_transition['from'] . '_to_' . $status_transition['to'], $this->get_id(), $this );
+				do_action( 'woocommerce_order_status_changed', $this->get_id(), $status_transition['from'], $status_transition['to'], $this );
 			} else {
 				/* translators: %s: new order status */
-				$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $this->status_transition['to'] ) );
+				$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['to'] ) );
 			}
 
 			// Note the transition occurred
-			$this->add_order_note( trim( $this->status_transition['note'] . ' ' . $transition_note ), 0, $this->status_transition['manual'] );
-
-			// This has ran, so reset status transition variable
-			$this->status_transition = false;
+			$this->add_order_note( trim( $status_transition['note'] . ' ' . $transition_note ), 0, $status_transition['manual'] );
 		}
 	}
 


### PR DESCRIPTION
Related #16362