### PR TITLE
Include 'product_url' in wc_get_customer_available_downloads() results

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -449,6 +449,7 @@ function wc_get_customer_available_downloads( $customer_id ) {
 				'download_id'           => $result->download_id,
 				'product_id'            => $_product->get_id(),
 				'product_name'          => $_product->get_name(),
+				'product_url'           => $_product->is_visible() ? $_product->get_permalink() : '', // Since 3.3.0.
 				'download_name'         => $download_name,
 				'order_id'              => $order->get_id(),
 				'order_key'             => $order->get_order_key(),


### PR DESCRIPTION
Also required to fix #17925

Details:

`templates/order/order-downloads.php` is called in 2 different places, and receive data from 2 different sources.
In the previous PR #17934 I include `product_url` in `WC_Order->get_downloadable_items()`, but I forget about `wc_get_customer_available_downloads()`.