### PR TITLE
fixes https://github.com/woocommerce/woocommerce/issues/19961

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1799,8 +1799,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return string
 	 */
 	public function get_image( $size = 'woocommerce_thumbnail', $attr = array(), $placeholder = true ) {
-        $dimensions           = wc_get_image_size( $size );
-        $wp_media_dimensions  = array($dimensions['width'],$dimensions['height']);
+		$dimensions           = wc_get_image_size( $size );
+		$wp_media_dimensions  = array( $dimensions['width'], $dimensions['height'] );
 		if ( has_post_thumbnail( $this->get_id() ) ) {
 			$image = get_the_post_thumbnail( $this->get_id(), $wp_media_dimensions, $attr );
 		} elseif ( ( $parent_id = wp_get_post_parent_id( $this->get_id() ) ) && has_post_thumbnail( $parent_id ) ) { // @phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1799,12 +1799,14 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return string
 	 */
 	public function get_image( $size = 'woocommerce_thumbnail', $attr = array(), $placeholder = true ) {
+        $dimensions           = wc_get_image_size( $size );
+        $wp_media_dimensions  = array($dimensions['width'],$dimensions['height']);
 		if ( has_post_thumbnail( $this->get_id() ) ) {
-			$image = get_the_post_thumbnail( $this->get_id(), $size, $attr );
+			$image = get_the_post_thumbnail( $this->get_id(), $wp_media_dimensions, $attr );
 		} elseif ( ( $parent_id = wp_get_post_parent_id( $this->get_id() ) ) && has_post_thumbnail( $parent_id ) ) { // @phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
-			$image = get_the_post_thumbnail( $parent_id, $size, $attr );
+			$image = get_the_post_thumbnail( $parent_id, $wp_media_dimensions, $attr );
 		} elseif ( $placeholder ) {
-			$image = wc_placeholder_img( $size );
+			$image = wc_placeholder_img( $wp_media_dimensions );
 		} else {
 			$image = '';
 		}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2335,13 +2335,14 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 	function woocommerce_subcategory_thumbnail( $category ) {
 		$small_thumbnail_size = apply_filters( 'subcategory_archive_thumbnail_size', 'woocommerce_thumbnail' );
 		$dimensions           = wc_get_image_size( $small_thumbnail_size );
+        $wp_media_dimensions  = array($dimensions['width'],$dimensions['height']);
 		$thumbnail_id         = get_woocommerce_term_meta( $category->term_id, 'thumbnail_id', true );
 
 		if ( $thumbnail_id ) {
-			$image        = wp_get_attachment_image_src( $thumbnail_id, $small_thumbnail_size );
+			$image        = wp_get_attachment_image_src( $thumbnail_id, $wp_media_dimensions );
 			$image        = $image[0];
-			$image_srcset = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $thumbnail_id, $small_thumbnail_size ) : false;
-			$image_sizes  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $thumbnail_id, $small_thumbnail_size ) : false;
+			$image_srcset = function_exists( 'wp_get_attachment_image_srcset' ) ? wp_get_attachment_image_srcset( $thumbnail_id, $wp_media_dimensions ) : false;
+			$image_sizes  = function_exists( 'wp_get_attachment_image_sizes' ) ? wp_get_attachment_image_sizes( $thumbnail_id, $wp_media_dimensions ) : false;
 		} else {
 			$image        = wc_placeholder_img_src();
 			$image_srcset = false;

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2335,7 +2335,7 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 	function woocommerce_subcategory_thumbnail( $category ) {
 		$small_thumbnail_size = apply_filters( 'subcategory_archive_thumbnail_size', 'woocommerce_thumbnail' );
 		$dimensions           = wc_get_image_size( $small_thumbnail_size );
-        $wp_media_dimensions  = array($dimensions['width'],$dimensions['height']);
+		$wp_media_dimensions  = array( $dimensions['width'], $dimensions['height'] );
 		$thumbnail_id         = get_woocommerce_term_meta( $category->term_id, 'thumbnail_id', true );
 
 		if ( $thumbnail_id ) {


### PR DESCRIPTION
fixes https://github.com/woocommerce/woocommerce/issues/19961 by
passing width and height array to wordpress image functions in order to
find correctly sized image

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Set some rectangular images to category featured image and product featured image
2. set woocommerce thumbnails to cropped 1:1
3. catalogue will show rectangular images where uploaded in step 1 (except in customizer)
4. apply changes
5. cropped 1:1 images will be shown for the rectangular images

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed category thumbnail sizing in catalogue
> Fixed product thumbnail sizing in catalogue
