### PR TITLE
Add “key" for list items in react

### DIFF
--- a/assets/js/gutenberg/products-block.js
+++ b/assets/js/gutenberg/products-block.js
@@ -257,7 +257,7 @@ var ProductCategoryList = withAPIData(function (props) {
 			filteredCategories.map(function (category) {
 				return wp.element.createElement(
 					"li",
-					null,
+					{ key: category.id },
 					wp.element.createElement(
 						"label",
 						{ htmlFor: 'product-category-' + category.id },
@@ -538,7 +538,7 @@ var ProductsBlockPreview = withAPIData(function (_ref4) {
 		"div",
 		{ className: classes },
 		products.data.map(function (product) {
-			return wp.element.createElement(ProductPreview, { product: product, attributes: attributes });
+			return wp.element.createElement(ProductPreview, { key: product.id, product: product, attributes: attributes });
 		})
 	);
 });

--- a/assets/js/gutenberg/products-block.jsx
+++ b/assets/js/gutenberg/products-block.jsx
@@ -116,7 +116,7 @@ const ProductCategoryList = withAPIData( ( props ) => {
 			return ( filteredCategories.length > 0 ) && (
 				<ul>
 					{ filteredCategories.map( ( category ) => (
-						<li>
+						<li key={ category.id }>
 							<label htmlFor={ 'product-category-' + category.id }>
 								<input type="checkbox"
 								       id={ 'product-category-' + category.id }
@@ -294,7 +294,7 @@ const ProductsBlockPreview = withAPIData( ( { attributes } ) => {
 	return (
 		<div className={ classes }>
 			{ products.data.map( ( product ) => (
-				<ProductPreview product={ product } attributes={ attributes } />
+				<ProductPreview key={ product.id } product={ product } attributes={ attributes } />
 			) ) }
 		</div>
 	);


### PR DESCRIPTION
Fix two of the `Warning: Each child in an array or iterator should have a unique "key" prop.` warnings.

There is one more, but I cant seem to track it down. It's happening somewhere in `edit`, and I'm suspecting it has to do with the `withAPIData` component somehow, but that's just a guess.