### PR TITLE
Setup wizard: don't set PPEC "API Subject" when WCS rerouting is unchecked

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1036,10 +1036,10 @@ p.jetpack-terms {
 	}
 }
 
-.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_api_subject {
+.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email {
 	margin-top: 0.75em;
 
-	label.stripe_email, label.ppec_paypal_api_subject {
+	label.stripe_email, label.ppec_paypal_email {
 		position: absolute;
 		margin: -1px;
 		padding: 0;

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -130,14 +130,14 @@ jQuery( function( $ ) {
 				.find( 'input.payment-email-input' )
 				.prop( 'required', true );
 			$( this ).closest( '.wc-wizard-service-settings' )
-				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_api_subject' )
+				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email' )
 				.show();
 		} else {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
 				.prop( 'required', false );
 			$( this ).closest( '.wc-wizard-service-settings' )
-				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_api_subject' )
+				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email' )
 				.hide();
 		}
 	} ).find( 'input#stripe_create_account, input#ppec_paypal_reroute_requests' ).change();

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1155,7 +1155,7 @@ class WC_Admin_Setup_Wizard {
 						'placeholder' => '',
 						'required'    => false,
 					),
-					'api_subject' => array(
+					'email' => array(
 						'label'       => __( 'Direct payments to email address:', 'woocommerce' ),
 						'type'        => 'email',
 						'value'       => $user_email,


### PR DESCRIPTION
Currently, the PayPal Express Checkout plugin's `api_subject` setting is being set to the default email address if the gateway is enabled in the wizard, even if the "Accept payments without linking a PayPal account" option is not opted into.

Simply changed the email field's name from `api_subject` to `email`, which WooCommerce Services will pick up and copy into the API Subject: https://github.com/Automattic/woocommerce-services/pull/1254/commits/4f12b2826e9e6d25058d95851bcd353e423a3b57