### PR TITLE
Add after shipping address action hook

### DIFF
--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -52,6 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				<address>
 					<?php echo ( $address = $order->get_formatted_shipping_address() ) ? $address : __( 'N/A', 'woocommerce' ); ?>
+					<?php do_action( 'woocommerce_customer_details_after_shipping_address', $order ); ?>
 				</address>
 
 			</div><!-- /.col-2 -->


### PR DESCRIPTION
I want to add the action hook, because of some shipping company needs phone number of shipping address.
So I want to display it. Now if use 'woocommerce_localisation_address_formats' filter hook, billing address display same phone number twice.