### PR TITLE
Throw an error when the order is not loaded on checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -1017,6 +1017,10 @@ class WC_Checkout {
 					throw new Exception( $order_id->get_error_message() );
 				}
 
+				if ( ! $order ) {
+					throw new Exception( __( 'Unable to create order.', 'woocommerce' ) );
+				}
+
 				do_action( 'woocommerce_checkout_order_processed', $order_id, $posted_data, $order );
 
 				if ( WC()->cart->needs_payment() ) {


### PR DESCRIPTION
This is not a fix for #19786 but it will add a more useful error message if the order cannot be loaded for whatever reason. Hardening.