### PR TITLE
Apostrophe in product search breaks nav filters (invalid characters in hrefs & form data)

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -412,7 +412,7 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		if ( is_array( $value ) ) {
 			$html .= wc_query_string_form_fields( $value, $exclude, $key, true );
 		} else {
-			$html .= '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '" />';
+			$html .= '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( stripslashes($value) ) . '" />';
 		}
 	}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -412,7 +412,7 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		if ( is_array( $value ) ) {
 			$html .= wc_query_string_form_fields( $value, $exclude, $key, true );
 		} else {
-			$html .= '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( stripslashes($value) ) . '" />';
+			$html .= '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( wp_unslash( $value ) ) . '" />';
 		}
 	}
 

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -72,7 +72,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 		 * To support quote characters, first they are decoded from &quot; entities, then URL encoded.
 		 */
 		if ( get_search_query() ) {
-			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query() ) ), $link );
+			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query(false) ) ), $link );
 		}
 
 		// Post Type Arg

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -72,7 +72,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 		 * To support quote characters, first they are decoded from &quot; entities, then URL encoded.
 		 */
 		if ( get_search_query() ) {
-			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query(false) ) ), $link );
+			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query( false ) ) ), $link );
 		}
 
 		// Post Type Arg

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -356,7 +356,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		 * To support quote characters, first they are decoded from &quot; entities, then URL encoded.
 		 */
 		if ( get_search_query() ) {
-			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query(false) ) ), $link );
+			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query( false ) ) ), $link );
 		}
 
 		// Post Type Arg.

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -356,7 +356,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		 * To support quote characters, first they are decoded from &quot; entities, then URL encoded.
 		 */
 		if ( get_search_query() ) {
-			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query() ) ), $link );
+			$link = add_query_arg( 's', rawurlencode( htmlspecialchars_decode( get_search_query(false) ) ), $link );
 		}
 
 		// Post Type Arg.


### PR DESCRIPTION
Applies code standards to https://github.com/woocommerce/woocommerce/pull/17792

Closes #17762