### PR TITLE
Add default row/column control for themes

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -361,7 +361,7 @@ function wc_get_default_product_rows_per_page() {
  *
  * @since 3.3.0
  */
-function wc_maybe_reset_product_grid() {
+function wc_reset_product_grid_settings() {
 	$theme_support = get_theme_support( 'woocommerce' );
 	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
 
@@ -377,7 +377,7 @@ function wc_maybe_reset_product_grid() {
 		delete_option( 'woocommerce_catalog_columns' );
 	}
 }
-add_action( 'after_switch_theme', 'wc_maybe_reset_product_grid' );
+add_action( 'after_switch_theme', 'wc_reset_product_grid_settings' );
 
 /**
  * Get classname for woocommerce loops.

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -357,6 +357,29 @@ function wc_get_default_product_rows_per_page() {
 }
 
 /**
+ * Reset the product grid settings if the current theme has default product grid settings defined.
+ *
+ * @since 3.3.0
+ */
+function wc_maybe_reset_product_grid() {
+	$theme_support = get_theme_support( 'woocommerce' );
+	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
+
+	if ( isset( $theme_support['product_grid']['default_rows'] ) ) {
+		update_option( 'woocommerce_catalog_rows', absint( $theme_support['product_grid']['default_rows'] ) );
+	} else {
+		delete_option( 'woocommerce_catalog_rows' );
+	}
+
+	if ( isset( $theme_support['product_grid']['default_rows'] ) ) {
+		update_option( 'woocommerce_catalog_columns', absint( $theme_support['product_grid']['default_columns'] ) );
+	} else {
+		delete_option( 'woocommerce_catalog_columns' );
+	}
+}
+add_action( 'after_switch_theme', 'wc_maybe_reset_product_grid' );
+
+/**
  * Get classname for woocommerce loops.
  *
  * @since 2.6.0
@@ -960,7 +983,8 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 if ( ! function_exists( 'woocommerce_pagination' ) ) {
 
 	/**
-	 * Output the pagination.	 */
+	 * Output the pagination.
+	 */
 	function woocommerce_pagination() {
 		if ( ! wc_get_loop_prop( 'is_paginated' ) || ! woocommerce_products_will_display() ) {
 			return;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -357,7 +357,7 @@ function wc_get_default_product_rows_per_page() {
 }
 
 /**
- * Reset the product grid settings if the current theme has default product grid settings defined.
+ * Reset the product grid settings when a new theme is activated.
  *
  * @since 3.3.0
  */

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -310,11 +310,12 @@ function wc_product_cat_class( $class = '', $category = null ) {
  * @return int
  */
 function wc_get_default_products_per_row() {
-	$columns = get_option( 'woocommerce_catalog_columns', 3 );
-
 	// Theme support.
 	$theme_support = get_theme_support( 'woocommerce' );
 	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
+
+	$default_columns = isset( $theme_support['product_grid']['default_columns'] ) ? absint( $theme_support['product_grid']['default_columns'] ) : 3;
+	$columns = get_option( 'woocommerce_catalog_columns', $default_columns );
 
 	if ( isset( $theme_support['product_grid']['min_columns'] ) && $columns < $theme_support['product_grid']['min_columns'] ) {
 		$columns = $theme_support['product_grid']['min_columns'];
@@ -339,11 +340,12 @@ function wc_get_default_products_per_row() {
  * @return int
  */
 function wc_get_default_product_rows_per_page() {
-	$rows = absint( get_option( 'woocommerce_catalog_rows', 4 ) );
-
 	// Theme support.
 	$theme_support = get_theme_support( 'woocommerce' );
 	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
+
+	$default_rows = isset( $theme_support['product_grid']['default_rows'] ) ? absint( $theme_support['product_grid']['default_rows'] ) : 4;
+	$rows = absint( get_option( 'woocommerce_catalog_rows', $default_rows ) );
 
 	if ( isset( $theme_support['product_grid']['min_rows'] ) && $rows < $theme_support['product_grid']['min_rows'] ) {
 		$rows = $theme_support['product_grid']['min_rows'];
@@ -960,7 +962,8 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 if ( ! function_exists( 'woocommerce_pagination' ) ) {
 
 	/**
-	 * Output the pagination.	 */
+	 * Output the pagination.
+	 */
 	function woocommerce_pagination() {
 		if ( ! wc_get_loop_prop( 'is_paginated' ) || ! woocommerce_products_will_display() ) {
 			return;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -310,12 +310,11 @@ function wc_product_cat_class( $class = '', $category = null ) {
  * @return int
  */
 function wc_get_default_products_per_row() {
+	$columns = get_option( 'woocommerce_catalog_columns', 3 );
+
 	// Theme support.
 	$theme_support = get_theme_support( 'woocommerce' );
 	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
-	$default_columns = isset( $theme_support['product_grid']['default_columns'] ) ? absint( $theme_support['product_grid']['default_columns'] ) : 3;
-	$columns = get_option( 'woocommerce_catalog_columns', $default_columns );
 
 	if ( isset( $theme_support['product_grid']['min_columns'] ) && $columns < $theme_support['product_grid']['min_columns'] ) {
 		$columns = $theme_support['product_grid']['min_columns'];
@@ -340,12 +339,11 @@ function wc_get_default_products_per_row() {
  * @return int
  */
 function wc_get_default_product_rows_per_page() {
+	$rows = absint( get_option( 'woocommerce_catalog_rows', 4 ) );
+
 	// Theme support.
 	$theme_support = get_theme_support( 'woocommerce' );
 	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
-	$default_rows = isset( $theme_support['product_grid']['default_rows'] ) ? absint( $theme_support['product_grid']['default_rows'] ) : 4;
-	$rows = absint( get_option( 'woocommerce_catalog_rows', $default_rows ) );
 
 	if ( isset( $theme_support['product_grid']['min_rows'] ) && $rows < $theme_support['product_grid']['min_rows'] ) {
 		$rows = $theme_support['product_grid']['min_rows'];
@@ -962,8 +960,7 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 if ( ! function_exists( 'woocommerce_pagination' ) ) {
 
 	/**
-	 * Output the pagination.
-	 */
+	 * Output the pagination.	 */
 	function woocommerce_pagination() {
 		if ( ! wc_get_loop_prop( 'is_paginated' ) || ! woocommerce_products_will_display() ) {
 			return;


### PR DESCRIPTION
Closes #18064 

Usage:
```
add_theme_support( 'woocommerce', array(
	'thumbnail_image_width' => 140,
	'single_image_width'    => 300,
	'product_grid'          => array(
		'default_columns' => 4,
		'default_rows'    => 3,
	),
) );

```