### PR TITLE
Importer file names

### DIFF
--- a/assets/js/admin/wc-product-export.js
+++ b/assets/js/admin/wc-product-export.js
@@ -22,24 +22,28 @@
 	 */
 	productExportForm.prototype.onSubmit = function( event ) {
 		event.preventDefault();
+
+		var currentDate    = new Date(),
+			day            = currentDate.getDate(),
+			month          = currentDate.getMonth() + 1,
+			year           = currentDate.getFullYear(),
+			timestamp      = currentDate.getTime(),
+			filename       = 'wc-product-export-' + day + '-' + month + '-' + year + '-' + timestamp + '.csv';
+
 		event.data.productExportForm.$form.addClass( 'woocommerce-exporter__exporting' );
 		event.data.productExportForm.$form.find('.woocommerce-exporter-progress').val( 0 );
 		event.data.productExportForm.$form.find('.woocommerce-exporter-button').prop( 'disabled', true );
-		event.data.productExportForm.processStep( 1, $( this ).serialize(), '' );
+		event.data.productExportForm.processStep( 1, $( this ).serialize(), '', filename );
 	};
 
 	/**
 	 * Process the current export step.
 	 */
-	productExportForm.prototype.processStep = function( step, data, columns ) {
+	productExportForm.prototype.processStep = function( step, data, columns, filename ) {
 		var $this         = this,
 			selected_columns = $( '.woocommerce-exporter-columns' ).val(),
 			export_meta      = $( '#woocommerce-exporter-meta:checked' ).length ? 1: 0,
 			export_types     = $( '.woocommerce-exporter-types' ).val();
-			currentDate      = new Date(),
-			day              = currentDate.getDate(),
-			month            = currentDate.getMonth() + 1,
-			year             = currentDate.getFullYear();
 
 		$.ajax( {
 			type: 'POST',
@@ -52,7 +56,7 @@
 				selected_columns : selected_columns,
 				export_meta      : export_meta,
 				export_types     : export_types,
-				filename         : 'wc-product-export-' + day + '-' + month + '-' + year + '.csv',
+				filename         : filename,
 				security         : wc_product_export_params.export_nonce
 			},
 			dataType: 'json',
@@ -67,7 +71,7 @@
 						}, 2000 );
 					} else {
 						$this.$form.find('.woocommerce-exporter-progress').val( response.data.percentage );
-						$this.processStep( parseInt( response.data.step, 10 ), data, response.data.columns );
+						$this.processStep( parseInt( response.data.step, 10 ), data, response.data.columns, filename );
 					}
 				}
 

