### PR TITLE
Made discount unit tests more robust using a PHPunit Data Provider

### DIFF
--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -7,6 +7,17 @@
 class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
 	/**
+	 * Clean up after each test. DB changes are reverted in parent::tearDown().
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		WC()->cart->empty_cart();
+
+		WC()->cart->remove_coupons();
+	}
+
+	/**
 	 * Test get and set items.
 	 */
 	public function test_get_set_items_from_cart() {
@@ -41,11 +52,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts = new WC_Discounts();
 		$discounts->set_items_from_cart( false );
 		$this->assertEquals( array(), $discounts->get_items() );
-
-		// Cleanup.
-		WC()->cart->empty_cart();
-		$product->delete( true );
-		$order->delete( true );
 	}
 
 	/**
@@ -80,297 +86,414 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts->set_items_from_cart( WC()->cart );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( 0, $discounts->get_discounted_price( current( $discounts->get_items() ) ), print_r( $discounts->get_discounts(), true ) );
-
-		// Cleanup.
-		WC()->cart->empty_cart();
-		$product->delete( true );
-		$coupon->delete( true );
 	}
 
 	/**
-	 * Test various discount calculations are working correctly and produding expected results.
+	 * Test various discount calculations are working correctly and producing expected results.
+	 *
+	 * @dataProvider calculations_test_provider
+	 *
+	 * @param array $test_data All of the settings to use for testing.
 	 */
-	public function test_calculations() {
-		$tax_rate = array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '20.0000',
-			'tax_rate_name'     => 'VAT',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
-		);
-		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
-		update_option( 'woocommerce_calc_taxes', 'yes' );
+	public function test_calculations( $test_data ) {
+		$discounts = new WC_Discounts();
+		$products  = array();
+		$coupons   = array();
 
-		$tests = array(
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'percent',
-						'amount'        => '20',
-					),
-				),
-				'expected_total_discount' => 2,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 2,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '10',
-					),
-				),
-				'expected_total_discount' => 10,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '10',
-					),
-				),
-				'expected_total_discount' => 10,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '10',
-					),
-				),
-				'expected_total_discount' => 10,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 2,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 3,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 2,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '10',
-					),
-				),
-				'expected_total_discount' => 10,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 1,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '10',
-					),
-				),
-				'expected_total_discount' => 10,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 1,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 1,
-						'qty'   => 1,
-					),
-					array(
-						'price' => 1,
-						'qty'   => 1,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'          => 'test',
-						'discount_type' => 'fixed_cart',
-						'amount'        => '1',
-					),
-				),
-				'expected_total_discount' => 1,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 2,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'                   => 'test',
-						'discount_type'          => 'percent',
-						'amount'                 => '10',
-						'limit_usage_to_x_items' => 1,
-					),
-				),
-				'expected_total_discount' => 1,
-			),
-			array(
-				'prices_include_tax' => false,
-				'cart' => array(
-					array(
-						'price' => 10,
-						'qty'   => 2,
-					),
-					array(
-						'price' => 10,
-						'qty'   => 2,
-					),
-				),
-				'coupons' => array(
-					array(
-						'code'                   => 'test',
-						'discount_type'          => 'percent',
-						'amount'                 => '10',
-						'limit_usage_to_x_items' => 1,
-					),
-				),
-				'expected_total_discount' => 1,
-			),
-		);
+		if ( isset( $test_data['tax_rate'] ) ) {
+			WC_Tax::_insert_tax_rate( $test_data['tax_rate'] );
+		}
 
