### PR TITLE
Enable clearing for attribute filter widget

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -290,7 +290,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
 							placeholder: '" . esc_html( $any_label ) . "',
 							minimumResultsForSearch: 5,
-							width: '100%'
+							width: '100%',
+							allowClear: true
 						} );
 					};
 					wc_layered_nav_select();

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -290,8 +290,9 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
 							placeholder: '" . esc_html( $any_label ) . "',
 							minimumResultsForSearch: 5,
-							width: '100%',
-							allowClear: true
+							width: '100%'"
+							. ( $multiple ? '' : ', allowClear: true' ) .
+							"
 						} );
 					};
 					wc_layered_nav_select();

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -290,9 +290,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
 							placeholder: '" . esc_html( $any_label ) . "',
 							minimumResultsForSearch: 5,
-							width: '100%'"
-							. ( $multiple ? '' : ', allowClear: true' ) .
-							"
+							width: '100%',
+							allowClear: " . ( $multiple ? 'false' : 'true' ) . "
 						} );
 					};
 					wc_layered_nav_select();


### PR DESCRIPTION
Fixes #17085 

Enables the [allowClear](https://select2.org/selections#clearable-selections) setting for the AND filter.

<img width="277" alt="screen shot 2017-10-06 at 9 43 41 am" src="https://user-images.githubusercontent.com/7317227/31289103-89794016-aa7c-11e7-9f61-b3c8b16657af.png">
