### PR TITLE
Unslash shipping forms and addresses

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -846,7 +846,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$shipping             = $this->get_prop( 'shipping', 'edit' );
 		$shipping['country']  = $country;
-		$shipping['state']    =  stripslashes( $state );
+		$shipping['state']    = $state;
 		$shipping['postcode'] = $postcode;
 		$shipping['city']     = $city;
 		$this->set_prop( 'shipping', $shipping );

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -846,7 +846,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
 		$shipping             = $this->get_prop( 'shipping', 'edit' );
 		$shipping['country']  = $country;
-		$shipping['state']    = $state;
+		$shipping['state']    =  stripslashes( $state );
 		$shipping['postcode'] = $postcode;
 		$shipping['city']     = $city;
 		$this->set_prop( 'shipping', $shipping );

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -97,7 +97,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 					$session_key = str_replace( 'billing_', '', $session_key );
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
-					$customer->{"set_{$function_key}"}( stripslashes( $data[ $session_key ] ) );
+					$customer->{"set_{$function_key}"}( wp_unslash( $data[ $session_key ] ) );
 				}
 			}
 		}

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -97,7 +97,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 					$session_key = str_replace( 'billing_', '', $session_key );
 				}
 				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
-					$customer->{"set_{$function_key}"}( $data[ $session_key ] );
+					$customer->{"set_{$function_key}"}( stripslashes( $data[ $session_key ] ) );
 				}
 			}
 		}

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -23,10 +23,10 @@ class WC_Shortcode_Cart {
 		try {
 			WC()->shipping->reset_shipping();
 
-			$country  = wc_clean( $_POST['calc_shipping_country'] );
-			$state    = wc_clean( isset( $_POST['calc_shipping_state'] ) ? $_POST['calc_shipping_state'] : '' );
-			$postcode = apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true ) ? wc_clean( $_POST['calc_shipping_postcode'] ) : '';
-			$city     = apply_filters( 'woocommerce_shipping_calculator_enable_city', false ) ? wc_clean( $_POST['calc_shipping_city'] ) : '';
+			$country  = wc_clean( wp_unslash( $_POST['calc_shipping_country'] ) );
+			$state    = wc_clean( wp_unslash( isset( $_POST['calc_shipping_state'] ) ? $_POST['calc_shipping_state'] : '' ) );
+			$postcode = apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true ) ? wc_clean( wp_unslash( $_POST['calc_shipping_postcode'] ) ) : '';
+			$city     = apply_filters( 'woocommerce_shipping_calculator_enable_city', false ) ? wc_clean( wp_unslash( $_POST['calc_shipping_city'] ) ) : '';
 
 			if ( $postcode && ! WC_Validation::is_postcode( $postcode, $country ) ) {
 				throw new Exception( __( 'Please enter a valid postcode / ZIP.', 'woocommerce' ) );


### PR DESCRIPTION
Use unslash when processing the shipping calculator, and reading the session.

Closes #17576 
Closes #17572 
Fixes #17576 
Fixes #17570