### PR TITLE
Adjust how permalinks are retrieved and saved

### DIFF
--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -194,7 +194,7 @@ class WC_Admin_Permalink_Settings {
 					$product_base = '/' . _x( 'product', 'slug', 'woocommerce' ) . $product_base;
 				}
 			} elseif ( empty( $product_base ) ) {
-				$product_base = false;
+				$product_base = _x( 'product', 'slug', 'woocommerce' );
 			}
 
 			$permalinks['product_base'] = wc_sanitize_permalink( $product_base );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -886,12 +886,9 @@ add_filter( 'rewrite_rules_array', 'wc_fix_rewrite_rules' );
  * @return string
  */
 function wc_fix_product_attachment_link( $link, $post_id ) {
-	$post = get_post( $post_id );
-	if ( 'product' === get_post_type( $post->post_parent ) ) {
-		$permalinks = wc_get_permalink_structure();
-		if ( preg_match( '/\/(.+)(\/%product_cat%)$/', $permalinks['product_rewrite_slug'], $matches ) ) {
-			$link = home_url( '/?attachment_id=' . $post->ID );
-		}
+	$parent_type = get_post_type( wp_get_post_parent_id( $post_id ) );
+	if ( 'product' === $parent_type || 'product_variation' === $parent_type ) {
+		$link = home_url( '/?attachment_id=' . $post_id );
 	}
 	return $link;
 }
@@ -1674,33 +1671,36 @@ function wc_list_pluck( $list, $callback_or_field, $index_key = null ) {
 }
 
 /**
- * Get permalink settings for WooCommerce independent of the user locale.
+ * Get permalink settings for things like products and taxonomies.
+ *
+ * As of 3.3.0, the permalink settings are stored to the option instead of
+ * being blank and inheritting from the locale. This speeds up page loading
+ * times by negating the need to switch locales on each page load.
+ *
+ * This is more inline with WP core behavior which does not localize slugs.
  *
  * @since  3.0.0
  * @return array
  */
 function wc_get_permalink_structure() {
-	if ( did_action( 'admin_init' ) ) {
-		wc_switch_to_site_locale();
-	}
-
-	$permalinks = wp_parse_args( (array) get_option( 'woocommerce_permalinks', array() ), array(
-		'product_base'           => '',
-		'category_base'          => '',
-		'tag_base'               => '',
+	$saved_permalinks = (array) get_option( 'woocommerce_permalinks', array() );
+	$permalinks       = wp_parse_args( $saved_permalinks, array(
+		'product_base'           => _x( 'product', 'slug', 'woocommerce' ),
+		'category_base'          => _x( 'product-category', 'slug', 'woocommerce' ),
+		'tag_base'               => _x( 'product-tag', 'slug', 'woocommerce' ),
 		'attribute_base'         => '',
 		'use_verbose_page_rules' => false,
 	) );
 
-	// Ensure rewrite slugs are set.
-	$permalinks['product_rewrite_slug']   = untrailingslashit( empty( $permalinks['product_base'] ) ? _x( 'product', 'slug', 'woocommerce' )             : $permalinks['product_base'] );
-	$permalinks['category_rewrite_slug']  = untrailingslashit( empty( $permalinks['category_base'] ) ? _x( 'product-category', 'slug', 'woocommerce' )   : $permalinks['category_base'] );
-	$permalinks['tag_rewrite_slug']       = untrailingslashit( empty( $permalinks['tag_base'] ) ? _x( 'product-tag', 'slug', 'woocommerce' )             : $permalinks['tag_base'] );
-	$permalinks['attribute_rewrite_slug'] = untrailingslashit( empty( $permalinks['attribute_base'] ) ? '' : $permalinks['attribute_base'] );
-
-	if ( did_action( 'admin_init' ) ) {
-		wc_restore_locale();
+	if ( $saved_permalinks !== $permalinks ) {
+		update_option( 'woocommerce_permalinks', $permalinks );
 	}
+
+	$permalinks['product_rewrite_slug']   = untrailingslashit( $permalinks['product_base'] );
+	$permalinks['category_rewrite_slug']  = untrailingslashit( $permalinks['category_base'] );
+	$permalinks['tag_rewrite_slug']       = untrailingslashit( $permalinks['tag_base'] );
+	$permalinks['attribute_rewrite_slug'] = untrailingslashit( $permalinks['attribute_base'] );
+
 	return $permalinks;
 }
 


### PR DESCRIPTION
Closes #17337 

#17337 showed a performance slow down at some point which I traced back to our locale switching code https://github.com/woocommerce/woocommerce/compare/253bb07...984ed08

That basically switches the locale when we get permalinks so the permalinks are translated correctly.

The problem is however, this is done on every page load several times (whenever the option is loaded) and can be slow. That was what slowed the gallery.

I checked how WP handles this and noticed it does not even translate the default permalinks/slugs. They are hardcoded.

Because of this I’ve adjusted our logic;

- It will always use the settings on Settings > Permalinks
- If the settings are empty, it will save the localised defaults once.
- From then on, to change the permalinks one must use the settings.

This removes the need to change locale on the fly and improves page loading times.