### PR TITLE
GDPR - log audit

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1217,7 +1217,7 @@ class WC_Helper {
 		}
 
 		if ( ! $activated ) {
-			self::log( 'Could not activate a subscription upon plugin activation: ' . $$filename );
+			self::log( 'Could not activate a subscription upon plugin activation: ' . $filename );
 			return;
 		}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -352,6 +352,7 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_orders' );
+		wp_clear_scheduled_hook( 'woocommerce_cleanup_logs' );
 		wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
@@ -366,7 +367,8 @@ class WC_Install {
 		}
 
 		wp_schedule_event( time(), 'daily', 'woocommerce_cleanup_orders' );
-		wp_schedule_event( time(), 'twicedaily', 'woocommerce_cleanup_sessions' );
+		wp_schedule_event( time() + ( 3 * HOUR_IN_SECONDS ), 'daily', 'woocommerce_cleanup_logs' );
+		wp_schedule_event( time() + ( 6 * HOUR_IN_SECONDS ), 'twicedaily', 'woocommerce_cleanup_sessions' );
 		wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
 		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
 

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -1,16 +1,16 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
 /**
  * Provides logging capabilities for debugging purposes.
  *
  * @class          WC_Logger
  * @version        2.0.0
  * @package        WooCommerce/Classes
- * @category       Class
- * @author         WooThemes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Logger class.
  */
 class WC_Logger implements WC_Logger_Interface {
 
@@ -31,12 +31,8 @@ class WC_Logger implements WC_Logger_Interface {
 	/**
 	 * Constructor for the logger.
 	 *
-	 * @param array $handlers Optional. Array of log handlers. If $handlers is not provided,
-	 *     the filter 'woocommerce_register_log_handlers' will be used to define the handlers.
-	 *     If $handlers is provided, the filter will not be applied and the handlers will be
-	 *     used directly.
-	 * @param string $threshold Optional. Define an explicit threshold. May be configured
-	 *     via  WC_LOG_THRESHOLD. By default, all logs will be processed.
+	 * @param array  $handlers Optional. Array of log handlers. If $handlers is not provided, the filter 'woocommerce_register_log_handlers' will be used to define the handlers. If $handlers is provided, the filter will not be applied and the handlers will be used directly.
+	 * @param string $threshold Optional. Define an explicit threshold. May be configured via  WC_LOG_THRESHOLD. By default, all logs will be processed.
 	 */
 	public function __construct( $handlers = null, $threshold = null ) {
 		if ( null === $handlers ) {
@@ -48,7 +44,7 @@ class WC_Logger implements WC_Logger_Interface {
 		if ( ! empty( $handlers ) && is_array( $handlers ) ) {
 			foreach ( $handlers as $handler ) {
 				$implements = class_implements( $handler );
-				if ( is_object( $handler ) && is_array( $implements ) && in_array( 'WC_Log_Handler_Interface', $implements ) ) {
+				if ( is_object( $handler ) && is_array( $implements ) && in_array( 'WC_Log_Handler_Interface', $implements, true ) ) {
 					$register_handlers[] = $handler;
 				} else {
 					wc_doing_it_wrong(
@@ -80,7 +76,7 @@ class WC_Logger implements WC_Logger_Interface {
 	/**
 	 * Determine whether to handle or ignore log.
 	 *
-	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug
+	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
 	 * @return bool True if the log should be handled.
 	 */
 	protected function should_handle( $level ) {
@@ -96,15 +92,17 @@ class WC_Logger implements WC_Logger_Interface {
 	 * This is not the preferred method for adding log messages. Please use log() or any one of
 	 * the level methods (debug(), info(), etc.). This method may be deprecated in the future.
 	 *
-	 * @param string $handle
-	 * @param string $message
-	 * @param string $level
-	 *
+	 * @param string $handle File handle.
+	 * @param string $message Message to log.
+	 * @param string $level Logging level.
 	 * @return bool
 	 */
 	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {
 		$message = apply_filters( 'woocommerce_logger_add_message', $message, $handle );
-		$this->log( $level, $message, array( 'source' => $handle, '_legacy' => true ) );
+		$this->log( $level, $message, array(
+			'source'  => $handle,
+			'_legacy' => true,
+		) );
 		wc_do_deprecated_action( 'woocommerce_log_add', array( $handle, $message ), '3.0', 'This action has been deprecated with no alternative.' );
 		return true;
 	}
@@ -122,7 +120,7 @@ class WC_Logger implements WC_Logger_Interface {
 	 *     'info': Informational messages.
 	 *     'debug': Debug-level messages.
 	 * @param string $message Log message.
-	 * @param array $context Optional. Additional information for log handlers.
+	 * @param array  $context Optional. Additional information for log handlers.
 	 */
 	public function log( $level, $message, $context = array() ) {
 		if ( ! WC_Log_Levels::is_valid_level( $level ) ) {
@@ -132,7 +130,7 @@ class WC_Logger implements WC_Logger_Interface {
 
 		if ( $this->should_handle( $level ) ) {
 			$timestamp = current_time( 'timestamp' );
-			$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
+			$message   = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
 
 			foreach ( $this->handlers as $handler ) {
 				$handler->handle( $timestamp, $level, $message, $context );
@@ -147,8 +145,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function emergency( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::EMERGENCY, $message, $context );
@@ -162,8 +160,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function alert( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::ALERT, $message, $context );
@@ -177,8 +175,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function critical( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::CRITICAL, $message, $context );
@@ -192,8 +190,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function error( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::ERROR, $message, $context );
@@ -209,8 +207,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function warning( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::WARNING, $message, $context );
@@ -223,8 +221,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function notice( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::NOTICE, $message, $context );
@@ -238,8 +236,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function info( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::INFO, $message, $context );
@@ -252,8 +250,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function debug( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::DEBUG, $message, $context );
@@ -262,7 +260,7 @@ class WC_Logger implements WC_Logger_Interface {
 	/**
 	 * Clear entries for a chosen file/source.
 	 *
-	 * @param string $source
+	 * @param string $source Source/handle to clear.
 	 * @return bool
 	 */
 	public function clear( $source = '' ) {
@@ -275,5 +273,21 @@ class WC_Logger implements WC_Logger_Interface {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Clear all logs older than a defined number of days. Defaults to 30 days.
+	 *
+	 * @since 3.4.0
+	 */
+	public function clear_expired_logs() {
+		$days      = absint( apply_filters( 'woocommerce_logger_days_to_retain_logs', 30 ) );
+		$timestamp = strtotime( "-{$days} days" );
+
+		foreach ( $this->handlers as $handler ) {
+			if ( is_callable( array( $handler, 'delete_logs_before_timestamp' ) ) ) {
+				$handler->delete_logs_before_timestamp( $timestamp );
+			}
+		}
 	}
 }

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -260,17 +260,20 @@ class WC_Logger implements WC_Logger_Interface {
 	}
 
 	/**
-	 * Clear entries from chosen file.
+	 * Clear entries for a chosen file/source.
 	 *
-	 * @deprecated 3.0.0
-	 *
-	 * @param string $handle
-	 *
+	 * @param string $source
 	 * @return bool
 	 */
-	public function clear( $handle ) {
-		wc_deprecated_function( 'WC_Logger::clear', '3.0', 'WC_Log_Handler_File::clear' );
-		$handler = new WC_Log_Handler_File();
-		return $handler->clear( $handle );
+	public function clear( $source = '' ) {
+		if ( ! $source ) {
+			return false;
+		}
+		foreach ( $this->handlers as $handler ) {
+			if ( is_callable( array( $handler, 'clear' ) ) ) {
+				$handler->clear( $source );
+			}
+		}
+		return true;
 	}
 }

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -409,27 +409,6 @@ class WC_Webhook extends WC_Legacy_Webhook {
 				'Body'        => wp_slash( $request['body'] ),
 			),
 		);
-		if ( is_wp_error( $response ) ) {
-			$message['Webhook Delivery']['Response'] = array(
-				'Code'    => $response->get_error_code(),
-				'Message' => $response->get_error_message(),
-				'Headers' => array(),
-				'Body'    => '',
-			);
-		} else {
-			$message['Webhook Delivery']['Response'] = array(
-				'Code'    => wp_remote_retrieve_response_code( $response ),
-				'Message' => wp_remote_retrieve_response_message( $response ),
-				'Headers' => wp_remote_retrieve_headers( $response ),
-				'Body'    => wp_remote_retrieve_body( $response ),
-			);
-		}
-
-		$logger->info(
-			wc_print_r( $message, true ), array(
-				'source' => 'webhooks-delivery',
-			)
-		);
 
 		// Parse response.
 		if ( is_wp_error( $response ) ) {
@@ -437,12 +416,23 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			$response_message = $response->get_error_message();
 			$response_headers = array();
 			$response_body    = '';
-
 		} else {
 			$response_code    = wp_remote_retrieve_response_code( $response );
 			$response_message = wp_remote_retrieve_response_message( $response );
 			$response_headers = wp_remote_retrieve_headers( $response );
 			$response_body    = wp_remote_retrieve_body( $response );
+		}
+
+		$message['Webhook Delivery']['Response'] = array(
+			'Code'    => $response_code,
+			'Message' => $response_message,
+			'Headers' => $response_headers,
+			'Body'    => $response_body,
+		);
+
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			$message['Webhook Delivery']['Body']             = 'Webhook body is not logged unless WP_DEBUG mode is turned on. This is to avoid the storing of personal data in the logs.';
+			$message['Webhook Delivery']['Response']['Body'] = 'Webhook body is not logged unless WP_DEBUG mode is turned on. This is to avoid the storing of personal data in the logs.';
 		}
 
 		$logger->info(

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -60,8 +60,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$this->email          = $this->get_option( 'email' );
 		$this->receiver_email = $this->get_option( 'receiver_email', $this->email );
 		$this->identity_token = $this->get_option( 'identity_token' );
-
-		self::$log_enabled = $this->debug;
+		self::$log_enabled    = $this->debug;
 
 		if ( $this->testmode ) {
 			/* translators: %s: Link to PayPal sandbox testing guide page */
@@ -114,6 +113,26 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			}
 			self::$log->log( $level, $message, array( 'source' => 'paypal' ) );
 		}
+	}
+
+	/**
+	 * Processes and saves options.
+	 * If there is an error thrown, will continue to save and validate fields, but will leave the erroring field out.
+	 *
+	 * @return bool was anything saved?
+	 */
+	public function process_admin_options() {
+		$saved = parent::process_admin_options();
+
+		// Maybe clear logs.
+		if ( 'yes' !== $this->get_option( 'debug', 'no' ) ) {
+			if ( empty( self::$log ) ) {
+				self::$log = wc_get_logger();
+			}
+			self::$log->clear( 'paypal' );
+		}
+
+		return $saved;
 	}
 
 	/**

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -99,16 +99,15 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 		// Post back to get a response.
 		$response = wp_safe_remote_post( $this->sandbox ? 'https://www.sandbox.paypal.com/cgi-bin/webscr' : 'https://www.paypal.com/cgi-bin/webscr', $params );
 
-		WC_Gateway_Paypal::log( 'IPN Request: ' . wc_print_r( $params, true ) );
 		WC_Gateway_Paypal::log( 'IPN Response: ' . wc_print_r( $response, true ) );
 
 		// Check to see if the request was valid.
 		if ( ! is_wp_error( $response ) && $response['response']['code'] >= 200 && $response['response']['code'] < 300 && strstr( $response['body'], 'VERIFIED' ) ) {
-			WC_Gateway_Paypal::log( 'Received valid response from PayPal' );
+			WC_Gateway_Paypal::log( 'Received valid response from PayPal IPN' );
 			return true;
 		}
 
-		WC_Gateway_Paypal::log( 'Received invalid response from PayPal' );
+		WC_Gateway_Paypal::log( 'Received invalid response from PayPal IPN' );
 
 		if ( is_wp_error( $response ) ) {
 			WC_Gateway_Paypal::log( 'Error response: ' . $response->get_error_message() );
@@ -347,15 +346,6 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	 * @param array    $posted Posted data.
 	 */
 	protected function save_paypal_meta_data( $order, $posted ) {
-		if ( ! empty( $posted['payer_email'] ) ) {
-			update_post_meta( $order->get_id(), 'Payer PayPal address', wc_clean( $posted['payer_email'] ) );
-		}
-		if ( ! empty( $posted['first_name'] ) ) {
-			update_post_meta( $order->get_id(), 'Payer first name', wc_clean( $posted['first_name'] ) );
-		}
-		if ( ! empty( $posted['last_name'] ) ) {
-			update_post_meta( $order->get_id(), 'Payer last name', wc_clean( $posted['last_name'] ) );
-		}
 		if ( ! empty( $posted['payment_type'] ) ) {
 			update_post_meta( $order->get_id(), 'Payment type', wc_clean( $posted['payment_type'] ) );
 		}

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -61,16 +61,26 @@ class WC_Gateway_Paypal_Request {
 	 * @return string
 	 */
 	public function get_request_url( $order, $sandbox = false ) {
-		if ( $sandbox ) {
-			$this->endpoint = 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&';
-		} else {
-			$this->endpoint = 'https://www.paypal.com/cgi-bin/webscr?';
-		}
-		$paypal_args = http_build_query( $this->get_paypal_args( $order ), '', '&' );
+		$this->endpoint = $sandbox ? 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&' : 'https://www.paypal.com/cgi-bin/webscr?';
+		$paypal_args    = $this->get_paypal_args( $order );
+		$mask           = array(
+			'first_name'    => '***',
+			'last_name'     => '***',
+			'address1'      => '***',
+			'address2'      => '***',
+			'city'          => '***',
+			'state'         => '***',
+			'zip'           => '***',
+			'country'       => '***',
+			'email'         => '***@***',
+			'night_phone_a' => '***',
+			'night_phone_b' => '***',
+			'night_phone_c' => '***',
+		);
 
-		WC_Gateway_Paypal::log( 'PayPal Request Args for order ' . $order->get_order_number() . ': ' . wc_print_r( $paypal_args, true ) );
+		WC_Gateway_Paypal::log( 'PayPal Request Args for order ' . $order->get_order_number() . ': ' . wc_print_r( array_merge( $paypal_args, array_intersect_key( $mask, $paypal_args ) ), true ) );
 
-		return $this->endpoint . $paypal_args;
+		return $this->endpoint . http_build_query( $paypal_args, '', '&' );
 	}
 
 	/**

--- a/includes/gateways/paypal/includes/settings-paypal.php
+++ b/includes/gateways/paypal/includes/settings-paypal.php
@@ -55,7 +55,7 @@ return array(
 		'label'       => __( 'Enable logging', 'woocommerce' ),
 		'default'     => 'no',
 		/* translators: %s: URL */
-		'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside %s', 'woocommerce' ), '<code>' . WC_Log_Handler_File::get_log_file_path( 'paypal' ) . '</code>' ),
+		'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside %s Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ), '<code>' . WC_Log_Handler_File::get_log_file_path( 'paypal' ) . '</code>' ),
 	),
 	'ipn_notification'      => array(
 		'title'       => __( 'IPN Email Notifications', 'woocommerce' ),

--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -94,6 +94,23 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 	}
 
 	/**
+	 * Clear entries for a chosen handle/source.
+	 *
+	 * @param string $source Log source.
+	 * @return bool
+	 */
+	public function clear( $source ) {
+		global $wpdb;
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE source = %s",
+				$source
+			)
+		);
+	}
+
+	/**
 	 * Delete selected logs from DB.
 	 *
 	 * @param int|string|array $log_ids Log ID or array of Log IDs to be deleted.

--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -76,7 +76,7 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 		);
 
 		if ( ! empty( $context ) ) {
-			$insert['context'] = serialize( $context );
+			$insert['context'] = serialize( $context ); // @codingStandardsIgnoreLine.
 		}
 
 		return false !== $wpdb->insert( "{$wpdb->prefix}woocommerce_log", $insert, $format );
@@ -128,10 +128,26 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 
 		$query_in = '(' . implode( ',', $format ) . ')';
 
-		return $wpdb->query(
+		return $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_log WHERE log_id IN {$query_in}" ); // @codingStandardsIgnoreLine.
+	}
+
+	/**
+	 * Delete all logs older than a defined timestamp.
+	 *
+	 * @since 3.4.0
+	 * @param integer $timestamp Timestamp to delete logs before.
+	 */
+	public static function delete_logs_before_timestamp( $timestamp = 0 ) {
+		if ( ! $timestamp ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE log_id IN {$query_in}", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-				$log_ids
+				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE timestamp < %d",
+				$timestamp
 			)
 		);
 	}
@@ -157,7 +173,7 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 			$debug_backtrace_arg = false;
 		}
 
-		$trace = debug_backtrace( $debug_backtrace_arg ); // phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.debug_backtrace_optionsFound
+		$trace = debug_backtrace( $debug_backtrace_arg ); // @codingStandardsIgnoreLine.
 		foreach ( $trace as $t ) {
 			if ( isset( $t['file'] ) ) {
 				$filename = pathinfo( $t['file'], PATHINFO_FILENAME );

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -48,12 +48,11 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	 * @param int $log_size_limit Optional. Size limit for log files. Default 5mb.
 	 */
 	public function __construct( $log_size_limit = null ) {
-
 		if ( null === $log_size_limit ) {
 			$log_size_limit = 5 * 1024 * 1024;
 		}
 
-		$this->log_size_limit = $log_size_limit;
+		$this->log_size_limit = apply_filters( 'woocommerce_log_file_size_limit', $log_size_limit );
 
 		add_action( 'plugins_loaded', array( $this, 'write_cached_logs' ) );
 	}
@@ -66,7 +65,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	public function __destruct() {
 		foreach ( $this->handles as $handle ) {
 			if ( is_resource( $handle ) ) {
-				fclose( $handle );
+				fclose( $handle ); // @codingStandardsIgnoreLine.
 			}
 		}
 	}
@@ -144,15 +143,15 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 
 		if ( $file ) {
 			if ( ! file_exists( $file ) ) {
-				$temphandle = @fopen( $file, 'w+' );
-				@fclose( $temphandle );
+				$temphandle = @fopen( $file, 'w+' ); // @codingStandardsIgnoreLine.
+				@fclose( $temphandle ); // @codingStandardsIgnoreLine.
 
 				if ( defined( 'FS_CHMOD_FILE' ) ) {
-					@chmod( $file, FS_CHMOD_FILE ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.chmod_chmod
+					@chmod( $file, FS_CHMOD_FILE ); // @codingStandardsIgnoreLine.
 				}
 			}
 
-			$resource = @fopen( $file, $mode );
+			$resource = @fopen( $file, $mode ); // @codingStandardsIgnoreLine.
 
 			if ( $resource ) {
 				$this->handles[ $handle ] = $resource;
@@ -183,7 +182,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		$result = false;
 
 		if ( $this->is_open( $handle ) ) {
-			$result = fclose( $this->handles[ $handle ] );
+			$result = fclose( $this->handles[ $handle ] ); // @codingStandardsIgnoreLine.
 			unset( $this->handles[ $handle ] );
 		}
 
@@ -206,7 +205,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		}
 
 		if ( $this->open( $handle ) && is_resource( $this->handles[ $handle ] ) ) {
-			$result = fwrite( $this->handles[ $handle ], $entry . PHP_EOL );
+			$result = fwrite( $this->handles[ $handle ], $entry . PHP_EOL ); // @codingStandardsIgnoreLine.
 		} else {
 			$this->cache_log( $entry, $handle );
 		}
@@ -356,13 +355,17 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Get a log file name.
 	 *
+	 * File names consist of the handle, followed by the date, followed by a hash, .log.
+	 *
 	 * @since 3.3
 	 * @param string $handle Log name.
 	 * @return bool|string The log file name or false if cannot be determined.
 	 */
 	public static function get_log_file_name( $handle ) {
 		if ( function_exists( 'wp_hash' ) ) {
-			return sanitize_file_name( $handle . '-' . wp_hash( $handle ) . '.log' );
+			$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
+			$hash_suffix = wp_hash( $handle );
+			return sanitize_file_name( implode( '-', array( $handle, $date_suffix, $hash_suffix ) ) . '.log' );
 		} else {
 			wc_doing_it_wrong( __METHOD__, __( 'This method should not be called before plugins_loaded.', 'woocommerce' ), '3.3' );
 			return false;
@@ -391,4 +394,48 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		}
 	}
 
+	/**
+	 * Delete all logs older than a defined timestamp.
+	 *
+	 * @since 3.4.0
+	 * @param integer $timestamp Timestamp to delete logs before.
+	 */
+	public static function delete_logs_before_timestamp( $timestamp = 0 ) {
+		if ( ! $timestamp ) {
+			return;
+		}
+
+		$log_files = self::get_log_files();
+
+		foreach ( $log_files as $log_file ) {
+			$last_modified = filemtime( trailingslashit( WC_LOG_DIR ) . $log_file );
+
+			if ( $last_modified < $timestamp ) {
+				@unlink( trailingslashit( WC_LOG_DIR ) . $log_file ); // @codingStandardsIgnoreLine.
+			}
+		}
+	}
+
+	/**
+	 * Get all log files in the log directory.
+	 *
+	 * @since 3.4.0
+	 * @return array
+	 */
+	public static function get_log_files() {
+		$files  = @scandir( WC_LOG_DIR ); // @codingStandardsIgnoreLine.
+		$result = array();
+
+		if ( ! empty( $files ) ) {
+			foreach ( $files as $key => $value ) {
+				if ( ! in_array( $value, array( '.', '..' ), true ) ) {
+					if ( ! is_dir( $value ) && strstr( $value, '.log' ) ) {
+						$result[ sanitize_title( $value ) ] = $value;
+					}
+				}
+			}
+		}
+
+		return $result;
+	}
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1661,6 +1661,20 @@ function wc_get_logger() {
 }
 
 /**
+ * Trigger logging cleanup using the logging class.
+ *
+ * @since 3.4.0
+ */
+function wc_cleanup_logs() {
+	$logger = wc_get_logger();
+
+	if ( is_callable( array( $logger, 'clear_expired_logs' ) ) ) {
+		$logger->clear_expired_logs();
+	}
+}
+add_action( 'woocommerce_cleanup_logs', 'wc_cleanup_logs' );
+
+/**
  * Prints human-readable information about a variable.
  *
  * Some server environments blacklist some debugging functions. This function provides a safe way to

--- a/tests/unit-tests/log/log-handler-file.php
+++ b/tests/unit-tests/log/log-handler-file.php
@@ -197,8 +197,9 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 */
 	public function test_get_log_file_path() {
 		$log_dir   = trailingslashit( WC_LOG_DIR );
+		$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
 		$hash_name = sanitize_file_name( wp_hash( 'unit-tests' ) );
-		$this->assertEquals( $log_dir . 'unit-tests-' . $hash_name . '.log', WC_Log_Handler_File::get_log_file_path( 'unit-tests' ) );
+		$this->assertEquals( $log_dir . 'unit-tests-' . $date_suffix . '-' . $hash_name . '.log', WC_Log_Handler_File::get_log_file_path( 'unit-tests' ) );
 	}
 
 }

--- a/tests/unit-tests/log/logger.php
+++ b/tests/unit-tests/log/logger.php
@@ -25,7 +25,10 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 				$this->greaterThanOrEqual( $time ),
 				$this->equalTo( 'notice' ),
 				$this->equalTo( 'this is a message' ),
-				$this->equalTo( array( 'source' => 'unit-tests', '_legacy' => true ) )
+				$this->equalTo( array(
+					'source' => 'unit-tests',
+					'_legacy' => true,
+				) )
 			);
 		$log = new WC_Logger( array( $handler ), 'debug' );
 
@@ -39,11 +42,10 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 */
 	public function test_clear() {
 		$file = wc_get_log_file_path( 'unit-tests' );
-		file_put_contents( $file, 'Test file content.' );
+		file_put_contents( $file, 'Test file content.' ); // @codingStandardsIgnoreLine.
 		$log = new WC_Logger();
 		$log->clear( 'unit-tests' );
 		$this->assertEquals( '', file_get_contents( $file ) );
-		$this->setExpectedDeprecated( 'WC_Logger::clear' );
 	}
 
 	/**

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -239,8 +239,9 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_log_file_path() {
 		$log_dir   = trailingslashit( WC_LOG_DIR );
 		$hash_name = sanitize_file_name( wp_hash( 'unit-tests' ) );
+		$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
 
-		$this->assertEquals( $log_dir . 'unit-tests-' . $hash_name . '.log', wc_get_log_file_path( 'unit-tests' ) );
+		$this->assertEquals( $log_dir . 'unit-tests-' . $date_suffix . '-' . $hash_name . '.log', wc_get_log_file_path( 'unit-tests' ) );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,6 +16,7 @@ wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
 wp_clear_scheduled_hook( 'woocommerce_cleanup_orders' );
+wp_clear_scheduled_hook( 'woocommerce_cleanup_logs' );
 wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 


### PR DESCRIPTION
This PR addresses PII stored in debug logs.

1. Webhook body is no longer logged unless DEBUG mode is enabled. No other PII data is included.
2. PayPal response data is no longer stored to meta.
3. PayPal logs mask user address data and no longer log full request/responses which could include PII
4. The debug setting in paypal includes a disclaimer about clearing logs when done.
5. When debug in paypal is disabled, logs are cleared. I’ve added support for the DB logger method too to allow clearing by source.

To test:

- Enable some webhooks and trigger them
- Checkout using PayPal stadard.
- Check WC > Status > Logs and ensure data is masked or missing.