### PR TITLE
Fix shipping tax when calling WC_Cart::calculate_shipping()

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1282,7 +1282,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		$this->set_shipping_total( array_sum( wp_list_pluck( $this->shipping_methods, 'cost' ) ) );
-		$this->set_shipping_tax( array_sum( $shipping_taxes ) );
+		$this->set_shipping_tax( array_sum( $merged_taxes ) );
 		$this->set_shipping_taxes( $merged_taxes );
 
 		return $this->shipping_methods;


### PR DESCRIPTION
In `WC_Cart::calculate_shipping()`, the `$shipping_taxes` variable contains a multidimensional array. e.g.

```
Array
(
    [0] => Array
        (
            [1] => 2.2
        )

)
```

Because of this, `array_sum()` does not correctly sum the values within that array, meaning the cart's shipping tax total is not set correctly.

The `$merged_taxes` variable is a single level array with all the same taxes already aggregated, so `array_sum()` can be reliably used on it instead to find the correct total tax.