### PR TITLE
Use subtotal for discounts in admin/orders

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -2,15 +2,11 @@
 /**
  * Discount calculation
  *
- * @author  Automattic
  * @package WooCommerce/Classes
- * @version 3.2.0
  * @since   3.2.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Discounts class.
@@ -71,7 +67,8 @@ class WC_Discounts {
 	 * @param WC_Cart $cart Cart object.
 	 */
 	public function set_items_from_cart( $cart ) {
-		$this->items = $this->discounts = array();
+		$this->items     = array();
+		$this->discounts = array();
 
 		if ( ! is_a( $cart, 'WC_Cart' ) ) {
 			return;
@@ -99,7 +96,8 @@ class WC_Discounts {
 	 * @param array $order Cart object.
 	 */
 	public function set_items_from_order( $order ) {
-		$this->items = $this->discounts = array();
+		$this->items     = array();
+		$this->discounts = array();
 
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return;
@@ -108,15 +106,15 @@ class WC_Discounts {
 		$this->object = $order;
 
 		foreach ( $order->get_items() as $order_item ) {
-			$item                = new stdClass();
-			$item->key           = $order_item->get_id();
-			$item->object        = $order_item;
-			$item->product       = $order_item->get_product();
-			$item->quantity      = $order_item->get_quantity();
-			$item->price         = wc_add_number_precision_deep( $order_item->get_total() );
+			$item           = new stdClass();
+			$item->key      = $order_item->get_id();
+			$item->object   = $order_item;
+			$item->product  = $order_item->get_product();
+			$item->quantity = $order_item->get_quantity();
+			$item->price    = wc_add_number_precision_deep( $order_item->get_subtotal() );
 
 			if ( $order->get_prices_include_tax() ) {
-				$item->price += wc_add_number_precision_deep( $order_item->get_total_tax() );
+				$item->price += wc_add_number_precision_deep( $order_item->get_subtotal_tax() );
 			}
 
 			$this->items[ $order_item->get_id() ] = $item;
@@ -243,16 +241,16 @@ class WC_Discounts {
 
 		// Core discounts are handled here as of 3.2.
 		switch ( $coupon->get_discount_type() ) {
-			case 'percent' :
+			case 'percent':
 				$this->apply_coupon_percent( $coupon, $items_to_apply );
 				break;
-			case 'fixed_product' :
+			case 'fixed_product':
 				$this->apply_coupon_fixed_product( $coupon, $items_to_apply );
 				break;
-			case 'fixed_cart' :
+			case 'fixed_cart':
 				$this->apply_coupon_fixed_cart( $coupon, $items_to_apply );
 				break;
-			default :
+			default:
 				foreach ( $items_to_apply as $item ) {
 					$discounted_price  = $this->get_discounted_price_in_cents( $item );
 					$price_to_discount = wc_remove_number_precision( ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price );
@@ -305,7 +303,7 @@ class WC_Discounts {
 	 * @return array
 	 */
 	protected function get_items_to_apply_coupon( $coupon ) {
-		$items_to_apply  = array();
+		$items_to_apply = array();
 
 		foreach ( $this->items as $item ) {
 			$item_to_apply = clone $item; // Clone the item so changes to this item do not affect the originals.
@@ -346,7 +344,7 @@ class WC_Discounts {
 
 		foreach ( $items_to_apply as $item ) {
 			// Find out how much price is available to discount for the item.
-			$discounted_price  = $this->get_discounted_price_in_cents( $item );
+			$discounted_price = $this->get_discounted_price_in_cents( $item );
 
 			// Get the price we actually want to discount, based on settings.
 			$price_to_discount = ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price;
@@ -409,7 +407,7 @@ class WC_Discounts {
 
 		foreach ( $items_to_apply as $item ) {
 			// Find out how much price is available to discount for the item.
-			$discounted_price  = $this->get_discounted_price_in_cents( $item );
+			$discounted_price = $this->get_discounted_price_in_cents( $item );
 
 			// Get the price we actually want to discount, based on settings.
 			$price_to_discount = ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price;
@@ -452,8 +450,9 @@ class WC_Discounts {
 		$total_discount = 0;
 		$amount         = $amount ? $amount : wc_add_number_precision( $coupon->get_amount() );
 		$items_to_apply = array_filter( $items_to_apply, array( $this, 'filter_products_with_price' ) );
+		$item_count     = array_sum( wp_list_pluck( $items_to_apply, 'quantity' ) );
 
-		if ( ! $item_count = array_sum( wp_list_pluck( $items_to_apply, 'quantity' ) ) ) {
+		if ( ! $item_count ) {
 			return $total_discount;
 		}
 
@@ -495,7 +494,7 @@ class WC_Discounts {
 		foreach ( $items_to_apply as $item ) {
 			for ( $i = 0; $i < $item->quantity; $i ++ ) {
 				// Find out how much price is available to discount for the item.
-				$discounted_price  = $this->get_discounted_price_in_cents( $item );
+				$discounted_price = $this->get_discounted_price_in_cents( $item );
 
 				// Get the price we actually want to discount, based on settings.
 				$price_to_discount = ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price;
@@ -519,12 +518,6 @@ class WC_Discounts {
 		}
 		return $total_discount;
 	}
-
-	/*
-	 |--------------------------------------------------------------------------
-	 | Validation & Error Handling
-	 |--------------------------------------------------------------------------
-	 */
 
 	/**
 	 * Ensure coupon exists or throw exception.
@@ -830,7 +823,7 @@ class WC_Discounts {
 					$product_cats = array_merge( $product_cats, wc_get_product_cat_ids( $item->product->get_parent_id() ) );
 				}
 
-				$cat_id_list  = array_intersect( $product_cats, $coupon->get_excluded_product_categories() );
+				$cat_id_list = array_intersect( $product_cats, $coupon->get_excluded_product_categories() );
 				if ( count( $cat_id_list ) > 0 ) {
 					foreach ( $cat_id_list as $cat_id ) {
 						$cat          = get_term( $cat_id, 'product_cat' );

--- a/tests/unit-tests/order/coupons.php
+++ b/tests/unit-tests/order/coupons.php
@@ -19,7 +19,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function setUp() {
 		$this->delete_objects();
 
-		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // @codingStandardsIgnoreLine.
 
 		update_option( 'woocommerce_default_customer_address', 'base' );
 		update_option( 'woocommerce_tax_based_on', 'base' );
@@ -29,13 +29,13 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		update_post_meta( $product->get_id(), '_price', '1000' );
 		$product = wc_get_product( $product->get_id() );
 
-		$coupon = new WC_Coupon;
+		$coupon = new WC_Coupon();
 		$coupon->set_code( 'test-coupon-1' );
 		$coupon->set_amount( 1.00 );
 		$coupon->set_discount_type( 'fixed_cart' );
 		$coupon->save();
 
-		$coupon2 = new WC_Coupon;
+		$coupon2 = new WC_Coupon();
 		$coupon2->set_code( 'test-coupon-2' );
 		$coupon2->set_amount( 20 );
 		$coupon2->set_discount_type( 'percent' );
@@ -159,7 +159,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	/**
 	 * Test: test_remove_coupon_from_order
 	 */
-	function test_remove_coupon_from_order() {
+	public function test_remove_coupon_from_order() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$this->setUp();
@@ -199,7 +199,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	/**
 	 * Test: test_add_coupon_to_order
 	 */
-	function test_add_coupon_to_order() {
+	public function test_add_coupon_to_order() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$this->setUp();
@@ -207,14 +207,22 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
 
+		$this->assertEquals( '799', $order->get_total(), $order->get_total() );
+
+		/**
+		 * Discount should be based on subtotal unless coupons apply sequencially.
+		 *
+		 * Coupon will therefore discount 200. Compare the total without tax so we can compare the ex tax price and avoid rounding mishaps.
+		 */
 		$order->apply_coupon( 'test-coupon-2' );
-		$this->assertEquals( '639.2', $order->get_total(), $order->get_total() );
+		$this->assertEquals( 401, round( $order->get_total_discount( false ), 2 ), $order->get_total_discount( false ) );
+		$this->assertEquals( 598.99, $order->get_total(), $order->get_total() );
 	}
 
 	/**
 	 * Test: test_remove_coupon_from_order_ex_tax
 	 */
-	function test_remove_coupon_from_order_ex_tax() {
+	public function test_remove_coupon_from_order_ex_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$this->setUp();
@@ -254,7 +262,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	/**
 	 * Test: test_add_coupon_to_order_ex_tax
 	 */
-	function test_add_coupon_to_order_ex_tax() {
+	public function test_add_coupon_to_order_ex_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$this->setUp();
@@ -263,13 +271,14 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order    = wc_get_order( $order_id );
 
 		$order->apply_coupon( 'test-coupon-2' );
-		$this->assertEquals( '703.12', $order->get_total(), $order->get_total() );
+		$this->assertEquals( 401, $order->get_discount_total(), $order->get_discount_total() );
+		$this->assertEquals( ( 1000 - 401 ) * 1.1, $order->get_total(), $order->get_total() );
 	}
 
 	/**
 	 * Test: test_remove_coupon_from_order_no_tax
 	 */
-	function test_remove_coupon_from_order_no_tax() {
+	public function test_remove_coupon_from_order_no_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		$this->setUp();
@@ -309,7 +318,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	/**
 	 * Test: test_add_coupon_to_order_no_tax
 	 */
-	function test_add_coupon_to_order_no_tax() {
+	public function test_add_coupon_to_order_no_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		$this->setUp();
@@ -318,13 +327,13 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order    = wc_get_order( $order_id );
 
 		$order->apply_coupon( 'test-coupon-2' );
-		$this->assertEquals( '639.2', $order->get_total(), $order->get_total() );
+		$this->assertEquals( '599', $order->get_total(), $order->get_total() );
 	}
 
 	/**
 	 * Test: test_remove_coupon_from_order_no_tax
 	 */
-	function test_remove_coupon_from_order_no_tax_inc_prices_on() {
+	public function test_remove_coupon_from_order_no_tax_inc_prices_on() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		$this->setUp();
@@ -364,7 +373,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	/**
 	 * Test: test_add_coupon_to_order_no_tax
 	 */
-	function test_add_coupon_to_order_no_tax_inc_prices_on() {
+	public function test_add_coupon_to_order_no_tax_inc_prices_on() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
 		$this->setUp();
@@ -373,6 +382,6 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order    = wc_get_order( $order_id );
 
 		$order->apply_coupon( 'test-coupon-2' );
-		$this->assertEquals( '639.2', $order->get_total(), $order->get_total() );
+		$this->assertEquals( '599', $order->get_total(), $order->get_total() );
 	}
 }


### PR DESCRIPTION
Ref #19124 

When applying coupons in the cart, the discount amount for % coupons is based on the product price, before other discounts.

In admin we were using get_total. This is the price after discounts.

Switching to subtotals makes both match.