### PR TITLE
Remove redundant CSS

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3010,7 +3010,6 @@ img.help_tip {
 
 	nav.woo-nav-tab-wrapper {
 		margin: 1.5em 0 1em;
-		border-bottom: 1px solid #ccc;
 	}
 
 	.subsubsub {


### PR DESCRIPTION
The `nav.woo-nav-tab-wrapper` CSS rule overrides WordPress core rule with the same CSS.

We can remove that from WooCommerce.

![screenshot 2017-08-13 22 34 56](https://user-images.githubusercontent.com/576623/29252884-41a2c376-8078-11e7-9b9e-1389a85ee36c.png)
