### PR TITLE
Add the "woocommerce_install_get_tables" filter to WC_Install::get_tables()

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -780,6 +780,15 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			$tables[] = "{$wpdb->prefix}woocommerce_termmeta";
 		}
 
+		/**
+		 * Filter the list of known WooCommerce tables.
+		 *
+		 * If WooCommerce plugins need to add new tables, they can inject them here.
+		 *
+		 * @param array $tables An array of WooCommerce-specific database table names.
+		 */
+		$tables = apply_filters( 'woocommerce_install_get_tables', $tables );
+
 		return $tables;
 	}
 

--- a/tests/unit-tests/util/install.php
+++ b/tests/unit-tests/util/install.php
@@ -125,4 +125,25 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $tables, WC_Install::get_tables() );
 	}
+
+	/**
+	 * Test - get tables should apply the woocommerce_install_get_tables filter.
+	 */
+	public function test_get_tables_enables_filter() {
+		$default = WC_Install::get_tables();
+		$added   = $this->append_table_to_get_tables( array() );
+
+		add_filter( 'woocommerce_install_get_tables', array( $this, 'append_table_to_get_tables' ) );
+
+		$this->assertEquals( $added, array_values( array_diff( WC_Install::get_tables(), $default ) ) );
+	}
+
+	/**
+	 * Filter callback for test_get_tables_enables_filter().
+	 */
+	public function append_table_to_get_tables( $tables ) {
+		$tables[] = 'some_table_name';
+
+		return $tables;
+	}
 }


### PR DESCRIPTION
This PR adds a new filter, "woocommerce_install_get_tables", to the WC_Install::get_tables() method, enabling WooCommerce extensions to register new, WooCommerce-specific tables.

Registration ensures that these tables can be cleaned up automatically should WooCommerce be uninstalled (useful for things like custom table data stores). Nothing gets added by default, but this provides an integration point for plugins like [WooCommerce Custom Orders Table](https://github.com/liquidweb/woocommerce-custom-orders-table).