### PR TITLE
Only append tax label if taxes are enabled

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1649,7 +1649,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 			$subtotal = wc_price( $subtotal, array( 'currency' => $this->get_currency() ) );
 
-			if ( 'excl' === $tax_display && $this->get_prices_include_tax() ) {
+			if ( 'excl' === $tax_display && $this->get_prices_include_tax() && wc_tax_enabled() ) {
 				$subtotal .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 			}
 		} else {


### PR DESCRIPTION
Fixes #19218 

To test, have prices showing in catalog excl tax, prices defined incl tax, and taxes disabled. You’ll see the label on the subtotal row without this patch.