### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/css/photoswipe/default-skin/default-skin.css
+++ b/assets/css/photoswipe/default-skin/default-skin.css
@@ -416,7 +416,6 @@ a.pswp__share--download:hover {
  */
 /* root element of UI */
 .pswp__ui {
-  -webkit-font-smoothing: auto;
   visibility: visible;
   opacity: 1;
   z-index: 1550; }


### PR DESCRIPTION
Removing `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in woocommerce/storefront#698 and came across this one too. "auto" seems to be invalid, in any case...