### PR TITLE
Check query var for orderby if not found in $_GET

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -427,7 +427,7 @@ class WC_Query {
 	public function get_catalog_ordering_args( $orderby = '', $order = '' ) {
 		// Get ordering from query string unless defined.
 		if ( ! $orderby ) {
-			$orderby_value = isset( $_GET['orderby'] ) ? wc_clean( (string) wp_unslash( $_GET['orderby'] ) ) : ''; // WPCS: sanitization ok, input var ok, CSRF ok.
+			$orderby_value = isset( $_GET['orderby'] ) ? wc_clean( (string) wp_unslash( $_GET['orderby'] ) ) : wc_clean( get_query_var( 'orderby' ) ); // WPCS: sanitization ok, input var ok, CSRF ok.
 
 			if ( ! $orderby_value ) {
 				if ( is_search() ) {


### PR DESCRIPTION
Fixes #19472

To test:
1. Add the following somewhere:
```
add_action( 'init', function() {
	add_rewrite_rule(
		'^cheapest/?',
		'index.php?post_type=product&orderby=price',
		'top'
	);
});
```
2. Flush your rewrite rules by going to the Permalink settings page.
3. Visit `example.com/cheapest/` and verify products are ordered by price ascending.
4. Visit the Shop page, try out different order options and verify they still work correctly.