### PR TITLE
Filter the used coupon URL in "edit order" screen

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -121,13 +121,13 @@ if ( wc_tax_enabled() ) {
 					<li class="<?php echo $class; ?>">
 						<?php if ( $post_id ) : ?>
 							<?php
-							$post_url = add_query_arg(
+							$post_url = apply_filters( 'woocommerce_admin_order_item_coupon_url', add_query_arg(
 								array(
 									'post'   => $post_id,
 									'action' => 'edit',
 								),
 								admin_url( 'post.php' )
-							);
+							), $item, $order );
 							?>
 							<a href="<?php echo esc_url( $post_url ); ?>" class="tips" data-tip="<?php echo esc_attr( wc_price( $item->get_discount(), array( 'currency' => $order->get_currency() ) ) ); ?>">
 								<span><?php echo esc_html( $item->get_code() ); ?></span>


### PR DESCRIPTION
This is helpful for plugins that make use of virtual coupons such as PDF product vouchers, and would let us link used voucher codes to the voucher record instead of the hidden / deleted coupon.