### PR TITLE
Remove three PHPCS VIP rules that don't apply to WooCommerce

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -22,8 +22,11 @@
 	<rule ref="PHPCompatibility"/>
 
 	<rule ref="WordPress">
-		<exclude name="WordPress.VIP.RestrictedFunctions" />
+		<exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />
+		<exclude name="WordPress.VIP.DirectDatabaseQuery.SchemaChange" />
+		<exclude name="WordPress.VIP.FileSystemWritesDisallow.file_ops_fwrite" />
 		<exclude name="WordPress.VIP.OrderByRand" />
+		<exclude name="WordPress.VIP.RestrictedFunctions" />
 	</rule>
 	<rule ref="WordPress.VIP.ValidatedSanitizedInput">
 		<properties>


### PR DESCRIPTION
This commit removes the following PHPCS VIP rules:

- WordPress.VIP.DirectDatabaseQuery.NoCaching
- WordPress.VIP.DirectDatabaseQuery.SchemaChange
- WordPress.VIP.FileSystemWritesDisallow.file_ops_fwrite

It also reorganizes the list of excluded rules alphabetically. 