### PR TITLE
Logout from My Account Menu now appends the nonce

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -173,8 +173,8 @@ function wc_get_account_endpoint_url( $endpoint ) {
 		return wc_get_page_permalink( 'myaccount' );
 	}
 
-	if('customer-logout' === $endpoint) {
-		return wc_logout_url(wc_get_page_permalink('myaccount'));
+	if ( 'customer-logout' === $endpoint) {
+		return wc_logout_url( wc_get_page_permalink( 'myaccount' ) );
 	}
 
 	return wc_get_endpoint_url( $endpoint, '', wc_get_page_permalink( 'myaccount' ) );

--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -173,6 +173,10 @@ function wc_get_account_endpoint_url( $endpoint ) {
 		return wc_get_page_permalink( 'myaccount' );
 	}
 
+	if('customer-logout' === $endpoint) {
+		return wc_logout_url(wc_get_page_permalink('myaccount'));
+	}
+
 	return wc_get_endpoint_url( $endpoint, '', wc_get_page_permalink( 'myaccount' ) );
 }
 


### PR DESCRIPTION
The logout menu item within My Account failed to logout correctly.

Appending the nonce to URL allows the logout functionality to work.