### PR TITLE
Updated wrapper-end.php default fallback to close containers correctly

### DIFF
--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -48,6 +48,6 @@ switch ( $template ) {
 		echo '</main></div>';
 		break;
 	default :
-		echo '</div></main>';
+		echo '</main></div>';
 		break;
 }


### PR DESCRIPTION
Default fallback needed to be reversed. Opening containers are div > main