### PR TITLE
Order Item unit tests

### DIFF
--- a/tests/unit-tests/order-items/order-item-coupon.php
+++ b/tests/unit-tests/order-items/order-item-coupon.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Order Item Coupon Tests.
+ * @package WooCommerce\Tests\Order_Items
+ * @since 3.2.0
+ */
+class WC_Tests_Order_Item_Coupon extends WC_Unit_Test_Case {
+
+	/**
+	 * Test the setter and getter methods.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_setters_getters() {
+		$coupon = new WC_Order_Item_Coupon;
+
+		$coupon->set_name( 'testcoupon' );
+		$this->assertTrue( 'testcoupon' === $coupon->get_name() && $coupon->get_name() === $coupon->get_code() );
+		$coupon->set_code( 'testcoupon2' );
+		$this->assertTrue( 'testcoupon2' === $coupon->get_name() && $coupon->get_name() === $coupon->get_code() );
+
+		$coupon->set_discount( '5.00' );
+		$this->assertEquals( '5.00', $coupon->get_discount() );
+
+		$coupon->set_discount_tax( '0.50' );
+		$this->assertEquals( '0.50', $coupon->get_discount_tax() );
+	}
+}

--- a/tests/unit-tests/order-items/order-item-fee.php
+++ b/tests/unit-tests/order-items/order-item-fee.php
@@ -8,66 +8,28 @@
 class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {
 
 	/**
-	 * Test set_amount and get_amount methods of WC_Order_Item_Fee.
+	 * Test WC_Order_Item_Fee setters and getters.
 	 *
 	 * @since 3.2.0
 	 */
-	public function test_set_get_amount() {
+	public function test_setters_getters() {
 		$fee = new WC_Order_Item_Fee;
+
 		$fee->set_amount( '20.00' );
 		$this->assertEquals( '20.00', $fee->get_amount() );
-	}
 
-	/**
-	 * Test set_tax_class and get_tax_class methods of WC_Order_Item_Fee.
-	 *
-	 * @since 3.2.0
-	 */
-	public function test_set_get_tax_class() {
-		$old_classes = get_option( 'woocommerce_tax_classes' );
-		update_option( 'woocommerce_tax_classes', 'testclass' );
+		$fee->set_tax_class( 'reduced-rate' );
+		$this->assertEquals( 'reduced-rate', $fee->get_tax_class() );
 
-		$fee = new WC_Order_Item_Fee;
-		$fee->set_tax_class( 'testclass' );
-		$this->assertEquals( 'testclass', $fee->get_tax_class() );
-
-		// Clean up.
-		update_option( 'woocommerce_tax_classes', $old_classes );
-	}
-
-	/**
-	 * Test set_total and get_total methods of WC_Order_Item_Fee.
-	 *
-	 * @since 3.2.0
-	 */
-	public function test_set_get_total() {
-		$fee = new WC_Order_Item_Fee;
 		$fee->set_total( '15.01' );
 		$this->assertEquals( '15.01', $fee->get_total() );
-	}
 
-	/**
-	 * Test set_total_tax and get_total_tax methods of WC_Order_Item_Fee.
-	 *
-	 * @since 3.2.0
-	 */
-	public function test_set_get_total_tax() {
-		$fee = new WC_Order_Item_Fee;
 		$fee->set_total_tax( '5.01' );
 		$this->assertEquals( '5.01', $fee->get_total_tax() );
-	}
 
-	/**
-	 * Test set_taxes and get_taxes methods of WC_Order_Item_Fee.
-	 *
-	 * @since 3.2.0
-	 */
-	public function test_set_get_taxes() {
 		$taxes = array(
 			'total' => array( '10', '2.4' ),
 		);
-
-		$fee = new WC_Order_Item_Fee;
 		$fee->set_taxes( $taxes );
 		$this->assertEquals( $taxes, $fee->get_taxes() );
 		$this->assertEquals( '12.4', $fee->get_total_tax() );

--- a/tests/unit-tests/order-items/order-item-fee.php
+++ b/tests/unit-tests/order-items/order-item-fee.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * Order Item Fee Tests.
+ * @package WooCommerce\Tests\Order_Items
+ * @since 3.2.0
+ */
+class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {
+
+	/**
+	 * Test set_amount and get_amount methods of WC_Order_Item_Fee.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_amount() {
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_amount( '20.00' );
+		$this->assertEquals( '20.00', $fee->get_amount() );
+	}
+
+	/**
+	 * Test set_tax_class and get_tax_class methods of WC_Order_Item_Fee.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_tax_class() {
+		$old_classes = get_option( 'woocommerce_tax_classes' );
+		update_option( 'woocommerce_tax_classes', 'testclass' );
+
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_tax_class( 'testclass' );
+		$this->assertEquals( 'testclass', $fee->get_tax_class() );
+
+		// Clean up.
+		update_option( 'woocommerce_tax_classes', $old_classes );
+	}
+
+	/**
+	 * Test set_total and get_total methods of WC_Order_Item_Fee.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_total() {
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_total( '15.01' );
+		$this->assertEquals( '15.01', $fee->get_total() );
+	}
+
+	/**
+	 * Test set_total_tax and get_total_tax methods of WC_Order_Item_Fee.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_total_tax() {
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_total_tax( '5.01' );
+		$this->assertEquals( '5.01', $fee->get_total_tax() );
+	}
+
+	/**
+	 * Test set_taxes and get_taxes methods of WC_Order_Item_Fee.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_taxes() {
+		$taxes = array(
+			'total' => array( '10', '2.4' ),
+		);
+
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_taxes( $taxes );
+		$this->assertEquals( $taxes, $fee->get_taxes() );
+		$this->assertEquals( '12.4', $fee->get_total_tax() );
+	}
+
+	/**
+	 * Test calculate_taxes method of WC_Order_Item_Fee.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_calculate_taxes() {
+		global $wpdb;
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'TAX',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+		$order = WC_Helper_Order::create_order();
+
+		// Positive fee.
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_amount( '5.00' );
+		$fee->set_total( '5.00' );
+		$fee->set_order_id( $order->get_id() );
+
+		$fee->calculate_taxes( array(
+			'country' => 'US',
+			'state' => 'OR',
+			'postcode' => 97266,
+			'city' => 'Portland',
+		) );
+
+		$taxes = $fee->get_taxes();
+		$total_taxes = array_values( $taxes['total'] );
+		$expected = array( '0.5' );
+		$this->assertEquals( $expected, $total_taxes );
+		$this->assertEquals( '0.5', $fee->get_total_tax() );
+
+		// Negative fee.
+		$fee = new WC_Order_Item_Fee;
+		$fee->set_amount( '-5.00' );
+		$fee->set_total( '-5.00' );
+		$fee->set_order_id( $order->get_id() );
+
+		$fee->calculate_taxes( array(
+			'country' => 'US',
+			'state' => 'OR',
+			'postcode' => 97266,
+			'city' => 'Portland',
+		) );
+
+		$taxes = $fee->get_taxes();
+		$total_taxes = array_values( $taxes['total'] );
+		$expected = array( '-0.5' );
+		$this->assertEquals( $expected, $total_taxes );
+		$this->assertEquals( '-0.5', $fee->get_total_tax() );
+
+		// Clean up.
+		WC_Helper_Order::delete_order( $order->get_id() );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
+	}
+}

--- a/tests/unit-tests/order-items/order-item-meta.php
+++ b/tests/unit-tests/order-items/order-item-meta.php
@@ -43,4 +43,57 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 		// Clean up.
 		$item->delete( true );
 	}
+
+	/**
+	 * Test the get_formatted method of WC_Order_Item_Meta.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_get_formatted() {
+		wp_insert_term( 'Testing Categories', 'category', array( 'slug' => 'testing' ) );
+
+		$item = new WC_Order_Item_Fee();
+		$item->add_meta_data( 'regularkey', '1' );
+		$item->add_meta_data( 'category', 'testing' );
+		$item->add_meta_data( '_hiddenkey', '3' );
+		$item->save();
+
+		$meta = new WC_Order_Item_Meta( $item );
+
+		$expected = array( 'regularkey' => '1', 'category' => 'Testing Categories' );
+		$actual = wp_list_pluck( $meta->get_formatted(), 'value', 'key' );
+		$this->assertEquals( $expected, $actual );
+
+		// Clean up.
+		$item->delete( true );
+	}
+
+
+	/**
+	 * Test the display method of WC_Order_Item_Meta.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_display() {
+		$item = new WC_Order_Item_Fee();
+		$item->add_meta_data( 'regularkey', '1' );
+		$item->add_meta_data( 'category', 'testing' );
+		$item->add_meta_data( '_hiddenkey', '3' );
+		$item->save();
+
+		$meta = new WC_Order_Item_Meta( $item );
+
+		$expected = "regularkey: 1, \ncategory: Testing Categories";
+		$flat = $meta->display( true, true );
+		$this->assertEquals( $expected, $flat );
+
+		$not_flat = $meta->display( false, true );
+		$this->assertContains( 'class="variation-regularkey">regularkey:', $not_flat );
+		$this->assertContains( 'class="variation-regularkey"><p>1</p>', $not_flat );
+		$this->assertContains( 'class="variation-category">category:', $not_flat );
+		$this->assertContains( 'class="variation-category"><p>Testing Categories</p>', $not_flat );
+
+		// Clean up.
+		$item->delete( true );
+	}
 }

--- a/tests/unit-tests/order-items/order-item-product.php
+++ b/tests/unit-tests/order-items/order-item-product.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Order Item Product Tests.
+ * @package WooCommerce\Tests\Order_Items
+ * @since 3.2.0
+ */
+class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
+
+	/**
+	 * Test generic setters and getters for WC_Order_Item_Product.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_generic_setters_getters() {
+		$simple_product = new WC_Product_Simple;
+		$simple_product->save();
+
+		$variation_product = new WC_Product_Variation;
+		$variation_product->save();
+
+		$product_item = new WC_Order_Item_Product;
+
+		$product_item->set_quantity( 3 );
+		$this->assertEquals( 3, $product_item->get_quantity() );
+
+		$product_item->set_tax_class( 'reduced-rate' );
+		$this->assertEquals( 'reduced-rate', $product_item->get_tax_class() );
+
+		$product_item->set_product_id( $simple_product->get_id() );
+		$this->assertEquals( $simple_product->get_id(), $product_item->get_product_id() );
+
+		$product_item->set_variation_id( $variation_product->get_id() );
+		$this->assertEquals( $variation_product->get_id(), $product_item->get_variation_id() );
+
+		$product_item->set_subtotal( '12.00' );
+		$this->assertEquals( '12.00', $product_item->get_subtotal() );
+
+		$product_item->set_total( '10.00' );
+		$this->assertEquals( '10.00', $product_item->get_total() );
+
+		$product_item->set_subtotal_tax( '0.50' );
+		$this->assertEquals( '0.50', $product_item->get_subtotal_tax() );
+
+		$product_item->set_total_tax( '0.30' );
+		$this->assertEquals( '0.30', $product_item->get_total_tax() );
+	}
+
+	/**
+	 * Test set_taxes and get_taxes for WC_Order_Item_Product.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_taxes() {
+		$product_item = new WC_Order_Item_Product;
+
+		$taxes = array(
+			'total'    => array( '10', '2.4' ),
+			'subtotal' => array( '12', '3.1' ),
+		);
+		$product_item->set_taxes( $taxes );
+		$this->assertEquals( $taxes, $product_item->get_taxes() );
+		$this->assertEquals( '12.4', $product_item->get_total_tax() );
+		$this->assertEquals( '15.1', $product_item->get_subtotal_tax() );
+	}
+
+	/**
+	 * Test set_product and get_product for WC_Order_Item_Product.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_set_get_product() {
+		$simple_product = new WC_Product_Simple;
+		$simple_product->set_name( 'Test Simple' );
+		$simple_product->set_tax_class( 'reduced-rate' );
+		$simple_product->save();
+
+		$parent_product = new WC_Product_Variable;
+		$parent_product->set_name( 'Test Parent' );
+		$parent_product->save();
+
+		$variation_product = new WC_Product_Variation;
+		$variation_product->set_name( 'Test Variation' );
+		$variation_product->set_parent_id( $parent_product->get_id() );
+		$variation_product->save();
+
+		// Simple product.
+		$product_item = new WC_Order_Item_Product;
+		$product_item->set_product( $simple_product );
+		$this->assertEquals( 'Test Simple', $product_item->get_name() );
+		$this->assertEquals( $simple_product->get_id(), $product_item->get_product_id() );
+		$this->assertEquals( 0, $product_item->get_variation_id() );
+		$this->assertEquals( 'reduced-rate', $product_item->get_tax_class() );
+
+		$retrieved = $product_item->get_product();
+		$this->assertEquals( $simple_product->get_id(), $retrieved->get_id() );
+
+		// Variation product.
+		$product_item = new WC_Order_Item_Product;
+		$product_item->set_product( $variation_product );
+		$this->assertEquals( 'Test Parent', $product_item->get_name() );
+		$this->assertEquals( $parent_product->get_id(), $product_item->get_product_id() );
+		$this->assertEquals( $variation_product->get_id(), $product_item->get_variation_id() );
+		$this->assertEquals( '', $product_item->get_tax_class() );
+
+		$retrieved = $product_item->get_product();
+		$this->assertEquals( $variation_product->get_id(), $retrieved->get_id() );
+	}
+
+	/**
+	 * Test get_item_download_url method for WC_Order_Item_Product.
+	 *
+	 * @since 3.2.0
+	 */
+	public function test_get_item_download_url() {
+		$product = new WC_Product_Simple;
+		$product->save();
+
+		$order = new WC_Order;
+		$order->set_billing_email( 'test@woocommerce.com' );
+		$order->save();
+
+		$product_item = new WC_Order_Item_Product;
+		$product_item->set_product( $product );
+		$product_item->set_order_id( $order->get_id() );
+
+		$expected_regex = '/download_file=.*&order=wc_order_.*&email=test%40woocommerce.com&key=100/';
+		$this->assertRegexp( $expected_regex, $product_item->get_item_download_url( 100 ) );
+	}
+}


### PR DESCRIPTION
There weren't really any tests for the order item classes, so I've added some. I wouldn't expect big gains in test coverage, as some of these lines were being covered throughout the normal course of other tests. This should still increase our coverage and these are going to come in handy if we refactor things.