### PR TITLE
Fix --date_created and --date_created_gmt args for wc product_review

### DIFF
--- a/includes/api/v1/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/v1/class-wc-rest-product-reviews-controller.php
@@ -475,6 +475,14 @@ class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {
 			$prepared_review['comment_author_email'] = $request['email'];
 		}
 
+		if ( isset( $request['date_created'] ) ) {
+			$prepared_review['comment_date'] = $request['date_created'];
+		}
+
+		if ( isset( $request['date_created_gmt'] ) ) {
+			$prepared_review['comment_date_gmt'] = $request['date_created_gmt'];
+		}
+
 		return apply_filters( 'rest_preprocess_product_review', $prepared_review, $request );
 	}
 


### PR DESCRIPTION
The [documentation](https://github.com/woocommerce/woocommerce/wiki/WC-CLI-Commands#wc-product_review-create-product_id) for the wp-cli commands
`wc product_review create` and `wc product_review update`
mention passing a --date_created and --date_created_gmt argument to specify the review date. 
The same arguments are listed when running the help commands via a terminal. 

The product reviews controller uses a method `prepare_item_for_database` to convert the passed arguments to match a comments data before inserting or updating. At this point there is no conversion setup to allow passing these date arguments.

This pull simply includes the necessary conversions of these arguments. 

