### PR TITLE
Setup wizard: various style and copy tweaks

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1048,11 +1048,12 @@ p.jetpack-terms {
 
 .wc-wizard-service-setting-stripe_create_account, .wc-wizard-service-setting-ppec_paypal_reroute_requests {
 	display: flex;
-	align-items: flex-end;
+	align-items: flex-start;
 	margin-top: 0.75em;
 
 	.payment-checkbox-input {
 		order: 1;
+		margin-top: 5px;
 		margin-left: 0;
 		margin-right: 0;
 		width: 1.5em;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -326,7 +326,7 @@ body {
 	width:100%;
 	display: inline-flex;
 	li {
-		width: 20%;
+		width: 100%;
 		float: left;
 		padding: 0 0 0.8em;
 		margin: 0;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -508,7 +508,10 @@ body {
 		align-self: stretch;
 		display: flex;
 		align-items: baseline;
-		justify-content: center;
+
+		.wc-wizard-payment-gateway-form & {
+			justify-content: center;
+		}
 
 		img {
 			max-width: 75px;
@@ -709,7 +712,10 @@ body {
 		display: flex;
 		flex-direction: column;
 		color: #a6a6a6;
-		font-size: 0.92em;
+
+		.wc-wizard-service-item:not(:first-child) & {
+			font-size: 0.92em;
+		}
 	}
 
 	.shipping-method-setting {

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -840,7 +840,7 @@ h3.jetpack-reasons {
 	font-size: 13px;
 	font-weight: 500;
 	margin-bottom: 0.5em;
-	margin-top: 1em;
+	margin-top: 0.85em;
 	display: inline-block;
 }
 
@@ -869,7 +869,7 @@ h3.jetpack-reasons {
 }
 
 .store-address-container {
-	margin-bottom: 24px; // match margin-bottom on top paragraph
+	margin-top: 4px;
 
 	.city-and-postcode {
 		display: flex;
@@ -883,6 +883,16 @@ h3.jetpack-reasons {
 			}
 		}
 	}
+}
+.store-currency-container {
+	margin-top: 10px;
+}
+.product-type-container {
+	margin-top: 14px;
+	margin-bottom: 1px;
+}
+#woocommerce_sell_in_person {
+	margin-left: 0;
 }
 
 .wc-wizard-service-settings {

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -680,7 +680,7 @@ body {
 	// List header
 	.wc-wizard-service-item {
 		padding-left: 2em;
-		padding-top: 1em;
+		padding-top: 0.67em;
 
 		&:first-child {
 			border-bottom: 0;
@@ -719,6 +719,7 @@ body {
 	}
 	.wc-wizard-service-item:not(:first-child) .wc-wizard-service-description {
 		font-size: 0.92em;
+		padding-bottom: 10px;
 	}
 
 	.shipping-method-setting {

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -716,10 +716,9 @@ body {
 		display: flex;
 		flex-direction: column;
 		color: #a6a6a6;
-
-		.wc-wizard-service-item:not(:first-child) & {
-			font-size: 0.92em;
-		}
+	}
+	.wc-wizard-service-item:not(:first-child) .wc-wizard-service-description {
+		font-size: 0.92em;
 	}
 
 	.shipping-method-setting {

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -672,11 +672,15 @@ body {
 	.wc-wizard-service-name {
 		font-weight: normal;
 		text-align: left;
+		align-items: center;
+		max-height: 5em;
+		padding: 0;
 	}
 
 	// List header
 	.wc-wizard-service-item {
 		padding-left: 2em;
+		padding-top: 1em;
 
 		&:first-child {
 			border-bottom: 0;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -554,10 +554,6 @@ body {
 			margin-bottom: 0;
 		}
 
-		.wc-wizard-service-settings {
-			margin-top: 1em;
-		}
-
 		.wc-wizard-service-settings-description {
 			display: block;
 			font-style: italic;

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -74,7 +74,7 @@ jQuery( function( $ ) {
 			.removeClass( 'hide' )
 			.find( '.shipping-method-required-field' )
 			.prop( 'required', true );
-	} );
+	} ).find( '.wc-wizard-shipping-method-select .method' ).change();
 
 	$( '.wc-wizard-services' ).on( 'change', '.wc-wizard-shipping-method-enable', function() {
 		var checked = $( this ).is( ':checked' );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1663,13 +1663,13 @@ class WC_Admin_Setup_Wizard {
 		$description_base = __( 'Your store is almost ready! To activate services like %s, just connect with Jetpack.', 'woocommerce' );
 
 		if ( $payment_enabled && $taxes_enabled && $rates_enabled ) {
-			$description = sprintf( $description_base, __( 'payments, automated taxes, live rates and discounted shipping labels', 'woocommerce' ) );
+			$description = sprintf( $description_base, __( 'payment setup, automated taxes, live rates and discounted shipping labels', 'woocommerce' ) );
 		} else if ( $payment_enabled && $taxes_enabled ) {
-			$description = sprintf( $description_base, __( 'payments and automated taxes', 'woocommerce' ) );
+			$description = sprintf( $description_base, __( 'payment setup and automated taxes', 'woocommerce' ) );
 		} else if ( $payment_enabled && $rates_enabled ) {
-			$description = sprintf( $description_base, __( 'payments, live rates and discounted shipping labels', 'woocommerce' ) );
+			$description = sprintf( $description_base, __( 'payment setup, live rates and discounted shipping labels', 'woocommerce' ) );
 		} else if ( $payment_enabled ) {
-			$description = sprintf( $description_base, __( 'payments', 'woocommerce' ) );
+			$description = sprintf( $description_base, __( 'payment setup', 'woocommerce' ) );
 		} else if ( $taxes_enabled && $rates_enabled ) {
 			$description = sprintf( $description_base, __( 'automated taxes, live rates and discounted shipping labels', 'woocommerce' ) );
 		} else if ( $taxes_enabled ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -426,13 +426,7 @@ class WC_Admin_Setup_Wizard {
 			>
 				<option value=""><?php esc_html_e( 'Choose a currency&hellip;', 'woocommerce' ); ?></option>
 				<?php foreach ( get_woocommerce_currencies() as $code => $name ) : ?>
-					<option value="<?php echo esc_attr( $code ); ?>" <?php selected( $currency, $code ); ?>>
-						<?php
-						// @codingStandardsIgnoreStart
-						printf( esc_html__( '%1$s (%2$s)', 'woocommerce' ), $name, get_woocommerce_currency_symbol( $code ) );
-						// // @codingStandardsIgnoreEnd
-						?>
-					</option>
+					<option value="<?php echo esc_attr( $code ); ?>" <?php selected( $currency, $code ); ?>><?php printf( esc_html__( '%1$s (%2$s)', 'woocommerce' ), $name, get_woocommerce_currency_symbol( $code ) ); ?></option>
 				<?php endforeach; ?>
 			</select>
 			<script type="text/javascript">
@@ -722,9 +716,7 @@ class WC_Admin_Setup_Wizard {
 			<div class="wc-wizard-shipping-method-dropdown">
 				<select id="<?php echo esc_attr( "{$input_prefix}[method]" ); ?>" name="<?php echo esc_attr( "{$input_prefix}[method]" ); ?>" class="method wc-enhanced-select">
 				<?php foreach ( $shipping_methods as $method_id => $method ) : ?>
-					<option value="<?php echo esc_attr( $method_id ); ?>" <?php selected( $selected, $method_id ); ?>>
-						<?php echo esc_html( $method['name'] ); ?>
-					</option>
+					<option value="<?php echo esc_attr( $method_id ); ?>" <?php selected( $selected, $method_id ); ?>><?php echo esc_html( $method['name'] ); ?></option>
 				<?php endforeach; ?>
 				</select>
 			</div>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1691,7 +1691,7 @@ class WC_Admin_Setup_Wizard {
 		if ( isset( $_GET['activate_error'] ) ) {
 			$has_jetpack_error = true;
 
-			$title = __( "Sorry, We couldn't connect your store to Jetpack", 'woocommerce' );
+			$title = __( "Sorry, we couldn't connect your store to Jetpack", 'woocommerce' );
 
 			$error_message = $this->get_activate_error_message( sanitize_text_field( wp_unslash( $_GET['activate_error'] ) ) );
 			$description = $error_message;
@@ -1735,7 +1735,14 @@ class WC_Admin_Setup_Wizard {
 				<input type="hidden" name="save_step" value="activate" />
 				<?php wp_nonce_field( 'wc-setup' ); ?>
 			</form>
-			<h3 class="jetpack-reasons"><?php esc_html_e( "Bonus reasons you'll love Jetpack", 'woocommerce' ); ?></h3>
+			<h3 class="jetpack-reasons">
+				<?php
+					echo esc_html( $description ?
+						__( "Bonus reasons you'll love Jetpack", 'woocommerce' ) :
+						__( "Reasons you'll love Jetpack", 'woocommerce' )
+					);
+				?>
+			</h3>
 			<ul class="wc-wizard-features">
 				<li class="wc-wizard-feature-item">
 					<p class="wc-wizard-feature-name">

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1108,7 +1108,7 @@ class WC_Admin_Setup_Wizard {
 		$paypal_ec_description = '<p>' . sprintf(
 			/* translators: %s: URL */
 			__( 'Safe and secure payments using credit cards or your customer\'s PayPal account. <a href="%s" target="_blank">Learn more</a>.', 'woocommerce' ),
-			'https://wordpress.org/plugins/woocommerce-gateway-paypal-express-checkout/'
+			'https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/'
 		) . '</p>';
 		$klarna_checkout_description = '<p>' . sprintf(
 			/* translators: %s: URL */

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1426,7 +1426,7 @@ class WC_Admin_Setup_Wizard {
 							),
 						)
 					),
-					esc_url( admin_url( 'admin.php?page=wc-addons&view=payment_gateways' ) )
+					esc_url( admin_url( 'admin.php?page=wc-addons&section=payment-gateways' ) )
 				);
 				?>
 			</p>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -414,6 +414,7 @@ class WC_Admin_Setup_Wizard {
 			</div>
 		</div>
 
+			<div class="store-currency-container">
 			<label class="location-prompt" for="currency_code">
 				<?php esc_html_e( 'What currency do you use?', 'woocommerce' ); ?>
 			</label>
@@ -432,7 +433,9 @@ class WC_Admin_Setup_Wizard {
 			<script type="text/javascript">
 				var wc_setup_currencies = <?php echo wp_json_encode( $currency_by_country ); ?>;
 			</script>
+			</div>
 
+			<div class="product-type-container">
 			<label class="location-prompt" for="product_type">
 				<?php esc_html_e( 'What type of product do you plan to sell?', 'woocommerce' ); ?>
 			</label>
@@ -446,6 +449,7 @@ class WC_Admin_Setup_Wizard {
 				<option value="physical" <?php selected( $product_type, 'physical' ); ?>><?php esc_html_e( 'I plan to sell physical products', 'woocommerce' ); ?></option>
 				<option value="virtual" <?php selected( $product_type, 'virtual' ); ?>><?php esc_html_e( 'I plan to sell digital products', 'woocommerce' ); ?></option>
 			</select>
+			</div>
 
 			<input
 				type="checkbox"


### PR DESCRIPTION
commit | description | master | this PR
-- | -- | -- | --
https://github.com/woocommerce/woocommerce/pull/18588/commits/4eb1c182b2c18ef45be6e7a22c675a30b4dae2ba | Point PPEC "Learn more" link to woocommerce.com instead of wordpress.org: <img width="659" alt="screen shot 2018-01-25 at 12 22 58 am" src="https://user-images.githubusercontent.com/1867547/35372077-f0c07b28-0165-11e8-9055-0b9f5b01c75a.png"> | <img width="1000" alt="screen shot 2018-01-25 at 12 23 27 am" src="https://user-images.githubusercontent.com/1867547/35372105-1fcf8a08-0166-11e8-89c9-cfc4ed2aed2c.png"> | <img width="1001" alt="screen shot 2018-01-25 at 12 24 21 am" src="https://user-images.githubusercontent.com/1867547/35372108-2256a798-0166-11e8-82de-b603d801d0da.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/591dd9ec2dd02d34369fa30755625cdefcce51ca | Clarify 'payments' (in WCS feature list) to 'payment setup' | <img width="638" alt="screen shot 2018-01-25 at 1 09 43 am" src="https://user-images.githubusercontent.com/1867547/35373458-77fe18ec-016c-11e8-9dbc-3a889dc28980.png"> | <img width="636" alt="screen shot 2018-01-25 at 1 09 35 am" src="https://user-images.githubusercontent.com/1867547/35373461-7909b28c-016c-11e8-88b3-8b725dd10ff1.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/7f973c2c791e648739af3e156568201ceb88bd40 | Tweak Activate step lower heading to reflect listing of features of above: removed the word "Bonus" in "Bonus reasons you'll love Jetpack" if there are no WooCommerce Services features listed above | <img width="721" alt="screen shot 2018-01-25 at 1 12 32 am" src="https://user-images.githubusercontent.com/1867547/35373544-f3ac37a8-016c-11e8-9ebb-a6cfd566d0a0.png"> | <img width="729" alt="screen shot 2018-01-25 at 1 13 11 am" src="https://user-images.githubusercontent.com/1867547/35373547-f5042e80-016c-11e8-85e4-73f2a066e6a0.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/6dfcdab1bcb98fe15a81822d006604b23eca8bab | Remove margin before service settings, as margin now follows text content above | <img width="665" alt="screen shot 2018-01-25 at 1 16 23 am" src="https://user-images.githubusercontent.com/1867547/35373640-7014285a-016d-11e8-8245-6166bf9d150e.png"> | <img width="664" alt="screen shot 2018-01-25 at 12 18 45 am" src="https://user-images.githubusercontent.com/1867547/35371984-5c9fae64-0165-11e8-99c7-130b9a7bc70d.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/e5d00fa98ea3479fbf8f57a6824f656b76a9320b | Fix payment addons link again: <img width="659" alt="screen shot 2018-01-25 at 12 21 33 am" src="https://user-images.githubusercontent.com/1867547/35372047-bae5e0c4-0165-11e8-8207-53ab537a0fb6.png"> | <img width="510" alt="screen shot 2018-01-25 at 12 20 03 am" src="https://user-images.githubusercontent.com/1867547/35372014-92ec2e8e-0165-11e8-93dc-4044cc42918e.png"> | <img width="515" alt="screen shot 2018-01-25 at 12 20 21 am" src="https://user-images.githubusercontent.com/1867547/35372017-93f98a9c-0165-11e8-9e55-30044777e7a7.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/5cc6a589aba8daf036d10c990b39d236c76d6fe5 | Make step navigation take up full width, even if there are fewer than 5 — not sure if it's still a problem but there used to only be 4 steps if country was India and Jetpack was already connected | <img width="728" alt="screen shot 2018-01-25 at 12 31 09 am" src="https://user-images.githubusercontent.com/1867547/35372288-15f231e2-0167-11e8-9089-479514b5a2e5.png"> | <img width="726" alt="screen shot 2018-01-25 at 12 31 05 am" src="https://user-images.githubusercontent.com/1867547/35372289-1709aad8-0167-11e8-847a-41e3f1de4bc9.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/98fe2c7c3ea66f3b9874ce9f03af20d791fc4c33 | Remove newline and whitespace from dropdown option tooltips | <img width="427" alt="screen shot 2018-01-25 at 1 06 02 am" src="https://user-images.githubusercontent.com/1867547/35373322-fb11f18c-016b-11e8-9d55-ef14d96c71f2.png"> | <img width="373" alt="screen shot 2018-01-25 at 1 06 10 am" src="https://user-images.githubusercontent.com/1867547/35373325-fc396414-016b-11e8-93ac-d5b5e27755a0.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/b8384aa4a33c61c5c5d3e693a81c73179d560bcc, https://github.com/woocommerce/woocommerce/pull/18588/commits/eff0b623911e685ca022beaa97809f6a13965a99, https://github.com/woocommerce/woocommerce/pull/18588/commits/9f5f301aa4e0830aabd559f8983f9567ee34dcc4, https://github.com/woocommerce/woocommerce/pull/18588/commits/a2863156ccd52d533e99e45155c379c700798ddf | Scope service name styles to avoid unintended sizing and positioning; Tweak shipping service styles towards original static design | <img width="658" alt="screen shot 2018-01-25 at 1 03 09 am" src="https://user-images.githubusercontent.com/1867547/35373258-cebe9158-016b-11e8-9ee2-25205d3de8de.png"> | <img width="664" alt="screen shot 2018-01-25 at 1 03 03 am" src="https://user-images.githubusercontent.com/1867547/35373261-cfc4e340-016b-11e8-8251-4c9d971ca016.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/25373cadee5a522e22c4ae7a9dd674fa6bf01fe5 | Tweak spacing of store setup step towards original static design | <img width="659" alt="screen shot 2018-01-25 at 12 13 51 am" src="https://user-images.githubusercontent.com/1867547/35371857-aab1e7ee-0164-11e8-95aa-abd949ece984.png"> | <img width="665" alt="screen shot 2018-01-25 at 12 13 38 am" src="https://user-images.githubusercontent.com/1867547/35371859-ac1ea5e0-0164-11e8-9def-5c3314e417ef.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/d4a8ef4da12703f17e103a4d8f087c72e56a36f1 | Align payment service setting **checkboxes** to top of their labels rather than bottom | <img width="468" alt="screen shot 2018-01-25 at 12 32 31 am" src="https://user-images.githubusercontent.com/1867547/35372318-47efc4d4-0167-11e8-810b-9e7466122a02.png"> | <img width="472" alt="screen shot 2018-01-25 at 12 32 35 am" src="https://user-images.githubusercontent.com/1867547/35372319-4929d54c-0167-11e8-8771-22b60fcb0968.png">
https://github.com/woocommerce/woocommerce/pull/18588/commits/16430dfdaadcff279dfd09073cf502884f7d1245 | Keep shipping service description in sync with selected value after refresh | <img width="606" alt="screen shot 2018-01-25 at 1 07 34 am" src="https://user-images.githubusercontent.com/1867547/35373410-41395f7e-016c-11e8-86a0-3382afb8f315.png"> | <img width="610" alt="screen shot 2018-01-25 at 1 08 16 am" src="https://user-images.githubusercontent.com/1867547/35373412-41ef4852-016c-11e8-8f25-d92b997f8209.png">