### PR TITLE
try to get existing attribute id from taxonomy.

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -767,6 +767,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					$attribute_id   = absint( $attribute['id'] );
 					$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
 				} elseif ( ! empty( $attribute['name'] ) ) {
+					$attribute_id   = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
 					$attribute_name = wc_clean( $attribute['name'] );
 				}
 


### PR DESCRIPTION
try to retrieve the existing taxonomy attribute id by name, defaults back to 0 if it does not exist.