### PR TITLE
Add filter 'woocommerce_coupon_get_apply_quantity'

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -354,6 +354,7 @@ class WC_Discounts {
 
 			// See how many and what price to apply to.
 			$apply_quantity    = max( 0, ( $limit_usage_qty && ( $limit_usage_qty - $applied_count ) < $item->quantity ? $limit_usage_qty - $applied_count : $item->quantity ) );
+			$apply_quantity = apply_filters( 'woocommerce_coupon_get_apply_quantity', $apply_quantity, $item, $coupon, $this );
 			$price_to_discount = ( $price_to_discount / $item->quantity ) * $apply_quantity;
 
 			// Run coupon calculations.
@@ -417,9 +418,11 @@ class WC_Discounts {
 			// Run coupon calculations.
 			if ( $limit_usage_qty ) {
 				$apply_quantity = max( 0, ( $limit_usage_qty - $applied_count < $item->quantity ? $limit_usage_qty - $applied_count: $item->quantity ) );
+				$apply_quantity = apply_filters( 'woocommerce_coupon_get_apply_quantity', $apply_quantity, $item, $coupon, $this );
 				$discount       = min( $amount, $item->price / $item->quantity ) * $apply_quantity;
 			} else {
 				$apply_quantity = $item->quantity;
+				$apply_quantity = apply_filters( 'woocommerce_coupon_get_apply_quantity', $apply_quantity, $item, $coupon, $this );
 				$discount       = $amount * $apply_quantity;
 			}
 


### PR DESCRIPTION
It would be great if this were added to core:

**Filter: 'woocommerce_coupon_get_apply_quantity'  ( $apply_quantity, $item, $coupon, $discounts )**

This allows plugins to limit the quantity of products that are discounted on an order line (e.g. discount only 3 of the 5 items of an order line).

Currently I'm using woocommerce_coupon_get_discount_amount to achieve this, but that only works for cart discounts, not for order discounts applied from the backend...
