### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -282,8 +282,6 @@ body {
 				padding: 0 10px 0 0;
 				top: 1px;
 				position: relative;
-				-webkit-font-smoothing: antialiased;
-				-moz-osx-font-smoothing: grayscale;
 				text-decoration: none !important;
 				vertical-align: top;
 			}


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in woocommerce/storefront#698