### PR TITLE
WC_Product_Variation::get_tax_class unit tests

### DIFF
--- a/tests/unit-tests/product/product-variation.php
+++ b/tests/unit-tests/product/product-variation.php
@@ -1,7 +1,13 @@
 <?php
+/**
+ * Tests for the WC_Product_Variation class.
+ *
+ * @package WooCommerce\Tests\Product
+ */
 
 /**
  * Class Product_Variation.
+ *
  * @package WooCommerce\Tests\Product
  * @since 3.0
  */
@@ -24,5 +30,52 @@ class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
 
 		$variation = wc_get_product( $variation->get_id() );
 		$this->assertTrue( $variation->is_sold_individually() );
+	}
+
+	/**
+	 * Check get_tax_class against different parent child scenarios
+	 */
+	public function test_get_tax_class() {
+		$product = new WC_Product_Variable;
+		$product->set_tax_class( 'standard' );
+		$product->save();
+
+		$variation = new WC_Product_Variation;
+		$variation->set_parent_id( $product->get_id() );
+		$variation->set_tax_class( 'parent' );
+		$variation->save();
+
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( '', $variation->get_tax_class( 'unfiltered' ) );
+		$this->assertEquals( 'parent', $variation->get_tax_class( 'edit' ) );
+		$this->assertEquals( '', $variation->get_tax_class( 'view' ) );
+
+		$variation->set_tax_class( 'standard' );
+		$variation->save();
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( '', $variation->get_tax_class( 'unfiltered' ) );
+		$this->assertEquals( '', $variation->get_tax_class( 'edit' ) );
+		$this->assertEquals( '', $variation->get_tax_class( 'view' ) );
+
+		$variation->set_tax_class( 'reduced-rate' );
+		$variation->save();
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( 'reduced-rate', $variation->get_tax_class( 'unfiltered' ) );
+		$this->assertEquals( 'reduced-rate', $variation->get_tax_class( 'edit' ) );
+		$this->assertEquals( 'reduced-rate', $variation->get_tax_class( 'view' ) );
+
+		$product->set_tax_class( 'zero-rate' );
+		$product->save();
+
+		$variation->set_tax_class( 'parent' );
+		$variation->save();
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertEquals( 'zero-rate', $variation->get_tax_class( 'unfiltered' ) );
+		$this->assertEquals( 'parent', $variation->get_tax_class( 'edit' ) );
+		$this->assertEquals( 'zero-rate', $variation->get_tax_class( 'view' ) );
 	}
 }


### PR DESCRIPTION
Add tests to make sure get_tax_class always returns correct values depending on how the tax class is linked to the parent.