### PR TITLE
Importer/Exporter backorder compatibility

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -383,6 +383,11 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 */
 	protected function get_column_value_stock_status( $product ) {
 		$status = $product->get_stock_status( 'edit' );
+
+		if ( 'onbackorder' === $status ) {
+			return 'backorder';
+		}
+
 		return 'instock' === $status ? 1 : 0;
 	}
 

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -133,7 +133,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	public function get_params() {
 		return $this->params;
 	}
-	
+
 	/**
 	 * Get file pointer position from the last read.
 	 *
@@ -725,5 +725,23 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 */
 	protected function explode_values_formatter( $value ) {
 		return trim( str_replace( '::separator::', ',', $value ) );
+	}
+
+	/**
+	 * The exporter prepends a ' to fields that start with a - which causes
+	 * issues with negative numbers. This removes the ' if the input is still a valid
+	 * number after removal.
+	 *
+	 * @since 3.3.0
+	 * @param string $value A numeric string that may or may not have ' prepended.
+	 * @return string
+	 */
+	protected function unescape_negative_number( $value ) {
+		$unescaped = str_replace( "'-", '-', $value );
+		if ( is_numeric( $unescaped ) ) {
+			return $unescaped;
+		}
+
+		return $value;
 	}
 }

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -737,9 +737,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @return string
 	 */
 	protected function unescape_negative_number( $value ) {
-		$unescaped = str_replace( "'-", '-', $value );
-		if ( is_numeric( $unescaped ) ) {
-			return $unescaped;
+		if ( 0 === strpos( $value, "'-" ) ) {
+			$unescaped = substr_replace( $value, '', 0, 1 );
+			if ( is_numeric( $unescaped ) ) {
+				return $unescaped;
+			}
 		}
 
 		return $value;

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -280,6 +280,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return $value;
 		}
 
+		// Remove the ' prepended to fields that start with - if needed.
+		$value = $this->unescape_negative_number( $value );
+
 		return floatval( $value );
 	}
 
@@ -293,6 +296,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		if ( '' === $value ) {
 			return $value;
 		}
+
+		// Remove the ' prepended to fields that start with - if needed.
+		$value = $this->unescape_negative_number( $value );
 
 		return wc_stock_amount( $value );
 	}
@@ -633,16 +639,14 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$data['stock_status'] = isset( $data['stock_status'] ) ? $data['stock_status'] : true;
 			} else {
 				$data['manage_stock'] = true;
-
-				// Only auto set status when stock_status is empty.
-				if ( ! isset( $data['stock_status'] ) || isset( $data['stock_status'] ) && '' === $data['stock_status'] ) {
-					$data['stock_status'] = 0 < $data['stock_quantity'];
-				}
 			}
 		}
 
-		// Stock is bool.
+		// Stock is bool or 'backorder'.
 		if ( isset( $data['stock_status'] ) ) {
+			if ( 'backorder' === $data['stock_status'] ) {
+				$data['stock_status'] = 'onbackorder';
+			}
 			$data['stock_status'] = $data['stock_status'] ? 'instock' : 'outofstock';
 		}
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -646,8 +646,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		if ( isset( $data['stock_status'] ) ) {
 			if ( 'backorder' === $data['stock_status'] ) {
 				$data['stock_status'] = 'onbackorder';
+			} else {
+				$data['stock_status'] = $data['stock_status'] ? 'instock' : 'outofstock';
 			}
-			$data['stock_status'] = $data['stock_status'] ? 'instock' : 'outofstock';
 		}
 
 		// Prepare grouped products.


### PR DESCRIPTION
Related #11259 

Adds a `backorder` option to the `'In stock?'` CSV importer/exporter field. After this is merged the available options will be `0`, `1`, and `backorder`.

Also fixes a bug where negative numbers weren't working properly in the importer because of the `'` prepended to the number.

To test: create a product with the backorder status, export a CSV, then import the generated CSV (exclude ID and SKU fields when importing to create new products).
