### PR TITLE
Prevent duplicate IDs on checkout page

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -925,6 +925,7 @@ class WC_Form_Handler {
 	 * Process the login form.
 	 */
 	public static function process_login() {
+		// The global form-login.php template used `_wpnonce` in template versions < 3.3.0.
 		$nonce_value = isset( $_POST['_wpnonce'] ) ? $_POST['_wpnonce'] : '';
 		$nonce_value = isset( $_POST['woocommerce-login-nonce'] ) ? $_POST['woocommerce-login-nonce'] : $nonce_value;
 

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -44,7 +44,7 @@ if ( is_user_logged_in() ) {
 	<?php do_action( 'woocommerce_login_form' ); ?>
 
 	<p class="form-row">
-		<?php wp_nonce_field( 'woocommerce-login' ); ?>
+		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 		<button type="submit" class="button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ) ?>" />
 		<label class="woocommerce-form__label woocommerce-form__label-for-checkbox inline">


### PR DESCRIPTION
If the `Display returning customer login reminder on the "Checkout" page.` setting is enabled at WooCommerce > Settings > Accounts, and you visit the checkout page while not logged in, you see this console error: http://cld.wthms.co/86RdPd

Both the login form and and checkout form are using un-named nonces. This PR fixes the problem by naming the nonce for the login form. Note that the same named nonce was already in use for the my account login form.