### PR TITLE
Fix array to string conversion error

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -69,7 +69,7 @@ class WC_Meta_Box_Product_Images {
 				?>
 			</ul>
 
-			<input type="hidden" id="product_image_gallery" name="product_image_gallery" value="<?php echo esc_attr( $product_image_gallery ); ?>" />
+			<input type="hidden" id="product_image_gallery" name="product_image_gallery" value="<?php echo esc_attr( implode( ',', $updated_gallery_ids ) ) ?>" />
 
 		</div>
 		<p class="add_product_images hide-if-no-js">


### PR DESCRIPTION
```
PHP Notice:  Array to string conversion in /valet/sites/wccore/wp-includes/formatting.php on line 1045
PHP Stack trace:
PHP   1. {main}() /.composer/vendor/laravel/valet/server.php:0
PHP   2. require() /.composer/vendor/laravel/valet/server.php:133
PHP   3. include() /valet/sites/wccore/wp-admin/post.php:174
PHP   4. do_meta_boxes() /valet/sites/wccore/wp-admin/edit-form-advanced.php:707
PHP   5. WC_Meta_Box_Product_Images::output() /valet/sites/wccore/wp-admin/includes/template.php:1063
PHP   6. esc_attr() /valet/sites/wccore/wp-content/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-images.php:74
PHP   7. wp_check_invalid_utf8() /valet/sites/wccore/wp-includes/formatting.php:3977
```

`$product_image_gallery` is an array, following this commit: https://github.com/woocommerce/woocommerce/commit/f48985095bb0c7eba3b0d7bbf91e4edb000cd107#diff-47570ebdd9d13e1593c820e42f9983b5.