### PR TITLE
wc_caught_exception method

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -19,7 +19,7 @@ class WC_Order_Factory {
 	/**
 	 * Get order.
 	 *
-	 * @param  mixed $order_id (default: false)
+	 * @param  mixed $order_id (default: false) Order ID to get.
 	 * @return WC_Order|bool
 	 */
 	public static function get_order( $order_id = false ) {
@@ -46,13 +46,15 @@ class WC_Order_Factory {
 		try {
 			return new $classname( $order_id );
 		} catch ( Exception $e ) {
+			wc_caught_exception( $e, __FUNCTION__, func_get_args() );
 			return false;
 		}
 	}
 
 	/**
 	 * Get order item.
-	 * @param int
+	 *
+	 * @param int $item_id Order item ID to get.
 	 * @return WC_Order_Item|false if not found
 	 */
 	public static function get_order_item( $item_id = 0 ) {
@@ -108,7 +110,7 @@ class WC_Order_Factory {
 	 * Get the order ID depending on what was passed.
 	 *
 	 * @since 3.0.0
-	 * @param  mixed $order
+	 * @param  mixed $order Order data to convert to an ID.
 	 * @return int|bool false on failure
 	 */
 	public static function get_order_id( $order ) {

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -33,12 +33,13 @@ function wc_do_deprecated_action( $action, $args, $deprecated_in, $replacement )
 /**
  * Wrapper for deprecated functions so we can apply some extra logic.
  *
- * @since  3.0.0
- * @param  string $function
- * @param  string $version
- * @param  string $replacement
+ * @since 3.0.0
+ * @param string $function Function used.
+ * @param string $version Version the message was added in.
+ * @param string $replacement Replacement for the called function.
  */
 function wc_deprecated_function( $function, $version, $replacement = null ) {
+	// @codingStandardsIgnoreStart
 	if ( is_ajax() ) {
 		do_action( 'deprecated_function_run', $function, $replacement, $version );
 		$log_string  = "The {$function} function is deprecated since version {$version}.";
@@ -47,18 +48,37 @@ function wc_deprecated_function( $function, $version, $replacement = null ) {
 	} else {
 		_deprecated_function( $function, $version, $replacement );
 	}
+	// @codingStandardsIgnoreEnd
 }
 
+/**
+ * When catching an exception, this allows us to log it if unexpected.
+ *
+ * @since 3.3.0
+ * @param Exception $exception_object The exception object.
+ * @param string    $function The function which threw exception.
+ * @param array     $args The args passed to the function.
+ */
+function wc_caught_exception( $exception_object, $function = '', $args = array() ) {
+	// @codingStandardsIgnoreStart
+	$message  = $exception_object->getMessage();
+	$message .= '. Args: ' . print_r( $args, true ) . '.';
+
+	do_action( 'woocommerce_caught_exception', $exception_object, $function, $args );
+	error_log( "Exception caught in {$function}. {$message}." );
+	// @codingStandardsIgnoreEnd
+}
 
 /**
  * Wrapper for wc_doing_it_wrong.
  *
  * @since  3.0.0
- * @param  string $function
- * @param  string $version
- * @param  string $replacement
+ * @param string $function Function used.
+ * @param string $message Message to log.
+ * @param string $version Version the message was added in.
  */
 function wc_doing_it_wrong( $function, $message, $version ) {
+	// @codingStandardsIgnoreStart
 	$message .= ' Backtrace: ' . wp_debug_backtrace_summary();
 
 	if ( is_ajax() ) {
@@ -67,6 +87,7 @@ function wc_doing_it_wrong( $function, $message, $version ) {
 	} else {
 		_doing_it_wrong( $function, $message, $version );
 	}
+	// @codingStandardsIgnoreEnd
 }
 
 /**


### PR DESCRIPTION
Adds a new wc_caught_exception method to log data about exceptions. Action is fired, and error_log is called.

Closes #17101