### PR TITLE
Remove unwanted transient then were not set

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -83,7 +83,6 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 			// Clear any unwanted data and flush rules.
 			add_option( 'woocommerce_queue_flush_rewrite_rules', 'true' );
-			delete_transient( 'woocommerce_cache_excluded_uris' );
 			WC()->query->init_query_vars();
 			WC()->query->add_endpoints();
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -402,8 +402,6 @@ class WC_Install {
 		foreach ( $pages as $key => $page ) {
 			wc_create_page( esc_sql( $page['name'] ), 'woocommerce_' . $key . '_page_id', $page['title'], $page['content'], ! empty( $page['parent'] ) ? wc_get_page_id( $page['parent'] ) : '' );
 		}
-
-		delete_transient( 'woocommerce_cache_excluded_uris' );
 	}
 
 	/**


### PR DESCRIPTION
Ref: https://github.com/woocommerce/woocommerce/search?utf8=%E2%9C%93&q=woocommerce_cache_excluded_uris&type=