### PR TITLE
Allow woocommerce_form_field() have 'custom_attributes' equal 0

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1939,7 +1939,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 		// Custom attribute handling.
 		$custom_attributes         = array();
-		$args['custom_attributes'] = array_filter( (array) $args['custom_attributes'] );
+		$args['custom_attributes'] = array_filter( (array) $args['custom_attributes'], 'strlen' );
 
 		if ( $args['maxlength'] ) {
 			$args['custom_attributes']['maxlength'] = absint( $args['maxlength'] );


### PR DESCRIPTION
`array_filter()` by default will remove all `null` values, also `0` or `false`, but if trying to declare something like `array( 'min' => '0', 'max' => '10' )` this will be a problem. So including added `strlen()` as callback function will allow keep some strings but still remove `null` and `false` values.

```
wp> array_filter( array( 'min' => 0, 'max' => 10, 'foo' => null, 'bar' => false ) )
=> array(1) {
  ["max"]=>
  int(10)
}

wp> array_filter( array( 'min' => 0, 'max' => 10, 'foo' => null, 'bar' => false ), 'strlen' ) 
=> array(2) {
  ["min"]=>
  int(0)
  ["max"]=>
  int(10)
}

```

Ref #17940