### PR TITLE
Fix wc_is_active_theme test

### DIFF
--- a/tests/unit-tests/core/functions.php
+++ b/tests/unit-tests/core/functions.php
@@ -59,8 +59,9 @@ class WC_Tests_WooCommerce_Functions extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_wc_is_active_theme() {
-		$this->assertTrue( wc_is_active_theme( 'default' ) );
-		$this->assertFalse( wc_is_active_theme( 'twentyfifteen' ) );
-		$this->assertTrue( wc_is_active_theme( array( 'default', 'twentyseventeen' ) ) );
+		$current_theme = get_template();
+		$this->assertTrue( wc_is_active_theme( $current_theme ) );
+		$this->assertFalse( wc_is_active_theme( 'somegiberish' ) );
+		$this->assertTrue( wc_is_active_theme( array( $current_theme, 'somegiberish' ) ) );
 	}
 }


### PR DESCRIPTION
Make the test work on any test platform, do not hardcode a value to check.