### PR TITLE
"incl. VAT" is displayed even when no rates are defined on "as single total" display mode

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -307,7 +307,9 @@ function wc_cart_totals_order_total_html() {
 				$tax_string_array[] = sprintf( '%s %s', $tax->formatted_amount, $tax->label );
 			}
 		} else {
-			$tax_string_array[] = sprintf( '%s %s', wc_price( WC()->cart->get_taxes_total( true, true ) ), WC()->countries->tax_or_vat() );
+			if( ! empty( WC()->cart->get_tax_totals() ) ) {
+				$tax_string_array[] = sprintf( '%s %s', wc_price( WC()->cart->get_taxes_total( true, true ) ), WC()->countries->tax_or_vat() );
+			}
 		}
 
 		if ( ! empty( $tax_string_array ) ) {


### PR DESCRIPTION
If no tax rate is defined for a specific country it still shows "incl. VAT" at the checkout / cart when tax display is set to "As single total".

This pull request will solved that