### PR TITLE
Add wildcard email support for coupons.

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -257,7 +257,7 @@ class WC_Meta_Box_Coupon_Data {
 						'id'                => 'customer_email',
 						'label'             => __( 'Email restrictions', 'woocommerce' ),
 						'placeholder'       => __( 'No restrictions', 'woocommerce' ),
-						'description'       => __( 'List of allowed emails to check against the customer billing email when an order is placed. Separate email addresses with commas.', 'woocommerce' ),
+						'description'       => __( 'List of allowed emails to check against the customer billing email when an order is placed. Separate email addresses with commas. You can also use an asterisk (*) to match parts of an email. For example "*@gmail.com" would match all gmail addresses.', 'woocommerce' ),
 						'value'             => implode( ', ', (array) $coupon->get_email_restrictions() ),
 						'desc_tip'          => true,
 						'type'              => 'email',

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1451,7 +1451,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				// Limit to defined email addresses.
 				$restrictions = $coupon->get_email_restrictions();
 
-				if ( is_array( $restrictions ) && 0 < count( $restrictions ) && 0 === count( array_intersect( $check_emails, $restrictions ) ) ) {
+				if ( is_array( $restrictions ) && 0 < count( $restrictions ) && ! $this->is_coupon_emails_allowed( $check_emails, $restrictions ) ) {
 					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED );
 					$this->remove_coupon( $code );
 				}
@@ -1497,6 +1497,37 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 		}
 	}
+
+	/**
+	 * Checks if the given email address(es) matches the ones specified on the coupon.
+	 *
+	 * @param array $check_emails Array of customer email addresses.
+	 * @param array $restrictions Array of allowed email addresses.
+	 * @return bool
+	 */
+	public function email_is_accepted( $check_emails, $restrictions ){
+
+		foreach ( $check_emails as $check_email ) {
+			// With a direct match we return true.
+			if ( in_array( $check_email, $restrictions ) ) {
+				return true;
+			}
+
+			// Go through the allowed emails and return true if the email matches a wildcard.
+			foreach ( $restrictions as $restriction ) {
+				// Convert to PHP-regex syntax.
+				$regex = '/' . str_replace( '*', '(.+)?', $restriction ) . '/';
+				preg_match( $regex, $check_email, $match );
+				if ( ! empty( $match ) ) {
+					return true;
+				}
+			}
+		}
+
+		// No matches, this one isn't allowed.
+		return false;
+	}
+
 
 	/**
 	 * Returns whether or not a discount has been applied.

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1505,7 +1505,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param array $restrictions Array of allowed email addresses.
 	 * @return bool
 	 */
-	public function is_coupon_emails_allowed( $check_emails, $restrictions ){
+	public function is_coupon_emails_allowed( $check_emails, $restrictions ) {
 
 		foreach ( $check_emails as $check_email ) {
 			// With a direct match we return true.

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1505,7 +1505,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param array $restrictions Array of allowed email addresses.
 	 * @return bool
 	 */
-	public function email_is_accepted( $check_emails, $restrictions ){
+	public function is_coupon_emails_allowed( $check_emails, $restrictions ){
 
 		foreach ( $check_emails as $check_email ) {
 			// With a direct match we return true.

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -1421,4 +1421,16 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
 		update_option( 'woocommerce_calc_taxes', 'no' );
 	}
+
+	/**
+	 * Test is_coupon_emails_allowed function on the cart, specifically test wildcard emails.
+	 *
+	 * @return void
+	 */
+	public function test_is_coupon_emails_allowed() {
+		$this->assertEquals( true, WC()->cart->is_coupon_emails_allowed( array( 'customer@wc.local' ), array( '*.local' ) ) );
+		$this->assertEquals( false, WC()->cart->is_coupon_emails_allowed( array( 'customer@wc.local' ), array( '*.test' ) ) );
+		$this->assertEquals( true, WC()->cart->is_coupon_emails_allowed( array( 'customer@wc.local' ), array( 'customer@wc.local' ) ) );
+		$this->assertEquals( false, WC()->cart->is_coupon_emails_allowed( array( 'customer@wc.local' ), array( 'customer2@wc.local' ) ) );
+	}
 }


### PR DESCRIPTION
This PR adds willcard email support for coupons, you can now use * to wildcard parts of an email ie *@gmail.com will match all gmail addresses or coupon@*.com will match any email starting with coupon and ending with .com