### PR TITLE
GeoDB empty file handling

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -305,6 +305,8 @@ class WC_Geolocation {
 		$s_array  = fstat( $handle );
 		@fclose( $handle );
 		if ( ! isset( $s_array['size'] ) || 0 === $s_array['size'] ) {
+			$logger = wc_get_logger();
+			$logger->notice( 'Empty database file, deleting local copy.', array( 'source' => 'geolocation' ) );
 			// Delete the file as we do not want to keep empty files around.
 			@unlink( $filename );
 			return false;


### PR DESCRIPTION
This PR closes #17539 where if a GEODB download failed and it created a blank DB file it would cause warnings and errors.

We do not want to keep corrupt DB files around so I am deleting empty files. It also adds checks before reading from the DBs to ensure that we do not try and read empty files.