### PR TITLE
New shortcode features for products block

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -118,10 +118,10 @@ class WC_Shortcode_Products {
 			'order'          => 'ASC',     // ASC or DESC.
 			'ids'            => '',        // Comma separated IDs.
 			'skus'           => '',        // Comma separated SKUs.
-			'category'       => '',        // Comma separated category slugs.
+			'category'       => '',        // Comma separated category slugs or ids.
 			'cat_operator'   => 'IN',      // Operator to compare categories. Possible values are 'IN', 'NOT IN', 'AND'.
 			'attribute'      => '',        // Single attribute slug.
-			'terms'          => '',        // Comma separated term slugs.
+			'terms'          => '',        // Comma separated term slugs or ids.
 			'terms_operator' => 'IN',      // Operator to compare terms. Possible values are 'IN', 'NOT IN', 'AND'.
 			'tag'            => '',        // Comma separated tag slugs.
 			'visibility'     => 'visible', // Possible values are 'visible', 'catalog', 'search', 'hidden'.
@@ -275,10 +275,28 @@ class WC_Shortcode_Products {
 	 */
 	protected function set_attributes_query_args( &$query_args ) {
 		if ( ! empty( $this->attributes['attribute'] ) || ! empty( $this->attributes['terms'] ) ) {
+			$taxonomy = strstr( $this->attributes['attribute'], 'pa_' ) ? sanitize_title( $this->attributes['attribute'] ) : 'pa_' . sanitize_title( $this->attributes['attribute'] );
+			$terms = $this->attributes['terms'] ? array_map( 'sanitize_title', explode( ',', $this->attributes['terms'] ) ) : array();
+			$field = 'slug';
+
+			if ( $terms && is_numeric( $terms[0] ) ) {
+				$terms = array_map( 'absint', $terms );
+				$field = 'term_id';
+			}
+
+			// If no terms were specified get all products that are in the attribute taxonomy.
+			if ( ! $terms ) {
+				$terms = get_terms( array(
+					'taxonomy' => $taxonomy,
+					'fields' => 'ids',
+				) );
+				$field = 'term_id';
+			}
+
 			$query_args['tax_query'][] = array(
-				'taxonomy' => strstr( $this->attributes['attribute'], 'pa_' ) ? sanitize_title( $this->attributes['attribute'] ) : 'pa_' . sanitize_title( $this->attributes['attribute'] ),
-				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['terms'] ) ),
-				'field'    => 'slug',
+				'taxonomy' => $taxonomy,
+				'terms'    => $terms,
+				'field'    => $field,
 				'operator' => $this->attributes['terms_operator'],
 			);
 		}
@@ -292,10 +310,18 @@ class WC_Shortcode_Products {
 	 */
 	protected function set_categories_query_args( &$query_args ) {
 		if ( ! empty( $this->attributes['category'] ) ) {
+			$categories = array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) );
+			$field = 'slug';
+
+			if ( is_numeric( $categories[0] ) ) {
+				$categories = array_map( 'absint', $categories );
+				$field = 'term_id';
+			}
+
 			$query_args['tax_query'][] = array(
 				'taxonomy' => 'product_cat',
-				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['category'] ) ),
-				'field'    => 'slug',
+				'terms'    => $categories,
+				'field'    => $field,
 				'operator' => $this->attributes['cat_operator'],
 			);
 		}

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -68,7 +68,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$meta_query = WC()->query->get_meta_query();
 		$tax_query  = WC()->query->get_tax_query();
 
-		// Emtpy products shortcode.
+		// Empty products shortcode.
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
 			'post_type'           => 'product',
@@ -157,6 +157,36 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
+
+		// product_category shortcode using category ids.
+		$shortcode4_id = new WC_Shortcode_Products( array(
+			'per_page' => '12',
+			'columns'  => '4',
+			'orderby'  => 'title',
+			'order'    => 'ASC',
+			'category' => '123',
+			'operator' => 'IN',
+		), 'product_category' );
+		$expected4_id  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => '12',
+			'meta_query'          => $meta_query,
+			'tax_query'           => $tax_query,
+			'fields'              => 'ids',
+		);
+		$expected4_id['tax_query'][] = array(
+			'taxonomy' => 'product_cat',
+			'terms'    => array( 123 ),
+			'field'    => 'term_id',
+			'operator' => 'IN',
+		);
+
+		$this->assertEquals( $expected4_id, $shortcode4_id->get_query_args() );
 
 		// recent_products shortcode.
 		$shortcode5 = new WC_Shortcode_Products( array(
@@ -339,6 +369,37 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected11, $shortcode11->get_query_args() );
 
+		// product_attribute shortcode using term ids.
+		$shortcode11_id = new WC_Shortcode_Products( array(
+			'per_page'  => '12',
+			'columns'   => '4',
+			'orderby'   => 'title',
+			'order'     => 'asc',
+			'attribute' => 'color',
+			'terms'     => '123',
+		), 'product_attribute' );
+		$expected11_id  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => 12,
+			'meta_query'          => $meta_query,
+			'tax_query'           => array_merge( $tax_query, array(
+				array(
+					'taxonomy' => 'pa_color',
+					'terms'    => array( 123 ),
+					'field'    => 'term_id',
+					'operator' => 'IN',
+				),
+			) ),
+			'fields'              => 'ids',
+		);
+
+		$this->assertEquals( $expected11_id, $shortcode11_id->get_query_args() );
+
 		// Check for visibility shortcode.
 		$shortcode12 = new WC_Shortcode_Products( array(
 			'visibility' => 'hidden',
@@ -478,6 +539,9 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'groupby' => "$wpdb->posts.ID",
 		);
 
-		$this->assertEquals( $expected, WC_Shortcode_Products::order_by_rating_post_clauses( array( 'where' => '', 'join' => '' ) ) );
+		$this->assertEquals( $expected, WC_Shortcode_Products::order_by_rating_post_clauses( array(
+			'where' => '',
+			'join' => '',
+		) ) );
 	}
 }


### PR DESCRIPTION
This PR introduces some small new features to the `products` shortcode. These features are necessary for some of the features of the Gutenberg Products block.

1. The `category` shortcode attribute can now also accept term ids instead of only slugs.
2. The `attribute` shortcode attribute can now also accept term ids instead of only slugs.
3. Fixed/Improved logic for the `attribute` shortcode attribute without `terms` . Previously if no terms were specified the shortcode would not really do anything (it would query for all products with attribute values in `array( '' )` which is not going to give useful results. Now it will query for all products that have the attribute if no terms are specified (e.g. all products that have Color of any value).

To test: Verify unit tests pass and/or try out the `products` shortcode with the new features.