### PR TITLE
Prevent shipping zones PHP notice during setup wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -904,9 +904,9 @@ class WC_Admin_Setup_Wizard {
 
 		// @codingStandardsIgnoreStart
 		$setup_domestic   = isset( $_POST['shipping_zones']['domestic']['enabled'] ) && ( 'yes' === $_POST['shipping_zones']['domestic']['enabled'] );
-		$domestic_method  = sanitize_text_field( wp_unslash( $_POST['shipping_zones']['domestic']['method'] ) );
+		$domestic_method  = isset( $_POST['shipping_zones']['domestic']['method'] ) ? sanitize_text_field( wp_unslash( $_POST['shipping_zones']['domestic']['method'] ) ) : '';
 		$setup_intl       = isset( $_POST['shipping_zones']['intl']['enabled'] ) && ( 'yes' === $_POST['shipping_zones']['intl']['enabled'] );
-		$intl_method      = sanitize_text_field( wp_unslash( $_POST['shipping_zones']['intl']['method'] ) );
+		$intl_method      = isset( $_POST['shipping_zones']['intl']['method'] ) ? sanitize_text_field( wp_unslash( $_POST['shipping_zones']['intl']['method'] ) ) : '';
 		$weight_unit      = sanitize_text_field( wp_unslash( $_POST['weight_unit'] ) );
 		$dimension_unit   = sanitize_text_field( wp_unslash( $_POST['dimension_unit'] ) );
 		$existing_zones   = WC_Shipping_Zones::get_zones();


### PR DESCRIPTION
If shipping zones are already configured when going through the setup wizard, then the shipping screen will not show fields about methods/zones - only weight and dimensions settings.

As a result, you will get these two errors:

> PHP Notice:  Undefined index: shipping_zones in /sites/wccore/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php on line 907
PHP Stack trace:
> [1-7]
> PHP   8. WC_Admin_Setup_Wizard->wc_setup_shipping_save() /sites/wccore/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php:213

> PHP Notice:  Undefined index: shipping_zones in /sites/wccore/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php on line 909
PHP Stack trace:
> [1-7]
> PHP   8. WC_Admin_Setup_Wizard->wc_setup_shipping_save() /sites/wccore/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php:213