### PR TITLE
Adjust item limiting discount code to work with multiple coupons

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -292,39 +292,19 @@ class WC_Discounts {
 	 */
 	protected function get_items_to_apply_coupon( $coupon ) {
 		$items_to_apply  = array();
-		$limit_usage_qty = 0;
-		$applied_count   = 0;
-
-		if ( null !== $coupon->get_limit_usage_to_x_items() ) {
-			$limit_usage_qty = $coupon->get_limit_usage_to_x_items();
-		}
 
 		foreach ( $this->items as $item ) {
 			$item_to_apply = clone $item; // Clone the item so changes to this item do not affect the originals.
 
-			if ( 0 === $this->get_discounted_price_in_cents( $item_to_apply ) ) {
+			if ( 0 === $this->get_discounted_price_in_cents( $item_to_apply ) || 0 >= $item_to_apply->quantity ) {
 				continue;
 			}
+
 			if ( ! $coupon->is_valid_for_product( $item_to_apply->product, $item_to_apply->object ) && ! $coupon->is_valid_for_cart() ) {
 				continue;
 			}
 
-			if ( $limit_usage_qty && $applied_count >= $limit_usage_qty ) {
-				break;
-			}
-
-			if ( $limit_usage_qty && $item_to_apply->quantity > ( $limit_usage_qty - $applied_count ) ) {
-				$limit_to_qty            = absint( $limit_usage_qty - $applied_count );
-
-				// Lower the qty and cost so the discount is applied less.
-				$item_to_apply->price    = ( $item_to_apply->price / $item_to_apply->quantity ) * $limit_to_qty;
-				$item_to_apply->quantity = $limit_to_qty;
-			}
-			if ( 0 >= $item_to_apply->quantity ) {
-				continue;
-			}
 			$items_to_apply[] = $item_to_apply;
-			$applied_count   += $item_to_apply->quantity;
 		}
 		return $items_to_apply;
 	}
@@ -338,8 +318,14 @@ class WC_Discounts {
 	 * @return int Total discounted.
 	 */
 	protected function apply_coupon_percent( $coupon, $items_to_apply ) {
-		$total_discount = 0;
-		$cart_total     = 0;
+		$total_discount  = 0;
+		$cart_total      = 0;
+		$limit_usage_qty = 0;
+		$applied_count   = 0;
+
+		if ( null !== $coupon->get_limit_usage_to_x_items() ) {
+			$limit_usage_qty = $coupon->get_limit_usage_to_x_items();
+		}
 
 		// Because get_amount() could return an empty string, let's be sure to set our local variable to a known good value.
 		$coupon_amount  = ( '' === $coupon->get_amount() ) ? 0 : $coupon->get_amount();
@@ -351,8 +337,9 @@ class WC_Discounts {
 			// Get the price we actually want to discount, based on settings.
 			$price_to_discount = ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price;
 
-			// Total up.
-			$cart_total += $price_to_discount;
+			// See how many and what price to apply to.
+			$apply_quantity    = max( 0, ( $limit_usage_qty && ( $limit_usage_qty - $applied_count ) < $item->quantity ? $limit_usage_qty - $applied_count : $item->quantity ) );
+			$price_to_discount = ( $price_to_discount / $item->quantity ) * $apply_quantity;
 
 			// Run coupon calculations.
 			$discount = floor( $price_to_discount * ( $coupon_amount / 100 ) );
@@ -362,9 +349,10 @@ class WC_Discounts {
 				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}
 
-			$discount        = min( $discounted_price, $discount );
-
-			$total_discount += $discount;
+			$discount       = min( $discounted_price, $discount );
+			$cart_total     = $cart_total + $price_to_discount;
+			$total_discount = $total_discount + $discount;
+			$applied_count  = $applied_count + $apply_quantity;
 
 			// Store code and discount amount per item.
 			$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;
@@ -390,8 +378,14 @@ class WC_Discounts {
 	 * @return int Total discounted.
 	 */
 	protected function apply_coupon_fixed_product( $coupon, $items_to_apply, $amount = null ) {
-		$total_discount = 0;
-		$amount         = $amount ? $amount : wc_add_number_precision( $coupon->get_amount() );
+		$total_discount  = 0;
+		$amount          = $amount ? $amount: wc_add_number_precision( $coupon->get_amount() );
+		$limit_usage_qty = 0;
+		$applied_count   = 0;
+
+		if ( null !== $coupon->get_limit_usage_to_x_items() ) {
+			$limit_usage_qty = $coupon->get_limit_usage_to_x_items();
+		}
 
 		foreach ( $items_to_apply as $item ) {
 			// Find out how much price is available to discount for the item.
@@ -401,15 +395,22 @@ class WC_Discounts {
 			$price_to_discount = ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price;
 
 			// Run coupon calculations.
-			$discount = $amount * $item->quantity;
+			if ( $limit_usage_qty ) {
+				$apply_quantity = max( 0, ( $limit_usage_qty - $applied_count < $item->quantity ? $limit_usage_qty - $applied_count: $item->quantity ) );
+				$discount       = min( $amount, $item->price / $item->quantity ) * $apply_quantity;
+			} else {
+				$apply_quantity = $item->quantity;
+				$discount       = $amount * $apply_quantity;
+			}
 
 			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
 				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}
 
-			$discount        = min( $discounted_price, $discount );
-			$total_discount += $discount;
+			$discount       = min( $discounted_price, $discount );
+			$total_discount = $total_discount + $discount;
+			$applied_count  = $applied_count + $apply_quantity;
 
 			// Store code and discount amount per item.
 			$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -45,12 +45,10 @@ class WC_Discounts {
 	 * @param array $object Cart or order object.
 	 */
 	public function __construct( $object = array() ) {
-		$this->object = $object;
-
-		if ( is_a( $this->object, 'WC_Cart' ) ) {
-			$this->set_items_from_cart( $this->object );
-		} elseif ( is_a( $this->object, 'WC_Order' ) ) {
-			$this->set_items_from_order( $this->object );
+		if ( is_a( $object, 'WC_Cart' ) ) {
+			$this->set_items_from_cart( $object );
+		} elseif ( is_a( $object, 'WC_Order' ) ) {
+			$this->set_items_from_order( $object );
 		}
 	}
 
@@ -66,6 +64,8 @@ class WC_Discounts {
 		if ( ! is_a( $cart, 'WC_Cart' ) ) {
 			return;
 		}
+
+		$this->object = $cart;
 
 		foreach ( $cart->get_cart() as $key => $cart_item ) {
 			$item                = new stdClass();
@@ -87,11 +87,13 @@ class WC_Discounts {
 	 * @param array $order Cart object.
 	 */
 	public function set_items_from_order( $order ) {
-		$this->items     = $this->discounts      = array();
+		$this->items = $this->discounts = array();
 
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return;
 		}
+
+		$this->object = $order;
 
 		foreach ( $order->get_items() as $order_item ) {
 			$item                = new stdClass();

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -1282,6 +1282,100 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 					'expected_total_discount' => 20,
 				),
 			),
+			array(
+				array(
+					'desc' => 'Test multiple coupons with limits of 1. Discounting sequentially.',
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'wc_options' => array(
+						'woocommerce_calc_discounts_sequentially' => array(
+							'set'    => 'yes',
+							'revert' => 'no',
+						),
+					),
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 4,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'                   => 'one',
+							'discount_type'          => 'fixed_product',
+							'amount'                 => '10',
+							'limit_usage_to_x_items' => 1,
+						),
+						array(
+							'code'                   => 'two',
+							'discount_type'          => 'fixed_product',
+							'amount'                 => '10',
+							'limit_usage_to_x_items' => 1,
+						),
+						array(
+							'code'                   => 'three',
+							'discount_type'          => 'percent',
+							'amount'                 => '100',
+							'limit_usage_to_x_items' => 1,
+						),
+					),
+					'expected_total_discount' => 30,
+				),
+			),
+			array(
+				array(
+					'desc' => 'Test multiple coupons with limits of 1.',
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 10,
+							'qty'   => 4,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'                   => 'one',
+							'discount_type'          => 'fixed_product',
+							'amount'                 => '10',
+							'limit_usage_to_x_items' => 1,
+						),
+						array(
+							'code'                   => 'two',
+							'discount_type'          => 'fixed_product',
+							'amount'                 => '10',
+							'limit_usage_to_x_items' => 1,
+						),
+						array(
+							'code'                   => 'three',
+							'discount_type'          => 'percent',
+							'amount'                 => '100',
+							'limit_usage_to_x_items' => 1,
+						),
+					),
+					'expected_total_discount' => 30,
+				),
+			),
 		);
 	}
 

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -839,7 +839,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'limit_usage_to_x_items' => 5,
 						),
 					),
-					'expected_total_discount' => 18.30,
+					'expected_total_discount' => 18.60,
 				),
 			),
 			array(
@@ -1280,56 +1280,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						),
 					),
 					'expected_total_discount' => 20,
-				),
-			),
-			array(
-				array(
-					'desc' => 'Test multiple coupons with limits of 1. Discounting sequentially.',
-					'tax_rate' => array(
-						'tax_rate_country'  => '',
-						'tax_rate_state'    => '',
-						'tax_rate'          => '20.0000',
-						'tax_rate_name'     => 'VAT',
-						'tax_rate_priority' => '1',
-						'tax_rate_compound' => '0',
-						'tax_rate_shipping' => '1',
-						'tax_rate_order'    => '1',
-						'tax_rate_class'    => '',
-					),
-					'prices_include_tax' => false,
-					'wc_options' => array(
-						'woocommerce_calc_discounts_sequentially' => array(
-							'set'    => 'yes',
-							'revert' => 'no',
-						),
-					),
-					'cart' => array(
-						array(
-							'price' => 10,
-							'qty'   => 4,
-						),
-					),
-					'coupons' => array(
-						array(
-							'code'                   => 'one',
-							'discount_type'          => 'fixed_product',
-							'amount'                 => '10',
-							'limit_usage_to_x_items' => 1,
-						),
-						array(
-							'code'                   => 'two',
-							'discount_type'          => 'fixed_product',
-							'amount'                 => '10',
-							'limit_usage_to_x_items' => 1,
-						),
-						array(
-							'code'                   => 'three',
-							'discount_type'          => 'percent',
-							'amount'                 => '100',
-							'limit_usage_to_x_items' => 1,
-						),
-					),
-					'expected_total_discount' => 30,
 				),
 			),
 			array(


### PR DESCRIPTION
Fixes #17275 and #17330

Rather than changing the items, this applies the discount limit logic when calculating the discount amount.

Includes a test for issue #17275 and #17330