### PR TITLE
Prevent shortcode [product_page] redirecting to the actual product's page after add to cart

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -502,6 +502,9 @@ class WC_Shortcodes {
 			remove_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_title', 5 );
 		}
 
+		// Change form action to avoid redirect.
+		add_filter( 'woocommerce_add_to_cart_form_action', '__return_empty_string' );
+
 		$single_product = new WP_Query( $args );
 
 		$preselected_id = '0';
@@ -573,6 +576,8 @@ class WC_Shortcodes {
 		if ( isset( $atts['show_title'] ) && ! $atts['show_title'] ) {
 			add_action( 'woocommerce_single_product_summary', 'woocommerce_template_single_title', 5 );
 		}
+
+		remove_filter( 'woocommerce_add_to_cart_form_action', '__return_empty_string' );
 
 		return '<div class="woocommerce">' . ob_get_clean() . '</div>';
 	}

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -15,9 +15,8 @@
  * @package 	WooCommerce/Templates
  * @version     2.1.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+
+defined( 'ABSPATH' ) || exit;
 
 do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce/Templates
- * @version     3.3.0
+ * @version     3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,7 +21,7 @@ global $product, $post;
 
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="cart grouped_form" action="<?php echo esc_url( get_permalink() ); ?>" method="post" enctype='multipart/form-data'>
+<form class="cart grouped_form" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data'>
 	<table cellspacing="0" class="woocommerce-grouped-product-list group_table">
 		<tbody>
 			<?php
@@ -39,7 +39,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				$post               = $post_object; // WPCS: override ok.
 				setup_postdata( $post );
 
-				echo '<tr id="product-' . esc_attr( get_the_ID() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', get_post_class() ) ) . '">';
+				echo '<tr id="product-' . esc_attr( $grouped_product->get_id() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', get_post_class( '', $grouped_product->get_id() ) ) ) . '">';
 
 				// Output columns for each product.
 				foreach ( $grouped_product_columns as $column_id ) {
@@ -70,7 +70,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 							break;
 						case 'label':
 							$value  = '<label for="product-' . esc_attr( $grouped_product->get_id() ) . '">';
-							$value .= $grouped_product->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', get_permalink( $grouped_product->get_id() ), $grouped_product->get_id() ) ) . '">' . $grouped_product->get_name() . '</a>' : $grouped_product->get_name();
+							$value .= $grouped_product->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', $grouped_product->get_permalink(), $grouped_product->get_id() ) ) . '">' . $grouped_product->get_name() . '</a>' : $grouped_product->get_name();
 							$value .= '</label>';
 							break;
 						case 'price':

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -11,13 +11,11 @@
  * the readme will list any important changes.
  *
  * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     3.0.0
+ * @version     3.4.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+
+defined( 'ABSPATH' ) || exit;
 
 global $product;
 
@@ -31,7 +29,7 @@ if ( $product->is_in_stock() ) : ?>
 
 	<?php do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-	<form class="cart" action="<?php echo esc_url( get_permalink() ); ?>" method="post" enctype='multipart/form-data'>
+	<form class="cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data'>
 		<?php
 			/**
 			 * @since 2.1.0.

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -11,13 +11,11 @@
  * the readme will list any important changes.
  *
  * @see 	https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
- * @version 3.0.0
+ * @version 3.4.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+
+defined( 'ABSPATH' ) || exit;
 
 global $product;
 
@@ -25,7 +23,7 @@ $attribute_keys = array_keys( $attributes );
 
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="variations_form cart" action="<?php echo esc_url( get_permalink() ); ?>" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo htmlspecialchars( wp_json_encode( $available_variations ) ) ?>">
+<form class="variations_form cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo htmlspecialchars( wp_json_encode( $available_variations ) ) ?>">
 	<?php do_action( 'woocommerce_before_variations_form' ); ?>
 
 	<?php if ( empty( $available_variations ) && false !== $available_variations ) : ?>

--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -7,9 +7,8 @@
  * @package WooCommerce/Templates
  * @version 3.0.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+
+defined( 'ABSPATH' ) || exit;
 
 global $product;
 ?>

--- a/templates/single-product/add-to-cart/variation.php
+++ b/templates/single-product/add-to-cart/variation.php
@@ -10,15 +10,13 @@
  * @package WooCommerce/Templates
  * @version 2.5.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+
+defined( 'ABSPATH' ) || exit;
+
 ?>
 <script type="text/template" id="tmpl-variation-template">
 	<div class="woocommerce-variation-description">{{{ data.variation.variation_description }}}</div>
-
 	<div class="woocommerce-variation-price">{{{ data.variation.price_html }}}</div>
-
 	<div class="woocommerce-variation-availability">{{{ data.variation.availability_html }}}</div>
 </script>
 <script type="text/template" id="tmpl-unavailable-variation-template">


### PR DESCRIPTION
This needs to wait for 3.4 because it needs a new filter.

- Adds woocommerce_add_to_cart_form_action filter
- Removes global functions
- Sets action to empty string when using shortcode

Fixes #19032