### PR TITLE
Ajax customer search to cater for numeric usernames

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1449,7 +1449,7 @@ class WC_AJAX {
 			$ids = $data_store->search_customers( $term, $limit );
 		}
 
-			$found_customers = array();
+		$found_customers = array();
 
 		if ( ! empty( $_GET['exclude'] ) ) {
 			$ids = array_diff( $ids, (array) $_GET['exclude'] );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1426,17 +1426,19 @@ class WC_AJAX {
 			wp_die();
 		}
 
+		$ids = array();
 		// Search by ID.
 		if ( is_numeric( $term ) ) {
 			$customer = new WC_Customer( intval( $term ) );
 
 			// Customer does not exists.
-			if ( 0 === $customer->get_id() ) {
-				wp_die();
+			if ( 0 !== $customer->get_id() ) {
+				$ids = array( $customer->get_id() );
 			}
+		}
 
-			$ids = array( $customer->get_id() );
-		} else {
+		// Usernames can be numeric so we first check that no users was found by ID before searching for numeric username, this prevents performance issues with ID lookups.
+		if ( empty( $ids ) ) {
 			$data_store = WC_Data_Store::load( 'customer' );
 
 			// If search is smaller than 3 characters, limit result set to avoid
@@ -1447,7 +1449,7 @@ class WC_AJAX {
 			$ids = $data_store->search_customers( $term, $limit );
 		}
 
-		$found_customers = array();
+			$found_customers = array();
 
 		if ( ! empty( $_GET['exclude'] ) ) {
 			$ids = array_diff( $ids, (array) $_GET['exclude'] );


### PR DESCRIPTION
This PR fixes an issue where with numeric usernames would not show up via the ajax search, the reason was that we check for a numeric value first and then just search based on ID.

This still does the numeric check, but if no user is found with the ID it will fall back to regular customer search, reason I opted for this was was that we do not want to cause a performance issue with lookups based on ID as that is a faster check.

Closes #18527 