### PR TITLE
Feature: Add ability to import sample products

### DIFF
--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -60,13 +60,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</tr>
 				<tr class="woocommerce-importer-advanced hidden">
 					<th>
-						<label for="woocommerce-importer-file-url"><?php esc_html_e( '<em>or</em> enter the path to a CSV file on your server:', 'woocommerce' ); ?></label>
+						<label for="woocommerce-importer-file-url"><?php esc_html_e( 'Enter the path to a CSV file on your server:', 'woocommerce' ); ?></label>
 					</th>
 					<td>
 						<label for="woocommerce-importer-file-url" class="woocommerce-importer-file-url-field-wrapper">
 							<code><?php echo esc_html( ABSPATH ) . ' '; ?></code><input type="text" id="woocommerce-importer-file-url" name="file_url" />
 						</label>
 					</td>
+				</tr>
+				<tr class="woocommerce-importer-advanced hidden">
+					<th><label><?php esc_html_e( 'Import sample products', 'woocommerce' ); ?></label><br/></th>
+					<td><input type="checkbox" name="sample_products" value="1" /></td>
 				</tr>
 				<tr class="woocommerce-importer-advanced hidden">
 					<th><label><?php esc_html_e( 'CSV Delimiter', 'woocommerce' ); ?></label><br/></th>
@@ -87,6 +91,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 					jQuery( this ).text( jQuery( this ).data( 'showtext' ) );
 				}
 				return false;
+			} );
+			jQuery( 'input[name="file_url"]' ).on( 'keyup focusout', function() {
+				jQuery( 'input[name="import"]' ).prop( 'disabled', jQuery( this ).val().length !== 0 );
+			} );
+			jQuery( 'input[name="sample_products"]' ).on( 'click', function() {
+				jQuery( 'input[name="file_url"]' ).prop( 'disabled', jQuery( this ).is( ':checked' ) );
+
+				if ( jQuery( 'input[name="file_url"]' ).val().length === 0 ) {
+					jQuery( 'input[name="import"]' ).prop( 'disabled', jQuery( this ).is( ':checked' ) );
+				}
 			} );
 		});
 	</script>


### PR DESCRIPTION
Add the ability to import the sample products through the products importer. Video: http://cld.wthms.co/WDB0GJ

This uses the `sample_products.csv` file that ships with WC core, making it so the user doesn't have to download the plugin and go digging through the file system to use it.

#### 1) Could use some redesigning for the [first import screen](http://cld.wthms.co/AKcKB8).

There are now three settings that have the potential to override each other (upload file, enter path to file server, or use sample csv). I wrote some javascript that disabled some of the fields conditionally when a setting would be overriding it, but not too happy with this from a UX perspective.

#### 2) Could potentially skip the mapping screen when importing sample products.

This turned out to be a little more complex than I first thought, but certainly possible to do if ya'll think there is merit to the idea.

#### 3) Would be neat to make this option more noticeable for new stores / those without products.

I suppose this is apart of the first point above, but in the design it'd be neat if we put this option in front of the user if it's a new store for example.