### PR TITLE
Process embed shortcode in short description

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -53,6 +53,8 @@ add_filter( 'woocommerce_short_description', 'prepend_attachment' );
 add_filter( 'woocommerce_short_description', 'do_shortcode', 11 ); // After wpautop().
 add_filter( 'woocommerce_short_description', 'wc_format_product_short_description', 9999999 );
 add_filter( 'woocommerce_short_description', 'wc_do_oembeds' );
+add_filter( 'woocommerce_short_description', array( $GLOBALS['wp_embed'], 'run_shortcode' ), 8 ); // Before wpautop().
+add_filter( 'woocommerce_short_description', 'shortcode_unautop' );
 
 /**
  * Define a constant if it is not already defined.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -54,7 +54,6 @@ add_filter( 'woocommerce_short_description', 'do_shortcode', 11 ); // After wpau
 add_filter( 'woocommerce_short_description', 'wc_format_product_short_description', 9999999 );
 add_filter( 'woocommerce_short_description', 'wc_do_oembeds' );
 add_filter( 'woocommerce_short_description', array( $GLOBALS['wp_embed'], 'run_shortcode' ), 8 ); // Before wpautop().
-add_filter( 'woocommerce_short_description', 'shortcode_unautop' );
 
 /**
  * Define a constant if it is not already defined.


### PR DESCRIPTION
Fixes #18244 

The [embed shortcode gets added by itself and runs at priority 8 on the post content](https://github.com/WordPress/WordPress/blob/aaf99e691391cfceb004d848450dbbf3344b1bee/wp-includes/class-wp-embed.php#L31-L32), so I've replicated that for the short description.

I think we should also run it through [shortcode_unautop](https://github.com/WordPress/WordPress/blob/6da54f0d9be5e2cf8659427a39f1f23b0465ce72/wp-includes/default-filters.php#L149) so that shortcodes on their own line aren't wrapped in `<p>` tags. EDIT: We're already doing this.