### PR TITLE
Add cart object to filters with quantity updates

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1206,12 +1206,12 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function set_quantity( $cart_item_key, $quantity = 1, $refresh_totals = true ) {
 		if ( 0 === $quantity || $quantity < 0 ) {
-			do_action( 'woocommerce_before_cart_item_quantity_zero', $cart_item_key );
+			do_action( 'woocommerce_before_cart_item_quantity_zero', $cart_item_key, $this );
 			unset( $this->cart_contents[ $cart_item_key ] );
 		} else {
 			$old_quantity = $this->cart_contents[ $cart_item_key ]['quantity'];
 			$this->cart_contents[ $cart_item_key ]['quantity'] = $quantity;
-			do_action( 'woocommerce_after_cart_item_quantity_update', $cart_item_key, $quantity, $old_quantity );
+			do_action( 'woocommerce_after_cart_item_quantity_update', $cart_item_key, $quantity, $old_quantity, $this );
 		}
 
 		if ( $refresh_totals ) {


### PR DESCRIPTION
No issue.

Other filters (remove cart item, restore cart item) have the cart object passed as well. These ones should be too.