### PR TITLE
Include priceSpecification with valueAddedTaxIncluded

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -223,8 +223,13 @@ class WC_Structured_Data {
 
 				if ( $lowest === $highest ) {
 					$markup_offer = array(
-						'@type' => 'Offer',
-						'price' => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'@type'              => 'Offer',
+						'price'              => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'priceSpecification' => array(
+							'price'                 => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+							'priceCurrency'         => $currency,
+							'valueAddedTaxIncluded' => wc_prices_include_tax() ? 'true' : 'false',
+						),
 					);
 				} else {
 					$markup_offer = array(
@@ -237,6 +242,11 @@ class WC_Structured_Data {
 				$markup_offer = array(
 					'@type' => 'Offer',
 					'price' => wc_format_decimal( $product->get_price(), wc_get_price_decimals() ),
+					'priceSpecification' => array(
+						'price'                 => wc_format_decimal( $product->get_price(), wc_get_price_decimals() ),
+						'priceCurrency'         => $currency,
+						'valueAddedTaxIncluded' => wc_prices_include_tax() ? 'true' : 'false',
+					),
 				);
 			}
 
@@ -435,7 +445,7 @@ class WC_Structured_Data {
 		$markup['priceSpecification'] = array(
 			'price'                 => $order->get_total(),
 			'priceCurrency'         => $order->get_currency(),
-			'valueAddedTaxIncluded' => true,
+			'valueAddedTaxIncluded' => 'true',
 		);
 		$markup['billingAddress']     = array(
 			'@type'           => 'PostalAddress',


### PR DESCRIPTION
Difficult to test this one because there are no clear guidelines in place, but what this PR does is:

- includes a [priceSpecification](http://schema.org/PriceSpecification) property with the price, currency, and valueAddedTaxIncluded indicator.
- continues to use get_price which the store owner enters
- uses correct bool type for valueAddedTaxIncluded

This means if the output does not match the markup (due to settings) it can at least tell Google if the prices incl/excl tax. If user has a more complex setup a filter already exists to make adjustments (`woocommerce_structured_data_product_offer`).

Validation result:

![structured data testing tool 2018-02-22 16-35-42](https://user-images.githubusercontent.com/90977/36551286-28a50d66-17ef-11e8-8b5f-29d8f5bf10af.png)

Closes #18852 