### PR TITLE
Restored "lazy loading" of `woocommerce_tax_display_cart` option

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -45,13 +45,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	public $applied_coupons = array();
 
 	/**
-	 * Are prices in the cart displayed inc or excl tax.
-	 *
-	 * @var string
-	 */
-	public $tax_display_cart;
-
-	/**
 	 * This stores the chosen shipping methods for the cart item packages.
 	 *
 	 * @var array
@@ -107,7 +100,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function __construct() {
 		$this->session          = new WC_Cart_Session( $this );
 		$this->fees_api         = new WC_Cart_Fees( $this );
-		$this->tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
 
 		// Register hooks for the objects.
 		$this->session->init();

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -74,6 +74,16 @@ abstract class WC_Legacy_Cart {
 		$value = '';
 
 		switch ( $name ) {
+			case 'tax_display_cart' :
+				// Store the tax_display_cart value in a dynamically created property. This
+				// allows the __get() to be called only once, while still "lazy loading"
+				// the option value.
+				// This approach also prevents issues like the one reported in
+				// https://github.com/woocommerce/woocommerce/issues/17894, caused by
+				// option values being loaded too early
+				$this->tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
+				$value = $this->tax_display_cart;
+			break;
 			case 'dp' :
 				$value = wc_get_price_decimals();
 				break;


### PR DESCRIPTION
Ref. https://github.com/woocommerce/woocommerce/issues/17897

This patch restores the lazy loading of the `woocommerce_tax_display_cart` option, so that any filter attached to it is triggered only after WooCommerce objects (cart and customer) have been initialised. 

The change also caches the value of the option into a dynamically generated property, so that the `get_option()` function only has to be called once.

Important
==
For the patch to work, it's important that property `$tax_display_cart` is **not** explicitly declared in any of the classes that make the cart (which is why such property was removed). Such property has to be populated via the call to `__get()` magic method, which also takes care of storing the option value against the object instance.