### PR TITLE
Flag untested extensions on the status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -22,6 +22,8 @@ $theme            = $system_status->get_theme_info();
 $security         = $system_status->get_security_info();
 $settings         = $system_status->get_settings();
 $pages            = $system_status->get_pages();
+$plugin_updates   = new WC_Plugin_Updates;
+$untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor' );
 ?>
 <div class="updated woocommerce-message inline">
 	<p><?php _e( 'Please copy and paste this information in your ticket when contacting support:', 'woocommerce' ); ?> </p>
@@ -455,6 +457,7 @@ $pages            = $system_status->get_pages();
 
 				$version_string = '';
 				$network_string = '';
+				$untested_string = '';
 				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
 					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
 						/* translators: %s: plugin latest version */
@@ -464,6 +467,10 @@ $pages            = $system_status->get_pages();
 					if ( false != $plugin['network_activated'] ) {
 						$network_string = ' &ndash; <strong style="color:black;">' . __( 'Network enabled', 'woocommerce' ) . '</strong>';
 					}
+
+					if ( in_array( $plugin['plugin'], array_keys( $untested_plugins ) ) ) {
+						$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
+					}
 				}
 				?>
 				<tr>
@@ -472,7 +479,7 @@ $pages            = $system_status->get_pages();
 					<td><?php
 						/* translators: %s: plugin author */
 						printf( __( 'by %s', 'woocommerce' ), $plugin['author_name'] );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $network_string;
+						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string;
 					?></td>
 				</tr>
 				<?php

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -468,7 +468,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 						$network_string = ' &ndash; <strong style="color:black;">' . __( 'Network enabled', 'woocommerce' ) . '</strong>';
 					}
 
-					if ( in_array( $plugin['plugin'], array_keys( $untested_plugins ) ) ) {
+					if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
 						$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
 					}
 				}

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -457,7 +457,6 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 
 				$version_string = '';
 				$network_string = '';
-				$untested_string = '';
 				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
 					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
 						/* translators: %s: plugin latest version */
@@ -467,10 +466,10 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 					if ( false != $plugin['network_activated'] ) {
 						$network_string = ' &ndash; <strong style="color:black;">' . __( 'Network enabled', 'woocommerce' ) . '</strong>';
 					}
-
-					if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
-						$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
-					}
+				}
+				$untested_string = '';
+				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
+					$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
 				}
 				?>
 				<tr>


### PR DESCRIPTION
Uses the information gleaned from the new version headers (https://woocommerce.wordpress.com/2017/08/28/new-version-check-in-woocommerce-3-2/) on the status report to flag "untested" plugins.

Considerations:
* It looks like everything else is grabbed from WC_REST_System_Status_Controller - do we want to expose the list of untested plugins there, and fetch from there on the status report page?
* Is 'minor' the right thing to pass in to catch any plugins not tested with the current version?