### PR TITLE
Update a product’s modified_date for stock changes

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -43,6 +43,7 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 		// Re-read product data after updating stock, then have stock status calculated and saved.
 		$product_with_stock = wc_get_product( $product_id_with_stock );
 		$product_with_stock->set_stock_status();
+		$product_with_stock->set_date_modified( date() );
 		$product_with_stock->save();
 
 		do_action( $product_with_stock->is_type( 'variation' ) ? 'woocommerce_variation_set_stock' : 'woocommerce_product_set_stock', $product_with_stock );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/17841

Decided to place this here for now: https://github.com/woocommerce/woocommerce/blob/00e5189a0568aff8388200d8ede2b67edffadfbd/includes/wc-stock-functions.php#L43, since the product is being read again there.

However, there could be some places I don't know about where the `wc_update_product_stock` isn't used but `$data_store->update_product_stock` is.  In which case, this should probably be done here: https://github.com/woocommerce/woocommerce/blob/c1c02cd0aa61e59b8495013ebcd730c512b67ea9/includes/data-stores/class-wc-product-data-store-cpt.php#L1090 - which would require re-reading the product data once more.