### PR TITLE
Widget depth settings and improvements

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -180,60 +180,35 @@ function _wc_get_product_terms_parent_usort_callback( $a, $b ) {
  * Stuck with this until a fix for https://core.trac.wordpress.org/ticket/13258.
  * We use a custom walker, just like WordPress does.
  *
- * @param array $args
- * @param int $deprecated_hierarchical
- * @param int $deprecated_show_uncategorized (default: 1)
- * @param string $deprecated_orderby
- *
+ * @param array $args Args to control display of dropdown.
  * @return string
  */
-function wc_product_dropdown_categories( $args = array(), $deprecated_hierarchical = 1, $deprecated_show_uncategorized = 1, $deprecated_orderby = '' ) {
+function wc_product_dropdown_categories( $args = array() ) {
 	global $wp_query;
 
-	if ( ! is_array( $args ) ) {
-		wc_deprecated_argument( 'wc_product_dropdown_categories()', '2.1', 'show_counts, hierarchical, show_uncategorized and orderby arguments are invalid - pass a single array of values instead.' );
-
-		$args['show_count']         = $args;
-		$args['hierarchical']       = $deprecated_hierarchical;
-		$args['show_uncategorized'] = $deprecated_show_uncategorized;
-		$args['orderby']            = $deprecated_orderby;
-	}
-
-	$current_product_cat = isset( $wp_query->query_vars['product_cat'] ) ? $wp_query->query_vars['product_cat'] : '';
-	$defaults            = array(
+	$args = wp_parse_args( $args, array(
 		'pad_counts'         => 1,
 		'show_count'         => 1,
 		'hierarchical'       => 1,
 		'hide_empty'         => 1,
 		'show_uncategorized' => 1,
 		'orderby'            => 'name',
-		'selected'           => $current_product_cat,
+		'selected'           => isset( $wp_query->query_vars['product_cat'] ) ? $wp_query->query_vars['product_cat']: '',
 		'menu_order'         => false,
-		'option_select_text' => __( 'Select a category', 'woocommerce' ),
-	);
-
-	$args = wp_parse_args( $args, $defaults );
+		'show_option_none'   => __( 'Select a category', 'woocommerce' ),
+		'option_none_value'  => '',
+		'value_field'        => 'slug',
+		'taxonomy'           => 'product_cat',
+		'name'               => 'product_cat',
+		'class'              => 'dropdown_product_cat',
+	) );
 
 	if ( 'order' === $args['orderby'] ) {
 		$args['menu_order'] = 'asc';
 		$args['orderby']    = 'name';
 	}
 
-	$terms = get_terms( 'product_cat', apply_filters( 'wc_product_dropdown_categories_get_terms_args', $args ) );
-
-	if ( empty( $terms ) ) {
-		return;
-	}
-
-	$output  = "<select name='product_cat' class='dropdown_product_cat'>";
-	$output .= '<option value="" ' . selected( $current_product_cat, '', false ) . '>' . esc_html( $args['option_select_text'] ) . '</option>';
-	$output .= wc_walk_category_dropdown_tree( $terms, 0, $args );
-	if ( $args['show_uncategorized'] ) {
-		$output .= '<option value="0" ' . selected( $current_product_cat, '0', false ) . '>' . esc_html__( 'Uncategorized', 'woocommerce' ) . '</option>';
-	}
-	$output .= "</select>";
-
-	echo $output;
+	wp_dropdown_categories( $args );
 }
 
 /**

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -177,9 +177,6 @@ function _wc_get_product_terms_parent_usort_callback( $a, $b ) {
 /**
  * WooCommerce Dropdown categories.
  *
- * Stuck with this until a fix for https://core.trac.wordpress.org/ticket/13258.
- * We use a custom walker, just like WordPress does.
- *
  * @param array $args Args to control display of dropdown.
  * @return string
  */
@@ -212,7 +209,9 @@ function wc_product_dropdown_categories( $args = array() ) {
 }
 
 /**
- * Walk the Product Categories.
+ * Custom walker for Product Categories.
+ *
+ * Previously used by wc_product_dropdown_categories, but wp_dropdown_categories has been fixed in core.
  *
  * @return mixed
  */

--- a/includes/widgets/class-wc-widget-cart.php
+++ b/includes/widgets/class-wc-widget-cart.php
@@ -22,9 +22,9 @@ class WC_Widget_Cart extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_shopping_cart';
-		$this->widget_description = __( "Display the user's cart in the sidebar.", 'woocommerce' );
+		$this->widget_description = __( "Display the customer shopping cart.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_widget_cart';
-		$this->widget_name        = __( 'WooCommerce cart', 'woocommerce' );
+		$this->widget_name        = __( 'Cart', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -20,9 +20,9 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_layered_nav_filters';
-		$this->widget_description = __( 'Shows active layered nav filters so users can see and deactivate them.', 'woocommerce' );
+		$this->widget_description = __( 'Display a list of active product filters.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_layered_nav_filters';
-		$this->widget_name        = __( 'WooCommerce layered nav filters', 'woocommerce' );
+		$this->widget_name        = __( 'Active Product Filters', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -20,9 +20,9 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_layered_nav woocommerce-widget-layered-nav';
-		$this->widget_description = __( 'Shows a custom attribute in a widget which lets you narrow down the list of products when viewing product categories.', 'woocommerce' );
+		$this->widget_description = __( 'Display a list of attributes to filter products in your store.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_layered_nav';
-		$this->widget_name        = __( 'WooCommerce layered nav', 'woocommerce' );
+		$this->widget_name        = __( 'Filter Products by Attribute', 'woocommerce' );
 		parent::__construct();
 	}
 

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -22,9 +22,9 @@ class WC_Widget_Price_Filter extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_price_filter';
-		$this->widget_description = __( 'Shows a price filter slider in a widget which lets you narrow down the list of shown products when viewing product categories.', 'woocommerce' );
+		$this->widget_description = __( 'Display a slider to filter products in your store by price.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_price_filter';
-		$this->widget_name        = __( 'WooCommerce price filter', 'woocommerce' );
+		$this->widget_name        = __( 'Filter Products by Price', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -77,6 +77,11 @@ class WC_Widget_Product_Categories extends WC_Widget {
 				'std'   => 0,
 				'label' => __( 'Hide empty categories', 'woocommerce' ),
 			),
+			'max_depth'  => array(
+				'type'  => 'text',
+				'std'   => '',
+				'label' => __( 'Maximum depth', 'woocommerce' ),
+			),
 		);
 
 		parent::__construct();
@@ -86,7 +91,6 @@ class WC_Widget_Product_Categories extends WC_Widget {
 	 * Output widget.
 	 *
 	 * @see WP_Widget
-	 *
 	 * @param array $args
 	 * @param array $instance
 	 */
@@ -101,26 +105,26 @@ class WC_Widget_Product_Categories extends WC_Widget {
 		$hide_empty         = isset( $instance['hide_empty'] ) ? $instance['hide_empty'] : $this->settings['hide_empty']['std'];
 		$dropdown_args      = array( 'hide_empty' => $hide_empty );
 		$list_args          = array( 'show_count' => $count, 'hierarchical' => $hierarchical, 'taxonomy' => 'product_cat', 'hide_empty' => $hide_empty );
+		$max_depth          = absint( isset( $instance['max_depth'] ) ? $instance['max_depth'] : $this->settings['max_depth']['std']);
 
-		// Menu Order
 		$list_args['menu_order'] = false;
+		$dropdown_args['depth']  = $max_depth;
+		$list_args['depth']      = $max_depth;
+
 		if ( 'order' === $orderby ) {
 			$list_args['menu_order'] = 'asc';
 		} else {
 			$list_args['orderby']    = 'title';
 		}
 
-		// Setup Current Category
 		$this->current_cat   = false;
 		$this->cat_ancestors = array();
 
 		if ( is_tax( 'product_cat' ) ) {
-
 			$this->current_cat   = $wp_query->queried_object;
 			$this->cat_ancestors = get_ancestors( $this->current_cat->term_id, 'product_cat' );
 
 		} elseif ( is_singular( 'product' ) ) {
-
 			$product_category = wc_get_product_terms( $post->ID, 'product_cat', apply_filters( 'woocommerce_product_categories_widget_product_terms_args', array( 'orderby' => 'parent' ) ) );
 
 			if ( ! empty( $product_category ) ) {
@@ -129,56 +133,59 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			}
 		}
 
-		// Show Siblings and Children Only
+		// Show Siblings and Children Only.
 		if ( $show_children_only && $this->current_cat ) {
-
-			// Top level is needed
-			$top_level = get_terms(
-				'product_cat',
-				array(
-					'fields'       => 'ids',
-					'parent'       => 0,
-					'hierarchical' => true,
-					'hide_empty'   => false,
-				)
-			);
-
-			// Direct children are wanted
-			$direct_children = get_terms(
-				'product_cat',
-				array(
-					'fields'       => 'ids',
-					'parent'       => $this->current_cat->term_id,
-					'hierarchical' => true,
-					'hide_empty'   => false,
-				)
-			);
-
-			// Gather siblings of ancestors
-			$siblings  = array();
-			if ( $this->cat_ancestors ) {
-				foreach ( $this->cat_ancestors as $ancestor ) {
-					$ancestor_siblings = get_terms(
+			if ( $hierarchical ) {
+				$include = array_merge(
+					$this->cat_ancestors,
+					array( $this->current_cat->term_id ),
+					get_terms(
 						'product_cat',
 						array(
 							'fields'       => 'ids',
-							'parent'       => $ancestor,
-							'hierarchical' => false,
+							'parent'       => 0,
+							'hierarchical' => true,
 							'hide_empty'   => false,
 						)
-					);
-					$siblings = array_merge( $siblings, $ancestor_siblings );
+					),
+					get_terms(
+						'product_cat',
+						array(
+							'fields'       => 'ids',
+							'parent'       => $this->current_cat->term_id,
+							'hierarchical' => true,
+							'hide_empty'   => false,
+						)
+					)
+				);
+				// Gather siblings of ancestors.
+				if ( $this->cat_ancestors ) {
+					foreach ( $this->cat_ancestors as $ancestor ) {
+						$include = array_merge( $include, get_terms(
+							'product_cat',
+							array(
+								'fields'       => 'ids',
+								'parent'       => $ancestor,
+								'hierarchical' => false,
+								'hide_empty'   => false,
+							)
+						) );
+					}
 				}
-			}
-
-			if ( $hierarchical ) {
-				$include = array_merge( $top_level, $this->cat_ancestors, $siblings, $direct_children, array( $this->current_cat->term_id ) );
 			} else {
-				$include = array_merge( $direct_children );
+				// Direct children.
+				$include = get_terms(
+					'product_cat',
+					array(
+						'fields'       => 'ids',
+						'parent'       => $this->current_cat->term_id,
+						'hierarchical' => true,
+						'hide_empty'   => false,
+					)
+				);
 			}
 
-			$dropdown_args['include'] = implode( ',', $include );
-			$list_args['include']     = implode( ',', $include );
+			$dropdown_args['include'] = $list_args['include'] = implode( ',', $include );
 
 			if ( empty( $include ) ) {
 				return;
@@ -194,20 +201,14 @@ class WC_Widget_Product_Categories extends WC_Widget {
 
 		$this->widget_start( $args, $instance );
 
-		// Dropdown
 		if ( $dropdown ) {
-			$dropdown_defaults = array(
+			wc_product_dropdown_categories( apply_filters( 'woocommerce_product_categories_widget_dropdown_args', wp_parse_args( $dropdown_args, array(
 				'show_count'         => $count,
 				'hierarchical'       => $hierarchical,
 				'show_uncategorized' => 0,
 				'orderby'            => $orderby,
 				'selected'           => $this->current_cat ? $this->current_cat->slug : '',
-			);
-			$dropdown_args = wp_parse_args( $dropdown_args, $dropdown_defaults );
-
-			// Stuck with this until a fix for https://core.trac.wordpress.org/ticket/13258
-			wc_product_dropdown_categories( apply_filters( 'woocommerce_product_categories_widget_dropdown_args', $dropdown_args ) );
-
+			) ) ) );
 			wc_enqueue_js( "
 				jQuery( '.dropdown_product_cat' ).change( function() {
 					if ( jQuery(this).val() != '' ) {
@@ -222,17 +223,14 @@ class WC_Widget_Product_Categories extends WC_Widget {
 					}
 				});
 			" );
-
-		// List
 		} else {
-
 			include_once( WC()->plugin_path() . '/includes/walkers/class-product-cat-list-walker.php' );
 
 			$list_args['walker']                     = new WC_Product_Cat_List_Walker;
 			$list_args['title_li']                   = '';
 			$list_args['pad_counts']                 = 1;
 			$list_args['show_option_none']           = __( 'No product categories exist.', 'woocommerce' );
-			$list_args['current_category']           = ( $this->current_cat ) ? $this->current_cat->term_id : '';
+			$list_args['current_category']           = ( $this->current_cat ) ? $this->current_cat->term_id: '';
 			$list_args['current_category_ancestors'] = $this->cat_ancestors;
 
 			echo '<ul class="product-categories">';

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -36,7 +36,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 		$this->widget_cssclass    = 'woocommerce widget_product_categories';
 		$this->widget_description = __( 'A list or dropdown of product categories.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_product_categories';
-		$this->widget_name        = __( 'WooCommerce product categories', 'woocommerce' );
+		$this->widget_name        = __( 'Product Categories', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -1,17 +1,21 @@
 <?php
+/**
+ * Product Categories Widget
+ *
+ * @author   Automattic
+ * @category Widgets
+ * @package  WooCommerce/Widgets
+ * @version  2.3.0
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Product Categories Widget.
+ * Product categories widget class.
  *
- * @author   WooThemes
- * @category Widgets
- * @package  WooCommerce/Widgets
- * @version  2.3.0
- * @extends  WC_Widget
+ * @extends WC_Widget
  */
 class WC_Widget_Product_Categories extends WC_Widget {
 
@@ -91,8 +95,8 @@ class WC_Widget_Product_Categories extends WC_Widget {
 	 * Output widget.
 	 *
 	 * @see WP_Widget
-	 * @param array $args
-	 * @param array $instance
+	 * @param array $args     Widget arguments.
+	 * @param array $instance Widget instance.
 	 */
 	public function widget( $args, $instance ) {
 		global $wp_query, $post;
@@ -103,9 +107,16 @@ class WC_Widget_Product_Categories extends WC_Widget {
 		$dropdown           = isset( $instance['dropdown'] ) ? $instance['dropdown'] : $this->settings['dropdown']['std'];
 		$orderby            = isset( $instance['orderby'] ) ? $instance['orderby'] : $this->settings['orderby']['std'];
 		$hide_empty         = isset( $instance['hide_empty'] ) ? $instance['hide_empty'] : $this->settings['hide_empty']['std'];
-		$dropdown_args      = array( 'hide_empty' => $hide_empty );
-		$list_args          = array( 'show_count' => $count, 'hierarchical' => $hierarchical, 'taxonomy' => 'product_cat', 'hide_empty' => $hide_empty );
-		$max_depth          = absint( isset( $instance['max_depth'] ) ? $instance['max_depth'] : $this->settings['max_depth']['std']);
+		$dropdown_args      = array(
+			'hide_empty' => $hide_empty,
+		);
+		$list_args          = array(
+			'show_count'   => $count,
+			'hierarchical' => $hierarchical,
+			'taxonomy'     => 'product_cat',
+			'hide_empty'   => $hide_empty,
+		);
+		$max_depth          = absint( isset( $instance['max_depth'] ) ? $instance['max_depth'] : $this->settings['max_depth']['std'] );
 
 		$list_args['menu_order'] = false;
 		$dropdown_args['depth']  = $max_depth;
@@ -125,7 +136,9 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			$this->cat_ancestors = get_ancestors( $this->current_cat->term_id, 'product_cat' );
 
 		} elseif ( is_singular( 'product' ) ) {
-			$product_category = wc_get_product_terms( $post->ID, 'product_cat', apply_filters( 'woocommerce_product_categories_widget_product_terms_args', array( 'orderby' => 'parent' ) ) );
+			$product_category = wc_get_product_terms( $post->ID, 'product_cat', apply_filters( 'woocommerce_product_categories_widget_product_terms_args', array(
+				'orderby' => 'parent',
+			) ) );
 
 			if ( ! empty( $product_category ) ) {
 				$this->current_cat   = end( $product_category );
@@ -183,9 +196,10 @@ class WC_Widget_Product_Categories extends WC_Widget {
 						'hide_empty'   => false,
 					)
 				);
-			}
+			} // End if().
 
-			$dropdown_args['include'] = $list_args['include'] = implode( ',', $include );
+			$list_args['include']     = implode( ',', $include );
+			$dropdown_args['include'] = $list_args['include'];
 
 			if ( empty( $include ) ) {
 				return;
@@ -197,7 +211,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			$list_args['depth']            = 1;
 			$list_args['child_of']         = 0;
 			$list_args['hierarchical']     = 1;
-		}
+		} // End if().
 
 		$this->widget_start( $args, $instance );
 
@@ -230,7 +244,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			$list_args['title_li']                   = '';
 			$list_args['pad_counts']                 = 1;
 			$list_args['show_option_none']           = __( 'No product categories exist.', 'woocommerce' );
-			$list_args['current_category']           = ( $this->current_cat ) ? $this->current_cat->term_id: '';
+			$list_args['current_category']           = ( $this->current_cat ) ? $this->current_cat->term_id : '';
 			$list_args['current_category_ancestors'] = $this->cat_ancestors;
 
 			echo '<ul class="product-categories">';
@@ -238,7 +252,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 			wp_list_categories( apply_filters( 'woocommerce_product_categories_widget_args', $list_args ) );
 
 			echo '</ul>';
-		}
+		} // End if().
 
 		$this->widget_end( $args );
 	}

--- a/includes/widgets/class-wc-widget-product-search.php
+++ b/includes/widgets/class-wc-widget-product-search.php
@@ -20,9 +20,9 @@ class WC_Widget_Product_Search extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_product_search';
-		$this->widget_description = __( 'A Search box for products only.', 'woocommerce' );
+		$this->widget_description = __( 'A search form for your store.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_product_search';
-		$this->widget_name        = __( 'WooCommerce product search', 'woocommerce' );
+		$this->widget_name        = __( 'Product Search', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-product-tag-cloud.php
+++ b/includes/widgets/class-wc-widget-product-tag-cloud.php
@@ -20,9 +20,9 @@ class WC_Widget_Product_Tag_Cloud extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_product_tag_cloud';
-		$this->widget_description = __( 'Your most used product tags in cloud format.', 'woocommerce' );
+		$this->widget_description = __( 'A cloud of your most used product tags.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_product_tag_cloud';
-		$this->widget_name        = __( 'WooCommerce product tags', 'woocommerce' );
+		$this->widget_name        = __( 'Product Tag Cloud', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -20,9 +20,9 @@ class WC_Widget_Products extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_products';
-		$this->widget_description = __( 'Display a list of your products on your site.', 'woocommerce' );
+		$this->widget_description = __( "A list of your store's products.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_products';
-		$this->widget_name        = __( 'WooCommerce products', 'woocommerce' );
+		$this->widget_name        = __( 'Products', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -21,9 +21,9 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_rating_filter';
-		$this->widget_description = __( 'Filter products by rating when viewing product archives and categories.', 'woocommerce' );
+		$this->widget_description = __( 'Display a list of star ratings to filter products in your store.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_rating_filter';
-		$this->widget_name        = __( 'WooCommerce average rating filter', 'woocommerce' );
+		$this->widget_name        = __( 'Filter Products by Rating', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-recent-reviews.php
+++ b/includes/widgets/class-wc-widget-recent-reviews.php
@@ -20,9 +20,9 @@ class WC_Widget_Recent_Reviews extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_recent_reviews';
-		$this->widget_description = __( 'Display a list of your most recent reviews on your site.', 'woocommerce' );
+		$this->widget_description = __( 'Display a list of recent reviews from your store.', 'woocommerce' );
 		$this->widget_id          = 'woocommerce_recent_reviews';
-		$this->widget_name        = __( 'WooCommerce recent reviews', 'woocommerce' );
+		$this->widget_name        = __( 'Recent Product Reviews', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -20,13 +20,13 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_recently_viewed_products';
-		$this->widget_description = __( 'Display a list of recently viewed products.', 'woocommerce' );
+		$this->widget_description = __( "Display a list of a customer's recently viewed products.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_recently_viewed_products';
-		$this->widget_name        = __( 'WooCommerce recently viewed', 'woocommerce' );
+		$this->widget_name        = __( 'Recent Viewed Products', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',
-				'std'   => __( 'Recently viewed products', 'woocommerce' ),
+				'std'   => __( 'Recently Viewed Products', 'woocommerce' ),
 				'label' => __( 'Title', 'woocommerce' ),
 			),
 			'number' => array(

--- a/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/includes/widgets/class-wc-widget-top-rated-products.php
@@ -22,9 +22,9 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 	 */
 	public function __construct() {
 		$this->widget_cssclass    = 'woocommerce widget_top_rated_products';
-		$this->widget_description = __( 'Display a list of your top rated products on your site.', 'woocommerce' );
+		$this->widget_description = __( "A list of your store's top-rated products.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_top_rated_products';
-		$this->widget_name        = __( 'WooCommerce top rated products', 'woocommerce' );
+		$this->widget_name        = __( 'Products by Rating', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',


### PR DESCRIPTION
- Standardize widget names with title case and descriptions to match WP
- Add max depth option which closes #16132 
- Remove legacy code - we can use wp_dropdown_categories again! https://core.trac.wordpress.org/ticket/13258