### PR TITLE
Remove menu-ordering sorting

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1016,8 +1016,6 @@ if ( ! function_exists( 'woocommerce_grouped_add_to_cart' ) ) {
 		$products = array_filter( array_map( 'wc_get_product', $product->get_children() ), 'wc_products_array_filter_visible_grouped' );
 
 		if ( $products ) {
-			usort( $products, 'wc_products_array_orderby_menu_order' );
-
 			wc_get_template( 'single-product/add-to-cart/grouped.php', array(
 				'grouped_product'    => $product,
 				'grouped_products'   => $products,


### PR DESCRIPTION
3.2 allows grouped products to be sorted in admin so the admin can define a sort order.

This line wrecks that by forcing it to use menu order.