### PR TITLE
Webhooks do not need permission checks

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-webhooks.php
+++ b/includes/api/legacy/v2/class-wc-api-webhooks.php
@@ -84,11 +84,6 @@ class WC_API_Webhooks extends WC_API_Resource {
 		$webhooks = array();
 
 		foreach ( $query['results'] as $webhook_id ) {
-
-			if ( ! $this->is_readable( $webhook_id ) ) {
-				continue;
-			}
-
 			$webhooks[] = current( $this->get_webhook( $webhook_id, $fields ) );
 		}
 

--- a/includes/api/legacy/v3/class-wc-api-webhooks.php
+++ b/includes/api/legacy/v3/class-wc-api-webhooks.php
@@ -84,11 +84,6 @@ class WC_API_Webhooks extends WC_API_Resource {
 		$webhooks = array();
 
 		foreach ( $query['results'] as $webhook_id ) {
-
-			if ( ! $this->is_readable( $webhook_id ) ) {
-				continue;
-			}
-
 			$webhooks[] = current( $this->get_webhook( $webhook_id, $fields ) );
 		}
 


### PR DESCRIPTION
Fixes #19474 where permission checks fail due to no post object existing any more.

Needs @claudiosanches review.