### PR TITLE
CRUD Order Search

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -474,19 +474,19 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		if ( strpos( $term, ':' ) ) {
 			$term_array = explode( ' ', $term );
 			foreach ( $term_array as $the_term ) {
-				preg_match_all( '/(.*)[:](.*)/i', $the_term, $matches );
+				preg_match( '/(.*)[:](.*)/i', $the_term, $matches );
 				// Make sure we have one of the allowed special search terms present.
 				if (
-					! empty( $matches[1][0] )
-					&& ! empty( $matches[2][0] )
-					&& in_array( strtolower( $matches[1][0] ), array( 'date_created', 'date_modified', 'date_completed', 'date_paid' ), true )
+					! empty( $matches[1] )
+					&& ! empty( $matches[2] )
+					&& in_array( strtolower( $matches[1] ), array( 'date_created', 'date_modified', 'date_completed', 'date_paid' ), true )
 				) {
-					preg_match_all( '/(\.{3}|<=|>=|<|>)/i', $matches[2][0], $allowed_operators );
+					preg_match( '/(\.{3}|<=|>=|<|>)/i', $matches[2], $allowed_operators );
 					// If any of the allowed operators >, <, >=, <=, ... are present we can add it to the search fields.
 					if ( ! empty( $allowed_operators[0] ) ) {
-						$special_terms[ strtolower( $matches[1][0] ) ] = $matches[2][0];
+						$special_terms[ strtolower( $matches[1] ) ] = $matches[2];
 						// Remove the special term from the search term.
-						$term = str_replace( $matches[0][0], '', $term );
+						$term = str_replace( $matches[0], '', $term );
 					}
 				}
 			}


### PR DESCRIPTION
This PR converts the current order_search method from a custom query based one to using the CRUD search functionality via wc_get_orders.

To Do:
- [x] Convert search_orders functionality to wc_get_orders
- [x] Implement date based searching by parsing the term for date_created, date_modified, date_completed and date_paid values and passing it to wc_get_orders call.
- [ ] Pagination for list table