### PR TITLE
Setup wizard: Bug fix and support for non-slug filenames in plugin installer

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -648,7 +648,6 @@ class WC_Admin_Setup_Wizard {
 		$this->install_plugin(
 			'jetpack',
 			array(
-				'file'      => 'jetpack/jetpack.php',
 				'name'      => __( 'Jetpack', 'woocommerce' ),
 				'repo-slug' => 'jetpack',
 			)
@@ -663,7 +662,6 @@ class WC_Admin_Setup_Wizard {
 		$this->install_plugin(
 			'woocommerce-services',
 			array(
-				'file'      => 'woocommerce-services/woocommerce-services.php',
 				'name'      => __( 'WooCommerce Services', 'woocommerce' ),
 				'repo-slug' => 'woocommerce-services',
 			)
@@ -1892,7 +1890,6 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		WC_Install::background_installer( 'jetpack', array(
-			'file'      => 'jetpack/jetpack.php',
 			'name'      => __( 'Jetpack', 'woocommerce' ),
 			'repo-slug' => 'jetpack',
 		) );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -593,7 +593,7 @@ class WC_Admin_Setup_Wizard {
 	 * Helper method to queue the background install of a plugin.
 	 *
 	 * @param string $plugin_id  Plugin id used for background install.
-	 * @param array  $plugin_info Plugin info array containing at least main file and repo slug.
+	 * @param array  $plugin_info Plugin info array containing name and repo-slug, and optionally file if different from [repo-slug].php.
 	 */
 	protected function install_plugin( $plugin_id, $plugin_info ) {
 		// Make sure we don't trigger multiple simultaneous installs.
@@ -601,7 +601,8 @@ class WC_Admin_Setup_Wizard {
 			return;
 		}
 
-		if ( ! empty( $plugin_info['file'] ) && is_plugin_active( $plugin_info['file'] ) ) {
+		$plugin_file = isset( $plugin_info['file'] ) ? $plugin_info['file'] : $plugin_info['repo-slug'] . '.php';
+		if ( is_plugin_active( $plugin_info['repo-slug'] . '/' . $plugin_file ) ) {
 			return;
 		}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1058,13 +1058,12 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	/**
 	 * Get slug from path and associate it with the path.
 	 *
-	 * @param array  $plugins Associative array of plugin slugs to paths.
+	 * @param array  $plugins Associative array of plugin files to paths.
 	 * @param string $key Plugin relative path. Example: woocommerce/woocommerce.php.
 	 */
-	private static function associate_plugin_slug( $plugins, $key ) {
-		$slug                = explode( '/', $key );
-		$slug                = explode( '.', end( $slug ) );
-		$plugins[ $slug[0] ] = $key;
+	private static function associate_plugin_file( $plugins, $key ) {
+		$path                = explode( '/', $key );
+		$plugins[ $path[1] ] = $key;
 		return $plugins;
 	}
 
@@ -1091,15 +1090,16 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 
 			$skin              = new Automatic_Upgrader_Skin();
 			$upgrader          = new WP_Upgrader( $skin );
-			$installed_plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'associate_plugin_slug' ), array() );
+			$installed_plugins = array_reduce( array_keys( get_plugins() ), array( __CLASS__, 'associate_plugin_file' ), array() );
 			$plugin_slug       = $plugin_to_install['repo-slug'];
+			$plugin_file       = isset( $plugin_to_install['file'] ) ? $plugin_to_install['file'] : $plugin_slug . '.php';
 			$installed         = false;
 			$activate          = false;
 
 			// See if the plugin is installed already.
-			if ( isset( $installed_plugins[ $plugin_slug ] ) ) {
+			if ( isset( $installed_plugins[ $plugin_file ] ) ) {
 				$installed = true;
-				$activate  = ! is_plugin_active( $installed_plugins[ $plugin_slug ] );
+				$activate  = ! is_plugin_active( $installed_plugins[ $plugin_file ] );
 			}
 
 			// Install this thing!
@@ -1111,7 +1111,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 					$plugin_information = plugins_api(
 						'plugin_information',
 						array(
-							'slug'   => $plugin_to_install['repo-slug'],
+							'slug'   => $plugin_slug,
 							'fields' => array(
 								'short_description' => false,
 								'sections'          => false,
@@ -1175,7 +1175,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 							__( '%1$s could not be installed (%2$s). <a href="%3$s">Please install it manually by clicking here.</a>', 'woocommerce' ),
 							$plugin_to_install['name'],
 							$e->getMessage(),
-							esc_url( admin_url( 'index.php?wc-install-plugin-redirect=' . $plugin_to_install['repo-slug'] ) )
+							esc_url( admin_url( 'index.php?wc-install-plugin-redirect=' . $plugin_slug ) )
 						)
 					);
 				}
@@ -1189,7 +1189,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			// Activate this thing.
 			if ( $activate ) {
 				try {
-					$result = activate_plugin( $installed_plugins[ $plugin_slug ] );
+					$result = activate_plugin( $installed_plugins[ $plugin_file ] );
 
 					if ( is_wp_error( $result ) ) {
 						throw new Exception( $result->get_error_message() );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1189,7 +1189,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			// Activate this thing.
 			if ( $activate ) {
 				try {
-					$result = activate_plugin( $installed_plugins[ $plugin_file ] );
+					$result = activate_plugin( $installed ? $installed_plugins[ $plugin_file ] : $plugin_slug . '/' . $plugin_file );
 
 					if ( is_wp_error( $result ) ) {
 						throw new Exception( $result->get_error_message() );


### PR DESCRIPTION
Updates plugin installer (and caller code in wizard) to support plugin PHP filename distinct from repository slug, e.g. `mailchimp-for-woocommerce/mailchimp-woocommerce.php`.

Also fixes bug in which plugins weren't being activated after installation (introduced by yours truly in a prior PR, thankfully not yet part of a release).

Specific changes:

- 'file' in $plugin_info argument is now just the filename _without the directory_, and defaults to [repo-slug].php
- Now _always_ checks for active plugin before scheduling background install, and not only if 'file' is specified
- Background installer uses 'file' to check for the same plugin under a different directory (such as `woocommerce-square-master/woocommerce-square.php` — enhancement of solution in https://github.com/woocommerce/woocommerce/pull/19200)
- Fixes bug introduced in that PR, which thwarted activating plugin immediately after installation

Test cases:
- install and activate `woocommerce-square` (typical case)
- activate `woocommerce-square` when already installed into differently named directory
- install and activate `mailchimp-for-woocommerce` (for example, by modifying plugin info to `'repo-slug' => 'mailchimp-for-woocommerce', 'file' => 'mailchimp-woocommerce.php'`)

(Note: if https://github.com/woocommerce/woocommerce/pull/19723 is merged first, then this branch should be rebased and a line added `'file' => 'mailchimp-woocommerce.php',`)