### PR TITLE
Uncategorized category support

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -299,22 +299,29 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Render any custom filters and search inputs for the list table.
 	 */
 	protected function render_filters() {
-		$current_category_slug = isset( $_REQUEST['product_cat'] ) ? wc_clean( wp_unslash( $_REQUEST['product_cat'] ) )             : false; // WPCS: input var ok, sanitization ok.
-		$current_product_type  = isset( $_REQUEST['product_type'] ) ? wc_clean( wp_unslash( $_REQUEST['product_type'] ) )           : false; // WPCS: input var ok, sanitization ok.
-		// @codingStandardsIgnoreStart
-		$current_category      = $current_category_slug ? get_term_by( 'slug', $current_category_slug, 'product_cat' ): false;
-		// @codingStandardsIgnoreEnd
-		?>
-		<select class="wc-category-search" name="product_cat" data-placeholder="<?php esc_attr_e( 'Filter by category', 'woocommerce' ); ?>" data-allow_clear="true">
-			<?php if ( $current_category_slug && $current_category ) : ?>
-				<option value="<?php echo esc_attr( $current_category_slug ); ?>" selected="selected"><?php echo esc_html( $current_category->name ); ?><option>
-			<?php endif; ?>
-		</select>
-		<?php
+		// Category Filtering.
+		$categories_count = (int) wp_count_terms( 'product_cat' );
 
-		$terms   = get_terms( 'product_type' );
-		$output  = '<select name="product_type" id="dropdown_product_type">';
-		$output .= '<option value="">' . __( 'Filter by product type', 'woocommerce' ) . '</option>';
+		if ( $categories_count <= apply_filters( 'woocommerce_product_category_filter_threshold', 100 ) ) {
+			wc_product_dropdown_categories( array(
+				'option_select_text' => __( 'Filter by category', 'woocommerce' ),
+			) );
+		} else {
+			$current_category_slug = isset( $_GET['product_cat'] ) ? wc_clean( wp_unslash( $_GET['product_cat'] ) ) : false; // WPCS: input var ok, CSRF ok.
+			$current_category      = $current_category_slug ? get_term_by( 'slug', $current_category_slug, 'product_cat' ) : false;
+			?>
+			<select class="wc-category-search" name="product_cat" data-placeholder="<?php esc_attr_e( 'Filter by category', 'woocommerce' ); ?>" data-allow_clear="true">
+				<?php if ( $current_category_slug && $current_category ) : ?>
+					<option value="<?php echo esc_attr( $current_category_slug ); ?>" selected="selected"><?php echo esc_html( $current_category->name ); ?><option>
+				<?php endif; ?>
+			</select>
+			<?php
+		}
+
+		// Product type filtering.
+		$current_product_type = isset( $_REQUEST['product_type'] ) ? wc_clean( wp_unslash( $_REQUEST['product_type'] ) ) : false; // WPCS: input var ok, sanitization ok.
+		$terms                = get_terms( 'product_type' );
+		$output               = '<select name="product_type" id="dropdown_product_type"><option value="">' . __( 'Filter by product type', 'woocommerce' ) . '</option>';
 
 		foreach ( $terms as $term ) {
 			$output .= '<option value="' . sanitize_title( $term->name ) . '" ';

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -460,13 +460,25 @@ class WC_Install {
 			}
 		}
 
-		$default_product_cat_slug = sanitize_title( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ) );
+		$woocommerce_default_category = get_option( 'woocommerce_default_category', 0 );
 
-		if ( ! get_option( 'woocommerce_default_category', 0 ) && ! get_term_by( 'slug', $default_product_cat_slug, 'product_cat' ) ) { // @codingStandardsIgnoreLine.
-			$result = wp_insert_term( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ), 'product_cat', array( 'slug' => $default_product_cat_slug ) );
+		if ( ! $woocommerce_default_category || ! term_exists( $woocommerce_default_category, 'product_cat' ) ) {
+			$default_product_cat_id   = 0;
+			$default_product_cat_slug = sanitize_title( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ) );
+			$default_product_cat      = get_term_by( 'slug', $default_product_cat_slug, 'product_cat' ); // @codingStandardsIgnoreLine.
 
-			if ( ! empty( $result['term_id'] ) ) {
-				update_option( 'woocommerce_default_category', $result['term_id'] );
+			if ( $default_product_cat ) {
+				$default_product_cat_id = absint( $default_product_cat->term_id );
+			} else {
+				$result = wp_insert_term( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ), 'product_cat', array( 'slug' => $default_product_cat_slug ) );
+
+				if ( ! empty( $result['term_id'] ) ) {
+					$default_product_cat_id = absint( $result['term_id'] );
+				}
+			}
+
+			if ( $default_product_cat_id ) {
+				update_option( 'woocommerce_default_category', $default_product_cat_id );
 			}
 		}
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -98,6 +98,7 @@ class WC_Install {
 		),
 		'3.3.0' => array(
 			'wc_update_330_image_options',
+			'wc_update_330_set_default_product_cat',
 			'wc_update_330_db_version',
 		),
 	);
