### PR TITLE
Set status after order is created/updated.

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1423,7 +1423,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$fee_total += $item->get_total();
 		}
 
-		// Calculate taxes for items, shipping, discounts.
+		// Calculate taxes for items, shipping, discounts. Note; this also triggers save().
 		if ( $and_taxes ) {
 			$this->calculate_taxes();
 		}

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -433,6 +433,9 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 
 			if ( ! is_null( $value ) ) {
 				switch ( $key ) {
+					case 'status' :
+						// Status change should be done later so transitions have new data.
+						break;
 					case 'billing' :
 					case 'shipping' :
 						$this->update_address( $order, $value, $key );
@@ -514,24 +517,24 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 				$object->set_created_via( 'rest-api' );
 				$object->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 				$object->calculate_totals();
+			} else {
+				// If items have changed, recalculate order totals.
+				if ( isset( $request['billing'] ) || isset( $request['shipping'] ) || isset( $request['line_items'] ) || isset( $request['shipping_lines'] ) || isset( $request['fee_lines'] ) || isset( $request['coupon_lines'] ) ) {
+					$object->calculate_totals();
+				}
+			}
+
+			// Set status.
+			if ( ! empty( $request['status'] ) ) {
+				$object->set_status( $request['status'] );
 			}
 
 			$object->save();
 
 			// Actions for after the order is saved.
-			if ( $creating ) {
-				if ( true === $request['set_paid'] ) {
+			if ( true === $request['set_paid'] ) {
+				if ( $creating || $object->needs_payment() ) {
 					$object->payment_complete( $request['transaction_id'] );
-				}
-			} else {
-				// Handle set paid.
-				if ( $object->needs_payment() && true === $request['set_paid'] ) {
-					$object->payment_complete( $request['transaction_id'] );
-				}
-
-				// If items have changed, recalculate order totals.
-				if ( isset( $request['billing'] ) || isset( $request['shipping'] ) || isset( $request['line_items'] ) || isset( $request['shipping_lines'] ) || isset( $request['fee_lines'] ) || isset( $request['coupon_lines'] ) ) {
-					$object->calculate_totals();
 				}
 			}
 


### PR DESCRIPTION
When creating orders via API, some methods will save an order (calculate_taxes). This can occur before the grand total is set.

Also with the API, order status may be defined and updated before this occurs.

Combined, order total may be 0 when order emails are triggered on status transition events.

To fix; defer the status change until after totals are calculated.

Closes #18923