--- a/assets/js/admin/wc-product-export.js
+++ b/assets/js/admin/wc-product-export.js
@@ -32,10 +32,14 @@
 	 * Process the current export step.
 	 */
 	productExportForm.prototype.processStep = function( step, data, columns ) {
-		var $this = this,
+		var $this         = this,
 			selected_columns = $( '.woocommerce-exporter-columns' ).val(),
-			export_meta      = $( '#woocommerce-exporter-meta:checked' ).length ? 1 : 0,
+			export_meta      = $( '#woocommerce-exporter-meta:checked' ).length ? 1: 0,
 			export_types     = $( '.woocommerce-exporter-types' ).val();
+			currentDate      = new Date(),
+			day              = currentDate.getDate(),
+			month            = currentDate.getMonth() + 1,
+			year             = currentDate.getFullYear();
 
 		$.ajax( {
 			type: 'POST',
@@ -48,6 +52,7 @@
 				selected_columns : selected_columns,
 				export_meta      : export_meta,
 				export_types     : export_types,
+				filename         : 'wc-product-export-' + day + '-' + month + '-' + year + '.csv',
 				security         : wc_product_export_params.export_nonce
 			},
 			dataType: 'json',

--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -93,6 +93,11 @@ class WC_Admin_Exporters {
 		if ( isset( $_GET['action'], $_GET['nonce'] ) && wp_verify_nonce( wp_unslash( $_GET['nonce'] ), 'product-csv' ) && 'download_product_csv' === wp_unslash( $_GET['action'] ) ) { // WPCS: input var ok, sanitization ok.
 			include_once( WC_ABSPATH . 'includes/export/class-wc-product-csv-exporter.php' );
 			$exporter = new WC_Product_CSV_Exporter();
+
+			if ( ! empty( $_GET['filename'] ) ) { // WPCS: input var ok.
+				$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // WPCS: input var ok, sanitization ok.
+			}
+
 			$exporter->export();
 		}
 	}
@@ -135,7 +140,7 @@ class WC_Admin_Exporters {
 		$exporter->set_page( $step );
 		$exporter->generate_file();
 
-		$query_args = apply_filters( 'woocommerce_export_get_ajax_query_args', array( 'nonce' => wp_create_nonce( 'product-csv' ), 'action' => 'download_product_csv' ) );
+		$query_args = apply_filters( 'woocommerce_export_get_ajax_query_args', array( 'nonce' => wp_create_nonce( 'product-csv' ), 'action' => 'download_product_csv', 'filename' => $exporter->get_filename() ) );
 
 		if ( 100 === $exporter->get_percent_complete() ) {
 			wp_send_json_success( array(

--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -2,8 +2,6 @@
 /**
  * Init WooCommerce data exporters.
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin
  * @version     3.1.0
  */
@@ -128,6 +126,10 @@ class WC_Admin_Exporters {
 
 		if ( ! empty( $_POST['export_types'] ) ) { // WPCS: input var ok.
 			$exporter->set_product_types_to_export( wp_unslash( $_POST['export_types'] ) ); // WPCS: input var ok, sanitization ok.
+		}
+
+		if ( ! empty( $_POST['filename'] ) ) { // WPCS: input var ok.
+			$exporter->set_filename( wp_unslash( $_POST['filename'] ) ); // WPCS: input var ok, sanitization ok.
 		}
 
 		$exporter->set_page( $step );

--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -4,8 +4,6 @@
  *
  * Based on https://pippinsplugins.com/batch-processing-for-big-data/
  *
- * @author   Automattic
- * @category Admin
  * @package  WooCommerce/Export
  * @version  3.1.0
  */
@@ -26,13 +24,6 @@ if ( ! class_exists( 'WC_CSV_Exporter', false ) ) {
 abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 
 	/**
-	 * The file being exported to.
-	 *
-	 * @var string
-	 */
-	protected $file;
-
-	/**
 	 * Page being exported
 	 *
 	 * @var integer
@@ -43,9 +34,17 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$upload_dir         = wp_upload_dir();
-		$this->file         = trailingslashit( $upload_dir['basedir'] ) . $this->get_filename();
 		$this->column_names = $this->get_default_column_names();
+	}
+
+	/**
+	 * Get file path to export to.
+	 *
+	 * @return string
+	 */
+	protected function get_file_path() {
+		$upload_dir = wp_upload_dir();
+		return trailingslashit( $upload_dir['basedir'] ) . $this->get_filename();
 	}
 
 	/**
@@ -56,11 +55,11 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 */
 	public function get_file() {
 		$file = '';
-		if ( @file_exists( $this->file ) ) {
-			$file = @file_get_contents( $this->file );
+		if ( @file_exists( $this->get_file_path() ) ) {
+			$file = @file_get_contents( $this->get_file_path() );
 		} else {
-			@file_put_contents( $this->file, '' );
-			@chmod( $this->file, 0664 );
+			@file_put_contents( $this->get_file_path(), '' );
+			@chmod( $this->get_file_path(), 0664 );
 		}
 		return $file;
 	}
@@ -73,7 +72,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	public function export() {
 		$this->send_headers();
 		$this->send_content( $this->get_file() );
-		@unlink( $this->file );
+		@unlink( $this->get_file_path() );
 		die();
 	}
 
@@ -84,7 +83,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 */
 	public function generate_file() {
 		if ( 1 === $this->get_page() ) {
-			@unlink( $this->file );
+			@unlink( $this->get_file_path() );
 		}
 		$this->prepare_data_to_export();
 		$this->write_csv_data( $this->get_csv_data() );
@@ -105,7 +104,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		}
 
 		$file .= $data;
-		@file_put_contents( $this->file, $file );
+		@file_put_contents( $this->get_file_path(), $file );
 	}
 
 	/**

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -2,8 +2,6 @@
 /**
  * Handles CSV export.
  *
- * @author   Automattic
- * @category Admin
  * @package  WooCommerce/Export
  * @version  3.1.0
  */
@@ -23,6 +21,13 @@ abstract class WC_CSV_Exporter {
 	 * @var string
 	 */
 	protected $export_type = '';
+
+	/**
+	 * Filename to export to.
+	 *
+	 * @var string
+	 */
+	protected $filename = 'wc-export.csv';
 
 	/**
 	 * Batch limit.
@@ -184,14 +189,22 @@ abstract class WC_CSV_Exporter {
 	}
 
 	/**
+	 * Set filename to export to.
+	 *
+	 * @param  string $filename Filename to export to.
+	 * @return string
+	 */
+	public function set_filename( $filename ) {
+		$this->filename = sanitize_file_name( str_replace( '.csv', '', $filename ) . '.csv' );
+	}
+
+	/**
 	 * Generate and return a filename.
 	 *
 	 * @return string
 	 */
 	public function get_filename() {
-		$filename = 'wc-' . $this->export_type . '-export-' . date_i18n( 'Y-m-d', current_time( 'timestamp' ) ) . '.csv';
-
-		return sanitize_file_name( apply_filters( "woocommerce_{$this->export_type}_export_get_filename", $filename ) );
+		return sanitize_file_name( apply_filters( "woocommerce_{$this->export_type}_export_get_filename", $this->filename ) );
 	}
 
 	/**

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -2,8 +2,6 @@
 /**
  * Handles product CSV export.
  *
- * @author   Automattic
- * @category Admin
  * @package  WooCommerce/Export
  * @version  3.1.0
  */


### PR DESCRIPTION
I wasn’t able to replicate #18293 but I spotted a logic error which could cause something like that to happen.

Filenames are generated per request, so if the date changes, or the import runs multiple times, filenames may change or overlap.

This is fixed by generating it once and passing around.

Closes #18293