### PR TITLE
[3.2] Fix duplicated info in WC_Product_Variation::get_formatted_name

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -92,7 +92,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 
 		$formatted_variation_list = wc_get_formatted_variation( $this, true, true );
 
-		return sprintf( '%2$s (%1$s)', $identifier, $this->get_name() ) . '<span class="description">' . $formatted_variation_list . '</span>';
+		return sprintf( '%2$s (%1$s)', $identifier, $this->get_title() ) . '<span class="description">' . $formatted_variation_list . '</span>';
 	}
 
 	/**


### PR DESCRIPTION
`WC_Product_Variation::get_formatted_name` looks like it's showing attribute data twice: Once via `get_name` and once via `wc_get_formatted_variation`: https://cl.ly/363h412T2d33

Replacing `get_name` with `get_title` (parent title) would be a possible fix: https://cl.ly/3m2E0c3x073v