### PR TITLE
Mark $0 orders as payment complete when processing payments with core gateways

### DIFF
--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -342,8 +342,12 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 
 		$order = wc_get_order( $order_id );
 
-		// Mark as on-hold (we're awaiting the payment)
-		$order->update_status( 'on-hold', __( 'Awaiting BACS payment', 'woocommerce' ) );
+		if ( $order->get_total() > 0 ) {
+			// Mark as on-hold (we're awaiting the payment)
+			$order->update_status( 'on-hold', __( 'Awaiting BACS payment', 'woocommerce' ) );
+		} else {
+			$order->payment_complete();
+		}
 
 		// Reduce stock levels
 		wc_reduce_stock_levels( $order_id );

--- a/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -113,8 +113,12 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 
 		$order = wc_get_order( $order_id );
 
-		// Mark as on-hold (we're awaiting the cheque)
-		$order->update_status( 'on-hold', _x( 'Awaiting check payment', 'Check payment method', 'woocommerce' ) );
+		if ( $order->get_total() > 0 ) {
+			// Mark as on-hold (we're awaiting the cheque)
+			$order->update_status( 'on-hold', _x( 'Awaiting check payment', 'Check payment method', 'woocommerce' ) );
+		} else {
+			$order->payment_complete();
+		}
 
 		// Reduce stock levels
 		wc_reduce_stock_levels( $order_id );

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -178,8 +178,12 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		// Mark as processing or on-hold (payment won't be taken until delivery)
-		$order->update_status( apply_filters( 'woocommerce_cod_process_payment_order_status', $order->has_downloadable_item() ? 'on-hold' : 'processing', $order ), __( 'Payment to be made upon delivery.', 'woocommerce' ) );
+		if ( $order->get_total() > 0 ) {
+			// Mark as processing or on-hold (payment won't be taken until delivery)
+			$order->update_status( apply_filters( 'woocommerce_cod_process_payment_order_status', $order->has_downloadable_item() ? 'on-hold' : 'processing', $order ), __( 'Payment to be made upon delivery.', 'woocommerce' ) );
+		} else {
+			$order->payment_complete();
+		}
 
 		// Reduce stock levels
 		wc_reduce_stock_levels( $order_id );


### PR DESCRIPTION
There exist certain situations with Subscriptions (and possibly others) where the customer is required to select a payment method on checkout even if the cart total is $0 (subscriptions with free trials, the initial payment for synchronised renewals, non-prorated upgrades or downgrades for example). 

If the customer was to select one of the manual payment methods (COD, BACS, or cheque), after completing the checkout, the order status is set to on-hold when it should really be either processing or completed (`payment_complete()`) as there is nothing to collect. This is similar to how other payment gateways like Stripe call `payment_complete()` on orders with $0 totals in [`WC_Gateway_Stripe::process_payment()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L796).

This small PR calls payment complete on orders which have $0 totals when processing the payment with COD, BACS or Cheque. 