### PR TITLE
Improved speed of the "search_products" method

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1349,14 +1349,11 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			// phpcs:disable
 			$wpdb->prepare(
 				"SELECT DISTINCT posts.ID as product_id, posts.post_parent as parent_id FROM {$wpdb->posts} posts
-				LEFT JOIN {$wpdb->postmeta} postmeta ON posts.ID = postmeta.post_id
 				$type_join
 				WHERE (
 					posts.post_title LIKE %s
 					OR posts.post_content LIKE %s
-					OR (
-						postmeta.meta_key = '_sku' AND postmeta.meta_value LIKE %s
-					)
+					OR posts.ID IN (SELECT postmeta.post_id FROM {$wpdb->postmeta} postmeta WHERE postmeta.meta_key = '_sku' AND postmeta.meta_value LIKE %s)
 				)
 				AND posts.post_type IN ('" . implode( "','", $post_types ) . "')
 				$status_where


### PR DESCRIPTION
I replaced a join with a subquery. The join is slow because of missing indexes in WordPress. The subquery however is executed only once which significantly improves search speed (in my use case with 25000 products I could bring down the search speed from over 5 seconds to below 1 second per query).