### PR TITLE
Update single-product.js

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -25,7 +25,7 @@ jQuery( function( $ ) {
 				$tabs.find( 'li:first a' ).click();
 			}
 		} )
-		.on( 'click', '.wc-tabs li a, ul.tabs li a', function( e ) {
+		.on( 'click', '.wc-tabs li > a, ul.tabs li > a', function( e ) {
 			e.preventDefault();
 			var $tab          = $( this );
 			var $tabs_wrapper = $tab.closest( '.wc-tabs-wrapper, .woocommerce-tabs' );


### PR DESCRIPTION
Triggering the tab close action in the title _only_.
Without selecting the direct child (>), any anchor tag inside a tab will trigger the tab close action.