### PR TITLE
Improve the Add Payment Methods display

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -152,7 +152,7 @@ class WC_Payment_Gateways {
 
 		foreach ( $this->payment_gateways as $gateway ) {
 			if ( $gateway->is_available() ) {
-				if ( ! is_add_payment_method_page() && ! is_payment_methods_page() ) {
+				if ( ! is_add_payment_method_page() ) {
 					$_available_gateways[ $gateway->id ] = $gateway;
 				} elseif ( $gateway->supports( 'add_payment_method' ) || $gateway->supports( 'tokenization' ) ) {
 					$_available_gateways[ $gateway->id ] = $gateway;

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -152,7 +152,7 @@ class WC_Payment_Gateways {
 
 		foreach ( $this->payment_gateways as $gateway ) {
 			if ( $gateway->is_available() ) {
-				if ( ! is_add_payment_method_page() ) {
+				if ( ! is_add_payment_method_page() && ! is_payment_methods_page() ) {
 					$_available_gateways[ $gateway->id ] = $gateway;
 				} elseif ( $gateway->supports( 'add_payment_method' ) || $gateway->supports( 'tokenization' ) ) {
 					$_available_gateways[ $gateway->id ] = $gateway;

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -212,6 +212,22 @@ if ( ! function_exists( 'is_order_received_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_payment_methods_page' ) ) {
+
+	/**
+	 * Determines if the current page is Payment Methods.
+	 *
+	 * @since 3.3-dev
+	 *
+	 * @return bool
+	 */
+	function is_payment_methods_page() {
+		global $wp;
+
+		return ( is_page( wc_get_page_id( 'myaccount' ) ) && isset( $wp->query_vars['payment-methods'] ) );
+	}
+}
+
 if ( ! function_exists( 'is_add_payment_method_page' ) ) {
 
 	/**

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -212,22 +212,6 @@ if ( ! function_exists( 'is_order_received_page' ) ) {
 	}
 }
 
-if ( ! function_exists( 'is_payment_methods_page' ) ) {
-
-	/**
-	 * Determines if the current page is Payment Methods.
-	 *
-	 * @since 3.3-dev
-	 *
-	 * @return bool
-	 */
-	function is_payment_methods_page() {
-		global $wp;
-
-		return ( is_page( wc_get_page_id( 'myaccount' ) ) && isset( $wp->query_vars['payment-methods'] ) );
-	}
-}
-
 if ( ! function_exists( 'is_add_payment_method_page' ) ) {
 
 	/**
@@ -238,7 +222,7 @@ if ( ! function_exists( 'is_add_payment_method_page' ) ) {
 	function is_add_payment_method_page() {
 		global $wp;
 
-		return ( is_page( wc_get_page_id( 'myaccount' ) ) && isset( $wp->query_vars['add-payment-method'] ) );
+		return ( is_page( wc_get_page_id( 'myaccount' ) ) && ( isset( $wp->query_vars['payment-methods'] ) || isset( $wp->query_vars['add-payment-method'] ) ) );
 	}
 }
 

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -55,4 +55,6 @@ if ( $available_gateways = WC()->payment_gateways->get_available_payment_gateway
 			</div>
 		</div>
 	</form>
+<?php else : ?>
+	<p class="woocommerce-notice woocommerce-notice--info woocommerce-info"><?php esc_html_e( 'Sorry, it seems that there are no payment methods which support adding a new payment method. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' ); ?></p>
 <?php endif; ?>

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -76,4 +76,6 @@ do_action( 'woocommerce_before_account_payment_methods', $has_methods ); ?>
 
 <?php do_action( 'woocommerce_after_account_payment_methods', $has_methods ); ?>
 
-<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'add-payment-method' ) ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></a>
+<?php if ( WC()->payment_gateways->get_available_payment_gateways() ) : ?>
+	<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'add-payment-method' ) ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></a>
+<?php endif; ?>

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -78,4 +78,6 @@ do_action( 'woocommerce_before_account_payment_methods', $has_methods ); ?>
 
 <?php if ( WC()->payment_gateways->get_available_payment_gateways() ) : ?>
 	<a class="button" href="<?php echo esc_url( wc_get_endpoint_url( 'add-payment-method' ) ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></a>
+<?php else : ?>
+	<p class="woocommerce-Message woocommerce-Message--info woocommerce-info"><?php esc_html_e( 'New payment methods cannot be added from the My Account page.', 'woocommerce' ); ?></p>
 <?php endif; ?>


### PR DESCRIPTION
This reintroduces the error notice when visiting the Add Payment Method page and there are no gateways available that support the feature, which was removed in https://github.com/woocommerce/woocommerce/commit/dc1c8843a1b8af8db3d3ac7cc5f0e82afd6fcb1a. Since the page itself accessible directly, I think it'd be good to still have some sort of message there.

Adding to that, this PR also changes the **Add Payment Method** button itself to display only when available. Some gateways support tokenization, and thus the Payment Methods page, but do not support adding a payment method for various reasons.