### PR TITLE
Ensure coupon amount is not empty

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -459,13 +459,21 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @throws WC_Data_Exception
 	 */
 	public function set_amount( $amount ) {
+		$amount = wc_format_decimal( $amount );
+
+		if ( ! is_numeric( $amount ) ) {
+			$amount = 0;
+		}
+
 		if ( $amount < 0 ) {
 			$this->error( 'coupon_invalid_amount', __( 'Invalid discount amount', 'woocommerce' ) );
 		}
+
 		if ( 'percent' === $this->get_discount_type() && $amount > 100 ) {
 			$this->error( 'coupon_invalid_amount', __( 'Invalid discount amount', 'woocommerce' ) );
 		}
-		$this->set_prop( 'amount', wc_format_decimal( $amount ) );
+
+		$this->set_prop( 'amount', $amount );
 	}
 
 	/**

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -342,8 +342,7 @@ class WC_Discounts {
 			$limit_usage_qty = $coupon->get_limit_usage_to_x_items();
 		}
 
-		// Because get_amount() could return an empty string, let's be sure to set our local variable to a known good value.
-		$coupon_amount  = ( '' === $coupon->get_amount() ) ? 0 : $coupon->get_amount();
+		$coupon_amount = $coupon->get_amount();
 
 		foreach ( $items_to_apply as $item ) {
 			// Find out how much price is available to discount for the item.
@@ -400,7 +399,7 @@ class WC_Discounts {
 	 */
 	protected function apply_coupon_fixed_product( $coupon, $items_to_apply, $amount = null ) {
 		$total_discount  = 0;
-		$amount          = $amount ? $amount: wc_add_number_precision( $coupon->get_amount() );
+		$amount          = $amount ? $amount : wc_add_number_precision( $coupon->get_amount() );
 		$limit_usage_qty = 0;
 		$applied_count   = 0;
 

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -80,6 +80,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$coupon = new WC_Coupon();
 		$coupon->set_code( $code );
 		$coupon->set_description( 'This is a test coupon.' );
+		$coupon->set_amount( '' );
 		$coupon->set_usage_count( 5 );
 		$coupon->save();
 		$coupon_id = $coupon->get_id();
@@ -88,6 +89,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 5, $coupon_read->get_usage_count() );
 		$this->assertEquals( $code, $coupon_read->get_code() );
+		$this->assertEquals( 0, $coupon->get_amount() );
 		$this->assertEquals( 'This is a test coupon.', $coupon_read->get_description() );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/19095

Ensures the coupon amount is not empty (default to 0) before calculations are done with the value. 

Also theoretically helps ensure the other two conditionals in `set_amount` are being checked against an actual number.