### PR TITLE
OBW: Save locale-specific measurement units upon saving address

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -538,15 +538,17 @@ class WC_Admin_Setup_Wizard {
 
 		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
 
-		// Set currency formatting options based on chosen location and currency.
-		if (
-			isset( $locale_info[ $country ] ) &&
-			$locale_info[ $country ]['currency_code'] === $currency_code
-		) {
-			update_option( 'woocommerce_currency_pos', $locale_info[ $country ]['currency_pos'] );
-			update_option( 'woocommerce_price_decimal_sep', $locale_info[ $country ]['decimal_sep'] );
-			update_option( 'woocommerce_price_num_decimals', $locale_info[ $country ]['num_decimals'] );
-			update_option( 'woocommerce_price_thousand_sep', $locale_info[ $country ]['thousand_sep'] );
+		if ( isset( $locale_info[ $country ] ) ) {
+			update_option( 'woocommerce_weight_unit', $locale_info[ $country ]['weight_unit'] );
+			update_option( 'woocommerce_dimension_unit', $locale_info[ $country ]['dimension_unit'] );
+
+			// Set currency formatting options based on chosen location and currency.
+			if ( $locale_info[ $country ]['currency_code'] === $currency_code ) {
+				update_option( 'woocommerce_currency_pos', $locale_info[ $country ]['currency_pos'] );
+				update_option( 'woocommerce_price_decimal_sep', $locale_info[ $country ]['decimal_sep'] );
+				update_option( 'woocommerce_price_num_decimals', $locale_info[ $country ]['num_decimals'] );
+				update_option( 'woocommerce_price_thousand_sep', $locale_info[ $country ]['thousand_sep'] );
+			}
 		}
 
 		if ( $tracking ) {
@@ -819,19 +821,6 @@ class WC_Admin_Setup_Wizard {
 		$existing_zones        = WC_Shipping_Zones::get_zones();
 		$dimension_unit        = get_option( 'woocommerce_dimension_unit' );
 		$weight_unit           = get_option( 'woocommerce_weight_unit' );
-		$locale_info           = include WC()->plugin_path() . '/i18n/locale-info.php';
-
-		if ( ! $weight_unit && isset( $locale_info[ $country_code ] ) ) {
-			$weight_unit = $locale_info[ $country_code ]['weight_unit'];
-		} else {
-			$weight_unit = $weight_unit ? $weight_unit : 'kg';
-		}
-
-		if ( ! $dimension_unit && isset( $locale_info[ $country_code ] ) ) {
-			$dimension_unit = $locale_info[ $country_code ]['dimension_unit'];
-		} else {
-			$dimension_unit = $dimension_unit ? $dimension_unit : 'cm';
-		}
 
 		if ( ! empty( $existing_zones ) ) {
 			$intro_text = __( 'How would you like units on your store displayed?', 'woocommerce' );


### PR DESCRIPTION
In order to default to locale-specific weight and dimension units in the Shipping step (take 3 😄), sets the options to the locale's defaults when setting the locale in the Store Setup step (as originally described in https://github.com/woocommerce/woocommerce/pull/17298#issuecomment-339788848).

Code intended to default to these units in the Shipping step itself is removed, since it relies on missing option values — this doesn't work for practical purposes since the options are initialized when WC is activated.