### PR TITLE
Move custom image sizes registration to the init hook

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -176,6 +176,7 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Shortcodes', 'init' ) );
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'wpdb_table_fix' ), 0 );
+		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 	}
 
@@ -514,7 +515,6 @@ final class WooCommerce {
 		$this->define( 'WC_TEMPLATE_PATH', $this->template_path() );
 
 		$this->add_thumbnail_support();
-		$this->add_image_sizes();
 	}
 
 	/**
@@ -543,7 +543,7 @@ final class WooCommerce {
 	 *
 	 * @since 2.3
 	 */
-	private function add_image_sizes() {
+	public function add_image_sizes() {
 		$thumbnail = wc_get_image_size( 'thumbnail' );
 		$single    = wc_get_image_size( 'single' );
 


### PR DESCRIPTION
The `after_setup_theme` hook runs before the `add_theme_support()` declaration is processed, so the values returned by `wc_get_image_size()` at the time we currently register the custom sizes are always the default set by WooCommerce.

WordPress gets confused and doesn't output a `srcset` for any of the custom images.

This PR moves the custom image registration to the `init` hook.

Fixes #18501.