### PR TITLE
i18n: Merge two similar translation strings

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -263,7 +263,7 @@ $pages          = $system_status->get_pages();
 				if ( $environment['remote_post_successful'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'wp_remote_post() failed. Contact your hosting provider.', 'woocommerce' ) . ' ' . esc_html( $environment['remote_post_response'] ) . '</mark>';
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s failed. Contact your hosting provider.', 'woocommerce' ), 'wp_remote_post()' ) . ' ' . esc_html( $environment['remote_post_response'] ) . '</mark>';
 				} ?>
 			</td>
 		</tr>
@@ -274,7 +274,7 @@ $pages          = $system_status->get_pages();
 				if ( $environment['remote_get_successful'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'wp_remote_get() failed. Contact your hosting provider.', 'woocommerce' ) . ' ' . esc_html( $environment['remote_get_response'] ) . '</mark>';
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s failed. Contact your hosting provider.', 'woocommerce' ), 'wp_remote_get()' ) . ' ' . esc_html( $environment['remote_get_response'] ) . '</mark>';
 				} ?>
 			</td>
 		</tr>


### PR DESCRIPTION
Replace:

`wp_remote_get() failed. Contact your hosting provider.`
`wp_remote_post() failed. Contact your hosting provider.`

With:

`%s failed. Contact your hosting provider.`

Note:

This also a good practice because the function name is outside of the translation string, this way the translator can't misspell the function name.