### PR TITLE
Updated API settings making clear that is from our legacy REST API

### DIFF
--- a/includes/admin/settings/class-wc-settings-rest-api.php
+++ b/includes/admin/settings/class-wc-settings-rest-api.php
@@ -71,16 +71,16 @@ class WC_Settings_Rest_API extends WC_Settings_Page {
 				),
 
 				array(
-					'title'   => __( 'API', 'woocommerce' ),
-					'desc'    => __( 'Enable the REST API', 'woocommerce' ),
+					'title'   => __( 'Legacy API', 'woocommerce' ),
+					'desc'    => __( 'Enable the legacy REST API', 'woocommerce' ),
 					'id'      => 'woocommerce_api_enabled',
 					'type'    => 'checkbox',
-					'default' => 'yes',
+					'default' => 'no',
 				),
 
 				array(
 					'type' => 'sectionend',
-					'id' => 'general_options',
+					'id'   => 'general_options',
 				),
 			) );
 		}


### PR DESCRIPTION
It's time to have this disabled as default since is getting close to deprecated Legacy REST API v3: https://github.com/woocommerce/woocommerce/wiki/Contributing-to-the-WooCommerce-REST-API#deprecation-of-older-versions

We can leave to 3.4.

