### PR TITLE
Handle external URLs for images

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1743,7 +1743,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		} else {
 			$image = '';
 		}
-		return str_replace( 'http://', '//', $image );
+		return apply_filters( 'woocommerce_product_get_image', wc_get_relative_url( $image ), $this, $size, $attr, $placeholder );
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1857,3 +1857,27 @@ function wc_delete_expired_transients() {
 	return absint( $rows + $rows2 );
 }
 add_action( 'woocommerce_installed', 'wc_delete_expired_transients' );
+
+/**
+ * Make a URL relative, if possible.
+ *
+ * @since 3.2.0
+ * @param string $url URL to make relative.
+ * @return string
+ */
+function wc_get_relative_url( $url ) {
+	return wc_is_external_resource( $url ) ? $url : str_replace( array( 'http://', 'https://' ), '//', $url );
+}
+
+/**
+ * See if a resource is remote.
+ *
+ * @since 3.2.0
+ * @param string $url URL to check.
+ * @return bool
+ */
+function wc_is_external_resource( $url ) {
+	$wp_base = str_replace( array( 'http://', 'https://' ), '//', get_home_url( null, '/', 'http' ) );
+
+	return strstr( $url, '://' ) && strstr( $wp_base, $url );
+}


### PR DESCRIPTION
Adds 2 helper functions; wc_get_relative_url/wc_is_external_resource helpers

These are used to decide if a URL is to be made relative.

Also introduces a new filter for the get_image method.

Closes #16746