### PR TITLE
Do not hide coupons box when coupon already applied

### DIFF
--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -17,7 +17,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! wc_coupons_enabled() || ! empty( WC()->cart->applied_coupons ) ) { // @codingStandardsIgnoreLine.
+if ( ! wc_coupons_enabled() ) {
 	return;
 }
 


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/commit/9b6f3f6f9b1a299157c4b5ba3b31843fc78b8d08#diff-8fe10dba5f363db24246e9b310182e29 introduced a check to hide the coupons box on checkout when there is already a coupon applied.

This should not be the case since WooCommerce allows multiple coupons to be applied, the only exception would be when the coupon is specifically set to individual use.

This PR removed the check for applied coupons to ensure the coupon box always displays even if coupons are applied already.

Closes #19765 