### PR TITLE
Bugfix: Resolve 'non-numeric value encountered' error in PHP 7.1 when freeshipping coupon used

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -335,6 +335,9 @@ class WC_Discounts {
 		$total_discount = 0;
 		$cart_total     = 0;
 
+		// Because get_amount() could return an empty string, let's be sure to set our local variable to a known good value.
+		$coupon_amount  = ( '' === $coupon->get_amount() ) ? 0 : $coupon->get_amount();
+
 		foreach ( $items_to_apply as $item ) {
 			// Find out how much price is available to discount for the item.
 			$discounted_price  = $this->get_discounted_price_in_cents( $item );
@@ -346,7 +349,7 @@ class WC_Discounts {
 			$cart_total += $price_to_discount;
 
 			// Run coupon calculations.
-			$discount = floor( $price_to_discount * ( $coupon->get_amount() / 100 ) );
+			$discount = floor( $price_to_discount * ( $coupon_amount / 100 ) );
 
 			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
@@ -360,8 +363,8 @@ class WC_Discounts {
 			$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;
 		}
 
-		// Work out how much discount would have been given to the cart has a whole and compare to what was discounted on all line items.
-		$cart_total_discount = wc_cart_round_discount( $cart_total * ( $coupon->get_amount() / 100 ), 0 );
+		// Work out how much discount would have been given to the cart as a whole and compare to what was discounted on all line items.
+		$cart_total_discount = wc_cart_round_discount( $cart_total * ( $coupon_amount / 100 ), 0 );
 
 		if ( $total_discount < $cart_total_discount ) {
 			$total_discount += $this->apply_coupon_remainder( $coupon, $items_to_apply, $cart_total_discount - $total_discount );

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -372,4 +372,19 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		$coupon->delete( true );
 	}
+
+	public function test_free_shipping_coupon_no_products() {
+		$discounts = new WC_Discounts();
+		$coupon = WC_Helper_Coupon::create_coupon( 'freeshipping' );
+		$coupon->set_props( array(
+			'discount_type' => 'percent',
+			'amount' => '',
+			'free_shipping' => 'yes',
+		));
+
+		$discounts->apply_coupon( $coupon );
+
+		$all_discounts = $discounts->get_discounts();
+		$this->assertEquals( 0, count( $all_discounts['freeshipping'] ), 'Free shipping coupon should not have any discounts.' );
+	}
 }


### PR DESCRIPTION
In my work testing with coupons, I tried applying a coupon that only had free shipping on it. When I went to apply it to my WC_Discounts object I was getting the following warning:

`Warning: A non-numeric value encountered in /var/www/html/store/wp-content/plugins/woocommerce/includes/class-wc-discounts.php on line 365`

That line is the following:

`$cart_total_discount = wc_cart_round_discount( $cart_total * ( $coupon->get_amount() / 100 ), 0 );`

As you can see, it was assuming that `$coupon->get_amount()` will return a number. Instead, in the case of a free shipping-only coupon, the amount that's returned is an empty string. Hence, the warning. This warning only seems to happen in PHP 7.1.