### PR TITLE
Remove hardcoded /wp-content check for downloads.

### DIFF
--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -96,7 +96,7 @@ class WC_Product_Download implements ArrayAccess {
 		$file_url = $this->get_file();
 		if ( '..' === substr( $file_url, 0, 2 ) || '/' !== substr( $file_url, 0, 1 ) ) {
 			$file_url = realpath( ABSPATH . $file_url );
-		} elseif ( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) === substr( $file_url, 0, 11 ) ) {
+		} elseif ( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) === substr( $file_url, 0, strlen( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) ) ) ) {
 			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, 11 ) );
 		}
 		return apply_filters( 'woocommerce_downloadable_file_exists', file_exists( $file_url ), $this->get_file() );

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -96,7 +96,7 @@ class WC_Product_Download implements ArrayAccess {
 		$file_url = $this->get_file();
 		if ( '..' === substr( $file_url, 0, 2 ) || '/' !== substr( $file_url, 0, 1 ) ) {
 			$file_url = realpath( ABSPATH . $file_url );
-		} elseif ( '/wp-content' === substr( $file_url, 0, 11 ) ) {
+		} elseif ( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) === substr( $file_url, 0, 11 ) ) {
 			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, 11 ) );
 		}
 		return apply_filters( 'woocommerce_downloadable_file_exists', file_exists( $file_url ), $this->get_file() );


### PR DESCRIPTION
This PR replaces #18959 and closes #18958

Rather than hardcoding /wp-content in the check, make use of a combination of WP_CONTENT_DIR and ABSPATH to work out the value instead, this caters for sites running custom WP_CONTENT_DIR folders.