### PR TITLE
Fix: use string escape for order numbers

### DIFF
--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -25,7 +25,7 @@
   */
  do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
- <p><?php printf( __( 'The order #%1$d from %2$s has been cancelled. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p>
+ <p><?php printf( __( 'The order #%1$s from %2$s has been cancelled. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p>
 
  <?php
 

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -25,7 +25,7 @@
   */
  do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
- <p><?php printf( __( 'Payment for order #%1$d from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p>
+ <p><?php printf( __( 'Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p>
 
  <?php
 

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 echo "= " . $email_heading . " =\n\n";
 
-echo sprintf( __( 'The order #%1$d from %2$s has been cancelled. The order was as follows:', 'woocommerce' ), $order->get_id(), $order->get_formatted_billing_full_name() ) . "\n\n";
+echo sprintf( __( 'The order #%1$s from %2$s has been cancelled. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 echo "= " . $email_heading . " =\n\n";
 
-echo sprintf( __( 'Payment for order #%1$d from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_id(), $order->get_formatted_billing_full_name() ) . "\n\n";
+echo sprintf( __( 'Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
In most places, order numbers that originate from `get_order_number()` are correctly escaped as strings. These are a few stragglers in emails that are still escaping as digits, and are causing the wrong order # to be displayed for merchants using [Sequential Order Numbers Pro](https://woocommerce.com/products/sequential-order-numbers-pro/).

Also, in a couple of plain emails the order number was still pulling from `get_id()`, so I replaced with `get_order_number()`.