### PR TITLE
Ensure refund is deleted when exception is thrown during wc_create_refund()

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1735,9 +1735,6 @@ class WC_AJAX {
 			wp_send_json_success( $response_data );
 
 		} catch ( Exception $e ) {
-			if ( $refund && is_a( $refund, 'WC_Order_Refund' ) ) {
-				wp_delete_post( $refund->get_id(), true );
-			}
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -587,6 +587,9 @@ function wc_create_refund( $args = array() ) {
 		do_action( 'woocommerce_order_refunded', $order->get_id(), $refund->get_id() );
 
 	} catch ( Exception $e ) {
+		if ( isset( $refund ) && is_a( $refund, 'WC_Order_Refund' ) ) {
+			wp_delete_post( $refund->get_id(), true );
+		}
 		return new WP_Error( 'error', $e->getMessage() );
 	}
 

--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -82,6 +82,21 @@ class WC_Unit_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Throws an exception with an optional message and code.
+	 *
+	 * Note: can't use `throwException` as that's reserved.
+	 *
+	 * @since 3.3-dev
+	 * @param string $message
+	 * @param int    $code
+	 * @throws \Exception
+	 */
+	public function throwAnException( $message = null, $code = null ) {
+		$message = $message ? $message : "We're all doomed!";
+		throw new Exception( $message, $code );
+	}
+
+	/**
 	 * Backport assertNotFalse to PHPUnit 3.6.12 which only runs in PHP 5.2.
 	 *
 	 * @since  2.2

--- a/tests/unit-tests/order/crud.php
+++ b/tests/unit-tests/order/crud.php
@@ -1657,6 +1657,21 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that if an exception is thrown when creating a refund, the refund is deleted from database.
+	 */
+	function test_refund_exception() {
+		$order = WC_Helper_Order::create_order();
+		add_action( 'woocommerce_create_refund', array( $this, 'throwAnException' ) );
+		$refund = wc_create_refund( array(
+			'order_id'   => $order->get_id(),
+			'amount'     => $order->get_total(),
+			'line_items' => array(),
+		) );
+		remove_action( 'woocommerce_create_refund', array( $this, 'throwAnException' ) );
+		$this->assertEmpty( $order->get_refunds() );
+	}
+
+	/**
 	 * Test apply_coupon and remove_coupon with a fixed discount coupon.
 	 * @since 3.2.0
 	 */


### PR DESCRIPTION
Address an issue where a plugin hooks into `woocommerce_create_refund` and throws an exception, the refund is still created and stored in database. This is unexpected, as nothing else beyond the action hook gets executed (such as `woocommerce_refund_created` hook, etc).

The reason this happens is that `$refund->update_taxes()` (and `calculate_totals()`) call `$this->save()`, persisting the refund to the database. It looks like this [should be handled here by deleting the refund](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-ajax.php#L1738-L1740), but the problem is that `$refund` [will always be an instance of `WP_Error`](https://github.com/woocommerce/woocommerce/blob/master/includes/wc-order-functions.php#L590) when an Exception is thrown, so the refund never gets deleted.

Simply moving the deletion to `wc_create_refund()` will do the trick. An alternative approach would be to introduce a `$persist` flag to `update_taxes()` and other methods that call `save()` internally, so it's possible to perform calculations without persisting the order/refund to the database.