### PR TITLE
Adjust out of base discount logic

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -221,12 +221,13 @@ final class WC_Cart_Totals {
 
 		foreach ( $this->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$item                          = $this->get_default_item_props();
+			$item->key                     = $cart_item_key;
 			$item->object                  = $cart_item;
 			$item->tax_class               = $cart_item['data']->get_tax_class();
 			$item->taxable                 = 'taxable' === $cart_item['data']->get_tax_status();
 			$item->price_includes_tax      = wc_prices_include_tax();
 			$item->quantity                = $cart_item['quantity'];
-			$item->subtotal                = wc_add_number_precision_deep( $cart_item['data']->get_price() ) * $cart_item['quantity'];
+			$item->price                   = wc_add_number_precision_deep( $cart_item['data']->get_price() ) * $cart_item['quantity'];
 			$item->product                 = $cart_item['data'];
 			$item->tax_rates               = $this->get_item_tax_rates( $item );
 			$this->items[ $cart_item_key ] = $item;
@@ -426,10 +427,10 @@ final class WC_Cart_Totals {
 			$base_tax_rates           = WC_Tax::get_base_tax_rates( $item->product->get_tax_class( 'unfiltered' ) );
 
 			// Work out a new base price without the shop's base tax.
-			$taxes                    = WC_Tax::calc_tax( $item->subtotal, $base_tax_rates, true, true );
+			$taxes                    = WC_Tax::calc_tax( $item->price, $base_tax_rates, true, true );
 
 			// Now we have a new item price (excluding TAX).
-			$item->subtotal           = $item->subtotal - array_sum( $taxes );
+			$item->price              = absint( $item->price - array_sum( $taxes ) );
 			$item->price_includes_tax = false;
 		}
 		return $item;
@@ -453,10 +454,10 @@ final class WC_Cart_Totals {
 
 			if ( $item->tax_rates !== $base_tax_rates ) {
 				// Work out a new base price without the shop's base tax.
-				$taxes                    = WC_Tax::calc_tax( $item->subtotal, $base_tax_rates, true, true );
+				$taxes                    = WC_Tax::calc_tax( $item->price, $base_tax_rates, true, true );
 
 				// Now we have a new item price (excluding TAX).
-				$item->subtotal           = $item->subtotal - array_sum( $taxes );
+				$item->price              = absint( $item->price - array_sum( $taxes ) );
 				$item->price_includes_tax = false;
 			}
 		}
@@ -472,11 +473,7 @@ final class WC_Cart_Totals {
 	 */
 	protected function get_discounted_price_in_cents( $item_key ) {
 		$item  = $this->items[ $item_key ];
-		$price = isset( $this->coupon_discount_totals[ $item_key ] ) ? $item->subtotal - $this->coupon_discount_totals[ $item_key ] : $item->subtotal;
-
-		if ( $item->price_includes_tax ) {
-			$price += $item->subtotal_tax;
-		}
+		$price = isset( $this->coupon_discount_totals[ $item_key ] ) ? $item->price - $this->coupon_discount_totals[ $item_key ] : $item->price;
 		return $price;
 	}
 
@@ -648,8 +645,6 @@ final class WC_Cart_Totals {
 
 				if ( $item->price_includes_tax ) {
 					$item->total = $item->total - $item->total_tax;
-				} else {
-					$item->total = $item->total;
 				}
 			}
 
@@ -690,6 +685,7 @@ final class WC_Cart_Totals {
 				}
 			}
 
+			$item->subtotal = $item->price;
 			$subtotal_taxes = array();
 
 			if ( $this->calculate_tax && $item->product->is_taxable() ) {
@@ -727,6 +723,9 @@ final class WC_Cart_Totals {
 
 		$discounts = new WC_Discounts( $this->cart );
 
+		// Set items directly so the discounts class can see any tax adjustments made thus far using subtotals.
+		$discounts->set_items( $this->items );
+
 		foreach ( $this->coupons as $coupon ) {
 			$discounts->apply_coupon( $coupon );
 		}
@@ -743,19 +742,23 @@ final class WC_Cart_Totals {
 					$item = $this->items[ $item_key ];
 
 					if ( $item->product->is_taxable() ) {
+						// Item subtotals were sent, so set 3rd param.
 						$item_tax = array_sum( WC_Tax::calc_tax( $coupon_discount, $item->tax_rates, $item->price_includes_tax ) );
-						$coupon_discount_tax_amounts[ $coupon_code ] += $item_tax;
-					}
-				}
 
-				if ( wc_prices_include_tax() ) {
-					$coupon_discount_amounts[ $coupon_code ] -= $coupon_discount_tax_amounts[ $coupon_code ];
+						// Sum total tax.
+						$coupon_discount_tax_amounts[ $coupon_code ] += $item_tax;
+
+						// Remove tax from discount total.
+						if ( $item->price_includes_tax ) {
+							$coupon_discount_amounts[ $coupon_code ] -= $item_tax;
+						}
+					}
 				}
 			}
 		}
 
-		$this->coupon_discount_totals              = (array) $discounts->get_discounts_by_item( true );
-		$this->coupon_discount_tax_totals          = $coupon_discount_tax_amounts;
+		$this->coupon_discount_totals     = (array) $discounts->get_discounts_by_item( true );
+		$this->coupon_discount_tax_totals = $coupon_discount_tax_amounts;
 
 		if ( wc_prices_include_tax() ) {
 			$this->set_total( 'discounts_total', array_sum( $this->coupon_discount_totals ) - array_sum( $this->coupon_discount_tax_totals ) );

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -53,6 +53,18 @@ class WC_Discounts {
 	}
 
 	/**
+	 * Set items directly. Used by WC_Cart_Totals.
+	 *
+	 * @since 3.2.3
+	 * @param array $items Items to set.
+	 */
+	public function set_items( $items ) {
+		$this->items     = $items;
+		$this->discounts = array();
+		uasort( $this->items, array( $this, 'sort_by_price' ) );
+	}
+
+	/**
 	 * Normalise cart items which will be discounted.
 	 *
 	 * @since 3.2.0

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -915,7 +915,7 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 			} elseif ( $tax_rates !== $base_tax_rates && apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
 				$base_taxes   = WC_Tax::calc_tax( $line_price, $base_tax_rates, true );
 				$modded_taxes = WC_Tax::calc_tax( $line_price - array_sum( $base_taxes ), $tax_rates, false );
-				$return_price = round( $line_price - array_sum( $base_taxes ) + array_sum( $modded_taxes ), wc_get_price_decimals() );
+				$return_price = round( $line_price - array_sum( $base_taxes ) + wc_round_tax_total( array_sum( $modded_taxes ), wc_get_price_decimals() ), wc_get_price_decimals() );
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #17517 

The discount class was being passed the CART object to run discounts. This meant discounts would be based on prices input by the user and did not factor in taxes from the cart totals class.

So if you were out of the base location, and taxes were removed  from your prices, these would not be passed.

Tests pass after this change. Could use a manual sanity check.