### PR TITLE
PII Issue Prevention - Remove user login from reset password link.

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -46,10 +46,10 @@ class WC_Form_Handler {
 		if ( is_account_page() && isset( $_GET['key'] ) && ( isset( $_GET['id'] ) || isset( $_GET['login'] ) ) ) {
 
 			// If available, get $user_login from query string parameter for fallback purposes.
-			if( isset( $_GET['login'] ) ) {
+			if ( isset( $_GET['login'] ) ) {
 				$user_login = $_GET['login'];
 			} else {
-				$user = get_user_by( 'id', $_GET['id'] );
+				$user = get_user_by( 'id', absint( $_GET['id'] ) );
 				$user_login = $user ? $user->user_login : '';
 			}
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -43,8 +43,9 @@ class WC_Form_Handler {
 	 * Remove key and login from query string, set cookie, and redirect to account page to show the form.
 	 */
 	public static function redirect_reset_password_link() {
-		if ( is_account_page() && ! empty( $_GET['key'] ) && ! empty( $_GET['login'] ) ) {
-			$value = sprintf( '%s:%s', wp_unslash( $_GET['login'] ), wp_unslash( $_GET['key'] ) );
+		if ( is_account_page() && ! empty( $_GET['key'] ) && ! empty( $_GET['id'] ) ) {
+			$user_login = get_user_by('id', $_GET['id'])->user_login;
+			$value = sprintf( '%s:%s', wp_unslash( $user_login ), wp_unslash( $_GET['key'] ) );
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );
 
 			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', wc_lostpassword_url() ) );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -43,10 +43,15 @@ class WC_Form_Handler {
 	 * Remove key and user ID (or user login, as a fallback) from query string, set cookie, and redirect to account page to show the form.
 	 */
 	public static function redirect_reset_password_link() {
-		if ( is_account_page() && isset( $_GET['key'] ) && (isset( $_GET['id'] ) || isset( $_GET['login'] ) ) ) {
+		if ( is_account_page() && isset( $_GET['key'] ) && ( isset( $_GET['id'] ) || isset( $_GET['login'] ) ) ) {
 
 			// If available, get $user_login from query string parameter for fallback purposes.
-			$user_login = isset($_GET['login']) ? $_GET['login'] : get_user_by('id', $_GET['id'])->user_login;
+			if( isset( $_GET['login'] ) ) {
+				$user_login = $_GET['login'];
+			} else {
+				$user = get_user_by( 'id', $_GET['id'] );
+				$user_login = $user ? $user->user_login : '';
+			}
 
 			$value = sprintf( '%s:%s', wp_unslash( $user_login ), wp_unslash( $_GET['key'] ) );
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -40,14 +40,16 @@ class WC_Form_Handler {
 	}
 
 	/**
-	 * Remove key and login from query string, set cookie, and redirect to account page to show the form.
+	 * Remove key and user ID (or user login, as a fallback) from query string, set cookie, and redirect to account page to show the form.
 	 */
 	public static function redirect_reset_password_link() {
-		if ( is_account_page() && ! empty( $_GET['key'] ) && ! empty( $_GET['id'] ) ) {
-			$user_login = get_user_by('id', $_GET['id'])->user_login;
+		if ( is_account_page() && isset( $_GET['key'] ) && (isset( $_GET['id'] ) || isset( $_GET['login'] ) ) ) {
+
+			// If available, get $user_login from query string parameter for fallback purposes.
+			$user_login = isset($_GET['login']) ? $_GET['login'] : get_user_by('id', $_GET['id'])->user_login;
+
 			$value = sprintf( '%s:%s', wp_unslash( $user_login ), wp_unslash( $_GET['key'] ) );
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );
-
 			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', wc_lostpassword_url() ) );
 			exit;
 		}

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -20,6 +20,13 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 class WC_Email_Customer_Reset_Password extends WC_Email {
 
 	/**
+	 * User ID.
+	 *
+	 * @var integer
+	 */
+	public $user_id;
+
+	/**
 	 * User login name.
 	 *
 	 * @var string
@@ -92,6 +99,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 
 		if ( $user_login && $reset_key ) {
 			$this->object     = get_user_by( 'login', $user_login );
+			$this->user_id 	  = $this->object->ID;
 			$this->user_login = $user_login;
 			$this->reset_key  = $reset_key;
 			$this->user_email = stripslashes( $this->object->user_email );
@@ -114,6 +122,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	public function get_content_html() {
 		return wc_get_template_html( $this->template_html, array(
 			'email_heading' => $this->get_heading(),
+			'user_id' 		=> $this->user_id,
 			'user_login'    => $this->user_login,
 			'reset_key'     => $this->reset_key,
 			'blogname'      => $this->get_blogname(),
@@ -132,6 +141,7 @@ class WC_Email_Customer_Reset_Password extends WC_Email {
 	public function get_content_plain() {
 		return wc_get_template_html( $this->template_plain, array(
 			'email_heading' => $this->get_heading(),
+			'user_id' 		=> $this->user_id,
 			'user_login'    => $this->user_login,
 			'reset_key'     => $this->reset_key,
 			'blogname'      => $this->get_blogname(),

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p><?php _e( 'If this was a mistake, just ignore this email and nothing will happen.', 'woocommerce' ); ?></p>
 <p><?php _e( 'To reset your password, visit the following address:', 'woocommerce' ); ?></p>
 <p>
-	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'login' => rawurlencode( $user_login ) ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>">
+	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>">
 			<?php _e( 'Click here to reset your password', 'woocommerce' ); ?></a>
 </p>
 <p></p>

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -28,7 +28,7 @@ echo sprintf( __( 'Username: %s', 'woocommerce' ), $user_login ) . "\r\n\r\n";
 echo __( 'If this was a mistake, just ignore this email and nothing will happen.', 'woocommerce' ) . "\r\n\r\n";
 echo __( 'To reset your password, visit the following address:', 'woocommerce' ) . "\r\n\r\n";
 
-echo esc_url( add_query_arg( array( 'key' => $reset_key, 'login' => $user_login ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\r\n";
+echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\r\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
To best protect a user's personal information online, we should avoid passing a user login via query string in the reset password link that's included in the triggered email. This value is often similar to the user's actual name, which can potentially be collected by a third party (for example, Google Analytics), and used to identify the user. In fact, if Google ever receives this information, the website will be penalized until the issue is resolved.

https://support.google.com/adwords/answer/6389382?hl=en

To fix this, I've opted to pass the user's ID instead. This value is unique to the WordPress installation itself, and it is much harder to identify a user with this value outside the respective WordPress application. 

See further information here: https://support.google.com/adwords/answer/6389382?hl=en

"The PII in the URL can usually be replaced with a unique site-specific identifier or a unique user ID (UUID)."

Thanks!