### PR TITLE
Fix CSV import cleanup methods

### DIFF
--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -247,7 +247,7 @@ class WC_Admin_Importers {
 			) );
 			// @codingStandardsIgnoreEnd.
 
-			// Clean up orphanned data.
+			// Clean up orphaned data.
 			$wpdb->query( "
 				DELETE {$wpdb->posts}.* FROM {$wpdb->posts}
 				LEFT JOIN {$wpdb->posts} wp ON wp.ID = {$wpdb->posts}.post_parent

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -682,8 +682,6 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			$data['status'] = isset( $statuses[ $data['published'] ] ) ? $statuses[ $data['published'] ] : -1;
 
 			unset( $data['published'] );
-		} else {
-			$data['status'] = 'publish';
 		}
 
 		if ( isset( $data['stock_quantity'] ) ) {

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -543,7 +543,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * @return int
 	 */
 	public function parse_int_field( $value ) {
-		// Remove the ' prepended to fields that start with - if needed
+		// Remove the ' prepended to fields that start with - if needed.
 		$value = $this->unescape_negative_number( $value );
 
 		return intval( $value );
@@ -682,6 +682,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			$data['status'] = isset( $statuses[ $data['published'] ] ) ? $statuses[ $data['published'] ] : -1;
 
 			unset( $data['published'] );
+		} else {
+			$data['status'] = 'publish';
 		}
 
 		if ( isset( $data['stock_quantity'] ) ) {


### PR DESCRIPTION
This fixes #19863 by cleaning up orphan data correctly so SKU does not appear used.

Use the CSV and test instructions in #19863 to reproduce. For the import to succeed you need to unset the images column because those images don't exist.

If you leave it set, no products will import, but this fix will avoid the broken products lingering around.