### PR TITLE
Properly handle deprecated hooks

### DIFF
--- a/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -81,7 +81,7 @@ abstract class WC_Deprecated_Hooks {
 	 * @param string $new_hook
 	 */
 	protected function display_notice( $old_hook, $new_hook ) {
-		wc_deprecated_function( sprintf( 'The "%s" hook uses out of date data structures and', esc_html( $old_hook ) ), WC_VERSION, esc_html( $new_hook ) );
+		wc_deprecated_hook( esc_html( $old_hook ), WC_VERSION, esc_html( $new_hook ) );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -26,6 +26,13 @@ abstract class WC_Deprecated_Hooks {
 	protected $deprecated_hooks = array();
 
 	/**
+	 * Array of versions on each hook has been deprecated.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_version = array();
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -43,7 +50,7 @@ abstract class WC_Deprecated_Hooks {
 	/**
 	 * Get old hooks to map to new hook.
 	 *
-	 * @param  string $new_hook New hook.
+	 * @param  string $new_hook New hook name.
 	 * @return array
 	 */
 	public function get_old_hooks( $new_hook ) {
@@ -72,13 +79,23 @@ abstract class WC_Deprecated_Hooks {
 	/**
 	 * If the old hook is in-use, trigger it.
 	 *
-	 * @param  string $new_hook          New hook.
-	 * @param  string $old_hook          Old hook.
+	 * @param  string $new_hook          New hook name.
+	 * @param  string $old_hook          Old hook name.
 	 * @param  array  $new_callback_args New callback args.
 	 * @param  mixed  $return_value      Returned value.
 	 * @return mixed
 	 */
 	abstract public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
+
+	/**
+	 * Get deprecated version.
+	 *
+	 * @param string $old_hook Old hook name.
+	 * @return string
+	 */
+	protected function get_deprecated_version( $old_hook ) {
+		return ! empty( $this->deprecated_version[ $old_hook ] ) ? $this->deprecated_version[ $old_hook ] : WC_VERSION;
+	}
 
 	/**
 	 * Display a deprecated notice for old hooks.
@@ -87,13 +104,13 @@ abstract class WC_Deprecated_Hooks {
 	 * @param string $new_hook New hook.
 	 */
 	protected function display_notice( $old_hook, $new_hook ) {
-		wc_deprecated_hook( esc_html( $old_hook ), WC_VERSION, esc_html( $new_hook ) );
+		wc_deprecated_hook( esc_html( $old_hook ), esc_html( $this->get_deprecated_version( $old_hook ) ), esc_html( $new_hook ) );
 	}
 
 	/**
 	 * Fire off a legacy hook with it's args.
 	 *
-	 * @param  string $old_hook          Old hook.
+	 * @param  string $old_hook          Old hook name.
 	 * @param  array  $new_callback_args New callback args.
 	 * @return mixed
 	 */

--- a/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Abstract deprecated hooks
+ *
+ * @package WooCommerce\Abstracts
+ * @since   3.0.0
+ * @version 3.3.0
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -7,8 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * WC_Deprecated_Hooks class maps old actions and filters to new ones. This is the base class for handling those deprecated hooks.
  *
  * Based on the WCS_Hook_Deprecator class by Prospress.
- *
- * @since 3.0.0
  */
 abstract class WC_Deprecated_Hooks {
 
@@ -30,14 +36,14 @@ abstract class WC_Deprecated_Hooks {
 	/**
 	 * Hook into the new hook so we can handle deprecated hooks once fired.
 	 *
-	 * @param  string $hook_name
+	 * @param string $hook_name Hook name.
 	 */
-	abstract function hook_in( $hook_name );
+	abstract public function hook_in( $hook_name );
 
 	/**
 	 * Get old hooks to map to new hook.
 	 *
-	 * @param  string $new_hook
+	 * @param  string $new_hook New hook.
 	 * @return array
 	 */
 	public function get_old_hooks( $new_hook ) {
@@ -66,19 +72,19 @@ abstract class WC_Deprecated_Hooks {
 	/**
 	 * If the old hook is in-use, trigger it.
 	 *
-	 * @param string $new_hook
-	 * @param string $old_hook
-	 * @param array $new_callback_args
-	 * @param mixed $return_value
+	 * @param  string $new_hook          New hook.
+	 * @param  string $old_hook          Old hook.
+	 * @param  array  $new_callback_args New callback args.
+	 * @param  mixed  $return_value      Returned value.
 	 * @return mixed
 	 */
-	abstract function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
+	abstract public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
 
 	/**
 	 * Display a deprecated notice for old hooks.
 	 *
-	 * @param string $old_hook
-	 * @param string $new_hook
+	 * @param string $old_hook Old hook.
+	 * @param string $new_hook New hook.
 	 */
 	protected function display_notice( $old_hook, $new_hook ) {
 		wc_deprecated_hook( esc_html( $old_hook ), WC_VERSION, esc_html( $new_hook ) );
@@ -87,8 +93,8 @@ abstract class WC_Deprecated_Hooks {
 	/**
 	 * Fire off a legacy hook with it's args.
 	 *
-	 * @param  string $old_hook
-	 * @param  array $new_callback_args
+	 * @param  string $old_hook          Old hook.
+	 * @param  array  $new_callback_args New callback args.
 	 * @return mixed
 	 */
 	abstract protected function trigger_hook( $old_hook, $new_callback_args );

--- a/includes/class-wc-deprecated-action-hooks.php
+++ b/includes/class-wc-deprecated-action-hooks.php
@@ -1,12 +1,18 @@
 <?php
+/**
+ * Deprecated action hooks
+ *
+ * @package WooCommerce\Abstracts
+ * @since   3.0.0
+ * @version 3.3.0
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
  * Handles deprecation notices and triggering of legacy action hooks.
- *
- * @since 3.0.0
  */
 class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 
@@ -16,7 +22,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 	 * @var array
 	 */
 	protected $deprecated_hooks = array(
-		'woocommerce_new_order_item'                        => array(
+		'woocommerce_new_order_item'        => array(
 			'woocommerce_order_add_shipping',
 			'woocommerce_order_add_coupon',
 			'woocommerce_order_add_tax',
@@ -25,16 +31,16 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 			'woocommerce_add_order_item_meta',
 			'woocommerce_add_order_fee_meta',
 		),
-		'woocommerce_update_order_item'                     => array(
+		'woocommerce_update_order_item'     => array(
 			'woocommerce_order_edit_product',
 			'woocommerce_order_update_coupon',
 			'woocommerce_order_update_shipping',
 			'woocommerce_order_update_fee',
 			'woocommerce_order_update_tax',
 		),
-		'woocommerce_new_payment_token'                     => 'woocommerce_payment_token_created',
-		'woocommerce_new_product_variation'                 => 'woocommerce_create_product_variation',
-		'woocommerce_order_details_after_order_table_items' => 'woocommerce_order_items_table'
+		'woocommerce_new_payment_token'     => 'woocommerce_payment_token_created',
+		'woocommerce_new_product_variation' => 'woocommerce_create_product_variation',
+		'woocommerce_order_details_after_order_table_items' => 'woocommerce_order_items_table',
 	);
 
 	/**
@@ -62,7 +68,8 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 
 	/**
 	 * Hook into the new hook so we can handle deprecated hooks once fired.
-	 * @param  string $hook_name
+	 *
+	 * @param string $hook_name Hook name.
 	 */
 	public function hook_in( $hook_name ) {
 		add_action( $hook_name, array( $this, 'maybe_handle_deprecated_hook' ), -1000, 8 );
@@ -71,10 +78,10 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 	/**
 	 * If the old hook is in-use, trigger it.
 	 *
-	 * @param string $new_hook
-	 * @param string $old_hook
-	 * @param array $new_callback_args
-	 * @param mixed $return_value
+	 * @param  string $new_hook          New hook name.
+	 * @param  string $old_hook          Old hook name.
+	 * @param  array  $new_callback_args New callback args.
+	 * @param  mixed  $return_value      Returned value.
 	 * @return mixed
 	 */
 	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
@@ -88,14 +95,14 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 	/**
 	 * Fire off a legacy hook with it's args.
 	 *
-	 * @param  string $old_hook
-	 * @param  array $new_callback_args
+	 * @param  string $old_hook          Old hook name.
+	 * @param  array  $new_callback_args New callback args.
 	 * @return mixed
 	 */
 	protected function trigger_hook( $old_hook, $new_callback_args ) {
 		switch ( $old_hook ) {
-			case 'woocommerce_order_add_shipping' :
-			case 'woocommerce_order_add_fee' :
+			case 'woocommerce_order_add_shipping':
+			case 'woocommerce_order_add_fee':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -103,7 +110,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $order_id, $item_id, $item );
 				}
 				break;
-			case 'woocommerce_order_add_coupon' :
+			case 'woocommerce_order_add_coupon':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -111,7 +118,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $order_id, $item_id, $item->get_code(), $item->get_discount(), $item->get_discount_tax() );
 				}
 				break;
-			case 'woocommerce_order_add_tax' :
+			case 'woocommerce_order_add_tax':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -119,7 +126,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $order_id, $item_id, $item->get_rate_id(), $item->get_tax_total(), $item->get_shipping_tax_total() );
 				}
 				break;
-			case 'woocommerce_add_shipping_order_item' :
+			case 'woocommerce_add_shipping_order_item':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -127,7 +134,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $order_id, $item_id, $item->legacy_package_key );
 				}
 				break;
-			case 'woocommerce_add_order_item_meta' :
+			case 'woocommerce_add_order_item_meta':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -135,7 +142,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $item_id, $item->legacy_values, $item->legacy_cart_item_key );
 				}
 				break;
-			case 'woocommerce_add_order_fee_meta' :
+			case 'woocommerce_add_order_fee_meta':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -143,7 +150,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $order_id, $item_id, $item->legacy_fee, $item->legacy_fee_key );
 				}
 				break;
-			case 'woocommerce_order_edit_product' :
+			case 'woocommerce_order_edit_product':
 				$item_id  = $new_callback_args[0];
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
@@ -151,15 +158,15 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 					do_action( $old_hook, $order_id, $item_id, $item, $item->get_product() );
 				}
 				break;
-			case 'woocommerce_order_update_coupon' :
-			case 'woocommerce_order_update_shipping' :
-			case 'woocommerce_order_update_fee' :
-			case 'woocommerce_order_update_tax' :
+			case 'woocommerce_order_update_coupon':
+			case 'woocommerce_order_update_shipping':
+			case 'woocommerce_order_update_fee':
+			case 'woocommerce_order_update_tax':
 				if ( ! is_a( $item, 'WC_Order_Item_Product' ) ) {
 					do_action( $old_hook, $order_id, $item_id, $item );
 				}
 				break;
-			default :
+			default:
 				do_action_ref_array( $old_hook, $new_callback_args );
 				break;
 		}

--- a/includes/class-wc-deprecated-action-hooks.php
+++ b/includes/class-wc-deprecated-action-hooks.php
@@ -38,6 +38,29 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 	);
 
 	/**
+	 * Array of versions on each hook has been deprecated.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_version = array(
+		'woocommerce_order_add_shipping'       => '3.0.0',
+		'woocommerce_order_add_coupon'         => '3.0.0',
+		'woocommerce_order_add_tax'            => '3.0.0',
+		'woocommerce_order_add_fee'            => '3.0.0',
+		'woocommerce_add_shipping_order_item'  => '3.0.0',
+		'woocommerce_add_order_item_meta'      => '3.0.0',
+		'woocommerce_add_order_fee_meta'       => '3.0.0',
+		'woocommerce_order_edit_product'       => '3.0.0',
+		'woocommerce_order_update_coupon'      => '3.0.0',
+		'woocommerce_order_update_shipping'    => '3.0.0',
+		'woocommerce_order_update_fee'         => '3.0.0',
+		'woocommerce_order_update_tax'         => '3.0.0',
+		'woocommerce_payment_token_created'    => '3.0.0',
+		'woocommerce_create_product_variation' => '3.0.0',
+		'woocommerce_order_items_table'        => '3.0.0',
+	);
+
+	/**
 	 * Hook into the new hook so we can handle deprecated hooks once fired.
 	 * @param  string $hook_name
 	 */

--- a/includes/class-wc-deprecated-filter-hooks.php
+++ b/includes/class-wc-deprecated-filter-hooks.php
@@ -55,6 +55,49 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 	);
 
 	/**
+	 * Array of versions on each hook has been deprecated.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_version = array(
+		'woocommerce_email_order_schema_markup'      => '3.0.0',
+		'add_to_cart_fragments'                      => '3.0.0',
+		'add_to_cart_redirect'                       => '3.0.0',
+		'woocommerce_product_width'                  => '3.0.0',
+		'woocommerce_product_height'                 => '3.0.0',
+		'woocommerce_product_length'                 => '3.0.0',
+		'woocommerce_product_weight'                 => '3.0.0',
+		'woocommerce_get_sku'                        => '3.0.0',
+		'woocommerce_get_price'                      => '3.0.0',
+		'woocommerce_get_regular_price'              => '3.0.0',
+		'woocommerce_get_sale_price'                 => '3.0.0',
+		'woocommerce_product_tax_class'              => '3.0.0',
+		'woocommerce_get_stock_quantity'             => '3.0.0',
+		'woocommerce_get_product_attributes'         => '3.0.0',
+		'woocommerce_product_gallery_attachment_ids' => '3.0.0',
+		'woocommerce_product_review_count'           => '3.0.0',
+		'woocommerce_product_files'                  => '3.0.0',
+		'woocommerce_get_currency'                   => '3.0.0',
+		'woocommerce_order_amount_discount_total'    => '3.0.0',
+		'woocommerce_order_amount_discount_tax'      => '3.0.0',
+		'woocommerce_order_amount_shipping_total'    => '3.0.0',
+		'woocommerce_order_amount_shipping_tax'      => '3.0.0',
+		'woocommerce_order_amount_cart_tax'          => '3.0.0',
+		'woocommerce_order_amount_total'             => '3.0.0',
+		'woocommerce_order_amount_total_tax'         => '3.0.0',
+		'woocommerce_order_amount_total_discount'    => '3.0.0',
+		'woocommerce_order_amount_subtotal'          => '3.0.0',
+		'woocommerce_order_tax_totals'               => '3.0.0',
+		'woocommerce_refund_amount'                  => '3.0.0',
+		'woocommerce_refund_reason'                  => '3.0.0',
+		'default_checkout_country'                   => '3.0.0',
+		'default_checkout_state'                     => '3.0.0',
+		'default_checkout_postcode'                  => '3.0.0',
+		'woocommerce_debug_posting'                  => '3.0.0',
+		'wocommerce_credit_card_type_labels'         => '3.0.0',
+	);
+
+	/**
 	 * Hook into the new hook so we can handle deprecated hooks once fired.
 	 * @param  string $hook_name
 	 */

