### PR TITLE
PHPCS custom settings to support minimum WP version and text domain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "*",
-    "wp-coding-standards/wpcs": "0.13.1",
+    "wp-coding-standards/wpcs": "^0.14",
     "phpunit/phpunit": "6.2.3",
     "woocommerce/woocommerce-git-hooks": "1.0.3",
     "wimg/php-compatibility": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a9c7e81cc3a30935c03b1b2d64c201c",
+    "content-hash": "f8dbe5807f695e87ad3453a8b629b6bf",
     "packages": [
         {
             "name": "composer/installers",
@@ -1783,16 +1783,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.13.1",
+            "version": "0.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc"
+                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
-                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/8cadf48fa1c70b2381988e0a79e029e011a8f41c",
+                "reference": "8cadf48fa1c70b2381988e0a79e029e011a8f41c",
                 "shasum": ""
             },
             "require": {
@@ -1800,7 +1800,7 @@
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1819,7 +1819,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2017-08-05T16:08:58+00:00"
+            "time": "2017-11-01T15:10:46+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -11,7 +11,14 @@
 	<exclude-pattern>includes/gateways/simplify-commerce/includes/</exclude-pattern>
 	<exclude-pattern>includes/libraries/</exclude-pattern>
 	<exclude-pattern>includes/api/legacy/</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<!-- Configs -->
+	<config name="minimum_supported_wp_version" value="4.5" />
+	<config name="testVersion" value="5.2-"/>
+
+	<!-- Rueles -->
 	<rule ref="PHPCompatibility"/>
 
 	<rule ref="WordPress">
@@ -28,5 +35,11 @@
 		<properties>
 			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip" />
 		</properties>
-</rule>
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="woocommerce" />
+		</properties>
+	</rule>
 </ruleset>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -18,14 +18,13 @@
 	<config name="minimum_supported_wp_version" value="4.5" />
 	<config name="testVersion" value="5.2-"/>
 
-	<!-- Rueles -->
+	<!-- Rules -->
 	<rule ref="PHPCompatibility"/>
 
 	<rule ref="WordPress">
 		<exclude name="WordPress.VIP.RestrictedFunctions" />
 		<exclude name="WordPress.VIP.OrderByRand" />
 	</rule>
-
 	<rule ref="WordPress.VIP.ValidatedSanitizedInput">
 		<properties>
 			<property name="customSanitizingFunctions" type="array" value="wc_clean,wc_sanitize_tooltip,wc_format_decimal,wc_stock_amount" />
@@ -36,7 +35,6 @@
 			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip" />
 		</properties>
 	</rule>
-
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="woocommerce" />


### PR DESCRIPTION
Also makes sure that `PHPCompatibility` is looking for PHP 5.2+