### PR TITLE
Fix duplicate plugin install from wizard.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -526,7 +526,9 @@ class WC_Admin_Setup_Wizard {
 		if ( session_id() ) {
 			session_write_close();
 		}
-		set_time_limit( 0 );
+
+		wc_set_time_limit( 0 );
+
 		// fastcgi_finish_request is the cleanest way to send the response and keep the script running, but not every server has it.
 		if ( is_callable( 'fastcgi_finish_request' ) ) {
 			fastcgi_finish_request();

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -144,7 +144,7 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		// Whether or not there is a pending background install of Jetpack.
-		$pending_jetpack = ! class_exists( 'Jetpack' ) && get_option( 'woocommerce_setup_queued_jetpack_install' );
+		$pending_jetpack = ! class_exists( 'Jetpack' ) && get_option( 'woocommerce_setup_background_installing_jetpack' );
 
 		$this->steps = apply_filters( 'woocommerce_setup_wizard_steps', $default_steps );
 		$this->step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : current( array_keys( $this->steps ) );
@@ -615,8 +615,6 @@ class WC_Admin_Setup_Wizard {
 			'name'      => __( 'Jetpack', 'woocommerce' ),
 			'repo-slug' => 'jetpack',
 		) );
-
-		update_option( 'woocommerce_setup_queued_jetpack_install', true );
 	}
 
 	/**
@@ -1582,11 +1580,6 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_activate_save() {
 		check_admin_referer( 'wc-setup' );
 
-		// Clean up temporary Jetpack queued install option.
-		// This happens after the connection button is clicked
-		// and we waited for the pending install to finish.
-		delete_option( 'woocommerce_setup_queued_jetpack_install' );
-
 		// Leave a note for WooCommerce Services that Jetpack has been opted into.
 		update_option( 'woocommerce_setup_jetpack_opted_in', true );
 
@@ -1628,9 +1621,6 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_ready() {
 		// We've made it! Don't prompt the user to run the wizard again.
 		WC_Admin_Notices::remove_notice( 'install' );
-
-		// We're definitely done waiting for queued Jetpack install.
-		delete_option( 'woocommerce_setup_queued_jetpack_install' );
 
 		$user_email   = $this->get_current_user_email();
 		$videos_url   = 'https://docs.woocommerce.com/document/woocommerce-guided-tour-videos/?utm_source=setupwizard&utm_medium=product&utm_content=videos&utm_campaign=woocommerceplugin';

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -261,12 +261,8 @@ class WC_Admin {
 	 * See: WC_Admin_Setup_Wizard::install_jetpack()
 	 */
 	public function setup_wizard_check_jetpack() {
-		// Clean up temporary Jetpack queued install option.
-		// This happens after the connection button is clicked
-		// and we waited for the pending install to finish.
-		delete_option( 'woocommerce_setup_queued_jetpack_install' );
-
 		$jetpack_active = class_exists( 'Jetpack' );
+
 		wp_send_json_success( array(
 			'is_active' => $jetpack_active ? 'yes' : 'no',
 		) );


### PR DESCRIPTION
This PR seeks to avoid multiple background installations of Jetpack and WooCommerce Services. The install logic previously used WP Cron, but was switched to use shutdown hooks. The wizard relies on being able to signal that Jetpack/WCS need installation whenever relevant.

This PR removes the Jetpack-specific flag in favor of a background install flag set for all plugins installed by the wizard. Should the wizard signal that Jetpack is needed while it's in the process of install, the flag will prevent a concurrent installation from taking place.

To test:
* Ensure that Jetpack is not installed
* Step through setup wizard quickly (using a US/CA store), and enabling all WCS features
* Verify that no `fopen()` warnings/errors occur in your error log, and that Jetpack installs as expected