### PR TITLE
Enhancements for stock updates

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1036,8 +1036,34 @@ jQuery( function ( $ ) {
 					data: data,
 					type: 'POST',
 					success: function( response ) {
-						window.alert( response );
 						wc_meta_boxes_order_items.unblock();
+						var response = JSON.parse( response );
+
+						if ( ! response.success ) {
+							window.alert( response.note );
+							return;
+						}
+
+						var order_note_data = {
+							action:    'woocommerce_add_order_note',
+							post_id:   woocommerce_admin_meta_boxes.post_id,
+							note:      response.note,
+							note_type: '',
+							security:  woocommerce_admin_meta_boxes.add_order_note_nonce
+						};
+
+						$( '#woocommerce-order-notes' ).block({
+							message: null,
+							overlayCSS: {
+								background: '#fff',
+								opacity: 0.6
+							}
+						});
+
+						$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
+							$( 'ul.order_notes' ).prepend( response );
+							$( '#woocommerce-order-notes' ).unblock();
+						});
 					}
 				});
 			},
@@ -1072,8 +1098,34 @@ jQuery( function ( $ ) {
 					data: data,
 					type: 'POST',
 					success: function( response ) {
-						window.alert( response );
 						wc_meta_boxes_order_items.unblock();
+						var response = JSON.parse( response );
+
+						if ( ! response.success ) {
+							window.alert( response.note );
+							return;
+						}
+
+						var order_note_data = {
+							action:    'woocommerce_add_order_note',
+							post_id:   woocommerce_admin_meta_boxes.post_id,
+							note:      response.note,
+							note_type: '',
+							security:  woocommerce_admin_meta_boxes.add_order_note_nonce
+						};
+
+						$( '#woocommerce-order-notes' ).block({
+							message: null,
+							overlayCSS: {
+								background: '#fff',
+								opacity: 0.6
+							}
+						});
+
+						$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
+							$( 'ul.order_notes' ).prepend( response );
+							$( '#woocommerce-order-notes' ).unblock();
+						});
 					}
 				});
 			}

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1010,6 +1010,14 @@ jQuery( function ( $ ) {
 				e.preventDefault();
 				wc_meta_boxes_order_items.block();
 
+				$( '#woocommerce-order-notes' ).block({
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6
+					}
+				});
+
 				var $table = $( 'table.woocommerce_order_items' );
 				var $rows = $table.find( 'tr.selected' );
 				var quantities = {};
@@ -1039,31 +1047,28 @@ jQuery( function ( $ ) {
 						wc_meta_boxes_order_items.unblock();
 						var response = JSON.parse( response );
 
-						if ( ! response.success ) {
-							window.alert( response.note );
-							return;
-						}
+						$.map( response, function( item ) {
 
-						var order_note_data = {
-							action:    'woocommerce_add_order_note',
-							post_id:   woocommerce_admin_meta_boxes.post_id,
-							note:      response.note,
-							note_type: '',
-							security:  woocommerce_admin_meta_boxes.add_order_note_nonce
-						};
-
-						$( '#woocommerce-order-notes' ).block({
-							message: null,
-							overlayCSS: {
-								background: '#fff',
-								opacity: 0.6
+							// No items were updated.
+							if ( ! item.success ) {
+								window.alert( item.note );
+								return;
 							}
+
+							var order_note_data = {
+								action:    'woocommerce_add_order_note',
+								post_id:   woocommerce_admin_meta_boxes.post_id,
+								note:      item.note,
+								note_type: '',
+								security:  woocommerce_admin_meta_boxes.add_order_note_nonce
+							};
+
+							$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
+								$( 'ul.order_notes' ).prepend( response );
+							});
 						});
 
-						$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
-							$( 'ul.order_notes' ).prepend( response );
-							$( '#woocommerce-order-notes' ).unblock();
-						});
+						$( '#woocommerce-order-notes' ).unblock();
 					}
 				});
 			},
