### PR TITLE
Allow install-related directory creation to be bypassed

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -796,6 +796,11 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	 * Create files/directories.
 	 */
 	private static function create_files() {
+		// Bypass if system is read-only and/or non-standard upload system is used
+		if ( apply_filters( 'woocommerce_install_skip_create_files', false ) ) {
+			return;
+		}
+
 		// Install files and folders for uploading files and prevent hotlinking
 		$upload_dir      = wp_upload_dir();
 		$download_method = get_option( 'woocommerce_file_download_method', 'force' );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -796,7 +796,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	 * Create files/directories.
 	 */
 	private static function create_files() {
-		// Bypass if system is read-only and/or non-standard upload system is used
+		// Bypass if filesystem is read-only and/or non-standard upload system is used
 		if ( apply_filters( 'woocommerce_install_skip_create_files', false ) ) {
 			return;
 		}


### PR DESCRIPTION
`WC_Install` tries to create several directories on `admin_init`, but if the filesystem is read-only and/or a non-standard uploads system is used, these requests will continually fail. Bypassing them will cut down on unnecessary system calls and, depending on configuration, logging of errors.