### PR TITLE
Made common template functions pluggable

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -653,33 +653,45 @@ if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {
 		<?php
 	}
 }
-/**
- * Insert the opening anchor tag for products in the loop.
- */
-function woocommerce_template_loop_product_link_open() {
-	echo '<a href="' . esc_url( get_the_permalink() ) . '" class="woocommerce-LoopProduct-link woocommerce-loop-product__link">';
-}
-/**
- * Insert the opening anchor tag for products in the loop.
- */
-function woocommerce_template_loop_product_link_close() {
-	echo '</a>';
+
+if ( ! function_exists( 'woocommerce_template_loop_product_link_open' ) ) {
+	/**
+	 * Insert the opening anchor tag for products in the loop.
+	 */
+	function woocommerce_template_loop_product_link_open() {
+		echo '<a href="' . esc_url( get_the_permalink() ) . '" class="woocommerce-LoopProduct-link woocommerce-loop-product__link">';
+	}
 }
 
-/**
- * Insert the opening anchor tag for categories in the loop.
- *
- * @param int|object|string $category Category ID, Object or String.
- */
-function woocommerce_template_loop_category_link_open( $category ) {
-	echo '<a href="' . esc_url( get_term_link( $category, 'product_cat' ) ) . '">';
+if ( ! function_exists( 'woocommerce_template_loop_product_link_close' ) ) {
+	/**
+	 * Insert the opening anchor tag for products in the loop.
+	 */
+	function woocommerce_template_loop_product_link_close() {
+		echo '</a>';
+	}
 }
-/**
- * Insert the closing anchor tag for categories in the loop.
- */
-function woocommerce_template_loop_category_link_close() {
-	echo '</a>';
+
+if ( ! function_exists( 'woocommerce_template_loop_category_link_open' ) ) {
+	/**
+	 * Insert the opening anchor tag for categories in the loop.
+	 *
+	 * @param int|object|string $category Category ID, Object or String.
+	 */
+	function woocommerce_template_loop_category_link_open( $category ) {
+		echo '<a href="' . esc_url( get_term_link( $category, 'product_cat' ) ) . '">';
+	}
 }
+
+if ( ! function_exists( 'woocommerce_template_loop_category_link_close' ) ) {
+	/**
+	 * Insert the closing anchor tag for categories in the loop.
+	 */
+	function woocommerce_template_loop_category_link_close() {
+		echo '</a>';
+	}
+}
+
 if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 
 	/**


### PR DESCRIPTION
Most commonly used template functions like `woocommerce_template_loop_product_link_open`, `woocommerce_template_loop_product_link_close`, `woocommerce_template_loop_category_link_open` and `woocommerce_template_loop_category_link_close` are not pluggable. They also do not have any filters making it impossible to override. 

This change will allow people to achieve some common requirements like:

- link the product loop of an external product to link directly to the external website instead of single product page 

- open the single product page in a new link from the loop