### PR TITLE
Clear shipping transient when saving shipping method on zones screen

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2660,6 +2660,8 @@ class WC_AJAX {
 		$shipping_method->set_post_data( $_POST['data'] );
 		$shipping_method->process_admin_options();
 
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+
 		wp_send_json_success(
 			array(
 				'zone_id'   => $zone->get_id(),


### PR DESCRIPTION
Fixes #19657 

To test, have a cart with shipping already calculated.

Change the shipping label in WC> Settings > Shipping

After patch the shipping label in cart will update.

Before patch it would only update when saving a zone or other shipping settings due to cache.