### PR TITLE
Theme compat updates

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -264,6 +264,11 @@ class WC_Post_types {
 			$has_archive = false;
 		}
 
+		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
+		if ( update_option( 'current_theme_supports_woocommerce', current_theme_supports( 'woocommerce' ) ? 1 : 0 ) ) {
+			add_option( 'woocommerce_queue_flush_rewrite_rules', 'true' );
+		}
+
 		register_post_type( 'product',
 			apply_filters( 'woocommerce_register_post_type_product',
 				array(

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -566,7 +566,11 @@ class WC_Shortcode_Products {
 			$original_post = $GLOBALS['post'];
 
 			do_action( "woocommerce_shortcode_before_{$this->type}_loop", $this->attributes );
-			do_action( 'woocommerce_before_shop_loop' );
+
+			// Fire standard shop loop hooks when paginating results so we can show result counts and so on.
+			if ( wc_string_to_bool( $this->attributes['paginate'] ) ) {
+				do_action( 'woocommerce_before_shop_loop' );
+			}
 
 			woocommerce_product_loop_start();
 
@@ -589,7 +593,11 @@ class WC_Shortcode_Products {
 			$GLOBALS['post'] = $original_post; // WPCS: override ok.
 			woocommerce_product_loop_end();
 
-			do_action( 'woocommerce_after_shop_loop' );
+			// Fire standard shop loop hooks when paginating results so we can show result counts and so on.
+			if ( wc_string_to_bool( $this->attributes['paginate'] ) ) {
+				do_action( 'woocommerce_after_shop_loop' );
+			}
+
 			do_action( "woocommerce_shortcode_after_{$this->type}_loop", $this->attributes );
 
 			wp_reset_postdata();

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -165,11 +165,6 @@ function wc_setup_loop( $args = array() ) {
 		'current_page' => 1,
 	);
 
-	// Merge any existing values.
-	if ( isset( $GLOBALS['woocommerce_loop'] ) ) {
-		$default_args = array_merge( $default_args, $GLOBALS['woocommerce_loop'] );
-	}
-
 	// If this is a main WC query, use global args as defaults.
 	if ( $GLOBALS['wp_query']->get( 'wc_query' ) ) {
 		$default_args = array_merge( $default_args, array(
@@ -180,6 +175,11 @@ function wc_setup_loop( $args = array() ) {
 			'per_page'     => $GLOBALS['wp_query']->get( 'posts_per_page' ),
 			'current_page' => max( 1, $GLOBALS['wp_query']->get( 'paged', 1 ) ),
 		) );
+	}
+
+	// Merge any existing values.
+	if ( isset( $GLOBALS['woocommerce_loop'] ) ) {
+		$default_args = array_merge( $default_args, $GLOBALS['woocommerce_loop'] );
 	}
 
 	$GLOBALS['woocommerce_loop'] = wp_parse_args( $args, $default_args );


### PR DESCRIPTION
- Fixes issues when showing only subcats (total was not set to 0)
- Adds compatibility for themes/plugins that enable woocommerce compatibility but don’t trigger a permalink save.
- Triggers before/after loop actions in shortcodes only when pagination is on.