### PR TITLE
Set maxlength for order item meta key

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -882,7 +882,7 @@ jQuery( function ( $ ) {
 				var index  = $items.find('tr').length + 1;
 				var $row   = '<tr data-meta_id="0">' +
 					'<td>' +
-						'<input type="text" placeholder="' + woocommerce_admin_meta_boxes_order.placeholder_name + '" name="meta_key[' + $item.attr( 'data-order_item_id' ) + '][new-' + index + ']" />' +
+						'<input type="text" maxlength="255" placeholder="' + woocommerce_admin_meta_boxes_order.placeholder_name + '" name="meta_key[' + $item.attr( 'data-order_item_id' ) + '][new-' + index + ']" />' +
 						'<textarea placeholder="' + woocommerce_admin_meta_boxes_order.placeholder_value + '" name="meta_value[' + $item.attr( 'data-order_item_id' ) + '][new-' + index + ']"></textarea>' +
 					'</td>' +
 					'<td width="1%"><button class="remove_order_item_meta button">&times;</button></td>' +

--- a/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -44,7 +44,7 @@ $hidden_order_itemmeta = apply_filters( 'woocommerce_hidden_order_itemmeta', arr
 					?>
 					<tr data-meta_id="<?php echo esc_attr( $meta_id ); ?>">
 						<td>
-							<input type="text" placeholder="<?php esc_attr_e( 'Name (required)', 'woocommerce' ); ?>" name="meta_key[<?php echo esc_attr( $item_id ); ?>][<?php echo esc_attr( $meta_id ); ?>]" value="<?php echo esc_attr( $meta->key ); ?>" />
+							<input type="text" maxlength="255" placeholder="<?php esc_attr_e( 'Name (required)', 'woocommerce' ); ?>" name="meta_key[<?php echo esc_attr( $item_id ); ?>][<?php echo esc_attr( $meta_id ); ?>]" value="<?php echo esc_attr( $meta->key ); ?>" />
 							<textarea placeholder="<?php esc_attr_e( 'Value (required)', 'woocommerce' ); ?>" name="meta_value[<?php echo esc_attr( $item_id ); ?>][<?php echo esc_attr( $meta_id ); ?>]"><?php echo esc_textarea( rawurldecode( $meta->value ) ); ?></textarea>
 						</td>
 						<td width="1%"><button class="remove_order_item_meta button">&times;</button></td>

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -234,12 +234,8 @@ function wc_save_order_items( $order_id, $items ) {
 
 			if ( isset( $items['meta_key'][ $item_id ], $items['meta_value'][ $item_id ] ) ) {
 				foreach ( $items['meta_key'][ $item_id ] as $meta_id => $meta_key ) {
-					$meta_key   = wp_unslash( $meta_key );
+					$meta_key   = substr( wp_unslash( $meta_key ), 0, 255 );
 					$meta_value = isset( $items['meta_value'][ $item_id ][ $meta_id ] ) ? wp_unslash( $items['meta_value'][ $item_id ][ $meta_id ] ): '';
-
-					if ( strlen( $meta_key ) > 255 ) {
-						$meta_key = substr( $meta_key, 0, 255 );
-					}
 
 					if ( '' === $meta_key && '' === $meta_value ) {
 						if ( ! strstr( $meta_id, 'new-' ) ) {

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -237,6 +237,10 @@ function wc_save_order_items( $order_id, $items ) {
 					$meta_key   = wp_unslash( $meta_key );
 					$meta_value = isset( $items['meta_value'][ $item_id ][ $meta_id ] ) ? wp_unslash( $items['meta_value'][ $item_id ][ $meta_id ] ): '';
 
+					if ( strlen( $meta_key ) > 255 ) {
+						$meta_key = substr( $meta_key, 0, 255 );
+					}
+
 					if ( '' === $meta_key && '' === $meta_value ) {
 						if ( ! strstr( $meta_id, 'new-' ) ) {
 							$item->delete_meta_data_by_mid( $meta_id );


### PR DESCRIPTION
The meta_key field in the database is set to `varchar(255)`.

So if for some crazy reason somebody tries to add a massive amount of text as the meta key for an order item, it will just end up deleting itself after saving the order which isn't friendly UX.

Some more info here https://github.com/woocommerce/woocommerce-product-addons/issues/316

Question: It is useful to also prevent more than 255 chars from being saved? I know the html attribute doesn't truly prevent user input, so it's still technically possible. I assume SQL just says `no` and that's the end of it. But wondering if there is benefit to just stripping the string to 255 first before sending it?

https://github.com/woocommerce/woocommerce/blob/4b029f72528573dd8a1a07c1aaaa3997b998f02b/includes/admin/wc-admin-functions.php#L237