### PR TITLE
Update chromedriver version and add singles tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-preset-stage-2": "^6.13.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "chromedriver": "^2.25.0",
+    "chromedriver": "2.33.0",
     "config": "^1.24.0",
     "cross-env": "^3.0.0",
     "grunt": "~1.0.1",
@@ -43,7 +43,7 @@
     "grunt-wp-i18n": "~1.0.0",
     "istanbul": "^1.0.0-alpha",
     "mocha": "^3.0.2",
-    "wc-e2e-page-objects": "0.3.0"
+    "wc-e2e-page-objects": "0.4.0"
   },
   "engines": {
     "node": ">=6.9.4",

--- a/tests/e2e-tests/single-product.js
+++ b/tests/e2e-tests/single-product.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import test from 'selenium-webdriver/testing';
+import { WebDriverManager, WebDriverHelper as helper } from 'wp-e2e-webdriver';
+import { SingleProductPage, CartPage } from 'wc-e2e-page-objects';
+
+chai.use( chaiAsPromised );
+
+const assert = chai.assert;
+
+let manager;
+let driver;
+
+test.describe( 'Single Product Page', function() {
+	test.before( 'open browser', function() {
+		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
+
+		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
+		driver = manager.getDriver();
+
+		helper.clearCookiesAndDeleteLocalStorage( driver );
+	} );
+
+	this.timeout( config.get( 'mochaTimeoutMs' ) );
+
+	test.it( 'should be able to add simple products to the cart', () => {
+		const productPage = new SingleProductPage( driver, { url: manager.getPageUrl( '/product/happy-ninja' ) } );
+		productPage.setQuantity( 5 );
+		productPage.addToCart();
+
+		const cartPage = new CartPage( driver, { url: manager.getPageUrl( '/cart' ) } );
+		assert.eventually.equal( cartPage.hasItem( 'Happy Ninja', { qty: 5 } ), true );
+	} );
+
+	test.it( 'should be able to add variation products to the cart', () => {
+		const variableProductPage = new SingleProductPage( driver, { url: manager.getPageUrl( '/product/ship-your-idea-3/' ) } );
+		variableProductPage.selectVariation( 'Color', 'Black' );
+		variableProductPage.addToCart();
+
+		// Pause for a half-second. Driver goes to fast and makes wrong selections otherwise.
+		driver.sleep( 500 );
+
+		variableProductPage.selectVariation( 'Color', 'Green' );
+		variableProductPage.addToCart();
+
+		const cartPage = new CartPage( driver, { url: manager.getPageUrl( '/cart' ) } );
+		assert.eventually.equal( cartPage.hasItem( 'Ship Your Idea - Black' ), true );
+		assert.eventually.equal( cartPage.hasItem( 'Ship Your Idea - Green' ), true );
+	} );
+
+	test.after( 'quit browser', () => {
+		manager.quitBrowser();
+	} );
+} );


### PR DESCRIPTION
- Chromedriver 2.33 has a fix for the bug that was causing the e2e tests to fail if the element was off-screen
- wc-e2e-page-objects 0.4.0 has a new class for testing single product pages.

To test:
1. `npm install`
2. `grunt e2e-tests` or `grunt e2e-test --file=single-product.js` if you just want to see the new product single tests.

(Tagging this 3.2 so it can get merged into the release branch and we can run the e2e tests properly before 3.2 is released)