### PR TITLE
Filter for line items in abstract-wc-order.php

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1599,9 +1599,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	public function get_subtotal_to_display( $compound = false, $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 		$subtotal    = 0;
-
+		$items = apply_filters( 'woocommerce_subtotal_order_item_types', 'line_item' );
 		if ( ! $compound ) {
-			foreach ( $this->get_items() as $item ) {
+			foreach ( $items as $item ) {
 				$subtotal += $item->get_subtotal();
 
 				if ( 'incl' === $tax_display ) {
@@ -1619,7 +1619,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				return '';
 			}
 
-			foreach ( $this->get_items() as $item ) {
+			foreach ( $items as $item ) {
 				$subtotal += $item->get_subtotal();
 			}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1599,9 +1599,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	public function get_subtotal_to_display( $compound = false, $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 		$subtotal    = 0;
-		$items = apply_filters( 'woocommerce_subtotal_order_item_types', 'line_item' );
+		
 		if ( ! $compound ) {
-			foreach ( $items as $item ) {
+			foreach ( $this->get_items() as $item ) {
 				$subtotal += $item->get_subtotal();
 
 				if ( 'incl' === $tax_display ) {
@@ -1619,7 +1619,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				return '';
 			}
 
-			foreach ( $items as $item ) {
+			foreach ( $this->get_items() as $item ) {
 				$subtotal += $item->get_subtotal();
 			}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -708,7 +708,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
-		return apply_filters( 'woocommerce_order_get_items', $items, $this );
+		return apply_filters( 'woocommerce_order_get_items', $items, $this, $types );
 	}
 
 	/**


### PR DESCRIPTION
When creating custom product class there are places where line items is only value that can be handled. This is one of that places causing subtotal values after checkout not to be calculated and displayed.