### PR TITLE
OBW: Prevent MailChimp from redirecting after activation.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1704,6 +1704,9 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		if ( $setup_mailchimp ) {
+			// Prevent MailChimp from redirecting to its settings page during the OBW flow.
+			add_option( 'mailchimp_woocommerce_plugin_do_activation_redirect', false );
+
 			$this->install_plugin(
 				'mailchimp-for-woocommerce',
 				array(


### PR DESCRIPTION
MailChimp redirects to its settings page upon activation:

![mailchimp-dashboard-takeover](https://user-images.githubusercontent.com/63922/38903676-4008ebf0-4263-11e8-83df-04dca3dbb9cd.gif)

This PR prevents that.

To test:
- Verify that no redirection takes place when selecting MailChimp in the OBW