### PR TITLE
Added actions before & after scheduled sales initiation and completion

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -375,6 +375,7 @@ function wc_scheduled_sales() {
 	// Sales which are due to start
 	$product_ids = $data_store->get_starting_sales();
 	if ( $product_ids ) {
+		do_action('wc_before_products_starting_sales', $product_ids);
 		foreach ( $product_ids as $product_id ) {
 			if ( $product = wc_get_product( $product_id ) ) {
 				$sale_price = $product->get_sale_price();
@@ -390,6 +391,7 @@ function wc_scheduled_sales() {
 				$product->save();
 			}
 		}
+		do_action('wc_after_products_starting_sales', $product_ids);
 
 		delete_transient( 'wc_products_onsale' );
 	}
@@ -397,6 +399,7 @@ function wc_scheduled_sales() {
 	// Sales which are due to end
 	$product_ids = $data_store->get_ending_sales();
 	if ( $product_ids ) {
+		do_action('wc_before_products_ending_sales', $product_ids);
 		foreach ( $product_ids as $product_id ) {
 			if ( $product = wc_get_product( $product_id ) ) {
 				$regular_price = $product->get_regular_price();
@@ -407,6 +410,7 @@ function wc_scheduled_sales() {
 				$product->save();
 			}
 		}
+		do_action('wc_after_products_ending_sales', $product_ids);
 
 		WC_Cache_Helper::get_transient_version( 'product', true );
 		delete_transient( 'wc_products_onsale' );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -375,7 +375,7 @@ function wc_scheduled_sales() {
 	// Sales which are due to start
 	$product_ids = $data_store->get_starting_sales();
 	if ( $product_ids ) {
-		do_action('wc_before_products_starting_sales', $product_ids);
+		do_action( 'wc_before_products_starting_sales', $product_ids );
 		foreach ( $product_ids as $product_id ) {
 			if ( $product = wc_get_product( $product_id ) ) {
 				$sale_price = $product->get_sale_price();
@@ -391,7 +391,7 @@ function wc_scheduled_sales() {
 				$product->save();
 			}
 		}
-		do_action('wc_after_products_starting_sales', $product_ids);
+		do_action( 'wc_after_products_starting_sales', $product_ids );
 
 		delete_transient( 'wc_products_onsale' );
 	}
@@ -399,7 +399,7 @@ function wc_scheduled_sales() {
 	// Sales which are due to end
 	$product_ids = $data_store->get_ending_sales();
 	if ( $product_ids ) {
-		do_action('wc_before_products_ending_sales', $product_ids);
+		do_action( 'wc_before_products_ending_sales', $product_ids );
 		foreach ( $product_ids as $product_id ) {
 			if ( $product = wc_get_product( $product_id ) ) {
 				$regular_price = $product->get_regular_price();
@@ -410,7 +410,7 @@ function wc_scheduled_sales() {
 				$product->save();
 			}
 		}
-		do_action('wc_after_products_ending_sales', $product_ids);
+		do_action( 'wc_after_products_ending_sales', $product_ids );
 
 		WC_Cache_Helper::get_transient_version( 'product', true );
 		delete_transient( 'wc_products_onsale' );


### PR DESCRIPTION
We see an advantage in being able to kick off a series of events (or a single event) when a scheduled sale starts and ends. Example would be to send an e-mail, clear cache to reflect changes, etc. By adding actions at these points of the process, it would make that possible.