### PR TITLE
[3.3] Hide variation stock status setting conditionally

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -62,9 +62,11 @@ jQuery( function( $ ) {
 		 */
 		variable_manage_stock: function() {
 			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).hide();
+			$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_manage_stock' ).show();
 
 			if ( $( this ).is( ':checked' ) ) {
 				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).show();
+				$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_manage_stock' ).hide();
 			}
 		},
 

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -88,7 +88,7 @@ jQuery( function( $ ) {
 		return false;
 	});
 
-	// PRODUCT TYPE SPECIFIC OPTIONS.
+	// Product type specific options.
 	$( 'select#product-type' ).change( function() {
 
 		// Get value.
@@ -228,7 +228,7 @@ jQuery( function( $ ) {
 		return false;
 	});
 
-	// STOCK OPTIONS.
+	// Stock options.
 	$( 'input#_manage_stock' ).change( function() {
 		if ( $( this ).is( ':checked' ) ) {
 			$( 'div.stock_fields' ).show();
@@ -241,7 +241,7 @@ jQuery( function( $ ) {
 		}
 	}).change();
 
-	// DATE PICKER FIELDS.
+	// Date picker fields.
 	function date_picker_select( datepicker ) {
 		var option         = $( datepicker ).next().is( '.hasDatepicker' ) ? 'minDate' : 'maxDate',
 			otherDateField = 'minDate' === option ? $( datepicker ).next() : $( datepicker ).prev(),
@@ -264,7 +264,7 @@ jQuery( function( $ ) {
 		$( this ).find( 'input' ).each( function() { date_picker_select( $( this ) ); } );
 	});
 
-	// ATTRIBUTE TABLES.
+	// Attribute Tables.
 
 	// Initial order.
 	var woocommerce_attribute_items = $( '.product_attributes' ).find( '.woocommerce_attribute' ).get();

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -109,7 +109,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						'wrapper_class' => 'form-row form-row-first',
 						'placeholder'   => __( 'Variation price (required)', 'woocommerce' ),
 					) );
-				
+
 					$label = sprintf(
 						/* translators: %s: currency symbol */
 						__( 'Sale price (%s)', 'woocommerce' ),
@@ -207,7 +207,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						'options'       => wc_get_product_stock_status_options(),
 						'desc_tip'      => true,
 						'description'   => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
-						'wrapper_class' => 'form-row form-row-full',
+						'wrapper_class' => 'form-row form-row-full hide_if_variation_manage_stock',
 					) );
 
 					if ( wc_product_weight_enabled() ) {


### PR DESCRIPTION
"Stock status" shouldn't be an available setting for inventory managed variations. Fixes https://github.com/woocommerce/woocommerce/issues/18159

Video: http://cld.wthms.co/G0GKcm

Talked about this briefly in the dev chat @mikejolley, but I couldn't find any logic that covers this for variations. Maybe it never got merged into master? ¯\\\_(ツ)\_/¯