### PR TITLE
Fix PHPCS violations in a few files

### DIFF
--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -152,7 +152,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 	/**
 	 * Get shipping methods linked to this zone.
 	 *
-	 * @param bool $enabled_only Only return enabled methods.
+	 * @param bool   $enabled_only Only return enabled methods.
 	 * @param string $context Getting shipping methods for what context. Valid values, admin, json.
 	 * @return array of objects
 	 */
@@ -191,7 +191,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 					$methods[ $instance_id ]->method_order       = absint( $raw_method->method_order );
 					$methods[ $instance_id ]->enabled            = $raw_method->is_enabled ? 'yes' : 'no';
 					$methods[ $instance_id ]->has_settings       = $methods[ $instance_id ]->has_settings();
-					$methods[ $instance_id ]->settings_html      = $methods[ $instance_id ]->supports( 'instance-settings-modal' ) ? $methods[ $instance_id ]->get_admin_options_html(): false;
+					$methods[ $instance_id ]->settings_html      = $methods[ $instance_id ]->supports( 'instance-settings-modal' ) ? $methods[ $instance_id ]->get_admin_options_html() : false;
 					$methods[ $instance_id ]->method_description = wp_kses_post( wpautop( $methods[ $instance_id ]->method_description ) );
 				}
 

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -94,7 +94,7 @@ class WC_Shipping_Zones {
 		$wc_shipping         = WC_Shipping::instance();
 		$allowed_classes     = $wc_shipping->get_shipping_method_class_names();
 
-		if ( ! empty( $raw_shipping_method ) && in_array( $raw_shipping_method->method_id, array_keys( $allowed_classes ) ) ) {
+		if ( ! empty( $raw_shipping_method ) && in_array( $raw_shipping_method->method_id, array_keys( $allowed_classes ), true ) ) {
 			$class_name = $allowed_classes[ $raw_shipping_method->method_id ];
 			if ( is_object( $class_name ) ) {
 				$class_name = get_class( $class_name );

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -4,11 +4,9 @@
  *
  * Handles shipping and loads shipping methods via hooks.
  *
- * @class 		WC_Shipping
- * @version		2.6.0
- * @package		WooCommerce/Classes/Shipping
- * @category	Class
- * @author 		WooThemes
+ * @class       WC_Shipping
+ * @version     2.6.0
+ * @package     WooCommerce/Classes/Shipping
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,20 +18,38 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Shipping {
 
-	/** @var bool True if shipping is enabled. */
-	public $enabled					 = false;
-
-	/** @var array|null Stores methods loaded into woocommerce. */
-	public $shipping_methods         = null;
-
-	/** @var array Stores the shipping classes. */
-	public $shipping_classes		 = array();
-
-	/** @var array Stores packages to ship and to get quotes for. */
-	public $packages				 = array();
+	/**
+	 * True if shipping is enabled.
+	 *
+	 * @var bool
+	 */
+	public $enabled = false;
 
 	/**
-	 * @var WC_Shipping The single instance of the class
+	 * Stores methods loaded into woocommerce.
+	 *
+	 * @var array|null
+	 */
+	public $shipping_methods = null;
+
+	/**
+	 * Stores the shipping classes.
+	 *
+	 * @var array
+	 */
+	public $shipping_classes = array();
+
+	/**
+	 * Stores packages to ship and to get quotes for.
+	 *
+	 * @var array
+	 */
+	public $packages = array();
+
+	/**
+	 * The single instance of the class
+	 *
+	 * @var WC_Shipping
 	 * @since 2.1
 	 */
 	protected static $_instance = null;
@@ -80,10 +96,10 @@ class WC_Shipping {
 	 */
 	public function __get( $name ) {
 		// Grab from cart for backwards compatibility with versions prior to 3.2.
-		if ( 'shipping_total' === $name ){
+		if ( 'shipping_total' === $name ) {
 			return wc()->cart->get_shipping_total();
 		}
-		if ( 'shipping_taxes' === $name ){
+		if ( 'shipping_taxes' === $name ) {
 			return wc()->cart->get_shipping_taxes();
 		}
 	}
@@ -108,17 +124,18 @@ class WC_Shipping {
 
 	/**
 	 * Shipping methods register themselves by returning their main class name through the woocommerce_shipping_methods filter.
+	 *
 	 * @return array
 	 */
 	public function get_shipping_method_class_names() {
-		// Unique Method ID => Method Class name
+		// Unique Method ID => Method Class name.
 		$shipping_methods = array(
 			'flat_rate'     => 'WC_Shipping_Flat_Rate',
 			'free_shipping' => 'WC_Shipping_Free_Shipping',
 			'local_pickup'  => 'WC_Shipping_Local_Pickup',
 		);
 
-		// For backwards compatibility with 2.5.x we load any ENABLED legacy shipping methods here
+		// For backwards compatibility with 2.5.x we load any ENABLED legacy shipping methods here.
 		$maybe_load_legacy_methods = array( 'flat_rate', 'free_shipping', 'international_delivery', 'local_delivery', 'local_pickup' );
 
 		foreach ( $maybe_load_legacy_methods as $method ) {
@@ -135,7 +152,7 @@ class WC_Shipping {
 	 * Loads all shipping methods which are hooked in.
 	 * If a $package is passed some methods may add themselves conditionally and zones will be used.
 	 *
-	 * @param array $package
+	 * @param array $package Package information.
 	 * @return array
 	 */
 	public function load_shipping_methods( $package = array() ) {
@@ -144,7 +161,7 @@ class WC_Shipping {
 			$shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
 			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
 
-			// Debug output
+			// Debug output.
 			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' ) ) {
 				wc_add_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' );
 			}
@@ -160,7 +177,7 @@ class WC_Shipping {
 		// Methods can register themselves manually through this hook if necessary.
 		do_action( 'woocommerce_load_shipping_methods', $package );
 
-		// Return loaded methods
+		// Return loaded methods.
 		return $this->get_shipping_methods();
 	}
 
@@ -212,7 +229,12 @@ class WC_Shipping {
 	 */
 	public function get_shipping_classes() {
 		if ( empty( $this->shipping_classes ) ) {
-			$classes                = get_terms( 'product_shipping_class', array( 'hide_empty' => '0', 'orderby' => 'name' ) );
+			$classes                = get_terms(
+				'product_shipping_class', array(
+					'hide_empty' => '0',
+					'orderby'    => 'name',
+				)
+			);
 			$this->shipping_classes = ! is_wp_error( $classes ) ? $classes : array();
 		}
 		return apply_filters( 'woocommerce_get_shipping_classes', $this->shipping_classes );
@@ -220,7 +242,8 @@ class WC_Shipping {
 
 	/**
 	 * Get the default method.
-	 * @param  array  $available_methods
+	 *
+	 * @param  array   $available_methods
 	 * @param  boolean $current_chosen_method
 	 * @return string
 	 */
@@ -292,7 +315,7 @@ class WC_Shipping {
 		}
 
 		$allowed = array_keys( WC()->countries->get_shipping_countries() );
-		return in_array( $package['destination']['country'], $allowed );
+		return in_array( $package['destination']['country'], $allowed, true );
 	}
 
 	/**
@@ -338,10 +361,12 @@ class WC_Shipping {
 				$package['rates'] = apply_filters( 'woocommerce_package_rates', $package['rates'], $package );
 
 				// Store in session to avoid recalculation.
-				WC()->session->set( $session_key, array(
-					'package_hash' => $package_hash,
-					'rates'        => $package['rates'],
-				) );
+				WC()->session->set(
+					$session_key, array(
+						'package_hash' => $package_hash,
+						'rates'        => $package['rates'],
+					)
+				);
 			} else {
 				$package['rates'] = $stored_rates['rates'];
 			}
@@ -351,6 +376,7 @@ class WC_Shipping {
 
 	/**
 	 * Get packages.
+	 *
 	 * @return array
 	 */
 	public function get_packages() {
@@ -368,6 +394,8 @@ class WC_Shipping {
 	}
 
 	/**
+	 * Deprecated
+	 *
 	 * @deprecated 2.6.0 Was previously used to determine sort order of methods, but this is now controlled by zones and thus unused.
 	 */
 	public function sort_shipping_methods() {

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -241,31 +241,6 @@ class WC_Shipping {
 	}
 
 	/**
-	 * Get the default method.
-	 *
-	 * @param  array   $available_methods
-	 * @param  boolean $current_chosen_method
-	 * @return string
-	 */
-	private function get_default_method( $available_methods, $current_chosen_method = false ) {
-		if ( ! empty( $available_methods ) ) {
-			if ( ! empty( $current_chosen_method ) ) {
-				if ( isset( $available_methods[ $current_chosen_method ] ) ) {
-					return $available_methods[ $current_chosen_method ]->id;
-				} else {
-					foreach ( $available_methods as $method_key => $method ) {
-						if ( strpos( $method->id, $current_chosen_method ) === 0 ) {
-							return $method->id;
-						}
-					}
-				}
-			}
-			return current( $available_methods )->id;
-		}
-		return '';
-	}
-
-	/**
 	 * Calculate shipping for (multiple) packages of cart items.
 	 *
 	 * @param array $packages multi-dimensional array of cart items to calc shipping for.

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -2,8 +2,6 @@
 /**
  * Shortcodes
  *
- * @author   Automattic
- * @category Class
  * @package  WooCommerce/Classes
  * @version  3.2.0
  */


### PR DESCRIPTION
This PR fixes PHPCS violations in the following files:

- includes/class-wc-shortcodes.php
- includes/class-wc-shipping.php
- includes/class-wc-shipping-zones.php
- includes/class-wc-shipping-zone.php

It also remove an unused private method in includes/class-wc-shipping.php (see commit 45c1ade).