### PR TITLE
Introduce hooks to allow custom content into order preview

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -369,6 +369,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 									</div>
 								<# } #>
 							</div>
+							<?php do_action( 'woocommerce_admin_order_preview' ); ?>
 						</article>
 						<footer>
 							<div class="inner">

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -326,6 +326,8 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 							</button>
 						</header>
 						<article>
+							<?php do_action( 'woocommerce_admin_order_preview_start' ); ?>
+
 							{{{ data.item_html }}}
 
 							<div class="wc-order-preview-addresses">
@@ -369,7 +371,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 									</div>
 								<# } #>
 							</div>
-							<?php do_action( 'woocommerce_admin_order_preview' ); ?>
+							<?php do_action( 'woocommerce_admin_order_preview_end' ); ?>
 						</article>
 						<footer>
 							<div class="inner">

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -548,7 +548,7 @@ class WC_AJAX {
 			<?php
 			$item_html = ob_get_clean();
 
-			wp_send_json_success( array(
+			wp_send_json_success( apply_filters( 'woocommerce_ajax_get_order_details', array(
 				'data'                       => $order->get_data(),
 				'order_number'               => $order->get_order_number(),
 				'item_html'                  => $item_html,
@@ -559,7 +559,7 @@ class WC_AJAX {
 				'shipping_address_map_url'   => $order->get_shipping_address_map_url(),
 				'payment_via'                => $order->get_payment_method_title() . ( $order->get_transaction_id() ? ' (' . $order->get_transaction_id() . ')' : '' ),
 				'shipping_via'               => $order->get_shipping_method(),
-			) );
+			), $order ) );
 		}
 		exit;
 	}


### PR DESCRIPTION
Introduces:

- Action: `woocommerce_admin_order_preview`
- Filter: `woocommerce_ajax_get_order_details`

This should be enough to customize the content of order preview.