### PR TITLE
Tweak mobile view of order preview

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2271,14 +2271,6 @@ ul.wc_coupon_list_block {
 	}
 }
 
-@media screen and (max-width: 782px) {
-	.wc-action-button-group {
-		label {
-			display: none;
-		}
-	}
-}
-
 .wc-action-button-group {
 	vertical-align: middle;
 	line-height: 26px;
@@ -2319,6 +2311,33 @@ ul.wc_coupon_list_block {
 	.wc-action-button:last-child {
 		border-top-right-radius: 3px !important;
 		border-bottom-right-radius: 3px !important;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	.wc-order-preview .wc-action-button-group {
+		float: none;
+		margin: 0 0 10px;
+
+		label {
+			display: none;
+		}
+		.wc-action-button-group__items {
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
+		.wc-action-button {
+			flex: 1;
+			float: none;
+			text-align: center;
+			max-width: 50%;
+		}
+	}
+	.button-large {
+		width: 100%;
+		float: none;
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION
Closes #18900

![orders local wordpress dev wordpress 2018-02-09 14-43-13](https://user-images.githubusercontent.com/90977/36033137-0450a70a-0da8-11e8-8104-3be79bfdc6c0.png)

Gives more space to buttons so languages with longer strings don't wrap weirdly.