### PR TITLE
Prevent unwanted double cart notices

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -272,7 +272,7 @@ jQuery( function( $ ) {
 
 			$( document ).on(
 				'wc_update_cart',
-				function() { cart.update_cart(); } );
+				function() { cart.update_cart.apply( cart, [].slice.call( arguments, 1 ) ); } );
 			$( document ).on(
 				'click',
 				'.woocommerce-cart-form input[type=submit]',

--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -272,7 +272,7 @@ jQuery( function( $ ) {
 
 			$( document ).on(
 				'wc_update_cart',
-				this.update_cart );
+				function() { cart.update_cart(); } );
 			$( document ).on(
 				'click',
 				'.woocommerce-cart-form input[type=submit]',

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -131,7 +131,7 @@ class WC_Shipping {
 			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
 
 			// Debug output
-			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! wc_has_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' ) ) {
+			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' ) ) {
 				wc_add_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' );
 			}
 		} else {


### PR DESCRIPTION
This PR addresses 2 issues with duplicated cart notices.

1) Prevent an issue where the "Customer matched zone" debug message is shown twice after first selecting a shipping method and then changing a product's quantity in cart and clicking Update cart.

What happens is that when a shipping method is updated, the shipping zone debug notice is added to session, but it's not printed. Then, when a product's quantity is changed and cart is updated, the message is printed, and then added once more and printed once more. 

This PR addresses this by not adding the debug message when doing AJAX, as the message is not printed in this case anyway.

2) Prevent accidentally preserving cart notices when `wc_update_cart` event is triggered on body. If the event object is passed to update_cart() as the first param, it evaluates to true, forcing existing notices to be preserved. This issue was discovered in a support ticket for Local Pickup Plus which triggers the event quite often. However, if there are any cart notices, they will be preserved and re-added. with the AJAX refresh, resulting in multiples of same message to be shown.

This PR fixes it by wrapping the update_cart() call in an anonymous function and not passing the event object to it. Instead, the event object is removed from the arguments and the rest of the arguments are passed through as-is.

This allows 3rd parties to update the cart without resulting in duplicated messages, while still making it possible to preserve the messages when providing an optional second argument:

```javascript
$( body ).trigger( 'wc_update_cart' ); // existing notices are removed
$( body ).trigger( 'wc_update_cart', true ); // existing notices are preserved
```