### PR TITLE
Attribute name find

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -768,7 +768,9 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
 				} elseif ( ! empty( $attribute['name'] ) ) {
 					$attribute_id   = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
-					$attribute_name = wc_clean( $attribute['name'] );
+					if($attribute['global']) {
+						$attribute_name = wc_clean( $attribute['name'] );
+					}
 				}
 
 				if ( ! $attribute_id && ! $attribute_name ) {

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -767,6 +767,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					$attribute_id   = absint( $attribute['id'] );
 					$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
 				} elseif ( ! empty( $attribute['name'] ) ) {
+					$attribute_id   = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
 					$attribute_name = wc_clean( $attribute['name'] );
 				}
 

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -767,10 +767,10 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					$attribute_id   = absint( $attribute['id'] );
 					$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
 				} elseif ( ! empty( $attribute['name'] ) ) {
-					$attribute_id   = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
 					if($attribute['global']) {
-						$attribute_name = wc_clean( $attribute['name'] );
+						$attribute_id   = wc_attribute_taxonomy_id_by_name( $attribute['name'] );
 					}
+					$attribute_name = wc_clean( $attribute['name'] );
 				}
 
 				if ( ! $attribute_id && ! $attribute_name ) {


### PR DESCRIPTION
if attribute defines 'global'=true, then
try to retrieve the existing taxonomy attribute id by name, defaults back to 0 if it does not exist.

This would be helpful if you want to ensure the use of global attributes if they exist which is helpful for cross linking products.