### PR TITLE
Update unit tests for api coupon recalculating

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -430,7 +430,6 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					case 'line_items' :
 					case 'shipping_lines' :
 					case 'fee_lines' :
-					case 'coupon_lines' :
 						if ( is_array( $value ) ) {
 							foreach ( $value as $item ) {
 								if ( is_array( $item ) ) {
@@ -438,6 +437,28 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 										$order->remove_item( $item['id'] );
 									} else {
 										$this->set_item( $order, $key, $item );
+									}
+								}
+							}
+						}
+						break;
+					case 'coupon_lines' :
+						if ( is_array( $value ) ) {
+							foreach ( $value as $item ) {
+								if ( is_array( $item ) ) {
+									if ( $this->item_is_null( $item ) ) {
+										$item = $order->get_item( $item['id'] );
+										if ( $item && method_exists( $item, 'get_code' ) ) {
+											$order->remove_coupon( $item->get_code() );
+										} else {
+											$order->remove_item( $item['id'] );
+										}
+									} else {
+										if ( ! empty( $item['code'] ) ) {
+											$order->apply_coupon( $item['code'] );
+										} else {
+											$this->set_item( $order, $key, $item );
+										}
 									}
 								}
 							}

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -430,6 +430,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 					case 'line_items' :
 					case 'shipping_lines' :
 					case 'fee_lines' :
+					case 'coupon_lines' :
 						if ( is_array( $value ) ) {
 							foreach ( $value as $item ) {
 								if ( is_array( $item ) ) {
@@ -437,28 +438,6 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 										$order->remove_item( $item['id'] );
 									} else {
 										$this->set_item( $order, $key, $item );
-									}
-								}
-							}
-						}
-						break;
-					case 'coupon_lines' :
-						if ( is_array( $value ) ) {
-							foreach ( $value as $item ) {
-								if ( is_array( $item ) ) {
-									if ( $this->item_is_null( $item ) ) {
-										$item = $order->get_item( $item['id'] );
-										if ( $item && method_exists( $item, 'get_code' ) ) {
-											$order->remove_coupon( $item->get_code() );
-										} else {
-											$order->remove_item( $item['id'] );
-										}
-									} else {
-										if ( ! empty( $item['code'] ) ) {
-											$order->apply_coupon( $item['code'] );
-										} else {
-											$this->set_item( $order, $key, $item );
-										}
 									}
 								}
 							}

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -333,15 +333,15 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	/**
 	 * Tests updating an order and adding a coupon.
 	 *
-	 * @since 3.0.0
+	 * @since 3.3.0
 	 */
 	public function test_update_order_add_coupons() {
 		wp_set_current_user( $this->user );
 		$order = WC_Helper_Order::create_order();
+		$order_item = current( $order->get_items() );
 		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
-
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(
 			'coupon_lines' => array(
@@ -349,6 +349,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 					'code'           => 'fake-coupon',
 					'discount_total' => '5',
 					'discount_tax'   => '0',
+				),
+			),
+			'line_items' => array(
+				array(
+					'id' => $order_item->get_id(),
+					'product_id' => $order_item->get_product_id(),
+					'total' => '35.00',
 				),
 			),
 		) );
@@ -365,11 +372,12 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	/**
 	 * Tests updating an order and removing a coupon.
 	 *
-	 * @since 3.0.0
+	 * @since 3.3.0
 	 */
 	public function test_update_order_remove_coupons() {
 		wp_set_current_user( $this->user );
 		$order  = WC_Helper_Order::create_order();
+		$order_item = current( $order->get_items() );
 		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
@@ -388,6 +396,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 				array(
 					'id'   => $coupon_data->get_id(),
 					'code' => null,
+				),
+			),
+			'line_items' => array(
+				array(
+					'id' => $order_item->get_id(),
+					'product_id' => $order_item->get_product_id(),
+					'total' => '40.00',
 				),
 			),
 		) );

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -338,6 +338,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_update_order_add_coupons() {
 		wp_set_current_user( $this->user );
 		$order = WC_Helper_Order::create_order();
+		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
+		$coupon->set_amount( 5 );
+		$coupon->save();
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_body_params( array(


### PR DESCRIPTION
Proposed solution for #18236 (and merges into that branch).

I don't think this is 100% correct at the moment (but all tests now pass). 

Should the API accept coupon lines for coupons that do not exist? If so, should it create a new coupon or what is the expected behavior? 

If we go with this solution, the `discount` field in the [coupon line properties](https://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties) will be ignored and it will calculate the discount based on the coupon applied.
