### PR TITLE
Add 'woocommerce_variable_product_before_variations' hook to variations tab

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -47,7 +47,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<div class="clear"></div>
 			</div>
-
+			
+			<?php do_action( 'woocommerce_variable_product_before_variations' ); ?>
+			
 			<div class="toolbar toolbar-top">
 				<select id="field_to_edit" class="variation_actions">
 					<option data-global="true" value="add_variation"><?php esc_html_e( 'Add variation', 'woocommerce' ); ?></option>

--- a/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -47,9 +47,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<div class="clear"></div>
 			</div>
-			
+
 			<?php do_action( 'woocommerce_variable_product_before_variations' ); ?>
-			
+
 			<div class="toolbar toolbar-top">
 				<select id="field_to_edit" class="variation_actions">
 					<option data-global="true" value="add_variation"><?php esc_html_e( 'Add variation', 'woocommerce' ); ?></option>


### PR DESCRIPTION
## Description
Added a new action hook ('woocommerce_variable_product_before_variations') to make developers able to add additional generic fields to Variations tab.

![image](https://user-images.githubusercontent.com/1201868/38033969-87f8397e-32a1-11e8-93df-5b50c0df05b4.png)

## Problem
Other hooks (like "woocommerce_variation_options") already exist in this tab but none of them allow us to add additional generic (not related to a specific variation) product fields (like to customize the "From" price string in a product level).