### PR TITLE
When custom attributes are created, they are decoded. Make the values match.

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -284,12 +284,18 @@ class WC_Meta_Box_Product_Data {
 					$attribute_key = sanitize_title( $attribute->get_name() );
 
 					if ( ! is_null( $index ) ) {
-						$value = isset( $_POST[ $key_prefix . $attribute_key ][ $index ] ) ? stripslashes( $_POST[ $key_prefix . $attribute_key ][ $index ] ) : '';
+						$value = isset( $_POST[ $key_prefix . $attribute_key ][ $index ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ][ $index ] ) : '';
 					} else {
-						$value = isset( $_POST[ $key_prefix . $attribute_key ] ) ? stripslashes( $_POST[ $key_prefix . $attribute_key ] ) : '';
+						$value = isset( $_POST[ $key_prefix . $attribute_key ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ] ) : '';
 					}
 
-					$value                        = $attribute->is_taxonomy() ? sanitize_title( $value ) : wc_clean( $value ); // Don't use wc_clean as it destroys sanitized characters in terms.
+					if ( $attribute->is_taxonomy() ) {
+						// Don't use wc_clean as it destroys sanitized characters.
+						$value = sanitize_title( $value );
+					} else {
+						$value = html_entity_decode( wc_clean( $value ), ENT_QUOTES, get_bloginfo( 'charset' ) ); // WPCS: sanitization ok.
+					}
+
 					$attributes[ $attribute_key ] = $value;
 				}
 			}

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -887,7 +887,7 @@ class WC_Form_Handler {
 						// Don't use wc_clean as it destroys sanitized characters.
 						$value = sanitize_title( wp_unslash( $_REQUEST[ $taxonomy ] ) );
 					} else {
-						$value = wc_clean( wp_unslash( $_REQUEST[ $taxonomy ] ) ); // WPCS: sanitization ok.
+						$value = html_entity_decode( wc_clean( wp_unslash( $_REQUEST[ $taxonomy ] ) ), ENT_QUOTES, get_bloginfo( 'charset' ) ); // WPCS: sanitization ok.
 					}
 
 					// Allow if valid or show error.

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -258,7 +258,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			$meta->value   = rawurldecode( (string) $meta->value );
 			$attribute_key = str_replace( 'attribute_', '', $meta->key );
 			$display_key   = wc_attribute_label( $attribute_key, $product );
-			$display_value = $meta->value;
+			$display_value = sanitize_text_field( $meta->value );
 
 			if ( taxonomy_exists( $attribute_key ) ) {
 				$term = get_term_by( 'slug', $meta->value, $attribute_key );

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -332,8 +332,6 @@ function wc_attributes_array_filter_variation( $attribute ) {
  * @return bool
  */
 function wc_is_attribute_in_product_name( $attribute, $name ) {
-	$attribute  = html_entity_decode( $attribute, ENT_QUOTES, get_bloginfo( 'charset' ) );
-	$name       = html_entity_decode( $name, ENT_QUOTES, get_bloginfo( 'charset' ) );
 	$is_in_name = stristr( $name, ' ' . $attribute . ',' ) || 0 === stripos( strrev( $name ), strrev( ' ' . $attribute ) );
 	return apply_filters( 'woocommerce_is_attribute_in_product_name', $is_in_name, $attribute, $name );
 }

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -332,6 +332,8 @@ function wc_attributes_array_filter_variation( $attribute ) {
  * @return bool
  */
 function wc_is_attribute_in_product_name( $attribute, $name ) {
+	$attribute  = html_entity_decode( $attribute, ENT_QUOTES, get_bloginfo( 'charset' ) );
+	$name       = html_entity_decode( $name, ENT_QUOTES, get_bloginfo( 'charset' ) );
 	$is_in_name = stristr( $name, ' ' . $attribute . ',' ) || 0 === stripos( strrev( $name ), strrev( ' ' . $attribute ) );
 	return apply_filters( 'woocommerce_is_attribute_in_product_name', $is_in_name, $attribute, $name );
 }


### PR DESCRIPTION
When we create/link variations, the entities are decoded.

When the variation form is posted, the entities are encoded (esc_attr).
This decodes them so they match correctly. 

Fixes #17820