### PR TITLE
Remove rounding in wc_remove_number_precision

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1472,7 +1472,7 @@ function wc_add_number_precision( $value ) {
  */
 function wc_remove_number_precision( $value ) {
 	$precision = pow( 10, wc_get_price_decimals() );
-	return wc_format_decimal( $value / $precision, wc_get_price_decimals() );
+	return $value / $precision;
 }
 
 /**


### PR DESCRIPTION
Remove the rounding when removing precision so the cart can handle it.

For taxes, this means it can round down.

Fixes #17158