### PR TITLE
Setup wizard: omit unnecessary sentence from PPEC settings description

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1153,7 +1153,7 @@ class WC_Admin_Setup_Wizard {
 					'type'        => 'email',
 					'value'       => $user_email,
 					'placeholder' => __( 'Email address to receive payments', 'woocommerce' ),
-					'description' => __( "Enter your email address and we'll authenticate payments for you. To claim a payment, you'll need to have a PayPal Business account or create one later. WooCommerce Services and Jetpack will be installed and activated for you.", 'woocommerce' ),
+					'description' => __( "Enter your email address and we'll authenticate payments for you. WooCommerce Services and Jetpack will be installed and activated for you.", 'woocommerce' ),
 					'required'    => true,
 				),
 			),


### PR DESCRIPTION
Forgot to address https://github.com/woocommerce/woocommerce/pull/18039#issuecomment-349821532 with a code change in that PR, so here it is.