### PR TITLE
Ensure coupon amount is always a float value

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -183,7 +183,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return float
 	 */
 	public function get_amount( $context = 'view' ) {
-		return $this->get_prop( 'amount', $context );
+		return (float) $this->get_prop( 'amount', $context );
 	}
 
 	/**


### PR DESCRIPTION
This problem has been almost fixed with https://github.com/woocommerce/woocommerce/pull/19098 but old values already saved in the database maybe cause some trouble, so better ensure that it always return as a float value.

Closes #19889

