### PR TITLE
Shipping zone documentation help link was printing wrong

### DIFF
--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -60,7 +60,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<div class="wc-shipping-zone-postcodes">
 						<textarea name="zone_postcodes" data-attribute="zone_postcodes" id="zone_postcodes" placeholder="<?php esc_attr_e( 'List 1 postcode per line', 'woocommerce' ); ?>" class="input-text large-text" cols="25" rows="5"><?php echo esc_textarea( implode( "\n", $postcodes ) ); ?></textarea>
 						<?php /* translators: WooCommerce link to setting up shipping zones */ ?>
-						<span class="description"><?php sprintf( _e( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a>) for more information.', 'woocommerce' ), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/#section-3' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
+						<span class="description"><?php printf( __( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a>) for more information.', 'woocommerce' ), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/#section-3' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
 					</div>
 				</td>
 			<?php endif; ?>


### PR DESCRIPTION
Seems like a small unnoticed printing bug and was causing the link to be printed wrong/incomplete in **Shipping Zones** area.