### PR TITLE
Fix PHP errors when Registration is not set in Options

### DIFF
--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -65,11 +65,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php do_action( 'woocommerce_login_form_end' ); ?>
 
 		</form>
-
-<?php if ( get_option( 'woocommerce_enable_myaccount_registration' ) === 'yes' ) : ?>
-
 	</div>
-
+	
+<?php if ( get_option( 'woocommerce_enable_myaccount_registration' ) === 'yes' ) : ?>
 	<div class="u-column2 col-2">
 
 		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
@@ -113,8 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</form>
 
 	</div>
-
-</div>
 <?php endif; ?>
+</div>
 
 <?php do_action( 'woocommerce_after_customer_login_form' ); ?>

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -67,7 +67,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</form>
 	</div>
 	
-<?php if ( get_option( 'woocommerce_enable_myaccount_registration' ) === 'yes' ) : ?>
+
 	<div class="u-column2 col-2">
 
 		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
@@ -111,7 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</form>
 
 	</div>
-<?php endif; ?>
+
 </div>
 
 <?php do_action( 'woocommerce_after_customer_login_form' ); ?>


### PR DESCRIPTION
The location of the PHP conditions is off by two `div close`. 

The original code does not close the `div` elements properly resulting to unusual PHP server errors when Registration is not set in the Options. This pull resolves that issue.