### PR TITLE
Force long lines wrapping in the log viewer

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -807,6 +807,7 @@ table.wc_status_table--tools {
 	pre {
 		font-family: monospace;
 		white-space: pre-wrap;
+		word-wrap: break-word;
 	}
 }
 


### PR DESCRIPTION
Some log lines can get really long and they break the layout of the log viewer (WooCommerce -> Status -> Logs).