### PR TITLE
Pass $args to woocommerce_loop_add_to_cart_link filter

### DIFF
--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -32,4 +32,4 @@ echo apply_filters( 'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
 		esc_attr( $product->add_to_cart_description() ),
 		esc_html( $product->add_to_cart_text() )
 	),
-$product );
+$product, $args );


### PR DESCRIPTION
Fixes #18079

This is needed to recreate the button, otherwise you can't get the `$class` variable solely from the filter.