### PR TITLE
Use edit context when updating prices in the API

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1076,10 +1076,11 @@ class WC_API_Products extends WC_API_Resource {
 
 			$product->set_date_on_sale_to( $date_to );
 			$product->set_date_on_sale_from( $date_from );
+
 			if ( $product->is_on_sale() ) {
-				$product->set_price( $product->get_sale_price() );
+				$product->set_price( $product->get_sale_price( 'edit' ) );
 			} else {
-				$product->set_price( $product->get_regular_price() );
+				$product->set_price( $product->get_regular_price( 'edit' ) );
 			}
 		}
 

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1566,10 +1566,11 @@ class WC_API_Products extends WC_API_Resource {
 
 			$product->set_date_on_sale_to( $date_to );
 			$product->set_date_on_sale_from( $date_from );
+
 			if ( $product->is_on_sale() ) {
-				$product->set_price( $product->get_sale_price() );
+				$product->set_price( $product->get_sale_price( 'edit' ) );
 			} else {
-				$product->set_price( $product->get_regular_price() );
+				$product->set_price( $product->get_regular_price( 'edit' ) );
 			}
 		}
 


### PR DESCRIPTION
Using edit context means filters won't run, so the prices stored will be accurate.

Fixes #17125