### PR TITLE
Solving long table names

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -88,6 +88,10 @@ class WC_Install {
 			'wc_update_320_mexican_states',
 			'wc_update_320_db_version',
 		),
+		'4.0.0' => array(
+			'wc_update_400_table_names',
+			'wc_update_400_db_version',
+		),
 	);
 
 	/** @var object Background update class */
@@ -467,6 +471,9 @@ class WC_Install {
 	 *
 	 * Changing indexes may cause duplicate index notices in logs due to https://core.trac.wordpress.org/ticket/34870 but dropping
 	 * indexes first causes too much load on some servers/larger DB.
+	 *
+	 * Table names should be < 32 chars. Max allowable length is 64 for MySql - we need to leave room for the prefix.
+	 * WooCommerce prefix should be wc_.
 	 *
 	 * @return string
 	 */

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -33,6 +33,7 @@ class WC_Query {
 	 * @access public
 	 */
 	public function __construct() {
+		add_filter( 'query', array( $this, 'adjust_query_table_names' ) );
 		add_action( 'init', array( $this, 'add_endpoints' ) );
 		if ( ! is_admin() ) {
 			add_action( 'wp_loaded', array( $this, 'get_errors' ), 20 );
@@ -43,6 +44,32 @@ class WC_Query {
 			add_action( 'wp', array( $this, 'remove_ordering_args' ) );
 		}
 		$this->init_query_vars();
+	}
+
+	/**
+	 * Maintains compatibility with old table names used in queries after they were renamed in 4.0.0.
+	 *
+	 * @since  4.0.0
+	 * @return string
+	 */
+	public function adjust_query_table_names( $query ) {
+		$tables = array(
+			"{$wpdb->prefix}woocommerce_sessions"                         => "{$wpdb->prefix}wc_sessions",
+			"{$wpdb->prefix}woocommerce_api_keys"                         => "{$wpdb->prefix}wc_api_keys",
+			"{$wpdb->prefix}woocommerce_attribute_taxonomies"             => "{$wpdb->prefix}wc_attributes",
+			"{$wpdb->prefix}woocommerce_downloadable_product_permissions" => "{$wpdb->prefix}wc_customer_downloads",
+			"{$wpdb->prefix}woocommerce_order_items"                      => "{$wpdb->prefix}wc_order_items",
+			"{$wpdb->prefix}woocommerce_order_itemmeta"                   => "{$wpdb->prefix}wc_order_itemmeta",
+			"{$wpdb->prefix}woocommerce_tax_rates"                        => "{$wpdb->prefix}wc_tax_rates",
+			"{$wpdb->prefix}woocommerce_tax_rate_locations"               => "{$wpdb->prefix}wc_tax_rate_locations",
+			"{$wpdb->prefix}woocommerce_shipping_zones"                   => "{$wpdb->prefix}wc_shipping_zones",
+			"{$wpdb->prefix}woocommerce_shipping_zone_locations"          => "{$wpdb->prefix}wc_shipping_zone_locations",
+			"{$wpdb->prefix}woocommerce_shipping_zone_methods"            => "{$wpdb->prefix}wc_shipping_zone_methods",
+			"{$wpdb->prefix}woocommerce_payment_tokens"                   => "{$wpdb->prefix}wc_payment_tokens",
+			"{$wpdb->prefix}woocommerce_payment_tokenmeta"                => "{$wpdb->prefix}wc_payment_tokenmeta",
+			"{$wpdb->prefix}woocommerce_log"                              => "{$wpdb->prefix}wc_log",
+		);
+		return str_replace( array_keys( $tables ), array_values( $tables ), $query );
 	}
 
 	/**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1204,3 +1204,31 @@ function wc_update_320_mexican_states() {
 function wc_update_320_db_version() {
 	WC_Install::update_db_version( '3.2.0' );
 }
+
+/**
+ * Rename long tables.
+ */
+function wc_update_400_table_names() {
+	global $wpdb;
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_sessions TO {$wpdb->prefix}wc_sessions;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_api_keys TO {$wpdb->prefix}wc_api_keys;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_attribute_taxonomies TO {$wpdb->prefix}wc_attributes;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions TO {$wpdb->prefix}wc_customer_downloads;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_order_items TO {$wpdb->prefix}wc_order_items;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_order_itemmeta TO {$wpdb->prefix}wc_order_itemmeta;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_tax_rates TO {$wpdb->prefix}wc_tax_rates;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_tax_rate_locations TO {$wpdb->prefix}wc_tax_rate_locations;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_shipping_zones TO {$wpdb->prefix}wc_shipping_zones;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_shipping_zone_locations TO {$wpdb->prefix}wc_shipping_zone_locations;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods TO {$wpdb->prefix}wc_shipping_zone_methods;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_payment_tokens TO {$wpdb->prefix}wc_payment_tokens;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_payment_tokenmeta TO {$wpdb->prefix}wc_payment_tokenmeta;" );
+	$wpdb->query( "RENAME TABLE {$wpdb->prefix}woocommerce_log TO {$wpdb->prefix}wc_log;" );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_update_400_db_version() {
+	WC_Install::update_db_version( '4.0.0' );
+}


### PR DESCRIPTION
This is a start on https://github.com/woocommerce/woocommerce/issues/16276.

This would have to come in a major release because it is potentially breaking. 

So far this PR does a rename, and handles query filtering for bw compat.

TODO:

- [ ] Code throughout needs to use the new table names
- [ ] We need a helper function/method to get table names, or we need to set them to WPDB, so it uses the correct version pre/post update.
- [ ] Tests