### PR TITLE
Don't call WC_Install::install() on downgrades 

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -139,7 +139,7 @@ class WC_Install {
 	 * This check is done on all requests and runs if the versions do not match.
 	 */
 	public static function check_version() {
-		if ( ! defined( 'IFRAME_REQUEST' ) && get_option( 'woocommerce_version' ) !== WC()->version ) {
+		if ( ! defined( 'IFRAME_REQUEST' ) && version_compare( get_option( 'woocommerce_version' ), WC()->version, '<' ) ) {
 			self::install();
 			do_action( 'woocommerce_updated' );
 		}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -2,8 +2,6 @@
 /**
  * Installation related functions and actions.
  *
- * @author   WooThemes
- * @category Admin
  * @package  WooCommerce/Classes
  * @version  3.0.0
  */

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -11,13 +11,11 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 	 */
 	public function test_check_version() {
 		update_option( 'woocommerce_version', ( (float) WC()->version - 1 ) );
-		update_option( 'woocommerce_db_version', WC()->version );
 		WC_Install::check_version();
 
 		$this->assertTrue( did_action( 'woocommerce_updated' ) === 1 );
 
 		update_option( 'woocommerce_version', WC()->version );
-		update_option( 'woocommerce_db_version', WC()->version );
 		WC_Install::check_version();
 
 		$this->assertTrue( did_action( 'woocommerce_updated' ) === 1 );

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -19,6 +19,14 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 		WC_Install::check_version();
 
 		$this->assertTrue( did_action( 'woocommerce_updated' ) === 1 );
+
+		update_option( 'woocommerce_version', (float) WC()->version + 1 );
+		WC_Install::check_version();
+
+		$this->assertTrue(
+			did_action( 'woocommerce_updated' ) === 1,
+			'WC_Install::check_version() should not call install routine when the WC version stored in the database is bigger than the version in the code as downgrades are not supported.'
+		);
 	}
 
 	/**

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -33,12 +33,12 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 			define( 'WC_REMOVE_ALL_DATA', true );
 		}
 
-		include( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php' );
+		include dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php';
 		delete_transient( 'wc_installing' );
 
 		WC_Install::install();
 
-		$this->assertEquals( WC()->version, get_option( 'woocommerce_version' ), print_r( array( 'Stored version' => get_option( 'woocommerce_version' ), 'WC Version' => WC()->version ), true ) );
+		$this->assertEquals( WC()->version, get_option( 'woocommerce_version' ) );
 	}
 
 	/**
@@ -87,7 +87,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 			define( 'WP_UNINSTALL_PLUGIN', true );
 			define( 'WC_REMOVE_ALL_DATA', true );
 		}
-		include( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php' );
+		include dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/uninstall.php';
 
 		WC_Install::create_roles();
 


### PR DESCRIPTION
WC doesn't support downgrades, but the if condition that decides whether or not to call WC_Install::install() and apply database schema changes was checking if the WC version stored in the database is equal to the WC version in the code. This commit changes the check performed inside the if condition to verify if the WC version stored in the database is smaller than the version in the code.

This way `dbDelta()` won't be called automatically by WC when the version in the database is bigger than the version in the code reverting DB schema changes. This is particularly important for clustered providers where the version of the WC code running in one of the containers could be outdated and trigger a database downgrade.

I have tested and `version_compare()` works well with WC release candidates.

This PR includes phpcs fixes in the modified files.
