### PR TITLE
Aligned DocBlock using spaces instead of tabs.

### DIFF
--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -10,10 +10,10 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     3.3.0
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Aligned DocBlock using spaces instead of tabs due to coding standards.