### PR TITLE
Split layered nav transient per issue #17355

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -700,6 +700,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				foreach ( $attributes as $attribute_key => $attribute ) {
 					$value = '';
 
+					delete_transient( 'wc_layered_nav_counts_' . $attribute_key );
+					
 					if ( is_null( $attribute ) ) {
 						if ( taxonomy_exists( $attribute_key ) ) {
 							// Handle attributes that have been unset.
@@ -722,8 +724,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						'is_variation' => $attribute->get_variation() ? 1 : 0,
 						'is_taxonomy'  => $attribute->is_taxonomy() ? 1 : 0,
 					);
-
-					delete_transient( 'wc_layered_nav_counts_' . $attribute_key );
 				}
 			}
 			update_post_meta( $product->get_id(), '_product_attributes', $meta_values );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -722,10 +722,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						'is_variation' => $attribute->get_variation() ? 1 : 0,
 						'is_taxonomy'  => $attribute->is_taxonomy() ? 1 : 0,
 					);
+
+					delete_transient( 'wc_layered_nav_counts_' . $attribute_key );
 				}
 			}
 			update_post_meta( $product->get_id(), '_product_attributes', $meta_values );
-			delete_transient( 'wc_layered_nav_counts' );
 		}
 	}
 

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -371,13 +371,21 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 
 		// We have a query - let's see if cached results of this query already exist.
 		$query_hash    = md5( $query );
-		$cached_counts = (array) get_transient( 'wc_layered_nav_counts' );
+
+		// Maybe store a transient of the count values.
+		$cache = apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );
+
+		if ( true === $cache ) {
+			$cached_counts = (array) get_transient( 'wc_layered_nav_counts_' . $taxonomy );	
+		}
 
 		if ( ! isset( $cached_counts[ $query_hash ] ) ) {
 			$results                      = $wpdb->get_results( $query, ARRAY_A ); // @codingStandardsIgnoreLine
 			$counts                       = array_map( 'absint', wp_list_pluck( $results, 'term_count', 'term_count_id' ) );
 			$cached_counts[ $query_hash ] = $counts;
-			set_transient( 'wc_layered_nav_counts', $cached_counts, DAY_IN_SECONDS );
+			if ( true === $cache ) {
+				set_transient( 'wc_layered_nav_counts_' . $taxonomy, $cached_counts, DAY_IN_SECONDS );
+			}
 		}
 
 		return array_map( 'absint', (array) $cached_counts[ $query_hash ] );

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -377,8 +377,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		if ( true === $cache ) {
 			$cached_counts = (array) get_transient( 'wc_layered_nav_counts_' . $taxonomy );	
 		} else {
-            $cached_counts = array();
-        }
+			$cached_counts = array();
+		}
 
 		if ( ! isset( $cached_counts[ $query_hash ] ) ) {
 			$results                      = $wpdb->get_results( $query, ARRAY_A ); // @codingStandardsIgnoreLine

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -374,10 +374,11 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 
 		// Maybe store a transient of the count values.
 		$cache = apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );
-
 		if ( true === $cache ) {
 			$cached_counts = (array) get_transient( 'wc_layered_nav_counts_' . $taxonomy );	
-		}
+		} else {
+            $cached_counts = array();
+        }
 
 		if ( ! isset( $cached_counts[ $query_hash ] ) ) {
 			$results                      = $wpdb->get_results( $query, ARRAY_A ); // @codingStandardsIgnoreLine


### PR DESCRIPTION
Splits the layered nav counts into multiple transient records, by taxonomy. Adds a filter to allow bypassing caching. Relates to issue #17355 