### PR TITLE
Add filter to allow post processing on custom coupons

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -271,19 +271,7 @@ class WC_Discounts {
 				$this->apply_coupon_fixed_cart( $coupon, $items_to_apply );
 				break;
 			default:
-				foreach ( $items_to_apply as $item ) {
-					$discounted_price  = $this->get_discounted_price_in_cents( $item );
-					$price_to_discount = wc_remove_number_precision( ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price );
-					$discount          = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $item->quantity;
-					$discount          = min( $discounted_price, $discount );
-
-					// Store code and discount amount per item.
-					$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;
-				}
-
-				// Allow post-processing for custom coupon types (e.g. calculating discrepancy, etc)
-				$this->discounts[ $coupon->get_code() ] = apply_filters( 'woocommerce_coupon_custom_discounts_array', $this->discounts[ $coupon->get_code() ], $coupon );
-
+				$this->apply_coupon_custom( $coupon, $items_to_apply );
 				break;
 		}
 
@@ -500,6 +488,31 @@ class WC_Discounts {
 			}
 		}
 		return $total_discount;
+	}
+
+	/**
+	 * Apply custom coupon discount to items.
+	 *
+	 * @since  3.3
+	 * @param  WC_Coupon $coupon Coupon object. Passed through filters.
+	 * @param  array     $items_to_apply Array of items to apply the coupon to.
+	 * @return int Total discounted.
+	 */
+	protected function apply_coupon_custom( $coupon, $items_to_apply ) {
+		foreach ( $items_to_apply as $item ) {
+			$discounted_price  = $this->get_discounted_price_in_cents( $item );
+			$price_to_discount = wc_remove_number_precision( ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price );
+			$discount          = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $item->quantity;
+			$discount          = min( $discounted_price, $discount );
+
+			// Store code and discount amount per item.
+			$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;
+		}
+
+		// Allow post-processing for custom coupon types (e.g. calculating discrepancy, etc)
+		$this->discounts[ $coupon->get_code() ] = apply_filters( 'woocommerce_coupon_custom_discounts_array', $this->discounts[ $coupon->get_code() ], $coupon );
+
+		return array_sum( $this->discounts[ $coupon->get_code() ] );
 	}
 
 	/**

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -280,6 +280,10 @@ class WC_Discounts {
 					// Store code and discount amount per item.
 					$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;
 				}
+
+				// Allow post-processing for custom coupon types (e.g. calculating discrepancy, etc)
+				$this->discounts[ $coupon->get_code() ] = apply_filters( 'woocommerce_coupon_custom_discounts_array', $this->discounts[ $coupon->get_code() ], $coupon );
+
 				break;
 		}
 


### PR DESCRIPTION
This filter will allow developers to do post processing, e.g. calculate discrepancy after `woocommerce_coupon_get_discount_amount` was processed for every single item.

Core also does similar logic in this way [here](https://github.com/woocommerce/woocommerce/blob/3.3.3/includes/class-wc-discounts.php#L474) by re-applying the coupon while there is mismatch between coupon total and applied total.