### PR TITLE
Consistent cart forms and woocommerce_after_add_to_cart_button placement

### DIFF
--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -10,9 +10,8 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
  * @version     3.0.0
  */
 
@@ -21,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Hook Woocommerce_before_single_product.
+ * Hook: woocommerce_before_single_product.
  *
  * @hooked wc_print_notices - 10
  */

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -10,18 +10,21 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
- * @version     2.1.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
-do_action( 'woocommerce_before_add_to_cart_button' ); ?>
+do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<p class="cart">
-	<a href="<?php echo esc_url( $product_url ); ?>" rel="nofollow" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></a>
-</p>
+<form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="post">
+	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
+	<button type="submit" name="add-to-cart" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>
+
+	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
+</form>
+
+<?php do_action( 'woocommerce_after_add_to_cart_form' ); ?>

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
- * @version     3.4.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,44 +23,30 @@ if ( ! $product->is_purchasable() ) {
 	return;
 }
 
-echo wc_get_stock_html( $product );
+echo wc_get_stock_html( $product ); // WPCS: XSS ok.
 
 if ( $product->is_in_stock() ) : ?>
 
 	<?php do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 	<form class="cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data'>
+		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
+
 		<?php
-			/**
-			 * @since 2.1.0.
-			 */
-			do_action( 'woocommerce_before_add_to_cart_button' );
+		do_action( 'woocommerce_before_add_to_cart_quantity' );
 
-			/**
-			 * @since 3.0.0.
-			 */
-			do_action( 'woocommerce_before_add_to_cart_quantity' );
+		woocommerce_quantity_input( array(
+			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
+		) );
 
-			woocommerce_quantity_input( array(
-				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : $product->get_min_purchase_quantity(),
-			) );
-
-			/**
-			 * @since 3.0.0.
-			 */
-			do_action( 'woocommerce_after_add_to_cart_quantity' );
+		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
 		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
-		<?php
-			/**
-			 * @since 2.1.0.
-			 */
-			do_action( 'woocommerce_after_add_to_cart_button' );
-		?>
+		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 	</form>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_form' ); ?>

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -56,12 +56,12 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 		<div class="single_variation_wrap">
 			<?php
 				/**
-				 * Woocommerce_before_single_variation Hook.
+				 * Hook: woocommerce_before_single_variation.
 				 */
 				do_action( 'woocommerce_before_single_variation' );
 
 				/**
-				 * Woocommerce_single_variation hook. Used to output the cart button and placeholder for variation data.
+				 * Hook: woocommerce_single_variation. Used to output the cart button and placeholder for variation data.
 				 *
 				 * @since 2.4.0
 				 * @hooked woocommerce_single_variation - 10 Empty div for variation data.
@@ -70,7 +70,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				do_action( 'woocommerce_single_variation' );
 
 				/**
-				 * Woocommerce_after_single_variation Hook.
+				 * Hook: woocommerce_after_single_variation.
 				 */
 				do_action( 'woocommerce_after_single_variation' );
 			?>

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -10,7 +10,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
  * @version 3.4.0
  */
@@ -23,40 +23,46 @@ $attribute_keys = array_keys( $attributes );
 
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="variations_form cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo htmlspecialchars( wp_json_encode( $available_variations ) ) ?>">
+<form class="variations_form cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data' data-product_id="<?php echo absint( $product->get_id() ); ?>" data-product_variations="<?php echo htmlspecialchars( wp_json_encode( $available_variations ) ); // WPCS: XSS ok. ?>">
 	<?php do_action( 'woocommerce_before_variations_form' ); ?>
 
 	<?php if ( empty( $available_variations ) && false !== $available_variations ) : ?>
-		<p class="stock out-of-stock"><?php _e( 'This product is currently out of stock and unavailable.', 'woocommerce' ); ?></p>
+		<p class="stock out-of-stock"><?php esc_html_e( 'This product is currently out of stock and unavailable.', 'woocommerce' ); ?></p>
 	<?php else : ?>
 		<table class="variations" cellspacing="0">
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
 					<tr>
