### PR TITLE
PHPCS fixes for includes/payment-tokens directory

### DIFF
--- a/includes/payment-tokens/class-wc-payment-token-cc.php
+++ b/includes/payment-tokens/class-wc-payment-token-cc.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * Class WC_Payment_Token_CC file.
+ *
+ * @package WooCommerce\PaymentTokens
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -11,13 +17,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Payment_Token_CC
  * @version     3.0.0
  * @since       2.6.0
- * @category    PaymentTokens
  * @package     WooCommerce/PaymentTokens
- * @author      WooThemes
  */
 class WC_Payment_Token_CC extends WC_Payment_Token {
 
-	/** @protected string Token Type String. */
+	/**
+	 * Token Type String.
+	 *
+	 * @var string
+	 */
 	protected $type = 'CC';
 
 	/**
@@ -36,12 +44,12 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Get type to display to user.
 	 *
 	 * @since  2.6.0
-	 * @param  string $deprecated Deprecated since WooCommerce 3.0
+	 * @param  string $deprecated Deprecated since WooCommerce 3.0.
 	 * @return string
 	 */
 	public function get_display_name( $deprecated = '' ) {
-		/* translators: 1: credit card type 2: last 4 digits 3: expiry month 4: expiry year */
 		$display = sprintf(
+			/* translators: 1: credit card type 2: last 4 digits 3: expiry month 4: expiry year */
 			__( '%1$s ending in %2$s (expires %3$s/%4$s)', 'woocommerce' ),
 			wc_get_credit_card_type_label( $this->get_card_type() ),
 			$this->get_last4(),
@@ -108,7 +116,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Returns the card type (mastercard, visa, ...).
 	 *
 	 * @since  2.6.0
-	 * @param  string $context
+	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return string Card type
 	 */
 	public function get_card_type( $context = 'view' ) {
@@ -119,7 +127,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Set the card type (mastercard, visa, ...).
 	 *
 	 * @since 2.6.0
-	 * @param string $type
+	 * @param string $type Credit card type (mastercard, visa, ...).
 	 */
 	public function set_card_type( $type ) {
 		$this->set_prop( 'card_type', $type );
@@ -129,7 +137,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Returns the card expiration year (YYYY).
 	 *
 	 * @since  2.6.0
-	 * @param  string $context
+	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return string Expiration year
 	 */
 	public function get_expiry_year( $context = 'view' ) {
@@ -140,7 +148,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Set the expiration year for the card (YYYY format).
 	 *
 	 * @since 2.6.0
-	 * @param string $year
+	 * @param string $year Credit card expiration year.
 	 */
 	public function set_expiry_year( $year ) {
 		$this->set_prop( 'expiry_year', $year );
@@ -150,7 +158,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Returns the card expiration month (MM).
 	 *
 	 * @since  2.6.0
-	 * @param  string $context
+	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return string Expiration month
 	 */
 	public function get_expiry_month( $context = 'view' ) {
@@ -161,7 +169,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Set the expiration month for the card (formats into MM format).
 	 *
 	 * @since 2.6.0
-	 * @param string $month
+	 * @param string $month Credit card expiration month.
 	 */
 	public function set_expiry_month( $month ) {
 		$this->set_prop( 'expiry_month', str_pad( $month, 2, '0', STR_PAD_LEFT ) );
@@ -171,7 +179,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Returns the last four digits.
 	 *
 	 * @since  2.6.0
-	 * @param  string $context
+	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return string Last 4 digits
 	 */
 	public function get_last4( $context = 'view' ) {
@@ -182,7 +190,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 	 * Set the last four digits.
 	 *
 	 * @since 2.6.0
-	 * @param string $last4
+	 * @param string $last4 Credit card last four digits.
 	 */
 	public function set_last4( $last4 ) {
 		$this->set_prop( 'last4', $last4 );

--- a/includes/payment-tokens/class-wc-payment-token-cc.php
+++ b/includes/payment-tokens/class-wc-payment-token-cc.php
@@ -8,12 +8,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Representation of a payment token for credit cards.
  *
- * @class 		WC_Payment_Token_CC
+ * @class       WC_Payment_Token_CC
  * @version     3.0.0
- * @since		2.6.0
- * @category 	PaymentTokens
- * @package 	WooCommerce/PaymentTokens
- * @author		WooThemes
+ * @since       2.6.0
+ * @category    PaymentTokens
+ * @package     WooCommerce/PaymentTokens
+ * @author      WooThemes
  */
 class WC_Payment_Token_CC extends WC_Payment_Token {
 
@@ -117,6 +117,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 
 	/**
 	 * Set the card type (mastercard, visa, ...).
+	 *
 	 * @since 2.6.0
 	 * @param string $type
 	 */
@@ -137,6 +138,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 
 	/**
 	 * Set the expiration year for the card (YYYY format).
+	 *
 	 * @since 2.6.0
 	 * @param string $year
 	 */
@@ -157,6 +159,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 
 	/**
 	 * Set the expiration month for the card (formats into MM format).
+	 *
 	 * @since 2.6.0
 	 * @param string $month
 	 */
@@ -177,6 +180,7 @@ class WC_Payment_Token_CC extends WC_Payment_Token {
 
 	/**
 	 * Set the last four digits.
+	 *
 	 * @since 2.6.0
 	 * @param string $last4
 	 */

--- a/includes/payment-tokens/class-wc-payment-token-echeck.php
+++ b/includes/payment-tokens/class-wc-payment-token-echeck.php
@@ -9,14 +9,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Representation of a payment token for eChecks.
  *
- * @class       WC_Payment_Token_eCheck
+ * @class       WC_Payment_Token_ECheck
  * @version     3.0.0
  * @since       2.6.0
  * @category    PaymentTokens
  * @package     WooCommerce/PaymentTokens
  * @author      WooThemes
  */
-class WC_Payment_Token_eCheck extends WC_Payment_Token {
+class WC_Payment_Token_ECheck extends WC_Payment_Token {
 
 	/** @protected string Token Type String. */
 	protected $type = 'eCheck';

--- a/includes/payment-tokens/class-wc-payment-token-echeck.php
+++ b/includes/payment-tokens/class-wc-payment-token-echeck.php
@@ -1,7 +1,12 @@
 <?php
+/**
+ * Class WC_Payment_Token_eCheck file.
+ *
+ * @package WooCommerce\PaymentTokens
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -12,13 +17,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Payment_Token_ECheck
  * @version     3.0.0
  * @since       2.6.0
- * @category    PaymentTokens
  * @package     WooCommerce/PaymentTokens
- * @author      WooThemes
  */
 class WC_Payment_Token_ECheck extends WC_Payment_Token {
 
-	/** @protected string Token Type String. */
+	/**
+	 * Token Type String.
+	 *
+	 * @var string
+	 */
 	protected $type = 'eCheck';
 
 	/**
@@ -34,7 +41,7 @@ class WC_Payment_Token_ECheck extends WC_Payment_Token {
 	 * Get type to display to user.
 	 *
 	 * @since  2.6.0
-	 * @param  string $deprecated Deprecated since WooCommerce 3.0
+	 * @param  string $deprecated Deprecated since WooCommerce 3.0.
 	 * @return string
 	 */
 	public function get_display_name( $deprecated = '' ) {
@@ -74,7 +81,7 @@ class WC_Payment_Token_ECheck extends WC_Payment_Token {
 	 * Returns the last four digits.
 	 *
 	 * @since  2.6.0
-	 * @param  string $context
+	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return string Last 4 digits
 	 */
 	public function get_last4( $context = 'view' ) {
@@ -85,7 +92,7 @@ class WC_Payment_Token_ECheck extends WC_Payment_Token {
 	 * Set the last four digits.
 	 *
 	 * @since 2.6.0
-	 * @param string $last4
+	 * @param string $last4 eCheck last four digits.
 	 */
 	public function set_last4( $last4 ) {
 		$this->set_prop( 'last4', $last4 );

--- a/includes/payment-tokens/class-wc-payment-token-echeck.php
+++ b/includes/payment-tokens/class-wc-payment-token-echeck.php
@@ -9,12 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Representation of a payment token for eChecks.
  *
- * @class 		WC_Payment_Token_eCheck
+ * @class       WC_Payment_Token_eCheck
  * @version     3.0.0
- * @since		2.6.0
- * @category 	PaymentTokens
- * @package 	WooCommerce/PaymentTokens
- * @author		WooThemes
+ * @since       2.6.0
+ * @category    PaymentTokens
+ * @package     WooCommerce/PaymentTokens
+ * @author      WooThemes
  */
 class WC_Payment_Token_eCheck extends WC_Payment_Token {
 
@@ -83,6 +83,7 @@ class WC_Payment_Token_eCheck extends WC_Payment_Token {
 
 	/**
 	 * Set the last four digits.
+	 *
 	 * @since 2.6.0
 	 * @param string $last4
 	 */

--- a/tests/framework/helpers/class-wc-helper-payment-token.php
+++ b/tests/framework/helpers/class-wc-helper-payment-token.php
@@ -30,10 +30,10 @@ class WC_Helper_Payment_Token {
 	 * Create a new eCheck payment token
 	 *
 	 * @since 2.6
-	 * @return WC_Payment_Token_eCheck object
+	 * @return WC_Payment_Token_ECheck object
 	 */
 	public static function create_eCheck_token() {
-		$token = new WC_Payment_Token_eCheck();
+		$token = new WC_Payment_Token_ECheck();
 		$token->set_last4( 1234 );
 		$token->set_token( time() );
 		$token->save();

--- a/tests/unit-tests/account/functions.php
+++ b/tests/unit-tests/account/functions.php
@@ -243,7 +243,7 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_get_account_saved_payment_methods_list_item_echeck() {
-		$token = new WC_Payment_Token_eCheck();
+		$token = new WC_Payment_Token_ECheck();
 		$token->set_token( '1234' );
 		$token->set_gateway_id( 'bacs' );
 		$token->set_last4( '1234' );

--- a/tests/unit-tests/payment-tokens/echeck.php
+++ b/tests/unit-tests/payment-tokens/echeck.php
@@ -11,7 +11,7 @@ class WC_Tests_Payment_Token_eCheck extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_token_echeck_validate_empty() {
-		$token = new WC_Payment_Token_eCheck();
+		$token = new WC_Payment_Token_ECheck();
 		$token->set_token( time() . ' ' . __FUNCTION__ );
 		$this->assertFalse( $token->validate() );
 		$token->set_last4( '1111' );
@@ -23,7 +23,7 @@ class WC_Tests_Payment_Token_eCheck extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_echeck_last4() {
-		$token = new WC_Payment_Token_eCheck();
+		$token = new WC_Payment_Token_ECheck();
 		$token->set_last4( '1111' );
 		$this->assertEquals( '1111', $token->get_last4() );
 	}
@@ -36,7 +36,7 @@ class WC_Tests_Payment_Token_eCheck extends WC_Unit_Test_Case {
 		$token = WC_Helper_Payment_Token::create_eCheck_token();
 		$token_id = $token->get_id();
 
-		$token_read = new WC_Payment_Token_eCheck( $token_id );
+		$token_read = new WC_Payment_Token_ECheck( $token_id );
 		$this->assertEquals( '1234', $token_read->get_last4() );
 	}
 }


### PR DESCRIPTION
This PR fixes all PHPCS violations in the `includes/payment-tokens` directory.