### PR TITLE
calculate_totals totals running too often

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -104,7 +104,7 @@ final class WC_Cart_Session {
 
 		do_action( 'woocommerce_cart_loaded_from_session', $this->cart );
 
-		if ( $update_cart_session || is_null( $totals ) ) {
+		if ( $update_cart_session || is_null( WC()->session->get( 'cart_totals', null ) ) ) {
 			WC()->session->set( 'cart', $this->get_cart_for_session() );
 			$this->cart->calculate_totals();
 		}


### PR DESCRIPTION
This check was making cart totals recalc on each page load because it was comparing an earlier version of the session variable. Cart totals session is updated on the action `woocommerce_cart_loaded_from_session` which is fired before this line.

Ref: #17583