### PR TITLE
Fixed how to delete meta data on REST API v2

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -597,8 +597,9 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 	protected function maybe_set_item_meta_data( $item, $posted ) {
 		if ( ! empty( $posted['meta_data'] ) && is_array( $posted['meta_data'] ) ) {
 			foreach ( $posted['meta_data'] as $meta ) {
-				if ( isset( $meta['key'], $meta['value'] ) ) {
-					$item->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+				if ( isset( $meta['key'] ) ) {
+					$value = isset( $meta['value'] ) ? $meta['value'] : null;
+					$item->update_meta_data( $meta['key'], $value, isset( $meta['id'] ) ? $meta['id'] : '' );
 				}
 			}
 		}

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -16,15 +16,15 @@ class WC_Helper_Order {
 
 		$order = wc_get_order( $order_id );
 
-		// Delete all products in the order
-		foreach ( $order->get_items() as $item ) :
+		// Delete all products in the order.
+		foreach ( $order->get_items() as $item ) {
 			WC_Helper_Product::delete_product( $item['product_id'] );
-		endforeach;
+		}
 
 		WC_Helper_Shipping::delete_simple_flat_rate();
 
-		// Delete the order post
-		wp_delete_post( $order_id, true );
+		// Delete the order post.
+		$order->delete( true );
 	}
 
 	/**

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -267,12 +267,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Tests updating an order.
+	 *
 	 * @since 3.0.0
 	 */
 	public function test_update_order() {
 		wp_set_current_user( $this->user );
-		$order = WC_Helper_Order::create_order();
-		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/' . $order->get_id() );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(
 			'payment_method' => 'test-update',
 			'billing' => array(
@@ -288,17 +289,56 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'Fish', $data['billing']['first_name'] );
 		$this->assertEquals( 'Face', $data['billing']['last_name'] );
 
-		wp_delete_post( $order->get_id(), true );
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Tests updating an order and removing items.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_update_order_remove_items() {
+		wp_set_current_user( $this->user );
+		$order   = WC_Helper_Order::create_order();
+		$fee     = new WC_Order_Item_Fee();
+		$fee->set_props( array(
+			'name'       => 'Some Fee',
+			'tax_status' => 'taxable',
+			'total'      => '100',
+			'tax_class'  => '',
+		) );
+		$order->add_item( $fee );
+		$order->save();
+
+		$request  = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
+		$fee_data = current( $order->get_items( 'fee' ) );
+
+		$request->set_body_params( array(
+			'fee_lines' => array(
+				array(
+					'id'   => $fee_data->get_id(),
+					'name' => null,
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( empty( $data['fee_lines'] ) );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
 	 * Tests updating an order without the correct permissions.
+	 *
 	 * @since 3.0.0
 	 */
 	public function test_update_order_without_permission() {
 		wp_set_current_user( 0 );
-		$order = WC_Helper_Order::create_order();
-		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/' . $order->get_id() );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(
 			'payment_method' => 'test-update',
 			'billing' => array(
@@ -308,6 +348,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		) );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
+		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
Unit tests will fail as intended.
Need to change schema to `mixed` first, but coming in another PR.