### PR TITLE
Fix date query meta unset checking

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -644,8 +644,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 				// Remove any existing meta queries for the same keys to prevent conflicts.
 				$existing_queries = wp_list_pluck( $wp_query_args['meta_query'], 'key', true );
-				foreach ( $existing_queries as $query_index => $query_contents ) {
-					unset( $wp_query_args['meta_query'][ $query_index ] );
+				$meta_query_index = array_search( $db_key, $existing_queries );
+				if ( false !== $meta_query_index ) {
+					unset( $wp_query_args['meta_query'][ $meta_query_index ] );
 				}
 
 				$wp_query_args = $this->parse_date_for_wp_query( $query_vars[ $query_var_key ], $db_key, $wp_query_args );

--- a/tests/unit-tests/order/functions.php
+++ b/tests/unit-tests/order/functions.php
@@ -844,6 +844,80 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test wc_get_order date queries combined with meta queries.
+	 *
+	 * @since 3.2
+	 */
+	public function test_wc_get_order_mixed_date_shipping_country() {
+		// Set up dates.
+		$start = time() - 1; // Start from one second ago.
+		$yesterday = strtotime( '-1 day', $start );
+		$end = strtotime( '+1 day', $start );
+		$date_range = $start . '...' . $end;
+
+		// Populate orders.
+		$us_now = WC_Helper_Order::create_order();
+		$us_now->set_props( array(
+			'shipping_country' => 'US',
+		) );
+		$us_now->save();
+
+		$us_old = WC_Helper_Order::create_order();
+		$us_old->set_props( array(
+			'date_created' => $yesterday,
+			'shipping_country' => 'US',
+		) );
+		$us_old->save();
+
+		$mx_now = WC_Helper_Order::create_order();
+		$mx_now->set_props( array(
+			'shipping_country' => 'MX',
+		) );
+		$mx_now->save();
+
+		$mx_old = WC_Helper_Order::create_order();
+		$mx_old->set_props( array(
+			'date_created'     => $yesterday,
+			'shipping_country' => 'MX',
+		) );
+		$mx_old->save();
+
+		// Test just date range.
+		$args = array(
+			'return'       => 'ids',
+			'date_created' => $date_range,
+			'orderby'      => 'ID',
+			'order'        => 'ASC',
+		);
+		$orders = wc_get_orders( $args );
+		$expected = array( $us_now->get_id(), $mx_now->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		// Test just US orders.
+		$args = array(
+			'return'           => 'ids',
+			'shipping_country' => 'US',
+			'orderby'          => 'ID',
+			'order'            => 'ASC',
+		);
+		$orders = wc_get_orders( $args );
+		$expected = array( $us_now->get_id(), $us_old->get_id() );
+		$this->assertEquals( $expected, $orders );
+
+		// Test US orders with date range.
+		$args = array(
+			'return'           => 'ids',
+			'date_created'     => $date_range,
+			'shipping_country' => 'US',
+			'orderby'          => 'ID',
+			'order'            => 'ASC',
+		);
+		$orders = wc_get_orders( $args );
+		$expected = array( $us_now->get_id() );
+		$this->assertEquals( $expected, $orders );
+	}
+
+	/**
 	 * Test wc_get_order_note().
 	 *
 	 * @since 3.2.0


### PR DESCRIPTION
Fixes #17290.

There was a bug in the code that removes manual meta queries for date fields where it was removing all of the meta queries instead of just the problematic ones.

To test: run provided unit test