### PR TITLE
Decode single quotes in short description editor

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
@@ -36,6 +36,6 @@ class WC_Meta_Box_Product_Short_Description {
 			'editor_css'    => '<style>#wp-excerpt-editor-container .wp-editor-area{height:175px; width:100%;}</style>',
 		);
 
-		wp_editor( htmlspecialchars_decode( $post->post_excerpt ), 'excerpt', apply_filters( 'woocommerce_product_short_description_editor_settings', $settings ) );
+		wp_editor( htmlspecialchars_decode( $post->post_excerpt, ENT_QUOTES | ENT_HTML401 ), 'excerpt', apply_filters( 'woocommerce_product_short_description_editor_settings', $settings ) );
 	}
 }


### PR DESCRIPTION
This PR decodes single quotes from the `post_excerpt` property before being passed on to the `wp_editor` function. Having HTML entities stored in the database makes it hard to search for terms containing single quotes.

To test the issue before this PR;
- Edit product.
- Click the "Text" tab in the "Product short description" editor.
- Enter: `'` and click the "Update" button. The single quote is shown as HTML entity `&#039;`.
- Click the "Update" button again. The HTML entity is now stored in the database.