### PR TITLE
Attributes; remove 'text' display option

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -181,7 +181,7 @@ class WC_Admin_Attributes {
 				$att_name    = $attribute_to_edit->attribute_name;
 				$att_orderby = $attribute_to_edit->attribute_orderby;
 				$att_public  = $attribute_to_edit->attribute_public;
-			?>
+				?>
 				<form action="edit.php?post_type=product&amp;page=product_attributes&amp;edit=<?php echo absint( $edit ); ?>" method="post">
 					<table class="form-table">
 						<tbody>
@@ -213,28 +213,43 @@ class WC_Admin_Attributes {
 									<p class="description"><?php esc_html_e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
 								</td>
 							</tr>
-							<tr class="form-field form-required">
-								<th scope="row" valign="top">
-									<label for="attribute_type"><?php esc_html_e( 'Type', 'woocommerce' ); ?></label>
-								</th>
-								<td>
-									<select name="attribute_type" id="attribute_type">
-										<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
-											<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $att_type, $key ); ?>><?php echo esc_attr( $value ); ?></option>
-										<?php endforeach; ?>
+							<?php
+							/**
+							 * Attribute types can change the way attributes are displayed on the frontend and admin.
+							 *
+							 * By Default WooCommerce only includes the `select` type. Others can be added with the
+							 * `product_attributes_type_selector` filter. If there is only the default type registered,
+							 * this setting will be hidden.
+							 */
+							$attribute_types = wc_get_attribute_types();
 
-										<?php
-											/**
-											 * Deprecated action in favor of product_attributes_type_selector filter.
-											 *
-											 * @deprecated 2.4.0
-											 */
-											do_action( 'woocommerce_admin_attribute_types' );
-										?>
-									</select>
-									<p class="description"><?php esc_html_e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
-								</td>
-							</tr>
+							if ( 1 < count( $attribute_types ) || ! array_key_exists( 'select', $attribute_types ) ) {
+								?>
+								<tr class="form-field form-required">
+									<th scope="row" valign="top">
+										<label for="attribute_type"><?php esc_html_e( 'Type', 'woocommerce' ); ?></label>
+									</th>
+									<td>
+										<select name="attribute_type" id="attribute_type">
+											<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
+												<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $att_type, $key ); ?>><?php echo esc_attr( $value ); ?></option>
+											<?php endforeach; ?>
+											<?php
+												/**
+												 * Deprecated action in favor of product_attributes_type_selector filter.
+												 *
+												 * @todo Remove in 4.0.0
+												 * @deprecated 2.4.0
+												 */
+												do_action( 'woocommerce_admin_attribute_types' );
+											?>
+										</select>
+										<p class="description"><?php esc_html_e( "Determines how this attribute's values are displayed.", 'woocommerce' ); ?></p>
+									</td>
+								</tr>
+								<?php
+							}
+							?>
 							<tr class="form-field form-required">
 								<th scope="row" valign="top">
 									<label for="attribute_orderby"><?php esc_html_e( 'Default sort order', 'woocommerce' ); ?></label>
@@ -382,25 +397,39 @@ class WC_Admin_Attributes {
 									<p class="description"><?php esc_html_e( 'Enable this if you want this attribute to have product archives in your store.', 'woocommerce' ); ?></p>
 								</div>
 
-								<div class="form-field">
-									<label for="attribute_type"><?php esc_html_e( 'Type', 'woocommerce' ); ?></label>
-									<select name="attribute_type" id="attribute_type">
-										<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
-											<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $value ); ?></option>
-										<?php endforeach; ?>
+								<?php
+								/**
+								 * Attribute types can change the way attributes are displayed on the frontend and admin.
+								 *
+								 * By Default WooCommerce only includes the `select` type. Others can be added with the
+								 * `product_attributes_type_selector` filter. If there is only the default type registered,
+								 * this setting will be hidden.
+								 */
+								$attribute_types = wc_get_attribute_types();
 
-										<?php
-
-											/**
-											 * Deprecated action in favor of product_attributes_type_selector filter.
-											 *
-											 * @deprecated 2.4.0
-											 */
-											do_action( 'woocommerce_admin_attribute_types' );
-										?>
-									</select>
-									<p class="description"><?php esc_html_e( 'Determines how you select attributes for products. Under admin panel -> products -> product data -> attributes -> values, <strong>Text</strong> allows manual entry whereas <strong>select</strong> allows pre-configured terms in a drop-down list.', 'woocommerce' ); ?></p>
-								</div>
+								if ( 1 < count( $attribute_types ) || ! array_key_exists( 'select', $attribute_types ) ) {
+									?>
+									<div class="form-field">
+										<label for="attribute_type"><?php esc_html_e( 'Type', 'woocommerce' ); ?></label>
+										<select name="attribute_type" id="attribute_type">
+											<?php foreach ( wc_get_attribute_types() as $key => $value ) : ?>
+												<option value="<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $value ); ?></option>
+											<?php endforeach; ?>
+											<?php
+												/**
+												 * Deprecated action in favor of product_attributes_type_selector filter.
+												 *
+												 * @todo Remove in 4.0.0
+												 * @deprecated 2.4.0
+												 */
+												do_action( 'woocommerce_admin_attribute_types' );
+											?>
+										</select>
+										<p class="description"><?php esc_html_e( "Determines how this attribute's values are displayed.", 'woocommerce' ); ?></p>
+									</div>
+									<?php
+								}
+								?>
 
 								<div class="form-field">
 									<label for="attribute_orderby"><?php esc_html_e( 'Default sort order', 'woocommerce' ); ?></label>

