### PR TITLE
Add filter for recently viewed widget WP_Query args

### DIFF
--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -83,7 +83,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 			);
 		}
 
-		$r = new WP_Query( apply_filters( 'woocommerce_widget_product_list_args', $query_args) );
+		$r = new WP_Query( apply_filters( 'woocommerce_widget_product_list_args', $query_args ) );
 
 		if ( $r->have_posts() ) {
 

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -83,7 +83,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 			);
 		}
 
-		$r = new WP_Query( $query_args );
+		$r = new WP_Query( apply_filters( 'woocommerce_widget_product_list_args', $query_args) );
 
 		if ( $r->have_posts() ) {
 


### PR DESCRIPTION
I have ran into a situation where I need to amend query args and I thought this would be a good to have this filter instead of having to modify query via `pre_get_posts` filter.

Thanks! 