### PR TITLE
Underscores wrappers

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2736,33 +2736,5 @@ add_action( 'wp_head', 'wc_page_noindex' );
  * @return string
  */
 function wc_get_theme_slug_for_templates() {
-	/**
-	 * @hooked wc_check_for_underscores_theme
-	 * @since 3.3.0
-	 */
-	$template = apply_filters( 'woocommerce_theme_slug_for_templates', get_option( 'template' ) );
-
-	return $template;
+	return apply_filters( 'woocommerce_theme_slug_for_templates', get_option( 'template' ) );
 }
-
-/**
- * Treat all themes that don't formally support WooCommerce and are based on Underscores as one 'underscores' theme for templates.
- *
- * @since 3.3.0
- * @param string $template
- * @return string
- */
-function wc_check_for_underscores_theme( $template ) {
-	if ( ! current_theme_supports( 'woocommerce' ) && ! in_array( $template,  wc_get_core_supported_themes() ) ) {
-		$stylesheet = get_stylesheet_directory() . '/style.css';
-		if( file_exists( $stylesheet ) ) {
-			$stylesheet_contents = file_get_contents( $stylesheet );
-			if ( stripos( $stylesheet_contents, 'underscores' ) ) {
-				return 'underscores';
-			}
-		}
-	}
-
-	return $template;
-}
-add_filter( 'woocommerce_theme_slug_for_templates', 'wc_check_for_underscores_theme' );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2728,3 +2728,41 @@ function wc_page_noindex() {
 	}
 }
 add_action( 'wp_head', 'wc_page_noindex' );
+
+/**
+ * Get a slug identifying the current theme.
+ *
+ * @since 3.3.0
+ * @return string
+ */
+function wc_get_theme_slug_for_templates() {
+	/**
+	 * @hooked wc_check_for_underscores_theme
+	 * @since 3.3.0
+	 */
+	$template = apply_filters( 'woocommerce_theme_slug_for_templates', get_option( 'template' ) );
+
+	return $template;
+}
+
+/**
+ * Treat all themes that don't formally support WooCommerce and are based on Underscores as one 'underscores' theme for templates.
+ *
+ * @since 3.3.0
+ * @param string $template
+ * @return string
+ */
+function wc_check_for_underscores_theme( $template ) {
+	if ( ! current_theme_supports( 'woocommerce' ) && ! in_array( $template,  wc_get_core_supported_themes() ) ) {
+		$stylesheet = get_stylesheet_directory() . '/style.css';
+		if( file_exists( $stylesheet ) ) {
+			$stylesheet_contents = file_get_contents( $stylesheet );
+			if ( stripos( $stylesheet_contents, 'underscores' ) ) {
+				return 'underscores';
+			}
+		}
+	}
+
+	return $template;
+}
+add_filter( 'woocommerce_theme_slug_for_templates', 'wc_check_for_underscores_theme' );

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -13,14 +13,14 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     1.6.4
+ * @version     3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-$template = get_option( 'template' );
+$template = wc_get_theme_slug_for_templates();
 
 switch ( $template ) {
 	case 'twentyeleven' :
@@ -43,6 +43,9 @@ switch ( $template ) {
 		break;
 	case 'twentysixteen' :
 		echo '</main></div>';
+		break;
+	case 'underscores' :
+		echo '</div></main>';
 		break;
 	default :
 		echo '</div></div>';

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -23,6 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $template = wc_get_theme_slug_for_templates();
 
 switch ( $template ) {
+	case 'twentyten' :
+		echo '</div></div>';
+		break;
 	case 'twentyeleven' :
 		echo '</div>';
 		get_sidebar( 'shop' );
@@ -44,10 +47,7 @@ switch ( $template ) {
 	case 'twentysixteen' :
 		echo '</main></div>';
 		break;
-	case 'underscores' :
-		echo '</div></main>';
-		break;
 	default :
-		echo '</div></div>';
+		echo '</div></main>';
 		break;
 }

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -23,6 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 $template = wc_get_theme_slug_for_templates();
 
 switch ( $template ) {
+	case 'twentyten' :
+		echo '<div id="container"><div id="content" role="main">';
+		break;
 	case 'twentyeleven' :
 		echo '<div id="primary"><div id="content" role="main" class="twentyeleven">';
 		break;
@@ -41,10 +44,7 @@ switch ( $template ) {
 	case 'twentysixteen' :
 		echo '<div id="primary" class="content-area twentysixteen"><main id="main" class="site-main" role="main">';
 		break;
-	case 'underscores' :
-		echo '<div id="primary" class="content-area"><main id="main" class="site-main" role="main">';
-		break;
 	default :
-		echo '<div id="container"><div id="content" role="main">';
+		echo '<div id="primary" class="content-area"><main id="main" class="site-main" role="main">';
 		break;
 }

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -13,14 +13,14 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     1.6.4
+ * @version     3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-$template = get_option( 'template' );
+$template = wc_get_theme_slug_for_templates();
 
 switch ( $template ) {
 	case 'twentyeleven' :
@@ -40,6 +40,9 @@ switch ( $template ) {
 		break;
 	case 'twentysixteen' :
 		echo '<div id="primary" class="content-area twentysixteen"><main id="main" class="site-main" role="main">';
+		break;
+	case 'underscores' :
+		echo '<div id="primary" class="content-area"><main id="main" class="site-main" role="main">';
 		break;
 	default :
 		echo '<div id="container"><div id="content" role="main">';


### PR DESCRIPTION
Closes #17549 

Adds wrappers for _s-based themes that haven't declared WooCommerce support. 

The most reliable way I've found of determining if a theme is an _s theme is to check the style.css. There should be something something like:
```
Bassist is based on Underscores http://underscores.me/, (C) 2012-2016 Automattic, Inc.
Blog Fever is based on Underscores http://underscores.me/, (C) 2012-2014 Automattic, Inc.
Dauntless is based on Underscores http://underscores.me/, (C) 2012-2015 Automattic, Inc.
```

With the wrappers, _s-based themes are pretty much good-to-go:

<img width="1003" alt="screen shot 2017-11-06 at 1 53 23 pm" src="https://user-images.githubusercontent.com/7317227/32465896-f290b652-c2f9-11e7-8e94-aeb7e654175a.png">
<img width="1090" alt="screen shot 2017-11-06 at 1 55 43 pm" src="https://user-images.githubusercontent.com/7317227/32466016-5eee16fa-c2fa-11e7-948f-c7c16d922c71.png">
<img width="1087" alt="screen shot 2017-11-06 at 1 56 48 pm" src="https://user-images.githubusercontent.com/7317227/32466022-61de05fa-c2fa-11e7-92c6-ea085529705e.png">
