### PR TITLE
Fix warnings for wp_upload_dir on read-only filesystem

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -202,7 +202,7 @@ final class WooCommerce {
 	 * Define WC Constants.
 	 */
 	private function define_constants() {
-		$upload_dir = wp_upload_dir();
+		$upload_dir = wp_upload_dir( null, false );
 
 		$this->define( 'WC_ABSPATH', dirname( WC_PLUGIN_FILE ) . '/' );
 		$this->define( 'WC_PLUGIN_BASENAME', plugin_basename( WC_PLUGIN_FILE ) );


### PR DESCRIPTION
This fixes an issue where the define_constants routing would give a warning on every page load on a read-only filesystem.

By default wp_upload_dir will try and create the folder if it does not exist, passing false to the create param will avoid this. We simply want the location, not try and create it when defining constants.