### PR TITLE
Fix #18995

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2248,7 +2248,7 @@ ul.wc_coupon_list_block {
 	}
 	.wc-order-preview-addresses {
 		overflow:hidden;
-		.wc-order-preview-address {
+		.wc-order-preview-address, .wc-order-preview-note {
 			width: 50%;
 			float: left;
 			padding: 1.5em;
@@ -2263,20 +2263,8 @@ ul.wc_coupon_list_block {
 				margin-top: 1em;
 			}
 		}
-	}
-	.wc-order-preview-note {
-		overflow:hidden;
-		width: 100%;
-		padding: 1.5em;
-		box-sizing: border-box;
-		word-wrap: break-word;
-
-		h2 {
-			margin-top: 0;
-		}
-		strong {
-			display: block;
-			margin-top: 1em;
+		.wc-order-preview-note {
+			padding-top: 0;
 		}
 	}
 	.wc-action-button,

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2264,6 +2264,21 @@ ul.wc_coupon_list_block {
 			}
 		}
 	}
+	.wc-order-preview-note {
+		overflow:hidden;
+		width: 100%;
+		padding: 1.5em;
+		box-sizing: border-box;
+		word-wrap: break-word;
+
+		h2 {
+			margin-top: 0;
+		}
+		strong {
+			display: block;
+			margin-top: 1em;
+		}
+	}
 	.wc-action-button,
 	.wc-action-button-group {
 		float: left;

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -375,16 +375,18 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 											<a href="{{ data.shipping_address_map_url }}" target="_blank">{{{ data.formatted_shipping_address }}}</a>
 										<# } #>
 
-										<# if ( data.data.customer_note ) { #>
-											<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
-											{{ data.data.customer_note }}
-										<# } #>
-
 										<# if ( data.shipping_via ) { #>
 											<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
 											{{ data.shipping_via }}
 										<# } #>
 									</div>
+								<# } #>
+							</div>
+
+							<div class="wc-order-preview-note">
+								<h2><?php esc_html_e( 'Note', 'woocommerce' ); ?></h2>
+								<# if ( data.data.customer_note ) { #>
+									{{ data.data.customer_note }}
 								<# } #>
 							</div>
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -381,12 +381,12 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 										<# } #>
 									</div>
 								<# } #>
-							</div>
 
-							<div class="wc-order-preview-note">
-								<h2><?php esc_html_e( 'Note', 'woocommerce' ); ?></h2>
 								<# if ( data.data.customer_note ) { #>
-									{{ data.data.customer_note }}
+									<div class="wc-order-preview-note">
+										<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
+										{{ data.data.customer_note }}
+								</div>
 								<# } #>
 							</div>
 


### PR DESCRIPTION
Fixes #18995 by moving the note section outside the addresses container and unlink it from the shipping method conditional statement.

![](http://cld.wthms.co/T8qe0M+)