### PR TITLE
Generate code coverage report on a separate non-blocking Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ php:
 env:
   - WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
 
-# Additional tests against stable PHP (min recommended version is 5.6) and past supported versions of WP.
+# Additional tests against stable PHP (min recommended version is 5.6) and past supported versions of WP
+# and code coverage report.
 matrix:
+  fast_finish: true
   include:
   - php: 5.3
     env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
@@ -20,6 +22,10 @@ matrix:
   - php: 5.2
     env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
     dist: precise
+  - php: 7.1
+    env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1 RUN_CODE_COVERAGE=1
+  allow_failures:
+  - env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1 RUN_CODE_COVERAGE=1
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
     dist: precise
   - php: 7.1
-    env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1 RUN_CODE_COVERAGE=1
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   allow_failures:
-  - env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1 RUN_CODE_COVERAGE=1
+  - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [[ ${TRAVIS_PHP_VERSION} == '7.1' ]]; then
+if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
 	phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -25,7 +25,7 @@ fi
 
 if [ $1 == 'after' ]; then
 
-	if [[ ${TRAVIS_PHP_VERSION} == '7.1' ]]; then
+	if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
 		bash <(curl -s https://codecov.io/bash)
 		wget https://scrutinizer-ci.com/ocular.phar
 		chmod +x ocular.phar

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -17,7 +17,7 @@ if [ $1 == 'before' ]; then
 
 	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
 	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
-	if [[ ${TRAVIS_PHP_VERSION} != '7.1' ]]; then
+	if [[ ${RUN_CODE_COVERAGE} != 1 ]]; then
 		phpenv config-rm xdebug.ini
 	fi
 


### PR DESCRIPTION
Travis build is taking about 40 minutes to complete, and that is mostly because of the generation of the code coverage report.

To address that, this commit changes Travis configuration to run the command to generate code coverage report on a separate non-blocking Travis job. This way once the jobs that run the tests finishes, Travis will mark the build as successful and will keep running code coverage on a separate job.