### PR TITLE
Add product ID to row actions

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -64,6 +64,17 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	}
 
 	/**
+	 * Get row actions to show in the list table.
+	 *
+	 * @param array   $actions Array of actions.
+	 * @param WP_Post $post Current post object.
+	 * @return array
+	 */
+	protected function get_row_actions( $actions, $post ) {
+			return array_merge( array( 'id' => 'ID: ' . $post->ID ), $actions );
+	}
+
+	/**
 	 * Define which columns are sortable.
 	 *
 	 * @param array $columns Existing columns.


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce/issues/18736

Example: http://cld.wthms.co/1v0KZF

Functionality used to exist here, I think it was just forgotten when things were abstracted a bit: https://github.com/woocommerce/woocommerce/blob/7bb5dffc2fa793f74537625f2ae2bfe06045e74a/includes/admin/class-wc-admin-post-types.php#L773-L775