### PR TITLE
Fixed bug when using asbint() with wc_get_page_id()

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -828,7 +828,7 @@ class WC_Admin_Post_Types {
 	public function hide_cpt_archive_templates( $page_templates, $theme, $post ) {
 		$shop_page_id = wc_get_page_id( 'shop' );
 
-		if ( $post && absint( $shop_page_id ) === absint( $post->ID ) ) {
+		if ( $post && $shop_page_id === absint( $post->ID ) ) {
 			$page_templates = array();
 		}
 
@@ -843,7 +843,7 @@ class WC_Admin_Post_Types {
 	public function show_cpt_archive_notice( $post ) {
 		$shop_page_id = wc_get_page_id( 'shop' );
 
-		if ( $post && intval( $shop_page_id ) === intval( $post->ID ) ) {
+		if ( $post && $shop_page_id === absint( $post->ID ) ) {
 			echo '<div class="notice notice-info">';
 			echo '<p>' . sprintf( wp_kses_post( __( 'This is the WooCommerce shop page. The shop page is a special archive that lists your products. <a href="%s">You can read more about this here</a>.', 'woocommerce' ) ), 'https://docs.woocommerce.com/document/woocommerce-pages/#section-4' ) . '</p>';
 			echo '</div>';

--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -150,7 +150,7 @@ function wc_nav_menu_item_classes( $menu_items ) {
 		return $menu_items;
 	}
 
-	$shop_page      = (int) wc_get_page_id( 'shop' );
+	$shop_page      = wc_get_page_id( 'shop' );
 	$page_for_posts = (int) get_option( 'page_for_posts' );
 
 	if ( ! empty( $menu_items ) && is_array( $menu_items ) ) {


### PR DESCRIPTION
When a page does not exists `wc_get_page_id()` returns `-1`, so applying `absint()` should cause bugs when comparing with "Hello world!" page, that have ID equal 1.

Related to #19606