### PR TITLE
Do not load SESSION class during CRON events

### DIFF
--- a/includes/abstracts/abstract-wc-session.php
+++ b/includes/abstracts/abstract-wc-session.php
@@ -40,11 +40,16 @@ abstract class WC_Session {
 	protected $_dirty = false;
 
 	/**
-	 * Init hooks and session data.
+	 * Init hooks and session data. Extended by child classes.
 	 *
 	 * @since 3.3.0
 	 */
 	public function init() {}
+
+	/**
+	 * Cleanup session data. Extended by child classes.
+	 */
+	public function cleanup_sessions() {}
 
 	/**
 	 * Magic get method.

--- a/includes/abstracts/abstract-wc-session.php
+++ b/includes/abstracts/abstract-wc-session.php
@@ -1,9 +1,4 @@
-<?php
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
+<?php // @codingStandardsIgnoreLine.
 /**
  * Handle data for the current customers session
  *
@@ -11,23 +6,50 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @version     2.0.0
  * @package     WooCommerce/Abstracts
  * @category    Abstract Class
- * @author      WooThemes
+ * @author      Automattic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Session
  */
 abstract class WC_Session {
 
-	/** @var int $_customer_id */
+	/**
+	 * Customer ID.
+	 *
+	 * @var int $_customer_id Customer ID.
+	 */
 	protected $_customer_id;
 
-	/** @var array $_data  */
+	/**
+	 * Session Data.
+	 *
+	 * @var array $_data Data array.
+	 */
 	protected $_data = array();
 
-	/** @var bool $_dirty When something changes */
+	/**
+	 * Dirty when the session needs saving.
+	 *
+	 * @var bool $_dirty When something changes
+	 */
 	protected $_dirty = false;
 
 	/**
-	 * __get function.
+	 * Init hooks and session data.
 	 *
-	 * @param mixed $key
+	 * @since 3.3.0
+	 */
+	public function init() {}
+
+	/**
+	 * Magic get method.
+	 *
+	 * @param mixed $key Key to get.
 	 * @return mixed
 	 */
 	public function __get( $key ) {
@@ -35,29 +57,29 @@ abstract class WC_Session {
 	}
 
 	/**
-	 * __set function.
+	 * Magic set method.
 	 *
-	 * @param mixed $key
-	 * @param mixed $value
+	 * @param mixed $key Key to set.
+	 * @param mixed $value Value to set.
 	 */
 	public function __set( $key, $value ) {
 		$this->set( $key, $value );
 	}
 
-	 /**
-	  * __isset function.
-	  *
-	  * @param mixed $key
-	  * @return bool
-	  */
+	/**
+	 * Magic isset method.
+	 *
+	 * @param mixed $key Key to check.
+	 * @return bool
+	 */
 	public function __isset( $key ) {
 		return isset( $this->_data[ sanitize_title( $key ) ] );
 	}
 
 	/**
-	 * __unset function.
+	 * Magic unset method.
 	 *
-	 * @param mixed $key
+	 * @param mixed $key Key to unset.
 	 */
 	public function __unset( $key ) {
 		if ( isset( $this->_data[ $key ] ) ) {
@@ -69,8 +91,8 @@ abstract class WC_Session {
 	/**
 	 * Get a session variable.
 	 *
-	 * @param string $key
-	 * @param  mixed $default used if the session variable isn't set
+	 * @param string $key Key to get.
+	 * @param mixed  $default used if the session variable isn't set.
 	 * @return array|string value of session variable
 	 */
 	public function get( $key, $default = null ) {
@@ -81,20 +103,19 @@ abstract class WC_Session {
 	/**
 	 * Set a session variable.
 	 *
-	 * @param string $key
-	 * @param mixed $value
+	 * @param string $key Key to set.
+	 * @param mixed  $value Value to set.
 	 */
 	public function set( $key, $value ) {
 		if ( $value !== $this->get( $key ) ) {
 			$this->_data[ sanitize_key( $key ) ] = maybe_serialize( $value );
-			$this->_dirty = true;
+			$this->_dirty                        = true;
 		}
 	}
 
 	/**
-	 * get_customer_id function.
+	 * Get customer ID.
 	 *
-	 * @access public
 	 * @return int
 	 */
 	public function get_customer_id() {

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -249,17 +249,14 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Cleanup sessions.
+	 * Cleanup session data from the database and clear caches.
 	 */
 	public function cleanup_sessions() {
 		global $wpdb;
 
-		if ( ! defined( 'WP_SETUP_CONFIG' ) && ! defined( 'WP_INSTALLING' ) ) {
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $this->_table WHERE session_expiry < %d", time() ) ); // @codingStandardsIgnoreLine.
 
-			// Delete expired sessions.
-			$wpdb->query( $wpdb->prepare( "DELETE FROM $this->_table WHERE session_expiry < %d", time() ) ); // @codingStandardsIgnoreLine.
-
-			// Invalidate cache.
+		if ( class_exists( 'WC_Cache_Helper' ) ) {
 			WC_Cache_Helper::incr_cache_prefix( WC_SESSION_CACHE_GROUP );
 		}
 	}
@@ -282,7 +279,7 @@ class WC_Session_Handler extends WC_Session {
 		$value = wp_cache_get( $this->get_cache_prefix() . $customer_id, WC_SESSION_CACHE_GROUP );
 
 		if ( false === $value ) {
-			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT session_value FROM ' . esc_sql( $this->_table ) . ' WHERE session_key = %s', $customer_id ) ); // @codingStandardsIgnoreLine.
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT session_value FROM $this->_table WHERE session_key = %s", $customer_id ) ); // @codingStandardsIgnoreLine.
 
 			if ( is_null( $value ) ) {
 				$value = $default;

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -1,8 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * Handle data for the current customers session.
  * Implements the WC_Session abstract class.
@@ -13,41 +9,76 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @version  2.5.0
  * @package  WooCommerce/Classes
  * @category Class
- * @author   WooThemes
+ * @author   Automattic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Session_Handler
  */
 class WC_Session_Handler extends WC_Session {
 
-	/** @var string cookie name */
+	/**
+	 * Cookie name used for the session.
+	 *
+	 * @var string cookie name
+	 */
 	protected $_cookie;
 
-	/** @var string session due to expire timestamp */
+	/**
+	 * Stores session expiry.
+	 *
+	 * @var string session due to expire timestamp
+	 */
 	protected $_session_expiring;
 
-	/** @var string session expiration timestamp */
+	/**
+	 * Stores session due to expire timestamp.
+	 *
+	 * @var string session expiration timestamp
+	 */
 	protected $_session_expiration;
 
-	/** $var bool Bool based on whether a cookie exists **/
+	/**
+	 * True when the cookie exists.
+	 *
+	 * @var bool Based on whether a cookie exists.
+	 */
 	protected $_has_cookie = false;
 
-	/** @var string Custom session table name */
+	/**
+	 * Table name for session data.
+	 *
+	 * @var string Custom session table name
+	 */
 	protected $_table;
 
 	/**
 	 * Constructor for the session class.
 	 */
 	public function __construct() {
-		global $wpdb;
-
 		$this->_cookie = apply_filters( 'woocommerce_cookie', 'wp_woocommerce_session_' . COOKIEHASH );
-		$this->_table  = $wpdb->prefix . 'woocommerce_sessions';
+		$this->_table  = $GLOBALS['wpdb']->prefix . 'woocommerce_sessions';
+	}
 
-		if ( $cookie = $this->get_session_cookie() ) {
+	/**
+	 * Init hooks and session data.
+	 *
+	 * @since 3.3.0
+	 */
+	public function init() {
+		$cookie = $this->get_session_cookie();
+
+		if ( $cookie ) {
 			$this->_customer_id        = $cookie[0];
 			$this->_session_expiration = $cookie[1];
 			$this->_session_expiring   = $cookie[2];
 			$this->_has_cookie         = true;
 
-			// Update session if its close to expiring
+			// Update session if its close to expiring.
 			if ( time() > $this->_session_expiring ) {
 				$this->set_session_expiration();
 				$this->update_session_timestamp( $this->_customer_id, $this->_session_expiration );
@@ -59,11 +90,10 @@ class WC_Session_Handler extends WC_Session {
 
 		$this->_data = $this->get_session_data();
 
-		// Actions
 		add_action( 'woocommerce_set_cart_cookies', array( $this, 'set_customer_session_cookie' ), 10 );
-		add_action( 'woocommerce_cleanup_sessions', array( $this, 'cleanup_sessions' ), 10 );
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
+
 		if ( ! is_user_logged_in() ) {
 			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ) );
 		}
@@ -76,17 +106,15 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * Warning: Cookies will only be set if this is called before the headers are sent.
 	 *
-	 * @param bool $set
+	 * @param bool $set Should the session cookie be set.
 	 */
 	public function set_customer_session_cookie( $set ) {
 		if ( $set ) {
-			// Set/renew our cookie
 			$to_hash           = $this->_customer_id . '|' . $this->_session_expiration;
 			$cookie_hash       = hash_hmac( 'md5', $to_hash, wp_hash( $to_hash ) );
 			$cookie_value      = $this->_customer_id . '||' . $this->_session_expiration . '||' . $this->_session_expiring . '||' . $cookie_hash;
 			$this->_has_cookie = true;
 
-			// Set the cookie
 			wc_setcookie( $this->_cookie, $cookie_value, $this->_session_expiration, apply_filters( 'wc_session_use_secure_cookie', false ) );
 		}
 	}
@@ -97,7 +125,7 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool
 	 */
 	public function has_session() {
-		return isset( $_COOKIE[ $this->_cookie ] ) || $this->_has_cookie || is_user_logged_in();
+		return isset( $_COOKIE[ $this->_cookie ] ) || $this->_has_cookie || is_user_logged_in(); // @codingStandardsIgnoreLine.
 	}
 
 	/**
@@ -119,7 +147,7 @@ class WC_Session_Handler extends WC_Session {
 		if ( is_user_logged_in() ) {
 			return get_current_user_id();
 		} else {
-			require_once( ABSPATH . 'wp-includes/class-phpass.php' );
+			require_once ABSPATH . 'wp-includes/class-phpass.php';
 			$hasher = new PasswordHash( 8, false );
 			return md5( $hasher->get_random_bytes( 32 ) );
 		}
@@ -131,13 +159,15 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool|array
 	 */
 	public function get_session_cookie() {
-		if ( empty( $_COOKIE[ $this->_cookie ] ) || ! is_string( $_COOKIE[ $this->_cookie ] ) ) {
+		$cookie_value = isset( $_COOKIE[ $this->_cookie ] ) ? wp_unslash( $_COOKIE[ $this->_cookie ] ) : false; // @codingStandardsIgnoreLine.
+
+		if ( empty( $cookie_value ) || ! is_string( $cookie_value ) ) {
 			return false;
 		}
 
-		list( $customer_id, $session_expiration, $session_expiring, $cookie_hash ) = explode( '||', $_COOKIE[ $this->_cookie ] );
+		list( $customer_id, $session_expiration, $session_expiring, $cookie_hash ) = explode( '||', $cookie_value );
 
-		// Validate hash
+		// Validate hash.
 		$to_hash = $customer_id . '|' . $session_expiration;
 		$hash    = hash_hmac( 'md5', $to_hash, wp_hash( $to_hash ) );
 
@@ -170,15 +200,15 @@ class WC_Session_Handler extends WC_Session {
 	 * Save data.
 	 */
 	public function save_data() {
-		// Dirty if something changed - prevents saving nothing new
+		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;
 
-			$wpdb->replace(
+			$wpdb->replace( // @codingStandardsIgnoreLine.
 				$this->_table,
 				array(
-					'session_key' => $this->_customer_id,
-					'session_value' => maybe_serialize( $this->_data ),
+					'session_key'    => $this->_customer_id,
+					'session_value'  => maybe_serialize( $this->_data ),
 					'session_expiry' => $this->_session_expiration,
 				),
 				array(
@@ -188,10 +218,7 @@ class WC_Session_Handler extends WC_Session {
 				)
 			);
 
-			// Set cache
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
-
-			// Mark session clean after saving
 			$this->_dirty = false;
 		}
 	}
@@ -200,15 +227,12 @@ class WC_Session_Handler extends WC_Session {
 	 * Destroy all session data.
 	 */
 	public function destroy_session() {
-		// Clear cookie
 		wc_setcookie( $this->_cookie, '', time() - YEAR_IN_SECONDS, apply_filters( 'wc_session_use_secure_cookie', false ) );
 
 		$this->delete_session( $this->_customer_id );
 
-		// Clear cart
 		wc_empty_cart();
 
-		// Clear data
 		$this->_data        = array();
 		$this->_dirty       = false;
 		$this->_customer_id = $this->generate_customer_id();
@@ -217,8 +241,7 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * When a user is logged out, ensure they have a unique nonce by using the customer/session ID.
 	 *
-	 * @param int $uid
-	 *
+	 * @param int $uid User ID.
 	 * @return string
 	 */
 	public function nonce_user_logged_out( $uid ) {
@@ -233,10 +256,10 @@ class WC_Session_Handler extends WC_Session {
 
 		if ( ! defined( 'WP_SETUP_CONFIG' ) && ! defined( 'WP_INSTALLING' ) ) {
 
-			// Delete expired sessions
-			$wpdb->query( $wpdb->prepare( "DELETE FROM $this->_table WHERE session_expiry < %d", time() ) );
+			// Delete expired sessions.
+			$wpdb->query( $wpdb->prepare( "DELETE FROM $this->_table WHERE session_expiry < %d", time() ) ); // @codingStandardsIgnoreLine.
 
-			// Invalidate cache
+			// Invalidate cache.
 			WC_Cache_Helper::incr_cache_prefix( WC_SESSION_CACHE_GROUP );
 		}
 	}
@@ -244,8 +267,8 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Returns the session.
 	 *
-	 * @param string $customer_id
-	 * @param mixed $default
+	 * @param string $customer_id Custo ID.
+	 * @param mixed  $default Default session value.
 	 * @return string|array
 	 */
 	public function get_session( $customer_id, $default = false ) {
@@ -255,11 +278,11 @@ class WC_Session_Handler extends WC_Session {
 			return false;
 		}
 
-		// Try get it from the cache, it will return false if not present or if object cache not in use
+		// Try to get it from the cache, it will return false if not present or if object cache not in use.
 		$value = wp_cache_get( $this->get_cache_prefix() . $customer_id, WC_SESSION_CACHE_GROUP );
 
 		if ( false === $value ) {
-			$value = $wpdb->get_var( $wpdb->prepare( "SELECT session_value FROM $this->_table WHERE session_key = %s", $customer_id ) );
+			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT session_value FROM ' . esc_sql( $this->_table ) . ' WHERE session_key = %s', $customer_id ) ); // @codingStandardsIgnoreLine.
 
 			if ( is_null( $value ) ) {
 				$value = $default;
@@ -274,14 +297,14 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Delete the session from the cache and database.
 	 *
-	 * @param int $customer_id
+	 * @param int $customer_id Customer ID.
 	 */
 	public function delete_session( $customer_id ) {
 		global $wpdb;
 
 		wp_cache_delete( $this->get_cache_prefix() . $customer_id, WC_SESSION_CACHE_GROUP );
 
-		$wpdb->delete(
+		$wpdb->delete( // @codingStandardsIgnoreLine.
 			$this->_table,
 			array(
 				'session_key' => $customer_id,
@@ -292,12 +315,13 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Update the session expiry timestamp.
 	 *
-	 * @param string $customer_id
-	 * @param int $timestamp
+	 * @param string $customer_id Customer ID.
+	 * @param int    $timestamp Timestamp to expire the cookie.
 	 */
 	public function update_session_timestamp( $customer_id, $timestamp ) {
 		global $wpdb;
 
+		// @codingStandardsIgnoreStart.
 		$wpdb->update(
 			$this->_table,
 			array(
@@ -310,5 +334,6 @@ class WC_Session_Handler extends WC_Session {
 				'%d'
 			)
 		);
+		// @codingStandardsIgnoreEnd.
 	}
 }

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -475,11 +475,14 @@ final class WooCommerce {
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
 			// Session class, handles session data for users - can be overwritten if custom handler is needed.
-			$session_class  = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
-			$this->session  = new $session_class();
-			$this->cart            = new WC_Cart();                                  // Cart class, stores the cart contents.
-			$this->customer        = new WC_Customer( get_current_user_id(), true ); // Customer class, handles data such as customer location.
-			add_action( 'shutdown', array( $this->customer, 'save' ), 10 );          // Customer should be saved during shutdown.
+			$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+			$this->session = new $session_class();
+			$this->session->init();
+
+			$this->cart     = new WC_Cart();                                  // Cart class, stores the cart contents.
+			$this->customer = new WC_Customer( get_current_user_id(), true ); // Customer class, handles data such as customer location.
+
+			add_action( 'shutdown', array( $this->customer, 'save' ), 10 );   // Customer should be saved during shutdown.
 		}
 
 		$this->load_webhooks();

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -472,14 +472,11 @@ final class WooCommerce {
 		$this->deprecated_hook_handlers['actions'] = new WC_Deprecated_Action_Hooks();
 		$this->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
 
-		// Session class, handles session data for users - can be overwritten if custom handler is needed.
-		if ( $this->is_request( 'frontend' ) || $this->is_request( 'cron' ) ) {
-			$session_class  = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
-			$this->session  = new $session_class();
-		}
-
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
+			// Session class, handles session data for users - can be overwritten if custom handler is needed.
+			$session_class  = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+			$this->session  = new $session_class();
 			$this->cart            = new WC_Cart();                                  // Cart class, stores the cart contents.
 			$this->customer        = new WC_Customer( get_current_user_id(), true ); // Customer class, handles data such as customer location.
 			add_action( 'shutdown', array( $this->customer, 'save' ), 10 );          // Customer should be saved during shutdown.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1958,3 +1958,18 @@ function wc_is_external_resource( $url ) {
 function wc_is_active_theme( $theme ) {
 	return is_array( $theme ) ? in_array( get_template(), $theme, true ) : get_template() === $theme;
 }
+
+/**
+ * Cleans up session data - cron callback.
+ *
+ * @since 3.3.0
+ */
+function wc_cleanup_session_data() {
+	$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+	$session       = new $session_class();
+
+	if ( is_callable( array( $session, 'cleanup_sessions' ) ) ) {
+		$session->cleanup_sessions();
+	}
+}
+add_action( 'woocommerce_cleanup_sessions', 'wc_cleanup_session_data' );


### PR DESCRIPTION
Sessions and carts are not needed when CRON runs. This prevents it loading and fixes #16940 

This also adds methods for session cleanup which can run doing cron.