### PR TITLE
Dont use mysql functions directly on system status page

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -200,12 +200,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 
 		<?php
 
-		if ( $wpdb->use_mysqli ) {
-			$ver = mysqli_get_server_info( $wpdb->dbh );
-		} else {
-			$ver = mysql_get_server_info(); // @codingStandardsIgnoreLine
-		}
-		if ( ! empty( $wpdb->is_mysql ) && ! stristr( $ver, 'MariaDB' ) ) :
+		if ( ! empty( $wpdb->is_mysql ) ) :
 			?>
 			<tr>
 				<td data-export-label="MySQL Version"><?php esc_html_e( 'MySQL version', 'woocommerce' ); ?>:</td>


### PR DESCRIPTION
There is no need to use mysql*_ functions directly which could cause fatal errors when these functions are disabled for master/slave setups.

Since $wpdb already contains all the info needed and the rest api endpoint where the system status data is coming from already utilise $wpdb->db_version which has checks built in and return the version or an empty string there is no need to do direct function calls before displaying the data.

Closes #19279 