### PR TITLE
Make some strings easier to translate for translators

### DIFF
--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -136,7 +136,8 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					'title'    => __( 'Registration privacy policy', 'woocommerce' ),
 					'desc_tip' => __( 'Optionally add some text about your store privacy policy to show on account registration forms.', 'woocommerce' ),
 					'id'       => 'woocommerce_registration_privacy_policy_text',
-					'default'  => __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [privacy_policy].', 'woocommerce' ),
+					/* translators: %s privacy policy page name and link */
+					'default'  => sprintf( __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our %s.', 'woocommerce' ), '[privacy_policy]' ),
 					'type'     => 'textarea',
 					'css'      => 'min-width: 50%; height: 75px;',
 				),
@@ -145,7 +146,8 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					'title'    => __( 'Checkout privacy policy', 'woocommerce' ),
 					'desc_tip' => __( 'Optionally add some text about your store privacy policy to show during checkout.', 'woocommerce' ),
 					'id'       => 'woocommerce_checkout_privacy_policy_text',
-					'default'  => __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ),
+					/* translators: %s privacy policy page name and link */
+					'default'  => sprintf( __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our %s.', 'woocommerce' ), '[privacy_policy]' ),
 					'type'     => 'textarea',
 					'css'      => 'min-width: 50%; height: 75px;',
 				),

--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -118,7 +118,8 @@ class WC_Privacy_Exporters {
 			foreach ( $downloads as $download ) {
 				$data_to_export[] = array(
 					'group_id'    => 'woocommerce_downloads',
-					'group_label' => __( 'Order Downloads', 'woocommerce' ),
+					/* translators: This is the headline for a list of downloads purchased from the store for a given user. */
+					'group_label' => __( 'Purchased Downloads', 'woocommerce' ),
 					'item_id'     => 'download-' . $download->get_id(),
 					'data'        => self::get_download_personal_data( $download ),
 				);
@@ -128,7 +129,8 @@ class WC_Privacy_Exporters {
 				foreach ( $download_logs as $download_log ) {
 					$data_to_export[] = array(
 						'group_id'    => 'woocommerce_download_logs',
-						'group_label' => __( 'Download Logs', 'woocommerce' ),
+						/* translators: This is the headline for a list of access logs for downloads purchased from the store for a given user. */
+						'group_label' => __( 'Access to Purchased Downloads', 'woocommerce' ),
 						'item_id'     => 'download-log-' . $download_log->get_id(),
 						'data'        => array(
 							array(

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -746,7 +746,8 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_checkout_terms_and_conditions_checkbox_text',
 			array(
-				'default'           => __( 'I have read and agree to the website [terms]', 'woocommerce' ),
+				/* translators: %s terms and conditions page name and link */
+				'default'           => sprintf( __( 'I have read and agree to the website %s', 'woocommerce' ), '[terms]' ),
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
 				'sanitize_callback' => 'wp_kses_post',
@@ -757,7 +758,8 @@ class WC_Shop_Customizer {
 		$wp_customize->add_setting(
 			'woocommerce_checkout_privacy_policy_text',
 			array(
-				'default'           => __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ),
+				/* translators: %s privacy policy page name and link */
+				'default'           => sprintf( __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our %s.', 'woocommerce' ), '[privacy_policy]' ),
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
 				'sanitize_callback' => 'wp_kses_post',

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -727,7 +727,8 @@ function wc_terms_and_conditions_checkbox_enabled() {
  * @return string
  */
 function wc_get_terms_and_conditions_checkbox_text() {
-	return trim( apply_filters( 'woocommerce_get_terms_and_conditions_checkbox_text', get_option( 'woocommerce_checkout_terms_and_conditions_checkbox_text', __( 'I have read and agree to the website [terms]', 'woocommerce' ) ) ) );
+	/* translators: %s terms and conditions page name and link */
+	return trim( apply_filters( 'woocommerce_get_terms_and_conditions_checkbox_text', get_option( 'woocommerce_checkout_terms_and_conditions_checkbox_text', sprintf( __( 'I have read and agree to the website %s', 'woocommerce' ), '[terms]' ) ) ) );
 }
 
 /**
@@ -742,10 +743,12 @@ function wc_get_privacy_policy_text( $type = '' ) {
 
 	switch ( $type ) {
 		case 'checkout':
-			$text = get_option( 'woocommerce_checkout_privacy_policy_text', __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our [privacy_policy].', 'woocommerce' ) );
+			/* translators: %s privacy policy page name and link */
+			$text = get_option( 'woocommerce_checkout_privacy_policy_text', sprintf( __( 'Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our %s.', 'woocommerce' ), '[privacy_policy]' ) );
 			break;
 		case 'registration':
-			$text = get_option( 'woocommerce_registration_privacy_policy_text', __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our [privacy_policy].', 'woocommerce' ) );
+			/* translators: %s privacy policy page name and link */
+			$text = get_option( 'woocommerce_registration_privacy_policy_text', sprintf( __( 'Your personal data will be used to support your experience throughout this website, to manage access to your account, and for other purposes described in our %s.', 'woocommerce' ), '[privacy_policy]' ) );
 			break;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

String updates which make translation easier (comments + removal of placeholders).