### PR TITLE
Order: Make note of two more meta keys that we store for an order.

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -73,6 +73,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		'_shipping_address_index',
 		'_recorded_sales',
 		'_recorded_coupon_usage_counts',
+		'_download_permissions_granted',
+		'_order_stock_reduced',
 	);
 
 	/**


### PR DESCRIPTION
While reviewing the order CPT post meta for Automattic/Jetpack#8601 as part of resolving Automattic/wp-calypso#21243  I noticed these post_meta keys used by the CPT but not noted at the top of the file.