### PR TITLE
added actions and filters to modify tax calculation for shipping taxes and fee taxes #16938

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -313,7 +313,7 @@ final class WC_Cart_Totals {
 				}
 			}
 
-			$fee->taxes = apply_filters( 'woocommerce_get_fees_from_cart_taxes', $fee->taxes, $fee, $this );
+			$fee->taxes = apply_filters( 'woocommerce_cart_totals_get_fees_from_cart_taxes', $fee->taxes, $fee, $this );
 
 			$fee->total_tax = array_sum( $fee->taxes );
 

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -313,6 +313,8 @@ final class WC_Cart_Totals {
 				}
 			}
 
+			$fee->taxes = apply_filters( 'woocommerce_get_fees_from_cart_taxes', $fee->taxes, $fee, $this );
+
 			$fee->total_tax = array_sum( $fee->taxes );
 
 			if ( ! $this->round_at_subtotal() ) {

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -96,6 +96,9 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 		} else {
 			$this->set_taxes( false );
 		}
+		
+		do_action( 'woocommerce_order_item_fee_after_calculate_taxes', $this, $calculate_tax_for );
+
 		return true;
 	}
 

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -46,6 +46,9 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 		} else {
 			$this->set_taxes( false );
 		}
+
+		do_action( 'woocommerce_order_item_shipping_after_calculate_taxes', $this, $calculate_tax_for );
+
 		return true;
 	}
 

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -223,6 +223,9 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		} else {
 			$this->set_taxes( false );
 		}
+
+		do_action( 'woocommerce_order_item_after_calculate_taxes', $this, $calculate_tax_for );
+
 		return true;
 	}
 


### PR DESCRIPTION
Filters and actions are needed to ensure correct tax calculation by
German law.

The filter in class-wc-cart-totals.php is used to modify fee tax
calculation during checkout and in cart.

The actions in the other files are used to modify tax calculation in
backend for manual orders.