### PR TITLE
Cart totals: don't add shipping unless show_shipping is true.

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -338,6 +338,10 @@ final class WC_Cart_Totals {
 	protected function get_shipping_from_cart() {
 		$this->shipping = array();
 
+		if ( ! $this->cart->show_shipping() ) {
+			return;
+		}
+
 		foreach ( $this->cart->calculate_shipping() as $key => $shipping_object ) {
 			$shipping_line            = $this->get_default_shipping_props();
 			$shipping_line->object    = $shipping_object;


### PR DESCRIPTION
Closes #17412

to test, enable the ‘Hide shipping costs until an address is entered’ and ensure no shipping is added to the totals. 