### PR TITLE
Absolute value for gmt_offset in scheduled sales

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -307,8 +307,9 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
 		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
-
-		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . get_option( 'gmt_offset' ) . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
+		$abs_offset = absint( get_option( 'gmt_offset' ) );
+		
+		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . $abs_offset . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
 
 		$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -307,9 +307,8 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
 		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
-		$abs_offset = absint( get_option( 'gmt_offset' ) );
 		
-		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . $abs_offset . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
+		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . absint( get_option( 'gmt_offset' ) ) . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
 
 		$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -307,7 +307,7 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
 		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
-		
+
 		wp_schedule_event( strtotime( '00:00 tomorrow ' . $ve . absint( get_option( 'gmt_offset' ) ) . ' HOURS' ), 'daily', 'woocommerce_scheduled_sales' );
 
 		$held_duration = get_option( 'woocommerce_hold_stock_minutes', '60' );


### PR DESCRIPTION
In the event that you choose a -GMT value, the values are incorrect in some instances. For examples, if we choose a -7 GMT value, the gmt_offset will evaluate to '-7'.

On line 309, $ve will equal '+'.

On line 312, previously, $ve . get_option( 'gmt_offset' ) would evalute to '+-7'.