### PR TITLE
Geolocation: Remove port from string before checking IP

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -92,7 +92,7 @@ class WC_Geolocation {
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) { // WPCS: input var ok, CSRF ok.
 			// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2
 			// Make sure we always only send through the first IP in the list which should always be the client IP.
-			return (string) rest_is_ip_address( trim( current( explode( ',', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ); // WPCS: input var ok, CSRF ok.
+			return (string) rest_is_ip_address( trim( current( preg_split( '/[,:]/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ); // WPCS: input var ok, CSRF ok.
 		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // @codingStandardsIgnoreLine
 			return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ); // @codingStandardsIgnoreLine
 		}


### PR DESCRIPTION
Fix a bug where if `$_['HTTP_X_FORWARDED_FOR']` contains a port, then `rest_is_ip_address()` returns `bool(false)`.

WooCommerce Version: 3.1.2

Observed results of functions and variables:
```
WC_Geolocation::get_ip_address())	                                -> string(0) ""
$_SERVER['X-Real-IP']	                                                -> NULL
$_SERVER['HTTP_X_FORWARDED_FOR']	                                -> string(18) "203.41.99.98:50986"
trim( current( explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) )	-> string(18) "203.41.99.98:50986"
$_SERVER['REMOTE_ADDR']	                                                -> string(12) "203.41.99.98"
```

Old result of calling `WC_Geolocation::geolocate_ip()`:
```array(2) { ["country"]=> string(0) "" ["state"]=> string(0) "" }```

New result of calling `WC_Geolocation::geolocate_ip()`:
```array(2) { ["country"]=> string(2) "AU" ["state"]=> string(0) "" }```