### PR TITLE
[3.2] Add missing break in WC_Legacy_Cart class

### DIFF
--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -79,6 +79,7 @@ abstract class WC_Legacy_Cart {
 				break;
 			case 'prices_include_tax' :
 				$value = wc_prices_include_tax();
+				break;
 			case 'round_at_subtotal' :
 				$value = 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
 				break;


### PR DESCRIPTION
Props to @mikejolley for pointing out the obvious. 🥇 Been looking at it for at least a few minutes without noticing. One of the reasons I don't like `case`.