### PR TITLE
Change default text for checkout page link

### DIFF
--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php if ( $order->has_status( 'pending' ) ) : ?>
-	<p><?php printf( __( 'An order has been created for you on %1$s. To pay for this order please use the following link: %2$s', 'woocommerce' ), get_bloginfo( 'name', 'display' ), '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . __( 'pay', 'woocommerce' ) . '</a>' ); ?></p>
+	<p><?php printf( __( 'An order has been created for you on %1$s. To pay for this order please use the following link: %2$s', 'woocommerce' ), get_bloginfo( 'name', 'display' ), '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . __( 'Submit payment online.', 'woocommerce' ) . '</a>' ); ?></p>
 <?php endif; ?>
 
 <?php

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -33,15 +33,15 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	printf(
 		wp_kses(
 			/* translators: %1s item is the name of the site, %2s is a html link */
-			 __( 'An order has been created for you on %1$s. To pay for this order please use the following link: %2$s', 'woocommerce' ),
-			esc_html( get_bloginfo( 'name', 'display' ) ),
-			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Submit payment online.', 'woocommerce' ) . '</a>'
+			__( 'An order has been created for you on %1$s. To pay for this order please use the following link: %2$s', 'woocommerce' ),
+			array(
+				'a' => array(
+					'href' => array(),
+				),
+			)
 		),
-		array(
-			'a' => array(
-				'href' => array(),
-			),
-		)
+		esc_html( get_bloginfo( 'name', 'display' ) ),
+		'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Submit payment online.', 'woocommerce' ) . '</a>'
 	);
 	?>
 				</p>

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @author      WooThemes
+ * @package     WooCommerce/Templates/Emails
  * @version     2.5.0
  */
 
@@ -21,17 +21,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Executes the e-mail header.
+ *
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php if ( $order->has_status( 'pending' ) ) : ?>
-	<p><?php printf( __( 'An order has been created for you on %1$s. To pay for this order please use the following link: %2$s', 'woocommerce' ), get_bloginfo( 'name', 'display' ), '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . __( 'Submit payment online.', 'woocommerce' ) . '</a>' ); ?></p>
+	<p>
+	<?php
+	printf(
+		wp_kses(
+			/* translators: %1s item is the name of the site, %2s is a html link */
+			 __( 'An order has been created for you on %1$s. To pay for this order please use the following link: %2$s', 'woocommerce' ),
+			esc_html( get_bloginfo( 'name', 'display' ) ),
+			'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Submit payment online.', 'woocommerce' ) . '</a>'
+		),
+		array(
+			'a' => array(
+				'href' => array(),
+			),
+		)
+	);
+	?>
+				</p>
 <?php endif; ?>
 
 <?php
 
 /**
+ * Hook for the woocommerce_email_order_details
+ *
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -40,17 +60,23 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
 /**
+ * Hook for the woocommerce_email_order_meta
+ *
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
 /**
+ * Hook for woocommerce_email_customer_details
+ *
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
 /**
+ * Executes the email footer
+ *
  * @hooked WC_Emails::email_footer() Output the email footer
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -13,7 +13,7 @@
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @author      WooThemes
  * @package     WooCommerce/Templates/Emails
- * @version     2.5.0
+ * @version     3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Updates the default text to be more appealing out of the box without requiring modifications.

Fixes #17770 

I'm not married to this particular language either, but think we can find something that works better than simply `pay`.

