### PR TITLE
Gallery thumbnails handling

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -539,11 +539,13 @@ final class WooCommerce {
 	 * @since 2.3
 	 */
 	public function add_image_sizes() {
-		$thumbnail = wc_get_image_size( 'thumbnail' );
-		$single    = wc_get_image_size( 'single' );
+		$thumbnail         = wc_get_image_size( 'thumbnail' );
+		$single            = wc_get_image_size( 'single' );
+		$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
 
 		add_image_size( 'woocommerce_thumbnail', $thumbnail['width'], $thumbnail['height'], $thumbnail['crop'] );
 		add_image_size( 'woocommerce_single', $single['width'], $single['height'], $single['crop'] );
+		add_image_size( 'woocommerce_gallery_thumbnail', $gallery_thumbnail['width'], $gallery_thumbnail['height'], $gallery_thumbnail['crop'] );
 
 		// 2x thumbnail size for retina, and when showing less columns.
 		add_image_size( 'woocommerce_thumbnail_2x', $thumbnail['width'] * 2, '' !== $thumbnail['height'] ? $thumbnail['height'] * 2 : '', $thumbnail['crop'] );

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -156,7 +156,7 @@ class WC_Shop_Customizer {
 					setting.bind( function( value ) {
 						var min = parseInt( '<?php echo esc_js( $min_rows ); ?>', 10 );
 						var max = parseInt( '<?php echo esc_js( $max_rows ); ?>', 10 );
-						
+
 						value = parseInt( value, 10 );
 
 						if ( max && value > max ) {
@@ -496,7 +496,7 @@ class WC_Shop_Customizer {
 				'woocommerce_thumbnail_image_width',
 				array(
 					'label'       => __( 'Thumbnail width', 'woocommerce' ),
-					'description' => __( 'Image size used for products in the catalog and product gallery thumbnails.', 'woocommerce' ),
+					'description' => __( 'Image size used for products in the catalog.', 'woocommerce' ),
 					'section'     => 'woocommerce_product_images',
 					'settings'    => 'woocommerce_thumbnail_image_width',
 					'type'        => 'number',

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -722,6 +722,13 @@ function wc_get_image_size( $image_size ) {
 		'crop'   => 1,
 	);
 
+	// Size mapping.
+	if ( in_array( $image_size, array( 'shop_single', 'woocommerce_single' ), true ) ) {
+		$image_size = 'single';
+	} elseif ( in_array( $image_size, array( 'shop_thumbnail', 'shop_catalog', 'woocommerce_thumbnail' ), true ) ) {
+		$image_size = 'thumbnail';
+	}
+
 	if ( is_array( $image_size ) ) {
 		$size       = array(
 			'width'  => isset( $image_size[0] ) ? absint( $image_size[0] ) : 600,
@@ -729,12 +736,18 @@ function wc_get_image_size( $image_size ) {
 			'crop'   => isset( $image_size[2] ) ? absint( $image_size[2] ) : 1,
 		);
 		$image_size = $size['width'] . '_' . $size['height'];
-	} elseif ( in_array( $image_size, array( 'single', 'shop_single', 'woocommerce_single' ), true ) ) {
+
+	} elseif ( 'single' === $image_size ) {
 		$size['width']  = absint( wc_get_theme_support( 'single_image_width', get_option( 'woocommerce_single_image_width', 600 ) ) );
 		$size['height'] = '';
 		$size['crop']   = 0;
-		$image_size     = 'single';
-	} elseif ( in_array( $image_size, array( 'thumbnail', 'shop_thumbnail', 'shop_catalog', 'woocommerce_thumbnail' ), true ) ) {
+
+	} elseif ( 'gallery_thumbnail' === $image_size ) {
+		$size['width']  = absint( wc_get_theme_support( 'gallery_thumbnail_image_width', 100 ) );
+		$size['height'] = $size['width'];
+		$size['crop']   = 1;
+
+	} elseif ( 'thumbnail' === $image_size ) {
 		$size['width'] = absint( wc_get_theme_support( 'thumbnail_image_width', get_option( 'woocommerce_thumbnail_image_width', 300 ) ) );
 		$cropping      = get_option( 'woocommerce_thumbnail_cropping', '1:1' );
 
@@ -753,7 +766,6 @@ function wc_get_image_size( $image_size ) {
 			$size['height'] = round( ( $size['width'] / $width ) * $height );
 			$size['crop']   = 1;
 		}
-		$image_size = 'thumbnail';
 	}
 
 	return apply_filters( 'woocommerce_get_image_size_' . $image_size, $size );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1055,13 +1055,14 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  *
  * @since 3.3.2
  * @param int $attachment_id
+ * @param bool $main_image Is this the main image or a thumbnail?
  * @return string
  */
-function wc_get_gallery_image_html( $attachment_id ) {
+function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
 	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
 	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
-	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider ? 'woocommerce_single': $thumbnail_size );
+	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single': $thumbnail_size );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1050,6 +1050,33 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
 	}
 }
 
+/**
+ * Get HTML for a gallery image.
+ *
+ * @since 3.3.2
+ * @param int $attachment_id
+ * @return string
+ */
+function wc_get_gallery_image_html( $attachment_id ) {
+	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
+	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
+	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider ? 'woocommerce_single': $thumbnail_size );
+	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
+	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
+	$image             = wp_get_attachment_image( $attachment_id, $image_size, false, array(
+		'title'                   => get_post_field( 'post_title', $attachment_id ),
+		'data-caption'            => get_post_field( 'post_excerpt', $attachment_id ),
+		'data-src'                => $full_src[0],
+		'data-large_image'        => $full_src[0],
+		'data-large_image_width'  => $full_src[1],
+		'data-large_image_height' => $full_src[2],
+	) );
+
+	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+}
+
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {
 
 	/**

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -34,7 +34,7 @@ $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_cl
 		<?php
 		if ( has_post_thumbnail() ) {
 			// Note: `wc_get_gallery_image_html` was added in WC 3.3.2 and did not exist prior.
-			$html  = wc_get_gallery_image_html( $post_thumbnail_id );
+			$html  = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
 			$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src() ), esc_html__( 'Awaiting product image', 'woocommerce' ) );

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -13,22 +13,18 @@
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.1.0
+ * @version 3.3.2
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
-global $post, $product;
+global $product;
+
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
-$thumbnail_size    = apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' );
-$post_thumbnail_id = get_post_thumbnail_id( $post->ID );
-$full_size_image   = wp_get_attachment_image_src( $post_thumbnail_id, $thumbnail_size );
-$placeholder       = has_post_thumbnail() ? 'with-images' : 'without-images';
+$post_thumbnail_id = $product->get_image_id();
 $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_classes', array(
 	'woocommerce-product-gallery',
-	'woocommerce-product-gallery--' . $placeholder,
+	'woocommerce-product-gallery--' . ( has_post_thumbnail() ? 'with-images' : 'without-images' ),
 	'woocommerce-product-gallery--columns-' . absint( $columns ),
 	'images',
 ) );
@@ -36,26 +32,16 @@ $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_cl
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
-		$attributes = array(
-			'title'                   => get_post_field( 'post_title', $post_thumbnail_id ),
-			'data-caption'            => get_post_field( 'post_excerpt', $post_thumbnail_id ),
-			'data-src'                => $full_size_image[0],
-			'data-large_image'        => $full_size_image[0],
-			'data-large_image_width'  => $full_size_image[1],
-			'data-large_image_height' => $full_size_image[2],
-		);
-
 		if ( has_post_thumbnail() ) {
-			$html  = '<div data-thumb="' . get_the_post_thumbnail_url( $post->ID, 'woocommerce_thumbnail' ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_size_image[0] ) . '">';
-			$html .= get_the_post_thumbnail( $post->ID, 'woocommerce_single', $attributes );
-			$html .= '</a></div>';
+			// Note: `wc_get_gallery_image_html` was added in WC 3.3.2 and did not exist prior.
+			$html  = wc_get_gallery_image_html( $post_thumbnail_id );
 		} else {
 			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
 			$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src() ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
 			$html .= '</div>';
 		}
 
-		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, get_post_thumbnail_id( $post->ID ) );
+		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id );
 
 		do_action( 'woocommerce_product_thumbnails' );
 		?>

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -13,34 +13,18 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     3.1.0
+ * @version     3.3.2
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
-global $post, $product;
+global $product;
 
 $attachment_ids = $product->get_gallery_image_ids();
 
 if ( $attachment_ids && has_post_thumbnail() ) {
 	foreach ( $attachment_ids as $attachment_id ) {
-		$full_size_image = wp_get_attachment_image_src( $attachment_id, 'full' );
-		$thumbnail       = wp_get_attachment_image_src( $attachment_id, 'woocommerce_thumbnail' );
-		$attributes      = array(
-			'title'                   => get_post_field( 'post_title', $attachment_id ),
-			'data-caption'            => get_post_field( 'post_excerpt', $attachment_id ),
-			'data-src'                => $full_size_image[0],
-			'data-large_image'        => $full_size_image[0],
-			'data-large_image_width'  => $full_size_image[1],
-			'data-large_image_height' => $full_size_image[2],
-		);
-
-		$html  = '<div data-thumb="' . esc_url( $thumbnail[0] ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_size_image[0] ) . '">';
-		$html .= wp_get_attachment_image( $attachment_id, 'woocommerce_single', false, $attributes );
- 		$html .= '</a></div>';
-
-		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $attachment_id );
+		// Note: `wc_get_gallery_image_html` was added in WC 3.3.2 and did not exist prior.
+		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id  ), $attachment_id );
 	}
 }


### PR DESCRIPTION
This PR adds back an image size for gallery thumbnails. There is no UI for this, but themes can modify it and it can be filtered.

In addition, markup generation is handled by 1 function across all files for consistency and to move php logic out of template files.

The new helper function has filters in place to customise image sizes.

When we’re not using flex-slider, we can use thumbnail size in the gallery.

Closes #18910