### PR TITLE
Fixed PHP notice of trying to get property of non-object.

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -310,7 +310,7 @@ abstract class WC_Data {
 		if ( ! empty( $array_keys ) ) {
 			// We don't use the $this->meta_data property directly here because we don't want meta with a null value (i.e. meta which has been deleted via $this->delete_meta_data())
 			if ( $single ) {
-				$value = $meta_data[ current( $array_keys ) ]->value;
+				$value = $meta_data[ current( $array_keys ) ]['value'];
 			} else {
 				$value = array_intersect_key( $meta_data, array_flip( $array_keys ) );
 			}


### PR DESCRIPTION
This PR tries to address the notice by treating metadata item inside `get_meta` as an array, however, we could also always treat it as `WC_Meta_Data` instance by making sure `get_meta_data` always returns an array of `WC_Meta_Data` instances. If you take a look at:

https://github.com/woocommerce/woocommerce/blob/7460189752e06150500f43a7ed3fee566cecde37/includes/abstracts/abstract-wc-data.php#L265-L268

it returns an array.

Fixes #17047.