### PR TITLE
Fix admin coupon apply logic

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -897,11 +897,18 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( is_a( $raw_coupon, 'WC_Coupon' ) ) {
 			$coupon = $raw_coupon;
 		} elseif ( is_string( $raw_coupon ) ) {
-			$code   = wc_format_coupon_code( $raw_coupon );
-			$coupon = new WC_Coupon( $code );
+			$code      = wc_format_coupon_code( $raw_coupon );
+			$coupon    = new WC_Coupon( $code );
 
-			if ( $coupon->get_code() !== $code || ! $coupon->is_valid() ) {
+			if ( $coupon->get_code() !== $code ) {
 				return new WP_Error( 'invalid_coupon', __( 'Invalid coupon code', 'woocommerce' ) );
+			}
+
+			$discounts = new WC_Discounts( $this );
+			$valid     = $discounts->is_coupon_valid( $coupon );
+
+			if ( is_wp_error( $valid ) ) {
+				return $valid;
 			}
 		} else {
 			return new WP_Error( 'invalid_coupon', __( 'Invalid coupon', 'woocommerce' ) );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -928,8 +928,11 @@ class WC_AJAX {
 		try {
 			$order_id = absint( $_POST['order_id'] );
 			$order    = wc_get_order( $order_id );
+			$result   = $order->apply_coupon( wc_clean( $_POST['coupon'] ) );
 
-			$order->apply_coupon( wc_clean( $_POST['coupon'] ) );
+			if ( is_wp_error( $result ) ) {
+				throw new Exception( $result->get_error_message() );
+			}
 
 			ob_start();
 			include( 'admin/meta-boxes/views/html-order-items.php' );


### PR DESCRIPTION
Fixes validation by using the discounts class and passing order as the context.

Also fixes the appearance of validation messages when applying the coupon by throwing an exception.

Closes #16952