### PR TITLE
Fix default product category check

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -463,7 +463,7 @@ class WC_Install {
 			}
 		}
 
-		$woocommerce_default_category = get_option( 'default_product_cat', 0 );
+		$woocommerce_default_category = (int) get_option( 'default_product_cat', 0 );
 
 		if ( ! $woocommerce_default_category || ! term_exists( $woocommerce_default_category, 'product_cat' ) ) {
 			$default_product_cat_id   = 0;


### PR DESCRIPTION
This commit casts the 'default_product_cat' option to integer before passing it to `term_exists()`. If we don't do this, `get_option( 'default_product_cat' )` return a string that is passed to `term_exists( $woocommerce_default_category, 'product_cat' )`. `term_exists()` assumes that strings are term names or slugs and search only for this fields to check if the given term exist. So it will return false (unless the term name equals to the term ID which is unlikely) even though the term exists. To make it search for terms IDs to check if the given term exists, it is necessary to pass an integer.

```
>>> $woocommerce_default_category = get_option( 'default_product_cat', 0 );
=> "15"
>>> term_exists( $woocommerce_default_category, 'product_cat' )
=> null
>>> term_exists( (int) $woocommerce_default_category, 'product_cat' )
=> [
     "term_id" => "15",
     "term_taxonomy_id" => "15",
   ]
```

I found this while trying to reproduce #19377 