### PR TITLE
Fix - Undefined variable: empty_content in order screen

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -814,10 +814,10 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Get a formatted billing address for the order.
 	 *
-	 * @param string $empty_html Content to show if no address is present. @since 3.3.0.
+	 * @param string $empty_content Content to show if no address is present. @since 3.3.0.
 	 * @return string
 	 */
-	public function get_formatted_billing_address( $empty_html = '' ) {
+	public function get_formatted_billing_address( $empty_content = '' ) {
 		$address = apply_filters( 'woocommerce_order_formatted_billing_address', $this->get_address( 'billing' ), $this );
 		$address = WC()->countries->get_formatted_address( $address );
 
@@ -827,10 +827,10 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Get a formatted shipping address for the order.
 	 *
-	 * @param string $empty_html Content to show if no address is present. @since 3.3.0.
+	 * @param string $empty_content Content to show if no address is present. @since 3.3.0.
 	 * @return string
 	 */
-	public function get_formatted_shipping_address( $empty_html = '' ) {
+	public function get_formatted_shipping_address( $empty_content = '' ) {
 		$address = '';
 
 		if ( $this->has_shipping_address() ) {


### PR DESCRIPTION
@mikejolley Variable `$empty_html` is being declared but has been using `$empty_content` in #17233 :)