### PR TITLE
Remove wp_reset_postdata from up-sells

### DIFF
--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -44,5 +44,3 @@ if ( $upsells ) : ?>
 	</section>
 
 <?php endif;
-
-wp_reset_postdata();


### PR DESCRIPTION
Removing wp_reset_postdata as i think this is redundant now there is no longer a WP_Query