### PR TITLE
Bugfix: Discounts are one cent off with items of certain prices

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1457,7 +1457,7 @@ function wc_get_rounding_precision() {
  */
 function wc_add_number_precision( $value ) {
 	$precision = pow( 10, wc_get_price_decimals() );
-	return $value * $precision;
+	return intval( round( $value * $precision ) );
 }
 
 /**

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -1284,6 +1284,37 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
+					'desc' => 'Test single fixed product coupon on one item to illustrate type conversion precision bug.',
+					'tax_rate' => array(
+						'tax_rate_country'  => '',
+						'tax_rate_state'    => '',
+						'tax_rate'          => '20.0000',
+						'tax_rate_name'     => 'VAT',
+						'tax_rate_priority' => '1',
+						'tax_rate_compound' => '0',
+						'tax_rate_shipping' => '1',
+						'tax_rate_order'    => '1',
+						'tax_rate_class'    => '',
+					),
+					'prices_include_tax' => false,
+					'cart' => array(
+						array(
+							'price' => 8.95,
+							'qty'   => 1,
+						),
+					),
+					'coupons' => array(
+						array(
+							'code'                   => 'test',
+							'discount_type'          => 'fixed_product',
+							'amount'                 => '10',
+						),
+					),
+					'expected_total_discount' => 8.95,
+				),
+			),
+			array(
+				array(
 					'desc' => 'Test multiple coupons with limits of 1.',
 					'tax_rate' => array(
 						'tax_rate_country'  => '',


### PR DESCRIPTION
By random chance I ran across an issue where `WC_Discounts` was incorrectly returning a discount amount (one cent off on certain items).

For a $10 Fixed Product coupon with no limits and a product with a cost of $8.95, I was getting the discount for that item as $8.94. It should have discounted the full item at $8.95.

After some extensive digging into this, it seems to be a result of a type conversion and precision error. You could reproduce this error in plain PHP by running the following calculations:

![image](https://user-images.githubusercontent.com/221971/32401622-03e609b0-c0e9-11e7-8c77-fb439f840af6.png)

Code like that is run when adding precision in `wc_add_number_precision()`:

https://github.com/woocommerce/woocommerce/blob/787bb7f0c0fead3a6fe8f67b60261bebe20a2803/includes/wc-core-functions.php#L1451-L1461

Then, `absint()` is later called on that value and the result is `894` instead of `895`.

https://github.com/woocommerce/woocommerce/blob/624c1a951615823f3bd7733bf2ca6a8463a21075/includes/class-wc-discounts.php#L207-L216

This PR adds a test that fails without my attempts at fixing this. With my code that attempts to fix this, the test passes. I'm not certain, however, if how I'm fixing it is the best way to do this or if there is a better way to handle this. Please advise if there's a better way and I can fix it that way.