### PR TITLE
Use text color for email links

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -812,6 +812,27 @@ if ( ! function_exists( 'wc_hex_lighter' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wc_is_light' ) ) {
+
+	/**
+	 * Determine whether a hex color is light.
+	 *
+	 * @param mixed  $color Color.
+	 * @return bool  True if a light color.
+	 */
+	function wc_hex_is_light( $color ) {
+		$hex = str_replace( '#', '', $color );
+
+		$c_r = hexdec( substr( $hex, 0, 2 ) );
+		$c_g = hexdec( substr( $hex, 2, 2 ) );
+		$c_b = hexdec( substr( $hex, 4, 2 ) );
+
+		$brightness = ( ( $c_r * 299 ) + ( $c_g * 587 ) + ( $c_b * 114 ) ) / 1000;
+
+		return $brightness > 155;
+	}
+}
+
 if ( ! function_exists( 'wc_light_or_dark' ) ) {
 
 	/**
@@ -825,15 +846,7 @@ if ( ! function_exists( 'wc_light_or_dark' ) ) {
 	 * @return string
 	 */
 	function wc_light_or_dark( $color, $dark = '#000000', $light = '#FFFFFF' ) {
-		$hex = str_replace( '#', '', $color );
-
-		$c_r = hexdec( substr( $hex, 0, 2 ) );
-		$c_g = hexdec( substr( $hex, 2, 2 ) );
-		$c_b = hexdec( substr( $hex, 4, 2 ) );
-
-		$brightness = ( ( $c_r * 299 ) + ( $c_g * 587 ) + ( $c_b * 114 ) ) / 1000;
-
-		return $brightness > 155 ? $dark : $light;
+		return wc_hex_is_light( $color ) ? $dark : $light;
 	}
 }
 

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -13,7 +13,7 @@
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates/Emails
- * @version 3.2.7
+ * @version 3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -28,19 +28,10 @@ $base_text       = wc_light_or_dark( $base, '#202020', '#ffffff' );
 $text            = get_option( 'woocommerce_email_text_color' );
 
 // Pick a contrasting color for links.
-if ( wc_hex_is_light( $body ) ) :
-	if ( wc_hex_is_light( $base ) ) :
-		$link = $base_text;
-	else :
-		$link = $base;
-	endif;
-else :
-	if ( wc_hex_is_light( $base ) ) :
-		$link = $base;
-	else :
-		$link = $base_text;
-	endif;
-endif;
+$link = wc_hex_is_light( $base ) ? $base : $base_text;
+if ( wc_hex_is_light( $body ) ) {
+	$link = wc_hex_is_light( $base ) ? $base_text : $base;
+}
 
 $bg_darker_10    = wc_hex_darker( $bg, 10 );
 $body_darker_10  = wc_hex_darker( $body, 10 );

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -13,7 +13,7 @@
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates/Emails
- * @version 2.7.0
+ * @version 3.2.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -28,16 +28,16 @@ $base_text       = wc_light_or_dark( $base, '#202020', '#ffffff' );
 $text            = get_option( 'woocommerce_email_text_color' );
 
 // Pick a contrasting color for links.
-if ( wc_hex_is_light( $body ) ):
-	if ( wc_hex_is_light( $base ) ):
+if ( wc_hex_is_light( $body ) ) :
+	if ( wc_hex_is_light( $base ) ) :
 		$link = $base_text;
-	else:
+	else :
 		$link = $base;
 	endif;
-else:
-	if ( wc_hex_is_light( $base ) ):
+else :
+	if ( wc_hex_is_light( $base ) ) :
 		$link = $base;
-	else:
+	else :
 		$link = $base_text;
 	endif;
 endif;

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -13,7 +13,7 @@
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates/Emails
- * @version 2.3.0
+ * @version 2.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -26,6 +26,21 @@ $body            = get_option( 'woocommerce_email_body_background_color' );
 $base            = get_option( 'woocommerce_email_base_color' );
 $base_text       = wc_light_or_dark( $base, '#202020', '#ffffff' );
 $text            = get_option( 'woocommerce_email_text_color' );
+
+// Pick a contrasting color for links.
+if ( wc_hex_is_light( $body ) ):
+	if ( wc_hex_is_light( $base ) ):
+		$link = $base_text;
+	else:
+		$link = $base;
+	endif;
+else:
+	if ( wc_hex_is_light( $base ) ):
+		$link = $base;
+	else:
+		$link = $base_text;
+	endif;
+endif;
 
 $bg_darker_10    = wc_hex_darker( $bg, 10 );
 $body_darker_10  = wc_hex_darker( $body, 10 );
@@ -185,7 +200,7 @@ h3 {
 }
 
 a {
-	color: <?php echo esc_attr( $text ); ?>;
+	color: <?php echo esc_attr( $link ); ?>;
 	font-weight: normal;
 	text-decoration: underline;
 }

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -17,10 +17,10 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
-// Load colors
+// Load colors.
 $bg              = get_option( 'woocommerce_email_background_color' );
 $body            = get_option( 'woocommerce_email_body_background_color' );
 $base            = get_option( 'woocommerce_email_base_color' );
@@ -185,7 +185,7 @@ h3 {
 }
 
 a {
-	color: <?php echo esc_attr( $base_text ); ?>;
+	color: <?php echo esc_attr( $text ); ?>;
 	font-weight: normal;
 	text-decoration: underline;
 }


### PR DESCRIPTION
Fixes #18246. 

#17153 made it use a color that looks nice on the heading background, but we need a color that looks nice on the content background.

Example of what it will look like:
<img width="648" alt="screen shot 2017-12-21 at 6 36 43 am" src="https://user-images.githubusercontent.com/7317227/34260068-6f2cd4e2-e619-11e7-8693-86a1f6d83481.png">
