### PR TITLE
fixed : custom tab with no class error

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<ul class="product_data_tabs wc-tabs">
 		<?php foreach ( self::get_product_data_tabs() as $key => $tab ) : ?>
-			<li class="<?php echo $key; ?>_options <?php echo $key; ?>_tab <?php echo implode( ' ' , (array) $tab['class'] ); ?>">
+			<li class="<?php echo $key; ?>_options <?php echo $key; ?>_tab <?php echo if(isset($tab['class'])) implode( ' ' , (array) $tab['class'] ); ?>">
 				<a href="#<?php echo $tab['target']; ?>"><span><?php echo esc_html( $tab['label'] ); ?></span></a>
 			</li>
 		<?php endforeach; ?>


### PR DESCRIPTION
when class is not passed with custom tab. echo's undefined index error with classes fixed. throws an error when no class is passed with custom tab

below example throws the error, when a blank array with class passed it fixes it,
```php
public function addTab($product_data_tabs)
{
    $product_data_tabs[$this->tab] = array(
       'label' => __( 'Store Details', $this->text_domain ),
       'target' => $this->tab
    );
    return $product_data_tabs;
}
```

error looks like below,
![image](https://user-images.githubusercontent.com/14835725/30656288-373d7f4c-9e51-11e7-90ab-1c804d5a3a29.png)
