### PR TITLE
Travis: don't reinstall PHPUnit

### DIFF
--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -3,9 +3,6 @@
 
 if [ $1 == 'before' ]; then
 
-	# Composer install fails in PHP 5.2
-	[[ ${TRAVIS_PHP_VERSION} == '5.2' ]] && exit;
-
 	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
 	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
 	if [[ ${RUN_CODE_COVERAGE} != 1 ]]; then

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -12,12 +12,6 @@ if [ $1 == 'before' ]; then
 		phpenv config-rm xdebug.ini
 	fi
 
-	if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then
-		composer global require "phpunit/phpunit=4.8.*"
-	else
-		composer global require "phpunit/phpunit=6.2.*"
-	fi
-
 	if [[ ${RUN_PHPCS} == 1 ]]; then
 		composer install
 	fi


### PR DESCRIPTION
This commit removes the command to install PHPUnit on every Travis build job. I'm doing this because I don't see a reason for WooCommerce to re-install PHPUnit since it is already installed by default on every build job. Travis automatically handles installing the right PHPUnit version for each PHP version that we use.

This change should save around 10 seconds from each build job (https://travis-ci.org/woocommerce/woocommerce/jobs/306623161#L515).