### PR TITLE
Parent:0 terms via API PUT/POST

### DIFF
--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -491,6 +491,10 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$prepared_args['slug'] = $request['slug'];
 		}
 
+		if ( isset( $request['parent'] ) && 0 === $request['parent'] ) {
+			unset( $request['parent'] );
+		}
+
 		if ( isset( $request['parent'] ) ) {
 			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
 				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -381,6 +381,10 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$args['slug'] = $request['slug'];
 		}
 
+		if ( isset( $request['parent'] ) && 0 === $request['parent'] ) {
+			unset( $request['parent'] );
+		}
+
 		if ( isset( $request['parent'] ) ) {
 			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
 				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -380,25 +380,8 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		if ( isset( $request['slug'] ) ) {
 			$args['slug'] = $request['slug'];
 		}
-
 		if ( isset( $request['parent'] ) ) {
-			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
-				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );
-			}
-
-			$parent_id = (int) $request['parent'];
-			if ( 0 === $parent_id ) {
-				$args['parent'] = $parent_id;
-			} else {
-				$parent = get_term( $parent_id, $taxonomy );
-
-				// If is null or WP_Error is invalid parent term.
-				if ( ! $parent || is_wp_error( $parent ) ) {
-					return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
-				}
-
-				$args['parent'] = $parent->term_id;
-			}
+			$args['parent'] = $request['parent'];
 		}
 
 		$term = wp_insert_term( $name, $taxonomy, $args );
@@ -491,25 +474,8 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		if ( isset( $request['slug'] ) ) {
 			$prepared_args['slug'] = $request['slug'];
 		}
-
 		if ( isset( $request['parent'] ) ) {
-			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
-				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );
-			}
-
-			$parent_id = (int) $request['parent'];
-
-			if ( 0 === $parent_id ) {
-				$prepared_args['parent'] = $parent_id;
-			} else {
-				$parent = get_term( $parent_id, $taxonomy );
-
-				if ( ! $parent ) {
-					return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 400 ) );
-				}
-
-				$prepared_args['parent'] = $parent->term_id;
-			}
+			$prepared_args['parent'] = $request['parent'];
 		}
 
 		// Only update the term if we haz something to update.

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -381,23 +381,24 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$args['slug'] = $request['slug'];
 		}
 
-		if ( isset( $request['parent'] ) && 0 === $request['parent'] ) {
-			unset( $request['parent'] );
-		}
-
 		if ( isset( $request['parent'] ) ) {
 			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
 				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );
 			}
 
-			$parent = get_term( (int) $request['parent'], $taxonomy );
+			$parent_id = (int) $request['parent'];
+			if ( 0 === $parent_id ) {
+				$args['parent'] = $parent_id;
+			} else {
+				$parent = get_term( $parent_id, $taxonomy );
 
-			// If is null or WP_Error is invalid parent term.
-			if ( ! $parent || is_wp_error( $parent ) ) {
-				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+				// If is null or WP_Error is invalid parent term.
+				if ( ! $parent || is_wp_error( $parent ) ) {
+					return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Parent resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+				}
+
+				$args['parent'] = $parent->term_id;
 			}
-
-			$args['parent'] = $parent->term_id;
 		}
 
 		$term = wp_insert_term( $name, $taxonomy, $args );
@@ -489,10 +490,6 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		}
 		if ( isset( $request['slug'] ) ) {
 			$prepared_args['slug'] = $request['slug'];
-		}
-
-		if ( isset( $request['parent'] ) && 0 === $request['parent'] ) {
-			unset( $request['parent'] );
 		}
 
 		if ( isset( $request['parent'] ) ) {

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -381,6 +381,9 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$args['slug'] = $request['slug'];
 		}
 		if ( isset( $request['parent'] ) ) {
+			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
+				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );
+			}
 			$args['parent'] = $request['parent'];
 		}
 
@@ -475,6 +478,9 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			$prepared_args['slug'] = $request['slug'];
 		}
 		if ( isset( $request['parent'] ) ) {
+			if ( ! is_taxonomy_hierarchical( $taxonomy ) ) {
+				return new WP_Error( 'woocommerce_rest_taxonomy_not_hierarchical', __( 'Can not set resource parent, taxonomy is not hierarchical.', 'woocommerce' ), array( 'status' => 400 ) );
+			}
 			$prepared_args['parent'] = $request['parent'];
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a check that unsets the parent request when creating any term, ie Categories and Attributes, when the supplied value is 0. 0 means there is no parent as that is what is returned when you call GET request on these terms so we need to ensure we cover the scenario where a PUT or POST can be sent with parent:0.

I also notice no API unit tests for categories, I can add some, just want to make sure I did not miss it. Definitely nothing under the api folder in the unit test suite.

Closes #19924 

### How to test the changes in this Pull Request:

1. Create an product category via the API with a property of parent:0
2. No error response should be given.
3. The category should be created with no parent set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Allow category API PUT/POST requests with parent:0
