### PR TITLE
Make unit tests work again with PHP 5.2

### DIFF
--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -23,28 +23,6 @@ class WC_Unit_Test_Case extends WP_UnitTestCase {
 	protected $factory;
 
 	/**
-	 * Additional files, relative to the plugin's root directory, that should be explicitly included.
-	 *
-	 * @var array
-	 */
-	protected static $includes;
-
-	/**
-	 * If a test has declared include files, load them before running the tests in the class.
-	 *
-	 * @beforeClass
-	 */
-	public static function include_dependencies() {
-		$base_dir = trailingslashit( dirname( dirname( __DIR__ ) ) );
-
-		if ( ! empty( static::$includes ) ) {
-			foreach ( (array) static::$includes as $include ) {
-				include_once $base_dir . $include;
-			}
-		}
-	}
-
-	/**
 	 * Setup test case.
 	 *
 	 * @since 2.2

--- a/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -11,13 +11,12 @@
 class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 
 	/**
-	 * Additional files, relative to the plugin's root directory, that should be explicitly included.
+	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
 	 *
-	 * @var array
 	 */
-	public static $includes = array(
-		'includes/admin/reports/class-wc-admin-report.php',
-	);
+	public static function setUpBeforeClass() {
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';
+	}
 
 	/**
 	 * Clear cached report data.

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -11,14 +11,12 @@
 class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 	/**
-	 * Additional files, relative to the plugin's root directory, that should be explicitly included.
-	 *
-	 * @var array
+	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
 	 */
-	protected static $includes = array(
-		'includes/admin/reports/class-wc-admin-report.php',
-		'includes/admin/reports/class-wc-report-sales-by-date.php',
-	);
+	public static function setUpBeforeClass() {
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-admin-report.php';
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/reports/class-wc-report-sales-by-date.php';
+	}
 
 	/**
 	 * Clear cached report data.


### PR DESCRIPTION
This commit fixes WC PHPUnit tests in PHP 5.2 that have been broken since commit https://github.com/woocommerce/woocommerce/commit/e68084d7b81a16e75aa20d70d4ba3a6963179bbd#diff-b43983ff635e47e2ec510ae07726f0b4R30 was merged. The mentioned commit added a new method to WC_Unit_Test_Case that uses late static binding. The problem is that late static binding is available only since PHP 5.3 and WooCommerce still support PHP 5.2. Running WC tests with PHP 5.2 resulted in the following error:

`Parse error: syntax error, unexpected T_STATIC, expecting T_STRING or T_VARIABLE or '$' in /home/travis/build/woocommerce/woocommerce/tests/framework/class-wc-unit-test-case.php on line 40 (see https://travis-ci.org/woocommerce/woocommerce/jobs/350303315#L281)`

For now, I'm simply removing the method that used late static binding (WC_Unit_Test_Case::include_dependencies()) and manually loading the required dependencies in the two test classes that relied on it. I'm happy to add WC_Unit_Test_Case::include_dependencies() again if someone can find a way to make it compatible with PHP 5.2. If not, we can revisit this once WC drops support for PHP 5.2.

cc @stevegrunwell 