### PR TITLE
Admin product search fixes

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -460,6 +460,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			$data_store = WC_Data_Store::load( 'product' );
 			$ids        = $data_store->search_products( wc_clean( $query_vars['s'] ), '', true );
 			$query_vars['post__in'] = array_merge( $ids, array( 0 ) );
+			unset( $query_vars['s'] );
 		}
 
 		return $query_vars;

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -38,6 +38,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		add_filter( 'disable_months_dropdown', '__return_true' );
 		add_filter( 'query_vars', array( $this, 'add_custom_query_var' ) );
 		add_filter( 'views_edit-product', array( $this, 'product_views' ) );
+		add_filter( 'get_search_query', array( $this, 'search_label' ) );
 	}
 
 	/**
@@ -460,6 +461,8 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			$data_store = WC_Data_Store::load( 'product' );
 			$ids        = $data_store->search_products( wc_clean( $query_vars['s'] ), '', true );
 			$query_vars['post__in'] = array_merge( $ids, array( 0 ) );
+			// So we know we are searching products.
+			$query_vars['product_search'] = true;
 			unset( $query_vars['s'] );
 		}
 
@@ -499,5 +502,21 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 
 		return $views;
+	}
+
+	/**
+	 * Change the label when searching products
+	 *
+	 * @param string $query Search Query.
+	 * @return string
+	 */
+	public function search_label( $query ) {
+		global $pagenow, $typenow;
+
+		if ( 'edit.php' !== $pagenow || 'product' !== $typenow || ! get_query_var( 'product_search' ) || ! isset( $_GET['s'] ) ) { // WPCS: input var ok.
+			return $query;
+		}
+
+		return wc_clean( wp_unslash( $_GET['s'] ) ); // WPCS: input var ok, sanitization ok.
 	}
 }


### PR DESCRIPTION
This PR addresses #18757 by unsetting the search term when doing a search as we are using the product data store already to search.

Leaving the search term in place in the `s` query var will result in WordPress doing another search on products with less accurate results and which excludes meta data such as the sku field. IE double searching products.

Unfortunately doing this also removes the label here http://cld.wthms.co/7TIZap I am still working on a solution for this.
