### PR TITLE
[3.0+] Resolve undefined product notice in email-order-items.php

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -23,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 $text_align = is_rtl() ? 'right' : 'left';
 
 foreach ( $items as $item_id => $item ) :
+	$product = $item->get_product();
 	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
-		$product = $item->get_product();
 		?>
 		<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
 			<td class="td" style="text-align:<?php echo $text_align; ?>; vertical-align:middle; border: 1px solid #eee; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; word-wrap:break-word;"><?php


### PR DESCRIPTION
Resolves `PHP Notice:  Undefined variable: product in /srv/www/sites/wc31/wp-content/plugins/woocommerce/templates/emails/email-order-items.php on line 64`.

See https://github.com/franticpsyx/woocommerce/blob/d42fc93be746c96f3fc0634301908adf75822659/templates/emails/email-order-items.php#L60

No change to the existing behavior -- currently the purchase note is visible (if it exists), even if the line item is hidden.