### PR TITLE
#18317 Added filter to class for customer provided note field

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -459,7 +459,7 @@ class WC_Meta_Box_Order_Data {
 							}
 
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
-								echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> ' . nl2br( esc_html( $post->post_excerpt ) ) . '</p>';
+								echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> <span class="' . apply_filters( 'woocommerce_order_notes_class', '' ) . '">' . nl2br( esc_html( $post->post_excerpt ) ) . '</span></p>';
 							}
 							?>
 						</div>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -459,7 +459,7 @@ class WC_Meta_Box_Order_Data {
 							}
 
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
-								echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> ' . nl2br( esc_html( $post->post_excerpt ) ) . '</p>';
+								echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> <span class="' . apply_filters( 'woocommerce_order_notes_class', '') . '">' . nl2br( esc_html( $post->post_excerpt ) ) . '</span></p>';
 							}
 							?>
 						</div>


### PR DESCRIPTION
### All Submissions:

* [ X ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add new filter to customer provided note in admin order page.

### How to test the changes in this Pull Request:

1. check if add_filter( 'woocommerce_order_notes_class','your_function_name') works
2. return class name inisde your_function_name
3. check if class was created for customer provided note new span tag

### Other information:

* [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X ] Have you written new tests for your changes, as applicable?
* [ X ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added span and filter hook under "customer provided note" field for adding class to the user notes.
