### PR TITLE
Add action woocommerce_product_import_before_import

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -806,6 +806,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		);
 
 		foreach ( $this->parsed_data as $parsed_data_key => $parsed_data ) {
+			do_action( 'woocommerce_product_import_before_import', $parsed_data );
+
 			$id         = isset( $parsed_data['id'] ) ? absint( $parsed_data['id'] ) : 0;
 			$sku        = isset( $parsed_data['sku'] ) ? esc_attr( $parsed_data['sku'] ) : '';
 			$id_exists  = false;


### PR DESCRIPTION
Hi,

This PR is a follow up of #16559 (which proposed to add one filter for `wc_get_product_id_by_sku` and one action before the importer uses the function above), closed in favor of #16572 (which introduced only the filter).

The primary goal of #16559 was to allow importing multiple products sharing the same sku in a multilingual WooCommerce site. An action before the function `wc_get_product_id_by_sku` is used by the importer is needed to allow the 3d party plugin to be aware of the data currently processed when using the new filter `woocommerce_get_product_id_by_sku`