### PR TITLE
Fix bug in WC_Discount->get_discount() where number precision was removed twice

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -131,7 +131,7 @@ class WC_Discounts {
 	 */
 	public function get_discount( $key, $in_cents = false ) {
 		$item_discount_totals = $this->get_discounts_by_item( $in_cents );
-		return isset( $item_discount_totals[ $key ] ) ? ( $in_cents ? $item_discount_totals[ $key ] : wc_remove_number_precision( $item_discount_totals[ $key ] ) ) : 0;
+		return isset( $item_discount_totals[ $key ] ) ? $item_discount_totals[ $key ] : 0;
 	}
 
 	/**


### PR DESCRIPTION
I'm attempting to list coupon discounts per line item in the cart in my theme. I noticed that WC 3.2.0 added a `WC_Discounts` class that I saw could really help me. After looking through the code, it seems that the way to use this was through the following:

```
$cart_discounts = new WC_Discounts( WC()->cart );

foreach ( WC()->cart->get_coupons() as $code => $coupon ) {
	$cart_discounts->apply_coupon( $coupon );
}

$price_in_cents = $cart_discounts->get_discount( $cart_item_key, true );
$price = $cart_discounts->get_discount( $cart_item_key );
```

When I ran this code, I was noticing that $price_in_cents was correct (at 570 in my case), but the $price was incorrect (at 0.06). After stepping through the code, I found that the `get_discount()` function was accidentally applying the `wc_remove_number_precision()` twice. On line 133, `$this->get_discounts_by_item( $in_cents );` was already doing the precision removal based on the passed parameter value of `false` and then on line 134 it was doing this again based on the parameter value of `false`.