### PR TITLE
Add do_action which triggers when an order fails to be instantiated

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -46,6 +46,7 @@ class WC_Order_Factory {
 		try {
 			return new $classname( $order_id );
 		} catch ( Exception $e ) {
+			do_action( 'woocommerce_get_order_error', $e, $order_id, $classname );
 			return false;
 		}
 	}


### PR DESCRIPTION
When an order fails to instantiate due to an exception being caught, `WC_Order_Factory::get_order()` returns `false`. This can cause errors like, `Call to a member function {function_name} on boolean`. 

While it is possible to circumvent these errors with a simple `is_object()` or similar check, in most cases it would mean the code silently exits with no record of there being an error. This commit adds a `do_action()` so third parties can get more details which led to the error to help with diagnosing the cause.

A recent example we ran into with a customer's site with Subscriptions was this stack trace:  

```
Uncaught Error: Call to a member function get_total() on boolean in /wp-content/plugins/woocommerce-subscriptions/includes/class-wc-subscriptions-order.php:1048 Stack trace: 

#0 /wp-includes/class-wp-hook.php(300): WC_Subscriptions_Order::maybe_autocomplete_order('processing', 47870) 
#1 /wp-includes/plugin.php(203): WP_Hook->apply_filters('processing', Array) 
#2 /wp-content/plugins/woocommerce/includes/class-wc-order.php(119): apply_filters('woocommerce_pay...', 'processing', 47870, Object(WC_Order)) 
#3 /wp-content/plugins/woocommerce-subscriptions/includes/gateways/paypal/includes/class-wcs-paypal-standard-ipn-handler.php(360): WC_Order->payment_complete('') 
#4 /wp-content/plugins/woocommerce-subscriptions/includes/gateways/paypal/include
```

Essentially we called `WC_Order->payment_complete()` on an order object, and hooked onto a processing order status transition hook we weren't able to re-instantiate that order object.