### PR TITLE
Setup wizard: remove the “activate” step if Jetpack is already connected.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -132,7 +132,7 @@ class WC_Admin_Setup_Wizard {
 			unset( $default_steps['shipping'] );
 		}
 
-		// Hide the activate step if Jetpack is already active
+		// Hide the activate step if Jetpack is already active.
 		if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
 			unset( $default_steps['activate'] );
 		}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -132,6 +132,11 @@ class WC_Admin_Setup_Wizard {
 			unset( $default_steps['shipping'] );
 		}
 
+		// Hide the activate step if Jetpack is already active
+		if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
+			unset( $default_steps['activate'] );
+		}
+
 		// Whether or not there is a pending background install of Jetpack.
 		$pending_jetpack = ! class_exists( 'Jetpack' ) && get_option( 'woocommerce_setup_queued_jetpack_install' );
 


### PR DESCRIPTION
Fixes #17091.

To test:
* Verify that your Jetpack is connected
* Go to `/wp-admin/admin.php?page=wc-setup`
* Verify no "activate" step is present