### PR TITLE
 Update wc-e2e-page-objects package to version 0.5.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "istanbul": "^1.0.0-alpha",
     "mocha": "^3.0.2",
     "stylelint": "~8.2.0",
-    "wc-e2e-page-objects": "0.4.0"
+    "wc-e2e-page-objects": "0.5.0"
   },
   "engines": {
     "node": ">=6.9.4",

--- a/tests/e2e-tests/cart-page.js
+++ b/tests/e2e-tests/cart-page.js
@@ -93,7 +93,7 @@ test.describe( 'Cart page', function() {
 		);
 	} );
 
-	test.it( 'should go to the checkout page when "Proceed to Chcekout" is clicked', () => {
+	test.it( 'should go to the checkout page when "Proceed to Checkout" is clicked', () => {
 		const cartPage = new CartPage( driver, { url: manager.getPageUrl( '/cart' ) } );
 		const checkoutPage = cartPage.checkout();
 

--- a/tests/e2e-tests/cart-page.js
+++ b/tests/e2e-tests/cart-page.js
@@ -12,7 +12,8 @@ let manager;
 let driver;
 
 test.describe( 'Cart page', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -104,7 +105,8 @@ test.describe( 'Cart page', function() {
 		);
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/checkout-page.js
+++ b/tests/e2e-tests/checkout-page.js
@@ -26,7 +26,8 @@ let manager;
 let driver;
 
 test.describe( 'Checkout Page', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -148,7 +149,8 @@ test.describe( 'Checkout Page', function() {
 		);
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/single-product.js
+++ b/tests/e2e-tests/single-product.js
@@ -16,7 +16,8 @@ let manager;
 let driver;
 
 test.describe( 'Single Product Page', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -52,7 +53,8 @@ test.describe( 'Single Product Page', function() {
 		assert.eventually.equal( cartPage.hasItem( 'Hoodie - Green' ), true );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/wp-admin/wp-admin-coupon-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-coupon-new.js
@@ -12,7 +12,8 @@ let manager;
 let driver;
 
 test.describe( 'Add New Coupon Page', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -45,7 +46,8 @@ test.describe( 'Add New Coupon Page', function() {
 		assert.eventually.ok( couponPage.hasNotice( 'Coupon updated.' ) );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/wp-admin/wp-admin-order-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-order-new.js
@@ -12,7 +12,8 @@ let manager;
 let driver;
 
 test.describe( 'Add New Order Page', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -46,7 +47,8 @@ test.describe( 'Add New Order Page', function() {
 		assert.eventually.ok( orderNotes.hasNote( 'Order status changed from Pending payment to Processing.' ) );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/wp-admin/wp-admin-product-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-product-new.js
@@ -13,7 +13,8 @@ let manager;
 let driver;
 
 test.describe( 'Add New Product Page', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -24,7 +25,8 @@ test.describe( 'Add New Product Page', function() {
 
 	this.timeout( config.get( 'mochaTimeoutMs' ) );
 
-	test.before( 'login', () => {
+	// login
+	test.before( () => {
 		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
@@ -121,7 +123,8 @@ test.describe( 'Add New Product Page', function() {
 		assert.eventually.ok( product.hasNotice( '1 product moved to the Trash.' ) );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/wp-admin/wp-admin-wc-settings-general.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-wc-settings-general.js
@@ -13,7 +13,8 @@ let manager;
 let driver;
 
 test.describe( 'WooCommerce General Settings', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -24,7 +25,8 @@ test.describe( 'WooCommerce General Settings', function() {
 
 	this.timeout( config.get( 'mochaTimeoutMs' ) );
 
-	test.before( 'login', () => {
+	// login
+	test.before( () => {
 		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
@@ -64,7 +66,8 @@ test.describe( 'WooCommerce General Settings', function() {
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/wp-admin/wp-admin-wc-settings-products-downloadable.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-wc-settings-products-downloadable.js
@@ -13,7 +13,8 @@ let manager;
 let driver;
 
 test.describe( 'WooCommerce Products > Downloadable Products Settings', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -24,7 +25,8 @@ test.describe( 'WooCommerce Products > Downloadable Products Settings', function
 
 	this.timeout( config.get( 'mochaTimeoutMs' ) );
 
-	test.before( 'login', () => {
+	// login
+	test.before( () => {
 		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
@@ -49,7 +51,8 @@ test.describe( 'WooCommerce Products > Downloadable Products Settings', function
 		assert.eventually.ok( settings.hasNotice( 'Your settings have been saved.' ) );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );

--- a/tests/e2e-tests/wp-admin/wp-admin-wc-settings-tax.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-wc-settings-tax.js
@@ -13,7 +13,8 @@ let manager;
 let driver;
 
 test.describe( 'WooCommerce Tax Settings', function() {
-	test.before( 'open browser', function() {
+	// open browser
+	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
 
 		manager = new WebDriverManager( 'chrome', { baseUrl: config.get( 'url' ) } );
@@ -24,7 +25,8 @@ test.describe( 'WooCommerce Tax Settings', function() {
 
 	this.timeout( config.get( 'mochaTimeoutMs' ) );
 
-	test.before( 'login', () => {
+	// login
+	test.before( () => {
 		const wpLogin = new WPLogin( driver, { url: manager.getPageUrl( '/wp-login.php' ) } );
 		wpLogin.login( config.get( 'users.admin.username' ), config.get( 'users.admin.password' ) );
 	} );
@@ -93,7 +95,8 @@ test.describe( 'WooCommerce Tax Settings', function() {
 		assert.eventually.ifError( settings.hasSubTab( 'Fancy rates' ) );
 	} );
 
-	test.after( 'quit browser', () => {
+	// quit browser
+	test.after( () => {
 		manager.quitBrowser();
 	} );
 } );


### PR DESCRIPTION
This PR updates `wc-e2e-page-objects` package to version 0.5.0 to be able to run WC core e2e tests using Chrome headless.

`wc-e2e-page-objects` version 0.5.0 uses a newer version of `selenium-webdriver` that changed the signature of the methods `before()` and `after()`, so it was necessary to update our tests to reflect this change.