### PR TITLE
Add product export row action hook

### DIFF
--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -133,11 +133,13 @@ class WC_Admin_Exporters {
 		$exporter->set_page( $step );
 		$exporter->generate_file();
 
+		$query_args = apply_filters( 'woocommerce_export_get_ajax_query_args', array( 'nonce' => wp_create_nonce( 'product-csv' ), 'action' => 'download_product_csv' ) );
+
 		if ( 100 === $exporter->get_percent_complete() ) {
 			wp_send_json_success( array(
 				'step'       => 'done',
 				'percentage' => 100,
-				'url'        => add_query_arg( array( 'nonce' => wp_create_nonce( 'product-csv' ), 'action' => 'download_product_csv' ), admin_url( 'edit.php?post_type=product&page=product_exporter' ) ),
+				'url'        => add_query_arg( $query_args, admin_url( 'edit.php?post_type=product&page=product_exporter' ) ),
 			) );
 		} else {
 			wp_send_json_success( array(

--- a/includes/admin/views/html-admin-page-product-export.php
+++ b/includes/admin/views/html-admin-page-product-export.php
@@ -69,6 +69,7 @@ $total_rows      = $product_count->publish + $product_count->private + $variatio
 								<label for="woocommerce-exporter-meta"><?php esc_html_e( 'Yes, export all custom meta', 'woocommerce' ); ?></label>
 							</td>
 						</tr>
+						<?php do_action( 'woocommerce_product_export_row' ); ?>
 					</tbody>
 				</table>
 				<progress class="woocommerce-exporter-progress" max="100" value="0"></progress>

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -189,7 +189,9 @@ abstract class WC_CSV_Exporter {
 	 * @return string
 	 */
 	public function get_filename() {
-		return sanitize_file_name( 'wc-' . $this->export_type . '-export-' . date_i18n( 'Y-m-d', current_time( 'timestamp' ) ) . '.csv' );
+		$filename = 'wc-' . $this->export_type . '-export-' . date_i18n( 'Y-m-d', current_time( 'timestamp' ) ) . '.csv';
+
+		return sanitize_file_name( apply_filters( "woocommerce_{$this->export_type}_export_get_filename", $filename ) );
 	}
 
 	/**


### PR DESCRIPTION
having this hook is possible to actually use the `woocommerce_product_export_product_query_args` filter

```php
add_action( 'woocommerce_product_export_row', 'export_custom_product' );
add_filter( 'woocommerce_product_export_product_query_args', 'export_product_query_args');

// https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query
add_filter( 'woocommerce_product_data_store_cpt_get_products_query', 'handle_custom_query_var', 10, 2 );

function export_custom_product() {
  $args = [
    'show_option_all' =>  'Custom',
    'taxonomy'        =>  'pa_custom',
    'name'            =>  'custom',
    'orderby'         =>  'name',
    'order'           => 'ASC',
    'selected'        =>  isset($_REQUEST['custom']) ? $_REQUEST['custom'] : '',
    'show_count'      =>  true,
    'hide_empty'      =>  true,
    'menu_order'      => false
  ];
  ?>
  <tr>
    <th scope="row">
      <label for="custom">Filter by Custom</label>
    </th>
    <td>
      <?php wp_dropdown_categories($args); ?>
    </td>
  </tr>
  <?php
}

function export_product_query_args($args) {
  $args['custom'] = 'default';

  if ( ! empty( $_POST['form'] ) ) {
    $values = explode('=', $_POST['form']);
    if('custom' === $values[0]) {
      $args['custom'] = wp_unslash( $values[1] );
    }
  }

  return $args;
}

function handle_custom_query_var( $query, $query_vars ) {
  if ( ! empty( $query_vars['custom'] ) ) {
    $query['tax_query'][] = array(
      'taxonomy' => 'pa_ custom',
      'field' => 'id',
      'terms' => esc_attr( $query_vars['custom'] )
    );
  }

  return $query;
}
```