### PR TITLE
Make e2e tests fail less

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "grunt-wp-i18n": "~1.0.0",
     "istanbul": "^1.0.0-alpha",
     "mocha": "^3.0.2",
-    "wc-e2e-page-objects": "0.3.0"
+    "wc-e2e-page-objects": "0.3.1"
   },
   "engines": {
     "node": ">=6.9.4",

--- a/tests/e2e-tests/cart-page.js
+++ b/tests/e2e-tests/cart-page.js
@@ -17,6 +17,7 @@ test.describe( 'Cart page', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );

--- a/tests/e2e-tests/checkout-page.js
+++ b/tests/e2e-tests/checkout-page.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import test from 'selenium-webdriver/testing';
 import { WebDriverManager, WebDriverHelper as helper } from 'wp-e2e-webdriver';
-import { Helper, PageMap, CheckoutOrderReceivedPage, StoreOwnerFlow, GuestCustomerFlow } from 'wc-e2e-page-objects';
+import { Helper as wcHelper, PageMap, CheckoutOrderReceivedPage, StoreOwnerFlow, GuestCustomerFlow } from 'wc-e2e-page-objects';
 
 chai.use( chaiAsPromised );
 
@@ -31,6 +31,7 @@ test.describe( 'Checkout Page', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 
@@ -59,7 +60,7 @@ test.describe( 'Checkout Page', function() {
 		guest.fromShopAddProductsToCart( 'Flying Ninja', 'Happy Ninja' );
 
 		const checkoutPage = guest.openCheckout();
-		assert.eventually.ok( Helper.waitTillUIBlockNotPresent( driver ) );
+		assert.eventually.ok( wcHelper.waitTillUIBlockNotPresent( driver ) );
 
 		const orderReview = checkoutPage.components.orderReview;
 		assertOrderItem( orderReview, 'Flying Ninja', { qty: '1', total: '$12.00' } );
@@ -72,7 +73,7 @@ test.describe( 'Checkout Page', function() {
 		guest.fromShopAddProductsToCart( 'Flying Ninja', 'Happy Ninja' );
 
 		const checkoutPage = guest.openCheckout();
-		assert.eventually.ok( Helper.waitTillUIBlockNotPresent( driver ) );
+		assert.eventually.ok( wcHelper.waitTillUIBlockNotPresent( driver ) );
 		assert.eventually.ok( checkoutPage.selectPaymentMethod( 'PayPal' ) );
 		assert.eventually.ok( checkoutPage.selectPaymentMethod( 'Direct bank transfer' ) );
 		assert.eventually.ok( checkoutPage.selectPaymentMethod( 'Cash on delivery' ) );
@@ -83,7 +84,7 @@ test.describe( 'Checkout Page', function() {
 		guest.fromShopAddProductsToCart( 'Flying Ninja', 'Happy Ninja' );
 
 		const checkoutPage = guest.open( PAGE.CHECKOUT );
-		assert.eventually.ok( Helper.waitTillUIBlockNotPresent( driver ) );
+		assert.eventually.ok( wcHelper.waitTillUIBlockNotPresent( driver ) );
 
 		const billingDetails = checkoutPage.components.billingDetails;
 		assert.eventually.ok( billingDetails.setFirstName( 'John' ) );
@@ -104,7 +105,7 @@ test.describe( 'Checkout Page', function() {
 		guest.fromShopAddProductsToCart( 'Flying Ninja', 'Happy Ninja' );
 
 		const checkoutPage = guest.open( PAGE.CHECKOUT );
-		assert.eventually.ok( Helper.waitTillUIBlockNotPresent( driver ) );
+		assert.eventually.ok( wcHelper.waitTillUIBlockNotPresent( driver ) );
 		assert.eventually.ok( checkoutPage.checkShipToDifferentAddress() );
 
 		const shippingDetails = checkoutPage.components.shippingDetails;
@@ -114,6 +115,7 @@ test.describe( 'Checkout Page', function() {
 		assert.eventually.ok( shippingDetails.selectCountry( 'united states', 'United States (US)' ) );
 		assert.eventually.ok( shippingDetails.setAddress1( 'addr 1' ) );
 		assert.eventually.ok( shippingDetails.setAddress2( 'addr 2' ) );
+		helper.scrollDown( driver );
 		assert.eventually.ok( shippingDetails.setCity( 'San Francisco' ) );
 		assert.eventually.ok( shippingDetails.selectState( 'cali', 'California' ) );
 		assert.eventually.ok( shippingDetails.setZip( '94107' ) );
@@ -125,7 +127,7 @@ test.describe( 'Checkout Page', function() {
 
 		const checkoutPage = guest.open( PAGE.CHECKOUT );
 		const billingDetails = checkoutPage.components.billingDetails;
-		Helper.waitTillUIBlockNotPresent( driver );
+		wcHelper.waitTillUIBlockNotPresent( driver );
 		billingDetails.setFirstName( 'John' );
 		billingDetails.setLastName( 'Doe' );
 		billingDetails.setCompany( 'Automattic' );
@@ -138,8 +140,9 @@ test.describe( 'Checkout Page', function() {
 		billingDetails.selectState( 'cali', 'California' );
 		billingDetails.setZip( '94107' );
 		checkoutPage.selectPaymentMethod( 'Cash on delivery' );
+		helper.scrollDown( driver );
 		checkoutPage.placeOrder();
-		Helper.waitTillUIBlockNotPresent( driver );
+		wcHelper.waitTillUIBlockNotPresent( driver );
 
 		const orderReceivedPage = new CheckoutOrderReceivedPage( driver, { visit: false } );
 

--- a/tests/e2e-tests/wp-admin/wp-admin-coupon-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-coupon-new.js
@@ -17,6 +17,7 @@ test.describe( 'Add New Coupon Page', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );

--- a/tests/e2e-tests/wp-admin/wp-admin-order-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-order-new.js
@@ -17,6 +17,7 @@ test.describe( 'Add New Order Page', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );

--- a/tests/e2e-tests/wp-admin/wp-admin-product-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-product-new.js
@@ -18,6 +18,7 @@ test.describe( 'Add New Product Page', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );
@@ -66,14 +67,14 @@ test.describe( 'Add New Product Page', function() {
 		attr1.toggle();
 
 		const attr2 = panelAttributes.add();
-		assert.eventually.ok( attr1.displayed() );
+		assert.eventually.ok( attr2.displayed() );
 		attr2.setName( 'attr #2' );
 		attr2.checkVisibleOnTheProductPage();
 		attr2.checkUsedForVariations();
 		attr2.setValue( 'val1 | val2' );
 
 		const attr3 = panelAttributes.add();
-		assert.eventually.ok( attr1.displayed() );
+		assert.eventually.ok( attr3.displayed() );
 		attr3.setName( 'attr #3' );
 		attr3.checkVisibleOnTheProductPage();
 		attr3.checkUsedForVariations();
@@ -92,11 +93,15 @@ test.describe( 'Add New Product Page', function() {
 		var1.checkVirtual();
 		var1.setRegularPrice( '9.99' );
 
+		helper.scrollDown( driver );
+
 		const var2 = panelVaritions.getRow( 2 );
 		var2.toggle();
 		var2.checkEnabled();
 		var2.checkVirtual();
 		var2.setRegularPrice( '11.99' );
+
+		helper.scrollDown( driver );
 
 		const var3 = panelVaritions.getRow( 3 );
 		var3.toggle();

--- a/tests/e2e-tests/wp-admin/wp-admin-wc-settings-general.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-wc-settings-general.js
@@ -18,6 +18,7 @@ test.describe( 'WooCommerce General Settings', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );
@@ -38,11 +39,13 @@ test.describe( 'WooCommerce General Settings', function() {
 		// Set selling location to all countries first, so we can choose california
 		// as base location.
 		settings.selectSellingLocation( 'Sell to all countries' );
+		helper.scrollDown( driver );
 		settings.saveChanges();
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 
 		// Set base location with state CA.
 		settings.selectBaseLocation( 'california', 'United States (US) — California' );
+		helper.scrollDown( driver );
 		settings.saveChanges();
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 
@@ -52,6 +55,7 @@ test.describe( 'WooCommerce General Settings', function() {
 		settings.selectSellingLocation( 'Sell to specific countries' );
 		settings.removeChoiceInSellToSpecificCountries( 'United States (US)' );
 		settings.setSellToSpecificCountries( 'united states', 'United States (US)' );
+		helper.scrollDown( driver );
 		settings.saveChanges();
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 
@@ -60,6 +64,7 @@ test.describe( 'WooCommerce General Settings', function() {
 		settings.setDecimalSeparator( '.' );
 		settings.setNumberOfDecimals( '2' );
 
+		helper.scrollDown( driver );
 		settings.saveChanges();
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 	} );

--- a/tests/e2e-tests/wp-admin/wp-admin-wc-settings-products-downloadable.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-wc-settings-products-downloadable.js
@@ -18,6 +18,7 @@ test.describe( 'WooCommerce Products > Downloadable Products Settings', function
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );

--- a/tests/e2e-tests/wp-admin/wp-admin-wc-settings-tax.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-wc-settings-tax.js
@@ -18,6 +18,7 @@ test.describe( 'WooCommerce Tax Settings', function() {
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
 		driver = manager.getDriver();
+		driver.manage().window().maximize();
 
 		helper.clearCookiesAndDeleteLocalStorage( driver );
 	} );


### PR DESCRIPTION
This has 2 improvements that should dramatically reduce problems we have with e2e tests failing because an element is not on screen:
1. Vertically maximize the browser window before running the tests.
2. Add some scrolling in areas where the desired element is at the other end of the page.

To test:
1. `npm install`
2. `grunt e2e-tests`