### PR TITLE
Exclude the /tests/ directory from PHP Compatibility checks

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,6 +23,7 @@
 	<rule ref="WooCommerce-Core" />
 	<rule ref="PHPCompatibility">
 		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound" />
+		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress">


### PR DESCRIPTION
The `composer.json` file in WooCommerce specifies PHPUnit version 6.2.3 as a development dependency; [that version of PHPUnit sets PHP 7.0 as the minimum PHP version](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.2.0), effectively making the minimum development version for WooCommerce to be PHP 7.0 (hooray!).

With a more modern version of PHP as the minimum requirement for developers, the code that *isn't* distributed with WooCommerce (e.g. the `/tests/` directory) doesn't necessarily need to adhere to PHP 5.2-compatible coding standards. This PR removes the `/tests/` directory from the scope of the PHP Compatibility checks, enabling the test suite to leverage modern (relative to PHP 5.2, anyway) features like closures, short-array syntax, and namespaces.

Embracing more modern PHP in the test suite also opens up the possibilities of using libraries like Faker to populate dummy data, rather than the hard-coded helpers that exist now.

An example test enabled by this change: developers can now use closures for filter callbacks.

```php
add_filter( 'some_filter', function () {
    return 'the filtered value';
}

$this->assertEquals( 'the filtered value', my_function_that_calls_some_filter() );
```

Without a closure, this test would need to either write a one-off method in the test class or hack around it with static properties to configure the expected filter response.