### PR TITLE
Fix calculation of total rows exported

### DIFF
--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -135,7 +135,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @return int
 	 */
 	public function get_total_exported() {
-		return ( $this->get_page() * $this->get_limit() ) + $this->exported_row_count;
+		return ( ( $this->get_page() - 1 ) * $this->get_limit() ) + $this->exported_row_count;
 	}
 
 	/**


### PR DESCRIPTION
There was a bug in the way the number of rows that had been exported was calculated leading to the result always being out by a full page (50 by default). This meant that the percentage complete was also wrong and an additional AJAX loop was necessary to reach the 'done' step.

The total should be 'rows exported previously' + 'rows exported in this round'. To get 'rows exported previously' you need to reduce the page number by 1 before multiplying by the batch limit.