### PR TITLE
Add ID orderby fallback for when prices are the same across multiple products.

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -522,7 +522,7 @@ class WC_Query {
 		} else {
 			$args['join']    .= " INNER JOIN ( SELECT post_id, min( meta_value+0 ) price FROM $wpdb->postmeta WHERE meta_key='_price' GROUP BY post_id ) as price_query ON $wpdb->posts.ID = price_query.post_id ";
 		}
-		$args['orderby'] = ' price_query.price ASC ';
+		$args['orderby'] = " price_query.price ASC, $wpdb->posts.ID ASC ";
 		return $args;
 	}
 
@@ -552,7 +552,7 @@ class WC_Query {
 			$args['join'] .= " INNER JOIN ( SELECT post_id, max( meta_value+0 ) price FROM $wpdb->postmeta WHERE meta_key='_price' GROUP BY post_id ) as price_query ON $wpdb->posts.ID = price_query.post_id ";
 		}
 
-		$args['orderby'] = ' price_query.price DESC ';
+		$args['orderby'] = " price_query.price DESC, $wpdb->posts.ID DESC ";
 		return $args;
 	}
 


### PR DESCRIPTION
When multiple products have the same price the order can appear random per query.

This PR adds a fallback to sort by ID so the results are always consistent.

Fixes #18168