@@ -468,12 +469,12 @@ class WC_Install {
 			$default_product_cat      = get_term_by( 'slug', $default_product_cat_slug, 'product_cat' ); // @codingStandardsIgnoreLine.
 
 			if ( $default_product_cat ) {
-				$default_product_cat_id = absint( $default_product_cat->term_id );
+				$default_product_cat_id = absint( $default_product_cat->term_taxonomy_id );
 			} else {
 				$result = wp_insert_term( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ), 'product_cat', array( 'slug' => $default_product_cat_slug ) );
 
-				if ( ! empty( $result['term_id'] ) ) {
-					$default_product_cat_id = absint( $result['term_id'] );
+				if ( ! empty( $result['term_taxonomy_id'] ) ) {
+					$default_product_cat_id = absint( $result['term_taxonomy_id'] );
 				}
 			}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -460,7 +460,7 @@ class WC_Install {
 			}
 		}
 
-		$woocommerce_default_category = get_option( 'woocommerce_default_category', 0 );
+		$woocommerce_default_category = get_option( 'default_product_cat', 0 );
 
 		if ( ! $woocommerce_default_category || ! term_exists( $woocommerce_default_category, 'product_cat' ) ) {
 			$default_product_cat_id   = 0;
@@ -478,7 +478,7 @@ class WC_Install {
 			}
 
 			if ( $default_product_cat_id ) {
-				update_option( 'woocommerce_default_category', $default_product_cat_id );
+				update_option( 'default_product_cat', $default_product_cat_id );
 			}
 		}
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -454,9 +454,19 @@ class WC_Install {
 
 		foreach ( $taxonomies as $taxonomy => $terms ) {
 			foreach ( $terms as $term ) {
-				if ( ! get_term_by( 'name', $term, $taxonomy ) ) {
+				if ( ! get_term_by( 'name', $term, $taxonomy ) ) { // @codingStandardsIgnoreLine.
 					wp_insert_term( $term, $taxonomy );
 				}
+			}
+		}
+
+		$default_product_cat_slug = sanitize_title( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ) );
+
+		if ( ! get_option( 'woocommerce_default_category', 0 ) && ! get_term_by( 'slug', $default_product_cat_slug, 'product_cat' ) ) { // @codingStandardsIgnoreLine.
+			$result = wp_insert_term( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ), 'product_cat', array( 'slug' => $default_product_cat_slug ) );
+
+			if ( ! empty( $result['term_id'] ) ) {
+				update_option( 'woocommerce_default_category', $result['term_id'] );
 			}
 		}
 	}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -585,15 +585,21 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * For all stored terms in all taxonomies, save them to the DB.
 	 *
-	 * @param WC_Product
-	 * @param bool Force update. Used during create.
+	 * @param WC_Product $product Product object.
+	 * @param bool       $force Force update. Used during create.
 	 * @since 3.0.0
 	 */
 	protected function update_terms( &$product, $force = false ) {
 		$changes = $product->get_changes();
 
 		if ( $force || array_key_exists( 'category_ids', $changes ) ) {
-			wp_set_post_terms( $product->get_id(), $product->get_category_ids( 'edit' ), 'product_cat', false );
+			$categories = $product->get_category_ids( 'edit' );
+
+			if ( empty( $categories ) && get_option( 'woocommerce_default_category', 0 ) ) {
+				$categories = array( get_option( 'woocommerce_default_category', 0 ) );
+			}
+
+			wp_set_post_terms( $product->get_id(), $categories, 'product_cat', false );
 		}
 		if ( $force || array_key_exists( 'tag_ids', $changes ) ) {
 			wp_set_post_terms( $product->get_id(), $product->get_tag_ids( 'edit' ), 'product_tag', false );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -595,8 +595,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( $force || array_key_exists( 'category_ids', $changes ) ) {
 			$categories = $product->get_category_ids( 'edit' );
 
-			if ( empty( $categories ) && get_option( 'woocommerce_default_category', 0 ) ) {
-				$categories = array( get_option( 'woocommerce_default_category', 0 ) );
+			if ( empty( $categories ) && get_option( 'default_product_cat', 0 ) ) {
+				$categories = array( get_option( 'default_product_cat', 0 ) );
 			}
 
 			wp_set_post_terms( $product->get_id(), $categories, 'product_cat', false );


### PR DESCRIPTION
Like WP handling for the post Uncategorized category, this adds a new default product_cat called Uncategorized.

On install the term is created.

On upgrade, the term is applied to all products with no cats.

The term is then available for filtering in admin.

Closes #17321