### PR TITLE
Add action for webhook status change

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -773,7 +773,12 @@ class WC_Webhook {
 				break;
 		}
 
+		$prev_post_status = $this->get_status();
+
 		$wpdb->update( $wpdb->posts, array( 'post_status' => $post_status ), array( 'ID' => $this->id ) );
+
+		do_action( 'woocommerce_webhook_updated_status', $this->id, $post_status, $prev_post_status );
+
 		clean_post_cache( $this->id );
 	}
 


### PR DESCRIPTION
Since webhooks can be auto-disabled due to a set number of failures ([see `WC_Webhook::failed_delivery()`](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-webhook.php#L484)), adding an action would allow for web admins to setup notifications when a webhook has been auto-disabled.