### PR TITLE
Update chromedriver to version 2.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1334,9 +1334,9 @@
       }
     },
     "chromedriver": {
-      "version": "2.33.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.33.2.tgz",
-      "integrity": "sha512-etnQeM8Mqiys50ZB4IiuNqeB1WS2/EKFhVXwkPQ1qjzKMMAJUyrLjaRUcoZoHrbjGscnhBrWkRR+p3zcTGMhDg==",
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.36.0.tgz",
+      "integrity": "sha512-Lq2HrigCJ4RVdIdCmchenv1rVrejNSJ7EUCQojycQo12ww3FedQx4nb+GgTdqMhjbOMTqq5+ziaiZlrEN2z1gQ==",
       "dev": true,
       "requires": {
         "del": "3.0.0",
@@ -6032,9 +6032,9 @@
       "dev": true
     },
     "url-join": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.2.tgz",
-      "integrity": "sha1-wHJ1aWetJLi1nldBVRyqx49QuLc=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
     },
     "user-home": {
@@ -6086,9 +6086,9 @@
       }
     },
     "wc-e2e-page-objects": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/wc-e2e-page-objects/-/wc-e2e-page-objects-0.5.0.tgz",
-      "integrity": "sha1-7oAQnDRqn9HE4NUbi7h/oeHDcMs=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/wc-e2e-page-objects/-/wc-e2e-page-objects-0.9.0.tgz",
+      "integrity": "sha512-oGOLFAN+lNULLylZkhNIMGT0n5hO+elpcVkpNQcT4HgWfS1yPoGfeWgrfAX33b4ZGVlpViv78Fj3LM5TciXVHw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
@@ -6174,7 +6174,22 @@
         "selenium-webdriver": "3.6.0",
         "slugs": "0.1.3",
         "temp": "0.8.3",
-        "url-join": "2.0.2"
+        "url-join": "2.0.5"
+      },
+      "dependencies": {
+        "chromedriver": {
+          "version": "2.33.2",
+          "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.33.2.tgz",
+          "integrity": "sha512-etnQeM8Mqiys50ZB4IiuNqeB1WS2/EKFhVXwkPQ1qjzKMMAJUyrLjaRUcoZoHrbjGscnhBrWkRR+p3zcTGMhDg==",
+          "dev": true,
+          "requires": {
+            "del": "3.0.0",
+            "extract-zip": "1.6.6",
+            "kew": "0.7.0",
+            "mkdirp": "0.5.1",
+            "request": "2.83.0"
+          }
+        }
       }
     },
     "wrap-ansi": {
@@ -6209,13 +6224,13 @@
       "dev": true,
       "requires": {
         "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-stage-2": "^6.13.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "chromedriver": "^2.33.0",
+    "chromedriver": "^2.36.0",
     "config": "^1.24.0",
     "cross-env": "~5.1.1",
     "grunt": "~1.0.1",


### PR DESCRIPTION
This update is necessary as chromedriver 2.33.0 doesn't work well with the latest Chrome version and some e2e were failing because of that. With the latest version of chromedriver, all e2e tests are passing.