### PR TITLE
Clear subcategory cache

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -2,16 +2,10 @@
 /**
  * WC_Cache_Helper class.
  *
- * @class 		WC_Cache_Helper
- * @version		2.2.0
- * @package		WooCommerce/Classes
- * @category	Class
- * @author 		WooThemes
+ * @package WooCommerce/Classes
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Cache_Helper.
@@ -94,7 +88,7 @@ class WC_Cache_Helper {
 	public static function geolocation_ajax_redirect() {
 		if ( 'geolocation_ajax' === get_option( 'woocommerce_default_customer_address' ) && ! is_checkout() && ! is_cart() && ! is_account_page() && ! is_ajax() && empty( $_POST ) ) { // WPCS: CSRF ok, input var ok.
 			$location_hash = self::geolocation_ajax_get_location_hash();
-			$current_hash  = isset( $_GET['v'] ) ? wc_clean( wp_unslash( $_GET['v'] ) ) : ''; // WPCS: sanitization ok, input var ok.
+			$current_hash  = isset( $_GET['v'] ) ? wc_clean( wp_unslash( $_GET['v'] ) ) : ''; // WPCS: sanitization ok, input var ok, CSRF ok.
 			if ( empty( $current_hash ) || $current_hash !== $location_hash ) {
 				global $wp;
 
@@ -142,7 +136,10 @@ class WC_Cache_Helper {
 
 		if ( false === $transient_value || true === $refresh ) {
 			self::delete_version_transients( $transient_value );
-			set_transient( $transient_name, $transient_value = time() );
+
+			$transient_value = time();
+
+			set_transient( $transient_name, $transient_value );
 		}
 		return $transient_value;
 	}
@@ -197,7 +194,12 @@ class WC_Cache_Helper {
 		if ( $enabled && ! in_array( '_wc_session_', $settings, true ) ) {
 			?>
 			<div class="error">
-				<p><?php echo wp_kses_post( sprintf( __( 'In order for <strong>database caching</strong> to work with WooCommerce you must add %1$s to the "Ignored Query Strings" option in <a href="%2$s">W3 Total Cache settings</a>.', 'woocommerce' ), '<code>_wc_session_</code>', esc_url( admin_url( 'admin.php?page=w3tc_dbcache' ) ) ) ); ?></p>
+				<p>
+				<?php
+				/* translators: 1: key 2: URL */
+				echo wp_kses_post( sprintf( __( 'In order for <strong>database caching</strong> to work with WooCommerce you must add %1$s to the "Ignored Query Strings" option in <a href="%2$s">W3 Total Cache settings</a>.', 'woocommerce' ), '<code>_wc_session_</code>', esc_url( admin_url( 'admin.php?page=w3tc_dbcache' ) ) ) );
+				?>
+				</p>
 			</div>
 			<?php
 		}
@@ -207,7 +209,7 @@ class WC_Cache_Helper {
 	 * Clean term caches added by WooCommerce.
 	 *
 	 * @since 3.3.4
-	 * @param array $ids Array of ids to clear cache for.
+	 * @param array  $ids Array of ids to clear cache for.
 	 * @param string $taxonomy Taxonomy name.
 	 */
 	public static function clean_term_cache( $ids, $taxonomy ) {

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -26,6 +26,7 @@ class WC_Cache_Helper {
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
 		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
+		add_action( 'clean_term_cache', array( __CLASS__, 'clean_term_cache' ), 10, 2 );
 	}
 
 	/**
@@ -199,6 +200,21 @@ class WC_Cache_Helper {
 				<p><?php echo wp_kses_post( sprintf( __( 'In order for <strong>database caching</strong> to work with WooCommerce you must add %1$s to the "Ignored Query Strings" option in <a href="%2$s">W3 Total Cache settings</a>.', 'woocommerce' ), '<code>_wc_session_</code>', esc_url( admin_url( 'admin.php?page=w3tc_dbcache' ) ) ) ); ?></p>
 			</div>
 			<?php
+		}
+	}
+
+	/**
+	 * Clean term caches added by WooCommerce.
+	 *
+	 * @since 3.3.4
+	 * @param array $ids Array of ids to clear cache for.
+	 * @param string $taxonomy Taxonomy name.
+	 */
+	public static function clean_term_cache( $ids, $taxonomy ) {
+		if ( 'product_cat' === $taxonomy ) {
+			foreach ( $ids as $id ) {
+				wp_cache_delete( 'product-categories-' . $id, 'product_cat' );
+			}
 		}
 	}
 }

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -21,6 +21,7 @@ class WC_Cache_Helper {
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
 		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
 		add_action( 'clean_taxonomy_cache', array( __CLASS__, 'clean_taxonomy_cache' ) );
+		add_action( 'clean_term_cache', array( __CLASS__, 'clean_term_cache' ), 10, 2 );
 	}
 
 	/**
@@ -212,6 +213,19 @@ class WC_Cache_Helper {
 	 * @param string $taxonomy Taxonomy name.
 	 */
 	public static function clean_taxonomy_cache( $taxonomy ) {
+		if ( 'product_cat' === $taxonomy ) {
+			wp_cache_delete( 'product-category-hierarchy', 'product_cat' );
+		}
+	}
+
+	/**
+	 * Clean term caches added by WooCommerce.
+	 *
+	 * @since 3.3.4
+	 * @param array  $ids Array of ids to clear cache for.
+	 * @param string $taxonomy Taxonomy name.
+	 */
+	public static function clean_term_cache( $ids, $taxonomy ) {
 		if ( 'product_cat' === $taxonomy ) {
 			wp_cache_delete( 'product-category-hierarchy', 'product_cat' );
 		}

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -20,7 +20,7 @@ class WC_Cache_Helper {
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ) );
 		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
-		add_action( 'clean_term_cache', array( __CLASS__, 'clean_term_cache' ), 10, 2 );
+		add_action( 'clean_taxonomy_cache', array( __CLASS__, 'clean_taxonomy_cache' ) );
 	}
 
 	/**
@@ -209,14 +209,11 @@ class WC_Cache_Helper {
 	 * Clean term caches added by WooCommerce.
 	 *
 	 * @since 3.3.4
-	 * @param array  $ids Array of ids to clear cache for.
 	 * @param string $taxonomy Taxonomy name.
 	 */
