### PR TITLE
Product exists check when removing from cart

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -509,6 +509,8 @@ class WC_Form_Handler {
 			if ( $cart_item = WC()->cart->get_cart_item( $cart_item_key ) ) {
 				WC()->cart->remove_cart_item( $cart_item_key );
 
+				$product = wc_get_product( $cart_item['product_id'] );
+
 				$item_removed_title = apply_filters( 'woocommerce_cart_item_removed_title', $product ? sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), $product->get_name() ) : __( 'Item', 'woocommerce' ), $cart_item );
 
 				// Don't show undo link if removed item is out of stock.

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -509,12 +509,10 @@ class WC_Form_Handler {
 			if ( $cart_item = WC()->cart->get_cart_item( $cart_item_key ) ) {
 				WC()->cart->remove_cart_item( $cart_item_key );
 
-				$product = wc_get_product( $cart_item['product_id'] );
-
 				$item_removed_title = apply_filters( 'woocommerce_cart_item_removed_title', $product ? sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), $product->get_name() ) : __( 'Item', 'woocommerce' ), $cart_item );
 
 				// Don't show undo link if removed item is out of stock.
-				if ( $product->is_in_stock() && $product->has_enough_stock( $cart_item['quantity'] ) ) {
+				if ( $product && $product->is_in_stock() && $product->has_enough_stock( $cart_item['quantity'] ) ) {
 					$removed_notice  = sprintf( __( '%s removed.', 'woocommerce' ), $item_removed_title );
 					$removed_notice .= ' <a href="' . esc_url( wc_get_cart_undo_url( $cart_item_key ) ) . '" class="restore-item">' . __( 'Undo?', 'woocommerce' ) . '</a>';
 				} else {


### PR DESCRIPTION
This adds a check to ensure the product is not false before calling the product methods when removing from cart.

Closes #18768