### PR TITLE
Fix: WC API should not try to create a product image if an empty image is passed

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -290,7 +290,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 
 		// Thumbnail.
 		if ( isset( $request['image'] ) ) {
-			if ( is_array( $request['image'] ) ) {
+			if ( is_array( $request['image'] ) && ! empty( $request['image'] ) ) {
 				$image = $request['image'];
 				if ( is_array( $image ) ) {
 					$image['position'] = 0;


### PR DESCRIPTION
Currently if you try to create a product variation passing an empty array as the value of the image key using WC API:

Endpoint: `wp-json/wc/v2/products/PRODUCT_ID/variations`
Payload: `{ "attributes" : [ { "id" : 1, "name" : "color", "option" : "Green" } ], "dscription" : "Green Tea Variety", "image" : {} }`

WC will return the following error:

```
{ "code": "woocommerce_product_invalid_image_id", "data": { "status": 400 }, "message": "#0 is an invalid image ID." }
```

This is happening because the code that handles image creation
([includes/api/class-wc-rest-product-variations-controller.php#L292](https://github.com/woocommerce/woocommerce/blob/4e42b2cd30f7970307953d4a4045c2897579806d/includes/api/class-wc-rest-product-variations-controller.php#L292)) is not checking if `$request['image']` is empty before adding a new `position` key to it. To fix this problem, this commit adds a check to see if `$request['image']` is empty before proceeding.

Fixes #19964

### Changelog entry

Fix: WC API should not try to create a product image when creating a product variation if an empty image is passed