### PR TITLE
System status and php version notices

### DIFF
--- a/includes/admin/settings/class-wc-settings-general.php
+++ b/includes/admin/settings/class-wc-settings-general.php
@@ -2,357 +2,359 @@
 /**
  * WooCommerce General Settings
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin
  * @version     2.1.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+defined( 'ABSPATH' ) || exit;
+
+if ( class_exists( 'WC_Settings_General', false ) ) {
+	return new WC_Settings_General();
 }
 
-if ( ! class_exists( 'WC_Settings_General', false ) ) :
+/**
+ * WC_Admin_Settings_General.
+ */
+class WC_Settings_General extends WC_Settings_Page {
 
 	/**
-	 * WC_Admin_Settings_General.
+	 * Constructor.
 	 */
-	class WC_Settings_General extends WC_Settings_Page {
+	public function __construct() {
+		$this->id    = 'general';
+		$this->label = __( 'General', 'woocommerce' );
 
-		/**
-		 * Constructor.
-		 */
-		public function __construct() {
-			$this->id    = 'general';
-			$this->label = __( 'General', 'woocommerce' );
-
-			parent::__construct();
-		}
-
-		/**
-		 * Get settings array.
-		 *
-		 * @return array
-		 */
-		public function get_settings() {
-
-			$currency_code_options = get_woocommerce_currencies();
-
-			foreach ( $currency_code_options as $code => $name ) {
-				$currency_code_options[ $code ] = $name . ' (' . get_woocommerce_currency_symbol( $code ) . ')';
-			}
-
-			$settings = apply_filters(
-				'woocommerce_general_settings', array(
-
-					array(
-						'title' => __( 'Store Address', 'woocommerce' ),
-						'type'  => 'title',
-						'desc'  => __( 'This is where your business is located. Tax rates and shipping rates will use this address.', 'woocommerce' ),
-						'id'    => 'store_address',
-					),
-
-					array(
-						'title'    => __( 'Address line 1', 'woocommerce' ),
-						'desc'     => __( 'The street address for your business location.', 'woocommerce' ),
-						'id'       => 'woocommerce_store_address',
-						'default'  => '',
-						'type'     => 'text',
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'    => __( 'Address line 2', 'woocommerce' ),
-						'desc'     => __( 'An additional, optional address line for your business location.', 'woocommerce' ),
-						'id'       => 'woocommerce_store_address_2',
-						'default'  => '',
-						'type'     => 'text',
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'    => __( 'City', 'woocommerce' ),
-						'desc'     => __( 'The city in which your business is located.', 'woocommerce' ),
-						'id'       => 'woocommerce_store_city',
-						'default'  => '',
-						'type'     => 'text',
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'    => __( 'Country / State', 'woocommerce' ),
-						'desc'     => __( 'The country and state or province, if any, in which your business is located.', 'woocommerce' ),
-						'id'       => 'woocommerce_default_country',
-						'default'  => 'GB',
-						'type'     => 'single_select_country',
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'    => __( 'Postcode / ZIP', 'woocommerce' ),
-						'desc'     => __( 'The postal code, if any, in which your business is located.', 'woocommerce' ),
-						'id'       => 'woocommerce_store_postcode',
-						'css'      => 'min-width:50px;',
-						'default'  => '',
-						'type'     => 'text',
-						'desc_tip' => true,
-					),
-
-					array(
-						'type' => 'sectionend',
-						'id'   => 'store_address',
-					),
-
-					array(
-						'title' => __( 'General options', 'woocommerce' ),
-						'type'  => 'title',
-						'desc'  => '',
-						'id'    => 'general_options',
-					),
-
-					array(
-						'title'    => __( 'Selling location(s)', 'woocommerce' ),
-						'desc'     => __( 'This option lets you limit which countries you are willing to sell to.', 'woocommerce' ),
-						'id'       => 'woocommerce_allowed_countries',
-						'default'  => 'all',
-						'type'     => 'select',
-						'class'    => 'wc-enhanced-select',
-						'css'      => 'min-width: 350px;',
-						'desc_tip' => true,
-						'options'  => array(
-							'all'        => __( 'Sell to all countries', 'woocommerce' ),
-							'all_except' => __( 'Sell to all countries, except for&hellip;', 'woocommerce' ),
-							'specific'   => __( 'Sell to specific countries', 'woocommerce' ),
-						),
-					),
-
-					array(
-						'title'   => __( 'Sell to all countries, except for&hellip;', 'woocommerce' ),
-						'desc'    => '',
-						'id'      => 'woocommerce_all_except_countries',
-						'css'     => 'min-width: 350px;',
-						'default' => '',
-						'type'    => 'multi_select_countries',
-					),
-
-					array(
-						'title'   => __( 'Sell to specific countries', 'woocommerce' ),
-						'desc'    => '',
-						'id'      => 'woocommerce_specific_allowed_countries',
-						'css'     => 'min-width: 350px;',
-						'default' => '',
-						'type'    => 'multi_select_countries',
-					),
-
-					array(
-						'title'    => __( 'Shipping location(s)', 'woocommerce' ),
-						'desc'     => __( 'Choose which countries you want to ship to, or choose to ship to all locations you sell to.', 'woocommerce' ),
-						'id'       => 'woocommerce_ship_to_countries',
-						'default'  => '',
-						'type'     => 'select',
-						'class'    => 'wc-enhanced-select',
-						'desc_tip' => true,
-						'options'  => array(
-							''         => __( 'Ship to all countries you sell to', 'woocommerce' ),
-							'all'      => __( 'Ship to all countries', 'woocommerce' ),
-							'specific' => __( 'Ship to specific countries only', 'woocommerce' ),
-							'disabled' => __( 'Disable shipping &amp; shipping calculations', 'woocommerce' ),
-						),
-					),
-
-					array(
-						'title'   => __( 'Ship to specific countries', 'woocommerce' ),
-						'desc'    => '',
-						'id'      => 'woocommerce_specific_ship_to_countries',
-						'css'     => '',
-						'default' => '',
-						'type'    => 'multi_select_countries',
-					),
-
-					array(
-						'title'    => __( 'Default customer location', 'woocommerce' ),
-						'id'       => 'woocommerce_default_customer_address',
-						'desc_tip' => __( 'This option determines a customers default location. The MaxMind GeoLite Database will be periodically downloaded to your wp-content directory if using geolocation.', 'woocommerce' ),
-						'default'  => 'geolocation',
-						'type'     => 'select',
-						'class'    => 'wc-enhanced-select',
-						'options'  => array(
-							''                 => __( 'No location by default', 'woocommerce' ),
-							'base'             => __( 'Shop base address', 'woocommerce' ),
-							'geolocation'      => __( 'Geolocate', 'woocommerce' ),
-							'geolocation_ajax' => __( 'Geolocate (with page caching support)', 'woocommerce' ),
-						),
-					),
-
-					array(
-						'title'   => __( 'Enable taxes', 'woocommerce' ),
-						'desc'    => __( 'Enable taxes and tax calculations', 'woocommerce' ),
-						'id'      => 'woocommerce_calc_taxes',
-						'default' => 'no',
-						'type'    => 'checkbox',
-					),
-
-					array(
-						'type' => 'sectionend',
-						'id'   => 'general_options',
-					),
-
-					array(
-						'title' => __( 'Currency options', 'woocommerce' ),
-						'type'  => 'title',
-						'desc'  => __( 'The following options affect how prices are displayed on the frontend.', 'woocommerce' ),
-						'id'    => 'pricing_options',
-					),
-
-					array(
-						'title'    => __( 'Currency', 'woocommerce' ),
-						'desc'     => __( 'This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.', 'woocommerce' ),
-						'id'       => 'woocommerce_currency',
-						'default'  => 'GBP',
-						'type'     => 'select',
-						'class'    => 'wc-enhanced-select',
-						'desc_tip' => true,
-						'options'  => $currency_code_options,
-					),
-
-					array(
-						'title'    => __( 'Currency position', 'woocommerce' ),
-						'desc'     => __( 'This controls the position of the currency symbol.', 'woocommerce' ),
-						'id'       => 'woocommerce_currency_pos',
-						'class'    => 'wc-enhanced-select',
-						'default'  => 'left',
-						'type'     => 'select',
-						'options'  => array(
-							'left'        => __( 'Left', 'woocommerce' ),
-							'right'       => __( 'Right', 'woocommerce' ),
-							'left_space'  => __( 'Left with space', 'woocommerce' ),
-							'right_space' => __( 'Right with space', 'woocommerce' ),
-						),
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'    => __( 'Thousand separator', 'woocommerce' ),
-						'desc'     => __( 'This sets the thousand separator of displayed prices.', 'woocommerce' ),
-						'id'       => 'woocommerce_price_thousand_sep',
-						'css'      => 'width:50px;',
-						'default'  => ',',
-						'type'     => 'text',
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'    => __( 'Decimal separator', 'woocommerce' ),
-						'desc'     => __( 'This sets the decimal separator of displayed prices.', 'woocommerce' ),
-						'id'       => 'woocommerce_price_decimal_sep',
-						'css'      => 'width:50px;',
-						'default'  => '.',
-						'type'     => 'text',
-						'desc_tip' => true,
-					),
-
-					array(
-						'title'             => __( 'Number of decimals', 'woocommerce' ),
-						'desc'              => __( 'This sets the number of decimal points shown in displayed prices.', 'woocommerce' ),
-						'id'                => 'woocommerce_price_num_decimals',
-						'css'               => 'width:50px;',
-						'default'           => '2',
-						'desc_tip'          => true,
-						'type'              => 'number',
-						'custom_attributes' => array(
-							'min'  => 0,
-							'step' => 1,
-						),
-					),
-
-					array(
-						'type' => 'sectionend',
-						'id'   => 'pricing_options',
-					),
-
-				)
-			);
-
-			return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings );
-		}
-
-		/**
-		 * Output a color picker input box.
-		 *
-		 * @param mixed  $name
-		 * @param string $id
-		 * @param mixed  $value
-		 * @param string $desc (default: '')
-		 */
-		public function color_picker( $name, $id, $value, $desc = '' ) {
-			echo '<div class="color_box">' . wc_help_tip( $desc ) . '
-				<input name="' . esc_attr( $id ) . '" id="' . esc_attr( $id ) . '" type="text" value="' . esc_attr( $value ) . '" class="colorpick" /> <div id="colorPickerDiv_' . esc_attr( $id ) . '" class="colorpickdiv"></div>
-			</div>';
-		}
-
-		/**
-		 * Show a notice showing where the store notice setting has moved.
-		 *
-		 * @since 3.3.1
-		 * @todo remove in next major release.
-		 */
-		private function store_notice_setting_moved_notice() {
-			if ( get_user_meta( get_current_user_id(), 'dismissed_store_notice_setting_moved_notice', true ) ) {
-				return;
-			}
-			?>
-			<div id="message" class="updated woocommerce-message inline">
-				<a class="woocommerce-message-close notice-dismiss" style="top:0;" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'store_notice_setting_moved' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
-
-				<p>
-					<?php
-					/* translators: %s: URL to customizer. */
-					echo wp_kses(
-						sprintf(
-							__( 'Looking for the store notice setting? It can now be found <a href="%s">in the Customizer</a>.', 'woocommerce' ), esc_url(
-								add_query_arg(
-									array(
-										'autofocus' => array(
-											'panel' => 'woocommerce',
-										),
-										'url'       => wc_get_page_permalink( 'shop' ),
-									), admin_url( 'customize.php' )
-								)
-							)
-						), array(
-							'a' => array(
-								'href'  => array(),
-								'title' => array(),
-							),
-						)
-					);
-					?>
-				</p>
-			</div>
-			<?php
-		}
-
-		/**
-		 * Output the settings.
-		 */
-		public function output() {
-			$settings = $this->get_settings();
-
-			$this->store_notice_setting_moved_notice();
-
-			WC_Admin_Settings::output_fields( $settings );
-		}
-
-		/**
-		 * Save settings.
-		 */
-		public function save() {
-			$settings = $this->get_settings();
-
-			WC_Admin_Settings::save_fields( $settings );
-		}
+		parent::__construct();
 	}
 
-endif;
+	/**
+	 * Get settings array.
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+
+		$currency_code_options = get_woocommerce_currencies();
+
+		foreach ( $currency_code_options as $code => $name ) {
+			$currency_code_options[ $code ] = $name . ' (' . get_woocommerce_currency_symbol( $code ) . ')';
+		}
+
+		$woocommerce_default_customer_address_options = array(
+			''                 => __( 'No location by default', 'woocommerce' ),
+			'base'             => __( 'Shop base address', 'woocommerce' ),
+			'geolocation'      => __( 'Geolocate', 'woocommerce' ),
+			'geolocation_ajax' => __( 'Geolocate (with page caching support)', 'woocommerce' ),
+		);
+
+		if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
+			unset( $woocommerce_default_customer_address_options['geolocation'], $woocommerce_default_customer_address_options['geolocation_ajax'] );
+		}
+
+		$settings = apply_filters(
+			'woocommerce_general_settings', array(
+
+				array(
+					'title' => __( 'Store Address', 'woocommerce' ),
+					'type'  => 'title',
+					'desc'  => __( 'This is where your business is located. Tax rates and shipping rates will use this address.', 'woocommerce' ),
+					'id'    => 'store_address',
+				),
+
+				array(
+					'title'    => __( 'Address line 1', 'woocommerce' ),
+					'desc'     => __( 'The street address for your business location.', 'woocommerce' ),
+					'id'       => 'woocommerce_store_address',
+					'default'  => '',
+					'type'     => 'text',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Address line 2', 'woocommerce' ),
+					'desc'     => __( 'An additional, optional address line for your business location.', 'woocommerce' ),
+					'id'       => 'woocommerce_store_address_2',
+					'default'  => '',
+					'type'     => 'text',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'City', 'woocommerce' ),
+					'desc'     => __( 'The city in which your business is located.', 'woocommerce' ),
+					'id'       => 'woocommerce_store_city',
+					'default'  => '',
+					'type'     => 'text',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Country / State', 'woocommerce' ),
+					'desc'     => __( 'The country and state or province, if any, in which your business is located.', 'woocommerce' ),
+					'id'       => 'woocommerce_default_country',
+					'default'  => 'GB',
+					'type'     => 'single_select_country',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Postcode / ZIP', 'woocommerce' ),
+					'desc'     => __( 'The postal code, if any, in which your business is located.', 'woocommerce' ),
+					'id'       => 'woocommerce_store_postcode',
+					'css'      => 'min-width:50px;',
+					'default'  => '',
+					'type'     => 'text',
+					'desc_tip' => true,
+				),
+
+				array(
+					'type' => 'sectionend',
+					'id'   => 'store_address',
+				),
+
+				array(
+					'title' => __( 'General options', 'woocommerce' ),
+					'type'  => 'title',
+					'desc'  => '',
+					'id'    => 'general_options',
+				),
+
+				array(
+					'title'    => __( 'Selling location(s)', 'woocommerce' ),
+					'desc'     => __( 'This option lets you limit which countries you are willing to sell to.', 'woocommerce' ),
+					'id'       => 'woocommerce_allowed_countries',
+					'default'  => 'all',
+					'type'     => 'select',
+					'class'    => 'wc-enhanced-select',
+					'css'      => 'min-width: 350px;',
+					'desc_tip' => true,
+					'options'  => array(
+						'all'        => __( 'Sell to all countries', 'woocommerce' ),
+						'all_except' => __( 'Sell to all countries, except for&hellip;', 'woocommerce' ),
+						'specific'   => __( 'Sell to specific countries', 'woocommerce' ),
+					),
+				),
+
+				array(
+					'title'   => __( 'Sell to all countries, except for&hellip;', 'woocommerce' ),
+					'desc'    => '',
+					'id'      => 'woocommerce_all_except_countries',
+					'css'     => 'min-width: 350px;',
+					'default' => '',
+					'type'    => 'multi_select_countries',
+				),
+
+				array(
+					'title'   => __( 'Sell to specific countries', 'woocommerce' ),
+					'desc'    => '',
+					'id'      => 'woocommerce_specific_allowed_countries',
+					'css'     => 'min-width: 350px;',
+					'default' => '',
+					'type'    => 'multi_select_countries',
+				),
+
+				array(
+					'title'    => __( 'Shipping location(s)', 'woocommerce' ),
+					'desc'     => __( 'Choose which countries you want to ship to, or choose to ship to all locations you sell to.', 'woocommerce' ),
+					'id'       => 'woocommerce_ship_to_countries',
+					'default'  => '',
+					'type'     => 'select',
+					'class'    => 'wc-enhanced-select',
+					'desc_tip' => true,
+					'options'  => array(
+						''         => __( 'Ship to all countries you sell to', 'woocommerce' ),
+						'all'      => __( 'Ship to all countries', 'woocommerce' ),
+						'specific' => __( 'Ship to specific countries only', 'woocommerce' ),
+						'disabled' => __( 'Disable shipping &amp; shipping calculations', 'woocommerce' ),
+					),
+				),
+
+				array(
+					'title'   => __( 'Ship to specific countries', 'woocommerce' ),
+					'desc'    => '',
+					'id'      => 'woocommerce_specific_ship_to_countries',
+					'css'     => '',
+					'default' => '',
+					'type'    => 'multi_select_countries',
+				),
+
+				array(
+					'title'    => __( 'Default customer location', 'woocommerce' ),
+					'id'       => 'woocommerce_default_customer_address',
+					'desc_tip' => __( 'This option determines a customers default location. The MaxMind GeoLite Database will be periodically downloaded to your wp-content directory if using geolocation.', 'woocommerce' ),
+					'default'  => 'geolocation',
+					'type'     => 'select',
+					'class'    => 'wc-enhanced-select',
+					'options'  => $woocommerce_default_customer_address_options,
+				),
+
+				array(
+					'title'   => __( 'Enable taxes', 'woocommerce' ),
+					'desc'    => __( 'Enable taxes and tax calculations', 'woocommerce' ),
+					'id'      => 'woocommerce_calc_taxes',
+					'default' => 'no',
+					'type'    => 'checkbox',
+				),
+
+				array(
+					'type' => 'sectionend',
+					'id'   => 'general_options',
+				),
+
+				array(
+					'title' => __( 'Currency options', 'woocommerce' ),
+					'type'  => 'title',
+					'desc'  => __( 'The following options affect how prices are displayed on the frontend.', 'woocommerce' ),
+					'id'    => 'pricing_options',
+				),
+
+				array(
+					'title'    => __( 'Currency', 'woocommerce' ),
+					'desc'     => __( 'This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.', 'woocommerce' ),
+					'id'       => 'woocommerce_currency',
+					'default'  => 'GBP',
+					'type'     => 'select',
+					'class'    => 'wc-enhanced-select',
+					'desc_tip' => true,
+					'options'  => $currency_code_options,
+				),
+
+				array(
+					'title'    => __( 'Currency position', 'woocommerce' ),
+					'desc'     => __( 'This controls the position of the currency symbol.', 'woocommerce' ),
+					'id'       => 'woocommerce_currency_pos',
+					'class'    => 'wc-enhanced-select',
+					'default'  => 'left',
+					'type'     => 'select',
+					'options'  => array(
+						'left'        => __( 'Left', 'woocommerce' ),
+						'right'       => __( 'Right', 'woocommerce' ),
+						'left_space'  => __( 'Left with space', 'woocommerce' ),
+						'right_space' => __( 'Right with space', 'woocommerce' ),
+					),
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Thousand separator', 'woocommerce' ),
+					'desc'     => __( 'This sets the thousand separator of displayed prices.', 'woocommerce' ),
+					'id'       => 'woocommerce_price_thousand_sep',
+					'css'      => 'width:50px;',
+					'default'  => ',',
+					'type'     => 'text',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Decimal separator', 'woocommerce' ),
+					'desc'     => __( 'This sets the decimal separator of displayed prices.', 'woocommerce' ),
+					'id'       => 'woocommerce_price_decimal_sep',
+					'css'      => 'width:50px;',
+					'default'  => '.',
+					'type'     => 'text',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'             => __( 'Number of decimals', 'woocommerce' ),
+					'desc'              => __( 'This sets the number of decimal points shown in displayed prices.', 'woocommerce' ),
+					'id'                => 'woocommerce_price_num_decimals',
+					'css'               => 'width:50px;',
+					'default'           => '2',
+					'desc_tip'          => true,
+					'type'              => 'number',
+					'custom_attributes' => array(
+						'min'  => 0,
+						'step' => 1,
+					),
+				),
+
+				array(
+					'type' => 'sectionend',
+					'id'   => 'pricing_options',
+				),
+
+			)
+		);
+
+		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings );
+	}
+
+	/**
+	 * Output a color picker input box.
+	 *
+	 * @param mixed  $name Name of input.
+	 * @param string $id ID of input.
+	 * @param mixed  $value Value of input.
+	 * @param string $desc (default: '') Description for input.
+	 */
+	public function color_picker( $name, $id, $value, $desc = '' ) {
+		echo '<div class="color_box">' . wc_help_tip( $desc ) . '
+			<input name="' . esc_attr( $id ) . '" id="' . esc_attr( $id ) . '" type="text" value="' . esc_attr( $value ) . '" class="colorpick" /> <div id="colorPickerDiv_' . esc_attr( $id ) . '" class="colorpickdiv"></div>
+		</div>';
+	}
+
+	/**
+	 * Show a notice showing where the store notice setting has moved.
+	 *
+	 * @since 3.3.1
+	 * @todo remove in next major release.
+	 */
+	private function store_notice_setting_moved_notice() {
+		if ( get_user_meta( get_current_user_id(), 'dismissed_store_notice_setting_moved_notice', true ) ) {
+			return;
+		}
+		?>
+		<div id="message" class="updated woocommerce-message inline">
+			<a class="woocommerce-message-close notice-dismiss" style="top:0;" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'store_notice_setting_moved' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+			<p>
+				<?php
+				echo wp_kses(
+					sprintf(
+						/* translators: %s: URL to customizer. */
+						__( 'Looking for the store notice setting? It can now be found <a href="%s">in the Customizer</a>.', 'woocommerce' ), esc_url(
+							add_query_arg(
+								array(
+									'autofocus' => array(
+										'panel' => 'woocommerce',
+									),
+									'url'       => wc_get_page_permalink( 'shop' ),
+								), admin_url( 'customize.php' )
+							)
+						)
+					), array(
+						'a' => array(
+							'href'  => array(),
+							'title' => array(),
+						),
+					)
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Output the settings.
+	 */
+	public function output() {
+		$settings = $this->get_settings();
+
+		$this->store_notice_setting_moved_notice();
+
+		WC_Admin_Settings::output_fields( $settings );
+	}
+
+	/**
+	 * Save settings.
+	 */
+	public function save() {
+		$settings = $this->get_settings();
+
+		WC_Admin_Settings::save_fields( $settings );
+	}
+}
 
 return new WC_Settings_General();

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -187,11 +187,20 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of PHP installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
-				if ( version_compare( $environment['php_version'], '5.6', '<' ) ) {
-					/* Translators: %1$s: PHP version, %2$s: Recommended PHP version. */
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend a minimum PHP version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['php_version'] ), '<a href="https://docs.woocommerce.com/document/how-to-update-your-php-version/" target="_blank">' . esc_html__( 'How to update your PHP version', 'woocommerce' ) . '</a>' ) . '</mark>';
-				} else {
+				if ( version_compare( $environment['php_version'], '7.2', '>=' ) ) {
 					echo '<mark class="yes">' . esc_html( $environment['php_version'] ) . '</mark>';
+				} else {
+					$update_link = ' <a href="https://docs.woocommerce.com/document/how-to-update-your-php-version/" target="_blank">' . esc_html__( 'How to update your PHP version', 'woocommerce' ) . '</a>';
+
+					if ( version_compare( $environment['php_version'], '5.4', '<' ) ) {
+						$notice = __( 'WooCommerce will run under this version of PHP, however, some features such as geolocation are not compatible. Support for this version will be dropped in the next major release. We recommend using PHP version 7.2 or above for greater performance and security.', 'woocommerce' ) . $update_link;
+					} elseif ( version_compare( $environment['php_version'], '5.6', '<' ) ) {
+						$notice = __( 'WooCommerce will run under this version of PHP, however, it has reached end of life. We recommend using PHP version 7.2 or above for greater performance and security.', 'woocommerce' ) . $update_link;
+					} elseif ( version_compare( $environment['php_version'], '7.2', '<' ) ) {
+						$notice = __( 'We recommend using PHP version 7.2 or above for greater performance and security.', 'woocommerce' ) . $update_link;
+					}
+
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html( $environment['php_version'] ) . ' - ' . wp_kses_post( $notice ) . '</mark>';
 				}
 				?>
 			</td>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -426,7 +426,9 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				<td class="help"><?php echo wc_help_tip( esc_html__( 'The GeoIP database from MaxMind is used to geolocate customers.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
-					if ( file_exists( $database['maxmind_geoip_database'] ) ) {
+					if ( version_compare( $environment['php_version'], '5.4', '<' ) ) {
+						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . wp_kses_post( __( 'MaxMind GeoIP database requires at least PHP 5.4.', 'woocommerce' ) ) . '</mark>';
+					} elseif ( file_exists( $database['maxmind_geoip_database'] ) ) {
 						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> <code class="private">' . esc_html( $database['maxmind_geoip_database'] ) . '</code></mark> ';
 					} else {
 						/* Translators: %1$s: Library url, %2$s: install path. */

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Admin View: Page - Status Report.
+ *
+ * @package WooCommerce
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 global $wpdb;
 
@@ -56,58 +56,83 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	<tbody>
 		<tr>
 			<td data-export-label="Home URL"><?php esc_html_e( 'Home URL', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The homepage URL of your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The homepage URL of your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['home_url'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Site URL"><?php esc_html_e( 'Site URL', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The root URL of your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The root URL of your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['site_url'] ); ?></td>
 		</tr>
 		<tr>
-			<td data-export-label="WC Version"><?php esc_html_e( 'WC version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The version of WooCommerce installed on your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WC Version"><?php esc_html_e( 'WooCommerce version', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WooCommerce installed on your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['version'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Log Directory Writable"><?php esc_html_e( 'Log directory writable', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Several WooCommerce extensions can write logs which makes debugging problems easier. The directory must be writable for this to happen.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Several WooCommerce extensions can write logs which makes debugging problems easier. The directory must be writable for this to happen.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['log_directory_writable'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> <code class="private">' . esc_html( $environment['log_directory'] ) . '</code></mark> ';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'To allow logging, make %1$s writable or define a custom %2$s.', 'woocommerce' ), '<code>' . $environment['log_directory'] . '</code>', '<code>WC_LOG_DIR</code>' ) . '</mark>';
+					/* Translators: %1$s: Log directory, %2$s: Log directory constant */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'To allow logging, make %1$s writable or define a custom %2$s.', 'woocommerce' ), '<code>' . esc_html( $environment['log_directory'] ) . '</code>', '<code>WC_LOG_DIR</code>' ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
-			<td data-export-label="WP Version"><?php esc_html_e( 'WP version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The version of WordPress installed on your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
-			<td><?php echo esc_html( $environment['wp_version'] ); ?></td>
+			<td data-export-label="WP Version"><?php esc_html_e( 'WordPress version', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WordPress installed on your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td>
+				<?php
+				$latest_version = get_transient( 'woocommerce_system_status_wp_version_check' );
+
+				if ( false === $latest_version ) {
+					$version_check = wp_remote_get( 'https://api.wordpress.org/core/version-check/1.7/' );
+					$api_response  = json_decode( wp_remote_retrieve_body( $version_check ), true );
+
+					if ( $api_response && isset( $api_response['offers'], $api_response['offers'][0], $api_response['offers'][0]['version'] ) ) {
+						$latest_version = $api_response['offers'][0]['version'];
+					} else {
+						$latest_version = $environment['wp_version'];
+					}
+					set_transient( 'woocommerce_system_status_wp_version_check', $latest_version, DAY_IN_SECONDS );
+				}
+
+				if ( version_compare( $environment['wp_version'], $latest_version, '<' ) ) {
+					/* Translators: %1$s: Current version, %2$s: New version */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - There is a newer version of WordPress available (%2$s)', 'woocommerce' ), esc_html( $environment['wp_version'] ), esc_html( $latest_version ) ) . '</mark>';
+				} else {
+					echo '<mark class="yes">' . esc_html( $environment['wp_version'] ) . '</mark>';
+				}
+				?>
+			</td>
 		</tr>
 		<tr>
-			<td data-export-label="WP Multisite"><?php esc_html_e( 'WP multisite', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Whether or not you have WordPress Multisite enabled.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WP Multisite"><?php esc_html_e( 'WordPress multisite', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether or not you have WordPress Multisite enabled.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo ( $environment['wp_multisite'] ) ? '<span class="dashicons dashicons-yes"></span>' : '&ndash;'; ?></td>
 		</tr>
 		<tr>
-			<td data-export-label="WP Memory Limit"><?php esc_html_e( 'WP memory limit', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The maximum amount of memory (RAM) that your site can use at one time.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WP Memory Limit"><?php esc_html_e( 'WordPress memory limit', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The maximum amount of memory (RAM) that your site can use at one time.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['wp_memory_limit'] < 67108864 ) {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend setting memory to at least 64MB. See: %2$s', 'woocommerce' ), size_format( $environment['wp_memory_limit'] ), '<a href="https://codex.wordpress.org/Editing_wp-config.php#Increasing_memory_allocated_to_PHP" target="_blank">' . __( 'Increasing memory allocated to PHP', 'woocommerce' ) . '</a>' ) . '</mark>';
+					/* Translators: %1$s: Memory limit, %2$s: Docs link. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend setting memory to at least 64MB. See: %2$s', 'woocommerce' ), esc_html( size_format( $environment['wp_memory_limit'] ) ), '<a href="https://codex.wordpress.org/Editing_wp-config.php#Increasing_memory_allocated_to_PHP" target="_blank">' . esc_html__( 'Increasing memory allocated to PHP', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {
-					echo '<mark class="yes">' . size_format( $environment['wp_memory_limit'] ) . '</mark>';
+					echo '<mark class="yes">' . esc_html( size_format( $environment['wp_memory_limit'] ) ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
-			<td data-export-label="WP Debug Mode"><?php esc_html_e( 'WP debug mode', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Displays whether or not WordPress is in Debug Mode.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WP Debug Mode"><?php esc_html_e( 'WordPress debug mode', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether or not WordPress is in Debug Mode.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php if ( $environment['wp_debug_mode'] ) : ?>
 					<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>
@@ -117,8 +142,8 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			</td>
 		</tr>
 		<tr>
-			<td data-export-label="WP Cron"><?php esc_html_e( 'WP cron', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Displays whether or not WP Cron Jobs are enabled.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WP Cron"><?php esc_html_e( 'WordPress cron', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether or not WP Cron Jobs are enabled.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php if ( $environment['wp_cron'] ) : ?>
 					<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>
@@ -129,12 +154,12 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		</tr>
 		<tr>
 			<td data-export-label="Language"><?php esc_html_e( 'Language', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The current language used by WordPress. Default = English', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The current language used by WordPress. Default = English', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['language'] ); ?></td>
 		</tr>
 		<tr>
-			<td data-export-label="External object cache"><?php _e( 'External object cache', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Displays whether or not WordPress is using an external object cache.', 'woocommerce' ) ); ?></td>
+			<td data-export-label="External object cache"><?php esc_html_e( 'External object cache', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether or not WordPress is using an external object cache.', 'woocommerce' ) ); ?></td>
 			<td>
 				<?php if ( $environment['external_object_cache'] ) : ?>
 					<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>
@@ -154,16 +179,17 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	<tbody>
 		<tr>
 			<td data-export-label="Server Info"><?php esc_html_e( 'Server info', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Information about the web server that is currently hosting your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Information about the web server that is currently hosting your site.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $environment['server_info'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="PHP Version"><?php esc_html_e( 'PHP version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The version of PHP installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of PHP installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( version_compare( $environment['php_version'], '5.6', '<' ) ) {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend a minimum PHP version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['php_version'] ), '<a href="https://docs.woocommerce.com/document/how-to-update-your-php-version/" target="_blank">' . __( 'How to update your PHP version', 'woocommerce' ) . '</a>' ) . '</mark>';
+					/* Translators: %1$s: PHP version, %2$s: Recommended PHP version. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend a minimum PHP version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['php_version'] ), '<a href="https://docs.woocommerce.com/document/how-to-update-your-php-version/" target="_blank">' . esc_html__( 'How to update your PHP version', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {
 					echo '<mark class="yes">' . esc_html( $environment['php_version'] ) . '</mark>';
 				}
@@ -173,27 +199,27 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		<?php if ( function_exists( 'ini_get' ) ) : ?>
 			<tr>
 				<td data-export-label="PHP Post Max Size"><?php esc_html_e( 'PHP post max size', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The largest filesize that can be contained in one post.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The largest filesize that can be contained in one post.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo esc_html( size_format( $environment['php_post_max_size'] ) ); ?></td>
 			</tr>
 			<tr>
 				<td data-export-label="PHP Time Limit"><?php esc_html_e( 'PHP time limit', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The amount of time (in seconds) that your site will spend on a single operation before timing out (to avoid server lockups)', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The amount of time (in seconds) that your site will spend on a single operation before timing out (to avoid server lockups)', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo esc_html( $environment['php_max_execution_time'] ); ?></td>
 			</tr>
 			<tr>
 				<td data-export-label="PHP Max Input Vars"><?php esc_html_e( 'PHP max input vars', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The maximum number of variables your server can use for a single function to avoid overloads.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The maximum number of variables your server can use for a single function to avoid overloads.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo esc_html( $environment['php_max_input_vars'] ); ?></td>
 			</tr>
 			<tr>
 				<td data-export-label="cURL Version"><?php esc_html_e( 'cURL version', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The version of cURL installed on your server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of cURL installed on your server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo esc_html( $environment['curl_version'] ); ?></td>
 			</tr>
 			<tr>
 				<td data-export-label="SUHOSIN Installed"><?php esc_html_e( 'SUHOSIN installed', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'Suhosin is an advanced protection system for PHP installations. It was designed to protect your servers on the one hand against a number of well known problems in PHP applications and on the other hand against potential unknown vulnerabilities within these applications or the PHP core itself. If enabled on your server, Suhosin may need to be configured to increase its data submission limits.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'Suhosin is an advanced protection system for PHP installations. It was designed to protect your servers on the one hand against a number of well known problems in PHP applications and on the other hand against potential unknown vulnerabilities within these applications or the PHP core itself. If enabled on your server, Suhosin may need to be configured to increase its data submission limits.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo $environment['suhosin_installed'] ? '<span class="dashicons dashicons-yes"></span>' : '&ndash;'; ?></td>
 			</tr>
 		<?php endif; ?>
@@ -204,11 +230,12 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			?>
 			<tr>
 				<td data-export-label="MySQL Version"><?php esc_html_e( 'MySQL version', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The version of MySQL installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of MySQL installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
 					if ( version_compare( $environment['mysql_version'], '5.6', '<' ) ) {
-						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend a minimum MySQL version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['mysql_version'] ), '<a href="https://wordpress.org/about/requirements/" target="_blank">' . __( 'WordPress requirements', 'woocommerce' ) . '</a>' ) . '</mark>';
+						/* Translators: %1$s: MySQL version, %2$s: Recommended MySQL version. */
+						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend a minimum MySQL version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['mysql_version'] ), '<a href="https://wordpress.org/about/requirements/" target="_blank">' . esc_html__( 'WordPress requirements', 'woocommerce' ) . '</a>' ) . '</mark>';
 					} else {
 						echo '<mark class="yes">' . esc_html( $environment['mysql_version'] ) . '</mark>';
 					}
@@ -218,16 +245,17 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		<?php endif; ?>
 		<tr>
 			<td data-export-label="Max Upload Size"><?php esc_html_e( 'Max upload size', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The largest filesize that can be uploaded to your WordPress installation.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
-			<td><?php echo size_format( $environment['max_upload_size'] ); ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The largest filesize that can be uploaded to your WordPress installation.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td><?php echo esc_html( size_format( $environment['max_upload_size'] ) ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Default Timezone is UTC"><?php esc_html_e( 'Default timezone is UTC', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The default timezone for your server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The default timezone for your server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( 'UTC' !== $environment['default_timezone'] ) {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Default timezone is %s - it should be UTC', 'woocommerce' ), $environment['default_timezone'] ) . '</mark>';
+					/* Translators: %s: default timezone.. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'Default timezone is %s - it should be UTC', 'woocommerce' ), esc_html( $environment['default_timezone'] ) ) . '</mark>';
 				} else {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				}
@@ -236,91 +264,97 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		</tr>
 		<tr>
 			<td data-export-label="fsockopen/cURL"><?php esc_html_e( 'fsockopen/cURL', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Payment gateways can use cURL to communicate with remote servers to authorize payments, other plugins may also use it when communicating with remote services.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Payment gateways can use cURL to communicate with remote servers to authorize payments, other plugins may also use it when communicating with remote services.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['fsockopen_or_curl_enabled'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Your server does not have fsockopen or cURL enabled - PayPal IPN and other scripts which communicate with other servers will not work. Contact your hosting provider.', 'woocommerce' ) . '</mark>';
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Your server does not have fsockopen or cURL enabled - PayPal IPN and other scripts which communicate with other servers will not work. Contact your hosting provider.', 'woocommerce' ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="SoapClient"><?php esc_html_e( 'SoapClient', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Some webservices like shipping use SOAP to get information from remote servers, for example, live shipping quotes from FedEx require SOAP to be installed.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Some webservices like shipping use SOAP to get information from remote servers, for example, live shipping quotes from FedEx require SOAP to be installed.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['soapclient_enabled'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Your server does not have the %s class enabled - some gateway plugins which use SOAP may not work as expected.', 'woocommerce' ), '<a href="https://php.net/manual/en/class.soapclient.php">SoapClient</a>' ) . '</mark>';
+					/* Translators: %s classname and link. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'Your server does not have the %s class enabled - some gateway plugins which use SOAP may not work as expected.', 'woocommerce' ), '<a href="https://php.net/manual/en/class.soapclient.php">SoapClient</a>' ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="DOMDocument"><?php esc_html_e( 'DOMDocument', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'HTML/Multipart emails use DOMDocument to generate inline CSS in templates.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'HTML/Multipart emails use DOMDocument to generate inline CSS in templates.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['domdocument_enabled'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Your server does not have the %s class enabled - HTML/Multipart emails, and also some extensions, will not work without DOMDocument.', 'woocommerce' ), '<a href="https://php.net/manual/en/class.domdocument.php">DOMDocument</a>' ) . '</mark>';
+					/* Translators: %s: classname and link. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'Your server does not have the %s class enabled - HTML/Multipart emails, and also some extensions, will not work without DOMDocument.', 'woocommerce' ), '<a href="https://php.net/manual/en/class.domdocument.php">DOMDocument</a>' ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="GZip"><?php esc_html_e( 'GZip', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'GZip (gzopen) is used to open the GEOIP database from MaxMind.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'GZip (gzopen) is used to open the GEOIP database from MaxMind.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['gzip_enabled'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Your server does not support the %s function - this is required to use the GeoIP database from MaxMind.', 'woocommerce' ), '<a href="https://php.net/manual/en/zlib.installation.php">gzopen</a>' ) . '</mark>';
+					/* Translators: %s: classname and link. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'Your server does not support the %s function - this is required to use the GeoIP database from MaxMind.', 'woocommerce' ), '<a href="https://php.net/manual/en/zlib.installation.php">gzopen</a>' ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="Multibyte String"><?php esc_html_e( 'Multibyte string', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Multibyte String (mbstring) is used to convert character encoding, like for emails or converting characters to lowercase.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Multibyte String (mbstring) is used to convert character encoding, like for emails or converting characters to lowercase.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['mbstring_enabled'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Your server does not support the %s functions - this is required for better character encoding. Some fallbacks will be used instead for it.', 'woocommerce' ), '<a href="https://php.net/manual/en/mbstring.installation.php">mbstring</a>' ) . '</mark>';
+					/* Translators: %s: classname and link. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'Your server does not support the %s functions - this is required for better character encoding. Some fallbacks will be used instead for it.', 'woocommerce' ), '<a href="https://php.net/manual/en/mbstring.installation.php">mbstring</a>' ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="Remote Post"><?php esc_html_e( 'Remote post', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'PayPal uses this method of communicating when sending back transaction information.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'PayPal uses this method of communicating when sending back transaction information.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['remote_post_successful'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s failed. Contact your hosting provider.', 'woocommerce' ), 'wp_remote_post()' ) . ' ' . esc_html( $environment['remote_post_response'] ) . '</mark>';
+					/* Translators: %s: function name. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%s failed. Contact your hosting provider.', 'woocommerce' ), 'wp_remote_post()' ) . ' ' . esc_html( $environment['remote_post_response'] ) . '</mark>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="Remote Get"><?php esc_html_e( 'Remote get', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'WooCommerce plugins may use this method of communication when checking for plugin updates.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'WooCommerce plugins may use this method of communication when checking for plugin updates.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( $environment['remote_get_successful'] ) {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				} else {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%s failed. Contact your hosting provider.', 'woocommerce' ), 'wp_remote_get()' ) . ' ' . esc_html( $environment['remote_get_response'] ) . '</mark>';
+					/* Translators: %s: function name. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%s failed. Contact your hosting provider.', 'woocommerce' ), 'wp_remote_get()' ) . ' ' . esc_html( $environment['remote_get_response'] ) . '</mark>';
 				}
 				?>
 			</td>
@@ -338,10 +372,10 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			?>
 			<tr>
 				<td data-export-label="<?php echo esc_attr( $row['name'] ); ?>"><?php echo esc_html( $row['name'] ); ?>:</td>
-				<td class="help"><?php echo isset( $row['help'] ) ? $row['help'] : ''; ?></td>
+				<td class="help"><?php echo esc_html( isset( $row['help'] ) ? $row['help'] : '' ); ?></td>
 				<td>
 					<mark class="<?php echo esc_attr( $css_class ); ?>">
-						<?php echo $icon; ?>  <?php echo ! empty( $row['note'] ) ? wp_kses_data( $row['note'] ) : ''; ?>
+						<?php echo wp_kses_post( $icon ); ?> <?php echo wp_kses_data( ! empty( $row['note'] ) ? $row['note'] : '' ); ?>
 					</mark>
 				</td>
 			</tr>
@@ -358,8 +392,8 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	</thead>
 	<tbody>
 		<tr>
-			<td data-export-label="WC Database Version"><?php esc_html_e( 'WC database version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce version.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td data-export-label="WC Database Version"><?php esc_html_e( 'WooCommerce database version', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce version.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $database['wc_database_version'] ); ?></td>
 		</tr>
 		<tr>
@@ -368,7 +402,8 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			<td>
 				<?php
 				if ( strlen( $database['database_prefix'] ) > 20 ) {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( '%1$s - We recommend using a prefix with less than 20 characters. See: %2$s', 'woocommerce' ), esc_html( $database['database_prefix'] ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . __( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
+					/* Translators: %1$s: Database prefix, %2$s: Docs link. */
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend using a prefix with less than 20 characters. See: %2$s', 'woocommerce' ), esc_html( $database['database_prefix'] ), '<a href="https://docs.woocommerce.com/document/completed-order-email-doesnt-contain-download-links/#section-2" target="_blank">' . esc_html__( 'How to update your database table prefix', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {
 					echo '<mark class="yes">' . esc_html( $database['database_prefix'] ) . '</mark>';
 				}
@@ -379,13 +414,14 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		<?php if ( $settings['geolocation_enabled'] ) { ?>
 			<tr>
 				<td data-export-label="MaxMind GeoIP Database"><?php esc_html_e( 'MaxMind GeoIP database', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The GeoIP database from MaxMind is used to geolocate customers.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The GeoIP database from MaxMind is used to geolocate customers.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
 					if ( file_exists( $database['maxmind_geoip_database'] ) ) {
 						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> <code class="private">' . esc_html( $database['maxmind_geoip_database'] ) . '</code></mark> ';
 					} else {
-						printf( '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'The MaxMind GeoIP Database does not exist - Geolocation will not function. You can download and install it manually from %1$s to the path: %2$s. Scroll down to "Downloads" and download the "MaxMind DB binary, gzipped" file next to "GeoLite2 Country". Please remember to uncompress GeoLite2-Country_xxxxxxxx.tar.gz and upload the GeoLite2-Country.mmdb file only.', 'woocommerce' ), make_clickable( 'https://dev.maxmind.com/geoip/geoip2/geolite2/' ), '<code class="private">' . $database['maxmind_geoip_database'] . '</code>' ) . '</mark>', WC_LOG_DIR );
+						/* Translators: %1$s: Library url, %2$s: install path. */
+						printf( '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'The MaxMind GeoIP Database does not exist - Geolocation will not function. You can download and install it manually from %1$s to the path: %2$s. Scroll down to "Downloads" and download the "MaxMind DB binary, gzipped" file next to "GeoLite2 Country". Please remember to uncompress GeoLite2-Country_xxxxxxxx.tar.gz and upload the GeoLite2-Country.mmdb file only.', 'woocommerce' ), '<a href="https://dev.maxmind.com/geoip/geoip2/geolite2/">https://dev.maxmind.com/geoip/geoip2/geolite2/</a>', '<code class="private">' . esc_html( $database['maxmind_geoip_database'] ) . '</code>' ) . '</mark>', esc_html( WC_LOG_DIR ) );
 					}
 					?>
 				</td>
@@ -395,19 +431,19 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		<tr>
 			<td><?php esc_html_e( 'Total Database Size', 'woocommerce' ); ?></td>
 			<td class="help">&nbsp;</td>
-			<td><?php printf( '%.2fMB', $database['database_size']['data'] + $database['database_size']['index'] ); ?></td>
+			<td><?php printf( '%.2fMB', esc_html( $database['database_size']['data'] + $database['database_size']['index'] ) ); ?></td>
 		</tr>
 
 		<tr>
 			<td><?php esc_html_e( 'Database Data Size', 'woocommerce' ); ?></td>
 			<td class="help">&nbsp;</td>
-			<td><?php printf( '%.2fMB', $database['database_size']['data'] ); ?></td>
+			<td><?php printf( '%.2fMB', esc_html( $database['database_size']['data'] ) ); ?></td>
 		</tr>
 
 		<tr>
 			<td><?php esc_html_e( 'Database Index Size', 'woocommerce' ); ?></td>
 			<td class="help">&nbsp;</td>
-			<td><?php printf( '%.2fMB', $database['database_size']['index'] ); ?></td>
+			<td><?php printf( '%.2fMB', esc_html( $database['database_size']['index'] ) ); ?></td>
 		</tr>
 
 		<?php foreach ( $database['database_tables']['woocommerce'] as $table => $table_data ) { ?>
@@ -417,9 +453,10 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				<td>
 					<?php
 					if ( ! $table_data ) {
-						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Table does not exist', 'woocommerce' ) . '</mark>';
+						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Table does not exist', 'woocommerce' ) . '</mark>';
 					} else {
-						printf( __( 'Data: %1$.2fMB + Index: %2$.2fMB', 'woocommerce' ), wc_format_decimal( $table_data['data'], 2 ), wc_format_decimal( $table_data['index'], 2 ) );
+						/* Translators: %1$f: Table size, %2$f: Index size. */
+						printf( esc_html__( 'Data: %1$.2fMB + Index: %2$.2fMB', 'woocommerce' ), esc_html( wc_format_decimal( $table_data['data'], 2 ) ), esc_html( wc_format_decimal( $table_data['index'], 2 ) ) );
 					}
 					?>
 				</td>
@@ -431,7 +468,10 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				<td><?php echo esc_html( $table ); ?></td>
 				<td class="help">&nbsp;</td>
 				<td>
-					<?php printf( __( 'Data: %1$.2fMB + Index: %2$.2fMB', 'woocommerce' ), wc_format_decimal( $table_data['data'], 2 ), wc_format_decimal( $table_data['index'], 2 ) ); ?>
+					<?php
+					/* Translators: %1$f: Table size, %2$f: Index size. */
+					printf( esc_html__( 'Data: %1$.2fMB + Index: %2$.2fMB', 'woocommerce' ), esc_html( wc_format_decimal( $table_data['data'], 2 ) ), esc_html( wc_format_decimal( $table_data['index'], 2 ) ) );
+					?>
 				</td>
 			</tr>
 		<?php } ?>
@@ -466,18 +506,23 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	<tbody>
 		<tr>
 			<td data-export-label="Secure connection (HTTPS)"><?php esc_html_e( 'Secure connection (HTTPS)', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Is the connection to your store secure?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is the connection to your store secure?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php if ( $security['secure_connection'] ) : ?>
 					<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>
 				<?php else : ?>
-					<mark class="error"><span class="dashicons dashicons-warning"></span><?php printf( __( 'Your store is not using HTTPS. <a href="%s" target="_blank">Learn more about HTTPS and SSL Certificates</a>.', 'woocommerce' ), 'https://docs.woocommerce.com/document/ssl-and-https/' ); ?></mark>
+					<mark class="error"><span class="dashicons dashicons-warning"></span>
+					<?php
+					/* Translators: %s: docs link. */
+					echo wp_kses_post( sprintf( __( 'Your store is not using HTTPS. <a href="%s" target="_blank">Learn more about HTTPS and SSL Certificates</a>.', 'woocommerce' ), 'https://docs.woocommerce.com/document/ssl-and-https/' ) );
+					?>
+					</mark>
 				<?php endif; ?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="Hide errors from visitors"><?php esc_html_e( 'Hide errors from visitors', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'Error messages can contain sensitive information about your store environment. These should be hidden from untrusted visitors.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Error messages can contain sensitive information about your store environment. These should be hidden from untrusted visitors.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php if ( $security['hide_errors'] ) : ?>
 					<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>
@@ -514,8 +559,8 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 						$version_string = ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), $plugin['version_latest'] ) . '</strong>';
 					}
 
-					if ( false != $plugin['network_activated'] ) {
-						$network_string = ' &ndash; <strong style="color:black;">' . __( 'Network enabled', 'woocommerce' ) . '</strong>';
+					if ( false !== $plugin['network_activated'] ) {
+						$network_string = ' &ndash; <strong style="color:black;">' . esc_html__( 'Network enabled', 'woocommerce' ) . '</strong>';
 					}
 				}
 				$untested_string = '';
@@ -524,13 +569,13 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 				}
 				?>
 				<tr>
-					<td><?php echo $plugin_name; ?></td>
+					<td><?php echo wp_kses_post( $plugin_name ); ?></td>
 					<td class="help">&nbsp;</td>
 					<td>
 					<?php
 						/* translators: %s: plugin author */
-						printf( __( 'by %s', 'woocommerce' ), $plugin['author_name'] );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string;
+						printf( esc_html__( 'by %s', 'woocommerce' ), esc_html( $plugin['author_name'] ) );
+						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string; // WPCS: XSS ok.
 					?>
 					</td>
 				</tr>
@@ -549,42 +594,42 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	<tbody>
 		<tr>
 			<td data-export-label="API Enabled"><?php esc_html_e( 'API enabled', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Does your site have REST API enabled?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Does your site have REST API enabled?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo $settings['api_enabled'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Force SSL"><?php esc_html_e( 'Force SSL', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Does your site force a SSL Certificate for transactions?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Does your site force a SSL Certificate for transactions?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo $settings['force_ssl'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Currency"><?php esc_html_e( 'Currency', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'What currency prices are listed at in the catalog and which currency gateways will take payments in.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'What currency prices are listed at in the catalog and which currency gateways will take payments in.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $settings['currency'] ); ?> (<?php echo esc_html( $settings['currency_symbol'] ); ?>)</td>
 		</tr>
 		<tr>
 			<td data-export-label="Currency Position"><?php esc_html_e( 'Currency position', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'The position of the currency symbol.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The position of the currency symbol.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $settings['currency_position'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Thousand Separator"><?php esc_html_e( 'Thousand separator', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'The thousand separator of displayed prices.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The thousand separator of displayed prices.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $settings['thousand_separator'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Decimal Separator"><?php esc_html_e( 'Decimal separator', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'The decimal separator of displayed prices.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The decimal separator of displayed prices.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $settings['decimal_separator'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Number of Decimals"><?php esc_html_e( 'Number of decimals', 'woocommerce' ); ?></td>
-			<td class="help"><?php echo wc_help_tip( __( 'The number of decimal points shown in displayed prices.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The number of decimal points shown in displayed prices.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $settings['number_of_decimals'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Taxonomies: Product Types"><?php esc_html_e( 'Taxonomies: Product types', 'woocommerce' ); ?></th>
-			<td class="help"><?php echo wc_help_tip( __( 'A list of taxonomy terms that can be used in regard to order/product statuses.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'A list of taxonomy terms that can be used in regard to order/product statuses.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				$display_terms = array();
@@ -597,7 +642,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 		</tr>
 		<tr>
 			<td data-export-label="Taxonomies: Product Visibility"><?php esc_html_e( 'Taxonomies: Product visibility', 'woocommerce' ); ?></th>
-			<td class="help"><?php echo wc_help_tip( __( 'A list of taxonomy terms used for product visibility.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'A list of taxonomy terms used for product visibility.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				$display_terms = array();
@@ -613,7 +658,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 <table class="wc_status_table widefat" cellspacing="0">
 	<thead>
 		<tr>
-			<th colspan="3" data-export-label="WC Pages"><h2><?php esc_html_e( 'WC pages', 'woocommerce' ); ?></h2></th>
+			<th colspan="3" data-export-label="WC Pages"><h2><?php esc_html_e( 'WooCommerce pages', 'woocommerce' ); ?></h2></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -623,36 +668,39 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 			$error = false;
 
 			if ( $page['page_id'] ) {
-				$page_name = '<a href="' . get_edit_post_link( $page['page_id'] ) . '" aria-label="' . sprintf( __( 'Edit %s page', 'woocommerce' ), esc_html( $page['page_name'] ) ) . '">' . esc_html( $page['page_name'] ) . '</a>';
+				/* Translators: %s: page name. */
+				$page_name = '<a href="' . get_edit_post_link( $page['page_id'] ) . '" aria-label="' . sprintf( esc_html__( 'Edit %s page', 'woocommerce' ), esc_html( $page['page_name'] ) ) . '">' . esc_html( $page['page_name'] ) . '</a>';
 			} else {
 				$page_name = esc_html( $page['page_name'] );
 			}
 
-			echo '<tr><td data-export-label="' . esc_attr( $page_name ) . '">' . $page_name . ':</td>';
-			echo '<td class="help">' . wc_help_tip( sprintf( __( 'The URL of your %s page (along with the Page ID).', 'woocommerce' ), $page_name ) ) . '</td><td>';
+			echo '<tr><td data-export-label="' . esc_attr( $page_name ) . '">' . wp_kses_post( $page_name ) . ':</td>';
+			/* Translators: %s: page name. */
+			echo '<td class="help">' . wc_help_tip( sprintf( esc_html__( 'The URL of your %s page (along with the Page ID).', 'woocommerce' ), $page_name ) ) . '</td><td>';
 
 			// Page ID check.
 			if ( ! $page['page_set'] ) {
-				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Page not set', 'woocommerce' ) . '</mark>';
+				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Page not set', 'woocommerce' ) . '</mark>';
 				$error = true;
 			} elseif ( ! $page['page_exists'] ) {
-				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Page ID is set, but the page does not exist', 'woocommerce' ) . '</mark>';
+				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Page ID is set, but the page does not exist', 'woocommerce' ) . '</mark>';
 				$error = true;
 			} elseif ( ! $page['page_visible'] ) {
-				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Page visibility should be <a href="%s" target="_blank">public</a>', 'woocommerce' ), 'https://codex.wordpress.org/Content_Visibility' ) . '</mark>';
+				/* Translators: %s: docs link. */
+				echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . wp_kses_post( sprintf( __( 'Page visibility should be <a href="%s" target="_blank">public</a>', 'woocommerce' ), 'https://codex.wordpress.org/Content_Visibility' ) ) . '</mark>';
 				$error = true;
 			} else {
-				// Shortcode check
+				// Shortcode check.
 				if ( $page['shortcode_required'] ) {
 					if ( ! $page['shortcode_present'] ) {
-						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( __( 'Page does not contain the shortcode.', 'woocommerce' ), $page['shortcode'] ) . '</mark>';
+						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'Page does not contain the shortcode.', 'woocommerce' ), esc_html( $page['shortcode'] ) ) . '</mark>';
 						$error = true;
 					}
 				}
 			}
 
 			if ( ! $error ) {
-				echo '<mark class="yes">#' . absint( $page['page_id'] ) . ' - ' . str_replace( home_url(), '', get_permalink( $page['page_id'] ) ) . '</mark>';
+				echo '<mark class="yes">#' . absint( $page['page_id'] ) . ' - ' . esc_html( str_replace( home_url(), '', get_permalink( $page['page_id'] ) ) ) . '</mark>';
 			}
 
 			echo '</td></tr>';
@@ -669,66 +717,73 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 	<tbody>
 		<tr>
 			<td data-export-label="Name"><?php esc_html_e( 'Name', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The name of the current active theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The name of the current active theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $theme['name'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Version"><?php esc_html_e( 'Version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The installed version of the current active theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The installed version of the current active theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				echo esc_html( $theme['version'] );
 				if ( version_compare( $theme['version'], $theme['version_latest'], '<' ) ) {
 					/* translators: %s: theme latest version */
-					echo ' &ndash; <strong style="color:red;">' . sprintf( __( '%s is available', 'woocommerce' ), esc_html( $theme['version_latest'] ) ) . '</strong>';
+					echo ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), esc_html( $theme['version_latest'] ) ) . '</strong>';
 				}
 				?>
 			</td>
 		</tr>
 		<tr>
 			<td data-export-label="Author URL"><?php esc_html_e( 'Author URL', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'The theme developers URL.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The theme developers URL.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $theme['author_url'] ); ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Child Theme"><?php esc_html_e( 'Child theme', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Displays whether or not the current theme is a child theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether or not the current theme is a child theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
-				<?php echo $theme['is_child_theme'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<span class="dashicons dashicons-no-alt"></span> &ndash; ' . sprintf( __( 'If you are modifying WooCommerce on a parent theme that you did not build personally we recommend using a child theme. See: <a href="%s" target="_blank">How to create a child theme</a>', 'woocommerce' ), 'https://codex.wordpress.org/Child_Themes' ); ?>
-			</td>
+				<?php
+				if ( $theme['is_child_theme'] ) {
+					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
+				} else {
+					/* Translators: %s docs link. */
+					echo '<span class="dashicons dashicons-no-alt"></span> &ndash; ' . wp_kses_post( sprintf( __( 'If you are modifying WooCommerce on a parent theme that you did not build personally we recommend using a child theme. See: <a href="%s" target="_blank">How to create a child theme</a>', 'woocommerce' ), 'https://codex.wordpress.org/Child_Themes' ) );
+				}
+				?>
+				</td>
 		</tr>
 		<?php if ( $theme['is_child_theme'] ) : ?>
 			<tr>
 				<td data-export-label="Parent Theme Name"><?php esc_html_e( 'Parent theme name', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The name of the parent theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The name of the parent theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo esc_html( $theme['parent_name'] ); ?></td>
 			</tr>
 			<tr>
 				<td data-export-label="Parent Theme Version"><?php esc_html_e( 'Parent theme version', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The installed version of the parent theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The installed version of the parent theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
 					echo esc_html( $theme['parent_version'] );
 					if ( version_compare( $theme['parent_version'], $theme['parent_version_latest'], '<' ) ) {
-						/* translators: %s: parant theme latest version */
-						echo ' &ndash; <strong style="color:red;">' . sprintf( __( '%s is available', 'woocommerce' ), esc_html( $theme['parent_version_latest'] ) ) . '</strong>';
+						/* translators: %s: parent theme latest version */
+						echo ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), esc_html( $theme['parent_version_latest'] ) ) . '</strong>';
 					}
 					?>
 				</td>
 			</tr>
 			<tr>
 				<td data-export-label="Parent Theme Author URL"><?php esc_html_e( 'Parent theme author URL', 'woocommerce' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( __( 'The parent theme developers URL.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+				<td class="help"><?php echo wc_help_tip( esc_html__( 'The parent theme developers URL.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td><?php echo esc_html( $theme['parent_author_url'] ); ?></td>
 			</tr>
 		<?php endif ?>
 		<tr>
 			<td data-export-label="WooCommerce Support"><?php esc_html_e( 'WooCommerce support', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( __( 'Displays whether or not the current active theme declares WooCommerce support.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Displays whether or not the current active theme declares WooCommerce support.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
 				if ( ! $theme['has_woocommerce_support'] ) {
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . __( 'Not declared', 'woocommerce' ) . '</mark>';
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Not declared', 'woocommerce' ) . '</mark>';
 				} else {
 					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>';
 				}
@@ -740,7 +795,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 <table class="wc_status_table widefat" cellspacing="0">
 	<thead>
 		<tr>
-			<th colspan="3" data-export-label="Templates"><h2><?php esc_html_e( 'Templates', 'woocommerce' ); ?><?php echo wc_help_tip( __( 'This section shows any files that are overriding the default WooCommerce template pages.', 'woocommerce' ) ); ?></h2></th>
+			<th colspan="3" data-export-label="Templates"><h2><?php esc_html_e( 'Templates', 'woocommerce' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows any files that are overriding the default WooCommerce template pages.', 'woocommerce' ) ); ?></h2></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -763,10 +818,11 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 						if ( $override['core_version'] && ( empty( $override['version'] ) || version_compare( $override['version'], $override['core_version'], '<' ) ) ) {
 							$current_version = $override['version'] ? $override['version'] : '-';
 							printf(
-								__( '%1$s version %2$s is out of date. The core version is %3$s', 'woocommerce' ),
-								'<code>' . $override['file'] . '</code>',
-								'<strong style="color:red">' . $current_version . '</strong>',
-								$override['core_version']
+								/* Translators: %1$s: Template name, %2$s: Template version, %3$s: Core version. */
+								esc_html__( '%1$s version %2$s is out of date. The core version is %3$s', 'woocommerce' ),
+								'<code>' . esc_html( $override['file'] ) . '</code>',
+								'<strong style="color:red">' . esc_html( $current_version ) . '</strong>',
+								esc_html( $override['core_version'] )
 							);
 						} else {
 							echo esc_html( $override['file'] );

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -72,14 +72,31 @@ class WC_Geolocation {
 	}
 
 	/**
-	 * Hook in tabs.
+	 * Prevent geolocation via MaxMind when using legacy versions of php.
+	 *
+	 * @param string $default_customer_address current value.
+	 * @return string
+	 */
+	public static function disable_geolocation_on_legacy_php( $default_customer_address ) {
+		if ( in_array( $default_customer_address, array( 'geolocation', 'geolocation_ajax' ), true ) ) {
+			$default_customer_address = 'base';
+		}
+		return $default_customer_address;
+	}
+
+	/**
+	 * Hook in geolocation functionality.
 	 */
 	public static function init() {
-		// Only download the database from MaxMind if the geolocation function is enabled, or a plugin specifically requests it.
-		if ( self::supports_geolite2() && 'geolocation' === get_option( 'woocommerce_default_customer_address' ) || apply_filters( 'woocommerce_geolocation_update_database_periodically', false ) ) {
-			add_action( 'woocommerce_geoip_updater', array( __CLASS__, 'update_database' ) );
+		if ( self::supports_geolite2() ) {
+			// Only download the database from MaxMind if the geolocation function is enabled, or a plugin specifically requests it.
+			if ( in_array( get_option( 'woocommerce_default_customer_address' ), array( 'geolocation', 'geolocation_ajax' ), true ) || apply_filters( 'woocommerce_geolocation_update_database_periodically', false ) ) {
+				add_action( 'woocommerce_geoip_updater', array( __CLASS__, 'update_database' ) );
+			}
+			add_filter( 'pre_update_option_woocommerce_default_customer_address', array( __CLASS__, 'maybe_update_database' ), 10, 2 );
+		} else {
+			add_filter( 'pre_option_woocommerce_default_customer_address', array( __CLASS__, 'disable_geolocation_on_legacy_php' ) );
 		}
-		add_filter( 'pre_update_option_woocommerce_default_customer_address', array( __CLASS__, 'maybe_update_database' ), 10, 2 );
 	}
 
 	/**
@@ -90,7 +107,7 @@ class WC_Geolocation {
 	 * @return string
 	 */
 	public static function maybe_update_database( $new_value, $old_value ) {
-		if ( self::supports_geolite2() && $new_value !== $old_value && 'geolocation' === $new_value ) {
+		if ( $new_value !== $old_value && in_array( $new_value, array( 'geolocation', 'geolocation_ajax' ), true ) ) {
 			self::update_database();
 		}
 		return $new_value;

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -217,7 +217,7 @@ class WC_Geolocation {
 		$logger = wc_get_logger();
 
 		if ( ! self::supports_geolite2() ) {
-			$logger->notice( 'Required PHP 5.4 to be able to download MaxMind GeoLite2 database', array( 'source' => 'geolocation' ) );
+			$logger->notice( 'Requires PHP 5.4 to be able to download MaxMind GeoLite2 database', array( 'source' => 'geolocation' ) );
 			return;
 		}
 


### PR DESCRIPTION
Closes #19546 by including a WordPress update check, removing abbreviations, and recommending PHP 7.2 to our users. Also fixes phpcs.

To test, view the system status page and ensure the checks are output correctly under different versions of PHP.

Closes #19548 by:

- Disabling geolocation if using PHP 5.4 or lower.
- Adding a notice to system status if geolocation is disabled.
- Removing the geolocation option from the settings if unsupported.

![maxmind](https://user-images.githubusercontent.com/90977/38099886-a7f0c3e0-3373-11e8-8e50-b7de7a8e167a.png)

PHP version notices change based on current version.

![5 2](https://user-images.githubusercontent.com/90977/38099879-a5822112-3373-11e8-8185-d55d3ac6e2eb.png)

![5 5](https://user-images.githubusercontent.com/90977/38099891-ab915d7a-3373-11e8-931d-30aa546f042b.png)

![5 6](https://user-images.githubusercontent.com/90977/38099894-ae394a38-3373-11e8-94cc-42d638069542.png)

