### PR TITLE
Packages should be shippable until proven otherwise.

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -282,6 +282,12 @@ class WC_Shipping {
 	 * @return boolean
 	 */
 	protected function is_package_shippable( $package ) {
+
+		// Packages are shippable until proven otherwise.
+		if ( empty( $package['destination']['country'] ) ) {
+			return true;
+		}
+
 		$allowed = array_keys( WC()->countries->get_shipping_countries() );
 		return in_array( $package['destination']['country'], $allowed );
 	}
@@ -297,7 +303,7 @@ class WC_Shipping {
 	 * @return array|bool
 	 */
 	public function calculate_shipping_for_package( $package = array(), $package_key = 0 ) {
-		if ( ! $this->enabled || empty( $package ) || ( $package['destination']['country'] && ! $this->is_package_shippable( $package ) ) ) {
+		if ( ! $this->enabled || empty( $package ) || ! $this->is_package_shippable( $package ) ) {
 			return false;
 		}
 

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -132,8 +132,6 @@ class WC_Shipping {
 	}
 
 	/**
-	 * Loads all shipping methods which are hooked in. If a $package is passed some methods may add themselves conditionally.
-	 *
 	 * Loads all shipping methods which are hooked in.
 	 * If a $package is passed some methods may add themselves conditionally and zones will be used.
 	 *
@@ -263,7 +261,7 @@ class WC_Shipping {
 		}
 
 		/**
-		 * Allow packages to be reorganized after calculate the shipping.
+		 * Allow packages to be reorganized after calculating the shipping.
 		 *
 		 * This filter can be used to apply some extra manipulation after the shipping costs are calculated for the packages
 		 * but before Woocommerce does anything with them. A good example of usage is to merge the shipping methods for multiple
@@ -299,7 +297,7 @@ class WC_Shipping {
 	 * @return array|bool
 	 */
 	public function calculate_shipping_for_package( $package = array(), $package_key = 0 ) {
-		if ( ! $this->enabled || empty( $package ) || ! $this->is_package_shippable( $package ) ) {
+		if ( ! $this->enabled || empty( $package ) || ( $package['destination']['country'] && ! $this->is_package_shippable( $package ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #17526 
Doesn't regress #11642 :)

If the country was not set all packages were getting marked as "not shippable", so the Cart shipping calculator wasn't showing because there were no shippable packages.