### PR TITLE
i18n: Simpler translation string with placeholders

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1530,8 +1530,11 @@ function wc_get_logger() {
 			wc_doing_it_wrong(
 				__FUNCTION__,
 				sprintf(
-					__( 'The class <code>%s</code> provided by woocommerce_logging_class filter must implement <code>WC_Logger_Interface</code>.', 'woocommerce' ),
-					esc_html( is_object( $class ) ? get_class( $class ) : $class )
+					/* translators: 1: class name 2: woocommerce_logging_class 3: WC_Logger_Interface */ 
+					__( 'The class %1$s provided by %2$s filter must implement %3$s.', 'woocommerce' ),
+					'<code>' . esc_html( is_object( $class ) ? get_class( $class ) : $class ) . '</code>',
+					'<code>woocommerce_logging_class</code>',
+					'<code>WC_Logger_Interface</code>'
 				),
 				'3.0'
 			);


### PR DESCRIPTION
Replace:

`The class <code>%s</code> provided by woocommerce_logging_class filter must implement <code>WC_Logger_Interface</code>.`

With:

`The class %1$s provided by %2$s filter must implement %3$s.`