### PR TITLE
Improve filter 'woocommerce_cart_item_data_to_validate'

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -480,10 +480,12 @@ function wc_get_cart_item_data_hash( $product ) {
 	return md5(
 		wp_json_encode(
 			apply_filters(
-				'woocommerce_cart_item_data_to_validate', array(
+				'woocommerce_cart_item_data_to_validate',
+				array(
 					'type'       => $product->get_type(),
 					'attributes' => 'variation' === $product->get_type() ? $product->get_variation_attributes() : '',
-				)
+				),
+				$product
 			)
 		)
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I propose to add $product as second argument for the filter 'woocommerce_cart_item_data_to_validate'. This is necessary to get information about the cart item.