### PR TITLE
add file array key similar to other functions

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1377,6 +1377,10 @@ class WC_Order extends WC_Abstract_Order {
 							'order_key'           => $this->get_order_key(),
 							'downloads_remaining' => $file['downloads_remaining'],
 							'access_expires'      => $file['access_expires'],
+							'file'                => array(
+								'name' => $file['name'],
+								'file' => $file['file'],
+							),
 						);
 					}
 				}


### PR DESCRIPTION
See also https://github.com/woocommerce/woocommerce/blob/master/includes/wc-user-functions.php#L458-L461

Allows the `woocommerce_order_get_downloadable_items` filter to access original file name and URL for custom handling (i.e., redirect to another URL rather than downloading a file).