### PR TITLE
[3.3] New download logging reports enhancements

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1,4 +1,4 @@
-/*global woocommerce_admin_meta_boxes, woocommerce_admin, accounting, woocommerce_admin_meta_boxes_order */
+/*global woocommerce_admin_meta_boxes, woocommerce_admin, accounting, woocommerce_admin_meta_boxes_order, wcSetClipboard, wcClearClipboard */
 jQuery( function ( $ ) {
 
 	/**
@@ -1274,7 +1274,10 @@ jQuery( function ( $ ) {
 		init: function() {
 			$( '.order_download_permissions' )
 				.on( 'click', 'button.grant_access', this.grant_access )
-				.on( 'click', 'button.revoke_access', this.revoke_access );
+				.on( 'click', 'button.revoke_access', this.revoke_access )
+				.on( 'click', '#copy-download-link', this.copy_link )
+				.on( 'aftercopy', '#copy-download-link', this.copy_success )
+				.on( 'aftercopyfailure', '#copy-download-link', this.copy_fail );
 		},
 
 		grant_access: function() {
@@ -1355,6 +1358,43 @@ jQuery( function ( $ ) {
 				}
 			}
 			return false;
+		},
+
+		/**
+		 * Copy download link.
+		 *
+		 * @param {Object} evt Copy event.
+		 */
+		copy_link: function( evt ) {
+			wcClearClipboard();
+			wcSetClipboard( $( this ).attr( 'href' ), $( this ) );
+			evt.preventDefault();
+		},
+
+		/**
+		 * Display a "Copied!" tip when success copying
+		 */
+		copy_success: function() {
+			$( this ).tipTip({
+				'attribute':  'data-tip',
+				'activation': 'focus',
+				'fadeIn':     50,
+				'fadeOut':    50,
+				'delay':      0
+			}).focus();
+		},
+
+		/**
+		 * Displays the copy error message when failure copying.
+		 */
+		copy_fail: function() {
+			$( this ).tipTip({
+				'attribute':  'data-tip-failed',
+				'activation': 'focus',
+				'fadeIn':     50,
+				'fadeOut':    50,
+				'delay':      0
+			}).focus();
 		}
 	};
 

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -238,7 +238,7 @@ class WC_Admin_Assets {
 		if ( in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
 			$default_location = wc_get_customer_default_location();
 
-			wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo' ), WC_VERSION );
+			wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard' ), WC_VERSION );
 			wp_localize_script( 'wc-admin-order-meta-boxes', 'woocommerce_admin_meta_boxes_order', array(
 				'countries'              => json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
 				'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),

--- a/includes/admin/meta-boxes/views/html-order-download-permission.php
+++ b/includes/admin/meta-boxes/views/html-order-download-permission.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							admin_url( 'admin.php?page=wc-reports&tab=orders&report=downloads' )
 						);
 						echo '<a class="button" href="' . esc_url( $report_url ) . '">';
-						echo __( 'View Report', 'woocommerce' );
+						echo __( 'View report', 'woocommerce' );
 						echo '</a>';
 					?>
 				</td>

--- a/includes/admin/meta-boxes/views/html-order-download-permission.php
+++ b/includes/admin/meta-boxes/views/html-order-download-permission.php
@@ -40,10 +40,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 							'key'           => $download->get_download_id(),
 						), trailingslashit( home_url() ) );
 					?>
-					<a id="copy-download-link" class="button" href="<?php echo esc_url( $download_link ) ?>" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>" data-tip-failed="<?php esc_attr_e( 'Copying to clipboard failed. You should be able to right-click the button and copy.', 'woocommerce' ); ?>"><?php _e( 'Copy link', 'woocommerce' ); ?></a>
+					<a id="copy-download-link" class="button" href="<?php echo esc_url( $download_link ) ?>" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>" data-tip-failed="<?php esc_attr_e( 'Copying to clipboard failed. You should be able to right-click the button and copy.', 'woocommerce' ); ?>"><?php esc_html_e( 'Copy link', 'woocommerce' ); ?></a>
 				</td>
 				<td>
-					<label><?php esc_html_e( 'Customer download report', 'woocommerce' ); ?></label>
+					<label><?php esc_html_e( 'Customer download log', 'woocommerce' ); ?></label>
 					<?php
 						$report_url = add_query_arg(
 							'permission_id',
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							admin_url( 'admin.php?page=wc-reports&tab=orders&report=downloads' )
 						);
 						echo '<a class="button" href="' . esc_url( $report_url ) . '">';
-						echo __( 'View report', 'woocommerce' );
+						esc_html_e( 'View report', 'woocommerce' );
 						echo '</a>';
 					?>
 				</td>

--- a/includes/admin/meta-boxes/views/html-order-download-permission.php
+++ b/includes/admin/meta-boxes/views/html-order-download-permission.php
@@ -39,9 +39,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							'email'         => urlencode( $download->get_user_email() ),
 							'key'           => $download->get_download_id(),
 						), trailingslashit( home_url() ) );
