### PR TITLE
Fix JS state/country inputs

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -112,9 +112,6 @@ jQuery( function ( $ ) {
 
 			if ( ! $country_input.val() ) {
 				$country_input.val( woocommerce_admin_meta_boxes_order.default_country ).change();
-			}
-
-			if ( ! $state_input.val() ) {
 				$state_input.val( woocommerce_admin_meta_boxes_order.default_state ).change();
 			}
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -360,6 +360,15 @@ class WC_Meta_Box_Order_Data {
 								if ( ! isset( $field['id'] ) ) {
 									$field['id'] = '_billing_' . $key;
 								}
+
+								$field_name = 'billing_' . $key;
+
+								if ( is_callable( array( $order, 'get_' . $field_name ) ) ) {
+									$field['value'] = $order->{"get_$field_name"}( 'edit' );
+								} else {
+									$field['value'] = $order->get_meta( '_' . $field_name );
+								}
+
 								switch ( $field['type'] ) {
 									case 'select':
 										woocommerce_wp_select( $field );
@@ -460,6 +469,14 @@ class WC_Meta_Box_Order_Data {
 									}
 									if ( ! isset( $field['id'] ) ) {
 										$field['id'] = '_shipping_' . $key;
+									}
+
+									$field_name = 'shipping_' . $key;
+
+									if ( is_callable( array( $order, 'get_' . $field_name ) ) ) {
+										$field['value'] = $order->{"get_$field_name"}( 'edit' );
+									} else {
+										$field['value'] = $order->get_meta( '_' . $field_name );
 									}
 
 									switch ( $field['type'] ) {

--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -214,6 +214,7 @@ function woocommerce_wp_select( $field ) {
 	$field_attributes['style'] = $field['style'];
 	$field_attributes['id']    = $field['id'];
 	$field_attributes['name']  = $field['name'];
+	$field_attributes['class'] = $field['class'];
 
 	$tooltip     = ! empty( $field['description'] ) && false !== $field['desc_tip'] ? $field['description'] : '';
 	$description = ! empty( $field['description'] ) && false === $field['desc_tip'] ? $field['description'] : '';


### PR DESCRIPTION
Prevents default state applying unless the country was also unset.

Also fixes the selectwoo implantation due to missing classes.

Test instructions are in https://github.com/woocommerce/woocommerce/issues/19222

Fixes #19222