### PR TITLE
Default currency responds to country selection in setup wizard

### DIFF
--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -1,4 +1,5 @@
 /*global wc_setup_params */
+/*global wc_setup_currencies */
 jQuery( function( $ ) {
 	function blockWizardUI() {
 		$('.wc-setup-content').block({
@@ -139,8 +140,7 @@ jQuery( function( $ ) {
 
 	$( 'select#store_country_state' ).on( 'change', function() {
 		var countryCode = this.value.split( ':' )[ 0 ];
-		var currencyCode = $( 'input#currency_by_country' ).data( 'map' )[ countryCode ];
-		$( 'select#currency_code' ).val( currencyCode ).change();
+		$( 'select#currency_code' ).val( wc_setup_currencies[ countryCode ] ).change();
 	} );
 	$( 'select#store_country_state' ).change();
 } );

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -142,5 +142,4 @@ jQuery( function( $ ) {
 		var countryCode = this.value.split( ':' )[ 0 ];
 		$( 'select#currency_code' ).val( wc_setup_currencies[ countryCode ] ).change();
 	} );
-	$( 'select#store_country_state' ).change();
 } );

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -136,4 +136,11 @@ jQuery( function( $ ) {
 	} );
 
 	$( '.wc-wizard-services input#stripe_create_account' ).change();
+
+	$( 'select#store_country_state' ).on( 'change', function() {
+		var countryCode = this.value.split( ':' )[ 0 ];
+		var currencyCode = $( 'input#currency_by_country' ).data( 'map' )[ countryCode ];
+		$( 'select#currency_code' ).val( currencyCode ).change();
+	} );
+	$( 'select#store_country_state' ).change();
 } );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -304,10 +304,7 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		$locale_info = include( WC()->plugin_path() . '/i18n/locale-info.php' );
-		function get_currency_code( $country ) {
-			return $country[ 'currency_code' ];
-		}
-		$currency_by_country = array_map( 'get_currency_code', $locale_info );
+		$currency_by_country = wp_list_pluck( $locale_info, 'currency_code' );
 
 		?>
 		<form method="post" class="address-step">

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -293,6 +293,7 @@ class WC_Admin_Setup_Wizard {
 		$state          = WC()->countries->get_base_state();
 		$country        = WC()->countries->get_base_country();
 		$postcode       = WC()->countries->get_base_postcode();
+		$currency       = get_option( 'woocommerce_currency', 'GBP' );
 		$product_type   = get_option( 'woocommerce_product_type' );
 
 		if ( empty( $country ) ) {
@@ -388,7 +389,7 @@ class WC_Admin_Setup_Wizard {
 			>
 				<option value=""><?php esc_html_e( 'Choose a currency&hellip;', 'woocommerce' ); ?></option>
 				<?php foreach ( get_woocommerce_currencies() as $code => $name ) : ?>
-					<option value="<?php echo esc_attr( $code ); ?>">
+					<option value="<?php echo esc_attr( $code ); ?>" <?php selected( $currency, $code ); ?>>
 						<?php printf( esc_html__( '%1$s (%2$s)', 'woocommerce' ), $name, get_woocommerce_currency_symbol( $code ) ); ?>
 					</option>
 				<?php endforeach; ?>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -393,11 +393,9 @@ class WC_Admin_Setup_Wizard {
 					</option>
 				<?php endforeach; ?>
 			</select>
-			<input
-				id="currency_by_country"
-				type="hidden"
-				data-map="<?php esc_attr_e( json_encode( $currency_by_country ) ); ?>"
-			/>
+			<script type="text/javascript">
+				var wc_setup_currencies = <?php echo json_encode( $currency_by_country ); ?>;
+			</script>
 
 			<label class="location-prompt" for="product_type">
 				<?php esc_html_e( 'What type of product do you plan to sell?', 'woocommerce' ); ?>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -293,7 +293,6 @@ class WC_Admin_Setup_Wizard {
 		$state          = WC()->countries->get_base_state();
 		$country        = WC()->countries->get_base_country();
 		$postcode       = WC()->countries->get_base_postcode();
-		$currency       = get_option( 'woocommerce_currency', 'GBP' );
 		$product_type   = get_option( 'woocommerce_product_type' );
 
 		if ( empty( $country ) ) {
@@ -303,6 +302,12 @@ class WC_Admin_Setup_Wizard {
 		} elseif ( empty( $state ) ) {
 			$state = '*';
 		}
+
+		$locale_info = include( WC()->plugin_path() . '/i18n/locale-info.php' );
+		function get_currency_code( $country ) {
+			return $country[ 'currency_code' ];
+		}
+		$currency_by_country = array_map( 'get_currency_code', $locale_info );
 
 		?>
 		<form method="post" class="address-step">
@@ -386,11 +391,16 @@ class WC_Admin_Setup_Wizard {
 			>
 				<option value=""><?php esc_html_e( 'Choose a currency&hellip;', 'woocommerce' ); ?></option>
 				<?php foreach ( get_woocommerce_currencies() as $code => $name ) : ?>
-					<option value="<?php echo esc_attr( $code ); ?>" <?php selected( $currency, $code ); ?>>
+					<option value="<?php echo esc_attr( $code ); ?>">
 						<?php printf( esc_html__( '%1$s (%2$s)', 'woocommerce' ), $name, get_woocommerce_currency_symbol( $code ) ); ?>
 					</option>
 				<?php endforeach; ?>
 			</select>
+			<input
+				id="currency_by_country"
+				type="hidden"
+				data-map="<?php esc_attr_e( json_encode( $currency_by_country ) ); ?>"
+			/>
 
 			<label class="location-prompt" for="product_type">
 				<?php esc_html_e( 'What type of product do you plan to sell?', 'woocommerce' ); ?>


### PR DESCRIPTION
For convenience, and to reduce the likelihood of accidental country-currency mismatch: upon selecting a country (and on initial load of setup wizard), update the currency to match.

![currency-responds-to-country](https://user-images.githubusercontent.com/1867547/31833791-9f6b18cc-b599-11e7-8a24-958855b7bef4.gif)

Note: now ignores existing `woocommerce_currency` option value (as established in https://github.com/woocommerce/woocommerce/issues/17260#issuecomment-337632863), but the default is unchanged as `GBP` is the currency for the default country.

A somewhat more elegant & performant implementation may be to put a `data-currency` attribute on country select `<option>`s and `<optgroup>`s but I believe this would require modifying the `country_dropdown_options` function.