### PR TITLE
Add check for 0 as a string

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -243,7 +243,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * @return array
 	 */
 	public function parse_comma_field( $value ) {
-		if ( empty( $value ) ) {
+		if ( empty( $value ) && $value !== '0' ) {
 			return array();
 		}
 


### PR DESCRIPTION
Potential fix for #16884

Opted for checking for a string of 0 based on conversations I've seen:
https://stackoverflow.com/questions/4139301/php-0-as-a-string-with-empty
http://www.webhostingtalk.com/showthread.php?t=501610

There are several other ways to go about it with a second condition like:
$value == null
0 === strlen( $value )

But in this case I figure the fix is for this bug specifically which seems to be an issue with PHP empty().