### PR TITLE
Ensure item totals are not empty

### DIFF
--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -96,6 +96,10 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_subtotal( $value ) {
+		if ( ! is_numeric( $value ) ) {
+			$value = 0;
+		}
+
 		$this->set_prop( 'subtotal', wc_format_decimal( $value ) );
 	}
 
@@ -106,6 +110,10 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_total( $value ) {
+		if ( ! is_numeric( $value ) ) {
+			$value = 0;
+		}
+
 		$this->set_prop( 'total', wc_format_decimal( $value ) );
 
 		// Subtotal cannot be less than total


### PR DESCRIPTION
Solves some PHP errors when adding a product with no price to an order manually.

To test:

1) Create a new product, just give it a title and save.
2) Create a new order and add item to the order.
3) Recalculate totals, try to add a coupon, etc.
4) Note the errors in the logs.

> PHP Warning:  A non-numeric value encountered in /Users/Caleb/valet/sites/wccore/wp-content/plugins/woocommerce/includes/wc-core-functions.php on line 1560

> PHP Warning:  A non-numeric value encountered in /Users/Caleb/valet/sites/wctest/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php on line 1400

And it kind of just funnels out into more errors where price calculations are done and where prices displayed in html templates.