--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -27,12 +27,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</td>
 					<td rowspan="3">
 						<label><?php esc_html_e( 'Value(s)', 'woocommerce' ); ?>:</label>
-
 						<?php
-						if ( $attribute->is_taxonomy() && $attribute_taxonomy = $attribute->get_taxonomy_object() ) :
-						?>
-							<?php if ( 'select' === $attribute_taxonomy->attribute_type ) : ?>
+						if ( $attribute->is_taxonomy() && $attribute_taxonomy = $attribute->get_taxonomy_object() ) {
+							$attribute_types = wc_get_attribute_types();
 
+							if ( ! array_key_exists( $attribute_taxonomy->attribute_type, $attribute_types ) ) {
+								$attribute_taxonomy->attribute_type = 'select';
+							}
+
+							if ( 'select' === $attribute_taxonomy->attribute_type ) {
+								?>
 								<select multiple="multiple" data-placeholder="<?php esc_attr_e( 'Select terms', 'woocommerce' ); ?>" class="multiselect attribute_values wc-enhanced-select" name="attribute_values[<?php echo esc_attr( $i ); ?>][]">
 									<?php
 									$args = array(
@@ -52,30 +56,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<button class="button plus select_all_attributes"><?php esc_html_e( 'Select all', 'woocommerce' ); ?></button>
 								<button class="button minus select_no_attributes"><?php esc_html_e( 'Select none', 'woocommerce' ); ?></button>
 								<button class="button fr plus add_new_attribute"><?php esc_html_e( 'Add new', 'woocommerce' ); ?></button>
+								<?php
+							}
 
-							<?php elseif ( 'text' === $attribute_taxonomy->attribute_type ) : ?>
-
-								<input type="text" name="attribute_values[<?php echo esc_attr( $i ); ?>]" value="<?php
-
-									// Text attributes should list terms pipe separated
-									echo esc_attr( wc_implode_text_attributes( wp_list_pluck( $attribute->get_terms(), 'name' ) ) );
-
-								?>" placeholder="<?php
-
-									/* translators: %s: WC_DELIMITER */
-									printf( esc_attr__( '"%s" separate terms', 'woocommerce' ), WC_DELIMITER );
-
-								?>" />
-
-							<?php endif; ?>
-
-							<?php do_action( 'woocommerce_product_option_terms', $attribute_taxonomy, $i ); ?>
-
-						<?php else : ?>
-							<?php /* translators: %s: WC_DELIMITER */ ?>
-							<textarea name="attribute_values[<?php echo esc_attr( $i ); ?>]" cols="5" rows="5" placeholder="<?php printf( esc_attr__( 'Enter some text, or some attributes by "%s" separating values.', 'woocommerce' ), WC_DELIMITER ); ?>"><?php echo esc_textarea( wc_implode_text_attributes( $attribute->get_options() ) ); ?></textarea>
-
-						<?php endif; ?>
+							do_action( 'woocommerce_product_option_terms', $attribute_taxonomy, $i );
+						} else {
+							/* translators: %s: WC_DELIMITER */
+							?><textarea name="attribute_values[<?php echo esc_attr( $i ); ?>]" cols="5" rows="5" placeholder="<?php printf( esc_attr__( 'Enter some text, or some attributes by "%s" separating values.', 'woocommerce' ), WC_DELIMITER ); ?>"><?php echo esc_textarea( wc_implode_text_attributes( $attribute->get_options() ) ); ?></textarea><?php
+						}
+						?>
 					</td>
 				</tr>
 				<tr>

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -194,7 +194,6 @@ function wc_get_attribute_taxonomy_names() {
 function wc_get_attribute_types() {
 	return (array) apply_filters( 'product_attributes_type_selector', array(
 		'select' => __( 'Select', 'woocommerce' ),
-		'text'   => __( 'Text', 'woocommerce' ),
 	) );
 }
 
@@ -208,7 +207,7 @@ function wc_get_attribute_types() {
 function wc_get_attribute_type_label( $type ) {
 	$types = wc_get_attribute_types();
 
-	return isset( $types[ $type ] ) ? $types[ $type ] : ucfirst( $type );
+	return isset( $types[ $type ] ) ? $types[ $type ] : __( 'Select', 'woocommerce' );
 }
 
 /**

--- a/tests/unit-tests/attributes/functions.php
+++ b/tests/unit-tests/attributes/functions.php
@@ -84,7 +84,7 @@ class WC_Tests_Attributes_Functions extends WC_Unit_Test_Case {
 			'id'           => $id,
 			'name'         => 'Brand',
 			'slug'         => 'pa_brand',
-			'type'         => 'text',
+			'type'         => 'select',
 			'order_by'     => 'menu_order',
 			'has_archives' => true,
 		);


### PR DESCRIPTION
Ref #18045 

Since this setting is confusing users (presentation looks no different when using text or select, just the admin input) this PR removes it.

Filters are preserved so developers can still implement custom types if needed. Use case; adding a radio select type. If there is only 1 type registered, the option is hidden.

If a type is invalid, it defaults to select. BW compat is preserved.

This option may have been included before we had the ‘add new’ button on select attributes. That flow is preferred.