### PR TITLE
Disable autocomplete for refund amount and reason

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -265,14 +265,14 @@ if ( wc_tax_enabled() ) {
 		<tr>
 			<td class="label"><label for="refund_amount"><?php _e( 'Refund amount', 'woocommerce' ); ?>:</label></td>
 			<td class="total">
-				<input type="text" class="text" id="refund_amount" name="refund_amount" class="wc_input_price" />
+				<input type="text" class="text" id="refund_amount" name="refund_amount" class="wc_input_price" autocomplete="off" />
 				<div class="clear"></div>
 			</td>
 		</tr>
 		<tr>
 			<td class="label"><label for="refund_reason"><?php _e( 'Reason for refund (optional)', 'woocommerce' ); ?>:</label></td>
 			<td class="total">
-				<input type="text" class="text" id="refund_reason" name="refund_reason" />
+				<input type="text" class="text" id="refund_reason" name="refund_reason" autocomplete="off" />
 				<div class="clear"></div>
 			</td>
 		</tr>


### PR DESCRIPTION
Usually refund amounts and reasons are unique to an order. Enabling autocomplete raises the risk of another order's data being entered especially due to the limited width of the refund reason text box.