### PR TITLE
Avoid storing coupon `used_by` data

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -530,7 +530,11 @@ class WC_Checkout {
 					'discount_tax' => $cart->get_coupon_discount_tax_amount( $code ),
 				)
 			);
-			$item->add_meta_data( 'coupon_data', $coupon->get_data() );
+
+			// Avoid storing used_by - it's not needed and can get large.
+			$coupon_data = $coupon->get_data();
+			unset( $coupon_data['used_by'] );
+			$item->add_meta_data( 'coupon_data', $coupon_data );
 
 			/**
 			 * Action hook to adjust item before save.


### PR DESCRIPTION
When orders are saved, a copy of the coupon is stored to meta data so the discount can be reapplied in the future should the original be deleted.

A side effect of this is that `used_by` also gets stored - this is an array of emails which have used the coupon in the past. We don’t need this data stored to orders.

To fix, simply unsets `used_by` when saving the data to the order.

Sadly there isn’t a way to clean up old orders because this meta is serialized.

To test, apply a coupon to cart and submit a new order. Check the `coupon_data` meta key in oreritem_data table. `used_by` should not be in the value.

Closes #19450