### PR TITLE
Fix importer fatal error

### DIFF
--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -620,7 +620,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 		$wc_product_attributes = array();
 
 		foreach ( wc_get_attribute_taxonomies() as $taxonomy ) {
-			$wc_product_attributes[ wc_attribute_taxonomy_name( $taxonomy['attribute_name'] ) ] = $taxonomy;
+			$wc_product_attributes[ wc_attribute_taxonomy_name( $taxonomy->attribute_name ) ] = $taxonomy;
 		}
 
 		return $attribute_id;


### PR DESCRIPTION
Fixes:
`
[18-Aug-2017 16:10:12 UTC] PHP Fatal error:  Uncaught Error: Cannot use object of type stdClass as array in /srv/www/wordpress-default/public_html/wp-content/plugins/woocommerce/includes/import/abstract-wc-product-importer.php:623
`

EDIT: Switched milestone to 3.2 because this isn't a problem in 3.1