### PR TITLE
Helper: Fix automatic subscription activation

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1113,7 +1113,7 @@ class WC_Helper {
 			}
 
 			// No more sites available in this subscription.
-			if ( $_sub['sites_active'] >= $_sub['sites_max'] ) {
+			if ( $_sub['sites_max'] && $_sub['sites_active'] >= $_sub['sites_max'] ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes a bug where automatic subscription activation upon plugin
activation does not trigger due to the subscription being unlimited.