### PR TITLE
Return amount refunded as a float

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -283,7 +283,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * Get amount already refunded.
 	 *
 	 * @param  WC_Order $order Order object.
-	 * @return string
+	 * @return float
 	 */
 	public function get_total_refunded( $order ) {
 		global $wpdb;
@@ -299,7 +299,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			)
 		);
 
-		return $total;
+		return floatval( $total );
 	}
 
 	/**


### PR DESCRIPTION
An amount refunded should be numeric, I was receiving pHP notices that a non numeric value was encountered. Seems this is something potentially new as of PHP 7.1? Is there any reason we should **not** return a float here? Any null or empty response from the SQL query would be 0, which would still be accurate for the total that was refunded for that order.

```2018/01/27 16:50:50 [error] 46797#0: *2930 FastCGI sent in stderr: "PHP message: PHP Warning:  A non-numeric value encountered in /wp-content/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php on line 212
PHP message: PHP Stack trace:
PHP message: PHP   1. include() /cms/wp-admin/post.php:174
PHP message: PHP   2. do_meta_boxes() /cms/wp-admin/edit-form-advanced.php:714
PHP message: PHP   3. WC_Meta_Box_Order_Items::output() /cms/wp-admin/includes/template.php:1063
PHP message: PHP   4. include() /wp-content/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php:41
```