### PR TITLE
Fix: product type filter should show selected product type

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -340,17 +340,11 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			if ( 'simple' === $term->name ) {
 
 				$output .= '<option value="downloadable" ';
-
-				if ( isset( $wp_query->query['product_type'] ) ) {
-					$output .= selected( 'downloadable', $current_product_type, false );
-				}
-
+				$output .= selected( 'downloadable', $current_product_type, false );
 				$output .= '> ' . ( is_rtl() ? '&larr;' : '&rarr;' ) . ' ' . __( 'Downloadable', 'woocommerce' ) . '</option>';
 
 				$output .= '<option value="virtual" ';
-
 				$output .= selected( 'virtual', $current_product_type, false );
-
 				$output .= '> ' . ( is_rtl() ? '&larr;' : '&rarr;' ) . ' ' . __( 'Virtual', 'woocommerce' ) . '</option>';
 			}
 		}


### PR DESCRIPTION
Since admin lists were refactored in 8f37ea33edae4a3d9df045b636a5e4e98b29149a, a bug was introduced that prevented the "Filter by product type" select box in the products list page in the admin from showing the selected product type when filtering by "Downloadable" products. Before marking this option as selected, the code was checking if `$wp_query->query['product_type']` is set. This check made sense before the refactor (see https://github.com/woocommerce/woocommerce/commit/8f37ea33edae4a3d9df045b636a5e4e98b29149a#diff-a116210e8adc50b0853846ba935daaadL1544), but it doesn't make sense anymore. In the new method, `$wp_query` is not even used.

### How to test the changes in this Pull Request:

1. Go to /wp-admin/edit.php?post_type=product
2. Filter products by download products
3. The list of products will show only downloadable products as expected and the "Filter by product type" select box will show the string "-> Downloadable". Before the change proposed in this PR, the select box shows the string "Filter by product type" instead of "-> Downloadable".

### Changelog entry

Fix: product type filter should show selected product type when filtering by downloadable products
