### PR TITLE
Correct version number on form-checkout.php

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -13,7 +13,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     2.3.0
+ * @version     3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
I believe there was a typo here and that this template should now be @version 3.3.0