### PR TITLE
Fixed converting letters with accents to uppercase in templates

### DIFF
--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -10,28 +10,31 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version     3.2.1
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.4.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "\n" . strtoupper( __( 'Billing address', 'woocommerce' ) ) . "\n\n";
-echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address() ) . "\n";
+echo "\n" . esc_html( wc_strtoupper( __( 'Billing address', 'woocommerce' ) ) ) . "\n\n";
+echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address() ) . "\n"; // WPCS: XSS ok.
 
 if ( $order->get_billing_phone() ) {
-	echo $order->get_billing_phone() . "\n";
+	echo $order->get_billing_phone() . "\n"; // WPCS: XSS ok.
 }
 
 if ( $order->get_billing_email() ) {
-	echo $order->get_billing_email() . "\n";
+	echo $order->get_billing_email() . "\n"; // WPCS: XSS ok.
 }
 
-if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) {
-	echo "\n" . strtoupper( __( 'Shipping address', 'woocommerce' ) ) . "\n\n";
-	echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n";
+if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() ) {
+	$shipping = $order->get_formatted_shipping_address();
+
+	if ( $shipping ) {
+		echo "\n" . esc_html( wc_strtoupper( __( 'Shipping address', 'woocommerce' ) ) ) . "\n\n";
+		echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n"; // WPCS: XSS ok.
+	}
 }

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -12,17 +12,16 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see         https://docs.woocommerce.com/document/template-structure/
- * @author      WooThemes
- * @package     WooCommerce/Templates/Emails/Plain
- * @version     2.5.0
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.4.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo strtoupper( __( 'Customer details', 'woocommerce' ) ) . "\n\n";
+echo esc_html( wc_strtoupper( __( 'Customer details', 'woocommerce' ) ) ) . "\n\n";
 
 foreach ( $fields as $field ) {
 	echo wp_kses_post( $field['label'] ) . ': ' . wp_kses_post( $field['value'] ) . "\n";

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.3.0
+ * @version 3.4.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
 
 /* translators: %s: Order ID. */
-echo wp_kses_post( strtoupper( sprintf( __( 'Order number: %s', 'woocommerce' ), $order->get_order_number() ) ) ) . "\n";
+echo wp_kses_post( wc_strtoupper( sprintf( __( 'Order number: %s', 'woocommerce' ), $order->get_order_number() ) ) ) . "\n";
 echo wc_format_datetime( $order->get_date_created() ) . "\n";  // WPCS: XSS ok.
 echo "\n" . wc_get_email_order_items( $order, array( // WPCS: XSS ok.
 	'show_sku'      => $sent_to_admin,


### PR DESCRIPTION
Just changing `strtoupper()` to `wc_strtoupper()` where should use `mb_strtoupper()` if available.

Closes #19084