### PR TITLE
Test setup methods should call parent setup method

### DIFF
--- a/tests/unit-tests/exporter/product.php
+++ b/tests/unit-tests/exporter/product.php
@@ -69,12 +69,24 @@ class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 		$expected = 'cat1, cat2, cat3';
 		$this->assertEquals( $expected, $exporter->format_term_ids( array( $term1, $term2, $term3 ), 'category' ) );
 
-		wp_insert_category( array( 'cat_ID' => $term2, 'cat_name' => 'cat2', 'category_parent' => $term1 ) );
+		wp_insert_category(
+			array(
+				'cat_ID'          => $term2,
+				'cat_name'        => 'cat2',
+				'category_parent' => $term1,
+			)
+		);
 
 		$expected = 'cat1, cat1 > cat2, cat3';
 		$this->assertEquals( $expected, $exporter->format_term_ids( array( $term1, $term2, $term3 ), 'category' ) );
 
-		wp_insert_category( array( 'cat_ID' => $term3, 'cat_name' => 'cat3', 'category_parent' => $term2 ) );
+		wp_insert_category(
+			array(
+				'cat_ID'          => $term3,
+				'cat_name'        => 'cat3',
+				'category_parent' => $term2,
+			)
+		);
 		$expected = 'cat1, cat1 > cat2, cat1 > cat2 > cat3';
 		$this->assertEquals( $expected, $exporter->format_term_ids( array( $term1, $term2, $term3 ), 'category' ) );
 	}
@@ -96,7 +108,7 @@ class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 		$product->set_width( 1 );
 
 		$sale_start = time();
-		$sale_end = $sale_start + DAY_IN_SECONDS;
+		$sale_end   = $sale_start + DAY_IN_SECONDS;
 		$product->set_date_on_sale_from( $sale_start );
 		$product->set_date_on_sale_to( $sale_end );
 
@@ -136,9 +148,9 @@ class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 		$this->assertContains( $row['backorders'], array( 1, 0, 'notify' ) );
 
 		$expected_parent = '';
-		$parent_id = $product->get_parent_id();
+		$parent_id       = $product->get_parent_id();
 		if ( $parent_id ) {
-			$parent = wc_get_product( $parent_id );
+			$parent          = wc_get_product( $parent_id );
 			$expected_parent = $parent->get_sku() ? $parent->get_sku() : 'id:' . $parent->get_id();
 		}
 		$this->assertEquals( $expected_parent, $row['parent_id'] );

--- a/tests/unit-tests/exporter/product.php
+++ b/tests/unit-tests/exporter/product.php
@@ -10,6 +10,8 @@ class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 	 * Load up the exporter classes since they aren't loaded by default.
 	 */
 	public function setUp() {
+		parent::setUp();
+
 		$bootstrap = WC_Unit_Tests_Bootstrap::instance();
 		require_once $bootstrap->plugin_dir . '/includes/export/class-wc-product-csv-exporter.php';
 	}

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -17,6 +17,8 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 * Load up the importer classes since they aren't loaded by default.
 	 */
 	public function setUp() {
+		parent::setUp();
+
 		$this->csv_file = dirname( __FILE__ ) . '/sample.csv';
 
 		$bootstrap = WC_Unit_Tests_Bootstrap::instance();
@@ -97,11 +99,6 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, count( $results['failed'] ) );
 		$this->assertEquals( 0, count( $results['updated'] ) );
 		$this->assertEquals( 0, count( $results['skipped'] ) );
