### PR TITLE
Removed line item limit and made sure the URL is shorter than 2083 ch…

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -53,15 +53,16 @@ class WC_Gateway_Paypal_Request {
 	 * @return string
 	 */
 	public function get_request_url( $order, $sandbox = false ) {
+		if ( $sandbox ) {
+			$this->request_url_prefix = 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&';
+		} else {
+			$this->request_url_prefix = 'https://www.paypal.com/cgi-bin/webscr?';
+		}
 		$paypal_args = http_build_query( $this->get_paypal_args( $order ), '', '&' );
 
 		WC_Gateway_Paypal::log( 'PayPal Request Args for order ' . $order->get_order_number() . ': ' . wc_print_r( $paypal_args, true ) );
 
-		if ( $sandbox ) {
-			return 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&' . $paypal_args;
-		} else {
-			return 'https://www.paypal.com/cgi-bin/webscr?' . $paypal_args;
-		}
+		return $this->request_url_prefix . $paypal_args;
 	}
 
 	/**
@@ -72,8 +73,12 @@ class WC_Gateway_Paypal_Request {
 	 * @return string
 	 */
 	protected function limit_length( $string, $limit = 127 ) {
-		if ( strlen( $string ) > $limit ) {
-			$string = substr( $string, 0, $limit - 3 ) . '...';
+		// As the output is to be used in http_build_query which applies URL encoding, the string needs to be
+		// cut as if it was URL-encoded, but returned non-encoded (it will be encoded by http_build_query later).
+		$url_encoded_str = rawurlencode( $string );
+
+		if ( strlen( $url_encoded_str ) > $limit ) {
+			$string = rawurldecode( substr( $url_encoded_str, 0, $limit - 3 ) . '...' );
 		}
 		return $string;
 	}
@@ -87,43 +92,49 @@ class WC_Gateway_Paypal_Request {
 	protected function get_paypal_args( $order ) {
 		WC_Gateway_Paypal::log( 'Generating payment form for order ' . $order->get_order_number() . '. Notify URL: ' . $this->notify_url );
 
+		$initial_paypal_args = array(
+			'cmd'           => '_cart',
+			'business'      => $this->gateway->get_option( 'email' ),
+			'no_note'       => 1,
+			'currency_code' => get_woocommerce_currency(),
+			'charset'       => 'utf-8',
+			'rm'            => is_ssl() ? 2 : 1,
+			'upload'        => 1,
+			'return'        => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
+			'cancel_return' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+			'page_style'    => $this->gateway->get_option( 'page_style' ),
+			'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
+			'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
+			'bn'            => 'WooThemes_Cart',
+			'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
+			'custom'        => wp_json_encode(
+				array(
+					'order_id'  => $order->get_id(),
+					'order_key' => $order->get_order_key(),
+				)
+			),
+			'notify_url'    => $this->limit_length( $this->notify_url, 255 ),
+			'first_name'    => $this->limit_length( $order->get_billing_first_name(), 32 ),
+			'last_name'     => $this->limit_length( $order->get_billing_last_name(), 64 ),
+			'address1'      => $this->limit_length( $order->get_billing_address_1(), 100 ),
+			'address2'      => $this->limit_length( $order->get_billing_address_2(), 100 ),
+			'city'          => $this->limit_length( $order->get_billing_city(), 40 ),
+			'state'         => $this->get_paypal_state( $order->get_billing_country(), $order->get_billing_state() ),
+			'zip'           => $this->limit_length( wc_format_postcode( $order->get_billing_postcode(), $order->get_billing_country() ), 32 ),
+			'country'       => $this->limit_length( $order->get_billing_country(), 2 ),
+			'email'         => $this->limit_length( $order->get_billing_email() ),
+		);
+		$phone_number_args = $this->get_phone_number_args( $order );
+		$shipping_args     = $this->get_shipping_args( $order );
+		$query_str_except_line_items = http_build_query( array_merge( $initial_paypal_args, $phone_number_args, $shipping_args ), '', '&' );
+		$url_except_line_items_length = strlen( $this->request_url_prefix . $query_str_except_line_items );
+
 		return apply_filters(
 			'woocommerce_paypal_args', array_merge(
-				array(
-					'cmd'           => '_cart',
-					'business'      => $this->gateway->get_option( 'email' ),
-					'no_note'       => 1,
-					'currency_code' => get_woocommerce_currency(),
-					'charset'       => 'utf-8',
-					'rm'            => is_ssl() ? 2 : 1,
-					'upload'        => 1,
-					'return'        => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
-					'cancel_return' => esc_url_raw( $order->get_cancel_order_url_raw() ),
-					'page_style'    => $this->gateway->get_option( 'page_style' ),
-					'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
-					'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
-					'bn'            => 'WooThemes_Cart',
-					'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
-					'custom'        => wp_json_encode(
-						array(
-							'order_id'  => $order->get_id(),
-							'order_key' => $order->get_order_key(),
-						)
-					),
-					'notify_url'    => $this->limit_length( $this->notify_url, 255 ),
-					'first_name'    => $this->limit_length( $order->get_billing_first_name(), 32 ),
-					'last_name'     => $this->limit_length( $order->get_billing_last_name(), 64 ),
-					'address1'      => $this->limit_length( $order->get_billing_address_1(), 100 ),
-					'address2'      => $this->limit_length( $order->get_billing_address_2(), 100 ),
-					'city'          => $this->limit_length( $order->get_billing_city(), 40 ),
-					'state'         => $this->get_paypal_state( $order->get_billing_country(), $order->get_billing_state() ),
-					'zip'           => $this->limit_length( wc_format_postcode( $order->get_billing_postcode(), $order->get_billing_country() ), 32 ),
-					'country'       => $this->limit_length( $order->get_billing_country(), 2 ),
-					'email'         => $this->limit_length( $order->get_billing_email() ),
-				),
-				$this->get_phone_number_args( $order ),
-				$this->get_shipping_args( $order ),
-				$this->get_line_item_args( $order )
+				$initial_paypal_args,
+				$phone_number_args,
+				$shipping_args,
+				$this->get_line_item_args( $order, $url_except_line_items_length )
 			), $order
 		);
 	}
@@ -181,18 +192,62 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * Get shipping cost line item args for paypal request.
+	 *
+	 * @param  WC_Order $order Order object.
+	 * @param  bool     $include_shipping_tax Whether to include shipping tax or not.
+	 * @return array
+	 */
+	protected function get_shipping_cost_line_item( $order, $include_shipping_tax ) {
+		$line_item_args = array();
+		$shipping_total = $order->get_shipping_total();
+		if ( $include_shipping_tax ) {
+			$shipping_total += $order->get_shipping_tax();
+		}
+
+		// Add shipping costs. Paypal ignores anything over 5 digits (999.99 is the max).
+		// We also check that shipping is not the **only** cost as PayPal won't allow payment
+		// if the items have no cost.
+		if ( $order->get_shipping_total() > 0 && $order->get_shipping_total() < 999.99 && $this->number_format( $order->get_shipping_total() + $order->get_shipping_tax(), $order ) !== $this->number_format( $order->get_total(), $order ) ) {
+			$line_item_args['shipping_1'] = $this->number_format( $shipping_total, $order );
+		} elseif ( $order->get_shipping_total() > 0 ) {
+			/* translators: %s: Order shipping method */
+			$this->add_line_item( sprintf( __( 'Shipping via %s', 'woocommerce' ), $order->get_shipping_method() ), 1, $this->number_format( $shipping_total, $order ) );
+		}
+
+		return $line_item_args;
+	}
+
+	/**
+	 * Get line item args for paypal request as a single line item.
+	 *
+	 * @param  WC_Order $order Order object.
+	 * @param  bool     $include_shipping_tax Whether to include shipping tax or not.
+	 * @return array
+	 */
+	protected function get_line_item_args_single_item( $order, $include_shipping_tax ) {
+		$this->delete_line_items();
+
+		$all_items_name = $this->get_order_item_names( $order );
+		$this->add_line_item( $all_items_name ? $all_items_name : __( 'Order', 'woocommerce' ), 1, $this->number_format( $order->get_total() - $this->round( $order->get_shipping_total() + $order->get_shipping_tax(), $order ), $order ), $order->get_order_number() );
+		$line_item_args = $this->get_shipping_cost_line_item( $order, $include_shipping_tax );
+
+		return array_merge( $line_item_args, $this->get_line_items() );
+	}
+
+	/**
 	 * Get line item args for paypal request.
 	 *
 	 * @param  WC_Order $order Order object.
+	 * @param  int      $url_except_line_items_length Length of URL without line items.
 	 * @return array
 	 */
-	protected function get_line_item_args( $order ) {
+	protected function get_line_item_args( $order, $url_except_line_items_length ) {
 
 		/**
 		 * Try passing a line item per product if supported.
 		 */
 		if ( ( ! wc_tax_enabled() || ! wc_prices_include_tax() ) && $this->prepare_line_items( $order ) ) {
-
 			$line_item_args             = array();
 			$line_item_args['tax_cart'] = $this->number_format( $order->get_total_tax(), $order );
 
@@ -200,41 +255,29 @@ class WC_Gateway_Paypal_Request {
 				$line_item_args['discount_amount_cart'] = $this->number_format( $this->round( $order->get_total_discount(), $order ), $order );
 			}
 
-			// Add shipping costs. Paypal ignores anything over 5 digits (999.99 is the max).
-			// We also check that shipping is not the **only** cost as PayPal won't allow payment
-			// if the items have no cost.
-			if ( $order->get_shipping_total() > 0 && $order->get_shipping_total() < 999.99 && $this->number_format( $order->get_shipping_total() + $order->get_shipping_tax(), $order ) !== $this->number_format( $order->get_total(), $order ) ) {
-				$line_item_args['shipping_1'] = $this->number_format( $order->get_shipping_total(), $order );
-			} elseif ( $order->get_shipping_total() > 0 ) {
-				/* translators: %s: Order shipping method */
-				$this->add_line_item( sprintf( __( 'Shipping via %s', 'woocommerce' ), $order->get_shipping_method() ), 1, $this->number_format( $order->get_shipping_total(), $order ) );
-			}
-
+			$include_shipping_tax = false;
+			$line_item_args = array_merge( $line_item_args, $this->get_shipping_cost_line_item( $order, $include_shipping_tax ) );
 			$line_item_args = array_merge( $line_item_args, $this->get_line_items() );
+
+			$line_items_query_str_length = strlen( http_build_query( $line_item_args, '', '&' ) );
+
+			// If URL is longer than 2,083 chars, ignore line items and send cart to Paypal as a single item.
+			// One item's name can only be 127 characters long, so the URL should not be longer than limit.
+			// URL character limit via:
+			// https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer
+			// +1 for '&' that needs to connect 2 query strings.
+			if ( $url_except_line_items_length + 1 + $line_items_query_str_length > 2083 ) {
+				$line_item_args = $this->get_line_item_args_single_item( $order, $include_shipping_tax );
+			}
 		} else {
 			/**
 			 * Send order as a single item.
 			 *
 			 * For shipping, we longer use shipping_1 because paypal ignores it if *any* shipping rules are within paypal, and paypal ignores anything over 5 digits (999.99 is the max).
 			 */
+			$include_shipping_tax = true;
+			$line_item_args = $this->get_line_item_args_single_item( $order, $include_shipping_tax );
 
-			$this->delete_line_items();
-
-			$line_item_args = array();
-			$all_items_name = $this->get_order_item_names( $order );
-			$this->add_line_item( $all_items_name ? $all_items_name : __( 'Order', 'woocommerce' ), 1, $this->number_format( $order->get_total() - $this->round( $order->get_shipping_total() + $order->get_shipping_tax(), $order ), $order ), $order->get_order_number() );
-
-			// Add shipping costs. Paypal ignores anything over 5 digits (999.99 is the max).
-			// We also check that shipping is not the **only** cost as PayPal won't allow payment
-			// if the items have no cost.
-			if ( $order->get_shipping_total() > 0 && $order->get_shipping_total() < 999.99 && $this->number_format( $order->get_shipping_total() + $order->get_shipping_tax(), $order ) !== $this->number_format( $order->get_total(), $order ) ) {
-				$line_item_args['shipping_1'] = $this->number_format( $order->get_shipping_total() + $order->get_shipping_tax(), $order );
-			} elseif ( $order->get_shipping_total() > 0 ) {
-				/* translators: %s: Order shipping method */
-				$this->add_line_item( sprintf( __( 'Shipping via %s', 'woocommerce' ), $order->get_shipping_method() ), 1, $this->number_format( $order->get_shipping_total() + $order->get_shipping_tax(), $order ) );
-			}
-
-			$line_item_args = array_merge( $line_item_args, $this->get_line_items() );
 		}
 
 		return $line_item_args;
@@ -364,7 +407,7 @@ class WC_Gateway_Paypal_Request {
 	protected function add_line_item( $item_name, $quantity = 1, $amount = 0.0, $item_number = '' ) {
 		$index = ( count( $this->line_items ) / 4 ) + 1;
 
-		if ( $amount < 0 || $index > 9 ) {
+		if ( $amount < 0 ) {
 			return false;
 		}
 

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -36,6 +36,14 @@ class WC_Gateway_Paypal_Request {
 	protected $notify_url;
 
 	/**
+	 * Endpoint for requests from PayPal.
+	 *
+	 * @var string
+	 */
+	protected $endpoint;
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WC_Gateway_Paypal $gateway Paypal gateway object.
@@ -54,15 +62,15 @@ class WC_Gateway_Paypal_Request {
 	 */
 	public function get_request_url( $order, $sandbox = false ) {
 		if ( $sandbox ) {
-			$this->request_url_prefix = 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&';
+			$this->endpoint = 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&';
 		} else {
-			$this->request_url_prefix = 'https://www.paypal.com/cgi-bin/webscr?';
+			$this->endpoint = 'https://www.paypal.com/cgi-bin/webscr?';
 		}
 		$paypal_args = http_build_query( $this->get_paypal_args( $order ), '', '&' );
 
 		WC_Gateway_Paypal::log( 'PayPal Request Args for order ' . $order->get_order_number() . ': ' . wc_print_r( $paypal_args, true ) );
 
-		return $this->request_url_prefix . $paypal_args;
+		return $this->endpoint . $paypal_args;
 	}
 
 	/**
@@ -84,6 +92,67 @@ class WC_Gateway_Paypal_Request {
 	}
 
 	/**
+	 * If the default request with line items is too long, generate a new one with only one line item.
+	 *
+	 * @param WC_Order $order Order to be sent to Paypal.
+	 * @param array    $paypal_args Arguments sent to Paypal in the request.
+	 *
+	 * @return array
+	 */
+	protected function fix_request_legth( $order, $paypal_args ) {
+		$max_paypal_length = 2083;
+		$query_candidate   = http_build_query( $paypal_args, '', '&' );
+		// If URL is longer than 2,083 chars, ignore line items and send cart to Paypal as a single item.
+		// One item's name can only be 127 characters long, so the URL should not be longer than limit.
+		// URL character limit via:
+		// https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer
+		if ( strlen( $this->endpoint . $query_candidate ) <= $max_paypal_length ) {
+			return $paypal_args;
+		}
+
+		return apply_filters(
+			'woocommerce_paypal_args', array_merge(
+				array(
+					'cmd'           => '_cart',
+					'business'      => $this->gateway->get_option( 'email' ),
+					'no_note'       => 1,
+					'currency_code' => get_woocommerce_currency(),
+					'charset'       => 'utf-8',
+					'rm'            => is_ssl() ? 2 : 1,
+					'upload'        => 1,
+					'return'        => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
+					'cancel_return' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+					'page_style'    => $this->gateway->get_option( 'page_style' ),
+					'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
+					'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
+					'bn'            => 'WooThemes_Cart',
+					'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
+					'custom'        => wp_json_encode(
+						array(
+							'order_id'  => $order->get_id(),
+							'order_key' => $order->get_order_key(),
+						)
+					),
+					'notify_url'    => $this->limit_length( $this->notify_url, 255 ),
+					'first_name'    => $this->limit_length( $order->get_billing_first_name(), 32 ),
+					'last_name'     => $this->limit_length( $order->get_billing_last_name(), 64 ),
+					'address1'      => $this->limit_length( $order->get_billing_address_1(), 100 ),
+					'address2'      => $this->limit_length( $order->get_billing_address_2(), 100 ),
+					'city'          => $this->limit_length( $order->get_billing_city(), 40 ),
+					'state'         => $this->get_paypal_state( $order->get_billing_country(), $order->get_billing_state() ),
+					'zip'           => $this->limit_length( wc_format_postcode( $order->get_billing_postcode(), $order->get_billing_country() ), 32 ),
+					'country'       => $this->limit_length( $order->get_billing_country(), 2 ),
+					'email'         => $this->limit_length( $order->get_billing_email() ),
+				),
+				$this->get_phone_number_args( $order ),
+				$this->get_shipping_args( $order ),
+				$this->get_line_item_args( $order, true )
+			), $order
+		);
+
+	}
+
+	/**
 	 * Get PayPal Args for passing to PP.
 	 *
 	 * @param  WC_Order $order Order object.
@@ -92,51 +161,47 @@ class WC_Gateway_Paypal_Request {
 	protected function get_paypal_args( $order ) {
 		WC_Gateway_Paypal::log( 'Generating payment form for order ' . $order->get_order_number() . '. Notify URL: ' . $this->notify_url );
 
-		$initial_paypal_args = array(
-			'cmd'           => '_cart',
-			'business'      => $this->gateway->get_option( 'email' ),
-			'no_note'       => 1,
-			'currency_code' => get_woocommerce_currency(),
-			'charset'       => 'utf-8',
-			'rm'            => is_ssl() ? 2 : 1,
-			'upload'        => 1,
-			'return'        => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
-			'cancel_return' => esc_url_raw( $order->get_cancel_order_url_raw() ),
-			'page_style'    => $this->gateway->get_option( 'page_style' ),
-			'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
-			'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
-			'bn'            => 'WooThemes_Cart',
-			'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
-			'custom'        => wp_json_encode(
-				array(
-					'order_id'  => $order->get_id(),
-					'order_key' => $order->get_order_key(),
-				)
-			),
-			'notify_url'    => $this->limit_length( $this->notify_url, 255 ),
-			'first_name'    => $this->limit_length( $order->get_billing_first_name(), 32 ),
-			'last_name'     => $this->limit_length( $order->get_billing_last_name(), 64 ),
-			'address1'      => $this->limit_length( $order->get_billing_address_1(), 100 ),
-			'address2'      => $this->limit_length( $order->get_billing_address_2(), 100 ),
-			'city'          => $this->limit_length( $order->get_billing_city(), 40 ),
-			'state'         => $this->get_paypal_state( $order->get_billing_country(), $order->get_billing_state() ),
-			'zip'           => $this->limit_length( wc_format_postcode( $order->get_billing_postcode(), $order->get_billing_country() ), 32 ),
-			'country'       => $this->limit_length( $order->get_billing_country(), 2 ),
-			'email'         => $this->limit_length( $order->get_billing_email() ),
-		);
-		$phone_number_args = $this->get_phone_number_args( $order );
-		$shipping_args     = $this->get_shipping_args( $order );
-		$query_str_except_line_items = http_build_query( array_merge( $initial_paypal_args, $phone_number_args, $shipping_args ), '', '&' );
-		$url_except_line_items_length = strlen( $this->request_url_prefix . $query_str_except_line_items );
-
-		return apply_filters(
+		$paypal_args = apply_filters(
 			'woocommerce_paypal_args', array_merge(
-				$initial_paypal_args,
-				$phone_number_args,
-				$shipping_args,
-				$this->get_line_item_args( $order, $url_except_line_items_length )
+				array(
+					'cmd'           => '_cart',
+					'business'      => $this->gateway->get_option( 'email' ),
+					'no_note'       => 1,
+					'currency_code' => get_woocommerce_currency(),
+					'charset'       => 'utf-8',
+					'rm'            => is_ssl() ? 2 : 1,
+					'upload'        => 1,
+					'return'        => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
+					'cancel_return' => esc_url_raw( $order->get_cancel_order_url_raw() ),
+					'page_style'    => $this->gateway->get_option( 'page_style' ),
+					'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
+					'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
+					'bn'            => 'WooThemes_Cart',
+					'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
+					'custom'        => wp_json_encode(
+						array(
+							'order_id'  => $order->get_id(),
+							'order_key' => $order->get_order_key(),
+						)
+					),
+					'notify_url'    => $this->limit_length( $this->notify_url, 255 ),
+					'first_name'    => $this->limit_length( $order->get_billing_first_name(), 32 ),
+					'last_name'     => $this->limit_length( $order->get_billing_last_name(), 64 ),
+					'address1'      => $this->limit_length( $order->get_billing_address_1(), 100 ),
+					'address2'      => $this->limit_length( $order->get_billing_address_2(), 100 ),
+					'city'          => $this->limit_length( $order->get_billing_city(), 40 ),
+					'state'         => $this->get_paypal_state( $order->get_billing_country(), $order->get_billing_state() ),
+					'zip'           => $this->limit_length( wc_format_postcode( $order->get_billing_postcode(), $order->get_billing_country() ), 32 ),
+					'country'       => $this->limit_length( $order->get_billing_country(), 2 ),
+					'email'         => $this->limit_length( $order->get_billing_email() ),
+				),
+				$this->get_phone_number_args( $order ),
+				$this->get_shipping_args( $order ),
+				$this->get_line_item_args( $order )
 			), $order
 		);
+
+		return $this->fix_request_legth( $order, $paypal_args );
 	}
 
 	/**
@@ -239,35 +304,29 @@ class WC_Gateway_Paypal_Request {
 	 * Get line item args for paypal request.
 	 *
 	 * @param  WC_Order $order Order object.
-	 * @param  int      $url_except_line_items_length Length of URL without line items.
+	 * @param  bool     $force_one_line_item Create only one item for this order.
 	 * @return array
 	 */
-	protected function get_line_item_args( $order, $url_except_line_items_length ) {
+	protected function get_line_item_args( $order, $force_one_line_item = false ) {
 
 		/**
 		 * Try passing a line item per product if supported.
 		 */
 		if ( ( ! wc_tax_enabled() || ! wc_prices_include_tax() ) && $this->prepare_line_items( $order ) ) {
-			$line_item_args             = array();
-			$line_item_args['tax_cart'] = $this->number_format( $order->get_total_tax(), $order );
-
-			if ( $order->get_total_discount() > 0 ) {
-				$line_item_args['discount_amount_cart'] = $this->number_format( $this->round( $order->get_total_discount(), $order ), $order );
-			}
-
+			$line_item_args       = array();
 			$include_shipping_tax = false;
-			$line_item_args = array_merge( $line_item_args, $this->get_shipping_cost_line_item( $order, $include_shipping_tax ) );
-			$line_item_args = array_merge( $line_item_args, $this->get_line_items() );
-
-			$line_items_query_str_length = strlen( http_build_query( $line_item_args, '', '&' ) );
-
-			// If URL is longer than 2,083 chars, ignore line items and send cart to Paypal as a single item.
-			// One item's name can only be 127 characters long, so the URL should not be longer than limit.
-			// URL character limit via:
-			// https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer
-			// +1 for '&' that needs to connect 2 query strings.
-			if ( $url_except_line_items_length + 1 + $line_items_query_str_length > 2083 ) {
+			if ( $force_one_line_item ) {
 				$line_item_args = $this->get_line_item_args_single_item( $order, $include_shipping_tax );
+			} else {
+				$line_item_args['tax_cart'] = $this->number_format( $order->get_total_tax(), $order );
+
+				if ( $order->get_total_discount() > 0 ) {
+					$line_item_args['discount_amount_cart'] = $this->number_format( $this->round( $order->get_total_discount(), $order ), $order );
+				}
+
+				$line_item_args = array_merge( $line_item_args, $this->get_shipping_cost_line_item( $order, $include_shipping_tax ) );
+				$line_item_args = array_merge( $line_item_args, $this->get_line_items() );
+
 			}
 		} else {
 			/**

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -240,12 +240,13 @@ class WC_Gateway_Paypal_Request {
 	 * Get shipping cost line item args for paypal request.
 	 *
 	 * @param  WC_Order $order Order object.
+	 * @param  bool     $force_one_line_item Whether one line item was forced by validation or URL length.
 	 * @return array
 	 */
-	protected function get_shipping_cost_line_item( $order ) {
+	protected function get_shipping_cost_line_item( $order, $force_one_line_item ) {
 		$line_item_args = array();
 		$shipping_total = $order->get_shipping_total();
-		if ( wc_tax_enabled() && wc_prices_include_tax() || ! $this->line_items_valid( $order ) ) {
+		if ( $force_one_line_item ) {
 			$shipping_total += $order->get_shipping_tax();
 		}
 
@@ -273,7 +274,7 @@ class WC_Gateway_Paypal_Request {
 
 		$all_items_name = $this->get_order_item_names( $order );
 		$this->add_line_item( $all_items_name ? $all_items_name : __( 'Order', 'woocommerce' ), 1, $this->number_format( $order->get_total() - $this->round( $order->get_shipping_total() + $order->get_shipping_tax(), $order ), $order ), $order->get_order_number() );
-		$line_item_args = $this->get_shipping_cost_line_item( $order );
+		$line_item_args = $this->get_shipping_cost_line_item( $order, true );
 
 		return array_merge( $line_item_args, $this->get_line_items() );
 	}
@@ -309,7 +310,7 @@ class WC_Gateway_Paypal_Request {
 				$line_item_args['discount_amount_cart'] = $this->number_format( $this->round( $order->get_total_discount(), $order ), $order );
 			}
 
-			$line_item_args = array_merge( $line_item_args, $this->get_shipping_cost_line_item( $order ) );
+			$line_item_args = array_merge( $line_item_args, $this->get_shipping_cost_line_item( $order, false ) );
 			$line_item_args = array_merge( $line_item_args, $this->get_line_items() );
 
 		}

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -105,7 +105,7 @@ class WC_Gateway_Paypal_Request {
 		// If URL is longer than 2,083 chars, ignore line items and send cart to Paypal as a single item.
 		// One item's name can only be 127 characters long, so the URL should not be longer than limit.
 		// URL character limit via:
-		// https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer
+		// https://support.microsoft.com/en-us/help/208427/maximum-url-length-is-2-083-characters-in-internet-explorer.
 		if ( strlen( $this->endpoint . $query_candidate ) <= $max_paypal_length ) {
 			return $paypal_args;
 		}

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -289,9 +289,6 @@ class WC_Gateway_Paypal_Request {
 	 */
 	protected function get_line_item_args( $order, $force_one_line_item = false ) {
 
-		/**
-		 * Try passing a line item per product if supported.
-		 */
 		if ( ( ! wc_tax_enabled() || ! wc_prices_include_tax() ) && $this->prepare_line_items( $order ) ) {
 			$include_shipping_tax = false;
 		} else {

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -214,7 +214,6 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			$this->assertTrue( array_key_exists( 'cmd', $query_array ) );
 			$this->assertEquals( '_cart', $query_array['cmd'] );
 
-
 			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_name_' . $i ] ) );
 			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_number_' . $i ] ) );
 

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -356,7 +356,8 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			$this->check_small_order( 11, $shipping_tax_included, $testmode );
 
 			// Test order with URL longer than limit.
-			$this->check_large_order( $shipping_tax_included, $testmode );
+			// Many items in order -> forced to use one line item -> shipping tax included.
+			$this->check_large_order( true, $testmode );
 
 			// Test amount < 0.
 			$this->check_negative_amount( $testmode );

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -228,13 +228,16 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		// Paths through code changed by:
-		// $sandbox (true/false)
-		// wc_tax_enabled() === get_option( 'woocommerce_calc_taxes' ) === 'yes'
-		// wc_prices_include_tax() === wc_tax_enabled() && 'yes' === get_option( 'woocommerce_prices_include_tax' );.
+		// - $sandbox (true/false)
+		// - wc_tax_enabled()
+		// - wc_prices_include_tax().
+		// wc_tax_enabled() and wc_prices_include_tax() determine if shipping tax should be included,
+		// these are the correct options.
 		$correct_options = array(
+			// woocommerce_calc_taxes, woocommerce_prices_include_tax, $shipping_tax_included values.
 			array( 'no', 'no', false ),
 			array( 'yes', 'no', false ),
-			// array( 'no',  'yes',  false ), // this is not a valid option due to definition of wc_prices_include_tax
+			// array( 'no',  'yes',  false ), // this is not a valid option due to definition of wc_prices_include_tax()
 			array( 'yes', 'yes', true ),
 		);
 

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -4,10 +4,21 @@
  *
  * @package WooCommerce\Tests\Gateways\Paypal
  */
-
 class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
+	/**
+	 * Products to use in order.
+	 *
+	 * @var array
+	 */
 	protected $products;
+
+	/**
+	 * Order to submit to PayPal.
+	 *
+	 * @var WC_Order
+	 */
+	protected $order;
 
 	/**
 	 * Create $product_count simple products and store them in $this->products.
@@ -34,26 +45,30 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	/**
 	 * Add products from $this->products to $order as items, clearing existing order items.
 	 *
-	 * @param WC_Order $order  Order to which the products should be added.
+	 * @param WC_Order $order Order to which the products should be added.
+	 * @param array    $prices Array of prices to use for created products. Leave empty for default prices.
 	 */
-	protected function add_products_to_order( $order ) {
+	protected function add_products_to_order( $order, $prices = array() ) {
 		// Remove previous items.
 		foreach ( $order->get_items() as $item ) {
 			$order->remove_item( $item->get_id() );
 		}
 
 		// Add new products.
+		$prod_count = 0;
 		foreach ( $this->products as $product ) {
 			$item = new WC_Order_Item_Product();
 			$item->set_props( array(
 				'product'  => $product,
 				'quantity' => 3,
-				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
-				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
+				'subtotal' => $prices ? $prices[ $prod_count ] : wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
+				'total'    => $prices ? $prices[ $prod_count ] : wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
 			) );
 
 			$item->save();
 			$order->add_item( $item );
+
+			$prod_count++;
 		}
 
 	}
@@ -75,33 +90,65 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	/**
 	 * Create Paypal request URL for $product_count number of products.
 	 *
-	 * @param int  $product_count Number of products to include in the order.
-	 * @param bool $testmode      Whether to test using sandbox or not.
-	 *
+	 * @param int   $product_count Number of products to include in the order.
+	 * @param bool  $testmode Whether to test using sandbox or not.
+	 * @param array $product_prices Array of prices to use for created products. Leave empty for default prices.
+	 * @param bool  $calc_order_totals Whether the WC_Order::calculate_totals() should be triggered when creating order.
 	 * @return string
 	 * @throws WC_Data_Exception
 	 */
-	protected function get_request_url( $product_count, $testmode ) {
+	protected function get_request_url( $product_count, $testmode, $product_prices = array(), $calc_order_totals = true ) {
 		// Create products.
 		$this->create_products( $product_count );
 
 		$this->order = WC_Helper_Order::create_order( $this->user );
-		$this->add_products_to_order( $this->order );
+		$this->add_products_to_order( $this->order, $product_prices );
 
 		// Set payment method to Paypal.
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 		$this->order->set_payment_method( $payment_gateways['paypal'] );
-		$this->order->calculate_totals();
+
+		// Add tax.
+		if ( wc_tax_enabled() ) {
+			$tax_rate = array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '11.0000',
+				'tax_rate_name'     => 'TAX',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			);
+			WC_Tax::_insert_tax_rate( $tax_rate );
+
+			$tax_item = new WC_Order_Item_Tax();
+			$tax_item->set_rate( 100 );
+			$tax_item->set_tax_total( 100 );
+			$tax_item->set_shipping_tax_total( 100 );
+			$this->order->add_item( $tax_item );
+			$this->order->save();
+		}
+
 		$this->order->calculate_shipping();
+		if ( $calc_order_totals ) {
+			$this->order->calculate_totals();
+		}
 
 		return $this->paypal_request->get_request_url( $this->order, $testmode );
 	}
 
 	/**
-	 * Clean up order, deletes all products in order, too.
+	 * Clean up order, tax, deletes all products in order, too.
 	 */
 	protected function clean_up() {
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
+
 		WC_Helper_Order::delete_order( $this->order->get_id() );
+
 	}
 
 	/**
@@ -116,7 +163,8 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			$shipping_total += $this->order->get_shipping_tax();
 		}
 		$epsilon = 0.01;
-		$this->assertTrue( abs( $shipping_total - floatval( $query_array['shipping_1'] ) ) < $epsilon );
+		$this->assertTrue( abs( $shipping_total - floatval( $query_array['shipping_1'] ) ) < $epsilon,
+		'Shipping tax mismatch: shipping total=' . $shipping_total . ' vs request shipping=' . $query_array['shipping_1'] );
 
 	}
 
@@ -140,12 +188,10 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 *
 	 * @param  bool $shipping_tax_included Whether the shipping tax should be included or not.
 	 * @param  bool $testmode              Whether to use Paypal sandbox.
-	 *
 	 * @throws WC_Data_Exception
 	 */
 	protected function check_large_order( $shipping_tax_included, $testmode ) {
 		$request_url = $this->get_request_url( 30, $testmode );
-
 		$this->check_order_common_props( $request_url, $testmode );
 
 		// Check fields limited to 127 characters for length.
@@ -178,18 +224,29 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 	}
 
+
+	/**
+	 * Return true if value is < 0, false otherwise.
+	 *
+	 * @param int|float $value Tested value.
+	 * @return bool
+	 */
+	protected function is_negative( $value ) {
+		return $value < 0;
+	}
+
 	/**
 	 * Test small order with fewer items, URL length should be < 2083 characters.
 	 *
-	 * @param int  $product_count         Number of products to include in the order.
-	 * @param bool $shipping_tax_included Whether the shipping tax should be included or not.
-	 * @param bool $testmode              Whether to use Paypal sandbox.
-	 *
+	 * @param int   $product_count Number of products to include in the order.
+	 * @param bool  $shipping_tax_included Whether the shipping tax should be included or not.
+	 * @param bool  $testmode Whether to use Paypal sandbox.
+	 * @param array $product_prices Array of prices to use for created products. Leave empty for default prices.
+	 * @param bool  $calc_order_totals Whether the WC_Order::calculate_totals() should be triggered when creating order.
 	 * @throws WC_Data_Exception
 	 */
-	protected function check_small_order( $product_count, $shipping_tax_included, $testmode ) {
-		$request_url = $this->get_request_url( $product_count, $testmode );
-
+	protected function check_small_order( $product_count, $shipping_tax_included, $testmode, $product_prices = array(), $calc_order_totals = true ) {
+		$request_url = $this->get_request_url( $product_count, $testmode, $product_prices, $calc_order_totals );
 		$this->check_order_common_props( $request_url, $testmode );
 
 		$query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
@@ -200,7 +257,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 		// Check that there are $product_count line items in the request URL.
 		// However, if shipping tax is included, there is only one item.
-		if ( $shipping_tax_included ) {
+		if ( $shipping_tax_included || array_filter( $product_prices, array( $this, 'is_negative' ) ) || ! $calc_order_totals ) {
 			$product_count = 1;
 		}
 
@@ -226,6 +283,36 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test order with one product having negative amount.
+	 * Amount < 0 forces tax inclusion and single line item, since WC_Gateway_Paypal_Request::prepare_line_items()
+	 * will return false.
+	 *
+	 * @param bool $testmode Whether PayPal request should point to sandbox or live production.
+	 * @throws WC_Data_Exception
+	 */
+	protected function check_negative_amount( $testmode ) {
+		$shipping_tax_included = true;
+		$product_prices = array( 6, 6, 6, 6, -3 );
+		$this->check_small_order( count( $product_prices ), $shipping_tax_included, $testmode, $product_prices );
+	}
+
+	/**
+	 * Test order with totals mismatched.
+	 * This forces tax inclusion and single line item, since WC_Gateway_Paypal_Request::prepare_line_items()
+	 * will return false.
+	 *
+	 * @param bool $testmode Whether PayPal request should point to sandbox or live production.
+	 * @throws WC_Data_Exception
+	 */
+	protected function check_totals_mismatch( $testmode ) {
+		// totals mismatch forces tax inclusion and single line item.
+		$shipping_tax_included = true;
+		$this->check_small_order( 5, $shipping_tax_included, $testmode, array(), false );
+	}
+
+	/**
+	 * Test for request_url() method.
+	 *
 	 * @throws WC_Data_Exception
 	 */
 	public function test_request_url() {
@@ -235,17 +322,16 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		) );
 		wp_set_current_user( $this->user );
 
-		// Paths through code changed by:
-		// - $sandbox (true/false)
-		// - wc_tax_enabled()
-		// - wc_prices_include_tax().
-		// wc_tax_enabled() and wc_prices_include_tax() determine if shipping tax should be included,
-		// these are the correct options.
+		// wc_tax_enabled(), wc_prices_include_tax() and WC_Gateway_Paypal_Request::prepare_line_items() determine if
+		// shipping tax should be included, these are the correct options.
+		// Note that prepare_line_items() can return false in 2 cases, tested separately below:
+		// - order totals mismatch and
+		// - item amount < 0.
 		$correct_options = array(
 			// woocommerce_calc_taxes, woocommerce_prices_include_tax, $shipping_tax_included values.
 			array( 'no', 'no', false ),
 			array( 'yes', 'no', false ),
-			// array( 'no',  'yes',  false ), // this is not a valid option due to definition of wc_prices_include_tax()
+			// array( 'no',  'yes',  false ), // this is not a valid option due to definition of wc_prices_include_tax().
 			array( 'yes', 'yes', true ),
 		);
 
@@ -271,6 +357,12 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 			// Test order with URL longer than limit.
 			$this->check_large_order( $shipping_tax_included, $testmode );
+
+			// Test amount < 0.
+			$this->check_negative_amount( $testmode );
+
+			// Check order totals mismatch.
+			$this->check_totals_mismatch( $testmode );
 
 		}
 

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -232,27 +232,35 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		// wc_tax_enabled() === get_option( 'woocommerce_calc_taxes' ) === 'yes'
 		// wc_prices_include_tax() === wc_tax_enabled() && 'yes' === get_option( 'woocommerce_prices_include_tax' );.
 		$correct_options = array(
-			[ 'no', 'no', false ],
-			[ 'yes', 'no', false ],
-			// ['no',  'yes',  false], // this is not a valid option due to definition of wc_prices_include_tax
-			[ 'yes', 'yes', true ],
+			array( 'no', 'no', false ),
+			array( 'yes', 'no', false ),
+			// array( 'no',  'yes',  false ), // this is not a valid option due to definition of wc_prices_include_tax
+			array( 'yes', 'yes', true ),
 		);
-		foreach ( array( true, false ) as $testmode ) {
-			foreach ( $correct_options as $values ) {
-				update_option( 'woocommerce_calc_taxes', $values[0] );
-				update_option( 'woocommerce_prices_include_tax', $values[1] );
-				$shipping_tax_included = $values[2];
 
-				// Test order with < 9 items (URL shorter than limit).
-				$this->check_small_order( 5, $shipping_tax_included, $testmode );
+		// One test without sandbox.
+		$testmode = false;
+		update_option( 'woocommerce_calc_taxes', 'no' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		$shipping_tax_included = false;
+		$this->check_small_order( 5, $shipping_tax_included, $testmode );
 
-				// Test order with >9 items with URL shorter than limit.
-				$this->check_small_order( 11, $shipping_tax_included, $testmode );
+		// Other tests with sandbox active.
+		$testmode = true;
+		foreach ( $correct_options as $values ) {
+			update_option( 'woocommerce_calc_taxes', $values[0] );
+			update_option( 'woocommerce_prices_include_tax', $values[1] );
+			$shipping_tax_included = $values[2];
 
-				// Test order with URL longer than limit.
-				$this->check_large_order( $shipping_tax_included, $testmode );
+			// Test order with < 9 items (URL shorter than limit).
+			$this->check_small_order( 5, $shipping_tax_included, $testmode );
 
-			}
+			// Test order with >9 items with URL shorter than limit.
+			$this->check_small_order( 11, $shipping_tax_included, $testmode );
+
+			// Test order with URL longer than limit.
+			$this->check_large_order( $shipping_tax_included, $testmode );
+
 		}
 
 	}

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Unit tests for Paypal standard gateway request.
+ *
+ * @package WooCommerce\Tests\Gateways\Paypal
+ */
+
+class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
+
+	protected $products;
+
+	/**
+	 * Create $product_count simple products and store them in $this->products.
+	 *
+	 * @param int $product_count Number of products to create.
+	 */
+	protected function create_products( $product_count = 30 ) {
+		$this->products = array();
+		for ( $i = 0; $i < $product_count; $i++ ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->set_name( 'Dummy Product ' . $i );
+			$this->products[] = $product;
+
+		}
+
+		// To test limit length properly, we need a product with a name that is shorter than 127 chars,
+		// but longer than 127 chars when URL-encoded.
+		if ( array_key_exists( 0, $this->products ) ) {
+			$this->products[0]->set_name( 'Dummy Product 😎😎😎😎😎😎😎😎😎😎😎' );
+		}
+
+	}
+
+	/**
+	 * Add products from $this->products to $order as items, clearing existing order items.
+	 *
+	 * @param WC_Order $order  Order to which the products should be added.
+	 */
+	protected function add_products_to_order( $order ) {
+		// Remove previous items.
+		foreach ( $order->get_items() as $item ) {
+			$order->remove_item( $item->get_id() );
+		}
+
+		// Add new products.
+		foreach ( $this->products as $product ) {
+			$item = new WC_Order_Item_Product();
+			$item->set_props( array(
+				'product'  => $product,
+				'quantity' => 3,
+				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
+				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
+			) );
+
+			$item->save();
+			$order->add_item( $item );
+		}
+
+	}
+
+	/**
+	 * Initialize the Paypal gateway and Request objects.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$bootstrap = WC_Unit_Tests_Bootstrap::instance();
+		include_once $bootstrap->plugin_dir . '/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php';
+
+		$this->paypal_gateway = new WC_Gateway_Paypal();
+		$this->paypal_request = new WC_Gateway_Paypal_Request( $this->paypal_gateway );
+	}
+
+
+	/**
+	 * Create Paypal request URL for $product_count number of products.
+	 *
+	 * @param int  $product_count Number of products to include in the order.
+	 * @param bool $testmode      Whether to test using sandbox or not.
+	 *
+	 * @return string
+	 * @throws WC_Data_Exception
+	 */
+	protected function get_request_url( $product_count, $testmode ) {
+		// Create products.
+		$this->create_products( $product_count );
+
+		$this->order = WC_Helper_Order::create_order( $this->user );
+		$this->add_products_to_order( $this->order );
+
+		// Set payment method to Paypal.
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$this->order->set_payment_method( $payment_gateways['paypal'] );
+		$this->order->calculate_totals();
+		$this->order->calculate_shipping();
+
+		return $this->paypal_request->get_request_url( $this->order, $testmode );
+	}
+
+	/**
+	 * Clean up order, deletes all products in order, too.
+	 */
+	protected function clean_up() {
+		WC_Helper_Order::delete_order( $this->order->get_id() );
+	}
+
+	/**
+	 * Check if the shipping tax is included in the total according to $shipping_tax_included.
+	 *
+	 * @param array $query_array           Request URL parsed into associative array.
+	 * @param bool  $shipping_tax_included Whether the shipping tax should be included or not.
+	 */
+	protected function check_shipping_tax( $query_array, $shipping_tax_included ) {
+		$shipping_total = $this->order->get_shipping_total();
+		if ( $shipping_tax_included ) {
+			$shipping_total += $this->order->get_shipping_tax();
+		}
+		$epsilon = 0.01;
+		$this->assertTrue( abs( $shipping_total - floatval( $query_array['shipping_1'] ) ) < $epsilon );
+
+	}
+
+	/**
+	 * Test common order asserts.
+	 *
+	 * @param string $request_url Paypal request URL.
+	 * @param bool   $testmode    Whether Paypal sandbox is used or not.
+	 */
+	protected function check_order_common_props( $request_url, $testmode ) {
+		if ( $testmode ) {
+			$this->assertEquals( 'https://www.sandbox.paypal.com', substr( $request_url, 0, 30 ) );
+		} else {
+			$this->assertEquals( 'https://www.paypal.com', substr( $request_url, 0, 22 ) );
+		}
+		$this->assertLessThanOrEqual( 2083, strlen( $request_url ) );
+	}
+
+	/**
+	 * Test large order with 30 items, URL length > 2083 characters.
+	 *
+	 * @param  bool $shipping_tax_included Whether the shipping tax should be included or not.
+	 * @param  bool $testmode              Whether to use Paypal sandbox.
+	 *
+	 * @throws WC_Data_Exception
+	 */
+	protected function check_large_order( $shipping_tax_included, $testmode ) {
+		$request_url = $this->get_request_url( 30, $testmode );
+
+		$this->check_order_common_props( $request_url, $testmode );
+
+		// Check fields limited to 127 characters for length.
+		$fields_limited_to_127_chars = array(
+			'invoice',
+			'item_name_1',
+			'item_number_1',
+		);
+
+		$query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
+			? wp_parse_url( $request_url, PHP_URL_QUERY )
+			: '';
+		$query_array = array();
+		parse_str( $query_string, $query_array );
+		foreach ( $fields_limited_to_127_chars as $field_name ) {
+			$this->assertLessThanOrEqual( 127, strlen( $query_array[ $field_name ] ) );
+		}
+
+		// Check that there is actually only one item for order with URL length > limit.
+		$this->assertFalse( array_key_exists( 'item_name_2', $query_array ) );
+
+		$this->check_shipping_tax( $query_array, $shipping_tax_included );
+
+		// Remove order and created products.
+		$this->clean_up();
+
+	}
+
+	/**
+	 * Test small order with fewer items, URL length should be < 2083 characters.
+	 *
+	 * @param int  $product_count         Number of products to include in the order.
+	 * @param bool $shipping_tax_included Whether the shipping tax should be included or not.
+	 * @param bool $testmode              Whether to use Paypal sandbox.
+	 *
+	 * @throws WC_Data_Exception
+	 */
+	protected function check_small_order( $product_count, $shipping_tax_included, $testmode ) {
+		$request_url = $this->get_request_url( $product_count, $testmode );
+
+		$this->check_order_common_props( $request_url, $testmode );
+
+		$query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
+			? wp_parse_url( $request_url, PHP_URL_QUERY )
+			: '';
+		$query_array = array();
+		parse_str( $query_string, $query_array );
+
+		// Check that there are $product_count line items in the request URL.
+		// However, if shipping tax is included, there is only one item.
+		if ( $shipping_tax_included ) {
+			$product_count = 1;
+		}
+
+		for ( $i = 1; $i <= $product_count; $i++ ) {
+			$this->assertTrue( array_key_exists( 'item_name_' . $i, $query_array ), 'Item name ' . $i . ' does not exist' );
+			$this->assertTrue( array_key_exists( 'quantity_' . $i, $query_array ) );
+			$this->assertTrue( array_key_exists( 'amount_' . $i, $query_array ) );
+			$this->assertTrue( array_key_exists( 'item_number_' . $i, $query_array ) );
+
+			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_name_' . $i ] ) );
+			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_number_' . $i ] ) );
+
+		}
+
+		$this->check_shipping_tax( $query_array, $shipping_tax_included );
+
+		// Remove order and created products.
+		$this->clean_up();
+	}
+
+	/**
+	 * @throws WC_Data_Exception
+	 */
+	public function test_request_url() {
+		// User set up.
+		$this->user = $this->factory->user->create( array(
+			'role' => 'administrator',
+		) );
+		wp_set_current_user( $this->user );
+
+		// Paths through code changed by:
+		// $sandbox (true/false)
+		// wc_tax_enabled() === get_option( 'woocommerce_calc_taxes' ) === 'yes'
+		// wc_prices_include_tax() === wc_tax_enabled() && 'yes' === get_option( 'woocommerce_prices_include_tax' );.
+		$correct_options = array(
+			[ 'no', 'no', false ],
+			[ 'yes', 'no', false ],
+			// ['no',  'yes',  false], // this is not a valid option due to definition of wc_prices_include_tax
+			[ 'yes', 'yes', true ],
+		);
+		foreach ( array( true, false ) as $testmode ) {
+			foreach ( $correct_options as $values ) {
+				update_option( 'woocommerce_calc_taxes', $values[0] );
+				update_option( 'woocommerce_prices_include_tax', $values[1] );
+				$shipping_tax_included = $values[2];
+
+				// Test order with < 9 items (URL shorter than limit).
+				$this->check_small_order( 5, $shipping_tax_included, $testmode );
+
+				// Test order with >9 items with URL shorter than limit.
+				$this->check_small_order( 11, $shipping_tax_included, $testmode );
+
+				// Test order with URL longer than limit.
+				$this->check_large_order( $shipping_tax_included, $testmode );
+
+			}
+		}
+
+	}
+
+}
+

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -167,6 +167,10 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		// Check that there is actually only one item for order with URL length > limit.
 		$this->assertFalse( array_key_exists( 'item_name_2', $query_array ) );
 
+		// Check that non-line item parameters are included.
+		$this->assertTrue( array_key_exists( 'cmd', $query_array ) );
+		$this->assertEquals( '_cart', $query_array['cmd'] );
+
 		$this->check_shipping_tax( $query_array, $shipping_tax_included );
 
 		// Remove order and created products.
@@ -205,6 +209,11 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			$this->assertTrue( array_key_exists( 'quantity_' . $i, $query_array ) );
 			$this->assertTrue( array_key_exists( 'amount_' . $i, $query_array ) );
 			$this->assertTrue( array_key_exists( 'item_number_' . $i, $query_array ) );
+
+			// Check that non-line item parameters are included.
+			$this->assertTrue( array_key_exists( 'cmd', $query_array ) );
+			$this->assertEquals( '_cart', $query_array['cmd'] );
+
 
 			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_name_' . $i ] ) );
 			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_number_' . $i ] ) );


### PR DESCRIPTION
…aracters

- removed limit to 9 line items per Paypal order
- if the request URL with all line items will be longer than 2083 characters, send it as one line item
- fix the character limit function to account for URL encoding happening in http_build_query

fixes #19404 

Testing instructions:
Ideally, both following scenarios should work correctly:
- Order with 10 items should show all items correctly in PayPal (please note that products are sent as individual line items only if  either `wc_tax_enabled() == false` or `wc_prices_include_tax() == false`)
- Order with large number of items (20-30) should be sent to PayPal as one line item
- In either case, PayPal URL request should be shorter than 2083 characters.

