### PR TITLE
[3.4] Deprecate woocommerce_ajax_added_order_items action

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -822,6 +822,7 @@ class WC_AJAX {
 			$order        = wc_get_order( $order_id );
 			$items_to_add = wp_parse_id_list( is_array( $_POST['item_to_add'] ) ? $_POST['item_to_add'] : array( $_POST['item_to_add'] ) );
 			$items        = ( ! empty( $_POST['items'] ) ) ? $_POST['items'] : '';
+			$added_items  = array();
 
 			if ( ! $order ) {
 				throw new Exception( __( 'Invalid order', 'woocommerce' ) );
@@ -836,15 +837,23 @@ class WC_AJAX {
 			}
 
 			foreach ( $items_to_add as $item_to_add ) {
+
 				if ( ! in_array( get_post_type( $item_to_add ), array( 'product', 'product_variation' ) ) ) {
 					continue;
 				}
+
 				$item_id = $order->add_product( wc_get_product( $item_to_add ) );
 				$item    = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id );
+
+				$added_items[ $item_id ] = $item;
+
 				do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item, $order );
 			}
 
-			do_action( 'woocommerce_ajax_added_order_items', $item_id, $item, $order );
+			$last_item = ! empty( $added_items ) ? end( $added_items ) : null;
+			wc_do_deprecated_action( 'woocommerce_ajax_added_order_items', array( is_a( $last_item, 'WC_Order_Item' ) ? $last_item->get_id() : null, $last_item, $order ), '3.4', 'woocommerce_ajax_order_items_added action instead.' );
+
+			do_action( 'woocommerce_ajax_order_items_added', $added_items, $order );
 
 			$data = get_post_meta( $order_id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The arguments passed into the `woocommerce_ajax_added_order_items` action seem quite useless as essentially what's being passed there is the ID and object corresponding to the last item added in the loop above (if any at all).

This seems to be an error of an older refactor.

One way to deal with this is to deprecate the old hook and introduce a new one. As the 3.4 release is imminent, it's probably a good opportunity to review this.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Deprecated 'woocommerce_ajax_added_order_items' hook and introduced 'woocommerce_ajax_order_items_added' in its place.