### PR TITLE
Fix min/max/step issue in the cart update

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1162,8 +1162,12 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 		global $product;
 
 		if ( $product ) {
+			$qty = apply_filters( 'woocommerce_quantity_input_min', 1, $product );
+			if (0 == $qty || empty($qty)) {
+				$qty = 1;
+			}
 			$defaults = array(
-				'quantity'   => 1,
+				'quantity'   => $qty,
 				'class'      => implode( ' ', array_filter( array(
 					'button',
 					'product_type_' . $product->get_type(),

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -105,8 +105,9 @@ do_action( 'woocommerce_before_cart' ); ?>
 							$product_quantity = woocommerce_quantity_input( array(
 								'input_name'   => "cart[{$cart_item_key}][qty]",
 								'input_value'  => $cart_item['quantity'],
-								'max_value'    => $_product->get_max_purchase_quantity(),
-								'min_value'    => '0',
+								'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $_product->get_max_purchase_quantity(), $_product ),
+								'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $_product->get_min_purchase_quantity(), $_product ),
+								'step'        => apply_filters( 'woocommerce_quantity_input_step', 1, $_product ),
 								'product_name' => $_product->get_name(),
 							), $_product, false );
 						}


### PR DESCRIPTION
if woocommerce_quantity_input_min or woocommerce_quantity_input_step is overriden, it works on the main product page, but doesn't affect the cart quantity adjustment form. e.g. if I set min from woocommerce_quantity_input_min to 10, I can reduce it to 1 in the cart page.
This patch fixes this behavior.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. set min from woocommerce_quantity_input_min to 10
2. make new order, go to cart
3. change quantity to 1
4. save changes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

The woocommerce_quantity_input_min and woocommerce_quantity_input_step hooks are supported in the cart form now.