### PR TITLE
Docblock: wc_get_orders returns WC_Order[]

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since  2.6.0
  * @param  array $args Array of args (above).
- * @return array|stdClass Number of pages and an array of order objects if
+ * @return WC_Order[]|stdClass Number of pages and an array of order objects if
  *                             paginate is true, or just an array of values.
  */
 function wc_get_orders( $args ) {


### PR DESCRIPTION
For PHPStorm validation and hints.