### PR TITLE
Remove all WC tables when uninstalling the plugin

### DIFF
--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -110,4 +110,19 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 		$this->assertNull( get_role( 'customer' ) );
 		$this->assertNull( get_role( 'shop_manager' ) );
 	}
+
+	/**
+	 * Make sure the list of tables returned by WC_Install::get_tables() and used when uninstalling the plugin
+	 * or deleting a site in a multi site install is not missing any of the WC tables. If a table is added to
+	 * WC_Install:get_schema() but not to WC_Install::get_tables(), this test will fail.
+	 */
+	public function test_get_tables() {
+		global $wpdb;
+
+		$tables = $wpdb->get_col(
+			"SHOW TABLES WHERE `Tables_in_{$wpdb->dbname}` LIKE '{$wpdb->prefix}woocommerce\_%' OR `Tables_in_{$wpdb->dbname}` LIKE '{$wpdb->prefix}wc\_%'"
+		);
+
+		$this->assertEquals( $tables, WC_Install::get_tables() );
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -4,8 +4,6 @@
  *
  * Uninstalling WooCommerce deletes user roles, pages, tables, and options.
  *
- * @author      WooCommerce
- * @category    Core
  * @package     WooCommerce/Uninstaller
  * @version     2.3.0
  */
@@ -29,7 +27,7 @@ wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
  */
 if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Roles + caps.
-	include_once( dirname( __FILE__ ) . '/includes/class-wc-install.php' );
+	include_once dirname( __FILE__ ) . '/includes/class-wc-install.php';
 	WC_Install::remove_roles();
 
 	// Pages.
@@ -71,9 +69,9 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_items" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_order_itemmeta" );
 
-	// Delete terms if > WP 4.2 (term splitting was added in 4.2)
+	// Delete terms if > WP 4.2 (term splitting was added in 4.2).
 	if ( version_compare( $wp_version, '4.2', '>=' ) ) {
-		// Delete term taxonomies
+		// Delete term taxonomies.
 		foreach ( array( 'product_cat', 'product_tag', 'product_shipping_class', 'product_type' ) as $taxonomy ) {
 			$wpdb->delete(
 				$wpdb->term_taxonomy,
@@ -83,7 +81,7 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 			);
 		}
 
-		// Delete term attributes
+		// Delete term attributes.
 		foreach ( $wc_attributes as $taxonomy ) {
 			$wpdb->delete(
 				$wpdb->term_taxonomy,
@@ -93,18 +91,18 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 			);
 		}
 
-		// Delete orphan relationships
+		// Delete orphan relationships.
 		$wpdb->query( "DELETE tr FROM {$wpdb->term_relationships} tr LEFT JOIN {$wpdb->posts} posts ON posts.ID = tr.object_id WHERE posts.ID IS NULL;" );
 
-		// Delete orphan terms
+		// Delete orphan terms.
 		$wpdb->query( "DELETE t FROM {$wpdb->terms} t LEFT JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id WHERE tt.term_id IS NULL;" );
 
-		// Delete orphan term meta
+		// Delete orphan term meta.
 		if ( ! empty( $wpdb->termmeta ) ) {
 			$wpdb->query( "DELETE tm FROM {$wpdb->termmeta} tm LEFT JOIN {$wpdb->term_taxonomy} tt ON tm.term_id = tt.term_id WHERE tt.term_id IS NULL;" );
 		}
 	}
 
-	// Clear any cached data that has been removed
+	// Clear any cached data that has been removed.
 	wp_cache_flush();
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -47,18 +47,7 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	}
 
 	// Tables.
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_api_keys" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_attribute_taxonomies" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_downloadable_product_permissions" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_termmeta" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_tax_rates" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_tax_rate_locations" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_shipping_zone_methods" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_shipping_zone_locations" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_shipping_zones" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_sessions" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_payment_tokens" );
-	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_payment_tokenmeta" );
+	WC_Install::drop_tables();
 
 	// Delete options.
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'woocommerce\_%';" );


### PR DESCRIPTION
There were two outdated lists of WC tables. One used to drop tables when WC is uninstalled and another one to drop tables when a site is deleted in a multi site environment. This commit creates a new unified list of WC tables, adds the missing tables to this list and introduces a unit test that will fail if the list gets outdated.