### PR TITLE
Enhanced the logic for elseif

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -315,8 +315,17 @@ class WC_Checkout {
 
 					// Store custom fields prefixed with wither shipping_ or billing_. This is for backwards compatibility with 2.6.x.
 					// TODO: Fix conditional to only include shipping/billing address fields in a smarter way without str(i)pos.
-				} elseif ( ( 0 === stripos( $key, 'billing_' ) || 0 === stripos( $key, 'shipping_' ) )
-					&& ! in_array( $key, array( 'shipping_method', 'shipping_total', 'shipping_tax' ), true ) ) {
+				} elseif (
+					(
+						'billing' === current( explode( '_', $key ) )
+						|| 'shipping' === current( explode( '_', $key ) )
+					)
+					&& (
+						'shipping_method' !== $key
+						|| 'shipping_total' !== $key
+						|| 'shipping_tax' !== $key
+					)
+				) {
 					$order->update_meta_data( '_' . $key, $value );
 				}
 			}


### PR DESCRIPTION
Here I'm proposing the logic for `elseif` to enhance the performance. This usage of `current()` and `explode()` function is significantly faster than `stripos()` and `in_array()` functions for upgraded **PHP** versions.

[Here is the benchmark for above.](http://sandbox.onlinephpfunctions.com/code/ca905309749a80ae3ee093ce1ee94db2f2d8be49) 

Setting the `current( explode( '_', $key )` on the fly to a variable we can cut the time to almost half. But **WPCS** doesn't allow setting a variable on the fly in side a condition check. But after not using on the fly variable the time is very low.

[Here is the benchmark for second approach.](http://sandbox.onlinephpfunctions.com/code/4a462f2cf9e433f862f77c3e77a6bfb064d33a14) 

I thought about using the `array_shift()` also, but it only works on variable. So the second issue occurs or we need to define a separate method for this.