### PR TITLE
Remove useless translators comment

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -109,7 +109,6 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				'css'         => 'width:300px; height: 75px;',
 				'placeholder' => __( 'N/A', 'woocommerce' ),
 				'type'        => 'textarea',
-				/* translators: %s: site name */
 				'default'     => '{site_title}',
 				'autoload'    => false,
 				'desc_tip'    => true,


### PR DESCRIPTION
e26302b1ff67ebef5dbd6811e2423b7589e50103 removed a translated string, but the translators comment has not been removed.