### PR TITLE
Add precision after multiplying quantity

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -227,7 +227,7 @@ final class WC_Cart_Totals {
 			$item->taxable                 = 'taxable' === $cart_item['data']->get_tax_status();
 			$item->price_includes_tax      = wc_prices_include_tax();
 			$item->quantity                = $cart_item['quantity'];
-			$item->price                   = wc_add_number_precision_deep( $cart_item['data']->get_price() ) * $cart_item['quantity'];
+			$item->price                   = wc_add_number_precision_deep( $cart_item['data']->get_price() * $cart_item['quantity'] );
 			$item->product                 = $cart_item['data'];
 			$item->tax_rates               = $this->get_item_tax_rates( $item );
 			$this->items[ $cart_item_key ] = $item;


### PR DESCRIPTION
Closes #17860

Has no effect on core it seems because we only store prices to the DP
setting. This would be to correct precision added by plugins.