### PR TITLE
Allow for chromedriver patch version updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-stage-2": "^6.13.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "chromedriver": "2.33.0",
+    "chromedriver": "^2.33.0",
     "config": "^1.24.0",
     "cross-env": "^3.0.0",
     "grunt": "~1.0.1",


### PR DESCRIPTION
e2e-tests were failing on my environment when using chromedriver 2.32.0 but they work when using chromedriver 2.32.2. I decided to change the version to `^2.32.0` instead of `2.32.2` to allow future patch version updates to happen automatically and to follow the version definition used for the other packages used by WC.