### PR TITLE
PHPCS fixes for includes/emails directory

### DIFF
--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -6,172 +6,176 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 
-/**
- * Cancelled Order Email.
- *
- * An email sent to the admin when an order is cancelled.
- *
- * @class       WC_Email_Cancelled_Order
- * @version     2.2.7
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Cancelled_Order extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'cancelled_order';
-		$this->title          = __( 'Cancelled order', 'woocommerce' );
-		$this->description    = __( 'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously processing or on-hold).', 'woocommerce' );
-		$this->template_html  = 'emails/admin-cancelled-order.php';
-		$this->template_plain = 'emails/plain/admin-cancelled-order.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers for this email
-		add_action( 'woocommerce_order_status_processing_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
-
-		// Call parent constructor
-		parent::__construct();
-
-		// Other settings
-		$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
-	}
-
-	/**
-	 * Get email subject.
+	 * Cancelled Order Email.
 	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( '[{site_title}] Cancelled order ({order_number})', 'woocommerce' );
-	}
-
-	/**
-	 * Get email heading.
+	 * An email sent to the admin when an order is cancelled.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_Cancelled_Order
+	 * @version     2.2.7
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_heading() {
-		return __( 'Cancelled order', 'woocommerce' );
-	}
+	class WC_Email_Cancelled_Order extends WC_Email {
 
-	/**
-	 * Trigger the sending of this email.
-	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
-	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'cancelled_order';
+			$this->title          = __( 'Cancelled order', 'woocommerce' );
+			$this->description    = __( 'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously processing or on-hold).', 'woocommerce' );
+			$this->template_html  = 'emails/admin-cancelled-order.php';
+			$this->template_plain = 'emails/plain/admin-cancelled-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
 
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+			// Triggers for this email
+			add_action( 'woocommerce_order_status_processing_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor
+			parent::__construct();
+
+			// Other settings
+			$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( '[{site_title}] Cancelled order ({order_number})', 'woocommerce' );
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Cancelled order', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => true,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => true,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
-	}
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
 
-	/**
-	 * Initialise settings form fields.
-	 */
-	public function init_form_fields() {
-		$this->form_fields = array(
-			'enabled' => array(
-				'title'         => __( 'Enable/Disable', 'woocommerce' ),
-				'type'          => 'checkbox',
-				'label'         => __( 'Enable this email notification', 'woocommerce' ),
-				'default'       => 'yes',
-			),
-			'recipient' => array(
-				'title'         => __( 'Recipient(s)', 'woocommerce' ),
-				'type'          => 'text',
-				/* translators: %s: admin email */
-				'description'   => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
-				'placeholder'   => '',
-				'default'       => '',
-				'desc_tip'      => true,
-			),
-			'subject' => array(
-				'title'         => __( 'Subject', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_subject(),
-				'default'       => '',
-			),
-			'heading' => array(
-				'title'         => __( 'Email heading', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_heading(),
-				'default'       => '',
-			),
-			'email_type' => array(
-				'title'         => __( 'Email type', 'woocommerce' ),
-				'type'          => 'select',
-				'description'   => __( 'Choose which format of email to send.', 'woocommerce' ),
-				'default'       => 'html',
-				'class'         => 'email_type wc-enhanced-select',
-				'options'       => $this->get_email_type_options(),
-				'desc_tip'      => true,
-			),
-		);
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => true,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => true,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled'    => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'yes',
+				),
+				'recipient'  => array(
+					'title'       => __( 'Recipient(s)', 'woocommerce' ),
+					'type'        => 'text',
+					/* translators: %s: admin email */
+					'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				),
+				'subject'    => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'    => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'email_type' => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Cancelled_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 	 * @class       WC_Email_Cancelled_Order
 	 * @version     2.2.7
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Cancelled_Order extends WC_Email {
@@ -34,14 +38,14 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 				'{order_number}' => '',
 			);
 
-			// Triggers for this email
+			// Triggers for this email.
 			add_action( 'woocommerce_order_status_processing_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
 			add_action( 'woocommerce_order_status_on-hold_to_cancelled_notification', array( $this, 'trigger' ), 10, 2 );
 
-			// Call parent constructor
+			// Call parent constructor.
 			parent::__construct();
 
-			// Other settings
+			// Other settings.
 			$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
 		}
 
@@ -68,8 +72,8 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order Order object.
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
 		 */
 		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -1,7 +1,12 @@
 <?php
+/**
+ * Class WC_Email_Customer_Completed_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 	 * @class       WC_Email_Customer_Completed_Order
 	 * @version     2.0.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Completed_Order extends WC_Email {
@@ -35,18 +39,18 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 				'{order_number}' => '',
 			);
 
-			// Triggers for this email
+			// Triggers for this email.
 			add_action( 'woocommerce_order_status_completed_notification', array( $this, 'trigger' ), 10, 2 );
 
-			// Call parent constructor
+			// Call parent constructor.
 			parent::__construct();
 		}
 
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order Order object.
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
 		 */
 		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -6,161 +6,165 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 
-/**
- * Customer Completed Order Email.
- *
- * Order complete emails are sent to the customer when the order is marked complete and usual indicates that the order has been shipped.
- *
- * @class       WC_Email_Customer_Completed_Order
- * @version     2.0.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_Completed_Order extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'customer_completed_order';
-		$this->customer_email = true;
-		$this->title          = __( 'Completed order', 'woocommerce' );
-		$this->description    = __( 'Order complete emails are sent to customers when their orders are marked completed and usually indicate that their orders have been shipped.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-completed-order.php';
-		$this->template_plain = 'emails/plain/customer-completed-order.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers for this email
-		add_action( 'woocommerce_order_status_completed_notification', array( $this, 'trigger' ), 10, 2 );
-
-		// Call parent constructor
-		parent::__construct();
-	}
-
-	/**
-	 * Trigger the sending of this email.
+	 * Customer Completed Order Email.
 	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
+	 * Order complete emails are sent to the customer when the order is marked complete and usual indicates that the order has been shipped.
+	 *
+	 * @class       WC_Email_Customer_Completed_Order
+	 * @version     2.0.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
+	class WC_Email_Customer_Completed_Order extends WC_Email {
 
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_completed_order';
+			$this->customer_email = true;
+			$this->title          = __( 'Completed order', 'woocommerce' );
+			$this->description    = __( 'Order complete emails are sent to customers when their orders are marked completed and usually indicate that their orders have been shipped.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-completed-order.php';
+			$this->template_plain = 'emails/plain/customer-completed-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
+
+			// Triggers for this email
+			add_action( 'woocommerce_order_status_completed_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor
+			parent::__construct();
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->recipient                      = $this->object->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
+
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->recipient                      = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Your {site_title} order from {order_date} is complete', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Your order is complete', 'woocommerce' );
+		}
 
-	/**
-	 * Get email subject.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( 'Your {site_title} order from {order_date} is complete', 'woocommerce' );
-	}
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
 
-	/**
-	 * Get email heading.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_heading() {
-		return __( 'Your order is complete', 'woocommerce' );
-	}
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled'    => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'yes',
+				),
+				'subject'    => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'    => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'email_type' => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+		}
 	}
-
-	/**
-	 * Get content plain.
-	 *
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
-	}
-
-	/**
-	 * Initialise settings form fields.
-	 */
-	public function init_form_fields() {
-		$this->form_fields = array(
-			'enabled' => array(
-				'title'         => __( 'Enable/Disable', 'woocommerce' ),
-				'type'          => 'checkbox',
-				'label'         => __( 'Enable this email notification', 'woocommerce' ),
-				'default'       => 'yes',
-			),
-			'subject' => array(
-				'title'         => __( 'Subject', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_subject(),
-				'default'       => '',
-			),
-			'heading' => array(
-				'title'         => __( 'Email heading', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_heading(),
-				'default'       => '',
-			),
-			'email_type' => array(
-				'title'         => __( 'Email type', 'woocommerce' ),
-				'type'          => 'select',
-				'description'   => __( 'Choose which format of email to send.', 'woocommerce' ),
-				'default'       => 'html',
-				'class'         => 'email_type wc-enhanced-select',
-				'options'       => $this->get_email_type_options(),
-				'desc_tip'      => true,
-			),
-		);
-	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -1,220 +1,224 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 
-/**
- * Customer Invoice.
- *
- * An email sent to the customer via admin.
- *
- * @class       WC_Email_Customer_Invoice
- * @version     2.3.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_Invoice extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'customer_invoice';
-		$this->customer_email = true;
-		$this->title          = __( 'Customer invoice / Order details', 'woocommerce' );
-		$this->description    = __( 'Customer invoice emails can be sent to customers containing their order information and payment links.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-invoice.php';
-		$this->template_plain = 'emails/plain/customer-invoice.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Call parent constructor
-		parent::__construct();
-
-		$this->manual         = true;
-	}
-
-	/**
-	 * Get email subject.
+	 * Customer Invoice.
 	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject( $paid = false ) {
-		if ( $paid ) {
-			return __( 'Your {site_title} order from {order_date}', 'woocommerce' );
-		} else {
-			return __( 'Invoice for order {order_number}', 'woocommerce' );
-		}
-	}
-
-	/**
-	 * Get email heading.
+	 * An email sent to the customer via admin.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_Customer_Invoice
+	 * @version     2.3.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_heading( $paid = false ) {
-		if ( $paid ) {
-			return __( 'Your order details', 'woocommerce' );
-		} else {
-			return __( 'Invoice for order {order_number}', 'woocommerce' );
-		}
-	}
+	class WC_Email_Customer_Invoice extends WC_Email {
 
-	/**
-	 * Get email subject.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_subject() {
-		if ( $this->object->has_status( array( 'completed', 'processing' ) ) ) {
-			$subject = $this->get_option( 'subject_paid', $this->get_default_subject( true ) );
-			$action  = 'woocommerce_email_subject_customer_invoice_paid';
-		} else {
-			$subject = $this->get_option( 'subject', $this->get_default_subject() );
-			$action  = 'woocommerce_email_subject_customer_invoice';
-		}
-		return apply_filters( $action, $this->format_string( $subject ), $this->object );
-	}
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_invoice';
+			$this->customer_email = true;
+			$this->title          = __( 'Customer invoice / Order details', 'woocommerce' );
+			$this->description    = __( 'Customer invoice emails can be sent to customers containing their order information and payment links.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-invoice.php';
+			$this->template_plain = 'emails/plain/customer-invoice.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
 
-	/**
-	 * Get email heading.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_heading() {
-		if ( $this->object->has_status( wc_get_is_paid_statuses() ) ) {
-			$heading = $this->get_option( 'heading_paid', $this->get_default_heading( true ) );
-			$action  = 'woocommerce_email_heading_customer_invoice_paid';
-		} else {
-			$heading = $this->get_option( 'heading', $this->get_default_heading() );
-			$action  = 'woocommerce_email_heading_customer_invoice';
-		}
-		return apply_filters( $action, $this->format_string( $heading ), $this->object );
-	}
+			// Call parent constructor.
+			parent::__construct();
 
-	/**
-	 * Trigger the sending of this email.
-	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
-	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
-
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+			$this->manual = true;
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->recipient                      = $this->object->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject( $paid = false ) {
+			if ( $paid ) {
+				return __( 'Your {site_title} order from {order_date}', 'woocommerce' );
+			} else {
+				return __( 'Invoice for order {order_number}', 'woocommerce' );
+			}
 		}
 
-		if ( $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading( $paid = false ) {
+			if ( $paid ) {
+				return __( 'Your order details', 'woocommerce' );
+			} else {
+				return __( 'Invoice for order {order_number}', 'woocommerce' );
+			}
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Get email subject.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_subject() {
+			if ( $this->object->has_status( array( 'completed', 'processing' ) ) ) {
+				$subject = $this->get_option( 'subject_paid', $this->get_default_subject( true ) );
+				$action  = 'woocommerce_email_subject_customer_invoice_paid';
+			} else {
+				$subject = $this->get_option( 'subject', $this->get_default_subject() );
+				$action  = 'woocommerce_email_subject_customer_invoice';
+			}
+			return apply_filters( $action, $this->format_string( $subject ), $this->object );
+		}
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
+		/**
+		 * Get email heading.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_heading() {
+			if ( $this->object->has_status( wc_get_is_paid_statuses() ) ) {
+				$heading = $this->get_option( 'heading_paid', $this->get_default_heading( true ) );
+				$action  = 'woocommerce_email_heading_customer_invoice_paid';
+			} else {
+				$heading = $this->get_option( 'heading', $this->get_default_heading() );
+				$action  = 'woocommerce_email_heading_customer_invoice';
+			}
+			return apply_filters( $action, $this->format_string( $heading ), $this->object );
+		}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
-	}
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Initialise settings form fields.
-	 */
-	public function init_form_fields() {
-		$this->form_fields = array(
-			'subject' => array(
-				'title'         => __( 'Subject', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_subject(),
-				'default'       => '',
-			),
-			'heading' => array(
-				'title'         => __( 'Email heading', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_heading(),
-				'default'       => '',
-			),
-			'subject_paid' => array(
-				'title'         => __( 'Subject (paid)', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_subject( true ),
-				'default'       => '',
-			),
-			'heading_paid' => array(
-				'title'         => __( 'Email heading (paid)', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_heading( true ),
-				'default'       => '',
-			),
-			'email_type' => array(
-				'title'         => __( 'Email type', 'woocommerce' ),
-				'type'          => 'select',
-				'description'   => __( 'Choose which format of email to send.', 'woocommerce' ),
-				'default'       => 'html',
-				'class'         => 'email_type wc-enhanced-select',
-				'options'       => $this->get_email_type_options(),
-				'desc_tip'      => true,
-			),
-		);
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->recipient                      = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
+
+			if ( $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'subject'      => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'      => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'subject_paid' => array(
+					'title'       => __( 'Subject (paid)', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject( true ),
+					'default'     => '',
+				),
+				'heading_paid' => array(
+					'title'       => __( 'Email heading (paid)', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading( true ),
+					'default'     => '',
+				),
+				'email_type'   => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_Invoice file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 	 * @class       WC_Email_Customer_Invoice
 	 * @version     2.3.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Invoice extends WC_Email {
@@ -44,6 +48,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		/**
 		 * Get email subject.
 		 *
+		 * @param bool $paid Whether the order has been paid or not.
 		 * @since  3.1.0
 		 * @return string
 		 */
@@ -58,6 +63,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		/**
 		 * Get email heading.
 		 *
+		 * @param bool $paid Whether the order has been paid or not.
 		 * @since  3.1.0
 		 * @return string
 		 */

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -1,152 +1,156 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 
-/**
- * Customer New Account.
- *
- * An email sent to the customer when they create an account.
- *
- * @class       WC_Email_Customer_New_Account
- * @version     2.3.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_New_Account extends WC_Email {
-
 	/**
-	 * User login name.
+	 * Customer New Account.
 	 *
-	 * @var string
-	 */
-	public $user_login;
-
-	/**
-	 * User email.
+	 * An email sent to the customer when they create an account.
 	 *
-	 * @var string
+	 * @class       WC_Email_Customer_New_Account
+	 * @version     2.3.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public $user_email;
+	class WC_Email_Customer_New_Account extends WC_Email {
 
-	/**
-	 * User password.
-	 *
-	 * @var string
-	 */
-	public $user_pass;
+		/**
+		 * User login name.
+		 *
+		 * @var string
+		 */
+		public $user_login;
 
-	/**
-	 * Is the password generated?
-	 *
-	 * @var bool
-	 */
-	public $password_generated;
+		/**
+		 * User email.
+		 *
+		 * @var string
+		 */
+		public $user_email;
 
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'customer_new_account';
-		$this->customer_email = true;
-		$this->title          = __( 'New account', 'woocommerce' );
-		$this->description    = __( 'Customer "new account" emails are sent to the customer when a customer signs up via checkout or account pages.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-new-account.php';
-		$this->template_plain = 'emails/plain/customer-new-account.php';
+		/**
+		 * User password.
+		 *
+		 * @var string
+		 */
+		public $user_pass;
 
-		// Call parent constructor
-		parent::__construct();
-	}
+		/**
+		 * Is the password generated?
+		 *
+		 * @var bool
+		 */
+		public $password_generated;
 
-	/**
-	 * Get email subject.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( 'Your account on {site_title}', 'woocommerce' );
-	}
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_new_account';
+			$this->customer_email = true;
+			$this->title          = __( 'New account', 'woocommerce' );
+			$this->description    = __( 'Customer "new account" emails are sent to the customer when a customer signs up via checkout or account pages.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-new-account.php';
+			$this->template_plain = 'emails/plain/customer-new-account.php';
 
-	/**
-	 * Get email heading.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_heading() {
-		return __( 'Welcome to {site_title}', 'woocommerce' );
-	}
-
-	/**
-	 * Trigger.
-	 *
-	 * @param int $user_id
-	 * @param string $user_pass
-	 * @param bool $password_generated
-	 */
-	public function trigger( $user_id, $user_pass = '', $password_generated = false ) {
-		$this->setup_locale();
-
-		if ( $user_id ) {
-			$this->object             = new WP_User( $user_id );
-
-			$this->user_pass          = $user_pass;
-			$this->user_login         = stripslashes( $this->object->user_login );
-			$this->user_email         = stripslashes( $this->object->user_email );
-			$this->recipient          = $this->user_email;
-			$this->password_generated = $password_generated;
+			// Call parent constructor.
+			parent::__construct();
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Your account on {site_title}', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Welcome to {site_title}', 'woocommerce' );
+		}
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'email_heading'      => $this->get_heading(),
-			'user_login'         => $this->user_login,
-			'user_pass'          => $this->user_pass,
-			'blogname'           => $this->get_blogname(),
-			'password_generated' => $this->password_generated,
-			'sent_to_admin'      => false,
-			'plain_text'         => false,
-			'email'				 => $this,
-		) );
-	}
+		/**
+		 * Trigger.
+		 *
+		 * @param int    $user_id
+		 * @param string $user_pass
+		 * @param bool   $password_generated
+		 */
+		public function trigger( $user_id, $user_pass = '', $password_generated = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'email_heading'      => $this->get_heading(),
-			'user_login'         => $this->user_login,
-			'user_pass'          => $this->user_pass,
-			'blogname'           => $this->get_blogname(),
-			'password_generated' => $this->password_generated,
-			'sent_to_admin'      => false,
-			'plain_text'         => true,
-			'email'			     => $this,
-		) );
+			if ( $user_id ) {
+				$this->object = new WP_User( $user_id );
+
+				$this->user_pass          = $user_pass;
+				$this->user_login         = stripslashes( $this->object->user_login );
+				$this->user_email         = stripslashes( $this->object->user_email );
+				$this->recipient          = $this->user_email;
+				$this->password_generated = $password_generated;
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'email_heading'      => $this->get_heading(),
+					'user_login'         => $this->user_login,
+					'user_pass'          => $this->user_pass,
+					'blogname'           => $this->get_blogname(),
+					'password_generated' => $this->password_generated,
+					'sent_to_admin'      => false,
+					'plain_text'         => false,
+					'email'              => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'email_heading'      => $this->get_heading(),
+					'user_login'         => $this->user_login,
+					'user_pass'          => $this->user_pass,
+					'blogname'           => $this->get_blogname(),
+					'password_generated' => $this->password_generated,
+					'sent_to_admin'      => false,
+					'plain_text'         => true,
+					'email'              => $this,
+				)
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_New_Account file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 	 * @class       WC_Email_Customer_New_Account
 	 * @version     2.3.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_New_Account extends WC_Email {
@@ -85,9 +89,9 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		/**
 		 * Trigger.
 		 *
-		 * @param int    $user_id
-		 * @param string $user_pass
-		 * @param bool   $password_generated
+		 * @param int    $user_id User ID.
+		 * @param string $user_pass User password.
+		 * @param bool   $password_generated Whether the password was generated automatically or not.
 		 */
 		public function trigger( $user_id, $user_pass = '', $password_generated = false ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_Note file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 	 * @class       WC_Email_Customer_Note
 	 * @version     2.3.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Note extends WC_Email {
@@ -72,7 +76,7 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 		/**
 		 * Trigger.
 		 *
-		 * @param array $args
+		 * @param array $args Email arguments.
 		 */
 		public function trigger( $args ) {
 			$this->setup_locale();
@@ -85,13 +89,18 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 
 				$args = wp_parse_args( $args, $defaults );
 
-				extract( $args );
+				$order_id      = $args['order_id'];
+				$customer_note = $args['customer_note'];
 
-				if ( $order_id && ( $this->object = wc_get_order( $order_id ) ) ) {
-					$this->recipient                      = $this->object->get_billing_email();
-					$this->customer_note                  = $customer_note;
-					$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-					$this->placeholders['{order_number}'] = $this->object->get_order_number();
+				if ( $order_id ) {
+					$this->object = wc_get_order( $order_id );
+
+					if ( $this->object ) {
+						$this->recipient                      = $this->object->get_billing_email();
+						$this->customer_note                  = $customer_note;
+						$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+						$this->placeholders['{order_number}'] = $this->object->get_order_number();
+					}
 				}
 			}
 

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -1,141 +1,145 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 
-/**
- * Customer Note Order Email.
- *
- * Customer note emails are sent when you add a note to an order.
- *
- * @class       WC_Email_Customer_Note
- * @version     2.3.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_Note extends WC_Email {
-
 	/**
-	 * Customer note.
+	 * Customer Note Order Email.
 	 *
-	 * @var string
-	 */
-	public $customer_note;
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'customer_note';
-		$this->customer_email = true;
-		$this->title          = __( 'Customer note', 'woocommerce' );
-		$this->description    = __( 'Customer note emails are sent when you add a note to an order.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-note.php';
-		$this->template_plain = 'emails/plain/customer-note.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers
-		add_action( 'woocommerce_new_customer_note_notification', array( $this, 'trigger' ) );
-
-		// Call parent constructor
-		parent::__construct();
-	}
-
-	/**
-	 * Get email subject.
+	 * Customer note emails are sent when you add a note to an order.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_Customer_Note
+	 * @version     2.3.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_subject() {
-		return __( 'Note added to your {site_title} order from {order_date}', 'woocommerce' );
-	}
+	class WC_Email_Customer_Note extends WC_Email {
 
-	/**
-	 * Get email heading.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_heading() {
-		return __( 'A note has been added to your order', 'woocommerce' );
-	}
+		/**
+		 * Customer note.
+		 *
+		 * @var string
+		 */
+		public $customer_note;
 
-	/**
-	 * Trigger.
-	 *
-	 * @param array $args
-	 */
-	public function trigger( $args ) {
-		$this->setup_locale();
-
-		if ( ! empty( $args ) ) {
-			$defaults = array(
-				'order_id'      => '',
-				'customer_note' => '',
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_note';
+			$this->customer_email = true;
+			$this->title          = __( 'Customer note', 'woocommerce' );
+			$this->description    = __( 'Customer note emails are sent when you add a note to an order.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-note.php';
+			$this->template_plain = 'emails/plain/customer-note.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
 			);
 
-			$args = wp_parse_args( $args, $defaults );
+			// Triggers.
+			add_action( 'woocommerce_new_customer_note_notification', array( $this, 'trigger' ) );
 
-			extract( $args );
+			// Call parent constructor.
+			parent::__construct();
+		}
 
-			if ( $order_id && ( $this->object = wc_get_order( $order_id ) ) ) {
-				$this->recipient                      = $this->object->get_billing_email();
-				$this->customer_note                  = $customer_note;
-				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Note added to your {site_title} order from {order_date}', 'woocommerce' );
+		}
+
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'A note has been added to your order', 'woocommerce' );
+		}
+
+		/**
+		 * Trigger.
+		 *
+		 * @param array $args
+		 */
+		public function trigger( $args ) {
+			$this->setup_locale();
+
+			if ( ! empty( $args ) ) {
+				$defaults = array(
+					'order_id'      => '',
+					'customer_note' => '',
+				);
+
+				$args = wp_parse_args( $args, $defaults );
+
+				extract( $args );
+
+				if ( $order_id && ( $this->object = wc_get_order( $order_id ) ) ) {
+					$this->recipient                      = $this->object->get_billing_email();
+					$this->customer_note                  = $customer_note;
+					$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+					$this->placeholders['{order_number}'] = $this->object->get_order_number();
+				}
 			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'customer_note' => $this->customer_note,
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
 		}
 
-		$this->restore_locale();
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'customer_note' => $this->customer_note,
+					'sent_to_admin' => false,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
 	}
-
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'customer_note' => $this->customer_note,
-			'sent_to_admin' => false,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
-
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'customer_note' => $this->customer_note,
-			'sent_to_admin' => false,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
-	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -1,127 +1,131 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 
-/**
- * Customer On-hold Order Email.
- *
- * An email sent to the customer when a new order is on-hold for.
- *
- * @class       WC_Email_Customer_On_Hold_Order
- * @version     2.6.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_On_Hold_Order extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'customer_on_hold_order';
-		$this->customer_email = true;
-		$this->title          = __( 'Order on-hold', 'woocommerce' );
-		$this->description    = __( 'This is an order notification sent to customers containing order details after an order is placed on-hold.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-on-hold-order.php';
-		$this->template_plain = 'emails/plain/customer-on-hold-order.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers for this email
-		add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
-
-		// Call parent constructor
-		parent::__construct();
-	}
-
-	/**
-	 * Get email subject.
+	 * Customer On-hold Order Email.
 	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
-	}
-
-	/**
-	 * Get email heading.
+	 * An email sent to the customer when a new order is on-hold for.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_Customer_On_Hold_Order
+	 * @version     2.6.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_heading() {
-		return __( 'Thank you for your order', 'woocommerce' );
-	}
+	class WC_Email_Customer_On_Hold_Order extends WC_Email {
 
-	/**
-	 * Trigger the sending of this email.
-	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
-	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_on_hold_order';
+			$this->customer_email = true;
+			$this->title          = __( 'Order on-hold', 'woocommerce' );
+			$this->description    = __( 'This is an order notification sent to customers containing order details after an order is placed on-hold.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-on-hold-order.php';
+			$this->template_plain = 'emails/plain/customer-on-hold-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
 
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+			// Triggers for this email.
+			add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->recipient                      = $this->object->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Thank you for your order', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => false,
-			'email'         => $this,
-		) );
-	}
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->recipient                      = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_On_Hold_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 	 * @class       WC_Email_Customer_On_Hold_Order
 	 * @version     2.6.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_On_Hold_Order extends WC_Email {
@@ -66,8 +70,8 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order Order object.
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
 		 */
 		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -1,129 +1,133 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 
-/**
- * Customer Processing Order Email.
- *
- * An email sent to the customer when a new order is paid for.
- *
- * @class       WC_Email_Customer_Processing_Order
- * @version     2.0.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_Processing_Order extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id               = 'customer_processing_order';
-		$this->customer_email   = true;
-
-		$this->title            = __( 'Processing order', 'woocommerce' );
-		$this->description      = __( 'This is an order notification sent to customers containing order details after payment.', 'woocommerce' );
-		$this->template_html    = 'emails/customer-processing-order.php';
-		$this->template_plain   = 'emails/plain/customer-processing-order.php';
-		$this->placeholders = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers for this email
-		add_action( 'woocommerce_order_status_failed_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_on-hold_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_pending_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
-
-		// Call parent constructor
-		parent::__construct();
-	}
-
-	/**
-	 * Get email subject.
+	 * Customer Processing Order Email.
 	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
-	}
-
-	/**
-	 * Get email heading.
+	 * An email sent to the customer when a new order is paid for.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_Customer_Processing_Order
+	 * @version     2.0.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_heading() {
-		return __( 'Thank you for your order', 'woocommerce' );
-	}
+	class WC_Email_Customer_Processing_Order extends WC_Email {
 
-	/**
-	 * Trigger the sending of this email.
-	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
-	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'customer_processing_order';
+			$this->customer_email = true;
 
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+			$this->title          = __( 'Processing order', 'woocommerce' );
+			$this->description    = __( 'This is an order notification sent to customers containing order details after payment.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-processing-order.php';
+			$this->template_plain = 'emails/plain/customer-processing-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
+
+			// Triggers for this email.
+			add_action( 'woocommerce_order_status_failed_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_on-hold_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_pending_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->recipient                      = $this->object->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Thank you for your order', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => false,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->recipient                      = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => false,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_Processing_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 	 * @class       WC_Email_Customer_Processing_Order
 	 * @version     2.0.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Processing_Order extends WC_Email {
@@ -68,8 +72,8 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order Order object.
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
 		 */
 		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_Refunded_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 	 * @class    WC_Email_Customer_Refunded_Order
 	 * @version  2.4.0
 	 * @package  WooCommerce/Classes/Emails
-	 * @author   WooThemes
 	 * @extends  WC_Email
 	 */
 	class WC_Email_Customer_Refunded_Order extends WC_Email {
@@ -60,6 +64,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Get email subject.
 		 *
+		 * @param bool $partial Whether it is a partial refund or a full refund.
 		 * @since  3.1.0
 		 * @return string
 		 */
@@ -74,6 +79,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
+		 * @param bool $partial Whether it is a partial refund or a full refund.
 		 * @since  3.1.0
 		 * @return string
 		 */
@@ -118,6 +124,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Set email strings.
 		 *
+		 * @param bool $partial_refund Whether it is a partial refund or a full refund.
 		 * @deprecated 3.1.0 Unused.
 		 */
 		public function set_email_strings( $partial_refund = false ) {}
@@ -125,8 +132,8 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Full refund notification.
 		 *
-		 * @param int $order_id
-		 * @param int $refund_id
+		 * @param int $order_id Order ID.
+		 * @param int $refund_id Refund ID.
 		 */
 		public function trigger_full( $order_id, $refund_id = null ) {
 			$this->trigger( $order_id, false, $refund_id );
@@ -135,8 +142,8 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Partial refund notification.
 		 *
-		 * @param int $order_id
-		 * @param int $refund_id
+		 * @param int $order_id Order ID.
+		 * @param int $refund_id Refund ID.
 		 */
 		public function trigger_partial( $order_id, $refund_id = null ) {
 			$this->trigger( $order_id, true, $refund_id );
@@ -145,9 +152,9 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Trigger.
 		 *
-		 * @param int  $order_id
-		 * @param bool $partial_refund
-		 * @param int  $refund_id
+		 * @param int  $order_id Order ID.
+		 * @param bool $partial_refund Whether it is a partial refund or a full refund.
+		 * @param int  $refund_id Refund ID.
 		 */
 		public function trigger( $order_id, $partial_refund = false, $refund_id = null ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -1,272 +1,277 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 
-/**
- * Customer Refunded Order Email.
- *
- * Order refunded emails are sent to the customer when the order is marked refunded.
- *
- * @class    WC_Email_Customer_Refunded_Order
- * @version  2.4.0
- * @package  WooCommerce/Classes/Emails
- * @author   WooThemes
- * @extends  WC_Email
- */
-class WC_Email_Customer_Refunded_Order extends WC_Email {
-
 	/**
-	 * Refund order.
+	 * Customer Refunded Order Email.
 	 *
-	 * @var WC_Order|bool
-	 */
-	public $refund;
-
-	/**
-	 * Is the order partial refunded?
+	 * Order refunded emails are sent to the customer when the order is marked refunded.
 	 *
-	 * @var bool
+	 * @class    WC_Email_Customer_Refunded_Order
+	 * @version  2.4.0
+	 * @package  WooCommerce/Classes/Emails
+	 * @author   WooThemes
+	 * @extends  WC_Email
 	 */
-	public $partial_refund;
+	class WC_Email_Customer_Refunded_Order extends WC_Email {
 
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->customer_email = true;
-		$this->id             = 'customer_refunded_order';
-		$this->title          = __( 'Refunded order', 'woocommerce' );
-		$this->description    = __( 'Order refunded emails are sent to customers when their orders are refunded.', 'woocommerce' );
-		$this->template_html  = 'emails/customer-refunded-order.php';
-		$this->template_plain = 'emails/plain/customer-refunded-order.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
+		/**
+		 * Refund order.
+		 *
+		 * @var WC_Order|bool
+		 */
+		public $refund;
 
-		// Triggers for this email
-		add_action( 'woocommerce_order_fully_refunded_notification', array( $this, 'trigger_full' ), 10, 2 );
-		add_action( 'woocommerce_order_partially_refunded_notification', array( $this, 'trigger_partial' ), 10, 2 );
+		/**
+		 * Is the order partial refunded?
+		 *
+		 * @var bool
+		 */
+		public $partial_refund;
 
-		// Call parent constructor.
-		parent::__construct();
-	}
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->customer_email = true;
+			$this->id             = 'customer_refunded_order';
+			$this->title          = __( 'Refunded order', 'woocommerce' );
+			$this->description    = __( 'Order refunded emails are sent to customers when their orders are refunded.', 'woocommerce' );
+			$this->template_html  = 'emails/customer-refunded-order.php';
+			$this->template_plain = 'emails/plain/customer-refunded-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
 
-	/**
-	 * Get email subject.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject( $partial = false ) {
-		if ( $partial ) {
-			return __( 'Your {site_title} order from {order_date} has been partially refunded', 'woocommerce' );
-		} else {
-			return __( 'Your {site_title} order from {order_date} has been refunded', 'woocommerce' );
-		}
-	}
+			// Triggers for this email.
+			add_action( 'woocommerce_order_fully_refunded_notification', array( $this, 'trigger_full' ), 10, 2 );
+			add_action( 'woocommerce_order_partially_refunded_notification', array( $this, 'trigger_partial' ), 10, 2 );
 
-	/**
-	 * Get email heading.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_heading( $partial = false ) {
-		if ( $partial ) {
-			return __( 'Your order has been partially refunded', 'woocommerce' );
-		} else {
-			return __( 'Order {order_number} details', 'woocommerce' );
-		}
-	}
-
-	/**
-	 * Get email subject.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_subject() {
-		if ( $this->partial_refund ) {
-			$subject = $this->get_option( 'subject_partial', $this->get_default_subject( true ) );
-		} else {
-			$subject = $this->get_option( 'subject_full', $this->get_default_subject() );
-		}
-		return apply_filters( 'woocommerce_email_subject_customer_refunded_order', $this->format_string( $subject ), $this->object );
-	}
-
-	/**
-	 * Get email heading.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_heading() {
-		if ( $this->partial_refund ) {
-			$heading = $this->get_option( 'heading_partial', $this->get_default_heading( true ) );
-		} else {
-			$heading = $this->get_option( 'heading_full', $this->get_default_heading() );
-		}
-		return apply_filters( 'woocommerce_email_heading_customer_refunded_order', $this->format_string( $heading ), $this->object );
-	}
-
-	/**
-	 * Set email strings.
-	 * @deprecated 3.1.0 Unused.
-	 */
-	public function set_email_strings( $partial_refund = false ) {}
-
-	/**
-	 * Full refund notification.
-	 *
-	 * @param int $order_id
-	 * @param int $refund_id
-	 */
-	public function trigger_full( $order_id, $refund_id = null ) {
-		$this->trigger( $order_id, false, $refund_id );
-	}
-
-	/**
-	 * Partial refund notification.
-	 *
-	 * @param int $order_id
-	 * @param int $refund_id
-	 */
-	public function trigger_partial( $order_id, $refund_id = null ) {
-		$this->trigger( $order_id, true, $refund_id );
-	}
-
-	/**
-	 * Trigger.
-	 *
-	 * @param int $order_id
-	 * @param bool $partial_refund
-	 * @param int $refund_id
-	 */
-	public function trigger( $order_id, $partial_refund = false, $refund_id = null ) {
-		$this->setup_locale();
-		$this->partial_refund = $partial_refund;
-		$this->id             = $this->partial_refund ? 'customer_partially_refunded_order' : 'customer_refunded_order';
-
-		if ( $order_id ) {
-			$this->object                         = wc_get_order( $order_id );
-			$this->recipient                      = $this->object->get_billing_email();
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			// Call parent constructor.
+			parent::__construct();
 		}
 
-		if ( ! empty( $refund_id ) ) {
-			$this->refund = wc_get_order( $refund_id );
-		} else {
-			$this->refund = false;
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject( $partial = false ) {
+			if ( $partial ) {
+				return __( 'Your {site_title} order from {order_date} has been partially refunded', 'woocommerce' );
+			} else {
+				return __( 'Your {site_title} order from {order_date} has been refunded', 'woocommerce' );
+			}
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading( $partial = false ) {
+			if ( $partial ) {
+				return __( 'Your order has been partially refunded', 'woocommerce' );
+			} else {
+				return __( 'Order {order_number} details', 'woocommerce' );
+			}
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Get email subject.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_subject() {
+			if ( $this->partial_refund ) {
+				$subject = $this->get_option( 'subject_partial', $this->get_default_subject( true ) );
+			} else {
+				$subject = $this->get_option( 'subject_full', $this->get_default_subject() );
+			}
+			return apply_filters( 'woocommerce_email_subject_customer_refunded_order', $this->format_string( $subject ), $this->object );
+		}
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'          => $this->object,
-			'refund'		 => $this->refund,
-			'partial_refund' => $this->partial_refund,
-			'email_heading'  => $this->get_heading(),
-			'sent_to_admin'  => false,
-			'plain_text'     => false,
-			'email'			 => $this,
-		) );
-	}
+		/**
+		 * Get email heading.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_heading() {
+			if ( $this->partial_refund ) {
+				$heading = $this->get_option( 'heading_partial', $this->get_default_heading( true ) );
+			} else {
+				$heading = $this->get_option( 'heading_full', $this->get_default_heading() );
+			}
+			return apply_filters( 'woocommerce_email_heading_customer_refunded_order', $this->format_string( $heading ), $this->object );
+		}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'          => $this->object,
-			'refund'		 => $this->refund,
-			'partial_refund' => $this->partial_refund,
-			'email_heading'  => $this->get_heading(),
-			'sent_to_admin'  => false,
-			'plain_text'     => true,
-			'email'			 => $this,
-		) );
-	}
+		/**
+		 * Set email strings.
+		 *
+		 * @deprecated 3.1.0 Unused.
+		 */
+		public function set_email_strings( $partial_refund = false ) {}
 
-	/**
-	 * Initialise settings form fields.
-	 */
-	public function init_form_fields() {
-		$this->form_fields = array(
-			'enabled' => array(
-				'title'   => __( 'Enable/Disable', 'woocommerce' ),
-				'type'    => 'checkbox',
-				'label'   => __( 'Enable this email notification', 'woocommerce' ),
-				'default' => 'yes',
-			),
-			'subject_full' => array(
-				'title'       => __( 'Full refund subject', 'woocommerce' ),
-				'type'        => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder' => $this->get_default_subject(),
-				'default'     => '',
-			),
-			'subject_partial' => array(
-				'title'       => __( 'Partial refund subject', 'woocommerce' ),
-				'type'        => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder' => $this->get_default_subject( true ),
-				'default'     => '',
-			),
-			'heading_full' => array(
-				'title'       => __( 'Full refund email heading', 'woocommerce' ),
-				'type'        => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder' => $this->get_default_heading(),
-				'default'     => '',
-			),
-			'heading_partial' => array(
-				'title'       => __( 'Partial refund email heading', 'woocommerce' ),
-				'type'        => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder' => $this->get_default_heading( true ),
-				'default'     => '',
-			),
-			'email_type' => array(
-				'title'       => __( 'Email type', 'woocommerce' ),
-				'type'        => 'select',
-				'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
-				'default'     => 'html',
-				'class'       => 'email_type wc-enhanced-select',
-				'options'     => $this->get_email_type_options(),
-				'desc_tip'    => true,
-			),
-		);
+		/**
+		 * Full refund notification.
+		 *
+		 * @param int $order_id
+		 * @param int $refund_id
+		 */
+		public function trigger_full( $order_id, $refund_id = null ) {
+			$this->trigger( $order_id, false, $refund_id );
+		}
+
+		/**
+		 * Partial refund notification.
+		 *
+		 * @param int $order_id
+		 * @param int $refund_id
+		 */
+		public function trigger_partial( $order_id, $refund_id = null ) {
+			$this->trigger( $order_id, true, $refund_id );
+		}
+
+		/**
+		 * Trigger.
+		 *
+		 * @param int  $order_id
+		 * @param bool $partial_refund
+		 * @param int  $refund_id
+		 */
+		public function trigger( $order_id, $partial_refund = false, $refund_id = null ) {
+			$this->setup_locale();
+			$this->partial_refund = $partial_refund;
+			$this->id             = $this->partial_refund ? 'customer_partially_refunded_order' : 'customer_refunded_order';
+
+			if ( $order_id ) {
+				$this->object                         = wc_get_order( $order_id );
+				$this->recipient                      = $this->object->get_billing_email();
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
+
+			if ( ! empty( $refund_id ) ) {
+				$this->refund = wc_get_order( $refund_id );
+			} else {
+				$this->refund = false;
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'          => $this->object,
+					'refund'         => $this->refund,
+					'partial_refund' => $this->partial_refund,
+					'email_heading'  => $this->get_heading(),
+					'sent_to_admin'  => false,
+					'plain_text'     => false,
+					'email'          => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'          => $this->object,
+					'refund'         => $this->refund,
+					'partial_refund' => $this->partial_refund,
+					'email_heading'  => $this->get_heading(),
+					'sent_to_admin'  => false,
+					'plain_text'     => true,
+					'email'          => $this,
+				)
+			);
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled'         => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'yes',
+				),
+				'subject_full'    => array(
+					'title'       => __( 'Full refund subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'subject_partial' => array(
+					'title'       => __( 'Partial refund subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject( true ),
+					'default'     => '',
+				),
+				'heading_full'    => array(
+					'title'       => __( 'Full refund email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'heading_partial' => array(
+					'title'       => __( 'Partial refund email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading( true ),
+					'default'     => '',
+				),
+				'email_type'      => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -1,156 +1,160 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 
-/**
- * Customer Reset Password.
- *
- * An email sent to the customer when they reset their password.
- *
- * @class       WC_Email_Customer_Reset_Password
- * @version     2.3.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Customer_Reset_Password extends WC_Email {
-
 	/**
-	 * User ID.
+	 * Customer Reset Password.
 	 *
-	 * @var integer
-	 */
-	public $user_id;
-
-	/**
-	 * User login name.
+	 * An email sent to the customer when they reset their password.
 	 *
-	 * @var string
+	 * @class       WC_Email_Customer_Reset_Password
+	 * @version     2.3.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public $user_login;
+	class WC_Email_Customer_Reset_Password extends WC_Email {
 
-	/**
-	 * User email.
-	 *
-	 * @var string
-	 */
-	public $user_email;
+		/**
+		 * User ID.
+		 *
+		 * @var integer
+		 */
+		public $user_id;
 
-	/**
-	 * Reset key.
-	 *
-	 * @var string
-	 */
-	public $reset_key;
+		/**
+		 * User login name.
+		 *
+		 * @var string
+		 */
+		public $user_login;
 
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
+		/**
+		 * User email.
+		 *
+		 * @var string
+		 */
+		public $user_email;
 
-		$this->id               = 'customer_reset_password';
-		$this->customer_email   = true;
+		/**
+		 * Reset key.
+		 *
+		 * @var string
+		 */
+		public $reset_key;
 
-		$this->title            = __( 'Reset password', 'woocommerce' );
-		$this->description      = __( 'Customer "reset password" emails are sent when customers reset their passwords.', 'woocommerce' );
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
 
-		$this->template_html    = 'emails/customer-reset-password.php';
-		$this->template_plain   = 'emails/plain/customer-reset-password.php';
+			$this->id             = 'customer_reset_password';
+			$this->customer_email = true;
 
-		// Trigger
-		add_action( 'woocommerce_reset_password_notification', array( $this, 'trigger' ), 10, 2 );
+			$this->title       = __( 'Reset password', 'woocommerce' );
+			$this->description = __( 'Customer "reset password" emails are sent when customers reset their passwords.', 'woocommerce' );
 
-		// Call parent constructor
-		parent::__construct();
-	}
+			$this->template_html  = 'emails/customer-reset-password.php';
+			$this->template_plain = 'emails/plain/customer-reset-password.php';
 
-	/**
-	 * Get email subject.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( 'Password reset for {site_title}', 'woocommerce' );
-	}
+			// Trigger.
+			add_action( 'woocommerce_reset_password_notification', array( $this, 'trigger' ), 10, 2 );
 
-	/**
-	 * Get email heading.
-	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_heading() {
-		return __( 'Password reset instructions', 'woocommerce' );
-	}
-
-	/**
-	 * Trigger.
-	 *
-	 * @param string $user_login
-	 * @param string $reset_key
-	 */
-	public function trigger( $user_login = '', $reset_key = '' ) {
-		$this->setup_locale();
-
-		if ( $user_login && $reset_key ) {
-			$this->object     = get_user_by( 'login', $user_login );
-			$this->user_id 	  = $this->object->ID;
-			$this->user_login = $user_login;
-			$this->reset_key  = $reset_key;
-			$this->user_email = stripslashes( $this->object->user_email );
-			$this->recipient  = $this->user_email;
+			// Call parent constructor.
+			parent::__construct();
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( 'Password reset for {site_title}', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Password reset instructions', 'woocommerce' );
+		}
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'email_heading' => $this->get_heading(),
-			'user_id' 		=> $this->user_id,
-			'user_login'    => $this->user_login,
-			'reset_key'     => $this->reset_key,
-			'blogname'      => $this->get_blogname(),
-			'sent_to_admin' => false,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
+		/**
+		 * Trigger.
+		 *
+		 * @param string $user_login
+		 * @param string $reset_key
+		 */
+		public function trigger( $user_login = '', $reset_key = '' ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'email_heading' => $this->get_heading(),
-			'user_id' 		=> $this->user_id,
-			'user_login'    => $this->user_login,
-			'reset_key'     => $this->reset_key,
-			'blogname'      => $this->get_blogname(),
-			'sent_to_admin' => false,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
+			if ( $user_login && $reset_key ) {
+				$this->object     = get_user_by( 'login', $user_login );
+				$this->user_id    = $this->object->ID;
+				$this->user_login = $user_login;
+				$this->reset_key  = $reset_key;
+				$this->user_email = stripslashes( $this->object->user_email );
+				$this->recipient  = $this->user_email;
+			}
+
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'email_heading' => $this->get_heading(),
+					'user_id'       => $this->user_id,
+					'user_login'    => $this->user_login,
+					'reset_key'     => $this->reset_key,
+					'blogname'      => $this->get_blogname(),
+					'sent_to_admin' => false,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'email_heading' => $this->get_heading(),
+					'user_id'       => $this->user_id,
+					'user_login'    => $this->user_login,
+					'reset_key'     => $this->reset_key,
+					'blogname'      => $this->get_blogname(),
+					'sent_to_admin' => false,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Customer_Reset_Password file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 	 * @class       WC_Email_Customer_Reset_Password
 	 * @version     2.3.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Reset_Password extends WC_Email {
@@ -91,8 +95,8 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		/**
 		 * Trigger.
 		 *
-		 * @param string $user_login
-		 * @param string $reset_key
+		 * @param string $user_login User login.
+		 * @param string $reset_key Password reset key.
 		 */
 		public function trigger( $user_login = '', $reset_key = '' ) {
 			$this->setup_locale();

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_Failed_Order file.
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 	 * @class       WC_Email_Failed_Order
 	 * @version     2.5.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Failed_Order extends WC_Email {
@@ -68,8 +72,8 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order Order object.
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
 		 */
 		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();
@@ -140,6 +144,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 				'recipient'  => array(
 					'title'       => __( 'Recipient(s)', 'woocommerce' ),
 					'type'        => 'text',
+					/* translators: %s: WP admin email */
 					'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
 					'placeholder' => '',
 					'default'     => '',

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -6,171 +6,175 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 
-/**
- * Failed Order Email.
- *
- * An email sent to the admin when payment fails to go through.
- *
- * @class       WC_Email_Failed_Order
- * @version     2.5.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_Failed_Order extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'failed_order';
-		$this->title          = __( 'Failed order', 'woocommerce' );
-		$this->description    = __( 'Failed order emails are sent to chosen recipient(s) when orders have been marked failed (if they were previously processing or on-hold).', 'woocommerce' );
-		$this->template_html  = 'emails/admin-failed-order.php';
-		$this->template_plain = 'emails/plain/admin-failed-order.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers for this email
-		add_action( 'woocommerce_order_status_pending_to_failed_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_on-hold_to_failed_notification', array( $this, 'trigger' ), 10, 2 );
-
-		// Call parent constructor
-		parent::__construct();
-
-		// Other settings
-		$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
-	}
-
-	/**
-	 * Get email subject.
+	 * Failed Order Email.
 	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( '[{site_title}] Failed order ({order_number})', 'woocommerce' );
-	}
-
-	/**
-	 * Get email heading.
+	 * An email sent to the admin when payment fails to go through.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_Failed_Order
+	 * @version     2.5.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_heading() {
-		return __( 'Failed order', 'woocommerce' );
-	}
+	class WC_Email_Failed_Order extends WC_Email {
 
-	/**
-	 * Trigger the sending of this email.
-	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
-	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'failed_order';
+			$this->title          = __( 'Failed order', 'woocommerce' );
+			$this->description    = __( 'Failed order emails are sent to chosen recipient(s) when orders have been marked failed (if they were previously processing or on-hold).', 'woocommerce' );
+			$this->template_html  = 'emails/admin-failed-order.php';
+			$this->template_plain = 'emails/plain/admin-failed-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
 
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+			// Triggers for this email.
+			add_action( 'woocommerce_order_status_pending_to_failed_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_on-hold_to_failed_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			// Other settings.
+			$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( '[{site_title}] Failed order ({order_number})', 'woocommerce' );
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'Failed order', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => true,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => true,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
-	}
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
 
-	/**
-	 * Initialise settings form fields.
-	 */
-	public function init_form_fields() {
-		$this->form_fields = array(
-			'enabled' => array(
-				'title'         => __( 'Enable/Disable', 'woocommerce' ),
-				'type'          => 'checkbox',
-				'label'         => __( 'Enable this email notification', 'woocommerce' ),
-				'default'       => 'yes',
-			),
-			'recipient' => array(
-				'title'         => __( 'Recipient(s)', 'woocommerce' ),
-				'type'          => 'text',
-				'description'   => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
-				'placeholder'   => '',
-				'default'       => '',
-				'desc_tip'      => true,
-			),
-			'subject' => array(
-				'title'         => __( 'Subject', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_subject(),
-				'default'       => '',
-			),
-			'heading' => array(
-				'title'         => __( 'Email heading', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_heading(),
-				'default'       => '',
-			),
-			'email_type' => array(
-				'title'         => __( 'Email type', 'woocommerce' ),
-				'type'          => 'select',
-				'description'   => __( 'Choose which format of email to send.', 'woocommerce' ),
-				'default'       => 'html',
-				'class'         => 'email_type wc-enhanced-select',
-				'options'       => $this->get_email_type_options(),
-				'desc_tip'      => true,
-			),
-		);
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => true,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => true,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled'    => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'yes',
+				),
+				'recipient'  => array(
+					'title'       => __( 'Recipient(s)', 'woocommerce' ),
+					'type'        => 'text',
+					'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				),
+				'subject'    => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'    => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'email_type' => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -6,176 +6,180 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 
-/**
- * New Order Email.
- *
- * An email sent to the admin when a new order is received/paid for.
- *
- * @class       WC_Email_New_Order
- * @version     2.0.0
- * @package     WooCommerce/Classes/Emails
- * @author      WooThemes
- * @extends     WC_Email
- */
-class WC_Email_New_Order extends WC_Email {
-
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->id             = 'new_order';
-		$this->title          = __( 'New order', 'woocommerce' );
-		$this->description    = __( 'New order emails are sent to chosen recipient(s) when a new order is received.', 'woocommerce' );
-		$this->template_html  = 'emails/admin-new-order.php';
-		$this->template_plain = 'emails/plain/admin-new-order.php';
-		$this->placeholders   = array(
-			'{site_title}'   => $this->get_blogname(),
-			'{order_date}'   => '',
-			'{order_number}' => '',
-		);
-
-		// Triggers for this email
-		add_action( 'woocommerce_order_status_pending_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_pending_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_failed_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_failed_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
-		add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
-
-		// Call parent constructor
-		parent::__construct();
-
-		// Other settings
-		$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
-	}
-
-	/**
-	 * Get email subject.
+	 * New Order Email.
 	 *
-	 * @since  3.1.0
-	 * @return string
-	 */
-	public function get_default_subject() {
-		return __( '[{site_title}] New customer order ({order_number}) - {order_date}', 'woocommerce' );
-	}
-
-	/**
-	 * Get email heading.
+	 * An email sent to the admin when a new order is received/paid for.
 	 *
-	 * @since  3.1.0
-	 * @return string
+	 * @class       WC_Email_New_Order
+	 * @version     2.0.0
+	 * @package     WooCommerce/Classes/Emails
+	 * @author      WooThemes
+	 * @extends     WC_Email
 	 */
-	public function get_default_heading() {
-		return __( 'New customer order', 'woocommerce' );
-	}
+	class WC_Email_New_Order extends WC_Email {
 
-	/**
-	 * Trigger the sending of this email.
-	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order $order Order object.
-	 */
-	public function trigger( $order_id, $order = false ) {
-		$this->setup_locale();
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->id             = 'new_order';
+			$this->title          = __( 'New order', 'woocommerce' );
+			$this->description    = __( 'New order emails are sent to chosen recipient(s) when a new order is received.', 'woocommerce' );
+			$this->template_html  = 'emails/admin-new-order.php';
+			$this->template_plain = 'emails/plain/admin-new-order.php';
+			$this->placeholders   = array(
+				'{site_title}'   => $this->get_blogname(),
+				'{order_date}'   => '',
+				'{order_number}' => '',
+			);
 
-		if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
-			$order = wc_get_order( $order_id );
+			// Triggers for this email.
+			add_action( 'woocommerce_order_status_pending_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_pending_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_failed_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_failed_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
+			add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
+
+			// Call parent constructor.
+			parent::__construct();
+
+			// Other settings.
+			$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
 		}
 
-		if ( is_a( $order, 'WC_Order' ) ) {
-			$this->object                         = $order;
-			$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-			$this->placeholders['{order_number}'] = $this->object->get_order_number();
+		/**
+		 * Get email subject.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_subject() {
+			return __( '[{site_title}] New customer order ({order_number}) - {order_date}', 'woocommerce' );
 		}
 
-		if ( $this->is_enabled() && $this->get_recipient() ) {
-			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		/**
+		 * Get email heading.
+		 *
+		 * @since  3.1.0
+		 * @return string
+		 */
+		public function get_default_heading() {
+			return __( 'New customer order', 'woocommerce' );
 		}
 
-		$this->restore_locale();
-	}
+		/**
+		 * Trigger the sending of this email.
+		 *
+		 * @param int      $order_id The order ID.
+		 * @param WC_Order $order Order object.
+		 */
+		public function trigger( $order_id, $order = false ) {
+			$this->setup_locale();
 
-	/**
-	 * Get content html.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_html() {
-		return wc_get_template_html( $this->template_html, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => true,
-			'plain_text'    => false,
-			'email'			=> $this,
-		) );
-	}
+			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
+				$order = wc_get_order( $order_id );
+			}
 
-	/**
-	 * Get content plain.
-	 *
-	 * @access public
-	 * @return string
-	 */
-	public function get_content_plain() {
-		return wc_get_template_html( $this->template_plain, array(
-			'order'         => $this->object,
-			'email_heading' => $this->get_heading(),
-			'sent_to_admin' => true,
-			'plain_text'    => true,
-			'email'			=> $this,
-		) );
-	}
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$this->object                         = $order;
+				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+			}
 
-	/**
-	 * Initialise settings form fields.
-	 */
-	public function init_form_fields() {
-		$this->form_fields = array(
-			'enabled' => array(
-				'title'         => __( 'Enable/Disable', 'woocommerce' ),
-				'type'          => 'checkbox',
-				'label'         => __( 'Enable this email notification', 'woocommerce' ),
-				'default'       => 'yes',
-			),
-			'recipient' => array(
-				'title'         => __( 'Recipient(s)', 'woocommerce' ),
-				'type'          => 'text',
-				'description'   => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
-				'placeholder'   => '',
-				'default'       => '',
-				'desc_tip'      => true,
-			),
-			'subject' => array(
-				'title'         => __( 'Subject', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_subject(),
-				'default'       => '',
-			),
-			'heading' => array(
-				'title'         => __( 'Email heading', 'woocommerce' ),
-				'type'          => 'text',
-				'desc_tip'      => true,
-				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
-				'placeholder'   => $this->get_default_heading(),
-				'default'       => '',
-			),
-			'email_type' => array(
-				'title'         => __( 'Email type', 'woocommerce' ),
-				'type'          => 'select',
-				'description'   => __( 'Choose which format of email to send.', 'woocommerce' ),
-				'default'       => 'html',
-				'class'         => 'email_type wc-enhanced-select',
-				'options'       => $this->get_email_type_options(),
-				'desc_tip'      => true,
-			),
-		);
+			if ( $this->is_enabled() && $this->get_recipient() ) {
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+			}
+
+			$this->restore_locale();
+		}
+
+		/**
+		 * Get content html.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_html() {
+			return wc_get_template_html(
+				$this->template_html, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => true,
+					'plain_text'    => false,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Get content plain.
+		 *
+		 * @access public
+		 * @return string
+		 */
+		public function get_content_plain() {
+			return wc_get_template_html(
+				$this->template_plain, array(
+					'order'         => $this->object,
+					'email_heading' => $this->get_heading(),
+					'sent_to_admin' => true,
+					'plain_text'    => true,
+					'email'         => $this,
+				)
+			);
+		}
+
+		/**
+		 * Initialise settings form fields.
+		 */
+		public function init_form_fields() {
+			$this->form_fields = array(
+				'enabled'    => array(
+					'title'   => __( 'Enable/Disable', 'woocommerce' ),
+					'type'    => 'checkbox',
+					'label'   => __( 'Enable this email notification', 'woocommerce' ),
+					'default' => 'yes',
+				),
+				'recipient'  => array(
+					'title'       => __( 'Recipient(s)', 'woocommerce' ),
+					'type'        => 'text',
+					'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
+					'placeholder' => '',
+					'default'     => '',
+					'desc_tip'    => true,
+				),
+				'subject'    => array(
+					'title'       => __( 'Subject', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_subject(),
+					'default'     => '',
+				),
+				'heading'    => array(
+					'title'       => __( 'Email heading', 'woocommerce' ),
+					'type'        => 'text',
+					'desc_tip'    => true,
+					/* translators: %s: list of placeholders */
+					'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>{site_title}, {order_date}, {order_number}</code>' ),
+					'placeholder' => $this->get_default_heading(),
+					'default'     => '',
+				),
+				'email_type' => array(
+					'title'       => __( 'Email type', 'woocommerce' ),
+					'type'        => 'select',
+					'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
+					'default'     => 'html',
+					'class'       => 'email_type wc-enhanced-select',
+					'options'     => $this->get_email_type_options(),
+					'desc_tip'    => true,
+				),
+			);
+		}
 	}
-}
 
 endif;
 

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class WC_Email_New_Order file
+ *
+ * @package WooCommerce\Emails
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -14,7 +19,6 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 	 * @class       WC_Email_New_Order
 	 * @version     2.0.0
 	 * @package     WooCommerce/Classes/Emails
-	 * @author      WooThemes
 	 * @extends     WC_Email
 	 */
 	class WC_Email_New_Order extends WC_Email {
@@ -72,8 +76,8 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		/**
 		 * Trigger the sending of this email.
 		 *
-		 * @param int      $order_id The order ID.
-		 * @param WC_Order $order Order object.
+		 * @param int            $order_id The order ID.
+		 * @param WC_Order|false $order Order object.
 		 */
 		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();
@@ -145,6 +149,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 				'recipient'  => array(
 					'title'       => __( 'Recipient(s)', 'woocommerce' ),
 					'type'        => 'text',
+					/* translators: %s: WP admin email */
 					'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s.', 'woocommerce' ), '<code>' . esc_attr( get_option( 'admin_email' ) ) . '</code>' ),
 					'placeholder' => '',
 					'default'     => '',

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -23,24 +23,28 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Email method ID.
+	 *
 	 * @var String
 	 */
 	public $id;
 
 	/**
 	 * Email method title.
+	 *
 	 * @var string
 	 */
 	public $title;
 
 	/**
 	 * 'yes' if the method is enabled.
+	 *
 	 * @var string yes, no
 	 */
 	public $enabled;
 
 	/**
 	 * Description for the email.
+	 *
 	 * @var string
 	 */
 	public $description;
@@ -67,60 +71,70 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Plain text template path.
+	 *
 	 * @var string
 	 */
 	public $template_plain;
 
 	/**
 	 * HTML template path.
+	 *
 	 * @var string
 	 */
 	public $template_html;
 
 	/**
 	 * Template path.
+	 *
 	 * @var string
 	 */
 	public $template_base;
 
 	/**
 	 * Recipients for the email.
+	 *
 	 * @var string
 	 */
 	public $recipient;
 
 	/**
 	 * Object this email is for, for example a customer, product, or email.
+	 *
 	 * @var object|bool
 	 */
 	public $object;
 
 	/**
 	 * Mime boundary (for multipart emails).
+	 *
 	 * @var string
 	 */
 	public $mime_boundary;
 
 	/**
 	 * Mime boundary header (for multipart emails).
+	 *
 	 * @var string
 	 */
 	public $mime_boundary_header;
 
 	/**
 	 * True when email is being sent.
+	 *
 	 * @var bool
 	 */
 	public $sending;
 
 	/**
 	 * True when the email notification is sent manually only.
+	 *
 	 * @var bool
 	 */
 	protected $manual = false;
 
 	/**
 	 * True when the email notification is sent to customers.
+	 *
 	 * @var bool
 	 */
 	protected $customer_email = false;
@@ -129,56 +143,58 @@ class WC_Email extends WC_Settings_API {
 	 *  List of preg* regular expression patterns to search for,
 	 *  used in conjunction with $plain_replace.
 	 *  https://raw.github.com/ushahidi/wp-silcc/master/class.html2text.inc
+	 *
 	 *  @var array $plain_search
 	 *  @see $plain_replace
 	 */
 	public $plain_search = array(
-		"/\r/",                                                  // Non-legal carriage return
-		'/&(nbsp|#0*160);/i',                                    // Non-breaking space
-		'/&(quot|rdquo|ldquo|#0*8220|#0*8221|#0*147|#0*148);/i', // Double quotes
-		'/&(apos|rsquo|lsquo|#0*8216|#0*8217);/i',               // Single quotes
-		'/&gt;/i',                                               // Greater-than
-		'/&lt;/i',                                               // Less-than
-		'/&#0*38;/i',                                            // Ampersand
-		'/&amp;/i',                                              // Ampersand
-		'/&(copy|#0*169);/i',                                    // Copyright
-		'/&(trade|#0*8482|#0*153);/i',                           // Trademark
-		'/&(reg|#0*174);/i',                                     // Registered
-		'/&(mdash|#0*151|#0*8212);/i',                           // mdash
-		'/&(ndash|minus|#0*8211|#0*8722);/i',                    // ndash
-		'/&(bull|#0*149|#0*8226);/i',                            // Bullet
-		'/&(pound|#0*163);/i',                                   // Pound sign
-		'/&(euro|#0*8364);/i',                                   // Euro sign
-		'/&(dollar|#0*36);/i',                                   // Dollar sign
-		'/&[^&\s;]+;/i',                                         // Unknown/unhandled entities
-		'/[ ]{2,}/',                                             // Runs of spaces, post-handling
+		"/\r/",                                                  // Non-legal carriage return.
+		'/&(nbsp|#0*160);/i',                                    // Non-breaking space.
+		'/&(quot|rdquo|ldquo|#0*8220|#0*8221|#0*147|#0*148);/i', // Double quotes.
+		'/&(apos|rsquo|lsquo|#0*8216|#0*8217);/i',               // Single quotes.
+		'/&gt;/i',                                               // Greater-than.
+		'/&lt;/i',                                               // Less-than.
+		'/&#0*38;/i',                                            // Ampersand.
+		'/&amp;/i',                                              // Ampersand.
+		'/&(copy|#0*169);/i',                                    // Copyright.
+		'/&(trade|#0*8482|#0*153);/i',                           // Trademark.
+		'/&(reg|#0*174);/i',                                     // Registered.
+		'/&(mdash|#0*151|#0*8212);/i',                           // mdash.
+		'/&(ndash|minus|#0*8211|#0*8722);/i',                    // ndash.
+		'/&(bull|#0*149|#0*8226);/i',                            // Bullet.
+		'/&(pound|#0*163);/i',                                   // Pound sign.
+		'/&(euro|#0*8364);/i',                                   // Euro sign.
+		'/&(dollar|#0*36);/i',                                   // Dollar sign.
+		'/&[^&\s;]+;/i',                                         // Unknown/unhandled entities.
+		'/[ ]{2,}/',                                             // Runs of spaces, post-handling.
 	);
 
 	/**
 	 *  List of pattern replacements corresponding to patterns searched.
+	 *
 	 *  @var array $plain_replace
 	 *  @see $plain_search
 	 */
 	public $plain_replace = array(
-		'',                                             // Non-legal carriage return
-		' ',                                            // Non-breaking space
-		'"',                                            // Double quotes
-		"'",                                            // Single quotes
-		'>',                                            // Greater-than
-		'<',                                            // Less-than
-		'&',                                            // Ampersand
-		'&',                                            // Ampersand
-		'(c)',                                          // Copyright
-		'(tm)',                                         // Trademark
-		'(R)',                                          // Registered
-		'--',                                           // mdash
-		'-',                                            // ndash
-		'*',                                            // Bullet
-		'£',                                            // Pound sign
-		'EUR',                                          // Euro sign. € ?
-		'$',                                            // Dollar sign
-		'',                                             // Unknown/unhandled entities
-		' ',                                             // Runs of spaces, post-handling
+		'',                                             // Non-legal carriage return.
+		' ',                                            // Non-breaking space.
+		'"',                                            // Double quotes.
+		"'",                                            // Single quotes.
+		'>',                                            // Greater-than.
+		'<',                                            // Less-than.
+		'&',                                            // Ampersand.
+		'&',                                            // Ampersand.
+		'(c)',                                          // Copyright.
+		'(tm)',                                         // Trademark.
+		'(R)',                                          // Registered.
+		'--',                                           // mdash.
+		'-',                                            // ndash.
+		'*',                                            // Bullet.
+		'£',                                            // Pound sign.
+		'EUR',                                          // Euro sign. € ?.
+		'$',                                            // Dollar sign.
+		'',                                             // Unknown/unhandled entities.
+		' ',                                             // Runs of spaces, post-handling.
 	);
 
 	/**
@@ -188,7 +204,7 @@ class WC_Email extends WC_Settings_API {
 	 */
 	protected $placeholders = array();
 
- 	/**
+	/**
 	 * Strings to find in subjects/headings.
 	 *
 	 * @deprecated 3.2.0 in favour of placeholders
@@ -208,18 +224,18 @@ class WC_Email extends WC_Settings_API {
 	 * Constructor.
 	 */
 	public function __construct() {
-		// Find/replace
+		// Find/replace.
 		if ( empty( $this->placeholders ) ) {
 			$this->placeholders = array(
 				'{site_title}' => $this->get_blogname(),
 			);
 		}
 
-		// Init settings
+		// Init settings.
 		$this->init_form_fields();
 		$this->init_settings();
 
-		// Default template base if not declared in child constructor
+		// Default template base if not declared in child constructor.
 		if ( is_null( $this->template_base ) ) {
 			$this->template_base = WC()->plugin_path() . '/templates/';
 		}
@@ -343,6 +359,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Get valid recipients.
+	 *
 	 * @return string
 	 */
 	public function get_recipient() {
@@ -358,7 +375,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_headers() {
-		$header = "Content-Type: " . $this->get_content_type() . "\r\n";
+		$header = 'Content-Type: ' . $this->get_content_type() . "\r\n";
 
 		if ( 'new_order' === $this->id && $this->object && $this->object->get_billing_email() && ( $this->object->get_billing_first_name() || $this->object->get_billing_last_name() ) ) {
 			$header .= 'Reply-to: ' . $this->object->get_billing_first_name() . ' ' . $this->object->get_billing_last_name() . ' <' . $this->object->get_billing_email() . ">\r\n";
@@ -392,17 +409,18 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function get_content_type() {
 		switch ( $this->get_email_type() ) {
-			case 'html' :
+			case 'html':
 				return 'text/html';
-			case 'multipart' :
+			case 'multipart':
 				return 'multipart/alternative';
-			default :
+			default:
 				return 'text/plain';
 		}
 	}
 
 	/**
 	 * Return the email's title
+	 *
 	 * @return string
 	 */
 	public function get_title() {
@@ -411,6 +429,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Return the email's description
+	 *
 	 * @return string
 	 */
 	public function get_description() {
@@ -431,6 +450,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Checks if this email is enabled and will be sent.
+	 *
 	 * @return bool
 	 */
 	public function is_enabled() {
@@ -439,6 +459,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Checks if this email is manually sent
+	 *
 	 * @return bool
 	 */
 	public function is_manual() {
@@ -447,6 +468,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Checks if this email is customer focussed.
+	 *
 	 * @return bool
 	 */
 	public function is_customer_email() {
@@ -486,13 +508,13 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function style_inline( $content ) {
-		// make sure we only inline CSS for html emails
+		// make sure we only inline CSS for html emails.
 		if ( in_array( $this->get_content_type(), array( 'text/html', 'multipart/alternative' ) ) && class_exists( 'DOMDocument' ) ) {
 			ob_start();
 			wc_get_template( 'emails/email-styles.php' );
 			$css = apply_filters( 'woocommerce_email_styles', ob_get_clean() );
 
-			// apply CSS styles inline for picky email clients
+			// apply CSS styles inline for picky email clients.
 			try {
 				$emogrifier = new Emogrifier( $content, $css );
 				$content    = $emogrifier->emogrify();
@@ -506,18 +528,23 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Get the email content in plain text format.
+	 *
 	 * @return string
 	 */
-	public function get_content_plain() { return ''; }
+	public function get_content_plain() {
+		return ''; }
 
 	/**
 	 * Get the email content in HTML format.
+	 *
 	 * @return string
 	 */
-	public function get_content_html() { return ''; }
+	public function get_content_html() {
+		return ''; }
 
 	/**
 	 * Get the from name for outgoing emails.
+	 *
 	 * @return string
 	 */
 	public function get_from_name() {
@@ -527,6 +554,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Get the from address for outgoing emails.
+	 *
 	 * @return string
 	 */
 	public function get_from_address() {
@@ -536,6 +564,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Send an email.
+	 *
 	 * @param string $to
 	 * @param string $subject
 	 * @param string $message
@@ -562,32 +591,32 @@ class WC_Email extends WC_Settings_API {
 	 * Initialise Settings Form Fields - these are generic email options most will use.
 	 */
 	public function init_form_fields() {
-		$this->form_fields    = array(
-			'enabled'         => array(
-				'title'       => __( 'Enable/Disable', 'woocommerce' ),
-				'type'        => 'checkbox',
-				'label'       => __( 'Enable this email notification', 'woocommerce' ),
-				'default'     => 'yes',
+		$this->form_fields = array(
+			'enabled'    => array(
+				'title'   => __( 'Enable/Disable', 'woocommerce' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Enable this email notification', 'woocommerce' ),
+				'default' => 'yes',
 			),
-			'subject'         => array(
+			'subject'    => array(
 				'title'       => __( 'Subject', 'woocommerce' ),
 				'type'        => 'text',
-				'desc_tip'      => true,
+				'desc_tip'    => true,
 				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . implode( '</code>, <code>', array_keys( $this->placeholders ) ) . '</code>' ),
+				'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . implode( '</code>, <code>', array_keys( $this->placeholders ) ) . '</code>' ),
 				'placeholder' => $this->get_default_subject(),
 				'default'     => '',
 			),
-			'heading'         => array(
+			'heading'    => array(
 				'title'       => __( 'Email heading', 'woocommerce' ),
 				'type'        => 'text',
-				'desc_tip'      => true,
+				'desc_tip'    => true,
 				/* translators: %s: list of placeholders */
-				'description'   => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . implode( '</code>, <code>', array_keys( $this->placeholders ) ) . '</code>' ),
+				'description' => sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '<code>' . implode( '</code>, <code>', array_keys( $this->placeholders ) ) . '</code>' ),
 				'placeholder' => $this->get_default_heading(),
 				'default'     => '',
 			),
-			'email_type'      => array(
+			'email_type' => array(
 				'title'       => __( 'Email type', 'woocommerce' ),
 				'type'        => 'select',
 				'description' => __( 'Choose which format of email to send.', 'woocommerce' ),
@@ -601,6 +630,7 @@ class WC_Email extends WC_Settings_API {
 
 	/**
 	 * Email type options.
+	 *
 	 * @return array
 	 */
 	public function get_email_type_options() {
@@ -618,12 +648,12 @@ class WC_Email extends WC_Settings_API {
 	 * Admin Panel Options Processing.
 	 */
 	public function process_admin_options() {
-		// Save regular options
+		// Save regular options.
 		parent::process_admin_options();
 
 		$post_data = $this->get_post_data();
 
-		// Save templates
+		// Save templates.
 		if ( isset( $post_data['template_html_code'] ) ) {
 			$this->save_template( $post_data['template_html_code'], $this->template_html );
 		}
@@ -658,9 +688,9 @@ class WC_Email extends WC_Settings_API {
 	 */
 	protected function save_template( $template_code, $template_path ) {
 		if ( current_user_can( 'edit_themes' ) && ! empty( $template_code ) && ! empty( $template_path ) ) {
-			$saved  = false;
-			$file   = get_stylesheet_directory() . '/' . WC()->template_path() . $template_path;
-			$code   = wp_unslash( $template_code );
+			$saved = false;
+			$file  = get_stylesheet_directory() . '/' . WC()->template_path() . $template_path;
+			$code  = wp_unslash( $template_code );
 
 			if ( is_writeable( $file ) ) {
 				$f = fopen( $file, 'w+' );
@@ -704,11 +734,11 @@ class WC_Email extends WC_Settings_API {
 
 				if ( wp_mkdir_p( dirname( $theme_file ) ) && ! file_exists( $theme_file ) ) {
 
-					// Locate template file
+					// Locate template file.
 					$core_file     = $this->template_base . $template;
 					$template_file = apply_filters( 'woocommerce_locate_core_template', $core_file, $template, $this->template_base, $this->id );
 
-					// Copy template file
+					// Copy template file.
 					copy( $template_file, $theme_file );
 
 					/**
@@ -758,7 +788,7 @@ class WC_Email extends WC_Settings_API {
 	 * Admin actions.
 	 */
 	protected function admin_actions() {
-		// Handle any actions
+		// Handle any actions.
 		if (
 			( ! empty( $this->template_html ) || ! empty( $this->template_plain ) )
 			&& ( ! empty( $_GET['move_template'] ) || ! empty( $_GET['delete_template'] ) )
@@ -799,11 +829,12 @@ class WC_Email extends WC_Settings_API {
 		<?php echo wpautop( wp_kses_post( $this->get_description() ) ); ?>
 
 		<?php
-			/**
-			 * woocommerce_email_settings_before action hook.
-			 * @param string $email The email object
-			 */
-			do_action( 'woocommerce_email_settings_before', $this );
+		/**
+		 * woocommerce_email_settings_before action hook.
+		 *
+		 * @param string $email The email object
+		 */
+		do_action( 'woocommerce_email_settings_before', $this );
 		?>
 
 		<table class="form-table">
@@ -811,16 +842,20 @@ class WC_Email extends WC_Settings_API {
 		</table>
 
 		<?php
-			/**
-			 * woocommerce_email_settings_after action hook.
-			 * @param string $email The email object
-			 */
-			do_action( 'woocommerce_email_settings_after', $this );
+		/**
+		 * woocommerce_email_settings_after action hook.
+		 *
+		 * @param string $email The email object
+		 */
+		do_action( 'woocommerce_email_settings_after', $this );
 		?>
 
-		<?php if ( current_user_can( 'edit_themes' ) && ( ! empty( $this->template_html ) || ! empty( $this->template_plain ) ) ) { ?>
+		<?php
+
+		if ( current_user_can( 'edit_themes' ) && ( ! empty( $this->template_html ) || ! empty( $this->template_plain ) ) ) {
+			?>
 			<div id="template">
-			<?php
+				<?php
 				$templates = array(
 					'template_html'  => __( 'HTML template', 'woocommerce' ),
 					'template_plain' => __( 'Plain text template', 'woocommerce' ),
@@ -839,11 +874,9 @@ class WC_Email extends WC_Settings_API {
 					$template_dir  = apply_filters( 'woocommerce_template_directory', 'woocommerce', $template );
 					?>
 					<div class="template <?php echo $template_type; ?>">
-
 						<h4><?php echo wp_kses_post( $title ); ?></h4>
 
-						<?php if ( file_exists( $local_file ) ) { ?>
-
+						<?php if ( file_exists( $local_file ) ) : ?>
 							<p>
 								<a href="#" class="button toggle_editor"></a>
 
@@ -855,33 +888,35 @@ class WC_Email extends WC_Settings_API {
 							</p>
 
 							<div class="editor" style="display:none">
-								<textarea class="code" cols="25" rows="20" <?php if ( ! is_writable( $local_file ) ) : ?>readonly="readonly" disabled="disabled"<?php else : ?>data-name="<?php echo $template_type . '_code'; ?>"<?php endif; ?>><?php echo file_get_contents( $local_file ); ?></textarea>
+								<textarea class="code" cols="25" rows="20"
+								<?php
+								if ( ! is_writable( $local_file ) ) :
+									?>
+									readonly="readonly" disabled="disabled"
+								<?php else : ?>
+									data-name="<?php echo $template_type . '_code'; ?>"<?php endif; ?>><?php echo file_get_contents( $local_file ); ?></textarea>
 							</div>
-
-						<?php } elseif ( file_exists( $template_file ) ) { ?>
-
+						<?php elseif ( file_exists( $template_file ) ) : ?>
 							<p>
 								<a href="#" class="button toggle_editor"></a>
 
 								<?php
-									$emails_dir    = get_stylesheet_directory() . '/' . $template_dir . '/emails';
-									$templates_dir = get_stylesheet_directory() . '/' . $template_dir;
-									$theme_dir     = get_stylesheet_directory();
+								$emails_dir    = get_stylesheet_directory() . '/' . $template_dir . '/emails';
+								$templates_dir = get_stylesheet_directory() . '/' . $template_dir;
+								$theme_dir     = get_stylesheet_directory();
 
-									if ( is_dir( $emails_dir ) ) {
-										$target_dir = $emails_dir;
-									} elseif ( is_dir( $templates_dir ) ) {
-										$target_dir = $templates_dir;
-									} else {
-										$target_dir = $theme_dir;
-									}
+								if ( is_dir( $emails_dir ) ) {
+									$target_dir = $emails_dir;
+								} elseif ( is_dir( $templates_dir ) ) {
+									$target_dir = $templates_dir;
+								} else {
+									$target_dir = $theme_dir;
+								}
 
-									if ( is_writable( $target_dir ) ) {
-										?>
-										<a href="<?php echo esc_url( wp_nonce_url( remove_query_arg( array( 'delete_template', 'saved' ), add_query_arg( 'move_template', $template_type ) ), 'woocommerce_email_template_nonce', '_wc_email_nonce' ) ); ?>" class="button"><?php _e( 'Copy file to theme', 'woocommerce' ); ?></a>
-										<?php
-									}
-								?>
+								if ( is_writable( $target_dir ) ) :
+									?>
+									<a href="<?php echo esc_url( wp_nonce_url( remove_query_arg( array( 'delete_template', 'saved' ), add_query_arg( 'move_template', $template_type ) ), 'woocommerce_email_template_nonce', '_wc_email_nonce' ) ); ?>" class="button"><?php _e( 'Copy file to theme', 'woocommerce' ); ?></a>
+								<?php endif; ?>
 
 								<?php printf( __( 'To override and edit this email template copy %1$s to your theme folder: %2$s.', 'woocommerce' ), '<code>' . plugin_basename( $template_file ) . '</code>', '<code>' . trailingslashit( basename( get_stylesheet_directory() ) ) . $template_dir . '/' . $template . '</code>' ); ?>
 							</p>
@@ -889,21 +924,16 @@ class WC_Email extends WC_Settings_API {
 							<div class="editor" style="display:none">
 								<textarea class="code" readonly="readonly" disabled="disabled" cols="25" rows="20"><?php echo file_get_contents( $template_file ); ?></textarea>
 							</div>
-
-						<?php } else { ?>
-
+						<?php else : ?>
 							<p><?php _e( 'File was not found.', 'woocommerce' ); ?></p>
-
-						<?php } ?>
-
+						<?php endif; ?>
 					</div>
-					<?php
-				endforeach;
-			?>
+				<?php endforeach; ?>
 			</div>
+
 			<?php
-			wc_enqueue_js( "
-				jQuery( 'select.email_type' ).change( function() {
+			wc_enqueue_js(
+				"jQuery( 'select.email_type' ).change( function() {
 
 					var val = jQuery( this ).val();
 
@@ -944,8 +974,8 @@ class WC_Email extends WC_Settings_API {
 					if ( name ) {
 						jQuery( this ).attr( 'name', name );
 					}
-				});
-			" );
+				});"
+			);
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes all PHPCS violations in the `includes/emails` directory. There were lots of indentation issues in the modified files that were fixed automatically using `phpcbf`. Those fixes were made in a separate commit (575e095). Probably easier to review this commit individually and then review the rest of the commits to see what I changed manually.