### PR TITLE
Fix WC_Data::delete_meta_data_by_mid()

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -456,7 +456,7 @@ abstract class WC_Data {
 	 */
 	public function delete_meta_data_by_mid( $mid ) {
 		$this->maybe_read_meta_data();
-		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'id' ), $mid );
+		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'id', 'id' ), $mid );
 
 		if ( $array_keys ) {
 			foreach ( $array_keys as $array_key ) {

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -66,6 +66,11 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 		$object = $this->create_test_post();
 		$object_id = $object->get_id();
 		$meta_id = add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+
+		$object = new WC_Mock_WC_Data( $object_id );
+
+		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
+
 		$object->delete_meta_data_by_mid( $meta_id );
 		$this->assertEmpty( $object->get_meta( 'test_meta_key' ) );
 	}


### PR DESCRIPTION
By making sure that the array returned by `wp_list_pluck()` uses the `'id'` as the key, as well as the value, so that the `array_keys()` filter (the 2nd param) works, rather than returning an empty set (at least when the meta ID doesn't happen to coincide with an array index value, like 1 or 2).

This PR also updates `WC_Tests_CRUD_Data::test_delete_meta_data_by_mid()` to make sure the test case is actually testing the meta is deleted correctly, and not just that it was either deleted or never set, which it is currently doing.