-	public static function clean_term_cache( $ids, $taxonomy ) {
+	public static function clean_taxonomy_cache( $taxonomy ) {
 		if ( 'product_cat' === $taxonomy ) {
-			foreach ( $ids as $id ) {
-				wp_cache_delete( 'product-categories-' . $id, 'product_cat' );
-			}
+			wp_cache_delete( 'product-category-hierarchy', 'product_cat' );
 		}
 	}
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1964,7 +1964,8 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 	 */
 	function woocommerce_get_product_subcategories( $parent_id = 0 ) {
 		$parent_id          = absint( $parent_id );
-		$product_categories = wp_cache_get( 'product-categories-' . $parent_id, 'product_cat' );
+		$cache              = array_filter( (array) wp_cache_get( 'product-category-hierarchy', 'product_cat' ) );
+		$product_categories = isset( $cache[ $parent_id ] ) ? $cache[ $parent_id ] : false;
 
 		if ( false === $product_categories ) {
 			// NOTE: using child_of instead of parent - this is not ideal but due to a WP bug ( https://core.trac.wordpress.org/ticket/15626 ) pad_counts won't work.
@@ -1976,7 +1977,10 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 				'taxonomy'     => 'product_cat',
 				'pad_counts'   => 1,
 			) ) );
-			wp_cache_set( 'product-categories-' . $parent_id, $product_categories, 'product_cat' );
+
+			$cache[ $parent_id ] = $product_categories;
+
+			wp_cache_set( 'product-category-hierarchy', $cache, 'product_cat' );
 		}
 
 		if ( apply_filters( 'woocommerce_product_subcategories_hide_empty', true ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1964,8 +1964,7 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 	 */
 	function woocommerce_get_product_subcategories( $parent_id = 0 ) {
 		$parent_id          = absint( $parent_id );
-		$cache              = array_filter( (array) wp_cache_get( 'product-category-hierarchy', 'product_cat' ) );
-		$product_categories = isset( $cache[ $parent_id ] ) ? $cache[ $parent_id ] : false;
+		$product_categories = wp_cache_get( 'product-category-hierarchy-' . $parent_id, 'product_cat' );
 
 		if ( false === $product_categories ) {
 			// NOTE: using child_of instead of parent - this is not ideal but due to a WP bug ( https://core.trac.wordpress.org/ticket/15626 ) pad_counts won't work.
@@ -1978,9 +1977,7 @@ if ( ! function_exists( 'woocommerce_get_product_subcategories' ) ) {
 				'pad_counts'   => 1,
 			) ) );
 
-			$cache[ $parent_id ] = $product_categories;
-
-			wp_cache_set( 'product-category-hierarchy', $cache, 'product_cat' );
+			wp_cache_set( 'product-category-hierarchy-' . $parent_id, $product_categories, 'product_cat' );
 		}
 
 		if ( apply_filters( 'woocommerce_product_subcategories_hide_empty', true ) ) {


### PR DESCRIPTION
`clean_taxonomy_cache` and `clean_term_cache` are WordPress functions ran when categories are edited/deleted. WordPress does it’s own cache clearing at this point.

We cache subcategories here: https://github.com/woocommerce/woocommerce/blob/bb497f213da754cb14624beca54fb9125a03373d/includes/wc-template-functions.php#L1979 

But this cache is never cleared. This PR should resolve that.

Note: this was reported on Pressable where object caching is in place. Unless you’re running object caching you won’t see this issue because the default WP cache does not persist. 

To test:

1.  Run w3 total cache and enable object caching.
2. Edit a category and choose to show subcategories.
3. View the category.
4. Edit one of the children and remove it from the category.
5. View category again.

Before this patch the children wouldn't have updated due to caching. 

After this patch, the cache will clear and updated results will be shown.
