### PR TITLE
Filter/whitelist response fields doesn't work as expected

### DIFF
--- a/includes/api/legacy/v1/class-wc-api-resource.php
+++ b/includes/api/legacy/v1/class-wc-api-resource.php
@@ -258,7 +258,11 @@ class WC_API_Resource {
 
 				list( $name, $value ) = explode( '.', $field );
 
-				$sub_fields[ $name ] = $value;
+				if ( ! in_array( $name, array_keys( $sub_fields ) ) ) {
+					$sub_fields[ $name ] = array();
+				}
+
+				array_push( $sub_fields[ $name ], $value );
 			}
 		}
 
@@ -272,7 +276,7 @@ class WC_API_Resource {
 				foreach ( $data_value as $sub_field => $sub_field_value ) {
 
 					// remove non-matching sub-fields
-					if ( ! in_array( $sub_field, $sub_fields ) ) {
+					if ( ! in_array( $sub_field, $sub_fields[ $data_field ] ) ) {
 						unset( $data[ $data_field ][ $sub_field ] );
 					}
 				}

--- a/includes/api/legacy/v2/class-wc-api-resource.php
+++ b/includes/api/legacy/v2/class-wc-api-resource.php
@@ -317,7 +317,11 @@ class WC_API_Resource {
 
 				list( $name, $value ) = explode( '.', $field );
 
-				$sub_fields[ $name ] = $value;
+				if ( ! in_array( $name, array_keys( $sub_fields ) ) ) {
+					$sub_fields[ $name ] = array();
+				}
+
+				array_push( $sub_fields[ $name ], $value );
 			}
 		}
 
@@ -331,7 +335,7 @@ class WC_API_Resource {
 				foreach ( $data_value as $sub_field => $sub_field_value ) {
 
 					// remove non-matching sub-fields
-					if ( ! in_array( $sub_field, $sub_fields ) ) {
+					if ( ! in_array( $sub_field, $sub_fields[ $data_field ] ) ) {
 						unset( $data[ $data_field ][ $sub_field ] );
 					}
 				}

--- a/includes/api/legacy/v3/class-wc-api-resource.php
+++ b/includes/api/legacy/v3/class-wc-api-resource.php
@@ -319,7 +319,11 @@ class WC_API_Resource {
 
 				list( $name, $value ) = explode( '.', $field );
 
-				$sub_fields[ $name ] = $value;
+				if ( ! in_array( $name, array_keys( $sub_fields ) ) ) {
+					$sub_fields[ $name ] = array();
+				}
+
+				array_push( $sub_fields[ $name ], $value );
 			}
 		}
 
@@ -333,7 +337,7 @@ class WC_API_Resource {
 				foreach ( $data_value as $sub_field => $sub_field_value ) {
 
 					// remove non-matching sub-fields
-					if ( ! in_array( $sub_field, $sub_fields ) ) {
+					if ( ! in_array( $sub_field, $sub_fields[ $data_field ] ) ) {
 						unset( $data[ $data_field ][ $sub_field ] );
 					}
 				}


### PR DESCRIPTION
All Submissions:
[ x] Have you followed the WooCommerce Contributing guideline?
[ x] Does your code follow the WordPress' coding standards?
[ x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Changes proposed in this Pull Request:
This PR is regarding this issue (https://github.com/woocommerce/woocommerce/issues/19835).

Changelog entry
This change tries to fix the original intention of the ability to whitelist 'sub_fields', also when multiple 'sub_fields' requested by query. Currently this functionality doesn't work as intended.