### PR TITLE
Fixing external image scheme

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1743,7 +1743,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		} else {
 			$image = '';
 		}
-		return str_replace( array( 'https://', 'http://' ), '//', $image );
+		return $image;
 	}
 
 	/**


### PR DESCRIPTION
If image source is located on external resource, hardcoding '//' will break if local and remote schemes do not match.
For example local shop site is https://, while remote CDN is http://, images will not be displayed.