--- a/includes/class-wc-deprecated-filter-hooks.php
+++ b/includes/class-wc-deprecated-filter-hooks.php
@@ -1,12 +1,18 @@
 <?php
+/**
+ * Deprecated filter hooks
+ *
+ * @package WooCommerce\Abstracts
+ * @since   3.0.0
+ * @version 3.3.0
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Handles deprecation notices and triggering of legacy filter hooks.
- *
- * @since 3.0.0
+ * Handles deprecation notices and triggering of legacy filter hooks
  */
 class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 
@@ -99,7 +105,8 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 
 	/**
 	 * Hook into the new hook so we can handle deprecated hooks once fired.
-	 * @param  string $hook_name
+	 *
+	 * @param string $hook_name Hook name.
 	 */
 	public function hook_in( $hook_name ) {
 		add_filter( $hook_name, array( $this, 'maybe_handle_deprecated_hook' ), -1000, 8 );
@@ -108,10 +115,10 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 	/**
 	 * If the old hook is in-use, trigger it.
 	 *
-	 * @param string $new_hook
-	 * @param string $old_hook
-	 * @param array $new_callback_args
-	 * @param mixed $return_value
+	 * @param  string $new_hook          New hook name.
+	 * @param  string $old_hook          Old hook name.
+	 * @param  array  $new_callback_args New callback args.
+	 * @param  mixed  $return_value      Returned value.
 	 * @return mixed
 	 */
 	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
@@ -125,8 +132,8 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 	/**
 	 * Fire off a legacy hook with it's args.
 	 *
-	 * @param  string $old_hook
-	 * @param  array $new_callback_args
+	 * @param  string $old_hook          Old hook name.
+	 * @param  array  $new_callback_args New callback args.
 	 * @return mixed
 	 */
 	protected function trigger_hook( $old_hook, $new_callback_args ) {

--- a/tests/unit-tests/util/deprecated-hooks.php
+++ b/tests/unit-tests/util/deprecated-hooks.php
@@ -40,6 +40,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 
 	function setUp() {
 		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
 		$this->handlers = WC()->deprecated_hook_handlers;
 	}
 


### PR DESCRIPTION
- Introduced wrapper for `_deprecated_hook()`.
- Handle deprecated versions, all deprecated in 3.0.0.
- Updated strings to match `_deprecated_hook()` messages.

Closes #17508 