### PR TITLE
Improved shortcode attributes names

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -131,12 +131,12 @@ class WC_Shortcodes {
 		}
 
 		$atts = array_merge( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'menu_order title',
-			'order'    => 'ASC',
-			'category' => '',
-			'operator' => 'IN',
+			'limit'        => '12',
+			'columns'      => '4',
+			'orderby'      => 'menu_order title',
+			'order'        => 'ASC',
+			'category'     => '',
+			'cat_operator' => 'IN',
 		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'product_category' );
@@ -153,8 +153,12 @@ class WC_Shortcodes {
 	public static function product_categories( $atts ) {
 		global $woocommerce_loop;
 
+		if ( isset( $atts['number'] ) ) {
+			$atts['limit'] = $atts['number'];
+		}
+
 		$atts = shortcode_atts( array(
-			'number'     => null,
+			'limit'      => '-1',
 			'orderby'    => 'name',
 			'order'      => 'ASC',
 			'columns'    => '4',
@@ -192,8 +196,9 @@ class WC_Shortcodes {
 			}
 		}
 
-		if ( $atts['number'] ) {
-			$product_categories = array_slice( $product_categories, 0, $atts['number'] );
+		$atts['limit'] = '-1' === $atts['limit'] ? null : intval( $atts['limit'] );
+		if ( $atts['limit'] ) {
+			$product_categories = array_slice( $product_categories, 0, $atts['limit'] );
 		}
 
 		$columns = absint( $atts['columns'] );
@@ -226,12 +231,12 @@ class WC_Shortcodes {
 	 */
 	public static function recent_products( $atts ) {
 		$atts = array_merge( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'date',
-			'order'    => 'DESC',
-			'category' => '',
-			'operator' => 'IN',
+			'limit'        => '12',
+			'columns'      => '4',
+			'orderby'      => 'date',
+			'order'        => 'DESC',
+			'category'     => '',
+			'cat_operator' => 'IN',
 		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'recent_products' );
@@ -276,10 +281,10 @@ class WC_Shortcodes {
 			return '';
 		}
 
-		$atts['skus']     = isset( $atts['sku'] ) ? $atts['sku'] : '';
-		$atts['ids']      = isset( $atts['id'] ) ? $atts['id'] : '';
-		$atts['per_page'] = '1';
-		$shortcode        = new WC_Shortcode_Products( (array) $atts, 'product' );
+		$atts['skus']  = isset( $atts['sku'] ) ? $atts['sku'] : '';
+		$atts['ids']   = isset( $atts['id'] ) ? $atts['id'] : '';
+		$atts['limit'] = '1';
+		$shortcode     = new WC_Shortcode_Products( (array) $atts, 'product' );
 
 		return $shortcode->get_content();
 	}
@@ -382,12 +387,12 @@ class WC_Shortcodes {
 	 */
 	public static function sale_products( $atts ) {
 		$atts = array_merge( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'category' => '',
-			'operator' => 'IN',
+			'limit'        => '12',
+			'columns'      => '4',
+			'orderby'      => 'title',
+			'order'        => 'ASC',
+			'category'     => '',
+			'cat_operator' => 'IN',
 		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'sale_products' );
@@ -403,10 +408,10 @@ class WC_Shortcodes {
 	 */
 	public static function best_selling_products( $atts ) {
 		$atts = array_merge( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'category' => '',
-			'operator' => 'IN',
+			'limit'        => '12',
+			'columns'      => '4',
+			'category'     => '',
+			'cat_operator' => 'IN',
 		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'best_selling_products' );
@@ -422,12 +427,12 @@ class WC_Shortcodes {
 	 */
 	public static function top_rated_products( $atts ) {
 		$atts = array_merge( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'category' => '',
-			'operator' => 'IN',
+			'limit'        => '12',
+			'columns'      => '4',
+			'orderby'      => 'title',
+			'order'        => 'ASC',
+			'category'     => '',
+			'cat_operator' => 'IN',
 		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'top_rated_products' );
@@ -443,12 +448,12 @@ class WC_Shortcodes {
 	 */
 	public static function featured_products( $atts ) {
 		$atts = array_merge( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'date',
-			'order'    => 'DESC',
-			'category' => '',
-			'operator' => 'IN',
+			'limit'        => '12',
+			'columns'      => '4',
+			'orderby'      => 'date',
+			'order'        => 'DESC',
+			'category'     => '',
+			'cat_operator' => 'IN',
 		), (array) $atts );
 
 		$shortcode = new WC_Shortcode_Products( $atts, 'featured_products' );
@@ -594,15 +599,15 @@ class WC_Shortcodes {
 	 */
 	public static function product_attribute( $atts ) {
 		$atts = array_merge( array(
-			'per_page'  => '12',
+			'limit'     => '12',
 			'columns'   => '4',
 			'orderby'   => 'title',
 			'order'     => 'ASC',
 			'attribute' => '',
-			'filter'    => '',
+			'terms'     => '',
 		), (array) $atts );
 
-		if ( empty( $atts['attribute'] ) || empty( $atts['filter'] ) ) {
+		if ( empty( $atts['attribute'] ) ) {
 			return '';
 		}
 
@@ -618,9 +623,13 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function related_products( $atts ) {
+		if ( isset( $atts['per_page'] ) ) {
+			$atts['limit'] = $atts['per_page'];
+		}
+
 		// @codingStandardsIgnoreStart
 		$atts = shortcode_atts( array(
-			'per_page' => '4',
+			'limit'    => '4',
 			'columns'  => '4',
 			'orderby'  => 'rand',
 		), $atts, 'related_products' );
@@ -629,7 +638,7 @@ class WC_Shortcodes {
 		ob_start();
 
 		// Rename arg.
-		$atts['posts_per_page'] = absint( $atts['per_page'] );
+		$atts['posts_per_page'] = absint( $atts['limit'] );
 
 		woocommerce_related_products( $atts );
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -102,17 +102,18 @@ class WC_Shortcode_Products {
 	 */
 	protected function parse_attributes( $attributes ) {
 		return shortcode_atts( array(
-			'per_page'  => '-1',
-			'columns'   => '4',
-			'orderby'   => 'title',
-			'order'     => 'ASC',
-			'ids'       => '',
-			'skus'      => '',
-			'category'  => '',   // Slugs.
-			'operator'  => 'IN', // Category operator. Possible values are 'IN', 'NOT IN', 'AND'.
-			'class'     => '',
-			'attribute' => '',
-			'filter'    => '',
+			'limit'          => '-1',    // Results limit.
+			'columns'        => '4',     // Number of columns.
+			'orderby'        => 'title', // menu_order, title, date, rand, price, popularity, rating, or id.
+			'order'          => 'ASC',   // ASC or DESC.
+			'ids'            => '',      // Comma separated IDs.
+			'skus'           => '',      // Comma separated SKUs.
+			'category'       => '',      // Comma separated category slugs.
+			'cat_operator'   => 'IN',    // Operator to compare categories. Possible values are 'IN', 'NOT IN', 'AND'.
+			'attribute'      => '',      // Single attribute slug.
+			'terms'          => '',      // Comma separated term slugs.
+			'terms_operator' => 'IN',    // Operator to compare terms. Possible values are 'IN', 'NOT IN', 'AND'.
+			'class'          => '',      // HTML class.
 		), $attributes, $this->type );
 	}
 
@@ -133,7 +134,7 @@ class WC_Shortcode_Products {
 		);
 
 		// @codingStandardsIgnoreStart
-		$query_args['posts_per_page'] = (int) $this->attributes['per_page'];
+		$query_args['posts_per_page'] = (int) $this->attributes['limit'];
 		$query_args['meta_query']     = WC()->query->get_meta_query();
 		$query_args['tax_query']      = WC()->query->get_tax_query();
 		// @codingStandardsIgnoreEnd
@@ -203,8 +204,9 @@ class WC_Shortcode_Products {
 		if ( ! empty( $this->attributes['attribute'] ) || ! empty( $this->attributes['filter'] ) ) {
 			$query_args['tax_query'][] = array(
 				'taxonomy' => strstr( $this->attributes['attribute'], 'pa_' ) ? sanitize_title( $this->attributes['attribute'] ) : 'pa_' . sanitize_title( $this->attributes['attribute'] ),
-				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['filter'] ) ),
+				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['terms'] ) ),
 				'field'    => 'slug',
+				'operator' => $this->attributes['terms_operator'],
 			);
 		}
 	}
@@ -231,7 +233,7 @@ class WC_Shortcode_Products {
 				'taxonomy' => 'product_cat',
 				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) ),
 				'field'    => 'slug',
-				'operator' => $this->attributes['operator'],
+				'operator' => $this->attributes['cat_operator'],
 			);
 		}
 	}

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -97,10 +97,13 @@ class WC_Shortcode_Products {
 	/**
 	 * Parse attributes.
 	 *
+	 * @since  3.2.0
 	 * @param  array $attributes Shortcode attributes.
 	 * @return array
 	 */
 	protected function parse_attributes( $attributes ) {
+		$attributes = $this->parse_legacy_attributes( $attributes );
+
 		return shortcode_atts( array(
 			'limit'          => '-1',    // Results limit.
 			'columns'        => '4',     // Number of columns.
@@ -115,6 +118,30 @@ class WC_Shortcode_Products {
 			'terms_operator' => 'IN',    // Operator to compare terms. Possible values are 'IN', 'NOT IN', 'AND'.
 			'class'          => '',      // HTML class.
 		), $attributes, $this->type );
+	}
+
+	/**
+	 * Parse legacy attributes.
+	 *
+	 * @since  3.2.0
+	 * @param  array  $attributes Attributes.
+	 * @return array
+	 */
+	protected function parse_legacy_attributes( $attributes ) {
+		$mapping = array(
+			'per_page' => 'limit',
+			'operator' => 'cat_operator',
+			'filter'   => 'terms',
+		);
+
+		foreach ( $mapping as $old => $new ) {
+			if ( isset( $attributes[ $old ] ) ) {
+				$attributes[ $new ] = $attributes[ $old ];
+				unset( $attributes[ $old ] );
+			}
+		}
+
+		return $attributes;
 	}
 
 	/**

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -13,17 +13,18 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 	public function test_get_attributes() {
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
-			'per_page'  => '-1',
-			'columns'   => '4',
-			'orderby'   => 'title',
-			'order'     => 'ASC',
-			'ids'       => '',
-			'skus'      => '',
-			'category'  => '',
-			'operator'  => 'IN',
-			'class'     => '',
-			'attribute' => '',
-			'filter'    => '',
+			'limit'          => '-1',
+			'columns'        => '4',
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+			'ids'            => '',
+			'skus'           => '',
+			'category'       => '',
+			'cat_operator'   => 'IN',
+			'attribute'      => '',
+			'terms'          => '',
+			'terms_operator' => 'IN',
+			'class'          => '',
 		);
 		$this->assertEquals( $expected, $shortcode->get_attributes() );
 
@@ -32,17 +33,18 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'   => 'DESC',
 		) );
 		$expected2  = array(
-			'per_page'  => '-1',
-			'columns'   => '4',
-			'orderby'   => 'id',
-			'order'     => 'DESC',
-			'ids'       => '',
-			'skus'      => '',
-			'category'  => '',
-			'operator'  => 'IN',
-			'class'     => '',
-			'attribute' => '',
-			'filter'    => '',
+			'limit'          => '-1',
+			'columns'        => '4',
+			'orderby'        => 'id',
+			'order'          => 'DESC',
+			'ids'            => '',
+			'skus'           => '',
+			'category'       => '',
+			'cat_operator'   => 'IN',
+			'attribute'      => '',
+			'terms'          => '',
+			'terms_operator' => 'IN',
+			'class'          => '',
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_attributes() );
 	}
@@ -301,6 +303,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 					'taxonomy' => 'pa_color',
 					'terms'    => array( 'black' ),
 					'field'    => 'slug',
+					'operator' => 'IN',
 				),
 			) ),
 		);


### PR DESCRIPTION
Changed some attributes names:

- `per_page` to `limit`.
- `number` to `limit`.
- `operator` to `cat_operator`.
- `filter` to `terms`.

Introduces `terms_operator` to improve attributes queries.

Ref #15979