### PR TITLE
Add filter to wc_get_product_id_by_sku

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -805,6 +805,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		);
 
 		foreach ( $this->parsed_data as $parsed_data_key => $parsed_data ) {
+			do_action( 'woocommerce_product_import_before_import', $parsed_data );
+
 			$id         = isset( $parsed_data['id'] ) ? absint( $parsed_data['id'] ) : 0;
 			$sku        = isset( $parsed_data['sku'] ) ? esc_attr( $parsed_data['sku'] ) : '';
 			$id_exists  = false;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -566,6 +566,7 @@ function wc_product_generate_unique_sku( $product_id, $sku, $index = 0 ) {
 function wc_get_product_id_by_sku( $sku ) {
 	$data_store = WC_Data_Store::load( 'product' );
 	$product_id = $data_store->get_product_id_by_sku( $sku );
+	$product_id = apply_filters( 'wc_get_product_id_by_sku', $product_id, $sku );
 
 	return ( $product_id ) ? intval( $product_id ) : 0;
 }


### PR DESCRIPTION
Hi,

In a multilingual context (with one product per language), the sku must not be unique to one product but must be unique to a set of translated products (all translations of a product share the same sku). In WC 3.0, the existing filter `wc_product_has_unique_sku` was sufficient to allow sharing the sku across product translations when editing products for the WooCommerce backend.  

However the importer introduced in WC 3.1 relies on the function `wc_get_product_id_by_sku` and blocks the import if an existing product has the same sku as the product currently beign imported. This makes it impossible to import translations of a product.

I propose to add a filter to `wc_get_product_id_by_sku` to allow 3rd party plugins to modify the result of the function. 

In addition, I propose to add an action before the function `wc_get_product_id_by_sku` is used by the importer, to allow the 3d party plugin to be aware of the data currently processed when using the above filter.