### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -65,8 +65,6 @@ span.mce_woocommerce_shortcodes_button {
 			font: 400 18px/1 dashicons;
 			speak: none;
 			margin: 0 8px 0 -2px;
-			-webkit-font-smoothing: antialiased;
-			-moz-osx-font-smoothing: grayscale;
 			vertical-align: top;
 		}
 


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in woocommerce/storefront#698