### PR TITLE
Add protocol to URLs for thumbnails in cart.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1809,7 +1809,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$image = '';
 		}
 
-		return apply_filters( 'woocommerce_product_get_image', wc_get_relative_url( $image ), $this, $size, $attr, $placeholder, $image );
+		return apply_filters( 'woocommerce_product_get_image', $image, $this, $size, $attr, $placeholder );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1809,7 +1809,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$image = '';
 		}
 
-		return apply_filters( 'woocommerce_product_get_image', $image, $this, $size, $attr, $placeholder );
+		return apply_filters( 'woocommerce_product_get_image', $image, $this, $size, $attr, $placeholder, $image );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -78,7 +78,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * @return bool true if the widget is cached otherwise false
 	 */
 	public function get_cached_widget( $args ) {
-		$cache = wp_cache_get( apply_filters( 'woocommerce_cached_widget_id', $this->get_widget_id_for_cache( $this->widget_id ) ), 'widget' );
+		$cache = wp_cache_get( $this->get_widget_id_for_cache( $this->widget_id ), 'widget' );
 
 		if ( ! is_array( $cache ) ) {
 			$cache = array();
@@ -100,7 +100,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * @return string the content that was cached
 	 */
 	public function cache_widget( $args, $content ) {
-		$cache = wp_cache_get( apply_filters( 'woocommerce_cached_widget_id', $this->get_widget_id_for_cache( $this->widget_id ) ), 'widget' );
+		$cache = wp_cache_get( $this->get_widget_id_for_cache( $this->widget_id ), 'widget' );
 
 		if ( ! is_array( $cache ) ) {
 			$cache = array();
@@ -108,7 +108,7 @@ abstract class WC_Widget extends WP_Widget {
 
 		$cache[ $this->get_widget_id_for_cache( $args['widget_id'] ) ] = $content;
 
-		wp_cache_set( apply_filters( 'woocommerce_cached_widget_id', $this->get_widget_id_for_cache( $this->widget_id ) ), $cache, 'widget' );
+		wp_cache_set( $this->get_widget_id_for_cache( $this->widget_id ), $cache, 'widget' );
 
 		return $content;
 	}
@@ -118,7 +118,7 @@ abstract class WC_Widget extends WP_Widget {
 	 */
 	public function flush_widget_cache() {
 		foreach ( array( '-https', '-http' ) as $scheme ) {
-			wp_cache_delete( apply_filters( 'woocommerce_cached_widget_id', $this->widget_id . $scheme ), 'widget' );
+			wp_cache_delete( $this->get_widget_id_for_cache( $this->widget_id, $scheme ), 'widget' );
 		}
 	}
 
@@ -353,10 +353,18 @@ abstract class WC_Widget extends WP_Widget {
 	/**
 	 * Get widget id plus scheme/protocol to prevent serving mixed content from (persistently) cached widgets.
 	 *
-	 * @param string $widget_id Id of the cached widget.
-	 * @return string Widget id including scheme/protocol.
+	 * @since  3.4.0
+	 * @param  string $widget_id Id of the cached widget.
+	 * @param  string $scheme    Scheme for the widget id.
+	 * @return string            Widget id including scheme/protocol.
 	 */
-	protected function get_widget_id_for_cache( $widget_id ) {
-		return $widget_id . ( is_ssl() ? '-https' : '-http' );
+	protected function get_widget_id_for_cache( $widget_id, $scheme = '' ) {
+		if ( $scheme ) {
+			$widget_id_for_cache = $widget_id . $scheme;
+		} else {
+			$widget_id_for_cache = $widget_id . ( is_ssl() ? '-https' : '-http' );
+		}
+
+		return apply_filters( 'woocommerce_cached_widget_id', $widget_id_for_cache );
 	}
 }

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -117,7 +117,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * Flush the cache.
 	 */
 	public function flush_widget_cache() {
-		foreach ( array( '-https', '-http' ) as $scheme ) {
+		foreach ( array( 'https', 'http' ) as $scheme ) {
 			wp_cache_delete( $this->get_widget_id_for_cache( $this->widget_id, $scheme ), 'widget' );
 		}
 	}
@@ -360,9 +360,9 @@ abstract class WC_Widget extends WP_Widget {
 	 */
 	protected function get_widget_id_for_cache( $widget_id, $scheme = '' ) {
 		if ( $scheme ) {
-			$widget_id_for_cache = $widget_id . $scheme;
+			$widget_id_for_cache = $widget_id . '-' . $scheme;
 		} else {
-			$widget_id_for_cache = $widget_id . ( is_ssl() ? '-https' : '-http' );
+			$widget_id_for_cache = $widget_id . '-' . ( is_ssl() ? 'https' : 'http' );
 		}
 
 		return apply_filters( 'woocommerce_cached_widget_id', $widget_id_for_cache );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1998,17 +1998,6 @@ function wc_delete_expired_transients() {
 add_action( 'woocommerce_installed', 'wc_delete_expired_transients' );
 
 /**
- * Make a URL relative, if possible.
- *
- * @since 3.2.0
- * @param string $url URL to make relative.
- * @return string
- */
-function wc_get_relative_url( $url ) {
-	return wc_is_external_resource( $url ) ? $url : str_replace( array( 'http://', 'https://' ), '//', $url );
-}
-
-/**
  * See if a resource is remote.
  *
  * @since 3.2.0

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1998,19 +1998,6 @@ function wc_delete_expired_transients() {
 add_action( 'woocommerce_installed', 'wc_delete_expired_transients' );
 
 /**
- * See if a resource is remote.
- *
- * @since 3.2.0
- * @param string $url URL to check.
- * @return bool
- */
-function wc_is_external_resource( $url ) {
-	$wp_base = str_replace( array( 'http://', 'https://' ), '//', get_home_url( null, '/', 'http' ) );
-
-	return strstr( $url, '://' ) && ! strstr( $url, $wp_base );
-}
-
-/**
  * See if theme/s is activate or not.
  *
  * @since 3.3.0

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2008,7 +2008,6 @@ function wc_get_relative_url( $url ) {
 	return wc_is_external_resource( $url ) ? $url : str_replace( array( 'http://', 'https://' ), '//', $url );
 }
 
-
 /**
  * See if a resource is remote.
  *

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1998,6 +1998,31 @@ function wc_delete_expired_transients() {
 add_action( 'woocommerce_installed', 'wc_delete_expired_transients' );
 
 /**
+ * Make a URL relative, if possible.
+ *
+ * @since 3.2.0
+ * @param string $url URL to make relative.
+ * @return string
+ */
+function wc_get_relative_url( $url ) {
+	return wc_is_external_resource( $url ) ? $url : str_replace( array( 'http://', 'https://' ), '//', $url );
+}
+
+
+/**
+ * See if a resource is remote.
+ *
+ * @since 3.2.0
+ * @param string $url URL to check.
+ * @return bool
+ */
+function wc_is_external_resource( $url ) {
+	$wp_base = str_replace( array( 'http://', 'https://' ), '//', get_home_url( null, '/', 'http' ) );
+
+	return strstr( $url, '://' ) && ! strstr( $url, $wp_base );
+}
+
+/**
  * See if theme/s is activate or not.
  *
  * @since 3.3.0

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -51,10 +51,10 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 						), $cart_item_key );
 						?>
 						<?php if ( empty( $product_permalink ) ) : ?>
-							<?php echo str_replace( array( 'http:', 'https:' ), '', $thumbnail ) . $product_name . '&nbsp;'; ?>
+							<?php echo $thumbnail . $product_name . '&nbsp;'; ?>
 						<?php else : ?>
 							<a href="<?php echo esc_url( $product_permalink ); ?>">
-								<?php echo str_replace( array( 'http:', 'https:' ), '', $thumbnail ) . $product_name . '&nbsp;'; ?>
+								<?php echo $thumbnail . $product_name . '&nbsp;'; ?>
 							</a>
 						<?php endif; ?>
 						<?php echo wc_get_formatted_cart_item_data( $cart_item ); ?>


### PR DESCRIPTION
and removed `wc_get_relative_url()`, as it's not used anymore.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #19819 .

This change replaces protocol-relative thumbnail URLs with protocol-specific URLs. It should resolve issues #19819 and #17577, mitigate problems introduced by using protocol-relative URLs such as [[1]](https://www.paulirish.com/2010/the-protocol-relative-url/) and [[2]](https://jeremywagner.me/blog/stop-using-the-protocol-relative-url/). 

Ad caching:
Cart hash is stored in a cookie which is served both via http and https, so any time a cart is updated, the widget cache gets updated both over http and https.
Since the sessionStoreage and localStorage are different for http and https, there should not be a problem with https cart page fetching images via http protocol and vice versa. Cart fragments are loaded via AJAX and they should be served correctly (unless AJAX call is cached, but then cart would not work anyway).

As single product page uses full URLs for images already, sites would most likely already be broken if they had images served from a CDN over http while running the checkout on https (links from checkout back to shop are https).
Even if a site is http only with checkout forcing https, then I see the following eventualities today:
- http pages: images will be served via //, thus fetched via http
- https pages (e.g. checkout): images served via //, thus fetched via https
Therefore, it looks to me that providing protocol in the beginning of the URL actually does not change much--even today the shop needs resources on both http and https if it wants to run in this mixed mode.

If there is a website that uses a more persistent widget cache (e.g. W3 Total Cache) that would cache the protocol-relative image URLs (i.e. starting with `//`), then if the widget is embedded/displayed on the checkout website accessed via https, using protocol-relative URLs means that the images would be accessed via https, while on other pages those would be accessed via http. Thus, the images should be present over both protocols already today if the site should work correctly with protocol-relative URLs.

I think the only problem happens when a resource is accessed via http, cached, then accessed via https protocol. To fix this behaviour, I slightly modified the widget id used for caching to include the scheme/protocol.

Please let me know if there are any other scenarios I might have missed, especially around CDNs serving over http only, I haven't tried that set up yet. (I guess if CDN serves over https, then there should not be any problem).


### How to test the changes in this Pull Request:
0. Set WC to not use https by default, only force it for checkout.
1. Add some products to cart.
2. Observe the images/thumbnails are displayed in cart.
3. Configure WC to run on a specific port, e.g. 8080
4. Observe the images are *not* displayed in cart.
5. Activate persistent object caching, e.g. W3 Total Cache with sufficiently large timeout.
6. Add `Top rated products` widget to the layout, e.g. on the shop site below header.
7. Refresh the page to cache the widget.
8. Go to the same page using https, observe mixed content warnings in the dev console, images missing from products in the widget (if they are blocked by default).
9. Apply branch. 
10. Refresh while accessing via http and https, check that both versions serve widget with correct links and images.
11. Go to cart.
12. Observe images are displayed correctly (in contrast to step 4).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Replaced protocol-relative URLs for thumbnails in the cart and mini-cart with protocol-specific URLs to prevent problems with URLs that include port section.
