### PR TITLE
add button for creating coupons to coupon blank state

### DIFF
--- a/i18n/languages/woocommerce.pot
+++ b/i18n/languages/woocommerce.pot
@@ -9888,6 +9888,10 @@ msgstr ""
 msgid "Learn more about coupons"
 msgstr ""
 
+#: includes/admin/list-tables/class-wc-admin-list-table-coupons.php:49
+msgid "Create your first coupon"
+msgstr ""
+
 #: includes/admin/list-tables/class-wc-admin-list-table-coupons.php:83
 msgid "Code"
 msgstr ""

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -47,6 +47,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 		echo '<div class="woocommerce-BlankState">';
 		echo '<h2 class="woocommerce-BlankState-message">' . esc_html__( 'Coupons are a great way to offer discounts and rewards to your customers. They will appear here once created.', 'woocommerce' ) . '</h2>';
 		echo '<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://docs.woocommerce.com/document/coupon-management/?utm_source=blankslate&utm_medium=product&utm_content=couponsdoc&utm_campaign=woocommerceplugin">' . esc_html__( 'Learn more about coupons', 'woocommerce' ) . '</a>';
+		echo '<a class="woocommerce-BlankState-cta button-primary button" href="' . get_admin_url() . 'post-new.php?post_type=shop_coupon">' . esc_html__( 'Create your first coupon', 'woocommerce' ) . '</a>';
 		echo '</div>';
 	}
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -47,7 +47,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 		echo '<div class="woocommerce-BlankState">';
 		echo '<h2 class="woocommerce-BlankState-message">' . esc_html__( 'Coupons are a great way to offer discounts and rewards to your customers. They will appear here once created.', 'woocommerce' ) . '</h2>';
 		echo '<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://docs.woocommerce.com/document/coupon-management/?utm_source=blankslate&utm_medium=product&utm_content=couponsdoc&utm_campaign=woocommerceplugin">' . esc_html__( 'Learn more about coupons', 'woocommerce' ) . '</a>';
-		echo '<a class="woocommerce-BlankState-cta button-primary button" href="' . get_admin_url() . 'post-new.php?post_type=shop_coupon">' . esc_html__( 'Create your first coupon', 'woocommerce' ) . '</a>';
+		echo '<a class="woocommerce-BlankState-cta button-primary button" href="' . esc_url ( admin_url( 'post-new.php?post_type=shop_coupon' ) ) . '">' . esc_html__( 'Create your first coupon', 'woocommerce' ) . '</a>';
 		echo '</div>';
 	}
 


### PR DESCRIPTION
Makes the blank-state coupon screen more user-friendly for someone unfamiliar with WordPress/WooCommerce, and even for those who are familiar and don’t immediately see the typical “Add Coupon” button in the top left corner by the header.