### PR TITLE
[REST API] Fixed default value of "dp" on orders and refunds endpoints

### DIFF
--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -181,8 +181,9 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function prepare_object_for_response( $object, $request ) {
-		$this->request = $request;
-		$order         = wc_get_order( (int) $request['order_id'] );
+		$this->request       = $request;
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : $this->request['dp'];
+		$order               = wc_get_order( (int) $request['order_id'] );
 
 		if ( ! $order ) {
 			return new WP_Error( 'woocommerce_rest_invalid_order_id', __( 'Invalid order ID.', 'woocommerce' ), 404 );

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -182,7 +182,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 	 */
 	public function prepare_object_for_response( $object, $request ) {
 		$this->request       = $request;
-		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : $this->request['dp'];
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
 		$order               = wc_get_order( (int) $request['order_id'] );
 
 		if ( ! $order ) {

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -281,12 +281,13 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_object_for_response( $object, $request ) {
-		$this->request = $request;
-		$data          = $this->get_formatted_item_data( $object );
-		$context       = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data          = $this->add_additional_fields_to_object( $data, $request );
-		$data          = $this->filter_response_by_context( $data, $context );
-		$response      = rest_ensure_response( $data );
+		$this->request       = $request;
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : $this->request['dp'];
+		$data                = $this->get_formatted_item_data( $object );
+		$context             = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data                = $this->add_additional_fields_to_object( $data, $request );
+		$data                = $this->filter_response_by_context( $data, $context );
+		$response            = rest_ensure_response( $data );
 		$response->add_links( $this->prepare_links( $object, $request ) );
 
 		/**
@@ -1647,7 +1648,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['dp'] = array(
-			'default'           => 2,
+			'default'           => wc_get_price_decimals(),
 			'description'       => __( 'Number of decimal points to use in each resource.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -282,7 +282,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 	 */
 	public function prepare_object_for_response( $object, $request ) {
 		$this->request       = $request;
-		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : $this->request['dp'];
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
 		$data                = $this->get_formatted_item_data( $object );
 		$context             = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data                = $this->add_additional_fields_to_object( $data, $request );

--- a/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
@@ -98,13 +98,14 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	 * @return WP_REST_Response $data
 	 */
 	public function prepare_item_for_response( $post, $request ) {
-		$this->request     = $request;
-		$statuses          = wc_get_order_statuses();
-		$order             = wc_get_order( $post );
-		$data              = array_merge( array( 'id' => $order->get_id() ), $order->get_data() );
-		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
-		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
-		$format_line_items = array( 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines' );
+		$this->request       = $request;
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : $this->request['dp'];
+		$statuses            = wc_get_order_statuses();
+		$order               = wc_get_order( $post );
+		$data                = array_merge( array( 'id' => $order->get_id() ), $order->get_data() );
+		$format_decimal      = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
+		$format_date         = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
+		$format_line_items   = array( 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines' );
 
 		// Format decimal values.
 		foreach ( $format_decimal as $key ) {

--- a/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
@@ -99,7 +99,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 	 */
 	public function prepare_item_for_response( $post, $request ) {
 		$this->request       = $request;
-		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : $this->request['dp'];
+		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
 		$statuses            = wc_get_order_statuses();
 		$order               = wc_get_order( $post );
 		$data                = array_merge( array( 'id' => $order->get_id() ), $order->get_data() );

--- a/includes/api/v1/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/v1/class-wc-rest-order-refunds-controller.php
@@ -133,7 +133,7 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 			return new WP_Error( 'woocommerce_rest_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 404 );
 		}
 
-		$dp = $request['dp'];
+		$dp = is_null( $request['dp'] ) ? wc_get_price_decimals() : $request['dp'];
 
 		$data = array(
 			'id'           => $refund->get_id(),
@@ -511,7 +511,7 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 		$params = parent::get_collection_params();
 
 		$params['dp'] = array(
-			'default'           => 2,
+			'default'           => wc_get_price_decimals(),
 			'description'       => __( 'Number of decimal points to use in each resource.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',

--- a/includes/api/v1/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/v1/class-wc-rest-order-refunds-controller.php
@@ -133,7 +133,7 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 			return new WP_Error( 'woocommerce_rest_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 404 );
 		}
 
-		$dp = is_null( $request['dp'] ) ? wc_get_price_decimals() : $request['dp'];
+		$dp = is_null( $request['dp'] ) ? wc_get_price_decimals() : absint( $request['dp'] );
 
 		$data = array(
 			'id'           => $refund->get_id(),

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -126,7 +126,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function prepare_item_for_response( $post, $request ) {
 		$order = wc_get_order( $post );
-		$dp    = is_null( $request['dp'] ) ? wc_get_price_decimals() : $request['dp'];
+		$dp    = is_null( $request['dp'] ) ? wc_get_price_decimals() : absint( $request['dp'] );
 
 		$data = array(
 			'id'                   => $order->get_id(),

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -126,7 +126,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 	 */
 	public function prepare_item_for_response( $post, $request ) {
 		$order = wc_get_order( $post );
-		$dp    = $request['dp'];
+		$dp    = is_null( $request['dp'] ) ? wc_get_price_decimals() : $request['dp'];
 
 		$data = array(
 			'id'                   => $order->get_id(),
@@ -1609,7 +1609,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['dp'] = array(
-			'default'           => 2,
+			'default'           => wc_get_price_decimals(),
 			'description'       => __( 'Number of decimal points to use in each resource.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',


### PR DESCRIPTION
Reported by @ryelle in https://github.com/woocommerce/woocommerce/pull/17628#issuecomment-342972852

Targeting 3.3.0, since this not occurs in 3.2, but can be applied into 3.2.4 too.

Due a [change](https://github.com/woocommerce/woocommerce/commit/8cd754d8b61fdab0c1d6dd4ff81ed297b074d1e8#diff-cafa345f153232ba102492f58156ad02R289) on `wc_format_decimal()` making more strict we could catch this bug.
Currently `dp` should be equal to `2`, but this value is not been set in any place leaving `dp` as  `null`, so this makes `wc_format_decimal()` use `wc_get_price_decimals()`... What is in fact better than fix this value as `2` :rofl: 

So to solve this problem and avoid any compatibility issue, now is tested if `dp` is `null`, and then applies `wc_format_decimal()` still on the REST API side.
