### PR TITLE
Eircode validation and formatting

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -673,8 +673,16 @@ class WC_Checkout {
 					$data[ $key ] = wc_format_postcode( $data[ $key ], $country );
 
 					if ( '' !== $data[ $key ] && ! WC_Validation::is_postcode( $data[ $key ], $country ) ) {
-						/* translators: %s: field name */
-						$errors->add( 'validation', sprintf( __( '%s is not a valid postcode / ZIP.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' ) );
+						switch ( $country ) {
+							case 'IE':
+								/* translators: %1$s: field name, %2$s finder.eircode.ie URL */
+								$postcode_validation_notice = sprintf( __( '%1$s is not a valid. You can look up the correct Eircode <a target="_blank" href="%2$s">here</a>.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>', 'https://finder.eircode.ie' );
+								break;
+							default:
+								/* translators: %s: field name */
+								$postcode_validation_notice = sprintf( __( '%s is not a valid postcode / ZIP.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' );
+						}
+						$errors->add( 'validation', apply_filters( 'woocommerce_checkout_postcode_validation_notice', $postcode_validation_notice, $country, $data[ $key ] ) );
 					}
 				}
 

--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -69,6 +69,9 @@ class WC_Validation {
 			case 'GB':
 				$valid = self::is_gb_postcode( $postcode );
 				break;
+			case 'IE':
+				$valid = (bool) preg_match( '/([AC-FHKNPRTV-Y]\d{2}|D6W)[0-9AC-FHKNPRTV-Y]{4}/', wc_normalize_postcode( $postcode ) );
+				break;
 			case 'JP':
 				$valid = (bool) preg_match( '/^([0-9]{3})([-])([0-9]{4})$/', $postcode );
 				break;

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -900,6 +900,9 @@ function wc_format_postcode( $postcode, $country ) {
 		case 'GB':
 			$postcode = trim( substr_replace( $postcode, ' ', -3, 0 ) );
 			break;
+		case 'IE':
+			$postcode = trim( substr_replace( $postcode, ' ', 3, 0 ) );
+			break;
 		case 'BR':
 		case 'PL':
 			$postcode = substr_replace( $postcode, '-', -3, 0 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds Eircode (which is optional) formatting and validation.

Closes #19745.

### How to test the changes in this Pull Request:

1. Go to checkout and set country to Ireland
2. Try to checkout with no postcode. It should work.
3. Try to checkout with invalid Eircode - you should see an error notice
4. Try to checkout with valid Eircode A65 F4E2 - it should work.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added validation and formatting for Eircodes.
