### PR TITLE
Meaning of word 'Shipping'

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -286,7 +286,7 @@ class WC_Meta_Box_Order_Data {
 					</div>
 					<div class="order_data_column">
 						<h3>
-							<?php esc_html_e( 'Billing', 'woocommerce' ); ?>
+							<?php esc_html_e( 'Billing Info', 'woocommerce' ); ?>
 							<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 							<span>
 								<a href="#" class="load_customer_billing" style="display:none;"><?php esc_html_e( 'Load billing address', 'woocommerce' ); ?></a>
@@ -382,7 +382,7 @@ class WC_Meta_Box_Order_Data {
 					<div class="order_data_column">
 
 						<h3>
-							<?php esc_html_e( 'Shipping', 'woocommerce' ); ?>
+							<?php esc_html_e( 'Shipping Address', 'woocommerce' ); ?>
 							<a href="#" class="edit_address"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 							<span>
 								<a href="#" class="load_customer_shipping" style="display:none;"><?php esc_html_e( 'Load shipping address', 'woocommerce' ); ?></a>


### PR DESCRIPTION
The word "Shipping" is used for 'Shipping charge' and 'Shipping address' and 'Shipping method'.
These three notations are different in some languages(Japanese), and it is confused at present.
Please add the word for this meaning.
I added letters to 'Billing' in consideration of balance.