### PR TITLE
Reduce priority value for WooCommerce personal data exports

### DIFF
--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -30,7 +30,8 @@ class WC_Privacy {
 		add_action( 'woocommerce_cleanup_orders', array( __CLASS__, 'order_cleanup_process' ) );
 
 		// This hook registers WooCommerce data exporters.
-		add_filter( 'wp_privacy_personal_data_exporters', array( __CLASS__, 'register_data_exporters' ), 10 );
+		// We set priority to 5 to help WooCommerce's findings appear before those from extensions in exported items
+		add_filter( 'wp_privacy_personal_data_exporters', array( __CLASS__, 'register_data_exporters' ), 5 );
 
 		// When this is fired, data is removed in a given order. Called from bulk actions.
 		add_action( 'woocommerce_remove_order_personal_data', array( __CLASS__, 'remove_order_personal_data' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Set priority to 5 to help WooCommerce's findings appear before those from extensions in exported items

Closes #19879

### How to test the changes in this Pull Request:

1. Install WordPress core from today's trunk
2. Install the latest Personal Data exporter patch from https://core.trac.wordpress.org/attachment/ticket/43546/43546.6.diff
3. Install at least one other extension that implements personal data export (e.g. Stripe)
4. Kick off a personal data export for a test user with at least one order
5. Make sure WooCommerce "findings" for the order appear first in the item's exported information.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
