### PR TITLE
Hash customer email address in download URLs.

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -54,7 +54,7 @@ class WC_Download_Handler {
 			$order = new WC_Order( $order_id );
 			$email_address = $order->get_billing_email();
 
-			if( $_GET['uid'] !== hash( 'sha256', $email_address ) ) {
+			if ( ! hash_equals( $_GET['uid'], hash( 'sha256', $email_address ) ) ) {
 				self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 			}
 		}

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -21,7 +21,7 @@ class WC_Download_Handler {
 	 * Hook in methods.
 	 */
 	public static function init() {
-		if ( isset( $_GET['download_file'], $_GET['order'] ) && ( isset($_GET['email'] ) || isset( $_GET['uid'] ) ) ) {
+		if ( isset( $_GET['download_file'], $_GET['order'] ) && ( isset( $_GET['email'] ) || isset( $_GET['uid'] ) ) ) {
 			add_action( 'init', array( __CLASS__, 'download_product' ) );
 		}
 		add_action( 'woocommerce_download_file_redirect', array( __CLASS__, 'download_file_redirect' ), 10, 2 );
@@ -42,19 +42,19 @@ class WC_Download_Handler {
 		}
 
 		// Fallback, accept email address if it's passed.
-		if ( empty($_GET['email'] ) && empty( $_GET['uid'] ) ) {
+		if ( empty( $_GET['email'] ) && empty( $_GET['uid'] ) ) {
 			self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 		}
 
-		if(isset($_GET['email'])) {
+		if ( isset( $_GET['email'] ) ) {
 			$email_address = $_GET['email'];
 		} else {
 			// Get email address from order to verify hash.
-			$order_id = wc_get_order_id_by_order_key($_GET['order']);
-			$order = new WC_Order($order_id);
+			$order_id = wc_get_order_id_by_order_key( $_GET['order'] );
+			$order = new WC_Order( $order_id );
 			$email_address = $order->get_billing_email();
 
-			if( $_GET['uid'] !== hash('sha256', $email_address) ) {
+			if( $_GET['uid'] !== hash( 'sha256', $email_address ) ) {
 				self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 			}
 		}

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -21,7 +21,7 @@ class WC_Download_Handler {
 	 * Hook in methods.
 	 */
 	public static function init() {
-		if ( isset( $_GET['download_file'], $_GET['order'], $_GET['email'] ) ) {
+		if ( isset( $_GET['download_file'], $_GET['order'] ) && ( isset($_GET['email'] ) || isset( $_GET['uid'] ) ) ) {
 			add_action( 'init', array( __CLASS__, 'download_product' ) );
 		}
 		add_action( 'woocommerce_download_file_redirect', array( __CLASS__, 'download_file_redirect' ), 10, 2 );
@@ -41,8 +41,26 @@ class WC_Download_Handler {
 			self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 		}
 
+		// Fallback, accept email address if it's passed.
+		if ( empty($_GET['email'] ) && empty( $_GET['uid'] ) ) {
+			self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
+		}
+
+		if(isset($_GET['email'])) {
+			$email_address = $_GET['email'];
+		} else {
+			// Get email address from order to verify hash.
+			$order_id = wc_get_order_id_by_order_key($_GET['order']);
+			$order = new WC_Order($order_id);
+			$email_address = $order->get_billing_email();
+
+			if( $_GET['uid'] !== hash('sha256', $email_address) ) {
+				self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
+			}
+		}
+
 		$download_ids = $data_store->get_downloads( array(
-			'user_email'  => sanitize_email( str_replace( ' ', '+', $_GET['email'] ) ),
+			'user_email'  => sanitize_email( str_replace( ' ', '+', $email_address ) ),
 			'order_key'   => wc_clean( $_GET['order'] ),
 			'product_id'  => $product_id,
 			'download_id' => wc_clean( preg_replace( '/\s+/', ' ', $_GET['key'] ) ),

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -51,10 +51,10 @@ class WC_Download_Handler {
 		} else {
 			// Get email address from order to verify hash.
 			$order_id = wc_get_order_id_by_order_key( $_GET['order'] );
-			$order = new WC_Order( $order_id );
-			$email_address = $order->get_billing_email();
+			$order = wc_get_order( $order_id );
+			$email_address = is_a( $order, 'WC_Order' ) ? $order->get_billing_email() : null;
 
-			if ( ! hash_equals( $_GET['uid'], hash( 'sha256', $email_address ) ) ) {
+			if ( is_null( $email_address ) || ! hash_equals( $_GET['uid'], hash( 'sha256', $email_address ) ) ) {
 				self::download_error( __( 'Invalid download link.', 'woocommerce' ) );
 			}
 		}

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -383,7 +383,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 					$files[ $download_id ]['download_url']        = add_query_arg( array(
 						'download_file' => $product_id,
 						'order'         => $order->get_order_key(),
-						'uid'         	=> hash('sha256', $order->get_billing_email()),
+						'uid'         	=> hash( 'sha256', $order->get_billing_email() ),
 						'key'           => $download_id,
 					), trailingslashit( home_url() ) );
 				}

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -383,7 +383,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 					$files[ $download_id ]['download_url']        = add_query_arg( array(
 						'download_file' => $product_id,
 						'order'         => $order->get_order_key(),
-						'email'         => urlencode( $order->get_billing_email() ),
+						'uid'         	=> hash('sha256', $order->get_billing_email()),
 						'key'           => $download_id,
 					), trailingslashit( home_url() ) );
 				}


### PR DESCRIPTION
Fixes #18835. This PR removes a customer's email address from product download links by hashing the value using the `sha256` hashing algorithm. I opted for that algorithm instead of `md5` because that's what I'm consistently reading that Google requires for hashing values. 

Tested for purchases made by both account holders and guests. Additionally, fallbacks are in place for users who click older download links that still pass an email in the URL. For all new links, a `uid` is passed instead. 

https://support.google.com/analytics/answer/6366371?hl=en
https://developers.google.com/analytics/solutions/crm-integration#user_id

Open to feedback on the most maintainable way to implement this!