-
-						echo '<a href="' . esc_url( $download_link ) . '">' . esc_html( $file_count ) . '</a>';
 					?>
+					<a id="copy-download-link" class="button" href="<?php echo esc_url( $download_link ) ?>" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>" data-tip-failed="<?php esc_attr_e( 'Copying to clipboard failed. You should be able to right-click the button and copy.', 'woocommerce' ); ?>"><?php _e( 'Copy link', 'woocommerce' ); ?></a>
 				</td>
 				<td>
 					<label><?php esc_html_e( 'Customer download report', 'woocommerce' ); ?></label>
@@ -51,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							rawurlencode( $download->get_id() ),
 							admin_url( 'admin.php?page=wc-reports&tab=orders&report=downloads' )
 						);
-						echo '<a href="' . esc_url( $report_url ) . '">';
+						echo '<a class="button" href="' . esc_url( $report_url ) . '">';
 						echo __( 'View Report', 'woocommerce' );
 						echo '</a>';
 					?>

--- a/includes/admin/meta-boxes/views/html-order-download-permission.php
+++ b/includes/admin/meta-boxes/views/html-order-download-permission.php
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					?>
 				</td>
 				<td>
-					<label><?php esc_html_e( 'Downloads completed', 'woocommerce' ); ?></label>
+					<label><?php esc_html_e( 'Customer download report', 'woocommerce' ); ?></label>
 					<?php
 						$report_url = add_query_arg(
 							'permission_id',
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							admin_url( 'admin.php?page=wc-reports&tab=orders&report=downloads' )
 						);
 						echo '<a href="' . esc_url( $report_url ) . '">';
-						echo esc_html( number_format_i18n( $download->get_download_count() ) );
+						echo __( 'View Report', 'woocommerce' );
 						echo '</a>';
 					?>
 				</td>

--- a/includes/admin/reports/class-wc-report-downloads.php
+++ b/includes/admin/reports/class-wc-report-downloads.php
@@ -115,8 +115,12 @@ class WC_Report_Downloads extends WP_List_Table {
 			$filter_list[] = $filter_names[ $key ] . ' ' . $display_value . ' <a href="' . esc_url( remove_query_arg( $key ) ) . '" class="woocommerce-reports-remove-filter">&times;</a>';
 		}
 
-		echo $filter_list ? ' - ' . wp_kses_post( implode( ', ', $filter_list ) ) : '';
 		echo '</h1>';
+
+		echo '<div id="active-filters" class="woocommerce-reports-wide"><h2>';
+		echo __( 'Active filters', 'woocommerce' ) . ': ';
+		echo $filter_list ? wp_kses_post( implode( ', ', $filter_list ) ) : '';
+		echo '</h2></div>';
 
 		echo '<div id="poststuff" class="woocommerce-reports-wide">';
 		$this->display();

--- a/includes/admin/reports/class-wc-report-downloads.php
+++ b/includes/admin/reports/class-wc-report-downloads.php
@@ -118,7 +118,7 @@ class WC_Report_Downloads extends WP_List_Table {
 		echo '</h1>';
 
 		echo '<div id="active-filters" class="woocommerce-reports-wide"><h2>';
-		echo __( 'Active filters', 'woocommerce' ) . ': ';
+		echo esc_html__( 'Active filters', 'woocommerce' ) . ': ';
 		echo $filter_list ? wp_kses_post( implode( ', ', $filter_list ) ) : '';
 		echo '</h2></div>';
 


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce/issues/18161

1) The download count is already shown above in the title, so the the important item is just the action to go view the logs. Added a "view report" button instead of a link that just says the download count. http://cld.wthms.co/Mn7Bft

2) To match the above change better, and solve some support burdens, also changed the other link to be a "copy link" button. We've  been contacted in support quite a few times regarding the previous link, since clicking it takes them to a forbidden page. This change helps make the use case a little more clear, and is more convenient for the admin. http://cld.wthms.co/fZaHEy

3) Still don't think this part is ideal, but I think it's better. http://cld.wthms.co/Fvju1L