### PR TITLE
Don't schedule event to delete transients if limit set to 0

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -161,7 +161,7 @@ class WC_Cache_Helper {
 			$affected = $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s ORDER BY option_id LIMIT %d;", '\_transient\_%' . $version, $limit ) ); // WPCS: cache ok, db call ok.
 
 			// If affected rows is equal to limit, there are more rows to delete. Delete in 10 secs.
-			if ( $affected === $limit ) {
+			if ( $affected === $limit && 0 !== $limit ) {
 				wp_schedule_single_event( time() + 10, 'delete_version_transients', array( $version ) );
 			}
 		}

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -157,11 +157,16 @@ class WC_Cache_Helper {
 		if ( ! wp_using_ext_object_cache() && ! empty( $version ) ) {
 			global $wpdb;
 
-			$limit    = apply_filters( 'woocommerce_delete_version_transients_limit', 1000 );
+			$limit = apply_filters( 'woocommerce_delete_version_transients_limit', 1000 );
+
+			if ( ! $limit ) {
+				return;
+			}
+
 			$affected = $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s ORDER BY option_id LIMIT %d;", '\_transient\_%' . $version, $limit ) ); // WPCS: cache ok, db call ok.
 
 			// If affected rows is equal to limit, there are more rows to delete. Delete in 10 secs.
-			if ( $affected === $limit && 0 !== $limit ) {
+			if ( $affected === $limit ) {
 				wp_schedule_single_event( time() + 10, 'delete_version_transients', array( $version ) );
 			}
 		}


### PR DESCRIPTION
Third-party code can set the limit of transients to be deleted to 0 using the filter `woocommerce_delete_version_transients_limit`. If this happens, the code shouldn't schedule a cron event to delete more transients to avoid flooding the list of cron jobs.

@glagonikas, could you please test this PR to see if it fixes the issue you reported? Out of interest, why are you disabling the transient cleanup?

Fixes #19890

### Changelog entry

Fix: prevent flooding cron job list with event to delete transient when the filter woocommerce_delete_version_transients_limit is used to set the limit to zero