### PR TITLE
Cast multiselect keys as strings

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -378,9 +378,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 											<?php
 
 											if ( is_array( $option_value ) ) {
-												selected( in_array( (string)$key, $option_value, true ), true );
+												selected( in_array( (string) $key, $option_value, true ), true );
 											} else {
-												selected( $option_value, (string)$key );
+												selected( $option_value, (string) $key );
 											}
 
 										?>

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -378,9 +378,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 											<?php
 
 											if ( is_array( $option_value ) ) {
-												selected( in_array( $key, $option_value, true ), true );
+												selected( in_array( (string)$key, $option_value, true ), true );
 											} else {
-												selected( $option_value, $key );
+												selected( $option_value, (string)$key );
 											}
 
 										?>


### PR DESCRIPTION
Since html does not cate for data types passing integers through will result in it being used as strings. This PR just typecast values as strings when doing the selected calls to ensure that an int matches its string equivalent.

Closes #18645 