### PR TITLE
Adding check for product tax status before automatically removing 'ta…

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -670,7 +670,7 @@ final class WC_Cart_Totals {
 	 */
 	protected function calculate_item_subtotals() {
 		foreach ( $this->items as $item_key => $item ) {
-			if ( $item->price_includes_tax ) {
+			if ( $item->price_includes_tax && $item->product->is_taxable() ) {
 				if ( $this->cart->get_customer()->get_is_vat_exempt() ) {
 					$item = $this->remove_item_base_taxes( $item );
 				} elseif ( apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {


### PR DESCRIPTION
When prices include tax, the base taxes are automatically removed when the tax region doesn't require tax to be applied.
In this scenario, if you have a non-taxable product then the price naturally won't have a tax component, so removing the base taxes from the price will result in an incorrect price.
To stop this behaviour we can check to see if the product is taxable before adjusting the subtotals.
Alternatively we make this check earlier on when determining the value of `$item->price_includes_tax`, though I've not had a chance to trace the impact of this alternative.