### PR TITLE
Fixed the jetpack redirect url for sites in subdirectories

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1576,12 +1576,12 @@ class WC_Admin_Setup_Wizard {
 			exit;
 		}
 
-		$redirect_url   = add_query_arg( array(
+		$redirect_url = add_query_arg( array(
 			'page'           => 'wc-setup',
 			'step'           => 'activate',
 			'from'           => 'wpcom',
 			'activate_error' => false,
-		), get_admin_url() );
+		), admin_url() );
 		$connection_url = Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
 
 		wp_redirect( esc_url_raw( $connection_url ) );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1576,10 +1576,12 @@ class WC_Admin_Setup_Wizard {
 			exit;
 		}
 
-		$redirect_url   = site_url( add_query_arg( array(
+		$redirect_url   = add_query_arg( array(
+			'page'           => 'wc-setup',
+			'step'           => 'activate',
 			'from'           => 'wpcom',
 			'activate_error' => false,
-		) ) );
+		), get_admin_url() );
 		$connection_url = Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
 
 		wp_redirect( esc_url_raw( $connection_url ) );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1576,12 +1576,12 @@ class WC_Admin_Setup_Wizard {
 			exit;
 		}
 
-		$redirect_url = add_query_arg( array(
+		$redirect_url = esc_url_raw( add_query_arg( array(
 			'page'           => 'wc-setup',
 			'step'           => 'activate',
 			'from'           => 'wpcom',
 			'activate_error' => false,
-		), admin_url() );
+		), admin_url() ) );
 		$connection_url = Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
 
 		wp_redirect( esc_url_raw( $connection_url ) );


### PR DESCRIPTION
Fixes #17296

To test:
* Set up a wordpress site in a subdirectory
* Checkout this branch
* Go through the setup wizard and select a service that requires a Jetpack connection
* Connect Jetpack via a wizard step and verify that you're redirected back to the wizard
* Should also still work for the sites located at the root directory