### PR TITLE
Update allow_failures for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   allow_failures:
-  - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - php: 7.1
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
This PR updates the allowed_failures definition to match the matrix definition of the job that is allowed to fail.

If you take https://travis-ci.org/woocommerce/woocommerce/builds/304618499 as an example, the failed job is one that should be allowed to fail, however because the definition is missing the php env it is failing the job and the build.

According to https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail all conditions must be met exactly.