### PR TITLE
Added logic to install the plugins and themes asynchronously without using wp-cron

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -451,18 +451,14 @@ class WC_Admin_Setup_Wizard {
 	 *
 	 * @param string $plugin_id  Plugin id used for background install.
 	 * @param array  $plugin_info Plugin info array containing at least main file and repo slug.
-	 * @param bool   $background Optional. Whether or not to queue the install in the background.
 	 */
-	protected function install_plugin( $plugin_id, $plugin_info, $background = true ) {
+	protected function install_plugin( $plugin_id, $plugin_info ) {
 		if ( ! empty( $plugin_info['file'] ) && is_plugin_active( $plugin_info['file'] ) ) {
 			return;
 		}
 
-		if ( $background ) {
-			wp_schedule_single_event( time() + 10, 'woocommerce_plugin_background_installer', array( $plugin_id, $plugin_info ) );
-		} else {
-			WC_Install::background_installer( $plugin_id, $plugin_info );
-		}
+		wp_schedule_single_event( time() + 10, 'woocommerce_plugin_background_installer', array( $plugin_id, $plugin_info ) );
+		// WC_Install::background_installer( $plugin_id, $plugin_info );
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -24,6 +24,9 @@ class WC_Admin_Setup_Wizard {
 	/** @var array Steps for the setup wizard */
 	private $steps  = array();
 
+	/** @var array Actions to be executed after the HTTP response has completed */
+	private $deferred_actions  = array();
+
 	/** @var array Tweets user can optionally send after install */
 	private $tweets = array(
 		'Someone give me woo-t, I just set up a new store with #WordPress and @WooCommerce!',
@@ -447,6 +450,41 @@ class WC_Admin_Setup_Wizard {
 	}
 
 	/**
+	 * Finishes replying to the client, but keeps the process running for further (async) code execution.
+	 * @see https://core.trac.wordpress.org/ticket/41358
+	 */
+	protected function close_http_connection() {
+		// Only 1 PHP process can access a session object at a time, close this so the next request isn't kept waiting.
+		if ( session_id() ) {
+			session_write_close();
+		}
+		set_time_limit( 0 );
+		// fastcgi_finish_request is the cleanest way to send the response and keep the script running, but not every server has it.
+		if ( is_callable( 'fastcgi_finish_request' ) ) {
+			fastcgi_finish_request();
+		} else {
+			// Fallback: send headers and flush buffers.
+			if ( ! headers_sent() ) {
+				header( 'Connection: close' );
+			}
+			@ob_end_flush();
+			flush();
+		}
+	}
+
+	/**
+	 * Function called after the HTTP request is finished, so it's executed without the client having to wait for it.
+	 * @see WC_Admin_Setup_Wizard::install_plugin
+	 * @see WC_Admin_Setup_Wizard::install_theme
+	 */
+	public function run_deferred_actions() {
+		$this->close_http_connection();
+		foreach ( $this->deferred_actions as $action ) {
+			call_user_func_array( $action['func'], $action['args'] );
+		}
+	}
+
+	/**
 	 * Helper method to queue the background install of a plugin.
 	 *
 	 * @param string $plugin_id  Plugin id used for background install.
@@ -456,14 +494,29 @@ class WC_Admin_Setup_Wizard {
 		if ( ! empty( $plugin_info['file'] ) && is_plugin_active( $plugin_info['file'] ) ) {
 			return;
 		}
-
-		wp_schedule_single_event( time() + 10, 'woocommerce_plugin_background_installer', array( $plugin_id, $plugin_info ) );
-		// WC_Install::background_installer( $plugin_id, $plugin_info );
+		if ( empty( $this->deferred_actions ) ) {
+			add_action( 'shutdown', array( $this, 'run_deferred_actions' ) );
+		}
+		array_push( $this->deferred_actions, array(
+			'func' => array( 'WC_Install', 'background_installer' ),
+			'args' => array( $plugin_id, $plugin_info )
+		) );
 	}
 
+
+	/**
+	 * Helper method to queue the background install of a theme.
+	 *
+	 * @param string $theme_id  Theme id used for background install.
+	 */
 	protected function install_theme( $theme_id ) {
-		wp_schedule_single_event( time() + 1, 'woocommerce_theme_background_installer', array( $theme_id ) );
-		// WC_Install::theme_background_installer( $theme_id );
+		if ( empty( $this->deferred_actions ) ) {
+			add_action( 'shutdown', array( $this, 'run_deferred_actions' ) );
+		}
+		array_push( $this->deferred_actions, array(
+			'func' => array( 'WC_Install', 'theme_background_installer' ),
+			'args' => array( $theme_id )
+		) );
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -461,6 +461,11 @@ class WC_Admin_Setup_Wizard {
 		// WC_Install::background_installer( $plugin_id, $plugin_info );
 	}
 
+	protected function install_theme( $theme_id ) {
+		wp_schedule_single_event( time() + 1, 'woocommerce_theme_background_installer', array( $theme_id ) );
+		// WC_Install::theme_background_installer( $theme_id );
+	}
+
 	/**
 	 * Helper method to install Jetpack.
 	 */
@@ -1180,7 +1185,7 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		if ( $install_storefront ) {
-			wp_schedule_single_event( time() + 1, 'woocommerce_theme_background_installer', array( 'storefront' ) );
+			$this->install_theme( 'storefront' );
 		}
 
 		wp_redirect( esc_url_raw( $this->get_next_step_link() ) );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -467,19 +467,15 @@ class WC_Admin_Setup_Wizard {
 
 	/**
 	 * Helper method to install Jetpack.
-	 *
-	 * @param bool $now Optional. Whether or not to queue the install.
 	 */
-	protected function install_jetpack( $now = false ) {
+	protected function install_jetpack() {
 		$this->install_plugin( 'jetpack', array(
 			'file'      => 'jetpack/jetpack.php',
 			'name'      => __( 'Jetpack', 'woocommerce' ),
 			'repo-slug' => 'jetpack',
-		), ! $now );
+		) );
 
-		if ( ! $now ) {
-			update_option( 'woocommerce_setup_queued_jetpack_install', true );
-		}
+		update_option( 'woocommerce_setup_queued_jetpack_install', true );
 	}
 
 	/**


### PR DESCRIPTION
Currently (even in the currently released WC version), the setup wizard uses `wp-cron` to enqueue async installs of themes (Storefront) and plugins (Paypal, Stripe, etc). With the changes from https://github.com/woocommerce/woocommerce/pull/16755, the enqueuing logic is the same (using `wp-cron` to run the installs a few seconds into the future), but now there are more plugins to install (Jetpack, WooCommerce Services).

`wp-cron` seems to me too fragile for this task. Many guides recommend switching it to "real" cron (in that case our code wouldn't work at all), and running it depends on any user loading any page in the future. Overall, it seems that it's not the best solution, specially since we just want to install the plugins/themes "as soon as possible" without making the user wait to show the next step of the wizard.

This PR implements a different mechanism:
* The plugins/themes to install are stored in a list.
* A `shutdown` hook is added.
* In that hook, the HTTP connection is closed so the client can finish rendering the page.
* After closing the connection, the plugins and themes are installed normally.

I've checked in my local server (Apache, without the FastCGI module) and it works fine.

PS: I'm fine if this doesn't make it to the `3.2` release, if you folks consider this is too big a change I'll cherrypick my changes and rebase them on `master`.