### PR TITLE
Wizard: Only save JP TOS opt-in after connection

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1392,6 +1392,9 @@ class WC_Admin_Setup_Wizard {
 			class_exists( 'Jetpack' ) &&
 			Jetpack::is_active()
 		) {
+			// Leave a note for WooCommerce Services that Jetpack has been opted into.
+			update_option( 'woocommerce_setup_jetpack_opted_in', true );
+
 			wp_redirect( esc_url_raw( remove_query_arg( 'from', $this->get_next_step_link() ) ) );
 			exit;
 		}
@@ -1544,9 +1547,6 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function wc_setup_activate_save() {
 		check_admin_referer( 'wc-setup' );
-
-		// Leave a note for WooCommerce Services that Jetpack has been opted into.
-		update_option( 'woocommerce_setup_jetpack_opted_in', true );
 
 		WC_Install::background_installer( 'jetpack', array(
 			'file'      => 'jetpack/jetpack.php',


### PR DESCRIPTION
Before, we were saving the TOS acceptance option when the Connect button was clicked on the activate step (i.e. the Jetpack step).

Now, we are saving only after the user comes back successfully from the Jetpack connection process.

Steps to repro:

1. Deactivate Jetpack on your site
2. Remove the WCS tos option from the db by removing the `wc_connect_options` option
3. Make sure you are on a local dev site, so that you get a JP connection error in wp-admin
4. Go through wizard flow
5. See that the option `woocommerce_setup_jetpack_opted_in` gets saved
6. See that the function `pre_wc_init()` is run, and that `tos_accepted` option is saved in WCS

cc @jeffstieler 