### PR TITLE
Load meta box input values using CRUD and edit context

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -78,6 +78,7 @@ class WC_Meta_Box_Coupon_Data {
 						'id'      => 'discount_type',
 						'label'   => __( 'Discount type', 'woocommerce' ),
 						'options' => wc_get_coupon_types(),
+						'value'   => $coupon->get_discount_type( 'edit' ),
 					)
 				);
 
@@ -90,6 +91,7 @@ class WC_Meta_Box_Coupon_Data {
 						'description' => __( 'Value of the coupon.', 'woocommerce' ),
 						'data_type'   => 'price',
 						'desc_tip'    => true,
+						'value'       => $coupon->get_amount( 'edit' ),
 					)
 				);
 
@@ -100,12 +102,13 @@ class WC_Meta_Box_Coupon_Data {
 							'id'          => 'free_shipping',
 							'label'       => __( 'Allow free shipping', 'woocommerce' ),
 							'description' => sprintf( __( 'Check this box if the coupon grants free shipping. A <a href="%s" target="_blank">free shipping method</a> must be enabled in your shipping zone and be set to require "a valid free shipping coupon" (see the "Free Shipping Requires" setting).', 'woocommerce' ), 'https://docs.woocommerce.com/document/free-shipping/' ),
+							'value'       => wc_bool_to_string( $coupon->get_free_shipping( 'edit' ) ),
 						)
 					);
 				}
 
 				// Expiry date.
-				$expiry_date = $coupon->get_date_expires() ? $coupon->get_date_expires()->date( 'Y-m-d' ) : '';
+				$expiry_date = $coupon->get_date_expires( 'edit' ) ? $coupon->get_date_expires( 'edit' )->date( 'Y-m-d' ) : '';
 				woocommerce_wp_text_input(
 					array(
 						'id'                => 'expiry_date',
@@ -138,6 +141,7 @@ class WC_Meta_Box_Coupon_Data {
 						'description' => __( 'This field allows you to set the minimum spend (subtotal) allowed to use the coupon.', 'woocommerce' ),
 						'data_type'   => 'price',
 						'desc_tip'    => true,
+						'value'       => $coupon->get_minimum_amount( 'edit' ),
 					)
 				);
 
@@ -150,6 +154,7 @@ class WC_Meta_Box_Coupon_Data {
 						'description' => __( 'This field allows you to set the maximum spend (subtotal) allowed when using the coupon.', 'woocommerce' ),
 						'data_type'   => 'price',
 						'desc_tip'    => true,
+						'value'       => $coupon->get_maximum_amount( 'edit' ),
 					)
 				);
 
@@ -159,6 +164,7 @@ class WC_Meta_Box_Coupon_Data {
 						'id'          => 'individual_use',
 						'label'       => __( 'Individual use only', 'woocommerce' ),
 						'description' => __( 'Check this box if the coupon cannot be used in conjunction with other coupons.', 'woocommerce' ),
+						'value'       => wc_bool_to_string( $coupon->get_individual_use( 'edit' ) ),
 					)
 				);
 
@@ -168,6 +174,7 @@ class WC_Meta_Box_Coupon_Data {
 						'id'          => 'exclude_sale_items',
 						'label'       => __( 'Exclude sale items', 'woocommerce' ),
 						'description' => __( 'Check this box if the coupon should not apply to items on sale. Per-item coupons will only work if the item is not on sale. Per-cart coupons will only work if there are items in the cart that are not on sale.', 'woocommerce' ),
+						'value'       => wc_bool_to_string( $coupon->get_exclude_sale_items( 'edit' ) ),
 					)
 				);
 
