### PR TITLE
[Importer] Allow "unfiltered_html" for name, description and short description fields

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -443,6 +443,19 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
+	 * Just skip current field.
+	 *
+	 * By default is applied wc_clean() to all not listed fields
+	 * in self::get_formating_callback(), use this method to skip any formating.
+	 *
+	 * @param  string $value Field value.
+	 * @return string
+	 */
+	public function parse_skip_field( $value ) {
+		return $value;
+	}
+
+	/**
 	 * Get formatting callback.
 	 *
 	 * @return array
@@ -460,9 +473,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'featured'          => array( $this, 'parse_bool_field' ),
 			'date_on_sale_from' => array( $this, 'parse_date_field' ),
 			'date_on_sale_to'   => array( $this, 'parse_date_field' ),
-			'name'              => 'wp_filter_post_kses',
-			'short_description' => 'wp_filter_post_kses',
-			'description'       => 'wp_filter_post_kses',
+			'name'              => array( $this, 'parse_skip_field' ),
+			'short_description' => array( $this, 'parse_skip_field' ),
+			'description'       => array( $this, 'parse_skip_field' ),
 			'manage_stock'      => array( $this, 'parse_bool_field' ),
 			'backorders'        => array( $this, 'parse_backorders_field' ),
 			'stock_status'      => array( $this, 'parse_bool_field' ),

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -125,17 +125,17 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * If mapping to a SKU and the product ID does not exist, a temporary object
 	 * will be created so it can be updated later.
 	 *
-	 * @param  string $field Field value.
+	 * @param  string $value Field value.
 	 * @return int|string
 	 */
