### PR TITLE
Regenerate Image Functionality

### DIFF
--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -46,6 +46,11 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 		if ( ! is_array( $item ) && ! isset( $item['attachment_id'] ) ) {
 			return false;
 		}
+
+		if ( ! function_exists( 'wp_crop_image' ) ) {
+			include( ABSPATH . 'wp-admin/includes/image.php' );
+		}
+
 		$attachment_id = absint( $item['attachment_id'] );
 
 		$attachment = get_post( $attachment_id );

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -56,6 +56,9 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' !== substr( $attachment->post_mime_type, 0, 6 ) ) {
 			return false;
 		}
+		$log = wc_get_logger();
+		// translators: %s: ID of the attachment.
+		$log->info( sprintf( __( 'Regenerating images for attachment ID: %s', 'woocommerce' ), absint( $attachment->ID ) ) );
 
 		$fullsizepath = get_attached_file( $attachment->ID );
 

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -32,7 +32,11 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 	 */
 	public function dispatch() {
 		$log = wc_get_logger();
-		$log->info( __( 'Starting product image regeneration job.', 'woocommerce' ) );
+		$log->info( __( 'Starting product image regeneration job.', 'woocommerce' ),
+			array(
+				'source' => 'wc-image-regeneration',
+			)
+		);
 		parent::dispatch();
 	}
 
@@ -59,7 +63,11 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 		}
 		$log = wc_get_logger();
 		// translators: %s: ID of the attachment.
-		$log->info( sprintf( __( 'Regenerating images for attachment ID: %s', 'woocommerce' ), absint( $attachment->ID ) ) );
+		$log->info( sprintf( __( 'Regenerating images for attachment ID: %s', 'woocommerce' ), absint( $attachment->ID ) ),
+			array(
+				'source' => 'wc-image-regeneration',
+			)
+		);
 
 		$fullsizepath = get_attached_file( $attachment->ID );
 
@@ -91,7 +99,11 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 	protected function complete() {
 		parent::complete();
 		$log = wc_get_logger();
-		$log->info( __( 'Completed product image regeneration job.', 'woocommerce' ) );
+		$log->info( __( 'Completed product image regeneration job.', 'woocommerce' ),
+			array(
+				'source' => 'wc-image-regeneration',
+			)
+		);
 	}
 
 

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -53,7 +53,7 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 		$attachment_id = absint( $message['attachment_id'] );
 
 		$attachment = get_post( $attachment_id );
