### PR TITLE
Caches product variation attributes (alt)

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -109,6 +109,7 @@ function wc_delete_product_transients( $post_id = 0 ) {
 	// Transient names that include an ID
 	$post_transient_names = array(
 		'wc_product_children_',
+		'wc_product_variations_attributes_',
 		'wc_var_prices_',
 		'wc_related_',
 		'wc_child_has_weight_',


### PR DESCRIPTION
Variants of the fix proposed by @rodrigoprimo, allowing the caching of variations in transients, rather than the WP cache.

Greatly improves the number of queries if many attributes with many values.

Fix #17120
Original PR #17141