### PR TITLE
Further improve the speed of the Travis build

### DIFF
--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -6,6 +6,12 @@ if [ $1 == 'before' ]; then
 	# Composer install fails in PHP 5.2
 	[[ ${TRAVIS_PHP_VERSION} == '5.2' ]] && exit;
 
+	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
+	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
+	if [[ ${RUN_CODE_COVERAGE} != 1 ]]; then
+		phpenv config-rm xdebug.ini
+	fi
+
 	if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then
 		composer global require "phpunit/phpunit=4.8.*"
 	else
@@ -14,12 +20,6 @@ if [ $1 == 'before' ]; then
 
 	if [[ ${RUN_PHPCS} == 1 ]]; then
 		composer install
-	fi
-
-	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
-	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
-	if [[ ${RUN_CODE_COVERAGE} != 1 ]]; then
-		phpenv config-rm xdebug.ini
 	fi
 
 fi

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -6,9 +6,6 @@ if [ $1 == 'before' ]; then
 	# Composer install fails in PHP 5.2
 	[[ ${TRAVIS_PHP_VERSION} == '5.2' ]] && exit;
 
-	# No Xdebug and therefore no coverage in PHP 5.3
-	[[ ${TRAVIS_PHP_VERSION} == '5.3' ]] && exit;
-
 	if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then
 		composer global require "phpunit/phpunit=4.8.*"
 	else


### PR DESCRIPTION
This PR makes two changes to the Travis build to improve its speed:

- Remove Xdebug from PHP 5.3 build job. When I removed Xdebug from PHP build jobs (#17659), I missed an `if` statement that meant that Xdebug was kept for PHP 5.3.
- Remove Xdebug from PHP build jobs before running composer