### PR TITLE
Added `{site_title}` replacement to Email footer

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -103,13 +103,14 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 			array(
 				'title'       => __( 'Footer text', 'woocommerce' ),
-				'desc'        => __( 'The text to appear in the footer of WooCommerce emails.', 'woocommerce' ),
+				'desc'        => __( 'The text to appear in the footer of WooCommerce emails.', 'woocommerce' )
+					 . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title}' ),
 				'id'          => 'woocommerce_email_footer_text',
 				'css'         => 'width:300px; height: 75px;',
 				'placeholder' => __( 'N/A', 'woocommerce' ),
 				'type'        => 'textarea',
 				/* translators: %s: site name */
-				'default'     => get_bloginfo( 'name', 'display' ),
+				'default'     => '{site_title}',
 				'autoload'    => false,
 				'desc_tip'    => true,
 			),

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -177,6 +177,9 @@ class WC_Emails {
 		add_action( 'woocommerce_product_on_backorder_notification', array( $this, 'backorder' ) );
 		add_action( 'woocommerce_created_customer_notification', array( $this, 'customer_new_account' ), 10, 3 );
 
+		//Hook for replacing {site_title} in email-footer
+		add_filter( 'woocommerce_email_footer_text' , array( $this, 'email_footer_replace_site_title' ) );
+
 		// Let 3rd parties unhook the above via this hook
 		do_action( 'woocommerce_email', $this );
 	}
@@ -249,6 +252,15 @@ class WC_Emails {
 	 */
 	public function email_footer() {
 		wc_get_template( 'emails/email-footer.php' );
+	}
+
+	/**
+	 * Filter callback to replace {site_title} in email footer 
+	 * @param  string $string Email footer text
+	 * @return string         Email footer text with any replacements done.
+	 */
+	public function email_footer_replace_site_title( $string ) {
+		return str_replace( '{site_title}', $this->get_blogname(), $string );
 	}
 
 	/**


### PR DESCRIPTION
Hi there, I wrote this up as a fix for issue #17039, here are some notes/questions/comments for alongside the code: 

 - Most email class (eg `WC_Email_Cancelled_Order`) already have `{site_title}` replacement built into them for the subject, so its not as important currently compared to having the updated site title in the footer. 
 - Shoud we continue to use `get_bloginfo( 'name', 'display' )` instead of `get_option( 'blogname' )` for the `bloginfo` filter? I opted to use `get_option` as it matches more closely with what is being used elsewhere but may be considered a minor BC break...
 - Is `WC_Emails` constructor the best place to put the `add_filter` call?
 - I combined 2 strings in `WC_Settings_Emails` Footer text settings so that no new translations were needed, is there a better way of doing this or should a new translation be added?
 - I didn't add ` - Powered by WooCommerce` because there is no translation for just that used elsewhere

Let me know if there is anything you want me to fix up! 