-	public function parse_relative_field( $field ) {
+	public function parse_relative_field( $value ) {
 		global $wpdb;
 
-		if ( empty( $field ) ) {
+		if ( empty( $value ) ) {
 			return '';
 		}
 
-		if ( preg_match( '/^id:(\d+)$/', $field, $matches ) ) {
+		if ( preg_match( '/^id:(\d+)$/', $value, $matches ) ) {
 			$id          = intval( $matches[1] );
 			$original_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_original_id' AND meta_value = %s;", $id ) );
 
@@ -154,15 +154,15 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return $id;
 		}
 
-		if ( $id = wc_get_product_id_by_sku( $field ) ) {
+		if ( $id = wc_get_product_id_by_sku( $value ) ) {
 			return $id;
 		}
 
 		try {
 			$product = new WC_Product_Simple();
-			$product->set_name( 'Import placeholder for ' . $field );
+			$product->set_name( 'Import placeholder for ' . $value );
 			$product->set_status( 'importing' );
-			$product->set_sku( $field );
+			$product->set_sku( $value );
 			$id = $product->save();
 
 			if ( $id && ! is_wp_error( $id ) ) {
@@ -181,13 +181,13 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * If we're not doing an update, create a placeholder product so mapping works
 	 * for rows following this one.
 	 *
-	 * @param  stirng $field
+	 * @param  string $value Field value.
 	 * @return int
 	 */
-	public function parse_id_field( $field ) {
+	public function parse_id_field( $value ) {
 		global $wpdb;
 
-		$id = absint( $field );
+		$id = absint( $value );
 
 		if ( ! $id ) {
 			return 0;
@@ -225,77 +225,77 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse relative comma-delineated field and return product ID.
 	 *
-	 * @param string $field Field value.
+	 * @param string $value Field value.
 	 * @return array
 	 */
-	public function parse_relative_comma_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_relative_comma_field( $value ) {
+		if ( empty( $value ) ) {
 			return array();
 		}
 
-		return array_filter( array_map( array( $this, 'parse_relative_field' ), $this->explode_values( $field ) ) );
+		return array_filter( array_map( array( $this, 'parse_relative_field' ), $this->explode_values( $value ) ) );
 	}
 
 	/**
 	 * Parse a comma-delineated field from a CSV.
 	 *
-	 * @param string $field Field value.
+	 * @param string $value Field value.
 	 * @return array
 	 */
-	public function parse_comma_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_comma_field( $value ) {
+		if ( empty( $value ) ) {
 			return array();
 		}
 
-		return array_map( 'wc_clean', $this->explode_values( $field ) );
+		return array_map( 'wc_clean', $this->explode_values( $value ) );
 	}
 
 	/**
 	 * Parse a field that is generally '1' or '0' but can be something else.
 	 *
-	 * @param string $field Field value.
+	 * @param string $value Field value.
 	 * @return bool|string
 	 */
-	public function parse_bool_field( $field ) {
-		if ( '0' === $field ) {
+	public function parse_bool_field( $value ) {
+		if ( '0' === $value ) {
 			return false;
 		}
 
-		if ( '1' === $field ) {
+		if ( '1' === $value ) {
 			return true;
 		}
 
 		// Don't return explicit true or false for empty fields or values like 'notify'.
-		return wc_clean( $field );
+		return wc_clean( $value );
 	}
 
 	/**
 	 * Parse a float value field.
 	 *
-	 * @param string $field Field value.
+	 * @param string $value Field value.
 	 * @return float|string
 	 */
-	public function parse_float_field( $field ) {
-		if ( '' === $field ) {
-			return $field;
+	public function parse_float_field( $value ) {
+		if ( '' === $value ) {
+			return $value;
 		}
 
-		return floatval( $field );
+		return floatval( $value );
 	}
 
 	/**
 	 * Parse a category field from a CSV.
 	 * Categories are separated by commas and subcategories are "parent > subcategory".
 	 *
-	 * @param string $field Field value.
+	 * @param string $value Field value.
 	 * @return array of arrays with "parent" and "name" keys.
 	 */
-	public function parse_categories_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_categories_field( $value ) {
+		if ( empty( $value ) ) {
 			return array();
 		}
 
-		$row_terms  = $this->explode_values( $field );
+		$row_terms  = $this->explode_values( $value );
 		$categories = array();
 
 		foreach ( $row_terms as $row_term ) {
@@ -332,15 +332,15 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse a tag field from a CSV.
 	 *
-	 * @param  string $field Field value.
+	 * @param  string $value Field value.
 	 * @return array
 	 */
-	public function parse_tags_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_tags_field( $value ) {
+		if ( empty( $value ) ) {
 			return array();
 		}
 
-		$names = $this->explode_values( $field );
+		$names = $this->explode_values( $value );
 		$tags  = array();
 
 		foreach ( $names as $name ) {
@@ -359,18 +359,18 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse a shipping class field from a CSV.
 	 *
-	 * @param  string $field Field value.
+	 * @param  string $value Field value.
 	 * @return int
 	 */
-	public function parse_shipping_class_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_shipping_class_field( $value ) {
+		if ( empty( $value ) ) {
 			return 0;
 		}
 
-		$term = get_term_by( 'name', $field, 'product_shipping_class' );
+		$term = get_term_by( 'name', $value, 'product_shipping_class' );
 
 		if ( ! $term || is_wp_error( $term ) ) {
-			$term = (object) wp_insert_term( $field, 'product_shipping_class' );
+			$term = (object) wp_insert_term( $value, 'product_shipping_class' );
 		}
 
 		return $term->term_id;
@@ -379,17 +379,17 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse images list from a CSV. Images can be filenames or URLs.
 	 *
-	 * @param  string $field Field value.
+	 * @param  string $value Field value.
 	 * @return array
 	 */
-	public function parse_images_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_images_field( $value ) {
+		if ( empty( $value ) ) {
 			return array();
 		}
 
 		$images = array();
 
-		foreach ( $this->explode_values( $field ) as $image ) {
+		foreach ( $this->explode_values( $value ) as $image ) {
 			if ( stristr( $image, '://' ) ) {
 				$images[] = esc_url_raw( $image );
 			} else {
@@ -404,17 +404,17 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse dates from a CSV.
 	 * Dates requires the format YYYY-MM-DD and time is optional.
 	 *
-	 * @param  string $field Field value.
+	 * @param  string $value Field value.
 	 * @return string|null
 	 */
-	public function parse_date_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_date_field( $value ) {
+		if ( empty( $value ) ) {
 			return null;
 		}
 
-		if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])([ 01-9:]*)$/', $field ) ) {
+		if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])([ 01-9:]*)$/', $value ) ) {
 			// Don't include the time if the field had time in it.
-			return current( explode( ' ', $field ) );
+			return current( explode( ' ', $value ) );
 		}
 
 		return null;
@@ -423,20 +423,20 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse backorders from a CSV.
 	 *
-	 * @param  string $field Field value.
+	 * @param  string $value Field value.
 	 * @return string
 	 */
-	public function parse_backorders_field( $field ) {
-		if ( empty( $field ) ) {
+	public function parse_backorders_field( $value ) {
+		if ( empty( $value ) ) {
 			return '';
 		}
 
-		$field = $this->parse_bool_field( $field );
+		$value = $this->parse_bool_field( $value );
 
-		if ( 'notify' === $field ) {
+		if ( 'notify' === $value ) {
 			return 'notify';
-		} elseif ( is_bool( $field ) ) {
-			return $field ? 'yes' : 'no';
+		} elseif ( is_bool( $value ) ) {
+			return $value ? 'yes' : 'no';
 		}
 
 		return '';


### PR DESCRIPTION
Should simulate the same behavior from WP admin, so just need to skip extra sanitization, so WP can handle it while salving with `wp_insert_post()` and `wp_update_post()` where will check for
`unfiltered_html` capability.

WP core already did something like it, but on REST API: https://core.trac.wordpress.org/ticket/38609

Fixes #16195