### PR TITLE
Extensions helper caching fixes

### DIFF
--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -307,17 +307,8 @@ class WC_Helper_Updater {
 	public static function flush_updates_cache() {
 		delete_transient( '_woocommerce_helper_updates' );
 		delete_transient( '_woocommerce_helper_updates_count' );
-
-		// Refresh update transients
-		$update_plugins = get_site_transient( 'update_plugins' );
-		if ( ! empty( $update_plugins ) ) {
-			set_site_transient( 'update_plugins', $update_plugins );
-		}
-
-		$update_themes = get_site_transient( 'update_themes' );
-		if ( ! empty( $update_themes ) ) {
-			set_site_transient( 'update_themes', $update_themes );
-		}
+		delete_site_transient( 'update_plugins' );
+		delete_site_transient( 'update_themes' );
 	}
 
 	/**

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -741,6 +741,7 @@ class WC_Helper {
 		}
 
 		self::_flush_subscriptions_cache();
+		self::_flush_updates_cache();
 
 		// Enable tracking when connected.
 		if ( class_exists( 'WC_Tracker' ) ) {
@@ -858,6 +859,8 @@ class WC_Helper {
 		}
 
 		self::_flush_subscriptions_cache();
+		self::_flush_updates_cache();
+
 		$redirect_uri = add_query_arg(
 			array(
 				'page'                 => 'wc-addons',
@@ -1220,6 +1223,7 @@ class WC_Helper {
 
 		self::log( 'Auto-activated a subscription for ' . $filename );
 		self::_flush_subscriptions_cache();
+		self::_flush_updates_cache();
 	}
 
 	/**
@@ -1280,6 +1284,7 @@ class WC_Helper {
 		if ( $deactivated ) {
 			self::log( sprintf( 'Auto-deactivated %d subscription(s) for %s', $deactivated, $filename ) );
 			self::_flush_subscriptions_cache();
+			self::_flush_updates_cache();
 		}
 	}
 


### PR DESCRIPTION
Fixes #19831 by:

1. When clearing transients, rather than updating (and allow our hooks to fire) just delete the updates transient so caches update naturally.

2. After activating a subscription, clears caches so that plugins which already cached updates get refreshed and show updates from our servers.

To test:

1. Install a WooCommerce extension you have a subscription for on woo.com
2. Change version to something old 
3. Check for plugin updates. You should see one but “updates not available”
4. Activate subscription on WooCommerce > Extensions menu

At this point, before the patch the ‘update’ link on our extensions screen would go to a page saying “no update available”.

After patch it works and updates the extension.