### PR TITLE
New filter to determine subtotal for coupon amount

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -390,11 +390,9 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			 *
 			 * Uses price inc tax if prices include tax to work around https://github.com/woocommerce/woocommerce/issues/7669 and https://github.com/woocommerce/woocommerce/issues/8074.
 			 */
-			if ( wc_prices_include_tax() ) {
-				$discount_percent = ( wc_get_price_including_tax( $cart_item['data'] ) * $cart_item_qty ) / WC()->cart->subtotal;
-			} else {
-				$discount_percent = ( wc_get_price_excluding_tax( $cart_item['data'] ) * $cart_item_qty ) / WC()->cart->subtotal_ex_tax;
-			}
+			$subtotal_to_calculate_discount = apply_filters( 'woocommerce_coupon_subtotal_to_calculate_fixed_cart_discount', 
+					wc_prices_include_tax() ? WC()->cart->subtotal : WC()->cart->subtotal_ex_tax, $this, $cart_item );
+			$discount_percent = ( wc_get_price_including_tax( $cart_item['data'] ) * $cart_item_qty ) / $subtotal_to_calculate_discount;
 			$discount = ( (float) $this->get_amount() * $discount_percent ) / $cart_item_qty;
 
 		} elseif ( $this->is_type( 'fixed_product' ) ) {


### PR DESCRIPTION
Added filter to calculate cart subtotal when calculating fixed-cart coupon amounts per item. 
Using this new filter, along with the already-existing woocommerce_coupon_get_discount_amount filter, you can ignore items while calculating coupon amounts.