### PR TITLE
Add option to disable rounding when adding precision

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -349,8 +349,8 @@ final class WC_Cart_Totals {
 			$shipping_line->tax_class = get_option( 'woocommerce_shipping_tax_class' );
 			$shipping_line->taxable   = true;
 			$shipping_line->total     = wc_add_number_precision_deep( $shipping_object->cost );
-			$shipping_line->taxes     = wc_add_number_precision_deep( $shipping_object->taxes );
-			$shipping_line->total_tax = wc_add_number_precision_deep( array_sum( $shipping_object->taxes ) );
+			$shipping_line->taxes     = wc_add_number_precision_deep( $shipping_object->taxes, false );
+			$shipping_line->total_tax = wc_add_number_precision_deep( array_sum( $shipping_object->taxes ), false );
 
 			if ( ! $this->round_at_subtotal() ) {
 				$shipping_line->total_tax = wc_round_tax_total( $shipping_line->total_tax, wc_get_rounding_precision() );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1495,11 +1495,13 @@ function wc_get_rounding_precision() {
  *
  * @since  3.2.0
  * @param  float $value Number to add precision to.
- * @return int
+ * @param  bool $round Should we round after adding precision?
+ * @return int|float
  */
-function wc_add_number_precision( $value ) {
+function wc_add_number_precision( $value, $round = false ) {
 	$precision = pow( 10, wc_get_price_decimals() );
-	return intval( round( $value * $precision ) );
+	$value     = $value * $precision;
+	return $round ? intval( round( $value ) ) : $value;
 }
 
 /**
@@ -1519,15 +1521,16 @@ function wc_remove_number_precision( $value ) {
  *
  * @since  3.2.0
  * @param  array $value Number to add precision to.
+ * @param  bool $round Should we round after adding precision?
  * @return int
  */
-function wc_add_number_precision_deep( $value ) {
+function wc_add_number_precision_deep( $value, $round = false ) {
 	if ( is_array( $value ) ) {
 		foreach ( $value as $key => $subvalue ) {
-			$value[ $key ] = wc_add_number_precision_deep( $subvalue );
+			$value[ $key ] = wc_add_number_precision_deep( $subvalue, $round );
 		}
 	} else {
-		$value = wc_add_number_precision( $value );
+		$value = wc_add_number_precision( $value, $round );
 	}
 	return $value;
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1498,7 +1498,7 @@ function wc_get_rounding_precision() {
  * @param  bool $round Should we round after adding precision?
  * @return int|float
  */
-function wc_add_number_precision( $value, $round = false ) {
+function wc_add_number_precision( $value, $round = true ) {
 	$precision = pow( 10, wc_get_price_decimals() );
 	$value     = $value * $precision;
 	return $round ? intval( round( $value ) ) : $value;
@@ -1524,7 +1524,7 @@ function wc_remove_number_precision( $value ) {
  * @param  bool $round Should we round after adding precision?
  * @return int
  */
-function wc_add_number_precision_deep( $value, $round = false ) {
+function wc_add_number_precision_deep( $value, $round = true ) {
 	if ( is_array( $value ) ) {
 		foreach ( $value as $key => $subvalue ) {
 			$value[ $key ] = wc_add_number_precision_deep( $subvalue, $round );


### PR DESCRIPTION
Taxes have some extra options around rounding, which converting to ints breaks.

This adds an option to disable rounding when adding precision and applies it to taxes only. 

Other line item taxes are not affected because the values are calculated (as floats) within the cart totals class. Shipping taxes were imported.

Fixes #17779