### PR TITLE
Caches call to load product variation attributes

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File for WC Variable Product Data Store class.
+ *
+ * @package WooCommerce/Classes
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -24,7 +30,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param WC_Product $product
+	 * @param WC_Product $product Product object.
 	 */
 	protected function read_product_data( &$product ) {
 		parent::read_product_data( $product );
@@ -43,8 +49,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	/**
 	 * Loads variation child IDs.
 	 *
-	 * @param  WC_Product
-	 * @param  bool $force_read True to bypass the transient.
+	 * @param  WC_Product $product Product object.
+	 * @param  bool       $force_read True to bypass the transient.
 	 * @return array
 	 */
 	protected function read_children( &$product, $force_read = false ) {
@@ -83,7 +89,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	/**
 	 * Loads an array of attributes used for variations, as well as their possible values.
 	 *
-	 * @param WC_Product
+	 * @param WC_Product $product Product object.
 	 * @return array
 	 */
 	protected function read_variation_attributes( &$product ) {
@@ -101,20 +107,20 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 
 				// Get possible values for this attribute, for only visible variations.
 				$values = array_unique( $wpdb->get_col( $wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (" . implode( ',', array_map( 'absint', $child_ids ) ) . ")",
+					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND post_id IN (" . implode( ',', array_map( 'absint', $child_ids ) ) . ')',
 					wc_variation_attribute_name( $attribute['name'] )
 				) ) );
 
 				// Empty value indicates that all options for given attribute are available.
 				if ( in_array( '', $values ) || empty( $values ) ) {
 					$values = $attribute['is_taxonomy'] ? wc_get_object_terms( $product->get_id(), $attribute['name'], 'slug' ) : wc_get_text_attributes( $attribute['value'] );
-				// Get custom attributes (non taxonomy) as defined.
+					// Get custom attributes (non taxonomy) as defined.
 				} elseif ( ! $attribute['is_taxonomy'] ) {
 					$text_attributes          = wc_get_text_attributes( $attribute['value'] );
 					$assigned_text_attributes = $values;
 					$values                   = array();
 
-					// Pre 2.4 handling where 'slugs' were saved instead of the full text attribute
+					// Pre 2.4 handling where 'slugs' were saved instead of the full text attribute.
 					if ( version_compare( get_post_meta( $product->get_id(), '_product_version', true ), '2.4.0', '<' ) ) {
 						$assigned_text_attributes = array_map( 'sanitize_title', $assigned_text_attributes );
 						foreach ( $text_attributes as $text_attribute ) {
@@ -144,14 +150,15 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * This is to ensure modified prices are not cached, unless intended.
 	 *
 	 * @since  3.0.0
-	 * @param  WC_Product
-	 * @param  bool $include_taxes If taxes should be calculated or not.
+	 * @param  WC_Product $product Product object.
+	 * @param  bool       $include_taxes If taxes should be calculated or not.
 	 * @return array of prices
 	 */
 	public function read_price_data( &$product, $include_taxes = false ) {
 
 		/**
 		 * Transient name for storing prices for this product (note: Max transient length is 45)
+		 *
 		 * @since 2.5.0 a single transient is used per product for all prices, rather than many transients per product.
 		 */
 		$transient_name = 'wc_var_prices_' . $product->get_id();
@@ -182,17 +189,17 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price( 'edit' ), $variation, $product );
 						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price( 'edit' ), $variation, $product );
 
-						// Skip empty prices
+						// Skip empty prices.
 						if ( '' === $price ) {
 							continue;
 						}
 
-						// If sale price does not equal price, the product is not yet on sale
+						// If sale price does not equal price, the product is not yet on sale.
 						if ( $sale_price === $regular_price || $sale_price !== $price ) {
 							$sale_price = $regular_price;
 						}
 
-						// If we are getting prices for display, we need to account for taxes
+						// If we are getting prices for display, we need to account for taxes.
 						if ( $include_taxes ) {
 							if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
 								$price         = '' === $price ? ''         : wc_get_price_including_tax( $variation, array( 'qty' => 1, 'price' => $price ) );
@@ -234,8 +241,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * DEVELOPERS should filter this hash if offering conditional pricing to keep it unique.
 	 *
 	 * @since  3.0.0
-	 * @param  WC_Product
-	 * @param  bool $include_taxes If taxes should be calculated or not.
+	 * @param  WC_Product $product Product object.
+	 * @param  bool       $include_taxes If taxes should be calculated or not.
 	 * @return string
 	 */
 	protected function get_price_hash( &$product, $include_taxes = false ) {
@@ -264,48 +271,48 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Does a child have a weight set?
 	 *
 	 * @since 3.0.0
-	 * @param WC_Product
+	 * @param WC_Product $product Product object.
 	 * @return boolean
 	 */
 	public function child_has_weight( $product ) {
 		global $wpdb;
 		$children = $product->get_visible_children();
-		return $children ? null !== $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_weight' AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+		return $children ? null !== $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_weight' AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . ' )' ) : false;
 	}
 
 	/**
 	 * Does a child have dimensions set?
 	 *
 	 * @since 3.0.0
-	 * @param WC_Product
+	 * @param WC_Product $product Product object.
 	 * @return boolean
 	 */
 	public function child_has_dimensions( $product ) {
 		global $wpdb;
 		$children = $product->get_visible_children();
-		return $children ? null !== $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key IN ( '_length', '_width', '_height' ) AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : false;
+		return $children ? null !== $wpdb->get_var( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key IN ( '_length', '_width', '_height' ) AND meta_value > 0 AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . ' )' ) : false;
 	}
 
 	/**
 	 * Is a child in stock?
 	 *
 	 * @since 3.0.0
-	 * @param WC_Product
+	 * @param WC_Product $product Product object.
 	 * @return boolean
 	 */
 	public function child_is_in_stock( $product ) {
 		global $wpdb;
 		$children            = $product->get_children();
-		$oufofstock_children = $children ? $wpdb->get_var( "SELECT COUNT( post_id ) FROM $wpdb->postmeta WHERE meta_key = '_stock_status' AND meta_value = 'outofstock' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) : 0;
+		$oufofstock_children = $children ? $wpdb->get_var( "SELECT COUNT( post_id ) FROM $wpdb->postmeta WHERE meta_key = '_stock_status' AND meta_value = 'outofstock' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . ' )' ) : 0;
 		return count( $children ) > $oufofstock_children;
 	}
 
 	/**
 	 * Syncs all variation names if the parent name is changed.
 	 *
-	 * @param WC_Product $product
-	 * @param string $previous_name
-	 * @param string $new_name
+	 * @param WC_Product $product Product object.
+	 * @param string     $previous_name Variation previous name.
+	 * @param string     $new_name Variation new name.
 	 * @since 3.0.0
 	 */
 	public function sync_variation_names( &$product, $previous_name = '', $new_name = '' ) {
@@ -322,7 +329,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 				$previous_name ? $previous_name : 'AUTO-DRAFT',
 				$new_name,
 				$product->get_id()
-			 ) );
+			) );
 		}
 	}
 
@@ -330,7 +337,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Stock managed at the parent level - update children being managed by this product.
 	 * This sync function syncs downwards (from parent to child) when the variable product is saved.
 	 *
-	 * @param WC_Product
+	 * @param WC_Product $product Product object.
 	 * @since 3.0.0
 	 */
 	public function sync_managed_variation_stock_status( &$product ) {
@@ -339,7 +346,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		if ( $product->get_manage_stock() ) {
 			$status           = $product->get_stock_status();
 			$children         = $product->get_children();
-			$managed_children = $children ? array_unique( $wpdb->get_col( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_manage_stock' AND meta_value != 'yes' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) ) : array();
+			$managed_children = $children ? array_unique( $wpdb->get_col( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_manage_stock' AND meta_value != 'yes' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . ' )' ) ) : array();
 			$changed          = false;
 			foreach ( $managed_children as $managed_child ) {
 				if ( update_post_meta( $managed_child, '_stock_status', $status ) ) {
@@ -358,13 +365,13 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Sync variable product prices with children.
 	 *
 	 * @since 3.0.0
-	 * @param WC_Product|int $product
+	 * @param WC_Product $product Product object.
 	 */
 	public function sync_price( &$product ) {
 		global $wpdb;
 
 		$children = $product->get_visible_children();
-		$prices   = $children ? array_unique( $wpdb->get_col( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_price' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . " )" ) ) : array();
+		$prices   = $children ? array_unique( $wpdb->get_col( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_price' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . ' )' ) ) : array();
 
 		delete_post_meta( $product->get_id(), '_price' );
 
@@ -385,7 +392,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Change does not persist unless saved by caller.
 	 *
 	 * @since 3.0.0
-	 * @param WC_Product|int $product
+	 * @param WC_Product $product Product object.
 	 */
 	public function sync_stock_status( &$product ) {
 		$product->set_stock_status( $product->child_is_in_stock() ? 'instock' : 'outofstock' );
@@ -395,7 +402,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	 * Delete variations of a product.
 	 *
 	 * @since 3.0.0
-	 * @param int $product_id
+	 * @param int  $product_id Product ID.
 	 * @param bool $force_delete False to trash.
 	 */
 	public function delete_variations( $product_id, $force_delete = false ) {
@@ -427,7 +434,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	/**
 	 * Untrash variations.
 	 *
-	 * @param int $product_id
+	 * @param int $product_id Product ID.
 	 */
 	public function untrash_variations( $product_id ) {
 		$variation_ids = wp_parse_id_list( get_posts( array(

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -98,6 +98,13 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		$variation_attributes = array();
 		$attributes           = $product->get_attributes();
 		$child_ids            = $product->get_children();
+		$cache_key            = WC_Cache_Helper::get_cache_prefix( 'products' ) . 'product_variation_attributes_' . $product->get_id();
+		$cache_group          = 'products';
+		$cached_data          = wp_cache_get( $cache_key, $cache_group );
+
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
 
 		if ( ! empty( $child_ids ) && ! empty( $attributes ) ) {
 			foreach ( $attributes as $attribute ) {
@@ -139,6 +146,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 				$variation_attributes[ $attribute['name'] ] = array_unique( $values );
 			}
 		}
+
+		wp_cache_set( $cache_key, $variation_attributes, $cache_group );
 
 		return $variation_attributes;
 	}

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -126,8 +126,17 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		// Does this product have a parent?
 		$product = wc_get_product( $post_id );
 
-		if ( $product && $product->get_parent_id() > 0 ) {
-			wc_delete_product_transients( $product->get_parent_id() );
+		if ( $product ) {
+			if ( $product->get_parent_id() > 0 ) {
+				wc_delete_product_transients( $product->get_parent_id() );
+			}
+
+			if ( 'variable' === $product->get_type() ) {
+				wp_cache_delete(
+					WC_Cache_Helper::get_cache_prefix( 'products' ) . 'product_variation_attributes_' . $product->get_id(),
+					'products'
+				);
+			}
 		}
 	}
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1,8 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WooCommerce Product Functions
  *
@@ -14,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @version  3.0.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Standard way of retrieving products based on certain parameters.
  *
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query
  *
  * @since  3.0.0
- * @param  array $args Array of args (above)
+ * @param  array $args Array of args (above).
  * @return array|stdClass Number of pages and an array of product objects if
  *                             paginate is true, or just an array of values.
  */
@@ -70,6 +70,7 @@ function wc_get_product( $the_product = false, $deprecated = array() ) {
 
 /**
  * Returns whether or not SKUS are enabled.
+ *
  * @return bool
  */
 function wc_product_sku_enabled() {
@@ -78,6 +79,7 @@ function wc_product_sku_enabled() {
 
 /**
  * Returns whether or not product weights are enabled.
+ *
  * @return bool
  */
 function wc_product_weight_enabled() {
@@ -86,6 +88,7 @@ function wc_product_weight_enabled() {
 
 /**
  * Returns whether or not product dimensions (HxWxD) are enabled.
+ *
  * @return bool
  */
 function wc_product_dimensions_enabled() {
@@ -95,10 +98,10 @@ function wc_product_dimensions_enabled() {
 /**
  * Clear all transients cache for product data.
  *
- * @param int $post_id (default: 0)
+ * @param int $post_id (default: 0).
  */
 function wc_delete_product_transients( $post_id = 0 ) {
-	// Core transients
+	// Core transients.
 	$transients_to_clear = array(
 		'wc_products_onsale',
 		'wc_featured_products',
@@ -106,7 +109,7 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		'wc_low_stock_count',
 	);
 
-	// Transient names that include an ID
+	// Transient names that include an ID.
 	$post_transient_names = array(
 		'wc_product_children_',
 		'wc_var_prices_',
@@ -128,12 +131,12 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		}
 	}
 
-	// Delete transients
+	// Delete transients.
 	foreach ( $transients_to_clear as $transient ) {
 		delete_transient( $transient );
 	}
 
-	// Increments the transient version to invalidate cache
+	// Increments the transient version to invalidate cache.
 	WC_Cache_Helper::get_transient_version( 'product', true );
 
 	do_action( 'woocommerce_delete_product_transients', $post_id );
@@ -146,10 +149,10 @@ function wc_delete_product_transients( $post_id = 0 ) {
  * @return array
  */
 function wc_get_product_ids_on_sale() {
-	// Load from cache
+	// Load from cache.
 	$product_ids_on_sale = get_transient( 'wc_products_onsale' );
 
-	// Valid cache found
+	// Valid cache found.
 	if ( false !== $product_ids_on_sale ) {
 		return $product_ids_on_sale;
 	}
@@ -170,10 +173,10 @@ function wc_get_product_ids_on_sale() {
  * @return array
  */
 function wc_get_featured_product_ids() {
-	// Load from cache
+	// Load from cache.
 	$featured_product_ids = get_transient( 'wc_featured_products' );
 
-	// Valid cache found
+	// Valid cache found.
 	if ( false !== $featured_product_ids ) {
 		return $featured_product_ids;
 	}
@@ -193,7 +196,7 @@ function wc_get_featured_product_ids() {
  * Filter to allow product_cat in the permalinks for products.
  *
  * @param  string  $permalink The existing permalink URL.
- * @param  WP_Post $post
+ * @param  WP_Post $post WP_Post object.
  * @return string
  */
 function wc_product_post_type_link( $permalink, $post ) {
@@ -228,7 +231,7 @@ function wc_product_post_type_link( $permalink, $post ) {
 			}
 		}
 	} else {
-		// If no terms are assigned to this post, use a string instead (can't leave the placeholder there)
+		// If no terms are assigned to this post, use a string instead (can't leave the placeholder there).
 		$product_cat = _x( 'uncategorized', 'slug', 'woocommerce' );
 	}
 
@@ -278,7 +281,7 @@ function wc_placeholder_img_src() {
  *
  * @access public
  *
- * @param string $size
+ * @param string $size Image size.
  *
  * @return string
  */
@@ -294,9 +297,9 @@ function wc_placeholder_img( $size = 'shop_thumbnail' ) {
  * Gets a formatted version of variation data or item meta.
  *
  * @param array|WC_Product_Variation $variation Variation object.
- * @param bool $flat (default: false) Should this be a flat list or HTML list?
- * @param bool $include_names include attribute names/labels in the list.
- * @param bool $skip_attributes_in_name Do not list attributes already part of the variation name.
+ * @param bool                       $flat Should this be a flat list or HTML list? (default: false).
+ * @param bool                       $include_names include attribute names/labels in the list.
+ * @param bool                       $skip_attributes_in_name Do not list attributes already part of the variation name.
  * @return string
  */
 function wc_get_formatted_variation( $variation, $flat = false, $include_names = true, $skip_attributes_in_name = false ) {
@@ -376,7 +379,7 @@ function wc_get_formatted_variation( $variation, $flat = false, $include_names =
 function wc_scheduled_sales() {
 	$data_store = WC_Data_Store::load( 'product' );
 
-	// Sales which are due to start
+	// Sales which are due to start.
 	$product_ids = $data_store->get_starting_sales();
 	if ( $product_ids ) {
 		foreach ( $product_ids as $product_id ) {
@@ -398,7 +401,7 @@ function wc_scheduled_sales() {
 		delete_transient( 'wc_products_onsale' );
 	}
 
-	// Sales which are due to end
+	// Sales which are due to end.
 	$product_ids = $data_store->get_ending_sales();
 	if ( $product_ids ) {
 		foreach ( $product_ids as $product_id ) {
@@ -422,7 +425,7 @@ add_action( 'woocommerce_scheduled_sales', 'wc_scheduled_sales' );
  * Get attachment image attributes.
  *
  * @access public
- * @param array $attr
+ * @param array $attr Image attributes.
  * @return array
  */
 function wc_get_attachment_image_attributes( $attr ) {
@@ -438,7 +441,7 @@ add_filter( 'wp_get_attachment_image_attributes', 'wc_get_attachment_image_attri
  * Prepare attachment for JavaScript.
  *
  * @access public
- * @param array $response
+ * @param array $response JS version of a attachment post object.
  * @return array
  */
 function wc_prepare_attachment_for_js( $response ) {
@@ -476,11 +479,11 @@ function wc_track_product_view() {
 		$viewed_products[] = $post->ID;
 	}
 
-	if ( sizeof( $viewed_products ) > 15 ) {
+	if ( count( $viewed_products ) > 15 ) {
 		array_shift( $viewed_products );
 	}
 
-	// Store for session only
+	// Store for session only.
 	wc_setcookie( 'woocommerce_recently_viewed', implode( '|', $viewed_products ) );
 }
 
@@ -505,8 +508,8 @@ function wc_get_product_types() {
  * Check if product sku is unique.
  *
  * @since 2.2
- * @param int $product_id
- * @param string $sku
+ * @param int    $product_id Product ID.
+ * @param string $sku Product SKU.
  * @return bool
  */
 function wc_product_has_unique_sku( $product_id, $sku ) {
@@ -524,7 +527,7 @@ function wc_product_has_unique_sku( $product_id, $sku ) {
  * Force a unique SKU.
  *
  * @since  3.0.0
- * @param  integer $product_id
+ * @param  integer $product_id Product ID.
  */
 function wc_product_force_unique_sku( $product_id ) {
 	$product = wc_get_product( $product_id );
@@ -545,9 +548,9 @@ function wc_product_force_unique_sku( $product_id ) {
  * Recursively appends a suffix until a unique SKU is found.
  *
  * @since  3.0.0
- * @param  integer $product_id
- * @param  string  $sku
- * @param  integer $index
+ * @param  integer $product_id Product ID.
+ * @param  string  $sku Product SKU.
+ * @param  integer $index An optional index that can be added to the product SKU.
  * @return string
  */
 function wc_product_generate_unique_sku( $product_id, $sku, $index = 0 ) {
@@ -574,33 +577,33 @@ function wc_get_product_id_by_sku( $sku ) {
 
 /**
  * Get attibutes/data for an individual variation from the database and maintain it's integrity.
- * @param revisit?
+ *
  * @since  2.4.0
- * @param  int $variation_id
+ * @param  int $variation_id Variation ID.
  * @return array
  */
 function wc_get_product_variation_attributes( $variation_id ) {
-	// Build variation data from meta
+	// Build variation data from meta.
 	$all_meta                = get_post_meta( $variation_id );
 	$parent_id               = wp_get_post_parent_id( $variation_id );
 	$parent_attributes       = array_filter( (array) get_post_meta( $parent_id, '_product_attributes', true ) );
 	$found_parent_attributes = array();
 	$variation_attributes    = array();
 
-	// Compare to parent variable product attributes and ensure they match
+	// Compare to parent variable product attributes and ensure they match.
 	foreach ( $parent_attributes as $attribute_name => $options ) {
 		if ( ! empty( $options['is_variation'] ) ) {
 			$attribute                 = 'attribute_' . sanitize_title( $attribute_name );
 			$found_parent_attributes[] = $attribute;
 			if ( ! array_key_exists( $attribute, $variation_attributes ) ) {
-				$variation_attributes[ $attribute ] = ''; // Add it - 'any' will be asumed
+				$variation_attributes[ $attribute ] = ''; // Add it - 'any' will be asumed.
 			}
 		}
 	}
 
-	// Get the variation attributes from meta
+	// Get the variation attributes from meta.
 	foreach ( $all_meta as $name => $value ) {
-		// Only look at valid attribute meta, and also compare variation level attributes and remove any which do not exist at parent level
+		// Only look at valid attribute meta, and also compare variation level attributes and remove any which do not exist at parent level.
 		if ( 0 !== strpos( $name, 'attribute_' ) || ! in_array( $name, $found_parent_attributes ) ) {
 			unset( $variation_attributes[ $name ] );
 			continue;
@@ -633,8 +636,9 @@ function wc_get_product_variation_attributes( $variation_id ) {
 
 /**
  * Get all product cats for a product by ID, including hierarchy
+ *
  * @since  2.5.0
- * @param  int $product_id
+ * @param  int $product_id Product ID.
  * @return array
  */
 function wc_get_product_cat_ids( $product_id ) {
@@ -649,10 +653,11 @@ function wc_get_product_cat_ids( $product_id ) {
 
 /**
  * Gets data about an attachment, such as alt text and captions.
+ *
  * @since 2.6.0
  *
- * @param int $attachment_id
- * @param object $product
+ * @param int|null        $attachment_id Attachment ID.
+ * @param WC_Product|bool $product WC_Product object.
  *
  * @return array
  */
@@ -692,7 +697,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$props['srcset'] = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $attachment_id, 'shop_single' ) : false;
 		$props['sizes']  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $attachment_id, 'shop_single' ) : false;
 
-		// Alt text fallbacks
+		// Alt text fallbacks.
 		$props['alt'] = empty( $props['alt'] ) ? $props['caption']                                               : $props['alt'];
 		$props['alt'] = empty( $props['alt'] ) ? trim( strip_tags( $attachment->post_title ) )                   : $props['alt'];
 		$props['alt'] = empty( $props['alt'] ) && $product ? trim( strip_tags( get_the_title( $product->ID ) ) ) : $props['alt'];
@@ -850,9 +855,10 @@ function wc_get_product_term_ids( $product_id, $taxonomy ) {
 
 /**
  * For a given product, and optionally price/qty, work out the price with tax included, based on store settings.
+ *
  * @since  3.0.0
- * @param  WC_Product $product
- * @param  array $args
+ * @param  WC_Product $product WC_Product object.
+ * @param  array      $args Optional arguments to pass product quantity and price.
  * @return float
  */
 function wc_get_price_including_tax( $product, $args = array() ) {
@@ -892,7 +898,7 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 				$remove_tax   = array_sum( $remove_taxes );
 				$return_price = round( $line_price - $remove_tax, wc_get_price_decimals() );
 
-			/**
+				/**
 			 * The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations.
 			 * e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.
 			 * This feature is experimental @since 2.4.7 and may change in the future. Use at your risk.
@@ -909,9 +915,10 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 
 /**
  * For a given product, and optionally price/qty, work out the price with tax excluded, based on store settings.
+ *
  * @since  3.0.0
- * @param  WC_Product $product
- * @param  array $args
+ * @param  WC_Product $product WC_Product object.
+ * @param  array      $args Optional arguments to pass product quantity and price.
  * @return float
  */
 function wc_get_price_excluding_tax( $product, $args = array() ) {
@@ -942,9 +949,10 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 
 /**
  * Returns the price including or excluding tax, based on the 'woocommerce_tax_display_shop' setting.
+ *
  * @since  3.0.0
- * @param  WC_Product $product
- * @param  array $args
+ * @param  WC_Product $product WC_Product object.
+ * @param  array      $args Optional arguments to pass product quantity and price.
  * @return float
  */
 function wc_get_price_to_display( $product, $args = array() ) {
@@ -962,7 +970,7 @@ function wc_get_price_to_display( $product, $args = array() ) {
 /**
  * Returns the product categories in a list.
  *
- * @param int $product_id
+ * @param int    $product_id Product ID.
  * @param string $sep (default: ', ').
  * @param string $before (default: '').
  * @param string $after (default: '').
@@ -975,7 +983,7 @@ function wc_get_product_category_list( $product_id, $sep = ', ', $before = '', $
 /**
  * Returns the product tags in a list.
  *
- * @param int $product_id
+ * @param int    $product_id Product ID.
  * @param string $sep (default: ', ').
  * @param string $before (default: '').
  * @param string $after (default: '').
@@ -987,8 +995,9 @@ function wc_get_product_tag_list( $product_id, $sep = ', ', $before = '', $after
 
 /**
  * Callback for array filter to get visible only.
+ *
  * @since  3.0.0
- * @param  WC_Product $product
+ * @param  WC_Product $product WC_Product object.
  * @return bool
  */
 function wc_products_array_filter_visible( $product ) {
@@ -999,7 +1008,7 @@ function wc_products_array_filter_visible( $product ) {
  * Callback for array filter to get visible grouped products only.
  *
  * @since  3.1.0
- * @param  WC_Product $product
+ * @param  WC_Product $product WC_Product object.
  * @return bool
  */
 function wc_products_array_filter_visible_grouped( $product ) {
@@ -1010,7 +1019,7 @@ function wc_products_array_filter_visible_grouped( $product ) {
  * Callback for array filter to get products the user can edit only.
  *
  * @since  3.0.0
- * @param  WC_Product $product
+ * @param  WC_Product $product WC_Product object.
  * @return bool
  */
 function wc_products_array_filter_editable( $product ) {
@@ -1019,11 +1028,12 @@ function wc_products_array_filter_editable( $product ) {
 
 /**
  * Sort an array of products by a value.
+ *
  * @since  3.0.0
  *
- * @param array $products
- * @param string $orderby
- * @param string $order
+ * @param array  $products List of products to be ordered.
+ * @param string $orderby Optional order criteria.
+ * @param string $order Ascending or descending order.
  *
  * @return array
  */
@@ -1051,9 +1061,10 @@ function wc_products_array_orderby( $products, $orderby = 'date', $order = 'desc
 
 /**
  * Sort by title.
+ *
  * @since  3.0.0
- * @param  WC_Product object $a
- * @param  WC_Product object $b
+ * @param  WC_Product $a First WC_Product object.
+ * @param  WC_Product $b Second WC_Product object.
  * @return int
  */
 function wc_products_array_orderby_title( $a, $b ) {
@@ -1062,9 +1073,10 @@ function wc_products_array_orderby_title( $a, $b ) {
 
 /**
  * Sort by id.
+ *
  * @since  3.0.0
- * @param  WC_Product object $a
- * @param  WC_Product object $b
+ * @param  WC_Product $a First WC_Product object.
+ * @param  WC_Product $b Second WC_Product object.
  * @return int
  */
 function wc_products_array_orderby_id( $a, $b ) {
@@ -1076,9 +1088,10 @@ function wc_products_array_orderby_id( $a, $b ) {
 
 /**
  * Sort by date.
+ *
  * @since  3.0.0
- * @param  WC_Product object $a
- * @param  WC_Product object $b
+ * @param  WC_Product $a First WC_Product object.
+ * @param  WC_Product $b Second WC_Product object.
  * @return int
  */
 function wc_products_array_orderby_date( $a, $b ) {
@@ -1090,9 +1103,10 @@ function wc_products_array_orderby_date( $a, $b ) {
 
 /**
  * Sort by modified.
+ *
  * @since  3.0.0
- * @param  WC_Product object $a
- * @param  WC_Product object $b
+ * @param  WC_Product $a First WC_Product object.
+ * @param  WC_Product $b Second WC_Product object.
  * @return int
  */
 function wc_products_array_orderby_modified( $a, $b ) {
@@ -1104,9 +1118,10 @@ function wc_products_array_orderby_modified( $a, $b ) {
 
 /**
  * Sort by menu order.
+ *
  * @since  3.0.0
- * @param  WC_Product object $a
- * @param  WC_Product object $b
+ * @param  WC_Product $a First WC_Product object.
+ * @param  WC_Product $b Second WC_Product object.
  * @return int
  */
 function wc_products_array_orderby_menu_order( $a, $b ) {
@@ -1118,9 +1133,10 @@ function wc_products_array_orderby_menu_order( $a, $b ) {
 
 /**
  * Sort by price low to high.
+ *
  * @since  3.0.0
- * @param  WC_Product object $a
- * @param  WC_Product object $b
+ * @param  WC_Product $a First WC_Product object.
+ * @param  WC_Product $b Second WC_Product object.
  * @return int
  */
 function wc_products_array_orderby_price( $a, $b ) {
@@ -1133,7 +1149,7 @@ function wc_products_array_orderby_price( $a, $b ) {
 /**
  * Queue a product for syncing at the end of the request.
  *
- * @param  int $product_id
+ * @param int $product_id Product ID.
  */
 function wc_deferred_product_sync( $product_id ) {
 	global $wc_deferred_product_sync;


### PR DESCRIPTION
This PR adds product variation attributes to WP cache when they are first loaded to avoid running the same database queries when the same product is loaded multiple times. This cache will be invalidated whenever product attributes are changed.

WP coding standards fixes were also included.
    
Fixes #17120