### PR TITLE
Add privacy policy to account pages

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -548,6 +548,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							'class'            => $value['class'],
 							'echo'             => false,
 							'selected'         => absint( self::get_option( $value['id'], $value['default'] ) ),
+							'post_status'      => 'publish,private,draft',
 						);
 
 						if ( isset( $value['args'] ) ) {

--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -101,6 +101,47 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					'id'   => 'account_registration_options',
 				),
 
+				array(
+					'title' => __( 'Privacy policy', 'woocommerce' ),
+					'type'  => 'title',
+					'id'    => 'privacy_policy_options',
+					'desc'  => __( 'This section controls the display of your website privacy policy. The privacy notices below will not show up unless a privacy page is first set.', 'woocommerce' ),
+				),
+
+				array(
+					'title'    => __( 'Privacy page', 'woocommerce' ),
+					'desc'     => __( 'Choose a page to act as your privacy policy.', 'woocommerce' ),
+					'id'       => 'wp_page_for_privacy_policy',
+					'type'     => 'single_select_page',
+					'default'  => '',
+					'class'    => 'wc-enhanced-select-nostd',
+					'css'      => 'min-width:300px;',
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Registration privacy policy', 'woocommerce' ),
+					'desc_tip' => __( 'Optionally add some text about your store privacy policy to show on account registration forms.', 'woocommerce' ),
+					'id'       => 'woocommerce_registration_privacy_policy_text',
+					'default'  => __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [privacy_policy].', 'woocommerce' ),
+					'type'     => 'textarea',
+					'css'      => 'min-width: 50%; height: 75px;',
+				),
+
+				array(
+					'title'    => __( 'Checkout privacy policy', 'woocommerce' ),
+					'desc_tip' => __( 'Optionally add some text about your store privacy policy to show during checkout.', 'woocommerce' ),
+					'id'       => 'woocommerce_checkout_privacy_policy_text',
+					'default'  => __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ),
+					'type'     => 'textarea',
+					'css'      => 'min-width: 50%; height: 75px;',
+				),
+
+				array(
+					'type' => 'sectionend',
+					'id'   => 'privacy_policy_options',
+				),
+
 			)
 		);
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -595,10 +595,20 @@ function wc_get_terms_and_conditions_checkbox_text() {
  * Get the privacy policy text, if set.
  *
  * @since 3.4.0
+ * @param string $type Type of policy to load. Valid values include registration and checkout.
  * @return string
  */
-function wc_get_privacy_policy_text() {
-	return trim( apply_filters( 'woocommerce_get_privacy_policy_text', get_option( 'woocommerce_checkout_privacy_policy_text', __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ) ) ) );
+function wc_get_privacy_policy_text( $type = '' ) {
+	switch ( $type ) {
+		case 'checkout':
+			$text = get_option( 'woocommerce_checkout_privacy_policy_text', __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ) );
+			break;
+		case 'registration':
+			$text = get_option( 'woocommerce_registration_privacy_policy_text', __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [privacy_policy].', 'woocommerce' ) );
+			break;
+	}
+
+	return trim( apply_filters( 'woocommerce_get_privacy_policy_text', $text, $type ) );
 }
 
 /**
@@ -636,16 +646,23 @@ function wc_terms_and_conditions_page_content() {
 }
 
 /**
- * Output t&c text. This is custom text which can be added via the customizer.
+ * Output privacy policy text. This is custom text which can be added via the customizer/privacy settings section.
+ *
+ * Loads the relevent policy for the current page unless a specfic policy text is required.
  *
  * @since 3.4.0
+ * @param string $type Type of policy to load. Valid values include registration and checkout.
  */
-function wc_privacy_policy_text() {
+function wc_privacy_policy_text( $type = '' ) {
 	if ( ! wc_privacy_policy_page_id() ) {
 		return;
 	}
 
-	$text = wc_get_privacy_policy_text();
+	if ( ! $type ) {
+		$type = is_checkout() ? 'checkout' : 'registration';
+	}
+
+	$text = wc_get_privacy_policy_text( $type );
 
 	if ( ! $text ) {
 		return;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -599,6 +599,8 @@ function wc_get_terms_and_conditions_checkbox_text() {
  * @return string
  */
 function wc_get_privacy_policy_text( $type = '' ) {
+	$text = '';
+
 	switch ( $type ) {
 		case 'checkout':
 			$text = get_option( 'woocommerce_checkout_privacy_policy_text', __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ) );

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -287,3 +287,4 @@ add_action( 'woocommerce_account_edit-address_endpoint', 'woocommerce_account_ed
 add_action( 'woocommerce_account_payment-methods_endpoint', 'woocommerce_account_payment_methods' );
 add_action( 'woocommerce_account_add-payment-method_endpoint', 'woocommerce_account_add_payment_method' );
 add_action( 'woocommerce_account_edit-account_endpoint', 'woocommerce_account_edit_account' );
+add_action( 'woocommerce_register_form', 'wc_privacy_policy_text', 20 );


### PR DESCRIPTION
This implements some privacy settings to control text on checkout/account, and updates the template functions to handle the new options.

Settings:

![settings](https://user-images.githubusercontent.com/90977/38886477-f8912192-426d-11e8-9498-bc28f2273911.png)

And end result on account page:

![form](https://user-images.githubusercontent.com/90977/38886486-fe3d8cfc-426d-11e8-94a5-4867dd2ff140.png)

Both options require a privacy page to be set. This shares the same option name with WP core.

Closes #19734