### PR TITLE
[REST API] Allow string to be null in order to keep backwards compatibility

### DIFF
--- a/includes/api/class-wc-rest-coupons-controller.php
+++ b/includes/api/class-wc-rest-coupons-controller.php
@@ -491,6 +491,10 @@ class WC_REST_Coupons_Controller extends WC_REST_Legacy_Coupons_Controller {
 					'description' => __( 'Meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -338,6 +338,10 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V1_Controller {
 					'description' => __( 'Meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -385,6 +385,10 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 					'description' => __( 'Meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -411,6 +415,10 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Orders_Controller {
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -597,8 +597,9 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 	protected function maybe_set_item_meta_data( $item, $posted ) {
 		if ( ! empty( $posted['meta_data'] ) && is_array( $posted['meta_data'] ) ) {
 			foreach ( $posted['meta_data'] as $meta ) {
-				if ( isset( $meta['key'], $meta['value'] ) ) {
-					$item->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+				if ( isset( $meta['key'] ) ) {
+					$value = isset( $meta['value'] ) ? $meta['value'] : null;
+					$item->update_meta_data( $meta['key'], $value, isset( $meta['id'] ) ? $meta['id'] : '' );
 				}
 			}
 		}

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1102,6 +1102,10 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					'description' => __( 'Meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1128,6 +1132,10 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1334,6 +1342,10 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					'description' => __( 'Shipping lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1420,6 +1432,10 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					'description' => __( 'Fee lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1518,6 +1534,10 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					'description' => __( 'Coupons line data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -929,6 +929,10 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 					'description' => __( 'Meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1975,6 +1975,10 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 					'description' => __( 'Meta data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/v1/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/v1/class-wc-rest-order-refunds-controller.php
@@ -367,6 +367,10 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -1200,6 +1200,10 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Line items data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1386,6 +1390,10 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Shipping lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1446,6 +1454,10 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Fee lines data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -1517,6 +1529,10 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 					'description' => __( 'Coupons line data.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wc_rest_sanitize_request_arg_backwards_compatibility',
+						'validate_callback' => 'wc_rest_validate_request_arg_backwards_compatibility',
+					),
 					'items'       => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/includes/wc-rest-functions.php
+++ b/includes/wc-rest-functions.php
@@ -445,12 +445,12 @@ function wc_rest_sanitize_request_arg_backwards_compatibility( $value, $request,
  *
  * @param mixed $value The value to sanitize.
  * @param array $args  Schema array to use for sanitization.
- * @return true|WP_Error
+ * @return mixed
  */
 function wc_rest_sanitize_value_from_schema_backwards_compatibility( $value, $args ) {
 	if ( 'string' === $args['type'] ) {
 		if ( is_null( $value ) ) {
-			return true;
+			return null;
 		}
 
 		return strval( $value );

--- a/includes/wc-rest-functions.php
+++ b/includes/wc-rest-functions.php
@@ -320,3 +320,141 @@ function wc_rest_check_manager_permissions( $object, $context = 'read' ) {
 
 	return apply_filters( 'woocommerce_rest_check_permissions', $permission, $context, 0, $object );
 }
+
+/**
+ * Validate a request argument based on details registered to the route.
+ * Function to keep backwards compatibility in our REST API v1 and v2 in WP 4.9+.
+ * This function is for internal use only, and should be removed in a future version.
+ *
+ * @since 3.2.5
+ *
+ * @param  mixed            $value   value.
+ * @param  WP_REST_Request  $request Request instance.
+ * @param  string           $param   Parameter.
+ * @return WP_Error|bool
+ */
+function wc_rest_validate_request_arg_backwards_compatibility( $value, $request, $param ) {
+	$attributes = $request->get_attributes();
+
+	if ( ! isset( $attributes['args'][ $param ] ) || ! is_array( $attributes['args'][ $param ] ) ) {
+		return true;
+	}
+
+	$args = $attributes['args'][ $param ];
+
+	return wc_rest_validate_value_from_schema_backwards_compatibility( $value, $args, $param );
+}
+
+/**
+ * Validate a value based on a schema.
+ * Function to keep backwards compatibility in our REST API v1 and v2 in WP 4.9+.
+ * This function is for internal use only, and should be removed in a future version.
+ *
+ * @since 3.2.5
+ *
+ * @param mixed  $value The value to validate.
+ * @param array  $args  Schema array to use for validation.
+ * @param string $param The parameter name, used in error messages.
+ * @return true|WP_Error
+ */
+function wc_rest_validate_value_from_schema_backwards_compatibility( $value, $args, $param = '' ) {
+	$is_valid = false;
+
+	if ( 'array' === $args['type'] ) {
+		if ( ! is_array( $value ) ) {
+			$value = preg_split( '/[\s,]+/', $value );
+		}
+		if ( ! wp_is_numeric_array( $value ) ) {
+			/* translators: 1: parameter, 2: type name */
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.' ), $param, 'array' ) );
+		}
+		foreach ( $value as $index => $v ) {
+			$is_valid = wc_rest_validate_value_from_schema_backwards_compatibility( $v, $args['items'], $param . '[' . $index . ']' );
+			if ( is_wp_error( $is_valid ) ) {
+				return $is_valid;
+			}
+		}
+	}
+
+	if ( 'object' === $args['type'] ) {
+		if ( $value instanceof stdClass ) {
+			$value = (array) $value;
+		}
+		if ( ! is_array( $value ) ) {
+			/* translators: 1: parameter, 2: type name */
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.' ), $param, 'object' ) );
+		}
+
+		foreach ( $value as $property => $v ) {
+			if ( isset( $args['properties'][ $property ] ) ) {
+				$is_valid = wc_rest_validate_value_from_schema_backwards_compatibility( $v, $args['properties'][ $property ], $param . '[' . $property . ']' );
+				if ( is_wp_error( $is_valid ) ) {
+					return $is_valid;
+				}
+			} elseif ( isset( $args['additionalProperties'] ) && false === $args['additionalProperties'] ) {
+				return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not a valid property of Object.' ), $property ) );
+			}
+		}
+	}
+
+	// Allow null to keep backwards compatibility.
+	if ( 'string' === $args['type'] ) {
+		if ( is_string( $value ) || is_null( $value ) ) {
+			return true;
+		}
+
+		/* translators: 1: parameter, 2: type name */
+		return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.' ), $param, 'string' ) );
+	}
+
+	if ( ! $is_valid ) {
+		return rest_validate_value_from_schema( $value, $args, $param );
+	}
+
+	return $is_valid;
+}
+
+/**
+ * Sanitize a request argument based on details registered to the route.
+ * Function to keep backwards compatibility in our REST API v1 and v2 in WP 4.9+.
+ * This function is for internal use only, and should be removed in a future version.
+ *
+ * @since 3.2.5
+ *
+ * @param  mixed            $value   value.
+ * @param  WP_REST_Request  $request Request instance.
+ * @param  string           $param   Parameter.
+ * @return mixed
+ */
+function wc_rest_sanitize_request_arg_backwards_compatibility( $value, $request, $param ) {
+	$attributes = $request->get_attributes();
+	if ( ! isset( $attributes['args'][ $param ] ) || ! is_array( $attributes['args'][ $param ] ) ) {
+		return $value;
+	}
+	$args = $attributes['args'][ $param ];
+
+	return wc_rest_sanitize_value_from_schema_backwards_compatibility( $value, $args );
+}
+
+/**
+ * Sanitize a value based on a schema.
+ * Function to keep backwards compatibility in our REST API v1 and v2 in WP 4.9+.
+ * This function is for internal use only, and should be removed in a future version.
+ *
+ * @since 3.2.5
+ *
+ * @param mixed $value The value to sanitize.
+ * @param array $args  Schema array to use for sanitization.
+ * @return true|WP_Error
+ */
+function wc_rest_sanitize_value_from_schema_backwards_compatibility( $value, $args ) {
+	if ( 'string' === $args['type'] ) {
+		if ( is_null( $value ) ) {
+			return true;
+		}
+
+		return strval( $value );
+	}
+
+	return rest_sanitize_value_from_schema( $value, $args );
+}

--- a/includes/wc-rest-functions.php
+++ b/includes/wc-rest-functions.php
@@ -366,7 +366,7 @@ function wc_rest_validate_value_from_schema_backwards_compatibility( $value, $ar
 		}
 		if ( ! wp_is_numeric_array( $value ) ) {
 			/* translators: 1: parameter, 2: type name */
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.' ), $param, 'array' ) );
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.', 'woocommerce' ), $param, 'array' ) );
 		}
 		foreach ( $value as $index => $v ) {
 			$is_valid = wc_rest_validate_value_from_schema_backwards_compatibility( $v, $args['items'], $param . '[' . $index . ']' );
@@ -382,7 +382,7 @@ function wc_rest_validate_value_from_schema_backwards_compatibility( $value, $ar
 		}
 		if ( ! is_array( $value ) ) {
 			/* translators: 1: parameter, 2: type name */
-			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.' ), $param, 'object' ) );
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.', 'woocommerce' ), $param, 'object' ) );
 		}
 
 		foreach ( $value as $property => $v ) {
@@ -392,7 +392,7 @@ function wc_rest_validate_value_from_schema_backwards_compatibility( $value, $ar
 					return $is_valid;
 				}
 			} elseif ( isset( $args['additionalProperties'] ) && false === $args['additionalProperties'] ) {
-				return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not a valid property of Object.' ), $property ) );
+				return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not a valid property of Object.', 'woocommerce' ), $property ) );
 			}
 		}
 	}
@@ -404,7 +404,7 @@ function wc_rest_validate_value_from_schema_backwards_compatibility( $value, $ar
 		}
 
 		/* translators: 1: parameter, 2: type name */
-		return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.' ), $param, 'string' ) );
+		return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s is not of type %2$s.', 'woocommerce' ), $param, 'string' ) );
 	}
 
 	if ( ! $is_valid ) {

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -16,15 +16,15 @@ class WC_Helper_Order {
 
 		$order = wc_get_order( $order_id );
 
-		// Delete all products in the order
-		foreach ( $order->get_items() as $item ) :
+		// Delete all products in the order.
+		foreach ( $order->get_items() as $item ) {
 			WC_Helper_Product::delete_product( $item['product_id'] );
-		endforeach;
+		}
 
 		WC_Helper_Shipping::delete_simple_flat_rate();
 
-		// Delete the order post
-		wp_delete_post( $order_id, true );
+		// Delete the order post.
+		$order->delete( true );
 	}
 
 	/**

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -267,12 +267,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Tests updating an order.
+	 *
 	 * @since 3.0.0
 	 */
 	public function test_update_order() {
 		wp_set_current_user( $this->user );
-		$order = WC_Helper_Order::create_order();
-		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/' . $order->get_id() );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(
 			'payment_method' => 'test-update',
 			'billing' => array(
@@ -288,17 +289,56 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'Fish', $data['billing']['first_name'] );
 		$this->assertEquals( 'Face', $data['billing']['last_name'] );
 
-		wp_delete_post( $order->get_id(), true );
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Tests updating an order and removing items.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_update_order_remove_items() {
+		wp_set_current_user( $this->user );
+		$order   = WC_Helper_Order::create_order();
+		$fee     = new WC_Order_Item_Fee();
+		$fee->set_props( array(
+			'name'       => 'Some Fee',
+			'tax_status' => 'taxable',
+			'total'      => '100',
+			'tax_class'  => '',
+		) );
+		$order->add_item( $fee );
+		$order->save();
+
+		$request  = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
+		$fee_data = current( $order->get_items( 'fee' ) );
+
+		$request->set_body_params( array(
+			'fee_lines' => array(
+				array(
+					'id'   => $fee_data->get_id(),
+					'name' => null,
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( empty( $data['fee_lines'] ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
 	 * Tests updating an order without the correct permissions.
+	 *
 	 * @since 3.0.0
 	 */
 	public function test_update_order_without_permission() {
 		wp_set_current_user( 0 );
-		$order = WC_Helper_Order::create_order();
-		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/' . $order->get_id() );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(
 			'payment_method' => 'test-update',
 			'billing' => array(
@@ -308,6 +348,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		) );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
+		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
Not nice, however it's a way to keep backwards compatibility.
We need to improve it on v3, maybe include a new param or even an endpoint to remove this things.

Closes #17818