### PR TITLE
Add extra lines back in admin order summary

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -124,27 +124,31 @@ if ( wc_tax_enabled() ) {
 		}
 	?>
 	<table class="wc-order-totals">
-		<tr>
-			<td class="label"><?php echo wc_help_tip( __( 'This is the total discount. Discounts are defined per line item.', 'woocommerce' ) ); ?> <?php _e( 'Discount:', 'woocommerce' ); ?></td>
-			<td width="1%"></td>
-			<td class="total">
-				<?php echo wc_price( $order->get_total_discount(), array( 'currency' => $order->get_currency() ) ); ?>
-			</td>
-		</tr>
+		<?php if ( 0 < $order->get_total_discount() ) : ?>
+			<tr>
+				<td class="label"><?php _e( 'Discount:', 'woocommerce' ); ?></td>
+				<td width="1%"></td>
+				<td class="total">
+					<?php echo wc_price( $order->get_total_discount(), array( 'currency' => $order->get_currency() ) ); ?>
+				</td>
+			</tr>
+		<?php endif; ?>
 
 		<?php do_action( 'woocommerce_admin_order_totals_after_discount', $order->get_id() ); ?>
 
-		<tr>
-			<td class="label"><?php echo wc_help_tip( __( 'This is the shipping and handling total costs for the order.', 'woocommerce' ) ); ?> <?php _e( 'Shipping:', 'woocommerce' ); ?></td>
-			<td width="1%"></td>
-			<td class="total"><?php
-				if ( ( $refunded = $order->get_total_shipping_refunded() ) > 0 ) {
-					echo '<del>' . strip_tags( wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) ) ) . '</del> <ins>' . wc_price( $order->get_shipping_total() - $refunded, array( 'currency' => $order->get_currency() ) ) . '</ins>';
-				} else {
-					echo wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) );
-				}
-			?></td>
-		</tr>
+		<?php if ( $order->get_shipping_methods() ) : ?>
+			<tr>
+				<td class="label"><?php _e( 'Shipping:', 'woocommerce' ); ?></td>
+				<td width="1%"></td>
+				<td class="total"><?php
+					if ( ( $refunded = $order->get_total_shipping_refunded() ) > 0 ) {
+						echo '<del>' . strip_tags( wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) ) ) . '</del> <ins>' . wc_price( $order->get_shipping_total() - $refunded, array( 'currency' => $order->get_currency() ) ) . '</ins>';
+					} else {
+						echo wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) );
+					}
+				?></td>
+			</tr>
+		<?php endif; ?>
 
 		<?php do_action( 'woocommerce_admin_order_totals_after_shipping', $order->get_id() ); ?>
 
@@ -167,7 +171,7 @@ if ( wc_tax_enabled() ) {
 		<?php do_action( 'woocommerce_admin_order_totals_after_tax', $order->get_id() ); ?>
 
 		<tr>
-			<td class="label"><?php _e( 'Order total', 'woocommerce' ); ?>:</td>
+			<td class="label"><?php _e( 'Total', 'woocommerce' ); ?>:</td>
 			<td width="1%"></td>
 			<td class="total">
 				<?php echo $order->get_formatted_order_total(); ?>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -124,7 +124,28 @@ if ( wc_tax_enabled() ) {
 		}
 	?>
 	<table class="wc-order-totals">
+		<tr>
+			<td class="label"><?php echo wc_help_tip( __( 'This is the total discount. Discounts are defined per line item.', 'woocommerce' ) ); ?> <?php _e( 'Discount:', 'woocommerce' ); ?></td>
+			<td width="1%"></td>
+			<td class="total">
+				<?php echo wc_price( $order->get_total_discount(), array( 'currency' => $order->get_currency() ) ); ?>
+			</td>
+		</tr>
+
 		<?php do_action( 'woocommerce_admin_order_totals_after_discount', $order->get_id() ); ?>
+
+		<tr>
+			<td class="label"><?php echo wc_help_tip( __( 'This is the shipping and handling total costs for the order.', 'woocommerce' ) ); ?> <?php _e( 'Shipping:', 'woocommerce' ); ?></td>
+			<td width="1%"></td>
+			<td class="total"><?php
+				if ( ( $refunded = $order->get_total_shipping_refunded() ) > 0 ) {
+					echo '<del>' . strip_tags( wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) ) ) . '</del> <ins>' . wc_price( $order->get_shipping_total() - $refunded, array( 'currency' => $order->get_currency() ) ) . '</ins>';
+				} else {
+					echo wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) );
+				}
+			?></td>
+		</tr>
+
 		<?php do_action( 'woocommerce_admin_order_totals_after_shipping', $order->get_id() ); ?>
 
 		<?php if ( wc_tax_enabled() ) : ?>

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -726,8 +726,13 @@ final class WC_Cart_Totals {
 		$this->coupon_discount_totals              = (array) $discounts->get_discounts_by_item( true );
 		$this->coupon_discount_tax_totals          = $coupon_discount_tax_amounts;
 
-		$this->set_total( 'discounts_total', array_sum( $this->coupon_discount_totals ) );
-		$this->set_total( 'discounts_tax_total', array_sum( $this->coupon_discount_tax_totals ) );
+		if ( wc_prices_include_tax() ) {
+			$this->set_total( 'discounts_total', array_sum( $this->coupon_discount_totals ) - array_sum( $this->coupon_discount_tax_totals ) );
+			$this->set_total( 'discounts_tax_total', array_sum( $this->coupon_discount_tax_totals ) );
+		} else {
+			$this->set_total( 'discounts_total', array_sum( $this->coupon_discount_totals ) );
+			$this->set_total( 'discounts_tax_total', array_sum( $this->coupon_discount_tax_totals ) );
+		}
 
 		$this->cart->set_coupon_discount_totals( wc_remove_number_precision_deep( $coupon_discount_amounts ) );
 		$this->cart->set_coupon_discount_tax_totals( wc_remove_number_precision_deep( $coupon_discount_tax_amounts ) );
@@ -775,7 +780,7 @@ final class WC_Cart_Totals {
 	protected function calculate_totals() {
 		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ) ) );
 
-		// Add totals to cart object.
+		// Add totals to cart object. Note: Discount total for cart is excl tax.
 		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
 		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );
 		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );


### PR DESCRIPTION
Fixes #17172 

Just using the old code here works well as far as I can tell. 

It gets a little weird on the discount total line if prices include tax because the reduced taxes are counted as a discount (Tax reductions aren't counted in the discount total if prices exclude tax):

<img width="1171" alt="screen shot 2017-10-12 at 2 09 28 pm" src="https://user-images.githubusercontent.com/7317227/31519710-1b490870-af58-11e7-8b37-c04cb2c9af6c.png">

That is the one thing I noticed that may need tweaking.
