### PR TITLE
Shipping selection for multiple packages

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -185,12 +185,10 @@ jQuery( function( $ ) {
 		 * @param {Object} evt The JQuery event.
 		 */
 		shipping_method_selected: function( evt ) {
-			var target = evt.currentTarget;
-
 			var shipping_methods = {};
 
 			$( 'select.shipping_method, input[name^=shipping_method][type=radio]:checked, input[name^=shipping_method][type=hidden]' ).each( function() {
-				shipping_methods[ $( target ).data( 'index' ) ] = $( target ).val();
+				shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();
 			} );
 
 			block( $( 'div.cart_totals' ) );


### PR DESCRIPTION
Allow for shipping method selection at cart when using multiple packages.

Previous code selected/posted only the changed method, but multiple packages require all methods.