### PR TITLE
Remove duplicate check

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1300,7 +1300,7 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function has_downloadable_item() {
 		foreach ( $this->get_items() as $item ) {
-			if ( $item->is_type( 'line_item' ) && ( $product = $item->get_product() ) && $product->is_downloadable() && $product->has_file() ) {
+			if ( $item->is_type( 'line_item' ) && ( $product = $item->get_product() ) && $product->has_file() ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Products `is_downloadable()` is re-checked in `has_file()` at https://github.com/woocommerce/woocommerce/blob/0337293e392f381da92607b57c855f52df25045d/includes/abstracts/abstract-wc-product.php#L1593