### PR TITLE
Calculate shipping after discounts

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -804,14 +804,14 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_totals() {
-		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ) ) );
-
 		// Add totals to cart object. Note: Discount total for cart is excl tax.
 		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
 		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );
 
 		// Calculate shipping after discounts have been calculated.
 		$this->calculate_shipping_totals();
+
+		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ) ) );
 
 		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );
 

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -134,6 +134,7 @@ final class WC_Cart_Totals {
 	 */
 	protected function calculate() {
 		$this->calculate_item_totals();
+		$this->calculate_shipping_totals();
 		$this->calculate_fee_totals();
 		$this->calculate_totals();
 	}
@@ -762,6 +763,10 @@ final class WC_Cart_Totals {
 
 		$this->cart->set_coupon_discount_totals( wc_remove_number_precision_deep( $coupon_discount_amounts ) );
 		$this->cart->set_coupon_discount_tax_totals( wc_remove_number_precision_deep( $coupon_discount_tax_amounts ) );
+
+		// Add totals to cart object. Note: Discount total for cart is excl tax.
+		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
+		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );
 	}
 
 	/**
@@ -804,15 +809,7 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_totals() {
-		// Add totals to cart object. Note: Discount total for cart is excl tax.
-		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
-		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );
-
-		// Calculate shipping after discounts have been calculated.
-		$this->calculate_shipping_totals();
-
 		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ) ) );
-
 		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );
 
 		// Allow plugins to hook and alter totals before final total is calculated.

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -134,7 +134,6 @@ final class WC_Cart_Totals {
 	 */
 	protected function calculate() {
 		$this->calculate_item_totals();
-		$this->calculate_shipping_totals();
 		$this->calculate_fee_totals();
 		$this->calculate_totals();
 	}
@@ -810,6 +809,10 @@ final class WC_Cart_Totals {
 		// Add totals to cart object. Note: Discount total for cart is excl tax.
 		$this->cart->set_discount_total( $this->get_total( 'discounts_total' ) );
 		$this->cart->set_discount_tax( $this->get_total( 'discounts_tax_total' ) );
+
+		// Calculate shipping after discounts have been calculated.
+		$this->calculate_shipping_totals();
+
 		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );
 
 		// Allow plugins to hook and alter totals before final total is calculated.


### PR DESCRIPTION
Fixes #17274 

The cart's `discount_total` needs to be calculated and set before shipping is processed. Currently `discount_total` is always `0` when shipping methods use it.

To test: try the examples in #17274

EDIT: Broke a bunch of tests. Back to the drawing board.
EDIT2: Back in business.