### PR TITLE
Improved PHPCS installed_paths and included Woo sanitization and escaping functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ project.properties
 .project
 .settings*
 .idea
+.vscode
+*.sublime-project
+*.sublime-workspace
 
 # Grunt
 /node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ project.properties
 .vscode
 *.sublime-project
 *.sublime-workspace
+.sublimelinterrc
 
 # Grunt
 /node_modules/

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "wp-coding-standards/wpcs": "0.13.1",
     "phpunit/phpunit": "6.2.3",
     "woocommerce/woocommerce-git-hooks": "1.0.3",
-    "wimg/php-compatibility": "^8.0"
+    "wimg/php-compatibility": "^8.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },
   "scripts": {
     "pre-update-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "990370f7f1455724582fc62049c57da5",
+    "content-hash": "9a9c7e81cc3a30935c03b1b2d64c201c",
     "packages": [
         {
             "name": "composer/installers",
@@ -125,6 +125,74 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DealerDirect/phpcodesniffer-composer-installer.git",
+                "reference": "63c0ec0ac286d31651d3c70e5bf76ad87db3ba23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DealerDirect/phpcodesniffer-composer-installer/zipball/63c0ec0ac286d31651d3c70e5bf76ad87db3ba23",
+                "reference": "63c0ec0ac286d31651d3c70e5bf76ad87db3ba23",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-09-18T07:49:36+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.1.0",

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -24,7 +24,12 @@
 
 	<rule ref="WordPress.VIP.ValidatedSanitizedInput">
 		<properties>
-			<property name="customSanitizingFunctions" type="array" value="wc_clean" />
+			<property name="customSanitizingFunctions" type="array" value="wc_clean,wc_sanitize_tooltip,wc_format_decimal,wc_stock_amount" />
 		</properties>
 	</rule>
+	<rule ref="WordPress.XSS.EscapeOutput">
+		<properties>
+			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_format_decimal" />
+		</properties>
+</rule>
 </ruleset>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -5,9 +5,6 @@
 
 	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
 
-	<!-- Include WPCS and PHPCompatibility paths -->
-	<config name="installed_paths" value="vendor/wp-coding-standards/wpcs,vendor/wimg/php-compatibility" />
-
 	<!-- Exclude paths -->
 	<exclude-pattern>tests/cli/</exclude-pattern>
 	<exclude-pattern>apigen/</exclude-pattern>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -26,7 +26,7 @@
 	</rule>
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
-			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_format_decimal" />
+			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip" />
 		</properties>
 </rule>
 </ruleset>


### PR DESCRIPTION
This Pull Request introduce a few improvements to PHPCS:

- Included new sanitation functions support: `wc_sanitize_tooltip`, `wc_format_decimal`, and `wc_stock_amount`
- Included escaping functions support: `wc_help_tip`, and `wc_sanitize_tooltip`.
- Ignored IDE project files
- Autoloaded PHPCS plugins when composer is updated.

After merged it's good to run:

```bash
composer install
```