### PR TITLE
Sanitize whole class name

### DIFF
--- a/templates/cart/cart-item-data.php
+++ b/templates/cart/cart-item-data.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <dl class="variation">
 	<?php foreach ( $item_data as $data ) : ?>
-		<dt class="variation-<?php echo sanitize_html_class( $data['key'] ); ?>"><?php echo wp_kses_post( $data['key'] ); ?>:</dt>
-		<dd class="variation-<?php echo sanitize_html_class( $data['key'] ); ?>"><?php echo wp_kses_post( wpautop( $data['display'] ) ); ?></dd>
+		<dt class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?>"><?php echo wp_kses_post( $data['key'] ); ?>:</dt>
+		<dd class="<?php echo sanitize_html_class( 'variation-' . $data['key'] ); ?>"><?php echo wp_kses_post( wpautop( $data['display'] ) ); ?></dd>
 	<?php endforeach; ?>
 </dl>


### PR DESCRIPTION
Data should be sanitized in whole not in part. Therefore the class prefix should be inside the function call.