### PR TITLE
Display zero value when using shipping classes

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -342,7 +342,7 @@ function wc_cart_totals_fee_html( $fee ) {
 function wc_cart_totals_shipping_method_label( $method ) {
 	$label = $method->get_label();
 
-	if ( $method->cost >= 0 && $method->get_method_id() != 'free_shipping' ) {
+	if ( $method->cost >= 0 && $method->get_method_id() !== 'free_shipping' ) {
 		if ( WC()->cart->display_prices_including_tax() ) {
 			$label .= ': ' . wc_price( $method->cost + $method->get_shipping_tax() );
 			if ( $method->get_shipping_tax() > 0 && ! wc_prices_include_tax() ) {

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -342,7 +342,7 @@ function wc_cart_totals_fee_html( $fee ) {
 function wc_cart_totals_shipping_method_label( $method ) {
 	$label = $method->get_label();
 
-	if ( $method->cost >= 0 $method->get_method_id() != 'free_shipping' ) {
+	if ( $method->cost >= 0 && $method->get_method_id() != 'free_shipping' ) {
 		if ( WC()->cart->display_prices_including_tax() ) {
 			$label .= ': ' . wc_price( $method->cost + $method->get_shipping_tax() );
 			if ( $method->get_shipping_tax() > 0 && ! wc_prices_include_tax() ) {

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -342,7 +342,7 @@ function wc_cart_totals_fee_html( $fee ) {
 function wc_cart_totals_shipping_method_label( $method ) {
 	$label = $method->get_label();
 
-	if ( $method->cost > 0 ) {
+	if ( $method->cost >= 0 ) {
 		if ( WC()->cart->display_prices_including_tax() ) {
 			$label .= ': ' . wc_price( $method->cost + $method->get_shipping_tax() );
 			if ( $method->get_shipping_tax() > 0 && ! wc_prices_include_tax() ) {

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -342,7 +342,7 @@ function wc_cart_totals_fee_html( $fee ) {
 function wc_cart_totals_shipping_method_label( $method ) {
 	$label = $method->get_label();
 
-	if ( $method->cost >= 0 ) {
+	if ( $method->cost >= 0 $method->get_method_id() != 'free_shipping' ) {
 		if ( WC()->cart->display_prices_including_tax() ) {
 			$label .= ': ' . wc_price( $method->cost + $method->get_shipping_tax() );
 			if ( $method->get_shipping_tax() > 0 && ! wc_prices_include_tax() ) {


### PR DESCRIPTION
When offering free shipping on certain products via a shipping class, the price (albeit zero value) isn't shown to the end user.
![2018-01-27_1320](https://user-images.githubusercontent.com/11464425/35472360-9dd2ee94-0365-11e8-8ca9-3aad6cbb770b.png)


It makes for a better user experience to actually show the 0.00 price to ensure there isn't any doubt and stop any abandoned carts or useless customer interaction
![2018-01-27_1321](https://user-images.githubusercontent.com/11464425/35472363-a185414a-0365-11e8-91b5-8392e433f754.png)
