### PR TITLE
Ignore legacy directory and deprecated functions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,8 +10,10 @@
 	<exclude-pattern>apigen/</exclude-pattern>
 	<exclude-pattern>includes/gateways/simplify-commerce/includes/</exclude-pattern>
 	<exclude-pattern>includes/libraries/</exclude-pattern>
+	<exclude-pattern>includes/legacy/</exclude-pattern>
 	<exclude-pattern>includes/api/legacy/</exclude-pattern>
 	<exclude-pattern>includes/api/v1/</exclude-pattern>
+	<exclude-pattern>includes/wc-deprecated-functions.php</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 


### PR DESCRIPTION
We don't need to fix any PHPCS violation on that files, since we should remove in future versions.