### PR TITLE
Use correct arg when making rest request in cli

### DIFF
--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -376,7 +376,7 @@ EOT;
 		$route                = $this->route;
 
 		foreach ( $this->get_supported_ids() as $id_name => $id_desc ) {
-			if ( strpos( $route, '<' . $id_name . '>' ) !== false && ! empty( $args ) ) {
+			if ( 'id' !== $id_name && strpos( $route, '<' . $id_name . '>' ) !== false && ! empty( $args ) ) {
 				$route                = str_replace( '(?P<' . $id_name . '>[\d]+)', $args[0], $route );
 				$supported_id_matched = true;
 			}

--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -97,13 +97,13 @@ class WC_CLI_Runner {
 		// Define IDs that we are looking for in the routes (in addition to id)
 		// so that we can pass it to the rest command, and use it here to generate documentation.
 		$supported_ids = array(
-				'id'           => __( 'ID.', 'woocommerce' ),
 				'product_id'   => __( 'Product ID.', 'woocommerce' ),
 				'customer_id'  => __( 'Customer ID.', 'woocommerce' ),
 				'order_id'     => __( 'Order ID.', 'woocommerce' ),
 				'refund_id'    => __( 'Refund ID.', 'woocommerce' ),
 				'attribute_id' => __( 'Attribute ID.', 'woocommerce' ),
 				'zone_id'      => __( 'Zone ID.', 'woocommerce' ),
+				'id'           => __( 'ID.', 'woocommerce' ),
 		);
 		$rest_command->set_supported_ids( $supported_ids );
 		$positional_args = array_keys( $supported_ids );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/19123

`?P<id>[\d]+)` will be replaced in the next conditional, and it will properly use the second arg in the array if possible. So just need to skip it in the first loop.


https://github.com/woocommerce/woocommerce/blob/e365d1e01a3e532b50c45e2992bb58f3b337a8f8/includes/cli/class-wc-cli-rest-command.php#L385-L388


____

Also seems to be a bit inconsistent in arguments order:

wp help says: 

`wp wc product_attribute_term get <id> <attribute_id> [--id=<id>] [--attribute_id=<attribute_id>]
  [--context=<context>] [--fields=<fields>] [--field=<field>] [--format=<format>]`

The GH wiki says: 

`wc product_attribute_term get <attribute_id> <id>`

I think it's meant to to be the wiki way, and that's how it will work after this patch.