### PR TITLE
Change nocache_headers hook firing

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -59,7 +59,7 @@ class WC_AJAX {
 		@header( 'Content-Type: text/html; charset=' . get_option( 'blog_charset' ) );
 		@header( 'X-Robots-Tag: noindex' );
 		send_nosniff_header();
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 		status_header( 200 );
 	}
 

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -86,7 +86,7 @@ class WC_API extends WC_Legacy_API {
 			ob_start();
 
 			// No cache headers.
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 
 			// Clean the API request.
 			$api_request = $wp->query_vars['wc-api'];

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -20,8 +20,6 @@ class WC_Cache_Helper {
 	 */
 	public static function init() {
 		add_action( 'template_redirect', array( __CLASS__, 'geolocation_ajax_redirect' ) );
-		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
-		add_filter( 'nocache_headers', array( __CLASS__, 'set_nocache_constants' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
 	}
@@ -150,39 +148,16 @@ class WC_Cache_Helper {
 	}
 
 	/**
-	 * Prevent caching on dynamic pages.
-	 */
-	public static function prevent_caching() {
-		if ( ! is_blog_installed() ) {
-			return;
-		}
-		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
-
-		if ( isset( $_GET['download_file'] ) || isset( $_GET['add-to-cart'] ) || is_page( $page_ids ) ) {
-			nocache_headers();
-		}
-	}
-
-	/**
-	 * Set constants to prevent caching by some plugins.
+	 * Helper function that sets constants and headers to prefent caching
 	 *
-	 * Hooked into nocache_headers filter but does not change headers.
-	 *
-	 * @param  array $value
-	 * @return array
+	 * @return void
 	 */
-	public static function set_nocache_constants( $value ) {
-		if ( ! is_blog_installed() ) {
-			return $value;
-		}
-		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
+	public static function do_not_cache_page() {
+		wc_maybe_define_constant( 'DONOTCACHEPAGE', true );
+		wc_maybe_define_constant( 'DONOTCACHEOBJECT', true );
+		wc_maybe_define_constant( 'DONOTCACHEDB', true );
 
-		if ( isset( $_GET['download_file'] ) || isset( $_GET['add-to-cart'] ) || is_page( $page_ids ) ) {
-			wc_maybe_define_constant( 'DONOTCACHEPAGE', true );
-			wc_maybe_define_constant( 'DONOTCACHEOBJECT', true );
-			wc_maybe_define_constant( 'DONOTCACHEDB', true );
-		}
-		return $value;
+		nocache_headers();
 	}
 
 	/**

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -77,7 +77,6 @@ class WC_Cache_Helper {
 		if ( is_page( $page_ids ) ) {
 			self::do_not_cache_page();
 		}
-		return $values;
 	}
 
 	/**

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -21,6 +21,7 @@ class WC_Cache_Helper {
 	public static function init() {
 		add_action( 'template_redirect', array( __CLASS__, 'geolocation_ajax_redirect' ) );
 		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
+		add_filter( 'nocache_headers', array( __CLASS__, 'set_nocache_constants' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
 	}
@@ -158,7 +159,6 @@ class WC_Cache_Helper {
 		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
 
 		if ( isset( $_GET['download_file'] ) || isset( $_GET['add-to-cart'] ) || is_page( $page_ids ) ) {
-			add_filter( 'nocache_headers', array( __CLASS__, 'set_nocache_constants' ) );
 			nocache_headers();
 		}
 	}
@@ -172,9 +172,16 @@ class WC_Cache_Helper {
 	 * @return array
 	 */
 	public static function set_nocache_constants( $value ) {
-		wc_maybe_define_constant( 'DONOTCACHEPAGE', true );
-		wc_maybe_define_constant( 'DONOTCACHEOBJECT', true );
-		wc_maybe_define_constant( 'DONOTCACHEDB', true );
+		if ( ! is_blog_installed() ) {
+			return $value;
+		}
+		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
+
+		if ( isset( $_GET['download_file'] ) || isset( $_GET['add-to-cart'] ) || is_page( $page_ids ) ) {
+			wc_maybe_define_constant( 'DONOTCACHEPAGE', true );
+			wc_maybe_define_constant( 'DONOTCACHEOBJECT', true );
+			wc_maybe_define_constant( 'DONOTCACHEDB', true );
+		}
 		return $value;
 	}
 

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -22,6 +22,7 @@ class WC_Cache_Helper {
 		add_action( 'template_redirect', array( __CLASS__, 'geolocation_ajax_redirect' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
+		add_action( 'wp', array( __CLASS__, 'prevent_page_caching' ) );
 	}
 
 	/**
@@ -61,6 +62,22 @@ class WC_Cache_Helper {
 		$location['postcode'] = $customer->get_billing_postcode();
 		$location['city']     = $customer->get_billing_city();
 		return substr( md5( implode( '', $location ) ), 0, 12 );
+	}
+
+	/**
+	 * Prevent caching on certain pages
+	 *
+	 * @return void
+	 */
+	public static function prevent_page_caching() {
+		if ( ! is_blog_installed() ) {
+			return;
+		}
+		$page_ids = array_filter( array( wc_get_page_id( 'cart' ), wc_get_page_id( 'checkout' ), wc_get_page_id( 'myaccount' ) ) );
+		if ( is_page( $page_ids ) ) {
+			self::do_not_cache_page();
+		}
+		return $values;
 	}
 
 	/**

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -305,7 +305,7 @@ class WC_Download_Handler {
 	private static function download_headers( $file_path, $filename ) {
 		self::check_server_config();
 		self::clean_buffers();
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 
 		header( "X-Robots-Tag: noindex, nofollow", true );
 		header( "Content-Type: " . self::get_download_content_type( $file_path ) );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -67,7 +67,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 
 		$user_id = get_current_user_id();
 
@@ -181,7 +181,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 
 		$errors       = new WP_Error();
 		$user         = new stdClass();
@@ -278,7 +278,7 @@ class WC_Form_Handler {
 	 */
 	public static function checkout_action() {
 		if ( isset( $_POST['woocommerce_checkout_place_order'] ) || isset( $_POST['woocommerce_checkout_update_totals'] ) ) {
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 
 			if ( WC()->cart->is_empty() ) {
 				wp_redirect( wc_get_page_permalink( 'cart' ) );
@@ -298,7 +298,7 @@ class WC_Form_Handler {
 		global $wp;
 
 		if ( isset( $_POST['woocommerce_pay'] ) && isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-pay' ) ) {
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 			ob_start();
 
 			// Pay for existing order
@@ -377,7 +377,7 @@ class WC_Form_Handler {
 	 */
 	public static function add_payment_method_action() {
 		if ( isset( $_POST['woocommerce_add_payment_method'], $_POST['payment_method'], $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'woocommerce-add-payment-method' ) ) {
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 			ob_start();
 
 			$payment_method_id  = wc_clean( wp_unslash( $_POST['payment_method'] ) );
@@ -422,7 +422,7 @@ class WC_Form_Handler {
 		global $wp;
 
 		if ( isset( $wp->query_vars['delete-payment-method'] ) ) {
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 
 			$token_id = absint( $wp->query_vars['delete-payment-method'] );
 			$token    = WC_Payment_Tokens::get( $token_id );
@@ -447,7 +447,7 @@ class WC_Form_Handler {
 		global $wp;
 
 		if ( isset( $wp->query_vars['set-default-payment-method'] ) ) {
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 
 			$token_id = absint( $wp->query_vars['set-default-payment-method'] );
 			$token    = WC_Payment_Tokens::get( $token_id );
@@ -473,7 +473,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 
 		if ( ! empty( $_POST['apply_coupon'] ) && ! empty( $_POST['coupon_code'] ) ) {
 			WC()->cart->add_discount( sanitize_text_field( $_POST['coupon_code'] ) );
@@ -587,7 +587,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 
 		if ( apply_filters( 'woocommerce_empty_cart_when_order_again', true ) ) {
 			WC()->cart->empty_cart();
@@ -678,7 +678,7 @@ class WC_Form_Handler {
 			isset( $_GET['order_id'] ) &&
 			( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( $_GET['_wpnonce'], 'woocommerce-cancel_order' ) )
 		) {
-			nocache_headers();
+			WC_Cache_Helper::do_not_cache_page();
 
 			$order_key        = $_GET['order'];
 			$order_id         = absint( $_GET['order_id'] );
@@ -725,7 +725,7 @@ class WC_Form_Handler {
 			return;
 		}
 
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 
 		$product_id          = apply_filters( 'woocommerce_add_to_cart_product_id', absint( $_REQUEST['add-to-cart'] ) );
 		$was_added_to_cart   = false;

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -168,7 +168,7 @@ abstract class WC_CSV_Exporter {
 		@ini_set( 'output_handler', '' );
 		ignore_user_abort( true );
 		wc_set_time_limit( 0 );
-		nocache_headers();
+		WC_Cache_Helper::do_not_cache_page();
 		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename=' . $this->get_filename() );
 		header( 'Pragma: no-cache' );


### PR DESCRIPTION
It seems the nocache_headers hook was firing too late when run via the wp hook, even though the page headers are set correctly the constant being used by some plugins were not set in time.

This PR moves the constants back to the nocache_headers filter with some additional checks to ensure it only runs on certain pages.

To test you will need to install a plugin like W3 Total Cache and make sure that the cart/checkout and my account pages are not cached, test this logged in and logged out. Also try different incognito session to make sure when adding from one session it does not show on other.