### PR TITLE
Use wc_get_default_products_per_row as the default for product shortcodes

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -113,7 +113,7 @@ class WC_Shortcode_Products {
 		$attributes = shortcode_atts(
 			array(
 				'limit'          => '-1',      // Results limit.
-				'columns'        => wc_get_default_products_per_row(), // Number of columns.
+				'columns'        => '',        // Number of columns.
 				'rows'           => '',        // Number of rows. If defined, limit will be ignored.
 				'orderby'        => 'title',   // menu_order, title, date, rand, price, popularity, rating, or id.
 				'order'          => 'ASC',     // ASC or DESC.
@@ -134,7 +134,7 @@ class WC_Shortcode_Products {
 		);
 
 		if ( ! absint( $attributes['columns'] ) ) {
-			$attributes['columns'] = 3;
+			$attributes['columns'] = wc_get_default_products_per_row();
 		}
 
 		return $attributes;

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -113,7 +113,7 @@ class WC_Shortcode_Products {
 		$attributes = shortcode_atts(
 			array(
 				'limit'          => '-1',      // Results limit.
-				'columns'        => '3',       // Number of columns.
+				'columns'        => wc_get_default_products_per_row(), // Number of columns.
 				'rows'           => '',        // Number of rows. If defined, limit will be ignored.
 				'orderby'        => 'title',   // menu_order, title, date, rand, price, popularity, rating, or id.
 				'order'          => 'ASC',     // ASC or DESC.

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -14,7 +14,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
 			'limit'          => '-1',
-			'columns'        => '3',
+			'columns'        => '4',
 			'orderby'        => 'title',
 			'order'          => 'ASC',
 			'ids'            => '',
@@ -40,7 +40,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		) );
 		$expected2  = array(
 			'limit'          => '-1',
-			'columns'        => '3',
+			'columns'        => '4',
 			'orderby'        => 'id',
 			'order'          => 'DESC',
 			'ids'            => '',


### PR DESCRIPTION
Closes #19408

Will apply if no fixed columns are provided via the shortcode args.