### PR TITLE
[REST API] Fix category "image" returned type when is empty

### DIFF
--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -32,9 +32,9 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 	/**
 	 * Prepare a single product category output for response.
 	 *
-	 * @param WP_Term $item Term object.
-	 * @param WP_REST_Request $request
-	 * @return WP_REST_Response $response
+	 * @param WP_Term         $item    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
@@ -56,7 +56,8 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 		);
 
 		// Get category image.
-		if ( $image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' ) ) {
+		$image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' );
+		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 
 			$data['image'] = array(

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -50,7 +50,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 			'parent'      => (int) $item->parent,
 			'description' => $item->description,
 			'display'     => $display_type ? $display_type : 'default',
-			'image'       => array(),
+			'image'       => null,
 			'menu_order'  => (int) $menu_order,
 			'count'       => (int) $item->count,
 		);

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -46,9 +46,9 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 	/**
 	 * Prepare a single product category output for response.
 	 *
-	 * @param WP_Term $item Term object.
-	 * @param WP_REST_Request $request
-	 * @return WP_REST_Response $response
+	 * @param WP_Term         $item    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
@@ -70,7 +70,8 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 		);
 
 		// Get category image.
-		if ( $image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' ) ) {
+		$image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' );
+		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 
 			$data['image'] = array(
@@ -106,8 +107,8 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 	/**
 	 * Update term meta fields.
 	 *
-	 * @param WP_Term $term
-	 * @param WP_REST_Request $request
+	 * @param WP_Term         $term    Term object.
+	 * @param WP_REST_Request $request Request instance.
 	 * @return bool|WP_Error
 	 */
 	protected function update_term_meta_fields( $term, $request ) {
@@ -145,7 +146,10 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 
 				// Set the image title.
 				if ( ! empty( $request['image']['title'] ) ) {
-					wp_update_post( array( 'ID' => $image_id, 'post_title' => wc_clean( $request['image']['title'] ) ) );
+					wp_update_post( array(
+						'ID'         => $image_id,
+						'post_title' => wc_clean( $request['image']['title'] ),
+					) );
 				}
 			} else {
 				delete_woocommerce_term_meta( $id, 'thumbnail_id' );

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -64,7 +64,7 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 			'parent'      => (int) $item->parent,
 			'description' => $item->description,
 			'display'     => $display_type ? $display_type : 'default',
-			'image'       => array(),
+			'image'       => null,
 			'menu_order'  => (int) $menu_order,
 			'count'       => (int) $item->count,
 		);


### PR DESCRIPTION
Categories only have a single object returned and should use `null` when empty.

Note that unit tests will fail because the filename that we should fix only on 3.3.

```
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 1 | ERROR | Class file names should be based on the class name with
   |       | "class-" prepended. Expected
   |       | class-wc-rest-product-categories-v1-controller.php, but
   |       | found class-wc-rest-product-categories-controller.php.
----------------------------------------------------------------------
```

Fixes #17332