### PR TITLE
Tool for cleaning up permissions table

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -119,37 +119,42 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 	 */
 	public function get_tools() {
 		$tools = array(
-			'clear_transients'           => array(
+			'clear_transients'                   => array(
 				'name'   => __( 'WooCommerce transients', 'woocommerce' ),
 				'button' => __( 'Clear transients', 'woocommerce' ),
 				'desc'   => __( 'This tool will clear the product/shop transients cache.', 'woocommerce' ),
 			),
-			'clear_expired_transients'   => array(
+			'clear_expired_transients'           => array(
 				'name'   => __( 'Expired transients', 'woocommerce' ),
 				'button' => __( 'Clear transients', 'woocommerce' ),
 				'desc'   => __( 'This tool will clear ALL expired transients from WordPress.', 'woocommerce' ),
 			),
-			'delete_orphaned_variations' => array(
+			'delete_orphaned_variations'         => array(
 				'name'   => __( 'Orphaned variations', 'woocommerce' ),
 				'button' => __( 'Delete orphaned variations', 'woocommerce' ),
 				'desc'   => __( 'This tool will delete all variations which have no parent.', 'woocommerce' ),
 			),
-			'add_order_indexes'          => array(
+			'clear_expired_download_permissions' => array(
+				'name'   => __( 'Used-up download permissions', 'woocommerce' ),
+				'button' => __( 'Clean up download permissions', 'woocommerce' ),
+				'desc'   => __( 'This tool will delete expired download permissions and permissions with 0 remaining downloads.', 'woocommerce' ),
+			),
+			'add_order_indexes'                  => array(
 				'name'   => __( 'Order address indexes', 'woocommerce' ),
 				'button' => __( 'Index orders', 'woocommerce' ),
 				'desc'   => __( 'This tool will add address indexes to orders that do not have them yet. This improves order search results.', 'woocommerce' ),
 			),
-			'recount_terms'              => array(
+			'recount_terms'                      => array(
 				'name'   => __( 'Term counts', 'woocommerce' ),
 				'button' => __( 'Recount terms', 'woocommerce' ),
 				'desc'   => __( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', 'woocommerce' ),
 			),
-			'reset_roles'                => array(
+			'reset_roles'                        => array(
 				'name'   => __( 'Capabilities', 'woocommerce' ),
 				'button' => __( 'Reset capabilities', 'woocommerce' ),
 				'desc'   => __( 'This tool will reset the admin, customer and shop_manager roles to default. Use this if your users cannot access all of the WooCommerce admin pages.', 'woocommerce' ),
 			),
-			'clear_sessions'             => array(
+			'clear_sessions'                     => array(
 				'name'   => __( 'Clear customer sessions', 'woocommerce' ),
 				'button' => __( 'Clear', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -158,7 +163,7 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 					__( 'This tool will delete all customer session data from the database, including current carts and saved carts in the database.', 'woocommerce' )
 				),
 			),
-			'install_pages'              => array(
+			'install_pages'                      => array(
 				'name'   => __( 'Create default WooCommerce pages', 'woocommerce' ),
 				'button' => __( 'Create pages', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -167,7 +172,7 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 					__( 'This tool will install all the missing WooCommerce pages. Pages already defined and set up will not be replaced.', 'woocommerce' )
 				),
 			),
-			'delete_taxes'               => array(
+			'delete_taxes'                       => array(
 				'name'   => __( 'Delete WooCommerce tax rates', 'woocommerce' ),
 				'button' => __( 'Delete tax rates', 'woocommerce' ),
 				'desc'   => sprintf(
@@ -176,12 +181,12 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 					__( 'This option will delete ALL of your tax rates, use with caution. This action cannot be reversed.', 'woocommerce' )
 				),
 			),
-			'reset_tracking'             => array(
+			'reset_tracking'                     => array(
 				'name'   => __( 'Reset usage tracking', 'woocommerce' ),
 				'button' => __( 'Reset', 'woocommerce' ),
 				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
 			),
-			'regenerate_thumbnails'      => array(
+			'regenerate_thumbnails'              => array(
 				'name'   => __( 'Regenerate shop thumbnails', 'woocommerce' ),
 				'button' => __( 'Regenerate', 'woocommerce' ),
 				'desc'   => __( 'This will regenerate all shop thumbnails to match your theme and/or image settings.', 'woocommerce' ),
@@ -425,6 +430,21 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				);
 				/* translators: %d: amount of orphaned variations */
 				$message = sprintf( __( '%d orphaned variations deleted', 'woocommerce' ), $result );
+				break;
+
+			case 'clear_expired_download_permissions':
+				// Delete expired download permissions and ones with 0 downloads remaining.
+				$result = absint(
+					$wpdb->query(
+						$wpdb->prepare(
+							"DELETE FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions
+							WHERE ( downloads_remaining != '' AND downloads_remaining = 0 ) OR ( access_expires IS NOT NULL AND access_expires < %s )",
+							date( 'Y-m-d', current_time( 'timestamp' ) )
+						)
+					)
+				);
+				/* translators: %d: amount of permissions */
+				$message = sprintf( __( '%d permissions deleted', 'woocommerce' ), $result );
 				break;
 
 			case 'add_order_indexes':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/19916#issuecomment-385677871

The main purpose of having the expired/0-count download permissions in the table is so that if the user tries to download they will get a useful error message ("Sorry, you have reached your download limit for this file" or "Sorry, this download has expired") and not have to contact the site owner to figure out why they can't download something they purchased.

It could be possible to automatically clean up expired download permissions after X days, but the same sort of programmatic cleanup X days after the download is used-up is not really possible for downloads with 0 remaining downloads. For this reason I've gone with a tool in the system status that can be run to clean up unnecessary rows from the download permissions table.

The alternative to this PR (or addition to this PR) is a cron task that deletes **only expired download permissions** 30 days after they've expired. If you think that's a better solution, let me know.

### How to test the changes in this Pull Request:

1. Purchase a downloadable product and use SQL to force the download permission to expire or the downloads remaining to be 0.
2. Run the tool in the System Status tools section.
3. Check the SQL table and verify it's been cleaned up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added tool for cleaning up download permissions table.
