### PR TITLE
Setup wizard: PayPal Express Checkout settings for rerouting via WCS

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -987,7 +987,7 @@ p.jetpack-terms {
 	font-size: 0.9em;
 }
 
-.wc-wizard-service-setting-stripe_create_account {
+.wc-wizard-service-setting-stripe_create_account, .wc-wizard-service-setting-ppec_paypal_reroute_requests {
 	display: flex;
 	align-items: flex-end;
 	margin-top: 0.75em;
@@ -999,16 +999,16 @@ p.jetpack-terms {
 		width: 1.5em;
 	}
 
-	.stripe_create_account {
+	.stripe_create_account, .ppec_paypal_reroute_requests {
 		order: 2;
 		margin-left: 0.3em;
 	}
 }
 
-.wc-wizard-service-setting-stripe_email {
+.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_api_subject {
 	margin-top: 0.75em;
 
-	label.stripe_email {
+	label.stripe_email, label.ppec_paypal_api_subject {
 		position: absolute;
 		margin: -1px;
 		padding: 0;

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -124,25 +124,23 @@ jQuery( function( $ ) {
 		waitForJetpackInstall();
 	} );
 
-	$( '.wc-wizard-services' ).on( 'change', 'input#stripe_create_account', function() {
+	$( '.wc-wizard-services' ).on( 'change', 'input#stripe_create_account, input#ppec_paypal_reroute_requests', function() {
 		if ( $( this ).is( ':checked' ) ) {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
 				.prop( 'required', true );
 			$( this ).closest( '.wc-wizard-service-settings' )
-				.find( '.wc-wizard-service-setting-stripe_email' )
+				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_api_subject' )
 				.show();
 		} else {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
 				.prop( 'required', false );
 			$( this ).closest( '.wc-wizard-service-settings' )
-				.find( '.wc-wizard-service-setting-stripe_email' )
+				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_api_subject' )
 				.hide();
 		}
-	} );
-
-	$( '.wc-wizard-services input#stripe_create_account' ).change();
+	} ).find( 'input#stripe_create_account, input#ppec_paypal_reroute_requests' ).change();
 
 	$( 'select#store_country_state' ).on( 'change', function() {
 		var countryCode = this.value.split( ':' )[ 0 ];

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1078,7 +1078,7 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'woocommerce-gateway-paypal-express-checkout',
 				'settings'    => array(
 					'reroute_requests' => array(
-						'label'       => __( 'Defer linking PayPal account until payment received', 'woocommerce' ),
+						'label'       => __( 'Accept payments without linking a PayPal account', 'woocommerce' ),
 						'type'        => 'checkbox',
 						'value'       => 'yes',
 						'placeholder' => '',

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1075,6 +1075,23 @@ class WC_Admin_Setup_Wizard {
 				'image'       => WC()->plugin_url() . '/assets/images/paypal.png',
 				'description' => $paypal_ec_description,
 				'repo-slug'   => 'woocommerce-gateway-paypal-express-checkout',
+				'settings'    => array(
+					'reroute_requests' => array(
+						'label'       => __( 'Set up Express Checkout payments for me', 'woocommerce' ),
+						'type'        => 'checkbox',
+						'value'       => 'yes',
+						'placeholder' => '',
+						'required'    => false,
+					),
+					'api_subject' => array(
+						'label'       => __( 'Direct payments to email address:', 'woocommerce' ),
+						'type'        => 'email',
+						'value'       => $user_email,
+						'placeholder' => __( 'Email address to receive payments', 'woocommerce' ),
+						'description' => __( "Enter your email address and we'll authenticate payments for you. To claim a payment, you'll need to have a PayPal Business account or create one later. WooCommerce Services and Jetpack will be installed and activated for you.", 'woocommerce' ),
+						'required'    => true,
+					),
+				),
 			),
 			'paypal' => array(
 				'name'        => __( 'PayPal Standard', 'woocommerce' ),

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1340,10 +1340,16 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_payment_save() {
 		check_admin_referer( 'wc-setup' );
 
-		// Install WooCommerce Services with Stripe to enable deferred account creation.
 		if (
-			! empty( $_POST['wc-wizard-service-stripe-enabled'] ) &&
-			! empty( $_POST['stripe_create_account'] )
+			(
+				// Install WooCommerce Services with Stripe to enable deferred account creation
+				! empty( $_POST['wc-wizard-service-stripe-enabled'] ) &&
+				! empty( $_POST['stripe_create_account'] )
+			) || (
+				// Install WooCommerce Services with PayPal EC to enable proxied payments
+				! empty( $_POST['wc-wizard-service-ppec_paypal-enabled'] ) &&
+				! empty( $_POST['ppec_paypal_reroute_requests'] )
+			)
 		) {
 			$this->install_woocommerce_services();
 		}
@@ -1491,6 +1497,11 @@ class WC_Admin_Setup_Wizard {
 		$stripe_enabled  = is_array( $stripe_settings )
 			&& isset( $stripe_settings['create_account'] ) && 'yes' === $stripe_settings['create_account']
 			&& isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
+		$ppec_settings   = get_option( 'woocommerce_ppec_paypal_settings', false );
+		$ppec_enabled    = is_array( $ppec_settings )
+			&& isset( $ppec_settings['reroute_requests'] ) && 'yes' === $ppec_settings['reroute_requests']
+			&& isset( $ppec_settings['enabled'] ) && 'yes' === $ppec_settings['enabled'];
+		$payment_enabled = $stripe_enabled || $ppec_enabled;
 		$taxes_enabled   = (bool) get_option( 'woocommerce_setup_automated_taxes', false );
 		$domestic_rates  = (bool) get_option( 'woocommerce_setup_domestic_live_rates_zone', false );
 		$intl_rates      = (bool) get_option( 'woocommerce_setup_intl_live_rates_zone', false );
@@ -1499,14 +1510,14 @@ class WC_Admin_Setup_Wizard {
 		/* translators: %s: list of features, potentially comma separated */
 		$description_base = __( 'Your store is almost ready! To activate services like %s, just connect with Jetpack.', 'woocommerce' );
 
-		if ( $stripe_enabled && $taxes_enabled && $rates_enabled ) {
-			$description = sprintf( $description_base, __( 'Stripe payments, automated taxes, live rates and discounted shipping labels', 'woocommerce' ) );
-		} else if ( $stripe_enabled && $taxes_enabled ) {
-			$description = sprintf( $description_base, __( 'Stripe payments and automated taxes', 'woocommerce' ) );
-		} else if ( $stripe_enabled && $rates_enabled ) {
-			$description = sprintf( $description_base, __( 'Stripe payments, live rates and discounted shipping labels', 'woocommerce' ) );
-		} else if ( $stripe_enabled ) {
-			$description = sprintf( $description_base, __( 'Stripe payments', 'woocommerce' ) );
+		if ( $payment_enabled && $taxes_enabled && $rates_enabled ) {
+			$description = sprintf( $description_base, __( 'payments, automated taxes, live rates and discounted shipping labels', 'woocommerce' ) );
+		} else if ( $payment_enabled && $taxes_enabled ) {
+			$description = sprintf( $description_base, __( 'payments and automated taxes', 'woocommerce' ) );
+		} else if ( $payment_enabled && $rates_enabled ) {
+			$description = sprintf( $description_base, __( 'payments, live rates and discounted shipping labels', 'woocommerce' ) );
+		} else if ( $payment_enabled ) {
+			$description = sprintf( $description_base, __( 'payments', 'woocommerce' ) );
 		} else if ( $taxes_enabled && $rates_enabled ) {
 			$description = sprintf( $description_base, __( 'automated taxes, live rates and discounted shipping labels', 'woocommerce' ) );
 		} else if ( $taxes_enabled ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1362,7 +1362,7 @@ class WC_Admin_Setup_Wizard {
 			// @codingStandardsIgnoreStart
 			if ( ! empty( $gateway['settings'] ) ) {
 				foreach ( $gateway['settings'] as $setting_id => $setting ) {
-					$settings[ $setting_id ] = 'yes' === $settings['enabled']
+					$settings[ $setting_id ] = 'yes' === $settings['enabled'] && isset( $_POST[ $gateway_id . '_' . $setting_id ] )
 						? wc_clean( wp_unslash( $_POST[ $gateway_id . '_' . $setting_id ] ) )
 						: false;
 				}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1078,7 +1078,7 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'woocommerce-gateway-paypal-express-checkout',
 				'settings'    => array(
 					'reroute_requests' => array(
-						'label'       => __( 'Set up Express Checkout payments for me', 'woocommerce' ),
+						'label'       => __( 'Defer linking PayPal account until payment received', 'woocommerce' ),
 						'type'        => 'checkbox',
 						'value'       => 'yes',
 						'placeholder' => '',

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1342,11 +1342,11 @@ class WC_Admin_Setup_Wizard {
 
 		if (
 			(
-				// Install WooCommerce Services with Stripe to enable deferred account creation
+				// Install WooCommerce Services with Stripe to enable deferred account creation.
 				! empty( $_POST['wc-wizard-service-stripe-enabled'] ) &&
 				! empty( $_POST['stripe_create_account'] )
 			) || (
-				// Install WooCommerce Services with PayPal EC to enable proxied payments
+				// Install WooCommerce Services with PayPal EC to enable proxied payments.
 				! empty( $_POST['wc-wizard-service-ppec_paypal-enabled'] ) &&
 				! empty( $_POST['ppec_paypal_reroute_requests'] )
 			)

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1074,6 +1074,7 @@ class WC_Admin_Setup_Wizard {
 				'name'        => __( 'PayPal Express Checkout', 'woocommerce' ),
 				'image'       => WC()->plugin_url() . '/assets/images/paypal.png',
 				'description' => $paypal_ec_description,
+				'class'       => 'checked',
 				'repo-slug'   => 'woocommerce-gateway-paypal-express-checkout',
 				'settings'    => array(
 					'reroute_requests' => array(


### PR DESCRIPTION
<img width="430" alt="screen shot 2017-12-06 at 4 54 18 am" src="https://user-images.githubusercontent.com/1867547/33655623-8e19d5dc-da41-11e7-978e-1f7dd8d1788f.png">

Optionally sets `reroute_requests` and `api_subject` settings, which triggers WCS + Jetpack install, and are sufficient to make PPEC payment requests work if WCS is active — requires https://github.com/Automattic/woocommerce-services/pull/1254. (Context in p7bbVw-2kH-p2.)

Open to feedback / ideas on copy. Alternate possibilities considered for the checkbox label: "Set up [or] Authenticate [or] Sign [or] Handle Express Checkout payments for me". Also open to a more apt setting name than `reroute_requests`.

For comparison:
<img width="649" src="https://user-images.githubusercontent.com/1867547/33655626-943d333c-da41-11e7-9b94-ea9baeacfe1b.png">
(The "Defer linking..." text currently wraps, but I optimistically applied a style change from https://github.com/woocommerce/woocommerce/pull/17738 for the screenshot.)

To test behavior:
- Enable option, keep checkbox unchecked, continue — make sure WCS and Jetpack are not installed
- Check checkbox, enter email, continue — make sure WCS and Jetpack are installed
  - Connect in the "Activate" step, complete wizard — make sure Live API Subject field is set to entered email in PayPal Express Checkout settings