### PR TITLE
Allow removing coupons even if coupons disabled

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1688,10 +1688,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function remove_coupon( $coupon_code ) {
-		if ( ! wc_coupons_enabled() ) {
-			return false;
-		}
-
 		$coupon_code  = wc_format_coupon_code( $coupon_code );
 		$position     = array_search( $coupon_code, $this->get_applied_coupons(), true );
 


### PR DESCRIPTION
Fixes #17553 

It should be OK if we allow the removal of coupons even if coupons are disabled. Except in the situation mentioned in #17553, removing a coupon when coupons are disabled won't do anything since there won't be any coupons applied to the cart.