### PR TITLE
Add missing woocommerce_options_panel class to Product Attributes panel

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div id="product_attributes" class="panel wc-metaboxes-wrapper hidden">
+<div id="product_attributes" class="panel woocommerce_options_panel wc-metaboxes-wrapper hidden">
 	<div class="toolbar toolbar-top">
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>


### PR DESCRIPTION
Add missing woocommerce_options_panel class to Product Attributes panel so that Custom Fields display properly formatted