### PR TITLE
Customizer visual feedback for columns and rows

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -169,16 +169,10 @@ class WC_Regenerate_Images {
 	}
 
 	/**
-	 * Check if we should generate images when new themes declares custom sizes
-	 *
-	 * @return void
+	 * Check if we should generate images when new themes declares custom sizes.
 	 */
 	public static function maybe_regenerate_image_theme_switch() {
-		$theme_support = get_theme_support( 'woocommerce' );
-		$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
-		// Only queue image generation if the theme declares custom sizes via theme_support.
-		if ( is_array( $theme_support ) && ( isset( $theme_support['single_image_width'] ) || isset( $theme_support['thumbnail_image_width'] ) ) ) {
+		if ( wc_get_theme_support( 'single_image_width' ) || wc_get_theme_support( 'thumbnail_image_width' ) ) {
 			self::queue_image_regeneration();
 		}
 	}

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -77,6 +77,10 @@ class WC_Shop_Customizer {
 	 * Scripts to improve our form.
 	 */
 	public function add_scripts() {
+		$min_rows    = wc_get_theme_support( 'product_grid::min_rows', 1 );
+		$max_rows    = wc_get_theme_support( 'product_grid::max_rows', '' );
+		$min_columns = wc_get_theme_support( 'product_grid::min_columns', 1 );
+		$max_columns = wc_get_theme_support( 'product_grid::max_columns', '' );
 		?>
 		<script type="text/javascript">
 			jQuery( document ).ready( function( $ ) {
@@ -95,6 +99,68 @@ class WC_Shop_Customizer {
 
 				wp.customize.bind( 'ready', function() { // Ready?
 					$( '.woocommerce-cropping-control' ).find( 'input:checked' ).change();
+				} );
+
+				wp.customize( 'woocommerce_catalog_columns', function( setting ) {
+					setting.bind( function( value ) {
+						var min = '<?php echo esc_js( $min_columns ); ?>';
+						var max = '<?php echo esc_js( $max_columns ); ?>';
+
+						if ( max && value > max ) {
+							setting.notifications.add( 'max_columns_error', new wp.customize.Notification(
+								'max_columns_error',
+								{
+									type   : 'error',
+									message: '<?php echo esc_js( sprintf( __( 'The maximum allowed setting for columns is %d', 'woocommerce' ), $max_columns ) ); ?>'
+								}
+							) );
+						} else {
+							setting.notifications.remove( 'max_columns_error' );
+						}
+
+						if ( min && value < min ) {
+							setting.notifications.add( 'min_columns_error', new wp.customize.Notification(
+								'min_columns_error',
+								{
+									type   : 'error',
+									message: '<?php echo esc_js( sprintf( __( 'The minimum allowed setting for columns is %d', 'woocommerce' ), $min_columns ) ); ?>'
+								}
+							) );
+						} else {
+							setting.notifications.remove( 'min_columns_error' );
+						}
+					} );
+				} );
+
+				wp.customize( 'woocommerce_catalog_rows', function( setting ) {
+					setting.bind( function( value ) {
+						var min = '<?php echo esc_js( $min_rows ); ?>';
+						var max = '<?php echo esc_js( $max_rows ); ?>';
+
+						if ( max && value > max ) {
+							setting.notifications.add( 'max_rows_error', new wp.customize.Notification(
+								'max_rows_error',
+								{
+									type   : 'error',
+									message: '<?php echo esc_js( sprintf( __( 'The maximum allowed setting for rows is %d', 'woocommerce' ), $max_rows ) ); ?>'
+								}
+							) );
+						} else {
+							setting.notifications.remove( 'max_rows_error' );
+						}
+
+						if ( min && value < min ) {
+							setting.notifications.add( 'min_rows_error', new wp.customize.Notification(
+								'min_rows_error',
+								{
+									type   : 'error',
+									message: '<?php echo esc_js( sprintf( __( 'The minimum allowed setting for rows is %d', 'woocommerce' ), $min_rows ) ); ?>'
+								}
+							) );
+						} else {
+							setting.notifications.remove( 'min_rows_error' );
+						}
+					} );
 				} );
 			} );
 		</script>
@@ -214,9 +280,6 @@ class WC_Shop_Customizer {
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
 	public function add_product_catalog_section( $wp_customize ) {
-		$theme_support = get_theme_support( 'woocommerce' );
-		$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
 		$wp_customize->add_section(
 			'woocommerce_product_catalog',
 			array(
@@ -333,8 +396,8 @@ class WC_Shop_Customizer {
 				'settings'    => 'woocommerce_catalog_columns',
 				'type'        => 'number',
 				'input_attrs' => array(
-					'min'  => isset( $theme_support['product_grid']['min_columns'] ) ? absint( $theme_support['product_grid']['min_columns'] ) : 1,
-					'max'  => isset( $theme_support['product_grid']['max_columns'] ) ? absint( $theme_support['product_grid']['max_columns'] ) : '',
+					'min'  => wc_get_theme_support( 'product_grid::min_columns', 1 ),
+					'max'  => wc_get_theme_support( 'product_grid::max_columns', '' ),
 					'step' => 1,
 				),
 			)
@@ -360,8 +423,8 @@ class WC_Shop_Customizer {
 				'settings'    => 'woocommerce_catalog_rows',
 				'type'        => 'number',
 				'input_attrs' => array(
-					'min'  => isset( $theme_support['product_grid']['min_rows'] ) ? absint( $theme_support['product_grid']['min_rows'] ) : 1,
-					'max'  => isset( $theme_support['product_grid']['max_rows'] ) ? absint( $theme_support['product_grid']['max_rows'] ) : '',
+					'min'  => wc_get_theme_support( 'product_grid::min_rows', 1 ),
+					'max'  => wc_get_theme_support( 'product_grid::max_rows', '' ),
 					'step' => 1,
 				),
 			)
@@ -374,9 +437,6 @@ class WC_Shop_Customizer {
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
 	private function add_product_images_section( $wp_customize ) {
-		$theme_support = get_theme_support( 'woocommerce' );
-		$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
 		$wp_customize->add_section(
 			'woocommerce_product_images',
 			array(
@@ -387,7 +447,7 @@ class WC_Shop_Customizer {
 			)
 		);
 
-		if ( ! isset( $theme_support['single_image_width'] ) ) {
+		if ( ! wc_get_theme_support( 'single_image_width' ) ) {
 			$wp_customize->add_setting(
 				'woocommerce_single_image_width',
 				array(
@@ -415,7 +475,7 @@ class WC_Shop_Customizer {
 			);
 		}
 
-		if ( ! isset( $theme_support['thumbnail_image_width'] ) ) {
+		if ( ! wc_get_theme_support( 'thumbnail_image_width' ) ) {
 			$wp_customize->add_setting(
 				'woocommerce_thumbnail_image_width',
 				array(

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -310,22 +310,20 @@ function wc_product_cat_class( $class = '', $category = null ) {
  * @return int
  */
 function wc_get_default_products_per_row() {
-	$columns = get_option( 'woocommerce_catalog_columns', 3 );
+	$columns      = get_option( 'woocommerce_catalog_columns', 3 );
+	$product_grid = wc_get_theme_support( 'product_grid' );
+	$min_columns  = isset( $product_grid['min_columns'] ) ? absint( $product_grid['min_columns'] ) : 0;
+	$max_columns  = isset( $product_grid['max_columns'] ) ? absint( $product_grid['max_columns'] ) : 0;
 
-	// Theme support.
-	$theme_support = get_theme_support( 'woocommerce' );
-	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
-	if ( isset( $theme_support['product_grid']['min_columns'] ) && $columns < $theme_support['product_grid']['min_columns'] ) {
-		$columns = $theme_support['product_grid']['min_columns'];
+	if ( $min_columns && $columns < $min_columns ) {
+		$columns = $min_columns;
 		update_option( 'woocommerce_catalog_columns', $columns );
-	} elseif ( ! empty( $theme_support['product_grid']['max_columns'] ) && $columns > $theme_support['product_grid']['max_columns'] ) {
-		$columns = $theme_support['product_grid']['max_columns'];
+	} elseif ( $max_columns && $columns > $max_columns ) {
+		$columns = $max_columns;
 		update_option( 'woocommerce_catalog_columns', $columns );
 	}
 
-	// Legacy filter.
-	if ( has_filter( 'loop_shop_columns' ) ) {
+	if ( has_filter( 'loop_shop_columns' ) ) { // Legacy filter handling.
 		$columns = apply_filters( 'loop_shop_columns', $columns );
 	}
 
@@ -339,17 +337,16 @@ function wc_get_default_products_per_row() {
  * @return int
  */
 function wc_get_default_product_rows_per_page() {
-	$rows = absint( get_option( 'woocommerce_catalog_rows', 4 ) );
+	$rows         = absint( get_option( 'woocommerce_catalog_rows', 4 ) );
+	$product_grid = wc_get_theme_support( 'product_grid' );
+	$min_rows     = isset( $product_grid['min_rows'] ) ? absint( $product_grid['min_rows'] ): 0;
+	$max_rows     = isset( $product_grid['max_rows'] ) ? absint( $product_grid['max_rows'] ): 0;
 
-	// Theme support.
-	$theme_support = get_theme_support( 'woocommerce' );
-	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
-
-	if ( isset( $theme_support['product_grid']['min_rows'] ) && $rows < $theme_support['product_grid']['min_rows'] ) {
-		$rows = $theme_support['product_grid']['min_rows'];
+	if ( $min_rows && $rows < $min_rows ) {
+		$rows = $min_rows;
 		update_option( 'woocommerce_catalog_rows', $rows );
-	} elseif ( ! empty( $theme_support['product_grid']['max_rows'] ) && $rows > $theme_support['product_grid']['max_rows'] ) {
-		$rows = $theme_support['product_grid']['max_rows'];
+	} elseif ( $max_rows && $rows > $max_rows ) {
+		$rows = $max_rows;
 		update_option( 'woocommerce_catalog_rows', $rows );
 	}
 
@@ -362,19 +359,14 @@ function wc_get_default_product_rows_per_page() {
  * @since 3.3.0
  */
 function wc_reset_product_grid_settings() {
-	$theme_support = get_theme_support( 'woocommerce' );
-	$theme_support = is_array( $theme_support ) ? $theme_support[0] : false;
+	$product_grid = wc_get_theme_support( 'product_grid' );
 
-	if ( isset( $theme_support['product_grid']['default_rows'] ) ) {
-		update_option( 'woocommerce_catalog_rows', absint( $theme_support['product_grid']['default_rows'] ) );
-	} else {
-		delete_option( 'woocommerce_catalog_rows' );
+	if ( ! empty( $product_grid['default_rows'] ) ) {
+		update_option( 'woocommerce_catalog_rows', absint( $product_grid['default_rows'] ) );
 	}
 
-	if ( isset( $theme_support['product_grid']['default_columns'] ) ) {
-		update_option( 'woocommerce_catalog_columns', absint( $theme_support['product_grid']['default_columns'] ) );
-	} else {
-		delete_option( 'woocommerce_catalog_columns' );
+	if ( ! empty( $product_grid['default_columns'] ) ) {
+		update_option( 'woocommerce_catalog_columns', absint( $product_grid['default_columns'] ) );
 	}
 }
 add_action( 'after_switch_theme', 'wc_reset_product_grid_settings' );


### PR DESCRIPTION
Using the customizer, in this branch if you set columns or rows to 0 (or go over a theme set limit) an error will be shown inline.

Closes #18364 

Supporting changes include a new function helper to get theme support props which is instead of accessing arrays manually.