### PR TITLE
explicitly mention email that is sent with order action

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -33,7 +33,7 @@ class WC_Meta_Box_Order_Actions {
 		}
 
 		$order_actions = apply_filters( 'woocommerce_order_actions', array(
-			'send_order_details'              => __( 'Email order details to customer', 'woocommerce' ),
+			'send_order_details'              => __( 'Email customer invoice to customer', 'woocommerce' ),
 			'send_order_details_admin'        => __( 'Resend new order notification', 'woocommerce' ),
 			'regenerate_download_permissions' => __( 'Regenerate download permissions', 'woocommerce' ),
 		) );


### PR DESCRIPTION
avoids confusion over wich email is actually sent (as discussed in https://github.com/woocommerce/woocommerce/issues/17186)

From a UX point of view it's important that the shop manager knows which email is being sent with this action. This makes the name of the email in the action correspond with the name in the WooCommerce > Emails settings.