### PR TITLE
[3.3+] Formalize context for working with order contents

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -691,10 +691,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Return an array of items/products within this order.
 	 *
+	 * Optionally pass a working context, e.g. 'shipping', 'inventory', etc,
+	 * which can be used to modify the itemset as needed.
+	 *
 	 * @param string|array $types Types of line items to get (array or string).
+	 * @param string $context Working context, e.g. 'shipping' or 'inventory'.
 	 * @return Array of WC_Order_item
 	 */
-	public function get_items( $types = 'line_item' ) {
+	public function get_items( $types = 'line_item', $context = '' ) {
 		$items = array();
 		$types = array_filter( (array) $types );
 
@@ -708,7 +712,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
-		return apply_filters( 'woocommerce_order_get_items', $items, $this );
+		return apply_filters( 'woocommerce_order_get_items', $items, $this, $context );
 	}
 
 	/**

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -312,9 +312,16 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * Get the associated product.
 	 *
+	 * Optionally pass a working context, e.g. 'shipping', 'inventory', etc,
+	 * which can be used to modify the props of the product as needed, e.g.:
+	 *
+	 * - modify shipping properties; or
+	 * - generate dynamic kit/bundle SKUs.
+	 *
+	 * @param  string $context Working context, e.g. 'shipping' or 'inventory'.
 	 * @return WC_Product|bool
 	 */
-	public function get_product() {
+	public function get_product( $context = '' ) {
 		if ( $this->get_variation_id() ) {
 			$product = wc_get_product( $this->get_variation_id() );
 		} else {
@@ -326,7 +333,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 			$product = apply_filters( 'woocommerce_get_product_from_item', $product, $this, $this->get_order() );
 		}
 
-		return apply_filters( 'woocommerce_order_item_product', $product, $this );
+		return apply_filters( 'woocommerce_order_item_product', $product, $this, $context );
 	}
 
 	/**


### PR DESCRIPTION
see #17669 

> A WooCommerce enhancement idea to discuss in an upcoming dev chat or here.
> 
> In the past we've discussed about allowing/introducing multiple "order statuses" to facilitate working with orders in different contexts, e.g.:
> 
> - payment;
> - shipping.
> 
> and possibly more.
> 
> We've also had brief discussions about the need to work with order items in different contexts, as well, e.g.:
> 
> - inventory;
> - shipping;
> - other.
> 
> I'd like to revive interest for the latter one.
> 
> ## Problem Description
> 
> External fulfillment services typically integrate with WooCommerce via an API / REST API call that retrieves order contents, sometimes requiring a plugin to glue it all together. This data is used to:
> 
> - process orders (pick items from a warehouse);
> - update inventory in an external database; and
> - sometimes even calculate shipping costs externally.
> 
> WooCommerce adopts a generic approach of treating every SKU as a line item with its own tax / totals, which is only fine in an accounting / payment context. 
> 
> Every line item in a WC order has:
> 
> - a single, static SKU;
> - static physical properties (always physical or always virtual, static weight and dimensions).
> 
> However, many applications require more flexibility. While WooCommerce includes filters for modifying the contents of an order, it does not provide a formal way that both extension developers + integration developers can use to work with order contents in different contexts.
> 
> **A typical example: Shipping + Inventory in Kitting Applications**
> 
> In bundling/kitting applications, there's a quite common need to "physically bundle" groups of physical items together when "processing" an order. 
> 
> This means that the final list of physical items that are actually shipped (and their physical properties) might be different compared to the initial list of SKUs / line items contained in a WC order:
> 
> Many external fulfillment services support "dynamic/compound" SKUs -- these are often used to represent "physical kits" containing multiple physical SKUs in a single physical item with its own compound totals, weight and dimensions.
> 
> When working with the "shipping API" of WooCommerce, it's quite straightforward to modify the contents of a shipping package in order to let Shipping Methods "see" a real-world accurate representation of a cart's contents -- and calculate rates correctly. 
> 
> However, when **order data** is exported and used to calculate shipping costs externally, there is no formal way to do something similar -- there's no "shipping" context formally defined anywhere.
> 
> Similarly, there is no "inventory" context to work with in a mutually understandable manner.
> 
> The result is that every kitting extension needs its own, separate integration with every other plugin that retrieves order data in a "shipping", or "inventory" context.
> 
> Here's an example of the current integration of **Product Bundles** with **Print Order Invoices and Packing Lists** ( cc @bekarice ):
> 
> 1. An "unassembled" bundle example:
> 
> - Order contents: https://cl.ly/0C3z0S080t2b
> - Order invoice: https://cl.ly/101F2K3G3039
> - Order packing list: https://cl.ly/2y3o0A2J3T0s
> 
> 2. Now let's turn that to an "assembled" bundle:
> 
> - Order contents: https://cl.ly/0C3z0S080t2b (same as above)
> - Order invoice: https://cl.ly/3k2N2k2Z3230
> - Order packing list: https://cl.ly/0Z2z0S120m2Y
> 
> BUT
> 
> - Order pick list: https://cl.ly/3c2h2p0L1L3e
> 
> 
> 
> In this integration example, it would be a lot easier if there was a "shipping" context for working with order contents that both PB and PIP could use.
> 
> - PIP would ask for data in "shipping" context when generating a "packing list".
> - PB would modify order data accordingly.
> 
> Without this, PIP needs to provide an application-specific filter that PB must use.
> 
> PIP is only the tip of the iceberg -- the "iceberg" here is fulfillment services such as Shipstation, which typically make a single API / REST API request to get:
> 
> - payment / invoicing data;
> - inventory data; and
> - shipping data.
> 
> ## Food For Thought
> 
> If WooCommerce provided a formal way for working with order contents in different contexts, one perhaps that could be supported in REST API requests via a `context` parameter, then it would be closer to solving a very difficult e-commerce problem which remains largely unsolved -- industry-wide.
> 
> @mikejolley has in the past suggested a "mild" approach -- presented in a separate PR in the best way I could understand/remember. It's been a long time since we last spoke about this, so the PR probably fails to capture a lot of what we discussed.
> 
> Adding a `context` param is probably not going to cut it as it fails to "formalize" a "basic" set of custom contexts -- "shipping" + "inventory" would be 2 I'd try to somehow "declare" or make formal.
> 
> Also there are more applications than kitting/bundling where this is relevant -- the most frequent one I've come across is summarized like this:
> 
> - Store sells goods that must be accompanied by a special "agent" (e.g. ice) or somehow specially "packaged" when shipped. 
> - The amount of that "agent" and the physical properties of the "packaging" change depending on what's in the order, or other variables such as the shipping destination.
> - The "agent" or "packaging" may need to be inventory-managed, as well.