### PR TITLE
error.php is different from notice and success

### DIFF
--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -25,8 +25,7 @@ if ( ! $messages ) {
 }
 
 ?>
-<ul class="woocommerce-error" role="alert">
-	<?php foreach ( $messages as $message ) : ?>
-		<li><?php echo wp_kses_post( $message ); ?></li>
-	<?php endforeach; ?>
-</ul>
+
+<?php foreach ( $messages as $message ) : ?>
+	<div class="woocommerce-error" role="alert"><?php echo wp_kses_post( $message ); ?></div>
+<?php endforeach; ?>


### PR DESCRIPTION
The error notice is displayed in &lt;ul&gt; tags while success and notice messages are displayed in div. This will make sure all the notices follow the same structure