### PR TITLE
fixes Price mismatch in JSON-LD data due to tax ref #18852

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -236,7 +236,7 @@ class WC_Structured_Data {
 			} else {
 				$markup_offer = array(
 					'@type' => 'Offer',
-					'price' => wc_format_decimal( $product->get_price(), wc_get_price_decimals() ),
+					'price' => wc_format_decimal( wc_get_price_to_display( $product ), wc_get_price_decimals() ),
 				);
 			}
 


### PR DESCRIPTION
Hi,
I have made some adjustment by adding wc_get_price_to_display( $product ) in class file and it worked for me please check for the same and let me know if any changes required.

Thanks.