### PR TITLE
Add npm scripts for grunt build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "license": "GPL-3.0+",
   "main": "Gruntfile.js",
   "scripts": {
+    "build": "grunt",
+    "build-watch": "grunt watch",
     "test": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha \"tests/e2e-tests\" --compilers js:babel-register --recursive",
     "test:grep": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha \"tests/e2e-tests\" --compilers js:babel-register --grep ",
     "test:single": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha --compilers js:babel-register"


### PR DESCRIPTION
In order to use the locally installed version of Grunt you must use a command like:  ./node_modules/.bin/grunt.  This PR adds shortcuts to the package.json so you don't have to type out the command to run them from the bin folder.

This is also helpful because many developers will look at the package.json scripts to figure out how to run the build scripts.  

A global grunt installation should not be used since it may be of a different version than the one specified in the package.json.

I can add another PR if you would like with other grunt commands.