### PR TITLE
Prevent infinite recursion in WC_Post_Data::variation_post_link()

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -66,7 +66,7 @@ class WC_Post_Data {
 	 * @return string
 	 */
 	public static function variation_post_link( $permalink, $post ) {
-		if ( isset( $post->ID, $post->post_type ) && 'product_variation' === $post->post_type && ( $variation = wc_get_product( $post->ID ) ) ) {
+		if ( isset( $post->ID, $post->post_type ) && 'product_variation' === $post->post_type && ( $variation = wc_get_product( $post->ID ) ) && $variation->get_parent_id() ) {
 			return $variation->get_permalink();
 		}
 		return $permalink;


### PR DESCRIPTION
If a variation's parent doesn't exist, `WC_Product_Variation::get_parent_id()` will return 0, which causes `WC_Post_Data::variation_post_link()` to enter into an infinite recursion trying to get the permalink of the non-existent parent