### PR TITLE
Variation Displayed in Cross-Sell and Upsells with Parent's Post Status set to 'draft' and 'pending review'

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1420,6 +1420,11 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$visible = false;
 		}
 
+		// Check if the product has a parent, meaning it is a variation and if it's parent is published.
+		if ( ( $parent_id = wp_get_post_parent_id( $this->get_id() ) ) && 'publish' !== get_post_status( $parent_id ) ) {
+			$visible = false;
+		}
+
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $this->is_in_stock() ) {
 			$visible = false;
 		}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1420,8 +1420,10 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$visible = false;
 		}
 
-		if ( ( $parent_id = wp_get_post_parent_id( $this->get_id() ) ) && 'publish' !== get_post_status( $parent_id ) ) {
-			$visible = false;
+		if ( !empty( $this->get_parent_id() ) ) {
+			if ( ( $parent_product = wc_get_product( $this->get_parent_id() ) ) && 'publish' !== $parent_product->get_status() ) {
+				$visible = false;
+			}
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $this->is_in_stock() ) {

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1420,8 +1420,9 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$visible = false;
 		}
 
-		if ( !empty( $this->get_parent_id() ) ) {
-			if ( ( $parent_product = wc_get_product( $this->get_parent_id() ) ) && 'publish' !== $parent_product->get_status() ) {
+		$parent_id = $this->get_parent_id();
+		if ( ! empty( $parent_id ) ) {
+			if ( ( $parent_product = wc_get_product( $parent_id ) ) && 'publish' !== $parent_product->get_status() ) {
 				$visible = false;
 			}
 		}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1421,7 +1421,9 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		}
 
 		if ( $this->get_parent_id() ) {
-			if ( ( $parent_product = wc_get_product( $this->get_parent_id() ) ) && 'publish' !== $parent_product->get_status() ) {
+			$parent_product = wc_get_product( $this->get_parent_id() );
+
+			if ( $parent_product && 'publish' !== $parent_product->get_status() ) {
 				$visible = false;
 			}
 		}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1420,7 +1420,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$visible = false;
 		}
 
-		// Check if the product has a parent, meaning it is a variation and if it's parent is published.
 		if ( ( $parent_id = wp_get_post_parent_id( $this->get_id() ) ) && 'publish' !== get_post_status( $parent_id ) ) {
 			$visible = false;
 		}

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1420,9 +1420,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$visible = false;
 		}
 
-		$parent_id = $this->get_parent_id();
-		if ( ! empty( $parent_id ) ) {
-			if ( ( $parent_product = wc_get_product( $parent_id ) ) && 'publish' !== $parent_product->get_status() ) {
+		if ( $this->get_parent_id() ) {
+			if ( ( $parent_product = wc_get_product( $this->get_parent_id() ) ) && 'publish' !== $parent_product->get_status() ) {
 				$visible = false;
 			}
 		}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1294,7 +1294,7 @@ class WC_AJAX {
 			$ids = array_slice( $ids, 0, absint( $_GET['limit'] ) );
 		}
 
-		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_editable' );
+		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_visible' );
 		$products        = array();
 
 		foreach ( $product_objects as $product_object ) {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1294,7 +1294,7 @@ class WC_AJAX {
 			$ids = array_slice( $ids, 0, absint( $_GET['limit'] ) );
 		}
 
-		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_visible' );
+		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_editable' );
 		$products        = array();
 
 		foreach ( $product_objects as $product_object ) {


### PR DESCRIPTION
Update the `json_search_products` function to use the `wc_products_array_filter_visible` filter rather than the `wc_products_array_filter_editable` filter.

Added an additional if condition to the `is_visible` function to check if the product had a parent and that parents post status.