### PR TITLE
Exclude includes/gateways/simplify-commerce from PHPCS checks

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,7 @@
 	<!-- Exclude paths -->
 	<exclude-pattern>tests/cli/</exclude-pattern>
 	<exclude-pattern>apigen/</exclude-pattern>
-	<exclude-pattern>includes/gateways/simplify-commerce/includes/</exclude-pattern>
+	<exclude-pattern>includes/gateways/simplify-commerce</exclude-pattern>
 	<exclude-pattern>includes/libraries/</exclude-pattern>
 	<exclude-pattern>includes/legacy/</exclude-pattern>
 	<exclude-pattern>includes/api/legacy/</exclude-pattern>


### PR DESCRIPTION
The Simplify Commerce gateway is deprecated since WC 2.6.0 and will be removed in WC 4.0.