### PR TITLE
Added an update_prices_from_children routine and fixed sync_prices

### DIFF
--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -45,20 +45,7 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 */
 	protected function handle_updated_props( &$product ) {
 		if ( in_array( 'children', $this->updated_props ) ) {
-			$child_prices = array();
-			foreach ( $product->get_children( 'edit' ) as $child_id ) {
-				$child = wc_get_product( $child_id );
-				if ( $child ) {
-					$child_prices[] = $child->get_price();
-				}
-			}
-			$child_prices = array_filter( $child_prices );
-			delete_post_meta( $product->get_id(), '_price' );
-
-			if ( ! empty( $child_prices ) ) {
-				add_post_meta( $product->get_id(), '_price', min( $child_prices ) );
-				add_post_meta( $product->get_id(), '_price', max( $child_prices ) );
-			}
+			$this->update_prices_from_children( $product );
 		}
 		parent::handle_updated_props( $product );
 	}
@@ -70,24 +57,28 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 	 * @param WC_Product|int $product
 	 */
 	public function sync_price( &$product ) {
-		global $wpdb;
+		$this->update_prices_from_children( $product );
+	}
 
-		$children_ids = get_posts( array(
-			'post_parent' => $product->get_id(),
-			'post_type'   => 'product',
-			'fields'      => 'ids',
-		) );
-		$prices = $children_ids ? array_unique( $wpdb->get_col( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_price' AND post_id IN ( " . implode( ',', array_map( 'absint', $children_ids ) ) . " )" ) ) : array();
-
-		delete_post_meta( $product->get_id(), '_price' );
-		delete_transient( 'wc_var_prices_' . $product->get_id() );
-
-		if ( $prices ) {
-			sort( $prices );
-			// To allow sorting and filtering by multiple values, we have no choice but to store child prices in this manner.
-			foreach ( $prices as $price ) {
-				add_post_meta( $product->get_id(), '_price', $price, false );
+	/**
+	 * Loop over child products and update the grouped product prices.
+	 *
+	 * @param WC_Product $product Product object.
+	 */
+	protected function update_prices_from_children( &$product ) {
+		$child_prices = array();
+		foreach ( $product->get_children( 'edit' ) as $child_id ) {
+			$child = wc_get_product( $child_id );
+			if ( $child ) {
+				$child_prices[] = $child->get_price();
 			}
+		}
+		$child_prices = array_filter( $child_prices );
+		delete_post_meta( $product->get_id(), '_price' );
+
+		if ( ! empty( $child_prices ) ) {
+			add_post_meta( $product->get_id(), '_price', min( $child_prices ) );
+			add_post_meta( $product->get_id(), '_price', max( $child_prices ) );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #17239 

To test, make a grouped product with some children. Ensure _price is set to all children prices.

Change a child price. Observe _price of the grouped product updates.