### PR TITLE
Updating repo slug for PayFast in the onboarding wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1281,7 +1281,7 @@ class WC_Admin_Setup_Wizard {
 				'image'       => WC()->plugin_url() . '/assets/images/payfast.png',
 				'class'       => 'payfast-logo',
 				'enabled'     => false,
-				'repo-slug'   => 'woocommerce-gateway-payfast',
+				'repo-slug'   => 'woocommerce-payfast-gateway',
 				'file'        => 'gateway-payfast.php',
 			),
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After PayFast was approved by WP.org the repo slug was changed to `woocommerce-payfast-gateway` which can be seen here: http://plugins.svn.wordpress.org/woocommerce-payfast-gateway

This updates the slug in the onboarding wizard for PayFast to the correct .org repo slug

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
