### PR TITLE
Excludes for PHPUnit to try and speed things up

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -38,9 +38,11 @@
 				<directory suffix=".php">./includes/updates</directory>
 				<directory suffix=".php">./includes/vendor</directory>
 				<directory suffix=".php">./includes/widgets</directory>
+				<directory>./vendor</directory>
 				<file>./includes/wc-deprecated-functions.php</file>
 				<file>./includes/wc-template-hooks.php</file>
 				<file>./includes/wc-widget-functions.php</file>
+				<file>./tests/bootstrap.php</file>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
This PR adds exclude rules for the vendor folder as well as the bootstrap file to the PHPUnit config, PHPUnit will by default try and run all files included unless specifically whitelisted, since the vendor folder and bootstrap file is part of the tests the coverage will run on those as well.