### PR TITLE
Setup wizard: activate but don't enable PPEC by default

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1520,8 +1520,8 @@ class WC_Admin_Setup_Wizard {
 			}
 
 			$settings_key = 'woocommerce_' . $gateway_id . '_settings';
-			$old_settings = array_filter( (array) get_option( $settings_key, array() ) );
-			update_option( $settings_key, array_merge( $old_settings, $settings ) );
+			$previously_saved_settings = array_filter( (array) get_option( $settings_key, array() ) );
+			update_option( $settings_key, array_merge( $previously_saved_settings, $settings ) );
 		}
 
 		wp_redirect( esc_url_raw( $this->get_next_step_link() ) );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1517,6 +1517,10 @@ class WC_Admin_Setup_Wizard {
 			}
 			// @codingStandardsIgnoreSEnd
 
+			if ( 'ppec_paypal' === $gateway_id && empty( $settings['reroute_requests'] ) ) {
+				$settings['enabled'] = 'no';
+			}
+
 			update_option( $settings_key, $settings );
 		}
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1503,9 +1503,7 @@ class WC_Admin_Setup_Wizard {
 				$this->install_plugin( $gateway_id, $gateway );
 			}
 
-			$settings_key        = 'woocommerce_' . $gateway_id . '_settings';
-			$settings            = array_filter( (array) get_option( $settings_key, array() ) );
-			$settings['enabled'] = ! empty( $_POST[ 'wc-wizard-service-' . $gateway_id . '-enabled' ] ) ? 'yes' : 'no'; // WPCS: CSRF ok, input var ok.
+			$settings = array( 'enabled' => ! empty( $_POST[ 'wc-wizard-service-' . $gateway_id . '-enabled' ] ) ? 'yes' : 'no' );  // WPCS: CSRF ok, input var ok.
 
 			// @codingStandardsIgnoreStart
 			if ( ! empty( $gateway['settings'] ) ) {
@@ -1518,10 +1516,12 @@ class WC_Admin_Setup_Wizard {
 			// @codingStandardsIgnoreSEnd
 
 			if ( 'ppec_paypal' === $gateway_id && empty( $settings['reroute_requests'] ) ) {
-				$settings['enabled'] = 'no';
+				unset( $settings['enabled'] );
 			}
 
-			update_option( $settings_key, $settings );
+			$settings_key = 'woocommerce_' . $gateway_id . '_settings';
+			$old_settings = array_filter( (array) get_option( $settings_key, array() ) );
+			update_option( $settings_key, array_merge( $old_settings, $settings ) );
 		}
 
 		wp_redirect( esc_url_raw( $this->get_next_step_link() ) );


### PR DESCRIPTION
When enabling a gateway via the WooCommerce (3.2+) setup wizard's "Payment" step, the gateway's settings are initialized with `enabled` set to "yes". In the case of PayPal Express Checkout, this results in the "Check out with PayPal" button defaulting to rendering in a broken state, since other necessary settings (such as credentials and button size) are missing, with no indication that anything's wrong:

<img width="467" src="https://user-images.githubusercontent.com/1867547/34449154-30492612-ecc3-11e7-9096-a9fb9f1c3903.png">

Since the PPEC extension essentially assumes that `enabled` would only be set explicitly and with awareness of other settings, we should continue to install and activate the plugin if the gateway is selected, but should not set the `enabled` option — except if "Accept payments without linking a PayPal account" option is checked, in which case the button will be functional by default.

To verify that PPEC is not enabled despite selecting it in the wizard, view cart after adding a test product to it, and confirm that nothing appears below the "Proceed to Checkout" button.