### PR TITLE
Introduces a few composer scripts for PHPUnit and PHP_CodeSniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,22 @@
     ],
     "post-update-cmd": [
       "WooCommerce\\GitHooks\\Hooks::postHooks"
+    ],
+    "test": [
+      "phpunit"
+    ],
+    "phpcs": [
+      "phpcs -s -p --standard=./phpcs.ruleset.xml"
+    ],
+    "phpcbf": [
+      "phpcs -p --standard=./phpcs.ruleset.xml"
     ]
+  },
+  "extra": {
+    "scripts-description": {
+      "test": "Run unit tests",
+      "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+      "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+    }
   }
 }


### PR DESCRIPTION
This allow shortcuts:

```
composer run-script test
composer run-script phpcs <file>
composer run-script phpcbf <file>
```
