### PR TITLE
Integrate cart sessions, getters and setters

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -568,6 +568,8 @@ final class WC_Cart_Totals {
 				$item = $this->adjust_non_base_location_price( $item );
 			}
 
+			$subtotal_taxes = array();
+
 			if ( $this->calculate_tax && $item->product->is_taxable() ) {
 				$subtotal_taxes     = WC_Tax::calc_tax( $item->subtotal, $item->tax_rates, $item->price_includes_tax );
 				$item->subtotal_tax = array_sum( $subtotal_taxes );

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -483,10 +483,15 @@ final class WC_Cart_Totals {
 	 * @param array $taxes Taxes to combine.
 	 * @return array
 	 */
-	protected function combine_item_taxes( $taxes ) {
+	protected function combine_item_taxes( $item_taxes ) {
 		$merged_taxes = array();
-		foreach ( $taxes as $tax ) {
-			$merged_taxes = $merged_taxes + $tax;
+		foreach ( $item_taxes as $taxes ) {
+			foreach ( $taxes as $tax_id => $tax_amount ) {
+				if ( ! isset( $merged_taxes[ $tax_id ] ) ) {
+					$merged_taxes[ $tax_id ] = 0;
+				}
+				$merged_taxes[ $tax_id ] += $tax_amount;
+			}
 		}
 		return $merged_taxes;
 	}

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -26,7 +26,7 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 * @var array
 	 */
-	protected $object;
+	protected $cart;
 
 	/**
 	 * Reference to customer object.
@@ -69,12 +69,20 @@ final class WC_Cart_Totals {
 	protected $coupons = array();
 
 	/**
-	 * Discount amounts in cents after calculation for the cart.
+	 * Item/coupon discount totals.
 	 *
 	 * @since 3.2.0
 	 * @var array
 	 */
-	protected $discount_totals = array();
+	protected $coupon_discount_totals = array();
+
+	/**
+	 * Item/coupon discount tax totals.
+	 *
+	 * @since 3.2.0
+	 * @var array
+	 */
+	protected $coupon_discount_tax_totals = array();
 
 	/**
 	 * Should taxes be calculated?
@@ -97,12 +105,9 @@ final class WC_Cart_Totals {
 		'items_total'         => 0,
 		'items_total_tax'     => 0,
 		'total'               => 0,
-		'taxes'               => array(),
-		'tax_total'           => 0,
 		'shipping_total'      => 0,
 		'shipping_tax_total'  => 0,
 		'discounts_total'     => 0,
-		'discounts_tax_total' => 0,
 	);
 
 	/**
@@ -113,7 +118,7 @@ final class WC_Cart_Totals {
 	 */
 	public function __construct( &$cart = null ) {
 		if ( is_a( $cart, 'WC_Cart' ) ) {
-			$this->object        = $cart;
+			$this->cart          = $cart;
 			$this->calculate_tax = wc_tax_enabled() && ! $cart->get_customer()->get_is_vat_exempt();
 			$this->calculate();
 		}
@@ -126,8 +131,8 @@ final class WC_Cart_Totals {
 	 */
 	protected function calculate() {
 		$this->calculate_item_totals();
-		$this->calculate_fee_totals();
 		$this->calculate_shipping_totals();
+		$this->calculate_fee_totals();
 		$this->calculate_totals();
 	}
 
@@ -140,6 +145,8 @@ final class WC_Cart_Totals {
 	protected function get_default_item_props() {
 		return (object) array(
 			'object'             => null,
+			'tax_class'          => '',
+			'taxable'            => false,
 			'quantity'           => 0,
 			'product'            => false,
 			'price_includes_tax' => false,
@@ -159,6 +166,9 @@ final class WC_Cart_Totals {
 	 */
 	protected function get_default_fee_props() {
 		return (object) array(
+			'object'    => null,
+			'tax_class' => '',
+			'taxable'   => false,
 			'total_tax' => 0,
 			'taxes'     => array(),
 		);
@@ -172,6 +182,9 @@ final class WC_Cart_Totals {
 	 */
 	protected function get_default_shipping_props() {
 		return (object) array(
+			'object'    => null,
+			'tax_class' => '',
+			'taxable'   => false,
 			'total'     => 0,
 			'total_tax' => 0,
 			'taxes'     => array(),
@@ -200,12 +213,14 @@ final class WC_Cart_Totals {
 	 *
 	 * @since 3.2.0
 	 */
-	protected function set_items() {
+	protected function get_items_from_cart() {
 		$this->items = array();
 
-		foreach ( $this->object->get_cart() as $cart_item_key => $cart_item ) {
+		foreach ( $this->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$item                          = $this->get_default_item_props();
 			$item->object                  = $cart_item;
+			$item->tax_class               = $cart_item['data']->get_tax_class();
+			$item->taxable                 = 'taxable' === $cart_item['data']->get_tax_status();
 			$item->price_includes_tax      = wc_prices_include_tax();
 			$item->quantity                = $cart_item['quantity'];
 			$item->subtotal                = wc_add_number_precision_deep( $cart_item['data']->get_price() ) * $cart_item['quantity'];
@@ -221,17 +236,19 @@ final class WC_Cart_Totals {
 	 *
 	 * @since 3.2.0
 	 */
-	protected function set_fees() {
+	protected function get_fees_from_cart() {
 		$this->fees = array();
-		$this->object->calculate_fees();
+		$this->cart->calculate_fees();
 
-		foreach ( $this->object->get_fees() as $fee_key => $fee_object ) {
-			$fee         = $this->get_default_fee_props();
-			$fee->object = $fee_object;
-			$fee->total  = wc_add_number_precision_deep( $fee->object->amount );
+		foreach ( $this->cart->get_fees() as $fee_key => $fee_object ) {
+			$fee            = $this->get_default_fee_props();
+			$fee->object    = $fee_object;
+			$fee->tax_class = $fee->object->tax_class;
+			$fee->taxable   = $fee->object->taxable;
+			$fee->total     = wc_add_number_precision_deep( $fee->object->amount );
 
 			if ( $this->calculate_tax && $fee->object->taxable ) {
-				$fee->taxes     = WC_Tax::calc_tax( $fee->total, WC_Tax::get_rates( $fee->object->tax_class, $this->object->get_customer() ), false );
+				$fee->taxes     = WC_Tax::calc_tax( $fee->total, WC_Tax::get_rates( $fee->object->tax_class, $this->cart->get_customer() ), false );
 				$fee->total_tax = array_sum( $fee->taxes );
 
 				if ( ! $this->round_at_subtotal() ) {
@@ -248,12 +265,14 @@ final class WC_Cart_Totals {
 	 *
 	 * @since 3.2.0
 	 */
-	protected function set_shipping() {
+	protected function get_shipping_from_cart() {
 		$this->shipping = array();
 
-		foreach ( $this->object->calculate_shipping() as $key => $shipping_object ) {
+		foreach ( $this->cart->calculate_shipping() as $key => $shipping_object ) {
 			$shipping_line            = $this->get_default_shipping_props();
 			$shipping_line->object    = $shipping_object;
+			$shipping_line->tax_class = get_option( 'woocommerce_shipping_tax_class' );
+			$shipping_line->taxable   = true;
 			$shipping_line->total     = wc_add_number_precision_deep( $shipping_object->cost );
 			$shipping_line->taxes     = wc_add_number_precision_deep( $shipping_object->taxes );
 			$shipping_line->total_tax = wc_add_number_precision_deep( array_sum( $shipping_object->taxes ) );
@@ -272,8 +291,8 @@ final class WC_Cart_Totals {
 	 *
 	 * @since  3.2.0
 	 */
-	protected function set_coupons() {
-		$this->coupons = $this->object->get_coupons();
+	protected function get_coupons_from_cart() {
+		$this->coupons = $this->cart->get_coupons();
 
 		foreach ( $this->coupons as $coupon ) {
 			switch ( $coupon->get_discount_type() ) {
@@ -292,7 +311,7 @@ final class WC_Cart_Totals {
 			}
 		}
 
-		uasort( $this->coupons, array( $this, 'sort_coupons' ) );
+		uasort( $this->coupons, array( $this, 'sort_coupons_callback' ) );
 	}
 
 	/**
@@ -302,7 +321,7 @@ final class WC_Cart_Totals {
 	 * @param WC_Coupon $b Coupon object.
 	 * @return int
 	 */
-	protected function sort_coupons( $a, $b ) {
+	protected function sort_coupons_callback( $a, $b ) {
 		if ( $a->sort === $b->sort ) {
 			return $a->get_id() - $b->get_id();
 		}
@@ -344,7 +363,7 @@ final class WC_Cart_Totals {
 	 */
 	protected function get_discounted_price_in_cents( $item_key ) {
 		$item  = $this->items[ $item_key ];
-		$price = isset( $this->discount_totals[ $item_key ] ) ? $item->subtotal - $this->discount_totals[ $item_key ] : $item->subtotal;
+		$price = isset( $this->coupon_discount_totals[ $item_key ] ) ? $item->subtotal - $this->coupon_discount_totals[ $item_key ] : $item->subtotal;
 
 		if ( $item->price_includes_tax ) {
 			$price += $item->subtotal_tax;
@@ -360,7 +379,33 @@ final class WC_Cart_Totals {
 	 */
 	protected function get_item_tax_rates( $item ) {
 		$tax_class = $item->product->get_tax_class();
-		return isset( $this->item_tax_rates[ $tax_class ] ) ? $this->item_tax_rates[ $tax_class ] : $this->item_tax_rates[ $tax_class ] = WC_Tax::get_rates( $item->product->get_tax_class(), $this->object->get_customer() );
+		return isset( $this->item_tax_rates[ $tax_class ] ) ? $this->item_tax_rates[ $tax_class ] : $this->item_tax_rates[ $tax_class ] = WC_Tax::get_rates( $item->product->get_tax_class(), $this->cart->get_customer() );
+	}
+
+	/**
+	 * Get item costs grouped by tax class.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	protected function get_item_costs_by_tax_class() {
+		$tax_classes = array(
+			'non-taxable' => 0,
+		);
+
+		foreach ( $this->items + $this->fees + $this->shipping as $item ) {
+			if ( ! isset( $tax_classes[ $item->tax_class ] ) ) {
+				$tax_classes[ $item->tax_class ] = 0;
+			}
+
+			if ( $item->taxable ) {
+				$tax_classes[ $item->tax_class ] += $item->total;
+			} else {
+				$tax_classes['non-taxable'] += $item->total;
+			}
+		}
+
+		return $tax_classes;
 	}
 
 	/**
@@ -399,32 +444,51 @@ final class WC_Cart_Totals {
 	}
 
 	/**
-	 * Get all tax rows from items (including shipping and product line items).
+	 * Get taxes merged by type.
 	 *
-	 * @since  3.2.0
+	 * @since 3.2.0
+	 * @param  array|string $types Types to merge and return. Defaults to all.
 	 * @return array
 	 */
-	protected function get_merged_taxes() {
+	protected function get_merged_taxes( $in_cents = false, $types = array( 'items', 'fees', 'shipping' ) ) {
+		$items = array();
 		$taxes = array();
 
-		foreach ( array_merge( $this->items, $this->fees, $this->shipping ) as $item ) {
-			foreach ( $item->taxes as $rate_id => $rate ) {
-				$taxes[ $rate_id ] = array( 'tax_total' => 0, 'shipping_tax_total' => 0 );
+		if ( is_string( $types ) ) {
+			$types = array( $types );
+		}
+
+		foreach ( $types as $type ) {
+			if ( isset( $this->$type ) ) {
+				$items = array_merge( $items, $this->$type );
 			}
 		}
 
-		foreach ( $this->items + $this->fees as $item ) {
+		foreach ( $items as $item ) {
 			foreach ( $item->taxes as $rate_id => $rate ) {
-				$taxes[ $rate_id ]['tax_total'] = $taxes[ $rate_id ]['tax_total'] + $rate;
+				if ( ! isset( $taxes[ $rate_id ] ) ) {
+					$taxes[ $rate_id ] = 0;
+				}
+				$taxes[ $rate_id ] += $rate;
 			}
 		}
 
-		foreach ( $this->shipping as $item ) {
-			foreach ( $item->taxes as $rate_id => $rate ) {
-				$taxes[ $rate_id ]['shipping_tax_total'] = $taxes[ $rate_id ]['shipping_tax_total'] + $rate;
-			}
+		return $in_cents ? $taxes : wc_remove_number_precision_deep( $taxes );
+	}
+
+	/**
+	 * Combine item taxes into a single array, preserving keys.
+	 *
+	 * @since 3.2.0
+	 * @param array $taxes Taxes to combine.
+	 * @return array
+	 */
+	protected function combine_item_taxes( $taxes ) {
+		$merged_taxes = array();
+		foreach ( $taxes as $tax ) {
+			$merged_taxes = $merged_taxes + $tax;
 		}
-		return $taxes;
+		return $merged_taxes;
 	}
 
 	/*
@@ -439,9 +503,9 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_item_totals() {
-		$this->set_items();
+		$this->get_items_from_cart();
 		$this->calculate_item_subtotals();
-		$this->calculate_item_discounts();
+		$this->calculate_discounts();
 
 		foreach ( $this->items as $item_key => $item ) {
 			$item->total     = $this->get_discounted_price_in_cents( $item_key );
@@ -453,10 +517,10 @@ final class WC_Cart_Totals {
 				 *
 				 * This is legacy and should probably be deprecated in the future.
 				 * $item->object is the cart item object.
-				 * $this->object is the cart object.
+				 * $this->cart is the cart object.
 				 */
 				$item->total = wc_add_number_precision(
-					apply_filters( 'woocommerce_get_discounted_price', wc_remove_number_precision( $item->total ), $item->object, $this->object )
+					apply_filters( 'woocommerce_get_discounted_price', wc_remove_number_precision( $item->total ), $item->object, $this->cart )
 				);
 			}
 
@@ -475,8 +539,9 @@ final class WC_Cart_Totals {
 				}
 			}
 
-			$this->object->cart_contents[ $item_key ]['line_total'] = wc_remove_number_precision( $item->total );
-			$this->object->cart_contents[ $item_key ]['line_tax']   = wc_remove_number_precision( $item->total_tax );
+			$this->cart->cart_contents[ $item_key ]['line_tax_data']['total'] = wc_remove_number_precision_deep( $item->taxes );
+			$this->cart->cart_contents[ $item_key ]['line_total']             = wc_remove_number_precision( $item->total );
+			$this->cart->cart_contents[ $item_key ]['line_tax']               = wc_remove_number_precision( $item->total_tax );
 		}
 
 		$this->set_total( 'items_total', array_sum( array_values( wp_list_pluck( $this->items, 'total' ) ) ) );
@@ -516,26 +581,27 @@ final class WC_Cart_Totals {
 				}
 			}
 
-			$this->object->cart_contents[ $item_key ]['line_subtotal']     = wc_remove_number_precision( $item->subtotal );
-			$this->object->cart_contents[ $item_key ]['line_subtotal_tax'] = wc_remove_number_precision( $item->subtotal_tax );
+			$this->cart->cart_contents[ $item_key ]['line_tax_data']     = array( 'subtotal' => wc_remove_number_precision_deep( $subtotal_taxes ) );
+			$this->cart->cart_contents[ $item_key ]['line_subtotal']     = wc_remove_number_precision( $item->subtotal );
+			$this->cart->cart_contents[ $item_key ]['line_subtotal_tax'] = wc_remove_number_precision( $item->subtotal_tax );
 		}
 		$this->set_total( 'items_subtotal', array_sum( array_values( wp_list_pluck( $this->items, 'subtotal' ) ) ) );
 		$this->set_total( 'items_subtotal_tax', array_sum( array_values( wp_list_pluck( $this->items, 'subtotal_tax' ) ) ) );
 
-		$this->object->subtotal        = $this->get_total( 'items_subtotal' ) + $this->get_total( 'items_subtotal_tax' );
-		$this->object->subtotal_ex_tax = $this->get_total( 'items_subtotal' );
+		$this->cart->set_subtotal( $this->get_total( 'items_subtotal' ) );
+		$this->cart->set_subtotal_tax( $this->get_total( 'items_subtotal_tax' ) );
 	}
 
 	/**
-	 * Calculate coupon based discounts which change item prices.
+	 * Calculate COUPON based discounts which change item prices.
 	 *
 	 * @since 3.2.0
 	 * @uses  WC_Discounts class.
 	 */
-	protected function calculate_item_discounts() {
-		$this->set_coupons();
+	protected function calculate_discounts() {
+		$this->get_coupons_from_cart();
 
-		$discounts = new WC_Discounts( $this->object );
+		$discounts = new WC_Discounts( $this->cart );
 
 		foreach ( $this->coupons as $coupon ) {
 			$discounts->apply_coupon( $coupon );
@@ -549,11 +615,11 @@ final class WC_Cart_Totals {
 			foreach ( $discounts->get_discounts( true ) as $coupon_code => $coupon_discounts ) {
 				$coupon_discount_tax_amounts[ $coupon_code ] = 0;
 
-				foreach ( $coupon_discounts as $item_key => $item_discount ) {
+				foreach ( $coupon_discounts as $item_key => $coupon_discount ) {
 					$item = $this->items[ $item_key ];
 
 					if ( $item->product->is_taxable() ) {
-						$item_tax                                     = array_sum( WC_Tax::calc_tax( $item_discount, $item->tax_rates, $item->price_includes_tax ) );
+						$item_tax = array_sum( WC_Tax::calc_tax( $coupon_discount, $item->tax_rates, $item->price_includes_tax ) );
 						$coupon_discount_tax_amounts[ $coupon_code ] += $item_tax;
 					}
 				}
@@ -564,27 +630,11 @@ final class WC_Cart_Totals {
 			}
 		}
 
-		$this->discount_totals                     = $discounts->get_discounts_by_item( true );
-		$this->object->coupon_discount_amounts     = wc_remove_number_precision_deep( $coupon_discount_amounts );
-		$this->object->coupon_discount_tax_amounts = wc_remove_number_precision_deep( $coupon_discount_tax_amounts );
+		$this->coupon_discount_totals              = (array) $discounts->get_discounts_by_item( true );
+		$this->coupon_discount_tax_totals          = $coupon_discount_tax_amounts;
 
-		$this->set_total( 'discounts_total', ! empty( $this->discount_totals ) ? array_sum( $this->discount_totals ) : 0 );
-		$this->set_total( 'discounts_tax_total', array_sum( $coupon_discount_tax_amounts ) );
-	}
-
-	/**
-	 * Return discounted tax amount for an item.
-	 *
-	 * @param  object $item Item object.
-	 * @param  int    $discount_amount Amount of discount.
-	 * @return int
-	 */
-	protected function get_item_discount_tax( $item, $discount_amount ) {
-		if ( $item->product->is_taxable() ) {
-			$taxes = WC_Tax::calc_tax( $discount_amount, $item->tax_rates, false );
-			return array_sum( $taxes );
-		}
-		return 0;
+		$this->cart->set_coupon_discount_totals( wc_remove_number_precision_deep( $coupon_discount_amounts ) );
+		$this->cart->set_coupon_discount_tax_totals( wc_remove_number_precision_deep( $coupon_discount_tax_amounts ) );
 	}
 
 	/**
@@ -595,15 +645,18 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_fee_totals() {
-		$this->set_fees();
+		$this->get_fees_from_cart();
 		$this->set_total( 'fees_total', array_sum( wp_list_pluck( $this->fees, 'total' ) ) );
 		$this->set_total( 'fees_total_tax', array_sum( wp_list_pluck( $this->fees, 'total_tax' ) ) );
 
 		foreach ( $this->fees as $fee_key => $fee ) {
-			$this->object->fees[ $fee_key ]->tax      = wc_remove_number_precision_deep( $fee->total_tax );
-			$this->object->fees[ $fee_key ]->tax_data = wc_remove_number_precision_deep( $fee->taxes );
+			$this->cart->fees[ $fee_key ]->tax      = wc_remove_number_precision_deep( $fee->total_tax );
+			$this->cart->fees[ $fee_key ]->tax_data = wc_remove_number_precision_deep( $fee->taxes );
 		}
-		$this->object->fee_total = wc_remove_number_precision_deep( array_sum( wp_list_pluck( $this->fees, 'total' ) ) );
+
+		$this->cart->set_fee_total( wc_remove_number_precision_deep( array_sum( wp_list_pluck( $this->fees, 'total' ) ) ) );
+		$this->cart->set_fee_tax( wc_remove_number_precision_deep( array_sum( wp_list_pluck( $this->fees, 'total_tax' ) ) ) );
+		$this->cart->set_fee_taxes( wc_remove_number_precision_deep( $this->combine_item_taxes( wp_list_pluck( $this->fees, 'taxes' ) ) ) );
 	}
 
 	/**
@@ -612,12 +665,13 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_shipping_totals() {
-		$this->set_shipping();
+		$this->get_shipping_from_cart();
 		$this->set_total( 'shipping_total', array_sum( wp_list_pluck( $this->shipping, 'total' ) ) );
 		$this->set_total( 'shipping_tax_total', array_sum( wp_list_pluck( $this->shipping, 'total_tax' ) ) );
 
-		$this->object->shipping_total     = $this->get_total( 'shipping_total' );
-		$this->object->shipping_tax_total = $this->get_total( 'shipping_tax_total' );
+		$this->cart->set_shipping_total( $this->get_total( 'shipping_total' ) );
+		$this->cart->set_shipping_tax( $this->get_total( 'shipping_tax_total' ) );
+		$this->cart->set_shipping_taxes( wc_remove_number_precision_deep( $this->combine_item_taxes( wp_list_pluck( $this->shipping, 'taxes' ) ) ) );
 	}
 
 	/**
@@ -626,26 +680,24 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_totals() {
-		$this->set_total( 'taxes', $this->get_merged_taxes() );
-		$this->set_total( 'tax_total', array_sum( wp_list_pluck( $this->get_total( 'taxes', true ), 'tax_total' ) ) );
-		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + $this->get_total( 'tax_total', true ) + $this->get_total( 'shipping_tax_total', true ) ) );
+		$this->set_total( 'discounts_total', array_sum( $this->coupon_discount_totals ) );
+		$this->set_total( 'discounts_tax_total', array_sum( $this->coupon_discount_tax_totals ) );
+		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ) ) );
 
 		// Add totals to cart object.
-		$this->object->taxes               = wp_list_pluck( $this->get_total( 'taxes' ), 'shipping_tax_total' );
-		$this->object->shipping_taxes      = wp_list_pluck( $this->get_total( 'taxes' ), 'tax_total' );
-		$this->object->cart_contents_total = $this->get_total( 'items_total' );
-		$this->object->tax_total           = $this->get_total( 'tax_total' );
-		$this->object->total               = $this->get_total( 'total' );
-		$this->object->discount_cart       = $this->get_total( 'discounts_total' ) - $this->get_total( 'discounts_tax_total' );
-		$this->object->discount_cart_tax   = $this->get_total( 'discounts_tax_total' );
+		$this->cart->set_cart_contents_total( $this->get_total( 'items_total' ) );
+		$this->cart->set_cart_contents_tax( array_sum( $this->get_merged_taxes( false, 'items' ) ) );
+		$this->cart->set_cart_contents_taxes( $this->get_merged_taxes( false, 'items' ) );
+		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
+		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );
+		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );
 
 		// Allow plugins to hook and alter totals before final total is calculated.
 		if ( has_action( 'woocommerce_calculate_totals' ) ) {
-			do_action( 'woocommerce_calculate_totals', $this->object );
+			do_action( 'woocommerce_calculate_totals', $this->cart );
 		}
 
 		// Allow plugins to filter the grand total, and sum the cart totals in case of modifications.
-		$totals_to_sum       = wc_add_number_precision_deep( array( $this->object->cart_contents_total, $this->object->tax_total, $this->object->shipping_tax_total, $this->object->shipping_total, $this->object->fee_total ) );
-		$this->object->total = max( 0, apply_filters( 'woocommerce_calculated_total', wc_remove_number_precision( round( array_sum( $totals_to_sum ) ) ), $this->object ) );
+		$this->cart->set_total( max( 0, apply_filters( 'woocommerce_calculated_total', $this->get_total( 'total' ), $this->cart ) ) );
 	}
 }

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1229,6 +1229,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		$this->reset_totals();
 
 		if ( $this->is_empty() ) {
+			$this->session->set_session();
 			return;
 		}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -15,7 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-include_once( 'legacy/class-wc-legacy-cart.php' );
+include_once( WC_ABSPATH . 'includes/legacy/class-wc-legacy-cart.php' );
+include_once( WC_ABSPATH . 'includes/class-wc-cart-session.php' );
 
 /**
  * WC_Cart class.
@@ -179,14 +180,56 @@ class WC_Cart extends WC_Legacy_Cart {
 	public $fees = array();
 
 	/**
+	 * Total defaults used to reset. @todo these need implementing to replace default method variables.
+	 *
+	 * @var array
+	 */
+	protected $default_totals = array(
+		'subtotal'       => 0,
+		'subtotal_tax'   => 0,
+		'shipping_total' => 0,
+		'shipping_tax'   => 0,
+		'discount_total' => 0,
+		'discount_tax'   => 0,
+		'cart_total'     => 0,
+		'cart_tax'       => 0,
+		'fee_total'      => 0,
+		'fee_taxes'      => 0,
+		'total'          => 0,
+		'total_tax'      => 0,
+		'taxes'          => array(
+			'shipping' => array(),
+			'cart'     => array(),
+			'fees'     => array(),
+		),
+	);
+	/**
+	 * Store calculated totals.
+	 *
+	 * @var array
+	 */
+	protected $totals = array();
+
+	/**
+	 * Reference to the cart session handling class.
+	 *
+	 * @var WC_Cart_Session
+	 */
+	protected $session;
+
+	/**
 	 * Constructor for the cart class. Loads options and hooks in the init method.
 	 */
 	public function __construct() {
-		add_action( 'wp_loaded', array( $this, 'init' ) ); // Get cart after WP and plugins are loaded.
-		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 ); // Set cookies.
-		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 ); // Set cookies before shutdown and ob flushing.
+		$this->session = new WC_Cart_Session( $this );
+
 		add_action( 'woocommerce_add_to_cart', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_applied_coupon', array( $this, 'calculate_totals' ), 20, 0 );
+		add_action( 'woocommerce_cart_item_removed', array( $this, 'calculate_totals' ), 20, 0 );
+		add_action( 'woocommerce_cart_item_restored', array( $this, 'calculate_totals' ), 20, 0 );
+		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_items' ), 1 );
+		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_coupons' ), 1 );
+		add_action( 'woocommerce_after_checkout_validation', array( $this, 'check_customer_coupons' ), 1 );
 	}
 
 	/**
@@ -231,130 +274,175 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 	}
 
-	/**
-	 * Loads the cart data from the PHP session during WordPress init and hooks in other methods.
-	 */
-	public function init() {
-		$this->get_cart_from_session();
-
-		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_items' ), 1 );
-		add_action( 'woocommerce_check_cart_items', array( $this, 'check_cart_coupons' ), 1 );
-		add_action( 'woocommerce_after_checkout_validation', array( $this, 'check_customer_coupons' ), 1 );
-	}
+	/*
+	|--------------------------------------------------------------------------
+	| Getters.
+	|--------------------------------------------------------------------------
+	|
+	| Methods to retrieve class properties and avoid direct access.
+	*/
 
 	/**
-	 * Will set cart cookies if needed, once, during WP hook.
-	 */
-	public function maybe_set_cart_cookies() {
-		if ( ! headers_sent() && did_action( 'wp_loaded' ) ) {
-			if ( ! $this->is_empty() ) {
-				$this->set_cart_cookies( true );
-			} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) {
-				$this->set_cart_cookies( false );
-			}
-		}
-	}
-
-	/**
-	 * Set cart hash cookie and items in cart.
+	 * Gets cart contents.
 	 *
-	 * @access private
-	 * @param bool $set Should cookies be set (true) or unset.
+	 * @since 3.2.0
+	 * @return array of applied coupons
 	 */
-	private function set_cart_cookies( $set = true ) {
-		if ( $set ) {
-			wc_setcookie( 'woocommerce_items_in_cart', 1 );
-			wc_setcookie( 'woocommerce_cart_hash', md5( wp_json_encode( $this->get_cart_for_session() ) ) );
-		} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) {
-			wc_setcookie( 'woocommerce_items_in_cart', 0, time() - HOUR_IN_SECONDS );
-			wc_setcookie( 'woocommerce_cart_hash', '', time() - HOUR_IN_SECONDS );
-		}
-		do_action( 'woocommerce_set_cart_cookies', $set );
+	public function get_cart_contents() {
+		return (array) $this->cart_contents;
 	}
 
 	/**
-	 * Get the cart data from the PHP session and store it in class variables.
+	 * Return items removed from the cart.
+	 *
+	 * @since 3.2.0
+	 * @return array
 	 */
-	public function get_cart_from_session() {
-		foreach ( $this->cart_session_data as $key => $default ) {
-			$this->$key = WC()->session->get( $key, $default );
-		}
-
-		$update_cart_session         = false;
-		$this->removed_cart_contents = array_filter( WC()->session->get( 'removed_cart_contents', array() ) );
-		$this->applied_coupons       = array_filter( WC()->session->get( 'applied_coupons', array() ) );
-
-		/**
-		 * Load the cart object. This defaults to the persistent cart if null.
-		 */
-		$cart = WC()->session->get( 'cart', null );
-
-		if ( is_null( $cart ) && ( $saved_cart = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), true ) ) ) {
-			$cart                = $saved_cart['cart'];
-			$update_cart_session = true;
-		} elseif ( is_null( $cart ) ) {
-			$cart = array();
-		}
-
-		if ( is_array( $cart ) ) {
-			// Prime meta cache to reduce future queries.
-			update_meta_cache( 'post', wp_list_pluck( $cart, 'product_id' ) );
-			update_object_term_cache( wp_list_pluck( $cart, 'product_id' ), 'product' );
-
-			foreach ( $cart as $key => $values ) {
-				$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
-
-				if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
-
-					if ( ! $product->is_purchasable() ) {
-						$update_cart_session = true; // Flag to indicate the stored cart should be updated.
-						/* translators: %s: product name */
-						wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
-						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
-
-					} else {
-
-						// Put session data into array. Run through filter so other plugins can load their own session data.
-						$session_data = array_merge( $values, array( 'data' => $product ) );
-						$this->cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
-					}
-				}
-			}
-		}
-
-		do_action( 'woocommerce_cart_loaded_from_session', $this );
-
-		if ( $update_cart_session ) {
-			WC()->session->cart = $this->get_cart_for_session();
-		}
-
-		// Queue re-calc if subtotal is not set.
-		if ( ( ! $this->subtotal && ! $this->is_empty() ) || $update_cart_session ) {
-			$this->calculate_totals();
-		}
+	public function get_removed_cart_contents() {
+		return $this->removed_cart_contents;
 	}
 
 	/**
-	 * Sets the php session data for the cart and coupons.
+	 * Gets the array of applied coupon codes.
+	 *
+	 * @return array of applied coupons
 	 */
-	public function set_session() {
-		$cart_session = $this->get_cart_for_session();
+	public function get_applied_coupons() {
+		return $this->applied_coupons;
+	}
 
-		WC()->session->set( 'cart', $cart_session );
-		WC()->session->set( 'applied_coupons', $this->applied_coupons );
-		WC()->session->set( 'coupon_discount_amounts', $this->coupon_discount_amounts );
-		WC()->session->set( 'coupon_discount_tax_amounts', $this->coupon_discount_tax_amounts );
-		WC()->session->set( 'removed_cart_contents', $this->removed_cart_contents );
+	/**
+	 * Return all calculated coupon totals.
+	 *
+	 * @since 3.2.0
+	 * @return array
+	 */
+	public function get_coupon_discount_totals() {
+		return $this->coupon_discount_totals;
+	}
+	/**
+	 * Return all calculated coupon tax totals.
+	 *
+	 * @since 3.2.0
+	 * @return array
+	 */
+	public function get_coupon_discount_tax_totals() {
+		return $this->coupon_discount_tax_totals;
+	}
 
-		foreach ( $this->cart_session_data as $key => $default ) {
-			WC()->session->set( $key, $this->$key );
+	/**
+	 * Return all calculated totals.
+	 *
+	 * @since 3.2.0
+	 * @return array
+	 */
+	public function get_totals() {
+		return empty( $this->totals ) ? $this->default_totals : $this->totals;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters.
+	|--------------------------------------------------------------------------
+	|
+	| Methods to set class properties and avoid direct access.
+	*/
+
+	/**
+	 * Sets the contents of the cart.
+	 *
+	 * @param array $value Cart array.
+	 */
+	public function set_cart_contents( $value ) {
+		$this->cart_contents = (array) $value;
+	}
+
+	/**
+	 * Set items removed from the cart.
+	 *
+	 * @since 3.2.0
+	 * @param array $value Item array.
+	 */
+	public function set_removed_cart_contents( $value = array() ) {
+		$this->removed_cart_contents = (array) $value;
+	}
+
+	/**
+	 * Sets the array of applied coupon codes.
+	 *
+	 * @param array $value List of applied coupon codes.
+	 */
+	public function set_applied_coupons( $value = array() ) {
+		$this->applied_coupons = (array) $value;
+	}
+
+	/**
+	 * Return all calculated coupon totals.
+	 *
+	 * @since 3.2.0
+	 * @param array $value Value to set.
+	 */
+	public function set_coupon_discount_totals( $value = array() ) {
+		$this->coupon_discount_totals = (array) $value;
+	}
+	/**
+	 * Return all calculated coupon tax totals.
+	 *
+	 * @since 3.2.0
+	 * @param array $value Value to set.
+	 */
+	public function set_coupon_discount_tax_totals( $value = array() ) {
+		$this->coupon_discount_tax_totals = (array) $value;
+	}
+
+	/**
+	 * Set all calculated totals.
+	 *
+	 * @since 3.2.0
+	 * @param array $value Value to set.
+	 */
+	public function set_totals( $value = array() ) {
+		$this->totals = wp_parse_args( $value, $this->default_totals );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Helper methods.
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Returns the contents of the cart in an array.
+	 *
+	 * @return array contents of the cart
+	 */
+	public function get_cart() {
+		if ( ! did_action( 'wp_loaded' ) ) {
+			wc_doing_it_wrong( __FUNCTION__, __( 'Get cart should not be called before the wp_loaded action.', 'woocommerce' ), '2.3' );
 		}
-
-		if ( get_current_user_id() ) {
-			$this->persistent_cart_update();
+		if ( ! did_action( 'woocommerce_cart_loaded_from_session' ) ) {
+			$this->session->get_cart_from_session();
 		}
+		return array_filter( $this->get_cart_contents() );
+	}
 
-		do_action( 'woocommerce_cart_updated' );
+	/**
+	 * Returns a specific item in the cart.
+	 *
+	 * @param string $item_key Cart item key.
+	 * @return array Item data
+	 */
+	public function get_cart_item( $item_key ) {
+		return isset( $this->cart_contents[ $item_key ] ) ? $this->cart_contents[ $item_key ] : array();
+	}
+
+	/**
+	 * Checks if the cart is empty.
+	 *
+	 * @return bool
+	 */
+	public function is_empty() {
+		return 0 === count( $this->get_cart() );
 	}
 
 	/**
@@ -363,33 +451,20 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param bool $clear_persistent_cart Should the persistant cart be cleared too. Defaults to true.
 	 */
 	public function empty_cart( $clear_persistent_cart = true ) {
-		$this->cart_contents = array();
-		$this->shipping_methods = null;
-		$this->reset( true );
+		$this->cart_contents              = array();
+		$this->removed_cart_contents      = array();
+		$this->shipping_methods           = array();
+		$this->coupon_discount_totals     = array();
+		$this->coupon_discount_tax_totals = array();
+		$this->applied_coupons            = array();
+		$this->fees                       = array();
+		$this->totals                     = $this->default_totals;
 
-		unset( WC()->session->order_awaiting_payment, WC()->session->applied_coupons, WC()->session->coupon_discount_amounts, WC()->session->coupon_discount_tax_amounts, WC()->session->cart );
-
-		if ( $clear_persistent_cart && get_current_user_id() ) {
-			$this->persistent_cart_destroy();
+		if ( $clear_persistent_cart ) {
+			$this->session->persistent_cart_destroy();
 		}
 
 		do_action( 'woocommerce_cart_emptied' );
-	}
-
-	/**
-	 * Save the persistent cart when the cart is updated.
-	 */
-	public function persistent_cart_update() {
-		update_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), array(
-			'cart' => WC()->session->get( 'cart' ),
-		) );
-	}
-
-	/**
-	 * Delete the persistent cart permanently.
-	 */
-	public function persistent_cart_destroy() {
-		delete_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id() );
 	}
 
 	/**
@@ -418,12 +493,19 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Checks if the cart is empty.
+	 * Get cart items quantities - merged so we can do accurate stock checks on items across multiple lines.
 	 *
-	 * @return bool
+	 * @return array
 	 */
-	public function is_empty() {
-		return 0 === count( $this->get_cart() );
+	public function get_cart_item_quantities() {
+		$quantities = array();
+
+		foreach ( $this->get_cart() as $cart_item_key => $values ) {
+			$product = $values['data'];
+			$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $values['quantity'] : $values['quantity'];
+		}
+
+		return $quantities;
 	}
 
 	/**
@@ -461,22 +543,6 @@ class WC_Cart extends WC_Legacy_Cart {
 				$this->remove_coupon( $code );
 			}
 		}
-	}
-
-	/**
-	 * Get cart items quantities - merged so we can do accurate stock checks on items across multiple lines.
-	 *
-	 * @return array
-	 */
-	public function get_cart_item_quantities() {
-		$quantities = array();
-
-		foreach ( $this->get_cart() as $cart_item_key => $values ) {
-			$product = $values['data'];
-			$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $values['quantity'] : $values['quantity'];
-		}
-
-		return $quantities;
 	}
 
 	/**
@@ -690,53 +756,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Returns the contents of the cart in an array.
-	 *
-	 * @return array contents of the cart
-	 */
-	public function get_cart() {
-		if ( ! did_action( 'wp_loaded' ) ) {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Get cart should not be called before the wp_loaded action.', 'woocommerce' ), '2.3' );
-		}
-		if ( ! did_action( 'woocommerce_cart_loaded_from_session' ) ) {
-			$this->get_cart_from_session();
-		}
-		return array_filter( (array) $this->cart_contents );
-	}
-
-	/**
-	 * Returns the contents of the cart in an array without the 'data' element.
-	 *
-	 * @return array contents of the cart
-	 */
-	public function get_cart_for_session() {
-		$cart_session = array();
-
-		if ( $this->get_cart() ) {
-			foreach ( $this->get_cart() as $key => $values ) {
-				$cart_session[ $key ] = $values;
-				unset( $cart_session[ $key ]['data'] ); // Unset product object.
-			}
-		}
-
-		return $cart_session;
-	}
-
-	/**
-	 * Returns a specific item in the cart.
-	 *
-	 * @param string $item_key Cart item key.
-	 * @return array Item data
-	 */
-	public function get_cart_item( $item_key ) {
-		if ( isset( $this->cart_contents[ $item_key ] ) ) {
-			return $this->cart_contents[ $item_key ];
-		}
-
-		return array();
-	}
-
-	/**
 	 * Returns the cart and shipping taxes, merged.
 	 *
 	 * @return array merged taxes
@@ -882,7 +901,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	/**
 	 * Add a product to the cart.
 	 *
-	 * @throws Exception To prevent adding to cart.
+	 * @throws Exception Plugins can throw an exception to prevent adding to cart.
 	 * @param int   $product_id contains the id of the product to add to the cart.
 	 * @param int   $quantity contains the quantity of the item to add.
 	 * @param int   $variation_id ID of the variation being added to the cart.
@@ -891,7 +910,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string|bool $cart_item_key
 	 */
 	public function add_to_cart( $product_id = 0, $quantity = 1, $variation_id = 0, $variation = array(), $cart_item_data = array() ) {
-		// Wrap in try catch so plugins can throw an exception to prevent adding to cart.
 		try {
 			$product_id   = absint( $product_id );
 			$variation_id = absint( $variation_id );
@@ -1001,6 +1019,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function remove_cart_item( $cart_item_key ) {
 		if ( isset( $this->cart_contents[ $cart_item_key ] ) ) {
 			$this->removed_cart_contents[ $cart_item_key ] = $this->cart_contents[ $cart_item_key ];
+
 			unset( $this->removed_cart_contents[ $cart_item_key ]['data'] );
 
 			do_action( 'woocommerce_remove_cart_item', $cart_item_key, $this );
@@ -1009,11 +1028,8 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			do_action( 'woocommerce_cart_item_removed', $cart_item_key, $this );
 
-			$this->calculate_totals();
-
 			return true;
 		}
-
 		return false;
 	}
 
@@ -1025,8 +1041,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function restore_cart_item( $cart_item_key ) {
 		if ( isset( $this->removed_cart_contents[ $cart_item_key ] ) ) {
-			$this->cart_contents[ $cart_item_key ] = $this->removed_cart_contents[ $cart_item_key ];
-			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $this->cart_contents[ $cart_item_key ]['variation_id'] ? $this->cart_contents[ $cart_item_key ]['variation_id'] : $this->cart_contents[ $cart_item_key ]['product_id'] );
+			$restore_item                                  = $this->removed_cart_contents[ $cart_item_key ];
+			$this->cart_contents[ $cart_item_key ]         = $restore_item;
+			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'] );
 
 			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this );
 
@@ -1034,11 +1051,8 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			do_action( 'woocommerce_cart_item_restored', $cart_item_key, $this );
 
-			$this->calculate_totals();
-
 			return true;
 		}
-
 		return false;
 	}
 
@@ -1068,22 +1082,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Reset cart totals to the defaults. Useful before running calculations.
-	 *
-	 * @param bool $unset_session If true, the session data will be forced unset.
-	 * @access private
-	 */
-	private function reset( $unset_session = false ) {
-		foreach ( $this->cart_session_data as $key => $default ) {
-			$this->$key = $default;
-			if ( $unset_session ) {
-				unset( WC()->session->$key );
-			}
-		}
-		do_action( 'woocommerce_cart_reset', $this, $unset_session );
-	}
-
-	/**
 	 * Get cart's owner.
 	 *
 	 * @since  3.2.0
@@ -1099,40 +1097,17 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @uses WC_Cart_Totals
 	 */
 	public function calculate_totals() {
-		$this->reset();
-
-		do_action( 'woocommerce_before_calculate_totals', $this );
+		$this->reset_totals();
 
 		if ( $this->is_empty() ) {
-			$this->set_session();
 			return;
 		}
+
+		do_action( 'woocommerce_before_calculate_totals', $this );
 
 		new WC_Cart_Totals( $this );
 
 		do_action( 'woocommerce_after_calculate_totals', $this );
-
-		$this->set_session();
-	}
-
-	/**
-	 * Remove taxes.
-	 */
-	public function remove_taxes() {
-		$this->shipping_tax_total = $this->tax_total = 0;
-		$this->subtotal           = $this->subtotal_ex_tax;
-
-		foreach ( $this->cart_contents as $cart_item_key => $item ) {
-			$this->cart_contents[ $cart_item_key ]['line_subtotal_tax'] = $this->cart_contents[ $cart_item_key ]['line_tax'] = 0;
-			$this->cart_contents[ $cart_item_key ]['line_tax_data']     = array( 'total' => array(), 'subtotal' => array() );
-		}
-
-		// If true, zero rate is applied so '0' tax is displayed on the frontend rather than nothing.
-		if ( apply_filters( 'woocommerce_cart_remove_taxes_apply_zero_rate', true ) ) {
-			$this->taxes = $this->shipping_taxes = array( apply_filters( 'woocommerce_cart_remove_taxes_zero_rate_id', 'zero-rated' ) => 0 );
-		} else {
-			$this->taxes = $this->shipping_taxes = array();
-		}
 	}
 
 	/**
@@ -1413,7 +1388,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $coupon_code - The code to apply.
 	 * @return bool	True if the coupon is applied, false if it does not exist or cannot be applied.
 	 */
-	public function add_discount( $coupon_code ) {
+	public function apply_coupon( $coupon_code ) {
 		// Coupons are globally disabled.
 		if ( ! wc_coupons_enabled() ) {
 			return false;
@@ -1520,15 +1495,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Gets the array of applied coupon codes.
-	 *
-	 * @return array of applied coupons
-	 */
-	public function get_applied_coupons() {
-		return $this->applied_coupons;
-	}
-
-	/**
 	 * Get the discount amount for a used coupon.
 	 *
 	 * @param  string $code coupon code.
@@ -1561,10 +1527,10 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param null $deprecated No longer used.
 	 */
 	public function remove_coupons( $deprecated = null ) {
-		$this->applied_coupons = $this->coupon_discount_amounts = $this->coupon_discount_tax_amounts = $this->coupon_applied_count = array();
-		WC()->session->set( 'applied_coupons', array() );
-		WC()->session->set( 'coupon_discount_amounts', array() );
-		WC()->session->set( 'coupon_discount_tax_amounts', array() );
+		$this->set_coupon_discount_totals( array() );
+		$this->set_coupon_discount_tax_totals( array() );
+		$this->set_applied_coupons( array() );
+		$this->session->set_session();
 	}
 
 	/**
@@ -1574,7 +1540,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function remove_coupon( $coupon_code ) {
-		// Coupons are globally disabled.
 		if ( ! wc_coupons_enabled() ) {
 			return false;
 		}
@@ -1586,7 +1551,6 @@ class WC_Cart extends WC_Legacy_Cart {
 			unset( $this->applied_coupons[ $position ] );
 		}
 
-		WC()->session->set( 'applied_coupons', $this->applied_coupons );
 		WC()->session->set( 'refresh_totals', true );
 
 		do_action( 'woocommerce_removed_coupon', $coupon_code );
@@ -1880,5 +1844,15 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function get_total_discount() {
 		return apply_filters( 'woocommerce_cart_total_discount', $this->get_cart_discount_total() ? wc_price( $this->get_cart_discount_total() ) : false, $this );
+	}
+
+	/**
+	 * Reset cart totals to the defaults. Useful before running calculations.
+	 *
+	 * @access private
+	 */
+	private function reset_totals() {
+		$this->totals = $this->default_totals;
+		do_action( 'woocommerce_cart_reset', $this, false );
 	}
 }

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1258,9 +1258,16 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function calculate_shipping() {
 		$this->shipping_methods = $this->needs_shipping() ? $this->get_chosen_shipping_methods( WC()->shipping->calculate_shipping( $this->get_shipping_packages() ) ) : array();
 
+		$shipping_taxes = wp_list_pluck( $this->shipping_methods, 'taxes' );
+		$merged_taxes   = array();
+
+		foreach ( $shipping_taxes as $tax ) {
+			$merged_taxes = $merged_taxes + $tax;
+		}
+
 		$this->set_shipping_total( array_sum( wp_list_pluck( $this->shipping_methods, 'cost' ) ) );
-		$this->set_shipping_tax( array_sum( wp_list_pluck( $this->shipping_methods, 'taxes' ) ) );
-		$this->set_shipping_taxes( wp_list_pluck( $this->shipping_methods, 'taxes' ) );
+		$this->set_shipping_tax( array_sum( $shipping_taxes ) );
+		$this->set_shipping_taxes( $merged_taxes );
 
 		return $this->shipping_methods;
 	}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -265,7 +265,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return array
 	 */
 	public function get_removed_cart_contents() {
-		return $this->removed_cart_contents;
+		return (array) $this->removed_cart_contents;
 	}
 
 	/**
@@ -274,7 +274,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return array of applied coupons
 	 */
 	public function get_applied_coupons() {
-		return $this->applied_coupons;
+		return (array) $this->applied_coupons;
 	}
 
 	/**
@@ -284,7 +284,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return array
 	 */
 	public function get_coupon_discount_totals() {
-		return $this->coupon_discount_totals;
+		return (array) $this->coupon_discount_totals;
 	}
 	/**
 	 * Return all calculated coupon tax totals.
@@ -293,7 +293,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return array
 	 */
 	public function get_coupon_discount_tax_totals() {
-		return $this->coupon_discount_tax_totals;
+		return (array) $this->coupon_discount_tax_totals;
 	}
 
 	/**
@@ -303,7 +303,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return array
 	 */
 	public function get_totals() {
-		return empty( $this->totals ) ? $this->default_totals : $this->totals;
+		return (array) empty( $this->totals ) ? $this->default_totals : $this->totals;
 	}
 
 	/*

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -66,7 +66,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	protected $shipping_methods;
 
 	/**
-	 * Total defaults used to reset. @todo these need implementing to replace default method variables.
+	 * Total defaults used to reset.
 	 *
 	 * @var array
 	 */
@@ -270,7 +270,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $context If the context is view, the value will be formatted for display. This keeps it compatible with pre-3.2 versions.
 	 * @return float
 	 */
-	public function get_total( $context = 'view' ) { // @todo conflict
+	public function get_total( $context = 'view' ) {
 		$total = apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['total'] );
 		return 'view' === $context ? apply_filters( 'woocommerce_cart_total', wc_price( $total ) ) : $total;
 	}
@@ -405,7 +405,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_subtotal( $value ) {
-		$this->totals['subtotal'] = $value;
+		$this->totals['subtotal'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -415,7 +415,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_subtotal_tax( $value ) {
-		$this->totals['subtotal_tax'] = $value;
+		$this->totals['subtotal_tax'] = wc_round_tax_total( $value );
 	}
 
 	/**
@@ -425,7 +425,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_discount_total( $value ) {
-		$this->totals['discount_total'] = $value;
+		$this->totals['discount_total'] = wc_cart_round_discount( $value, wc_get_price_decimals() );
 	}
 
 	/**
@@ -435,7 +435,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_discount_tax( $value ) {
-		$this->totals['discount_tax'] = $value;
+		$this->totals['discount_tax'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -445,7 +445,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_shipping_total( $value ) {
-		$this->totals['shipping_total'] = $value;
+		$this->totals['shipping_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -455,7 +455,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_shipping_tax( $value ) {
-		$this->totals['shipping_tax'] = $value;
+		$this->totals['shipping_tax'] = wc_round_tax_total( $value );
 	}
 
 	/**
@@ -465,7 +465,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_cart_contents_total( $value ) {
-		$this->totals['cart_contents_total'] = $value;
+		$this->totals['cart_contents_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -475,7 +475,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_cart_contents_tax( $value ) {
-		$this->totals['cart_contents_tax'] = $value;
+		$this->totals['cart_contents_tax'] = wc_round_tax_total( $value );
 	}
 
 	/**
@@ -485,7 +485,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_total( $value ) {
-		$this->totals['total'] = $value;
+		$this->totals['total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -495,7 +495,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_total_tax( $value ) {
-		$this->totals['total_tax'] = $value;
+		$this->totals['total_tax'] = wc_round_tax_total( $value );
 	}
 
 	/**
@@ -505,7 +505,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_fee_total( $value ) {
-		$this->totals['fee_total'] = $value;
+		$this->totals['fee_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -515,7 +515,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_fee_tax( $value ) {
-		$this->totals['fee_tax'] = $value;
+		$this->totals['fee_tax'] = wc_round_tax_total( $value );
 	}
 
 	/**
@@ -687,7 +687,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * Check cart coupons for errors.
 	 */
 	public function check_cart_coupons() {
-		foreach ( $this->applied_coupons as $code ) {
+		foreach ( $this->get_applied_coupons() as $code ) {
 			$coupon = new WC_Coupon( $code );
 
 			if ( ! $coupon->is_valid() ) {
@@ -972,11 +972,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string
 	 */
 	public function get_displayed_subtotal() {
-		if ( 'incl' === $this->tax_display_cart ) {
-			return wc_format_decimal( $this->subtotal );
-		} elseif ( 'excl' === $this->tax_display_cart ) {
-			return wc_format_decimal( $this->subtotal_ex_tax );
-		}
+		return 'incl' === $this->tax_display_cart ? $this->get_subtotal() + $this->get_subtotal_tax() : $this->get_subtotal();
 	}
 
 	/**
@@ -1253,7 +1249,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function needs_payment() {
-		return apply_filters( 'woocommerce_cart_needs_payment', $this->total > 0, $this );
+		return apply_filters( 'woocommerce_cart_needs_payment', 0 < $this->get_total( 'edit' ), $this );
 	}
 
 	/*
@@ -1266,9 +1262,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function calculate_shipping() {
 		$this->shipping_methods = $this->needs_shipping() ? $this->get_chosen_shipping_methods( WC()->shipping->calculate_shipping( $this->get_shipping_packages() ) ) : array();
 
-		// Set legacy totals for backwards compatibility with versions prior to 3.2.
-		$this->shipping_total = WC()->shipping->shipping_total = array_sum( wp_list_pluck( $this->shipping_methods, 'cost' ) );
-		$this->shipping_taxes = WC()->shipping->shipping_taxes = wp_list_pluck( $this->shipping_methods, 'taxes' );
+		$this->set_shipping_total( array_sum( wp_list_pluck( $this->shipping_methods, 'cost' ) ) );
+		$this->set_shipping_tax( array_sum( wp_list_pluck( $this->shipping_methods, 'taxes' ) ) );
+		$this->set_shipping_taxes( wp_list_pluck( $this->shipping_methods, 'taxes' ) );
 
 		return $this->shipping_methods;
 	}
@@ -1333,7 +1329,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				array(
 					'contents'        => $this->get_items_needing_shipping(),
 					'contents_cost'   => array_sum( wp_list_pluck( $this->get_items_needing_shipping(), 'line_total' ) ),
-					'applied_coupons' => $this->applied_coupons,
+					'applied_coupons' => $this->get_applied_coupons(),
 					'user'            => array(
 						'ID' => get_current_user_id(),
 					),
@@ -1362,12 +1358,10 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 		$needs_shipping = false;
 
-		if ( ! empty( $this->cart_contents ) ) {
-			foreach ( $this->cart_contents as $cart_item_key => $values ) {
-				if ( $values['data']->needs_shipping() ) {
-					$needs_shipping = true;
-					break;
-				}
+		foreach ( $this->get_cart_contents() as $cart_item_key => $values ) {
+			if ( $values['data']->needs_shipping() ) {
+				$needs_shipping = true;
+				break;
 			}
 		}
 
@@ -1389,7 +1383,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function show_shipping() {
-		if ( ! wc_shipping_enabled() || ! is_array( $this->cart_contents ) ) {
+		if ( ! wc_shipping_enabled() || ! $this->get_cart_contents() ) {
 			return false;
 		}
 
@@ -1410,31 +1404,28 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string price or string for the shipping total
 	 */
 	public function get_cart_shipping_total() {
-		if ( isset( $this->shipping_total ) ) {
-			if ( $this->shipping_total > 0 ) {
+		if ( 0 < $this->get_shipping_total() ) {
 
-				if ( 'excl' === $this->tax_display_cart ) {
-					$return = wc_price( $this->shipping_total );
+			if ( 'excl' === $this->tax_display_cart ) {
+				$return = wc_price( $this->shipping_total );
 
-					if ( $this->shipping_tax_total > 0 && wc_prices_include_tax() ) {
-						$return .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
-					}
-
-					return $return;
-				} else {
-					$return = wc_price( $this->shipping_total + $this->shipping_tax_total );
-
-					if ( $this->shipping_tax_total > 0 && ! wc_prices_include_tax() ) {
-						$return .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
-					}
-
-					return $return;
+				if ( $this->shipping_tax_total > 0 && wc_prices_include_tax() ) {
+					$return .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 				}
+
+				return $return;
 			} else {
-				return __( 'Free!', 'woocommerce' );
+				$return = wc_price( $this->shipping_total + $this->shipping_tax_total );
+
+				if ( $this->shipping_tax_total > 0 && ! wc_prices_include_tax() ) {
+					$return .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
+				}
+
+				return $return;
 			}
+		} else {
+			return __( 'Free!', 'woocommerce' );
 		}
-		return '';
 	}
 
 	/**
@@ -1447,62 +1438,60 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param array $posted Post data.
 	 */
 	public function check_customer_coupons( $posted ) {
-		if ( ! empty( $this->applied_coupons ) ) {
-			foreach ( $this->applied_coupons as $code ) {
-				$coupon = new WC_Coupon( $code );
+		foreach ( $this->get_applied_coupons() as $code ) {
+			$coupon = new WC_Coupon( $code );
 
-				if ( $coupon->is_valid() ) {
+			if ( $coupon->is_valid() ) {
 
-					// Get user and posted emails to compare.
-					$current_user = wp_get_current_user();
-					$check_emails = array_unique( array_filter( array_map( 'strtolower', array_map( 'sanitize_email', array(
-						$posted['billing_email'],
-						$current_user->user_email,
-					) ) ) ) );
+				// Get user and posted emails to compare.
+				$current_user = wp_get_current_user();
+				$check_emails = array_unique( array_filter( array_map( 'strtolower', array_map( 'sanitize_email', array(
+					$posted['billing_email'],
+					$current_user->user_email,
+				) ) ) ) );
 
-					// Limit to defined email addresses.
-					$restrictions = $coupon->get_email_restrictions();
+				// Limit to defined email addresses.
+				$restrictions = $coupon->get_email_restrictions();
 
-					if ( is_array( $restrictions ) && 0 < count( $restrictions ) && 0 === count( array_intersect( $check_emails, $restrictions ) ) ) {
-						$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED );
-						$this->remove_coupon( $code );
+				if ( is_array( $restrictions ) && 0 < count( $restrictions ) && 0 === count( array_intersect( $check_emails, $restrictions ) ) ) {
+					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED );
+					$this->remove_coupon( $code );
+				}
+
+				// Usage limits per user - check against billing and user email and user ID.
+				$limit_per_user = $coupon->get_usage_limit_per_user();
+
+				if ( 0 < $limit_per_user ) {
+					$used_by         = $coupon->get_used_by();
+					$usage_count     = 0;
+					$user_id_matches = array( get_current_user_id() );
+
+					// Check usage against emails.
+					foreach ( $check_emails as $check_email ) {
+						$usage_count      += count( array_keys( $used_by, $check_email, true ) );
+						$user              = get_user_by( 'email', $check_email );
+						$user_id_matches[] = $user ? $user->ID : 0;
 					}
 
-					// Usage limits per user - check against billing and user email and user ID.
-					$limit_per_user = $coupon->get_usage_limit_per_user();
+					// Check against billing emails of existing users.
+					$users_query = new WP_User_Query( array(
+						'fields'       => 'ID',
+						'meta_query'   => array(
+							'key'      => '_billing_email',
+							'value'    => $check_emails,
+							'compare'  => 'IN',
+						),
+					) );
 
-					if ( 0 < $limit_per_user ) {
-						$used_by         = $coupon->get_used_by();
-						$usage_count     = 0;
-						$user_id_matches = array( get_current_user_id() );
+					$user_id_matches = array_unique( array_filter( array_merge( $user_id_matches, $users_query->get_results() ) ) );
 
-						// Check usage against emails.
-						foreach ( $check_emails as $check_email ) {
-							$usage_count      += count( array_keys( $used_by, $check_email, true ) );
-							$user              = get_user_by( 'email', $check_email );
-							$user_id_matches[] = $user ? $user->ID : 0;
-						}
+					foreach ( $user_id_matches as $user_id ) {
+						$usage_count += count( array_keys( $used_by, $user_id ) );
+					}
 
-						// Check against billing emails of existing users.
-						$users_query = new WP_User_Query( array(
-							'fields'       => 'ID',
-							'meta_query'   => array(
-								'key'      => '_billing_email',
-								'value'    => $check_emails,
-								'compare'  => 'IN',
-							),
-						) );
-
-						$user_id_matches = array_unique( array_filter( array_merge( $user_id_matches, $users_query->get_results() ) ) );
-
-						foreach ( $user_id_matches as $user_id ) {
-							$usage_count += count( array_keys( $used_by, $user_id ) );
-						}
-
-						if ( $usage_count >= $coupon->get_usage_limit_per_user() ) {
-							$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED );
-							$this->remove_coupon( $code );
-						}
+					if ( $usage_count >= $coupon->get_usage_limit_per_user() ) {
+						$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED );
+						$this->remove_coupon( $code );
 					}
 				}
 			}
@@ -1639,7 +1628,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float discount amount
 	 */
 	public function get_coupon_discount_amount( $code, $ex_tax = true ) {
-		$discount_amount = isset( $this->coupon_discount_amounts[ $code ] ) ? $this->coupon_discount_amounts[ $code ] : 0;
+		$totals          = $this->get_coupon_discount_totals();
+		$discount_amount = isset( $totals[ $code ] ) ? $totals[ $code ]: 0;
 
 		if ( ! $ex_tax ) {
 			$discount_amount += $this->get_coupon_discount_tax_amount( $code );
@@ -1655,7 +1645,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float discount amount
 	 */
 	public function get_coupon_discount_tax_amount( $code ) {
-		return wc_cart_round_discount( isset( $this->coupon_discount_tax_amounts[ $code ] ) ? $this->coupon_discount_tax_amounts[ $code ] : 0, wc_get_price_decimals() );
+		$totals = $this->get_coupon_discount_tax_totals();
+		return wc_cart_round_discount( isset( $totals[ $code ] ) ? $totals[ $code ] : 0, wc_get_price_decimals() );
 	}
 
 	/**
@@ -1682,7 +1673,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		$coupon_code  = wc_format_coupon_code( $coupon_code );
-		$position     = array_search( $coupon_code, $this->applied_coupons, true );
+		$position     = array_search( $coupon_code, $this->get_applied_coupons(), true );
 
 		if ( false !== $position ) {
 			unset( $this->applied_coupons[ $position ] );
@@ -1745,32 +1736,37 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function calculate_fees() {
 		// Reset fees before calculation.
-		$this->fee_total = 0;
-		$this->fees      = array();
+		$this->set_fee_total( 0 );
+		$this->set_fee_tax( 0 );
+		$this->set_fee_taxes( array() );
+		$this->fees = array();
 
 		// Fire an action where developers can add their fees.
 		do_action( 'woocommerce_cart_calculate_fees', $this );
 
 		// If fees were added, total them and calculate tax.
 		if ( ! empty( $this->fees ) ) {
+			$fees_total = 0;
+			$fees_taxes = array();
+
 			foreach ( $this->fees as $fee_key => $fee ) {
-				$this->fee_total += $fee->amount;
+				$fees_total += $fee->amount;
 
 				if ( $fee->taxable ) {
 					$tax_rates = WC_Tax::get_rates( $fee->tax_class );
 					$fee_taxes = WC_Tax::calc_tax( $fee->amount, $tax_rates, false );
 
 					if ( ! empty( $fee_taxes ) ) {
-						$this->fees[ $fee_key ]->tax = array_sum( $fee_taxes );
+						$this->fees[ $fee_key ]->tax      = array_sum( $fee_taxes );
 						$this->fees[ $fee_key ]->tax_data = $fee_taxes;
-
-						// Tax rows - merge the totals we just got.
-						foreach ( array_keys( $this->taxes + $fee_taxes ) as $key ) {
-							$this->taxes[ $key ] = ( isset( $fee_taxes[ $key ] ) ? $fee_taxes[ $key ] : 0 ) + ( isset( $this->taxes[ $key ] ) ? $this->taxes[ $key ] : 0 );
-						}
+						$fees_taxes                       = wc_array_merge_recursive_numeric( $fees_taxes, $fee_taxes );
 					}
 				}
 			}
+
+			$this->set_fee_total( $fees_total );
+			$this->set_fee_tax( array_sum( $fees_taxes ) );
+			$this->set_fee_taxes( $fees_taxes );
 		}
 	}
 
@@ -1780,11 +1776,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string formatted price
 	 */
 	public function get_total_ex_tax() {
-		$total = $this->total - $this->tax_total - $this->shipping_tax_total;
-		if ( $total < 0 ) {
-			$total = 0;
-		}
-		return apply_filters( 'woocommerce_cart_total_ex_tax', wc_price( $total ) );
+		return apply_filters( 'woocommerce_cart_total_ex_tax', wc_price( max( 0, $this->get_total( 'edit' ) - $this->get_cart_contents_tax() - $this->get_shipping_tax() ) ) );
 	}
 
 	/**
@@ -1793,13 +1785,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string formatted price
 	 */
 	public function get_cart_total() {
-		if ( ! wc_prices_include_tax() ) {
-			$cart_contents_total = wc_price( $this->cart_contents_total );
-		} else {
-			$cart_contents_total = wc_price( $this->cart_contents_total + $this->tax_total );
-		}
-
-		return apply_filters( 'woocommerce_cart_contents_total', $cart_contents_total );
+		return apply_filters( 'woocommerce_cart_contents_total', wc_price( wc_prices_include_tax() ? $this->get_cart_contents_total() + $this->get_cart_contents_tax() : $this->get_cart_contents_total() ) );
 	}
 
 	/**
@@ -1809,23 +1795,22 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string formatted price
 	 */
 	public function get_cart_subtotal( $compound = false ) {
-
 		/**
 		 * If the cart has compound tax, we want to show the subtotal as cart + shipping + non-compound taxes (after discount).
 		 */
 		if ( $compound ) {
-			$cart_subtotal = wc_price( $this->cart_contents_total + $this->shipping_total + $this->get_taxes_total( false, false ) );
+			$cart_subtotal = wc_price( $this->get_cart_contents_total() + $this->get_shipping_total() + $this->get_taxes_total( false, false ) );
 
 		} elseif ( 'excl' === $this->tax_display_cart ) {
-			$cart_subtotal = wc_price( $this->subtotal_ex_tax );
+			$cart_subtotal = wc_price( $this->get_subtotal() );
 
-			if ( $this->tax_total > 0 && wc_prices_include_tax() ) {
+			if ( $this->get_subtotal_tax() > 0 && wc_prices_include_tax() ) {
 				$cart_subtotal .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 			}
 		} else {
-			$cart_subtotal = wc_price( $this->subtotal );
+			$cart_subtotal = wc_price( $this->get_subtotal() + $this->get_subtotal_tax() );
 
-			if ( $this->tax_total > 0 && ! wc_prices_include_tax() ) {
+			if ( $this->get_subtotal_tax() > 0 && ! wc_prices_include_tax() ) {
 				$cart_subtotal .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
 			}
 		}
@@ -1869,7 +1854,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				$row_price        = wc_get_price_excluding_tax( $product, array( 'qty' => $quantity ) );
 				$product_subtotal = wc_price( $row_price );
 
-				if ( wc_prices_include_tax() && $this->tax_total > 0 ) {
+				if ( wc_prices_include_tax() && $this->get_subtotal_tax() > 0 ) {
 					$product_subtotal .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 				}
 			} else {
@@ -1877,7 +1862,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				$row_price        = wc_get_price_including_tax( $product, array( 'qty' => $quantity ) );
 				$product_subtotal = wc_price( $row_price );
 
-				if ( ! wc_prices_include_tax() && $this->tax_total > 0 ) {
+				if ( ! wc_prices_include_tax() && $this->get_subtotal_tax() > 0 ) {
 					$product_subtotal .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
 				}
 			}
@@ -1895,7 +1880,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string formatted price
 	 */
 	public function get_cart_tax() {
-		$cart_total_tax = wc_round_tax_total( $this->tax_total + $this->shipping_tax_total );
+		$cart_total_tax = wc_round_tax_total( $this->get_cart_contents_tax() + $this->get_shipping_tax() + $this->get_fee_tax() );
 
 		return apply_filters( 'woocommerce_get_cart_tax', $cart_total_tax ? wc_price( $cart_total_tax ) : '' );
 	}
@@ -1907,7 +1892,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float amount
 	 */
 	public function get_tax_amount( $tax_rate_id ) {
-		return isset( $this->taxes[ $tax_rate_id ] ) ? $this->taxes[ $tax_rate_id ] : 0;
+		$taxes = wc_array_merge_recursive_numeric( $this->get_cart_contents_taxes(), $this->get_fee_taxes() );
+		return isset( $taxes[ $tax_rate_id ] ) ? $taxes[ $tax_rate_id ] : 0;
 	}
 
 	/**
@@ -1917,7 +1903,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float amount
 	 */
 	public function get_shipping_tax_amount( $tax_rate_id ) {
-		return isset( $this->shipping_taxes[ $tax_rate_id ] ) ? $this->shipping_taxes[ $tax_rate_id ] : 0;
+		$taxes = $this->get_shipping_taxes();
+		return isset( $taxes[ $tax_rate_id ] ) ? $taxes[ $tax_rate_id ] : 0;
 	}
 
 	/**
@@ -1929,13 +1916,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function get_taxes_total( $compound = true, $display = true ) {
 		$total = 0;
-		foreach ( $this->taxes as $key => $tax ) {
-			if ( ! $compound && WC_Tax::is_compound( $key ) ) {
-				continue;
-			}
-			$total += $tax;
-		}
-		foreach ( $this->shipping_taxes as $key => $tax ) {
+		$taxes = $this->get_taxes();
+		foreach ( $taxes as $key => $tax ) {
 			if ( ! $compound && WC_Tax::is_compound( $key ) ) {
 				continue;
 			}
@@ -1948,30 +1930,12 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
-	 * Get the total of all cart discounts.
-	 *
-	 * @return float
-	 */
-	public function get_cart_discount_total() {
-		return wc_cart_round_discount( $this->discount_cart, wc_get_price_decimals() );
-	}
-
-	/**
-	 * Get the total of all cart tax discounts (used for discounts on tax inclusive prices).
-	 *
-	 * @return float
-	 */
-	public function get_cart_discount_tax_total() {
-		return wc_cart_round_discount( $this->discount_cart_tax, wc_get_price_decimals() );
-	}
-
-	/**
-	 * Gets the total discount amount - both kinds.
+	 * Gets the total discount amount.
 	 *
 	 * @return mixed formatted price or false if there are none
 	 */
 	public function get_total_discount() {
-		return apply_filters( 'woocommerce_cart_total_discount', $this->get_cart_discount_total() ? wc_price( $this->get_cart_discount_total() ) : false, $this );
+		return apply_filters( 'woocommerce_cart_total_discount', $this->get_discount_total() ? wc_price( $this->get_discount_total() ) : false, $this );
 	}
 
 	/**

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1126,10 +1126,6 @@ class WC_Cart extends WC_Legacy_Cart {
 				) ), $cart_item_key );
 			}
 
-			if ( did_action( 'wp' ) ) {
-				$this->set_cart_cookies( ! $this->is_empty() );
-			}
-
 			do_action( 'woocommerce_add_to_cart', $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data );
 
 			return $cart_item_key;

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -192,19 +192,19 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @var array
 	 */
 	protected $default_totals = array(
-		'subtotal'       => 0,
-		'subtotal_tax'   => 0,
-		'shipping_total' => 0,
-		'shipping_tax'   => 0,
-		'discount_total' => 0,
-		'discount_tax'   => 0,
-		'cart_total'     => 0,
-		'cart_tax'       => 0,
-		'fee_total'      => 0,
-		'fee_taxes'      => 0,
-		'total'          => 0,
-		'total_tax'      => 0,
-		'taxes'          => array(
+		'subtotal'            => 0,
+		'subtotal_tax'        => 0,
+		'shipping_total'      => 0,
+		'shipping_tax'        => 0,
+		'discount_total'      => 0,
+		'discount_tax'        => 0,
+		'cart_contents_total' => 0,
+		'cart_contents_tax'   => 0,
+		'fee_total'           => 0,
+		'fee_tax'             => 0,
+		'total'               => 0,
+		'total_tax'           => 0,
+		'taxes'               => array(
 			'shipping' => array(),
 			'cart'     => array(),
 			'fees'     => array(),
@@ -306,6 +306,128 @@ class WC_Cart extends WC_Legacy_Cart {
 		return (array) empty( $this->totals ) ? $this->default_totals : $this->totals;
 	}
 
+	/**
+	 * Get subtotal.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_subtotal() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['subtotal'] );
+	}
+
+	/**
+	 * Get subtotal.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_subtotal_tax() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['subtotal_tax'] );
+	}
+
+	/**
+	 * Get discount_total.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_discount_total() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['discount_total'] );
+	}
+
+	/**
+	 * Get discount_tax.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_discount_tax() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['discount_tax'] );
+	}
+
+	/**
+	 * Get shipping_total.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_shipping_total() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['shipping_total'] );
+	}
+
+	/**
+	 * Get shipping_tax.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_shipping_tax() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['shipping_tax'] );
+	}
+
+	/**
+	 * Gets cart total. This is the total of items in the cart, but after discounts. Subtotal is before discounts.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_cart_contents_total() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['cart_contents_total'] );
+	}
+
+	/**
+	 * Gets cart tax amount.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_cart_contents_tax() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['cart_contents_tax'] );
+	}
+
+	/**
+	 * Gets cart total after calculation.
+	 *
+	 * @since 3.2.0
+	 * @param string $context If the context is view, the value will be formatted for display. This keeps it compatible with pre-3.2 versions.
+	 * @return float
+	 */
+	public function get_total( $context = 'view' ) { // @todo conflict
+		$total = apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['total'] );
+		return 'view' === $context ? apply_filters( 'woocommerce_cart_total', wc_price( $total ) ) : $total;
+	}
+
+	/**
+	 * Get total tax amount.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_total_tax() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['total_tax'] );
+	}
+
+	/**
+	 * Get total fee amount.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_fee_total() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['fee_total'] );
+	}
+
+	/**
+	 * Get total fee tax amount.
+	 *
+	 * @since 3.2.0
+	 * @return float
+	 */
+	public function get_fee_tax() {
+		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->totals['fee_total'] );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Setters.
@@ -369,6 +491,136 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function set_totals( $value = array() ) {
 		$this->totals = wp_parse_args( $value, $this->default_totals );
+	}
+
+	/**
+	 * Set subtotal.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_subtotal( $value ) {
+		$this->totals['subtotal'] = $value;
+	}
+
+	/**
+	 * Set subtotal.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_subtotal_tax( $value ) {
+		$this->totals['subtotal_tax'] = $value;
+	}
+
+	/**
+	 * Set discount_total.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_discount_total( $value ) {
+		$this->totals['discount_total'] = $value;
+	}
+
+	/**
+	 * Set discount_tax.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_discount_tax( $value ) {
+		$this->totals['discount_tax'] = $value;
+	}
+
+	/**
+	 * Set shipping_total.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_shipping_total( $value ) {
+		$this->totals['shipping_total'] = $value;
+	}
+
+	/**
+	 * Set shipping_tax.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_shipping_tax( $value ) {
+		$this->totals['shipping_tax'] = $value;
+	}
+
+	/**
+	 * Set cart_contents_total.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_cart_contents_total( $value ) {
+		$this->totals['cart_contents_total'] = $value;
+	}
+
+	/**
+	 * Set cart tax amount.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_cart_contents_tax( $value ) {
+		$this->totals['cart_contents_tax'] = $value;
+	}
+
+	/**
+	 * Set cart total.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_total( $value ) {
+		$this->totals['total'] = $value;
+	}
+
+	/**
+	 * Set total tax amount.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_total_tax( $value ) {
+		$this->totals['total_tax'] = $value;
+	}
+
+	/**
+	 * Set fee amount.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_fee_total( $value ) {
+		$this->totals['fee_total'] = $value;
+	}
+
+	/**
+	 * Set fee tax.
+	 *
+	 * @since 3.2.0
+	 * @param string $value Value to set.
+	 */
+	public function set_fee_tax( $value ) {
+		$this->totals['fee_tax'] = $value;
+	}
+
+	/**
+	 * Set taxes by type.
+	 *
+	 * @param string $type Type/group of tax. e.g. shipping
+	 * @param array $value Tax values.
+	 */
+	public function set_taxes( $type, $value ) {
+		$this->totals['taxes'][ $type ] = $value;
 	}
 
 	/*
@@ -1601,15 +1853,6 @@ class WC_Cart extends WC_Legacy_Cart {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Gets the order total (after calculation).
-	 *
-	 * @return string formatted price
-	 */
-	public function get_total() {
-		return apply_filters( 'woocommerce_cart_total', wc_price( $this->total ) );
 	}
 
 	/**

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -314,8 +314,8 @@ class WC_Checkout {
 			$order->set_customer_note( isset( $data['order_comments'] ) ? $data['order_comments'] : '' );
 			$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ]  : $data['payment_method'] );
 			$order->set_shipping_total( WC()->cart->shipping_total );
-			$order->set_discount_total( WC()->cart->get_cart_discount_total() );
-			$order->set_discount_tax( WC()->cart->get_cart_discount_tax_total() );
+			$order->set_discount_total( WC()->cart->get_discount_total() );
+			$order->set_discount_tax( WC()->cart->get_discount_tax_total() );
 			$order->set_cart_tax( WC()->cart->tax_total );
 			$order->set_shipping_tax( WC()->cart->shipping_tax_total );
 			$order->set_total( WC()->cart->total );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -313,12 +313,12 @@ class WC_Checkout {
 			$order->set_customer_user_agent( wc_get_user_agent() );
 			$order->set_customer_note( isset( $data['order_comments'] ) ? $data['order_comments'] : '' );
 			$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ]  : $data['payment_method'] );
-			$order->set_shipping_total( WC()->cart->shipping_total );
+			$order->set_shipping_total( WC()->cart->get_shipping_total() );
 			$order->set_discount_total( WC()->cart->get_discount_total() );
-			$order->set_discount_tax( WC()->cart->get_discount_tax_total() );
-			$order->set_cart_tax( WC()->cart->tax_total );
-			$order->set_shipping_tax( WC()->cart->shipping_tax_total );
-			$order->set_total( WC()->cart->total );
+			$order->set_discount_tax( WC()->cart->get_discount_tax() );
+			$order->set_cart_tax( WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax() );
+			$order->set_shipping_tax( WC()->cart->get_shipping_tax() );
+			$order->set_total( WC()->cart->get_total( 'edit' ) );
 			$this->create_order_line_items( $order, WC()->cart );
 			$this->create_order_fee_lines( $order, WC()->cart );
 			$this->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping->get_packages() );

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -73,6 +73,22 @@ class WC_Shipping {
 	}
 
 	/**
+	 * Magic getter.
+	 *
+	 * @param string $name Property name.
+	 * @return mixed
+	 */
+	public function __get( $name ) {
+		// Grab from cart for backwards compatibility with versions prior to 3.2.
+		if ( 'shipping_total' === $name ){
+			return wc()->cart->get_shipping_total();
+		}
+		if ( 'shipping_taxes' === $name ){
+			return wc()->cart->get_shipping_taxes();
+		}
+	}
+
+	/**
 	 * Initialize shipping.
 	 */
 	public function __construct() {

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -180,6 +180,24 @@ abstract class WC_Legacy_Cart {
 	public function persistent_cart_destroy() { $this->session->persistent_cart_destroy(); }
 
 	/**
+	 * Get the total of all cart discounts.
+	 *
+	 * @return float
+	 */
+	public function get_cart_discount_total() {
+		return $this->get_discount_total();
+	}
+
+	/**
+	 * Get the total of all cart tax discounts (used for discounts on tax inclusive prices).
+	 *
+	 * @return float
+	 */
+	public function get_cart_discount_tax_total() {
+		return $this->get_discount_tax();
+	}
+
+	/**
 	 * Renamed for consistency.
 	 *
 	 * @param string $coupon_code

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -29,6 +29,43 @@ abstract class WC_Legacy_Cart {
 	public $coupon_applied_count = array();
 
 	/**
+	 * Methods moved to session class in 3.2.0.
+	 */
+	public function get_cart_from_session() { $this->session->get_cart_from_session(); }
+	public function maybe_set_cart_cookies() { $this->session->maybe_set_cart_cookies(); }
+	public function set_session() { $this->session->set_session(); }
+	public function get_cart_for_session() { $this->session->get_cart_for_session(); }
+	public function persistent_cart_update() { $this->session->persistent_cart_update(); }
+	public function persistent_cart_destroy() { $this->session->persistent_cart_destroy(); }
+
+	/**
+	 * Renamed for consistency.
+	 *
+	 * @param string $coupon_code
+	 * @return bool	True if the coupon is applied, false if it does not exist or cannot be applied.
+	 */
+	public function add_discount( $coupon_code ) {
+		return $this->apply_coupon( $coupon_code );
+	}
+	/**
+	 * Remove taxes.
+	 *
+	 * @deprecated 3.2.0 Taxes are never calculated if customer is tax except making this function unused.
+	 */
+	public function remove_taxes() {
+		wc_deprecated_function( 'WC_Cart::remove_taxes', '3.2', '' );
+	}
+	/**
+	 * Init.
+	 *
+	 * @deprecated 3.2.0 Session is loaded via hooks rather than directly.
+	 */
+	public function init() {
+		wc_deprecated_function( 'WC_Cart::init', '3.2', '' );
+		$this->get_cart_from_session();
+	}
+
+	/**
 	 * Function to apply discounts to a product and get the discounted price (before tax is applied).
 	 *
 	 * @deprecated Calculation and coupon logic is handled in WC_Cart_Totals.

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -29,6 +29,45 @@ abstract class WC_Legacy_Cart {
 	public $coupon_applied_count = array();
 
 	/**
+	 * Auto-load in-accessible properties on demand.
+	 *
+	 * @param mixed $key Key to get.
+	 * @return mixed
+	 */
+	public function __get( $key ) {
+		switch ( $key ) {
+			case 'prices_include_tax' :
+				return wc_prices_include_tax();
+			break;
+			case 'round_at_subtotal' :
+				return 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
+			break;
+			case 'dp' :
+				return wc_get_price_decimals();
+			break;
+			case 'display_totals_ex_tax' :
+			case 'display_cart_ex_tax' :
+				return 'excl' === $this->tax_display_cart;
+			break;
+			case 'cart_contents_weight' :
+				return $this->get_cart_contents_weight();
+			break;
+			case 'cart_contents_count' :
+				return $this->get_cart_contents_count();
+			break;
+			case 'tax' :
+				wc_deprecated_argument( 'WC_Cart->tax', '2.3', 'Use WC_Tax:: directly' );
+				$this->tax = new WC_Tax();
+				return $this->tax;
+			case 'discount_total':
+				wc_deprecated_argument( 'WC_Cart->discount_total', '2.3', 'After tax coupons are no longer supported. For more information see: https://woocommerce.wordpress.com/2014/12/upcoming-coupon-changes-in-woocommerce-2-3/' );
+				return 0;
+			case 'coupons' :
+				return $this->get_coupons();
+		}
+	}
+
+	/**
 	 * Methods moved to session class in 3.2.0.
 	 */
 	public function get_cart_from_session() { $this->session->get_cart_from_session(); }

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -75,7 +75,7 @@ abstract class WC_Legacy_Cart {
 			case 'subtotal_ex_tax' :
 				return $this->get_subtotal();
 			case 'tax_total' :
-				return array_sum( wc_array_merge_recursive_numeric( $this->get_cart_contents_taxes(), $this->get_fee_taxes() ) ); // Should be fees + cart items.
+				return $this->get_fee_tax() + $this->get_cart_contents_tax();
 			case 'taxes' :
 				return $this->get_taxes();
 			case 'shipping_taxes' :

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -163,9 +163,9 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 			$total = WC()->cart->get_displayed_subtotal();
 
 			if ( 'incl' === WC()->cart->tax_display_cart ) {
-				$total = round( $total - ( WC()->cart->get_cart_discount_total() + WC()->cart->get_cart_discount_tax_total() ), wc_get_price_decimals() );
+				$total = round( $total - ( WC()->cart->get_discount_total() + WC()->cart->get_discount_tax() ), wc_get_price_decimals() );
 			} else {
-				$total = round( $total - WC()->cart->get_cart_discount_total(), wc_get_price_decimals() );
+				$total = round( $total - WC()->cart->get_discount_total(), wc_get_price_decimals() );
 			}
 
 			if ( $total >= $this->min_amount ) {

--- a/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
+++ b/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
@@ -174,7 +174,7 @@ class WC_Shipping_Legacy_Free_Shipping extends WC_Shipping_Method {
 		}
 
 		if ( in_array( $this->requires, array( 'min_amount', 'either', 'both' ) ) && isset( WC()->cart->cart_contents_total ) ) {
-			if ( WC()->cart->prices_include_tax ) {
+			if ( wc_prices_include_tax() ) {
 				$total = WC()->cart->cart_contents_total + array_sum( WC()->cart->taxes );
 			} else {
 				$total = WC()->cart->cart_contents_total;

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -344,12 +344,12 @@ function wc_cart_totals_shipping_method_label( $method ) {
 	if ( $method->cost > 0 ) {
 		if ( WC()->cart->tax_display_cart == 'excl' ) {
 			$label .= ': ' . wc_price( $method->cost );
-			if ( $method->get_shipping_tax() > 0 && WC()->cart->prices_include_tax ) {
+			if ( $method->get_shipping_tax() > 0 && wc_prices_include_tax() ) {
 				$label .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 			}
 		} else {
 			$label .= ': ' . wc_price( $method->cost + $method->get_shipping_tax() );
-			if ( $method->get_shipping_tax() > 0 && ! WC()->cart->prices_include_tax ) {
+			if ( $method->get_shipping_tax() > 0 && ! wc_prices_include_tax() ) {
 				$label .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
 			}
 		}

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -124,13 +124,6 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 			'items_total'         => 27.00,
 			'items_total_tax'     => 5.40,
 			'total'               => 90.40,
-			'taxes'               => array(
-				$this->ids['tax_rate_ids'][0] => array(
-					'tax_total'          => 11.40,
-					'shipping_tax_total' => 2.00,
-				),
-			),
-			'tax_total'           => 11.40,
 			'shipping_total'      => 10,
 			'shipping_tax_total'  => 2,
 			'discounts_total'     => 3.00,

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -137,13 +137,26 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	public function test_cart_totals() {
 		$cart = WC()->cart;
 
-		$this->assertEquals( 40.00, $cart->fee_total );
+		$this->assertEquals( 40.00, $cart->get_fee_total() );
+		$this->assertEquals( 27.00, $cart->get_cart_contents_total() );
+		$this->assertEquals( 90.40, $cart->get_total( 'edit' ) );
+		$this->assertEquals( 30.00, $cart->get_subtotal() );
+		$this->assertEquals( 6.00, $cart->get_subtotal_tax() );
+		$this->assertEquals( 5.40, $cart->get_cart_contents_tax() );
+		$this->assertEquals( 5.40, array_sum( $cart->get_cart_contents_taxes() ) );
+		$this->assertEquals( 6.00, $cart->get_fee_tax() );
+		$this->assertEquals( 6.00, array_sum( $cart->get_fee_taxes() ) );
+		$this->assertEquals( 3, $cart->get_discount_total() );
+		$this->assertEquals( 0.60, $cart->get_discount_tax() );
+		$this->assertEquals( 10, $cart->get_shipping_total() );
+		$this->assertEquals( 2, $cart->get_shipping_tax() );
+
 		$this->assertEquals( 27.00, $cart->cart_contents_total );
 		$this->assertEquals( 90.40, $cart->total );
 		$this->assertEquals( 36.00, $cart->subtotal );
 		$this->assertEquals( 30.00, $cart->subtotal_ex_tax );
 		$this->assertEquals( 11.40, $cart->tax_total );
-		$this->assertEquals( 2.40, $cart->discount_cart );
+		$this->assertEquals( 3, $cart->discount_cart );
 		$this->assertEquals( 0.60, $cart->discount_cart_tax );
 		$this->assertEquals( 40.00, $cart->fee_total );
 		$this->assertEquals( 10, $cart->shipping_total );


### PR DESCRIPTION
This does refactoring on the cart to add getters and setters for totals, and the new sessions class.

Totals are now all stored to a single session variable.

Getters and setters are mapped in the legacy class to old props.

This replaces #16502