### PR TITLE
Fix bug when parent term is invalid

### DIFF
--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -378,7 +378,8 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 
 			$parent = get_term( (int) $request['parent'], $taxonomy );
 
-			if ( ! $parent ) {
+			// If is null or WP_Error is invalid parent term.
+			if ( ! $parent || is_wp_error( $parent ) ) {
 				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 			}
 

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1078,6 +1078,11 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 				if ( ! empty( $image['name'] ) ) {
 					wp_update_post( array( 'ID' => $attachment_id, 'post_title' => $image['name'] ) );
 				}
+
+				// Set for future reference
+				if ( ! empty( $image['src'] ) ) {
+					update_post_meta( $attachment_id, '_wc_attachment_source', esc_url_raw( $image['src'] ) );
+				}
 			}
 
 			$product->set_gallery_image_ids( $gallery );

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1079,7 +1079,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					wp_update_post( array( 'ID' => $attachment_id, 'post_title' => $image['name'] ) );
 				}
 
-				// Set for future reference
+				// Set the image source if present, for future reference.
 				if ( ! empty( $image['src'] ) ) {
 					update_post_meta( $attachment_id, '_wc_attachment_source', esc_url_raw( $image['src'] ) );
 				}


### PR DESCRIPTION
When parent term is invalid return `null or WP_Error`.
And WP_Error was not being checked.