### PR TITLE
Avoid unnecessary query to wp_options on every request

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 			self::check_download_folder_protection();
 
 			// Clear any unwanted data and flush rules.
-			add_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 			WC()->query->init_query_vars();
 			WC()->query->add_endpoints();
 

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 			self::check_download_folder_protection();
 
 			// Clear any unwanted data and flush rules.
-			add_option( 'woocommerce_queue_flush_rewrite_rules', 'true' );
+			add_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 			WC()->query->init_query_vars();
 			WC()->query->add_endpoints();
 

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -266,7 +266,7 @@ class WC_Post_types {
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
 		if ( update_option( 'current_theme_supports_woocommerce', current_theme_supports( 'woocommerce' ) ? 1 : 0 ) ) {
-			add_option( 'woocommerce_queue_flush_rewrite_rules', 'true' );
+			add_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}
 
 		register_post_type( 'product',
@@ -511,7 +511,7 @@ class WC_Post_types {
 	 * @since 3.3.0
 	 */
 	public static function maybe_flush_rewrite_rules() {
-		if ( 'true' === get_option( 'woocommerce_queue_flush_rewrite_rules' ) ) {
+		if ( 'yes' === get_option( 'woocommerce_queue_flush_rewrite_rules' ) ) {
 			delete_option( 'woocommerce_queue_flush_rewrite_rules' );
 			self::flush_rewrite_rules();
 		}

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -266,7 +266,7 @@ class WC_Post_types {
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
 		if ( update_option( 'current_theme_supports_woocommerce', current_theme_supports( 'woocommerce' ) ? 1 : 0 ) ) {
-			add_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}
 
 		register_post_type( 'product',

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -512,7 +512,7 @@ class WC_Post_types {
 	 */
 	public static function maybe_flush_rewrite_rules() {
 		if ( 'yes' === get_option( 'woocommerce_queue_flush_rewrite_rules' ) ) {
-			delete_option( 'woocommerce_queue_flush_rewrite_rules' );
+			update_option( 'woocommerce_queue_flush_rewrite_rules', 'no' );
 			self::flush_rewrite_rules();
 		}
 	}


### PR DESCRIPTION
This PR changes the value of the option 'woocommerce_queue_flush_rewrite_rules' to 'no' instead of deleting it when rewrite rules are flushed. This way this option is autoloaded and the `get_option()` call below doesn't trigger a select query to the database on every request.

https://github.com/woocommerce/woocommerce/blob/61f037060b74ad9be8fb2d63e5ea3050fd95fb1e/includes/class-wc-post-types.php#L514

It also changes the value of the option 'woocommerce_queue_flush_rewrite_rules' to 'yes' or 'no' instead of 'true' or 'false' because the former seems to be the standard used by WC core and because the string 'false' can induce bugs as it is truthy.

The problem fixed here was introduced in WC 3.3.0, but it is not really a bug so I'm not sure if this PR should be merged included in 3.3.2 or 3.4.0 (cc @mikejolley).