### PR TITLE
Moved major update check into get_untested_plugins.

### DIFF
--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -169,18 +169,27 @@ class WC_Plugin_Updates {
 	/**
 	 * Get active plugins that have a tested version lower than the input version.
 	 *
-	 * @param string $version
+	 * @param string $new_version
 	 * @param string $release 'major' or 'minor'.
 	 * @return array of plugin info arrays
 	 */
-	public function get_untested_plugins( $version, $release ) {
-		$extensions    = array_merge( $this->get_plugins_with_header( self::VERSION_TESTED_HEADER ), $this->get_plugins_for_woocommerce() );
-		$untested      = array();
-		$version_parts = explode( '.', $version );
-		$version       = $version_parts[0];
+	public function get_untested_plugins( $new_version, $release ) {
+		$extensions        = array_merge( $this->get_plugins_with_header( self::VERSION_TESTED_HEADER ), $this->get_plugins_for_woocommerce() );
+		$untested          = array();
+		$new_version_parts = explode( '.', $new_version );
+		$version           = $new_version_parts[0];
 
 		if ( 'minor' === $release ) {
-			$version .= '.' . $version_parts[1];
+			$version .= '.' . $new_version_parts[1];
+		}
+
+		if ( 'major' === $release ) {
+			$current_version_parts = explode( '.', WC_VERSION );
+
+			// If user has already moved to the major version, we don't need to flag up anything.
+			if ( version_compare( $current_version_parts[0] . '.' . $current_version_parts[1], $new_version_parts[0] . '.0', '>=' ) ) {
+				return array();
+			}
 		}
 
 		foreach ( $extensions as $file => $plugin ) {

--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -50,11 +50,6 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 			return;
 		}
 
-		// If user has already moved to the major version, we should only shown minor notices and assume everything is "ok" for major.
-		if ( version_compare( $current_version_parts[0] . '.' . $current_version_parts[1], $new_version_parts[0] . '.0', '>=' ) ) {
-			$this->major_untested_plugins = array();
-		}
-
 		if ( ! empty( $this->major_untested_plugins ) ) {
 			$this->upgrade_notice .= $this->get_extensions_inline_warning_major();
 		}

--- a/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
@@ -38,19 +38,6 @@ class WC_Updates_Screen_Updates extends WC_Plugin_Updates {
 		$this->new_version            = wc_clean( $updateable_plugins['woocommerce/woocommerce.php']->update->new_version );
 		$this->major_untested_plugins = $this->get_untested_plugins( $this->new_version, 'major' );
 
-		$current_version_parts = explode( '.', WC_VERSION );
-		$new_version_parts     = explode( '.', $this->new_version );
-
-		// If user has already moved to the minor version, we don't need to flag up anything.
-		if ( version_compare( $current_version_parts[0] . '.' . $current_version_parts[1], $new_version_parts[0] . '.' . $new_version_parts[1], '=' ) ) {
-			return;
-		}
-
-		// If user has already moved to the major version, we should only shown minor notices and assume everything is "ok" for major.
-		if ( version_compare( $current_version_parts[0] . '.' . $current_version_parts[1], $new_version_parts[0] . '.0', '>=' ) ) {
-			$this->major_untested_plugins = array();
-		}
-
 		if ( ! empty( $this->major_untested_plugins ) ) {
 			echo $this->get_extensions_modal_warning();
 			$this->update_screen_modal_js();


### PR DESCRIPTION
Prevents results returning when already on the major.