### PR TITLE
Manual coupons support

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -969,12 +969,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$this->remove_item( $item_id );
 				$coupon_object = new WC_Coupon( $code );
 				$coupon_object->decrease_usage_count( $this->get_user_id() );
+				$this->recalculate_coupons();
 				break;
 			}
 		}
-
-		// Reset line item totals.
-		$this->recalculate_coupons();
 	}
 
 	/**
@@ -1000,8 +998,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( $coupon_id ) {
 				$coupon_object = new WC_Coupon( $coupon_id );
 
-			// If we don't have a coupon ID (was it virtual? has it been deleted?) we must create a temporary coupon using what data we have stored during checkout.
 			} elseif ( $original_coupon_data = $coupon_item->get_meta( 'coupon_data', true ) ) {
+
+				// If we do not have a coupon ID (was it virtual? has it been deleted?) we must create a temporary coupon using what data we have stored during checkout.
 				$coupon_object = new WC_Coupon();
 				$coupon_object->set_props( $original_coupon_data );
 				$coupon_object->set_code( $coupon_code );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -923,14 +923,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$this->set_coupon_discount_amounts( $discounts );
-
-		// Add discounts to line items.
-		if ( $item_discounts = $discounts->get_discounts_by_item() ) {
-			foreach ( $item_discounts as $item_id => $amount ) {
-				$item = $this->get_item( $item_id, false );
-				$item->set_total( max( 0, $item->get_total() - $amount ) );
-			}
-		}
+		$this->set_item_discount_amounts( $discounts );
 
 		// Recalculate totals and taxes.
 		$this->calculate_totals( true );
@@ -998,26 +991,25 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( $coupon_id ) {
 				$coupon_object = new WC_Coupon( $coupon_id );
 
-			} elseif ( $original_coupon_data = $coupon_item->get_meta( 'coupon_data', true ) ) {
+			} else {
 
 				// If we do not have a coupon ID (was it virtual? has it been deleted?) we must create a temporary coupon using what data we have stored during checkout.
 				$coupon_object = new WC_Coupon();
-				$coupon_object->set_props( $original_coupon_data );
+				$coupon_object->set_props( (array) $coupon_item->get_meta( 'coupon_data', true ) );
 				$coupon_object->set_code( $coupon_code );
 				$coupon_object->set_virtual( true );
 
 				// If there is no coupon amount (maybe dynamic?), set it to the given **discount** amount so the coupon's same value is applied.
 				if ( ! $coupon_object->get_amount() ) {
-					$coupon_object->set_amount( $coupon_item->get_discount() );
+
+					// If the order originally had prices including tax, remove the discount + discount tax.
+					if ( $this->get_prices_include_tax() ) {
+						$coupon_object->set_amount( $coupon_item->get_discount() + $coupon_item->get_discount_tax() );
+					} else {
+						$coupon_object->set_amount( $coupon_item->get_discount() );
+					}
 					$coupon_object->set_discount_type( 'fixed_cart' );
 				}
-			} else {
-				// No data? Make a virtual coupon.
-				$coupon_object = new WC_Coupon();
-				$coupon_object->set_code( $coupon_code );
-				$coupon_object->set_amount( $coupon_item->get_discount() );
-				$coupon_object->set_discount_type( 'fixed_cart' );
-				$coupon_object->set_virtual( true );
 			}
 
 			/**
@@ -1033,17 +1025,33 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$this->set_coupon_discount_amounts( $discounts );
-
-		// Add discounts to line items.
-		if ( $item_discounts = $discounts->get_discounts_by_item() ) {
-			foreach ( $item_discounts as $item_id => $amount ) {
-				$item = $this->get_item( $item_id, false );
-				$item->set_total( max( 0, $item->get_total() - $amount ) );
-			}
-		}
+		$this->set_item_discount_amounts( $discounts );
 
 		// Recalculate totals and taxes.
 		$this->calculate_totals( true );
+	}
+
+	/**
+	 * After applying coupons via the WC_Disounts class, update line items.
+	 *
+	 * @since 3.2.0
+	 * @param WC_Discounts $discounts Discounts class.
+	 */
+	protected function set_item_discount_amounts( $discounts ) {
+		if ( $item_discounts = $discounts->get_discounts_by_item() ) {
+			foreach ( $item_discounts as $item_id => $amount ) {
+				$item = $this->get_item( $item_id, false );
+
+				// If the prices include tax, discounts should be taken off the tax inclusive prices like in the cart.
+				if ( $this->get_prices_include_tax() ) {
+					$amount_tax = WC_Tax::get_tax_total( WC_Tax::calc_tax( $amount, WC_Tax::get_rates( $item->get_tax_class() ), true ) );
+					$amount    -= $amount_tax;
+					$item->set_total( max( 0, $item->get_total() - $amount ) );
+				} else {
+					$item->set_total( max( 0, $item->get_total() - $amount ) );
+				}
+			}
+		}
 	}
 
 	/**
@@ -1069,19 +1077,23 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$coupon_item = $this->get_item( $item_id, false );
 				}
 
-				$coupon_item->set_discount( $amount );
+				$discount_tax = 0;
 
 				// Work out how much tax has been removed as a result of the discount from this coupon.
-				if ( wc_tax_enabled() && isset( $all_discounts[ $coupon_code ] ) ) {
-					$discount_tax = 0;
+				foreach ( $all_discounts[ $coupon_code ] as $item_id => $item_discount_amount ) {
+					$item = $this->get_item( $item_id, false );
 
-					foreach ( $all_discounts[ $coupon_code ] as $item_id => $item_discount_amount ) {
-						$item          = $this->get_item( $item_id, false );
+					if ( $this->get_prices_include_tax() ) {
+						$amount_tax    = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ), true ) );
+						$discount_tax += $amount_tax;
+						$amount        = $amount - $amount_tax;
+					} else {
 						$discount_tax += array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ) ) );
 					}
-
-					$coupon_item->set_discount_tax( $discount_tax );
 				}
+
+				$coupon_item->set_discount( $amount );
+				$coupon_item->set_discount_tax( $discount_tax );
 
 				$this->add_item( $coupon_item );
 			}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -996,14 +996,17 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$coupon_id     = wc_get_coupon_id_by_code( $coupon_code );
 			$coupon_object = false;
 
+			// If we have a coupon ID (loaded via wc_get_coupon_id_by_code) we can simply load the new coupon object using the ID.
 			if ( $coupon_id ) {
 				$coupon_object = new WC_Coupon( $coupon_id );
+
+			// If we don't have a coupon ID (was it virtual? has it been deleted?) we must create a temporary coupon using what data we have stored during checkout.
 			} elseif ( $original_coupon_data = $coupon_item->get_meta( 'coupon_data', true ) ) {
 				$coupon_object = new WC_Coupon();
 				$coupon_object->set_props( $original_coupon_data );
 				$coupon_object->set_code( $coupon_code );
 
-				// If there is no amount, set it to the given discount amount.
+				// If there is no coupon amount (maybe dynamic?), set it to the given **discount** amount so the coupon's same value is applied.
 				if ( ! $coupon_object->get_amount() ) {
 					$coupon_object->set_amount( $coupon_item->get_discount() );
 					$coupon_object->set_discount_type( 'fixed_cart' );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1043,7 +1043,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$item = $this->get_item( $item_id, false );
 
 				// If the prices include tax, discounts should be taken off the tax inclusive prices like in the cart.
-				if ( $this->get_prices_include_tax() ) {
+				if ( $this->get_prices_include_tax() && wc_tax_enabled() ) {
 					$amount_tax = WC_Tax::get_tax_total( WC_Tax::calc_tax( $amount, WC_Tax::get_rates( $item->get_tax_class() ), true ) );
 					$amount    -= $amount_tax;
 					$item->set_total( max( 0, $item->get_total() - $amount ) );
@@ -1083,7 +1083,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				foreach ( $all_discounts[ $coupon_code ] as $item_id => $item_discount_amount ) {
 					$item = $this->get_item( $item_id, false );
 
-					if ( $this->get_prices_include_tax() ) {
+					if ( $this->get_prices_include_tax() && wc_tax_enabled() ) {
 						$amount_tax    = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ), true ) );
 						$discount_tax += $amount_tax;
 						$amount        = $amount - $amount_tax;

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1011,6 +1011,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$coupon_object->set_amount( $coupon_item->get_discount() );
 					$coupon_object->set_discount_type( 'fixed_cart' );
 				}
+			} else {
+				// No data? Make a virtual coupon.
+				$coupon_object = new WC_Coupon();
+				$coupon_object->set_code( $coupon_code );
+				$coupon_object->set_amount( $coupon_item->get_discount() );
+				$coupon_object->set_discount_type( 'fixed_cart' );
+				$coupon_object->set_virtual( true );
 			}
 
 			/**

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1005,6 +1005,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$coupon_object = new WC_Coupon();
 				$coupon_object->set_props( $original_coupon_data );
 				$coupon_object->set_code( $coupon_code );
+				$coupon_object->set_virtual( true );
 
 				// If there is no coupon amount (maybe dynamic?), set it to the given **discount** amount so the coupon's same value is applied.
 				if ( ! $coupon_object->get_amount() ) {

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -111,9 +111,12 @@ if ( wc_tax_enabled() ) {
 					echo '<li><strong>' . __( 'Coupon(s)', 'woocommerce' ) . '</strong></li>';
 					foreach ( $coupons as $item_id => $item ) {
 						$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' LIMIT 1;", $item->get_code() ) );
-						$link    = $post_id ? add_query_arg( array( 'post' => $post_id, 'action' => 'edit' ), admin_url( 'post.php' ) ) : add_query_arg( array( 's' => $item->get_code(), 'post_status' => 'all', 'post_type' => 'shop_coupon' ), admin_url( 'edit.php' ) );
 
-						echo '<li class="code"><a href="' . esc_url( $link ) . '" class="tips" data-tip="' . esc_attr( wc_price( $item->get_discount(), array( 'currency' => $order->get_currency() ) ) ) . '"><span>' . esc_html( $item->get_code() ) . '</span></a> <a class="remove-coupon" href="javascript:void(0)" aria-label="Remove" data-code="' . esc_attr( $item->get_code() ) . '"></a></li>';
+						if ( $post_id ) {
+							echo '<li class="code"><a href="' . esc_url( add_query_arg( array( 'post' => $post_id, 'action' => 'edit' ), admin_url( 'post.php' ) ) ) . '" class="tips" data-tip="' . esc_attr( wc_price( $item->get_discount(), array( 'currency' => $order->get_currency() ) ) ) . '"><span>' . esc_html( $item->get_code() ) . '</span></a> <a class="remove-coupon" href="javascript:void(0)" aria-label="Remove" data-code="' . esc_attr( $item->get_code() ) . '"></a></li>';
+						} else {
+							echo '<li class="code"><span class="tips" data-tip="' . esc_attr( wc_price( $item->get_discount(), array( 'currency' => $order->get_currency() ) ) ) . '"><span>' . esc_html( $item->get_code() ) . '</span></span> <a class="remove-coupon" href="javascript:void(0)" aria-label="Remove" data-code="' . esc_attr( $item->get_code() ) . '"></a></li>';
+						}
 					}
 				?></ul>
 			</div>

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -494,8 +494,8 @@ class WC_Checkout {
 	/**
 	 * Add coupon lines to the order.
 	 *
-	 * @param  WC_Order $order
-	 * @param WC_Cart $cart
+	 * @param WC_Order $order
+	 * @param WC_Cart  $cart
 	 */
 	public function create_order_coupon_lines( &$order, $cart ) {
 		foreach ( $cart->get_coupons() as $code => $coupon ) {
@@ -505,6 +505,7 @@ class WC_Checkout {
 				'discount'     => $cart->get_coupon_discount_amount( $code ),
 				'discount_tax' => $cart->get_coupon_discount_tax_amount( $code ),
 			) );
+			$item->add_meta_data( 'coupon_data', $coupon->get_data() );
 
 			/**
 			 * Action hook to adjust item before save.

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -46,6 +46,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		'maximum_amount'              => '',
 		'email_restrictions'          => array(),
 		'used_by'                     => array(),
+		'virtual'                     => false,
 	);
 
 	// Coupon message codes
@@ -72,13 +73,6 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @var string
 	 */
 	protected $cache_group = 'coupons';
-
-	/**
-	 * Is this coupon added through the woocommerce_get_shop_coupon_data filter?
-	 *
-	 * @var bool
-	 */
-	protected $is_virtual = false;
 
 	/**
 	 * Coupon constructor. Loads coupon data.
@@ -359,6 +353,17 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function get_used_by( $context = 'view' ) {
 		return $this->get_prop( 'used_by', $context );
+	}
+
+	/**
+	 * If the filter is added through the woocommerce_get_shop_coupon_data filter, it's virtual and not in the DB.
+	 *
+	 * @since 3.2.0
+	 * @param  string $context
+	 * @return boolean
+	 */
+	public function get_virtual( $context = 'view' ) {
+		return (bool) $this->get_prop( 'virtual', $context );
 	}
 
 	/**
@@ -649,6 +654,15 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$this->set_prop( 'used_by', array_filter( $used_by ) );
 	}
 
+	/**
+	 * Set coupon virtual state.
+	 * @param boolean $virtual Whether it is virtual or not.
+	 * @since 3.2.0
+	 */
+	public function set_virtual( $virtual ) {
+		$this->set_prop( 'virtual', (bool) $virtual );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Other Actions
@@ -700,17 +714,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		$this->set_props( $coupon );
 		$this->set_code( $code );
 		$this->set_id( 0 );
-		$this->is_virtual = true;
-	}
-
-	/**
-	 * If the filter is added through the woocommerce_get_shop_coupon_data filter, it's virtual and not in the DB.
-	 *
-	 * @since 3.2.0
-	 * @return boolean
-	 */
-	public function is_virtual() {
-		return (bool) $this->is_virtual;
+		$this->set_virtual( true );
 	}
 
 	/**

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -74,6 +74,13 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	protected $cache_group = 'coupons';
 
 	/**
+	 * Is this coupon added through the woocommerce_get_shop_coupon_data filter?
+	 *
+	 * @var bool
+	 */
+	protected $is_virtual = false;
+
+	/**
 	 * Coupon constructor. Loads coupon data.
 	 * @param mixed $data Coupon data, object, ID or code.
 	 */
@@ -690,8 +697,20 @@ class WC_Coupon extends WC_Legacy_Coupon {
 					break;
 			}
 		}
