### PR TITLE
[3.3] Customizer string updates

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -39,7 +39,7 @@ class WC_Shop_Customizer {
 		) );
 
 		$this->add_store_notice_section( $wp_customize );
-		$this->add_product_grid_section( $wp_customize );
+		$this->add_product_catalog_section( $wp_customize );
 		$this->add_product_images_section( $wp_customize );
 	}
 
@@ -209,18 +209,18 @@ class WC_Shop_Customizer {
 	}
 
 	/**
-	 * Product grid section.
+	 * Product catalog section.
 	 *
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
-	public function add_product_grid_section( $wp_customize ) {
+	public function add_product_catalog_section( $wp_customize ) {
 		$theme_support = get_theme_support( 'woocommerce' );
 		$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
 
 		$wp_customize->add_section(
-			'woocommerce_product_grid',
+			'woocommerce_product_catalog',
 			array(
-				'title'           => __( 'Product Grid', 'woocommerce' ),
+				'title'           => __( 'Product Catalog', 'woocommerce' ),
 				'priority'        => 10,
 				'active_callback' => array( $this, 'is_products_archive' ),
 				'panel'           => 'woocommerce',
@@ -242,7 +242,7 @@ class WC_Shop_Customizer {
 			array(
 				'label'       => __( 'Shop page display', 'woocommerce' ),
 				'description' => __( 'Choose what to display on the main shop page.', 'woocommerce' ),
-				'section'     => 'woocommerce_product_grid',
+				'section'     => 'woocommerce_product_catalog',
 				'settings'    => 'woocommerce_shop_page_display',
 				'type'        => 'select',
 				'choices'     => array(
@@ -268,7 +268,7 @@ class WC_Shop_Customizer {
 			array(
 				'label'       => __( 'Category display', 'woocommerce' ),
 				'description' => __( 'Choose what to display on product category pages.', 'woocommerce' ),
-				'section'     => 'woocommerce_product_grid',
+				'section'     => 'woocommerce_product_catalog',
 				'settings'    => 'woocommerce_category_archive_display',
 				'type'        => 'select',
 				'choices'     => array(
@@ -294,7 +294,7 @@ class WC_Shop_Customizer {
 			array(
 				'label'       => __( 'Default product sorting', 'woocommerce' ),
 				'description' => __( 'How should products by sorted in the catalog by default?', 'woocommerce' ),
-				'section'     => 'woocommerce_product_grid',
+				'section'     => 'woocommerce_product_catalog',
 				'settings'    => 'woocommerce_default_catalog_orderby',
 				'type'        => 'select',
 				'choices'     => apply_filters( 'woocommerce_default_catalog_orderby_options', array(
@@ -329,7 +329,7 @@ class WC_Shop_Customizer {
 			array(
 				'label'       => __( 'Products per row', 'woocommerce' ),
 				'description' => __( 'How many products should be shown per row?', 'woocommerce' ),
-				'section'     => 'woocommerce_product_grid',
+				'section'     => 'woocommerce_product_catalog',
 				'settings'    => 'woocommerce_catalog_columns',
 				'type'        => 'number',
 				'input_attrs' => array(
@@ -356,7 +356,7 @@ class WC_Shop_Customizer {
 			array(
 				'label'       => __( 'Rows per page', 'woocommerce' ),
 				'description' => __( 'How many rows of products should be shown per page?', 'woocommerce' ),
-				'section'     => 'woocommerce_product_grid',
+				'section'     => 'woocommerce_product_catalog',
 				'settings'    => 'woocommerce_catalog_rows',
 				'type'        => 'number',
 				'input_attrs' => array(

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -241,7 +241,7 @@ class WC_Shop_Customizer {
 			'woocommerce_shop_page_display',
 			array(
 				'label'       => __( 'Shop page display', 'woocommerce' ),
-				'description' => __( 'This controls what is shown on the product archive.', 'woocommerce' ),
+				'description' => __( 'Choose what to display on the main shop page.', 'woocommerce' ),
 				'section'     => 'woocommerce_product_grid',
 				'settings'    => 'woocommerce_shop_page_display',
 				'type'        => 'select',
@@ -266,8 +266,8 @@ class WC_Shop_Customizer {
 		$wp_customize->add_control(
 			'woocommerce_category_archive_display',
 			array(
-				'label'       => __( 'Default category display', 'woocommerce' ),
-				'description' => __( 'This controls what is shown on category archives.', 'woocommerce' ),
+				'label'       => __( 'Category display', 'woocommerce' ),
+				'description' => __( 'Choose what to display on product category pages.', 'woocommerce' ),
 				'section'     => 'woocommerce_product_grid',
 				'settings'    => 'woocommerce_category_archive_display',
 				'type'        => 'select',
@@ -293,7 +293,7 @@ class WC_Shop_Customizer {
 			'woocommerce_default_catalog_orderby',
 			array(
 				'label'       => __( 'Default product sorting', 'woocommerce' ),
-				'description' => __( 'This controls the default sort order of the catalog.', 'woocommerce' ),
+				'description' => __( 'How should products by sorted in the catalog by default?', 'woocommerce' ),
 				'section'     => 'woocommerce_product_grid',
 				'settings'    => 'woocommerce_default_catalog_orderby',
 				'type'        => 'select',

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -403,7 +403,7 @@ class WC_Shop_Customizer {
 				'single_image_width',
 				array(
 					'label'       => __( 'Main image width', 'woocommerce' ),
-					'description' => __( 'This is the width used by the main image on single product pages. These images will remain uncropped.', 'woocommerce' ),
+					'description' => __( 'Image size used for the main image on single product pages. These images will remain uncropped.', 'woocommerce' ),
 					'section'     => 'woocommerce_product_images',
 					'settings'    => 'single_image_width',
 					'type'        => 'number',
@@ -431,7 +431,7 @@ class WC_Shop_Customizer {
 				'thumbnail_image_width',
 				array(
 					'label'       => __( 'Thumbnail width', 'woocommerce' ),
-					'description' => __( 'This size is used for product archives and product listings.', 'woocommerce' ),
+					'description' => __( 'Image size used for products in the catalog and product gallery thumbnails.', 'woocommerce' ),
 					'section'     => 'woocommerce_product_images',
 					'settings'    => 'thumbnail_image_width',
 					'type'        => 'number',

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -273,7 +273,7 @@ class WC_Shop_Customizer {
 				'type'        => 'select',
 				'choices'     => array(
 					''              => __( 'Show products', 'woocommerce' ),
-					'subcategories' => __( 'Show categories', 'woocommerce' ),
+					'subcategories' => __( 'Show subcategories', 'woocommerce' ),
 					'both'          => __( 'Show subcategories &amp; products', 'woocommerce' ),
 				),
 			)


### PR DESCRIPTION
Attempt to add some clarity to the settings in the customizer.

"Products Grid" is a new term 3.3 is introducing, and it describes the per row/per page settings really well. Thought about this term a bit though with the broader scope of archive pages, and "Product Catalog" seems more fitting imo. In the past we've expected user's to know what an "archive" page means, which isn't a good expectation for those unfamiliar with WordPress. In support, I see references to the customer's "Catalog" most often.

Would be useful to bring in a copy writer though to maybe add some input on these strings and suggest some changes :). The settings could be more fluid if the voices were matched up (like the passive/active verb thingy).

New catalog settings: http://cld.wthms.co/BbYn50
New image settings: http://cld.wthms.co/rIgPg3

Also changed this to be "subcategories" instead which is more descriptive of what it does: http://cld.wthms.co/HSpfeH

(Will need a refresh after https://github.com/woocommerce/woocommerce/pull/18156 is merged)