### PR TITLE
Increase precision from 4 to 6

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -204,7 +204,7 @@ final class WooCommerce {
 		$this->define( 'WC_PLUGIN_BASENAME', plugin_basename( WC_PLUGIN_FILE ) );
 		$this->define( 'WC_VERSION', $this->version );
 		$this->define( 'WOOCOMMERCE_VERSION', $this->version );
-		$this->define( 'WC_ROUNDING_PRECISION', 4 );
+		$this->define( 'WC_ROUNDING_PRECISION', 6 );
 		$this->define( 'WC_DISCOUNT_ROUNDING_MODE', 2 );
 		$this->define( 'WC_TAX_ROUNDING_MODE', 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1 );
 		$this->define( 'WC_DELIMITER', '|' );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -978,7 +978,7 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
 		$tax_rates  = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$taxes      = WC_Tax::calc_tax( $price * $qty, $tax_rates, true );
-		$price      = WC_Tax::round( $price * $qty - array_sum( $taxes ) );
+		$price      = WC_Tax::round( $price * $qty - wc_round_tax_total( array_sum( $taxes ) ) );
 	} else {
 		$price = $price * $qty;
 	}

--- a/tests/unit-tests/core/main-class.php
+++ b/tests/unit-tests/core/main-class.php
@@ -42,7 +42,7 @@ class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 		$this->assertEquals( str_replace( 'tests/unit-tests/core/', '', plugin_dir_path( __FILE__ ) ) . 'woocommerce.php', WC_PLUGIN_FILE );
 		$this->assertEquals( $this->wc->version, WC_VERSION );
 		$this->assertEquals( WC_VERSION, WOOCOMMERCE_VERSION );
-		$this->assertEquals( 4, WC_ROUNDING_PRECISION );
+		$this->assertEquals( 6, WC_ROUNDING_PRECISION );
 		$this->assertEquals( 2, WC_DISCOUNT_ROUNDING_MODE );
 		$this->assertEquals( 'wc_session_id', WC_SESSION_CACHE_GROUP );
 		$this->assertContains( WC_TAX_ROUNDING_MODE, array( 2, 1, 'auto' ) );

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -423,7 +423,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	 * Test the rounding method.
 	 */
 	public function test_round() {
-		$this->assertEquals( WC_Tax::round( '2.1234567' ), '2.1235' );
+		$this->assertEquals( WC_Tax::round( '2.123456789' ), '2.123457' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #18653 

To fix long floats with scientific notation, https://github.com/woocommerce/woocommerce/pull/17602/files started returning them to precision. This causes a slight loss in precision when moving things from cart to orders for storage.

Increasing the precision from 4 to 6 will reduce the likelihood of a rounding error due to this. This fixes issue #18653 without breaking calculation tests.

Did revise tests which checked the value of the constant.