### PR TITLE
Trigger webhook when delivery URL is changed

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -536,7 +536,8 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			return new WP_Error( 'error', sprintf( __( 'Error: Delivery URL returned response code: %s', 'woocommerce' ), absint( $response_code ) ) );
 		}
 
-		delete_post_meta( $this->get_id(), '_webhook_pending_delivery' );
+		$this->set_pending_delivery( false );
+		$this->save();
 
 		return true;
 	}
@@ -771,7 +772,6 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	/**
 	 * Set the delivery URL.
 	 *
-	 * @todo trigger webhook when set new delivery URL.
 	 * @since 2.2.0
 	 * @param string $url Delivery URL.
 	 */

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -112,6 +112,8 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		global $wpdb;
 
 		$changes = $webhook->get_changes();
+		$trigger = isset( $changes['delivery_url'] );
+
 		if ( isset( $changes['date_modified'] ) ) {
 			$date_modified     = $webhook->get_date_modified()->date( 'Y-m-d H:i:s' );
 			$date_modified_gmt = gmdate( 'Y-m-d H:i:s', $webhook->get_date_modified()->getTimestamp() );
@@ -147,6 +149,11 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 
 		wp_cache_delete( $webhook->get_id(), 'webhooks' );
 		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
+
+		if ( $trigger || $webhook->get_pending_delivery() ) {
+			$webhook->deliver_ping();
+		}
+
 		do_action( 'woocommerce_webhook_updated', $webhook->get_id() );
 	}
 


### PR DESCRIPTION
Part of #12439

Requires activate WooCommerce again in order to create all necessary databases in order to test it.