### PR TITLE
Added actions before calculations order totals and taxes

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1289,6 +1289,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param array $args Added in 3.0.0 to pass things like location.
 	 */
 	public function calculate_taxes( $args = array() ) {
+		do_action( 'woocommerce_order_before_calculate_taxes', $args, $this );
+
 		$calculate_tax_for  = $this->get_tax_location( $args );
 		$shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
 
@@ -1368,6 +1370,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float calculated grand total.
 	 */
 	public function calculate_totals( $and_taxes = true ) {
+		do_action( 'woocommerce_order_before_calculate_totals', $and_taxes, $this );
+
 		$cart_subtotal      = 0;
 		$cart_total         = 0;
 		$fee_total          = 0;

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1298,13 +1298,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$shipping_tax_class = current( array_intersect( array_merge( array( '' ), WC_Tax::get_tax_class_slugs() ), $this->get_items_tax_classes() ) );
 		}
 
+		$is_vat_exempt = apply_filters( 'woocommerce_order_is_vat_exempt', 'yes' === $this->get_meta( 'is_vat_exempt' ) );
+
 		// Trigger tax recalculation for all items.
 		foreach ( $this->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
-			$item->calculate_taxes( $calculate_tax_for );
+			$item->calculate_taxes( $calculate_tax_for, $is_vat_exempt );
 		}
 
 		foreach ( $this->get_shipping_methods() as $item_id => $item ) {
-			$item->calculate_taxes( array_merge( $calculate_tax_for, array( 'tax_class' => $shipping_tax_class ) ) );
+			$item->calculate_taxes( array_merge( $calculate_tax_for, array( 'tax_class' => $shipping_tax_class ) ), $is_vat_exempt );
 		}
 
 		$this->update_taxes();

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -66,17 +66,18 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 *
 	 * @since  3.2.0
 	 * @param  array $calculate_tax_for Location data to get taxes for. Required.
+	 * @param  bool $is_vat_exempt Indicates if the order should not have VAT applied to it.
 	 * @return bool  True if taxes were calculated.
 	 */
-	public function calculate_taxes( $calculate_tax_for = array() ) {
+	public function calculate_taxes( $calculate_tax_for = array(), $is_vat_exempt = false ) {
 		if ( ! isset( $calculate_tax_for['country'], $calculate_tax_for['state'], $calculate_tax_for['postcode'], $calculate_tax_for['city'] ) ) {
 			return false;
 		}
 		// Use regular calculation unless the fee is negative.
 		if ( 0 <= $this->get_total() ) {
-			return parent::calculate_taxes( $calculate_tax_for );
+			return parent::calculate_taxes( $calculate_tax_for, $is_vat_exempt );
 		}
-		if ( wc_tax_enabled() && ( $order = $this->get_order() ) ) {
+		if ( ! $is_vat_exempt && wc_tax_enabled() && ( $order = $this->get_order() ) ) {
 			// Apportion taxes to order items, shipping, and fees.
 			$order           = $this->get_order();
 			$tax_class_costs = $this->get_tax_class_costs( $order );

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -33,13 +33,14 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	 *
 	 * @since  3.2.0
 	 * @param  array $calculate_tax_for Location data to get taxes for. Required.
+	 * @param  bool $is_vat_exempt Indicates if the order should not have VAT applied to it.
 	 * @return bool  True if taxes were calculated.
 	 */
-	public function calculate_taxes( $calculate_tax_for = array() ) {
+	public function calculate_taxes( $calculate_tax_for = array(), $is_vat_exempt = false ) {
 		if ( ! isset( $calculate_tax_for['country'], $calculate_tax_for['state'], $calculate_tax_for['postcode'], $calculate_tax_for['city'], $calculate_tax_for['tax_class'] ) ) {
 			return false;
 		}
-		if ( wc_tax_enabled() ) {
+		if ( ! $is_vat_exempt && wc_tax_enabled() ) {
 			$tax_rates = WC_Tax::find_shipping_rates( $calculate_tax_for );
 			$taxes     = WC_Tax::calc_tax( $this->get_total(), $tax_rates, false );
 			$this->set_taxes( array( 'total' => $taxes ) );

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -203,13 +203,14 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 *
 	 * @since  3.2.0
 	 * @param  array $calculate_tax_for Location data to get taxes for. Required.
+	 * @param  bool $is_vat_exempt Indicates if the order should not have VAT applied to it.
 	 * @return bool  True if taxes were calculated.
 	 */
-	public function calculate_taxes( $calculate_tax_for = array() ) {
+	public function calculate_taxes( $calculate_tax_for = array(), $is_vat_exempt = false ) {
 		if ( ! isset( $calculate_tax_for['country'], $calculate_tax_for['state'], $calculate_tax_for['postcode'], $calculate_tax_for['city'] ) ) {
 			return false;
 		}
-		if ( '0' !== $this->get_tax_class() && 'taxable' === $this->get_tax_status() && wc_tax_enabled() ) {
+		if ( ! $is_vat_exempt && '0' !== $this->get_tax_class() && 'taxable' === $this->get_tax_status() && wc_tax_enabled() ) {
 			$calculate_tax_for['tax_class'] = $this->get_tax_class();
 			$tax_rates                      = WC_Tax::find_rates( $calculate_tax_for );
 			$taxes                          = WC_Tax::calc_tax( $this->get_total(), $tax_rates, false );


### PR DESCRIPTION
Added two new actions, triggered before the calculation of order totals and taxes.

## Use case
During the checkout process, WooCommerce allows to apply a tax exemption on the customer, by calling `WC()->customer->set_is_vat_exempt()`. Doing so ensures that taxes are not applied. At the moment, there isn't anything equivalent for an existing order. Due to that, the following can happen:

1. A VAT exempt customer places an order on the frontend.
2. An order is created, without taxes, upon completion of checkout.
3. An Admin edits the order.
4. When the Admin uses the "Recalculate" function, the order totals and taxes are updated. The exemption that was applied at step 2 is ignored, and the taxes are added to the order.
5. The admin has to remove the taxes manually.

The new actions will allow 3rd parties to inspect the order for which totals are being (re)calculated and disable/remove taxes, if the criteria for the exemption is met, before the operation occurs. 