### PR TITLE
Delay tracking request

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -552,7 +552,7 @@ class WC_Admin_Setup_Wizard {
 
 		if ( $tracking ) {
 			update_option( 'woocommerce_allow_tracking', 'yes' );
-			WC_Tracker::send_tracking_data( true );
+			wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
 		} else {
 			update_option( 'woocommerce_allow_tracking', 'no' );
 		}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -368,7 +368,7 @@ class WC_Install {
 		wp_schedule_event( time(), 'daily', 'woocommerce_cleanup_orders' );
 		wp_schedule_event( time(), 'twicedaily', 'woocommerce_cleanup_sessions' );
 		wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
-		wp_schedule_event( time(), apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
+		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When you install WooCommerce and opt-in to tracking data it immediately fires a cron job, this PR delays the scheduling by 10 seconds so the cron does not fire on the current page load.

### How to test the changes in this Pull Request:

1. Do a clean WooCommerce Installation
2. In the OBW opt-in to tracking data
3. Upon finishing the wizard check that the tracker fires 10s after.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Delay initial tracker send when opting in 10s after.
