### PR TITLE
Exclude virtual tax classes from calcluation for shipping taxes

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1518,7 +1518,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return bool
 	 */
 	public function is_shipping_taxable() {
-		return $this->get_tax_status() === 'taxable' || $this->get_tax_status() === 'shipping';
+		return $this->needs_shipping() && ( $this->get_tax_status() === 'taxable' || $this->get_tax_status() === 'shipping' );
 	}
 
 	/**

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -968,6 +968,23 @@ class WC_Cart extends WC_Legacy_Cart {
 	}
 
 	/**
+	 * Get all tax classes for shipping based on the items in the cart.
+	 *
+	 * @return array
+	 */
+	public function get_cart_item_tax_classes_for_shipping() {
+		$found_tax_classes = array();
+
+		foreach ( WC()->cart->get_cart() as $item ) {
+			if ( $item['data'] && ( $item['data']->is_shipping_taxable() ) ) {
+				$found_tax_classes[] = $item['data']->get_tax_class();
+			}
+		}
+
+		return array_unique( $found_tax_classes );
+	}
+
+	/**
 	 * Determines the value that the customer spent and the subtotal
 	 * displayed, used for things like coupon validation.
 	 *

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -579,7 +579,7 @@ class WC_Tax {
 			} elseif ( WC()->cart->get_cart() ) {
 
 				// This will be per order shipping - loop through the order and find the highest tax class rate
-				$cart_tax_classes = WC()->cart->get_cart_item_tax_classes();
+				$cart_tax_classes = WC()->cart->get_cart_item_tax_classes_for_shipping();
 
 				// No tax classes = no taxable items.
 				if ( empty( $cart_tax_classes ) ) {


### PR DESCRIPTION
This is a fairly complex one, but I'll try to keep it simple. 

The scenario is as follows:
- Shipping tax class: `based on items`
- Tax rates:
    - standard: 10%
    - reduced 5%
- Products:
    - A, simple product: reduced taxable (5%)
    - B, virtual: standard taxable (10%)

Case 1) When either A or B is in the cart its fine, taxes are good.

Case 2) When A *and* B are in the cart, it will take the standard taxes of 10% for shipping, but since its a virtual product it probably shouldn't count towards the tax calculation.

I'm not 100% positive this should be implemented. My common sense says that virtual items shouldn't be counted towards the shipping tax classes, but there's also the question of how it should be with different governments etc. (are there any governments with rules that state 'shipping taxes should be based on highest order item tax percentage'?)

Hope I'm making sense!