### PR TITLE
Update NJ tax rate

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -774,7 +774,7 @@ return array(
 				array(
 					'country'  => 'US',
 					'state'    => 'NJ',
-					'rate'     => '7.0000',
+					'rate'     => '6.8750',
 					'name'     => 'State Tax',
 					'shipping' => true,
 				),


### PR DESCRIPTION
Updating the tax rate for NJ, US, to 6.875%.

According to Wikipedia and #771679-zen that is the correct tax rate:

![](http://d.wedj.at/qcI1P1+)
**Image Link**: http://d.wedj.at/qcI1P1+