### PR TITLE
[3.3-rc] Add `woocommerce_admin_html_order_preview_item_class` filter in order previews

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -459,9 +459,11 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 				<tbody>';
 
 		foreach ( $line_items as $item_id => $item ) {
-			$product_object = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : null;
 
-			$html .= '<tr class="wc-order-preview-table__item wc-order-preview-table__item--' . esc_attr( $item_id ) . '">';
+			$product_object = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : null;
+			$row_class      = apply_filters( 'woocommerce_admin_html_order_preview_item_class', '', $item, $order );
+
+			$html .= '<tr class="wc-order-preview-table__item wc-order-preview-table__item--' . esc_attr( $item_id ) . ( $row_class ? ' ' . esc_attr( $row_class ) : '' ) . '">';
 
 			foreach ( $columns as $column => $label ) {
 				$html .= '<td class="wc-order-preview-table__column--' . esc_attr( $column ) . '">';


### PR DESCRIPTION
Added to item markup in order previews, for parity with `woocommerce_admin_html_order_item_class` filter in `html-order-item.php` view (edit-order page).

Needed by grouped product types to provide visual cues of "hierarchy" between parent/child items: https://cl.ly/03372M0a2C1N

PS: @mikejolley really like the transformation of the code here, just had a chance to follow up since we chatted about this -- https://woocommerce.wordpress.com/2017/11/16/wc-3-3-order-screen-changes-including-a-new-preview-function-ready-for-feedback/#comment-3826
