### PR TITLE
Use table format as default.

### DIFF
--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -157,6 +157,10 @@ class WC_CLI_REST_Command {
 			$body = self::limit_item_to_fields( $body, $assoc_args['fields'] );
 		}
 
+		if ( ! isset( $assoc_args['format'] ) ) {
+			$assoc_args['format'] = 'table';
+		}
+
 		if ( 'headers' === $assoc_args['format'] ) {
 			echo json_encode( $headers );
 		} elseif ( 'body' === $assoc_args['format'] ) {

--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -157,7 +157,7 @@ class WC_CLI_REST_Command {
 			$body = self::limit_item_to_fields( $body, $assoc_args['fields'] );
 		}
 
-		if ( ! isset( $assoc_args['format'] ) ) {
+		if ( empty( $assoc_args['format'] ) ) {
 			$assoc_args['format'] = 'table';
 		}
 


### PR DESCRIPTION
When a format is not provided, then `table` is set as default format (fixes #18418).