### PR TITLE
Fix default columns isset check

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -371,7 +371,7 @@ function wc_reset_product_grid_settings() {
 		delete_option( 'woocommerce_catalog_rows' );
 	}
 
-	if ( isset( $theme_support['product_grid']['default_rows'] ) ) {
+	if ( isset( $theme_support['product_grid']['default_columns'] ) ) {
 		update_option( 'woocommerce_catalog_columns', absint( $theme_support['product_grid']['default_columns'] ) );
 	} else {
 		delete_option( 'woocommerce_catalog_columns' );


### PR DESCRIPTION
Just a small typo probably from copy and paste.

In the second `isset`, it should be `default_columns` instead of `default_rows `.