### PR TITLE
Add email to email address template

### DIFF
--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -13,7 +13,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails
- * @version     3.2.0
+ * @version     3.2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -30,7 +30,10 @@ $text_align = is_rtl() ? 'right' : 'left';
 			<address class="address">
 				<?php echo ( $address = $order->get_formatted_billing_address() ) ? $address : __( 'N/A', 'woocommerce' ); ?>
 				<?php if ( $order->get_billing_phone() ) : ?>
-					<p><?php echo esc_html( $order->get_billing_phone() ); ?></p>
+					<br/><?php echo esc_html( $order->get_billing_phone() ); ?>
+				<?php endif; ?>
+				<?php if ( $order->get_billing_email() ): ?>
+					<p><?php echo esc_html( $order->get_billing_email() ); ?></p>
 				<?php endif; ?>
 			</address>
 		</td>

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -13,7 +13,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates/Emails/Plain
- * @version     3.2.0
+ * @version     3.2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -25,6 +25,10 @@ echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address()
 
 if ( $order->get_billing_phone() ) {
 	echo $order->get_billing_phone() . "\n";
+}
+
+if ( $order->get_billing_email() ) {
+	echo $order->get_billing_email() . "\n";
 }
 
 if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) {


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/customer-details-not-appearing-in-order-emails-since-3-2-0/

Root cause was an incomplete refactor from [this commit](https://github.com/woocommerce/woocommerce/commit/94b32e644a57617b115d570fe178d3d415c05afb#diff-09b3cbbd74ba5510ac97ba1cb506f944R438).