### PR TITLE
[REST API v2] Unhandled exceptions thrown from update_additional_fields_for_object

### DIFF
--- a/includes/abstracts/abstract-wc-rest-crud-controller.php
+++ b/includes/abstracts/abstract-wc-rest-crud-controller.php
@@ -192,7 +192,15 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			return $object;
 		}
 
-		$this->update_additional_fields_for_object( $object, $request );
+		try {
+			$this->update_additional_fields_for_object( $object, $request );
+		} catch ( WC_Data_Exception $e ) {
+			$object->delete();
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), $e->getErrorData() );
+		} catch ( WC_REST_Exception $e ) {
+			$object->delete();
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
 
 		/**
 		 * Fires after a single object is created or updated via the REST API.
@@ -231,7 +239,13 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			return $object;
 		}
 
-		$this->update_additional_fields_for_object( $object, $request );
+		try {
+			$this->update_additional_fields_for_object( $object, $request );
+		} catch ( WC_Data_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), $e->getErrorData() );
+		} catch ( WC_REST_Exception $e ) {
+			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
 
 		/**
 		 * Fires after a single object is created or updated via the REST API.


### PR DESCRIPTION
REST API v2 no longer catches exceptions thrown by code running in `WC_REST_CRUD_Controller::update_additional_fields_for_object`.

This probably doesn't affect a lot of code, but in REST API v1 there was a try/catch in `create_item` and `update_item` which was moved down to `save_object` in v2.

For any code it affects, there's little that can be done as a workaround, so I'd suggest maintaining the v1 behavior here and catching any exceptions thrown by `update_additional_fields_for_object`.

Not a costly fix and a life saver for any poor souls affected by this, such as myself.

Closes #18424