### PR TITLE
Skip wp_kses_post call on image

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -132,7 +132,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Render columm: thumb.
 	 */
 	protected function render_thumb_column() {
-		echo '<a href="' . esc_url( get_edit_post_link( $this->object->get_id() ) ) . '">' . wp_kses_post( $this->object->get_image( 'thumbnail' ) ) . '</a>';
+		echo '<a href="' . esc_url( get_edit_post_link( $this->object->get_id() ) ) . '">' . $this->object->get_image( 'thumbnail' ) . '</a>';
 	}
 
 	/**


### PR DESCRIPTION
Using `wp_kses_post` can cause issues if the instance url is not using the default port 80.
![screen shot 2017-11-16 at 13 29 55 pm](https://user-images.githubusercontent.com/1620929/32891958-e055b9b4-cad4-11e7-91c2-d8750c9ac26b.png)

E.g. http://localhost:8080/wordpress/wp-admin/edit.php?post_type=product

It works fine for default port tho:
```
⬦ wp_kses_post( '<img src="//localhost/wordpress/wp-content/plugins/woocommerce/assets/images/placeholder.png" />' )
=
(string [96]) `<img src="//localhost/wordpress/wp-content/plugins/woocommerce/assets/images/placeholder.png" />`
```
vs
```
⬦ wp_kses_post( '<img src="//localhost:8080/wordpress/wp-content/plugins/woocommerce/assets/images/placeholder.png" />' )
=
(string [89]) `<img src="8080/wordpress/wp-content/plugins/woocommerce/assets/images/placeholder.png" />`
```