@@ -179,7 +186,7 @@ class WC_Meta_Box_Coupon_Data {
 					<label><?php _e( 'Products', 'woocommerce' ); ?></label>
 					<select class="wc-product-search" multiple="multiple" style="width: 50%;" name="product_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations">
 						<?php
-						$product_ids = $coupon->get_product_ids();
+						$product_ids = $coupon->get_product_ids( 'edit' );
 
 						foreach ( $product_ids as $product_id ) {
 							$product = wc_get_product( $product_id );
@@ -197,7 +204,7 @@ class WC_Meta_Box_Coupon_Data {
 					<label><?php _e( 'Exclude products', 'woocommerce' ); ?></label>
 					<select class="wc-product-search" multiple="multiple" style="width: 50%;" name="exclude_product_ids[]" data-placeholder="<?php esc_attr_e( 'Search for a product&hellip;', 'woocommerce' ); ?>" data-action="woocommerce_json_search_products_and_variations">
 						<?php
-						$product_ids = $coupon->get_excluded_product_ids();
+						$product_ids = $coupon->get_excluded_product_ids( 'edit' );
 
 						foreach ( $product_ids as $product_id ) {
 							$product = wc_get_product( $product_id );
@@ -219,7 +226,7 @@ class WC_Meta_Box_Coupon_Data {
 					<label for="product_categories"><?php _e( 'Product categories', 'woocommerce' ); ?></label>
 					<select id="product_categories" name="product_categories[]" style="width: 50%;"  class="wc-enhanced-select" multiple="multiple" data-placeholder="<?php esc_attr_e( 'Any category', 'woocommerce' ); ?>">
 						<?php
-						$category_ids = $coupon->get_product_categories();
+						$category_ids = $coupon->get_product_categories( 'edit' );
 						$categories   = get_terms( 'product_cat', 'orderby=name&hide_empty=0' );
 
 						if ( $categories ) {
@@ -236,7 +243,7 @@ class WC_Meta_Box_Coupon_Data {
 					<label for="exclude_product_categories"><?php _e( 'Exclude categories', 'woocommerce' ); ?></label>
 					<select id="exclude_product_categories" name="exclude_product_categories[]" style="width: 50%;"  class="wc-enhanced-select" multiple="multiple" data-placeholder="<?php esc_attr_e( 'No categories', 'woocommerce' ); ?>">
 						<?php
-						$category_ids = $coupon->get_excluded_product_categories();
+						$category_ids = $coupon->get_excluded_product_categories( 'edit' );
 						$categories   = get_terms( 'product_cat', 'orderby=name&hide_empty=0' );
 
 						if ( $categories ) {
@@ -258,7 +265,7 @@ class WC_Meta_Box_Coupon_Data {
 						'label'             => __( 'Email restrictions', 'woocommerce' ),
 						'placeholder'       => __( 'No restrictions', 'woocommerce' ),
 						'description'       => __( 'List of allowed emails to check against the customer billing email when an order is placed. Separate email addresses with commas. You can also use an asterisk (*) to match parts of an email. For example "*@gmail.com" would match all gmail addresses.', 'woocommerce' ),
-						'value'             => implode( ', ', (array) $coupon->get_email_restrictions() ),
+						'value'             => implode( ', ', (array) $coupon->get_email_restrictions( 'edit' ) ),
 						'desc_tip'          => true,
 						'type'              => 'email',
 						'class'             => '',
@@ -288,7 +295,7 @@ class WC_Meta_Box_Coupon_Data {
 								'step' => 1,
 								'min'  => 0,
 							),
-							'value'             => $coupon->get_usage_limit() ? $coupon->get_usage_limit() : '',
+							'value'             => $coupon->get_usage_limit( 'edit' ) ? $coupon->get_usage_limit( 'edit' ) : '',
 						)
 					);
 
@@ -306,7 +313,7 @@ class WC_Meta_Box_Coupon_Data {
 								'step' => 1,
 								'min'  => 0,
 							),
-							'value'             => $coupon->get_limit_usage_to_x_items() ? $coupon->get_limit_usage_to_x_items() : '',
+							'value'             => $coupon->get_limit_usage_to_x_items( 'edit' ) ? $coupon->get_limit_usage_to_x_items( 'edit' ) : '',
 						)
 					);
 
@@ -324,7 +331,7 @@ class WC_Meta_Box_Coupon_Data {
 								'step' => 1,
 								'min'  => 0,
 							),
-							'value'             => $coupon->get_usage_limit_per_user() ? $coupon->get_usage_limit_per_user() : '',
+							'value'             => $coupon->get_usage_limit_per_user( 'edit' ) ? $coupon->get_usage_limit_per_user( 'edit' ) : '',
 						)
 					);
 					?>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -409,6 +409,7 @@ class WC_Meta_Box_Order_Data {
 								array(
 									'id'    => '_transaction_id',
 									'label' => __( 'Transaction ID', 'woocommerce' ),
+									'value' => $order->get_transaction_id( 'edit' ),
 								)
 							);
 							?>


### PR DESCRIPTION
Closes #19641 

To test, just edit or add some coupons. The values in the input boxes should work/save/display normally.