### PR TITLE
Use verbose page rules when shop is in the URL, including shop base with category

### DIFF
--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -204,7 +204,7 @@ class WC_Admin_Permalink_Settings {
 			$shop_page_id   = wc_get_page_id( 'shop' );
 			$shop_permalink = ( $shop_page_id > 0 && get_post( $shop_page_id ) ) ? get_page_uri( $shop_page_id ) : _x( 'shop', 'default-slug', 'woocommerce' );
 
-			if ( $shop_page_id && trim( $permalinks['product_base'], '/' ) === $shop_permalink ) {
+			if ( $shop_page_id && stristr( trim( $permalinks['product_base'], '/' ), $shop_permalink ) ) {
 				$permalinks['use_verbose_page_rules'] = true;
 			}
 

--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -99,7 +99,7 @@ function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 		} else {
 			$query_string = '';
 		}
-		$url = trailingslashit( $permalink ) . $endpoint . '/' . $value . $query_string;
+		$url = trailingslashit( $permalink ) . $endpoint . '/' . $value . '/' . $query_string;
 	} else {
 		$url = add_query_arg( $endpoint, $value, $permalink );
 	}


### PR DESCRIPTION
Fixes #18891 

To test:

- Set permalinks as shop page with category
- Give the checkout page a parent of 'shop'
- Place an order

Before the patch you’ll see 404

After the patch and re-saving permalinks you’ll see the correct result.