### PR TITLE
Add filter to suppress admin WordPress.com connection message.

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1318,6 +1318,10 @@ class WC_Helper {
 	 * @param string $screen_id Current screen ID.
 	 */
 	private static function _prompt_helper_connect( $screen_id ) {
+		if ( apply_filters( 'woocommerce_helper_suppress_connect_notice', false ) ) {
+			return;
+		}
+
 		$screens   = wc_get_screen_ids();
 		$screens[] = 'plugins';
 


### PR DESCRIPTION
Allows developers to supress only the WordPress.com connection message, while still leaving other admin notices (eg., upgrade notice) in place.