### PR TITLE
Fix check for external resources

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1993,7 +1993,7 @@ function wc_get_relative_url( $url ) {
 function wc_is_external_resource( $url ) {
 	$wp_base = str_replace( array( 'http://', 'https://' ), '//', get_home_url( null, '/', 'http' ) );
 
-	return strstr( $url, '://' ) && strstr( $wp_base, $url );
+	return strstr( $url, '://' ) && !strstr( $url, $wp_base );
 }
 
 /**


### PR DESCRIPTION
The method `wc_is_external_resource()` in wc-core-functions.php ends with this line:
```php
return strstr( $url, '://' ) && strstr( $wp_base, $url );
```

This **always** returns `false` due to the param order of the second `strstr` call being the wrong way round. Note that in PHP's `strstr()` the first param is the haystack and the second one is the needle, so it should be `strstr( $url, $wp_base )` instead.

It looks like the logic is mixed up, too. If the URL contains the base URL then the resource is **not** external.

This PR fixes that.