### PR TITLE
Webhooks API error checking

### DIFF
--- a/includes/api/class-wc-rest-webhooks-controller.php
+++ b/includes/api/class-wc-rest-webhooks-controller.php
@@ -4,8 +4,6 @@
  *
  * Handles requests to the /webhooks endpoint.
  *
- * @author   WooThemes
- * @category API
  * @package  WooCommerce/API
  * @since    2.6.0
  */

--- a/includes/api/class-wc-rest-webhooks-controller.php
+++ b/includes/api/class-wc-rest-webhooks-controller.php
@@ -38,6 +38,11 @@ class WC_REST_Webhooks_Controller extends WC_REST_Webhooks_V1_Controller {
 	 */
 	public function prepare_item_for_response( $id, $request ) {
 		$webhook = wc_get_webhook( $id );
+
+		if ( empty( $webhook ) || is_null( $webhook ) ) {
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
 		$data    = array(
 			'id'                => $webhook->get_id(),
 			'name'              => $webhook->get_name(),

--- a/includes/api/v1/class-wc-rest-webhooks-controller.php
+++ b/includes/api/v1/class-wc-rest-webhooks-controller.php
@@ -362,7 +362,7 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 		$id      = (int) $request['id'];
 		$webhook = wc_get_webhook( $id );
 
-		if ( empty( $id ) || is_null( $webhook->get_id() ) ) {
+		if ( empty( $webhook ) || is_null( $webhook ) ) {
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
@@ -521,12 +521,17 @@ class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare a single webhook output for response.
 	 *
-	 * @param int               $id       Webhook ID.
+	 * @param int               $id       Webhook ID or object.
 	 * @param WP_REST_Request   $request  Request object.
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $id, $request ) {
-		$webhook = wc_get_webhook( (int) $id );
+		$webhook = wc_get_webhook( $id );
+
+		if ( empty( $webhook ) || is_null( $webhook ) ) {
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_invalid_id", __( 'ID is invalid.', 'woocommerce' ), array( 'status' => 400 ) );
+		}
+
 		$data    = array(
 			'id'            => $webhook->get_id(),
 			'name'          => $webhook->get_name(),

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -117,11 +117,11 @@ function wc_load_webhooks() {
 /**
  * Get webhook.
  *
- * @param  int $id Webhook ID.
+ * @param  int|WC_Webhook $id Webhook ID or object.
  * @return WC_Webhook|null
  */
 function wc_get_webhook( $id ) {
-	$webhook = new WC_Webhook( (int) $id );
+	$webhook = new WC_Webhook( $id );
 
 	return 0 !== $webhook->get_id() ? $webhook : null;
 }

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -2,8 +2,6 @@
 /**
  * WooCommerce Webhook functions
  *
- * @author   Automattic
- * @category Core
  * @package  WooCommerce/Functions
  * @version  3.3.0
  */


### PR DESCRIPTION
Ensures a webhook is not null before using it’s properties.

Also passes through ID without typecasting because it should support a WC_Webhook object.

Closes #18692