### PR TITLE
Add filters for default values of Product Images controls in Customizer

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -467,7 +467,7 @@ class WC_Shop_Customizer {
 			$wp_customize->add_setting(
 				'woocommerce_single_image_width',
 				array(
-					'default'              => 600,
+					'default'              => apply_filters('woocommerce_single_image_default_width',600),
 					'type'                 => 'option',
 					'capability'           => 'manage_woocommerce',
 					'sanitize_callback'    => 'absint',
@@ -495,7 +495,7 @@ class WC_Shop_Customizer {
 			$wp_customize->add_setting(
 				'woocommerce_thumbnail_image_width',
 				array(
-					'default'              => 300,
+					'default'              => apply_filters('woocommerce_thumbnail_image_default_width',300),
 					'type'                 => 'option',
 					'capability'           => 'manage_woocommerce',
 					'sanitize_callback'    => 'absint',
@@ -524,7 +524,7 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_thumbnail_cropping',
 			array(
-				'default'           => '1:1',
+				'default'           => apply_filters('woocommerce_default_thumbnail_cropping','1:1'),
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
 				'sanitize_callback' => 'wc_clean',
@@ -534,7 +534,7 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_thumbnail_cropping_custom_width',
 			array(
-				'default'              => '4',
+				'default'              => apply_filters('woocommerce_thumbnail_cropping_default_custom_width','4'),
 				'type'                 => 'option',
 				'capability'           => 'manage_woocommerce',
 				'sanitize_callback'    => 'absint',
@@ -545,7 +545,7 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_thumbnail_cropping_custom_height',
 			array(
-				'default'              => '3',
+				'default'              => apply_filters('woocommerce_thumbnail_cropping_default_custom_height','3'),
 				'type'                 => 'option',
 				'capability'           => 'manage_woocommerce',
 				'sanitize_callback'    => 'absint',

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -742,7 +742,7 @@ function wc_get_image_size( $image_size ) {
 		}
 
 		if ( 'single' === $image_size ) {
-			$size['width']  = absint( wc_get_theme_support( 'single_image_width', get_option( 'woocommerce_single_image_width', 600 ) ) );
+			$size['width']  = absint( wc_get_theme_support( 'single_image_width', get_option( 'woocommerce_single_image_width', apply_filters('woocommerce_single_image_width',600) ) ) );
 			$size['height'] = '';
 			$size['crop']   = 0;
 
@@ -752,15 +752,15 @@ function wc_get_image_size( $image_size ) {
 			$size['crop']   = 1;
 
 		} elseif ( 'thumbnail' === $image_size ) {
-			$size['width'] = absint( wc_get_theme_support( 'thumbnail_image_width', get_option( 'woocommerce_thumbnail_image_width', 300 ) ) );
-			$cropping      = get_option( 'woocommerce_thumbnail_cropping', '1:1' );
+			$size['width'] = absint( wc_get_theme_support( 'thumbnail_image_width', get_option( 'woocommerce_thumbnail_image_width', apply_filters('woocommerce_thumbnail_image_default_width',300) ) ) );
+			$cropping      = get_option( 'woocommerce_thumbnail_cropping', apply_filters('woocommerce_default_thumbnail_cropping','1:1') );
 
 			if ( 'uncropped' === $cropping ) {
 				$size['height'] = '';
 				$size['crop']   = 0;
 			} elseif ( 'custom' === $cropping ) {
-				$width          = max( 1, get_option( 'woocommerce_thumbnail_cropping_custom_width', '4' ) );
-				$height         = max( 1, get_option( 'woocommerce_thumbnail_cropping_custom_height', '3' ) );
+				$width          = max( 1, get_option( 'woocommerce_thumbnail_cropping_custom_width', apply_filters('woocommerce_thumbnail_cropping_default_custom_width','4') ) );
+				$height         = max( 1, get_option( 'woocommerce_thumbnail_cropping_custom_height', apply_filters('woocommerce_thumbnail_cropping_default_custom_height','3') ) );
 				$size['height'] = absint( round( ( $size['width'] / $width ) * $height ) );
 				$size['crop']   = 1;
 			} else {


### PR DESCRIPTION
In order to maintain compatibility with WooCommerce's new customizer controls in my theme and also don't break users images in their shops, I need those filters.