### PR TITLE
Fix deprecated functions in cart shortcode

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -38,8 +38,8 @@ class WC_Shortcode_Cart {
 				WC()->customer->set_location( $country, $state, $postcode, $city );
 				WC()->customer->set_shipping_location( $country, $state, $postcode, $city );
 			} else {
-				WC()->customer->set_to_base();
-				WC()->customer->set_shipping_to_base();
+				WC()->customer->set_billing_address_to_base();
+				WC()->customer->set_shipping_address_to_base();
 			}
 
 			WC()->customer->set_calculated_shipping( true );


### PR DESCRIPTION
These functions fire when someone tries to calculate shipping in the cart without entering a country. 