### PR TITLE
Ignore existing unit option values in wizard in favor of national unit conventions

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -524,7 +524,7 @@ return array(
 		'thousand_sep'	=> ',',
 		'decimal_sep'	 => '.',
 		'num_decimals'	=> 2,
-		'weight_unit'	 => 'lbs',
+		'weight_unit'	 => 'oz',
 		'dimension_unit' => 'in',
 		'tax_rates'		=> array(
 			'AL' => array(

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -708,8 +708,6 @@ class WC_Admin_Setup_Wizard {
 	 * Shipping.
 	 */
 	public function wc_setup_shipping() {
-		$dimension_unit        = get_option( 'woocommerce_dimension_unit', false );
-		$weight_unit           = get_option( 'woocommerce_weight_unit', false );
 		$country_code          = WC()->countries->get_base_country();
 		$country_name          = WC()->countries->countries[ $country_code ];
 		$prefixed_country_name = WC()->countries->estimated_for_prefix( $country_code ) . $country_name;
@@ -717,14 +715,12 @@ class WC_Admin_Setup_Wizard {
 		$wcs_carrier           = $this->get_wcs_shipping_carrier( $country_code, $currency_code );
 		$existing_zones        = WC_Shipping_Zones::get_zones();
 
-		if ( false === $dimension_unit || false === $weight_unit ) {
-			if ( 'US' === $country_code ) {
-				$dimension_unit = 'in';
-				$weight_unit    = 'oz';
-			} else {
-				$dimension_unit = 'cm';
-				$weight_unit    = 'kg';
-			}
+		if ( 'US' === $country_code ) {
+			$dimension_unit = 'in';
+			$weight_unit    = 'oz';
+		} else {
+			$dimension_unit = 'cm';
+			$weight_unit    = 'kg';
 		}
 
 		if ( ! empty( $existing_zones ) ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -715,9 +715,10 @@ class WC_Admin_Setup_Wizard {
 		$wcs_carrier           = $this->get_wcs_shipping_carrier( $country_code, $currency_code );
 		$existing_zones        = WC_Shipping_Zones::get_zones();
 
-		if ( 'US' === $country_code ) {
-			$dimension_unit = 'in';
-			$weight_unit    = 'oz';
+		$locale_info = include( WC()->plugin_path() . '/i18n/locale-info.php' );
+		if ( isset( $locale_info[ $country_code ] ) ) {
+			$dimension_unit = $locale_info[ $country_code ]['dimension_unit'];
+			$weight_unit    = $locale_info[ $country_code ]['weight_unit'];
 		} else {
 			$dimension_unit = 'cm';
 			$weight_unit    = 'kg';


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce/issues/17260

Disregards existing `woocommerce_dimension_unit` and `woocommerce_weight_unit` option values (and overwrites them on save) in favor of existing — but previously ineffectual in practice — defaults set in the wizard conditional on country.

Example of restored functionality, for US and then CA:

![national-unit-conventions](https://user-images.githubusercontent.com/1867547/31797942-045fb0c6-b4ff-11e7-92f4-3820c92343f7.gif)

Not so pertinent since the wizard is only intended to be run immediately on first install, but the settings in this test before entering the wizard were:

<img width="683" src="https://user-images.githubusercontent.com/1867547/31797965-1f88c9e6-b4ff-11e7-858b-e65ca02a66f1.png">