### PR TITLE
fix: show Maximum size with the size unit on the importer screen

### DIFF
--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								/* translators: %s: maximum upload size */
 								printf(
 									esc_html__( 'Maximum size: %s', 'woocommerce' ),
-									absint( $size )
+									$size
 								);
 								?>
 							</small>


### PR DESCRIPTION
fix: show Maximum size with the size unit on the importer screen