### PR TITLE
Allow stock to be overriden by filter when paying for orders

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -118,7 +118,7 @@ class WC_Shortcode_Checkout {
 					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
 						$product = $item->get_product();
 
-						if ( $product && ! $product->is_in_stock() ) {
+						if ( $product && ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
 							/* translators: %s: product name */
 							throw new Exception( sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name() ) );
 						}


### PR DESCRIPTION
A use case is WooCommerce Pre-Orders, where the stock is reduced once the product has been pre-ordered, and can be paid for later.

See https://github.com/woocommerce/woocommerce-pre-orders/issues/175 for details.