### PR TITLE
Use `get_variation_price` method in structured data to grab min/max so filters are ran.

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -215,9 +215,8 @@ class WC_Structured_Data {
 
 		if ( '' !== $product->get_price() ) {
 			if ( $product->is_type( 'variable' ) ) {
-				$prices  = $product->get_variation_prices();
-				$lowest  = reset( $prices['price'] );
-				$highest = end( $prices['price'] );
+				$lowest  = $product->get_variation_price( 'min', false );
+				$highest = $product->get_variation_price( 'max', false );
 
 				if ( $lowest === $highest ) {
 					$markup_offer = array(


### PR DESCRIPTION
To test, view page source on variable product single page before and after patch. Ensure variations have different prices.

`AggregateOffer` should be identical before and after the patch since we’re not filtering anything.

Closes #19519