### PR TITLE
Fixed #19125 - added spinner markup

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -310,6 +310,7 @@ class WC_Admin_Menus {
 				</span>
 				<span class="add-to-menu">
 					<button type="submit" class="button-secondary submit-add-to-menu right" value="<?php esc_attr_e( 'Add to menu', 'woocommerce' ); ?>" name="add-post-type-menu-item" id="submit-posttype-woocommerce-endpoints"><?php esc_html_e( 'Add to menu', 'woocommerce' ); ?></button>
+					<span class="spinner"></span>
 				</span>
 			</p>
 		</div>


### PR DESCRIPTION
Added spinner makup `<span class="spinner"></span>` which was missing.