### PR TITLE
OBW: Position State select between City and Zip inputs

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -405,17 +405,16 @@ class WC_Admin_Setup_Wizard {
 				<label class="location-prompt" for="store_address_2"><?php esc_html_e( 'Address line 2', 'woocommerce' ); ?></label>
 				<input type="text" id="store_address_2" class="location-input" name="store_address_2" value="<?php echo esc_attr( $address_2 ); ?>" />
 
-				<div class="store-state-container hidden">
-					<label for="store_state" class="location-prompt">
-						<?php esc_html_e( 'State', 'woocommerce' ); ?>
-					</label>
-					<select id="store_state" name="store_state" data-placeholder="<?php esc_attr_e( 'Choose a state&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'State', 'woocommerce' ); ?>" class="location-input wc-enhanced-select dropdown"></select>
-				</div>
-
 				<div class="city-and-postcode">
 					<div>
 						<label class="location-prompt" for="store_city"><?php esc_html_e( 'City', 'woocommerce' ); ?></label>
 						<input type="text" id="store_city" class="location-input" name="store_city" required value="<?php echo esc_attr( $city ); ?>" />
+					</div>
+					<div class="store-state-container hidden">
+						<label for="store_state" class="location-prompt">
+							<?php esc_html_e( 'State', 'woocommerce' ); ?>
+						</label>
+						<select id="store_state" name="store_state" data-placeholder="<?php esc_attr_e( 'Choose a state&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'State', 'woocommerce' ); ?>" class="location-input wc-enhanced-select dropdown"></select>
 					</div>
 					<div>
 						<label class="location-prompt" for="store_postcode"><?php esc_html_e( 'Postcode / ZIP', 'woocommerce' ); ?></label>


### PR DESCRIPTION
Places State dropdown between City and Zip, instead of on its own line, to match expected order of inputs (in the US — not sure about other countries) and more specifically to match design in p7bbVw-28G-p2.

Before | After
-- | --
<img width="664" alt="screen shot 2018-04-17 at 11 26 19 pm" src="https://user-images.githubusercontent.com/1867547/38910324-c48d37fe-4296-11e8-80a2-bd2417f751f6.png"> | <img width="667" alt="screen shot 2018-04-17 at 11 21 17 pm" src="https://user-images.githubusercontent.com/1867547/38910326-c88aa800-4296-11e8-9c93-3294ce2dc68a.png">
