### PR TITLE
Saving taxes should invalidate caches.

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -186,7 +186,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			break;
 		}
 
-		// Increments the transient version to invalidate cache
+		// Increments the transient version to invalidate cache.
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}
 

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -118,7 +118,9 @@ class WC_Settings_Tax extends WC_Settings_Page {
 			$this->save_tax_rates();
 		}
 
+		// Invalidate caches.
 		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}
 
 	/**

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2347,6 +2347,9 @@ class WC_AJAX {
 			}
 		}
 
+		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+
 		wp_send_json_success( array(
 			'rates' => WC_Tax::get_rates_for_tax_class( $current_class ),
 		) );


### PR DESCRIPTION
Could not replicate #18510 like for like, but did see abnormalities with tax totals when changing taxes and shipping rates which could cause an issue. 

Differently named taxes did calc correctly.

This PR invalidates caches on tax rate save and fixed the problems I saw.

Closes #18510