### PR TITLE
Assign type='button' to 'Copy from billing address'

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -179,7 +179,7 @@ class WC_Admin_Profile {
 							<?php elseif ( ! empty( $field['type'] ) && 'checkbox' === $field['type'] ) : ?>
 								<input type="checkbox" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="1" class="<?php echo esc_attr( $field['class'] ); ?>" <?php checked( (int) get_user_meta( $user->ID, $key, true ), 1, true ); ?> />
 							<?php elseif ( ! empty( $field['type'] ) && 'button' === $field['type'] ) : ?>
-								<button id="<?php echo esc_attr( $key ); ?>" class="button <?php echo esc_attr( $field['class'] ); ?>"><?php echo esc_html( $field['text'] ); ?></button>
+								<button type="button" id="<?php echo esc_attr( $key ); ?>" class="button <?php echo esc_attr( $field['class'] ); ?>"><?php echo esc_html( $field['text'] ); ?></button>
 							<?php else : ?>
 								<input type="text" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $this->get_user_meta( $user->ID, $key ) ); ?>" class="<?php echo ( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>" />
 							<?php endif; ?>


### PR DESCRIPTION
By default a `<button>` tag is considered a submit button. 

With this behaviour the JS code related to the button would prevent the profile page from saving when you press return on any of the text fields, instead it would copy over the billing address to shipping every time return is pressed. 
Source: https://www.w3.org/TR/html401/interact/forms.html#edef-BUTTON

Browser: Chrome