### PR TITLE
Compare the date modified when loading session data.

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -270,7 +270,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param bool $is_vat_exempt
 	 */
 	public function set_is_vat_exempt( $is_vat_exempt ) {
-		$this->is_vat_exempt = (bool) $is_vat_exempt;
+		$this->is_vat_exempt = wc_string_to_bool( $is_vat_exempt );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param boolean $calculated
 	 */
 	public function set_calculated_shipping( $calculated = true ) {
-		$this->calculated_shipping = (bool) $calculated;
+		$this->calculated_shipping = wc_string_to_bool( $calculated );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -77,9 +77,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 			}
 			$data[ $session_key ] = (string) $customer->{"get_$function_key"}( 'edit' );
 		}
-		if ( WC()->session->get( 'customer' ) !== $data ) {
-			WC()->session->set( 'customer', $data );
-		}
+		WC()->session->set( 'customer', $data );
 	}
 
 	/**
@@ -97,8 +95,11 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 		 *
 		 * If the user object has been updated since the session was created (based on date_modified) we should not load the session - data should be reloaded.
 		 */
-		if ( ! empty( $data ) && isset( $data['id'], $data['date_modified'] ) && $data['id'] === (string) $customer->get_id() && $data['date_modified'] === (string) $customer->get_date_modified( 'edit' ) ) {
+		if ( isset( $data['id'], $data['date_modified'] ) && $data['id'] === (string) $customer->get_id() && $data['date_modified'] === (string) $customer->get_date_modified( 'edit' ) ) {
 			foreach ( $this->session_keys as $session_key ) {
+				if ( in_array( $session_key, array( 'id', 'date_modified' ), true ) ) {
+					continue;
+				}
 				$function_key = $session_key;
 				if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
 					$session_key = str_replace( 'billing_', '', $session_key );

--- a/tests/framework/helpers/class-wc-helper-customer.php
+++ b/tests/framework/helpers/class-wc-helper-customer.php
@@ -13,9 +13,9 @@ class WC_Helper_Customer {
 	 * @return WC_Customer
 	 */
 	public static function create_mock_customer() {
-
 		$customer_data = array(
 			'id'                     => 0,
+			'date_modified'          => null,
 			'country' 				 => 'US',
 			'state' 				 => 'PA',
 			'postcode' 				 => '19123',
@@ -35,6 +35,7 @@ class WC_Helper_Customer {
 		WC_Helper_Customer::set_customer_details( $customer_data );
 
 		$customer = new WC_Customer( 0, true );
+
 		return $customer;
 	}
 
@@ -105,7 +106,7 @@ class WC_Helper_Customer {
 	 * @param string $default_shipping_method Shipping Method slug
 	 */
 	public static function set_customer_details( $customer_details ) {
-		WC()->session->set( 'customer', $customer_details );
+		WC()->session->set( 'customer', array_map( 'strval', $customer_details ) );
 	}
 
 	/**

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -442,8 +442,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_sessions() {
-		$customer = WC_Helper_Customer::create_customer();
-		$session  = WC_Helper_Customer::create_mock_customer(); // set into session....
+		$session = WC_Helper_Customer::create_mock_customer(); // set into session....
 
 		$this->assertEquals( '19123', $session->get_billing_postcode() );
 		$this->assertEquals( '123 South Street', $session->get_billing_address() );


### PR DESCRIPTION
When a user is updated from the backend, the user/session on the frontend did not see these changes.

By including the date modified in the session, we can compare if the user has been updated and then reload the data.

Using strings keeps session data in a similar, standard format. It also helps covert dates to a string format.

Fixes #18197