### PR TITLE
Shortcode enhancements for Gutenberg

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -509,6 +509,8 @@ class WC_Shortcode_Products {
 		foreach ( $this->removed_template_actions as $action ) {
 			add_action( $action['hook'], $action['callback'], isset( $action['priority'] ) ? $action['priority'] : 10 );
 		}
+
+		$this->removed_template_actions = array();
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -48,7 +48,7 @@ class WC_Shortcode_Products {
 	protected $custom_visibility = false;
 
 	/**
-	 * Keeps track of which templates have been removed by shortcode attributes.
+	 * Keeps track of which templates have been removed for shortcode rendering.
 	 *
 	 * @since 3.4.0
 	 * @var   array


### PR DESCRIPTION
This PR adds some enhancements we will need for Gutenberg to the Products shortcode:
- Adds `show_titles`, `show_price`, and `show_add_to_cart` attributes to shortcode.
- Modifies the `category` attribute to also accept category ids.

To test, try out the following shortcodes:
```
[products show_add_to_cart="0" show_price="0"]
[products show_titles="0"]
[products category="30,31"]
etc.
```
