### PR TITLE
Exclude CODE_OF_CONDUCT.md and package-lock.json from the release .zip files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,11 @@
 /.* export-ignore
 apigen* export-ignore
+CODE_OF_CONDUCT.md export-ignore
 CHANGELOG.txt export-ignore
 composer.* export-ignore
 Gruntfile.js export-ignore
 package.json export-ignore
+package-lock.json export-ignore
 phpcs.xml export-ignore
 phpunit.* export-ignore
 README.md export-ignore


### PR DESCRIPTION
cc @mikejolley as you added the CODE_OF_CONDUCT.md to make sure I'm right to assume we don't want to include it in the release .zip files.