### PR TITLE
Revert order detail header behavior

### DIFF
--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -32,7 +32,7 @@ $text_align = is_rtl() ? 'right' : 'left';
 				<?php if ( $order->get_billing_phone() ) : ?>
 					<br/><?php echo esc_html( $order->get_billing_phone() ); ?>
 				<?php endif; ?>
-				<?php if ( $order->get_billing_email() ): ?>
+				<?php if ( $order->get_billing_email() ) : ?>
 					<p><?php echo esc_html( $order->get_billing_email() ); ?></p>
 				<?php endif; ?>
 			</address>

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -24,7 +24,11 @@ $text_align = is_rtl() ? 'right' : 'left';
 
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email ); ?>
 
-<h2><?php _e( 'Order details', 'woocommerce' ); ?></h2>
+<?php if ( ! $sent_to_admin ) : ?>
+	<h2><?php _e( 'Order details', 'woocommerce' ); ?></h2>
+<?php else : ?>
+	<h2><a class="link" href="<?php echo esc_url( admin_url( 'post.php?post=' . $order->get_id() . '&action=edit' ) ); ?>"><?php printf( __( 'Order #%s', 'woocommerce' ), $order->get_order_number() ); ?></a> (<?php printf( '<time datetime="%s">%s</time>', $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ); ?>)</h2>
+<?php endif; ?>
 
 <table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; margin-bottom: 40px;" border="1">
 	<thead>


### PR DESCRIPTION
Fixes #17165

Root cause: [Template changes while refactoring the downloads area of the emails](https://github.com/woocommerce/woocommerce/commit/94b32e644a57617b115d570fe178d3d415c05afb#diff-e39a9512d67eab87610375f317a08d33R27)

We don't need to update the plain template for this one since that never had the edit order link.