### PR TITLE
Tweak new cart getter filters - use __FUNCTION__ not __METHOD__ to avoid including WC_Cart:: in hook names

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -202,7 +202,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_subtotal() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'subtotal' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'subtotal' ) );
 	}
 
 	/**
@@ -212,7 +212,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_subtotal_tax() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'subtotal_tax' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'subtotal_tax' ) );
 	}
 
 	/**
@@ -222,7 +222,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_discount_total() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'discount_total' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'discount_total' ) );
 	}
 
 	/**
@@ -232,7 +232,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_discount_tax() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'discount_tax' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'discount_tax' ) );
 	}
 
 	/**
@@ -242,7 +242,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_shipping_total() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'shipping_total' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'shipping_total' ) );
 	}
 
 	/**
@@ -252,7 +252,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_shipping_tax() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'shipping_tax' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'shipping_tax' ) );
 	}
 
 	/**
@@ -262,7 +262,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_cart_contents_total() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'cart_contents_total' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'cart_contents_total' ) );
 	}
 
 	/**
@@ -272,7 +272,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_cart_contents_tax() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'cart_contents_tax' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'cart_contents_tax' ) );
 	}
 
 	/**
@@ -283,7 +283,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_total( $context = 'view' ) {
-		$total = apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'total' ) );
+		$total = apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'total' ) );
 		return 'view' === $context ? apply_filters( 'woocommerce_cart_total', wc_price( $total ) ) : $total;
 	}
 
@@ -294,7 +294,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_total_tax() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'total_tax' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'total_tax' ) );
 	}
 
 	/**
@@ -304,7 +304,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_fee_total() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'fee_total' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'fee_total' ) );
 	}
 
 	/**
@@ -314,7 +314,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return float
 	 */
 	public function get_fee_tax() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'fee_tax' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'fee_tax' ) );
 	}
 
 	/**
@@ -323,7 +323,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @since 3.2.0
 	 */
 	public function get_shipping_taxes() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'shipping_taxes' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'shipping_taxes' ) );
 	}
 
 	/**
@@ -332,7 +332,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @since 3.2.0
 	 */
 	public function get_cart_contents_taxes() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'cart_contents_taxes' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'cart_contents_taxes' ) );
 
 	}
 
@@ -342,7 +342,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @since 3.2.0
 	 */
 	public function get_fee_taxes() {
-		return apply_filters( 'woocommerce_cart_' . __METHOD__, $this->get_totals_var( 'fee_taxes' ) );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, $this->get_totals_var( 'fee_taxes' ) );
 	}
 
 	/*


### PR DESCRIPTION
This patch substitutes the use of `__METHOD__` in the new cart filter names introduced with #16517 to use `__FUNCTION__` instead. This avoids those hook names including the `WC_Cart` class name and a double colon/Paamayim Nekudotayim (`::`).

Example hooks from `WC_Cart::get_total()`:

 * Before this PR: `'woocommerce_cart_WC_Cart::get_total'`
 * After this PR: `'woocommerce_cart_get_total'`

I'm assuming the later was the intended hook name. I couldn't see any justification for including `WC_Cart::` in the description on #16517 or SHA: b9fea8419b7. There also doesn't seem to be much benefit to adding `WC_Cart::` as the hooks are already prefixed with `'woocommerce_cart_'`. The use of `::` in a hook name is also inconsistent with other WP/WC hooks. However, if I'm wrong and `WC_Cart::` is required, feel free to close this. 🙂 