### PR TITLE
Add filter to woocommerce_order_again_button to match WC_Form_Handler

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1900,7 +1900,7 @@ if ( ! function_exists( 'woocommerce_order_again_button' ) ) {
 	 * @subpackage	Orders
 	 */
 	function woocommerce_order_again_button( $order ) {
-		if ( ! $order || ! $order->has_status( 'completed' ) || ! is_user_logged_in() ) {
+		if ( ! $order || ! ! $order->has_status( apply_filters( 'woocommerce_valid_order_statuses_for_order_again', array( 'completed' ) ) ) ) || ! is_user_logged_in() ) {
 			return;
 		}
 


### PR DESCRIPTION
resolves #16488 

This commit adds the `woocommerce_valid_order_statuses_for_order_again` filter to the conditional check
before displaying the order-again button.

The purpose is to enable consistency when altering the valid order again statuses - in the past a dev would
need to use this filter to let the order through the form handler, and then override the template file for a really
trivial reason just to get the button to display.