### PR TITLE
Keep link structure - prevent duplicate content

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -504,6 +504,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			}
 
 			if ( ! empty( $current_filter ) ) {
+                asort($current_filter);
 				$link = add_query_arg( $filter_name, implode( ',', $current_filter ), $link );
 
 				// Add Query type Arg to URL


### PR DESCRIPTION
Added asort($current_filter) so the urls always look the same and there are not millions of urls possibilities when adding multiple filters.

Current url example:
https://myurl.com/produkt-kategorie/mycategory/?filter_filter-color=yellow,brown,blue,red
https://myurl.com/produkt-kategorie/mycategory/?filter_filter-color=yellow,blue,red,brown
https://myurl.com/produkt-kategorie/mycategory/?filter_filter-color=blue,yellow,red,brown
...

With asort you only have this url:
https://myurl.com/produkt-kategorie/mycategory/?filter_filter-color=blue,brown,red,yellow

So it is independent on the sequence a user adds a filter