### PR TITLE
For code doing it wrong, ensure priority is set

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1237,7 +1237,7 @@ if ( ! function_exists( 'woocommerce_sort_product_tabs' ) ) {
 			 * @return bool
 			 */
 			function _sort_priority_callback( $a, $b ) {
-				if ( $a['priority'] === $b['priority'] ) {
+				if ( ! isset( $a['priority'], $b['priority'] ) || $a['priority'] === $b['priority'] ) {
 					return 0;
 				}
 				return ( $a['priority'] < $b['priority'] ) ? -1 : 1;


### PR DESCRIPTION
If someone is adding tabs but not setting priority, this avoids a notice.