### PR TITLE
Disable Refund indirect saving before calling woocommerce_create_refund

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1247,7 +1247,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$this->set_shipping_total( $shipping_total );
-
 		$this->save();
 
 		return $this->get_shipping_total();

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1247,6 +1247,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$this->set_shipping_total( $shipping_total );
+
 		$this->save();
 
 		return $this->get_shipping_total();
@@ -1349,7 +1350,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Update tax lines for the order based on the line item taxes themselves.
 	 */
-	public function update_taxes() {
+	public function update_taxes( $save = true ) {
 		$cart_taxes     = array();
 		$shipping_taxes = array();
 		$existing_taxes = $this->get_taxes();
@@ -1400,7 +1401,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->set_cart_tax( wc_round_tax_total( array_sum( $cart_taxes ) ) );
 		}
 
-		$this->save();
+		if ( $save ) {
+			$this->save();
+		}
+
 	}
 
 	/**
@@ -1408,9 +1412,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @since 2.2
 	 * @param  bool $and_taxes Calc taxes if true.
+	 * @param  bool $save Save order after calculating if true
 	 * @return float calculated grand total.
 	 */
-	public function calculate_totals( $and_taxes = true ) {
+	public function calculate_totals( $and_taxes = true, $save = true ) {
 		do_action( 'woocommerce_order_before_calculate_totals', $and_taxes, $this );
 
 		$cart_subtotal     = 0;
@@ -1466,7 +1471,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		do_action( 'woocommerce_order_after_calculate_totals', $and_taxes, $this );
 
-		$this->save();
+		if ( $save ) {
+			$this->save();
+		}
 
 		return $this->get_total();
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -546,8 +546,8 @@ function wc_create_refund( $args = array() ) {
 			}
 		}
 
-		$refund->update_taxes();
-		$refund->calculate_totals( false );
+		$refund->update_taxes( false );
+		$refund->calculate_totals( false, false );
 		$refund->set_total( $args['amount'] * -1 );
 
 		// this should remain after update_taxes(), as this will save the order, and write the current date to the db


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR prevents the saving of a refund before the woocommerce_create_refund hook is called. To do this, it adds a $save parameter to functions $order->calculate_totals() and $order->update_taxes(),  with true as default value. When this new parameter is false, these methods won't call $order->save().

Closes #19881 .

### How to test the changes in this Pull Request:

1. Configure a method that is called with the woocommerce_create_refund hook, so it simply raises an Exception.
2. Try to create a refund.
3. If the PR works, no refund should be created. Without this PR, the refund will be created in the background (even though the Exception message is shown), and it will only be visible after reloading the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Ensure that the refund is not saved before calling woocommerce_create_refund hook.
