### PR TITLE
Coding standards cleanup, primarily for the coupon unit tests

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -52,5 +52,12 @@
 	</rule>
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Commenting">
+		<exclude-pattern>tests/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting">
+		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,4 +60,7 @@
 	<rule ref="Squiz.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
+	<rule ref="PEAR.Functions.FunctionCallSignature.EmptyLine">
+		<exclude-pattern>tests/e2e-tests/</exclude-pattern>
+	</rule>
 </ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,13 +25,17 @@ class WC_Unit_Tests_Bootstrap {
 	 */
 	public function __construct() {
 
-		ini_set( 'display_errors','on' );
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions, WordPress.PHP.DevelopmentFunctions
+		ini_set( 'display_errors', 'on' );
 		error_reporting( E_ALL );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions, WordPress.PHP.DevelopmentFunctions
 
 		// Ensure server variable is set for WP email functions.
+		// phpcs:disable WordPress.VIP.SuperGlobalInputUsage.AccessDetected
 		if ( ! isset( $_SERVER['SERVER_NAME'] ) ) {
 			$_SERVER['SERVER_NAME'] = 'localhost';
 		}
+		// phpcs:enable WordPress.VIP.SuperGlobalInputUsage.AccessDetected
 
 		$this->tests_dir    = dirname( __FILE__ );
 		$this->plugin_dir   = dirname( $this->tests_dir );
@@ -81,11 +85,11 @@ class WC_Unit_Tests_Bootstrap {
 		if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
 			$GLOBALS['wp_roles']->reinit();
 		} else {
-			$GLOBALS['wp_roles'] = null;
+			$GLOBALS['wp_roles'] = null; // WPCS: override ok.
 			wp_roles();
 		}
 
-		echo 'Installing WooCommerce...' . PHP_EOL;
+		echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,7 +38,7 @@ class WC_Unit_Tests_Bootstrap {
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
 
 		// load test function so tests_add_filter() is available
-		require_once( $this->wp_tests_dir . '/includes/functions.php' );
+		require_once $this->wp_tests_dir . '/includes/functions.php';
 
 		// load WC
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
@@ -47,7 +47,7 @@ class WC_Unit_Tests_Bootstrap {
 		tests_add_filter( 'setup_theme', array( $this, 'install_wc' ) );
 
 		// load the WP testing environment
-		require_once( $this->wp_tests_dir . '/includes/bootstrap.php' );
+		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
 
 		// load WC testing framework
 		$this->includes();
@@ -60,7 +60,7 @@ class WC_Unit_Tests_Bootstrap {
 	 */
 	public function load_wc() {
 		define( 'WC_TAX_ROUNDING_MODE', 'auto' );
-		require_once( $this->plugin_dir . '/woocommerce.php' );
+		require_once $this->plugin_dir . '/woocommerce.php';
 	}
 
 	/**
@@ -73,7 +73,7 @@ class WC_Unit_Tests_Bootstrap {
 		// Clean existing install first.
 		define( 'WP_UNINSTALL_PLUGIN', true );
 		define( 'WC_REMOVE_ALL_DATA', true );
-		include( $this->plugin_dir . '/uninstall.php' );
+		include $this->plugin_dir . '/uninstall.php';
 
 		WC_Install::install();
 
@@ -96,28 +96,28 @@ class WC_Unit_Tests_Bootstrap {
 	public function includes() {
 
 		// framework
-		require_once( $this->tests_dir . '/framework/class-wc-unit-test-factory.php' );
-		require_once( $this->tests_dir . '/framework/class-wc-mock-session-handler.php' );
-		require_once( $this->tests_dir . '/framework/class-wc-mock-wc-data.php' );
-		require_once( $this->tests_dir . '/framework/class-wc-mock-wc-object-query.php' );
-		require_once( $this->tests_dir . '/framework/class-wc-payment-token-stub.php' );
-		require_once( $this->tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php' );
+		require_once $this->tests_dir . '/framework/class-wc-unit-test-factory.php';
+		require_once $this->tests_dir . '/framework/class-wc-mock-session-handler.php';
+		require_once $this->tests_dir . '/framework/class-wc-mock-wc-data.php';
+		require_once $this->tests_dir . '/framework/class-wc-mock-wc-object-query.php';
+		require_once $this->tests_dir . '/framework/class-wc-payment-token-stub.php';
+		require_once $this->tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 
 		// test cases
-		require_once( $this->tests_dir . '/framework/class-wc-unit-test-case.php' );
-		require_once( $this->tests_dir . '/framework/class-wc-api-unit-test-case.php' );
-		require_once( $this->tests_dir . '/framework/class-wc-rest-unit-test-case.php' );
+		require_once $this->tests_dir . '/framework/class-wc-unit-test-case.php';
+		require_once $this->tests_dir . '/framework/class-wc-api-unit-test-case.php';
+		require_once $this->tests_dir . '/framework/class-wc-rest-unit-test-case.php';
 
 		// Helpers
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-product.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-coupon.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-fee.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-shipping.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-customer.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-order.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-payment-token.php' );
-		require_once( $this->tests_dir . '/framework/helpers/class-wc-helper-settings.php' );
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-product.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-coupon.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-fee.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-shipping.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-customer.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-order.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-payment-token.php';
+		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-settings.php';
 	}
 
 	/**

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -15,12 +15,12 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		$string_code_1 = 'test';
 
 		// Coupon with a standard string code.
-		$coupon_1 = new WC_Coupon;
+		$coupon_1 = new WC_Coupon();
 		$coupon_1->set_code( $string_code_1 );
 		$coupon_1->save();
 
 		// Coupon with a string code that is the same as coupon 1's ID.
-		$coupon_2 = new WC_Coupon;
+		$coupon_2 = new WC_Coupon();
 		$coupon_2->set_code( (string) $coupon_1->get_id() );
 		$coupon_2->save();
 

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -24,8 +24,8 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		$coupon_2->set_code( (string) $coupon_1->get_id() );
 		$coupon_2->save();
 
-		$int_id_1 = $coupon_1->get_id();
-		$int_id_2 = $coupon_2->get_id();
+		$int_id_1      = $coupon_1->get_id();
+		$int_id_2      = $coupon_2->get_id();
 		$string_code_2 = $coupon_2->get_code();
 
 		// Test getting a coupon by integer ID.

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -10,7 +10,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0.0
 	 */
-	function test_coupon_store_loads() {
+	public function test_coupon_store_loads() {
 		$store = new WC_Data_Store( 'coupon' );
 		$this->assertTrue( is_callable( array( $store, 'read' ) ) );
 		$this->assertEquals( 'WC_Coupon_Data_Store_CPT', $store->get_current_class_name() );
@@ -20,7 +20,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon create.
 	 * @since 3.0.0
 	 */
-	function test_coupon_create() {
+	public function test_coupon_create() {
 		$code   = 'coupon-' . time();
 		$coupon = new WC_Coupon();
 		$coupon->set_code( $code );
@@ -35,7 +35,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon deletion.
 	 * @since 3.0.0
 	 */
-	function test_coupon_delete() {
+	public function test_coupon_delete() {
 		$coupon    = WC_Helper_Coupon::create_coupon();
 		$coupon_id = $coupon->get_id();
 		$this->assertNotEquals( 0, $coupon_id );
@@ -61,7 +61,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon update.
 	 * @since 3.0.0
 	 */
-	function test_coupon_update() {
+	public function test_coupon_update() {
 		$coupon    = WC_Helper_Coupon::create_coupon();
 		$coupon_id = $coupon->get_id();
 		$this->assertEquals( 'dummycoupon', $coupon->get_code() );
@@ -75,7 +75,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon reading from the DB.
 	 * @since 3.0.0
 	 */
-	function test_coupon_read() {
+	public function test_coupon_read() {
 		$code   = 'coupon-' . time();
 		$coupon = new WC_Coupon();
 		$coupon->set_code( $code );
@@ -95,7 +95,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon saving.
 	 * @since 3.0.0
 	 */
-	function test_coupon_save() {
+	public function test_coupon_save() {
 		$coupon    = WC_Helper_Coupon::create_coupon();
 		$coupon_id = $coupon->get_id();
 		$coupon->set_code( 'dummycoupon2' );
@@ -116,7 +116,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon date saving/loading.
 	 * @since 3.0.0
 	 */
-	function test_coupon_date_saving() {
+	public function test_coupon_date_saving() {
 		$expiry_date = time() - 10;
 
 		$coupon = WC_Helper_Coupon::create_coupon( 'coupon-' . time() );
@@ -132,7 +132,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * Test coupon increase, decrease, user usage count methods.
 	 * @since 3.0.0
 	 */
-	function test_coupon_usage_magic_methods() {
+	public function test_coupon_usage_magic_methods() {
 		$coupon  = WC_Helper_Coupon::create_coupon();
 		$user_id = 1;
 

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -21,7 +21,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function test_coupon_create() {
-		$code = 'coupon-' . time();
+		$code   = 'coupon-' . time();
 		$coupon = new WC_Coupon;
 		$coupon->set_code( $code );
 		$coupon->set_description( 'This is a test comment.' );
@@ -36,7 +36,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function test_coupon_delete() {
-		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon    = WC_Helper_Coupon::create_coupon();
 		$coupon_id = $coupon->get_id();
 		$this->assertNotEquals( 0, $coupon_id );
 		$coupon->delete( true );
@@ -52,7 +52,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$coupon->delete( true );
 
 		$cache_name = WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code();
-		$ids = wp_cache_get( $cache_name, 'coupons' );
+		$ids        = wp_cache_get( $cache_name, 'coupons' );
 
 		$this->assertEquals( false, $ids, sprintf( 'Object cache for %s was not removed upon deletion of coupon.', $cache_name ) );
 	}
@@ -62,7 +62,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function test_coupon_update() {
-		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon    = WC_Helper_Coupon::create_coupon();
 		$coupon_id = $coupon->get_id();
 		$this->assertEquals( 'dummycoupon', $coupon->get_code() );
 		$coupon->set_code( 'dummycoupon2' );
@@ -76,7 +76,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function test_coupon_read() {
-		$code = 'coupon-' . time();
+		$code   = 'coupon-' . time();
 		$coupon = new WC_Coupon;
 		$coupon->set_code( $code );
 		$coupon->set_description( 'This is a test coupon.' );
@@ -96,7 +96,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function test_coupon_save() {
-		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon    = WC_Helper_Coupon::create_coupon();
 		$coupon_id = $coupon->get_id();
 		$coupon->set_code( 'dummycoupon2' );
 		$coupon->save();

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -22,7 +22,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 */
 	function test_coupon_create() {
 		$code   = 'coupon-' . time();
-		$coupon = new WC_Coupon;
+		$coupon = new WC_Coupon();
 		$coupon->set_code( $code );
 		$coupon->set_description( 'This is a test comment.' );
 		$coupon->save();
@@ -77,7 +77,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 	 */
 	function test_coupon_read() {
 		$code   = 'coupon-' . time();
-		$coupon = new WC_Coupon;
+		$coupon = new WC_Coupon();
 		$coupon->set_code( $code );
 		$coupon->set_description( 'This is a test coupon.' );
 		$coupon->set_usage_count( 5 );
@@ -104,7 +104,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( 'dummycoupon2', $coupon->get_code() );
 		$this->assertEquals( $coupon_id, $coupon->get_id() );
 
-		$new_coupon = new WC_Coupon;
+		$new_coupon = new WC_Coupon();
 		$new_coupon->set_code( 'dummycoupon3' );
 		$new_coupon->save();
 		$new_coupon_id = $new_coupon->get_id();

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -163,7 +163,6 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_coupon_getters_and_setters() {
-		$time = time();
 		$standard_getters_and_setters = array(
 			'code'                       => 'test',
 			'description'                => 'hello world',

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -186,9 +186,9 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 			'used_by'                    => array( 1 ),
 		);
 
-		$coupon = new WC_Coupon;
-		 foreach ( $standard_getters_and_setters as $function => $value ) {
-		 	$function = $this->get_function_name( $function );
+		$coupon = new WC_Coupon();
+		foreach ( $standard_getters_and_setters as $function => $value ) {
+			$function = $this->get_function_name( $function );
 			$coupon->{"set_{$function}"}( $value );
 			$this->assertEquals( $value, $coupon->{"get_{$function}"}(), $function );
 		}

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -12,7 +12,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 	 * @return string
 	 * @since 3.0.0
 	 */
-	function get_function_name( $function ) {
+	public function get_function_name( $function ) {
 		if ( 'exclude_product_ids' === $function ) {
 			$function = 'excluded_product_ids';
 		} elseif ( 'exclude_product_categories' === $function ) {

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -32,7 +32,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 	public function test_coupon_backwards_compat_props_use_correct_getters() {
 		// Accessing properties directly will throw some wanted deprected notices
 		// So we need to let PHPUnit know we are expecting them and it's fine to continue
-		$legacy_keys = array(
+		$legacy_keys                   = array(
 			'id',
 			'exists',
 			'coupon_custom_fields',
@@ -92,7 +92,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_read_manual_coupon() {
-		$code = 'manual_coupon_' . time();
+		$code   = 'manual_coupon_' . time();
 		$coupon = new WC_Coupon( $code );
 		$coupon->read_manual_coupon( $code, array(
 			'id'                         => true,
@@ -122,10 +122,16 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 		 * setting these values this way will also throw a deprecated notice so we will let
 		 * PHPUnit know that its okay to continue.
 		 */
-		$legacy_keys = array( 'product_ids', 'exclude_product_ids', 'individual_use', 'free_shipping', 'exclude_sale_items' );
+		$legacy_keys                   = array(
+			'product_ids',
+			'exclude_product_ids',
+			'individual_use',
+			'free_shipping',
+			'exclude_sale_items',
+		);
 		$this->expected_doing_it_wrong = array_merge( $this->expected_doing_it_wrong, $legacy_keys );
-		$code = 'bc_manual_coupon_' . time();
-		$coupon = new WC_Coupon( $code );
+		$code                          = 'bc_manual_coupon_' . time();
+		$coupon                        = new WC_Coupon( $code );
 		$coupon->read_manual_coupon( $code, array(
 			'id'                         => true,
 			'type'                       => 'fixed_cart',
@@ -159,25 +165,25 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 	public function test_coupon_getters_and_setters() {
 		$time = time();
 		$standard_getters_and_setters = array(
-			'code' => 'test',
-			'description' => 'hello world',
-			'discount_type' => 'percent',
-			'amount' => 10.50,
-			'usage_count' => 5,
-			'individual_use' => true,
-			'product_ids' => array( 5, 10 ),
-			'exclude_product_ids' => array( 2, 1 ),
-			'usage_limit' => 2,
-			'usage_limit_per_user' => 10,
-			'limit_usage_to_x_items' => 2,
-			'free_shipping' => true,
-			'product_categories' => array( 6 ),
+			'code'                       => 'test',
+			'description'                => 'hello world',
+			'discount_type'              => 'percent',
+			'amount'                     => 10.50,
+			'usage_count'                => 5,
+			'individual_use'             => true,
+			'product_ids'                => array( 5, 10 ),
+			'exclude_product_ids'        => array( 2, 1 ),
+			'usage_limit'                => 2,
+			'usage_limit_per_user'       => 10,
+			'limit_usage_to_x_items'     => 2,
+			'free_shipping'              => true,
+			'product_categories'         => array( 6 ),
 			'exclude_product_categories' => array( 8 ),
-			'exclude_sale_items' => true,
-			'minimum_amount' => 2,
-			'maximum_amount' => 1000,
-			'customer_email' => array( 'test@woo.local' ),
-			'used_by' => array( 1 ),
+			'exclude_sale_items'         => true,
+			'minimum_amount'             => 2,
+			'maximum_amount'             => 1000,
+			'customer_email'             => array( 'test@woo.local' ),
+			'used_by'                    => array( 1 ),
 		);
 
 		$coupon = new WC_Coupon;
@@ -199,7 +205,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 		$coupon->add_meta_data( 'test_coupon_field', $meta_value, true );
 		$coupon->save_meta_data();
 
-		$coupon = new WC_Coupon( $coupon_id );
+		$coupon        = new WC_Coupon( $coupon_id );
 		$custom_fields = $coupon->get_meta_data();
 		$this->assertCount( 1, $custom_fields );
 		$this->assertEquals( $meta_value, $coupon->get_meta( 'test_coupon_field' ) );

--- a/tests/unit-tests/coupon/functions.php
+++ b/tests/unit-tests/coupon/functions.php
@@ -40,7 +40,7 @@ class WC_Tests_Functions extends WC_Unit_Test_Case {
 	 * @since 2.5.0
 	 */
 	public function test_wc_coupons_enabled() {
-		$this->assertEquals( apply_filters( 'woocommerce_coupons_enabled', get_option( 'woocommerce_enable_coupons' ) == 'yes' ), wc_coupons_enabled() );
+		$this->assertEquals( apply_filters( 'woocommerce_coupons_enabled', get_option( 'woocommerce_enable_coupons' ) === 'yes' ), wc_coupons_enabled() );
 	}
 
 	/**


### PR DESCRIPTION
As I've been submitting PRs recently, I've run into a number of instances where the git pre-commit hook fails due to lines untouched by my commits not passing PHP_CodeSniffer.

This PR attempts to clean up some of the existing `tests/` directory to make it less likely that people will run into trouble while trying to submit new/updated tests.