### PR TITLE
Fix shop on homepage with unsupported themes

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -370,7 +370,11 @@ class WC_Template_Loader {
 	 * @return string
 	 */
 	public static function unsupported_theme_title_filter( $title, $id ) {
-		if ( ! self::$theme_support && is_page( self::$shop_page_id ) && $id === self::$shop_page_id ) {
+		if ( self::$theme_support || ! $id !== self::$shop_page_id ) {
+			return $title;
+		}
+
+		if ( is_page( self::$shop_page_id ) || ( is_home() && 'page' === get_option( 'show_on_front' ) && absint( get_option( 'page_on_front' ) ) === self::$shop_page_id ) ) {
 			$args         = self::get_current_shop_view_args();
 			$title_suffix = array();
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -179,7 +179,7 @@ class WC_Shortcode_Products {
 		);
 
 		if ( wc_string_to_bool( $this->attributes['paginate'] ) ) {
-			$this->attributes['page'] = get_query_var( 'product-page', 1 );
+			$this->attributes['page'] = absint( empty( $_GET['product-page'] ) ? 1 : $_GET['product-page'] ); // WPCS: input var ok, CSRF ok.
 		}
 
 		if ( ! empty( $this->attributes['rows'] ) ) {

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -84,7 +84,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		$this->widget_start( $args, $instance );
 
 		if ( '' === get_option( 'permalink_structure' ) ) {
-			$form_action = remove_query_arg( array( 'page', 'paged' ), add_query_arg( $wp->query_string, '', home_url( $wp->request ) ) );
+			$form_action = remove_query_arg( array( 'page', 'paged', 'product-page' ), add_query_arg( $wp->query_string, '', home_url( $wp->request ) ) );
 		} else {
 			$form_action = preg_replace( '%\/page/[0-9]+%', '', home_url( trailingslashit( $wp->request ) ) );
 		}

--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -28,5 +28,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endforeach; ?>
 	</select>
 	<input type="hidden" name="paged" value="1" />
-	<?php wc_query_string_form_fields( null, array( 'orderby', 'submit', 'paged' ) ); ?>
+	<?php wc_query_string_form_fields( null, array( 'orderby', 'submit', 'paged', 'product-page' ) ); ?>
 </form>

--- a/tests/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/unit-tests/util/class-wc-tests-wc-query.php
@@ -43,8 +43,7 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 		// Test the default options are present.
 		WC()->query->init_query_vars();
 		$default_vars = WC()->query->get_query_vars();
-		$expected = array(
-			'product-page'               => '',
+		$expected     = array(
 			'order-pay'                  => 'order-pay',
 			'order-received'             => 'order-received',
 			'orders'                     => 'orders',


### PR DESCRIPTION
To test, use an unsupported WC theme, set the homepage to ‘shop’ and try pagination/orderby before and after the patch.