### PR TITLE
Update class-wc-ajax.php

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -32,7 +32,7 @@ class WC_AJAX {
 	 * @return string
 	 */
 	public static function get_endpoint( $request = '' ) {
-		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ), home_url( '/' ) ) ), $request ) );
+		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ), home_url( '/' . pll_current_language() . '/' ) ) ), $request ) );
 	}
 
 	/**


### PR DESCRIPTION
Changing the shipping option on the cart page with the non-default language will reset the shipping box language to the default one. This is due to the parameter wc_ajax_url in the js var wc_add_to_cart_params.

I'm not a WP expert, but this solved the problem for me.

Regards,
Luca