### PR TITLE
class-wc-widget-layered-nav.php - Crawling Budget

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -510,6 +510,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				if ( 'or' === $query_type && ! ( 1 === sizeof( $current_filter ) && $option_is_set ) ) {
 					$link = add_query_arg( 'query_type_' . sanitize_title( str_replace( 'pa_', '', $taxonomy ) ), 'or', $link );
 				}
+				$link = str_replace('%2C', ',', $link);
 			}
 
 			if ( $count > 0 || $option_is_set ) {


### PR DESCRIPTION
Additional optimization to save up crawling budget.
Added $link = str_replace('%2C', ',', $link); on line 513

https://mydomain.com/produkt-kategorie/my-category/?filter_filter-color=orange,black

If you add another filter it encodes the existing commas:
https://mydomain.com/produkt-kategorie/my-category/?filter_filter-color=orange%2Cblack&filter_manufacturer=adidas&filter_cut=men.children

So sometimes you have "," as seperator and sometimes you have encoded "%2C".

After implementing this pull-request the seperator stays ",":
https://mydomain.com/produkt-kategorie/my-category/?filter_filter-color=orange,black&filter_manufacturer=adidas&filter_cut=men.children

This pull request belongs to the optimization https://github.com/woocommerce/woocommerce/pull/17134 to save up crawling budget,