### PR TITLE
Fix product image on-the-fly generation

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -69,7 +69,7 @@ class WC_Regenerate_Images {
 		$size_settings = wc_get_image_size( $size );
 
 		// If size differs from image meta, regen.
-		if ( isset( $imagemeta['sizes'], $imagemeta['sizes'][ $size ] ) && ( $imagemeta['sizes'][ $size ]['width'] !== $size_settings['width'] || $imagemeta['sizes'][ $size ]['height'] !== $size_settings['height'] ) ) {
+		if ( ! isset( $imagemeta['sizes'], $imagemeta['sizes'][ $size ] ) || $imagemeta['sizes'][ $size ]['width'] !== $size_settings['width'] || $imagemeta['sizes'][ $size ]['height'] !== $size_settings['height'] ) {
 			$image = self::resize_and_return_image( $attachment_id, $image, $size, $icon );
 		}
 


### PR DESCRIPTION
maybe_resize_image was regenerating an image if the dimensions differed, but not if the image size didn’t exist at all.

This should fix #18690