### PR TITLE
Make methods public for multiple add-to-cart handlers

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -761,7 +761,7 @@ class WC_Form_Handler {
 	 * @param int $product_id Product ID to add to the cart.
 	 * @return bool success or not
 	 */
-	private static function add_to_cart_handler_simple( $product_id ) {
+	public static function add_to_cart_handler_simple( $product_id ) {
 		$quantity 			= empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( $_REQUEST['quantity'] );
 		$passed_validation 	= apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity );
 
@@ -779,7 +779,7 @@ class WC_Form_Handler {
 	 * @param int $product_id Product ID to add to the cart.
 	 * @return bool success or not
 	 */
-	private static function add_to_cart_handler_grouped( $product_id ) {
+	public static function add_to_cart_handler_grouped( $product_id ) {
 		$was_added_to_cart = false;
 		$added_to_cart     = array();
 
@@ -827,7 +827,7 @@ class WC_Form_Handler {
 	 * @param int $product_id Product ID to add to the cart.
 	 * @return bool success or not
 	 */
-	private static function add_to_cart_handler_variable( $product_id ) {
+	public static function add_to_cart_handler_variable( $product_id ) {
 		try {
 			$variation_id       = empty( $_REQUEST['variation_id'] ) ? '' : absint( $_REQUEST['variation_id'] );
 			$quantity           = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( $_REQUEST['quantity'] );


### PR DESCRIPTION
There is a relatively popular code snippet that provides a way to add multiple products to the cart using an `add-to-cart` link: https://dsgnwrks.pro/snippets/woocommerce-allow-adding-multiple-products-to-the-cart-via-the-add-to-cart-query-string/. This uses a hack to be able to call the WooCommerce.

I would prefer this not to be hack, hence this PR.

I would also be willing to contribute a way for WooCommerce itself to accept multiple products in an `add-to-cart` link. Or perhaps add this to a different query param, such as `multiple-add-to-cart`. Do you want me to create an issue for this?