-		$this->set_code( $code );
 		$this->set_props( $coupon );
+		$this->set_code( $code );
+		$this->set_id( 0 );
+		$this->is_virtual = true;
+	}
+
+	/**
+	 * If the filter is added through the woocommerce_get_shop_coupon_data filter, it's virtual and not in the DB.
+	 *
+	 * @since 3.2.0
+	 * @return boolean
+	 */
+	public function is_virtual() {
+		return (bool) $this->is_virtual;
 	}
 
 	/**

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -18,6 +18,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Discounts {
 
 	/**
+	 * Reference to cart or order object.
+	 *
+	 * @since 3.2.0
+	 * @var array
+	 */
+	protected $object;
+
+	/**
 	 * An array of items to discount.
 	 *
 	 * @var array
@@ -37,10 +45,12 @@ class WC_Discounts {
 	 * @param array $object Cart or order object.
 	 */
 	public function __construct( $object = array() ) {
-		if ( is_a( $object, 'WC_Cart' ) ) {
-			$this->set_items_from_cart( $object );
-		} elseif ( is_a( $object, 'WC_Order' ) ) {
-			$this->set_items_from_order( $object );
+		$this->object = $object;
+
+		if ( is_a( $this->object, 'WC_Cart' ) ) {
+			$this->set_items_from_cart( $this->object );
+		} elseif ( is_a( $this->object, 'WC_Order' ) ) {
+			$this->set_items_from_order( $this->object );
 		}
 	}
 
@@ -332,7 +342,7 @@ class WC_Discounts {
 			// Run coupon calculations.
 			$discount = floor( $price_to_discount * ( $coupon->get_amount() / 100 ) );
 
-			if ( has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
+			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
 				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}
@@ -377,7 +387,7 @@ class WC_Discounts {
 			// Run coupon calculations.
 			$discount = $amount * $item->quantity;
 
-			if ( has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
+			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
 				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}
@@ -487,7 +497,7 @@ class WC_Discounts {
 	 * @return bool
 	 */
 	protected function validate_coupon_exists( $coupon ) {
-		if ( ! $coupon->get_id() ) {
+		if ( ! $coupon->get_id() && ! $coupon->is_virtual() ) {
 			/* translators: %s: coupon code */
 			throw new Exception( sprintf( __( 'Coupon "%s" does not exist!', 'woocommerce' ), $coupon->get_code() ), 105 );
 		}

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -100,6 +100,11 @@ class WC_Discounts {
 			$item->product       = $order_item->get_product();
 			$item->quantity      = $order_item->get_quantity();
 			$item->price         = wc_add_number_precision_deep( $order_item->get_total() );
+
+			if ( $order->get_prices_include_tax() ) {
+				$item->price += wc_add_number_precision_deep( $order_item->get_total_tax() );
+			}
+
 			$this->items[ $order_item->get_id() ] = $item;
 		}
 

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -497,7 +497,7 @@ class WC_Discounts {
 	 * @return bool
 	 */
 	protected function validate_coupon_exists( $coupon ) {
-		if ( ! $coupon->get_id() && ! $coupon->is_virtual() ) {
+		if ( ! $coupon->get_id() && ! $coupon->get_virtual() ) {
 			/* translators: %s: coupon code */
 			throw new Exception( sprintf( __( 'Coupon "%s" does not exist!', 'woocommerce' ), $coupon->get_code() ), 105 );
 		}

--- a/tests/unit-tests/order/coupons.php
+++ b/tests/unit-tests/order/coupons.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Order coupon tests.
+ * @package WooCommerce\Tests\Orders
+ */
+class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
+
+	/**
+	 * Track ids.
+	 *
+	 * @var array
+	 */
+	protected $objects = array();
+
+	/**
+	 * Setup an order.
+	 */
+	public function setUp() {
+		$this->objects = array();
+
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_default_customer_address', 'base' );
+		update_option( 'woocommerce_tax_based_on', 'base' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		update_post_meta( $product->get_id(), '_regular_price', '1000' );
+		update_post_meta( $product->get_id(), '_price', '1000' );
+		$product = wc_get_product( $product->get_id() );
+
+		$coupon = new WC_Coupon;
+		$coupon->set_code( 'test-coupon-1' );
+		$coupon->set_amount( 1 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		$coupon2 = new WC_Coupon;
+		$coupon2->set_code( 'test-coupon-2' );
+		$coupon2->set_amount( 20 );
+		$coupon2->set_discount_type( 'percent' );
+		$coupon2->save();
+
+		$order = wc_create_order( array(
+			'status'        => 'pending',
+			'customer_id'   => 1,
+			'customer_note' => '',
+			'total'         => '',
+		) );
+
+		// Add order products
+		$item = new WC_Order_Item_Product();
+		$item->set_props( array(
+			'product'  => $product,
+			'quantity' => 1,
+			'subtotal' => 909.09, // Ex tax.
+			'total'    => 726.36,
+		) );
+		$item->save();
+		$order->add_item( $item );
+
+		$item = new WC_Order_Item_Coupon();
+		$item->set_props( array(
+			'code'         => 'test-coupon-1',
+			'discount'     => 1.00,
+			'discount_tax' => 0.01,
+		) );
+		$item->save();
+		$order->add_item( $item );
+
+		$item = new WC_Order_Item_Coupon();
+		$item->set_props( array(
+			'code'         => 'this-is-a-virtal-coupon',
+			'discount'     => 181.82,
+			'discount_tax' => 18.18,
+		) );
+		$item->save();
+		$order->add_item( $item );
+
+		$this->objects['coupons'][]      = $coupon;
+		$this->objects['coupons'][]      = $coupon2;
+		$this->objects['products'][]     = $product;
+		$this->objects['order']          = $order;
+		$this->objects['tax_rate_ids'][] = WC_Tax::_insert_tax_rate( array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'VAT',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		) );
+
+		$order->calculate_totals( true );
+		$order->save();
+	}
+
+	/**
+	 * Clean up after test.
+	 */
+	public function tearDown() {
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		foreach ( $this->objects['coupons'] + $this->objects['products'] as $object ) {
+			$object->delete( true );
+		}
+
+		$this->objects['order']->delete( true );
+
+		foreach ( $this->objects['tax_rate_ids'] as $tax_rate_id ) {
+			WC_Tax::_delete_tax_rate( $tax_rate_id );
+		}
+
+		$this->objects = array();
+	}
+
+	/**
+	 * Test: get_type
+	 */
+	function test_remove_coupon_from_order() {
+		$order_id = $this->objects['order']->get_id();
+		$order    = wc_get_order( $order_id );
+
+		// Check it's expected.
+		$this->assertEquals( 'shop_order', $order->get_type() );
+		$this->assertEquals( '799', $order->get_total(), $order->get_total() );
+
+		// Remove the virtual coupon. Total should be 999.
+		$order->remove_coupon( 'this-is-a-virtal-coupon' );
+		$this->assertEquals( '999', $order->get_total(), $order->get_total() );
+
+		// Remove the other coupon. Total should be 1000.
+		$order->remove_coupon( 'test-coupon-1' );
+		$this->assertEquals( '1000', $order->get_total(), $order->get_total() );
+
+		// Reset.
+		$this->tearDown();
+		$this->setUp();
+
+		// Do the above tests in reverse.
+		$order->remove_coupon( 'test-coupon-1' );
+		$this->assertEquals( '800', $order->get_total(), $order->get_total() );
+		$order->remove_coupon( 'this-is-a-virtal-coupon' );
+		$this->assertEquals( '1000', $order->get_total(), $order->get_total() );
+
+		// Reset.
+		$this->tearDown();
+		$this->setUp();
+	}
+
+	/**
+	 * Test: get_type
+	 */
+	function test_add_coupon_to_order() {
+		$order_id = $this->objects['order']->get_id();
+		$order    = wc_get_order( $order_id );
+
+		$order->apply_coupon( 'test-coupon-2' );
+		$this->assertEquals( '639.2', $order->get_total(), $order->get_total() );
+
+		// Reset.
+		$this->tearDown();
+		$this->setUp();
+	}
+}


### PR DESCRIPTION
Stores data about manual coupons so they can be re-applied in admin.

`woocommerce_order_recalculate_coupons_coupon_object` filter can tweak coupons before they are reapplied if more advanced code is needed.

`is_virtual` method added to coupon objects to track if they are manual or not.

To test:

1. Add manual coupon to cart
2. Add regular coupon to cart
3. Place order
4. Remove regular coupon from order
5. Check discounts are applied and manual coupon has correct discount amount set.

Fixes #16594