### PR TITLE
ZA tax rate changed from 14 to 15% on 1 April 2018

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -999,7 +999,7 @@ return array(
 				array(
 					'country'  => 'ZA',
 					'state'    => '',
-					'rate'     => '14.0000',
+					'rate'     => '15.0000',
 					'name'     => 'VAT',
 					'shipping' => true,
 				),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change South African default tax rate from 14% to 15%, new tax rate became effective 1 Apr 2018.

Closes #19908

### How to test the changes in this Pull Request:

1. Setup a new WC store
2. In the OBW select your locale as ZA and complete the wizard.
3. Go to WooCommerce -> Settings -> Tax -> Standard Rates and ensure the new rule there states 15% for South Africa.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Change ZA tax rate from 14% to 15%
