### PR TITLE
Allow [products] to be used instead of any other product shortcode

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -188,7 +188,7 @@ class WC_Shortcodes {
 			'order'    => 'ASC',
 			'category' => '',
 			'operator' => 'IN',
-		), $atts );
+		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'product_category' );
 
@@ -274,29 +274,18 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function recent_products( $atts ) {
-		$atts = shortcode_atts( array(
+		$atts = array_merge( array(
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'date',
-			'order'    => 'desc',
-			'category' => '',  // Slugs
-			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
-		), $atts, 'recent_products' );
+			'order'    => 'DESC',
+			'category' => '',
+			'operator' => 'IN',
+		), (array) $atts );
 
-		$query_args = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'posts_per_page'      => $atts['per_page'],
-			'orderby'             => $atts['orderby'],
-			'order'               => $atts['order'],
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
-		);
+		$shortcode = new WC_Shortcode_Products( $atts, 'recent_products' );
 
-		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
-
-		return self::product_loop( $query_args, $atts, 'recent_products' );
+		return $shortcode->get_content();
 	}
 
 	/**
@@ -306,7 +295,7 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function products( $atts ) {
-		$shortcode = new WC_Shortcode_Products( $atts );
+		$shortcode = new WC_Shortcode_Products( (array) $atts );
 
 		return $shortcode->get_content();
 	}

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -330,38 +330,9 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function products( $atts ) {
-		$atts = shortcode_atts( array(
-			'columns' => '4',
-			'orderby' => 'title',
-			'order'   => 'asc',
-			'ids'     => '',
-			'skus'    => '',
-		), $atts, 'products' );
+		$shortcode = new WC_Shortcode_Products( $atts );
 
-		$query_args = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'orderby'             => $atts['orderby'],
-			'order'               => $atts['order'],
-			'posts_per_page'      => -1,
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
-		);
-
-		if ( ! empty( $atts['skus'] ) ) {
-			$query_args['meta_query'][] = array(
-				'key'     => '_sku',
-				'value'   => array_map( 'trim', explode( ',', $atts['skus'] ) ),
-				'compare' => 'IN',
-			);
-		}
-
-		if ( ! empty( $atts['ids'] ) ) {
-			$query_args['post__in'] = array_map( 'trim', explode( ',', $atts['ids'] ) );
-		}
-
-		return self::product_loop( $query_args, $atts, 'products' );
+		return $shortcode->get_content();
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -475,38 +475,18 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function featured_products( $atts ) {
-		$atts = shortcode_atts( array(
+		$atts = array_merge( array(
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'date',
-			'order'    => 'desc',
-			'category' => '',  // Slugs
-			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
-		), $atts, 'featured_products' );
-
-		$meta_query  = WC()->query->get_meta_query();
-		$tax_query   = WC()->query->get_tax_query();
-		$tax_query[] = array(
-			'taxonomy' => 'product_visibility',
-			'field'    => 'name',
-			'terms'    => 'featured',
+			'order'    => 'DESC',
+			'category' => '',
 			'operator' => 'IN',
-		);
+		), (array) $atts );
 
-		$query_args = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'posts_per_page'      => $atts['per_page'],
-			'orderby'             => $atts['orderby'],
-			'order'               => $atts['order'],
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
-		);
+		$shortcode = new WC_Shortcode_Products( $atts, 'featured_products' );
 
-		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
-
-		return self::product_loop( $query_args, $atts, 'featured_products' );
+		return $shortcode->get_content();
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -435,27 +435,16 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function best_selling_products( $atts ) {
-		$atts = shortcode_atts( array(
+		$atts = array_merge( array(
 			'per_page' => '12',
 			'columns'  => '4',
-			'category' => '',  // Slugs
-			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
-		), $atts, 'best_selling_products' );
+			'category' => '',
+			'operator' => 'IN',
+		), (array) $atts );
 
-		$query_args = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'posts_per_page'      => $atts['per_page'],
-			'meta_key'            => 'total_sales',
-			'orderby'             => 'meta_value_num',
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
-		);
+		$shortcode = new WC_Shortcode_Products( $atts, 'best_selling_products' );
 
-		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
-
-		return self::product_loop( $query_args, $atts, 'best_selling_products' );
+		return $shortcode->get_content();
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -246,7 +246,21 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function products( $atts ) {
-		$shortcode = new WC_Shortcode_Products( (array) $atts );
+		$atts = (array) $atts;
+		$type = 'products';
+
+		// Allow list product based on specific cases.
+		if ( isset( $atts['on_sale'] ) && wc_string_to_bool( $atts['on_sale'] ) ) {
+			$type = 'sale_products';
+		} elseif ( isset( $atts['best_selling'] ) && wc_string_to_bool( $atts['best_selling'] ) ) {
+			$type = 'best_selling_products';
+		} elseif ( isset( $atts['top_rated'] ) && wc_string_to_bool( $atts['top_rated'] ) ) {
+			$type = 'top_rated_products';
+		} elseif ( isset( $atts['featured'] ) && wc_string_to_bool( $atts['featured'] ) ) {
+			$type = 'featured_products';
+		}
+
+		$shortcode = new WC_Shortcode_Products( $atts, $type );
 
 		return $shortcode->get_content();
 	}
@@ -583,7 +597,7 @@ class WC_Shortcodes {
 			'per_page'  => '12',
 			'columns'   => '4',
 			'orderby'   => 'title',
-			'order'     => 'asc',
+			'order'     => 'ASC',
 			'attribute' => '',
 			'filter'    => '',
 		), (array) $atts );

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -177,47 +177,23 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function product_category( $atts ) {
-		$atts = shortcode_atts( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'menu_order title',
-			'order'    => 'asc',
-			'category' => '',  // Slugs
-			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
-		), $atts, 'product_category' );
-
-		if ( ! $atts['category'] ) {
+		if ( empty( $atts['category'] ) ) {
 			return '';
 		}
 
-		// Default ordering args
-		$ordering_args = WC()->query->get_catalog_ordering_args( $atts['orderby'], $atts['order'] );
-		$meta_query    = WC()->query->get_meta_query();
-		$query_args    = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'orderby'             => $ordering_args['orderby'],
-			'order'               => $ordering_args['order'],
-			'posts_per_page'      => $atts['per_page'],
-			'meta_query'          => $meta_query,
-			'tax_query'           => WC()->query->get_tax_query(),
-		);
+		$atts = array_merge( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'menu_order title',
+			'order'    => 'ASC',
+			'category' => '',
+			'operator' => 'IN',
+		), $atts );
 
-		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
+		$shortcode = new WC_Shortcode_Products( $atts, 'product_category' );
 
-		if ( isset( $ordering_args['meta_key'] ) ) {
-			$query_args['meta_key'] = $ordering_args['meta_key'];
-		}
-
-		$return = self::product_loop( $query_args, $atts, 'product_cat' );
-
-		// Remove ordering query arguments
-		WC()->query->remove_ordering_args();
-
-		return $return;
+		return $shortcode->get_content();
 	}
-
 
 	/**
 	 * List all (or limited) product categories.

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -414,30 +414,18 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function sale_products( $atts ) {
-		$atts = shortcode_atts( array(
+		$atts = array_merge( array(
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
-			'order'    => 'asc',
-			'category' => '', // Slugs
-			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
-		), $atts, 'sale_products' );
+			'order'    => 'ASC',
+			'category' => '',
+			'operator' => 'IN',
+		), (array) $atts );
 
-		$query_args = array(
-			'posts_per_page' => $atts['per_page'],
-			'orderby'        => $atts['orderby'],
-			'order'          => $atts['order'],
-			'no_found_rows'  => 1,
-			'post_status'    => 'publish',
-			'post_type'      => 'product',
-			'meta_query'     => WC()->query->get_meta_query(),
-			'tax_query'      => WC()->query->get_tax_query(),
-			'post__in'       => array_merge( array( 0 ), wc_get_product_ids_on_sale() ),
-		);
+		$shortcode = new WC_Shortcode_Products( $atts, 'sale_products' );
 
-		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
-
-		return self::product_loop( $query_args, $atts, 'sale_products' );
+		return $shortcode->get_content();
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -454,35 +454,18 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function top_rated_products( $atts ) {
-		$atts = shortcode_atts( array(
+		$atts = array_merge( array(
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
-			'order'    => 'asc',
-			'category' => '',  // Slugs
-			'operator' => 'IN', // Possible values are 'IN', 'NOT IN', 'AND'.
-		), $atts, 'top_rated_products' );
+			'order'    => 'ASC',
+			'category' => '',
+			'operator' => 'IN',
+		), (array) $atts );
 
-		$query_args = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'orderby'             => $atts['orderby'],
-			'order'               => $atts['order'],
-			'posts_per_page'      => $atts['per_page'],
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
-		);
+		$shortcode = new WC_Shortcode_Products( $atts, 'top_rated_products' );
 
-		$query_args = self::_maybe_add_category_args( $query_args, $atts['category'], $atts['operator'] );
-
-		add_filter( 'posts_clauses', array( __CLASS__, 'order_by_rating_post_clauses' ) );
-
-		$return = self::product_loop( $query_args, $atts, 'top_rated_products' );
-
-		remove_filter( 'posts_clauses', array( __CLASS__, 'order_by_rating_post_clauses' ) );
-
-		return $return;
+		return $shortcode->get_content();
 	}
 
 	/**
@@ -641,20 +624,14 @@ class WC_Shortcodes {
 	}
 
 	/**
-	 * woocommerce_order_by_rating_post_clauses function.
+	 * Order by rating.
 	 *
-	 * @param array $args
-	 * @return array
+	 * @deprecated 3.2.0 Use WC_Shortcode_Products::order_by_rating_post_clauses().
+	 * @param      array $args Query args.
+	 * @return     array
 	 */
 	public static function order_by_rating_post_clauses( $args ) {
-		global $wpdb;
-
-		$args['where']   .= " AND $wpdb->commentmeta.meta_key = 'rating' ";
-		$args['join']    .= "LEFT JOIN $wpdb->comments ON($wpdb->posts.ID               = $wpdb->comments.comment_post_ID) LEFT JOIN $wpdb->commentmeta ON($wpdb->comments.comment_ID = $wpdb->commentmeta.comment_id)";
-		$args['orderby'] = "$wpdb->commentmeta.meta_value DESC";
-		$args['groupby'] = "$wpdb->posts.ID";
-
-		return $args;
+		return WC_Shortcode_Products::order_by_rating_post_clauses( $args );
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -622,33 +622,22 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function product_attribute( $atts ) {
-		$atts = shortcode_atts( array(
+		$atts = array_merge( array(
 			'per_page'  => '12',
 			'columns'   => '4',
 			'orderby'   => 'title',
 			'order'     => 'asc',
 			'attribute' => '',
 			'filter'    => '',
-		), $atts, 'product_attribute' );
+		), (array) $atts );
 
-		$query_args = array(
-			'post_type'           => 'product',
-			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
-			'posts_per_page'      => $atts['per_page'],
-			'orderby'             => $atts['orderby'],
-			'order'               => $atts['order'],
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
-		);
+		if ( empty( $atts['attribute'] ) || empty( $atts['filter'] ) ) {
+			return '';
+		}
 
-		$query_args['tax_query'][] = array(
-			'taxonomy' => strstr( $atts['attribute'], 'pa_' ) ? sanitize_title( $atts['attribute'] ) : 'pa_' . sanitize_title( $atts['attribute'] ),
-			'terms'    => array_map( 'sanitize_title', explode( ',', $atts['filter'] ) ),
-			'field'    => 'slug',
-		);
+		$shortcode = new WC_Shortcode_Products( $atts, 'product_attribute' );
 
-		return self::product_loop( $query_args, $atts, 'product_attribute' );
+		return $shortcode->get_content();
 	}
 
 	/**

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -311,56 +311,12 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$meta_query = WC()->query->get_meta_query();
+		$atts['skus']     = isset( $atts['sku'] ) ? $atts['sku'] : '';
+		$atts['ids']      = isset( $atts['id'] ) ? $atts['id'] : '';
+		$atts['per_page'] = '1';
+		$shortcode        = new WC_Shortcode_Products( (array) $atts, 'product' );
 
-		$args = array(
-			'post_type'      => 'product',
-			'posts_per_page' => 1,
-			'no_found_rows'  => 1,
-			'post_status'    => 'publish',
-			'meta_query'     => $meta_query,
-			'tax_query'      => WC()->query->get_tax_query(),
-		);
-
-		if ( isset( $atts['sku'] ) ) {
-			$args['meta_query'][] = array(
-				'key'     => '_sku',
-				'value'   => $atts['sku'],
-				'compare' => '=',
-			);
-		}
-
-		if ( isset( $atts['id'] ) ) {
-			$args['p'] = $atts['id'];
-		}
-
-		ob_start();
-
-		$products = new WP_Query( apply_filters( 'woocommerce_shortcode_products_query', $args, $atts, null ) );
-
-		if ( $products->have_posts() ) : ?>
-
-			<?php woocommerce_product_loop_start(); ?>
-
-				<?php while ( $products->have_posts() ) : $products->the_post(); ?>
-
-					<?php wc_get_template_part( 'content', 'product' ); ?>
-
-				<?php endwhile; // end of the loop. ?>
-
-			<?php woocommerce_product_loop_end(); ?>
-
-		<?php endif;
-
-		wp_reset_postdata();
-
-		$css_class = 'woocommerce';
-
-		if ( isset( $atts['class'] ) ) {
-			$css_class .= ' ' . $atts['class'];
-		}
-
-		return '<div class="' . esc_attr( $css_class ) . '">' . ob_get_clean() . '</div>';
+		return $shortcode->get_content();
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -175,6 +175,11 @@ class WC_Shortcode_Products {
 			}
 		}
 
+		// On sale.
+		if ( 'sale_products' === $this->type ) {
+			$query_args['post__in'] = array_merge( array( 0 ), wc_get_product_ids_on_sale() );
+		}
+
 		return apply_filters( 'woocommerce_shortcode_products_query', $query_args, $this->attributes, $this->type );
 	}
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -169,6 +169,16 @@ class WC_Shortcode_Products {
 			$query_args['orderby']  = 'meta_value_num';
 		}
 
+		// Featured products.
+		if ( 'featured_products' === $this->type ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'product_visibility',
+				'field'    => 'name',
+				'terms'    => 'featured',
+				'operator' => 'IN',
+			);
+		}
+
 		// Categories.
 		if ( ! empty( $this->attributes['category'] ) ) {
 			$ordering_args = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -102,15 +102,17 @@ class WC_Shortcode_Products {
 	 */
 	protected function parse_attributes( $attributes ) {
 		return shortcode_atts( array(
-			'per_page' => '-1',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'ids'      => '',
-			'skus'     => '',
-			'category' => '',   // Slugs.
-			'operator' => 'IN', // Category operator. Possible values are 'IN', 'NOT IN', 'AND'.
-			'class'    => '',
+			'per_page'  => '-1',
+			'columns'   => '4',
+			'orderby'   => 'title',
+			'order'     => 'ASC',
+			'ids'       => '',
+			'skus'      => '',
+			'category'  => '',   // Slugs.
+			'operator'  => 'IN', // Category operator. Possible values are 'IN', 'NOT IN', 'AND'.
+			'class'     => '',
+			'attribute' => '',
+			'filter'    => '',
 		), $attributes, $this->type );
 	}
 
@@ -173,9 +175,18 @@ class WC_Shortcode_Products {
 		if ( 'featured_products' === $this->type ) {
 			$query_args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
-				'field'    => 'name',
 				'terms'    => 'featured',
+				'field'    => 'name',
 				'operator' => 'IN',
+			);
+		}
+
+		// Attributes.
+		if ( ! empty( $this->attributes['attribute'] ) || ! empty( $this->attributes['filter'] ) ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => strstr( $this->attributes['attribute'], 'pa_' ) ? sanitize_title( $this->attributes['attribute'] ) : 'pa_' . sanitize_title( $this->attributes['attribute'] ),
+				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['filter'] ) ),
+				'field'    => 'slug',
 			);
 		}
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -83,11 +83,10 @@ class WC_Shortcode_Products {
 	 * Get the shortcode.
 	 *
 	 * @since  3.2.0
-	 * @param  array $atts Shortcode attributes.
 	 * @return string
 	 */
-	public static function get_shortcode( $atts ) {
-		return self::product_loop( $query_args, $atts );
+	public static function get_shortcode() {
+		return $this->product_loop();
 	}
 
 	/**
@@ -129,7 +128,7 @@ class WC_Shortcode_Products {
 	 * @since  3.2.0
 	 * @return string
 	 */
-	protected static function product_loop() {
+	protected function product_loop() {
 		global $woocommerce_loop;
 
 		$columns                     = absint( $this->attributes['columns'] );

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -46,8 +46,9 @@ class WC_Shortcode_Products {
 	 *
 	 * @since 3.2.0
 	 * @param array $attributes Shortcode attributes.
+	 * @param array $loop_name  Loop name.
 	 */
-	public function __construct( $attributes = array() ) {
+	public function __construct( $attributes = array(), $loop_name = 'products' ) {
 		$this->attributes = shortcode_atts( array(
 			'columns' => '4',
 			'orderby' => 'title',
@@ -57,6 +58,7 @@ class WC_Shortcode_Products {
 		), $attributes, $this->loop_name );
 
 		$this->query_args = $this->parse_query_args();
+		$this->loop_name  = $loop_name;
 	}
 
 	/**
@@ -77,6 +79,16 @@ class WC_Shortcode_Products {
 	 */
 	public function get_query_args() {
 		return $this->query_args;
+	}
+
+	/**
+	 * Get loop name.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	public function get_loop_name() {
+		return $this->loop_name;
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -136,24 +136,6 @@ class WC_Shortcode_Products {
 		$query_args['tax_query']      = WC()->query->get_tax_query();
 		// @codingStandardsIgnoreEnd
 
-		// Categories.
-		if ( ! empty( $this->attributes['category'] ) ) {
-			$ordering_args = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
-			$query_args['orderby'] = $ordering_args['orderby'];
-			$query_args['order']   = $ordering_args['order'];
-
-			if ( isset( $ordering_args['meta_key'] ) ) {
-				$query_args['meta_key'] = $ordering_args['meta_key'];
-			}
-
-			$query_args['tax_query'][] = array(
-				'taxonomy' => 'product_cat',
-				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) ),
-				'field'    => 'slug',
-				'operator' => $this->attributes['operator'],
-			);
-		}
-
 		// SKUs.
 		if ( ! empty( $this->attributes['skus'] ) ) {
 			$skus = array_map( 'trim', explode( ',', $this->attributes['skus'] ) );
@@ -178,6 +160,31 @@ class WC_Shortcode_Products {
 		// On sale.
 		if ( 'sale_products' === $this->type ) {
 			$query_args['post__in'] = array_merge( array( 0 ), wc_get_product_ids_on_sale() );
+		}
+
+		// Best selling.
+		if ( 'best_selling_products' === $this->type ) {
+			$query_args['meta_key'] = 'total_sales';
+			$query_args['order']    = 'DESC';
+			$query_args['orderby']  = 'meta_value_num';
+		}
+
+		// Categories.
+		if ( ! empty( $this->attributes['category'] ) ) {
+			$ordering_args = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
+			$query_args['orderby'] = $ordering_args['orderby'];
+			$query_args['order']   = $ordering_args['order'];
+
+			if ( isset( $ordering_args['meta_key'] ) ) {
+				$query_args['meta_key'] = $ordering_args['meta_key'];
+			}
+
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'product_cat',
+				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) ),
+				'field'    => 'slug',
+				'operator' => $this->attributes['operator'],
+			);
 		}
 
 		return apply_filters( 'woocommerce_shortcode_products_query', $query_args, $this->attributes, $this->type );

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Products shortcode
+ *
+ * @author   Automattic
+ * @category Shortcodes
+ * @package  WooCommerce/Shortcodes
+ * @version  3.2.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Products shortcode class.
+ */
+class WC_Shortcode_Products {
+
+	/**
+	 * Loop name.
+	 *
+	 * @since 3.2.0
+	 * @var   string
+	 */
+	protected $loop_name = 'products';
+
+	/**
+	 * Attributes.
+	 *
+	 * @since 3.2.0
+	 * @var   array
+	 */
+	protected $attributes = array();
+
+	/**
+	 * Query args.
+	 *
+	 * @since 3.2.0
+	 * @var   array
+	 */
+	protected $query_args = array();
+
+	/**
+	 * Initialize shortcode.
+	 *
+	 * @since 3.2.0
+	 * @param array $attributes Shortcode attributes.
+	 */
+	public function __construct( $attributes ) {
+		$this->attributes = shortcode_atts( array(
+			'columns' => '4',
+			'orderby' => 'title',
+			'order'   => 'asc',
+			'ids'     => '',
+			'skus'    => '',
+		), $attributes, $this->loop_name );
+
+		$this->query_args = $this->get_query_args();
+	}
+
+	/**
+	 * Get query args.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	public function get_query_args() {
+		return $this->query_args;
+	}
+
+	/**
+	 * Get shortcode attributes.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	public function get_attributes() {
+		return $this->attributes;
+	}
+
+	/**
+	 * Get the shortcode.
+	 *
+	 * @since  3.2.0
+	 * @param  array $atts Shortcode attributes.
+	 * @return string
+	 */
+	public static function get_shortcode( $atts ) {
+		return self::product_loop( $query_args, $atts );
+	}
+
+	/**
+	 * Parse query args.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	protected function parse_query_args() {
+		$this->query_args = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => $this->attributes['orderby'],
+			'order'               => $this->attributes['order'],
+			'posts_per_page'      => -1,
+			'meta_query'          => WC()->query->get_meta_query(),
+			'tax_query'           => WC()->query->get_tax_query(),
+		);
+
+		if ( ! empty( $this->attributes['skus'] ) ) {
+			$this->query_args['meta_query'][] = array(
+				'key'     => '_sku',
+				'value'   => array_map( 'trim', explode( ',', $this->attributes['skus'] ) ),
+				'compare' => 'IN',
+			);
+		}
+
+		if ( ! empty( $this->attributes['ids'] ) ) {
+			$this->query_args['post__in'] = array_map( 'trim', explode( ',', $this->attributes['ids'] ) );
+		}
+
+		return $this->query_args;
+	}
+
+	/**
+	 * Loop over found products.
+	 *
+	 * @since  3.2.0
+	 * @return string
+	 */
+	protected static function product_loop() {
+		global $woocommerce_loop;
+
+		$columns                     = absint( $this->attributes['columns'] );
+		$woocommerce_loop['columns'] = $columns;
+		$woocommerce_loop['name']    = $this->loop_name;
+		$this->query_args            = apply_filters( 'woocommerce_shortcode_products_query', $this->query_args, $this->attributes, $this->loop_name );
+		$transient_name              = 'wc_loop' . substr( md5( wp_json_encode( $this->query_args ) . $this->loop_name ), 28 ) . WC_Cache_Helper::get_transient_version( 'product_query' );
+		$products                    = get_transient( $transient_name );
+
+		if ( false === $products || ! is_a( $products, 'WP_Query' ) ) {
+			$products = new WP_Query( $this->query_args );
+			set_transient( $transient_name, $products, DAY_IN_SECONDS * 30 );
+		}
+
+		ob_start();
+
+		if ( $products->have_posts() ) {
+			// Prime caches before grabbing objects.
+			update_post_caches( $products->posts, array( 'product', 'product_variation' ) );
+
+			do_action( "woocommerce_shortcode_before_{$this->loop_name}_loop", $this->attributes );
+
+			woocommerce_product_loop_start();
+
+			while ( $products->have_posts() ) {
+				$products->the_post();
+				wc_get_template_part( 'content', 'product' );
+			}
+
+			woocommerce_product_loop_end();
+
+			do_action( "woocommerce_shortcode_after_{$this->loop_name}_loop", $this->attributes );
+		} else {
+			do_action( "woocommerce_shortcode_{$this->loop_name}_loop_no_results", $this->attributes );
+		}
+
+		woocommerce_reset_loop();
+		wp_reset_postdata();
+
+		return '<div class="woocommerce columns-' . $columns . '">' . ob_get_clean() . '</div>';
+	}
+}

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -56,7 +56,7 @@ class WC_Shortcode_Products {
 			'skus'    => '',
 		), $attributes, $this->loop_name );
 
-		$this->query_args = $this->get_query_args();
+		$this->query_args = $this->parse_query_args();
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -120,7 +120,7 @@ class WC_Shortcode_Products {
 	 * @return array
 	 */
 	protected function parse_query_args() {
-		$this->query_args = array(
+		$query_args = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
@@ -129,22 +129,22 @@ class WC_Shortcode_Products {
 		);
 
 		// @codingStandardsIgnoreStart
-		$this->query_args['posts_per_page'] = (int) $this->attributes['per_page'];
-		$this->query_args['meta_query']     = WC()->query->get_meta_query();
-		$this->query_args['tax_query']      = WC()->query->get_tax_query();
+		$query_args['posts_per_page'] = (int) $this->attributes['per_page'];
+		$query_args['meta_query']     = WC()->query->get_meta_query();
+		$query_args['tax_query']      = WC()->query->get_tax_query();
 		// @codingStandardsIgnoreEnd
 
 		// Categories.
 		if ( ! empty( $this->attributes['category'] ) ) {
-			$ordering_args = WC()->query->get_catalog_ordering_args( $this->query_args['orderby'], $this->query_args['order'] );
-			$this->query_args['orderby'] = $ordering_args['orderby'];
-			$this->query_args['order']   = $ordering_args['order'];
+			$ordering_args = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
+			$query_args['orderby'] = $ordering_args['orderby'];
+			$query_args['order']   = $ordering_args['order'];
 
 			if ( isset( $ordering_args['meta_key'] ) ) {
-				$this->query_args['meta_key'] = $ordering_args['meta_key'];
+				$query_args['meta_key'] = $ordering_args['meta_key'];
 			}
 
-			$this->query_args['tax_query'][] = array(
+			$query_args['tax_query'][] = array(
 				'taxonomy' => 'product_cat',
 				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) ),
 				'field'    => 'slug',
@@ -154,7 +154,7 @@ class WC_Shortcode_Products {
 
 		// SKUs.
 		if ( ! empty( $this->attributes['skus'] ) ) {
-			$this->query_args['meta_query'][] = array(
+			$query_args['meta_query'][] = array(
 				'key'     => '_sku',
 				'value'   => array_map( 'trim', explode( ',', $this->attributes['skus'] ) ),
 				'compare' => 'IN',
@@ -163,10 +163,10 @@ class WC_Shortcode_Products {
 
 		// IDs.
 		if ( ! empty( $this->attributes['ids'] ) ) {
-			$this->query_args['post__in'] = array_map( 'trim', explode( ',', $this->attributes['ids'] ) );
+			$query_args['post__in'] = array_map( 'trim', explode( ',', $this->attributes['ids'] ) );
 		}
 
-		return $this->query_args;
+		return apply_filters( 'woocommerce_shortcode_products_query', $query_args, $this->attributes, $this->loop_name );
 	}
 
 	/**
@@ -181,7 +181,6 @@ class WC_Shortcode_Products {
 		$columns                     = absint( $this->attributes['columns'] );
 		$woocommerce_loop['columns'] = $columns;
 		$woocommerce_loop['name']    = $this->loop_name;
-		$this->query_args            = apply_filters( 'woocommerce_shortcode_products_query', $this->query_args, $this->attributes, $this->loop_name );
 		$transient_name              = 'wc_loop' . substr( md5( wp_json_encode( $this->query_args ) . $this->loop_name ), 28 ) . WC_Cache_Helper::get_transient_version( 'product_query' );
 		$products                    = get_transient( $transient_name );
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -102,10 +102,13 @@ class WC_Shortcode_Products {
 			'ignore_sticky_posts' => 1,
 			'orderby'             => $this->attributes['orderby'],
 			'order'               => $this->attributes['order'],
-			'posts_per_page'      => -1,
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
 		);
+
+		// @codingStandardsIgnoreStart
+		$this->query_args['posts_per_page'] = -1;
+		$this->query_args['meta_query']     = WC()->query->get_meta_query();
+		$this->query_args['tax_query']      = WC()->query->get_tax_query();
+		// @codingStandardsIgnoreEnd
 
 		if ( ! empty( $this->attributes['skus'] ) ) {
 			$this->query_args['meta_query'][] = array(

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -80,12 +80,12 @@ class WC_Shortcode_Products {
 	}
 
 	/**
-	 * Get the shortcode.
+	 * Get shortcode content.
 	 *
 	 * @since  3.2.0
 	 * @return string
 	 */
-	public static function get_shortcode() {
+	public static function get_content() {
 		return $this->product_loop();
 	}
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -166,7 +166,9 @@ class WC_Shortcode_Products {
 
 		// Best selling.
 		if ( 'best_selling_products' === $this->type ) {
+			// @codingStandardsIgnoreStart
 			$query_args['meta_key'] = 'total_sales';
+			// @codingStandardsIgnoreEnd
 			$query_args['order']    = 'DESC';
 			$query_args['orderby']  = 'meta_value_num';
 		}
@@ -197,7 +199,9 @@ class WC_Shortcode_Products {
 			$query_args['order']   = $ordering_args['order'];
 
 			if ( isset( $ordering_args['meta_key'] ) ) {
+				// @codingStandardsIgnoreStart
 				$query_args['meta_key'] = $ordering_args['meta_key'];
+				// @codingStandardsIgnoreEnd
 			}
 
 			$query_args['tax_query'][] = array(

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -18,12 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Shortcode_Products {
 
 	/**
-	 * Loop name.
+	 * Shortcode type.
 	 *
 	 * @since 3.2.0
 	 * @var   string
 	 */
-	protected $loop_name = 'products';
+	protected $type = 'products';
 
 	/**
 	 * Attributes.
@@ -46,10 +46,10 @@ class WC_Shortcode_Products {
 	 *
 	 * @since 3.2.0
 	 * @param array $attributes Shortcode attributes.
-	 * @param array $loop_name  Loop name.
+	 * @param array $type       Shortcode type.
 	 */
-	public function __construct( $attributes = array(), $loop_name = 'products' ) {
-		$this->loop_name  = $loop_name;
+	public function __construct( $attributes = array(), $type = 'products' ) {
+		$this->type       = $type;
 		$this->attributes = $this->parse_attributes( $attributes );
 		$this->query_args = $this->parse_query_args();
 	}
@@ -75,13 +75,13 @@ class WC_Shortcode_Products {
 	}
 
 	/**
-	 * Get loop name.
+	 * Get shortcode type.
 	 *
 	 * @since  3.2.0
 	 * @return array
 	 */
-	public function get_loop_name() {
-		return $this->loop_name;
+	public function get_type() {
+		return $this->type;
 	}
 
 	/**
@@ -111,7 +111,7 @@ class WC_Shortcode_Products {
 			'category' => '',   // Slugs.
 			'operator' => 'IN', // Category operator. Possible values are 'IN', 'NOT IN', 'AND'.
 			'class'    => '',
-		), $attributes, $this->loop_name );
+		), $attributes, $this->type );
 	}
 
 	/**
@@ -175,7 +175,7 @@ class WC_Shortcode_Products {
 			}
 		}
 
-		return apply_filters( 'woocommerce_shortcode_products_query', $query_args, $this->attributes, $this->loop_name );
+		return apply_filters( 'woocommerce_shortcode_products_query', $query_args, $this->attributes, $this->type );
 	}
 
 	/**
@@ -189,8 +189,8 @@ class WC_Shortcode_Products {
 
 		$columns                     = absint( $this->attributes['columns'] );
 		$woocommerce_loop['columns'] = $columns;
-		$woocommerce_loop['name']    = $this->loop_name;
-		$transient_name              = 'wc_loop' . substr( md5( wp_json_encode( $this->query_args ) . $this->loop_name ), 28 ) . WC_Cache_Helper::get_transient_version( 'product_query' );
+		$woocommerce_loop['name']    = $this->type;
+		$transient_name              = 'wc_loop' . substr( md5( wp_json_encode( $this->query_args ) . $this->type ), 28 ) . WC_Cache_Helper::get_transient_version( 'product_query' );
 		$products                    = get_transient( $transient_name );
 
 		if ( false === $products || ! is_a( $products, 'WP_Query' ) ) {
@@ -209,7 +209,7 @@ class WC_Shortcode_Products {
 			// Prime caches before grabbing objects.
 			update_post_caches( $products->posts, array( 'product', 'product_variation' ) );
 
-			do_action( "woocommerce_shortcode_before_{$this->loop_name}_loop", $this->attributes );
+			do_action( "woocommerce_shortcode_before_{$this->type}_loop", $this->attributes );
 
 			woocommerce_product_loop_start();
 
@@ -220,16 +220,16 @@ class WC_Shortcode_Products {
 
 			woocommerce_product_loop_end();
 
-			do_action( "woocommerce_shortcode_after_{$this->loop_name}_loop", $this->attributes );
+			do_action( "woocommerce_shortcode_after_{$this->type}_loop", $this->attributes );
 		} else {
-			do_action( "woocommerce_shortcode_{$this->loop_name}_loop_no_results", $this->attributes );
+			do_action( "woocommerce_shortcode_{$this->type}_loop_no_results", $this->attributes );
 		}
 
 		woocommerce_reset_loop();
 		wp_reset_postdata();
 
 		$classes = array( 'woocommerce' );
-		if ( 'product' !== $this->loop_name ) {
+		if ( 'product' !== $this->type ) {
 			$classes[] = 'columns-' . $columns;
 		}
 		$classes[] = $this->attributes['class'];

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -47,7 +47,7 @@ class WC_Shortcode_Products {
 	 * @since 3.2.0
 	 * @param array $attributes Shortcode attributes.
 	 */
-	public function __construct( $attributes ) {
+	public function __construct( $attributes = array() ) {
 		$this->attributes = shortcode_atts( array(
 			'columns' => '4',
 			'orderby' => 'title',
@@ -57,16 +57,6 @@ class WC_Shortcode_Products {
 		), $attributes, $this->loop_name );
 
 		$this->query_args = $this->parse_query_args();
-	}
-
-	/**
-	 * Get query args.
-	 *
-	 * @since  3.2.0
-	 * @return array
-	 */
-	public function get_query_args() {
-		return $this->query_args;
 	}
 
 	/**
@@ -80,12 +70,22 @@ class WC_Shortcode_Products {
 	}
 
 	/**
+	 * Get query args.
+	 *
+	 * @since  3.2.0
+	 * @return array
+	 */
+	public function get_query_args() {
+		return $this->query_args;
+	}
+
+	/**
 	 * Get shortcode content.
 	 *
 	 * @since  3.2.0
 	 * @return string
 	 */
-	public static function get_content() {
+	public function get_content() {
 		return $this->product_loop();
 	}
 

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Class WC_Shortcode_Products.
+ *
+ * @package WooCommerce\Tests\Shortcodes
+ */
+class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
+
+	/**
+	 * Test: WC_Shortcode_Products::get_attributes.
+	 */
+	public function test_get_attributes() {
+		$shortcode = new WC_Shortcode_Products();
+		$expected  = array(
+			'columns' => '4',
+			'orderby' => 'title',
+			'order'   => 'asc',
+			'ids'     => '',
+			'skus'    => '',
+		);
+		$this->assertEquals( $expected, $shortcode->get_attributes() );
+
+		$shortcode2 = new WC_Shortcode_Products( array(
+			'orderby' => 'id',
+			'order'   => 'desc',
+		) );
+		$expected2  = array(
+			'columns' => '4',
+			'orderby' => 'id',
+			'order'   => 'desc',
+			'ids'     => '',
+			'skus'    => '',
+		);
+		$this->assertEquals( $expected2, $shortcode2->get_attributes() );
+	}
+
+	/**
+	 * Test: WC_Shortcode_Products::get_query_args.
+	 */
+	public function test_get_query_args() {
+		$shortcode = new WC_Shortcode_Products();
+		$expected  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => 'title',
+			'order'               => 'asc',
+			'posts_per_page'      => -1,
+			'meta_query'          => WC()->query->get_meta_query(),
+			'tax_query'           => WC()->query->get_tax_query(),
+		);
+		$this->assertEquals( $expected, $shortcode->get_query_args() );
+
+		$shortcode2 = new WC_Shortcode_Products( array(
+			'orderby' => 'id',
+			'order'   => 'desc',
+		) );
+		$expected2  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => 'id',
+			'order'               => 'desc',
+			'posts_per_page'      => -1,
+			'meta_query'          => WC()->query->get_meta_query(),
+			'tax_query'           => WC()->query->get_tax_query(),
+		);
+		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
+
+		$shortcode2 = new WC_Shortcode_Products( array(
+			'ids'  => '1,2,3',
+			'skus' => 'foo,bar',
+		) );
+		$expected2  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => 'title',
+			'order'               => 'asc',
+			'posts_per_page'      => -1,
+			'meta_query'          => WC()->query->get_meta_query(),
+			'tax_query'           => WC()->query->get_tax_query(),
+			'post__in'            => array( '1', '2', '3' ),
+		);
+		$expected2['meta_query'][] = array(
+			'key'     => '_sku',
+			'value'   => array( 'foo', 'bar' ),
+			'compare' => 'IN',
+		);
+
+		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
+	}
+
+	/**
+	 * Test: WC_Shortcode_Products::get_content.
+	 */
+	public function test_get_content() {
+		$shortcode = new WC_Shortcode_Products();
+
+		$this->assertTrue( ! empty( $shortcode->get_content() ) );
+	}
+}

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -224,6 +224,29 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected7, $shortcode7->get_query_args() );
+
+		// top_rated_products shortcode.
+		$shortcode8 = new WC_Shortcode_Products( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'title',
+			'order'    => 'ASC',
+			'category' => '',
+			'operator' => 'IN',
+		), 'top_rated_products' );
+		$expected8  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
+		);
+
+		$this->assertEquals( $expected8, $shortcode8->get_query_args() );
 	}
 
 	/**
@@ -240,8 +263,24 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	 */
 	public function test_get_content() {
 		$shortcode = new WC_Shortcode_Products();
-		$results   = $shortcode->get_content();
+		$result    = $shortcode->get_content();
 
-		$this->assertTrue( ! empty( $results ) );
+		$this->assertTrue( ! empty( $result ) );
+	}
+
+	/**
+	 * Test: WC_Shortcode_Products::order_by_rating_post_clauses.
+	 */
+	public function test_order_by_rating_post_clauses() {
+		global $wpdb;
+
+		$expected = array(
+			'where'   => " AND $wpdb->commentmeta.meta_key = 'rating' ",
+			'join'    => "LEFT JOIN $wpdb->comments ON($wpdb->posts.ID = $wpdb->comments.comment_post_ID) LEFT JOIN $wpdb->commentmeta ON($wpdb->comments.comment_ID = $wpdb->commentmeta.comment_id)",
+			'orderby' => "$wpdb->commentmeta.meta_value DESC",
+			'groupby' => "$wpdb->posts.ID",
+		);
+
+		$this->assertEquals( $expected, WC_Shortcode_Products::order_by_rating_post_clauses( array( 'where' => '', 'join' => '' ) ) );
 	}
 }

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -13,15 +13,17 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	public function test_get_attributes() {
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
-			'per_page' => '-1',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'ids'      => '',
-			'skus'     => '',
-			'category' => '',
-			'operator' => 'IN',
-			'class'    => '',
+			'per_page'  => '-1',
+			'columns'   => '4',
+			'orderby'   => 'title',
+			'order'     => 'ASC',
+			'ids'       => '',
+			'skus'      => '',
+			'category'  => '',
+			'operator'  => 'IN',
+			'class'     => '',
+			'attribute' => '',
+			'filter'    => '',
 		);
 		$this->assertEquals( $expected, $shortcode->get_attributes() );
 
@@ -30,15 +32,17 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'   => 'DESC',
 		) );
 		$expected2  = array(
-			'per_page' => '-1',
-			'columns'  => '4',
-			'orderby'  => 'id',
-			'order'    => 'DESC',
-			'ids'      => '',
-			'skus'     => '',
-			'category' => '',
-			'operator' => 'IN',
-			'class'    => '',
+			'per_page'  => '-1',
+			'columns'   => '4',
+			'orderby'   => 'id',
+			'order'     => 'DESC',
+			'ids'       => '',
+			'skus'      => '',
+			'category'  => '',
+			'operator'  => 'IN',
+			'class'     => '',
+			'attribute' => '',
+			'filter'    => '',
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_attributes() );
 	}
@@ -274,7 +278,34 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			) ),
 		);
 
-		$this->assertEquals( $expected9, $shortcode9->get_query_args() );
+		// product_attribute shortcode.
+		$shortcode10 = new WC_Shortcode_Products( array(
+			'per_page'  => '12',
+			'columns'   => '4',
+			'orderby'   => 'title',
+			'order'     => 'asc',
+			'attribute' => 'color',
+			'filter'    => 'black',
+		), 'product_attribute' );
+		$expected10  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => array_merge( $tax_query, array(
+				array(
+					'taxonomy' => 'pa_color',
+					'terms'    => array( 'black' ),
+					'field'    => 'slug',
+				),
+			) ),
+		);
+
+		$this->assertEquals( $expected10, $shortcode10->get_query_args() );
 	}
 
 	/**

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -160,11 +160,11 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
 
 		// product shortcode.
-		$shortcode4 = new WC_Shortcode_Products( array(
+		$shortcode5 = new WC_Shortcode_Products( array(
 			'ids'      => '1',
 			'per_page' => '1',
 		), 'product' );
-		$expected4  = array(
+		$expected5  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
@@ -175,6 +175,30 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'meta_query'          => $meta_query,
 			'tax_query'           => $tax_query,
 			'p'                   => '1',
+		);
+
+		$this->assertEquals( $expected5, $shortcode5->get_query_args() );
+
+		// sale_products shortcode.
+		$shortcode4 = new WC_Shortcode_Products( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'title',
+			'order'    => 'ASC',
+			'category' => '',
+			'operator' => 'IN',
+		), 'sale_products' );
+		$expected4  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
+			'post__in'            => array_merge( array( 0 ), wc_get_product_ids_on_sale() ),
 		);
 
 		$this->assertEquals( $expected4, $shortcode4->get_query_args() );

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -180,7 +180,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected5, $shortcode5->get_query_args() );
 
 		// sale_products shortcode.
-		$shortcode4 = new WC_Shortcode_Products( array(
+		$shortcode6 = new WC_Shortcode_Products( array(
 			'per_page' => '12',
 			'columns'  => '4',
 			'orderby'  => 'title',
@@ -188,7 +188,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'category' => '',
 			'operator' => 'IN',
 		), 'sale_products' );
-		$expected4  = array(
+		$expected6  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
@@ -201,7 +201,29 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post__in'            => array_merge( array( 0 ), wc_get_product_ids_on_sale() ),
 		);
 
-		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
+		$this->assertEquals( $expected6, $shortcode6->get_query_args() );
+
+		// best_selling_products shortcode.
+		$shortcode7 = new WC_Shortcode_Products( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'category' => '',
+			'operator' => 'IN',
+		), 'best_selling_products' );
+		$expected7  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'meta_value_num',
+			'order'               => 'DESC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
+			'meta_key'            => 'total_sales',
+		);
+
+		$this->assertEquals( $expected7, $shortcode7->get_query_args() );
 	}
 
 	/**

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -181,12 +181,12 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: WC_Shortcode_Products::get_loop_name.
+	 * Test: WC_Shortcode_Products::get_type.
 	 */
 	public function test_loop_name() {
 		$shortcode = new WC_Shortcode_Products();
 
-		$this->assertEquals( 'products', $shortcode->get_loop_name() );
+		$this->assertEquals( 'products', $shortcode->get_type() );
 	}
 
 	/**

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -45,6 +45,10 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	 * Test: WC_Shortcode_Products::get_query_args.
 	 */
 	public function test_get_query_args() {
+		$meta_query = WC()->query->get_meta_query();
+		$tax_query  = WC()->query->get_tax_query();
+
+		// Emtpy products shortcode.
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
 			'post_type'           => 'product',
@@ -53,11 +57,12 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
 		);
 		$this->assertEquals( $expected, $shortcode->get_query_args() );
 
+		// products shortcode with attributes.
 		$shortcode2 = new WC_Shortcode_Products( array(
 			'orderby' => 'id',
 			'order'   => 'DESC',
@@ -69,8 +74,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'id',
 			'order'               => 'DESC',
 			'posts_per_page'      => -1,
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
 
@@ -85,8 +90,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
 			'post__in'            => array( '1', '2', '3' ),
 		);
 		$expected2['meta_query'][] = array(
@@ -97,11 +102,14 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
 
-		// With categories.
+		// product_category shortcode.
 		$shortcode3 = new WC_Shortcode_Products( array(
-			'category' => 'clothing',
-			'orderby'  => 'menu_order title',
 			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'menu_order title',
+			'order'    => 'ASC',
+			'category' => 'clothing',
+			'operator' => 'IN',
 		) );
 		$expected3  = array(
 			'post_type'           => 'product',
@@ -110,8 +118,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
-			'meta_query'          => WC()->query->get_meta_query(),
-			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
 			'meta_key'            => '',
 		);
 		$expected3['tax_query'][] = array(
@@ -120,8 +128,29 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'field'    => 'slug',
 			'operator' => 'IN',
 		);
-
 		$this->assertEquals( $expected3, $shortcode3->get_query_args() );
+
+		// recent_products shortcode.
+		$shortcode4 = new WC_Shortcode_Products( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'date',
+			'order'    => 'DESC',
+			'category' => '',
+			'operator' => 'IN',
+		) );
+		$expected4  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => 'date',
+			'order'               => 'DESC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
+		);
+
+		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
 	}
 
 	/**

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -93,6 +93,15 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: WC_Shortcode_Products::get_loop_name.
+	 */
+	public function test_loop_name() {
+		$shortcode = new WC_Shortcode_Products();
+
+		$this->assertEquals( 'products', $shortcode->get_loop_name() );
+	}
+
+	/**
 	 * Test: WC_Shortcode_Products::get_content.
 	 */
 	public function test_get_content() {

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -21,6 +21,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'skus'     => '',
 			'category' => '',
 			'operator' => 'IN',
+			'class'    => '',
 		);
 		$this->assertEquals( $expected, $shortcode->get_attributes() );
 
@@ -37,6 +38,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'skus'     => '',
 			'category' => '',
 			'operator' => 'IN',
+			'class'    => '',
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_attributes() );
 	}
@@ -53,7 +55,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$expected  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
@@ -70,7 +73,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$expected2  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
 			'orderby'             => 'id',
 			'order'               => 'DESC',
 			'posts_per_page'      => -1,
@@ -86,7 +90,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$expected2  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
@@ -110,11 +115,12 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'    => 'ASC',
 			'category' => 'clothing',
 			'operator' => 'IN',
-		) );
+		), 'product_category' );
 		$expected3  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
 			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
