### PR TITLE
Fixed permalink default values

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1683,8 +1683,8 @@ function wc_list_pluck( $list, $callback_or_field, $index_key = null ) {
  * @return array
  */
 function wc_get_permalink_structure() {
-	$saved_permalinks = array_filter( (array) get_option( 'woocommerce_permalinks', array() ) );
-	$permalinks       = wp_parse_args( $saved_permalinks, array(
+	$saved_permalinks = (array) get_option( 'woocommerce_permalinks', array() );
+	$permalinks       = wp_parse_args( array_filter( $saved_permalinks ), array(
 		'product_base'           => _x( 'product', 'slug', 'woocommerce' ),
 		'category_base'          => _x( 'product-category', 'slug', 'woocommerce' ),
 		'tag_base'               => _x( 'product-tag', 'slug', 'woocommerce' ),

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1683,7 +1683,7 @@ function wc_list_pluck( $list, $callback_or_field, $index_key = null ) {
  * @return array
  */
 function wc_get_permalink_structure() {
-	$saved_permalinks = (array) get_option( 'woocommerce_permalinks', array() );
+	$saved_permalinks = array_filter( (array) get_option( 'woocommerce_permalinks', array() ) );
 	$permalinks       = wp_parse_args( $saved_permalinks, array(
 		'product_base'           => _x( 'product', 'slug', 'woocommerce' ),
 		'category_base'          => _x( 'product-category', 'slug', 'woocommerce' ),


### PR DESCRIPTION
`woocommerce_permalinks` may return a list with empty results, like:

```
wp> get_option( 'woocommerce_permalinks', array() )
=> array(5) {
  ["product_base"]=>
    string(8) "/product"
  ["category_base"]=>
    string(16) ""
  ["tag_base"]=>
    string(11) ""
  ["attribute_base"]=>
    string(0) ""
  ["use_verbose_page_rules"]=>
    bool(false)
}
```

This override all placeholders declared with `wp_parse_args()`.

`wp_parse_args()` can apply default values only when missing, and not empty.

This PR removes all empty values in order to use the placeholders.

Fixes a bug introduced in #17358