-		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
-
-		foreach ( $tests as $test_index => $test ) {
-			$discounts = new WC_Discounts();
-			$products  = array();
-
-			foreach ( $test['cart'] as $item ) {
-				$product = WC_Helper_Product::create_simple_product();
-				$product->set_regular_price( $item['price'] );
-				$product->set_tax_status( 'taxable' );
-				$product->save();
-				WC()->cart->add_to_cart( $product->get_id(), $item['qty'] );
-				$products[] = $product;
-			}
-
-			$discounts->set_items_from_cart( WC()->cart );
-
-			foreach ( $test['coupons'] as $coupon_props ) {
-				$coupon->set_props( $coupon_props );
-				$discounts->apply_coupon( $coupon );
-			}
-
-			$all_discounts = $discounts->get_discounts();
-			$this->assertEquals( $test['expected_total_discount'], array_sum( $all_discounts['test'] ), 'Test case ' . $test_index . ' failed (' . print_r( $test, true ) . ' - ' . print_r( $discounts->get_discounts(), true ) . ')' );
-
-			// Clean.
-			WC()->cart->empty_cart();
-
-			foreach ( $products as $product ) {
-				$product->delete( true );
+		if ( isset( $test_data['wc_options'] ) ) {
+			foreach ( $test_data['wc_options'] as $_option_name => $_option_value ) {
+				update_option( $_option_name, $_option_value );
 			}
 		}
 
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
-		update_option( 'woocommerce_calc_taxes', 'no' );
-		$coupon->delete( true );
+		foreach ( $test_data['cart'] as $item ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_regular_price( $item['price'] );
+			$product->set_tax_status( 'taxable' );
+			$product->save();
+			WC()->cart->add_to_cart( $product->get_id(), $item['qty'] );
+			$products[] = $product;
+		}
+
+		$discounts->set_items_from_cart( WC()->cart );
+
+		foreach ( $test_data['coupons'] as $coupon_props ) {
+			$coupon = WC_Helper_Coupon::create_coupon( $coupon_props['code'] );
+			$coupon->set_props( $coupon_props );
+			$discounts->apply_coupon( $coupon );
+
+			$coupons[ $coupon_props['code'] ] = $coupon;
+		}
+
+		$all_discounts = $discounts->get_discounts();
+
+		$discount_total = 0;
+		foreach ( $all_discounts as $code_name => $discounts_by_coupon ) {
+			$discount_total += array_sum( $discounts_by_coupon );
+		}
+
+		$this->assertEquals( $test_data['expected_total_discount'], $discount_total, 'Failed (' . print_r( $test_data, true ) . ' - ' . print_r( $discounts->get_discounts(), true ) . ')' );
+	}
+
+	/**
+	 * This is a dataProvider for test_calculations().
+	 *
+	 * @return array An array of discount tests to be run.
+	 */
+	public function calculations_test_provider() {
+		return array(
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'wc_options' => array(
+						'woocommerce_calc_taxes' => 'yes',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'percent',
+							'amount'        => '20',
+						),
+					),
+					'expected_total_discount' => 2,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 2,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'fixed_cart',
+							'amount'        => '10',
+						),
+					),
+					'expected_total_discount' => 10,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'fixed_cart',
+							'amount'        => '10',
+						),
+					),
+					'expected_total_discount' => 10,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'fixed_cart',
+							'amount'        => '10',
+						),
+					),
+					'expected_total_discount' => 10,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 2,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 3,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 2,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'fixed_cart',
+							'amount'        => '10',
+						),
+					),
+					'expected_total_discount' => 10,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 1,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'fixed_cart',
+							'amount'        => '10',
+						),
+					),
+					'expected_total_discount' => 10,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 1,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 1,
+							'qty'   => 1,
+						),
+						array(
+							'price' => 1,
+							'qty'   => 1,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'          => 'test',
+							'discount_type' => 'fixed_cart',
+							'amount'        => '1',
+						),
+					),
+					'expected_total_discount' => 1,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 2,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'                   => 'test',
+							'discount_type'          => 'percent',
+							'amount'                 => '10',
+							'limit_usage_to_x_items' => 1,
+						),
+					),
+					'expected_total_discount' => 1,
+				),
+			),
+			array(
+				array(
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 2,
+						),
+						array(
+							'price' => 10,
+							'qty'   => 2,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'                   => 'test',
+							'discount_type'          => 'percent',
+							'amount'                 => '10',
+							'limit_usage_to_x_items' => 1,
+						),
+					),
+					'expected_total_discount' => 1,
+				),
+			),
+		);
 	}
 
 	public function test_free_shipping_coupon_no_products() {


### PR DESCRIPTION
I'm in the process of creating more unit tests for testing the discounts. This change is a refactor of the `test_calculations()` function to be more in line with how PHPUnit is meant to work. Basically, instead of one unit test that actually ran a bunch of tests, I used a PHPUnit Data Provider to provide the data to test against. This allows PHPUnit to run the same code on multiple sets of data and considers them different tests.

Along with this, I added the ability to specify Woocommerce options for when the test runs and be able to process multiple coupons in a test.

I have some additional tests that I've created that are failing because I think they are pointing to a bug or two, but I haven't included them in this PR so this PR actually tests out correctly. I'll submit another PR with those other tests after this PR has been implemented.