### PR TITLE
i18n: Rewrite the translation string logic

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -13,11 +13,25 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 
 	<td class="name">
 		<?php
-			/* translators: 1: refund id 2: date */
-			printf( __( 'Refund #%1$s - %2$s', 'woocommerce' ), $refund->get_id(), wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) ) );
-
 			if ( $who_refunded->exists() ) {
-				echo ' ' . esc_attr_x( 'by', 'Ex: Refund - $date >by< $username', 'woocommerce' ) . ' ' . '<abbr class="refund_by" title="' . sprintf( esc_attr__( 'ID: %d', 'woocommerce' ), absint( $who_refunded->ID ) ) . '">' . esc_attr( $who_refunded->display_name ) . '</abbr>' ;
+				printf(
+					/* translators: 1: refund id 2: refund date 3: username */
+					__( 'Refund #%1$s - %2$s by %3$s', 'woocommerce' ),
+					$refund->get_id(),
+					wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) ),
+					sprintf(
+						'<abbr class="refund_by" title="%1$s">%2$s</abbr>',
+						sprintf( esc_attr__( 'ID: %d', 'woocommerce' ), absint( $who_refunded->ID ) ),
+						esc_html( $who_refunded->display_name )
+					)
+				);
+			} else {
+				printf(
+					/* translators: 1: refund id 2: refund date */
+					__( 'Refund #%1$s - %2$s', 'woocommerce' ),
+					$refund->get_id(),
+					wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) )
+				);
 			}
 		?>
 		<?php if ( $refund->get_reason() ) : ?>


### PR DESCRIPTION
The single translation string `by` is not easy to translate without a context. In this case, using the context function `_x()` is not the best solution.

A better way would be to create two complete translation strings for refund with a user and without a user.