### PR TITLE
Reintroduce find and replace variables

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -190,6 +190,22 @@ class WC_Email extends WC_Settings_API {
 	 */
 	protected $placeholders = array();
 
+ 	/**
+	 * Strings to find in subjects/headings.
+	 *
+	 * @deprecated 3.2.0 in favour of placeholders
+	 * @var array
+	 */
+	public $find = array();
+
+	/**
+	 * Strings to replace in subjects/headings.
+	 *
+	 * @deprecated 3.2.0 in favour of placeholders
+	 * @var array
+	 */
+	public $replace = array();
+
 	/**
 	 * Constructor.
 	 */
@@ -242,15 +258,13 @@ class WC_Email extends WC_Settings_API {
 		$replace = array_values( $this->placeholders );
 
 		// If using legacy find replace, add those to our find/replace arrays first. @todo deprecate in 4.0.0.
-		if ( isset( $this->find, $this->replace ) ) {
-			$find    = array_merge( $this->find, $find );
-			$replace = array_merge( $this->replace, $replace );
-		}
+		$find    = array_merge( $this->find, $find );
+		$replace = array_merge( $this->replace, $replace );
 
 		// If using the older style filters for find and replace, ensure the array is associative and then pass through filters. @todo deprecate in 4.0.0.
 		if ( has_filter( 'woocommerce_email_format_string_replace' ) || has_filter( 'woocommerce_email_format_string_find' ) ) {
-			$legacy_find    = isset( $this->find ) ? $this->find : array();
-			$legacy_replace = isset( $this->replace ) ? $this->replace : array();
+			$legacy_find    = $this->find;
+			$legacy_replace = $this->replace;
 
 			foreach ( $this->placeholders as $find => $replace ) {
 				$legacy_key                    = sanitize_title( str_replace( '_', '-', trim( $find, '{}' ) ) );


### PR DESCRIPTION
[This](https://github.com/woocommerce/woocommerce/pull/16709/files#r136945832) was wrong. We need to keep those variables, in cases such as [this](https://github.com/woocommerce/woocommerce-bookings/blob/520bd3b/includes/emails/class-wc-email-new-booking.php#L82).