### PR TITLE
Add admin notice when helper plugin is deactivated

### DIFF
--- a/includes/admin/helper/class-wc-helper-compat.php
+++ b/includes/admin/helper/class-wc-helper-compat.php
@@ -135,7 +135,21 @@ class WC_Helper_Compat {
 
 		if ( is_plugin_active( 'woothemes-updater/woothemes-updater.php' ) ) {
 			deactivate_plugins( 'woothemes-updater/woothemes-updater.php' );
+
+			// Notify the user when the plugin is deactivated.
+			add_action( 'pre_current_active_plugins', array( __CLASS__, 'plugin_deactivation_notice' ) );
 		}
+	}
+
+	/**
+	 * Display admin notice directing the user where to go.
+	 */
+	public static function plugin_deactivation_notice() {
+		?>
+		<div id="message" class="error is-dismissible">
+			<p><?php printf( __( 'The WooCommerce Helper plugin is no longer needed. <a href="%s">Manage subscriptions</a> from the extensions tab instead.', 'woocommerce' ), esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ) ); ?></p>
+		</div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
Re-opening https://github.com/woocommerce/woocommerce/pull/15832, after seeing this to be an a cause of confusion - even many months after release.

Used the `pre_current_active_plugins` hook this time instead though, so the notice shows up underneath the "plugin activated" message for clarity. Also added a link to direct the user on where to go.

![helper](https://user-images.githubusercontent.com/8536129/33592174-33368216-d94f-11e7-878d-07354bac9d71.png)
