### PR TITLE
Rest API: Update the schema types for tax_class and price

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1159,7 +1159,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 							),
 							'tax_class' => array(
 								'description' => __( 'Tax class of product.', 'woocommerce' ),
-								'type'        => 'integer',
+								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'subtotal' => array(
@@ -1244,7 +1244,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 							),
 							'price' => array(
 								'description' => __( 'Product price.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => 'number',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -1238,7 +1238,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 							),
 							'tax_class' => array(
 								'description' => __( 'Tax class of product.', 'woocommerce' ),
-								'type'        => 'integer',
+								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),


### PR DESCRIPTION
As of WordPress 4.9, [`rest_validate_value_from_schema` is validating into objects](https://core.trac.wordpress.org/ticket/38583), which brought up an issue where the type wasn't correct for `tax_class` and `price` in order line_items.

To reproduce, on master with WP 4.9: `POST /orders/:id`

```js
{
	"line_items": [
		{
			"product_id": [some valid product ID],
			"quantity": 1,
			"tax_class": "",
			"subtotal": "18.00",
			"total": "18.00",
			"price": 18
		}
	]
}
```

This will fail with `Invalid parameter(s): line_items`, specifically "line_items[0][tax_class] is not of type integer."

Check out this branch, and try again, the order is successfully updated this time.