### PR TITLE
Wizard: Skip Activate step if Jetpack connected

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1352,8 +1352,6 @@ class WC_Admin_Setup_Wizard {
 	 */
 	protected function wc_setup_activate_actions() {
 		if (
-			isset( $_GET['from'] ) &&
-			'wpcom' === $_GET['from'] &&
 			class_exists( 'Jetpack' ) &&
 			Jetpack::is_active()
 		) {


### PR DESCRIPTION
`config`