### PR TITLE
Update GDPR abstract class to use associative arrays

### DIFF
--- a/includes/abstracts/abstract-wc-privacy.php
+++ b/includes/abstracts/abstract-wc-privacy.php
@@ -40,13 +40,6 @@ abstract class WC_Abstract_Privacy {
 	protected $erasers = array();
 
 	/**
-	 * Track ordering for adding export/erase to WP array.
-	 *
-	 * @var int
-	 */
-	protected $count = 0;
-
-	/**
 	 * Constructor
 	 *
 	 * @param string $name Plugin identifier.
@@ -54,17 +47,6 @@ abstract class WC_Abstract_Privacy {
 	public function __construct( $name = '' ) {
 		$this->name = $name;
 		$this->init();
-	}
-
-	/**
-	 * Get next key to be added to the exporters/erasures list.
-	 * Maintain order since the array is associative.
-	 *
-	 * @return string
-	 */
-	protected function get_next_key() {
-		$this->count++;
-		return sanitize_title( $this->name . '-' . $this->count );
 	}
 
 	/**
@@ -107,8 +89,8 @@ abstract class WC_Abstract_Privacy {
 	 * @return array
 	 */
 	public function register_exporters( $exporters = array() ) {
-		foreach ( $this->exporters as $exporter ) {
-			$exporters[ $this->get_next_key() ] = $exporter;
+		foreach ( $this->exporters as $id => $exporter ) {
+			$exporters[ $id ] = $exporter;
 		}
 		return $exporters;
 	}
@@ -120,8 +102,8 @@ abstract class WC_Abstract_Privacy {
 	 * @return array
 	 */
 	public function register_erasers( $erasers = array() ) {
-		foreach ( $this->erasers as $eraser ) {
-			$erasers[ $this->get_next_key() ] = $eraser;
+		foreach ( $this->erasers as $id => $eraser ) {
+			$erasers[ $id ] = $eraser;
 		}
 		return $erasers;
 	}
@@ -129,11 +111,12 @@ abstract class WC_Abstract_Privacy {
 	/**
 	 * Add exporter to list of exporters.
 	 *
-	 * @param string $name Exporter name.
+	 * @param string $id       ID of the Exporter.
+	 * @param string $name     Exporter name.
 	 * @param string $callback Exporter callback.
 	 */
-	public function add_exporter( $name, $callback ) {
-		$this->exporters[] = array(
+	public function add_exporter( $id, $name, $callback ) {
+		$this->exporters[ sanitize_title( $this->name . '-' . $id ) ] = array(
 			'exporter_friendly_name' => $name,
 			'callback'               => $callback,
 		);
@@ -141,13 +124,14 @@ abstract class WC_Abstract_Privacy {
 	}
 
 	/**
-	 * Add eraser to list of exporters.
+	 * Add eraser to list of erasers.
 	 *
-	 * @param string $name Exporter name.
+	 * @param string $id       ID of the Eraser.
+	 * @param string $name     Exporter name.
 	 * @param string $callback Exporter callback.
 	 */
-	public function add_eraser( $name, $callback ) {
-		$this->erasers[] = array(
+	public function add_eraser( $id, $name, $callback ) {
+		$this->erasers[ sanitize_title( $this->name . '-' . $id ) ] = array(
 			'eraser_friendly_name' => $name,
 			'callback'             => $callback,
 		);

--- a/includes/abstracts/abstract-wc-privacy.php
+++ b/includes/abstracts/abstract-wc-privacy.php
@@ -116,7 +116,7 @@ abstract class WC_Abstract_Privacy {
 	 * @param string $callback Exporter callback.
 	 */
 	public function add_exporter( $id, $name, $callback ) {
-		$this->exporters[ sanitize_title( $this->name . '-' . $id ) ] = array(
+		$this->exporters[ $id ] = array(
 			'exporter_friendly_name' => $name,
 			'callback'               => $callback,
 		);
@@ -131,7 +131,7 @@ abstract class WC_Abstract_Privacy {
 	 * @param string $callback Exporter callback.
 	 */
 	public function add_eraser( $id, $name, $callback ) {
-		$this->erasers[ sanitize_title( $this->name . '-' . $id ) ] = array(
+		$this->erasers[ $id ] = array(
 			'eraser_friendly_name' => $name,
 			'callback'             => $callback,
 		);

--- a/includes/abstracts/abstract-wc-privacy.php
+++ b/includes/abstracts/abstract-wc-privacy.php
@@ -40,6 +40,13 @@ abstract class WC_Abstract_Privacy {
 	protected $erasers = array();
 
 	/**
+	 * Track ordering for adding export/erase to WP array.
+	 *
+	 * @var int
+	 */
+	protected $count = 0;
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $name Plugin identifier.
@@ -47,6 +54,17 @@ abstract class WC_Abstract_Privacy {
 	public function __construct( $name = '' ) {
 		$this->name = $name;
 		$this->init();
+	}
+
+	/**
+	 * Get next key to be added to the exporters/erasures list.
+	 * Maintain order since the array is associative.
+	 *
+	 * @return string
+	 */
+	protected function get_next_key() {
+		$this->count++;
+		return sanitize_title( $this->name . '-' . $this->count );
 	}
 
 	/**
@@ -90,7 +108,7 @@ abstract class WC_Abstract_Privacy {
 	 */
 	public function register_exporters( $exporters = array() ) {
 		foreach ( $this->exporters as $exporter ) {
-			$exporters[] = $exporter;
+			$exporters[ $this->get_next_key() ] = $exporter;
 		}
 		return $exporters;
 	}
@@ -103,7 +121,7 @@ abstract class WC_Abstract_Privacy {
 	 */
 	public function register_erasers( $erasers = array() ) {
 		foreach ( $this->erasers as $eraser ) {
-			$erasers[] = $eraser;
+			$erasers[ $this->get_next_key() ] = $eraser;
 		}
 		return $erasers;
 	}

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -35,14 +35,14 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		include_once 'class-wc-privacy-exporters.php';
 
 		// This hook registers WooCommerce data exporters.
-		$this->add_exporter( __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );
-		$this->add_exporter( __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'order_data_exporter' ) );
-		$this->add_exporter( __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'download_data_exporter' ) );
+		$this->add_exporter( 'customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );
+		$this->add_exporter( 'customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'order_data_exporter' ) );
+		$this->add_exporter( 'customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'download_data_exporter' ) );
 
 		// This hook registers WooCommerce data erasers.
-		$this->add_eraser( __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_data_eraser' ) );
-		$this->add_eraser( __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'order_data_eraser' ) );
-		$this->add_eraser( __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'download_data_eraser' ) );
+		$this->add_eraser( 'customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_data_eraser' ) );
+		$this->add_eraser( 'customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'order_data_eraser' ) );
+		$this->add_eraser( 'customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'download_data_eraser' ) );
 
 		// Cleanup orders daily - this is a callback on a daily cron event.
 		add_action( 'woocommerce_cleanup_personal_data', array( $this, 'queue_cleanup_personal_data' ) );

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -24,7 +24,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 	 * Init - hook into events.
 	 */
 	public function __construct() {
-		parent::__construct( 'WooCommerce' );
+		parent::__construct( __( 'WooCommerce', 'woocommerce' ) );
 
 		if ( ! self::$background_process ) {
 			self::$background_process = new WC_Privacy_Background_Process();
@@ -35,14 +35,14 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		include_once 'class-wc-privacy-exporters.php';
 
 		// This hook registers WooCommerce data exporters.
-		$this->add_exporter( 'customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );
-		$this->add_exporter( 'customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'order_data_exporter' ) );
-		$this->add_exporter( 'customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'download_data_exporter' ) );
+		$this->add_exporter( 'woocommerce-customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );
+		$this->add_exporter( 'woocommerce-customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'order_data_exporter' ) );
+		$this->add_exporter( 'woocommerce-customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'download_data_exporter' ) );
 
 		// This hook registers WooCommerce data erasers.
-		$this->add_eraser( 'customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_data_eraser' ) );
-		$this->add_eraser( 'customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'order_data_eraser' ) );
-		$this->add_eraser( 'customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'download_data_eraser' ) );
+		$this->add_eraser( 'woocommerce-customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_data_eraser' ) );
+		$this->add_eraser( 'woocommerce-customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'order_data_eraser' ) );
+		$this->add_eraser( 'woocommerce-customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'download_data_eraser' ) );
 
 		// Cleanup orders daily - this is a callback on a daily cron event.
 		add_action( 'woocommerce_cleanup_personal_data', array( $this, 'queue_cleanup_personal_data' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Update abstract privacy class to use associative arrays

<img width="829" alt="exporters-and-erasers-associative" src="https://user-images.githubusercontent.com/1620929/39565940-22758158-4eba-11e8-968f-7163b50f6d01.png">