### PR TITLE
Backwards compatibility handling in session handler

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -125,6 +125,11 @@ class WC_Session_Handler extends WC_Session {
 	 * @return bool
 	 */
 	public function has_session() {
+		// Initialize session handler if it hasn't been intialized yet.
+		if ( ! $this->_session_expiration ) {
+			$this->init();
+		}
+
 		return isset( $_COOKIE[ $this->_cookie ] ) || $this->_has_cookie || is_user_logged_in(); // @codingStandardsIgnoreLine.
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/18561#issuecomment-361109276

@jconroy I still haven't been able to reproduce the cart issue, but this should preserve [the old behavior for the Stripe gateway](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/payment-methods/class-wc-stripe-payment-request.php#L146) and anywhere else that hasn't updated to use the new `init` method of `WC_Session_Handler`.