### PR TITLE
Customizer tweaks

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -103,6 +103,22 @@ class WC_Shop_Customizer {
 					$( '.woocommerce-cropping-control' ).find( 'input:checked' ).change();
 				} );
 
+				wp.customize.section( 'woocommerce_product_catalog', function( section ) {
+					section.expanded.bind( function( isExpanded ) {
+						if ( isExpanded ) {
+							wp.customize.previewer.previewUrl.set( '<?php echo esc_js( wc_get_page_permalink( 'shop' ) ); ?>' );
+						}
+					} );
+				} );
+
+				wp.customize.section( 'woocommerce_product_images', function( section ) {
+					section.expanded.bind( function( isExpanded ) {
+						if ( isExpanded ) {
+							wp.customize.previewer.previewUrl.set( '<?php echo esc_js( wc_get_page_permalink( 'shop' ) ); ?>' );
+						}
+					} );
+				} );
+
 				wp.customize( 'woocommerce_catalog_columns', function( setting ) {
 					setting.bind( function( value ) {
 						var min = '<?php echo esc_js( $min_columns ); ?>';
@@ -167,24 +183,6 @@ class WC_Shop_Customizer {
 			} );
 		</script>
 		<?php
-	}
-
-	/**
-	 * Should our settings show?
-	 *
-	 * @return boolean
-	 */
-	public function is_active() {
-		return is_woocommerce() || wc_post_content_has_shortcode( 'products' ) || ! current_theme_supports( 'woocommerce' );
-	}
-
-	/**
-	 * Should our settings show on product archives?
-	 *
-	 * @return boolean
-	 */
-	public function is_products_archive() {
-		return is_shop() || is_product_taxonomy() || is_product_category() || ! current_theme_supports( 'woocommerce' );
 	}
 
 	/**
@@ -285,10 +283,9 @@ class WC_Shop_Customizer {
 		$wp_customize->add_section(
 			'woocommerce_product_catalog',
 			array(
-				'title'           => __( 'Product Catalog', 'woocommerce' ),
-				'priority'        => 10,
-				'active_callback' => array( $this, 'is_products_archive' ),
-				'panel'           => 'woocommerce',
+				'title'    => __( 'Product Catalog', 'woocommerce' ),
+				'priority' => 10,
+				'panel'    => 'woocommerce',
 			)
 		);
 
@@ -442,10 +439,9 @@ class WC_Shop_Customizer {
 		$wp_customize->add_section(
 			'woocommerce_product_images',
 			array(
-				'title'           => __( 'Product Images', 'woocommerce' ),
-				'priority'        => 20,
-				'active_callback' => array( $this, 'is_active' ),
-				'panel'           => 'woocommerce',
+				'title'    => __( 'Product Images', 'woocommerce' ),
+				'priority' => 20,
+				'panel'    => 'woocommerce',
 			)
 		);
 

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -506,7 +506,7 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_thumbnail_cropping',
 			array(
-				'default'           => '1: 1',
+				'default'           => '1:1',
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
 				'sanitize_callback' => 'wc_clean',

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -4,12 +4,9 @@
  *
  * @version 3.3.0
  * @package WooCommerce
- * @author  WooCommerce
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Shop_Customizer class.
@@ -81,6 +78,11 @@ class WC_Shop_Customizer {
 		$max_rows    = wc_get_theme_support( 'product_grid::max_rows', '' );
 		$min_columns = wc_get_theme_support( 'product_grid::min_columns', 1 );
 		$max_columns = wc_get_theme_support( 'product_grid::max_columns', '' );
+
+		/* translators: %d: Setting value */
+		$min_notice = __( 'The minimum allowed setting is %d', 'woocommerce' );
+		/* translators: %d: Setting value */
+		$max_notice = __( 'The maximum allowed setting is %d', 'woocommerce' );
 		?>
 		<script type="text/javascript">
 			jQuery( document ).ready( function( $ ) {
@@ -111,7 +113,7 @@ class WC_Shop_Customizer {
 								'max_columns_error',
 								{
 									type   : 'error',
-									message: '<?php echo esc_js( sprintf( __( 'The maximum allowed setting for columns is %d', 'woocommerce' ), $max_columns ) ); ?>'
+									message: '<?php echo esc_js( sprintf( $max_notice, $max_columns ) ); ?>'
 								}
 							) );
 						} else {
@@ -123,7 +125,7 @@ class WC_Shop_Customizer {
 								'min_columns_error',
 								{
 									type   : 'error',
-									message: '<?php echo esc_js( sprintf( __( 'The minimum allowed setting for columns is %d', 'woocommerce' ), $min_columns ) ); ?>'
+									message: '<?php echo esc_js( sprintf( $min_notice, $min_columns ) ); ?>'
 								}
 							) );
 						} else {
@@ -142,7 +144,7 @@ class WC_Shop_Customizer {
 								'max_rows_error',
 								{
 									type   : 'error',
-									message: '<?php echo esc_js( sprintf( __( 'The maximum allowed setting for rows is %d', 'woocommerce' ), $max_rows ) ); ?>'
+									message: '<?php echo esc_js( sprintf( $min_notice, $max_rows ) ); ?>'
 								}
 							) );
 						} else {
@@ -154,7 +156,7 @@ class WC_Shop_Customizer {
 								'min_rows_error',
 								{
 									type   : 'error',
-									message: '<?php echo esc_js( sprintf( __( 'The minimum allowed setting for rows is %d', 'woocommerce' ), $min_rows ) ); ?>'
+									message: '<?php echo esc_js( sprintf( $min_notice, $min_rows ) ); ?>'
 								}
 							) );
 						} else {
@@ -194,7 +196,7 @@ class WC_Shop_Customizer {
 	public function sanitize_archive_display( $value ) {
 		$options = array( '', 'subcategories', 'both' );
 
-		return in_array( $value, $options ) ? $value : '';
+		return in_array( $value, $options, true ) ? $value : '';
 	}
 
 	/**
@@ -266,10 +268,10 @@ class WC_Shop_Customizer {
 		$wp_customize->add_control(
 			'woocommerce_demo_store',
 			array(
-				'label'       => __( 'Enable store notice', 'woocommerce' ),
-				'section'     => 'woocommerce_store_notice',
-				'settings'    => 'woocommerce_demo_store',
-				'type'        => 'checkbox',
+				'label'    => __( 'Enable store notice', 'woocommerce' ),
+				'section'  => 'woocommerce_store_notice',
+				'settings' => 'woocommerce_demo_store',
+				'type'     => 'checkbox',
 			)
 		);
 	}
@@ -293,10 +295,10 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_shop_page_display',
 			array(
-				'default'              => '',
-				'type'                 => 'option',
-				'capability'           => 'manage_woocommerce',
-				'sanitize_callback'    => array( $this, 'sanitize_archive_display' ),
+				'default'           => '',
+				'type'              => 'option',
+				'capability'        => 'manage_woocommerce',
+				'sanitize_callback' => array( $this, 'sanitize_archive_display' ),
 			)
 		);
 
@@ -319,10 +321,10 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_category_archive_display',
 			array(
-				'default'              => '',
-				'type'                 => 'option',
-				'capability'           => 'manage_woocommerce',
-				'sanitize_callback'    => array( $this, 'sanitize_archive_display' ),
+				'default'           => '',
+				'type'              => 'option',
+				'capability'        => 'manage_woocommerce',
+				'sanitize_callback' => array( $this, 'sanitize_archive_display' ),
 			)
 		);
 
@@ -345,10 +347,10 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_default_catalog_orderby',
 			array(
-				'default'              => 'menu_order',
-				'type'                 => 'option',
-				'capability'           => 'manage_woocommerce',
-				'sanitize_callback'    => array( $this, 'sanitize_default_catalog_orderby' ),
+				'default'           => 'menu_order',
+				'type'              => 'option',
+				'capability'        => 'manage_woocommerce',
+				'sanitize_callback' => array( $this, 'sanitize_default_catalog_orderby' ),
 			)
 		);
 
@@ -503,15 +505,15 @@ class WC_Shop_Customizer {
 			);
 		}
 
-		include_once( WC_ABSPATH . 'includes/customizer/class-wc-customizer-control-cropping.php' );
+		include_once WC_ABSPATH . 'includes/customizer/class-wc-customizer-control-cropping.php';
 
 		$wp_customize->add_setting(
 			'woocommerce_thumbnail_cropping',
 			array(
-				'default'              => '1:1',
-				'type'                 => 'option',
-				'capability'           => 'manage_woocommerce',
-				'sanitize_callback'    => 'wc_clean',
+				'default'           => '1: 1',
+				'type'              => 'option',
+				'capability'        => 'manage_woocommerce',
+				'sanitize_callback' => 'wc_clean',
 			)
 		);
 
@@ -550,15 +552,15 @@ class WC_Shop_Customizer {
 					),
 					'label'    => __( 'Thumbnail cropping', 'woocommerce' ),
 					'choices'  => array(
-						'1:1'             => array(
+						'1:1'       => array(
 							'label'       => __( '1:1', 'woocommerce' ),
 							'description' => __( 'Images will be cropped into a square', 'woocommerce' ),
 						),
-						'custom'          => array(
+						'custom'    => array(
 							'label'       => __( 'Custom', 'woocommerce' ),
 							'description' => __( 'Images will be cropped to a custom aspect ratio', 'woocommerce' ),
 						),
-						'uncropped'       => array(
+						'uncropped' => array(
 							'label'       => __( 'Uncropped', 'woocommerce' ),
 							'description' => __( 'Images will display using the aspect ratio in which they were uploaded', 'woocommerce' ),
 						),

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2019,7 +2019,7 @@ function wc_decimal_to_fraction( $decimal ) {
 	}
 
 	if ( 0 === $decimal ) {
-		return [ 0, 0 ];
+		return array( 0, 1 );
 	}
 
 	$tolerance   = 1.e-4;

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2004,3 +2004,42 @@ function wc_cleanup_session_data() {
 	}
 }
 add_action( 'woocommerce_cleanup_sessions', 'wc_cleanup_session_data' );
+
+/**
+ * Convert a decimal (e.g. 3.5) to a fraction (e.g. 7/2).
+ * From: https://www.designedbyaturtle.co.uk/2015/converting-a-decimal-to-a-fraction-in-php/
+ *
+ * @param float $decimal the decimal number.
+ * @return array|bool a 1/2 would be [1, 2] array (this can be imploded with '/' to form a string).
+ */
+function wc_decimal_to_fraction( $decimal ) {
+	if ( 0 > $decimal || ! is_numeric( $decimal ) ) {
+		// Negative digits need to be passed in as positive numbers and prefixed as negative once the response is imploded.
+		return false;
+	}
+
+	if ( 0 === $decimal ) {
+		return [ 0, 0 ];
+	}
+
+	$tolerance   = 1.e-4;
+	$numerator   = 1;
+	$h2          = 0;
+	$denominator = 0;
+	$k2          = 1;
+	$b           = 1 / $decimal;
+
+	do {
+		$b           = 1 / $b;
+		$a           = floor( $b );
+		$aux         = $numerator;
+		$numerator   = $a * $numerator + $h2;
+		$h2          = $aux;
+		$aux         = $denominator;
+		$denominator = $a * $denominator + $k2;
+		$k2          = $aux;
+		$b           = $b - $a;
+	} while ( abs( $decimal - $numerator / $denominator ) > $decimal * $tolerance );
+
+	return array( $numerator, $denominator );
+}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1465,15 +1465,38 @@ function wc_update_330_image_options() {
 	$old_single_size    = get_option( 'shop_single_image_size', array() );
 
 	if ( ! empty( $old_thumbnail_size['width'] ) ) {
-		update_option( 'woocommerce_thumbnail_image_width', absint( $old_thumbnail_size['width'] ) );
+		$width     = absint( $old_thumbnail_size['width'] );
+		$height    = absint( $old_thumbnail_size['height'] );
+		$hard_crop = ! empty( $old_thumbnail_size['crop'] );
+
+		if ( ! $width ) {
+			$width = 300;
+		}
+
+		if ( ! $height ) {
+			$height = $width;
+		}
+
+		update_option( 'woocommerce_thumbnail_image_width', $width );
+
+		// Calculate cropping mode from old image options.
+		if ( ! $hard_crop ) {
+			update_option( 'woocommerce_thumbnail_cropping', 'uncropped' );
+		} elseif ( $width === $height ) {
+			update_option( 'woocommerce_thumbnail_cropping', '1:1' );
+		} else {
+			$ratio    = $width / $height;
+			$fraction = wc_decimal_to_fraction( $ratio );
+
+			if ( $fraction ) {
+				update_option( 'woocommerce_thumbnail_cropping', 'custom' );
+				update_option( 'woocommerce_thumbnail_cropping_custom_width', $fraction[0] );
+				update_option( 'woocommerce_thumbnail_cropping_custom_height', $fraction[1] );
+			}
+		}
 	}
 
-	if ( ! empty( $old_thumbnail_size['crop'] ) ) {
-		update_option( 'woocommerce_thumbnail_cropping', '1:1' );
-	} elseif ( isset( $old_thumbnail_size['crop'] ) ) {
-		update_option( 'woocommerce_thumbnail_cropping', 'uncropped' );
-	}
-
+	// Single is uncropped.
 	if ( ! empty( $old_single_size['width'] ) ) {
 		update_option( 'woocommerce_single_image_width', absint( $old_single_size['width'] ) );
 	}


### PR DESCRIPTION
Addresses the issues in #18586 

- WooCommerce Customizer panels visible at all times
- Clicking WC Customizer panel will redirect to shop page.
- Upgrading will calculate thumbnail aspect ratio from old settings rather than forcing 1:1 cropping mode.