-		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' != substr( $attachment->post_mime_type, 0, 6 ) ) {
+		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' !== substr( $attachment->post_mime_type, 0, 6 ) ) {
 			return false;
 		}
 

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -43,14 +43,10 @@ class WC_Regenerate_Images_Request extends WP_Background_Process {
 	 * @return bool
 	 */
 	protected function task( $item ) {
-		$message = $this->get_message( $item );
-		$this->really_long_running_task();
-
-		if ( ! is_array( $message ) && ! isset( $message['attachment_id'] ) ) {
+		if ( ! is_array( $item ) && ! isset( $item['attachment_id'] ) ) {
 			return false;
 		}
-
-		$attachment_id = absint( $message['attachment_id'] );
+		$attachment_id = absint( $item['attachment_id'] );
 
 		$attachment = get_post( $attachment_id );
 		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' !== substr( $attachment->post_mime_type, 0, 6 ) ) {

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * All functionality to regenerate images in the background when settings change.
+ *
+ * @category Images
+ * @package WooCommerce/Classes
+ * @author Automattic
+ * @version 3.3.0
+ * @since 3.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class that extends WP_Background_Process to process image regeneration in the background
+ */
+class WC_Regenerate_Images_Request extends WP_Background_Process {
+
+	/**
+	 * Action to hook onto
+	 *
+	 * @var string
+	 */
+	protected $action = 'woocommerce_regenerate_images';
+
+	/**
+	 * Fires when the job should start
+	 *
+	 * @return void
+	 */
+	public function dispatch() {
+		$log = wc_get_logger();
+		$log->info( __( 'Starting product image regeneration job.', 'woocommerce' ) );
+		parent::dispatch();
+	}
+
+	/**
+	 * Code to execute for each item in the queue
+	 *
+	 * @param mixed $item Queue item to iterate over.
+	 * @return bool
+	 */
+	protected function task( $item ) {
+		$message = $this->get_message( $item );
+		$this->really_long_running_task();
+
+		if ( ! is_array( $message ) && ! isset( $message['attachment_id'] ) ) {
+			return false;
+		}
+
+		$attachment_id = absint( $message['attachment_id'] );
+
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' != substr( $attachment->post_mime_type, 0, 6 ) ) {
+			return false;
+		}
+
+		$fullsizepath = get_attached_file( $attachment->ID );
+
+		// Check if the file exists, if not just remove item from queue.
+		if ( false === $fullsizepath || ! file_exists( $fullsizepath ) ) {
+			return false;
+		}
+
+		// This function will generate the new image sizes.
+		$metadata = wp_generate_attachment_metadata( $attachment->ID, $fullsizepath );
+
+		// If something went wrong lets just remove the item from the queue.
+		if ( is_wp_error( $metadata ) || empty( $metadata ) ) {
+			return false;
+		}
+
+		// Update the meta data with the new size values.
+		wp_update_attachment_metadata( $attachment->ID, $metadata );
+
+		// We made it till the end, now lets remove the item from the queue.
+		return false;
+	}
+
+	/**
+	 * This runs once the job has completed all items on the queue.
+	 *
+	 * @return void
+	 */
+	protected function complete() {
+		parent::complete();
+		$log = wc_get_logger();
+		$log->info( __( 'Completed product image regeneration job.', 'woocommerce' ) );
+	}
+
+
+}

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -54,6 +54,10 @@ class WC_Regenerate_Images {
 			return $image;
 		}
 
+		if ( is_admin() ) {
+			return $image;
+		}
+
 		$imagemeta = wp_get_attachment_metadata( $attachment_id );
 
 		if ( false === $imagemeta || empty( $imagemeta ) ) {
@@ -177,11 +181,9 @@ class WC_Regenerate_Images {
 			"SELECT ID
 			FROM $wpdb->posts
 			WHERE post_type = 'attachment'
-			AND post_parent IN ( SELECT ID FROM $wpdb->posts WHERE post_type IN ( 'product','product_variation' ) )
 			AND post_mime_type LIKE 'image/%'
 			ORDER BY ID DESC"
 		);
-
 		foreach ( $images as $image ) {
 			self::$background_process->push_to_queue( array(
 				'attachment_id' => $image->ID,

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Regenerate Images Functionality
+ *
+ * All functionality pertaining to regenerating product images in realtime.
+ *
+ * @category Images
+ * @package WooCommerce/Classes
+ * @author Automattic
+ * @version 3.3.0
+ * @since 3.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Regenerate Images Class
+ */
+class WC_Regenerate_Images {
+
+	/**
+	 * Init function
+	 */
+	public static function init() {
+		add_action( 'wp_get_attachment_image_src', array( __CLASS__, 'maybe_resize_image' ), 10, 4 );
+	}
+
+	/**
+	 * Check if we should maybe generate a new image size if not already there.
+	 *
+	 * @param array        $image Properties of the image.
+	 * @param int          $attachment_id Attachment ID.
+	 * @param string|array $size Image size.
+	 * @param bool         $icon If icon or not.
+	 * @return array
+	 */
+	public static function maybe_resize_image( $image, $attachment_id, $size, $icon ) {
+		if ( ! apply_filters( 'woocommerce_resize_image', true ) ) {
+			return $image;
+		}
+
+		$imagemeta = wp_get_attachment_metadata( $attachment_id );
+
+		if ( false === $imagemeta || empty( $imagemeta ) ) {
+			return $image;
+		}
+
+		$size_settings = wc_get_image_size( $size );
+
+		if ( isset( $imagemeta['sizes'][ $size ] ) ) {
+			if ( $imagemeta['sizes'][ $size ]['width'] !== $size_settings['width'] || $imagemeta['sizes'][ $size ]['height'] !== $size_settings['height'] ) {
+				$image = self::resize_and_return_image( $attachment_id, $image, $size, $icon );
+			}
+		} else {
+			$image = self::resize_and_return_image( $attachment_id, $image, $size, $icon );
+		}
+		return $image;
+	}
+
+	/**
+	 * Regenerate the image sizes
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param array  $image Original Image.
+	 * @param string $size Size to return for new URL.
+	 * @param bool   $icon If icon or not.
+	 * @return string
+	 */
+	private static function resize_and_return_image( $attachment_id, $image, $size, $icon ) {
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' != substr( $attachment->post_mime_type, 0, 6 ) ) {
+			return $image;
+		}
+
+		if ( ! function_exists( 'wp_crop_image' ) ) {
+			include( ABSPATH . 'wp-admin/includes/image.php' );
+		}
+
+		$wp_uploads     = wp_upload_dir( null, false );
+		$wp_uploads_dir = $wp_uploads['basedir'];
+		$wp_uploads_url = $wp_uploads['baseurl'];
+
+		$original_image_file_path   = get_attached_file( $attachment->ID );
+
+		$rel_path = str_replace( $wp_uploads_dir, '', $original_image_file_path );
+
+		if ( ! file_exists( $original_image_file_path ) || ! getimagesize( $original_image_file_path ) ) {
+			return $image;
+		}
+
+		$info = pathinfo( $original_image_file_path );
+		$ext = $info['extension'];
+		list( $orig_w, $orig_h ) = getimagesize( $original_image_file_path );
+		// Get image size after cropping.
+		$image_size = wc_get_image_size( $size );
+		$dimensions = image_resize_dimensions( $orig_w, $orig_h, $image_size['width'], $image_size['height'], $image_size['crop'] );
+		if ( ! $dimensions || ! is_array( $dimensions ) ) {
+			return $image;
+		}
+
+		$dst_w        = $dimensions[4];
+		$dst_h        = $dimensions[5];
+		$suffix       = "{$dst_w}x{$dst_h}";
+		$dst_rel_path = str_replace( '.' . $ext, '', $original_image_file_path );
+		$destfilename = "{$dst_rel_path}-{$suffix}.{$ext}";
+
+		// If the file is already there perhaps just load it.
+		if ( file_exists( $destfilename ) ) {
+			return array(
+				0 => str_replace( $wp_uploads_dir, $wp_uploads_url, $destfilename ),
+				1 => $image_size['width'],
+				2 => $image_size['height'],
+			);
+		}
+
+		// Lets resize the image if it does not exist yet.
+		$editor = wp_get_image_editor( $original_image_file_path );
+		if ( is_wp_error( $editor ) || is_wp_error( $editor->resize( $image_size['width'], $image_size['height'], $image_size['crop'] ) ) ) {
+			return $image;
+		}
+		$resized_file = $editor->save();
+		if ( ! is_wp_error( $resized_file ) ) {
+			$img_url = str_replace( $wp_uploads_dir, $wp_uploads_url, $resized_file['path'] );
+			return array(
+				0 => $img_url,
+				1 => $image_size['width'],
+				2 => $image_size['height'],
+			);
+		}
+
+		// Lets just add this here as a fallback.
+		return $image;
+	}
+
+	/**
+	 * Regenerate the image sizes
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param array  $image Original Image.
+	 * @param string $size Size to return for new URL.
+	 * @param bool   $icon If icon or not.
+	 * @return string
+	 */
+	private static function resize_and_return_image_background( $attachment_id, $image, $size, $icon ) {
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' != substr( $attachment->post_mime_type, 0, 6 ) ) {
+			return $image;
+		}
+
+		$fullsizepath = get_attached_file( $attachment->ID );
+
+		// Check if the file exists, if not just return the original image.
+		if ( false === $fullsizepath || ! file_exists( $fullsizepath ) ) {
+			return $image;
+		}
+
+		// This function will generate the new image sizes.
+		$metadata = wp_generate_attachment_metadata( $attachment->ID, $fullsizepath );
+
+		// If something went wrong lets just return the original image.
+		if ( is_wp_error( $metadata ) || empty( $metadata ) ) {
+			return $image;
+		}
+
+		// Update the meta data with the new size values.
+		wp_update_attachment_metadata( $attachment->ID, $metadata );
+
+		$new_image = wp_get_attachment_image_src( $attachment->ID, $size, $icon );
+		if ( false === $new_image ) {
+			return $image;
+		}
+		return $new_image;
+	}
+}
+WC_Regenerate_Images::init();

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -101,8 +101,6 @@ class WC_Regenerate_Images {
 
 		$original_image_file_path   = get_attached_file( $attachment->ID );
 
-		$rel_path = str_replace( $wp_uploads_dir, '', $original_image_file_path );
-
 		if ( ! file_exists( $original_image_file_path ) || ! getimagesize( $original_image_file_path ) ) {
 			return $image;
 		}

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -44,7 +44,7 @@ class WC_Regenerate_Images {
 			add_action( 'update_option_woocommerce_thumbnail_cropping', array( __CLASS__, 'maybe_regenerate_images_option_update' ), 10, 3 );
 			add_action( 'update_option_woocommerce_thumbnail_image_width', array( __CLASS__, 'maybe_regenerate_images_option_update' ), 10, 3 );
 			add_action( 'update_option_woocommerce_single_image_width', array( __CLASS__, 'maybe_regenerate_images_option_update' ), 10, 3 );
-			add_action( 'after_theme_switch', array( __CLASS__, 'queue_image_regeneration' ) );
+			add_action( 'after_switch_theme', array( __CLASS__, 'queue_image_regeneration' ) );
 		}
 	}
 
@@ -161,7 +161,7 @@ class WC_Regenerate_Images {
 			return;
 		}
 
-		$this->queue_image_regeneration();
+		self::queue_image_regeneration();
 	}
 
 	/**
@@ -169,7 +169,7 @@ class WC_Regenerate_Images {
 	 *
 	 * @return void
 	 */
-	private static function queue_image_regeneration() {
+	public static function queue_image_regeneration() {
 		global $wpdb;
 		// First lets cancel existing running queue to avoid running it more than once.
 		self::$background_process->cancel_process();

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -21,9 +21,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Regenerate_Images {
 
 	/**
+	 * Background process to regenerate all images
+	 *
+	 * @var WC_Regenerate_Images_Request
+	 */
+	protected $background_process;
+
+	/**
 	 * Init function
 	 */
 	public static function init() {
+		include_once( WC_ABSPATH . 'includes/class-wc-regenerate-images-request.php' );
+		$this->background_process = new WC_Regenerate_Images_Request();
+
+		// Action to handle on-the-fly image resizing.
 		add_action( 'wp_get_attachment_image_src', array( __CLASS__, 'maybe_resize_image' ), 10, 4 );
 	}
 
@@ -37,7 +48,7 @@ class WC_Regenerate_Images {
 	 * @return array
 	 */
 	public static function maybe_resize_image( $image, $attachment_id, $size, $icon ) {
-		if ( ! apply_filters( 'woocommerce_resize_image', true ) ) {
+		if ( ! apply_filters( 'woocommerce_resize_images', true ) ) {
 			return $image;
 		}
 
@@ -60,7 +71,7 @@ class WC_Regenerate_Images {
 	}
 
 	/**
-	 * Regenerate the image sizes
+	 * Regenerate the image according to the required size
 	 *
 	 * @param int    $attachment_id Attachment ID.
 	 * @param array  $image Original Image.
@@ -135,43 +146,11 @@ class WC_Regenerate_Images {
 	}
 
 	/**
-	 * Regenerate the image sizes
-	 *
-	 * @param int    $attachment_id Attachment ID.
-	 * @param array  $image Original Image.
-	 * @param string $size Size to return for new URL.
-	 * @param bool   $icon If icon or not.
-	 * @return string
+	 * Regenerate the product images using a job queue in the background.
 	 */
-	private static function resize_and_return_image_background( $attachment_id, $image, $size, $icon ) {
-		$attachment = get_post( $attachment_id );
-		if ( ! $attachment || 'attachment' !== $attachment->post_type || 'image/' != substr( $attachment->post_mime_type, 0, 6 ) ) {
-			return $image;
-		}
-
-		$fullsizepath = get_attached_file( $attachment->ID );
-
-		// Check if the file exists, if not just return the original image.
-		if ( false === $fullsizepath || ! file_exists( $fullsizepath ) ) {
-			return $image;
-		}
-
-		// This function will generate the new image sizes.
-		$metadata = wp_generate_attachment_metadata( $attachment->ID, $fullsizepath );
-
-		// If something went wrong lets just return the original image.
-		if ( is_wp_error( $metadata ) || empty( $metadata ) ) {
-			return $image;
-		}
-
-		// Update the meta data with the new size values.
-		wp_update_attachment_metadata( $attachment->ID, $metadata );
-
-		$new_image = wp_get_attachment_image_src( $attachment->ID, $size, $icon );
-		if ( false === $new_image ) {
-			return $image;
-		}
-		return $new_image;
+	private static function regenerate_images_background() {
+		$this->background_process->push_to_queue( $item );
+		$this->background_process->save()->dispatch();
 	}
 }
 WC_Regenerate_Images::init();

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -25,14 +25,14 @@ class WC_Regenerate_Images {
 	 *
 	 * @var WC_Regenerate_Images_Request
 	 */
-	protected $background_process;
+	protected static $background_process;
 
 	/**
 	 * Init function
 	 */
 	public static function init() {
 		include_once( WC_ABSPATH . 'includes/class-wc-regenerate-images-request.php' );
-		$this->background_process = new WC_Regenerate_Images_Request();
+		self::$background_process = new WC_Regenerate_Images_Request();
 
 		// Action to handle on-the-fly image resizing.
 		add_action( 'wp_get_attachment_image_src', array( __CLASS__, 'maybe_resize_image' ), 10, 4 );
@@ -170,7 +170,7 @@ class WC_Regenerate_Images {
 
 		// If we made it till here, it means that image settings have changed.
 		// First lets cancel existing running queue to avoid running it more than once.
-		$this->background_process->cancel_process();
+		self::$background_process->cancel_process();
 
 		// Now lets find all product image attachments IDs and pop them onto the queue.
 		$images = $wpdb->get_results( // @codingStandardsIgnoreLine
@@ -183,13 +183,13 @@ class WC_Regenerate_Images {
 		);
 
 		foreach ( $images as $image ) {
-			$this->background_process->push_to_queue( array(
+			self::$background_process->push_to_queue( array(
 				'attachment_id' => $image->ID,
 			) );
 		}
 
 		// Lets dispatch the queue to start processing.
-		$this->background_process->save()->dispatch();
+		self::$background_process->save()->dispatch();
 	}
 }
 WC_Regenerate_Images::init();

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main WooCommerce Class.
  *
  * @class WooCommerce
- * @version	3.2.0
+ * @version 3.2.0
  */
 final class WooCommerce {
 
@@ -237,13 +237,13 @@ final class WooCommerce {
 	 */
 	private function is_request( $type ) {
 		switch ( $type ) {
-			case 'admin' :
+			case 'admin':
 				return is_admin();
-			case 'ajax' :
+			case 'ajax':
 				return defined( 'DOING_AJAX' );
-			case 'cron' :
+			case 'cron':
 				return defined( 'DOING_CRON' );
-			case 'frontend' :
+			case 'frontend':
 				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' );
 		}
 	}
@@ -319,11 +319,11 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-emails.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-data-exception.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-query.php' );
-		include_once( WC_ABSPATH . 'includes/class-wc-meta-data.php' ); // Meta data internal object
+		include_once( WC_ABSPATH . 'includes/class-wc-meta-data.php' ); // Meta data internal object.
 		include_once( WC_ABSPATH . 'includes/class-wc-order-factory.php' ); // Order factory.
 		include_once( WC_ABSPATH . 'includes/class-wc-order-query.php' ); // Order query.
 		include_once( WC_ABSPATH . 'includes/class-wc-product-factory.php' ); // Product factory.
-		include_once( WC_ABSPATH . 'includes/class-wc-product-query.php' ); // Product query
+		include_once( WC_ABSPATH . 'includes/class-wc-product-query.php' ); // Product query.
 		include_once( WC_ABSPATH . 'includes/class-wc-payment-tokens.php' ); // Payment tokens controller.
 		include_once( WC_ABSPATH . 'includes/class-wc-shipping-zone.php' );
 		include_once( WC_ABSPATH . 'includes/gateways/class-wc-payment-gateway-cc.php' ); // CC Payment Gateway.
@@ -337,6 +337,7 @@ final class WooCommerce {
 		include_once( WC_ABSPATH . 'includes/class-wc-background-emailer.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-discounts.php' );
 		include_once( WC_ABSPATH . 'includes/class-wc-cart-totals.php' );
+		include_once( WC_ABSPATH . 'includes/class-wc-regenerate-images.php' ); // Image regeneration class.
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.
@@ -407,28 +408,28 @@ final class WooCommerce {
 
 		if ( $this->is_active_theme( array( 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) ) ) {
 			switch ( get_template() ) {
-				case 'twentyten' :
+				case 'twentyten':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-ten.php' );
 					break;
-				case 'twentyeleven' :
+				case 'twentyeleven':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-eleven.php' );
 					break;
-				case 'twentytwelve' :
+				case 'twentytwelve':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twelve.php' );
 					break;
-				case 'twentythirteen' :
+				case 'twentythirteen':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-thirteen.php' );
 					break;
-				case 'twentyfourteen' :
+				case 'twentyfourteen':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-fourteen.php' );
 					break;
-				case 'twentyfifteen' :
+				case 'twentyfifteen':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-fifteen.php' );
 					break;
-				case 'twentysixteen' :
+				case 'twentysixteen':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-sixteen.php' );
 					break;
-				case 'twentyseventeen' :
+				case 'twentyseventeen':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-seventeen.php' );
 					break;
 			}
@@ -556,7 +557,7 @@ final class WooCommerce {
 	 */
 	private function add_image_sizes() {
 		$thumbnail = wc_get_image_size( 'thumbnail' );
-		$single	   = wc_get_image_size( 'single' );
+		$single    = wc_get_image_size( 'single' );
 
 		add_image_size( 'woocommerce_thumbnail', $thumbnail['width'], $thumbnail['height'], $thumbnail['crop'] );
 		add_image_size( 'woocommerce_single', $single['width'], $single['height'], $single['crop'] );
@@ -639,12 +640,12 @@ final class WooCommerce {
 			return;
 		}
 
-		if ( false === ( $webhooks = get_transient( 'woocommerce_webhook_ids' ) ) ) {
+		if ( false === ( $webhooks = get_transient( 'woocommerce_webhook_ids' ) ) ) { // @codingStandardsIgnoreLine
 			$webhooks = get_posts( array(
 				'fields'         => 'ids',
 				'post_type'      => 'shop_webhook',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // @codingStandardsIgnoreLine
 			) );
 			set_transient( 'woocommerce_webhook_ids', $webhooks );
 		}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -686,7 +686,7 @@ function wc_get_image_size( $image_size ) {
 			'crop'   => isset( $image_size[2] ) ? $image_size[2] : 1,
 		);
 		$image_size = $size['width'] . '_' . $size['height'];
-	} elseif ( in_array( $image_size, array( 'single', 'shop_single' ), true ) ) {
+	} elseif ( in_array( $image_size, array( 'single', 'shop_single', 'woocommerce_single' ), true ) ) {
 		// If the theme supports woocommerce, take image sizes from that definition.
 		if ( isset( $theme_support[ 'single_image_width' ] ) ) {
 			$size['width'] = $theme_support[ 'single_image_width' ];
@@ -696,7 +696,7 @@ function wc_get_image_size( $image_size ) {
 		$size['height'] = 9999999999;
 		$size['crop']   = 0;
 		$image_size     = 'single';
-	} elseif ( in_array( $image_size, array( 'thumbnail', 'shop_thumbnail', 'shop_catalog' ), true ) ) {
+	} elseif ( in_array( $image_size, array( 'thumbnail', 'shop_thumbnail', 'shop_catalog', 'woocommerce_thumbnail' ), true ) ) {
 		// If the theme supports woocommerce, take image sizes from that definition.
 		if ( isset( $theme_support[ 'thumbnail_image_width' ] ) ) {
 			$size['width'] = $theme_support[ 'thumbnail_image_width' ];


### PR DESCRIPTION
This PR adds functionality to regenerate product images.

It can regenerate image on the fly as they are requested or do it when settings are changed in the background.

All functionality can be disabled via filters.

The on-the-fly regeneration does not make use of wp_generate_attachment_metadata as that is slow due to it trying to re-generate all attachment sizes for the specific image, it does however still make use of wp specific functionality to generate and save the images.

The background processing job utilises wp_generate_attachment_metadata as that can run in the background.