### PR TITLE
Only published products are visible

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1015,7 +1015,7 @@ function wc_get_product_tag_list( $product_id, $sep = ', ', $before = '', $after
  * @return bool
  */
 function wc_products_array_filter_visible( $product ) {
-	return $product && is_a( $product, 'WC_Product' ) && $product->is_visible();
+	return $product && is_a( $product, 'WC_Product' ) && $product->is_visible() && 'publish' === $product->get_status();
 }
 
 /**


### PR DESCRIPTION
Fixes #18023 

To test: Add a product as an upsell and as a cross-sell. Trash the product. Verify the product is not shown on upsell and cross-sell areas of the site.