### PR TITLE
Travis configuration cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 7.1
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
+  - WP_VERSION=latest WP_MULTISITE=0
 
 # Additional tests against stable PHP (min recommended version is 5.6) and past supported versions of WP.
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,8 @@ env:
 matrix:
   include:
   - php: 5.3
-    env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
     dist: precise
   - php: 5.2
-    env: WP_VERSION=latest WP_MULTISITE=0 PHP_LATEST_STABLE=7.1
     dist: precise
 
 before_script:


### PR DESCRIPTION
This PR removes two things from the Travis configuration file:

- Commit d847323 removes the declaration of some environment variables for specific build jobs. They are not necessary as they are the same as the ones declared for all build jobs on line [12](https://github.com/woocommerce/woocommerce/compare/master...rodrigoprimo:update/remove-unnecessary-travis-config?expand=1#diff-354f30a63fb0907d4ad57269548329e3L12)
- Commit 9188f81 removes the environment variable `PHP_LATEST_STABLE` that as far as I could check is not used anywhere. @claudiosanches, could you please double check if this variable is indeed not used?