### PR TITLE
Remove "Type" column on attributes table by default.

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -221,9 +221,7 @@ class WC_Admin_Attributes {
 							 * `product_attributes_type_selector` filter. If there is only the default type registered,
 							 * this setting will be hidden.
 							 */
-							$attribute_types = wc_get_attribute_types();
-
-							if ( 1 < count( $attribute_types ) || ! array_key_exists( 'select', $attribute_types ) ) {
+							if ( wc_has_custom_attribute_types() ) {
 								?>
 								<tr class="form-field form-required">
 									<th scope="row" valign="top">
@@ -294,6 +292,9 @@ class WC_Admin_Attributes {
 								<tr>
 									<th scope="col"><?php esc_html_e( 'Name', 'woocommerce' ); ?></th>
 									<th scope="col"><?php esc_html_e( 'Slug', 'woocommerce' ); ?></th>
+									<?php if ( wc_has_custom_attribute_types() ) : ?>
+										<th scope="col"><?php esc_html_e( 'Type', 'woocommerce' ); ?></th>
+									<?php endif; ?>
 									<th scope="col"><?php esc_html_e( 'Order by', 'woocommerce' ); ?></th>
 									<th scope="col"><?php esc_html_e( 'Terms', 'woocommerce' ); ?></th>
 								</tr>
@@ -309,6 +310,9 @@ class WC_Admin_Attributes {
 													<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ) ); ?>"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a></span></div>
 												</td>
 												<td><?php echo esc_html( $tax->attribute_name ); ?></td>
+												<?php if ( wc_has_custom_attribute_types() ) : ?>
+													<td><?php echo esc_html( wc_get_attribute_type_label( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? esc_html__( '(Public)', 'woocommerce' ) : ''; ?></td>
+												<?php endif; ?>
 												<td><?php
 												switch ( $tax->attribute_orderby ) {
 													case 'name' :
@@ -403,9 +407,7 @@ class WC_Admin_Attributes {
 								 * `product_attributes_type_selector` filter. If there is only the default type registered,
 								 * this setting will be hidden.
 								 */
-								$attribute_types = wc_get_attribute_types();
-
-								if ( 1 < count( $attribute_types ) || ! array_key_exists( 'select', $attribute_types ) ) {
+								if ( wc_has_custom_attribute_types() ) {
 									?>
 									<div class="form-field">
 										<label for="attribute_type"><?php esc_html_e( 'Type', 'woocommerce' ); ?></label>

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -294,7 +294,6 @@ class WC_Admin_Attributes {
 								<tr>
 									<th scope="col"><?php esc_html_e( 'Name', 'woocommerce' ); ?></th>
 									<th scope="col"><?php esc_html_e( 'Slug', 'woocommerce' ); ?></th>
-									<th scope="col"><?php esc_html_e( 'Type', 'woocommerce' ); ?></th>
 									<th scope="col"><?php esc_html_e( 'Order by', 'woocommerce' ); ?></th>
 									<th scope="col"><?php esc_html_e( 'Terms', 'woocommerce' ); ?></th>
 								</tr>
@@ -310,7 +309,6 @@ class WC_Admin_Attributes {
 													<div class="row-actions"><span class="edit"><a href="<?php echo esc_url( add_query_arg( 'edit', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ) ); ?>"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a> | </span><span class="delete"><a class="delete" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'delete', $tax->attribute_id, 'edit.php?post_type=product&amp;page=product_attributes' ), 'woocommerce-delete-attribute_' . $tax->attribute_id ) ); ?>"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a></span></div>
 												</td>
 												<td><?php echo esc_html( $tax->attribute_name ); ?></td>
-												<td><?php echo esc_html( wc_get_attribute_type_label( $tax->attribute_type ) ); ?> <?php echo $tax->attribute_public ? esc_html__( '(Public)', 'woocommerce' ) : ''; ?></td>
 												<td><?php
 												switch ( $tax->attribute_orderby ) {
 													case 'name' :

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -198,6 +198,18 @@ function wc_get_attribute_types() {
 }
 
 /**
+ * Check if there are custom attribute types.
+ *
+ * @since  3.3.2
+ * @return bool True if there are custom types, otherwise false.
+ */
+function wc_has_custom_attribute_types() {
+	$types = wc_get_attribute_types();
+
+	return 1 < count( $types ) || ! array_key_exists( 'select', $types );
+}
+
+/**
  * Get attribute type label.
  *
  * @since  3.0.0


### PR DESCRIPTION
This column isn't needed anymore:

![](http://cld.wthms.co/VdPNLs+)

I suppose archives/public is still valid, but don't think it really needs to be in the table.

_____

`wc_get_attribute_type_label()` could also be deprecated as far as I can tell.
