### PR TITLE
Add error logging to status update failures.

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -124,6 +124,9 @@ class WC_Order extends WC_Abstract_Order {
 				do_action( 'woocommerce_payment_complete_order_status_' . $this->get_status(), $this->get_id() );
 			}
 		} catch ( Exception $e ) {
+			$logger = wc_get_logger();
+			$logger->error( sprintf( 'Payment complete of order #%d failed!', $this->get_id() ), array( 'order' => $this, 'error' => $e ) );
+
 			return false;
 		}
 		return true;
@@ -294,6 +297,9 @@ class WC_Order extends WC_Abstract_Order {
 			$this->set_status( $new_status, $note, $manual );
 			$this->save();
 		} catch ( Exception $e ) {
+			$logger = wc_get_logger();
+			$logger->error( sprintf( 'Update status of order #%d failed!', $this->get_id() ), array( 'order' => $this, 'error' => $e ) );
+
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Simplest possible for fix #17251.

A more comprehensive fix that either does a rollback or ensures status updates are still processed if a status transition actually did occur should probably be done but this at the very least prevents any errors from being silently swallowed.