### PR TITLE
Load own overridden product classes by cart data

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -88,7 +88,7 @@ final class WC_Cart_Session {
 			update_object_term_cache( wp_list_pluck( $cart, 'product_id' ), 'product' );
 
 			foreach ( $cart as $key => $values ) {
-				$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
+				$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'], array( 'cart_item_data' => $values ) );
 
 				if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1042,7 +1042,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				$product_id   = wp_get_post_parent_id( $variation_id );
 			}
 
-			$product_data = wc_get_product( $variation_id ? $variation_id : $product_id );
+			$product_data = wc_get_product( $variation_id ? $variation_id : $product_id, array( 'cart_item_data' => $cart_item_data ) );
 			$quantity     = apply_filters( 'woocommerce_add_to_cart_quantity', $quantity, $product_id );
 
 			if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {
@@ -1161,7 +1161,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( isset( $this->removed_cart_contents[ $cart_item_key ] ) ) {
 			$restore_item                                  = $this->removed_cart_contents[ $cart_item_key ];
 			$this->cart_contents[ $cart_item_key ]         = $restore_item;
-			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'] );
+			$this->cart_contents[ $cart_item_key ]['data'] = wc_get_product( $restore_item['variation_id'] ? $restore_item['variation_id'] : $restore_item['product_id'], array( 'cart_item_data' => $restore_item ) );
 
 			do_action( 'woocommerce_restore_cart_item', $cart_item_key, $this );
 

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -35,7 +35,7 @@ class WC_Product_Factory {
 			$product_type = $this->get_classname_from_product_type( $args['product_type'] );
 		}
 
-		$classname = $this->get_product_classname( $product_id, $product_type );
+		$classname = $this->get_product_classname( $product_id, $product_type, $args );
 
 		try {
 			return new $classname( $product_id, $args );
@@ -52,8 +52,8 @@ class WC_Product_Factory {
 	 * @param  string $product_type
 	 * @return string
 	 */
-	public static function get_product_classname( $product_id, $product_type ) {
-		$classname = apply_filters( 'woocommerce_product_class', self::get_classname_from_product_type( $product_type ), $product_type, 'variation' === $product_type ? 'product_variation' : 'product', $product_id );
+	public static function get_product_classname( $product_id, $product_type, $args ) {
+		$classname = apply_filters( 'woocommerce_product_class', self::get_classname_from_product_type( $product_type ), $product_type, 'variation' === $product_type ? 'product_variation' : 'product', $product_id, $args );
 
 		if ( ! $classname || ! class_exists( $classname ) ) {
 			$classname = 'WC_Product_Simple';

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -21,29 +21,24 @@ class WC_Product_Factory {
 	 * Get a product.
 	 *
 	 * @param mixed $product_id (default: false)
-	 * @param array $deprecated Previously used to pass arguments to the factory, e.g. to force a type.
+	 * @param array $args Can be used to pass arguments to the factory, e.g. to force a type.
 	 * @return WC_Product|bool Product object or null if the product cannot be loaded.
 	 */
-	public function get_product( $product_id = false, $deprecated = array() ) {
+	public function get_product( $product_id = false, $args = array() ) {
 		if ( ! $product_id = $this->get_product_id( $product_id ) ) {
 			return false;
 		}
 
 		$product_type = $this->get_product_type( $product_id );
 
-		// Backwards compatibility.
-		if ( ! empty( $deprecated ) ) {
-			wc_deprecated_argument( 'args', '3.0', 'Passing args to the product factory is deprecated. If you need to force a type, construct the product class directly.' );
-
-			if ( isset( $deprecated['product_type'] ) ) {
-				$product_type = $this->get_classname_from_product_type( $deprecated['product_type'] );
-			}
+		if ( isset( $args['product_type'] ) ) {
+			$product_type = $this->get_classname_from_product_type( $args['product_type'] );
 		}
 
 		$classname = $this->get_product_classname( $product_id, $product_type );
 
 		try {
-			return new $classname( $product_id, $deprecated );
+			return new $classname( $product_id, $args );
 		} catch ( Exception $e ) {
 			return false;
 		}


### PR DESCRIPTION
Hi everyone!

We are creating a plugin for variable product bundle handling for our own purposes and I stumbled upon some weird design flaws in similar plugins that may be unnecessary if there would be a chance to load an overridden Product class in the cart.

For example some premises:
* We want to sell bundles of simple products (which are also sold individually and have their own stock)
* Every bundle has its own stock (because the bundles are already prebundled in the warehouse)
* At the moment a customer adds the bundle to the cart, every simple product associated to the bundle will be added to the cart too (to be able to print the element on e.g. the invoice and refund single items of the bundle)

The example will only consider the stock for the moment to keep it simple - but the problem applies to all other product values too.

The problem: In the normal workflow of woocommerce the cart would check the stock for every simple product in the cart after it has been added by the bundle - I don't want that because the only stock that should be checked is the bundle stock.

My solution would be: At the moment my bundle cart logic adds the simple products to the cart, choose an extended version of the simple product which overrides e.g.
```php
public function managing_stock() {
	return false;
}
```
To do that i would pass some cart data which would then lead to the loading of my own product class implementation for simple products and the cart would skip the stock check and everything would be fine!

**Polymorphic design wins**

To the changes in this PR:
To be able to do that I "undeprecated" (is that even a word? :D) the $args parameter of the product class factory and pass it through to the filter which selects the class. And also I pass through the cart data in all `wc_get_product` calls in the cart which provide the additional information to load my specific implementation of the simple product.

Otherwise if you think thats not a good idea:
What would be another approach to get to the point where I can load my own classes in the cart?