### PR TITLE
Fix the US currency name and attribute check for creating variable product

### DIFF
--- a/tests/e2e-tests/checkout-page.js
+++ b/tests/e2e-tests/checkout-page.js
@@ -42,7 +42,7 @@ test.describe( 'Checkout Page', function() {
 			baseLocation: [ 'United States', 'United States (US) — California' ],
 			sellingLocation: 'Sell to all countries',
 			enableTaxes: true,
-			currency: [ 'United States', 'United States dollar ($)' ],
+			currency: [ 'United States', 'United States (US) dollar ($)' ],
 		} );
 
 		// Make sure payment method is set in setting.

--- a/tests/e2e-tests/wp-admin/wp-admin-product-new.js
+++ b/tests/e2e-tests/wp-admin/wp-admin-product-new.js
@@ -68,14 +68,14 @@ test.describe( 'Add New Product Page', function() {
 		attr1.toggle();
 
 		const attr2 = panelAttributes.add();
-		assert.eventually.ok( attr1.displayed() );
+		assert.eventually.ok( attr2.displayed() );
 		attr2.setName( 'attr #2' );
 		attr2.checkVisibleOnTheProductPage();
 		attr2.checkUsedForVariations();
 		attr2.setValue( 'val1 | val2' );
 
 		const attr3 = panelAttributes.add();
-		assert.eventually.ok( attr1.displayed() );
+		assert.eventually.ok( attr3.displayed() );
 		attr3.setName( 'attr #3' );
 		attr3.checkVisibleOnTheProductPage();
 		attr3.checkUsedForVariations();


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes e2e test that was failing.

### How to test the changes in this Pull Request:

1. Check travis results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally? --Locally, some tests still fail, but it seems a bit random.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed the US currency name and attribute check for creating variable product in e2e tests.
