### PR TITLE
Filter for e-mail exists error message

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -50,7 +50,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 		}
 
 		if ( email_exists( $email ) ) {
-			return new WP_Error( 'registration-error-email-exists', __( 'An account is already registered with your email address. Please log in.', 'woocommerce' ) );
+			return new WP_Error( 'registration-error-email-exists',  apply_filters( 'woocommerce-registration-error-email-exists', __( 'An account is already registered with your email address. Please log in.', 'woocommerce' ), $email ) );
 		}
 
 		// Handle username creation.


### PR DESCRIPTION
There is currently no way to change the message when a user's email already exists. The only way we could find to do it was to run it through the 'gettext' filter on the 'woocommerce' text domain  and do a string replace on that message but that is very inefficient for some obvious reasons (and potentially breakable if that messaging ever changes in future releases).