### PR TITLE
Fix download log unit test

### DIFF
--- a/tests/unit-tests/customer/customer-download-log.php
+++ b/tests/unit-tests/customer/customer-download-log.php
@@ -11,7 +11,16 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 	 * Test: get_id
 	 */
 	function test_get_id() {
+		$customer_id = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
+		$download    = new WC_Customer_Download();
+		$download->set_user_id( $customer_id );
+		$download->set_order_id( 1 );
+		$download->save();
+
 		$object = new WC_Customer_Download_Log();
+		$object->set_permission_id( $download->get_id() );
+		$object->set_user_id( $customer_id );
+		$object->set_user_ip_address( '1.2.3.4' );
 		$id = $object->save();
 		$this->assertEquals( $id, $object->get_id() );
 	}


### PR DESCRIPTION
This PR fixes #19755

#19330 Introduced a foreign key constraint which means that in order to save a download log entry you need to provide a download ID that exists. This PR simply modifies the unit test to create an actual download in the DB before testing the download log entry.