### PR TITLE
KSES instead of escaping of download names

### DIFF
--- a/templates/emails/email-downloads.php
+++ b/templates/emails/email-downloads.php
@@ -41,7 +41,7 @@ $text_align = is_rtl() ? 'right' : 'left';
 						switch ( $column_id ) {
 							case 'download-product':
 								?>
-								<a href="<?php echo esc_url( get_permalink( $download['product_id'] ) ); ?>"><?php echo esc_html( $download['product_name'] ); ?></a>
+								<a href="<?php echo esc_url( get_permalink( $download['product_id'] ) ); ?>"><?php echo wp_kses_post( $download['product_name'] ); ?></a>
 								<?php
 								break;
 							case 'download-file':


### PR DESCRIPTION
Fixes #19181

Prevents HTML being escaped for download names. It is not escaped when outputting product names in the same emails.

https://github.com/woocommerce/woocommerce/issues/19181 has instructions.

- Add html to product title
- Make downloadable product
- Purchase