### PR TITLE
Issue #17570 - stripslashes when setting customer data from the session

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -846,7 +846,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$shipping             = $this->get_prop( 'shipping', 'edit' );
 		$shipping['country']  = $country;
-		$shipping['state']    = $state;
+		$shipping['state']    =  stripslashes( $state );
 		$shipping['postcode'] = $postcode;
 		$shipping['city']     = $city;
 		$this->set_prop( 'shipping', $shipping );

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -97,7 +97,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 					$session_key = str_replace( 'billing_', '', $session_key );
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
-					$customer->{"set_{$function_key}"}( $data[ $session_key ] );
+					$customer->{"set_{$function_key}"}( stripslashes( $data[ $session_key ] ) );
 				}
 			}
 		}


### PR DESCRIPTION
The session data may contain escaped quotes. When the values were assigned directly the backslashes could inadvertently appear on checkout. Using stripslashes() resolves this issue. 

I  couldn't find any PHP Unit tests to change and didn't know where to create one.