### PR TITLE
Save unsaved items before adding new item to order

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1115,6 +1115,11 @@ jQuery( function ( $ ) {
 						data       : $( '#wc-backbone-modal-dialog form' ).serialize()
 					};
 
+					// Check if items have changed, if so pass them through so we can save them before adding a new item.
+					if ( 'true' === $( 'button.cancel-action' ).attr( 'data-reload' ) ) {
+						data.items = $( 'table.woocommerce_order_items :input[name], .wc-order-totals-items :input[name]' ).serialize();
+					}
+
 					$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 						if ( response.success ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).empty();

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -773,9 +773,18 @@ class WC_AJAX {
 			$order_id     = absint( $_POST['order_id'] );
 			$order        = wc_get_order( $order_id );
 			$items_to_add = wp_parse_id_list( is_array( $_POST['item_to_add'] ) ? $_POST['item_to_add'] : array( $_POST['item_to_add'] ) );
+			$items        = ( ! empty( $_POST['items'] ) ) ? $_POST['items'] : '';
 
 			if ( ! $order ) {
 				throw new Exception( __( 'Invalid order', 'woocommerce' ) );
+			}
+
+			// If we passed through items it means we need to save first before adding a new one.
+			if ( ! empty( $items ) ) {
+				$save_items = array();
+				parse_str( $items, $save_items );
+				// Save order items.
+				wc_save_order_items( $order->get_id(), $save_items );
 			}
 
 			foreach ( $items_to_add as $item_to_add ) {


### PR DESCRIPTION
When you add a product to an order and you made changes to existing items without saving first it would discard the changes. This PR makes sure that existing changes are saved first before adding the new product to the order.

To test: Add a product to an order and save, edit the item then without saving add another product, it should save the changes of the edited product and also add the new product.