### PR TITLE
Fix db warnings when using the "Add Order Indexes" tool

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -406,15 +406,15 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				 * that don't have address indexes yet.
 				 */
 				$sql = "INSERT INTO {$wpdb->postmeta}( post_id, meta_key, meta_value )
-					SELECT post_id, '%1\$s', GROUP_CONCAT( meta_value SEPARATOR ' ' )
+					SELECT post_id, '%s', GROUP_CONCAT( meta_value SEPARATOR ' ' )
 					FROM {$wpdb->postmeta}
-					WHERE meta_key IN ( '%2\$s', '%3\$s' )
+					WHERE meta_key IN ( '%s', '%s' )
 					AND post_id IN ( SELECT DISTINCT post_id FROM {$wpdb->postmeta}
-						WHERE post_id NOT IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key='%1\$s' )
-						AND post_id IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key='%3\$s' ) )
+						WHERE post_id NOT IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key='%s' )
+						AND post_id IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key='%s' ) )
 					GROUP BY post_id";
-				$rows = $wpdb->query( $wpdb->prepare( $sql, '_billing_address_index', '_billing_first_name', '_billing_last_name' ) );
-				$rows += $wpdb->query( $wpdb->prepare( $sql, '_shipping_address_index', '_shipping_first_name', '_shipping_last_name' ) );
+				$rows = $wpdb->query( $wpdb->prepare( $sql, '_billing_address_index', '_billing_first_name', '_billing_last_name', '_billing_address_index', '_billing_last_name' ) );
+				$rows += $wpdb->query( $wpdb->prepare( $sql, '_shipping_address_index', '_shipping_first_name', '_shipping_last_name', '_shipping_address_index', '_shipping_last_name') );
 
 				$message = sprintf( __( '%d indexes added', 'woocommerce' ), $rows );
 			break;


### PR DESCRIPTION
I got the following warnings while using the **WooCommerce > Status > Tools > Order address indexes** tool. 

```
PHP Notice:  wpdb::prepare was called <strong>incorrectly</strong>. The query does not contain the correct number of placeholders (5) for the number of arguments passed (3). Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 4.8.3.) in /wp-includes/functions.php on line 4139
```

According to https://developer.wordpress.org/reference/classes/wpdb/prepare/#description, numbered placeholders aren't allowed.