### PR TITLE
Tweak - Display current timestamp if date is not object

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1191,7 +1191,7 @@ function wc_format_datetime( $date, $format = '' ) {
 		$format = wc_date_format();
 	}
 	if ( ! is_a( $date, 'WC_DateTime' ) ) {
-		return '';
+		return date_i18n( $format );
 	}
 	return $date->date_i18n( $format );
 }


### PR DESCRIPTION
Since we can utilize `wc_format_datetime` instead of `date_i18n`. Please consider to return current timestamp if date is not the object of `WC_DateTime`.

CC @mikejolley @claudiosanches 