@@ -138,16 +144,37 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'    => 'DESC',
 			'category' => '',
 			'operator' => 'IN',
-		) );
+		), 'recent_products' );
 		$expected4  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
-			'ignore_sticky_posts' => 1,
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
 			'orderby'             => 'date',
 			'order'               => 'DESC',
 			'posts_per_page'      => 12,
 			'meta_query'          => $meta_query,
 			'tax_query'           => $tax_query,
+		);
+
+		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
+
+		// product shortcode.
+		$shortcode4 = new WC_Shortcode_Products( array(
+			'ids'      => '1',
+			'per_page' => '1',
+		), 'product' );
+		$expected4  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => 1,
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
+			'p'                   => '1',
 		);
 
 		$this->assertEquals( $expected4, $shortcode4->get_query_args() );

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -246,13 +246,41 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'tax_query'           => $tax_query,
 		);
 
-		$this->assertEquals( $expected8, $shortcode8->get_query_args() );
+		// featured_products shortcode.
+		$shortcode9 = new WC_Shortcode_Products( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'date',
+			'order'    => 'DESC',
+			'category' => '',
+			'operator' => 'IN',
+		), 'featured_products' );
+		$expected9  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'date',
+			'order'               => 'DESC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => array_merge( $tax_query, array(
+				array(
+					'taxonomy' => 'product_visibility',
+					'field'    => 'name',
+					'terms'    => 'featured',
+					'operator' => 'IN',
+				),
+			) ),
+		);
+
+		$this->assertEquals( $expected9, $shortcode9->get_query_args() );
 	}
 
 	/**
 	 * Test: WC_Shortcode_Products::get_type.
 	 */
