### PR TITLE
Fixed webhook initial test delivery ping

### DIFF
--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -36,6 +36,11 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 			$webhook->set_date_created( $date_created );
 		}
 
+		// Pending delivery by default if not set while creating a new webhook.
+		if ( ! isset( $changes['pending_delivery'] ) ) {
+			$webhook->set_pending_delivery( true );
+		}
+
 		$data = array(
 			'status'           => $webhook->get_status( 'edit' ),
 			'name'             => $webhook->get_name( 'edit' ),
@@ -150,7 +155,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		wp_cache_delete( $webhook->get_id(), 'webhooks' );
 		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
 
-		if ( $trigger || $webhook->get_pending_delivery() ) {
+		if ( 'active' === $webhook->get_status() && ( $trigger || $webhook->get_pending_delivery() ) ) {
 			$webhook->deliver_ping();
 		}
 


### PR DESCRIPTION
Should trigger test delivery when webhook is created and active or when active and delivery URL is changed.

Part of #12439 
