### PR TITLE
Min columns must be 1, not 0

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -323,7 +323,9 @@ function wc_get_default_products_per_row() {
 		$columns = apply_filters( 'loop_shop_columns', $columns );
 	}
 
-	return absint( $columns );
+	$columns = absint( $columns );
+
+	return max( 1, $columns );
 }
 
 /**


### PR DESCRIPTION
Ref: https://wordpress.org/support/topic/errors-after-updating-to-woocommerce-3-3/