### PR TITLE
When loading default attributes/variation, if there is no longer a match, reset the form and hide the notice

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -13,6 +13,7 @@
 		this.variationData        = $form.data( 'product_variations' );
 		this.useAjax              = false === this.variationData;
 		this.xhr                  = false;
+		this.loading              = true;
 
 		// Initial state.
 		this.$singleVariationWrap.show();
@@ -41,6 +42,7 @@
 		setTimeout( function() {
 			$form.trigger( 'check_variations' );
 			$form.trigger( 'wc_variation_form' );
+			$form.loading = loading;
 		}, 100 );
 	};
 
@@ -145,8 +147,12 @@
 							form.$form.trigger( 'found_variation', [ variation ] );
 						} else {
 							form.$form.trigger( 'reset_data' );
-							form.$form.find( '.single_variation' ).after( '<p class="wc-no-matching-variations woocommerce-info">' + wc_add_to_cart_variation_params.i18n_no_matching_variations_text + '</p>' );
-							form.$form.find( '.wc-no-matching-variations' ).slideDown( 200 );
+							attributes.chosenCount = 0;
+
+							if ( ! form.loading ) {
+								form.$form.find( '.single_variation' ).after( '<p class="wc-no-matching-variations woocommerce-info">' + wc_add_to_cart_variation_params.i18n_no_matching_variations_text + '</p>' );
+								form.$form.find( '.wc-no-matching-variations' ).slideDown( 200 );
+							}
 						}
 					},
 					complete: function() {
@@ -163,8 +169,12 @@
 					form.$form.trigger( 'found_variation', [ variation ] );
 				} else {
 					form.$form.trigger( 'reset_data' );
-					form.$form.find( '.single_variation' ).after( '<p class="wc-no-matching-variations woocommerce-info">' + wc_add_to_cart_variation_params.i18n_no_matching_variations_text + '</p>' );
-					form.$form.find( '.wc-no-matching-variations' ).slideDown( 200 );
+					attributes.chosenCount = 0;
+
+					if ( ! form.loading ) {
+						form.$form.find( '.single_variation' ).after( '<p class="wc-no-matching-variations woocommerce-info">' + wc_add_to_cart_variation_params.i18n_no_matching_variations_text + '</p>' );
+						form.$form.find( '.wc-no-matching-variations' ).slideDown( 200 );
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
When you set default attributes, on page load the matching variation is found and displayed.

If the matching variation is out of stock, a notice is shown saying it’s unavailable.

In these cases it should instead reset the form and show no notice so the customer doesn’t wonder what is going on.

To test:
- Setup variable product
- Make one of the variations out of stock
- Set the ‘default’ attributes to match the variation that is out of stock
- In Settings > products > inventory, hide out of stock products.
- Go to product page.

Closes #19188