### PR TITLE
fixes - Localize scrollTop offset in checkout.js ref #17156

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -386,7 +386,7 @@ jQuery( function( $ ) {
 
 						// Scroll to top
 						$( 'html, body' ).animate( {
-							scrollTop: ( $( 'form.checkout' ).offset().top - 100 )
+							scrollTop: ( $( 'form.checkout' ).offset().top - ( $( '.woocommerce-NoticeGroup-checkout' ).outerHeight() + 100 ) )
 						}, 1000 );
 
 					}
@@ -506,7 +506,7 @@ jQuery( function( $ ) {
 			wc_checkout_form.$checkout_form.removeClass( 'processing' ).unblock();
 			wc_checkout_form.$checkout_form.find( '.input-text, select, input:checkbox' ).blur();
 			$( 'html, body' ).animate({
-				scrollTop: ( $( 'form.checkout' ).offset().top - 100 )
+				scrollTop: ( $( 'form.checkout' ).offset().top - ( $( '.woocommerce-NoticeGroup-checkout' ).outerHeight() + 100 ) )
 			}, 1000 );
 			$( document.body ).trigger( 'checkout_error' );
 		}


### PR DESCRIPTION
Fixes : 
adding 100px to outer hight of  .woocommerce-NoticeGroup-checkout class works fine with a sticky and normal header. please check for the same and let me know if any changes required.

ref #17156

Thanks.