### PR TITLE
Allow for cloning the WC_Cart object

### DIFF
--- a/includes/class-wc-cart-fees.php
+++ b/includes/class-wc-cart-fees.php
@@ -68,7 +68,7 @@ final class WC_Cart_Fees {
 	/**
 	 * Register methods for this object on the appropriate WordPress hooks.
 	 */
-	public function register_hooks() {
+	public function init() {
 		add_action( 'woocommerce_cart_emptied', array( $this, 'remove_all_fees' ) );
 		add_action( 'woocommerce_cart_reset', array( $this, 'remove_all_fees' ) );
 	}

--- a/includes/class-wc-cart-fees.php
+++ b/includes/class-wc-cart-fees.php
@@ -63,6 +63,12 @@ final class WC_Cart_Fees {
 		}
 
 		$this->cart = $cart;
+	}
+
+	/**
+	 * Register methods for this object on the appropriate WordPress hooks.
+	 */
+	public function register_hooks() {
 		add_action( 'woocommerce_cart_emptied', array( $this, 'remove_all_fees' ) );
 		add_action( 'woocommerce_cart_reset', array( $this, 'remove_all_fees' ) );
 	}

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -38,7 +38,12 @@ final class WC_Cart_Session {
 		}
 
 		$this->cart = $cart;
+	}
 
+	/**
+	 * Register methods for this object on the appropriate WordPress hooks.
+	 */
+	public function register_hooks() {
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
 		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -43,7 +43,7 @@ final class WC_Cart_Session {
 	/**
 	 * Register methods for this object on the appropriate WordPress hooks.
 	 */
-	public function register_hooks() {
+	public function init() {
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
 		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -124,10 +124,11 @@ class WC_Cart extends WC_Legacy_Cart {
 
 	/**
 	 * When cloning, ensure object properties are handled.
+	 *
+	 * These properties store a reference to the cart, so we use new instead of clone.
 	 */
 	public function __clone() {
-		// These properties store a reference to the cart, so just use new instead of clone.
-		$this->session = new WC_Cart_Session( $this );
+		$this->session  = new WC_Cart_Session( $this );
 		$this->fees_api = new WC_Cart_Fees( $this );
 	}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -122,6 +122,15 @@ class WC_Cart extends WC_Legacy_Cart {
 		add_action( 'woocommerce_after_checkout_validation', array( $this, 'check_customer_coupons' ), 1 );
 	}
 
+	/**
+	 * When cloning, ensure object properties are handled.
+	 */
+	public function __clone() {
+		// These properties store a reference to the cart, so just use new instead of clone.
+		$this->session = new WC_Cart_Session( $this );
+		$this->fees_api = new WC_Cart_Fees( $this );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Getters.

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -110,8 +110,8 @@ class WC_Cart extends WC_Legacy_Cart {
 		$this->tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
 
 		// Register hooks for the objects.
-		$this->session->register_hooks();
-		$this->fees_api->register_hooks();
+		$this->session->init();
+		$this->fees_api->init();
 
 		add_action( 'woocommerce_add_to_cart', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_applied_coupon', array( $this, 'calculate_totals' ), 20, 0 );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -109,6 +109,10 @@ class WC_Cart extends WC_Legacy_Cart {
 		$this->fees_api         = new WC_Cart_Fees( $this );
 		$this->tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
 
+		// Register hooks for the objects.
+		$this->session->register_hooks();
+		$this->fees_api->register_hooks();
+
 		add_action( 'woocommerce_add_to_cart', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_applied_coupon', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_cart_item_removed', array( $this, 'calculate_totals' ), 20, 0 );

--- a/tests/unit-tests/cart/cart-fees.php
+++ b/tests/unit-tests/cart/cart-fees.php
@@ -15,7 +15,7 @@ class WC_Tests_WC_Cart_Fees extends WC_Unit_Test_Case {
 	public function test_set_get_remove_fees() {
 
 		$cart_fees = new WC_Cart_Fees( wc()->cart );
-		$cart_fees->register_hooks();
+		$cart_fees->init();
 
 		// Test add_fee.
 		$args = array(

--- a/tests/unit-tests/cart/cart-fees.php
+++ b/tests/unit-tests/cart/cart-fees.php
@@ -15,6 +15,7 @@ class WC_Tests_WC_Cart_Fees extends WC_Unit_Test_Case {
 	public function test_set_get_remove_fees() {
 
 		$cart_fees = new WC_Cart_Fees( wc()->cart );
+		$cart_fees->register_hooks();
 
 		// Test add_fee.
 		$args = array(


### PR DESCRIPTION
Fixes #17561.

This does two things:

* Adds separate methods to register hooks for the `WC_Cart_Session` and `WC_Cart_Fees` classes. This is necessary to allow for creating new instances of these classes (when cloning the cart) without also adding more hooks.
* Creates the `__clone()` method for `WC_Cart` to allow for cloning the cart object. This automatically creates new internal references to `WC_Cart_Session` and `WC_Cart_Fees` objects.