### PR TITLE
Reload items table after adding line item manually

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1095,17 +1095,19 @@ jQuery( function ( $ ) {
 						item_to_add: add_item_ids,
 						dataType   : 'json',
 						order_id   : woocommerce_admin_meta_boxes.post_id,
-						security   : woocommerce_admin_meta_boxes.order_item_nonce
+						security   : woocommerce_admin_meta_boxes.order_item_nonce,
+						data       : $( '#wc-backbone-modal-dialog form' ).serialize()
 					};
 
 					$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 						if ( response.success ) {
-							$( 'table.woocommerce_order_items tbody#order_line_items' ).append( response.data.html );
+							$( '#woocommerce-order-items' ).find( '.inside' ).empty();
+							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
+							wc_meta_boxes_order.init_tiptip();
+							wc_meta_boxes_order_items.stupidtable.init();
 						} else {
 							window.alert( response.data.error );
 						}
-
-						wc_meta_boxes_order.init_tiptip();
 						wc_meta_boxes_order_items.unblock();
 					});
 				}

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -56,7 +56,6 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items as $item_id => $item ) {
 				do_action( 'woocommerce_before_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 
-				$class = isset( $new_item_ids ) && is_array( $new_item_ids ) && in_array( $item_id, $new_item_ids ) ? 'new_row' : '';
 				include( 'html-order-item.php' );
 
 				do_action( 'woocommerce_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -56,6 +56,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items as $item_id => $item ) {
 				do_action( 'woocommerce_before_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 
+				$class = isset( $new_item_ids ) && is_array( $new_item_ids ) && in_array( $item_id, $new_item_ids ) ? 'new_row' : '';
 				include( 'html-order-item.php' );
 
 				do_action( 'woocommerce_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -770,7 +770,6 @@ class WC_AJAX {
 			$order_id     = absint( $_POST['order_id'] );
 			$order        = wc_get_order( $order_id );
 			$items_to_add = wp_parse_id_list( is_array( $_POST['item_to_add'] ) ? $_POST['item_to_add'] : array( $_POST['item_to_add'] ) );
-			$new_item_ids = array();
 
 			if ( ! $order ) {
 				throw new Exception( __( 'Invalid order', 'woocommerce' ) );
@@ -782,8 +781,6 @@ class WC_AJAX {
 				}
 				$item_id        = $order->add_product( wc_get_product( $item_to_add ) );
 				$item           = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id );
-				$new_item_ids[] = $item_id;
-
 				do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item, $order );
 			}
 


### PR DESCRIPTION
This behavior imitates how `add_tax` works. There's a bit of an overhead here but the added flexibility is probably worth it.

Refer to https://github.com/woocommerce/woocommerce/pull/9846/ for some possible use cases.

[This](https://github.com/woocommerce/woocommerce/compare/master...franticpsyx:reload-order-items-on-add?expand=1#diff-bdbde136beda4c33be12dd83d1bcdff2R1099) has been added to allow third parties to post custom data, if desired.

@mikejolley this is the stripped down version of #9846 that we talked about. 