@@ -1071,6 +1076,14 @@ jQuery( function ( $ ) {
 			do_reduce_stock: function( e ) {
 				e.preventDefault();
 				wc_meta_boxes_order_items.block();
+
+				$( '#woocommerce-order-notes' ).block({
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6
+					}
+				});
 
 				var $table = $( 'table.woocommerce_order_items' );
 				var $rows = $table.find( 'tr.selected' );
@@ -1101,31 +1114,28 @@ jQuery( function ( $ ) {
 						wc_meta_boxes_order_items.unblock();
 						var response = JSON.parse( response );
 
-						if ( ! response.success ) {
-							window.alert( response.note );
-							return;
-						}
+						$.map( response, function( item ) {
 
-						var order_note_data = {
-							action:    'woocommerce_add_order_note',
-							post_id:   woocommerce_admin_meta_boxes.post_id,
-							note:      response.note,
-							note_type: '',
-							security:  woocommerce_admin_meta_boxes.add_order_note_nonce
-						};
-
-						$( '#woocommerce-order-notes' ).block({
-							message: null,
-							overlayCSS: {
-								background: '#fff',
-								opacity: 0.6
+							// No items were updated.
+							if ( ! item.success ) {
+								window.alert( item.note );
+								return;
 							}
+
+							var order_note_data = {
+								action:    'woocommerce_add_order_note',
+								post_id:   woocommerce_admin_meta_boxes.post_id,
+								note:      item.note,
+								note_type: '',
+								security:  woocommerce_admin_meta_boxes.add_order_note_nonce
+							};
+
+							$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
+								$( 'ul.order_notes' ).prepend( response );
+							});
 						});
 
-						$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
-							$( 'ul.order_notes' ).prepend( response );
-							$( '#woocommerce-order-notes' ).unblock();
-						});
+						$( '#woocommerce-order-notes' ).unblock();
 					}
 				});
 			}

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1006,7 +1006,8 @@ jQuery( function ( $ ) {
 				}
 			},
 
