### PR TITLE
WooCommerce sniffs for main plugin file

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -6,13 +6,10 @@
  * Version: 3.3.0-rc.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
- *
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
  *
  * @package WooCommerce
- * @category Core
- * @author Automattic
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Since WC main plugin file will not be changed for long time as it only include `class-woocommerce.php` and all the stuffs are carried out through that class, so its better utilize WooCommerce-sniffs in this file as of 3.3 and leave as it is.

CC @claudiosanches 