### PR TITLE
Notice about HTTPS as a requirement

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -2,15 +2,11 @@
 /**
  * Display notices in admin
  *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin
- * @version     2.3.0
+ * @package WooCommerce\Admin
+ * @version 3.4.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Notices Class.
@@ -86,7 +82,7 @@ class WC_Admin_Notices {
 		$simplify_options = get_option( 'woocommerce_simplify_commerce_settings', array() );
 		$location         = wc_get_base_location();
 
-		if ( ! class_exists( 'WC_Gateway_Simplify_Commerce_Loader' ) && ! empty( $simplify_options['enabled'] ) && 'yes' === $simplify_options['enabled'] && in_array( $location['country'], apply_filters( 'woocommerce_gateway_simplify_commerce_supported_countries', array( 'US', 'IE' ) ) ) ) {
+		if ( ! class_exists( 'WC_Gateway_Simplify_Commerce_Loader' ) && ! empty( $simplify_options['enabled'] ) && 'yes' === $simplify_options['enabled'] && in_array( $location['country'], apply_filters( 'woocommerce_gateway_simplify_commerce_supported_countries', array( 'US', 'IE' ) ), true ) ) {
 			WC_Admin_Notices::add_notice( 'simplify_commerce' );
 		}
 
@@ -96,7 +92,7 @@ class WC_Admin_Notices {
 	/**
 	 * Show a notice.
 	 *
-	 * @param string $name
+	 * @param string $name Notice name.
 	 */
 	public static function add_notice( $name ) {
 		self::$notices = array_unique( array_merge( self::get_notices(), array( $name ) ) );
@@ -105,7 +101,7 @@ class WC_Admin_Notices {
 	/**
 	 * Remove a notice from being displayed.
 	 *
-	 * @param  string $name
+	 * @param string $name Notice name.
 	 */
 	public static function remove_notice( $name ) {
 		self::$notices = array_diff( self::get_notices(), array( $name ) );
@@ -115,27 +111,27 @@ class WC_Admin_Notices {
 	/**
 	 * See if a notice is being shown.
 	 *
-	 * @param  string $name
+	 * @param  string $name Notice name.
 	 * @return boolean
 	 */
 	public static function has_notice( $name ) {
-		return in_array( $name, self::get_notices() );
+		return in_array( $name, self::get_notices(), true );
 	}
 
 	/**
 	 * Hide a notice if the GET variable is set.
 	 */
 	public static function hide_notices() {
-		if ( isset( $_GET['wc-hide-notice'] ) && isset( $_GET['_wc_notice_nonce'] ) ) {
-			if ( ! wp_verify_nonce( $_GET['_wc_notice_nonce'], 'woocommerce_hide_notices_nonce' ) ) {
-				wp_die( __( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
+		if ( isset( $_GET['wc-hide-notice'] ) && isset( $_GET['_wc_notice_nonce'] ) ) { // WPCS: input var ok, CSRF ok.
+			if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wc_notice_nonce'] ) ), 'woocommerce_hide_notices_nonce' ) ) { // WPCS: input var ok, CSRF ok.
+				wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
 			}
 
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				wp_die( __( 'You don&#8217;t have permission to do this.', 'woocommerce' ) );
+				wp_die( esc_html__( 'You don&#8217;t have permission to do this.', 'woocommerce' ) );
 			}
 
-			$hide_notice = sanitize_text_field( $_GET['wc-hide-notice'] );
+			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
 
 			self::remove_notice( $hide_notice );
 
@@ -154,7 +150,7 @@ class WC_Admin_Notices {
 		if ( ! empty( $notices ) ) {
 			wp_enqueue_style( 'woocommerce-activation', plugins_url( '/assets/css/activation.css', WC_PLUGIN_FILE ), array(), WC_VERSION );
 
-			// Add RTL support
+			// Add RTL support.
 			wp_style_add_data( 'woocommerce-activation', 'rtl', 'replace' );
 
 			foreach ( $notices as $notice ) {
@@ -170,8 +166,8 @@ class WC_Admin_Notices {
 	/**
 	 * Add a custom notice.
 	 *
-	 * @param string $name
-	 * @param string $notice_html
+	 * @param string $name        Notice name.
+	 * @param string $notice_html Notice HTML.
 	 */
 	public static function add_custom_notice( $name, $notice_html ) {
 		self::add_notice( $name );
@@ -190,7 +186,7 @@ class WC_Admin_Notices {
 					$notice_html = get_option( 'woocommerce_admin_notice_' . $notice );
 
 					if ( $notice_html ) {
-						include 'views/html-notice-custom.php';
+						include dirname( __FILE__ ) . '/views/html-notice-custom.php';
 					}
 				}
 			}
@@ -203,13 +199,13 @@ class WC_Admin_Notices {
 	public static function update_notice() {
 		if ( version_compare( get_option( 'woocommerce_db_version' ), WC_VERSION, '<' ) ) {
 			$updater = new WC_Background_Updater();
-			if ( $updater->is_updating() || ! empty( $_GET['do_update_woocommerce'] ) ) {
-				include 'views/html-notice-updating.php';
+			if ( $updater->is_updating() || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+				include dirname( __FILE__ ) . '/views/html-notice-updating.php';
 			} else {
-				include 'views/html-notice-update.php';
+				include dirname( __FILE__ ) . '/views/html-notice-update.php';
 			}
 		} else {
-			include 'views/html-notice-updated.php';
+			include dirname( __FILE__ ) . '/views/html-notice-updated.php';
 		}
 	}
 
@@ -217,7 +213,7 @@ class WC_Admin_Notices {
 	 * If we have just installed, show a message with the install pages button.
 	 */
 	public static function install_notice() {
-		include 'views/html-notice-install.php';
+		include dirname( __FILE__ ) . '/views/html-notice-install.php';
 	}
 
 	/**
@@ -229,7 +225,7 @@ class WC_Admin_Notices {
 		wc_deprecated_function( 'WC_Admin_Notices::theme_check_notice', '3.3.0' );
 
 		if ( ! current_theme_supports( 'woocommerce' ) ) {
-			include 'views/html-notice-theme-support.php';
+			include dirname( __FILE__ ) . '/views/html-notice-theme-support.php';
 		}
 	}
 
@@ -265,7 +261,7 @@ class WC_Admin_Notices {
 		}
 
 		if ( $outdated ) {
-			include 'views/html-notice-template-check.php';
+			include dirname( __FILE__ ) . '/views/html-notice-template-check.php';
 		} else {
 			self::remove_notice( 'template_files' );
 		}
@@ -286,7 +282,7 @@ class WC_Admin_Notices {
 		}
 
 		if ( $enabled ) {
-			include 'views/html-notice-legacy-shipping.php';
+			include dirname( __FILE__ ) . '/views/html-notice-legacy-shipping.php';
 		} else {
 			self::remove_notice( 'template_files' );
 		}
@@ -296,12 +292,12 @@ class WC_Admin_Notices {
 	 * No shipping methods.
 	 */
 	public static function no_shipping_methods_notice() {
-		if ( wc_shipping_enabled() && ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) ) {
+		if ( wc_shipping_enabled() && ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) ) { // WPCS: input var ok, CSRF ok.
 			$product_count = wp_count_posts( 'product' );
 			$method_count  = wc_get_shipping_method_count();
 
 			if ( $product_count->publish > 0 && 0 === $method_count ) {
-				include 'views/html-notice-no-shipping-methods.php';
+				include dirname( __FILE__ ) . '/views/html-notice-no-shipping-methods.php';
 			}
 
 			if ( $method_count > 0 ) {
@@ -316,12 +312,12 @@ class WC_Admin_Notices {
 	public static function simplify_commerce_notice() {
 		$location = wc_get_base_location();
 
-		if ( class_exists( 'WC_Gateway_Simplify_Commerce_Loader' ) || ! in_array( $location['country'], apply_filters( 'woocommerce_gateway_simplify_commerce_supported_countries', array( 'US', 'IE' ) ) ) ) {
+		if ( class_exists( 'WC_Gateway_Simplify_Commerce_Loader' ) || ! in_array( $location['country'], apply_filters( 'woocommerce_gateway_simplify_commerce_supported_countries', array( 'US', 'IE' ) ), true ) ) {
 			self::remove_notice( 'simplify_commerce' );
 			return;
 		}
-		if ( empty( $_GET['action'] ) ) {
-			include 'views/html-notice-simplify-commerce.php';
+		if ( empty( $_GET['action'] ) ) { // WPCS: input var ok, CSRF ok.
+			include dirname( __FILE__ ) . '/views/html-notice-simplify-commerce.php';
 		}
 	}
 
@@ -329,7 +325,7 @@ class WC_Admin_Notices {
 	 * Notice shown when regenerating thumbnails background process is running.
 	 */
 	public static function regenerating_thumbnails_notice() {
-		include 'views/html-notice-regenerating-thumbnails.php';
+		include dirname( __FILE__ ) . '/views/html-notice-regenerating-thumbnails.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -37,6 +37,7 @@ class WC_Admin_Notices {
 		'no_shipping_methods'     => 'no_shipping_methods_notice',
 		'simplify_commerce'       => 'simplify_commerce_notice',
 		'regenerating_thumbnails' => 'regenerating_thumbnails_notice',
+		'no_secure_connection'    => 'secure_connection_notice',
 	);
 
 	/**
@@ -329,6 +330,13 @@ class WC_Admin_Notices {
 	 */
 	public static function regenerating_thumbnails_notice() {
 		include 'views/html-notice-regenerating-thumbnails.php';
+	}
+
+	/**
+	 * Notice about secure connection.
+	 */
+	public static function secure_connection_notice() {
+		include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
 	}
 }
 

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -81,9 +81,14 @@ class WC_Admin_Notices {
 	public static function reset_admin_notices() {
 		$simplify_options = get_option( 'woocommerce_simplify_commerce_settings', array() );
 		$location         = wc_get_base_location();
+		$shop_page        = 0 < wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : get_home_url();
 
 		if ( ! class_exists( 'WC_Gateway_Simplify_Commerce_Loader' ) && ! empty( $simplify_options['enabled'] ) && 'yes' === $simplify_options['enabled'] && in_array( $location['country'], apply_filters( 'woocommerce_gateway_simplify_commerce_supported_countries', array( 'US', 'IE' ) ), true ) ) {
 			WC_Admin_Notices::add_notice( 'simplify_commerce' );
+		}
+
+		if ( ! is_ssl() || 'https' !== substr( $shop_page, 0, 5 ) ) {
+			WC_Admin_Notices::add_notice( 'no_secure_connection' );
 		}
 
 		self::add_notice( 'template_files' );
@@ -332,6 +337,10 @@ class WC_Admin_Notices {
 	 * Notice about secure connection.
 	 */
 	public static function secure_connection_notice() {
+		if ( get_user_meta( get_current_user_id(), 'dismissed_no_secure_connection_notice', true ) ) {
+			return;
+		}
+
 		include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
 	}
 }

--- a/includes/admin/views/html-notice-secure-connection.php
+++ b/includes/admin/views/html-notice-secure-connection.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 	<?php
 		echo wp_kses_post( sprintf(
 			/* translators: %s: documentation URL */
-			__( 'Your store is not using HTTPS, this is requeried to sell in some countries and to protect your customer data. <a href="%s">Learn more about HTTPS and SSL Certificates.</a>', 'woocommerce' ),
+			__( 'Your store does not appear to be using a secure connection. We highly recommend serving your entire website over a https connection to help keep customer data secure. <a href="%s">Learn more here.</a>', 'woocommerce' ),
 			'https://docs.woocommerce.com/document/ssl-and-https/'
 		) );
 	?>

--- a/includes/admin/views/html-notice-secure-connection.php
+++ b/includes/admin/views/html-notice-secure-connection.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Admin View: Notice - Secure connection.
+ *
+ * @package WooCommerce\Admin\Notices
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div id="message" class="updated woocommerce-message">
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'no_secure_connection' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+	<p>
+	<?php
+		echo sprintf(
+			/* translators: %s: documentation URL */
+			esc_html__( 'Your store is not using HTTPS, this is requeried to sell in some countries and to protect your customer data. <a href="%s">Learn more about HTTPS and SSL Certificates.</a>', 'woocommerce' )
+		);
+	?>
+	</p>
+</div>

--- a/includes/admin/views/html-notice-secure-connection.php
+++ b/includes/admin/views/html-notice-secure-connection.php
@@ -13,10 +13,11 @@ defined( 'ABSPATH' ) || exit;
 
 	<p>
 	<?php
-		echo sprintf(
+		echo wp_kses_post( sprintf(
 			/* translators: %s: documentation URL */
-			esc_html__( 'Your store is not using HTTPS, this is requeried to sell in some countries and to protect your customer data. <a href="%s">Learn more about HTTPS and SSL Certificates.</a>', 'woocommerce' )
-		);
+			__( 'Your store is not using HTTPS, this is requeried to sell in some countries and to protect your customer data. <a href="%s">Learn more about HTTPS and SSL Certificates.</a>', 'woocommerce' ),
+			'https://docs.woocommerce.com/document/ssl-and-https/'
+		) );
 	?>
 	</p>
 </div>


### PR DESCRIPTION
### Requirements completed:

- [x] Add an admin notice if HTTPS is not used. This should check checkout and admin, and could also check site and home URLs. [¹]
- [x] Link to docs on how to get SSL setup
- [x] Should be dismissible but at least we've done our bit to inform the user

[¹] Checks using `is_ssl()` and/or the shop page, since should be better have HTTPS over all site instead of just a few pages, not to mention that is safer too.

Also the message will be displayed for every user on admin, and should be dismissable based on user metadata.

### Steps to test:

- Just change to a new theme.

Also it's possible forcing an update, but changing theme should be good enough for here.
For even running `WC_Admin_Notices::add_notice( 'no_secure_connection' );`.

Related to #19735