### PR TITLE
Add three new action hooks for admin shipping zone methods

### DIFF
--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <table class="form-table wc-shipping-zone-settings">
 	<tbody>
+		<?php do_action( 'woocommerce_shipping_zone_inside_top_methods_table' ); ?>
 		<?php if ( 0 !== $zone->get_id() ) : ?>
 			<tr valign="top" class="">
 				<th scope="row" class="titledesc">
@@ -97,8 +98,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</table>
 			</td>
 		</tr>
+	<?php do_action( 'woocommerce_shipping_zone_inside_bottom_methods_table' ); ?>
 	</tbody>
 </table>
+
+<?php do_action( 'woocommerce_shipping_zone_after_methods_table' ); ?>
+
 <p class="submit">
 	<button type="submit" name="submit" id="submit" class="button button-primary button-large wc-shipping-zone-method-save" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>" disabled><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 </p>

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -98,7 +98,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</table>
 			</td>
 		</tr>
-	<?php do_action( 'woocommerce_shipping_zone_inside_bottom_methods_table' ); ?>
+		<?php do_action( 'woocommerce_shipping_zone_inside_bottom_methods_table' ); ?>
 	</tbody>
 </table>
 

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -19,7 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <table class="form-table wc-shipping-zone-settings">
 	<tbody>
-		<?php do_action( 'woocommerce_shipping_zone_inside_top_methods_table' ); ?>
 		<?php if ( 0 !== $zone->get_id() ) : ?>
 			<tr valign="top" class="">
 				<th scope="row" class="titledesc">
@@ -98,7 +97,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</table>
 			</td>
 		</tr>
-		<?php do_action( 'woocommerce_shipping_zone_inside_bottom_methods_table' ); ?>
 	</tbody>
 </table>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I had a client project recently where I needed to edit the shipping zone methods screen to add in additional fields, but I noticed there's only one current action hook on the page:

`woocommerce_shipping_zone_before_methods_table`

The new action hooks are:

* woocommerce_shipping_zone_inside_top_methods_table
* woocommerce_shipping_zone_inside_bottom_methods_table
* woocommerce_shipping_zone_after_methods_table

This gives more control over the placement of custom data on the screen, instead of only allowing code to be included before the methods table.

### Changelog entry

> Added three action hooks to the admin shipping zone methods.
