### PR TITLE
Product rating count doesn't update when ratings are edited by admin is fixed #19581

### DIFF
--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -65,7 +65,7 @@ class WC_Admin_Meta_Boxes {
 		add_action( 'woocommerce_process_shop_coupon_meta', 'WC_Meta_Box_Coupon_Data::save', 10, 2 );
 
 		// Save Rating Meta Boxes.
-		add_action( 'comment_edit_redirect', 'WC_Meta_Box_Product_Reviews::save', 1, 2 );
+		add_filter( 'wp_update_comment_data', 'WC_Meta_Box_Product_Reviews::save', 1, 2 );
 
 		// Error handling (for showing errors from meta boxes on next page load).
 		add_action( 'admin_notices', array( $this, 'output_errors' ) );

--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -65,7 +65,7 @@ class WC_Admin_Meta_Boxes {
 		add_action( 'woocommerce_process_shop_coupon_meta', 'WC_Meta_Box_Coupon_Data::save', 10, 2 );
 
 		// Save Rating Meta Boxes.
-		add_filter( 'wp_update_comment_data', 'WC_Meta_Box_Product_Reviews::save', 1, 2 );
+		add_filter( 'wp_update_comment_data', 'WC_Meta_Box_Product_Reviews::save', 1 );
 
 		// Error handling (for showing errors from meta boxes on next page load).
 		add_action( 'admin_notices', array( $this, 'output_errors' ) );

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
@@ -40,16 +40,17 @@ class WC_Meta_Box_Product_Reviews {
 	/**
 	 * Save meta box data
 	 *
-	 * @param mixed $location
-	 * @param int   $comment_id
+	 * @param mixed $data
 	 *
 	 * @return mixed
 	 */
-	public static function save( $location, $comment_id ) {
+	public static function save( $data ) {
 		// Not allowed, return regular value without updating meta
 		if ( ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) && ! isset( $_POST['rating'] ) ) {
-			return $location;
+			return;
 		}
+
+		$comment_id = $data['comment_ID'];
 
 		// Update meta
 		update_comment_meta(
@@ -59,6 +60,6 @@ class WC_Meta_Box_Product_Reviews {
 		);
 
 		// Return regular value after updating
-		return $location;
+		return $data;
 	}
 }

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
@@ -50,6 +50,10 @@ class WC_Meta_Box_Product_Reviews {
 			return $data;
 		}
 
+		if ( $_POST['rating'] > 5 || $_POST['rating'] < 0 ) {
+			return $data;
+		}
+
 		$comment_id = $data['comment_ID'];
 
 		// Update meta

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
@@ -47,7 +47,7 @@ class WC_Meta_Box_Product_Reviews {
 	public static function save( $data ) {
 		// Not allowed, return regular value without updating meta
 		if ( ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) && ! isset( $_POST['rating'] ) ) {
-			return;
+			return $data;
 		}
 
 		$comment_id = $data['comment_ID'];


### PR DESCRIPTION
Here was the issue:
1. `add_action( 'wp_update_comment_count', array( __CLASS__, 'clear_transients' ) );` the clear_transients method was called on  wp_update_comment_count hook which was firing before the update_comment_meta is called. Meaning we were getting the old value instead of newly updated value.

2. `add_action( 'comment_edit_redirect', 'WC_Meta_Box_Product_Reviews::save', 1, 2 );`  Here the save method was called on the comment_edit_redirect hook.

So I've called the the save method on wp_update_comment_data hook by doing so now the clear_transients method is able to retrieve the newly updated value.

Please let me know if it's OK or do I need to change anything?
Regards
