### PR TITLE
\WC_Legacy_Cart::get_cart_for_session must return a value

### DIFF
--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -175,7 +175,7 @@ abstract class WC_Legacy_Cart {
 	public function get_cart_from_session() { $this->session->get_cart_from_session(); }
 	public function maybe_set_cart_cookies() { $this->session->maybe_set_cart_cookies(); }
 	public function set_session() { $this->session->set_session(); }
-	public function get_cart_for_session() { $this->session->get_cart_for_session(); }
+	public function get_cart_for_session() { return $this->session->get_cart_for_session(); }
 	public function persistent_cart_update() { $this->session->persistent_cart_update(); }
 	public function persistent_cart_destroy() { $this->session->persistent_cart_destroy(); }
 


### PR DESCRIPTION
This method appears to be a wrapper of \WC_Cart_Session::get_cart_for_session which does return a value.