### PR TITLE
Update only state fields when updating Mexican States

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -14,15 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Update file paths for 2.0
- *
- * @return void
- */
 function wc_update_200_file_paths() {
 	global $wpdb;
 
-	// Upgrade old style files paths to support multiple file paths.
+	// Upgrade old style files paths to support multiple file paths
 	$existing_file_paths = $wpdb->get_results( "SELECT meta_value, meta_id, post_id FROM {$wpdb->postmeta} WHERE meta_key = '_file_path' AND meta_value != '';" );
 
 	if ( $existing_file_paths ) {
@@ -43,13 +38,8 @@ function wc_update_200_file_paths() {
 	}
 }
 
-/**
- * Update permalinks for 2.0
- *
- * @return void
- */
 function wc_update_200_permalinks() {
-	// Setup default permalinks if shop page is defined.
+	// Setup default permalinks if shop page is defined
 	$permalinks 	= get_option( 'woocommerce_permalinks' );
 	$shop_page_id 	= wc_get_page_id( 'shop' );
 
@@ -57,7 +47,7 @@ function wc_update_200_permalinks() {
 
 		$base_slug 		= $shop_page_id > 0 && get_post( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
 
-		$category_base 	= get_option( 'woocommerce_prepend_shop_page_to_urls' ) == 'yes' ? trailingslashit( $base_slug ) : '';
+		$category_base 	= get_option( 'woocommerce_prepend_shop_page_to_urls' ) == "yes" ? trailingslashit( $base_slug ) : '';
 		$category_slug 	= get_option( 'woocommerce_product_category_slug' ) ? get_option( 'woocommerce_product_category_slug' ) : _x( 'product-category', 'slug', 'woocommerce' );
 		$tag_slug 		= get_option( 'woocommerce_product_tag_slug' ) ? get_option( 'woocommerce_product_tag_slug' ) : _x( 'product-tag', 'slug', 'woocommerce' );
 
@@ -86,13 +76,8 @@ function wc_update_200_permalinks() {
 	}
 }
 
-/**
- * Update sub-category display options for 2.0
- *
- * @return void
- */
 function wc_update_200_subcat_display() {
-	// Update subcat display settings.
+	// Update subcat display settings
 	if ( get_option( 'woocommerce_shop_show_subcategories' ) == 'yes' ) {
 		if ( get_option( 'woocommerce_hide_products_when_showing_subcategories' ) == 'yes' ) {
 			update_option( 'woocommerce_shop_page_display', 'subcategories' );
@@ -110,15 +95,10 @@ function wc_update_200_subcat_display() {
 	}
 }
 
-/**
- * Update tax rates for 2.0
- *
- * @return void
- */
 function wc_update_200_taxrates() {
 	global $wpdb;
 
-	// Update tax rates.
+	// Update tax rates
 	$loop = 0;
 	$tax_rates = get_option( 'woocommerce_tax_rates' );
 
@@ -136,7 +116,7 @@ function wc_update_200_taxrates() {
 					}
 
 					$wpdb->insert(
-						$wpdb->prefix . 'woocommerce_tax_rates',
+						$wpdb->prefix . "woocommerce_tax_rates",
 						array(
 							'tax_rate_country'  => $country,
 							'tax_rate_state'    => $state,
@@ -168,7 +148,7 @@ function wc_update_200_taxrates() {
 			}
 
 			$wpdb->insert(
-				$wpdb->prefix . 'woocommerce_tax_rates',
+				$wpdb->prefix . "woocommerce_tax_rates",
 				array(
 					'tax_rate_country'  => $tax_rate['country'],
 					'tax_rate_state'    => $tax_rate['state'],
@@ -188,7 +168,7 @@ function wc_update_200_taxrates() {
 				foreach ( $tax_rate['locations'] as $location ) {
 
 					$wpdb->insert(
-						$wpdb->prefix . 'woocommerce_tax_rate_locations',
+						$wpdb->prefix . "woocommerce_tax_rate_locations",
 						array(
 							'location_code' => $location,
 							'tax_rate_id'   => $tax_rate_id,
@@ -209,16 +189,11 @@ function wc_update_200_taxrates() {
 	delete_option( 'woocommerce_local_tax_rates' );
 }
 
-/**
- * Upadte order item line items for 2.0
- *
- * @return void
- */
 function wc_update_200_line_items() {
 	global $wpdb;
 
-	// Now its time for the massive update to line items - move them to the new DB tables.
-	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_items' WHERE meta_key = '_order_items_old'.
+	// Now its time for the massive update to line items - move them to the new DB tables
+	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_items' WHERE meta_key = '_order_items_old'
 	$order_item_rows = $wpdb->get_results( "
 		SELECT meta_value, post_id FROM {$wpdb->postmeta}
 		WHERE meta_key = '_order_items'
@@ -243,27 +218,27 @@ function wc_update_200_line_items() {
 			$order_item['line_subtotal'] 		= isset( $order_item['line_subtotal'] ) ? $order_item['line_subtotal'] : 0;
 
 			$item_id = wc_add_order_item( $order_item_row->post_id, array(
-				 'order_item_name' 		=> $order_item['name'],
-				 'order_item_type' 		=> 'line_item',
-			) );
+		 		'order_item_name' 		=> $order_item['name'],
+		 		'order_item_type' 		=> 'line_item',
+		 	) );
 
-			 // Add line item meta.
-			if ( $item_id ) {
-				wc_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
-				wc_add_order_item_meta( $item_id, '_tax_class', $order_item['tax_class'] );
-				wc_add_order_item_meta( $item_id, '_product_id', $order_item['id'] );
-				wc_add_order_item_meta( $item_id, '_variation_id', $order_item['variation_id'] );
-				wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( $order_item['line_subtotal'] ) );
-				wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( $order_item['line_subtotal_tax'] ) );
-				wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( $order_item['line_total'] ) );
-				wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( $order_item['line_tax'] ) );
+		 	// Add line item meta
+		 	if ( $item_id ) {
+			 	wc_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
+			 	wc_add_order_item_meta( $item_id, '_tax_class', $order_item['tax_class'] );
+			 	wc_add_order_item_meta( $item_id, '_product_id', $order_item['id'] );
+			 	wc_add_order_item_meta( $item_id, '_variation_id', $order_item['variation_id'] );
+			 	wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( $order_item['line_subtotal'] ) );
+			 	wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( $order_item['line_subtotal_tax'] ) );
+			 	wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( $order_item['line_total'] ) );
+			 	wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( $order_item['line_tax'] ) );
 
-				$meta_rows = array();
+			 	$meta_rows = array();
 
-				// Insert meta.
+				// Insert meta
 				if ( ! empty( $order_item['item_meta'] ) ) {
 					foreach ( $order_item['item_meta'] as $key => $meta ) {
-						// Backwards compatibility.
+						// Backwards compatibility
 						if ( is_array( $meta ) && isset( $meta['meta_name'] ) ) {
 							$meta_rows[] = '(' . $item_id . ',"' . esc_sql( $meta['meta_name'] ) . '","' . esc_sql( $meta['meta_value'] ) . '")';
 						} else {
@@ -272,29 +247,29 @@ function wc_update_200_line_items() {
 					}
 				}
 
-				// Insert meta rows at once.
-				if ( count( $meta_rows ) > 0 ) {
+				// Insert meta rows at once
+				if ( sizeof( $meta_rows ) > 0 ) {
 					$wpdb->query( $wpdb->prepare( "
 						INSERT INTO {$wpdb->prefix}woocommerce_order_itemmeta ( order_item_id, meta_key, meta_value )
-						VALUES " . implode( ',', $meta_rows ) . ';
-                    ', $order_item_row->post_id ) );
+						VALUES " . implode( ',', $meta_rows ) . ";
+					", $order_item_row->post_id ) );
 				}
 
-				// Delete from DB (rename).
+				// Delete from DB (rename)
 				$wpdb->query( $wpdb->prepare( "
 					UPDATE {$wpdb->postmeta}
 					SET meta_key = '_order_items_old'
 					WHERE meta_key = '_order_items'
 					AND post_id = %d
 				", $order_item_row->post_id ) );
-			}
+		 	}
 
 			unset( $meta_rows, $item_id, $order_item );
 		}
 	}
 
-	// Do the same kind of update for order_taxes - move to lines.
-	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_taxes' WHERE meta_key = '_order_taxes_old'.
+	// Do the same kind of update for order_taxes - move to lines
+	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_taxes' WHERE meta_key = '_order_taxes_old'
 	$order_tax_rows = $wpdb->get_results( "
 		SELECT meta_value, post_id FROM {$wpdb->postmeta}
 		WHERE meta_key = '_order_taxes'
@@ -312,18 +287,18 @@ function wc_update_200_line_items() {
 				}
 
 				$item_id = wc_add_order_item( $order_tax_row->post_id, array(
-					 'order_item_name' 		=> $order_tax['label'],
-					 'order_item_type' 		=> 'tax',
-				) );
+			 		'order_item_name' 		=> $order_tax['label'],
+			 		'order_item_type' 		=> 'tax',
+			 	) );
 
-				 // Add line item meta.
-				if ( $item_id ) {
-					wc_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
-					wc_add_order_item_meta( $item_id, 'tax_amount', wc_clean( $order_tax['cart_tax'] ) );
-					wc_add_order_item_meta( $item_id, 'shipping_tax_amount', wc_clean( $order_tax['shipping_tax'] ) );
+			 	// Add line item meta
+			 	if ( $item_id ) {
+				 	wc_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
+				 	wc_add_order_item_meta( $item_id, 'tax_amount', wc_clean( $order_tax['cart_tax'] ) );
+				 	wc_add_order_item_meta( $item_id, 'shipping_tax_amount', wc_clean( $order_tax['shipping_tax'] ) );
 				}
 
-				// Delete from DB (rename).
+				// Delete from DB (rename)
 				$wpdb->query( $wpdb->prepare( "
 					UPDATE {$wpdb->postmeta}
 					SET meta_key = '_order_taxes_old'
@@ -337,14 +312,9 @@ function wc_update_200_line_items() {
 	}
 }
 
-/**
- * Update image settings for 2.0
- *
- * @return void
- */
 function wc_update_200_images() {
 	// Grab the pre 2.0 Image options and use to populate the new image options settings,
-	// cleaning up afterwards like nice people do.
+	// cleaning up afterwards like nice people do
 	foreach ( array( 'catalog', 'single', 'thumbnail' ) as $value ) {
 
 		$old_settings = array_filter( array(
@@ -363,24 +333,14 @@ function wc_update_200_images() {
 	}
 }
 
-/**
- * Update DB version for 2.0
- *
- * @return void
- */
 function wc_update_200_db_version() {
 	WC_Install::update_db_version( '2.0.0' );
 }
 
-/**
- * Update Brazilian States for 2.0.9
- *
- * @return void
- */
 function wc_update_209_brazillian_state() {
 	global $wpdb;
 
-	// Update brazillian state codes.
+	// Update brazillian state codes
 	$wpdb->update(
 		$wpdb->postmeta,
 		array(
@@ -423,22 +383,12 @@ function wc_update_209_brazillian_state() {
 	);
 }
 
-/**
- * Update DB version for 2.0.9
- *
- * @return void
- */
 function wc_update_209_db_version() {
 	WC_Install::update_db_version( '2.0.9' );
 }
 
-/**
- * Remove pages for 2.1
- *
- * @return void
- */
 function wc_update_210_remove_pages() {
-	// Pages no longer used.
+	// Pages no longer used
 	wp_trash_post( get_option( 'woocommerce_pay_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_thanks_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_view_order_page_id' ) );
@@ -447,15 +397,10 @@ function wc_update_210_remove_pages() {
 	wp_trash_post( get_option( 'woocommerce_lost_password_page_id' ) );
 }
 
-/**
- * Update file paths to support multiple files for 2.1
- *
- * @return void
- */
 function wc_update_210_file_paths() {
 	global $wpdb;
 
-	// Upgrade file paths to support multiple file paths + names etc.
+	// Upgrade file paths to support multiple file paths + names etc
 	$existing_file_paths = $wpdb->get_results( "SELECT meta_value, meta_id FROM {$wpdb->postmeta} WHERE meta_key = '_file_paths' AND meta_value != '';" );
 
 	if ( $existing_file_paths ) {
@@ -488,20 +433,10 @@ function wc_update_210_file_paths() {
 	}
 }
 
-/**
- * Update DB version for 2.1
- *
- * @return void
- */
 function wc_update_210_db_version() {
 	WC_Install::update_db_version( '2.1.0' );
 }
 
-/**
- * Update shipping options for 2.2
- *
- * @return void
- */
 function wc_update_220_shipping() {
 	$woocommerce_ship_to_destination = 'shipping';
 
@@ -514,11 +449,6 @@ function wc_update_220_shipping() {
 	add_option( 'woocommerce_ship_to_destination', $woocommerce_ship_to_destination, '', 'no' );
 }
 
-/**
- * Update order statuses for 2.2
- *
- * @return void
- */
 function wc_update_220_order_status() {
 	global $wpdb;
 	$wpdb->query( "
@@ -607,14 +537,9 @@ function wc_update_220_order_status() {
 	);
 }
 
-/**
- * Update variations for 2.2
- *
- * @return void
- */
 function wc_update_220_variations() {
 	global $wpdb;
-	// Update variations which manage stock.
+	// Update variations which manage stock
 	$update_variations = $wpdb->get_results( "
 		SELECT DISTINCT posts.ID AS variation_id, posts.post_parent AS variation_parent FROM {$wpdb->posts} as posts
 		LEFT OUTER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id AND postmeta.meta_key = '_stock'
@@ -632,21 +557,16 @@ function wc_update_220_variations() {
 	}
 }
 
-/**
- * Update attributes for 2.2
- *
- * @return void
- */
 function wc_update_220_attributes() {
 	global $wpdb;
-	// Update taxonomy names with correct sanitized names.
-	$attribute_taxonomies = $wpdb->get_results( 'SELECT attribute_name, attribute_id FROM ' . $wpdb->prefix . 'woocommerce_attribute_taxonomies' );
+	// Update taxonomy names with correct sanitized names
+	$attribute_taxonomies = $wpdb->get_results( "SELECT attribute_name, attribute_id FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies" );
 
 	foreach ( $attribute_taxonomies as $attribute_taxonomy ) {
 		$sanitized_attribute_name = wc_sanitize_taxonomy_name( $attribute_taxonomy->attribute_name );
 		if ( $sanitized_attribute_name !== $attribute_taxonomy->attribute_name ) {
 			if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT 1=1 FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name = %s;", $sanitized_attribute_name ) ) ) {
-				// Update attribute.
+				// Update attribute
 				$wpdb->update(
 					"{$wpdb->prefix}woocommerce_attribute_taxonomies",
 					array(
@@ -657,7 +577,7 @@ function wc_update_220_attributes() {
 					)
 				);
 
-				// Update terms.
+				// Update terms
 				$wpdb->update(
 					$wpdb->term_taxonomy,
 					array( 'taxonomy' => wc_attribute_taxonomy_name( $sanitized_attribute_name ) ),
@@ -668,45 +588,25 @@ function wc_update_220_attributes() {
 	}
 }
 
-/**
- * Update DB version for 2.2
- *
- * @return void
- */
 function wc_update_220_db_version() {
 	WC_Install::update_db_version( '2.2.0' );
 }
 
-/**
- * Update options for 2.3
- *
- * @return void
- */
 function wc_update_230_options() {
 	// _money_spent and _order_count may be out of sync - clear them
 	delete_metadata( 'user', 0, '_money_spent', '', true );
 	delete_metadata( 'user', 0, '_order_count', '', true );
 
-	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default.
+	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default
 	if ( '' === get_option( 'woocommerce_default_customer_address', false ) && wc_prices_include_tax() ) {
 		update_option( 'woocommerce_default_customer_address', 'base' );
 	}
 }
 
-/**
- * Update DB version for 2.3
- *
- * @return void
- */
 function wc_update_230_db_version() {
 	WC_Install::update_db_version( '2.3.0' );
 }
 
-/**
- * Update calc discount options for 2.4
- *
- * @return void
- */
 function wc_update_240_options() {
 	/**
 	 * Coupon discount calculations.
@@ -715,11 +615,6 @@ function wc_update_240_options() {
 	update_option( 'woocommerce_calc_discounts_sequentially', 'yes' );
 }
 
-/**
- * Update shipping methods for 2.4
- *
- * @return void
- */
 function wc_update_240_shipping_methods() {
 	/**
 	 * Flat Rate Shipping.
@@ -730,9 +625,9 @@ function wc_update_240_shipping_methods() {
 		'woocommerce_international_delivery_flat_rates' => new WC_Shipping_Legacy_International_Delivery(),
 	);
 	foreach ( $shipping_methods as $flat_rate_option_key => $shipping_method ) {
-		// Stop this running more than once if routine is repeated.
+		// Stop this running more than once if routine is repeated
 		if ( version_compare( $shipping_method->get_option( 'version', 0 ), '2.4.0', '<' ) ) {
-			$has_classes                      = count( WC()->shipping->get_shipping_classes() ) > 0;
+			$has_classes                      = sizeof( WC()->shipping->get_shipping_classes() ) > 0;
 			$cost_key                         = $has_classes ? 'no_class_cost' : 'cost';
 			$min_fee                          = $shipping_method->get_option( 'minimum_fee' );
 			$math_cost_strings                = array( 'cost' => array(), 'no_class_cost' => array() );
@@ -761,7 +656,7 @@ function wc_update_240_shipping_methods() {
 				foreach ( $math_cost_strings as $key => $math_cost_string ) {
 					$math_cost_strings[ $key ] = array_filter( array_map( 'trim', $math_cost_strings[ $key ] ) );
 					if ( ! empty( $math_cost_strings[ $key ] ) ) {
-						$last_key                                = max( 0, count( $math_cost_strings[ $key ] ) - 1 );
+						$last_key                                = max( 0, sizeof( $math_cost_strings[ $key ] ) - 1 );
 						$math_cost_strings[ $key ][0]            = '( ' . $math_cost_strings[ $key ][0];
 						$math_cost_strings[ $key ][ $last_key ] .= ' ) * [qty]';
 					}
@@ -770,7 +665,7 @@ function wc_update_240_shipping_methods() {
 
 			$math_cost_strings['cost'][] = $shipping_method->get_option( 'cost_per_order' );
 
-			// Save settings.
+			// Save settings
 			foreach ( $math_cost_strings as $option_id => $math_cost_string ) {
 				$shipping_method->settings[ $option_id ] = implode( ' + ', array_filter( $math_cost_string ) );
 			}
@@ -783,11 +678,6 @@ function wc_update_240_shipping_methods() {
 	}
 }
 
-/**
- * Update API keys for 2.4
- *
- * @return void
- */
 function wc_update_240_api_keys() {
 	global $wpdb;
 	/**
@@ -796,7 +686,7 @@ function wc_update_240_api_keys() {
 	$api_users = $wpdb->get_results( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'woocommerce_api_consumer_key'" );
 	$apps_keys = array();
 
-	// Get user data.
+	// Get user data
 	foreach ( $api_users as $_user ) {
 		$user = get_userdata( $_user->user_id );
 		$apps_keys[] = array(
@@ -809,7 +699,7 @@ function wc_update_240_api_keys() {
 	}
 
 	if ( ! empty( $apps_keys ) ) {
-		// Create new apps.
+		// Create new apps
 		foreach ( $apps_keys as $app ) {
 			$wpdb->insert(
 				$wpdb->prefix . 'woocommerce_api_keys',
@@ -824,7 +714,7 @@ function wc_update_240_api_keys() {
 			);
 		}
 
-		// Delete old user keys from usermeta.
+		// Delete old user keys from usermeta
 		foreach ( $api_users as $_user ) {
 			$user_id = intval( $_user->user_id );
 			delete_user_meta( $user_id, 'woocommerce_api_consumer_key' );
@@ -834,11 +724,6 @@ function wc_update_240_api_keys() {
 	}
 }
 
-/**
- * Update webhooks for 2.4
- *
- * @return void
- */
 function wc_update_240_webhooks() {
 	/**
 	 * Webhooks.
@@ -856,11 +741,6 @@ function wc_update_240_webhooks() {
 	}
 }
 
-/**
- * Update refunds for 2.4
- *
- * @return void
- */
 function wc_update_240_refunds() {
 	global $wpdb;
 	/**
@@ -873,7 +753,7 @@ function wc_update_240_refunds() {
 		'post_status'    => array( 'wc-refunded' ),
 	) );
 
-	// Ensure emails are disabled during this update routine.
+	// Ensure emails are disabled during this update routine
 	remove_all_actions( 'woocommerce_order_status_refunded_notification' );
 	remove_all_actions( 'woocommerce_order_partially_refunded_notification' );
 	remove_action( 'woocommerce_order_status_refunded', array( 'WC_Emails', 'send_transactional_email' ) );
@@ -903,24 +783,14 @@ function wc_update_240_refunds() {
 	wc_delete_shop_order_transients();
 }
 
-/**
- * Update DB version for 2.4
- *
- * @return void
- */
 function wc_update_240_db_version() {
 	WC_Install::update_db_version( '2.4.0' );
 }
 
-/**
- * Update variations for 2.4.1
- *
- * @return void
- */
 function wc_update_241_variations() {
 	global $wpdb;
 
-	// Select variations that don't have any _stock_status implemented on WooCommerce 2.2.
+	// Select variations that don't have any _stock_status implemented on WooCommerce 2.2
 	$update_variations = $wpdb->get_results( "
 		SELECT DISTINCT posts.ID AS variation_id, posts.post_parent AS variation_parent
 		FROM {$wpdb->posts} as posts
@@ -930,34 +800,24 @@ function wc_update_241_variations() {
 	" );
 
 	foreach ( $update_variations as $variation ) {
-		// Get the parent _stock_status.
+		// Get the parent _stock_status
 		$parent_stock_status = get_post_meta( $variation->variation_parent, '_stock_status', true );
 
-		// Set the _stock_status.
+		// Set the _stock_status
 		add_post_meta( $variation->variation_id, '_stock_status', $parent_stock_status ? $parent_stock_status : 'instock', true );
 
-		// Delete old product children array.
+		// Delete old product children array
 		delete_transient( 'wc_product_children_' . $variation->variation_parent );
 	}
 
-	// Invalidate old transients such as wc_var_price.
+	// Invalidate old transients such as wc_var_price
 	WC_Cache_Helper::get_transient_version( 'product', true );
 }
 
-/**
- * Update DB version for 2.4.1
- *
- * @return void
- */
 function wc_update_241_db_version() {
 	WC_Install::update_db_version( '2.4.1' );
 }
 
-/**
- * Update currency settings for 2.5
- *
- * @return void
- */
 function wc_update_250_currency() {
 	global $wpdb;
 	// Fix currency settings for LAK currency.
@@ -980,22 +840,14 @@ function wc_update_250_currency() {
 	);
 }
 
-/**
- * Update DB version for 2.5
- *
- * @return void
- */
 function wc_update_250_db_version() {
 	WC_Install::update_db_version( '2.5.0' );
 }
 
-/**
- * Update ship to countries options for 2.6
- *
- * @return void
- */
 function wc_update_260_options() {
-	// woocommerce_calc_shipping option has been removed in 2.6.
+	/**
+	 * woocommerce_calc_shipping option has been removed in 2.6
+	 */
 	if ( 'no' === get_option( 'woocommerce_calc_shipping' ) ) {
 		update_option( 'woocommerce_ship_to_countries', 'disabled' );
 	}
@@ -1003,15 +855,10 @@ function wc_update_260_options() {
 	WC_Admin_Notices::add_notice( 'legacy_shipping' );
 }
 
-/**
- * Update term meta for 2.6
- *
- * @return void
- */
 function wc_update_260_termmeta() {
 	global $wpdb;
 	/**
-	 * Migrate term meta to WordPress tables.
+	 * Migrate term meta to WordPress tables
 	 */
 	if ( get_option( 'db_version' ) >= 34370 && $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}woocommerce_termmeta';" ) ) {
 		if ( $wpdb->query( "INSERT INTO {$wpdb->termmeta} ( term_id, meta_key, meta_value ) SELECT woocommerce_term_id, meta_key, meta_value FROM {$wpdb->prefix}woocommerce_termmeta;" ) ) {
@@ -1021,11 +868,6 @@ function wc_update_260_termmeta() {
 	}
 }
 
-/**
- * Update zones for 2.6
- *
- * @return void
- */
 function wc_update_260_zones() {
 	global $wpdb;
 	/**
@@ -1038,11 +880,6 @@ function wc_update_260_zones() {
 	}
 }
 
-/**
- * Update zone methods for 2.6
- *
- * @return void
- */
 function wc_update_260_zone_methods() {
 	global $wpdb;
 
@@ -1057,13 +894,13 @@ function wc_update_260_zone_methods() {
 			$max_new_id = $wpdb->get_var( "SELECT MAX(instance_id) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods" );
 			$max_old_id = $wpdb->get_var( "SELECT MAX(shipping_method_id) FROM {$wpdb->prefix}woocommerce_shipping_zone_shipping_methods" );
 
-			// Avoid ID conflicts.
+			// Avoid ID conflicts
 			$wpdb->query( $wpdb->prepare( "ALTER TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods AUTO_INCREMENT = %d;", max( $max_new_id, $max_old_id ) + 1 ) );
 
-			// Store changes.
+			// Store changes
 			$changes = array();
 
-			// Move data.
+			// Move data
 			foreach ( $old_methods as $old_method ) {
 				$wpdb->insert( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array(
 					'zone_id'      => $old_method->zone_id,
@@ -1073,18 +910,18 @@ function wc_update_260_zone_methods() {
 
 				$new_instance_id = $wpdb->insert_id;
 
-				// Move main settings.
+				// Move main settings
 				$older_settings_key = 'woocommerce_' . $old_method->shipping_method_type . '-' . $old_method->shipping_method_id . '_settings';
 				$old_settings_key   = 'woocommerce_' . $old_method->shipping_method_type . '_' . $old_method->shipping_method_id . '_settings';
 				add_option( 'woocommerce_' . $old_method->shipping_method_type . '_' . $new_instance_id . '_settings', get_option( $old_settings_key, get_option( $older_settings_key ) ) );
 
 				// Handling for table rate and flat rate box shipping.
 				if ( 'table_rate' === $old_method->shipping_method_type ) {
-					// Move priority settings.
+					// Move priority settings
 					add_option( 'woocommerce_table_rate_default_priority_' . $new_instance_id, get_option( 'woocommerce_table_rate_default_priority_' . $old_method->shipping_method_id ) );
 					add_option( 'woocommerce_table_rate_priorities_' . $new_instance_id, get_option( 'woocommerce_table_rate_priorities_' . $old_method->shipping_method_id ) );
 
-					// Move rates.
+					// Move rates
 					$wpdb->update(
 						$wpdb->prefix . 'woocommerce_shipping_table_rates',
 						array(
@@ -1120,15 +957,10 @@ function wc_update_260_zone_methods() {
 	$wpdb->query( "UPDATE {$wpdb->prefix}woocommerce_shipping_zone_locations SET location_code = REPLACE( location_code, '-', '...' );" );
 }
 
-/**
- * Update refunds for 2.6
- *
- * @return void
- */
 function wc_update_260_refunds() {
 	global $wpdb;
 	/**
-	 * Refund item qty should be negative.
+	 * Refund item qty should be negative
 	 */
 	$wpdb->query( "
 	UPDATE {$wpdb->prefix}woocommerce_order_itemmeta as item_meta
@@ -1139,20 +971,10 @@ function wc_update_260_refunds() {
 	" );
 }
 
-/**
- * Update DB version for 2.6
- *
- * @return void
- */
 function wc_update_260_db_version() {
 	WC_Install::update_db_version( '2.6.0' );
 }
 
-/**
- * Update webhooks for 3.0
- *
- * @return void
- */
 function wc_update_300_webhooks() {
 	/**
 	 * Make sure product.update webhooks get the woocommerce_product_quick_edit_save
@@ -1186,11 +1008,6 @@ function wc_update_300_comment_type_index() {
 	}
 }
 
-/**
- * Update grouped products for 3.0
- *
- * @return void
- */
 function wc_update_300_grouped_products() {
 	global $wpdb;
 	$parents = $wpdb->get_col( "SELECT DISTINCT( post_parent ) FROM {$wpdb->posts} WHERE post_parent > 0 AND post_type = 'product';" );
@@ -1219,11 +1036,6 @@ function wc_update_300_grouped_products() {
 	}
 }
 
-/**
- * Update shipping tax classes for 3.0
- *
- * @return void
- */
 function wc_update_300_settings() {
 	$woocommerce_shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
 	if ( '' === $woocommerce_shipping_tax_class ) {
@@ -1371,15 +1183,13 @@ function wc_update_320_mexican_states() {
 	);
 
 	foreach ( $mx_states as $old => $new ) {
-		$wpdb->query(
-			$wpdb->prepare(
-				"
-					UPDATE $wpdb->postmeta
-					SET meta_value = %s
-		 			WHERE meta_key IN ( '_billing_state', '_shipping_state' )
-		 			AND meta_value = %s
-				",
-				$new, $old
+		$wpdb->update(
+			$wpdb->postmeta,
+			array(
+				'meta_value' => $new,
+			),
+			array(
+				'meta_value' => $old,
 			)
 		);
 		$wpdb->update(

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -14,10 +14,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Update file paths for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_file_paths() {
 	global $wpdb;
 
-	// Upgrade old style files paths to support multiple file paths
+	// Upgrade old style files paths to support multiple file paths.
 	$existing_file_paths = $wpdb->get_results( "SELECT meta_value, meta_id, post_id FROM {$wpdb->postmeta} WHERE meta_key = '_file_path' AND meta_value != '';" );
 
 	if ( $existing_file_paths ) {
@@ -38,8 +43,13 @@ function wc_update_200_file_paths() {
 	}
 }
 
+/**
+ * Update permalinks for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_permalinks() {
-	// Setup default permalinks if shop page is defined
+	// Setup default permalinks if shop page is defined.
 	$permalinks 	= get_option( 'woocommerce_permalinks' );
 	$shop_page_id 	= wc_get_page_id( 'shop' );
 
@@ -47,7 +57,7 @@ function wc_update_200_permalinks() {
 
 		$base_slug 		= $shop_page_id > 0 && get_post( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
 
-		$category_base 	= get_option( 'woocommerce_prepend_shop_page_to_urls' ) == "yes" ? trailingslashit( $base_slug ) : '';
+		$category_base 	= get_option( 'woocommerce_prepend_shop_page_to_urls' ) == 'yes' ? trailingslashit( $base_slug ) : '';
 		$category_slug 	= get_option( 'woocommerce_product_category_slug' ) ? get_option( 'woocommerce_product_category_slug' ) : _x( 'product-category', 'slug', 'woocommerce' );
 		$tag_slug 		= get_option( 'woocommerce_product_tag_slug' ) ? get_option( 'woocommerce_product_tag_slug' ) : _x( 'product-tag', 'slug', 'woocommerce' );
 
@@ -76,8 +86,13 @@ function wc_update_200_permalinks() {
 	}
 }
 
+/**
+ * Update sub-category display options for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_subcat_display() {
-	// Update subcat display settings
+	// Update subcat display settings.
 	if ( get_option( 'woocommerce_shop_show_subcategories' ) == 'yes' ) {
 		if ( get_option( 'woocommerce_hide_products_when_showing_subcategories' ) == 'yes' ) {
 			update_option( 'woocommerce_shop_page_display', 'subcategories' );
@@ -95,10 +110,15 @@ function wc_update_200_subcat_display() {
 	}
 }
 
+/**
+ * Update tax rates for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_taxrates() {
 	global $wpdb;
 
-	// Update tax rates
+	// Update tax rates.
 	$loop = 0;
 	$tax_rates = get_option( 'woocommerce_tax_rates' );
 
@@ -116,7 +136,7 @@ function wc_update_200_taxrates() {
 					}
 
 					$wpdb->insert(
-						$wpdb->prefix . "woocommerce_tax_rates",
+						$wpdb->prefix . 'woocommerce_tax_rates',
 						array(
 							'tax_rate_country'  => $country,
 							'tax_rate_state'    => $state,
@@ -148,7 +168,7 @@ function wc_update_200_taxrates() {
 			}
 
 			$wpdb->insert(
-				$wpdb->prefix . "woocommerce_tax_rates",
+				$wpdb->prefix . 'woocommerce_tax_rates',
 				array(
 					'tax_rate_country'  => $tax_rate['country'],
 					'tax_rate_state'    => $tax_rate['state'],
@@ -168,7 +188,7 @@ function wc_update_200_taxrates() {
 				foreach ( $tax_rate['locations'] as $location ) {
 
 					$wpdb->insert(
-						$wpdb->prefix . "woocommerce_tax_rate_locations",
+						$wpdb->prefix . 'woocommerce_tax_rate_locations',
 						array(
 							'location_code' => $location,
 							'tax_rate_id'   => $tax_rate_id,
@@ -189,11 +209,16 @@ function wc_update_200_taxrates() {
 	delete_option( 'woocommerce_local_tax_rates' );
 }
 
+/**
+ * Upadte order item line items for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_line_items() {
 	global $wpdb;
 
-	// Now its time for the massive update to line items - move them to the new DB tables
-	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_items' WHERE meta_key = '_order_items_old'
+	// Now its time for the massive update to line items - move them to the new DB tables.
+	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_items' WHERE meta_key = '_order_items_old'.
 	$order_item_rows = $wpdb->get_results( "
 		SELECT meta_value, post_id FROM {$wpdb->postmeta}
 		WHERE meta_key = '_order_items'
@@ -218,27 +243,27 @@ function wc_update_200_line_items() {
 			$order_item['line_subtotal'] 		= isset( $order_item['line_subtotal'] ) ? $order_item['line_subtotal'] : 0;
 
 			$item_id = wc_add_order_item( $order_item_row->post_id, array(
-		 		'order_item_name' 		=> $order_item['name'],
-		 		'order_item_type' 		=> 'line_item',
-		 	) );
+				 'order_item_name' 		=> $order_item['name'],
+				 'order_item_type' 		=> 'line_item',
+			) );
 
-		 	// Add line item meta
-		 	if ( $item_id ) {
-			 	wc_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
-			 	wc_add_order_item_meta( $item_id, '_tax_class', $order_item['tax_class'] );
-			 	wc_add_order_item_meta( $item_id, '_product_id', $order_item['id'] );
-			 	wc_add_order_item_meta( $item_id, '_variation_id', $order_item['variation_id'] );
-			 	wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( $order_item['line_subtotal'] ) );
-			 	wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( $order_item['line_subtotal_tax'] ) );
-			 	wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( $order_item['line_total'] ) );
-			 	wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( $order_item['line_tax'] ) );
+			 // Add line item meta.
+			if ( $item_id ) {
+				wc_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
+				wc_add_order_item_meta( $item_id, '_tax_class', $order_item['tax_class'] );
+				wc_add_order_item_meta( $item_id, '_product_id', $order_item['id'] );
+				wc_add_order_item_meta( $item_id, '_variation_id', $order_item['variation_id'] );
+				wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( $order_item['line_subtotal'] ) );
+				wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( $order_item['line_subtotal_tax'] ) );
+				wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( $order_item['line_total'] ) );
+				wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( $order_item['line_tax'] ) );
 
-			 	$meta_rows = array();
+				$meta_rows = array();
 
-				// Insert meta
+				// Insert meta.
 				if ( ! empty( $order_item['item_meta'] ) ) {
 					foreach ( $order_item['item_meta'] as $key => $meta ) {
-						// Backwards compatibility
+						// Backwards compatibility.
 						if ( is_array( $meta ) && isset( $meta['meta_name'] ) ) {
 							$meta_rows[] = '(' . $item_id . ',"' . esc_sql( $meta['meta_name'] ) . '","' . esc_sql( $meta['meta_value'] ) . '")';
 						} else {
@@ -247,29 +272,29 @@ function wc_update_200_line_items() {
 					}
 				}
 
-				// Insert meta rows at once
-				if ( sizeof( $meta_rows ) > 0 ) {
+				// Insert meta rows at once.
+				if ( count( $meta_rows ) > 0 ) {
 					$wpdb->query( $wpdb->prepare( "
 						INSERT INTO {$wpdb->prefix}woocommerce_order_itemmeta ( order_item_id, meta_key, meta_value )
-						VALUES " . implode( ',', $meta_rows ) . ";
-					", $order_item_row->post_id ) );
+						VALUES " . implode( ',', $meta_rows ) . ';
+                    ', $order_item_row->post_id ) );
 				}
 
-				// Delete from DB (rename)
+				// Delete from DB (rename).
 				$wpdb->query( $wpdb->prepare( "
 					UPDATE {$wpdb->postmeta}
 					SET meta_key = '_order_items_old'
 					WHERE meta_key = '_order_items'
 					AND post_id = %d
 				", $order_item_row->post_id ) );
-		 	}
+			}
 
 			unset( $meta_rows, $item_id, $order_item );
 		}
 	}
 
-	// Do the same kind of update for order_taxes - move to lines
-	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_taxes' WHERE meta_key = '_order_taxes_old'
+	// Do the same kind of update for order_taxes - move to lines.
+	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_taxes' WHERE meta_key = '_order_taxes_old'.
 	$order_tax_rows = $wpdb->get_results( "
 		SELECT meta_value, post_id FROM {$wpdb->postmeta}
 		WHERE meta_key = '_order_taxes'
@@ -287,18 +312,18 @@ function wc_update_200_line_items() {
 				}
 
 				$item_id = wc_add_order_item( $order_tax_row->post_id, array(
-			 		'order_item_name' 		=> $order_tax['label'],
-			 		'order_item_type' 		=> 'tax',
-			 	) );
+					 'order_item_name' 		=> $order_tax['label'],
+					 'order_item_type' 		=> 'tax',
+				) );
 
-			 	// Add line item meta
-			 	if ( $item_id ) {
-				 	wc_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
-				 	wc_add_order_item_meta( $item_id, 'tax_amount', wc_clean( $order_tax['cart_tax'] ) );
-				 	wc_add_order_item_meta( $item_id, 'shipping_tax_amount', wc_clean( $order_tax['shipping_tax'] ) );
+				 // Add line item meta.
+				if ( $item_id ) {
+					wc_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
+					wc_add_order_item_meta( $item_id, 'tax_amount', wc_clean( $order_tax['cart_tax'] ) );
+					wc_add_order_item_meta( $item_id, 'shipping_tax_amount', wc_clean( $order_tax['shipping_tax'] ) );
 				}
 
-				// Delete from DB (rename)
+				// Delete from DB (rename).
 				$wpdb->query( $wpdb->prepare( "
 					UPDATE {$wpdb->postmeta}
 					SET meta_key = '_order_taxes_old'
@@ -312,9 +337,14 @@ function wc_update_200_line_items() {
 	}
 }
 
+/**
+ * Update image settings for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_images() {
 	// Grab the pre 2.0 Image options and use to populate the new image options settings,
-	// cleaning up afterwards like nice people do
+	// cleaning up afterwards like nice people do.
 	foreach ( array( 'catalog', 'single', 'thumbnail' ) as $value ) {
 
 		$old_settings = array_filter( array(
@@ -333,14 +363,24 @@ function wc_update_200_images() {
 	}
 }
 
+/**
+ * Update DB version for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_db_version() {
 	WC_Install::update_db_version( '2.0.0' );
 }
 
+/**
+ * Update Brazilian States for 2.0.9
+ *
+ * @return void
+ */
 function wc_update_209_brazillian_state() {
 	global $wpdb;
 
-	// Update brazillian state codes
+	// Update brazillian state codes.
 	$wpdb->update(
 		$wpdb->postmeta,
 		array(
@@ -383,12 +423,22 @@ function wc_update_209_brazillian_state() {
 	);
 }
 
+/**
+ * Update DB version for 2.0.9
+ *
+ * @return void
+ */
 function wc_update_209_db_version() {
 	WC_Install::update_db_version( '2.0.9' );
 }
 
+/**
+ * Remove pages for 2.1
+ *
+ * @return void
+ */
 function wc_update_210_remove_pages() {
-	// Pages no longer used
+	// Pages no longer used.
 	wp_trash_post( get_option( 'woocommerce_pay_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_thanks_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_view_order_page_id' ) );
@@ -397,10 +447,15 @@ function wc_update_210_remove_pages() {
 	wp_trash_post( get_option( 'woocommerce_lost_password_page_id' ) );
 }
 
+/**
+ * Update file paths to support multiple files for 2.1
+ *
+ * @return void
+ */
 function wc_update_210_file_paths() {
 	global $wpdb;
 
-	// Upgrade file paths to support multiple file paths + names etc
+	// Upgrade file paths to support multiple file paths + names etc.
 	$existing_file_paths = $wpdb->get_results( "SELECT meta_value, meta_id FROM {$wpdb->postmeta} WHERE meta_key = '_file_paths' AND meta_value != '';" );
 
 	if ( $existing_file_paths ) {
@@ -433,10 +488,20 @@ function wc_update_210_file_paths() {
 	}
 }
 
+/**
+ * Update DB version for 2.1
+ *
+ * @return void
+ */
 function wc_update_210_db_version() {
 	WC_Install::update_db_version( '2.1.0' );
 }
 
+/**
+ * Update shipping options for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_shipping() {
 	$woocommerce_ship_to_destination = 'shipping';
 
@@ -449,6 +514,11 @@ function wc_update_220_shipping() {
 	add_option( 'woocommerce_ship_to_destination', $woocommerce_ship_to_destination, '', 'no' );
 }
 
+/**
+ * Update order statuses for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_order_status() {
 	global $wpdb;
 	$wpdb->query( "
@@ -537,9 +607,14 @@ function wc_update_220_order_status() {
 	);
 }
 
+/**
+ * Update variations for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_variations() {
 	global $wpdb;
-	// Update variations which manage stock
+	// Update variations which manage stock.
 	$update_variations = $wpdb->get_results( "
 		SELECT DISTINCT posts.ID AS variation_id, posts.post_parent AS variation_parent FROM {$wpdb->posts} as posts
 		LEFT OUTER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id AND postmeta.meta_key = '_stock'
@@ -557,16 +632,21 @@ function wc_update_220_variations() {
 	}
 }
 
+/**
+ * Update attributes for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_attributes() {
 	global $wpdb;
-	// Update taxonomy names with correct sanitized names
-	$attribute_taxonomies = $wpdb->get_results( "SELECT attribute_name, attribute_id FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies" );
+	// Update taxonomy names with correct sanitized names.
+	$attribute_taxonomies = $wpdb->get_results( 'SELECT attribute_name, attribute_id FROM ' . $wpdb->prefix . 'woocommerce_attribute_taxonomies' );
 
 	foreach ( $attribute_taxonomies as $attribute_taxonomy ) {
 		$sanitized_attribute_name = wc_sanitize_taxonomy_name( $attribute_taxonomy->attribute_name );
 		if ( $sanitized_attribute_name !== $attribute_taxonomy->attribute_name ) {
 			if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT 1=1 FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name = %s;", $sanitized_attribute_name ) ) ) {
-				// Update attribute
+				// Update attribute.
 				$wpdb->update(
 					"{$wpdb->prefix}woocommerce_attribute_taxonomies",
 					array(
@@ -577,7 +657,7 @@ function wc_update_220_attributes() {
 					)
 				);
 
-				// Update terms
+				// Update terms.
 				$wpdb->update(
 					$wpdb->term_taxonomy,
 					array( 'taxonomy' => wc_attribute_taxonomy_name( $sanitized_attribute_name ) ),
@@ -588,25 +668,45 @@ function wc_update_220_attributes() {
 	}
 }
 
+/**
+ * Update DB version for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_db_version() {
 	WC_Install::update_db_version( '2.2.0' );
 }
 
+/**
+ * Update options for 2.3
+ *
+ * @return void
+ */
 function wc_update_230_options() {
 	// _money_spent and _order_count may be out of sync - clear them
 	delete_metadata( 'user', 0, '_money_spent', '', true );
 	delete_metadata( 'user', 0, '_order_count', '', true );
 
-	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default
+	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default.
 	if ( '' === get_option( 'woocommerce_default_customer_address', false ) && wc_prices_include_tax() ) {
 		update_option( 'woocommerce_default_customer_address', 'base' );
 	}
 }
 
+/**
+ * Update DB version for 2.3
+ *
+ * @return void
+ */
 function wc_update_230_db_version() {
 	WC_Install::update_db_version( '2.3.0' );
 }
 
+/**
+ * Update calc discount options for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_options() {
 	/**
 	 * Coupon discount calculations.
@@ -615,6 +715,11 @@ function wc_update_240_options() {
 	update_option( 'woocommerce_calc_discounts_sequentially', 'yes' );
 }
 
+/**
+ * Update shipping methods for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_shipping_methods() {
 	/**
 	 * Flat Rate Shipping.
@@ -625,9 +730,9 @@ function wc_update_240_shipping_methods() {
 		'woocommerce_international_delivery_flat_rates' => new WC_Shipping_Legacy_International_Delivery(),
 	);
 	foreach ( $shipping_methods as $flat_rate_option_key => $shipping_method ) {
-		// Stop this running more than once if routine is repeated
+		// Stop this running more than once if routine is repeated.
 		if ( version_compare( $shipping_method->get_option( 'version', 0 ), '2.4.0', '<' ) ) {
-			$has_classes                      = sizeof( WC()->shipping->get_shipping_classes() ) > 0;
+			$has_classes                      = count( WC()->shipping->get_shipping_classes() ) > 0;
 			$cost_key                         = $has_classes ? 'no_class_cost' : 'cost';
 			$min_fee                          = $shipping_method->get_option( 'minimum_fee' );
 			$math_cost_strings                = array( 'cost' => array(), 'no_class_cost' => array() );
@@ -656,7 +761,7 @@ function wc_update_240_shipping_methods() {
 				foreach ( $math_cost_strings as $key => $math_cost_string ) {
 					$math_cost_strings[ $key ] = array_filter( array_map( 'trim', $math_cost_strings[ $key ] ) );
 					if ( ! empty( $math_cost_strings[ $key ] ) ) {
-						$last_key                                = max( 0, sizeof( $math_cost_strings[ $key ] ) - 1 );
+						$last_key                                = max( 0, count( $math_cost_strings[ $key ] ) - 1 );
 						$math_cost_strings[ $key ][0]            = '( ' . $math_cost_strings[ $key ][0];
 						$math_cost_strings[ $key ][ $last_key ] .= ' ) * [qty]';
 					}
@@ -665,7 +770,7 @@ function wc_update_240_shipping_methods() {
 
 			$math_cost_strings['cost'][] = $shipping_method->get_option( 'cost_per_order' );
 
-			// Save settings
+			// Save settings.
 			foreach ( $math_cost_strings as $option_id => $math_cost_string ) {
 				$shipping_method->settings[ $option_id ] = implode( ' + ', array_filter( $math_cost_string ) );
 			}
@@ -678,6 +783,11 @@ function wc_update_240_shipping_methods() {
 	}
 }
 
+/**
+ * Update API keys for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_api_keys() {
 	global $wpdb;
 	/**
@@ -686,7 +796,7 @@ function wc_update_240_api_keys() {
 	$api_users = $wpdb->get_results( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'woocommerce_api_consumer_key'" );
 	$apps_keys = array();
 
-	// Get user data
+	// Get user data.
 	foreach ( $api_users as $_user ) {
 		$user = get_userdata( $_user->user_id );
 		$apps_keys[] = array(
@@ -699,7 +809,7 @@ function wc_update_240_api_keys() {
 	}
 
 	if ( ! empty( $apps_keys ) ) {
-		// Create new apps
+		// Create new apps.
 		foreach ( $apps_keys as $app ) {
 			$wpdb->insert(
 				$wpdb->prefix . 'woocommerce_api_keys',
@@ -714,7 +824,7 @@ function wc_update_240_api_keys() {
 			);
 		}
 
-		// Delete old user keys from usermeta
+		// Delete old user keys from usermeta.
 		foreach ( $api_users as $_user ) {
 			$user_id = intval( $_user->user_id );
 			delete_user_meta( $user_id, 'woocommerce_api_consumer_key' );
@@ -724,6 +834,11 @@ function wc_update_240_api_keys() {
 	}
 }
 
+/**
+ * Update webhooks for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_webhooks() {
 	/**
 	 * Webhooks.
@@ -741,6 +856,11 @@ function wc_update_240_webhooks() {
 	}
 }
 
+/**
+ * Update refunds for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_refunds() {
 	global $wpdb;
 	/**
@@ -753,7 +873,7 @@ function wc_update_240_refunds() {
 		'post_status'    => array( 'wc-refunded' ),
 	) );
 
-	// Ensure emails are disabled during this update routine
+	// Ensure emails are disabled during this update routine.
 	remove_all_actions( 'woocommerce_order_status_refunded_notification' );
 	remove_all_actions( 'woocommerce_order_partially_refunded_notification' );
 	remove_action( 'woocommerce_order_status_refunded', array( 'WC_Emails', 'send_transactional_email' ) );
@@ -783,14 +903,24 @@ function wc_update_240_refunds() {
 	wc_delete_shop_order_transients();
 }
 
+/**
+ * Update DB version for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_db_version() {
 	WC_Install::update_db_version( '2.4.0' );
 }
 
+/**
+ * Update variations for 2.4.1
+ *
+ * @return void
+ */
 function wc_update_241_variations() {
 	global $wpdb;
 
-	// Select variations that don't have any _stock_status implemented on WooCommerce 2.2
+	// Select variations that don't have any _stock_status implemented on WooCommerce 2.2.
 	$update_variations = $wpdb->get_results( "
 		SELECT DISTINCT posts.ID AS variation_id, posts.post_parent AS variation_parent
 		FROM {$wpdb->posts} as posts
@@ -800,24 +930,34 @@ function wc_update_241_variations() {
 	" );
 
 	foreach ( $update_variations as $variation ) {
-		// Get the parent _stock_status
+		// Get the parent _stock_status.
 		$parent_stock_status = get_post_meta( $variation->variation_parent, '_stock_status', true );
 
-		// Set the _stock_status
+		// Set the _stock_status.
 		add_post_meta( $variation->variation_id, '_stock_status', $parent_stock_status ? $parent_stock_status : 'instock', true );
 
-		// Delete old product children array
+		// Delete old product children array.
 		delete_transient( 'wc_product_children_' . $variation->variation_parent );
 	}
 
-	// Invalidate old transients such as wc_var_price
+	// Invalidate old transients such as wc_var_price.
 	WC_Cache_Helper::get_transient_version( 'product', true );
 }
 
+/**
+ * Update DB version for 2.4.1
+ *
+ * @return void
+ */
 function wc_update_241_db_version() {
 	WC_Install::update_db_version( '2.4.1' );
 }
 
+/**
+ * Update currency settings for 2.5
+ *
+ * @return void
+ */
 function wc_update_250_currency() {
 	global $wpdb;
 	// Fix currency settings for LAK currency.
@@ -840,14 +980,22 @@ function wc_update_250_currency() {
 	);
 }
 
+/**
+ * Update DB version for 2.5
+ *
+ * @return void
+ */
 function wc_update_250_db_version() {
 	WC_Install::update_db_version( '2.5.0' );
 }
 
+/**
+ * Update ship to countries options for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_options() {
-	/**
-	 * woocommerce_calc_shipping option has been removed in 2.6
-	 */
+	// woocommerce_calc_shipping option has been removed in 2.6.
 	if ( 'no' === get_option( 'woocommerce_calc_shipping' ) ) {
 		update_option( 'woocommerce_ship_to_countries', 'disabled' );
 	}
@@ -855,10 +1003,15 @@ function wc_update_260_options() {
 	WC_Admin_Notices::add_notice( 'legacy_shipping' );
 }
 
+/**
+ * Update term meta for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_termmeta() {
 	global $wpdb;
 	/**
-	 * Migrate term meta to WordPress tables
+	 * Migrate term meta to WordPress tables.
 	 */
 	if ( get_option( 'db_version' ) >= 34370 && $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}woocommerce_termmeta';" ) ) {
 		if ( $wpdb->query( "INSERT INTO {$wpdb->termmeta} ( term_id, meta_key, meta_value ) SELECT woocommerce_term_id, meta_key, meta_value FROM {$wpdb->prefix}woocommerce_termmeta;" ) ) {
@@ -868,6 +1021,11 @@ function wc_update_260_termmeta() {
 	}
 }
 
+/**
+ * Update zones for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_zones() {
 	global $wpdb;
 	/**
@@ -880,6 +1038,11 @@ function wc_update_260_zones() {
 	}
 }
 
+/**
+ * Update zone methods for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_zone_methods() {
 	global $wpdb;
 
@@ -894,13 +1057,13 @@ function wc_update_260_zone_methods() {
 			$max_new_id = $wpdb->get_var( "SELECT MAX(instance_id) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods" );
 			$max_old_id = $wpdb->get_var( "SELECT MAX(shipping_method_id) FROM {$wpdb->prefix}woocommerce_shipping_zone_shipping_methods" );
 
-			// Avoid ID conflicts
+			// Avoid ID conflicts.
 			$wpdb->query( $wpdb->prepare( "ALTER TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods AUTO_INCREMENT = %d;", max( $max_new_id, $max_old_id ) + 1 ) );
 
-			// Store changes
+			// Store changes.
 			$changes = array();
 
-			// Move data
+			// Move data.
 			foreach ( $old_methods as $old_method ) {
 				$wpdb->insert( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array(
 					'zone_id'      => $old_method->zone_id,
@@ -910,18 +1073,18 @@ function wc_update_260_zone_methods() {
 
 				$new_instance_id = $wpdb->insert_id;
 
-				// Move main settings
+				// Move main settings.
 				$older_settings_key = 'woocommerce_' . $old_method->shipping_method_type . '-' . $old_method->shipping_method_id . '_settings';
 				$old_settings_key   = 'woocommerce_' . $old_method->shipping_method_type . '_' . $old_method->shipping_method_id . '_settings';
 				add_option( 'woocommerce_' . $old_method->shipping_method_type . '_' . $new_instance_id . '_settings', get_option( $old_settings_key, get_option( $older_settings_key ) ) );
 
 				// Handling for table rate and flat rate box shipping.
 				if ( 'table_rate' === $old_method->shipping_method_type ) {
-					// Move priority settings
+					// Move priority settings.
 					add_option( 'woocommerce_table_rate_default_priority_' . $new_instance_id, get_option( 'woocommerce_table_rate_default_priority_' . $old_method->shipping_method_id ) );
 					add_option( 'woocommerce_table_rate_priorities_' . $new_instance_id, get_option( 'woocommerce_table_rate_priorities_' . $old_method->shipping_method_id ) );
 
-					// Move rates
+					// Move rates.
 					$wpdb->update(
 						$wpdb->prefix . 'woocommerce_shipping_table_rates',
 						array(
@@ -957,10 +1120,15 @@ function wc_update_260_zone_methods() {
 	$wpdb->query( "UPDATE {$wpdb->prefix}woocommerce_shipping_zone_locations SET location_code = REPLACE( location_code, '-', '...' );" );
 }
 
+/**
+ * Update refunds for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_refunds() {
 	global $wpdb;
 	/**
-	 * Refund item qty should be negative
+	 * Refund item qty should be negative.
 	 */
 	$wpdb->query( "
 	UPDATE {$wpdb->prefix}woocommerce_order_itemmeta as item_meta
@@ -971,10 +1139,20 @@ function wc_update_260_refunds() {
 	" );
 }
 
+/**
+ * Update DB version for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_db_version() {
 	WC_Install::update_db_version( '2.6.0' );
 }
 
+/**
+ * Update webhooks for 3.0
+ *
+ * @return void
+ */
 function wc_update_300_webhooks() {
 	/**
 	 * Make sure product.update webhooks get the woocommerce_product_quick_edit_save
@@ -1008,6 +1186,11 @@ function wc_update_300_comment_type_index() {
 	}
 }
 
+/**
+ * Update grouped products for 3.0
+ *
+ * @return void
+ */
 function wc_update_300_grouped_products() {
 	global $wpdb;
 	$parents = $wpdb->get_col( "SELECT DISTINCT( post_parent ) FROM {$wpdb->posts} WHERE post_parent > 0 AND post_type = 'product';" );
@@ -1036,6 +1219,11 @@ function wc_update_300_grouped_products() {
 	}
 }
 
+/**
+ * Update shipping tax classes for 3.0
+ *
+ * @return void
+ */
 function wc_update_300_settings() {
 	$woocommerce_shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
 	if ( '' === $woocommerce_shipping_tax_class ) {
@@ -1183,13 +1371,15 @@ function wc_update_320_mexican_states() {
 	);
 
 	foreach ( $mx_states as $old => $new ) {
-		$wpdb->update(
-			$wpdb->postmeta,
-			array(
-				'meta_value' => $new,
-			),
-			array(
-				'meta_value' => $old,
+		$wpdb->query(
+			$wpdb->prepare(
+				"
+					UPDATE $wpdb->postmeta
+					SET meta_value = %s
+		 			WHERE meta_key IN ( '_billing_state', '_shipping_state' )
+		 			AND meta_value = %s
+				",
+				$new, $old
 			)
 		);
 		$wpdb->update(

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1371,13 +1371,15 @@ function wc_update_320_mexican_states() {
 	);
 
 	foreach ( $mx_states as $old => $new ) {
-		$wpdb->update(
-			$wpdb->postmeta,
-			array(
-				'meta_value' => $new,
-			),
-			array(
-				'meta_value' => $old,
+		$wpdb->query(
+			$wpdb->prepare(
+				"
+					UPDATE $wpdb->postmeta
+					SET meta_value = %s
+		 			WHERE meta_key IN ( '_billing_state', '_shipping_state' )
+		 			AND meta_value = %s
+				",
+				$new, $old
 			)
 		);
 		$wpdb->update(

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -14,10 +14,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Update file paths for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_file_paths() {
 	global $wpdb;
 
-	// Upgrade old style files paths to support multiple file paths
+	// Upgrade old style files paths to support multiple file paths.
 	$existing_file_paths = $wpdb->get_results( "SELECT meta_value, meta_id, post_id FROM {$wpdb->postmeta} WHERE meta_key = '_file_path' AND meta_value != '';" );
 
 	if ( $existing_file_paths ) {
@@ -38,8 +43,13 @@ function wc_update_200_file_paths() {
 	}
 }
 
+/**
+ * Update permalinks for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_permalinks() {
-	// Setup default permalinks if shop page is defined
+	// Setup default permalinks if shop page is defined.
 	$permalinks 	= get_option( 'woocommerce_permalinks' );
 	$shop_page_id 	= wc_get_page_id( 'shop' );
 
@@ -47,7 +57,7 @@ function wc_update_200_permalinks() {
 
 		$base_slug 		= $shop_page_id > 0 && get_post( $shop_page_id ) ? get_page_uri( $shop_page_id ) : 'shop';
 
-		$category_base 	= get_option( 'woocommerce_prepend_shop_page_to_urls' ) == "yes" ? trailingslashit( $base_slug ) : '';
+		$category_base 	= get_option( 'woocommerce_prepend_shop_page_to_urls' ) == 'yes' ? trailingslashit( $base_slug ) : '';
 		$category_slug 	= get_option( 'woocommerce_product_category_slug' ) ? get_option( 'woocommerce_product_category_slug' ) : _x( 'product-category', 'slug', 'woocommerce' );
 		$tag_slug 		= get_option( 'woocommerce_product_tag_slug' ) ? get_option( 'woocommerce_product_tag_slug' ) : _x( 'product-tag', 'slug', 'woocommerce' );
 
@@ -76,8 +86,13 @@ function wc_update_200_permalinks() {
 	}
 }
 
+/**
+ * Update sub-category display options for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_subcat_display() {
-	// Update subcat display settings
+	// Update subcat display settings.
 	if ( get_option( 'woocommerce_shop_show_subcategories' ) == 'yes' ) {
 		if ( get_option( 'woocommerce_hide_products_when_showing_subcategories' ) == 'yes' ) {
 			update_option( 'woocommerce_shop_page_display', 'subcategories' );
@@ -95,10 +110,15 @@ function wc_update_200_subcat_display() {
 	}
 }
 
+/**
+ * Update tax rates for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_taxrates() {
 	global $wpdb;
 
-	// Update tax rates
+	// Update tax rates.
 	$loop = 0;
 	$tax_rates = get_option( 'woocommerce_tax_rates' );
 
@@ -116,7 +136,7 @@ function wc_update_200_taxrates() {
 					}
 
 					$wpdb->insert(
-						$wpdb->prefix . "woocommerce_tax_rates",
+						$wpdb->prefix . 'woocommerce_tax_rates',
 						array(
 							'tax_rate_country'  => $country,
 							'tax_rate_state'    => $state,
@@ -148,7 +168,7 @@ function wc_update_200_taxrates() {
 			}
 
 			$wpdb->insert(
-				$wpdb->prefix . "woocommerce_tax_rates",
+				$wpdb->prefix . 'woocommerce_tax_rates',
 				array(
 					'tax_rate_country'  => $tax_rate['country'],
 					'tax_rate_state'    => $tax_rate['state'],
@@ -168,7 +188,7 @@ function wc_update_200_taxrates() {
 				foreach ( $tax_rate['locations'] as $location ) {
 
 					$wpdb->insert(
-						$wpdb->prefix . "woocommerce_tax_rate_locations",
+						$wpdb->prefix . 'woocommerce_tax_rate_locations',
 						array(
 							'location_code' => $location,
 							'tax_rate_id'   => $tax_rate_id,
@@ -189,11 +209,16 @@ function wc_update_200_taxrates() {
 	delete_option( 'woocommerce_local_tax_rates' );
 }
 
+/**
+ * Upadte order item line items for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_line_items() {
 	global $wpdb;
 
-	// Now its time for the massive update to line items - move them to the new DB tables
-	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_items' WHERE meta_key = '_order_items_old'
+	// Now its time for the massive update to line items - move them to the new DB tables.
+	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_items' WHERE meta_key = '_order_items_old'.
 	$order_item_rows = $wpdb->get_results( "
 		SELECT meta_value, post_id FROM {$wpdb->postmeta}
 		WHERE meta_key = '_order_items'
@@ -218,27 +243,27 @@ function wc_update_200_line_items() {
 			$order_item['line_subtotal'] 		= isset( $order_item['line_subtotal'] ) ? $order_item['line_subtotal'] : 0;
 
 			$item_id = wc_add_order_item( $order_item_row->post_id, array(
-		 		'order_item_name' 		=> $order_item['name'],
-		 		'order_item_type' 		=> 'line_item',
-		 	) );
+				 'order_item_name' 		=> $order_item['name'],
+				 'order_item_type' 		=> 'line_item',
+			) );
 
-		 	// Add line item meta
-		 	if ( $item_id ) {
-			 	wc_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
-			 	wc_add_order_item_meta( $item_id, '_tax_class', $order_item['tax_class'] );
-			 	wc_add_order_item_meta( $item_id, '_product_id', $order_item['id'] );
-			 	wc_add_order_item_meta( $item_id, '_variation_id', $order_item['variation_id'] );
-			 	wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( $order_item['line_subtotal'] ) );
-			 	wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( $order_item['line_subtotal_tax'] ) );
-			 	wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( $order_item['line_total'] ) );
-			 	wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( $order_item['line_tax'] ) );
+			 // Add line item meta.
+			if ( $item_id ) {
+				wc_add_order_item_meta( $item_id, '_qty', absint( $order_item['qty'] ) );
+				wc_add_order_item_meta( $item_id, '_tax_class', $order_item['tax_class'] );
+				wc_add_order_item_meta( $item_id, '_product_id', $order_item['id'] );
+				wc_add_order_item_meta( $item_id, '_variation_id', $order_item['variation_id'] );
+				wc_add_order_item_meta( $item_id, '_line_subtotal', wc_format_decimal( $order_item['line_subtotal'] ) );
+				wc_add_order_item_meta( $item_id, '_line_subtotal_tax', wc_format_decimal( $order_item['line_subtotal_tax'] ) );
+				wc_add_order_item_meta( $item_id, '_line_total', wc_format_decimal( $order_item['line_total'] ) );
+				wc_add_order_item_meta( $item_id, '_line_tax', wc_format_decimal( $order_item['line_tax'] ) );
 
-			 	$meta_rows = array();
+				$meta_rows = array();
 
-				// Insert meta
+				// Insert meta.
 				if ( ! empty( $order_item['item_meta'] ) ) {
 					foreach ( $order_item['item_meta'] as $key => $meta ) {
-						// Backwards compatibility
+						// Backwards compatibility.
 						if ( is_array( $meta ) && isset( $meta['meta_name'] ) ) {
 							$meta_rows[] = '(' . $item_id . ',"' . esc_sql( $meta['meta_name'] ) . '","' . esc_sql( $meta['meta_value'] ) . '")';
 						} else {
@@ -247,29 +272,29 @@ function wc_update_200_line_items() {
 					}
 				}
 
-				// Insert meta rows at once
-				if ( sizeof( $meta_rows ) > 0 ) {
+				// Insert meta rows at once.
+				if ( count( $meta_rows ) > 0 ) {
 					$wpdb->query( $wpdb->prepare( "
 						INSERT INTO {$wpdb->prefix}woocommerce_order_itemmeta ( order_item_id, meta_key, meta_value )
-						VALUES " . implode( ',', $meta_rows ) . ";
-					", $order_item_row->post_id ) );
+						VALUES " . implode( ',', $meta_rows ) . ';
+                    ', $order_item_row->post_id ) );
 				}
 
-				// Delete from DB (rename)
+				// Delete from DB (rename).
 				$wpdb->query( $wpdb->prepare( "
 					UPDATE {$wpdb->postmeta}
 					SET meta_key = '_order_items_old'
 					WHERE meta_key = '_order_items'
 					AND post_id = %d
 				", $order_item_row->post_id ) );
-		 	}
+			}
 
 			unset( $meta_rows, $item_id, $order_item );
 		}
 	}
 
-	// Do the same kind of update for order_taxes - move to lines
-	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_taxes' WHERE meta_key = '_order_taxes_old'
+	// Do the same kind of update for order_taxes - move to lines.
+	// Reverse with UPDATE `wpwc_postmeta` SET meta_key = '_order_taxes' WHERE meta_key = '_order_taxes_old'.
 	$order_tax_rows = $wpdb->get_results( "
 		SELECT meta_value, post_id FROM {$wpdb->postmeta}
 		WHERE meta_key = '_order_taxes'
@@ -287,18 +312,18 @@ function wc_update_200_line_items() {
 				}
 
 				$item_id = wc_add_order_item( $order_tax_row->post_id, array(
-			 		'order_item_name' 		=> $order_tax['label'],
-			 		'order_item_type' 		=> 'tax',
-			 	) );
+					 'order_item_name' 		=> $order_tax['label'],
+					 'order_item_type' 		=> 'tax',
+				) );
 
-			 	// Add line item meta
-			 	if ( $item_id ) {
-				 	wc_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
-				 	wc_add_order_item_meta( $item_id, 'tax_amount', wc_clean( $order_tax['cart_tax'] ) );
-				 	wc_add_order_item_meta( $item_id, 'shipping_tax_amount', wc_clean( $order_tax['shipping_tax'] ) );
+				 // Add line item meta.
+				if ( $item_id ) {
+					wc_add_order_item_meta( $item_id, 'compound', absint( isset( $order_tax['compound'] ) ? $order_tax['compound'] : 0 ) );
+					wc_add_order_item_meta( $item_id, 'tax_amount', wc_clean( $order_tax['cart_tax'] ) );
+					wc_add_order_item_meta( $item_id, 'shipping_tax_amount', wc_clean( $order_tax['shipping_tax'] ) );
 				}
 
-				// Delete from DB (rename)
+				// Delete from DB (rename).
 				$wpdb->query( $wpdb->prepare( "
 					UPDATE {$wpdb->postmeta}
 					SET meta_key = '_order_taxes_old'
@@ -312,9 +337,14 @@ function wc_update_200_line_items() {
 	}
 }
 
+/**
+ * Update image settings for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_images() {
 	// Grab the pre 2.0 Image options and use to populate the new image options settings,
-	// cleaning up afterwards like nice people do
+	// cleaning up afterwards like nice people do.
 	foreach ( array( 'catalog', 'single', 'thumbnail' ) as $value ) {
 
 		$old_settings = array_filter( array(
@@ -333,14 +363,24 @@ function wc_update_200_images() {
 	}
 }
 
+/**
+ * Update DB version for 2.0
+ *
+ * @return void
+ */
 function wc_update_200_db_version() {
 	WC_Install::update_db_version( '2.0.0' );
 }
 
+/**
+ * Update Brazilian States for 2.0.9
+ *
+ * @return void
+ */
 function wc_update_209_brazillian_state() {
 	global $wpdb;
 
-	// Update brazillian state codes
+	// Update brazillian state codes.
 	$wpdb->update(
 		$wpdb->postmeta,
 		array(
@@ -383,12 +423,22 @@ function wc_update_209_brazillian_state() {
 	);
 }
 
+/**
+ * Update DB version for 2.0.9
+ *
+ * @return void
+ */
 function wc_update_209_db_version() {
 	WC_Install::update_db_version( '2.0.9' );
 }
 
+/**
+ * Remove pages for 2.1
+ *
+ * @return void
+ */
 function wc_update_210_remove_pages() {
-	// Pages no longer used
+	// Pages no longer used.
 	wp_trash_post( get_option( 'woocommerce_pay_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_thanks_page_id' ) );
 	wp_trash_post( get_option( 'woocommerce_view_order_page_id' ) );
@@ -397,10 +447,15 @@ function wc_update_210_remove_pages() {
 	wp_trash_post( get_option( 'woocommerce_lost_password_page_id' ) );
 }
 
+/**
+ * Update file paths to support multiple files for 2.1
+ *
+ * @return void
+ */
 function wc_update_210_file_paths() {
 	global $wpdb;
 
-	// Upgrade file paths to support multiple file paths + names etc
+	// Upgrade file paths to support multiple file paths + names etc.
 	$existing_file_paths = $wpdb->get_results( "SELECT meta_value, meta_id FROM {$wpdb->postmeta} WHERE meta_key = '_file_paths' AND meta_value != '';" );
 
 	if ( $existing_file_paths ) {
@@ -433,10 +488,20 @@ function wc_update_210_file_paths() {
 	}
 }
 
+/**
+ * Update DB version for 2.1
+ *
+ * @return void
+ */
 function wc_update_210_db_version() {
 	WC_Install::update_db_version( '2.1.0' );
 }
 
+/**
+ * Update shipping options for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_shipping() {
 	$woocommerce_ship_to_destination = 'shipping';
 
@@ -449,6 +514,11 @@ function wc_update_220_shipping() {
 	add_option( 'woocommerce_ship_to_destination', $woocommerce_ship_to_destination, '', 'no' );
 }
 
+/**
+ * Update order statuses for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_order_status() {
 	global $wpdb;
 	$wpdb->query( "
@@ -537,9 +607,14 @@ function wc_update_220_order_status() {
 	);
 }
 
+/**
+ * Update variations for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_variations() {
 	global $wpdb;
-	// Update variations which manage stock
+	// Update variations which manage stock.
 	$update_variations = $wpdb->get_results( "
 		SELECT DISTINCT posts.ID AS variation_id, posts.post_parent AS variation_parent FROM {$wpdb->posts} as posts
 		LEFT OUTER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id AND postmeta.meta_key = '_stock'
@@ -557,16 +632,21 @@ function wc_update_220_variations() {
 	}
 }
 
+/**
+ * Update attributes for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_attributes() {
 	global $wpdb;
-	// Update taxonomy names with correct sanitized names
-	$attribute_taxonomies = $wpdb->get_results( "SELECT attribute_name, attribute_id FROM " . $wpdb->prefix . "woocommerce_attribute_taxonomies" );
+	// Update taxonomy names with correct sanitized names.
+	$attribute_taxonomies = $wpdb->get_results( 'SELECT attribute_name, attribute_id FROM ' . $wpdb->prefix . 'woocommerce_attribute_taxonomies' );
 
 	foreach ( $attribute_taxonomies as $attribute_taxonomy ) {
 		$sanitized_attribute_name = wc_sanitize_taxonomy_name( $attribute_taxonomy->attribute_name );
 		if ( $sanitized_attribute_name !== $attribute_taxonomy->attribute_name ) {
 			if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT 1=1 FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name = %s;", $sanitized_attribute_name ) ) ) {
-				// Update attribute
+				// Update attribute.
 				$wpdb->update(
 					"{$wpdb->prefix}woocommerce_attribute_taxonomies",
 					array(
@@ -577,7 +657,7 @@ function wc_update_220_attributes() {
 					)
 				);
 
-				// Update terms
+				// Update terms.
 				$wpdb->update(
 					$wpdb->term_taxonomy,
 					array( 'taxonomy' => wc_attribute_taxonomy_name( $sanitized_attribute_name ) ),
@@ -588,25 +668,45 @@ function wc_update_220_attributes() {
 	}
 }
 
+/**
+ * Update DB version for 2.2
+ *
+ * @return void
+ */
 function wc_update_220_db_version() {
 	WC_Install::update_db_version( '2.2.0' );
 }
 
+/**
+ * Update options for 2.3
+ *
+ * @return void
+ */
 function wc_update_230_options() {
 	// _money_spent and _order_count may be out of sync - clear them
 	delete_metadata( 'user', 0, '_money_spent', '', true );
 	delete_metadata( 'user', 0, '_order_count', '', true );
 
-	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default
+	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default.
 	if ( '' === get_option( 'woocommerce_default_customer_address', false ) && wc_prices_include_tax() ) {
 		update_option( 'woocommerce_default_customer_address', 'base' );
 	}
 }
 
+/**
+ * Update DB version for 2.3
+ *
+ * @return void
+ */
 function wc_update_230_db_version() {
 	WC_Install::update_db_version( '2.3.0' );
 }
 
+/**
+ * Update calc discount options for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_options() {
 	/**
 	 * Coupon discount calculations.
@@ -615,6 +715,11 @@ function wc_update_240_options() {
 	update_option( 'woocommerce_calc_discounts_sequentially', 'yes' );
 }
 
+/**
+ * Update shipping methods for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_shipping_methods() {
 	/**
 	 * Flat Rate Shipping.
@@ -625,9 +730,9 @@ function wc_update_240_shipping_methods() {
 		'woocommerce_international_delivery_flat_rates' => new WC_Shipping_Legacy_International_Delivery(),
 	);
 	foreach ( $shipping_methods as $flat_rate_option_key => $shipping_method ) {
-		// Stop this running more than once if routine is repeated
+		// Stop this running more than once if routine is repeated.
 		if ( version_compare( $shipping_method->get_option( 'version', 0 ), '2.4.0', '<' ) ) {
-			$has_classes                      = sizeof( WC()->shipping->get_shipping_classes() ) > 0;
+			$has_classes                      = count( WC()->shipping->get_shipping_classes() ) > 0;
 			$cost_key                         = $has_classes ? 'no_class_cost' : 'cost';
 			$min_fee                          = $shipping_method->get_option( 'minimum_fee' );
 			$math_cost_strings                = array( 'cost' => array(), 'no_class_cost' => array() );
@@ -656,7 +761,7 @@ function wc_update_240_shipping_methods() {
 				foreach ( $math_cost_strings as $key => $math_cost_string ) {
 					$math_cost_strings[ $key ] = array_filter( array_map( 'trim', $math_cost_strings[ $key ] ) );
 					if ( ! empty( $math_cost_strings[ $key ] ) ) {
-						$last_key                                = max( 0, sizeof( $math_cost_strings[ $key ] ) - 1 );
+						$last_key                                = max( 0, count( $math_cost_strings[ $key ] ) - 1 );
 						$math_cost_strings[ $key ][0]            = '( ' . $math_cost_strings[ $key ][0];
 						$math_cost_strings[ $key ][ $last_key ] .= ' ) * [qty]';
 					}
@@ -665,7 +770,7 @@ function wc_update_240_shipping_methods() {
 
 			$math_cost_strings['cost'][] = $shipping_method->get_option( 'cost_per_order' );
 
-			// Save settings
+			// Save settings.
 			foreach ( $math_cost_strings as $option_id => $math_cost_string ) {
 				$shipping_method->settings[ $option_id ] = implode( ' + ', array_filter( $math_cost_string ) );
 			}
@@ -678,6 +783,11 @@ function wc_update_240_shipping_methods() {
 	}
 }
 
+/**
+ * Update API keys for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_api_keys() {
 	global $wpdb;
 	/**
@@ -686,7 +796,7 @@ function wc_update_240_api_keys() {
 	$api_users = $wpdb->get_results( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'woocommerce_api_consumer_key'" );
 	$apps_keys = array();
 
-	// Get user data
+	// Get user data.
 	foreach ( $api_users as $_user ) {
 		$user = get_userdata( $_user->user_id );
 		$apps_keys[] = array(
@@ -699,7 +809,7 @@ function wc_update_240_api_keys() {
 	}
 
 	if ( ! empty( $apps_keys ) ) {
-		// Create new apps
+		// Create new apps.
 		foreach ( $apps_keys as $app ) {
 			$wpdb->insert(
 				$wpdb->prefix . 'woocommerce_api_keys',
@@ -714,7 +824,7 @@ function wc_update_240_api_keys() {
 			);
 		}
 
-		// Delete old user keys from usermeta
+		// Delete old user keys from usermeta.
 		foreach ( $api_users as $_user ) {
 			$user_id = intval( $_user->user_id );
 			delete_user_meta( $user_id, 'woocommerce_api_consumer_key' );
@@ -724,6 +834,11 @@ function wc_update_240_api_keys() {
 	}
 }
 
+/**
+ * Update webhooks for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_webhooks() {
 	/**
 	 * Webhooks.
@@ -741,6 +856,11 @@ function wc_update_240_webhooks() {
 	}
 }
 
+/**
+ * Update refunds for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_refunds() {
 	global $wpdb;
 	/**
@@ -753,7 +873,7 @@ function wc_update_240_refunds() {
 		'post_status'    => array( 'wc-refunded' ),
 	) );
 
-	// Ensure emails are disabled during this update routine
+	// Ensure emails are disabled during this update routine.
 	remove_all_actions( 'woocommerce_order_status_refunded_notification' );
 	remove_all_actions( 'woocommerce_order_partially_refunded_notification' );
 	remove_action( 'woocommerce_order_status_refunded', array( 'WC_Emails', 'send_transactional_email' ) );
@@ -783,14 +903,24 @@ function wc_update_240_refunds() {
 	wc_delete_shop_order_transients();
 }
 
+/**
+ * Update DB version for 2.4
+ *
+ * @return void
+ */
 function wc_update_240_db_version() {
 	WC_Install::update_db_version( '2.4.0' );
 }
 
+/**
+ * Update variations for 2.4.1
+ *
+ * @return void
+ */
 function wc_update_241_variations() {
 	global $wpdb;
 
-	// Select variations that don't have any _stock_status implemented on WooCommerce 2.2
+	// Select variations that don't have any _stock_status implemented on WooCommerce 2.2.
 	$update_variations = $wpdb->get_results( "
 		SELECT DISTINCT posts.ID AS variation_id, posts.post_parent AS variation_parent
 		FROM {$wpdb->posts} as posts
@@ -800,24 +930,34 @@ function wc_update_241_variations() {
 	" );
 
 	foreach ( $update_variations as $variation ) {
-		// Get the parent _stock_status
+		// Get the parent _stock_status.
 		$parent_stock_status = get_post_meta( $variation->variation_parent, '_stock_status', true );
 
-		// Set the _stock_status
+		// Set the _stock_status.
 		add_post_meta( $variation->variation_id, '_stock_status', $parent_stock_status ? $parent_stock_status : 'instock', true );
 
-		// Delete old product children array
+		// Delete old product children array.
 		delete_transient( 'wc_product_children_' . $variation->variation_parent );
 	}
 
-	// Invalidate old transients such as wc_var_price
+	// Invalidate old transients such as wc_var_price.
 	WC_Cache_Helper::get_transient_version( 'product', true );
 }
 
+/**
+ * Update DB version for 2.4.1
+ *
+ * @return void
+ */
 function wc_update_241_db_version() {
 	WC_Install::update_db_version( '2.4.1' );
 }
 
+/**
+ * Update currency settings for 2.5
+ *
+ * @return void
+ */
 function wc_update_250_currency() {
 	global $wpdb;
 	// Fix currency settings for LAK currency.
@@ -840,14 +980,22 @@ function wc_update_250_currency() {
 	);
 }
 
+/**
+ * Update DB version for 2.5
+ *
+ * @return void
+ */
 function wc_update_250_db_version() {
 	WC_Install::update_db_version( '2.5.0' );
 }
 
+/**
+ * Update ship to countries options for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_options() {
-	/**
-	 * woocommerce_calc_shipping option has been removed in 2.6
-	 */
+	// woocommerce_calc_shipping option has been removed in 2.6.
 	if ( 'no' === get_option( 'woocommerce_calc_shipping' ) ) {
 		update_option( 'woocommerce_ship_to_countries', 'disabled' );
 	}
@@ -855,10 +1003,15 @@ function wc_update_260_options() {
 	WC_Admin_Notices::add_notice( 'legacy_shipping' );
 }
 
+/**
+ * Update term meta for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_termmeta() {
 	global $wpdb;
 	/**
-	 * Migrate term meta to WordPress tables
+	 * Migrate term meta to WordPress tables.
 	 */
 	if ( get_option( 'db_version' ) >= 34370 && $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}woocommerce_termmeta';" ) ) {
 		if ( $wpdb->query( "INSERT INTO {$wpdb->termmeta} ( term_id, meta_key, meta_value ) SELECT woocommerce_term_id, meta_key, meta_value FROM {$wpdb->prefix}woocommerce_termmeta;" ) ) {
@@ -868,6 +1021,11 @@ function wc_update_260_termmeta() {
 	}
 }
 
+/**
+ * Update zones for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_zones() {
 	global $wpdb;
 	/**
@@ -880,6 +1038,11 @@ function wc_update_260_zones() {
 	}
 }
 
+/**
+ * Update zone methods for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_zone_methods() {
 	global $wpdb;
 
@@ -894,13 +1057,13 @@ function wc_update_260_zone_methods() {
 			$max_new_id = $wpdb->get_var( "SELECT MAX(instance_id) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods" );
 			$max_old_id = $wpdb->get_var( "SELECT MAX(shipping_method_id) FROM {$wpdb->prefix}woocommerce_shipping_zone_shipping_methods" );
 
-			// Avoid ID conflicts
+			// Avoid ID conflicts.
 			$wpdb->query( $wpdb->prepare( "ALTER TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods AUTO_INCREMENT = %d;", max( $max_new_id, $max_old_id ) + 1 ) );
 
-			// Store changes
+			// Store changes.
 			$changes = array();
 
-			// Move data
+			// Move data.
 			foreach ( $old_methods as $old_method ) {
 				$wpdb->insert( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array(
 					'zone_id'      => $old_method->zone_id,
@@ -910,18 +1073,18 @@ function wc_update_260_zone_methods() {
 
 				$new_instance_id = $wpdb->insert_id;
 
-				// Move main settings
+				// Move main settings.
 				$older_settings_key = 'woocommerce_' . $old_method->shipping_method_type . '-' . $old_method->shipping_method_id . '_settings';
 				$old_settings_key   = 'woocommerce_' . $old_method->shipping_method_type . '_' . $old_method->shipping_method_id . '_settings';
 				add_option( 'woocommerce_' . $old_method->shipping_method_type . '_' . $new_instance_id . '_settings', get_option( $old_settings_key, get_option( $older_settings_key ) ) );
 
 				// Handling for table rate and flat rate box shipping.
 				if ( 'table_rate' === $old_method->shipping_method_type ) {
-					// Move priority settings
+					// Move priority settings.
 					add_option( 'woocommerce_table_rate_default_priority_' . $new_instance_id, get_option( 'woocommerce_table_rate_default_priority_' . $old_method->shipping_method_id ) );
 					add_option( 'woocommerce_table_rate_priorities_' . $new_instance_id, get_option( 'woocommerce_table_rate_priorities_' . $old_method->shipping_method_id ) );
 
-					// Move rates
+					// Move rates.
 					$wpdb->update(
 						$wpdb->prefix . 'woocommerce_shipping_table_rates',
 						array(
@@ -957,10 +1120,15 @@ function wc_update_260_zone_methods() {
 	$wpdb->query( "UPDATE {$wpdb->prefix}woocommerce_shipping_zone_locations SET location_code = REPLACE( location_code, '-', '...' );" );
 }
 
+/**
+ * Update refunds for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_refunds() {
 	global $wpdb;
 	/**
-	 * Refund item qty should be negative
+	 * Refund item qty should be negative.
 	 */
 	$wpdb->query( "
 	UPDATE {$wpdb->prefix}woocommerce_order_itemmeta as item_meta
@@ -971,10 +1139,20 @@ function wc_update_260_refunds() {
 	" );
 }
 
+/**
+ * Update DB version for 2.6
+ *
+ * @return void
+ */
 function wc_update_260_db_version() {
 	WC_Install::update_db_version( '2.6.0' );
 }
 
+/**
+ * Update webhooks for 3.0
+ *
+ * @return void
+ */
 function wc_update_300_webhooks() {
 	/**
 	 * Make sure product.update webhooks get the woocommerce_product_quick_edit_save
@@ -1008,6 +1186,11 @@ function wc_update_300_comment_type_index() {
 	}
 }
 
+/**
+ * Update grouped products for 3.0
+ *
+ * @return void
+ */
 function wc_update_300_grouped_products() {
 	global $wpdb;
 	$parents = $wpdb->get_col( "SELECT DISTINCT( post_parent ) FROM {$wpdb->posts} WHERE post_parent > 0 AND post_type = 'product';" );
@@ -1036,6 +1219,11 @@ function wc_update_300_grouped_products() {
 	}
 }
 
+/**
+ * Update shipping tax classes for 3.0
+ *
+ * @return void
+ */
 function wc_update_300_settings() {
 	$woocommerce_shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
 	if ( '' === $woocommerce_shipping_tax_class ) {


### PR DESCRIPTION
The current routine in 3.2 that update the Mexican states updated all meta data which contained the old state names, this included countries, first names and last names of some customers.

This PR makes it so it only updates the the billing and shipping state fields.

It also fixes the PHPCS issues which it forced me to do before being able to commit, @claudiosanches it seems like the implementation is very strict and not only tests the changes but the whole file you are working on.