### PR TITLE
Increase delay for json_search_customers

### DIFF
--- a/assets/js/admin/wc-enhanced-select.js
+++ b/assets/js/admin/wc-enhanced-select.js
@@ -164,7 +164,7 @@ jQuery( function( $ ) {
 						ajax: {
 							url:         wc_enhanced_select_params.ajax_url,
 							dataType:    'json',
-							delay:       250,
+							delay:       1000,
 							data:        function( params ) {
 								return {
 									term:     params.term,


### PR DESCRIPTION
Increases the delay for `woocommerce_json_search_customers` to 1000, to prevent a lot of unneeded queries from happening. 

Fixes #16805.