-
-		// Exclude imported products.
-		foreach ( $results['imported'] as $id ) {
-			wp_delete_post( $id, true );
-		}
 	}
 
 	/**
@@ -575,17 +572,5 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		}
 
 		$this->assertEquals( $items, $parsed_data );
-
-		// Remove temporary products.
-		$temp_products = get_posts(
-			array(
-				'post_status' => 'importing',
-				'post_type'   => 'product',
-				'fields'      => 'ids',
-			)
-		);
-		foreach ( $temp_products as $id ) {
-			wp_delete_post( $id, true );
-		}
 	}
 }

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -135,7 +135,13 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 * @since 3.1.0
 	 */
 	public function test_get_raw_data() {
-		$importer = new WC_Product_CSV_Importer( $this->csv_file, array( 'parse' => false, 'lines' => 2 ) );
+		$importer = new WC_Product_CSV_Importer(
+			$this->csv_file,
+			array(
+				'parse' => false,
+				'lines' => 2,
+			)
+		);
 		$items    = array(
 			array(
 				'simple',
@@ -433,40 +439,40 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 				'menu_order'            => 3,
 			),
 			array(
-				'type'                  => 'variation',
-				'sku'                   => '',
-				'name'                  => '',
-				'featured'              => '',
-				'catalog_visibility'    => 'visible',
-				'short_description'     => '',
-				'description'           => 'Lorem ipsum dolor sit amet, at exerci civibus appetere sit, iuvaret hendrerit mea no. Eam integre feugait liberavisse an.',
-				'date_on_sale_from'     => null,
-				'date_on_sale_to'       => null,
-				'tax_status'            => 'taxable',
-				'tax_class'             => 'standard',
-				'stock_status'          => 'instock',
-				'stock_quantity'        => 6,
-				'backorders'            => 'no',
-				'sold_individually'     => '',
-				'weight'                => 1.0,
-				'length'                => 2.0,
-				'width'                 => 25.0,
-				'height'                => 55.0,
-				'reviews_allowed'       => '',
-				'purchase_note'         => '',
-				'sale_price'            => '',
-				'regular_price'         => '20',
-				'shipping_class_id'     => 0,
-				'download_limit'        => 0,
-				'download_expiry'       => 0,
-				'product_url'           => '',
-				'button_text'           => '',
-				'status'                => 'publish',
-				'raw_image_id'          => 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_4_front.jpg',
-				'virtual'               => false,
-				'downloadable'          => false,
-				'manage_stock'          => true,
-				'raw_attributes'        => array(
+				'type'               => 'variation',
+				'sku'                => '',
+				'name'               => '',
+				'featured'           => '',
+				'catalog_visibility' => 'visible',
+				'short_description'  => '',
+				'description'        => 'Lorem ipsum dolor sit amet, at exerci civibus appetere sit, iuvaret hendrerit mea no. Eam integre feugait liberavisse an.',
+				'date_on_sale_from'  => null,
+				'date_on_sale_to'    => null,
+				'tax_status'         => 'taxable',
+				'tax_class'          => 'standard',
+				'stock_status'       => 'instock',
+				'stock_quantity'     => 6,
+				'backorders'         => 'no',
+				'sold_individually'  => '',
+				'weight'             => 1.0,
+				'length'             => 2.0,
+				'width'              => 25.0,
+				'height'             => 55.0,
+				'reviews_allowed'    => '',
+				'purchase_note'      => '',
+				'sale_price'         => '',
+				'regular_price'      => '20',
+				'shipping_class_id'  => 0,
+				'download_limit'     => 0,
+				'download_expiry'    => 0,
+				'product_url'        => '',
+				'button_text'        => '',
+				'status'             => 'publish',
+				'raw_image_id'       => 'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/T_4_front.jpg',
+				'virtual'            => false,
+				'downloadable'       => false,
+				'manage_stock'       => true,
+				'raw_attributes'     => array(
 					array(
 						'name' => 'Color',
 					),
@@ -475,7 +481,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 						'name'  => 'Size',
 					),
 				),
-				'menu_order'            => 1,
+				'menu_order'         => 1,
 			),
 			array(
 				'type'               => 'variation',
@@ -520,7 +526,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 						'name'  => 'Size',
 					),
 				),
-				'menu_order'            => 2,
+				'menu_order'         => 2,
 			),
 			array(
 				'type'                  => 'grouped',
@@ -571,11 +577,13 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		$this->assertEquals( $items, $parsed_data );
 
 		// Remove temporary products.
-		$temp_products = get_posts( array(
-			'post_status' => 'importing',
-			'post_type'   => 'product',
-			'fields'      => 'ids',
-		) );
+		$temp_products = get_posts(
+			array(
+				'post_status' => 'importing',
+				'post_type'   => 'product',
+				'fields'      => 'ids',
+			)
+		);
 		foreach ( $temp_products as $id ) {
 			wp_delete_post( $id, true );
 		}

--- a/tests/unit-tests/order-items/order-item-meta.php
+++ b/tests/unit-tests/order-items/order-item-meta.php
@@ -29,7 +29,7 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 		$expected = array();
 		foreach ( $item->get_meta_data() as $metadata ) {
 			$expected[ $metadata->id ] = array(
-				'key' => $metadata->key,
+				'key'   => $metadata->key,
 				'label' => wc_attribute_label( $metadata->key, null ),
 				'value' => $metadata->value,
 			);
@@ -60,8 +60,11 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 
 		$meta = new WC_Order_Item_Meta( $item );
 
-		$expected = array( 'regularkey' => '1', 'category' => 'Testing Categories' );
-		$actual = wp_list_pluck( $meta->get_formatted(), 'value', 'key' );
+		$expected = array(
+			'regularkey' => '1',
+			'category'   => 'Testing Categories',
+		);
+		$actual   = wp_list_pluck( $meta->get_formatted(), 'value', 'key' );
 		$this->assertEquals( $expected, $actual );
 
 		// Clean up.
@@ -84,7 +87,7 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 		$meta = new WC_Order_Item_Meta( $item );
 
 		$expected = "regularkey: 1, \ncategory: Testing Categories";
-		$flat = $meta->display( true, true );
+		$flat     = $meta->display( true, true );
 		$this->assertEquals( $expected, $flat );
 
 		$not_flat = $meta->display( false, true );

--- a/tests/unit-tests/order-items/order-item-meta.php
+++ b/tests/unit-tests/order-items/order-item-meta.php
@@ -11,7 +11,10 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 	 * Suppress deprecation notice from WC_Order_Item_Meta constructor.
 	 */
 	public function setUp() {
-		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		parent::setUp();
+
+		wp_insert_term( 'Testing Categories', 'category', array( 'slug' => 'testing' ) );
+		$this->setExpectedDeprecated( 'WC_Order_Item_Meta::__construct' );
 	}
 
 	/**
@@ -39,9 +42,6 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 3, count( $result ) );
 		$this->assertEquals( $expected, $result );
-
-		// Clean up.
-		$item->delete( true );
 	}
 
 	/**
@@ -50,8 +50,6 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 	 * @since 3.2.0
 	 */
 	public function test_get_formatted() {
-		wp_insert_term( 'Testing Categories', 'category', array( 'slug' => 'testing' ) );
-
 		$item = new WC_Order_Item_Fee();
 		$item->add_meta_data( 'regularkey', '1' );
 		$item->add_meta_data( 'category', 'testing' );
@@ -66,9 +64,6 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 		);
 		$actual   = wp_list_pluck( $meta->get_formatted(), 'value', 'key' );
 		$this->assertEquals( $expected, $actual );
-
-		// Clean up.
-		$item->delete( true );
 	}
 
 
@@ -95,8 +90,5 @@ class WC_Tests_Order_Item_Meta extends WC_Unit_Test_Case {
 		$this->assertContains( 'class="variation-regularkey"><p>1</p>', $not_flat );
 		$this->assertContains( 'class="variation-category">category:', $not_flat );
 		$this->assertContains( 'class="variation-category"><p>Testing Categories</p>', $not_flat );
-
-		// Clean up.
-		$item->delete( true );
 	}
 }

