### PR TITLE
Fix cloned cart issues with fees

### DIFF
--- a/includes/class-wc-cart-fees.php
+++ b/includes/class-wc-cart-fees.php
@@ -69,8 +69,8 @@ final class WC_Cart_Fees {
 	 * Register methods for this object on the appropriate WordPress hooks.
 	 */
 	public function init() {
-		add_action( 'woocommerce_cart_emptied', array( $this, 'remove_all_fees' ) );
-		add_action( 'woocommerce_cart_reset', array( $this, 'remove_all_fees' ) );
+		add_action( 'woocommerce_cart_emptied', array( $this, 'remove_all_cart_fees' ), 1 );
+		add_action( 'woocommerce_cart_reset', array( $this, 'remove_all_cart_fees' ), 1 );
 	}
 
 	/**
@@ -150,5 +150,16 @@ final class WC_Cart_Fees {
 	 */
 	private function generate_id( $fee ) {
 		return sanitize_title( $fee->name );
+	}
+
+	/**
+	 * Remove all fees belonging to a specific cart.
+	 *
+	 * @since 3.3.0
+	 */
+	public function remove_all_cart_fees( $cart ) {
+		if ( $this->cart === $cart ) {
+			$this->remove_all_fees();
+		}
 	}
 }

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -128,8 +128,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * These properties store a reference to the cart, so we use new instead of clone.
 	 */
 	public function __clone() {
-		$this->session  = new WC_Cart_Session( $this );
-		$this->fees_api = new WC_Cart_Fees( $this );
+		$this->session  = clone $this->session;
+		$this->fees_api = clone $this->fees_api;
 	}
 
 	/*


### PR DESCRIPTION
This PR has 2 parts, both related to dealing with cloned `WC_Carts` objects and fees. 

**1. Clone the child objects of the `WC_Cart` object rather than instantiating whole new objects (2c51cea)**

If I was to do something like:

```php
WC()->cart->add_fee( 'fee', 10 );
$cart_clone = clone WC()->cart;
```

I would expect `$cart_clone` to have the same fees as the original. On WC `master` that's not the case because a new `WC_Cart_Fees` is created when the clone is made. By cloning the objects it should still fix #17561 because the two carts will point to different instances of `WC_Cart_Fees`.

**2. Only remove fees which apply to the cart object which is emptied or had its totals reset (06f55d1)**

If you have multiple instances of a cart and you empty one of them or calculate the totals, all fees are removed from all cart instances.

For example: 

```php
WC()->cart->add_fee( 'fee', 10 );
$cart_clone = clone WC()->cart;
$cart_clone->calculate_totals() // this calls `WC_Cart::reset_totals` which triggers `woocommerce_cart_reset`
```

In this example, the core WC cart (`WC()->cart`) has its fees removed after calculating the cloned cart's totals. 

This happens because there are 2 instances of `WC_Cart` and therefore 2 instances of `WC_Cart_Fees`. When you call `WC_Cart::reset_totals` on 1 cart instance, all instances of `WC_Cart_Fees` will trigger `WC_Cart_Fees::remove_all_fees` because they all hooked in individually and therefore remove all the fees from all the carts.

The way I've got around that is to introduce `WC_Cart_Fees::remove_all_cart_fees()` which will only clear the fees if the cart being reset or emptied is the cart this instance of `WC_Cart_Fees` references. 

Let me know if there's a better way to do this.

Related to #17561 and #17599.