### PR TITLE
Fix build in PHP <=5.3

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -306,7 +306,7 @@ function wc_cart_totals_order_total_html() {
 			foreach ( WC()->cart->get_tax_totals() as $code => $tax ) {
 				$tax_string_array[] = sprintf( '%s %s', $tax->formatted_amount, $tax->label );
 			}
-		} elseif ( ! empty( WC()->cart->get_tax_totals() ) ) {
+		} elseif ( WC()->cart->get_tax_totals() ) {
 			$tax_string_array[] = sprintf( '%s %s', wc_price( WC()->cart->get_taxes_total( true, true ) ), WC()->countries->tax_or_vat() );
 		}
 


### PR DESCRIPTION
In PHP versions 5.3 and 5.2 [the unit tests](https://travis-ci.org/woocommerce/woocommerce/jobs/293806186) (and by definition the sites) break with a `Fatal error: Can't use method return value in write context in wc-cart-functions.php on line 309 ` error caused by evaluating a function inside `empty()`. Original cause of this is #17139.

The `! empty()` check isn't needed here. 

See: https://stackoverflow.com/a/4328049

