### PR TITLE
Save postmeta attachment image reference on import of products via AP rest.

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1078,6 +1078,11 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 				if ( ! empty( $image['name'] ) ) {
 					wp_update_post( array( 'ID' => $attachment_id, 'post_title' => $image['name'] ) );
 				}
+
+				// Set for future reference
+				if ( ! empty( $image['src'] ) ) {
+					update_post_meta( $attachment_id, '_wc_attachment_source', esc_url_raw( $image['src'] ) );
+				}
 			}
 
 			$product->set_gallery_image_ids( $gallery );

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1079,7 +1079,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					wp_update_post( array( 'ID' => $attachment_id, 'post_title' => $image['name'] ) );
 				}
 
-				// Set for future reference
+				// Set the image source if present, for future reference.
 				if ( ! empty( $image['src'] ) ) {
 					update_post_meta( $attachment_id, '_wc_attachment_source', esc_url_raw( $image['src'] ) );
 				}


### PR DESCRIPTION
In the creation of the product via API there is no image reference with imported external url.
This facilitates the verification of the image being imported.