### PR TITLE
Improve store notice customizer handling

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -20,6 +20,7 @@ class WC_Shop_Customizer {
 		add_action( 'customize_register', array( $this, 'add_sections' ) );
 		add_action( 'customize_controls_print_styles', array( $this, 'add_styles' ) );
 		add_action( 'customize_controls_print_scripts', array( $this, 'add_scripts' ), 30 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'add_frontend_scripts' ) );
 	}
 
 	/**
@@ -38,6 +39,18 @@ class WC_Shop_Customizer {
 		$this->add_store_notice_section( $wp_customize );
 		$this->add_product_catalog_section( $wp_customize );
 		$this->add_product_images_section( $wp_customize );
+	}
+
+	/**
+	 * Frontend CSS styles.
+	 */
+	public function add_frontend_scripts() {
+		if ( ! is_customize_preview() || ! is_store_notice_showing() ) {
+			return;
+		}
+
+		$css = '.woocommerce-store-notice, p.demo_store { display: block !important; }';
+		wp_add_inline_style( 'customize-preview', $css );
 	}
 
 	/**
@@ -101,6 +114,18 @@ class WC_Shop_Customizer {
 
 				wp.customize.bind( 'ready', function() { // Ready?
 					$( '.woocommerce-cropping-control' ).find( 'input:checked' ).change();
+				} );
+
+				wp.customize( 'woocommerce_demo_store', function( setting ) {
+					setting.bind( function( value ) {
+						var notice = wp.customize( 'woocommerce_demo_store_notice' );
+
+						if ( value && ! notice.callbacks.has( notice.preview ) ) {
+							notice.bind( notice.preview );
+						} else if ( ! value ) {
+							notice.unbind( notice.preview );
+						}
+					} );
 				} );
 
 				wp.customize( 'woocommerce_demo_store_notice', function( setting ) {

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -138,6 +138,21 @@ class WC_Shop_Customizer {
 					} );
 				} );
 
+				wp.customize.section( 'woocommerce_store_notice', function( section ) {
+					section.expanded.bind( function( isExpanded ) {
+						if ( isExpanded ) {
+							var notice   = wp.customize( 'woocommerce_demo_store_notice' ),
+								checkbox = wp.customize( 'woocommerce_demo_store' );
+
+							if ( checkbox.get() && ! notice.callbacks.has( notice.preview ) ) {
+								notice.bind( notice.preview );
+							} else if ( ! checkbox.get() ) {
+								notice.unbind( notice.preview );
+							}
+						}
+					} );
+				} );
+
 				wp.customize.section( 'woocommerce_product_catalog', function( section ) {
 					section.expanded.bind( function( isExpanded ) {
 						if ( isExpanded ) {

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -103,6 +103,16 @@ class WC_Shop_Customizer {
 					$( '.woocommerce-cropping-control' ).find( 'input:checked' ).change();
 				} );
 
+				wp.customize( 'woocommerce_demo_store_notice', function( setting ) {
+					setting.bind( function( value ) {
+						var checkbox = wp.customize( 'woocommerce_demo_store' );
+
+						if ( checkbox.get() ) {
+							$( '.woocommerce-store-notice' ).text( value );
+						}
+					} );
+				} );
+
 				wp.customize.section( 'woocommerce_product_catalog', function( section ) {
 					section.expanded.bind( function( isExpanded ) {
 						if ( isExpanded ) {
@@ -253,6 +263,7 @@ class WC_Shop_Customizer {
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
 				'sanitize_callback' => 'wp_kses_post',
+				'transport'         => 'postMessage',
 			)
 		);
 
@@ -276,6 +287,16 @@ class WC_Shop_Customizer {
 				'type'     => 'checkbox',
 			)
 		);
+
+		if ( isset( $wp_customize->selective_refresh ) ) {
+			$wp_customize->selective_refresh->add_partial(
+				'woocommerce_demo_store_notice', array(
+					'selector'            => '.woocommerce-store-notice',
+					'container_inclusive' => true,
+					'render_callback'     => 'woocommerce_demo_store',
+				)
+			);
+		}
 	}
 
 	/**
@@ -448,9 +469,11 @@ class WC_Shop_Customizer {
 		} elseif ( apply_filters( 'woocommerce_background_image_regeneration', true ) && ! is_multisite() ) {
 			$regen_description = __( 'After publishing your changes, new image sizes will be generated automatically.', 'woocommerce' );
 		} elseif ( apply_filters( 'woocommerce_background_image_regeneration', true ) && is_multisite() ) {
+			/* translators: 1: tools URL 2: regen thumbs url */
 			$regen_description = sprintf( __( 'After publishing your changes, new image sizes may not be shown until you regenerate thumbnails. You can do this from the <a href="%1$s" target="_blank">tools section in WooCommerce</a> or by using a plugin such as <a href="%2$s" target="_blank">Regenerate Thumbnails</a>.', 'woocommerce' ), admin_url( 'admin.php?page=wc-status&tab=tools' ), 'https://en-gb.wordpress.org/plugins/regenerate-thumbnails/' );
 		} else {
-			$regen_description = sprintf( __( 'After publishing your changes, new image sizes may not be shown until you <a href="%2$s" target="_blank">Regenerate Thumbnails</a>.', 'woocommerce' ), 'https://en-gb.wordpress.org/plugins/regenerate-thumbnails/' );
+			/* translators: %s: regen thumbs url */
+			$regen_description = sprintf( __( 'After publishing your changes, new image sizes may not be shown until you <a href="%s" target="_blank">Regenerate Thumbnails</a>.', 'woocommerce' ), 'https://en-gb.wordpress.org/plugins/regenerate-thumbnails/' );
 		}
 
 		$wp_customize->add_section(


### PR DESCRIPTION
Fixes #19145

Updates the store notice in the customizer partially, rather than doing a full request. Also disables events when the checkbox to enable the notice is disabled.

To test;

- Open customizer
- Go to WooCommerce > Store Notice
- type into the box. Nothing should happen.
- enable store notice.
- type again. displayed notice will update.

Thanks @tiagonoronha 