### PR TITLE
Fix "Undefined index: callback" notice

### DIFF
--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -40,7 +40,7 @@ if ( ! empty( $tabs ) ) : ?>
 		</ul>
 		<?php foreach ( $tabs as $key => $tab ) : ?>
 			<div class="woocommerce-Tabs-panel woocommerce-Tabs-panel--<?php echo esc_attr( $key ); ?> panel entry-content wc-tab" id="tab-<?php echo esc_attr( $key ); ?>" role="tabpanel" aria-labelledby="tab-title-<?php echo esc_attr( $key ); ?>">
-				<?php call_user_func( $tab['callback'], $key, $tab ); ?>
+				<?php if ( isset( $tab['callback'] ) ) { call_user_func( $tab['callback'], $key, $tab ); } ?>
 			</div>
 		<?php endforeach; ?>
 	</div>


### PR DESCRIPTION
I found this message below when I open any product page on my website:

> Notice: Undefined index: callback in /path/to/woocommerce/single-product/tabs/tabs.php on line 43

And I checked the values in `$tabs` array, it was:

```php
[
    'description' => [
        'title' => '...'
    ],
    'additional_information' => [
        'title' => '...',
        'priority' => '...',
        'callback' => '...',
    ]
]
```

The `callback` does not exists in `$tabs['description']` array. So I simply use the `isset` function to fix it and send PR.