### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1165,7 +1165,6 @@ ul.wc_coupon_list_block {
 				line-height: 14px;
 				font-size: 14px;
 				font-weight: 400;
-				-webkit-font-smoothing: antialiased;
 			}
 		}
 		a.edit_address::after {
@@ -1954,7 +1953,6 @@ ul.wc_coupon_list_block {
 				font-weight: normal;
 				font-variant: normal;
 				text-transform: none;
-				-webkit-font-smoothing: antialiased;
 				margin: 0;
 				text-indent: 0;
 				position: absolute;


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in woocommerce/storefront#698