### PR TITLE
Fix meta data returns in API using JsonSerializable

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -252,19 +252,18 @@ abstract class WC_Data {
 	 * @return bool
 	 */
 	protected function filter_null_meta( $meta ) {
-		$meta = (array) $meta;
-		return ! is_null( $meta['value'] );
+		return ! is_null( $meta->value );
 	}
 
 	/**
 	 * Get All Meta Data.
 	 *
 	 * @since 2.6.0
-	 * @return array
+	 * @return array of objects.
 	 */
 	public function get_meta_data() {
 		$this->maybe_read_meta_data();
-		return array_filter( wc_list_pluck( $this->meta_data, 'get_data' ), array( $this, 'filter_null_meta' ) );
+		return array_filter( $this->meta_data, array( $this, 'filter_null_meta' ) );
 	}
 
 	/**

--- a/includes/class-wc-meta-data.php
+++ b/includes/class-wc-meta-data.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Meta_Data class.
  */
-class WC_Meta_Data {
+class WC_Meta_Data implements JsonSerializable {
 
 	/**
 	 * Current data for metadata
@@ -44,6 +44,15 @@ class WC_Meta_Data {
 	public function __construct( $meta = array() ) {
 		$this->current_data = $meta;
 		$this->apply_changes();
+	}
+
+	/**
+	 * When converted to JSON.
+	 *
+	 * @return object
+	 */
+	public function jsonSerialize() {
+		return $this->get_data();
 	}
 
 	/**


### PR DESCRIPTION
WordPress has a JsonSerializable shim for 5.2 so this should be good to go :)

Closes #17048 
Fixes #17047