### PR TITLE
Add action woocommerce_before_delete_{$post_type}

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -258,6 +258,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		if ( $args['force_delete'] ) {
+			do_action( 'woocommerce_before_delete_' . $post_type, $id );
 			wp_delete_post( $id );
 			$product->set_id( 0 );
 			do_action( 'woocommerce_delete_' . $post_type, $id );


### PR DESCRIPTION
When a product is deleted, taxonomy terms and post metas are deleted in `wp_delete_post()` before the action `woocommerce_delete_{$post_type}` is fired. WordPress proposes the action `before_delete_post` to take actions based on the information contained in taxonomy terms and post metas when a post is deleted. I suggest to add a similar action in WooCommerce so that we can use a WooCommerce action instead of a WordPress action.