### PR TITLE
Change title of Customer invoice email

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -33,7 +33,7 @@ class WC_Meta_Box_Order_Actions {
 		}
 
 		$order_actions = apply_filters( 'woocommerce_order_actions', array(
-			'send_order_details'              => __( 'Email order details to customer', 'woocommerce' ),
+			'send_order_details'              => __( 'Email customer invoice / order details to customer', 'woocommerce' ),
 			'send_order_details_admin'        => __( 'Resend new order notification', 'woocommerce' ),
 			'regenerate_download_permissions' => __( 'Regenerate download permissions', 'woocommerce' ),
 		) );

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -33,7 +33,7 @@ class WC_Meta_Box_Order_Actions {
 		}
 
 		$order_actions = apply_filters( 'woocommerce_order_actions', array(
-			'send_order_details'              => __( 'Email customer invoice / order details to customer', 'woocommerce' ),
+			'send_order_details'              => __( 'Email invoice / order details to customer', 'woocommerce' ),
 			'send_order_details_admin'        => __( 'Resend new order notification', 'woocommerce' ),
 			'regenerate_download_permissions' => __( 'Regenerate download permissions', 'woocommerce' ),
 		) );

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -25,7 +25,7 @@ class WC_Email_Customer_Invoice extends WC_Email {
 	public function __construct() {
 		$this->id             = 'customer_invoice';
 		$this->customer_email = true;
-		$this->title          = __( 'Customer invoice', 'woocommerce' );
+		$this->title          = __( 'Customer invoice / Order details', 'woocommerce' );
 		$this->description    = __( 'Customer invoice emails can be sent to customers containing their order information and payment links.', 'woocommerce' );
 		$this->template_html  = 'emails/customer-invoice.php';
 		$this->template_plain = 'emails/plain/customer-invoice.php';


### PR DESCRIPTION
Change the title of the customer invoice email from "Customer invoice" to "Customer invoice / Order details" since the same email template is used for more than just sending invoices.

This PR replaces #17394