### PR TITLE
Extra on-the-fly image regeneration checks

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -2,8 +2,6 @@
 /**
  * Debug/Status page
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin/System Status
  * @version     2.2.0
  */

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -179,6 +179,11 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				'button' => __( 'Reset', 'woocommerce' ),
 				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
 			),
+			'regenerate_thumbnails'      => array(
+				'name'   => __( 'Regenerate shop thumbnails', 'woocommerce' ),
+				'button' => __( 'Regenerate', 'woocommerce' ),
+				'desc'   => __( 'This will regenerate all shop thumbnails to match your theme and/or image setting.', 'woocommerce' ),
+			)
 		);
 
 		return apply_filters( 'woocommerce_debug_tools', $tools );
@@ -466,6 +471,11 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				delete_option( 'woocommerce_allow_tracking' );
 				WC_Admin_Notices::add_notice( 'tracking' );
 				$message = __( 'Usage tracking settings successfully reset.', 'woocommerce' );
+				break;
+
+			case 'regenerate_thumbnails':
+				WC_Regenerate_Images::queue_image_regeneration();
+				$message = __( 'Thumbnail regeneration is running in the background. Depending on the amount of images in your store this might take a while, please check the logs for when it is complete.', 'woocommerce' );
 				break;
 
 			default:

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -132,6 +132,16 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 					$new_metadata['sizes'][ $old_size ] = $old_metadata['sizes'][ $old_size ];
 				}
 			}
+			// Handle legacy sizes.
+			if ( isset( $new_metadata['sizes']['shop_thumbnail'], $new_metadata['sizes']['woocommerce_thumbnail'] ) ) {
+				$new_metadata['sizes']['shop_thumbnail'] = $new_metadata['sizes']['woocommerce_thumbnail'];
+			}
+			if ( isset( $new_metadata['sizes']['shop_catalog'], $new_metadata['sizes']['woocommerce_thumbnail'] ) ) {
+				$new_metadata['sizes']['shop_catalog'] = $new_metadata['sizes']['woocommerce_thumbnail'];
+			}
+			if ( isset( $new_metadata['sizes']['shop_single'], $new_metadata['sizes']['woocommerce_single'] ) ) {
+				$new_metadata['sizes']['shop_single'] = $new_metadata['sizes']['woocommerce_single'];
+			}
 		}
 
 		// Update the meta data with the new size values.

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -106,7 +106,8 @@ class WC_Regenerate_Images {
 
 		$original_image_file_path = get_attached_file( $attachment->ID );
 
-		if ( ! file_exists( $original_image_file_path ) || ! getimagesize( $original_image_file_path ) ) {
+		// Check if the file exists, if not just return the original image.
+		if ( false === $original_image_file_path || is_wp_error( $original_image_file_path ) || ! file_exists( $original_image_file_path ) ) {
 			return $image;
 		}
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -744,13 +744,13 @@ function wc_get_image_size( $image_size ) {
 		} elseif ( 'custom' === $cropping ) {
 			$width          = max( 1, get_option( 'woocommerce_thumbnail_cropping_custom_width', '4' ) );
 			$height         = max( 1, get_option( 'woocommerce_thumbnail_cropping_custom_height', '3' ) );
-			$size['height'] = round( ( $size['width'] / $width ) * $height );
+			$size['height'] = absint( round( ( $size['width'] / $width ) * $height ) );
 			$size['crop']   = 1;
 		} else {
 			$cropping_split = explode( ':', $cropping );
 			$width          = max( 1, current( $cropping_split ) );
 			$height         = max( 1, end( $cropping_split ) );
-			$size['height'] = round( ( $size['width'] / $width ) * $height );
+			$size['height'] = absint( round( ( $size['width'] / $width ) * $height ) );
 			$size['crop']   = 1;
 		}
 		$image_size = 'thumbnail';


### PR DESCRIPTION
The PR's add extra checks before proceeding to process images for on-the-fly generation. 

Still need to test this with a copy of the WP Offload S3 plugin.

Closes #18842