### PR TITLE
Coupon min/max spend based on displayed subtotal

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -117,7 +117,7 @@ class WC_Meta_Box_Coupon_Data {
 					'id'          => 'minimum_amount',
 					'label'       => __( 'Minimum spend', 'woocommerce' ),
 					'placeholder' => __( 'No minimum', 'woocommerce' ),
-					'description' => __( 'This field allows you to set the minimum spend (displayed subtotal) allowed to use the coupon.', 'woocommerce' ),
+					'description' => __( 'This field allows you to set the minimum spend (subtotal) allowed to use the coupon.', 'woocommerce' ),
 					'data_type'   => 'price',
 					'desc_tip'    => true,
 				) );
@@ -127,7 +127,7 @@ class WC_Meta_Box_Coupon_Data {
 					'id'          => 'maximum_amount',
 					'label'       => __( 'Maximum spend', 'woocommerce' ),
 					'placeholder' => __( 'No maximum', 'woocommerce' ),
-					'description' => __( 'This field allows you to set the maximum spend (displayed subtotal) allowed when using the coupon.', 'woocommerce' ),
+					'description' => __( 'This field allows you to set the maximum spend (subtotal) allowed when using the coupon.', 'woocommerce' ),
 					'data_type'   => 'price',
 					'desc_tip'    => true,
 				) );

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -117,7 +117,7 @@ class WC_Meta_Box_Coupon_Data {
 					'id'          => 'minimum_amount',
 					'label'       => __( 'Minimum spend', 'woocommerce' ),
 					'placeholder' => __( 'No minimum', 'woocommerce' ),
-					'description' => __( 'This field allows you to set the minimum spend (subtotal, including taxes) allowed to use the coupon.', 'woocommerce' ),
+					'description' => __( 'This field allows you to set the minimum spend (displayed subtotal) allowed to use the coupon.', 'woocommerce' ),
 					'data_type'   => 'price',
 					'desc_tip'    => true,
 				) );
@@ -127,7 +127,7 @@ class WC_Meta_Box_Coupon_Data {
 					'id'          => 'maximum_amount',
 					'label'       => __( 'Maximum spend', 'woocommerce' ),
 					'placeholder' => __( 'No maximum', 'woocommerce' ),
-					'description' => __( 'This field allows you to set the maximum spend (subtotal, including taxes) allowed when using the coupon.', 'woocommerce' ),
+					'description' => __( 'This field allows you to set the maximum spend (displayed subtotal) allowed when using the coupon.', 'woocommerce' ),
 					'data_type'   => 'price',
 					'desc_tip'    => true,
 				) );

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -40,6 +40,13 @@ class WC_Discounts {
 	protected $discounts = array();
 
 	/**
+	 * Total taxes
+	 *
+	 * @var array
+	 */
+	protected $tax_total = 0;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $object Cart or order object.
@@ -78,6 +85,7 @@ class WC_Discounts {
 		}
 
 		$this->object = $cart;
+		$this->tax_total = $cart->get_taxes_total( true, false );
 
 		foreach ( $cart->get_cart() as $key => $cart_item ) {
 			$item                = new stdClass();
@@ -611,7 +619,7 @@ class WC_Discounts {
 	 * @return bool
 	 */
 	protected function validate_coupon_minimum_amount( $coupon ) {
-		$subtotal = wc_remove_number_precision( array_sum( wp_list_pluck( $this->items, 'price' ) ) );
+		$subtotal = wc_remove_number_precision( array_sum( wp_list_pluck( $this->items, 'price' ) ) + $this->tax_total );
 
 		if ( $coupon->get_minimum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_minimum_amount', $coupon->get_minimum_amount() > $subtotal, $coupon, $subtotal ) ) {
 			/* translators: %s: coupon minimum amount */
@@ -630,7 +638,7 @@ class WC_Discounts {
 	 * @return bool
 	 */
 	protected function validate_coupon_maximum_amount( $coupon ) {
-		$subtotal = wc_remove_number_precision( array_sum( wp_list_pluck( $this->items, 'price' ) ) );
+		$subtotal = wc_remove_number_precision( array_sum( wp_list_pluck( $this->items, 'price' ) ) + $this->tax_total );
 
 		if ( $coupon->get_maximum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_maximum_amount', $coupon->get_maximum_amount() < $subtotal, $coupon ) ) {
 			/* translators: %s: coupon maximum amount */


### PR DESCRIPTION
This PR fixes the issue where the min and max spend was not based on the displayed subtotal. Adjusted the functionality to work out based on what the customer is seeing as the subtotal in the cart and also updated the tooltip to reflect it is based on the displayed subtotal.

Closes #17697 