### PR TITLE
Fix gallery switching when image is the same

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -565,8 +565,9 @@
 			$product_link     = $product_img_wrap.find( 'a' ).eq( 0 );
 
 		if ( variation && variation.image && variation.image.src && variation.image.src.length > 1 ) {
+			$form.wc_variations_image_reset();
+
 			if ( $gallery_nav.find( 'li img[src="' + variation.image.gallery_thumbnail_src + '"]' ).length > 0 ) {
-				$form.wc_variations_image_reset();
 				$gallery_nav.find( 'li img[src="' + variation.image.gallery_thumbnail_src + '"]' ).trigger( 'click' );
 				$form.attr( 'current-image', variation.image_id );
 				return;


### PR DESCRIPTION
When there are multiple variations with the same image, if you update to a different variation the image will malfunction because it “thinks” the image is actually part of the gallery when it’s not.

This resets first to avoid the issue.

Can be tested with these instructions and CSV https://a8c.slack.com/archives/C0E1AV8T0/p1524746854000090