### PR TITLE
Fix: properly set orderby and order when calling WC_Customer_Download_Data_Store::get_downloads()

### DIFF
--- a/includes/data-stores/class-wc-customer-download-data-store.php
+++ b/includes/data-stores/class-wc-customer-download-data-store.php
@@ -223,7 +223,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 			'product_id'  => '',
 			'download_id' => '',
 			'orderby'     => 'permission_id',
-			'order'       => 'DESC',
+			'order'       => 'ASC',
 			'limit'       => -1,
 			'return'      => 'objects',
 		) );
@@ -252,9 +252,9 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 		}
 
 		$allowed_orders = array( 'permission_id', 'download_id', 'product_id', 'order_id', 'order_key', 'user_email', 'user_id', 'downloads_remaining', 'access_granted', 'access_expires', 'download_count' );
-		$order          = in_array( $args['order'], $allowed_orders ) ? $args['order'] : 'permission_id';
-		$orderby        = 'DESC' === strtoupper( $args['orderby'] ) ? 'DESC' : 'ASC';
-		$orderby_sql    = sanitize_sql_orderby( "{$order} {$orderby}" );
+		$orderby        = in_array( $args['orderby'], $allowed_orders, true ) ? $args['orderby'] : 'permission_id';
+		$order          = 'DESC' === strtoupper( $args['order'] ) ? 'DESC' : 'ASC';
+		$orderby_sql    = sanitize_sql_orderby( "{$orderby} {$order}" );
 		$query[]        = "ORDER BY {$orderby_sql}";
 
 		if ( 0 < $args['limit'] ) {

--- a/tests/unit-tests/customer/customer-download.php
+++ b/tests/unit-tests/customer/customer-download.php
@@ -50,17 +50,19 @@ class WC_Tests_Customer_Download extends WC_Unit_Test_Case {
 		$download_1->set_user_id( $customer_id );
 		$download_1->set_user_email( 'test@example.com' );
 		$download_1->set_order_id( 1 );
+		$download_1->set_access_granted( '2018-01-08' );
 		$download_1->save();
 
 		$download_2 = new WC_Customer_Download;
 		$download_2->set_user_id( $customer_id );
 		$download_2->set_user_email( 'test@example.com' );
-		$download_2->set_order_id( 1 );
+		$download_2->set_order_id( 2 );
+		$download_2->set_access_granted( '2018-01-08' );
 		$download_2->save();
 
 		$data_store = WC_Data_Store::load( 'customer-download' );
-		$downloads = $data_store->get_downloads( array( 'user_email' => 'test@example.com' ) );
-		$this->assertEquals( 2, count( $downloads ) );
+		$downloads = $data_store->get_downloads( array( 'user_email' => 'test@example.com', 'orderby' => 'order_id', 'order' => 'DESC' ) );
+		$this->assertEquals( array( $download_2, $download_1 ), $downloads );
 		$downloads = $data_store->get_downloads( array( 'user_email' => 'test2@example.com' ) );
 		$this->assertEquals( array(), $downloads );
 


### PR DESCRIPTION
This commit fixes a bug in WC_Customer_Download_Data_Store::get_downloads() that made impossible to change the order in which the query returned the results. This method accepts the arguments `order_by` and `order`, but it was ignoring them and always using the default values ('permission_id' and 'ASC' respectively).

One of the assertions of the WC_Customer_Download_Data_Store::get_downloads() test method was modified to make sure the code now works.

This bug was introduced by commit a443419.