### PR TITLE
Only show notices on specific screens

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -152,18 +152,32 @@ class WC_Admin_Notices {
 	public static function add_notices() {
 		$notices = self::get_notices();
 
-		if ( ! empty( $notices ) ) {
-			wp_enqueue_style( 'woocommerce-activation', plugins_url( '/assets/css/activation.css', WC_PLUGIN_FILE ), array(), WC_VERSION );
+		if ( empty( $notices ) ) {
+			return;
+		}
 
-			// Add RTL support.
-			wp_style_add_data( 'woocommerce-activation', 'rtl', 'replace' );
+		$screen          = get_current_screen();
+		$screen_id       = $screen ? $screen->id : '';
+		$show_on_screens = array(
+			'dashboard',
+			'plugins',
+		);
 
-			foreach ( $notices as $notice ) {
-				if ( ! empty( self::$core_notices[ $notice ] ) && apply_filters( 'woocommerce_show_admin_notice', true, $notice ) ) {
-					add_action( 'admin_notices', array( __CLASS__, self::$core_notices[ $notice ] ) );
-				} else {
-					add_action( 'admin_notices', array( __CLASS__, 'output_custom_notices' ) );
-				}
+		// Notices should only show on WooCommerce screens, the main dashboard, and on the plugins screen.
+		if ( ! in_array( $screen_id, wc_get_screen_ids(), true ) && ! in_array( $screen_id, $show_on_screens, true ) ) {
+			return;
+		}
+
+		wp_enqueue_style( 'woocommerce-activation', plugins_url( '/assets/css/activation.css', WC_PLUGIN_FILE ), array(), WC_VERSION );
+
+		// Add RTL support.
+		wp_style_add_data( 'woocommerce-activation', 'rtl', 'replace' );
+
+		foreach ( $notices as $notice ) {
+			if ( ! empty( self::$core_notices[ $notice ] ) && apply_filters( 'woocommerce_show_admin_notice', true, $notice ) ) {
+				add_action( 'admin_notices', array( __CLASS__, self::$core_notices[ $notice ] ) );
+			} else {
+				add_action( 'admin_notices', array( __CLASS__, 'output_custom_notices' ) );
 			}
 		}
 	}


### PR DESCRIPTION
Currently, `WC_Admin_Notices` spews notices on all screens in WP admin.

This PR adjusts this to only target:

- Dashboard
- plugins
- All WC screens

This keeps our notices a little more self-contained whilst still showing them in key, important places.

cc @claudiosanches 