### PR TITLE
 Always save last viewed product ID into woocommerce_recently_viewed cookie

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -484,9 +484,13 @@ function wc_track_product_view() {
 		$viewed_products = (array) explode( '|', $_COOKIE['woocommerce_recently_viewed'] );
 	}
 
-	if ( ! in_array( $post->ID, $viewed_products ) ) {
-		$viewed_products[] = $post->ID;
+	// Unset if already in viewed products list and append ID.
+	$keys = array_flip( $viewed_products );
+	if ( isset( $keys[ $post->ID ] ) ) {
+		unset( $viewed_products[ $keys[ $post->ID ] ] );
 	}
+
+	$viewed_products[] = $post->ID;
 
 	if ( count( $viewed_products ) > 15 ) {
 		array_shift( $viewed_products );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -484,7 +484,7 @@ function wc_track_product_view() {
 		$viewed_products = (array) explode( '|', $_COOKIE['woocommerce_recently_viewed'] );
 	}
 
-	// Unset if already in viewed products list and append ID.
+	// Unset if already in viewed products list.
 	$keys = array_flip( $viewed_products );
 	if ( isset( $keys[ $post->ID ] ) ) {
 		unset( $viewed_products[ $keys[ $post->ID ] ] );

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -33,7 +33,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 				'type'  => 'number',
 				'step'  => 1,
 				'min'   => 1,
-				'max'   => '',
+				'max'   => 15,
 				'std'   => 10,
 				'label' => __( 'Number of products to show', 'woocommerce' ),
 			),


### PR DESCRIPTION
Currently if you already visited a product it will not get listed at the top of the "Recent Viewed Products" widget.

This happens because we only include new items if they are not already in the list of viewed products.
So I had to change a little the logic, now excludes the ID from viewed products list and adding again at the end of the list.

Also including a limit of 15 products in the widget settings, since we already limit it to 15 while setting `woocommerce_recently_viewed` cookie.

Closes #17951