### PR TITLE
Add handling for long floats

### DIFF
--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -96,7 +96,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_subtotal( $value ) {
-		$this->set_prop( 'subtotal', floatval( wc_format_decimal( $value ) ) );
+		$this->set_prop( 'subtotal', wc_format_decimal( $value ) );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_total( $value ) {
-		$this->set_prop( 'total', floatval( wc_format_decimal( $value ) ) );
+		$this->set_prop( 'total', wc_format_decimal( $value ) );
 
 		// Subtotal cannot be less than total
 		if ( '' === $this->get_subtotal() || $this->get_subtotal() < $this->get_total() ) {

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -289,8 +289,10 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 		$dp     = intval( '' === $dp ? wc_get_price_decimals() : $dp );
 		$number = number_format( floatval( $number ), $dp, '.', '' );
 	} elseif ( is_float( $number ) ) {
-		// DP is false - don't use number format, just return a string in our format.
-		$number = wc_clean( str_replace( $decimals, '.', strval( $number ) ) );
+		// DP is false - don't use number format, just return a string using whatever is given. Remove scientific notation using sprintf.
+		$number     = str_replace( $decimals, '.', sprintf( '%.' . wc_get_rounding_precision() . 'f', $number ) );
+		// We already had a float, so trailing zeros are not needed.
+		$trim_zeros = true;
 	}
 
 	if ( $trim_zeros && strstr( $number, '.' ) ) {

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -285,17 +285,13 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
 	}
 
-	if ( false === $dp && '' === $number ) {
-		return '';
+	if ( false !== $dp ) {
+		$dp     = intval( '' === $dp ? wc_get_price_decimals() : $dp );
+		$number = number_format( floatval( $number ), $dp, '.', '' );
+	} elseif ( is_float( $number ) ) {
+		// DP is false - don't use number format, just return a string in our format.
+		$number = wc_clean( str_replace( $decimals, '.', strval( $number ) ) );
 	}
-
-	if ( false === $dp ) {
-		$dp = wc_get_rounding_precision();
-	} elseif ( '' === $dp ) {
-		$dp = wc_get_price_decimals();
-	}
-
-	$number = number_format( floatval( $number ), $dp, '.', '' );
 
 	if ( $trim_zeros && strstr( $number, '.' ) ) {
 		$number = rtrim( rtrim( $number, '0' ), '.' );

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -285,13 +285,17 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
 	}
 
-	if ( false !== $dp ) {
-		$dp     = intval( '' === $dp ? wc_get_price_decimals() : $dp );
-		$number = number_format( floatval( $number ), $dp, '.', '' );
-	} elseif ( is_float( $number ) ) {
-		// DP is false - don't use number format, just return a string in our format.
-		$number = wc_clean( str_replace( $decimals, '.', strval( $number ) ) );
+	if ( false === $dp && '' === $number ) {
+		return '';
 	}
+
+	if ( false === $dp ) {
+		$dp = wc_get_rounding_precision();
+	} elseif ( '' === $dp ) {
+		$dp = wc_get_price_decimals();
+	}
+
+	$number = number_format( floatval( $number ), $dp, '.', '' );
 
 	if ( $trim_zeros && strstr( $number, '.' ) ) {
 		$number = rtrim( rtrim( $number, '0' ), '.' );

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -294,6 +294,9 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// Trim zeros and round.
 		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
+		// Floats.
+		$this->assertEquals( '0.2222222222222222', wc_format_decimal( 0.2222222222222222 ) );
+
 		update_option( 'woocommerce_price_decimal_sep', '.' );
 		update_option( 'woocommerce_price_thousand_sep', ',' );
 	}

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -294,9 +294,13 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// Trim zeros and round.
 		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
-		// Floats.
-		$this->assertEquals( '0.2222222222222222', wc_format_decimal( 0.2222222222222222 ) );
+		update_option( 'woocommerce_price_num_decimals', '8' );
 
+		// Floats.
+		$this->assertEquals( '0.00001', wc_format_decimal( 0.00001 ) );
+		$this->assertEquals( '0.22222222', wc_format_decimal( 0.22222222 ) );
+
+		update_option( 'woocommerce_price_num_decimals', '2' );
 		update_option( 'woocommerce_price_decimal_sep', '.' );
 		update_option( 'woocommerce_price_thousand_sep', ',' );
 	}

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -12,6 +12,12 @@
  */
 class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
+	public function tearDown() {
+		update_option( 'woocommerce_price_num_decimals', '2' );
+		update_option( 'woocommerce_price_decimal_sep', '.' );
+		update_option( 'woocommerce_price_thousand_sep', ',' );
+	}
+
 	/**
 	 * Test wc_string_to_bool().
 	 *


### PR DESCRIPTION
I found that long floats containing scientific notation were not converted to stings correctly. This broke storage to orders.

Fixes #17581