### PR TITLE
Setup wizard: activate step shouldn't be hidden after a successful WPCOM connection.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -132,8 +132,14 @@ class WC_Admin_Setup_Wizard {
 			unset( $default_steps['shipping'] );
 		}
 
-		// Hide the activate step if Jetpack is already active.
-		if ( class_exists( 'Jetpack' ) && Jetpack::is_active() ) {
+		// Hide the activate step if Jetpack is already active, but not
+		// if we're returning from connecting Jetpack on WordPress.com.
+		if (
+			class_exists( 'Jetpack' ) &&
+			Jetpack::is_active() &&
+			! isset( $_GET['from'] ) &&
+			! isset( $_GET['activate_error'] )
+		) {
 			unset( $default_steps['activate'] );
 		}
 


### PR DESCRIPTION
Check for activate-step-specific GET parameters before hiding the step.

This was a bit overzealous, and broke successful connection flows from the wizard. (Introduced in 97faa49fc4596a41cfe09d0d18599c0298ec5df5)