### PR TITLE
Don't run PHPCS on the code coverage Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 php:
   - 5.6
   - 7.0
-  - 7.1
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -21,13 +20,14 @@ matrix:
   - php: 5.2
     dist: precise
   - php: 7.1
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1
+  - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   allow_failures:
   - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - if [[ $TRAVIS_PHP_VERSION == '7.1' ]]; then composer install; fi
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/travis.sh before
 

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ $TRAVIS_PHP_VERSION == '7.1' ]]; then
+if [[ ${RUN_PHPCS} == 1 ]]; then
 	CHANGED_FILES=`git diff --name-only --diff-filter=ACMR $TRAVIS_COMMIT_RANGE | grep \\\\.php | awk '{print}' ORS=' '`
 	IGNORE="tests/cli/,apigen/,includes/gateways/simplify-commerce/includes/,includes/libraries/,includes/api/legacy/"
 

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -15,6 +15,10 @@ if [ $1 == 'before' ]; then
 		composer global require "phpunit/phpunit=6.2.*"
 	fi
 
+	if [[ ${RUN_PHPCS} == 1 ]]; then
+		composer install
+	fi
+
 	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
 	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
 	if [[ ${RUN_CODE_COVERAGE} != 1 ]]; then


### PR DESCRIPTION
PR #17680 added a new PHP 7.1 Travis build job to generate code coverage report. PHPCS was configured to run on all PHP 7.1 build jobs. So this means that after #17680 was merged, Travis started running PHPCS twice.

This commit fixes this issue by setting a new environment variable called `$RUN_PHPCS` and using this variable, instead of the PHP version, to decide when to run PHPCS.

Marking this PR as "In Progress" while I wait for the Travis build to finish to make sure that it works.