### PR TITLE
Prevent Travis builds duplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,10 @@ script:
 
 after_script:
   - bash tests/bin/travis.sh after
+
+# Specifies that Travis should create builds for master and release branches and also tags.
+branches:
+  only:
+    - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^release\//


### PR DESCRIPTION
This commit changes Travis configuration file to specify a list of branches that it should build. This way Travis will only create a new build when a commit is pushed to the master branch and release branches and when tags are created. The behavior for PRs is not modified, and PR creation and updates will still trigger builds.

Doing this to speed up Travis build by preventing it from running two builds for PR that are created from a branch of the same repository. Before this change, Travis would create a build when the branch is pushed to GitHub (continuous-integration/travis-ci/push) and another one when the PR is created (continuous-integration/travis-ci/pr). As an example, see https://github.com/woocommerce/woocommerce/pull/17680.