### PR TITLE
Enable filtering GET /products by multiple product attributes

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -232,6 +232,17 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 			}
 		}
 
+        // Filter by multiple attributes and terms.
+        foreach ( wc_get_attribute_taxonomy_names() as $attribute ) {
+            if ( ! empty( $request[$attribute] ) ) {
+                $tax_query[] = array(
+                    'taxonomy' => $attribute,
+                    'field'    => 'term_id',
+                    'terms'    => $request[$attribute],
+                );
+            }
+        }
+
 		if ( ! empty( $tax_query ) ) {
 			$args['tax_query'] = $tax_query; // WPCS: slow query ok.
 		}


### PR DESCRIPTION
Modifies the `products` controller to check the `$request` for any product attribute taxonomies and add them to a tax query.

Example:
Create Foo and Bar product attributes. This should produce `pa_foo` and `pa_bar` taxonomies.
`/products?pa_foo=3&pa_bar=4,5` will show products that have term with `term_id` 3 for the Foo attribute and the terms with `term_id` 4 or 5 for the Bar attribute.

Fixes #18221