### PR TITLE
Escape attribute name commas in CSV exporter

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -494,7 +494,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 
 						if ( 0 === strpos( $attribute_name, 'pa_' ) ) {
 							$option_term = get_term_by( 'slug', $attribute, $attribute_name );
-							$row[ 'attributes:value' . $i ]    = $option_term && ! is_wp_error( $option_term ) ? $option_term->name : $attribute;
+							$row[ 'attributes:value' . $i ]    = $option_term && ! is_wp_error( $option_term ) ? str_replace( ',', '\\,', $option_term->name ) : $attribute;
 							$row[ 'attributes:taxonomy' . $i ] = 1;
 						} else {
 							$row[ 'attributes:value' . $i ]    = $attribute;


### PR DESCRIPTION
Fixes #17306 

I believe you should just be able to import this CSV and verify variations have correct attributes to test:
```
ID,Type,SKU,Name,Published,"Is featured?","Visibility in catalog","Short description",Description,"Date sale price starts","Date sale price ends","Tax status","Tax class","In stock?",Stock,"Backorders allowed?","Sold individually?","Weight (lbs)","Length (in)","Width (in)","Height (in)","Allow customer reviews?","Purchase note","Sale price","Regular price",Categories,Tags,"Shipping class",Images,"Download limit","Download expiry days",Parent,"Grouped products",Upsells,Cross-sells,"External URL","Button text",Position,"Attribute 1 name","Attribute 1 value(s)","Attribute 1 visible","Attribute 1 global"
443,variable,,"Comma Variable",1,0,visible,,,,,taxable,,1,,0,0,,,,,1,,,,,,,,,,,,,,,,0,Commattribute,"a\, b, c",1,1
444,variation,ab,"Comma Variable - a, b",1,0,visible,,,,,taxable,,1,,0,0,,,,,0,,,10,,,,,,,id:443,,,,,,1,Commattribute,"a\, b",,1
445,variation,c,"Comma Variable - c",1,0,visible,,,,,taxable,,1,,0,0,,,,,0,,,10,,,,,,,id:443,,,,,,2,Commattribute,c,,1
```

EDIT: Switched to in-progress while I'm working on #17390. Probably going to make some sort of generalized thing that solves both these issues.
EDIT2: Didn't need to make anything for #17390. Not worth making a generalized solution to replace one `str_replace`.