### PR TITLE
OBW: List all plugins to be installed upon continuing to next step

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -973,7 +973,12 @@ h3.jetpack-reasons {
 }
 
 .plugin-install-source {
-	background: rgba( #bb77ae, 0.15 );
+	$background: rgba( #bb77ae, 0.15 );
+	background: $background;
+
+	&:not(.wc-wizard-service-item) {
+		box-shadow: 0 0 0 10px $background;
+	}
 }
 
 .location-prompt {

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -958,6 +958,10 @@ h3.jetpack-reasons {
 	& > * {
 		display: block;
 	}
+	
+	.plugin-install-info-list-item:not(:last-child)::after {
+		content: ', ';
+	}
 
 	a {
 		white-space: nowrap;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -947,6 +947,27 @@ h3.jetpack-reasons {
 	}
 }
 
+.wc-setup .wc-setup-actions .plugin-install-info {
+	display: block;
+	font-style: italic;
+	color: #999;
+	font-size: 14px;
+	line-height: 1.5em;
+	margin: 5px 0;
+
+	& > * {
+		display: block;
+	}
+
+	a {
+		white-space: nowrap;
+
+		&:not(:hover):not(:focus) {
+			color: inherit;
+		}
+	}
+}
+
 .location-prompt {
 	color: #666;
 	font-size: 13px;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -711,6 +711,7 @@ body {
 
 	.wc-wizard-service-settings {
 		display: none;
+		margin-top: 0.75em;
 		margin-bottom: 0;
 		cursor: default;
 
@@ -1202,7 +1203,6 @@ p.jetpack-terms {
 .wc-wizard-service-setting-stripe_create_account, .wc-wizard-service-setting-ppec_paypal_reroute_requests {
 	display: flex;
 	align-items: flex-start;
-	margin-top: 0.75em;
 
 	.payment-checkbox-input {
 		order: 1;
@@ -1220,6 +1220,7 @@ p.jetpack-terms {
 
 .wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email {
 	margin-top: 0.75em;
+	margin-left: 1.5em;
 
 	label.stripe_email, label.ppec_paypal_email {
 		position: absolute;
@@ -1233,13 +1234,10 @@ p.jetpack-terms {
 	}
 
 	input.payment-email-input {
-		margin-left: 1.5em;
+		box-sizing: border-box;
 		margin-bottom: .5em;
 		width: 100%;
-	}
-
-	.wc-wizard-service-settings-description {
-		margin-left: 1.5em;
+		height: 32px;
 	}
 }
 

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -972,6 +972,10 @@ h3.jetpack-reasons {
 	}
 }
 
+.plugin-install-source {
+	background: rgba( #bb77ae, 0.15 );
+}
+
 .location-prompt {
 	color: #666;
 	font-size: 13px;

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -180,7 +180,7 @@ jQuery( function( $ ) {
 	$( '.wc-setup-content' ).on( 'change', '[data-plugins]', function() {
 		var pluginLinkBySlug = {};
 
-		function addPlugins( $el ) {
+		function addPlugins( $el, hover ) {
 			var plugins = $el.data( 'plugins' );
 			if ( ! Array.isArray( plugins ) ) {
 				return;
@@ -193,25 +193,34 @@ jQuery( function( $ ) {
 						$( '<span class="plugin-install-info-list-item">' )
 							.append( '<a href="https://wordpress.org/plugins/' + slug + '/" target="_blank">' + plugins[ i ].name + '</a>' );
 				}
+
+				var $hover = hover ? $el.closest( hover ) : $el;
+				pluginLinkBySlug[ slug ].find( 'a' )
+					.on( 'mouseenter', ( function( $hover ) {
+						$hover.addClass( 'plugin-install-source' );
+					} ).bind( null, $hover ) )
+					.on( 'mouseleave', ( function( $hover ) {
+						$hover.removeClass( 'plugin-install-source' );
+					} ).bind( null, $hover ) );
 			}
 		}
 
 		$( '.wc-wizard-service-enable input:checked' ).each( function() {
-			addPlugins( $( this ) );
+			addPlugins( $( this ), '.wc-wizard-service-item' );
 			$( this ).closest( '.wc-wizard-service-item' ).find( 'input.payment-checkbox-input:checked' ).each( function() {
-				addPlugins( $( this ) );
+				addPlugins( $( this ), '.wc-wizard-service-settings' );
 			} );
 		} );
 
 		$( '.wc-wizard-shipping-method-select .method' ).each( function() {
 			var $this = $( this );
 			if ( 'live_rates' === $this.val() ) {
-				addPlugins( $this );
+				addPlugins( $this, '.wc-wizard-service-item' );
 			}
 		} );
 
 		$( '.recommended-item-checkbox:checked' ).each( function() {
-			addPlugins( $( this ) );
+			addPlugins( $( this ), '.recommended-item' );
 		} );
 
 		// Render list of plugins.

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -176,4 +176,34 @@ jQuery( function( $ ) {
 		var countryCode = $( this ).val();
 		$( 'select#currency_code' ).val( wc_setup_currencies[ countryCode ] ).change();
 	} );
+
+	$( '.wc-setup-content' ).on( 'change', '[data-plugins]', function() {
+		var pluginLinkBySlug = {};
+
+		function addPlugins( plugins ) {
+			if ( Array.isArray( plugins ) ) {
+				for ( var i in plugins ) {
+					var pluginLink = '<a href="https://wordpress.org/plugins/' + plugins[ i ].slug + '/" target="_blank">' + plugins[ i ].name + '</a>';
+					pluginLinkBySlug[ plugins[ i ].slug ] = pluginLink;
+				}
+			}
+		}
+
+		$( '.wc-wizard-service-enable input:checked' ).each( function() {
+			addPlugins( $( this ).data( 'plugins' ) );
+		} );
+
+		// Render list of plugins.
+		if ( Object.keys( pluginLinkBySlug ).length ) {
+			var pluginLinks = [];
+			for ( var slug in pluginLinkBySlug ) {
+				pluginLinks.push( pluginLinkBySlug[ slug ] );
+			}
+			
+			$( 'span.plugin-install-info' ).show();
+			$( 'span.plugin-install-info-list' ).html( pluginLinks.join( ', ' ) );
+		} else {
+			$( 'span.plugin-install-info' ).hide();
+		}
+	} ).find( '[data-plugins]' ).change();
 } );

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -196,6 +196,12 @@ jQuery( function( $ ) {
 			} );
 		} );
 
+		$( '.wc-wizard-shipping-method-select .method' ).each( function() {
+			if ( 'live_rates' === $( this ).val() ) {
+				addPlugins( $( this ).data( 'plugins' ) );
+			}
+		} );
+
 		// Render list of plugins.
 		if ( Object.keys( pluginLinkBySlug ).length ) {
 			var pluginLinks = [];

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -180,41 +180,47 @@ jQuery( function( $ ) {
 	$( '.wc-setup-content' ).on( 'change', '[data-plugins]', function() {
 		var pluginLinkBySlug = {};
 
-		function addPlugins( plugins ) {
-			if ( Array.isArray( plugins ) ) {
-				for ( var i in plugins ) {
-					var pluginLink = '<a href="https://wordpress.org/plugins/' + plugins[ i ].slug + '/" target="_blank">' + plugins[ i ].name + '</a>';
-					pluginLinkBySlug[ plugins[ i ].slug ] = pluginLink;
+		function addPlugins( $el ) {
+			var plugins = $el.data( 'plugins' );
+			if ( ! Array.isArray( plugins ) ) {
+				return;
+			}
+
+			for ( var i in plugins ) {
+				var slug = plugins[ i ].slug;
+				if ( ! pluginLinkBySlug[ slug ] ) {
+					pluginLinkBySlug[ slug ] =
+						$( '<span class="plugin-install-info-list-item">' )
+							.append( '<a href="https://wordpress.org/plugins/' + slug + '/" target="_blank">' + plugins[ i ].name + '</a>' );
 				}
 			}
 		}
 
 		$( '.wc-wizard-service-enable input:checked' ).each( function() {
-			addPlugins( $( this ).data( 'plugins' ) );
+			addPlugins( $( this ) );
 			$( this ).closest( '.wc-wizard-service-item' ).find( 'input.payment-checkbox-input:checked' ).each( function() {
-				addPlugins( $( this ).data( 'plugins' ) );
+				addPlugins( $( this ) );
 			} );
 		} );
 
 		$( '.wc-wizard-shipping-method-select .method' ).each( function() {
-			if ( 'live_rates' === $( this ).val() ) {
-				addPlugins( $( this ).data( 'plugins' ) );
+			var $this = $( this );
+			if ( 'live_rates' === $this.val() ) {
+				addPlugins( $this );
 			}
 		} );
 
 		$( '.recommended-item-checkbox:checked' ).each( function() {
-			addPlugins( $( this ).data( 'plugins' ) );
+			addPlugins( $( this ) );
 		} );
 
 		// Render list of plugins.
 		if ( Object.keys( pluginLinkBySlug ).length ) {
-			var pluginLinks = [];
-			for ( var slug in pluginLinkBySlug ) {
-				pluginLinks.push( pluginLinkBySlug[ slug ] );
-			}
-			
 			$( 'span.plugin-install-info' ).show();
-			$( 'span.plugin-install-info-list' ).html( pluginLinks.join( ', ' ) );
+			var $list = $( 'span.plugin-install-info-list' ).empty();
+			for ( var slug in pluginLinkBySlug ) {
+				$list.append( pluginLinkBySlug[ slug ] );
+			}
 		} else {
 			$( 'span.plugin-install-info' ).hide();
 		}

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -207,16 +207,17 @@ jQuery( function( $ ) {
 
 		$( '.wc-wizard-service-enable input:checked' ).each( function() {
 			addPlugins( $( this ), '.wc-wizard-service-item' );
-			$( this ).closest( '.wc-wizard-service-item' ).find( 'input.payment-checkbox-input:checked' ).each( function() {
+
+			var $container = $( this ).closest( '.wc-wizard-service-item' );
+			$container.find( 'input.payment-checkbox-input:checked' ).each( function() {
 				addPlugins( $( this ), '.wc-wizard-service-settings' );
 			} );
-		} );
-
-		$( '.wc-wizard-shipping-method-select .method' ).each( function() {
-			var $this = $( this );
-			if ( 'live_rates' === $this.val() ) {
-				addPlugins( $this, '.wc-wizard-service-item' );
-			}
+			$container.find( '.wc-wizard-shipping-method-select .method' ).each( function() {
+				var $this = $( this );
+				if ( 'live_rates' === $this.val()  ) {
+					addPlugins( $this, '.wc-wizard-service-item' );
+				}
+			} );
 		} );
 
 		$( '.recommended-item-checkbox:checked' ).each( function() {

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -202,6 +202,10 @@ jQuery( function( $ ) {
 			}
 		} );
 
+		$( '.recommended-item-checkbox:checked' ).each( function() {
+			addPlugins( $( this ).data( 'plugins' ) );
+		} );
+
 		// Render list of plugins.
 		if ( Object.keys( pluginLinkBySlug ).length ) {
 			var pluginLinks = [];

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -47,6 +47,8 @@ jQuery( function( $ ) {
 			$( '.store-state-container' ).hide();
 			$state_select.empty().val( '' ).change().prop( 'required', false );
 		}
+
+		$( '#currency_code' ).val( wc_setup_currencies[ country ] ).change();
 	} );
 
 	$( '#store_country' ).change();
@@ -171,11 +173,6 @@ jQuery( function( $ ) {
 				.hide();
 		}
 	} ).find( 'input#stripe_create_account, input#ppec_paypal_reroute_requests' ).change();
-
-	$( 'select#store_country' ).on( 'change', function() {
-		var countryCode = $( this ).val();
-		$( 'select#currency_code' ).val( wc_setup_currencies[ countryCode ] ).change();
-	} );
 
 	$( '.wc-setup-content' ).on( 'change', '[data-plugins]', function() {
 		var pluginLinkBySlug = {};

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -191,6 +191,9 @@ jQuery( function( $ ) {
 
 		$( '.wc-wizard-service-enable input:checked' ).each( function() {
 			addPlugins( $( this ).data( 'plugins' ) );
+			$( this ).closest( '.wc-wizard-service-item' ).find( 'input.payment-checkbox-input:checked' ).each( function() {
+				addPlugins( $( this ).data( 'plugins' ) );
+			} );
 		} );
 
 		// Render list of plugins.

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -174,62 +174,50 @@ jQuery( function( $ ) {
 		}
 	} ).find( 'input#stripe_create_account, input#ppec_paypal_reroute_requests' ).change();
 
-	$( '.wc-setup-content' ).on( 'change', '[data-plugins]', function() {
+	function addPlugins( bySlug, $el, hover ) {
+		var plugins = $el.data( 'plugins' );
+		for ( var i in Array.isArray( plugins ) ? plugins : [] ) {
+			var slug = plugins[ i ].slug;
+			bySlug[ slug ] = bySlug[ slug ] ||
+				$( '<span class="plugin-install-info-list-item">' )
+					.append( '<a href="https://wordpress.org/plugins/' + slug + '/" target="_blank">' + plugins[ i ].name + '</a>' );
+
+			bySlug[ slug ].find( 'a' )
+				.on( 'mouseenter mouseleave', ( function( $hover, event ) {
+					$hover.toggleClass( 'plugin-install-source', 'mouseenter' === event.type );
+				} ).bind( null, hover ? $el.closest( hover ) : $el ) );
+		}
+	}
+
+	function updatePluginInfo() {
 		var pluginLinkBySlug = {};
 
-		function addPlugins( $el, hover ) {
-			var plugins = $el.data( 'plugins' );
-			if ( ! Array.isArray( plugins ) ) {
-				return;
-			}
-
-			for ( var i in plugins ) {
-				var slug = plugins[ i ].slug;
-				if ( ! pluginLinkBySlug[ slug ] ) {
-					pluginLinkBySlug[ slug ] =
-						$( '<span class="plugin-install-info-list-item">' )
-							.append( '<a href="https://wordpress.org/plugins/' + slug + '/" target="_blank">' + plugins[ i ].name + '</a>' );
-				}
-
-				var $hover = hover ? $el.closest( hover ) : $el;
-				pluginLinkBySlug[ slug ].find( 'a' )
-					.on( 'mouseenter', ( function( $hover ) {
-						$hover.addClass( 'plugin-install-source' );
-					} ).bind( null, $hover ) )
-					.on( 'mouseleave', ( function( $hover ) {
-						$hover.removeClass( 'plugin-install-source' );
-					} ).bind( null, $hover ) );
-			}
-		}
-
 		$( '.wc-wizard-service-enable input:checked' ).each( function() {
-			addPlugins( $( this ), '.wc-wizard-service-item' );
+			addPlugins( pluginLinkBySlug, $( this ), '.wc-wizard-service-item' );
 
 			var $container = $( this ).closest( '.wc-wizard-service-item' );
 			$container.find( 'input.payment-checkbox-input:checked' ).each( function() {
-				addPlugins( $( this ), '.wc-wizard-service-settings' );
+				addPlugins( pluginLinkBySlug, $( this ), '.wc-wizard-service-settings' );
 			} );
 			$container.find( '.wc-wizard-shipping-method-select .method' ).each( function() {
 				var $this = $( this );
 				if ( 'live_rates' === $this.val()  ) {
-					addPlugins( $this, '.wc-wizard-service-item' );
+					addPlugins( pluginLinkBySlug, $this, '.wc-wizard-service-item' );
 				}
 			} );
 		} );
 
 		$( '.recommended-item-checkbox:checked' ).each( function() {
-			addPlugins( $( this ), '.recommended-item' );
+			addPlugins( pluginLinkBySlug, $( this ), '.recommended-item' );
 		} );
 
-		// Render list of plugins.
-		if ( Object.keys( pluginLinkBySlug ).length ) {
-			$( 'span.plugin-install-info' ).show();
-			var $list = $( 'span.plugin-install-info-list' ).empty();
-			for ( var slug in pluginLinkBySlug ) {
-				$list.append( pluginLinkBySlug[ slug ] );
-			}
-		} else {
-			$( 'span.plugin-install-info' ).hide();
+		var $list = $( 'span.plugin-install-info-list' ).empty();
+		for ( var slug in pluginLinkBySlug ) {
+			$list.append( pluginLinkBySlug[ slug ] );
 		}
-	} ).find( '[data-plugins]' ).change();
+		$( 'span.plugin-install-info' ).toggle( $list.length > 0 );
+	}
+
+	updatePluginInfo();
+	$( '.wc-setup-content' ).on( 'change', '[data-plugins]', updatePluginInfo );
 } );

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -215,7 +215,7 @@ jQuery( function( $ ) {
 		for ( var slug in pluginLinkBySlug ) {
 			$list.append( pluginLinkBySlug[ slug ] );
 		}
-		$( 'span.plugin-install-info' ).toggle( $list.length > 0 );
+		$( 'span.plugin-install-info' ).toggle( $list.children().length > 0 );
 	}
 
 	updatePluginInfo();

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -691,6 +691,11 @@ class WC_Admin_Setup_Wizard {
 		);
 	}
 
+	/**
+	 * Retrieve info for missing WooCommerce Services and/or Jetpack plugin.
+	 *
+	 * @return array
+	 */
 	protected function get_wcs_requisite_plugins() {
 		$plugins = array();
 		if ( ! is_plugin_active( 'woocommerce-services/woocommerce-services.php' ) ) {
@@ -700,6 +705,21 @@ class WC_Admin_Setup_Wizard {
 			$plugins[] = array( 'name' => __( 'Jetpack', 'woocommerce' ), 'slug' => 'jetpack' );
 		}
 		return $plugins;
+	}
+
+	/**
+	 * Plugin install info message markup with heading.
+	 *
+	 * @param array $service Service info array.
+	 * @return boolean
+	 */
+	public function plugin_install_info() {
+		?>
+		<span class="plugin-install-info">
+			<span class="plugin-install-info-label"><?php esc_html_e( 'The following plugins will be installed and activated for you:', 'woocommerce' ); ?></span>
+			<span class="plugin-install-info-list"></span>
+		</span>
+		<?php
 	}
 
 	/**
@@ -1517,15 +1537,6 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function is_not_featured_service( $service ) {
 		return ! $this->is_featured_service( $service );
-	}
-
-	public function plugin_install_info() {
-		?>
-		<span class="plugin-install-info">
-			<span class="plugin-install-info-label"><?php esc_html_e( 'The following plugins will be installed and activated for you:', 'woocommerce' ); ?></span>
-			<span class="plugin-install-info-list"></span>
-		</span>
-		<?php
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -691,6 +691,13 @@ class WC_Admin_Setup_Wizard {
 		);
 	}
 
+	protected function get_wcs_requisite_plugins() {
+		return array(
+			array( 'name' => __( 'WooCommerce Services', 'woocommerce' ), 'slug' => 'woocommerce-services' ),
+			array( 'name' => __( 'Jetpack', 'woocommerce' ), 'slug' => 'jetpack' ),
+		);
+	}
+
 	/**
 	 * Get the WCS shipping carrier for a given country code.
 	 *
@@ -1193,6 +1200,7 @@ class WC_Admin_Setup_Wizard {
 						'value'       => 'yes',
 						'placeholder' => '',
 						'required'    => false,
+						'plugins'     => $this->get_wcs_requisite_plugins(),
 					),
 					'email'          => array(
 						'label'       => __( 'Stripe email address:', 'woocommerce' ),
@@ -1218,6 +1226,7 @@ class WC_Admin_Setup_Wizard {
 						'value'       => 'yes',
 						'placeholder' => '',
 						'required'    => false,
+						'plugins'     => $this->get_wcs_requisite_plugins(),
 					),
 					'email'            => array(
 						'label'       => __( 'Direct payments to email address:', 'woocommerce' ),
@@ -1454,6 +1463,7 @@ class WC_Admin_Setup_Wizard {
 									placeholder="<?php echo esc_attr( $setting['placeholder'] ); ?>"
 									<?php echo ( $setting['required'] ) ? 'required' : ''; ?>
 									<?php echo $is_checkbox ? checked( isset( $checked ) && $checked, true, false ) : ''; ?>
+									data-plugins="<?php echo esc_attr( json_encode( isset( $setting['plugins'] ) ? $setting['plugins'] : null ) ); ?>"
 								/>
 								<?php if ( ! empty( $setting['description'] ) ) : ?>
 									<span class="wc-wizard-service-settings-description"><?php echo esc_html( $setting['description'] ); ?></span>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -692,10 +692,14 @@ class WC_Admin_Setup_Wizard {
 	}
 
 	protected function get_wcs_requisite_plugins() {
-		return array(
-			array( 'name' => __( 'WooCommerce Services', 'woocommerce' ), 'slug' => 'woocommerce-services' ),
-			array( 'name' => __( 'Jetpack', 'woocommerce' ), 'slug' => 'jetpack' ),
-		);
+		$plugins = array();
+		if ( ! is_plugin_active( 'woocommerce-services/woocommerce-services.php' ) ) {
+			$plugins[] = array( 'name' => __( 'WooCommerce Services', 'woocommerce' ), 'slug' => 'woocommerce-services' );
+		}
+		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
+			$plugins[] = array( 'name' => __( 'Jetpack', 'woocommerce' ), 'slug' => 'jetpack' );
+		}
+		return $plugins;
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -698,20 +698,23 @@ class WC_Admin_Setup_Wizard {
 	 */
 	protected function get_wcs_requisite_plugins() {
 		$plugins = array();
-		if ( ! is_plugin_active( 'woocommerce-services/woocommerce-services.php' ) ) {
-			$plugins[] = array( 'name' => __( 'WooCommerce Services', 'woocommerce' ), 'slug' => 'woocommerce-services' );
+		if ( ! is_plugin_active( 'woocommerce-services/woocommerce-services.php' ) && ! get_option( 'woocommerce_setup_background_installing_woocommerce-services' ) ) {
+			$plugins[] = array(
+				'name' => __( 'WooCommerce Services', 'woocommerce' ),
+				'slug' => 'woocommerce-services',
+			);
 		}
-		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
-			$plugins[] = array( 'name' => __( 'Jetpack', 'woocommerce' ), 'slug' => 'jetpack' );
+		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) && ! get_option( 'woocommerce_setup_background_installing_jetpack' ) ) {
+			$plugins[] = array(
+				'name' => __( 'Jetpack', 'woocommerce' ),
+				'slug' => 'jetpack',
+			);
 		}
 		return $plugins;
 	}
 
 	/**
 	 * Plugin install info message markup with heading.
-	 *
-	 * @param array $service Service info array.
-	 * @return boolean
 	 */
 	public function plugin_install_info() {
 		?>
@@ -1445,7 +1448,14 @@ class WC_Admin_Setup_Wizard {
 			$should_enable_toggle = isset( $item_info['enabled'] ) && $item_info['enabled'];
 		}
 
-		$plugins = isset( $item_info['repo-slug'] ) ? array( array( 'slug' => $item_info['repo-slug'], 'name' => $item_info['name'] ) ) : null;
+		$plugins = null;
+		if ( isset( $item_info['repo-slug'] ) ) {
+			$plugin = array(
+				'slug' => $item_info['repo-slug'],
+				'name' => $item_info['name'],
+			);
+			$plugins = array( $plugin );
+		}
 
 		?>
 		<li class="<?php echo esc_attr( $item_class ); ?>">

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1406,6 +1406,8 @@ class WC_Admin_Setup_Wizard {
 			$should_enable_toggle = isset( $item_info['enabled'] ) && $item_info['enabled'];
 		}
 
+		$plugins = isset( $item_info['repo-slug'] ) ? array( array( 'slug' => $item_info['repo-slug'], 'name' => $item_info['name'] ) ) : null;
+
 		?>
 		<li class="<?php echo esc_attr( $item_class ); ?>">
 			<div class="wc-wizard-service-name">
@@ -1468,6 +1470,7 @@ class WC_Admin_Setup_Wizard {
 						type="checkbox"
 						name="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>-enabled"
 						value="yes" <?php checked( $should_enable_toggle ); ?>
+						data-plugins="<?php echo esc_attr( json_encode( $plugins ) ); ?>"
 					/>
 					<label for="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>">
 				</span>
@@ -1494,6 +1497,15 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function is_not_featured_service( $service ) {
 		return ! $this->is_featured_service( $service );
+	}
+
+	public function plugin_install_info() {
+		?>
+		<span class="plugin-install-info">
+			<span class="plugin-install-info-label"><?php esc_html_e( 'The following plugins will be installed and activated for you:', 'woocommerce' ); ?></span>
+			<span class="plugin-install-info-list"></span>
+		</span>
+		<?php
 	}
 
 	/**
@@ -1561,6 +1573,7 @@ class WC_Admin_Setup_Wizard {
 				?>
 			</ul>
 			<p class="wc-setup-actions step">
+				<?php $this->plugin_install_info(); ?>
 				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'wc-setup' ); ?>
 			</p>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -772,7 +772,12 @@ class WC_Admin_Setup_Wizard {
 		?>
 		<div class="wc-wizard-shipping-method-select">
 			<div class="wc-wizard-shipping-method-dropdown">
-				<select id="<?php echo esc_attr( "{$input_prefix}[method]" ); ?>" name="<?php echo esc_attr( "{$input_prefix}[method]" ); ?>" class="method wc-enhanced-select">
+				<select
+					id="<?php echo esc_attr( "{$input_prefix}[method]" ); ?>"
+					name="<?php echo esc_attr( "{$input_prefix}[method]" ); ?>"
+					class="method wc-enhanced-select"
+					data-plugins="<?php echo esc_attr( json_encode( $this->get_wcs_requisite_plugins() ) ); ?>"
+				>
 				<?php foreach ( $shipping_methods as $method_id => $method ) : ?>
 					<option value="<?php echo esc_attr( $method_id ); ?>" <?php selected( $selected, $method_id ); ?>><?php echo esc_html( $method['name'] ); ?></option>
 				<?php endforeach; ?>
@@ -935,6 +940,7 @@ class WC_Admin_Setup_Wizard {
 			</div>
 
 			<p class="wc-setup-actions step">
+				<?php $this->plugin_install_info(); ?>
 				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'wc-setup' ); ?>
 			</p>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1664,7 +1664,9 @@ class WC_Admin_Setup_Wizard {
 					type="checkbox"
 					name="<?php echo esc_attr( 'setup_' . $type ); ?>"
 					value="yes"
-					checked />
+					checked
+					data-plugins="<?php echo esc_attr( json_encode( isset( $item_info['plugins'] ) ? $item_info['plugins'] : null ) ); ?>"
+				/>
 				<img
 					src="<?php echo esc_url( $img_url ); ?>"
 					class="<?php echo esc_attr( 'recommended-item-icon-' . $type ); ?> recommended-item-icon"
@@ -1730,6 +1732,7 @@ class WC_Admin_Setup_Wizard {
 						'description' => __( 'Save time and errors with automated tax calculation and collection at checkout. Powered by WooCommerce Services and Jetpack.', 'woocommerce' ),
 						'img_url'     => WC()->plugin_url() . '/assets/images/obw-taxes-icon.svg',
 						'img_alt'     => __( 'automated taxes icon', 'woocommerce' ),
+						'plugins'     => $this->get_wcs_requisite_plugins(),
 					) );
 				endif;
 
@@ -1740,11 +1743,13 @@ class WC_Admin_Setup_Wizard {
 						'description' => __( 'Join the 16 million customers who use MailChimp. Sync list and store data to send automated emails, and targeted campaigns.', 'woocommerce' ),
 						'img_url'     => WC()->plugin_url() . '/assets/images/obw-mailchimp-icon.svg',
 						'img_alt'     => __( 'MailChimp icon', 'woocommerce' ),
+						'plugins'     => array( array( 'name' => __( 'MailChimp for WooCommerce', 'woocommerce' ), 'slug' => 'mailchimp-for-woocommerce' ) ),
 					) );
 				endif;
 			?>
 		</ul>
 			<p class="wc-setup-actions step">
+				<?php $this->plugin_install_info(); ?>
 				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'wc-setup' ); ?>
 			</p>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1194,7 +1194,7 @@ class WC_Admin_Setup_Wizard {
 
 		return array(
 			'stripe'          => array(
-				'name'        => __( 'Stripe', 'woocommerce' ),
+				'name'        => __( 'WooCommerce Stripe Gateway', 'woocommerce' ),
 				'image'       => WC()->plugin_url() . '/assets/images/stripe.png',
 				'description' => $stripe_description,
 				'class'       => 'checked stripe-logo',
@@ -1219,7 +1219,7 @@ class WC_Admin_Setup_Wizard {
 				),
 			),
 			'ppec_paypal'     => array(
-				'name'        => __( 'PayPal Express Checkout', 'woocommerce' ),
+				'name'        => __( 'WooCommerce PayPal Express Checkout Gateway', 'woocommerce' ),
 				'image'       => WC()->plugin_url() . '/assets/images/paypal.png',
 				'description' => $paypal_ec_description,
 				'enabled'     => true,
@@ -1259,7 +1259,7 @@ class WC_Admin_Setup_Wizard {
 				),
 			),
 			'klarna_checkout' => array(
-				'name'        => __( 'Klarna Checkout', 'woocommerce' ),
+				'name'        => __( 'Klarna Checkout for WooCommerce', 'woocommerce' ),
 				'description' => $klarna_checkout_description,
 				'image'       => WC()->plugin_url() . '/assets/images/klarna-white.png',
 				'enabled'     => true,
@@ -1267,7 +1267,7 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'klarna-checkout-for-woocommerce',
 			),
 			'klarna_payments' => array(
-				'name'        => __( 'Klarna Payments', 'woocommerce' ),
+				'name'        => __( 'Klarna Payments for WooCommerce', 'woocommerce' ),
 				'description' => $klarna_payments_description,
 				'image'       => WC()->plugin_url() . '/assets/images/klarna-white.png',
 				'enabled'     => true,
@@ -1275,7 +1275,7 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'klarna-payments-for-woocommerce',
 			),
 			'square'          => array(
-				'name'        => __( 'Square', 'woocommerce' ),
+				'name'        => __( 'WooCommerce Square', 'woocommerce' ),
 				'description' => $square_description,
 				'image'       => WC()->plugin_url() . '/assets/images/square-white.png',
 				'class'       => 'square-logo',
@@ -1283,7 +1283,7 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'woocommerce-square',
 			),
 			'eway'            => array(
-				'name'        => __( 'eWAY', 'woocommerce' ),
+				'name'        => __( 'WooCommerce eWAY Gateway', 'woocommerce' ),
 				'description' => __( 'The eWAY extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.', 'woocommerce' ),
 				'image'       => WC()->plugin_url() . '/assets/images/eway-logo.jpg',
 				'enabled'     => false,
@@ -1291,7 +1291,7 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'woocommerce-gateway-eway',
 			),
 			'payfast'         => array(
-				'name'        => __( 'PayFast', 'woocommerce' ),
+				'name'        => __( 'WooCommerce PayFast Gateway', 'woocommerce' ),
 				'description' => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.', 'woocommerce' ),
 				'image'       => WC()->plugin_url() . '/assets/images/payfast.png',
 				'class'       => 'payfast-logo',

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -729,7 +729,7 @@ class WC_Admin_Setup_Wizard {
 		$shipping_methods = array(
 			'live_rates'    => array(
 				'name'        => __( 'Live Rates', 'woocommerce' ),
-				'description' => __( 'WooCommerce Services and Jetpack will be installed and activated for you.', 'woocommerce' ),
+				'description' => __( 'Powered by WooCommerce Services and Jetpack.', 'woocommerce' ),
 			),
 			'flat_rate'     => array(
 				'name'        => __( 'Flat Rate', 'woocommerce' ),
@@ -1213,7 +1213,7 @@ class WC_Admin_Setup_Wizard {
 						'type'        => 'email',
 						'value'       => $user_email,
 						'placeholder' => __( 'Stripe email address', 'woocommerce' ),
-						'description' => __( "Enter your email address and we'll handle account creation. WooCommerce Services and Jetpack will be installed and activated for you.", 'woocommerce' ),
+						'description' => __( "Enter your email address and we'll handle account creation. Powered by WooCommerce Services and Jetpack.", 'woocommerce' ),
 						'required'    => true,
 					),
 				),
@@ -1239,7 +1239,7 @@ class WC_Admin_Setup_Wizard {
 						'type'        => 'email',
 						'value'       => $user_email,
 						'placeholder' => __( 'Email address to receive payments', 'woocommerce' ),
-						'description' => __( "Enter your email address and we'll authenticate payments for you. WooCommerce Services and Jetpack will be installed and activated for you.", 'woocommerce' ),
+						'description' => __( "Enter your email address and we'll authenticate payments for you. Powered by WooCommerce Services and Jetpack.", 'woocommerce' ),
 						'required'    => true,
 					),
 				),

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -873,7 +873,7 @@ class WC_Admin_Setup_Wizard {
 						</div>
 						<div class="wc-wizard-service-enable">
 							<span class="wc-wizard-service-toggle">
-								<input id="shipping_zones[domestic][enabled]" type="checkbox" name="shipping_zones[domestic][enabled]" value="yes" checked="checked" class="wc-wizard-shipping-method-enable" />
+								<input id="shipping_zones[domestic][enabled]" type="checkbox" name="shipping_zones[domestic][enabled]" value="yes" checked="checked" class="wc-wizard-shipping-method-enable" data-plugins="true" />
 								<label for="shipping_zones[domestic][enabled]">
 							</span>
 						</div>
@@ -887,7 +887,7 @@ class WC_Admin_Setup_Wizard {
 						</div>
 						<div class="wc-wizard-service-enable">
 							<span class="wc-wizard-service-toggle">
-								<input id="shipping_zones[intl][enabled]" type="checkbox" name="shipping_zones[intl][enabled]" value="yes" checked="checked" class="wc-wizard-shipping-method-enable"/>
+								<input id="shipping_zones[intl][enabled]" type="checkbox" name="shipping_zones[intl][enabled]" value="yes" checked="checked" class="wc-wizard-shipping-method-enable" data-plugins="true" />
 								<label for="shipping_zones[intl][enabled]">
 							</span>
 						</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a message above the "Continue" button listing any plugins that will be installed by clicking it:

<img width="652" alt="screen shot 2018-05-03 at 6 31 03 am" src="https://user-images.githubusercontent.com/1867547/39572018-9bfadaec-4e9b-11e8-947b-70ed219f4ed0.png">

(As proposed in p7bbVw-2wa-p2.)

Each plugin links to its WP.org page, and hovering on the link highlights the part of the UI which in its current state requires the plugin. Walkthrough: https://cloudup.com/cnNHBZsP0v0

As part of these changes, the payment gateway `name` (as encoded in the wizard but only rendered as `alt` text) is changed to the plugin name.

This currently affects only the "Payment", "Shipping", and "Recommended" steps. In the case where no WooCommerce Services features are selected, should the "Activate" step include this message as well?

Also, currently WooCommerce Services and Jetpack are not listed if they were already installed or are being installed, but no such check is implemented for other plugins. Though people generally wouldn't have WooCommerce extensions activated at this point, do we want to check for this?

### How to test the changes in this Pull Request:

- Go through the setup wizard, modifying options and ensuring that the plugin list updates in accordance with the selection
- Hover plugins in the list, and ensure that the proper UI element(s) is highlighted
- Make sure WooCommerce Services and Jetpack appear only when they are not already active

### Other information:

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Wizard: List out all plugins to be installed upon proceeding to the next step, with a highlight on hover indicating relevant settings.