### PR TITLE
Only set prices if set in request for legacy API

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1034,7 +1034,7 @@ class WC_API_Products extends WC_API_Resource {
 			$product->set_attributes( $attributes );
 		}
 
-		// Sales and prices
+		// Sales and prices.
 		if ( in_array( $product->get_type(), array( 'variable', 'grouped' ) ) ) {
 
 			// Variable and grouped products have no prices.
@@ -1046,22 +1046,17 @@ class WC_API_Products extends WC_API_Resource {
 
 		} else {
 
-			// Regular Price
+			// Regular Price.
 			if ( isset( $data['regular_price'] ) ) {
 				$regular_price = ( '' === $data['regular_price'] ) ? '' : $data['regular_price'];
-			} else {
-				$regular_price = $product->get_regular_price();
+				$product->set_regular_price( $regular_price );
 			}
 
-			// Sale Price
+			// Sale Price.
 			if ( isset( $data['sale_price'] ) ) {
 				$sale_price = ( '' === $data['sale_price'] ) ? '' : $data['sale_price'];
-			} else {
-				$sale_price = $product->get_sale_price();
+				$product->set_sale_price( $sale_price );
 			}
-
-			$product->set_regular_price( $regular_price );
-			$product->set_sale_price( $sale_price );
 
 			if ( isset( $data['sale_price_dates_from'] ) ) {
 				$date_from = $data['sale_price_dates_from'];

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1536,22 +1536,17 @@ class WC_API_Products extends WC_API_Resource {
 
 		} else {
 
-			// Regular Price
+			// Regular Price.
 			if ( isset( $data['regular_price'] ) ) {
 				$regular_price = ( '' === $data['regular_price'] ) ? '' : $data['regular_price'];
-			} else {
-				$regular_price = $product->get_regular_price();
+				$product->set_regular_price( $regular_price );
 			}
 
-			// Sale Price
+			// Sale Price.
 			if ( isset( $data['sale_price'] ) ) {
 				$sale_price = ( '' === $data['sale_price'] ) ? '' : $data['sale_price'];
-			} else {
-				$sale_price = $product->get_sale_price();
+				$product->set_sale_price( $sale_price );
 			}
-
-			$product->set_regular_price( $regular_price );
-			$product->set_sale_price( $sale_price );
 
 			if ( isset( $data['sale_price_dates_from'] ) ) {
 				$date_from = $data['sale_price_dates_from'];


### PR DESCRIPTION
Fixes #16826 

I've also tested that scenario in the modern APIs, and they do not have the problem.

Easy test:

Add the filter somewhere:
```
add_filter( 'woocommerce_product_get_sale_price', 'discount_filter', 10, 2);

function discount_filter( $sales_price, $product ) {
	return $sales_price * 0.9;
}

```

In terminal:
```
curl --insecure -X PUT https://local.wordpress.dev/wc-api/v2/products/48 \
    -u key:secret \
    -H "Content-Type: application/json" \
    -d '{
  "product": {
    "title": "newtitle",
    "sku": "newsku"
  }
}'
```
Observe price doesn't change but title and sku do.