### PR TITLE
Set is_shortcode loop prop when outputting subcategories

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -200,6 +200,7 @@ class WC_Shortcodes {
 		$columns = absint( $atts['columns'] );
 
 		wc_set_loop_prop( 'columns', $columns );
+		wc_set_loop_prop( 'is_shortcode', true );
 
 		ob_start();
 


### PR DESCRIPTION
Fixes #19439

To test;

- Edit a parent category
- Add a `[product_categories ids=“X”]` shortcode in the category description where X is another parent category
- View the page

Before the patch, the children of the current category would be shown.