### PR TITLE
Focus on inputs when clicked instead of sorting

### DIFF
--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -178,6 +178,10 @@ jQuery( function ( $ ) {
 			ui.item.removeAttr( 'style' );
 		}
 	});
+	// Focus on inputs within the table if clicked instead of trying to sort.
+	$( '.wc_input_table.sortable tbody input' ).on( 'click', function() {
+		$( this ).focus();
+	} );
 
 	$( '.wc_input_table .remove_rows' ).click( function() {
 		var $tbody = $( this ).closest( '.wc_input_table' ).find( 'tbody' );


### PR DESCRIPTION
Fixes #18287.

This seems like the best solution from [this thread](http://forum.jquery.com/topic/jquery-ui-sortable-disableselection-firefox-issue-with-inputs).

To test: Simulate iPhone using the Chrome mobile emulator and click on BACS fields.