### PR TITLE
Use minimum price to order variable products on term archives

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -508,7 +508,7 @@ class WC_Query {
 			$search_within_terms   = get_term_children( $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy );
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join']         .= " INNER JOIN (
-				SELECT post_id, max( meta_value+0 ) price
+				SELECT post_id, min( meta_value+0 ) price
 				FROM $wpdb->postmeta
 				INNER JOIN (
 					SELECT $wpdb->term_relationships.object_id


### PR DESCRIPTION
Commit 12d7bf7 added a specific query to order products by price from low to high on term archives (see #17690 and #16694 for more details), but, probably due to a copy and paste error, it changed the behavior when dealing with variable products. Instead of using the smallest variation price of each variable product, it was using the highest variation price. This commit changes this new query to use the smallest variation price of each variable product. This way ordering by price from low to high on term archives will again behave in the same way that on the shop page when dealing with variable products.