### PR TITLE
Load up gateways on ajax order status transitions

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -459,10 +459,10 @@ class WC_AJAX {
 			$status = sanitize_text_field( $_GET['status'] );
 			$order  = wc_get_order( absint( $_GET['order_id'] ) );
 
-			// Initialize payment gateways in case order has hooked status transition actions.
-			wc()->payment_gateways();
-
 			if ( wc_is_order_status( 'wc-' . $status ) && $order ) {
+				// Initialize payment gateways in case order has hooked status transition actions.
+				wc()->payment_gateways();
+
 				$order->update_status( $status, '', true );
 				do_action( 'woocommerce_order_edit_status', $order->get_id(), $status );
 			}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -459,6 +459,9 @@ class WC_AJAX {
 			$status = sanitize_text_field( $_GET['status'] );
 			$order  = wc_get_order( absint( $_GET['order_id'] ) );
 
+			// Initialize payment gateways in case order has hooked status transition actions.
+			wc()->payment_gateways();
+
 			if ( wc_is_order_status( 'wc-' . $status ) && $order ) {
 				$order->update_status( $status, '', true );
 				do_action( 'woocommerce_order_edit_status', $order->get_id(), $status );


### PR DESCRIPTION
Fixes #16802

To test: 
1. Set up PayPal with Authorize setting in WC.
2. Place an order.
3. Change the order status to "Completed" using the button on the "Orders" screen.
4. Verify `WC_Gateway_Paypal::capture_payment` fired.

cc @FreshPhil 