### PR TITLE
WC_Product_Query() does not respect the 'paged' argument (but wc_get_products() does)

### DIFF
--- a/includes/abstracts/abstract-wc-object-query.php
+++ b/includes/abstracts/abstract-wc-object-query.php
@@ -82,7 +82,7 @@ abstract class WC_Object_Query {
 			'exclude'        => '',
 
 			'limit'          => get_option( 'posts_per_page' ),
-			'page'           => 1,
+			'paged'          => 1,
 			'offset'         => '',
 			'paginate'       => false,
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -30,7 +30,6 @@ function wc_get_products( $args ) {
 		'post_status'    => 'status',
 		'post_parent'    => 'parent',
 		'posts_per_page' => 'limit',
-		'paged'          => 'page',
 	);
 
 	foreach ( $map_legacy as $from => $to ) {


### PR DESCRIPTION
`wc_get_products()` works fine when using the `paged` argument for custom loop pagination, but `WC_Product_Query()` seems to expect the argument to be `page` and will always return the first page results during a custom loop.