### PR TITLE
Adds new hook to allow customize downlodable file permissions

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -366,6 +366,8 @@ function wc_downloadable_file_permission( $download_id, $product, $order, $qty =
 		$download->set_access_expires( strtotime( $from_date . ' + ' . $expiry . ' DAY' ) );
 	}
 
+	$download = apply_filters( 'woocommerce_downloadable_file_permission', $download, $product, $order, $qty );
+
 	return $download->save();
 }
 


### PR DESCRIPTION
This is needed on Product Custom Tables in order to allow control expire
and remaining downloads per file.