### PR TITLE
Apply strip_tags to attributes in loop template

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -893,6 +893,10 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 
 			$args = apply_filters( 'woocommerce_loop_add_to_cart_args', wp_parse_args( $args, $defaults ), $product );
 
+			if ( array_key_exists( 'attributes', $args ) && array_key_exists( 'aria-label', $args['attributes'] ) ) {
+				$args['attributes']['aria-label'] = strip_tags( $args['attributes']['aria-label'] );
+			}
+
 			wc_get_template( 'loop/add-to-cart.php', $args );
 		}
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -893,7 +893,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 
 			$args = apply_filters( 'woocommerce_loop_add_to_cart_args', wp_parse_args( $args, $defaults ), $product );
 
-			if ( array_key_exists( 'attributes', $args ) && array_key_exists( 'aria-label', $args['attributes'] ) ) {
+			if ( isset( $args['attributes']['aria-label'] ) ) {
 				$args['attributes']['aria-label'] = strip_tags( $args['attributes']['aria-label'] );
 			}
 

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -10,9 +10,8 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
  * @version     3.3.0
  */
 

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -10,8 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @see 	    https://docs.woocommerce.com/document/template-structure/
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates
  * @version     3.3.0
  */
 
@@ -26,7 +27,7 @@ echo apply_filters( 'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),
 		esc_attr( isset( $args['class'] ) ? $args['class'] : 'button' ),
-		isset( $args['attributes'] ) ? wc_implode_html_attributes( array_map( 'strip_tags', $args['attributes'] ) ) : '',
+		isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
 		esc_html( $product->add_to_cart_text() )
 	),
 $product, $args );

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -27,7 +27,7 @@ echo apply_filters( 'woocommerce_loop_add_to_cart_link', // WPCS: XSS ok.
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( isset( $args['quantity'] ) ? $args['quantity'] : 1 ),
 		esc_attr( isset( $args['class'] ) ? $args['class'] : 'button' ),
-		isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
+		isset( $args['attributes'] ) ? wc_implode_html_attributes( array_map( 'strip_tags', $args['attributes'] ) ) : '',
 		esc_html( $product->add_to_cart_text() )
 	),
 $product, $args );


### PR DESCRIPTION
Fixes #19491 

Testing instructions:
1. Create a product with html tags in the title, e.g. <em>Very</em> nice beanie.
2. Go to /shop/ page (tested with Storefront theme).
3. Look for `aria-label` attribute for `/shop/?add-to-cart=X` anchor; before the fix, you should see `aria-label="Add “<em>Very</em> nice Beanie” to your cart"`.
4. After the fix, the `<em>` tags are stripped: `aria-label="Add “Very nice Beanie” to your cart"`