--- a/tests/unit-tests/privacy/export.php
+++ b/tests/unit-tests/privacy/export.php
@@ -24,6 +24,8 @@ class WC_Test_Privacy_Export extends WC_Unit_Test_Case {
 	 * Load up the importer classes since they aren't loaded by default.
 	 */
 	public function setUp() {
+		parent::setUp();
+
 		$customer1 = WC_Helper_Customer::create_customer( 'customer1', 'password', 'test1@test.com' );
 		$customer1->set_billing_email( 'customer1@test.com' );
 		$customer1->save();
@@ -49,18 +51,6 @@ class WC_Test_Privacy_Export extends WC_Unit_Test_Case {
 		$this->orders[] = WC_Helper_Order::create_order( $customer1->get_id() );
 		$this->orders[] = WC_Helper_Order::create_order( $customer2->get_id() );
 		$this->orders[] = WC_Helper_Order::create_order( $customer2->get_id() );
-	}
-
-	/**
-	 * Clean up after test.
-	 */
-	public function tearDown() {
-		foreach ( $this->orders as $object ) {
-			$object->delete( true );
-		}
-		foreach ( $this->customers as $object ) {
-			$object->delete( true );
-		}
 	}
 
 	/**

--- a/tests/unit-tests/privacy/export.php
+++ b/tests/unit-tests/privacy/export.php
@@ -74,67 +74,70 @@ class WC_Test_Privacy_Export extends WC_Unit_Test_Case {
 		// Do a test export and check response.
 		$response = WC_Privacy::customer_data_exporter( 'test1@test.com', 1 );
 		$this->assertTrue( $response['done'] );
-		$this->assertEquals( array(
+		$this->assertEquals(
 			array(
-				'group_id'    => 'woocommerce_customer',
-				'group_label' => 'Customer Data',
-				'item_id'     => 'user',
-				'data'        => array(
-					array(
-						'name'  => 'Billing Address 1',
-						'value' => '123 South Street',
-					),
-					array(
-						'name'  => 'Billing Address 2',
-						'value' => 'Apt 1',
-					),
-					array(
-						'name'  => 'Billing City',
-						'value' => 'Philadelphia',
-					),
-					array(
-						'name'  => 'Billing Postal/Zip Code',
-						'value' => '19123',
-					),
-					array(
-						'name'  => 'Billing State',
-						'value' => 'PA',
-					),
-					array(
-						'name'  => 'Billing Country',
-						'value' => 'US',
-					),
-					array(
-						'name'  => 'Email Address',
-						'value' => 'customer1@test.com',
-					),
-					array(
-						'name'  => 'Shipping Address 1',
-						'value' => '123 South Street',
-					),
-					array(
-						'name'  => 'Shipping Address 2',
-						'value' => 'Apt 1',
-					),
-					array(
-						'name'  => 'Shipping City',
-						'value' => 'Philadelphia',
-					),
-					array(
-						'name'  => 'Shipping Postal/Zip Code',
-						'value' => '19123',
-					),
-					array(
-						'name'  => 'Shipping State',
-						'value' => 'PA',
-					),
-					array(
-						'name'  => 'Shipping Country',
-						'value' => 'US',
+				array(
+					'group_id'    => 'woocommerce_customer',
+					'group_label' => 'Customer Data',
+					'item_id'     => 'user',
+					'data'        => array(
+						array(
+							'name'  => 'Billing Address 1',
+							'value' => '123 South Street',
+						),
+						array(
+							'name'  => 'Billing Address 2',
+							'value' => 'Apt 1',
+						),
+						array(
+							'name'  => 'Billing City',
+							'value' => 'Philadelphia',
+						),
+						array(
+							'name'  => 'Billing Postal/Zip Code',
+							'value' => '19123',
+						),
+						array(
+							'name'  => 'Billing State',
+							'value' => 'PA',
+						),
+						array(
+							'name'  => 'Billing Country',
+							'value' => 'US',
+						),
+						array(
+							'name'  => 'Email Address',
+							'value' => 'customer1@test.com',
+						),
+						array(
+							'name'  => 'Shipping Address 1',
+							'value' => '123 South Street',
+						),
+						array(
+							'name'  => 'Shipping Address 2',
+							'value' => 'Apt 1',
+						),
+						array(
+							'name'  => 'Shipping City',
+							'value' => 'Philadelphia',
+						),
+						array(
+							'name'  => 'Shipping Postal/Zip Code',
+							'value' => '19123',
+						),
+						array(
+							'name'  => 'Shipping State',
+							'value' => 'PA',
+						),
+						array(
+							'name'  => 'Shipping Country',
+							'value' => 'US',
+						),
 					),
 				),
 			),
-		), $response['data'] );
+			$response['data']
+		);
 	}
 
 	/**

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -28,6 +28,8 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	 * Setup the cart for totals calculation.
 	 */
 	public function setUp() {
+		parent::setUp();
+
 		$this->ids = array();
 
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -34,7 +34,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 			define( 'WOOCOMMERCE_CHECKOUT', 1 );
 		}
 
-		$tax_rate = array(
+		$tax_rate    = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
 			'tax_rate'          => '20.0000',
@@ -54,7 +54,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		$product  = WC_Helper_Product::create_simple_product();
 		$product2 = WC_Helper_Product::create_simple_product();
 		// Variations with parent tax class.
-		$product3 = WC_Helper_Product::create_variation_product();
+		$product3   = WC_Helper_Product::create_variation_product();
 		$variations = $product3->get_available_variations();
 
 		// Update product3 so that each variation has the parent tax class.
@@ -67,7 +67,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		WC_Helper_Shipping::create_simple_flat_rate();
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
 
-		$coupon = new WC_Coupon;
+		$coupon = new WC_Coupon();
 		$coupon->set_code( 'test-coupon-10' );
 		$coupon->set_amount( 10 );
 		$coupon->set_discount_type( 'percent' );
@@ -131,19 +131,22 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	 * Test get and set items.
 	 */
 	public function test_get_totals() {
-		$this->assertEquals( array(
-			'fees_total'          => 40.00,
-			'fees_total_tax'      => 6.00,
-			'items_subtotal'      => 40.00,
-			'items_subtotal_tax'  => 8.00,
-			'items_total'         => 36.00,
-			'items_total_tax'     => 7.20,
-			'total'               => 101.20,
-			'shipping_total'      => 10,
-			'shipping_tax_total'  => 2,
-			'discounts_total'     => 4.00,
-			'discounts_tax_total' => 0.80,
-		), $this->totals->get_totals() );
+		$this->assertEquals(
+			array(
+				'fees_total'          => 40.00,
+				'fees_total_tax'      => 6.00,
+				'items_subtotal'      => 40.00,
+				'items_subtotal_tax'  => 8.00,
+				'items_total'         => 36.00,
+				'items_total_tax'     => 7.20,
+				'total'               => 101.20,
+				'shipping_total'      => 10,
+				'shipping_tax_total'  => 2,
+				'discounts_total'     => 4.00,
+				'discounts_tax_total' => 0.80,
+			),
+			$this->totals->get_totals()
+		);
 	}
 
 	/**


### PR DESCRIPTION
parent::setUp() should be called inside test setup methods to make sure database changes are automatically reverted after each test is executed. This way it is not necessary to manually remove inserted data.

I found this issue while debugging woocommerce/woocommerce-product-tables-feature-plugin#81. It turns out this test was failing because WC_Tests_Product_CSV_Importer::test_import() was leaving one post in the database due to a bug in the custom product tables plugin.

This PR also fixes PHPCS violations in the modified files.