### PR TITLE
Rename filters to be unique

### DIFF
--- a/includes/class-wc-product-query.php
+++ b/includes/class-wc-product-query.php
@@ -67,8 +67,8 @@ class WC_Product_Query extends WC_Object_Query {
 	 * @return array of WC_Product objects
 	 */
 	public function get_products() {
-		$args = apply_filters( 'woocommerce_product_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_product_object_query_args', $this->get_query_vars() );
 		$results = WC_Data_Store::load( 'product' )->query( $args );
-		return apply_filters( 'woocommerce_product_query', $results, $args );
+		return apply_filters( 'woocommerce_product_object_query', $results, $args );
 	}
 }


### PR DESCRIPTION
`woocommerce_product_query` is already used elsewhere for an action, so we can't use it again here.