### PR TITLE
Save offline gateways in wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1468,7 +1468,7 @@ class WC_Admin_Setup_Wizard {
 			$this->install_woocommerce_services();
 		}
 
-		$gateways = $this->get_wizard_in_cart_payment_gateways();
+		$gateways = array_merge( $this->get_wizard_in_cart_payment_gateways(), $this->get_wizard_manual_payment_gateways() );
 
 		foreach ( $gateways as $gateway_id => $gateway ) {
 			// If repo-slug is defined, download and install plugin from .org.


### PR DESCRIPTION
Fixes #18149 

To test: 
1. Deactivate your offline gateways
2. Launch the wizard and activate the offline gateways through the Payment step
3. Verify the gateways were activated