### PR TITLE
Shipping calculator and taxes

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -23,10 +23,10 @@ class WC_Shortcode_Cart {
 		try {
 			WC()->shipping->reset_shipping();
 
-			$country  = wc_clean( wp_unslash( $_POST['calc_shipping_country'] ) );
-			$state    = wc_clean( wp_unslash( isset( $_POST['calc_shipping_state'] ) ? $_POST['calc_shipping_state'] : '' ) );
-			$postcode = apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true ) ? wc_clean( wp_unslash( $_POST['calc_shipping_postcode'] ) ) : '';
-			$city     = apply_filters( 'woocommerce_shipping_calculator_enable_city', false ) ? wc_clean( wp_unslash( $_POST['calc_shipping_city'] ) ) : '';
+			$country  = isset( $_POST['calc_shipping_country'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_country'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$state    = isset( $_POST['calc_shipping_state'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_state'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$postcode = isset( $_POST['calc_shipping_postcode'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_postcode'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$city     = isset( $_POST['calc_shipping_city'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_city'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
 
 			if ( $postcode && ! WC_Validation::is_postcode( $postcode, $country ) ) {
 				throw new Exception( __( 'Please enter a valid postcode / ZIP.', 'woocommerce' ) );

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -17,7 +17,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 if ( 'no' === get_option( 'woocommerce_enable_shipping_calc' ) || ! WC()->cart->needs_shipping() ) {
@@ -30,56 +30,47 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 <form class="woocommerce-shipping-calculator" action="<?php echo esc_url( wc_get_cart_url() ); ?>" method="post">
 
-	<p><a href="#" class="shipping-calculator-button"><?php _e( 'Calculate shipping', 'woocommerce' ); ?></a></p>
+	<p><a href="#" class="shipping-calculator-button"><?php esc_html_e( 'Calculate shipping', 'woocommerce' ); ?></a></p>
 
 	<section class="shipping-calculator-form" style="display:none;">
 
 		<p class="form-row form-row-wide" id="calc_shipping_country_field">
 			<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state">
-				<option value=""><?php _e( 'Select a country&hellip;', 'woocommerce' ); ?></option>
+				<option value=""><?php esc_html_e( 'Select a country&hellip;', 'woocommerce' ); ?></option>
 				<?php
-					foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
-						echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
-					}
+				foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
+					echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
+				}
 				?>
 			</select>
 		</p>
 
 		<p class="form-row form-row-wide" id="calc_shipping_state_field">
 			<?php
-				$current_cc = WC()->customer->get_shipping_country();
-				$current_r  = WC()->customer->get_shipping_state();
-				$states     = WC()->countries->get_states( $current_cc );
+			$current_cc = WC()->customer->get_shipping_country();
+			$current_r  = WC()->customer->get_shipping_state();
+			$states     = WC()->countries->get_states( $current_cc );
 
-				// Hidden Input
-				if ( is_array( $states ) && empty( $states ) ) {
-
-					?><input type="hidden" name="calc_shipping_state" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" /><?php
-
-				// Dropdown Input
-				} elseif ( is_array( $states ) ) {
-
-					?><span>
-						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
-							<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
-							<?php
-								foreach ( $states as $ckey => $cvalue ) {
-									echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';
-								}
-							?>
-						</select>
-					</span><?php
-
-				// Standard Input
-				} else {
-
-					?><input type="text" class="input-text" value="<?php echo esc_attr( $current_r ); ?>" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" name="calc_shipping_state" id="calc_shipping_state" /><?php
-
-				}
+			if ( is_array( $states ) && empty( $states ) ) {
+				?><input type="hidden" name="calc_shipping_state" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" /><?php
+			} elseif ( is_array( $states ) ) {
+				?><span>
+					<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
+						<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
+						<?php
+						foreach ( $states as $ckey => $cvalue ) {
+							echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';
+						}
+						?>
+					</select>
+				</span><?php
+			} else {
+				?><input type="text" class="input-text" value="<?php echo esc_attr( $current_r ); ?>" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" name="calc_shipping_state" id="calc_shipping_state" /><?php
+			}
 			?>
 		</p>
 
-		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_city', false ) ) : ?>
+		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_city', true ) ) : ?>
 
 			<p class="form-row form-row-wide" id="calc_shipping_city_field">
 				<input type="text" class="input-text" value="<?php echo esc_attr( WC()->customer->get_shipping_city() ); ?>" placeholder="<?php esc_attr_e( 'City', 'woocommerce' ); ?>" name="calc_shipping_city" id="calc_shipping_city" />
@@ -95,7 +86,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 		<?php endif; ?>
 
-		<p><button type="submit" name="calc_shipping" value="1" class="button"><?php _e( 'Update totals', 'woocommerce' ); ?></button></p>
+		<p><button type="submit" name="calc_shipping" value="1" class="button"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button></p>
 
 		<?php wp_nonce_field( 'woocommerce-cart' ); ?>
 	</section>


### PR DESCRIPTION
Because the shipping calculator does not have a city field, if taxes have a city they will be hidden after posting the form. City will be unset, and the tax no longer matches.

Fix by including city field by default.

Fixes #18069

