### PR TITLE
cart.php: added strip_tags to product_name

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -105,7 +105,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 								'input_value'   => $cart_item['quantity'],
 								'max_value'     => $_product->get_max_purchase_quantity(),
 								'min_value'     => '0',
-								'product_name'  => $_product->get_name(),
+								'product_name'  => strip_tags($_product->get_name()),
 							), $_product, false );
 						}
 


### PR DESCRIPTION
Small fix for shops using html-tags in product titles, aria-labelledby breaks on these sites and the quantity cell gets messed up.