### PR TITLE
Access to importer parameters - DRY

### DIFF
--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -126,6 +126,15 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	}
 
 	/**
+	 * Get importer parameters.
+	 *
+	 * @return array
+	 */
+	public function get_params() {
+		return $this->params;
+	}
+	
+	/**
 	 * Get file pointer position from the last read.
 	 *
 	 * @return int


### PR DESCRIPTION
Access (read only) to params can be required in many cases when you're playing with importing. 
In my case it was extending importer with filters and actions (procedural way - within original csv importer process) but it relates to objective way (extending importer class), too.

I wanted to know if 'update_existing' flag is set (other way than $_POST values) within filter 'woocommerce_product_importer_parsed_data' in parse/expand loop (called from class-wc-product-csv-importer.php 'set_parsed_data' method). Unfortunately this (and similiar) filter doesn't receive importer instance, only row data (raw, parsed and product object). Thanks to https://github.com/woocommerce/woocommerce/pull/15796 we have 'woocommerce_product_importer_formatting_callbacks' filter receiving importer instance. Unfortunately importer '$params' field is not accessible (protected in abstract). This PR resolves this simple problem - we can get this flag (and other params) before importing loops, processing rows etc.