### PR TITLE
Tweak - Fix IPN validation for PayPal as its notify URL has different case

### DIFF
--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -89,7 +89,7 @@ class WC_API extends WC_Legacy_API {
 			wc_nocache_headers();
 
 			// Clean the API request.
-			$api_request = $wp->query_vars['wc-api'];
+			$api_request = strtolower( wc_clean( $wp->query_vars['wc-api'] ) );
 
 			// Trigger generic action before request hook.
 			do_action( 'woocommerce_api_request', $api_request );


### PR DESCRIPTION
@claudiosanches Action hook  `woocommerce_api_wc_gateway_paypal` is not triggered as the notify URL looks like this:

https://github.com/woocommerce/woocommerce/blob/106e6533f262efda56e5a787eb2ef66fc51b5b32/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php#L36