### PR TITLE
Issue #17575 - perform stripslashes when setting shipping state

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -846,7 +846,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$shipping             = $this->get_prop( 'shipping', 'edit' );
 		$shipping['country']  = $country;
-		$shipping['state']    = $state;
+		$shipping['state']    = stripslashes( $state );
 		$shipping['postcode'] = $postcode;
 		$shipping['city']     = $city;
 		$this->set_prop( 'shipping', $shipping );


### PR DESCRIPTION
perform stripslashes when setting shipping state to avoid unwanted backslashes.

As with #17572 I couldn't find where to add/change PHPUnit tests.