### PR TITLE
Only show T&C's notice if there is a valid T&Cs page

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -693,7 +693,7 @@ class WC_Checkout {
 		$this->validate_posted_data( $data, $errors );
 		$this->check_cart_items();
 
-		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && apply_filters( 'woocommerce_checkout_show_terms', wc_get_page_id( 'terms' ) > 0 ) ) {
+		if ( empty( $data['woocommerce_checkout_update_totals'] ) && ! empty( $_POST['terms-field'] ) && empty( $data['terms'] ) && apply_filters( 'woocommerce_checkout_show_terms', wc_get_page_id( 'terms' ) > 0 ) ) {
 			$errors->add( 'terms', __( 'You must accept our Terms &amp; Conditions.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
Bug technically introduced here: https://github.com/woocommerce/woocommerce/pull/18993

If you trash a T&C's page and try to checkout, it won't allow you as it will warn you about not accepting the terms and conditions.

Using the same check used here: https://github.com/woocommerce/woocommerce/blob/f49491809ff57ceffc46a3785c4d4a256821dd21/includes/class-wc-form-handler.php#L351-L354

Just checks for this field existing, before also requiring the checkbox to be checked: https://github.com/woocommerce/woocommerce/blob/f49491809ff57ceffc46a3785c4d4a256821dd21/templates/checkout/terms.php#L28