### PR TITLE
Added WooCommerce-Core sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "squizlabs/php_codesniffer": "*",
     "wp-coding-standards/wpcs": "^0.14",
     "phpunit/phpunit": "6.2.3",
-    "woocommerce/woocommerce-git-hooks": "1.0.5",
+    "woocommerce/woocommerce-git-hooks": "*",
+    "woocommerce/woocommerce-sniffs": "*",
     "wimg/php-compatibility": "^8.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8573ce329aa198e3005e0909584ac4d8",
+    "content-hash": "9e4cf8ae38469f0ca73e43f81be7b998",
     "packages": [
         {
             "name": "composer/installers",
@@ -1562,16 +1562,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4064632daf602552d40dcff30a1658ab76fc1621"
+                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4064632daf602552d40dcff30a1658ab76fc1621",
-                "reference": "4064632daf602552d40dcff30a1658ab76fc1621",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
                 "shasum": ""
             },
             "require": {
@@ -1609,7 +1609,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-18T00:24:01+00:00"
+            "time": "2017-12-19T21:44:46+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1785,6 +1785,47 @@
             ],
             "description": "WooCommerce Git Hooks",
             "time": "2017-12-18T16:55:42+00:00"
+        },
+        {
+            "name": "woocommerce/woocommerce-sniffs",
+            "version": "0.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
+                "reference": "383d5b361c1d7532ae1ca6156fd7619fd37bbc05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/383d5b361c1d7532ae1ca6156fd7619fd37bbc05",
+                "reference": "383d5b361c1d7532ae1ca6156fd7619fd37bbc05",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "squizlabs/php_codesniffer": "^3.0.2"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Claudio Sanches",
+                    "email": "claudio@automattic.com"
+                }
+            ],
+            "description": "WooCommerce sniffs",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "woocommerce",
+                "wordpress"
+            ],
+            "time": "2017-12-21T22:52:52+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,8 @@
 	<config name="testVersion" value="5.2-"/>
 
 	<!-- Rules -->
-	<rule ref="PHPCompatibility"/>
+	<rule ref="WooCommerce-Core" />
+	<rule ref="PHPCompatibility" />
 
 	<rule ref="WordPress">
 		<exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />


### PR DESCRIPTION
I just created a new package to allow check for new sniffs, now checking for docblock tags.

Example:

![screenshot from 2017-12-21 21-32-24](https://user-images.githubusercontent.com/1264099/34279191-79c62d0e-e696-11e7-9956-7f1e756fb21a.png)


Closes #18245 