### PR TITLE
Lock install routine to only allow for one execution

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -165,6 +165,13 @@ class WC_Install {
 			return;
 		}
 
+		// Check if we are not already running this routine.
+		if ( 'yes' === get_transient( 'wc_installing' ) ) {
+			return;
+		}
+
+		// If we made it till here nothing is running yet, lets set the transient now.
+		set_transient( 'wc_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 		wc_maybe_define_constant( 'WC_INSTALLING', true );
 
 		self::remove_admin_notices();
@@ -178,6 +185,8 @@ class WC_Install {
 		self::maybe_enable_setup_wizard();
 		self::update_wc_version();
 		self::maybe_update_db_version();
+
+		delete_transient( 'wc_installing' );
 
 		do_action( 'woocommerce_flush_rewrite_rules' );
 		do_action( 'woocommerce_installed' );


### PR DESCRIPTION
Due to the check_version method running on init it can fire multiple times during a page load causing race condition when doing a new install.

This PR adds a transient lock to ensure we are only running this once.