### PR TITLE
Dont show row settings if something is managing products per page

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -404,16 +404,19 @@ class WC_Shop_Customizer {
 			)
 		);
 
-		$wp_customize->add_setting(
-			'woocommerce_catalog_rows',
-			array(
-				'default'              => 4,
-				'type'                 => 'option',
-				'capability'           => 'manage_woocommerce',
-				'sanitize_callback'    => 'absint',
-				'sanitize_js_callback' => 'absint',
-			)
-		);
+		// Only add this setting if something else isn't managing the number of products per page.
+		if ( ! has_filter( 'loop_shop_per_page' ) ) {
+			$wp_customize->add_setting(
+				'woocommerce_catalog_rows',
+				array(
+					'default'              => 4,
+					'type'                 => 'option',
+					'capability'           => 'manage_woocommerce',
+					'sanitize_callback'    => 'absint',
+					'sanitize_js_callback' => 'absint',
+				)
+			);
+		}
 
 		$wp_customize->add_control(
 			'woocommerce_catalog_rows',


### PR DESCRIPTION
This setting doesn't do anything when the theme is managing the number of products per page, so don't show it.

To test: Activate Flatsome theme then go to the WC settings and observe setting is missing. In the Customizer, go to the Shop > Category Page > Products per Page setting and use that. Observe that one works.