### PR TITLE
REST API: Adding + removing coupons via API doesn't recalculate totals correctly

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -430,7 +430,6 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					case 'line_items' :
 					case 'shipping_lines' :
 					case 'fee_lines' :
-					case 'coupon_lines' :
 						if ( is_array( $value ) ) {
 							foreach ( $value as $item ) {
 								if ( is_array( $item ) ) {
@@ -438,6 +437,28 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 										$order->remove_item( $item['id'] );
 									} else {
 										$this->set_item( $order, $key, $item );
+									}
+								}
+							}
+						}
+						break;
+					case 'coupon_lines' :
+						if ( is_array( $value ) ) {
+							foreach ( $value as $item ) {
+								if ( is_array( $item ) ) {
+									if ( $this->item_is_null( $item ) ) {
+										$item = $order->get_item( $item['id'] );
+										if ( $item && method_exists( $item, 'get_code' ) ) {
+											$order->remove_coupon( $item->get_code() );
+										} else {
+											$order->remove_item( $item['id'] );
+										}
+									} else {
+										if ( ! empty( $item['code'] ) ) {
+											$order->apply_coupon( $item['code'] );
+										} else {
+											$this->set_item( $order, $key, $item );
+										}
 									}
 								}
 							}

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -430,6 +430,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					case 'line_items' :
 					case 'shipping_lines' :
 					case 'fee_lines' :
+					case 'coupon_lines' :
 						if ( is_array( $value ) ) {
 							foreach ( $value as $item ) {
 								if ( is_array( $item ) ) {
@@ -437,28 +438,6 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 										$order->remove_item( $item['id'] );
 									} else {
 										$this->set_item( $order, $key, $item );
-									}
-								}
-							}
-						}
-						break;
-					case 'coupon_lines' :
-						if ( is_array( $value ) ) {
-							foreach ( $value as $item ) {
-								if ( is_array( $item ) ) {
-									if ( $this->item_is_null( $item ) ) {
-										$item = $order->get_item( $item['id'] );
-										if ( $item && method_exists( $item, 'get_code' ) ) {
-											$order->remove_coupon( $item->get_code() );
-										} else {
-											$order->remove_item( $item['id'] );
-										}
-									} else {
-										if ( ! empty( $item['code'] ) ) {
-											$order->apply_coupon( $item['code'] );
-										} else {
-											$this->set_item( $order, $key, $item );
-										}
 									}
 								}
 							}

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -333,15 +333,15 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	/**
 	 * Tests updating an order and adding a coupon.
 	 *
-	 * @since 3.0.0
+	 * @since 3.3.0
 	 */
 	public function test_update_order_add_coupons() {
 		wp_set_current_user( $this->user );
 		$order = WC_Helper_Order::create_order();
+		$order_item = current( $order->get_items() );
 		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
-
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(
 			'coupon_lines' => array(
@@ -349,6 +349,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 					'code'           => 'fake-coupon',
 					'discount_total' => '5',
 					'discount_tax'   => '0',
+				),
+			),
+			'line_items' => array(
+				array(
+					'id' => $order_item->get_id(),
+					'product_id' => $order_item->get_product_id(),
+					'total' => '35.00',
 				),
 			),
 		) );
@@ -365,11 +372,12 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	/**
 	 * Tests updating an order and removing a coupon.
 	 *
-	 * @since 3.0.0
+	 * @since 3.3.0
 	 */
 	public function test_update_order_remove_coupons() {
 		wp_set_current_user( $this->user );
 		$order  = WC_Helper_Order::create_order();
+		$order_item = current( $order->get_items() );
 		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
@@ -388,6 +396,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 				array(
 					'id'   => $coupon_data->get_id(),
 					'code' => null,
+				),
+			),
+			'line_items' => array(
+				array(
+					'id' => $order_item->get_id(),
+					'product_id' => $order_item->get_product_id(),
+					'total' => '40.00',
 				),
 			),
 		) );

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -338,6 +338,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_update_order_add_coupons() {
 		wp_set_current_user( $this->user );
 		$order = WC_Helper_Order::create_order();
+		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
+		$coupon->set_amount( 5 );
+		$coupon->save();
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -331,6 +331,74 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests updating an order and adding a coupon.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_update_order_add_coupons() {
+		wp_set_current_user( $this->user );
+		$order = WC_Helper_Order::create_order();
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
+		$request->set_body_params( array(
+			'coupon_lines' => array(
+				array(
+					'code'           => 'fake-coupon',
+					'discount_total' => '5',
+					'discount_tax'   => '0',
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data['coupon_lines'] );
+		$this->assertEquals( '45.00', $data['total'] );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
+	 * Tests updating an order and removing a coupon.
+	 *
+	 * @since 3.0.0
+	 */
+	public function test_update_order_remove_coupons() {
+		wp_set_current_user( $this->user );
+		$order  = WC_Helper_Order::create_order();
+		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
+		$coupon->set_amount( 5 );
+		$coupon->save();
+
+		$order->apply_coupon( $coupon );
+		$order->save();
+
+		// Check that the coupon is applied.
+		$this->assertEquals( '45.00', $order->get_total() );
+
+		$request     = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
+		$coupon_data = current( $order->get_items( 'coupon' ) );
+
+		$request->set_body_params( array(
+			'coupon_lines' => array(
+				array(
+					'id'   => $coupon_data->get_id(),
+					'code' => null,
+				),
+			),
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( empty( $data['coupon_lines'] ) );
+		$this->assertEquals( '50.00', $data['total'] );
+
+		WC_Helper_Order::delete_order( $order->get_id() );
+	}
+
+	/**
 	 * Tests updating an order without the correct permissions.
 	 *
 	 * @since 3.0.0


### PR DESCRIPTION
This PR is proof of an issue, rather than a fix in itself. When coupons are added or removed from an existing order via the API, the item totals are not updated. I've added two failing tests in this PR, one for adding & one for removing a coupon.

You can also replicate the issue manually, by sending requests to  `POST orders/:orderId`

Add a coupon:
```json
{
    "coupon_lines": [
        {
            "code": <coupon-code>
        }
    ]
}
```

Remove a coupon:
```json
{
    "coupon_lines": [
        {
            "id": <couponLineId>,
            "code": null
        }
    ]
}
```

In both cases, the line items are not updated (the discount is not applied to line items, or it's not removed from line items), which means the order total is not updated again when `calculate_totals` is run. It looks like a fix might be to run `WC_Order::recalculate_coupons` if `coupon_lines` changes, but that's a protected function in the abstract class. An alternate approach could be to use the apply_coupon/remove_coupon functions directly for coupon_lines.

Feel free to take over this PR to fix this, or give me a pointer & I'll fix it. We'll probably end up porting whatever fix we end up with into https://github.com/woocommerce/wc-api-dev, so letting @justinshreve & @timmyc know this exists :)