### PR TITLE
Wizard: Fix escaping in payment description

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1265,8 +1265,14 @@ class WC_Admin_Setup_Wizard {
 		<form method="post" class="wc-wizard-payment-gateway-form">
 			<p>
 				<?php printf(
-					esc_html__(
-						'WooCommerce can accept both online and offline payments. <a href="%1$s" target="_blank">Additional payment methods</a> can be installed later.', 'woocommerce'
+					wp_kses(
+						__( 'WooCommerce can accept both online and offline payments. <a href="%1$s" target="_blank">Additional payment methods</a> can be installed later.', 'woocommerce' ),
+						array(
+							'a' => array(
+								'href' => array(),
+								'target' => array(),
+							),
+						)
 					),
 					esc_url( admin_url( 'admin.php?page=wc-addons&view=payment-gateways' ) )
 				); ?>


### PR DESCRIPTION
Before:

<img width="723" alt="escape-before" src="https://user-images.githubusercontent.com/11487924/32902862-844668ac-cac1-11e7-92bc-eed996e00e56.png">

After:

<img width="715" alt="escape-after" src="https://user-images.githubusercontent.com/11487924/32902870-8806045c-cac1-11e7-9422-fe6e7a7be3e4.png">
