### PR TITLE
Fix spike in update queries on the wp_options table

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -265,7 +265,7 @@ class WC_Post_types {
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		if ( update_option( 'current_theme_supports_woocommerce', current_theme_supports( 'woocommerce' ) ? 1 : 0 ) ) {
+		if ( update_option( 'current_theme_supports_woocommerce', current_theme_supports( 'woocommerce' ) ? 'yes' : 'no' ) ) {
 			add_option( 'woocommerce_queue_flush_rewrite_rules', 'true' );
 		}
 


### PR DESCRIPTION
Since WC 3.3.1, the following query is executed on every page load:

```
UPDATE `wp_options` SET `option_value` = '1' WHERE `option_name` = 'current_theme_supports_woocommerce'
```

This is happening because of the following call to `update_option()`:

https://github.com/woocommerce/woocommerce/blob/02cac7d63736fe504f86756241b41f7bc453469f/includes/class-wc-post-types.php#L268

`update_option()` shouldn't update the option when the value hasn't changed, but in this case it is updating on every request because, when the current theme supports WC, `1` (integer) is passed to `update_option()` and this function internally compares it against the old value stored in the database which is `"1"` (string). A strict comparison (`===`) is used (https://github.com/WordPress/WordPress/blob/f3eaddd2dcf51a31781a2d11088614c40ae10c3a/wp-includes/option.php#L343), so the function assumes that the value changed and proceeds with the update.

This PR fixes this problem by using the values `"yes"` and `"no"` instead of `1` and `0`.