### PR TITLE
Check if wp_insert_term() returned a term before using it

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -475,7 +475,7 @@ class WC_Install {
 			} else {
 				$result = wp_insert_term( _x( 'Uncategorized', 'Default category slug', 'woocommerce' ), 'product_cat', array( 'slug' => $default_product_cat_slug ) );
 
-				if ( ! empty( $result['term_taxonomy_id'] ) ) {
+				if ( ! is_wp_error( $result ) && ! empty( $result['term_taxonomy_id'] ) ) {
 					$default_product_cat_id = absint( $result['term_taxonomy_id'] );
 				}
 			}


### PR DESCRIPTION
This commit adds a check to make sure wp_insert_term() returned a term and not an instance of WP_Error before trying to access it. Without this change, the old code could produce the following fatal error:

Uncaught Error: Cannot use object of type WP_Error as array in includes/class-wc-install.php:478

Fixes #19377