### PR TITLE
Product downloads - API and download check fixes

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1177,7 +1177,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			if ( is_a( $download, 'WC_Product_Download' ) ) {
 				$download_object = $download;
 			} else {
-				$download_object           = new WC_Product_Download();
+				$download_object = new WC_Product_Download();
 
 				// If we don't have a previous hash, generate UUID for download.
 				if ( empty( $download['download_id'] ) ) {

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1172,10 +1172,10 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 			}
 
 			$download = new WC_Product_Download();
-			$download->set_id( $key );
+			$download->set_id( $file['id'] ? $file['id'] : wp_generate_uuid4() );
 			$download->set_name( $file['name'] ? $file['name'] : wc_get_filename_from_url( $file['file'] ) );
 			$download->set_file( apply_filters( 'woocommerce_file_download_path', $file['file'], $product, $key ) );
-			$files[]  = $download;
+			$files[] = $download;
 		}
 		$product->set_downloads( $files );
 

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -1527,7 +1527,7 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			$download = new WC_Product_Download();
-			$download->set_id( $key );
+			$download->set_id( $file['id'] ? $file['id'] : wp_generate_uuid4() );
 			$download->set_name( $file['name'] ? $file['name'] : wc_get_filename_from_url( $file['file'] ) );
 			$download->set_file( apply_filters( 'woocommerce_file_download_path', $file['file'], $product, $key ) );
 			$files[]  = $download;

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -2031,7 +2031,7 @@ class WC_API_Products extends WC_API_Resource {
 			}
 
 			$download = new WC_Product_Download();
-			$download->set_id( $key );
+			$download->set_id( $file['id'] ? $file['id'] : wp_generate_uuid4() );
 			$download->set_name( $file['name'] ? $file['name'] : wc_get_filename_from_url( $file['file'] ) );
 			$download->set_file( apply_filters( 'woocommerce_file_download_path', $file['file'], $product, $key ) );
 			$files[]  = $download;

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -960,7 +960,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 			}
 
 			$download = new WC_Product_Download();
-			$download->set_id( $key );
+			$download->set_id( $file['id'] ? $file['id'] : wp_generate_uuid4() );
 			$download->set_name( $file['name'] ? $file['name'] : wc_get_filename_from_url( $file['file'] ) );
 			$download->set_file( apply_filters( 'woocommerce_file_download_path', $file['file'], $product, $key ) );
 			$files[]  = $download;

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -37,7 +37,7 @@ class WC_Download_Handler {
 		$product      = wc_get_product( $product_id );
 		$data_store   = WC_Data_Store::load( 'customer-download' );
 
-		if ( ! $product || ! isset( $_GET['key'], $_GET['order'] ) ) {
+		if ( ! $product || empty( $_GET['key'] ) || empty( $_GET['order'] ) ) {
 			self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
Download links should check for ID and order before downloading.

Fixes #18328 

API should update the file download ID, or generate it, rather than set a numeric key.

Fixes #18330