### PR TITLE
Update refunds items schema to match actual response keys.

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -1619,7 +1619,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'reason' => array(
+							'refund' => array(
 								'description' => __( 'Refund reason.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -226,7 +226,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 		foreach ( $object->get_refunds() as $refund ) {
 			$data['refunds'][] = array(
 				'id'     => $refund->get_id(),
-				'refund' => $refund->get_reason() ? $refund->get_reason() : '',
+				'reason' => $refund->get_reason() ? $refund->get_reason() : '',
 				'total'  => '-' . wc_format_decimal( $refund->get_amount(), $this->request['dp'] ),
 			);
 		}
@@ -1619,7 +1619,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'refund' => array(
+							'reason' => array(
 								'description' => __( 'Refund reason.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR updates the schema for refund reason on orders to match the actual response key which is refund. Schema stated it to be reason. Updating the schema instead of the actual returned key to ensure nothing breaks for existing applications utilising this.

Closes #19925 

### How to test the changes in this Pull Request:

1. Generate new API docs
2. Check that the docs state the key to be refund and not reason.
3. Ensure the actual API response still returns refund as the key.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - API docs refund reason key to reflect actual returned key.
