### PR TITLE
Made get_on_sale_products respect the setting to hide outofstock products

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -809,14 +809,28 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function get_on_sale_products() {
 		global $wpdb;
 
-		$decimals = absint( wc_get_price_decimals() );
+		$decimals                    = absint( wc_get_price_decimals() );
+		$exclude_term_ids            = array();
+		$outofstock_join             = '';
+		$outofstock_where            = '';
+		$product_visibility_term_ids = wc_get_product_visibility_term_ids();
 
-		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && $product_visibility_term_ids['outofstock'] ) {
+			$exclude_term_ids[] = $product_visibility_term_ids['outofstock'];
+		}
+
+		if ( count( $exclude_term_ids ) ) {
+			$outofstock_join  = " LEFT JOIN ( SELECT object_id FROM {$wpdb->term_relationships} WHERE term_taxonomy_id IN ( " . implode( ',', array_map( 'absint', $exclude_term_ids ) ) . ' ) ) AS exclude_join ON exclude_join.object_id = id';
+			$outofstock_where = ' AND exclude_join.object_id IS NULL';
+		}
+
+		// @codingStandardsIgnoreStart.
 		return $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT post.ID as id, post.post_parent as parent_id FROM `$wpdb->posts` AS post
 				LEFT JOIN `$wpdb->postmeta` AS meta ON post.ID = meta.post_id
 				LEFT JOIN `$wpdb->postmeta` AS meta2 ON post.ID = meta2.post_id
+				$outofstock_join
 				WHERE post.post_type IN ( 'product', 'product_variation' )
 					AND post.post_status = 'publish'
 					AND meta.meta_key = '_sale_price'
@@ -824,11 +838,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					AND CAST( meta.meta_value AS DECIMAL ) >= 0
 					AND CAST( meta.meta_value AS CHAR ) != ''
 					AND CAST( meta.meta_value AS DECIMAL( 10, %d ) ) = CAST( meta2.meta_value AS DECIMAL( 10, %d ) )
+					$outofstock_where
 				GROUP BY post.ID",
 				$decimals,
 				$decimals
 			)
 		);
+		// @codingStandardsIgnoreEnd.
 	}
 
 	/**
@@ -1304,7 +1320,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @param  string $term Search term.
 	 * @param  string $type Type of product.
 	 * @param  bool   $include_variations Include variations in search or not.
-	 * @param  bool   $all_statuses Should we search all statuses or limit to published?
+	 * @param  bool   $all_statuses Should we search all statuses or limit to published.
 	 * @return array of ids
 	 */
 	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false ) {


### PR DESCRIPTION
Closes #18981

To Test, follow steps in https://github.com/woocommerce/woocommerce/issues/18981

Test with and without the ‘hide out of stock products from catalog’ setting. Inbetween tests you may need to save a product/clear transients because sale product IDs are cached.