### PR TITLE
Fix cloned cart fee issues redux

### DIFF
--- a/includes/class-wc-cart-fees.php
+++ b/includes/class-wc-cart-fees.php
@@ -66,14 +66,6 @@ final class WC_Cart_Fees {
 	}
 
 	/**
-	 * Register methods for this object on the appropriate WordPress hooks.
-	 */
-	public function init() {
-		add_action( 'woocommerce_cart_emptied', array( $this, 'remove_all_fees' ) );
-		add_action( 'woocommerce_cart_reset', array( $this, 'remove_all_fees' ) );
-	}
-
-	/**
 	 * Add a fee. Fee IDs must be unique.
 	 *
 	 * @since 3.2.0

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -127,8 +127,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * These properties store a reference to the cart, so we use new instead of clone.
 	 */
 	public function __clone() {
-		$this->session  = new WC_Cart_Session( $this );
-		$this->fees_api = new WC_Cart_Fees( $this );
+		$this->session  = clone $this->session;
+		$this->fees_api = clone $this->fees_api;
 	}
 
 	/*

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -111,7 +111,6 @@ class WC_Cart extends WC_Legacy_Cart {
 
 		// Register hooks for the objects.
 		$this->session->init();
-		$this->fees_api->init();
 
 		add_action( 'woocommerce_add_to_cart', array( $this, 'calculate_totals' ), 20, 0 );
 		add_action( 'woocommerce_applied_coupon', array( $this, 'calculate_totals' ), 20, 0 );
@@ -639,6 +638,8 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( $clear_persistent_cart ) {
 			$this->session->persistent_cart_destroy();
 		}
+
+		$this->fees_api->remove_all_fees();
 
 		do_action( 'woocommerce_cart_emptied' );
 	}
@@ -1901,6 +1902,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	private function reset_totals() {
 		$this->totals = $this->default_totals;
+		$this->fees_api->remove_all_fees();
 		do_action( 'woocommerce_cart_reset', $this, false );
 	}
 }


### PR DESCRIPTION
This is a resubmit of #18015 with the changes discussed in https://github.com/woocommerce/woocommerce/pull/18015#discussion_r155188129

-------------------------

This PR has 2 parts, both related to dealing with cloned `WC_Carts` objects and fees. 

**1. Clone the child objects of the `WC_Cart` object rather than instantiating whole new objects (82c282e)**

If I was to do something like:

```php
WC()->cart->add_fee( 'fee', 10 );
$cart_clone = clone WC()->cart;
```

I would expect `$cart_clone` to have the same fees as the original. On WC `master` that's not the case because a new `WC_Cart_Fees` is created when the clone is made. By cloning the objects it should still fix #17561 because the two carts will point to different instances of `WC_Cart_Fees`.

**2. Only remove fees which apply to the cart object which is emptied or had its totals reset (83de162)**

If you have multiple instances of a cart and you empty one of them or calculate the totals, all fees are removed from all cart instances.

For example: 

```php
WC()->cart->add_fee( 'fee', 10 );
$cart_clone = clone WC()->cart;
$cart_clone->calculate_totals() // this calls `WC_Cart::reset_totals` which triggers `woocommerce_cart_reset`
```

In this example, the core WC cart (`WC()->cart`) has its fees removed after calculating the cloned cart's totals. 

This happens because there are 2 instances of `WC_Cart` and therefore 2 instances of `WC_Cart_Fees`. When you call `WC_Cart::reset_totals` on 1 cart instance, all instances of `WC_Cart_Fees` will trigger `WC_Cart_Fees::remove_all_fees` because they all hooked in individually and therefore remove all the fees from all the carts.

To avoid that, I removed the hook and callback approach and instead remove the fees directly from within the cart instance.

Related to #17561 and #17599.