### PR TITLE
Clear comment count transient when cleaning product transients

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -103,6 +103,7 @@ function wc_delete_product_transients( $post_id = 0 ) {
 		'wc_featured_products',
 		'wc_outofstock_count',
 		'wc_low_stock_count',
+		'wc_count_comments',
 	);
 
 	// Transient names that include an ID.


### PR DESCRIPTION
fixes #19621 

Testing instructions:
1. Clear transients via WC Status > Tools > Clear transients
2. `SELECT * FROM 'wp_options' where option_name = '_transient_wc_count_comments'` still shows transients
3. Apply fix
4. Clear transients via WC Status > Tools > Clear transients
5. `SELECT * FROM 'wp_options' where option_name = '_transient_wc_count_comments'` should be empty now.