### PR TITLE
Required fields should be marked with *

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -444,7 +444,7 @@ class WC_Install {
 		// Define other defaults if not in setting screens.
 		add_option( 'woocommerce_single_image_width', '600', '', 'yes' );
 		add_option( 'woocommerce_thumbnail_image_width', '300', '', 'yes' );
-		add_option( 'woocommerce_checkout_highlight_required_fields', 'no', '', 'yes' );
+		add_option( 'woocommerce_checkout_highlight_required_fields', 'yes', '', 'yes' );
 		add_option( 'woocommerce_demo_store', 'no', '', 'no' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

To match WooCommerce 3.3, the new option `woocommerce_checkout_highlight_required_fields` should default to `yes`.

### How to test the changes in this Pull Request:

1. On a new install, go to the checkout page.
2. Required fields should be marked with an *.