### PR TITLE
Add WOOCOMMERCE_CHECKOUT check to is_checkout

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -15,7 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * is_woocommerce - Returns true if on a page which uses WooCommerce templates (cart and checkout are standard pages with shortcodes and thus are not included).
+ * Is_woocommerce - Returns true if on a page which uses WooCommerce templates (cart and checkout are standard pages with shortcodes and thus are not included).
+ *
  * @return bool
  */
 function is_woocommerce() {
@@ -25,7 +26,8 @@ function is_woocommerce() {
 if ( ! function_exists( 'is_shop' ) ) {
 
 	/**
-	 * is_shop - Returns true when viewing the product type archive (shop).
+	 * Is_shop - Returns true when viewing the product type archive (shop).
+	 *
 	 * @return bool
 	 */
 	function is_shop() {
@@ -36,7 +38,8 @@ if ( ! function_exists( 'is_shop' ) ) {
 if ( ! function_exists( 'is_product_taxonomy' ) ) {
 
 	/**
-	 * is_product_taxonomy - Returns true when viewing a product taxonomy archive.
+	 * Is_product_taxonomy - Returns true when viewing a product taxonomy archive.
+	 *
 	 * @return bool
 	 */
 	function is_product_taxonomy() {
@@ -47,7 +50,8 @@ if ( ! function_exists( 'is_product_taxonomy' ) ) {
 if ( ! function_exists( 'is_product_category' ) ) {
 
 	/**
-	 * is_product_category - Returns true when viewing a product category.
+	 * Is_product_category - Returns true when viewing a product category.
+	 *
 	 * @param  string $term (default: '') The term slug your checking for. Leave blank to return true on any.
 	 * @return bool
 	 */
@@ -59,7 +63,8 @@ if ( ! function_exists( 'is_product_category' ) ) {
 if ( ! function_exists( 'is_product_tag' ) ) {
 
 	/**
-	 * is_product_tag - Returns true when viewing a product tag.
+	 * Is_product_tag - Returns true when viewing a product tag.
+	 *
 	 * @param  string $term (default: '') The term slug your checking for. Leave blank to return true on any.
 	 * @return bool
 	 */
@@ -71,7 +76,8 @@ if ( ! function_exists( 'is_product_tag' ) ) {
 if ( ! function_exists( 'is_product' ) ) {
 
 	/**
-	 * is_product - Returns true when viewing a single product.
+	 * Is_product - Returns true when viewing a single product.
+	 *
 	 * @return bool
 	 */
 	function is_product() {
@@ -82,7 +88,8 @@ if ( ! function_exists( 'is_product' ) ) {
 if ( ! function_exists( 'is_cart' ) ) {
 
 	/**
-	 * is_cart - Returns true when viewing the cart page.
+	 * Is_cart - Returns true when viewing the cart page.
+	 *
 	 * @return bool
 	 */
 	function is_cart() {
@@ -93,7 +100,8 @@ if ( ! function_exists( 'is_cart' ) ) {
 if ( ! function_exists( 'is_checkout' ) ) {
 
 	/**
-	 * is_checkout - Returns true when viewing the checkout page.
+	 * Is_checkout - Returns true when viewing the checkout page.
+	 *
 	 * @return bool
 	 */
 	function is_checkout() {
@@ -104,7 +112,8 @@ if ( ! function_exists( 'is_checkout' ) ) {
 if ( ! function_exists( 'is_checkout_pay_page' ) ) {
 
 	/**
-	 * is_checkout_pay - Returns true when viewing the checkout's pay page.
+	 * Is_checkout_pay - Returns true when viewing the checkout's pay page.
+	 *
 	 * @return bool
 	 */
 	function is_checkout_pay_page() {
@@ -117,8 +126,9 @@ if ( ! function_exists( 'is_checkout_pay_page' ) ) {
 if ( ! function_exists( 'is_wc_endpoint_url' ) ) {
 
 	/**
-	 * is_wc_endpoint_url - Check if an endpoint is showing.
-	 * @param  string $endpoint
+	 * Is_wc_endpoint_url - Check if an endpoint is showing.
+	 *
+	 * @param string $endpoint Whether endpoint.
 	 * @return bool
 	 */
 	function is_wc_endpoint_url( $endpoint = false ) {
@@ -149,7 +159,8 @@ if ( ! function_exists( 'is_wc_endpoint_url' ) ) {
 if ( ! function_exists( 'is_account_page' ) ) {
 
 	/**
-	 * is_account_page - Returns true when viewing an account page.
+	 * Is_account_page - Returns true when viewing an account page.
+	 *
 	 * @return bool
 	 */
 	function is_account_page() {
@@ -160,7 +171,8 @@ if ( ! function_exists( 'is_account_page' ) ) {
 if ( ! function_exists( 'is_view_order_page' ) ) {
 
 	/**
-	 * is_view_order_page - Returns true when on the view order page.
+	 * Is_view_order_page - Returns true when on the view order page.
+	 *
 	 * @return bool
 	 */
 	function is_view_order_page() {
@@ -189,7 +201,8 @@ if ( ! function_exists( 'is_edit_account_page' ) ) {
 if ( ! function_exists( 'is_order_received_page' ) ) {
 
 	/**
-	 * is_order_received_page - Returns true when viewing the order received page.
+	 * Is_order_received_page - Returns true when viewing the order received page.
+	 *
 	 * @return bool
 	 */
 	function is_order_received_page() {
@@ -202,7 +215,8 @@ if ( ! function_exists( 'is_order_received_page' ) ) {
 if ( ! function_exists( 'is_add_payment_method_page' ) ) {
 
 	/**
-	 * is_add_payment_method_page - Returns true when viewing the add payment method page.
+	 * Is_add_payment_method_page - Returns true when viewing the add payment method page.
+	 *
 	 * @return bool
 	 */
 	function is_add_payment_method_page() {
@@ -215,7 +229,8 @@ if ( ! function_exists( 'is_add_payment_method_page' ) ) {
 if ( ! function_exists( 'is_lost_password_page' ) ) {
 
 	/**
-	 * is_lost_password_page - Returns true when viewing the lost password page.
+	 * Is_lost_password_page - Returns true when viewing the lost password page.
+	 *
 	 * @return bool
 	 */
 	function is_lost_password_page() {
@@ -228,7 +243,8 @@ if ( ! function_exists( 'is_lost_password_page' ) ) {
 if ( ! function_exists( 'is_ajax' ) ) {
 
 	/**
-	 * is_ajax - Returns true when the page is loaded via ajax.
+	 * Is_ajax - Returns true when the page is loaded via ajax.
+	 *
 	 * @return bool
 	 */
 	function is_ajax() {
@@ -239,7 +255,8 @@ if ( ! function_exists( 'is_ajax' ) ) {
 if ( ! function_exists( 'is_store_notice_showing' ) ) {
 
 	/**
-	 * is_store_notice_showing - Returns true when store notice is active.
+	 * Is_store_notice_showing - Returns true when store notice is active.
+	 *
 	 * @return bool
 	 */
 	function is_store_notice_showing() {
@@ -250,11 +267,12 @@ if ( ! function_exists( 'is_store_notice_showing' ) ) {
 if ( ! function_exists( 'is_filtered' ) ) {
 
 	/**
-	 * is_filtered - Returns true when filtering products using layered nav or price sliders.
+	 * Is_filtered - Returns true when filtering products using layered nav or price sliders.
+	 *
 	 * @return bool
 	 */
 	function is_filtered() {
-		return apply_filters( 'woocommerce_is_filtered', ( sizeof( WC_Query::get_layered_nav_chosen_attributes() ) > 0 || isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) || isset( $_GET['rating_filter'] ) ) );
+		return apply_filters( 'woocommerce_is_filtered', ( count( WC_Query::get_layered_nav_chosen_attributes() ) > 0 || isset( $_GET['max_price'] ) || isset( $_GET['min_price'] ) || isset( $_GET['rating_filter'] ) ) );
 	}
 }
 
@@ -262,8 +280,9 @@ if ( ! function_exists( 'taxonomy_is_product_attribute' ) ) {
 
 	/**
 	 * Returns true when the passed taxonomy name is a product attribute.
+	 *
 	 * @uses   $wc_product_attributes global which stores taxonomy names upon registration
-	 * @param  string $name of the attribute
+	 * @param  string $name of the attribute.
 	 * @return bool
 	 */
 	function taxonomy_is_product_attribute( $name ) {
@@ -277,9 +296,10 @@ if ( ! function_exists( 'meta_is_product_attribute' ) ) {
 
 	/**
 	 * Returns true when the passed meta name is a product attribute.
-	 * @param  string $name of the attribute
-	 * @param  string $value
-	 * @param  int $product_id
+	 *
+	 * @param  string $name of the attribute.
+	 * @param  string $value of the attribute.
+	 * @param  int    $product_id to check for attribute.
 	 * @return bool
 	 */
 	function meta_is_product_attribute( $name, $value, $product_id ) {
@@ -299,6 +319,7 @@ if ( ! function_exists( 'wc_tax_enabled' ) ) {
 
 	/**
 	 * Are store-wide taxes enabled?
+	 *
 	 * @return bool
 	 */
 	function wc_tax_enabled() {
@@ -310,6 +331,7 @@ if ( ! function_exists( 'wc_shipping_enabled' ) ) {
 
 	/**
 	 * Is shipping enabled?
+	 *
 	 * @return bool
 	 */
 	function wc_shipping_enabled() {
@@ -321,6 +343,7 @@ if ( ! function_exists( 'wc_prices_include_tax' ) ) {
 
 	/**
 	 * Are prices inclusive of tax?
+	 *
 	 * @return bool
 	 */
 	function wc_prices_include_tax() {
@@ -334,12 +357,12 @@ if ( ! function_exists( 'wc_prices_include_tax' ) ) {
  * + starts with `action.woocommerce_` or `action.wc_`.
  * + it has a valid resource & event.
  *
- * @param  string $topic webhook topic
+ * @param  string $topic webhook topic.
  * @return bool true if valid, false otherwise
  */
 function wc_is_webhook_valid_topic( $topic ) {
 
-	// Custom topics are prefixed with woocommerce_ or wc_ are valid
+	// Custom topics are prefixed with woocommerce_ or wc_ are valid.
 	if ( 0 === strpos( $topic, 'action.woocommerce_' ) || 0 === strpos( $topic, 'action.wc_' ) ) {
 		return true;
 	}
@@ -363,17 +386,18 @@ function wc_is_webhook_valid_topic( $topic ) {
 /**
  * Simple check for validating a URL, it must start with http:// or https://.
  * and pass FILTER_VALIDATE_URL validation.
- * @param  string $url
+ *
+ * @param  string $url to check.
  * @return bool
  */
 function wc_is_valid_url( $url ) {
 
-	// Must start with http:// or https://
+	// Must start with http:// or https://.
 	if ( 0 !== strpos( $url, 'http://' ) && 0 !== strpos( $url, 'https://' ) ) {
 		return false;
 	}
 
-	// Must pass validation
+	// Must pass validation.
 	if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
 		return false;
 	}

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -105,7 +105,7 @@ if ( ! function_exists( 'is_checkout' ) ) {
 	 * @return bool
 	 */
 	function is_checkout() {
-		return is_page( wc_get_page_id( 'checkout' ) ) || wc_post_content_has_shortcode( 'woocommerce_checkout' ) || apply_filters( 'woocommerce_is_checkout', false );
+		return is_page( wc_get_page_id( 'checkout' ) ) || wc_post_content_has_shortcode( 'woocommerce_checkout' ) || apply_filters( 'woocommerce_is_checkout', false ) || defined( 'WOOCOMMERCE_CHECKOUT' );
 	}
 }
 


### PR DESCRIPTION
As per #17094 and discussed in slack with the team the is_checkout conditional does not currently return true when called via ajax. is_cart has a similar check so just makes sense to add it to is_checkout.

Also testing with the latest stripe confirmed the bug, although we acknowledge external code should not be using these conditionals in ajax requests the consequences of a lot of stuff breaking due to the recent ajax changes is just too big, this change is needed to ensure backward compatibility.