### PR TITLE
Show theme overrides that are done through the wc_get_template filter in WooCommerce > Status

### DIFF
--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -836,7 +836,11 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		$outdated_templates = false;
 		$scan_files         = WC_Admin_Status::scan_template_files( WC()->plugin_path() . '/templates/' );
 		foreach ( $scan_files as $file ) {
-			if ( file_exists( get_stylesheet_directory() . '/' . $file ) ) {
+			$located = apply_filters( 'wc_get_template', $file, $file, array(), WC()->template_path(), WC()->plugin_path() . '/templates/' );
+
+			if ( file_exists( $located ) ) {
+				$theme_file = $located;
+			} elseif ( file_exists( get_stylesheet_directory() . '/' . $file ) ) {
 				$theme_file = get_stylesheet_directory() . '/' . $file;
 			} elseif ( file_exists( get_stylesheet_directory() . '/' . WC()->template_path() . $file ) ) {
 				$theme_file = get_stylesheet_directory() . '/' . WC()->template_path() . $file;


### PR DESCRIPTION
Fixes #17043

Call the wc_get_template filter on each template and show the file if it exists.

![screen shot 2017-10-13 at 22 50 33](https://user-images.githubusercontent.com/1266907/31557712-19ea56ba-b074-11e7-8849-e42267d0e297.png)
