### PR TITLE
Set the order created_via property for orders created via admin area

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -600,6 +600,11 @@ class WC_Meta_Box_Order_Data {
 
 		$props['date_created'] = $date;
 
+		// Set created via prop if new post.
+		if ( isset( $_POST['original_post_status'] ) && $_POST['original_post_status'] === 'auto-draft' ) {
+			$props['created_via'] = 'admin';
+		}
+
 		// Save order data.
 		$order->set_props( $props );
 		$order->set_status( wc_clean( $_POST['order_status'] ), '', true );


### PR DESCRIPTION
This is really minor but I think it would be useful to set this order created_via property to 'admin' when new orders are created via the admin area.

This change will only apply to future orders, existing admin created orders will have an empty value.