### PR TITLE
Add Shipping Calculator State filter

### DIFF
--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -45,6 +45,8 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 			</select>
 		</p>
 
+		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) ) : ?>
+
 		<p class="form-row form-row-wide" id="calc_shipping_state_field">
 			<?php
 			$current_cc = WC()->customer->get_shipping_country();
@@ -69,6 +71,8 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 			}
 			?>
 		</p>
+
+		<?php endif; ?>
 
 		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_city', true ) ) : ?>
 

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -47,30 +47,30 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) ) : ?>
 
-		<p class="form-row form-row-wide" id="calc_shipping_state_field">
-			<?php
-			$current_cc = WC()->customer->get_shipping_country();
-			$current_r  = WC()->customer->get_shipping_state();
-			$states     = WC()->countries->get_states( $current_cc );
+			<p class="form-row form-row-wide" id="calc_shipping_state_field">
+				<?php
+				$current_cc = WC()->customer->get_shipping_country();
+				$current_r  = WC()->customer->get_shipping_state();
+				$states     = WC()->countries->get_states( $current_cc );
 
-			if ( is_array( $states ) && empty( $states ) ) {
-				?><input type="hidden" name="calc_shipping_state" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" /><?php
-			} elseif ( is_array( $states ) ) {
-				?><span>
-					<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
-						<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
-						<?php
-						foreach ( $states as $ckey => $cvalue ) {
-							echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';
-						}
-						?>
-					</select>
-				</span><?php
-			} else {
-				?><input type="text" class="input-text" value="<?php echo esc_attr( $current_r ); ?>" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" name="calc_shipping_state" id="calc_shipping_state" /><?php
-			}
-			?>
-		</p>
+				if ( is_array( $states ) && empty( $states ) ) {
+					?><input type="hidden" name="calc_shipping_state" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" /><?php
+				} elseif ( is_array( $states ) ) {
+					?><span>
+						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
+							<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
+							<?php
+							foreach ( $states as $ckey => $cvalue ) {
+								echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';
+							}
+							?>
+						</select>
+					</span><?php
+				} else {
+					?><input type="text" class="input-text" value="<?php echo esc_attr( $current_r ); ?>" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>" name="calc_shipping_state" id="calc_shipping_state" /><?php
+				}
+				?>
+			</p>
 
 		<?php endif; ?>
 


### PR DESCRIPTION
There is a filter to disable the city and postcode however there isn't one to disable the state. It is not required to have the shipping calculator still return results if only the country is selected. This would provide the filter to disable state instead of having to edit the template. 