### PR TITLE
woocommerce_variation_is_active default to variation_is_visible

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -484,7 +484,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @return bool
 	 */
 	public function variation_is_active() {
-		return apply_filters( 'woocommerce_variation_is_active', true, $this );
+		return apply_filters( 'woocommerce_variation_is_active', $this->variation_is_visible(), $this );
 	}
 
 	/**


### PR DESCRIPTION
Closes #18864 

This will make attributes with no variations available non-selectable.

@franticpsyx Any thoughts on why we didn’t do this before?

@WPprodigy We should get feedback for this before merge.