### PR TITLE
Allow tax_class slugs when adding a fee

### DIFF
--- a/includes/class-wc-cart-fees.php
+++ b/includes/class-wc-cart-fees.php
@@ -77,7 +77,7 @@ final class WC_Cart_Fees {
 	public function add_fee( $args = array() ) {
 		$fee_props            = (object) wp_parse_args( $args, $this->default_fee_props );
 		$fee_props->name      = $fee_props->name ? $fee_props->name : __( 'Fee', 'woocommerce' );
-		$fee_props->tax_class = in_array( $fee_props->tax_class, WC_Tax::get_tax_classes(), true ) ? $fee_props->tax_class: '';
+		$fee_props->tax_class = in_array( $fee_props->tax_class, array_merge( WC_Tax::get_tax_classes(), WC_Tax::get_tax_class_slugs() ), true ) ? $fee_props->tax_class: '';
 		$fee_props->taxable   = wc_string_to_bool( $fee_props->taxable );
 		$fee_props->amount    = wc_format_decimal( $fee_props->amount );
 


### PR DESCRIPTION
Previously when adding a fee to the cart it allowed for the `tax_class` property to be a slug because it was getting tax rates by finding them via the `WC_Tax::find_rates()` method. This re-instates the allowance of slugs alongside the actual tax rate names (which I believe is new in 3.2.0).