### PR TITLE
i18n: Simpler translation string with placeholders

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -54,8 +54,10 @@ class WC_Logger implements WC_Logger_Interface {
 					wc_doing_it_wrong(
 						__METHOD__,
 						sprintf(
-							__( 'The provided handler <code>%s</code> does not implement WC_Log_Handler_Interface.', 'woocommerce' ),
-							esc_html( is_object( $handler ) ? get_class( $handler ) : $handler )
+							/* translators: 1: class name 2: WC_Log_Handler_Interface */
+							__( 'The provided handler %1$s does not implement %2$s.', 'woocommerce' ),
+							'<code>' . esc_html( is_object( $handler ) ? get_class( $handler ) : $handler ) . '</code>',
+							'<code>WC_Log_Handler_Interface</code>'
 						),
 						'3.0'
 					);


### PR DESCRIPTION
Replace:

`The provided handler <code>%s</code> does not implement WC_Log_Handler_Interface.`

With:

`The provided handler %1$s does not implement %2$s.`