### PR TITLE
Added fiter to user provided note field

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -459,8 +459,8 @@ class WC_Meta_Box_Order_Data {
 							}
 
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
-								echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> ' . nl2br( esc_html( $post->post_excerpt ) ) . '</p>';
-							}
+                                echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> <span class="' . apply_filters( 'woocommerce_order_notes_class', '' ) . '">' . nl2br( esc_html( $post->post_excerpt ) ) . '</span></p>';
+                            }
 							?>
 						</div>
 						<div class="edit_address">

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -459,8 +459,8 @@ class WC_Meta_Box_Order_Data {
 							}
 
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
-								echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> ' . nl2br( esc_html( $post->post_excerpt ) ) . '</p>';
-							}
+                                echo '<p><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> <span class="customer-provided-note-text">' . nl2br( esc_html( $post->post_excerpt ) ) . '</span></p>';
+                            }
 							?>
 						</div>
 						<div class="edit_address">


### PR DESCRIPTION
### All Submissions:

* [X ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Added span and filter to this span for costumer provided notes field so user can make changes to this text area by adding class.

### How to test the changes in this Pull Request:

1.  add to function.php add_filter( 'woocommerce_order_notes_class', 'order_notes', 10, 3 ); 
2. return class name from order_notes function
3. check field has new class returned from function

### Other information:

* [X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X] Have you written new tests for your changes, as applicable?
* [ X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added filter to "customer provided notes" text field .