### PR TITLE
Prevent cookie header sent error, and improve error message wording

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -220,8 +220,6 @@ class WC_Shortcode_My_Account {
 						'key'   => $rp_key,
 						'login' => $rp_login,
 					) );
-				} else {
-					self::set_reset_password_cookie();
 				}
 			}
 		}
@@ -327,8 +325,7 @@ class WC_Shortcode_My_Account {
 		$user = check_password_reset_key( $key, $login );
 
 		if ( is_wp_error( $user ) ) {
-			wc_add_notice( $user->get_error_message(), 'error' );
-
+			wc_add_notice( __( 'This key is invalid or has already been used. Please reset your password again if needed.', 'woocommerce' ), 'error' );
 			return false;
 		}
 


### PR DESCRIPTION
Closes #17379

To test, reset your password via email.

Then click the reset link in the email again.