### PR TITLE
Log file cleanup/purge

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -352,6 +352,7 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_orders' );
+		wp_clear_scheduled_hook( 'woocommerce_cleanup_logs' );
 		wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 
@@ -366,7 +367,8 @@ class WC_Install {
 		}
 
 		wp_schedule_event( time(), 'daily', 'woocommerce_cleanup_orders' );
-		wp_schedule_event( time(), 'twicedaily', 'woocommerce_cleanup_sessions' );
+		wp_schedule_event( time() + ( 3 * HOUR_IN_SECONDS ), 'daily', 'woocommerce_cleanup_logs' );
+		wp_schedule_event( time() + ( 6 * HOUR_IN_SECONDS ), 'twicedaily', 'woocommerce_cleanup_sessions' );
 		wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
 		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
 

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -1,16 +1,16 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
 /**
  * Provides logging capabilities for debugging purposes.
  *
  * @class          WC_Logger
  * @version        2.0.0
  * @package        WooCommerce/Classes
- * @category       Class
- * @author         WooThemes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Logger class.
  */
 class WC_Logger implements WC_Logger_Interface {
 
@@ -31,12 +31,8 @@ class WC_Logger implements WC_Logger_Interface {
 	/**
 	 * Constructor for the logger.
 	 *
-	 * @param array $handlers Optional. Array of log handlers. If $handlers is not provided,
-	 *     the filter 'woocommerce_register_log_handlers' will be used to define the handlers.
-	 *     If $handlers is provided, the filter will not be applied and the handlers will be
-	 *     used directly.
-	 * @param string $threshold Optional. Define an explicit threshold. May be configured
-	 *     via  WC_LOG_THRESHOLD. By default, all logs will be processed.
+	 * @param array  $handlers Optional. Array of log handlers. If $handlers is not provided, the filter 'woocommerce_register_log_handlers' will be used to define the handlers. If $handlers is provided, the filter will not be applied and the handlers will be used directly.
+	 * @param string $threshold Optional. Define an explicit threshold. May be configured via  WC_LOG_THRESHOLD. By default, all logs will be processed.
 	 */
 	public function __construct( $handlers = null, $threshold = null ) {
 		if ( null === $handlers ) {
@@ -48,7 +44,7 @@ class WC_Logger implements WC_Logger_Interface {
 		if ( ! empty( $handlers ) && is_array( $handlers ) ) {
 			foreach ( $handlers as $handler ) {
 				$implements = class_implements( $handler );
-				if ( is_object( $handler ) && is_array( $implements ) && in_array( 'WC_Log_Handler_Interface', $implements ) ) {
+				if ( is_object( $handler ) && is_array( $implements ) && in_array( 'WC_Log_Handler_Interface', $implements, true ) ) {
 					$register_handlers[] = $handler;
 				} else {
 					wc_doing_it_wrong(
@@ -80,7 +76,7 @@ class WC_Logger implements WC_Logger_Interface {
 	/**
 	 * Determine whether to handle or ignore log.
 	 *
-	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug
+	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
 	 * @return bool True if the log should be handled.
 	 */
 	protected function should_handle( $level ) {
@@ -96,15 +92,17 @@ class WC_Logger implements WC_Logger_Interface {
 	 * This is not the preferred method for adding log messages. Please use log() or any one of
 	 * the level methods (debug(), info(), etc.). This method may be deprecated in the future.
 	 *
-	 * @param string $handle
-	 * @param string $message
-	 * @param string $level
-	 *
+	 * @param string $handle File handle.
+	 * @param string $message Message to log.
+	 * @param string $level Logging level.
 	 * @return bool
 	 */
 	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {
 		$message = apply_filters( 'woocommerce_logger_add_message', $message, $handle );
-		$this->log( $level, $message, array( 'source' => $handle, '_legacy' => true ) );
+		$this->log( $level, $message, array(
+			'source'  => $handle,
+			'_legacy' => true,
+		) );
 		wc_do_deprecated_action( 'woocommerce_log_add', array( $handle, $message ), '3.0', 'This action has been deprecated with no alternative.' );
 		return true;
 	}
@@ -122,7 +120,7 @@ class WC_Logger implements WC_Logger_Interface {
 	 *     'info': Informational messages.
 	 *     'debug': Debug-level messages.
 	 * @param string $message Log message.
-	 * @param array $context Optional. Additional information for log handlers.
+	 * @param array  $context Optional. Additional information for log handlers.
 	 */
 	public function log( $level, $message, $context = array() ) {
 		if ( ! WC_Log_Levels::is_valid_level( $level ) ) {
@@ -132,7 +130,7 @@ class WC_Logger implements WC_Logger_Interface {
 
 		if ( $this->should_handle( $level ) ) {
 			$timestamp = current_time( 'timestamp' );
-			$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
+			$message   = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
 
 			foreach ( $this->handlers as $handler ) {
 				$handler->handle( $timestamp, $level, $message, $context );
@@ -147,8 +145,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function emergency( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::EMERGENCY, $message, $context );
@@ -162,8 +160,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function alert( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::ALERT, $message, $context );
@@ -177,8 +175,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function critical( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::CRITICAL, $message, $context );
@@ -192,8 +190,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function error( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::ERROR, $message, $context );
@@ -209,8 +207,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function warning( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::WARNING, $message, $context );
@@ -223,8 +221,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function notice( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::NOTICE, $message, $context );
@@ -238,8 +236,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function info( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::INFO, $message, $context );
@@ -252,8 +250,8 @@ class WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @see WC_Logger::log
 	 *
-	 * @param string $message
-	 * @param array $context
+	 * @param string $message Message to log.
+	 * @param array  $context Log context.
 	 */
 	public function debug( $message, $context = array() ) {
 		$this->log( WC_Log_Levels::DEBUG, $message, $context );
@@ -262,7 +260,7 @@ class WC_Logger implements WC_Logger_Interface {
 	/**
 	 * Clear entries for a chosen file/source.
 	 *
-	 * @param string $source
+	 * @param string $source Source/handle to clear.
 	 * @return bool
 	 */
 	public function clear( $source = '' ) {
@@ -275,5 +273,21 @@ class WC_Logger implements WC_Logger_Interface {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Clear all logs older than a defined number of days. Defaults to 30 days.
+	 *
+	 * @since 3.4.0
+	 */
+	public function clear_expired_logs() {
+		$days      = absint( apply_filters( 'woocommerce_logger_days_to_retain_logs', 30 ) );
+		$timestamp = strtotime( "-{$days} days" );
+
+		foreach ( $this->handlers as $handler ) {
+			if ( is_callable( array( $handler, 'delete_logs_before_timestamp' ) ) ) {
+				$handler->delete_logs_before_timestamp( $timestamp );
+			}
+		}
 	}
 }

--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -76,7 +76,7 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 		);
 
 		if ( ! empty( $context ) ) {
-			$insert['context'] = serialize( $context );
+			$insert['context'] = serialize( $context ); // @codingStandardsIgnoreLine.
 		}
 
 		return false !== $wpdb->insert( "{$wpdb->prefix}woocommerce_log", $insert, $format );
@@ -128,10 +128,26 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 
 		$query_in = '(' . implode( ',', $format ) . ')';
 
-		return $wpdb->query(
+		return $wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_log WHERE log_id IN {$query_in}" ); // @codingStandardsIgnoreLine.
+	}
+
+	/**
+	 * Delete all logs older than a defined timestamp.
+	 *
+	 * @since 3.4.0
+	 * @param integer $timestamp Timestamp to delete logs before.
+	 */
+	public static function delete_logs_before_timestamp( $timestamp = 0 ) {
+		if ( ! $timestamp ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE log_id IN {$query_in}", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-				$log_ids
+				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE timestamp < %d",
+				$timestamp
 			)
 		);
 	}
@@ -157,7 +173,7 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 			$debug_backtrace_arg = false;
 		}
 
-		$trace = debug_backtrace( $debug_backtrace_arg ); // phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.debug_backtrace_optionsFound
+		$trace = debug_backtrace( $debug_backtrace_arg ); // @codingStandardsIgnoreLine.
 		foreach ( $trace as $t ) {
 			if ( isset( $t['file'] ) ) {
 				$filename = pathinfo( $t['file'], PATHINFO_FILENAME );

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -48,12 +48,11 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	 * @param int $log_size_limit Optional. Size limit for log files. Default 5mb.
 	 */
 	public function __construct( $log_size_limit = null ) {
-
 		if ( null === $log_size_limit ) {
 			$log_size_limit = 5 * 1024 * 1024;
 		}
 
-		$this->log_size_limit = $log_size_limit;
+		$this->log_size_limit = apply_filters( 'woocommerce_log_file_size_limit', $log_size_limit );
 
 		add_action( 'plugins_loaded', array( $this, 'write_cached_logs' ) );
 	}
@@ -66,7 +65,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	public function __destruct() {
 		foreach ( $this->handles as $handle ) {
 			if ( is_resource( $handle ) ) {
-				fclose( $handle );
+				fclose( $handle ); // @codingStandardsIgnoreLine.
 			}
 		}
 	}
@@ -144,15 +143,15 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 
 		if ( $file ) {
 			if ( ! file_exists( $file ) ) {
-				$temphandle = @fopen( $file, 'w+' );
-				@fclose( $temphandle );
+				$temphandle = @fopen( $file, 'w+' ); // @codingStandardsIgnoreLine.
+				@fclose( $temphandle ); // @codingStandardsIgnoreLine.
 
 				if ( defined( 'FS_CHMOD_FILE' ) ) {
-					@chmod( $file, FS_CHMOD_FILE ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.chmod_chmod
+					@chmod( $file, FS_CHMOD_FILE ); // @codingStandardsIgnoreLine.
 				}
 			}
 
-			$resource = @fopen( $file, $mode );
+			$resource = @fopen( $file, $mode ); // @codingStandardsIgnoreLine.
 
 			if ( $resource ) {
 				$this->handles[ $handle ] = $resource;
@@ -183,7 +182,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		$result = false;
 
 		if ( $this->is_open( $handle ) ) {
-			$result = fclose( $this->handles[ $handle ] );
+			$result = fclose( $this->handles[ $handle ] ); // @codingStandardsIgnoreLine.
 			unset( $this->handles[ $handle ] );
 		}
 
@@ -206,7 +205,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		}
 
 		if ( $this->open( $handle ) && is_resource( $this->handles[ $handle ] ) ) {
-			$result = fwrite( $this->handles[ $handle ], $entry . PHP_EOL );
+			$result = fwrite( $this->handles[ $handle ], $entry . PHP_EOL ); // @codingStandardsIgnoreLine.
 		} else {
 			$this->cache_log( $entry, $handle );
 		}
@@ -356,13 +355,17 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	/**
 	 * Get a log file name.
 	 *
+	 * File names consist of the handle, followed by the date, followed by a hash, .log.
+	 *
 	 * @since 3.3
 	 * @param string $handle Log name.
 	 * @return bool|string The log file name or false if cannot be determined.
 	 */
 	public static function get_log_file_name( $handle ) {
 		if ( function_exists( 'wp_hash' ) ) {
-			return sanitize_file_name( $handle . '-' . wp_hash( $handle ) . '.log' );
+			$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
+			$hash_suffix = wp_hash( $handle );
+			return sanitize_file_name( implode( '-', array( $handle, $date_suffix, $hash_suffix ) ) . '.log' );
 		} else {
 			wc_doing_it_wrong( __METHOD__, __( 'This method should not be called before plugins_loaded.', 'woocommerce' ), '3.3' );
 			return false;
@@ -391,4 +394,48 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		}
 	}
 
+	/**
+	 * Delete all logs older than a defined timestamp.
+	 *
+	 * @since 3.4.0
+	 * @param integer $timestamp Timestamp to delete logs before.
+	 */
+	public static function delete_logs_before_timestamp( $timestamp = 0 ) {
+		if ( ! $timestamp ) {
+			return;
+		}
+
+		$log_files = self::get_log_files();
+
+		foreach ( $log_files as $log_file ) {
+			$last_modified = filemtime( trailingslashit( WC_LOG_DIR ) . $log_file );
+
+			if ( $last_modified < $timestamp ) {
+				@unlink( trailingslashit( WC_LOG_DIR ) . $log_file ); // @codingStandardsIgnoreLine.
+			}
+		}
+	}
+
+	/**
+	 * Get all log files in the log directory.
+	 *
+	 * @since 3.4.0
+	 * @return array
+	 */
+	public static function get_log_files() {
+		$files  = @scandir( WC_LOG_DIR ); // @codingStandardsIgnoreLine.
+		$result = array();
+
+		if ( ! empty( $files ) ) {
+			foreach ( $files as $key => $value ) {
+				if ( ! in_array( $value, array( '.', '..' ), true ) ) {
+					if ( ! is_dir( $value ) && strstr( $value, '.log' ) ) {
+						$result[ sanitize_title( $value ) ] = $value;
+					}
+				}
+			}
+		}
+
+		return $result;
+	}
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1661,6 +1661,20 @@ function wc_get_logger() {
 }
 
 /**
+ * Trigger logging cleanup using the logging class.
+ *
+ * @since 3.4.0
+ */
+function wc_cleanup_logs() {
+	$logger = wc_get_logger();
+
+	if ( is_callable( array( $logger, 'clear_expired_logs' ) ) ) {
+		$logger->clear_expired_logs();
+	}
+}
+add_action( 'woocommerce_cleanup_logs', 'wc_cleanup_logs' );
+
+/**
  * Prints human-readable information about a variable.
  *
  * Some server environments blacklist some debugging functions. This function provides a safe way to

--- a/tests/unit-tests/log/log-handler-file.php
+++ b/tests/unit-tests/log/log-handler-file.php
@@ -197,8 +197,9 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 */
 	public function test_get_log_file_path() {
 		$log_dir   = trailingslashit( WC_LOG_DIR );
+		$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
 		$hash_name = sanitize_file_name( wp_hash( 'unit-tests' ) );
-		$this->assertEquals( $log_dir . 'unit-tests-' . $hash_name . '.log', WC_Log_Handler_File::get_log_file_path( 'unit-tests' ) );
+		$this->assertEquals( $log_dir . 'unit-tests-' . $date_suffix . '-' . $hash_name . '.log', WC_Log_Handler_File::get_log_file_path( 'unit-tests' ) );
 	}
 
 }

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -239,8 +239,9 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_log_file_path() {
 		$log_dir   = trailingslashit( WC_LOG_DIR );
 		$hash_name = sanitize_file_name( wp_hash( 'unit-tests' ) );
+		$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
 
-		$this->assertEquals( $log_dir . 'unit-tests-' . $hash_name . '.log', wc_get_log_file_path( 'unit-tests' ) );
+		$this->assertEquals( $log_dir . 'unit-tests-' . $date_suffix . '-' . $hash_name . '.log', wc_get_log_file_path( 'unit-tests' ) );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,6 +16,7 @@ wp_clear_scheduled_hook( 'woocommerce_scheduled_sales' );
 wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 wp_clear_scheduled_hook( 'woocommerce_cleanup_sessions' );
 wp_clear_scheduled_hook( 'woocommerce_cleanup_orders' );
+wp_clear_scheduled_hook( 'woocommerce_cleanup_logs' );
 wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
 


### PR DESCRIPTION
This PR implements a new cron job to clean up log files after (default) 30 days.

To work this,

- Rotates the log file daily by appending the date to the file name.
- Adds a new daily cron job for log cleanup.
- Cleanup calls the current logger to delete logs before a timestamp
- File based logger loops over log files and deletes based on last modified time.
- DB based logger does a delete query to clear based on timestamp.

Resolves phpcs issues with edited files.

Closes #19916