### PR TITLE
Fix Rest API featured filter

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -246,6 +246,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 				'taxonomy' => 'product_visibility',
 				'field'    => 'name',
 				'terms'    => 'featured',
+				'operator' => true === $request['featured'] ? 'IN' : 'NOT IN',
 			);
 		}
 

--- a/includes/api/legacy/class-wc-rest-legacy-products-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-products-controller.php
@@ -94,6 +94,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 				'taxonomy' => 'product_visibility',
 				'field'    => 'name',
 				'terms'    => 'featured',
+				'operator' => true === $request['featured'] ? 'IN' : 'NOT IN',
 			);
 		}
 


### PR DESCRIPTION
Fixes #19674

The logic was just looking to see if `featured` was set. It was not setting the correct `operator` to include/exclude featured products.

To test, test endpoints:

https://local.wordpress.test/wp-json/wc/v2/products?featured=true
https://local.wordpress.test/wp-json/wc/v2/products?featured=false

They should contain different results.