### PR TITLE
add filter to change help video list

### DIFF
--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -158,6 +158,7 @@ class WC_Admin_Help {
 				'id'    => 'n8n0sa8hee',
 			),
 		);
+		$video_map = apply_filters( 'woocommerce_help_videos', $video_map );
 
 		$page      = empty( $_GET['page'] ) ? '' : sanitize_title( $_GET['page'] );
 		$tab       = empty( $_GET['tab'] ) ? '' : sanitize_title( $_GET['tab'] );


### PR DESCRIPTION
The video service requests a file from wistia.net, and that also uses a library hosted on a 3rd domain ( litix.io ). If there's strict rules about these resources loaded from third party, there will be errors ( https://wordpress.org/support/topic/wistia-js-errors/, https://wordpress.org/support/topic/error-mux-js/ ). 

This way, its possible to prevent the errors and allow others to opt out of loading 3rd party resources.