### PR TITLE
Fix filename image handling

### DIFF
--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -504,8 +504,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		$base_url   = $upload_dir['baseurl'] . '/';
 
 		// Check first if attachment is on WordPress uploads directory.
-		if ( false !== strpos( $url, $base_url ) ) {
-			// Search for yyyy/mm/slug.extension
+		if ( false === strpos( $url, $base_url ) ) {
+			// Search for yyyy/mm/slug.extension.
 			$file = str_replace( $base_url, '', $url );
 			$args = array(
 				'post_type'   => 'attachment',
@@ -515,11 +515,10 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 					array(
 						'value'   => $file,
 						'compare' => 'LIKE',
-						'key'     => '_wp_attachment_metadata',
+						'key'     => '_wp_attached_file',
 					),
 				),
 			);
-
 			if ( $ids = get_posts( $args ) ) {
 				$id = current( $ids );
 			}
@@ -535,14 +534,13 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 					),
 				),
 			);
-
 			if ( $ids = get_posts( $args ) ) {
 				$id = current( $ids );
 			}
 		}
 
 		// Upload if attachment does not exists.
-		if ( ! $id ) {
+		if ( ! $id && stristr( $url, '://' ) ) {
 			$upload = wc_rest_upload_image_from_url( $url );
 
 			if ( is_wp_error( $upload ) ) {
@@ -557,6 +555,10 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 			// Save attachment source for future reference.
 			update_post_meta( $id, '_wc_attachment_source', $url );
+		}
+
+		if ( ! $id ) {
+			throw new Exception( sprintf( __( 'Unable to use image "%s".', 'woocommerce' ), $url ), 400 );
 		}
 
 		return $id;

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -377,7 +377,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
-	 * Parse images list from a CSV.
+	 * Parse images list from a CSV. Images can be filenames or URLs.
 	 *
 	 * @param  string $field Field value.
 	 * @return array
@@ -387,7 +387,17 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return array();
 		}
 
-		return array_map( 'esc_url_raw', $this->explode_values( $field ) );
+		$images = array();
+
+		foreach ( $this->explode_values( $field ) as $image ) {
+			if ( stristr( $image, '://' ) ) {
+				$images[] = esc_url_raw( $image );
+			} else {
+				$images[] = sanitize_file_name( $image );
+			}
+		}
+
+		return $images;
 	}
 
 	/**


### PR DESCRIPTION
Prevents escaping non-URLs and fixes the logic which compares the filename to existing filenames - the check `!==` was backwards.

Fixes #16316