### PR TITLE
Grouped add to cart price hooks

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -70,8 +70,8 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 								<?php echo $grouped_product->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', get_permalink( $grouped_product->get_id() ), $grouped_product->get_id() ) ) . '">' . $grouped_product->get_name() . '</a>' : $grouped_product->get_name(); ?>
 							</label>
 						</td>
-						<?php do_action( 'woocommerce_grouped_product_list_before_price', $grouped_product ); ?>
 						<td class="price">
+							<?php do_action( 'woocommerce_grouped_product_list_before_price', $grouped_product ); ?>
 							<?php
 								echo $grouped_product->get_price_html();
 								echo wc_get_stock_html( $grouped_product );

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -76,6 +76,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 								echo $grouped_product->get_price_html();
 								echo wc_get_stock_html( $grouped_product );
 							?>
+							<?php do_action( 'woocommerce_grouped_product_list_after_price', $grouped_product ); ?>
 						</td>
 					</tr>
 					<?php


### PR DESCRIPTION
I was testing whether Name Your Price could be added in grouped products and found the `woocommerce_grouped_product_list_before_price` hook. However, it is outside of the `<td>` element so that adding anything to it displays outside of the tabular markup. 

![grouped product with info displaying out of place](https://user-images.githubusercontent.com/507025/31354298-73e28a38-acfb-11e7-8358-a040e12f35d3.png)

I've moved it in the price column and added an "after" hook for good measure. 