### PR TITLE
On 3.3 upgrade set PayPal sandbox API credentials

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -100,6 +100,7 @@ class WC_Install {
 			'wc_update_330_product_stock_status',
 			'wc_update_330_set_default_product_cat',
 			'wc_update_330_clear_transients',
+			'wc_update_330_set_paypal_sandbox_credentials',
 			'wc_update_330_db_version',
 		),
 	);

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1595,3 +1595,21 @@ function wc_update_330_clear_transients() {
 	delete_transient( 'wc_addons_sections' );
 	delete_transient( 'wc_addons_featured' );
 }
+
+/**
+ * Set PayPal's sandbox credentials.
+ */
+function wc_update_330_set_paypal_sandbox_credentials() {
+
+	$paypal_settings = get_option( 'woocommerce_paypal_settings' );
+
+	if ( isset( $paypal_settings['testmode'] ) && 'yes' === $paypal_settings['testmode'] ) {
+		foreach ( array( 'api_username', 'api_password', 'api_signature' ) as $credential ) {
+			if ( ! empty( $paypal_settings[ $credential ] ) ) {
+				$paypal_settings[ 'sandbox_' . $credential ] = $paypal_settings[ $credential ];
+			}
+		}
+
+		update_option( 'woocommerce_paypal_settings', $paypal_settings );
+	}
+}


### PR DESCRIPTION
If you had Paypal running in sandbox mode prior to upgrading to WC 3.3. After the upgrade, the PayPal API credentials get cleared. 

PayPal settings before upgrade:

![screen shot 2018-01-23 at 1 30 03 pm](https://user-images.githubusercontent.com/8490476/35256843-9c7a7c82-0041-11e8-8f24-15726bf8675c.png)

PayPal settings after: 
![35253944-c65b9f30-0033-11e8-993f-2fa9513e75f5](https://user-images.githubusercontent.com/8490476/35256885-e1f95184-0041-11e8-9d74-657f9f68de3e.png)

This PR fixes that by copying over the API credentials to the sandbox credentials if the site is running in sandbox mode at the time of updating. 
