### PR TITLE
If selecting text, don't link to order on row click.

### DIFF
--- a/assets/js/admin/wc-orders.js
+++ b/assets/js/admin/wc-orders.js
@@ -22,6 +22,10 @@ jQuery( function( $ ) {
 			return true;
 		}
 
+		if ( window.getSelection && window.getSelection().toString().length ) {
+			return true;
+		}
+
 		var $row = $( this ).closest( 'tr' ),
 			href = $row.find( 'a.order-view' ).attr( 'href' );
 


### PR DESCRIPTION
To test, add the shipping column back and try copying the address value to clipboard.