### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/css/_mixins.scss
+++ b/assets/css/_mixins.scss
@@ -179,7 +179,6 @@
 	font-variant: normal;
 	text-transform: none;
 	line-height: 1;
-	-webkit-font-smoothing: antialiased;
 	margin: 0;
 	text-indent: 0;
 	position: absolute;


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in woocommerce/storefront#698