### PR TITLE
Add missing action for settings pages that override save method

### DIFF
--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -373,6 +373,10 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 				}
 			}
 		}
+
+		if ( $current_section ) {
+			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+		}
 	}
 }
 

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -214,6 +214,10 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 			}
 		}
+
+		if ( $current_section ) {
+			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+		}
 	}
 
 	/**

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -214,10 +214,6 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 			}
 		}
-
-		if ( $current_section ) {
-			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
-		}
 	}
 
 	/**

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -94,6 +94,10 @@ class WC_Settings_Products extends WC_Settings_Page {
 
 		$settings = $this->get_settings( $current_section );
 		WC_Admin_Settings::save_fields( $settings );
+
+		if ( $current_section ) {
+			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+		}
 	}
 
 	/**

--- a/includes/admin/settings/class-wc-settings-rest-api.php
+++ b/includes/admin/settings/class-wc-settings-rest-api.php
@@ -146,6 +146,10 @@ class WC_Settings_Rest_API extends WC_Settings_Page {
 		if ( apply_filters( 'woocommerce_rest_api_valid_to_save', ! in_array( $current_section, array( 'keys', 'webhooks' ), true ) ) ) {
 			$settings = $this->get_settings();
 			WC_Admin_Settings::save_fields( $settings );
+
+			if ( $current_section ) {
+				do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+			}
 		}
 	}
 }

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -186,6 +186,10 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			break;
 		}
 
+		if ( $current_section ) {
+			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+		}
+
 		// Increments the transient version to invalidate cache.
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -118,6 +118,10 @@ class WC_Settings_Tax extends WC_Settings_Page {
 			$this->save_tax_rates();
 		}
 
+		if ( $current_section ) {
+			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
+		}
+
 		// Invalidate caches.
 		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );


### PR DESCRIPTION
The main settings page class has a save method which executes the action woocommerce_update_options_*_* when a current section is present.

However most of the individual settings page clasess override the save method with their own and do not contain this action.

This PR adds the action to all the overrides.

Closes #18608 