### PR TITLE
Only set some fields on new orders

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -115,11 +115,15 @@ function wc_create_order( $args = array() ) {
 			$order->set_cart_hash( sanitize_text_field( $args['cart_hash'] ) );
 		}
 
+		// Set these fields when creating a new order but not when updating an existing order.
+		if ( ! $args['order_id'] ) {
+			$order->set_currency( get_woocommerce_currency() );
+			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
+			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
+			$order->set_customer_user_agent( wc_get_user_agent() );
+		}
+
 		// Update other order props set automatically
-		$order->set_currency( get_woocommerce_currency() );
-		$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
-		$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
-		$order->set_customer_user_agent( wc_get_user_agent() );
 		$order->save();
 	} catch ( Exception $e ) {
 		return new WP_Error( 'error', $e->getMessage() );
@@ -135,7 +139,7 @@ function wc_create_order( $args = array() ) {
  * @return string | WC_Order
  */
 function wc_update_order( $args ) {
-	if ( ! $args['order_id'] ) {
+	if ( empty( $args['order_id'] ) ) {
 		return new WP_Error( __( 'Invalid order ID.', 'woocommerce' ) );
 	}
 	return wc_create_order( $args );

--- a/tests/unit-tests/core/functions.php
+++ b/tests/unit-tests/core/functions.php
@@ -24,4 +24,32 @@ class WC_Tests_WooCommerce_Functions extends WC_Unit_Test_Case {
 		wc_maybe_define_constant( 'WC_TESTING_DEFINE_FUNCTION', false );
 		$this->assertTrue( WC_TESTING_DEFINE_FUNCTION );
 	}
+
+	/**
+	 * Tests wc_create_order() and wc_update_order() currency handling.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_wc_create_update_order_currency() {
+		$old_currency = get_woocommerce_currency();
+		$new_currency = 'BGN';
+
+		update_option( 'woocommerce_currency', $new_currency );
+
+		// New order should be created using shop currency.
+		$order = wc_create_order( array(
+			'status'      => 'pending',
+			'customer_id' => 1,
+		) );
+		$this->assertEquals( $new_currency, $order->get_currency() );
+
+		update_option( 'woocommerce_currency', $old_currency );
+
+		// Currency should not change when order is updated.
+		$order = wc_update_order( array(
+			'customer_id' => 2,
+			'order_id'    => $order->get_id(),
+		) );
+		$this->assertEquals( $new_currency, $order->get_currency() );
+	}
 }


### PR DESCRIPTION
Fixes #16736 

The automatically-populated order fields will only get populated on new orders.