### PR TITLE
Checking class exists is insufficient allows for a fatal error when Jetpack's class defined without specific method

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -84,7 +84,7 @@ class WC_Regenerate_Images {
 		// See if the image size has changed from our settings.
 		if ( ! self::image_size_matches_settings( $data, $size ) ) {
 			// If Photon is running we can just return false and let Jetpack handle regeneration.
-			if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
+			if ( method_exists('Jetpack', 'is_module_active') && Jetpack::is_module_active( 'photon' ) ) {
 				return false;
 			} else {
 				// If we get here, Jetpack is not running and we don't have the correct image sized stored. Try to return closest match.

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -43,7 +43,7 @@ class WC_Regenerate_Images {
 		}
 
 		// Not required when Jetpack Photon is in use.
-		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
+		if ( method_exists('Jetpack', 'is_module_active') && Jetpack::is_module_active( 'photon' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
There are a half dozen stripped-down versions of JetPack's modules like JP Custom CSS, JP Widget visibility, etc... https://wordpress.org/plugins/search/JP/

These define a class called "Jetpack" but don't define all the methods.

Introduced here https://github.com/woocommerce/woocommerce/pull/18955 I don't see an issue referenced, LMK if you need one created.
