### PR TITLE
Add free shipping coupon unit test for WC_Discounts

### DIFF
--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -372,4 +372,19 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		$coupon->delete( true );
 	}
+
+	public function test_free_shipping_coupon_no_products() {
+		$discounts = new WC_Discounts();
+		$coupon = WC_Helper_Coupon::create_coupon( 'freeshipping' );
+		$coupon->set_props( array(
+			'discount_type' => 'percent',
+			'amount' => '',
+			'free_shipping' => 'yes',
+		));
+
+		$discounts->apply_coupon( $coupon );
+
+		$all_discounts = $discounts->get_discounts();
+		$this->assertEquals( 0, array_sum( $all_discounts['freeshipping'] ), 'Free shipping coupon returned an unexpected amount.' );
+	}
 }


### PR DESCRIPTION
In my work testing with coupons, I tried applying a coupon that only had free shipping on it. When I went to apply it to my WC_Discounts object I was getting the following warning:

`Warning: A non-numeric value encountered in /var/www/html/store/wp-content/plugins/woocommerce/includes/class-wc-discounts.php on line 365`

That line is the following:

`$cart_total_discount = wc_cart_round_discount( $cart_total * ( $coupon->get_amount() / 100 ), 0 );`

As you can see, it's assuming that `$coupon->get_amount()` will return a number. Instead, in the case of a free shipping-only coupon, the amount that's returned is an empty string. Hence, the warning. This unit test tests for this, but it doesn't resolve the issue as I'm not sure what is the right way to resolve this.

This error occurs when the unit test applies the coupon to the `$discounts` object. Obviously, this unit test is failing because it is meant to point out a bug.

On a side note, if [PR 16768](https://github.com/woocommerce/woocommerce/pull/16768) gets merged in, I'll resubmit a free shipping unit test using that method.