### PR TITLE
i18n: Simpler translation string with placeholders

### DIFF
--- a/includes/vendor/abstract-wp-rest-controller.php
+++ b/includes/vendor/abstract-wp-rest-controller.php
@@ -27,7 +27,7 @@ abstract class WP_REST_Controller {
 	 * Register the routes for the objects of the controller.
 	 */
 	public function register_routes() {
-		wc_doing_it_wrong( 'WP_REST_Controller::register_routes', __( 'The register_routes() method must be overridden', 'woocommerce' ), 'WPAPI-2.0' );
+		wc_doing_it_wrong( 'WP_REST_Controller::register_routes', sprintf( __( "Method '%s' must be overridden.", 'woocommerce' ), 'register_routes()' ), 'WPAPI-2.0' );
 	}
 
 	/**


### PR DESCRIPTION
One more... replacing function name with `%s` placeholder, this way translators can't misspell the function name.