### PR TITLE
Check parent status when seeing if variation is purchasable.

### DIFF
--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -473,7 +473,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @return bool
 	 */
 	public function is_purchasable() {
-		return apply_filters( 'woocommerce_variation_is_purchasable', $this->variation_is_visible() && parent::is_purchasable(), $this );
+		return apply_filters( 'woocommerce_variation_is_purchasable', $this->variation_is_visible() && parent::is_purchasable() && ( 'publish' === $this->parent_data['status'] || current_user_can( 'edit_post', $this->get_parent_id() ) ), $this );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -317,6 +317,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		$product->set_parent_data( array(
 			'title'              => $parent_object ? $parent_object->post_title : '',
+			'status'             => $parent_object ? $parent_object->post_status : '',
 			'sku'                => get_post_meta( $product->get_parent_id(), '_sku', true ),
 			'manage_stock'       => get_post_meta( $product->get_parent_id(), '_manage_stock', true ),
 			'backorders'         => get_post_meta( $product->get_parent_id(), '_backorders', true ),


### PR DESCRIPTION
Closes #19039 

Gets parent status when loading the variation and checks if it’s published, or editable, when seeing if purchasable.

This matches how other product types work - the difference here it it checks the parent rather than itself.