-	public function test_loop_name() {
+	public function test_get_type() {
 		$shortcode = new WC_Shortcode_Products();
 
 		$this->assertEquals( 'products', $shortcode->get_type() );

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -13,24 +13,30 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	public function test_get_attributes() {
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
-			'columns' => '4',
-			'orderby' => 'title',
-			'order'   => 'asc',
-			'ids'     => '',
-			'skus'    => '',
+			'per_page' => '-1',
+			'columns'  => '4',
+			'orderby'  => 'title',
+			'order'    => 'ASC',
+			'ids'      => '',
+			'skus'     => '',
+			'category' => '',
+			'operator' => 'IN',
 		);
 		$this->assertEquals( $expected, $shortcode->get_attributes() );
 
 		$shortcode2 = new WC_Shortcode_Products( array(
 			'orderby' => 'id',
-			'order'   => 'desc',
+			'order'   => 'DESC',
 		) );
 		$expected2  = array(
-			'columns' => '4',
-			'orderby' => 'id',
-			'order'   => 'desc',
-			'ids'     => '',
-			'skus'    => '',
+			'per_page' => '-1',
+			'columns'  => '4',
+			'orderby'  => 'id',
+			'order'    => 'DESC',
+			'ids'      => '',
+			'skus'     => '',
+			'category' => '',
+			'operator' => 'IN',
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_attributes() );
 	}
@@ -45,7 +51,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'orderby'             => 'title',
-			'order'               => 'asc',
+			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => WC()->query->get_meta_query(),
 			'tax_query'           => WC()->query->get_tax_query(),
@@ -54,14 +60,14 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
 		$shortcode2 = new WC_Shortcode_Products( array(
 			'orderby' => 'id',
-			'order'   => 'desc',
+			'order'   => 'DESC',
 		) );
 		$expected2  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'orderby'             => 'id',
-			'order'               => 'desc',
+			'order'               => 'DESC',
 			'posts_per_page'      => -1,
 			'meta_query'          => WC()->query->get_meta_query(),
 			'tax_query'           => WC()->query->get_tax_query(),
@@ -77,7 +83,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => 1,
 			'orderby'             => 'title',
-			'order'               => 'asc',
+			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => WC()->query->get_meta_query(),
 			'tax_query'           => WC()->query->get_tax_query(),
@@ -90,6 +96,32 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
+
+		// With categories.
+		$shortcode3 = new WC_Shortcode_Products( array(
+			'category' => 'clothing',
+			'orderby'  => 'menu_order title',
+			'per_page' => '12',
+		) );
+		$expected3  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => 1,
+			'orderby'             => 'menu_order title',
+			'order'               => 'ASC',
+			'posts_per_page'      => 12,
+			'meta_query'          => WC()->query->get_meta_query(),
+			'tax_query'           => WC()->query->get_tax_query(),
+			'meta_key'            => '',
+		);
+		$expected3['tax_query'][] = array(
+			'taxonomy' => 'product_cat',
+			'terms'    => array( 'clothing' ),
+			'field'    => 'slug',
+			'operator' => 'IN',
+		);
+
+		$this->assertEquals( $expected3, $shortcode3->get_query_args() );
 	}
 
 	/**

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -218,7 +218,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	 */
 	public function test_get_content() {
 		$shortcode = new WC_Shortcode_Products();
+		$results   = $shortcode->get_content();
 
-		$this->assertTrue( ! empty( $shortcode->get_content() ) );
+		$this->assertTrue( ! empty( $results ) );
 	}
 }


### PR DESCRIPTION
**Should be reviewed and merged only after #16600 is merged**

This allow `[products]` to be used instaed of `[product_category]`, `[featured_products]`, `[sale_products]`, `[best_selling_products]`, `[recent_products]`, `[product_attribute]`, and `[top_rated_products]`.

Ref #15979