### PR TITLE
Fix coupon discount calculations for third party coupon types

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -242,7 +242,7 @@ class WC_Discounts {
 				foreach ( $items_to_apply as $item ) {
 					$discounted_price  = $this->get_discounted_price_in_cents( $item );
 					$price_to_discount = wc_remove_number_precision( ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price );
-					$discount          = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount, $item->object ) ) * $item->quantity;
+					$discount          = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $item->quantity;
 					$discount          = min( $discounted_price, $discount );
 
 					// Store code and discount amount per item.


### PR DESCRIPTION
When calculating the discount amount for custom coupons the discount amount is multiplied by the quantity after it has been calculated ([here](https://github.com/woocommerce/woocommerce/blob/3.2.1/includes/class-wc-discounts.php#L245)). Because of this, I think the `$single` arg should be `true`. Without it, `get_discount_amount()` will calculate the discount based on the full item quantity ([here](https://github.com/woocommerce/woocommerce/blob/3.2.0/includes/class-wc-coupon.php#L402) for example) and then that will get multiplied by the quantity again.

So for example, a $5 fixed product coupon applied to a cart item with a quantity of 3 has its discount calculated at $15 (by `get_discount_amount()`) then it has that value multiplied again by 3.

Because it's now calculating the single discount, I had to divide the `$price_to_discount` by the quantity as well for this to work correctly. 

It might seem like a strange way to do it - divide the price by the quantity only to multiply the discount by it later but `get_discount_amount()` accepts a `$item->object` (cart item or line item) and that object _can_ have a different quantity to the `$item->quantity` variable (when the coupon has a usage limit to x items for example).

Let me know if there's a better way to do this.