### PR TITLE
Use order->get_id instead of undefined order_id

### DIFF
--- a/templates/checkout/order-receipt.php
+++ b/templates/checkout/order-receipt.php
@@ -42,6 +42,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php endif; ?>
 </ul>
 
-<?php do_action( 'woocommerce_receipt_' . $order->get_payment_method(), $order_id ); ?>
+<?php do_action( 'woocommerce_receipt_' . $order->get_payment_method(), $order->get_id() ); ?>
 
 <div class="clear"></div>


### PR DESCRIPTION
[In the code](https://github.com/woocommerce/woocommerce/blob/30a85e9/includes/shortcodes/class-wc-shortcode-checkout.php#L160), there is no `order_id`, so we need to use `order->get_id()` instead.