### PR TITLE
Add option to disable validation when applying coupons

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1020,7 +1020,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$coupon_object = apply_filters( 'woocommerce_order_recalculate_coupons_coupon_object', $coupon_object, $coupon_code, $coupon_item, $this );
 
 			if ( $coupon_object ) {
-				$discounts->apply_coupon( $coupon_object );
+				$discounts->apply_coupon( $coupon_object, false );
 			}
 		}
 

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -206,14 +206,15 @@ class WC_Discounts {
 	 *
 	 * @since  3.2.0
 	 * @param  WC_Coupon $coupon Coupon object being applied to the items.
+	 * @param  bool      $validate Set to false to skip coupon validation.
 	 * @return bool|WP_Error True if applied or WP_Error instance in failure.
 	 */
-	public function apply_coupon( $coupon ) {
+	public function apply_coupon( $coupon, $validate = true ) {
 		if ( ! is_a( $coupon, 'WC_Coupon' ) ) {
 			return new WP_Error( 'invalid_coupon', __( 'Invalid coupon', 'woocommerce' ) );
 		}
 
-		$is_coupon_valid = $this->is_coupon_valid( $coupon );
+		$is_coupon_valid = $validate ? $this->is_coupon_valid( $coupon ) : true;
 
 		if ( is_wp_error( $is_coupon_valid ) ) {
 			return $is_coupon_valid;


### PR DESCRIPTION
Closes #16720

Validation is not needed when the coupon is already applied to an order.