### PR TITLE
Use array_replace in order item apply_changes

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -68,6 +68,19 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		}
 	}
 
+	/**
+	 * Merge changes with data and clear.
+	 * Overrides WC_Data::apply_changes.
+	 * array_replace_recursive does not work well for order items because it merges taxes instead
+	 * of replacing them.
+	 *
+	 * @since 3.2.0
+	 */
+	public function apply_changes() {
+		$this->data    = array_replace( $this->data, $this->changes );
+		$this->changes = array();
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Getters

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -77,7 +77,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @since 3.2.0
 	 */
 	public function apply_changes() {
-		$this->data    = array_replace( $this->data, $this->changes );
+		$this->data    = array_merge( $this->data, $this->changes );
 		$this->changes = array();
 	}
 

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -77,7 +77,13 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @since 3.2.0
 	 */
 	public function apply_changes() {
-		$this->data    = array_merge( $this->data, $this->changes );
+		if ( function_exists( 'array_replace' ) ) {
+			$this->data = array_replace( $this->data, $this->changes );
+		} else { // PHP 5.2 compatibility.
+			foreach ( $this->changes as $key => $change ) {
+				$this->data[ $key ] = $change;
+			}
+		}
 		$this->changes = array();
 	}
 


### PR DESCRIPTION
Fixes #16415 

I don't think there is going to be a good way of making the base `WC_Data::apply_changes` work properly in all cases, because there are some cases we want a deep replace (order addresses) and some cases we don't (order item taxes). 

Overriding `apply_changes` in the order item class solves the issue cleanly.

EDIT: Fun fact - WP has `array_replace_recursive` but not `array_replace` . . .