### PR TITLE
Allow Ctrl+Click

### DIFF
--- a/assets/js/admin/wc-orders.js
+++ b/assets/js/admin/wc-orders.js
@@ -28,7 +28,7 @@ jQuery( function( $ ) {
 		if ( href.length ) {
 			e.preventDefault();
 
-			if ( e.metaKey ) {
+			if ( e.metaKey || e.ctrlKey ) {
 				window.open( href, '_blank' );
 			} else {
 				window.location = href;


### PR DESCRIPTION
Restores ctrl+click opens new background tab behavior in Firefox, Chrome and Opera for Windows.