### PR TITLE
Add new grunt task to run only a selection of e2e tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,6 +258,9 @@ module.exports = function( grunt ) {
 			},
 			e2e_tests: {
 				command: 'npm run --silent test'
+			},
+			e2e_tests_grep: {
+				command: 'npm run --silent test:grep "' + grunt.option( 'grep' ) + '"'
 			}
 		},
 
@@ -361,6 +364,10 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( 'e2e-tests', [
 		'shell:e2e_tests'
+	]);
+
+	grunt.registerTask( 'e2e-tests-grep', [
+		'shell:e2e_tests_grep'
 	]);
 
 	grunt.registerTask( 'e2e-test', [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "Gruntfile.js",
   "scripts": {
     "test": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha \"tests/e2e-tests\" --compilers js:babel-register --recursive",
+    "test:grep": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha \"tests/e2e-tests\" --compilers js:babel-register --grep ",
     "test:single": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha --compilers js:babel-register"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds a new grunt task to run only a selection of e2e tests.

Example:

`node_modules/grunt/bin/grunt e2e-tests-grep --grep='should be able to add simple products to the cart'`

When `grunt e2e-tests-grep --grep=''` is called, `mocha` will run only tests that match the pattern passed to `--grep`.

I'm not familiar with `grunt`, so I'm not sure if there is a better way to create this task.