-						<td class="label"><label for="<?php echo sanitize_title( $attribute_name ); ?>"><?php echo wc_attribute_label( $attribute_name ); ?></label></td>
+						<td class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo esc_html( wc_attribute_label( $attribute_name ) ); ?></label></td>
 						<td class="value">
 							<?php
-								$selected = isset( $_REQUEST[ 'attribute_' . $attribute_name ] ) ? wc_clean( stripslashes( urldecode( $_REQUEST[ 'attribute_' . $attribute_name ] ) ) ) : $product->get_variation_default_attribute( $attribute_name );
-								wc_dropdown_variation_attribute_options( array( 'options' => $options, 'attribute' => $attribute_name, 'product' => $product, 'selected' => $selected ) );
-								echo end( $attribute_keys ) === $attribute_name ? apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) : '';
+								$selected = isset( $_REQUEST[ 'attribute_' . $attribute_name ] ) ? wc_clean( urldecode( wp_unslash( $_REQUEST[ 'attribute_' . $attribute_name ] ) ) ) : $product->get_variation_default_attribute( $attribute_name ); // WPCS: input var ok, CSRF ok, sanitization ok.
+
+								wc_dropdown_variation_attribute_options( array(
+									'options'   => $options,
+									'attribute' => $attribute_name,
+									'product'   => $product,
+									'selected'  => $selected,
+								) );
+
+								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';
 							?>
 						</td>
 					</tr>
-				<?php endforeach;?>
+				<?php endforeach; ?>
 			</tbody>
 		</table>
-
-		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
 		<div class="single_variation_wrap">
 			<?php
 				/**
-				 * woocommerce_before_single_variation Hook.
+				 * Woocommerce_before_single_variation Hook.
 				 */
 				do_action( 'woocommerce_before_single_variation' );
 
 				/**
-				 * woocommerce_single_variation hook. Used to output the cart button and placeholder for variation data.
+				 * Woocommerce_single_variation hook. Used to output the cart button and placeholder for variation data.
+				 *
 				 * @since 2.4.0
 				 * @hooked woocommerce_single_variation - 10 Empty div for variation data.
 				 * @hooked woocommerce_single_variation_add_to_cart_button - 20 Qty and cart button.
@@ -64,13 +70,11 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				do_action( 'woocommerce_single_variation' );
 
 				/**
-				 * woocommerce_after_single_variation Hook.
+				 * Woocommerce_after_single_variation Hook.
 				 */
 				do_action( 'woocommerce_after_single_variation' );
 			?>
 		</div>
-
-		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 	<?php endif; ?>
 
 	<?php do_action( 'woocommerce_after_variations_form' ); ?>

--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -2,10 +2,9 @@
 /**
  * Single variation cart button
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.0.0
+ * @version 3.4.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,24 +12,24 @@ defined( 'ABSPATH' ) || exit;
 global $product;
 ?>
 <div class="woocommerce-variation-add-to-cart variations_button">
+	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
+
 	<?php
-		/**
-		 * @since 3.0.0.
-		 */
-		do_action( 'woocommerce_before_add_to_cart_quantity' );
+	do_action( 'woocommerce_before_add_to_cart_quantity' );
 
-		woocommerce_quantity_input( array(
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( $_POST['quantity'] ) : $product->get_min_purchase_quantity(),
-		) );
+	woocommerce_quantity_input( array(
+		'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+		'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+		'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
+	) );
 
-		/**
-		 * @since 3.0.0.
-		 */
-		do_action( 'woocommerce_after_add_to_cart_quantity' );
+	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>
+
 	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+
+	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
+
 	<input type="hidden" name="add-to-cart" value="<?php echo absint( $product->get_id() ); ?>" />
 	<input type="hidden" name="product_id" value="<?php echo absint( $product->get_id() ); ?>" />
 	<input type="hidden" name="variation_id" class="variation_id" value="0" />


### PR DESCRIPTION
Fixes #19654 by making all add to cart forms honour the correct placement of `woocommerce_after_add_to_cart_button`.

For external products, this also replaces the link with a form tag so it better matches simple products.

Most templates were already bumped; I fixed PHPCS violations.

View simple, grouped, external, and variable product forms to test - they should the same after updating.