### PR TITLE
Infinite scroll compatibility

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -433,7 +433,7 @@ class WC_Query {
 				if ( is_search() ) {
 					$orderby_value = 'relevance';
 				} else {
-					$orderby_value = apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby' ) );
+					$orderby_value = apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby', 'menu_order' ) );
 				}
 			}
 

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -44,8 +44,8 @@ class WC_Query {
 			add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
 			add_action( 'parse_request', array( $this, 'parse_request' ), 0 );
 			add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
-			add_action( 'wp', array( $this, 'remove_product_query' ) );
-			add_action( 'wp', array( $this, 'remove_ordering_args' ) );
+			//add_action( 'wp', array( $this, 'remove_product_query' ) );
+			//add_action( 'wp', array( $this, 'remove_ordering_args' ) );
 			add_filter( 'get_pagenum_link', array( $this, 'remove_add_to_cart_pagination' ), 10, 1 );
 		}
 		$this->init_query_vars();
@@ -342,7 +342,7 @@ class WC_Query {
 		$this->product_query( $q );
 
 		// And remove the pre_get_posts hook.
-		$this->remove_product_query();
+		//$this->remove_product_query();
 	}
 
 	/**

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -44,8 +44,7 @@ class WC_Query {
 			add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
 			add_action( 'parse_request', array( $this, 'parse_request' ), 0 );
 			add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
-			//add_action( 'wp', array( $this, 'remove_product_query' ) );
-			//add_action( 'wp', array( $this, 'remove_ordering_args' ) );
+			add_filter( 'the_posts', array( $this, 'remove_product_query_filters' ) );
 			add_filter( 'get_pagenum_link', array( $this, 'remove_add_to_cart_pagination' ), 10, 1 );
 		}
 		$this->init_query_vars();
@@ -340,9 +339,20 @@ class WC_Query {
 		}
 
 		$this->product_query( $q );
+	}
 
-		// And remove the pre_get_posts hook.
-		//$this->remove_product_query();
+	/**
+	 * Pre_get_posts above may adjust the main query to add WooCommerce logic. When this query is done, we need to ensure
+	 * all custom filters are removed.
+	 *
+	 * This is done here during the_posts filter. The input is not changed.
+	 *
+	 * @param array $posts Posts from WP Query.
+	 * @return array
+	 */
+	public function remove_product_query_filters( $posts ) {
+		$this->remove_ordering_args();
+		return $posts;
 	}
 
 	/**


### PR DESCRIPTION
These are some changes to help us support infinite scroll in Jetpack.

Specifically this:

- Ensures orderby cannot be empty on a clean install
- Rather than unhooking product query after `wp`, or after it runs, it only unhooks after pre_get_posts has worked it’s magic.

The queries ran by infinite scroll run too late without these changes leading to odd results.

True compatibility also requires some changes in Infinite scroll so this is not testable alone.

cc @tiagonoronha 
