### PR TITLE
[WC 3.3] Fix fatal if gateway is deactivated

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -575,9 +575,10 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$transaction_id   = $order->get_transaction_id();
 
 		if ( $transaction_id ) {
-			$url = $payment_gateways[ $payment_method ]->get_transaction_url( $order );
 
-			if ( isset( $payment_gateways[ $payment_method ] ) && $url ) {
+			$url = isset( $payment_gateways[ $payment_method ] ) ? $payment_gateways[ $payment_method ]->get_transaction_url( $order ) : false;
+
+			if ( $url ) {
 				$payment_via .= ' (<a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $transaction_id ) . '</a>)';
 			} else {
 				$payment_via .= ' (' . esc_html( $transaction_id ) . ')';


### PR DESCRIPTION
Fixes PHP notice + Fatal error in order preview if gateway is deactivated

<details><summary>PHP notice stack trace</summary>
<pre>
PHP Notice:  Undefined index: braintree_credit_card in woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php on line 578
PHP Stack trace:
PHP   1. {main}() woobeta.dev/wp-admin/admin-ajax.php:0
PHP   2. do_action() woobeta.dev/wp-admin/admin-ajax.php:97
PHP   3. WP_Hook->do_action() woobeta.dev/wp-includes/plugin.php:453
PHP   4. WP_Hook->apply_filters() woobeta.dev/wp-includes/class-wp-hook.php:310
PHP   5. WC_AJAX::get_order_details() woobeta.dev/wp-includes/class-wp-hook.php:286
PHP   6. WC_Admin_List_Table_Orders::order_preview_get_order_details() woocommerce/includes/class-wc-ajax.php:491
</pre></details>

<details><summary>Fatal error stack trace</summary>
<pre>
PHP Fatal error:  Uncaught Error: Call to a member function get_transaction_url() on null in woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php:578
Stack trace:
#0 woocommerce/includes/class-wc-ajax.php(491): WC_Admin_List_Table_Orders::order_preview_get_order_details(Object(WC_Order))
#1 woobeta.dev/wp-includes/class-wp-hook.php(286): WC_AJAX::get_order_details('')
#2 woobeta.dev/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#3 woobeta.dev/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#4 woobeta.dev/wp-admin/admin-ajax.php(97): do_action('wp_ajax_woocomm...')
#5 {main}
  thrown in woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php on line 578
</pre></details>