### PR TITLE
Handle manage_stock mixed content for variations

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -335,7 +335,11 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 
 		// Stock handling.
 		if ( isset( $request['manage_stock'] ) ) {
-			$variation->set_manage_stock( $request['manage_stock'] );
+			if ( 'parent' === $request['manage_stock'] ) {
+				$variation->set_manage_stock( false ); // This just indicates the variation does not manage stock, but the parent does.
+			} else {
+				$variation->set_manage_stock( wc_string_to_bool( $request['manage_stock'] ) );
+			}
 		}
 
 		if ( isset( $request['in_stock'] ) ) {
@@ -802,7 +806,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 				),
 				'manage_stock'          => array(
 					'description' => __( 'Stock management at variation level.', 'woocommerce' ),
-					'type'        => 'boolean',
+					'type'        => 'mixed',
 					'default'     => false,
 					'context'     => array( 'view', 'edit' ),
 				),


### PR DESCRIPTION
The API returns data by default in `view` context. Under view context some values are filtered and/or changed from how they are stored. `manage_stock` is an example of this for variations.

Variations `manage_stock` is always true, or false, but when in view context, if the parent product manages stock, this can return `parent`.

To reflect this in the API, the content type needs to be `mixed`, and when updating the value we should map `parent` to `false`.

Added a test to ensure correct handling is applied.

Closes #19500