### PR TITLE
Exclude add-to-cart from pagination link

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -42,6 +42,7 @@ class WC_Query {
 			add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
 			add_action( 'wp', array( $this, 'remove_product_query' ) );
 			add_action( 'wp', array( $this, 'remove_ordering_args' ) );
+			add_filter( 'get_pagenum_link', array( $this, 'remove_add_to_cart_pagination' ), 10, 1 );
 		}
 		$this->init_query_vars();
 	}
@@ -839,5 +840,15 @@ class WC_Query {
 	 */
 	public function layered_nav_query( $deprecated ) {
 		wc_deprecated_function( 'layered_nav_query', '2.6' );
+	}
+
+	/**
+	 * Remove the add-to-cart param from pagination urls.
+	 *
+	 * @param string $url URL.
+	 * @return string
+	 */
+	public function remove_add_to_cart_pagination( $url ) {
+		return remove_query_arg( 'add-to-cart', $url );
 	}
 }


### PR DESCRIPTION
I'm pretty sure WP made some changes to the paginate_links function, it now calls get_pagenum_link from within the function even if you pass the base param. This PR uses the get_pagenum_link filter instead to remove the add-to-cart param.

To test go to a url such as https://wc.dev/shop/?add-to-cart=338 it should add a product to cart and then when you scroll to the pagination links each link should not have the add-to-cart param in them.

Closes #17944 