### PR TITLE
Spelling correction

### DIFF
--- a/i18n/states/JP.php
+++ b/i18n/states/JP.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $states['JP'] = array(
-	'JP01' => __( 'Hokkaido', 'woocommerce' ),
+	'JP01' => __( 'Hokkai-do', 'woocommerce' ),
 	'JP02' => __( 'Aomori-ken', 'woocommerce' ),
 	'JP03' => __( 'Iwate-ken', 'woocommerce' ),
 	'JP04' => __( 'Miyagi-ken', 'woocommerce' ),


### PR DESCRIPTION
Japanese prefecture Hokkai-do required hyphen to speparate prefecture from prefecture type.