### PR TITLE
Option value comparison when saving select settings

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -733,7 +733,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							break;
 						}
 						$default = ( empty( $option['default'] ) ? $allowed_values[0] : $option['default'] );
-						$value   = in_array( $raw_value, $allowed_values, true ) ? $raw_value : $default;
+						$value   = in_array( $raw_value, $allowed_values ) ? $raw_value : $default;
 						break;
 					default:
 						$value = wc_clean( $raw_value );

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -727,13 +727,13 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 						break;
 					case 'select':
-						$allowed_values = empty( $option['options'] ) ? array() : array_keys( $option['options'] );
+						$allowed_values = empty( $option['options'] ) ? array() : array_map( 'strval', array_keys( $option['options'] ) );
 						if ( empty( $option['default'] ) && empty( $allowed_values ) ) {
 							$value = null;
 							break;
 						}
 						$default = ( empty( $option['default'] ) ? $allowed_values[0] : $option['default'] );
-						$value   = in_array( $raw_value, $allowed_values ) ? $raw_value : $default;
+						$value   = in_array( $raw_value, $allowed_values, true ) ? $raw_value : $default;
 						break;
 					default:
 						$value = wc_clean( $raw_value );


### PR DESCRIPTION
wp_unslash will always return a string when you pass an int through, which means when you have a select field with int values and you save the settings it will return the default because in_array with the strict param will fail testing a string against an int.

Because html values also do not care about data type it is safe to just convert the values to a string before comparing it.

To test create a custom select setting with int options and a default value and then try and save a value that is not default, it should not save the default value but the actual selected option value.