### PR TITLE
Tracker opt-out api call to erase personal data

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -184,7 +184,7 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 			'reset_tracking'                     => array(
 				'name'   => __( 'Reset usage tracking', 'woocommerce' ),
 				'button' => __( 'Reset', 'woocommerce' ),
-				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
+				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data. It will also remove any personal data from the woocommerce.com servers.', 'woocommerce' ),
 			),
 			'regenerate_thumbnails'              => array(
 				'name'   => __( 'Regenerate shop thumbnails', 'woocommerce' ),

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -184,7 +184,7 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 			'reset_tracking'                     => array(
 				'name'   => __( 'Reset usage tracking', 'woocommerce' ),
 				'button' => __( 'Reset', 'woocommerce' ),
-				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data. It will also remove any personal data from the woocommerce.com servers.', 'woocommerce' ),
+				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
 			),
 			'regenerate_thumbnails'              => array(
 				'name'   => __( 'Regenerate shop thumbnails', 'woocommerce' ),

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -513,6 +513,10 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 				break;
 
 			case 'reset_tracking':
+				if ( ! class_exists( 'WC_Tracker' ) ) {
+					include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
+				}
+				WC_Tracker::opt_out_request();
 				delete_option( 'woocommerce_allow_tracking' );
 				WC_Admin_Notices::add_notice( 'tracking' );
 				$message = __( 'Usage tracking settings successfully reset.', 'woocommerce' );

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -487,6 +487,28 @@ class WC_Tracker {
 
 		return $min_max;
 	}
+
+	/**
+	 * Make a request when opting out of tracker usage.
+	 *
+	 * @return void
+	 */
+	public static function opt_out_request() {
+		$body = array(
+			'event' => 'opt-out',
+			'email' => apply_filters( 'woocommerce_tracker_admin_email', get_option( 'admin_email' ) ),
+			'url'   => home_url(),
+		);
+		wp_safe_remote_post( self::$api_url . 'event/', array(
+			'method'      => 'POST',
+			'redirection' => 5,
+			'httpversion' => '1.0',
+			'blocking'    => false,
+			'headers'     => array( 'user-agent' => 'WooCommerceTracker/' . md5( esc_url_raw( home_url( '/' ) ) ) . ';' ),
+			'body'        => wp_json_encode( $body ),
+			'cookies'     => array(),
+		) );
+	}
 }
 
 WC_Tracker::init();

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -238,7 +238,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 				'id'          => 'reset_tracking',
 				'name'        => 'Reset usage tracking',
 				'action'      => 'Reset',
-				'description' => 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.',
+				'description' => 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data. It will also remove any personal data from the woocommerce.com servers.',
 				'_links'      => array(
 					'item' => array(
 						array(

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -238,7 +238,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 				'id'          => 'reset_tracking',
 				'name'        => 'Reset usage tracking',
 				'action'      => 'Reset',
-				'description' => 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data. It will also remove any personal data from the woocommerce.com servers.',
+				'description' => 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.',
 				'_links'      => array(
 					'item' => array(
 						array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds functionality that when you opt out of data tracking, it will send an API request with the email and url to erase personal data on woo.com side. Forms part of GDPR.

### How to test the changes in this Pull Request:

1. Opt-in for data tracking
2. Opt-out of data tracking
3. Observe that an API call is made to api.woocommerce.com. No noticeable changes should be present from the UI side.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
