### PR TITLE
Handle sale dates on the fly in case of missed cron schedule.

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -318,6 +318,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			'download_expiry'    => get_post_meta( $id, '_download_expiry', true ),
 			'image_id'           => get_post_thumbnail_id( $id ),
 		) );
+
+		// Handle sale dates on the fly in case of missed cron schedule.
+		if ( $product->is_on_sale( 'edit' ) && $product->get_sale_price( 'edit' ) !== $product->get_price( 'edit' ) ) {
+			update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
+			$product->set_price( $product->get_sale_price( 'edit' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Closes #16907

To test, via the DB, set the sale price to 1, regular price to 300, sale price date from to a timestamp in the past and view a product page. The correct sale price should be displayed, and the DB values should update.