### PR TITLE
Only show 'Apply coupon' in admin if coupons are enabled

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -203,7 +203,9 @@ if ( wc_tax_enabled() ) {
 	<p class="add-items">
 		<?php if ( $order->is_editable() ) : ?>
 			<button type="button" class="button add-line-item"><?php esc_html_e( 'Add item(s)', 'woocommerce' ); ?></button>
-			<button type="button" class="button add-coupon"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
+			<?php if ( wc_coupons_enabled() ) : ?>
+				<button type="button" class="button add-coupon"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
+			<?php endif; ?>
 		<?php else : ?>
 			<span class="description"><?php echo wc_help_tip( __( 'To edit this order change the status back to "Pending"', 'woocommerce' ) ); ?> <?php esc_html_e( 'This order is no longer editable.', 'woocommerce' ); ?></span>
 		<?php endif; ?>


### PR DESCRIPTION
![](http://cld.wthms.co/VVPLEc+)

Furthermore, also had the idea to either create a new coupon helper function, or tie into `wc_coupons_enabled()` and return false if the user has no active coupons.

As a result, we could hide all front-end coupon interfaces as well if the store has no coupons. Unsure if that is overstepping on what a merchant would want, but imo it would make sense to declutter the UI if it's not truly useable. Just an idea, wanted to get some feedback before continuing.