### PR TITLE
Add fallback for themes that just get the pagination template

### DIFF
--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -10,15 +10,19 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     3.3.0
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.3.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+$total   = isset( $total ) ? $total : wc_get_loop_prop( 'total_pages' );
+$current = isset( $current ) ? $current : wc_get_loop_prop( 'current_page' );
+$base    = isset( $base ) ? $base : esc_url_raw( str_replace( 999999999, '%#%', remove_query_arg( 'add-to-cart', get_pagenum_link( 999999999, false ) ) ) );
+$format  = isset( $format ) ? $format : '';
 
 if ( $total <= 1 ) {
 	return;
@@ -26,7 +30,7 @@ if ( $total <= 1 ) {
 ?>
 <nav class="woocommerce-pagination">
 	<?php
-		echo paginate_links( apply_filters( 'woocommerce_pagination_args', array(
+		echo paginate_links( apply_filters( 'woocommerce_pagination_args', array( // WPCS: XSS ok.
 			'base'         => $base,
 			'format'       => $format,
 			'add_args'     => false,


### PR DESCRIPTION
Currently themes that just get the pagination.php template encounter a bunch of undefined variable errors. This adds some fall-back logic for those themes to prevent that from happening. Variable logic is the same as `woocommerce_pagination`.

To test: Try out this PR with the Reykjavik theme and verify pagination works well.