### PR TITLE
Legacy API - Use "edit" context when checking if the product is on sale during an "edit" operation

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1077,7 +1077,7 @@ class WC_API_Products extends WC_API_Resource {
 			$product->set_date_on_sale_to( $date_to );
 			$product->set_date_on_sale_from( $date_from );
 
-			if ( $product->is_on_sale() ) {
+			if ( $product->is_on_sale( 'edit' ) ) {
 				$product->set_price( $product->get_sale_price( 'edit' ) );
 			} else {
 				$product->set_price( $product->get_regular_price( 'edit' ) );

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -1567,7 +1567,7 @@ class WC_API_Products extends WC_API_Resource {
 			$product->set_date_on_sale_to( $date_to );
 			$product->set_date_on_sale_from( $date_from );
 
-			if ( $product->is_on_sale() ) {
+			if ( $product->is_on_sale( 'edit' ) ) {
 				$product->set_price( $product->get_sale_price( 'edit' ) );
 			} else {
 				$product->set_price( $product->get_regular_price( 'edit' ) );


### PR DESCRIPTION
Ensures that the "edit" context is used when checking if the product is on sale, like it's done when fetching product's regular and sale prices. This prevents price filters from running and, potentially, altering the prices set via the API.

* Ref. [https://github.com/woocommerce/woocommerce/issues/17125](https://github.com/woocommerce/woocommerce/issues/17125)
* Complements commit https://github.com/woocommerce/woocommerce/commit/6e5cdc60e8a2b80520e73f1871c12bfc377fd420