-			do_increase_stock: function( e ) {
+			modify_stock: function( e, action ) {
+				console.log(e);
 				e.preventDefault();
 				wc_meta_boxes_order_items.block();
 
@@ -1035,7 +1036,7 @@ jQuery( function ( $ ) {
 					order_id:       woocommerce_admin_meta_boxes.post_id,
 					order_item_ids: item_ids,
 					order_item_qty: quantities,
-					action:         'woocommerce_increase_order_item_stock',
+					action:         action,
 					security:       woocommerce_admin_meta_boxes.order_item_nonce
 				};
 
@@ -1073,71 +1074,12 @@ jQuery( function ( $ ) {
 				});
 			},
 
+			do_increase_stock: function( e ) {
+				wc_meta_boxes_order_items.bulk_actions.modify_stock( e, 'woocommerce_increase_order_item_stock' );
+			},
+
 			do_reduce_stock: function( e ) {
-				e.preventDefault();
-				wc_meta_boxes_order_items.block();
-
-				$( '#woocommerce-order-notes' ).block({
-					message: null,
-					overlayCSS: {
-						background: '#fff',
-						opacity: 0.6
-					}
-				});
-
-				var $table = $( 'table.woocommerce_order_items' );
-				var $rows = $table.find( 'tr.selected' );
-				var quantities = {};
-				var item_ids = $.map( $rows, function( $row ) {
-					return parseInt( $( $row ).data( 'order_item_id' ), 10 );
-				});
-
-				$rows.each(function() {
-					if ( $( this ).find( 'input.quantity' ).length ) {
-						quantities[ $( this ).attr( 'data-order_item_id' ) ] = $( this ).find( 'input.quantity' ).val();
-					}
-				});
-
-				var data = {
-					order_id:       woocommerce_admin_meta_boxes.post_id,
-					order_item_ids: item_ids,
-					order_item_qty: quantities,
-					action:         'woocommerce_reduce_order_item_stock',
-					security:       woocommerce_admin_meta_boxes.order_item_nonce
-				};
-
-				$.ajax({
-					url: woocommerce_admin_meta_boxes.ajax_url,
-					data: data,
-					type: 'POST',
-					success: function( response ) {
-						wc_meta_boxes_order_items.unblock();
-						var response = JSON.parse( response );
-
-						$.map( response, function( item ) {
-
-							// No items were updated.
-							if ( ! item.success ) {
-								window.alert( item.note );
-								return;
-							}
-
-							var order_note_data = {
-								action:    'woocommerce_add_order_note',
-								post_id:   woocommerce_admin_meta_boxes.post_id,
-								note:      item.note,
-								note_type: '',
-								security:  woocommerce_admin_meta_boxes.add_order_note_nonce
-							};
-
-							$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
-								$( 'ul.order_notes' ).prepend( response );
-							});
-						});
-
-						$( '#woocommerce-order-notes' ).unblock();
-					}
-				});
+				wc_meta_boxes_order_items.bulk_actions.modify_stock( e, 'woocommerce_reduce_order_item_stock' );
 			}
 		},
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -918,9 +918,10 @@ jQuery( function ( $ ) {
 			}
 
 			var $rows = $table.find( 'tr.selected' );
+			var $bulk_edit_wraper = $( 'div.wc-order-item-bulk-edit' );
 
-			if ( $rows.length ) {
-				$( 'div.wc-order-item-bulk-edit' ).slideDown();
+			if ( $rows.length && $bulk_edit_wraper.children().length > 0 ) {
+				$bulk_edit_wraper.slideDown();
 
 				var selected_product = false;
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1007,7 +1007,6 @@ jQuery( function ( $ ) {
 			},
 
 			modify_stock: function( e, action ) {
-				console.log(e);
 				e.preventDefault();
 				wc_meta_boxes_order_items.block();
 

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -98,8 +98,11 @@ if ( wc_tax_enabled() ) {
 		<button type="button" class="button bulk-delete-items"><?php esc_html_e( 'Delete selected row(s)', 'woocommerce' ); ?></button>
 	<?php endif; ?>
 
-	<button type="button" class="button bulk-decrease-stock"><?php esc_html_e( 'Reduce stock', 'woocommerce' ); ?></button>
-	<button type="button" class="button bulk-increase-stock"><?php esc_html_e( 'Increase stock', 'woocommerce' ); ?></button>
+	<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>
+		<button type="button" class="button bulk-decrease-stock"><?php esc_html_e( 'Reduce stock', 'woocommerce' ); ?></button>
+		<button type="button" class="button bulk-increase-stock"><?php esc_html_e( 'Increase stock', 'woocommerce' ); ?></button>
+	<?php endif; ?>
+
 	<?php do_action( 'woocommerce_admin_order_item_bulk_actions', $order ); ?>
 </div>
 <div class="wc-order-data-row wc-order-totals-items wc-order-items-editable">

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1120,7 +1120,7 @@ class WC_AJAX {
 					$item_name    = $_product->get_formatted_name();
 					$note         = sprintf( __( '%1$s stock reduced from %2$s to %3$s.', 'woocommerce' ), $item_name, $new_stock + $stock_change, $new_stock );
 					$return[]     = $note;
-					$order->add_order_note( $note );
+					$order->add_order_note( $note, 0, true );
 				}
 			}
 			do_action( 'woocommerce_reduce_order_stock', $order );
@@ -1160,7 +1160,7 @@ class WC_AJAX {
 					$item_name    = $_product->get_formatted_name();
 					$note         = sprintf( __( '%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $item_name, $old_stock, $new_quantity );
 					$return[]     = $note;
-					$order->add_order_note( $note );
+					$order->add_order_note( $note, 0, true );
 				}
 			}
 			do_action( 'woocommerce_restore_order_stock', $order );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1115,17 +1115,21 @@ class WC_AJAX {
 				}
 				$_product = $order_item->get_product();
 				if ( $_product && $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
-					$stock_change      = apply_filters( 'woocommerce_reduce_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
-					$new_stock         = wc_update_product_stock( $_product, $stock_change, 'decrease' );
-					$item_name         = $_product->get_formatted_name();
-					$return['note']    = sprintf( wp_kses_post( __( '%1$s stock reduced from %2$s to %3$s.', 'woocommerce' ) ), $item_name, $new_stock + $stock_change, $new_stock );
-					$return['success'] = true;
+					$stock_change = apply_filters( 'woocommerce_reduce_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
+					$new_stock    = wc_update_product_stock( $_product, $stock_change, 'decrease' );
+					$item_name    = $_product->get_formatted_name();
+					$return[]     = array(
+						'note'    => sprintf( wp_kses_post( __( '%1$s stock reduced from %2$s to %3$s.', 'woocommerce' ) ), $item_name, $new_stock + $stock_change, $new_stock ),
+						'success' => true,
+					);
 				}
 			}
 			do_action( 'woocommerce_reduce_order_stock', $order );
 			if ( empty( $return ) ) {
-				$return['note']    = wp_kses_post( __( 'No products had their stock reduced - they may not have stock management enabled.', 'woocommerce' ) );
-				$return['success'] = false;
+				$return[] = array(
+					'note'    => wp_kses_post( __( 'No products had their stock reduced - they may not have stock management enabled.', 'woocommerce' ) ),
+					'success' => false,
+				);
 			}
 			echo json_encode( $return );
 		}
@@ -1155,17 +1159,21 @@ class WC_AJAX {
 				$_product = $order_item->get_product();
 				if ( $_product && $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
 					$old_stock    = $_product->get_stock_quantity();
-					$stock_change      = apply_filters( 'woocommerce_restore_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
-					$new_quantity      = wc_update_product_stock( $_product, $stock_change, 'increase' );
-					$item_name         = $_product->get_formatted_name();
-					$return['note']    = sprintf( wp_kses_post( __( '%1$s stock increased from %2$s to %3$s.', 'woocommerce' ) ), $item_name, $old_stock, $new_quantity );
-					$return['success'] = true;
+					$stock_change = apply_filters( 'woocommerce_restore_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
+					$new_quantity = wc_update_product_stock( $_product, $stock_change, 'increase' );
+					$item_name    = $_product->get_formatted_name();
+					$return[]     = array(
+						'note'    => sprintf( wp_kses_post( __( '%1$s stock increased from %2$s to %3$s.', 'woocommerce' ) ), $item_name, $old_stock, $new_quantity ),
+						'success' => true,
+					);
 				}
 			}
 			do_action( 'woocommerce_restore_order_stock', $order );
 			if ( empty( $return ) ) {
-				$return['note']    = wp_kses_post( __( 'No products had their stock increased - they may not have stock management enabled.', 'woocommerce' ) );
-				$return['success'] = false;
+				$return[] = array(
+					'note'    => wp_kses_post( __( 'No products had their stock increased - they may not have stock management enabled.', 'woocommerce' ) ),
+					'success' => false,
+				);
 			}
 			echo json_encode( $return );
 		}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1117,8 +1117,8 @@ class WC_AJAX {
 				if ( $_product && $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
 					$stock_change = apply_filters( 'woocommerce_reduce_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
 					$new_stock    = wc_update_product_stock( $_product, $stock_change, 'decrease' );
-					$item_name    = $_product->get_sku() ? $_product->get_sku() : $_product->get_id();
-					$note         = sprintf( __( 'Item %1$s stock reduced from %2$s to %3$s.', 'woocommerce' ), $item_name, $new_stock + $stock_change, $new_stock );
+					$item_name    = $_product->get_formatted_name();
+					$note         = sprintf( __( '%1$s stock reduced from %2$s to %3$s.', 'woocommerce' ), $item_name, $new_stock + $stock_change, $new_stock );
 					$return[]     = $note;
 					$order->add_order_note( $note );
 				}
@@ -1157,8 +1157,8 @@ class WC_AJAX {
 					$old_stock    = $_product->get_stock_quantity();
 					$stock_change = apply_filters( 'woocommerce_restore_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
 					$new_quantity = wc_update_product_stock( $_product, $stock_change, 'increase' );
-					$item_name    = $_product->get_sku() ? $_product->get_sku() : $_product->get_id();
-					$note         = sprintf( __( 'Item %1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $item_name, $old_stock, $new_quantity );
+					$item_name    = $_product->get_formatted_name();
+					$note         = sprintf( __( '%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $item_name, $old_stock, $new_quantity );
 					$return[]     = $note;
 					$order->add_order_note( $note );
 				}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1115,19 +1115,19 @@ class WC_AJAX {
 				}
 				$_product = $order_item->get_product();
 				if ( $_product && $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
-					$stock_change = apply_filters( 'woocommerce_reduce_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
-					$new_stock    = wc_update_product_stock( $_product, $stock_change, 'decrease' );
-					$item_name    = $_product->get_formatted_name();
-					$note         = sprintf( __( '%1$s stock reduced from %2$s to %3$s.', 'woocommerce' ), $item_name, $new_stock + $stock_change, $new_stock );
-					$return[]     = $note;
-					$order->add_order_note( $note, 0, true );
+					$stock_change      = apply_filters( 'woocommerce_reduce_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
+					$new_stock         = wc_update_product_stock( $_product, $stock_change, 'decrease' );
+					$item_name         = $_product->get_formatted_name();
+					$return['note']    = sprintf( wp_kses_post( __( '%1$s stock reduced from %2$s to %3$s.', 'woocommerce' ) ), $item_name, $new_stock + $stock_change, $new_stock );
+					$return['success'] = true;
 				}
 			}
 			do_action( 'woocommerce_reduce_order_stock', $order );
 			if ( empty( $return ) ) {
-				$return[] = __( 'No products had their stock reduced - they may not have stock management enabled.', 'woocommerce' );
+				$return['note']    = wp_kses_post( __( 'No products had their stock reduced - they may not have stock management enabled.', 'woocommerce' ) );
+				$return['success'] = false;
 			}
-			echo wp_kses_post( implode( ', ', $return ) );
+			echo json_encode( $return );
 		}
 		wp_die();
 	}
@@ -1155,19 +1155,19 @@ class WC_AJAX {
 				$_product = $order_item->get_product();
 				if ( $_product && $_product->exists() && $_product->managing_stock() && isset( $order_item_qty[ $item_id ] ) && $order_item_qty[ $item_id ] > 0 ) {
 					$old_stock    = $_product->get_stock_quantity();
-					$stock_change = apply_filters( 'woocommerce_restore_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
-					$new_quantity = wc_update_product_stock( $_product, $stock_change, 'increase' );
-					$item_name    = $_product->get_formatted_name();
-					$note         = sprintf( __( '%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $item_name, $old_stock, $new_quantity );
-					$return[]     = $note;
-					$order->add_order_note( $note, 0, true );
+					$stock_change      = apply_filters( 'woocommerce_restore_order_stock_quantity', $order_item_qty[ $item_id ], $item_id );
+					$new_quantity      = wc_update_product_stock( $_product, $stock_change, 'increase' );
+					$item_name         = $_product->get_formatted_name();
+					$return['note']    = sprintf( wp_kses_post( __( '%1$s stock increased from %2$s to %3$s.', 'woocommerce' ) ), $item_name, $old_stock, $new_quantity );
+					$return['success'] = true;
 				}
 			}
 			do_action( 'woocommerce_restore_order_stock', $order );
 			if ( empty( $return ) ) {
-				$return[] = __( 'No products had their stock increased - they may not have stock management enabled.', 'woocommerce' );
+				$return['note']    = wp_kses_post( __( 'No products had their stock increased - they may not have stock management enabled.', 'woocommerce' ) );
+				$return['success'] = false;
 			}
-			echo wp_kses_post( implode( ', ', $return ) );
+			echo json_encode( $return );
 		}
 		wp_die();
 	}


### PR DESCRIPTION
This PR does three things (though I only intended to tackle the first):

1) Standardizes the stock update messages using `get_formatted_name()`. Before, the message for automatically changed stock (by the payment gateway) looked different than the message for manually reduced stock. Here are  screenshots of the [before](https://user-images.githubusercontent.com/8536129/33793229-9cee89f6-dc79-11e7-8b45-aee6be547d73.png) and [after](https://user-images.githubusercontent.com/8536129/33793262-1a7b7cda-dc7a-11e7-953b-505848c4bfb9.png) (also added a SKU). This results in less translation strings as well.

2) As seen in the after image above, this also switches on the `$added_by_user` order note flag when stock is manually changed. Since this is a user action, like when changing the order status, it makes sense to show it as such, along with which user did it.

3) Add the order notes in via ajax when stock is changed: http://cld.wthms.co/Mq2aeE. I removed the JS alert on success, but left in there on failure: http://cld.wthms.co/zTitEL

Thoughts:

- Not having a JS alert when stock is successfully reduced feels nice, but I'm a little worried that a new order note might not always catch the user's attention - and thereby they might feel nothing happened. Maybe some sort of temporary checkmark next to the button would be cool, or a neat border/highlight around the new order note temporarily (could be used when an order note is manually added as well).

- I haven't worked with ajax much, so pls double check the security n stuffs. Also had to move the `wp_kses_post`, so not sure if it belongs inside the `sprintf` or not.

- I have a few more ideas around better order notes / logging, and ideally they will all be added via ajax right away. So perhaps making this more DRY would be good :)

_______

For testing, you'll need to turn on script debug since I haven't minified the JS. Also unsure how script versioning is preferred, so didn't increase that either. Might need to hard refresh while testing.