### PR TITLE
Call empty cart when completing payment in PayPal

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -65,6 +65,7 @@ abstract class WC_Gateway_Paypal_Response {
 	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
 		$order->add_order_note( $note );
 		$order->payment_complete( $txn_id );
+		WC()->cart->empty_cart();
 	}
 
 	/**


### PR DESCRIPTION
Appeared to be missing. Could lead to carts being present when using PayPal PDT.

Ref: #19506