### PR TITLE
Support payment_method_in when selecting orders

### DIFF
--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -232,7 +232,7 @@ class WC_Data_Store_WP {
 				$wp_query_args['meta_query'][] = array(
 					'key'     => '_' . $key,
 					'value'   => $value,
-					'compare' => '=',
+					'compare' => is_array( $value ) ? 'IN' : '=',
 				);
 			} else { // Other vars get mapped to wp_query args or just left alone.
 				$key_mapping = array(

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -711,24 +711,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
-		if ( ! empty( $query_vars['payment_method__in'] ) ) {
-			if ( ! is_array( $query_vars['payment_method__in'] ) ) {
-				$query_vars['payment_method__in'] = array( $query_vars['payment_method__in'] );
-			}
-
-			$payment_methods = array();
-
-			foreach ( $query_vars['payment_method__in'] as $value ) {
-				$payment_methods[] = array(
-					'key'     => '_payment_method',
-					'value'   => $value,
-					'compare' => '=',
-				);
-			}
-
-			$wp_query_args['meta_query'][] = array_merge( array( 'relation' => 'OR' ), $payment_methods );
-		}
-
 		if ( ! isset( $query_vars['paginate'] ) || ! $query_vars['paginate'] ) {
 			$wp_query_args['no_found_rows'] = true;
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -711,6 +711,24 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 
+		if ( ! empty( $query_vars['payment_method__in'] ) ) {
+			if ( ! is_array( $query_vars['payment_method__in'] ) ) {
+				$query_vars['payment_method__in'] = array( $query_vars['payment_method__in'] );
+			}
+
+			$payment_methods = array();
+
+			foreach ( $query_vars['payment_method__in'] as $value ) {
+				$payment_methods[] = array(
+					'key'     => '_payment_method',
+					'value'   => $value,
+					'compare' => '=',
+				);
+			}
+
+			$wp_query_args['meta_query'][] = array_merge( array( 'relation' => 'OR' ), $payment_methods );
+		}
+
 		if ( ! isset( $query_vars['paginate'] ) || ! $query_vars['paginate'] ) {
 			$wp_query_args['no_found_rows'] = true;
 		}


### PR DESCRIPTION
Example usage:
```
boro@bor0:~/dev/www/wp_develop$ wp shell
wp> $orders = wc_get_orders( [ 'payment_method__in' => [ 'stripe', 'stripe_alipay' ] ] );
wp> array_map( function( $order ) { return $order->get_payment_method(); }, $orders );
array(3) {
  [0] =>
  string(6) "stripe"
  [1] =>
  string(13) "stripe_alipay"
  [2] =>
  string(6) "stripe"
}
```

Example usage:
```
boro@bor0:~/dev/www/wp_develop$ wp shell
wp> $orders = wc_get_orders( [ 'payment_method__in' => 'cod' ] );
wp> array_map( function( $order ) { return $order->get_payment_method(); }, $orders );
array(1) {
  [0] =>
  string(3) "cod"
}
```