### PR TITLE
Rewrite wc_get_customer_last_order() to leverage the customer data store

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -603,24 +603,12 @@ function wc_get_customer_saved_methods_list( $customer_id ) {
  *
  * @since 2.6.0
  * @param int $customer_id Customer ID.
- * @return WC_Order Order object if successful or false.
+ * @return WC_Order|bool Order object if successful or false.
  */
 function wc_get_customer_last_order( $customer_id ) {
-	global $wpdb;
+	$customer = new WC_Customer( $customer_id );
 
-	$customer_id = absint( $customer_id );
-
-	$id = $wpdb->get_var( "SELECT id
-		FROM $wpdb->posts AS posts
-		LEFT JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
-		WHERE meta.meta_key = '_customer_user'
-		AND   meta.meta_value = {$customer_id}
-		AND   posts.post_type = 'shop_order'
-		AND   posts.post_status IN ( '" . implode( "','", array_keys( wc_get_order_statuses() ) ) . "' )
-		ORDER BY posts.ID DESC
-	" );
-
-	return wc_get_order( $id );
+	return $customer->get_last_order();
 }
 
 /**


### PR DESCRIPTION
The `wc_get_customer_last_order()` function (used by the v1 API) was performing a hard-coded SQL query against the `$wpdb->postmeta` table, regardless of the data store used by the `WC_Customer` class.

This PR effectively makes the function act as a wrapper around [`WC_Customer::get_last_order()`](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-customer.php#L296), reducing code duplication and ensuring that custom data stores can manipulate the output.