### PR TITLE
When populating defaults, sanitize

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -686,7 +686,7 @@ class WC_AJAX {
 		$product_object   = wc_get_product( $product_id );
 		$variation_object = new WC_Product_Variation();
 		$variation_object->set_parent_id( $product_id );
-		$variation_object->set_attributes( array_fill_keys( array_keys( $product_object->get_variation_attributes() ), '' ) );
+		$variation_object->set_attributes( array_fill_keys( array_map( 'sanitize_title', array_keys( $product_object->get_variation_attributes() ) ), '' ) );
 		$variation_id     = $variation_object->save();
 		$variation        = get_post( $variation_id );
 		$variation_data   = array_merge( array_map( 'maybe_unserialize', get_post_custom( $variation_id ) ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.


### PR DESCRIPTION
Part of #17775

Caused by https://github.com/woocommerce/woocommerce/pull/17629/files
leaving attribute names uppercase.