### PR TITLE
i18n: Avoid using HTML tags in translation strings

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -234,8 +234,12 @@ class WC_Admin {
 		if ( isset( $current_screen->id ) && apply_filters( 'woocommerce_display_admin_footer_text', in_array( $current_screen->id, $wc_pages ) ) ) {
 			// Change the footer text
 			if ( ! get_option( 'woocommerce_admin_footer_text_rated' ) ) {
-				/* translators: %s: five stars */
-				$footer_text = sprintf( __( 'If you like <strong>WooCommerce</strong> please leave us a %s rating. A huge thanks in advance!', 'woocommerce' ), '<a href="https://wordpress.org/support/plugin/woocommerce/reviews?rate=5#new-post" target="_blank" class="wc-rating-link" data-rated="' . esc_attr__( 'Thanks :)', 'woocommerce' ) . '">&#9733;&#9733;&#9733;&#9733;&#9733;</a>' );
+				$footer_text = sprintf(
+					/* translators: 1: WooCommerce 2:: five stars */
+					__( 'If you like %1$s please leave us a %2$s rating. A huge thanks in advance!', 'woocommerce' ),
+					sprintf( '<strong>%s<strong>', esc_html__( 'WooCommerce', 'woocommerce' ) ),
+					'<a href="https://wordpress.org/support/plugin/woocommerce/reviews?rate=5#new-post" target="_blank" class="wc-rating-link" data-rated="' . esc_attr__( 'Thanks :)', 'woocommerce' ) . '">&#9733;&#9733;&#9733;&#9733;&#9733;</a>'
+				);
 				wc_enqueue_js( "
 					jQuery( 'a.wc-rating-link' ).click( function() {
 						jQuery.post( '" . WC()->ajax_url() . "', { action: 'woocommerce_rated' } );


### PR DESCRIPTION
Old translation string:

* `If you like <strong>WooCommerce</strong> please leave us a %s rating. A huge thanks in advance!`

New translation string:

* `If you like %1$s please leave us a %2$s rating. A huge thanks in advance!`