### PR TITLE
Moving cart rounding discount function to core functions

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -379,7 +379,7 @@ class WC_Discounts {
 				}
 			}
 
-			$discount       = wc_cart_round_discount( min( $discounted_price, $discount ), 0 );
+			$discount       = wc_round_discount( min( $discounted_price, $discount ), 0 );
 			$cart_total     = $cart_total + $price_to_discount;
 			$total_discount = $total_discount + $discount;
 			$applied_count  = $applied_count + $apply_quantity;
@@ -389,7 +389,7 @@ class WC_Discounts {
 		}
 
 		// Work out how much discount would have been given to the cart as a whole and compare to what was discounted on all line items.
-		$cart_total_discount = wc_cart_round_discount( $cart_total * ( $coupon_amount / 100 ), 0 );
+		$cart_total_discount = wc_round_discount( $cart_total * ( $coupon_amount / 100 ), 0 );
 
 		if ( $total_discount < $cart_total_discount && $adjust_final_discount ) {
 			$total_discount += $this->apply_coupon_remainder( $coupon, $items_to_apply, $cart_total_discount - $total_discount );

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -374,13 +374,7 @@ function wc_cart_totals_shipping_method_label( $method ) {
  * @return float
  */
 function wc_cart_round_discount( $value, $precision ) {
-	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
-		return round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE );
-	} elseif ( 2 === WC_DISCOUNT_ROUNDING_MODE ) {
-		return wc_legacy_round_half_down( $value, $precision );
-	} else {
-		return round( $value, $precision );
-	}
+	return wc_round_discount( $value, $precision );
 }
 
 /**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2060,3 +2060,20 @@ function wc_decimal_to_fraction( $decimal ) {
 
 	return array( $numerator, $denominator );
 }
+
+/**
+ * Round discount.
+ *
+ * @param  double $value Amount to round.
+ * @param  int    $precision DP to round.
+ * @return float
+ */
+function wc_round_discount( $value, $precision ) {
+	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
+		return round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE );
+	} elseif ( 2 === WC_DISCOUNT_ROUNDING_MODE ) {
+		return wc_legacy_round_half_down( $value, $precision );
+	} else {
+		return round( $value, $precision );
+	}
+}


### PR DESCRIPTION
In response to https://github.com/woocommerce/woocommerce/issues/19233

Moved the rounding function from cart functions to core functions and given it a general name.
Changed the function name in WC_Discounts to the general name so it's more appropriate,

I've left the original cart function so now it just returns the value from the core function, just in case it's being used by 3rd parties and to save changing the function name throughout woocommerce where it's currently being used.