### PR TITLE
[REST API] Return empty result when there is no on_sale products

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -281,8 +281,13 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 
 		// Filter by on sale products.
 		if ( is_bool( $request['on_sale'] ) ) {
-			$on_sale_key           = $request['on_sale'] ? 'post__in' : 'post__not_in';
-			$args[ $on_sale_key ] += wc_get_product_ids_on_sale();
+			$on_sale_key = $request['on_sale'] ? 'post__in' : 'post__not_in';
+			$on_sale_ids = wc_get_product_ids_on_sale();
+
+			// Use 0 when there's no on sale products to avoid return all products.
+			$on_sale_ids = empty( $on_sale_ids ) ? array( 0 ) : $on_sale_ids;
+
+			$args[ $on_sale_key ] += $on_sale_ids;
 		}
 
 		// Force the post_type argument, since it's not a user input variable.


### PR DESCRIPTION
This forces return an empty array as result when using `on_sale=true` on products endpoint.

By default `WP_Query` will return all results when `post__in` is equal to `array()`, so changing to `array( 0 )` will force the expected behavior.

Closes #16933