### PR TITLE
including `isset` check for nonce variable.

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
@@ -46,7 +46,7 @@ class WC_Meta_Box_Product_Reviews {
 	 */
 	public static function save( $data ) {
 		// Not allowed, return regular value without updating meta
-		if ( ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) && ! isset( $_POST['rating'] ) ) {
+		if ( ! isset( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) && ! isset( $_POST['rating'] ) ) {
 			return $data;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the `isset` check for the nonce when saving a review using `wp_update_comment`. This prevents the missing index error that is generated.

Closes #19911 

### Changelog entry

> Including isset check for nonce variable when updating a review via `wp_update_comment`
