### PR TITLE
a11y: add `role=alert` to woocommerce message div

### DIFF
--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -27,5 +27,5 @@ if ( ! $messages ) {
 ?>
 
 <?php foreach ( $messages as $message ) : ?>
-	<div class="woocommerce-message"><?php echo wp_kses_post( $message ); ?></div>
+	<div class="woocommerce-message" role="alert"><?php echo wp_kses_post( $message ); ?></div>
 <?php endforeach; ?>


### PR DESCRIPTION
Help assistive technology and to mark the message as important message. When this role is added to an element, the browser will send out an accessible alert event to assistive technology products which can then notify the user about it.