### PR TITLE
WP-CLI integration per_page default

### DIFF
--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -206,6 +206,10 @@ class WC_CLI_REST_Command {
 			$method = 'GET';
 		}
 
+		if ( ! isset( $assoc_args['per_page'] ) || empty( $assoc_args['per_page'] ) ) {
+			$assoc_args['per_page'] = '100';
+		}
+
 		list( $status, $body, $headers ) = $this->do_request( $method, $this->get_filled_route( $args ), $assoc_args );
 		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
 			$items = array_column( $body, 'id' );
@@ -221,10 +225,6 @@ class WC_CLI_REST_Command {
 
 		if ( empty( $assoc_args['format'] ) ) {
 			$assoc_args['format'] = 'table';
-		}
-
-		if ( empty( $assoc_args['per_page'] ) ) {
-			$assoc_args['per_page'] = '-1';
 		}
 
 		if ( ! empty( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {

--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -223,6 +223,10 @@ class WC_CLI_REST_Command {
 			$assoc_args['format'] = 'table';
 		}
 
+		if ( empty( $assoc_args['per_page'] ) ) {
+			$assoc_args['per_page'] = '-1';
+		}
+
 		if ( ! empty( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
 			echo (int) $headers['X-WP-Total'];
 		} elseif ( 'headers' === $assoc_args['format'] ) {


### PR DESCRIPTION
Default the per_page associative arguments for list actions to display all items instead of using pagination. This is the default behavior when using default WP-CLI command for retrieving posts.

Closes #19547

To test use the `wp wc product list` CLI command, it should return all products by default, then test with the the command `wp wc product list --per_page=1` which should only return 1 product.

I also updated the wiki docs to include it will return all items by default when --per_page is not defined.