### PR TITLE
Check for proper currency when getting WCS live rates carrier in setup wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -586,11 +586,12 @@ class WC_Admin_Setup_Wizard {
 	 *
 	 * Can also be used to determine if WCS supports a given country.
 	 *
-	 * @param $country_code
+	 * @param string $country_code
+	 * @param string $currency_code
 	 * @return bool|string Carrier name if supported, boolean False otherwise.
 	 */
-	protected function get_wcs_shipping_carrier( $country_code, $currency ) {
-		switch ( array( $country_code, $currency ) ) {
+	protected function get_wcs_shipping_carrier( $country_code, $currency_code ) {
+		switch ( array( $country_code, $currency_code ) ) {
 			case array( 'US', 'USD' ):
 				return 'USPS';
 			case array( 'CA', 'CAD' ):
@@ -603,10 +604,11 @@ class WC_Admin_Setup_Wizard {
 	/**
 	 * Get shipping methods based on country code.
 	 *
-	 * @param $country_code
+	 * @param string $country_code
+	 * @param string $currency_code
 	 * @return array
 	 */
-	protected function get_wizard_shipping_methods( $country_code, $currency ) {
+	protected function get_wizard_shipping_methods( $country_code, $currency_code ) {
 		$shipping_methods = array(
 			'live_rates' => array(
 				'name'        => __( 'Live Rates', 'woocommerce' ),
@@ -630,7 +632,7 @@ class WC_Admin_Setup_Wizard {
 			),
 		);
 
-		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code, $currency );
+		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code, $currency_code );
 
 		if ( false === $live_rate_carrier || ! current_user_can('install_plugins') ) {
 			unset( $shipping_methods['live_rates'] );
@@ -643,12 +645,13 @@ class WC_Admin_Setup_Wizard {
 	 * Render the available shipping methods for a given country code.
 	 *
 	 * @param string $country_code
+	 * @param string $currency_code
 	 * @param string $input_prefix
 	 */
-	protected function shipping_method_selection_form( $country_code, $currency, $input_prefix ) {
-		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code, $currency );
+	protected function shipping_method_selection_form( $country_code, $currency_code, $input_prefix ) {
+		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code, $currency_code );
 		$selected          = $live_rate_carrier ? 'live_rates' : 'flat_rate';
-		$shipping_methods  = $this->get_wizard_shipping_methods( $country_code, $currency );
+		$shipping_methods  = $this->get_wizard_shipping_methods( $country_code, $currency_code );
 		?>
 		<div class="wc-wizard-shipping-method-select">
 			<div class="wc-wizard-shipping-method-dropdown">
@@ -702,8 +705,8 @@ class WC_Admin_Setup_Wizard {
 		$country_code          = WC()->countries->get_base_country();
 		$country_name          = WC()->countries->countries[ $country_code ];
 		$prefixed_country_name = WC()->countries->estimated_for_prefix( $country_code ) . $country_name;
-		$currency              = get_woocommerce_currency();
-		$wcs_carrier           = $this->get_wcs_shipping_carrier( $country_code, $currency );
+		$currency_code         = get_woocommerce_currency();
+		$wcs_carrier           = $this->get_wcs_shipping_carrier( $country_code, $currency_code );
 		$existing_zones        = WC_Shipping_Zones::get_zones();
 
 		if ( false === $dimension_unit || false === $weight_unit ) {
@@ -752,7 +755,7 @@ class WC_Admin_Setup_Wizard {
 							<p><?php echo esc_html( $country_name ); ?></p>
 						</div>
 						<div class="wc-wizard-service-description">
-							<?php $this->shipping_method_selection_form( $country_code, $currency, 'shipping_zones[domestic]' ); ?>
+							<?php $this->shipping_method_selection_form( $country_code, $currency_code, 'shipping_zones[domestic]' ); ?>
 						</div>
 						<div class="wc-wizard-service-enable">
 							<span class="wc-wizard-service-toggle">
@@ -766,7 +769,7 @@ class WC_Admin_Setup_Wizard {
 							<p><?php echo esc_html_e( 'Locations not covered by your other zones', 'woocommerce' ); ?></p>
 						</div>
 						<div class="wc-wizard-service-description">
-							<?php $this->shipping_method_selection_form( $country_code, $currency, 'shipping_zones[intl]' ); ?>
+							<?php $this->shipping_method_selection_form( $country_code, $currency_code, 'shipping_zones[intl]' ); ?>
 						</div>
 						<div class="wc-wizard-service-enable">
 							<span class="wc-wizard-service-toggle">

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -589,11 +589,11 @@ class WC_Admin_Setup_Wizard {
 	 * @param $country_code
 	 * @return bool|string Carrier name if supported, boolean False otherwise.
 	 */
-	protected function get_wcs_shipping_carrier( $country_code ) {
-		switch ( $country_code ) {
-			case 'US':
+	protected function get_wcs_shipping_carrier( $country_code, $currency ) {
+		switch ( array( $country_code, $currency ) ) {
+			case array( 'US', 'USD' ):
 				return 'USPS';
-			case 'CA':
+			case array( 'CA', 'CAD' ):
 				return 'Canada Post';
 			default:
 				return false;
@@ -606,7 +606,7 @@ class WC_Admin_Setup_Wizard {
 	 * @param $country_code
 	 * @return array
 	 */
-	protected function get_wizard_shipping_methods( $country_code ) {
+	protected function get_wizard_shipping_methods( $country_code, $currency ) {
 		$shipping_methods = array(
 			'live_rates' => array(
 				'name'        => __( 'Live Rates', 'woocommerce' ),
@@ -630,7 +630,7 @@ class WC_Admin_Setup_Wizard {
 			),
 		);
 
-		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code );
+		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code, $currency );
 
 		if ( false === $live_rate_carrier || ! current_user_can('install_plugins') ) {
 			unset( $shipping_methods['live_rates'] );
@@ -645,10 +645,10 @@ class WC_Admin_Setup_Wizard {
 	 * @param string $country_code
 	 * @param string $input_prefix
 	 */
-	protected function shipping_method_selection_form( $country_code, $input_prefix ) {
-		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code );
+	protected function shipping_method_selection_form( $country_code, $currency, $input_prefix ) {
+		$live_rate_carrier = $this->get_wcs_shipping_carrier( $country_code, $currency );
 		$selected          = $live_rate_carrier ? 'live_rates' : 'flat_rate';
-		$shipping_methods  = $this->get_wizard_shipping_methods( $country_code );
+		$shipping_methods  = $this->get_wizard_shipping_methods( $country_code, $currency );
 		?>
 		<div class="wc-wizard-shipping-method-select">
 			<div class="wc-wizard-shipping-method-dropdown">
@@ -702,7 +702,8 @@ class WC_Admin_Setup_Wizard {
 		$country_code          = WC()->countries->get_base_country();
 		$country_name          = WC()->countries->countries[ $country_code ];
 		$prefixed_country_name = WC()->countries->estimated_for_prefix( $country_code ) . $country_name;
-		$wcs_carrier           = $this->get_wcs_shipping_carrier( $country_code );
+		$currency              = get_woocommerce_currency();
+		$wcs_carrier           = $this->get_wcs_shipping_carrier( $country_code, $currency );
 		$existing_zones        = WC_Shipping_Zones::get_zones();
 
 		if ( false === $dimension_unit || false === $weight_unit ) {
@@ -751,7 +752,7 @@ class WC_Admin_Setup_Wizard {
 							<p><?php echo esc_html( $country_name ); ?></p>
 						</div>
 						<div class="wc-wizard-service-description">
-							<?php $this->shipping_method_selection_form( $country_code, 'shipping_zones[domestic]' ); ?>
+							<?php $this->shipping_method_selection_form( $country_code, $currency, 'shipping_zones[domestic]' ); ?>
 						</div>
 						<div class="wc-wizard-service-enable">
 							<span class="wc-wizard-service-toggle">
@@ -765,7 +766,7 @@ class WC_Admin_Setup_Wizard {
 							<p><?php echo esc_html_e( 'Locations not covered by your other zones', 'woocommerce' ); ?></p>
 						</div>
 						<div class="wc-wizard-service-description">
-							<?php $this->shipping_method_selection_form( $country_code, 'shipping_zones[intl]' ); ?>
+							<?php $this->shipping_method_selection_form( $country_code, $currency, 'shipping_zones[intl]' ); ?>
 						</div>
 						<div class="wc-wizard-service-enable">
 							<span class="wc-wizard-service-toggle">


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce/issues/17217

Before offering live rates, make sure proper currency (i.e. USD for the US, or CAD for Canada) is set. To test, go through wizard with no shipping zones configured, select US or CA as country, select a currency other than that country's national currency, and verify that Live Rates doesn't appear in the Shipping Method dropdowns in the Shipping step. (Also verify that Live Rates does appear if the currency does match.)