### PR TITLE
Pass image to get_image_filter as well

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1808,7 +1808,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		} else {
 			$image = '';
 		}
-		return apply_filters( 'woocommerce_product_get_image', wc_get_relative_url( $image ), $this, $size, $attr, $placeholder );
+
+		return apply_filters( 'woocommerce_product_get_image', wc_get_relative_url( $image ), $this, $size, $attr, $placeholder, $image );
 	}
 
 	/**


### PR DESCRIPTION
Pass image to get_image_filter as well so that devs can work with it before it's converted with relative URLs.

As an example, see how we had to duplicate code in https://github.com/woocommerce/woocommerce-follow-up-emails/pull/507/files#diff-1512ec4164c206672302b9ba2f031cbcR45 just to skip `wc_get_relative_url` call, since mail clients don't support `//` or `://`, but do support `http://` and `https://` for images.