### PR TITLE
Set woocommerce_hide_invisible_variations to true.

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -272,8 +272,8 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price)
-			if ( apply_filters( 'woocommerce_hide_invisible_variations', false, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
+			// Filter 'woocommerce_hide_invisible_variations' to optionally hide invisible variations (disabled variations and variations with empty price).
+			if ( apply_filters( 'woocommerce_hide_invisible_variations', true, $this->get_id(), $variation ) && ! $variation->variation_is_visible() ) {
 				continue;
 			}
 


### PR DESCRIPTION
I found a change to `read_children` in the variable product data store which has changed which variations/attributes are shown on the frontend in 3.3.

See https://github.com/woocommerce/woocommerce/blob/3.2.4/includes/data-stores/class-wc-product-variable-data-store-cpt.php#L50-L81

Blame: https://github.com/woocommerce/woocommerce/commit/11d0293ddd1b7e5579c8f100d12792a96e4be394

Fixing: https://github.com/woocommerce/woocommerce/issues/17713

Because this read will now return all variations, even those disabled, it seems a good time to switch `woocommerce_hide_invisible_variations` on by default. This will hide variations with no price and variations that are not enabled from the call to `get_available_variations` and hide invalidate combos once again.

To test, edit a variable product in the dummy data e.g. V-Neck T-Shirt  and make one of the variations disabled. Note it's color/attribute.

Before the patch, that attribute will be visible.

After the patch and with 3.2, that attribute will be hidden.

Closes #18878
Fixes #18864