### PR TITLE
Add notice for moved product display settings

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -128,7 +128,11 @@ class WC_Admin_Notices {
 			}
 
 			$hide_notice = sanitize_text_field( $_GET['wc-hide-notice'] );
+
 			self::remove_notice( $hide_notice );
+
+			update_user_meta( get_current_user_id(), 'dismissed_' . $hide_notice . '_notice', true );
+
 			do_action( 'woocommerce_hide_' . $hide_notice . '_notice' );
 		}
 	}

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -54,7 +54,36 @@ class WC_Settings_Products extends WC_Settings_Page {
 
 		$settings = $this->get_settings( $current_section );
 
+		$this->product_display_settings_moved_notice();
+
 		WC_Admin_Settings::output_fields( $settings );
+	}
+
+	/**
+	 * Show a notice showing where some options have moved.
+	 *
+	 * @since 3.3.0
+	 * @todo remove in next major release.
+	 */
+	private function product_display_settings_moved_notice() {
+		if ( get_user_meta( get_current_user_id(), 'dismissed_product_display_settings_moved_notice', true ) ) {
+			return;
+		}
+		?>
+		<div id="message" class="updated woocommerce-message inline">
+			<a class="woocommerce-message-close notice-dismiss" style="top:0;" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'product_display_settings_moved' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+			<p><?php
+			/* translators: %s: URL to customizer. */
+			echo wp_kses( sprintf( __( 'Looking for the product display options? They can now be found in the Customizer. <a href="%s">Go see them in action here.</a>', 'woocommerce' ), esc_url( admin_url( 'customize.php?url=' . wc_get_page_permalink( 'shop' ) . '&autofocus[panel]=woocommerce' ) ) ), array(
+				'a' => array(
+					'href'  => array(),
+					'title' => array(),
+				),
+			) );
+			?></p>
+		</div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
Adds a notice (dismissible) to our settings screen which links through to the customizer.

![woocommerce settings test wordpress 2018-01-24 17-17-42](https://user-images.githubusercontent.com/90977/35346644-b89e55de-012a-11e8-8d60-c778cfc0a1cf.png)

Closes #18574