### PR TITLE
Coupon usage check against customer not logged in user in admin

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -574,7 +574,11 @@ class WC_Discounts {
 	 */
 	protected function validate_coupon_user_usage_limit( $coupon, $user_id = 0 ) {
 		if ( empty( $user_id ) ) {
-			$user_id = get_current_user_id();
+			if ( $this->object instanceof WC_Order ) {
+				$user_id = $this->object->get_customer_id();
+			} else {
+				$user_id = get_current_user_id();
+			}
 		}
 
 		if ( $coupon && $user_id && $coupon->get_usage_limit_per_user() > 0 && $coupon->get_id() && $coupon->get_data_store() ) {


### PR DESCRIPTION
When validating coupons applied via the admin area on orders the usage limit should be checked based on the customer of the order and not the logged in user.

Closes #18614 