### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -165,7 +165,6 @@ h1 {
 	margin: 0;
 	text-align: <?php echo is_rtl() ? 'right' : 'left'; ?>;
 	text-shadow: 0 1px 0 <?php echo esc_attr( $base_lighter_20 ); ?>;
-	-webkit-font-smoothing: antialiased;
 }
 
 h2 {


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in woocommerce/storefront#698