### PR TITLE
Serve WC core copy of the WC logo instead of WC.com copy

### DIFF
--- a/includes/admin/helper/views/html-oauth-start.php
+++ b/includes/admin/helper/views/html-oauth-start.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit();
 
 		<div class="start-container">
 			<div class="text">
-				<img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png" alt="WooCommerce" style="width:180px;">
+				<img src="<?php echo esc_url( WC()->plugin_url() . '/assets/images/woocommerce_logo.png' ); ?>" alt="WooCommerce" style="width:180px;">
 
 				<?php if ( ! empty( $_GET['wc-helper-status'] ) && 'helper-disconnected' === $_GET['wc-helper-status'] ) : ?>
 					<p><?php esc_html_e( '<strong>Sorry to see you go</strong>. Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>

--- a/includes/admin/helper/views/html-oauth-start.php
+++ b/includes/admin/helper/views/html-oauth-start.php
@@ -1,21 +1,30 @@
-<?php defined( 'ABSPATH' ) or exit(); ?>
+<?php
+/**
+ * Admin -> WooCommerce -> Extensions -> WooCommerce.com Subscriptions main page.
+ *
+ * @package WooCommerce\Views
+ */
+
+defined( 'ABSPATH' ) || exit();
+
+?>
 
 <div class="wrap woocommerce wc_addons_wrap wc-helper">
-	<?php include( WC_Helper::get_view_filename( 'html-section-nav.php' ) ); ?>
-	<h1 class="screen-reader-text"><?php _e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>
-	<?php include( WC_Helper::get_view_filename( 'html-section-notices.php' ) ); ?>
+	<?php require WC_Helper::get_view_filename( 'html-section-nav.php' ); ?>
+	<h1 class="screen-reader-text"><?php esc_html_e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>
+	<?php require WC_Helper::get_view_filename( 'html-section-notices.php' ); ?>
 
 		<div class="start-container">
 			<div class="text">
 				<img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png" alt="WooCommerce" style="width:180px;">
 
 				<?php if ( ! empty( $_GET['wc-helper-status'] ) && 'helper-disconnected' === $_GET['wc-helper-status'] ) : ?>
-					<p><?php _e( '<strong>Sorry to see you go</strong>. Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>
+					<p><?php esc_html_e( '<strong>Sorry to see you go</strong>. Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>
 				<?php endif; ?>
 
-				<h2><?php _e( 'Manage your subscriptions, get important product notifications, and updates, all from the convenience of your WooCommerce dashboard', 'woocommerce' ); ?></h2>
-				<p><?php _e( 'Once connected, your WooCommerce.com purchases will be listed here.', 'woocommerce' ); ?></p>
-				<p><a class="button button-primary" href="<?php echo esc_url( $connect_url ); ?>"><?php _e( 'Connect', 'woocommerce' ); ?></a></p>
+				<h2><?php esc_html_e( 'Manage your subscriptions, get important product notifications, and updates, all from the convenience of your WooCommerce dashboard', 'woocommerce' ); ?></h2>
+				<p><?php esc_html_e( 'Once connected, your WooCommerce.com purchases will be listed here.', 'woocommerce' ); ?></p>
+				<p><a class="button button-primary" href="<?php echo esc_url( $connect_url ); ?>"><?php esc_html_e( 'Connect', 'woocommerce' ); ?></a></p>
 			</div>
 		</div>
 </div>


### PR DESCRIPTION
This PR changes the URL of the WC logo displayed in the WooCommerce.com Subscriptions page inside WooCommerce admin to use an image served from WC core instead of WC.com.

PHPCS fixes to all the violations in the modified file include in a separate commit.

cc @kovshenin as you worked on the first version of the WooCommerce.com Subscriptions page