### PR TITLE
Do not load unsupported theme functionality when shop page -1

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -193,7 +193,7 @@ class WC_Template_Loader {
 	 * @since 3.3.0
 	 */
 	public static function unsupported_theme_init() {
-		if ( self::$shop_page_id ) {
+		if ( self::$shop_page_id && intval( self::$shop_page_id ) > 0 ) {
 			if ( is_product_taxonomy() ) {
 				self::unsupported_theme_tax_archive_init();
 			} elseif ( is_product() ) {

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -193,7 +193,7 @@ class WC_Template_Loader {
 	 * @since 3.3.0
 	 */
 	public static function unsupported_theme_init() {
-		if ( self::$shop_page_id && intval( self::$shop_page_id ) > 0 ) {
+		if ( 0 < self::$shop_page_id ) {
 			if ( is_product_taxonomy() ) {
 				self::unsupported_theme_tax_archive_init();
 			} elseif ( is_product() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where the shop page ID can result in a -1 when the option does not exist in the DB due to how wc_get_page_id works. When WooCommerce then checks to see if the unsupported theme functionality should be loaded it will load it even if there is no shop page defined as -1 is seen as true when checking boolean values.

Closes #19790 

### How to test the changes in this Pull Request:

1. Delete the option for woocommerce_shop_page_id from the wp_options table
2. Try and load the shop page, it should not load the unsupported WooCommerce theme functionality.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Unsupported theme functionality loading when no shop page defined.
