### PR TITLE
Save order paid date as GMT+0

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -259,7 +259,7 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function maybe_set_date_paid() {
 		if ( ! $this->get_date_paid( 'edit' ) && $this->has_status( apply_filters( 'woocommerce_payment_complete_order_status', $this->needs_processing() ? 'processing' : 'completed', $this->get_id(), $this ) ) ) {
-			$this->set_date_paid( current_time( 'timestamp' ) );
+			$this->set_date_paid( current_time( 'timestamp', true ) );
 		}
 	}
 


### PR DESCRIPTION
All dates should be saved as GMT+0 in order to make `WC_DateTime` work correct.

Fixes #16932