### PR TITLE
sanitize_text_field does not preserve line breaks. wp_kses_post seems more appropriate.

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -270,7 +270,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 			$meta->value   = rawurldecode( (string) $meta->value );
 			$attribute_key = str_replace( 'attribute_', '', $meta->key );
 			$display_key   = wc_attribute_label( $attribute_key, $product );
-			$display_value = sanitize_text_field( $meta->value );
+			$display_value = wp_kses_post( $meta->value );
 
 			if ( taxonomy_exists( $attribute_key ) ) {
 				$term = get_term_by( 'slug', $meta->value, $attribute_key );


### PR DESCRIPTION
Fixes #19661

To test, add some meta to an order line item with line breaks. See description in https://github.com/woocommerce/woocommerce/issues/19661