### PR TITLE
Unsupported theme taxonomy archive support

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -237,7 +237,16 @@ class WC_Template_Loader {
 		global $wp_query, $post;
 
 		$queried_object = get_queried_object();
-		$shortcode_args = array();
+		$args           = self::get_current_shop_view_args();
+		$shortcode_args = array(
+			'page'     => $args->page,
+			'columns'  => $args->columns,
+			'rows'     => $args->rows,
+			'orderby'  => '',
+			'order'    => '',
+			'paginate' => true,
+			'cache'    => false,
+		);
 
 		if ( is_product_category() ) {
 			$shortcode_args['category'] = sanitize_title( $queried_object->slug );

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -237,19 +237,17 @@ class WC_Template_Loader {
 		global $wp_query, $post;
 
 		$queried_object = get_queried_object();
-		$shortcode_args = array(
-
-		);
+		$shortcode_args = array();
 
 		if ( is_product_category() ) {
-			$shortcode_args['category'] = $queried_object->slug;
+			$shortcode_args['category'] = sanitize_title( $queried_object->slug );
 		} elseif ( taxonomy_is_product_attribute( $queried_object->taxonomy ) ) {
-			$shortcode_args['attribute'] = $queried_object->taxonomy;
-			$shortcode_args['terms'] = $queried_object->slug;
+			$shortcode_args['attribute'] = sanitize_title( $queried_object->taxonomy );
+			$shortcode_args['terms'] = sanitize_title( $queried_object->slug );
 		} elseif ( is_product_tag() ) {
-			// todo
-			die( "NOT IMPLEMENTED" );
+			$shortcode_args['tag'] = sanitize_title( $queried_object->slug );
 		} else {
+			// Default theme archive for all other taxonomies.
 			return;
 		}
 
@@ -267,7 +265,7 @@ class WC_Template_Loader {
 			'post_modified'         => $shop_page->post_modified,
 			'post_modified_gmt'     => $shop_page->post_modified_gmt,
 			'post_content'          => $shortcode->get_content(),
-			'post_title'            => $queried_object->name,
+			'post_title'            => wc_clean( $queried_object->name ),
 			'post_excerpt'          => '',
 			'post_content_filtered' => '',
 			'post_mime_type'        => '',

--- a/includes/customizer/class-wc-customizer.php
+++ b/includes/customizer/class-wc-customizer.php
@@ -107,7 +107,7 @@ class WC_Customizer {
 	 * @return boolean
 	 */
 	public function is_active() {
-		return is_woocommerce() || wc_post_content_has_shortcode( 'products' );
+		return is_woocommerce() || wc_post_content_has_shortcode( 'products' ) || ! current_theme_supports( 'woocommerce' );
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -125,6 +125,7 @@ class WC_Shortcode_Products {
 			'attribute'      => '',        // Single attribute slug.
 			'terms'          => '',        // Comma separated term slugs.
 			'terms_operator' => 'IN',      // Operator to compare terms. Possible values are 'IN', 'NOT IN', 'AND'.
+			'tag'            => '',        // Comma separated tag slugs.
 			'visibility'     => 'visible', // Possible values are 'visible', 'catalog', 'search', 'hidden'.
 			'class'          => '',        // HTML class.
 			'page'           => 1,         // Page for pagination.
@@ -216,6 +217,9 @@ class WC_Shortcode_Products {
 		// Categories.
 		$this->set_categories_query_args( $query_args );
 
+		// Tags.
+		$this->set_tags_query_args( $query_args );
+
 		return apply_filters( 'woocommerce_shortcode_products_query', $query_args, $this->attributes, $this->type );
 	}
 
@@ -284,6 +288,23 @@ class WC_Shortcode_Products {
 				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) ),
 				'field'    => 'slug',
 				'operator' => $this->attributes['cat_operator'],
+			);
+		}
+	}
+
+	/**
+	 * Set tags query args.
+	 *
+	 * @since 3.3.0
+	 * @param array $query_args Query args.
+	 */
+	protected function set_tags_query_args( &$query_args ) {
+		if ( ! empty( $this->attributes['tag'] ) ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'product_tag',
+				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['tag'] ) ),
+				'field'    => 'slug',
+				'operator' => 'IN',
 			);
 		}
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wc_template_redirect() {
 	global $wp_query, $wp;
 
-	if ( ! empty( $_GET['page_id'] ) && '' === get_option( 'permalink_structure' ) && wc_get_page_id( 'shop' ) == $_GET['page_id'] ) {
+	if ( ! empty( $_GET['page_id'] ) && '' === get_option( 'permalink_structure' ) && wc_get_page_id( 'shop' ) === absint( $_GET['page_id'] ) && get_post_type_archive_link( 'product' ) ) {
 
 		// When default permalinks are enabled, redirect shop page to post type archive url.
 		wp_safe_redirect( get_post_type_archive_link( 'product' ) );

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -30,7 +30,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'page'           => 1,
 			'paginate'       => false,
 			'cache'          => true,
-
+			'tag'            => '',
 		);
 		$this->assertEquals( $expected, $shortcode->get_attributes() );
 
@@ -56,6 +56,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'page'           => 1,
 			'paginate'       => false,
 			'cache'          => true,
+			'tag'            => '',
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_attributes() );
 	}


### PR DESCRIPTION
Closes #17773.
Related #13087.

Adds product taxonomy archive support on unsupported themes. I also refactored and cleaned up the template handler code to make it easier to follow the logic for the different unsupported page types.

To test:
1. Activate a theme that doesn't formally declare WooCommerce support (Hamilton, Bassist, etc.)
2. Go to a product category page on the frontend
3. Go to a product attribute page on the frontend
4. Go to a product tag page on the frontend

Once this is merged into the feature branch I'll bring the feature branch up-to-date with master so we can prepare to merge it.