### PR TITLE
Use protected instead of private methods to allow easy override

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -18,19 +18,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Session_Handler extends WC_Session {
 
 	/** @var string cookie name */
-	private $_cookie;
+	protected $_cookie;
 
 	/** @var string session due to expire timestamp */
-	private $_session_expiring;
+	protected $_session_expiring;
 
 	/** @var string session expiration timestamp */
-	private $_session_expiration;
+	protected $_session_expiration;
 
 	/** $var bool Bool based on whether a cookie exists **/
-	private $_has_cookie = false;
+	protected $_has_cookie = false;
 
 	/** @var string Custom session table name */
-	private $_table;
+	protected $_table;
 
 	/**
 	 * Constructor for the session class.


### PR DESCRIPTION
Using private methods can be tricky, especially when someone tries to override classes.

I believe in general, for non-final classes, `private` properties should be avoided.

See [this as an example](https://github.com/woocommerce/woocommerce-follow-up-emails/blob/fix/issue-388/includes/addons/class-fue-session-handler.php) where in attempt to fix a bug in FUE, we had to come up with a workaround due to how FUE handles cart, coupled with sessions (that's [another issue](https://github.com/woocommerce/woocommerce-follow-up-emails/issues/450) which will take more time).


We worked together with @gedex on this one, so cc-ing him.