### PR TITLE
Storefront in wizard for non WC themes and default themes

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -75,8 +75,10 @@ class WC_Admin_Setup_Wizard {
 		return (
 			current_user_can( 'install_themes' ) &&
 			current_user_can( 'switch_themes' ) &&
-			! is_multisite() &&
-			! current_theme_supports( 'woocommerce' )
+			! is_multisite() && (
+				! current_theme_supports( 'woocommerce' ) ||
+				WC()->is_active_theme( array( 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) )
+			)
 		);
 	}
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -72,13 +72,23 @@ class WC_Admin_Setup_Wizard {
 	 * and the store doesn't already have a WooCommerce compatible theme.
 	 */
 	protected function should_show_theme_extra() {
+		$is_default_theme = wc_is_active_theme( array(
+			'twentyseventeen',
+			'twentysixteen',
+			'twentyfifteen',
+			'twentyfourteen',
+			'twentythirteen',
+			'twentyeleven',
+			'twentytwelve',
+			'twentyten',
+		) );
+
+		$support_woocommerce = current_theme_supports( 'woocommerce' ) && ! $is_default_theme;
 		return (
 			current_user_can( 'install_themes' ) &&
 			current_user_can( 'switch_themes' ) &&
-			! is_multisite() && (
-				! current_theme_supports( 'woocommerce' ) ||
-				WC()->is_active_theme( array( 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) )
-			)
+			! is_multisite() &&
+			! $support_woocommerce
 		);
 	}
 

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -254,7 +254,7 @@ final class WooCommerce {
 	 * @param  string $theme Theme slug to check.
 	 * @return bool
 	 */
-	private function is_active_theme( $theme ) {
+	public function is_active_theme( $theme ) {
 		return is_array( $theme ) ? in_array( get_template(), $theme, true ) : get_template() === $theme;
 	}
 

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -248,17 +248,6 @@ final class WooCommerce {
 	}
 
 	/**
-	 * Check the active theme.
-	 *
-	 * @since  2.6.9
-	 * @param  string $theme Theme slug to check.
-	 * @return bool
-	 */
-	public function is_active_theme( $theme ) {
-		return is_array( $theme ) ? in_array( get_template(), $theme, true ) : get_template() === $theme;
-	}
-
-	/**
 	 * Include required core files used in admin and on the frontend.
 	 */
 	public function includes() {
@@ -408,7 +397,7 @@ final class WooCommerce {
 	 * @since 3.3.0
 	 */
 	private function theme_support_includes() {
-		if ( $this->is_active_theme( array( 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) ) ) {
+		if ( wc_is_active_theme( array( 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) ) ) {
 			switch ( get_template() ) {
 				case 'twentyten':
 					include_once( WC_ABSPATH . 'includes/theme-support/class-wc-twenty-ten.php' );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1947,3 +1947,14 @@ function wc_is_external_resource( $url ) {
 
 	return strstr( $url, '://' ) && strstr( $wp_base, $url );
 }
+
+/**
+ * See if theme/s is activate or not.
+ *
+ * @since 3.3.0
+ * @param string|array $theme Theme name or array of theme names to check.
+ * @return boolean
+ */
+function wc_is_active_theme( $theme ) {
+	return is_array( $theme ) ? in_array( get_template(), $theme, true ) : get_template() === $theme;
+}

--- a/tests/unit-tests/core/functions.php
+++ b/tests/unit-tests/core/functions.php
@@ -52,4 +52,15 @@ class WC_Tests_WooCommerce_Functions extends WC_Unit_Test_Case {
 		) );
 		$this->assertEquals( $new_currency, $order->get_currency() );
 	}
+
+	/**
+	 * Test the wc_is_active_theme function.
+	 *
+	 * @return void
+	 */
+	public function test_wc_is_active_theme() {
+		$this->assertTrue( wc_is_active_theme( 'default' ) );
+		$this->assertFalse( wc_is_active_theme( 'twentyfifteen' ) );
+		$this->assertTrue( wc_is_active_theme( array( 'default', 'twentyseventeen' ) ) );
+	}
 }


### PR DESCRIPTION
The wizard will recommend storefront as a theme to install when a theme with no woocommerce support is active, however since we add woocommerce support for default themes the notice is not displaying.

This PR addresses the issue by showing the theme when a theme with no woocommerce support is active, or when using one of the default themes.

Closes #18182 