### PR TITLE
Bugfix: coupon object cache not being cleared upon deletion

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -185,6 +185,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 
 		if ( $args['force_delete'] ) {
 			wp_delete_post( $id );
+
+			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
+
 			$coupon->set_id( 0 );
 			do_action( 'woocommerce_delete_coupon', $id );
 		} else {

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -45,6 +45,19 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test coupon accurately cleans up object cache upon deletion.
+	 */
+	public function test_coupon_cache_deletion() {
+		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
+		$coupon->delete( true );
+
+		$cache_name = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code();
+		$ids = wp_cache_get( $cache_name, 'coupons' );
+
+		$this->assertEquals( false, $ids, sprintf( 'Object cache for %s was not removed upon deletion of coupon.', $cache_name ) );
+	}
+
+	/**
 	 * Test coupon update.
 	 * @since 3.0.0
 	 */


### PR DESCRIPTION
While I was working on making the unit-tests/discounts/discounts.php have some more robust testing, I found that if I created a coupon with a name, deleted that coupon, then created the coupon again with the same name, it was throwing an exception of "Invalid Coupon". Here's the crux of the code that caused me to find this bug.

```
$coupon = WC_Helper_Coupon::create_coupon( 'test' );
$coupon->delete( true );

$coupon = WC_Helper_Coupon::create_coupon( 'test' );
$coupon->delete( true );
```

The error with the cache is identified in the [wc_get_coupon_id_by_code() function includes/wc-coupon-functions.php](https://github.com/woocommerce/woocommerce/blob/419244051e893501ff8755a1a568aae7e7e49132/includes/wc-coupon-functions.php#L93-L107). In there it is checking for a particular item in the cache and will pull it from the cache if it exists in there. In the example above, the first creation of the coupon will get an ID of 8 (for example) and the section one will get an ID of 9. Since the first deletion did not remove the object from the cache, when `wc_get_coupon_id_by_code()` check for the object in cache, it finds it and returns it. The problem is it's returning the no longer existent coupon.

This PR adds an additional unit test for showing this bug as well as what I think is the fix for it. It's possible that I'm not correctly fixing the issue, so please advise if this is correct or not.