### PR TITLE
Allow display_name to be searchable - this will commonly be full name

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -602,3 +602,16 @@ function wc_get_customer_last_order( $customer_id ) {
 
 	return wc_get_order( $id );
 }
+
+/**
+ * Add support for searching by display_name.
+ *
+ * @since 3.2.0
+ * @param array $search_columns Column names.
+ * @return array
+ */
+function wc_user_search_columns( $search_columns ) {
+	$search_columns[] = 'display_name';
+	return $search_columns;
+}
+add_filter( 'user_search_columns', 'wc_user_search_columns' );


### PR DESCRIPTION
Closes #17104

We had code in place to search display_name but it’s non-functional without this.

@claudiulodro 