### PR TITLE
Category/tag descriptions for unsupported themes

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -258,11 +258,17 @@ class WC_Template_Loader {
 
 		if ( is_product_category() ) {
 			$shortcode_args['category'] = sanitize_title( $queried_object->slug );
+			
+			// Add category description above products loop.
+			add_action( 'woocommerce_before_shop_loop', 'woocommerce_taxonomy_archive_description', 15 );
 		} elseif ( taxonomy_is_product_attribute( $queried_object->taxonomy ) ) {
 			$shortcode_args['attribute'] = sanitize_title( $queried_object->taxonomy );
 			$shortcode_args['terms']     = sanitize_title( $queried_object->slug );
 		} elseif ( is_product_tag() ) {
 			$shortcode_args['tag'] = sanitize_title( $queried_object->slug );
+
+			// Add tag description above products loop.
+			add_action( 'woocommerce_before_shop_loop', 'woocommerce_taxonomy_archive_description', 15 );
 		} else {
 			// Default theme archive for all other taxonomies.
 			return;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/18733

The output is similar to how the shop page is handled for an unsupported theme. The only difference is the description is output inside of the `woocommerce` div rather than right above. The appearance is the same though w/ the themes I tested.

I originally tried to take the same approach as the shop page, with something like this:

```
if ( is_product_category() ) {
  [...]
  $description = woocommerce_taxonomy_archive_description();
}

[...]

$dummy_post_properties = array(
  'post_content'  => $description . $shortcode->get_content()
);
```

But unfortunately `woocommerce_taxonomy_archive_description` echo's the content rather than return it. Making a similar method in the `WC_Template_Loader` though just for this (or use the code in this function) could be worth perhaps?

Related section: https://github.com/woocommerce/woocommerce/blob/9eeac2f93a1a38f556f99f75ab7d0ab65126ef9e/includes/class-wc-template-loader.php#L244-L299