### PR TITLE
Removed "Delete WebHook logs" tool

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -174,15 +174,6 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 					__( 'This option will delete ALL of your tax rates, use with caution. This action cannot be reversed.', 'woocommerce' )
 				),
 			),
-			'delete_webhook_logs' => array(
-				'name'    => __( 'Delete WebHook logs', 'woocommerce' ),
-				'button'  => __( 'Delete logs', 'woocommerce' ),
-				'desc'    => sprintf(
-					'<strong class="red">%1$s</strong> %2$s',
-					__( 'Note:', 'woocommerce' ),
-					__( 'This tool removes WebHook logs. This will not delete the WebHooks themselves.', 'woocommerce' )
-				),
-			),
 			'reset_tracking' => array(
 				'name'    => __( 'Reset usage tracking', 'woocommerce' ),
 				'button'  => __( 'Reset', 'woocommerce' ),
@@ -446,12 +437,6 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_tax_rate_locations;" );
 				WC_Cache_Helper::incr_cache_prefix( 'taxes' );
 				$message = __( 'Tax rates successfully deleted', 'woocommerce' );
-			break;
-			case 'delete_webhook_logs' :
-
-				$result = absint( $wpdb->query( "DELETE FROM {$wpdb->comments} WHERE comment_type='webhook_delivery';" ) );
-				$wpdb->query( "DELETE commentmeta FROM {$wpdb->commentmeta} commentmeta LEFT JOIN {$wpdb->comments} comments ON comments.comment_ID = commentmeta.comment_id WHERE comments.comment_ID IS NULL;" );
-				$message = sprintf( __( '%d logs deleted', 'woocommerce' ), $result );
 			break;
 			case 'reset_tracking' :
 				delete_option( 'woocommerce_allow_tracking' );


### PR DESCRIPTION
Not needed anymore, since now uses our logging system.

Part of #12439