### PR TITLE
Remove WC API unit tests cleanup code

### DIFF
--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -19,9 +19,11 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Orders_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -84,7 +86,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_item() {
 		wp_set_current_user( $this->user );
-		$order          = WC_Helper_Order::create_order();
+		$order = WC_Helper_Order::create_order();
 		$order->add_meta_data( 'key', 'value' );
 		$order->add_meta_data( 'key2', 'value2' );
 		$order->save();
@@ -135,46 +137,48 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
 		$request = new WP_REST_Request( 'POST', '/wc/v2/orders' );
-		$request->set_body_params( array(
-			'payment_method' => 'bacs',
-			'payment_method_title' => 'Direct Bank Transfer',
-			'set_paid' => true,
-			'billing' => array(
-				'first_name' => 'John',
-				'last_name'  => 'Doe',
-				'address_1'  => '969 Market',
-				'address_2'  => '',
-				'city'       => 'San Francisco',
-				'state'      => 'CA',
-				'postcode'   => '94103',
-				'country'    => 'US',
-				'email'      => 'john.doe@example.com',
-				'phone'      => '(555) 555-5555',
-			),
-			'shipping' => array(
-				'first_name' => 'John',
-				'last_name'  => 'Doe',
-				'address_1'  => '969 Market',
-				'address_2'  => '',
-				'city'       => 'San Francisco',
-				'state'      => 'CA',
-				'postcode'   => '94103',
-				'country'    => 'US',
-			),
-			'line_items' => array(
-				array(
-					'product_id' => $product->get_id(),
-					'quantity'   => 2,
+		$request->set_body_params(
+			array(
+				'payment_method'       => 'bacs',
+				'payment_method_title' => 'Direct Bank Transfer',
+				'set_paid'             => true,
+				'billing'              => array(
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+					'address_1'  => '969 Market',
+					'address_2'  => '',
+					'city'       => 'San Francisco',
+					'state'      => 'CA',
+					'postcode'   => '94103',
+					'country'    => 'US',
+					'email'      => 'john.doe@example.com',
+					'phone'      => '(555) 555-5555',
 				),
-			),
-			'shipping_lines' => array(
-				array(
-					'method_id'    => 'flat_rate',
-					'method_title' => 'Flat rate',
-					'total'        => '10',
+				'shipping'             => array(
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+					'address_1'  => '969 Market',
+					'address_2'  => '',
+					'city'       => 'San Francisco',
+					'state'      => 'CA',
+					'postcode'   => '94103',
+					'country'    => 'US',
 				),
-			),
-		) );
+				'line_items'           => array(
+					array(
+						'product_id' => $product->get_id(),
+						'quantity'   => 2,
+					),
+				),
+				'shipping_lines'       => array(
+					array(
+						'method_id'    => 'flat_rate',
+						'method_title' => 'Flat rate',
+						'total'        => '10',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$order    = wc_get_order( $data['id'] );
@@ -218,47 +222,49 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		// non-existent customer
 		$request = new WP_REST_Request( 'POST', '/wc/v2/orders' );
-		$request->set_body_params( array(
-			'payment_method'       => 'bacs',
-			'payment_method_title' => 'Direct Bank Transfer',
-			'set_paid'             => true,
-			'customer_id'          => 99999,
-			'billing'              => array(
-				'first_name' => 'John',
-				'last_name'  => 'Doe',
-				'address_1'  => '969 Market',
-				'address_2'  => '',
-				'city'       => 'San Francisco',
-				'state'      => 'CA',
-				'postcode'   => '94103',
-				'country'    => 'US',
-				'email'      => 'john.doe@example.com',
-				'phone'      => '(555) 555-5555',
-			),
-			'shipping' => array(
-				'first_name' => 'John',
-				'last_name'  => 'Doe',
-				'address_1'  => '969 Market',
-				'address_2'  => '',
-				'city'       => 'San Francisco',
-				'state'      => 'CA',
-				'postcode'   => '94103',
-				'country'    => 'US',
-			),
-			'line_items' => array(
-				array(
-					'product_id' => $product->get_id(),
-					'quantity'   => 2,
+		$request->set_body_params(
+			array(
+				'payment_method'       => 'bacs',
+				'payment_method_title' => 'Direct Bank Transfer',
+				'set_paid'             => true,
+				'customer_id'          => 99999,
+				'billing'              => array(
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+					'address_1'  => '969 Market',
+					'address_2'  => '',
+					'city'       => 'San Francisco',
+					'state'      => 'CA',
+					'postcode'   => '94103',
+					'country'    => 'US',
+					'email'      => 'john.doe@example.com',
+					'phone'      => '(555) 555-5555',
 				),
-			),
-			'shipping_lines' => array(
-				array(
-					'method_id'    => 'flat_rate',
-					'method_title' => 'Flat rate',
-					'total'        => 10,
+				'shipping'             => array(
+					'first_name' => 'John',
+					'last_name'  => 'Doe',
+					'address_1'  => '969 Market',
+					'address_2'  => '',
+					'city'       => 'San Francisco',
+					'state'      => 'CA',
+					'postcode'   => '94103',
+					'country'    => 'US',
 				),
-			),
-		) );
+				'line_items'           => array(
+					array(
+						'product_id' => $product->get_id(),
+						'quantity'   => 2,
+					),
+				),
+				'shipping_lines'       => array(
+					array(
+						'method_id'    => 'flat_rate',
+						'method_title' => 'Flat rate',
+						'total'        => 10,
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 400, $response->get_status() );
@@ -274,13 +280,15 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$order   = WC_Helper_Order::create_order();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
-		$request->set_body_params( array(
-			'payment_method' => 'test-update',
-			'billing' => array(
-				'first_name' => 'Fish',
-				'last_name'  => 'Face',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'payment_method' => 'test-update',
+				'billing'        => array(
+					'first_name' => 'Fish',
+					'last_name'  => 'Face',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -299,28 +307,32 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_remove_items() {
 		wp_set_current_user( $this->user );
-		$order   = WC_Helper_Order::create_order();
-		$fee     = new WC_Order_Item_Fee();
-		$fee->set_props( array(
-			'name'       => 'Some Fee',
-			'tax_status' => 'taxable',
-			'total'      => '100',
-			'tax_class'  => '',
-		) );
+		$order = WC_Helper_Order::create_order();
+		$fee   = new WC_Order_Item_Fee();
+		$fee->set_props(
+			array(
+				'name'       => 'Some Fee',
+				'tax_status' => 'taxable',
+				'total'      => '100',
+				'tax_class'  => '',
+			)
+		);
 		$order->add_item( $fee );
 		$order->save();
 
 		$request  = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$fee_data = current( $order->get_items( 'fee' ) );
 
-		$request->set_body_params( array(
-			'fee_lines' => array(
-				array(
-					'id'   => $fee_data->get_id(),
-					'name' => null,
+		$request->set_body_params(
+			array(
+				'fee_lines' => array(
+					array(
+						'id'   => $fee_data->get_id(),
+						'name' => null,
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -337,28 +349,30 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_add_coupons() {
 		wp_set_current_user( $this->user );
-		$order = WC_Helper_Order::create_order();
+		$order      = WC_Helper_Order::create_order();
 		$order_item = current( $order->get_items() );
-		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
+		$coupon     = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
-		$request->set_body_params( array(
-			'coupon_lines' => array(
-				array(
-					'code'           => 'fake-coupon',
-					'discount_total' => '5',
-					'discount_tax'   => '0',
+		$request->set_body_params(
+			array(
+				'coupon_lines' => array(
+					array(
+						'code'           => 'fake-coupon',
+						'discount_total' => '5',
+						'discount_tax'   => '0',
+					),
 				),
-			),
-			'line_items' => array(
-				array(
-					'id' => $order_item->get_id(),
-					'product_id' => $order_item->get_product_id(),
-					'total' => '35.00',
+				'line_items'   => array(
+					array(
+						'id'         => $order_item->get_id(),
+						'product_id' => $order_item->get_product_id(),
+						'total'      => '35.00',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -376,9 +390,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_remove_coupons() {
 		wp_set_current_user( $this->user );
-		$order  = WC_Helper_Order::create_order();
+		$order      = WC_Helper_Order::create_order();
 		$order_item = current( $order->get_items() );
-		$coupon = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
+		$coupon     = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
 
@@ -391,21 +405,23 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request     = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
 		$coupon_data = current( $order->get_items( 'coupon' ) );
 
-		$request->set_body_params( array(
-			'coupon_lines' => array(
-				array(
-					'id'   => $coupon_data->get_id(),
-					'code' => null,
+		$request->set_body_params(
+			array(
+				'coupon_lines' => array(
+					array(
+						'id'   => $coupon_data->get_id(),
+						'code' => null,
+					),
 				),
-			),
-			'line_items' => array(
-				array(
-					'id' => $order_item->get_id(),
-					'product_id' => $order_item->get_product_id(),
-					'total' => '40.00',
+				'line_items'   => array(
+					array(
+						'id'         => $order_item->get_id(),
+						'product_id' => $order_item->get_product_id(),
+						'total'      => '40.00',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -425,13 +441,15 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 		$order   = WC_Helper_Order::create_order();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
-		$request->set_body_params( array(
-			'payment_method' => 'test-update',
-			'billing' => array(
-				'first_name' => 'Fish',
-				'last_name'  => 'Face',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'payment_method' => 'test-update',
+				'billing'        => array(
+					'first_name' => 'Fish',
+					'last_name'  => 'Face',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 		WC_Helper_Order::delete_order( $order->get_id() );
@@ -444,13 +462,15 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_update_order_invalid_id() {
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/999999' );
-		$request->set_body_params( array(
-			'payment_method' => 'test-update',
-			'billing' => array(
-				'first_name' => 'Fish',
-				'last_name'  => 'Face',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'payment_method' => 'test-update',
+				'billing'        => array(
+					'first_name' => 'Fish',
+					'last_name'  => 'Face',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 	}
@@ -461,8 +481,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_order() {
 		wp_set_current_user( $this->user );
-		$order    = WC_Helper_Order::create_order();
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v2/orders/' . $order->get_id() );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -475,8 +495,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_order_without_permission() {
 		wp_set_current_user( 0 );
-		$order    = WC_Helper_Order::create_order();
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v2/orders/' . $order->get_id() );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'DELETE', '/wc/v2/orders/' . $order->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
@@ -490,7 +510,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_order_invalid_id() {
 		wp_set_current_user( $this->user );
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v2/orders/9999999' );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v2/orders/9999999' );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
@@ -507,18 +527,20 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$order3 = WC_Helper_Order::create_order();
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/orders/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'             => $order1->get_id(),
-					'payment_method' => 'updated',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'             => $order1->get_id(),
+						'payment_method' => 'updated',
+					),
 				),
-			),
-			'delete' => array(
-				$order2->get_id(),
-				$order3->get_id(),
-			),
-		) );
+				'delete' => array(
+					$order2->get_id(),
+					$order3->get_id(),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -38,16 +38,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Cleanup.
-	 */
-	public function stoppit_and_tidyup() {
-		foreach ( $this->orders as $order ) {
-			wp_delete_post( $order->get_id(), true );
-		}
-		$this->orders = array();
-	}
-
-	/**
 	 * Test getting all orders.
 	 * @since 3.0.0
 	 */
@@ -64,7 +54,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 10, count( $orders ) );
-		$this->stoppit_and_tidyup();
 	}
 
 	/**
@@ -77,7 +66,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->orders[] = WC_Helper_Order::create_order();
 		$response       = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders' ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$this->stoppit_and_tidyup();
 	}
 
 	/**
@@ -102,8 +90,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'value', $data['meta_data'][0]->value );
 		$this->assertEquals( 'key2', $data['meta_data'][1]->key );
 		$this->assertEquals( 'value2', $data['meta_data'][1]->value );
-
-		$this->stoppit_and_tidyup();
 	}
 
 	/**
@@ -116,7 +102,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->orders[] = $order;
 		$response       = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$this->stoppit_and_tidyup();
 	}
 
 	/**
@@ -207,9 +192,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $order->get_shipping_country(), $data['shipping']['country'] );
 		$this->assertEquals( 1, count( $data['line_items'] ) );
 		$this->assertEquals( 1, count( $data['shipping_lines'] ) );
-
-		wp_delete_post( $product->get_id(), true );
-		wp_delete_post( $data['id'], true );
 	}
 
 	/**
@@ -268,7 +250,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 400, $response->get_status() );
-		wp_delete_post( $product->get_id(), true );
 	}
 
 	/**
@@ -296,8 +277,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'test-update', $data['payment_method'] );
 		$this->assertEquals( 'Fish', $data['billing']['first_name'] );
 		$this->assertEquals( 'Face', $data['billing']['last_name'] );
-
-		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
@@ -338,8 +317,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( empty( $data['fee_lines'] ) );
-
-		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
@@ -379,8 +356,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 1, $data['coupon_lines'] );
 		$this->assertEquals( '45.00', $data['total'] );
-
-		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
@@ -428,8 +403,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( empty( $data['coupon_lines'] ) );
 		$this->assertEquals( '50.00', $data['total'] );
-
-		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
@@ -452,7 +425,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		WC_Helper_Order::delete_order( $order->get_id() );
 	}
 
 	/**
@@ -500,7 +472,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		wp_delete_post( $order->get_id(), true );
 	}
 
 	/**
@@ -552,10 +523,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
-
-		wp_delete_post( $order1->get_id(), true );
-		wp_delete_post( $order2->get_id(), true );
-		wp_delete_post( $order3->get_id(), true );
 	}
 
 	/**
@@ -572,6 +539,5 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 42, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
-		wp_delete_post( $order->get_id(), true );
 	}
 }

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -14,9 +14,11 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Product_Reviews_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -43,38 +45,40 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 			$review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 		}
 
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews' ) );
+		$response        = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews' ) );
 		$product_reviews = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 10, count( $product_reviews ) );
-		$this->assertContains( array(
-			'id'               => $review_id,
-			'date_created'     => $product_reviews[0]['date_created'],
-			'date_created_gmt' => $product_reviews[0]['date_created_gmt'],
-			'review'           => 'Review content here',
-			'rating'           => 0,
-			'name'             => 'admin',
-			'email'            => 'woo@woo.local',
-			'verified'         => false,
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/products/' . $product->get_id() . '/reviews/' . $review_id ),
+		$this->assertContains(
+			array(
+				'id'               => $review_id,
+				'date_created'     => $product_reviews[0]['date_created'],
+				'date_created_gmt' => $product_reviews[0]['date_created_gmt'],
+				'review'           => 'Review content here',
+				'rating'           => 0,
+				'name'             => 'admin',
+				'email'            => 'woo@woo.local',
+				'verified'         => false,
+				'_links'           => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/products/' . $product->get_id() . '/reviews/' . $review_id ),
+						),
+					),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/products/' . $product->get_id() . '/reviews' ),
+						),
+					),
+					'up'         => array(
+						array(
+							'href' => rest_url( '/wc/v2/products/' . $product->get_id() ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/products/' . $product->get_id() . '/reviews' ),
-					),
-				),
-				'up' => array(
-					array(
-						'href' => rest_url( '/wc/v2/products/' . $product->get_id() ),
-					),
-				),
-			),
-		), $product_reviews );
+			), $product_reviews
+		);
 
 		$product->delete( true );
 	}
@@ -86,7 +90,7 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_product_reviews_without_permission() {
 		wp_set_current_user( 0 );
-		$product = WC_Helper_Product::create_simple_product();
+		$product  = WC_Helper_Product::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews' ) );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
@@ -110,23 +114,25 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_product_review() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id ) );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'               => $product_review_id,
-			'date_created'     => $data['date_created'],
-			'date_created_gmt' => $data['date_created_gmt'],
-			'review'           => 'Review content here',
-			'rating'           => 0,
-			'name'             => 'admin',
-			'email'            => 'woo@woo.local',
-			'verified'         => false,
-		), $data );
+		$this->assertEquals(
+			array(
+				'id'               => $product_review_id,
+				'date_created'     => $data['date_created'],
+				'date_created_gmt' => $data['date_created_gmt'],
+				'review'           => 'Review content here',
+				'rating'           => 0,
+				'name'             => 'admin',
+				'email'            => 'woo@woo.local',
+				'verified'         => false,
+			), $data
+		);
 		$product->delete( true );
 	}
 
@@ -137,9 +143,9 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_product_review_without_permission() {
 		wp_set_current_user( 0 );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id ) );
+		$response          = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id ) );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
 	}
@@ -151,7 +157,7 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_product_review_invalid_id() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
+		$product  = WC_Helper_Product::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/0' ) );
 		$this->assertEquals( 404, $response->get_status() );
 		$product->delete( true );
@@ -166,26 +172,30 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/reviews' );
-		$request->set_body_params( array(
-			'review' => 'Hello world.',
-			'name'   => 'Admin',
-			'email'  => 'woo@woo.local',
-			'rating' => '5',
-		) );
+		$request->set_body_params(
+			array(
+				'review' => 'Hello world.',
+				'name'   => 'Admin',
+				'email'  => 'woo@woo.local',
+				'rating' => '5',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( array(
-			'id'               => $data['id'],
-			'date_created'     => $data['date_created'],
-			'date_created_gmt' => $data['date_created_gmt'],
-			'review'           => 'Hello world.',
-			'rating'           => 5,
-			'name'             => 'Admin',
-			'email'            => 'woo@woo.local',
-			'verified'         => false,
-		), $data );
+		$this->assertEquals(
+			array(
+				'id'               => $data['id'],
+				'date_created'     => $data['date_created'],
+				'date_created_gmt' => $data['date_created_gmt'],
+				'review'           => 'Hello world.',
+				'rating'           => 5,
+				'name'             => 'Admin',
+				'email'            => 'woo@woo.local',
+				'verified'         => false,
+			), $data
+		);
 		$product->delete( true );
 	}
 
@@ -200,34 +210,40 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 
 		// missing review
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/reviews' );
-		$request->set_body_params( array(
-			'name'   => 'Admin',
-			'email'  => 'woo@woo.local',
-		) );
+		$request->set_body_params(
+			array(
+				'name'  => 'Admin',
+				'email' => 'woo@woo.local',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 
 		// missing name
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/reviews' );
-		$request->set_body_params( array(
-			'review' => 'Hello world.',
-			'email'  => 'woo@woo.local',
-		) );
+		$request->set_body_params(
+			array(
+				'review' => 'Hello world.',
+				'email'  => 'woo@woo.local',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 
 		// missing email
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/reviews' );
-		$request->set_body_params( array(
-			'review' => 'Hello world.',
-			'name'   => 'Admin',
-		) );
+		$request->set_body_params(
+			array(
+				'review' => 'Hello world.',
+				'name'   => 'Admin',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 		$product->delete( true );
@@ -240,7 +256,7 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_product_review() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id ) );
@@ -251,14 +267,16 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 0, $data['rating'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id );
-		$request->set_body_params( array(
-			'review' => 'Hello world - updated.',
-			'name'   => 'Justin',
-			'email'  => 'woo2@woo.local',
-			'rating' => 3,
-		) );
+		$request->set_body_params(
+			array(
+				'review' => 'Hello world - updated.',
+				'name'   => 'Justin',
+				'email'  => 'woo2@woo.local',
+				'rating' => 3,
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 'Hello world - updated.', $data['review'] );
 		$this->assertEquals( 'Justin', $data['name'] );
 		$this->assertEquals( 'woo2@woo.local', $data['email'] );
@@ -273,17 +291,19 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_product_review_without_permission() {
 		wp_set_current_user( 0 );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id );
-		$request->set_body_params( array(
-			'review' => 'Hello world.',
-			'name'   => 'Admin',
-			'email'  => 'woo@woo.dev',
-		) );
+		$request->set_body_params(
+			array(
+				'review' => 'Hello world.',
+				'name'   => 'Admin',
+				'email'  => 'woo@woo.dev',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
@@ -299,13 +319,15 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/reviews/0' );
-		$request->set_body_params( array(
-			'review' => 'Hello world.',
-			'name'   => 'Admin',
-			'email'  => 'woo@woo.dev',
-		) );
+		$request->set_body_params(
+			array(
+				'review' => 'Hello world.',
+				'name'   => 'Admin',
+				'email'  => 'woo@woo.dev',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 404, $response->get_status() );
 		$product->delete( true );
@@ -318,7 +340,7 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_product_review() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$request = new WP_REST_Request( 'DELETE', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id );
@@ -335,10 +357,10 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_product_without_permission() {
 		wp_set_current_user( 0 );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
@@ -352,7 +374,7 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_product_review_invalid_id() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
+		$product           = WC_Helper_Product::create_simple_product();
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$request = new WP_REST_Request( 'DELETE', '/wc/v2/products/' . $product->get_id() . '/reviews/0' );
@@ -376,36 +398,38 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$review_4_id = WC_Helper_Product::create_product_review( $product->get_id() );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/reviews/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'     => $review_1_id,
-					'review' => 'Updated review.',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'     => $review_1_id,
+						'review' => 'Updated review.',
+					),
 				),
-			),
-			'delete' => array(
-				$review_2_id,
-				$review_3_id,
-			),
-			'create' => array(
-				array(
-					'review' => 'New review.',
-					'name'   => 'Justin',
-					'email'  => 'woo3@woo.local',
+				'delete' => array(
+					$review_2_id,
+					$review_3_id,
 				),
-			),
-		) );
+				'create' => array(
+					array(
+						'review' => 'New review.',
+						'name'   => 'Justin',
+						'email'  => 'woo3@woo.local',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'Updated review.', $data['update'][0]['review'] );
 		$this->assertEquals( 'New review.', $data['create'][0]['review'] );
 		$this->assertEquals( $review_2_id, $data['delete'][0]['id'] );
 		$this->assertEquals( $review_3_id, $data['delete'][1]['id'] );
 
-		$request = new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews' );
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
 		$product->delete( true );
@@ -418,10 +442,10 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_product_review_schema() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/products/' . $product->get_id() . '/reviews' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$product    = WC_Helper_Product::create_simple_product();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/products/' . $product->get_id() . '/reviews' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 8, count( $properties ) );

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -79,8 +79,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 				),
 			), $product_reviews
 		);
-
-		$product->delete( true );
 	}
 
 	/**
@@ -93,7 +91,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$product  = WC_Helper_Product::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews' ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -133,7 +130,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 				'verified'         => false,
 			), $data
 		);
-		$product->delete( true );
 	}
 
 	/**
@@ -147,7 +143,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$product_review_id = WC_Helper_Product::create_product_review( $product->get_id() );
 		$response          = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/' . $product_review_id ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -160,7 +155,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$product  = WC_Helper_Product::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/reviews/0' ) );
 		$this->assertEquals( 404, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -196,7 +190,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 				'verified'         => false,
 			), $data
 		);
-		$product->delete( true );
 	}
 
 	/**
@@ -246,7 +239,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -281,7 +273,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'Justin', $data['name'] );
 		$this->assertEquals( 'woo2@woo.local', $data['email'] );
 		$this->assertEquals( 3, $data['rating'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -306,7 +297,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -330,7 +320,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 404, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -347,7 +336,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -364,7 +352,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -382,7 +369,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 404, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -432,7 +418,6 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$product->delete( true );
 	}
 
 	/**
@@ -457,6 +442,5 @@ class Product_Reviews extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'email', $properties );
 		$this->assertArrayHasKey( 'verified', $properties );
-		$product->delete( true );
 	}
 }

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -47,7 +47,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 2, count( $variations ) );
 		$this->assertEquals( 'DUMMY SKU VARIABLE LARGE', $variations[0]['sku'] );
 		$this->assertEquals( 'size', $variations[0]['attributes'][0]['name'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -60,7 +59,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$product  = WC_Helper_Product::create_variation_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -80,7 +78,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $variation_id, $variation['id'] );
 		$this->assertEquals( 'size', $variation['attributes'][0]['name'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -95,7 +92,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$variation_id = $children[0];
 		$response     = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -117,7 +113,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' ) );
 		$variations = $response->get_data();
 		$this->assertEquals( 1, count( $variations ) );
-		$product->delete( true );
 	}
 
 	/**
@@ -135,7 +130,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -150,7 +144,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -202,7 +195,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'medium', $variation['attributes'][0]['option'] );
 		$this->assertContains( 'Dr1Bczxq4q', $variation['image']['src'] );
 		$this->assertContains( 'test upload image', $variation['image']['alt'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -224,7 +216,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -243,7 +234,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -286,7 +276,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' ) );
 		$variations = $response->get_data();
 		$this->assertEquals( 3, count( $variations ) );
-		$product->delete( true );
 	}
 
 	/**
@@ -314,7 +303,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -369,7 +357,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
-		$product->delete( true );
 	}
 
 	/**
@@ -421,7 +408,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'attributes', $properties );
 		$this->assertArrayHasKey( 'menu_order', $properties );
 		$this->assertArrayHasKey( 'meta_data', $properties );
-		$product->delete( true );
 	}
 
 	/**
@@ -482,7 +468,5 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'parent', $variation['manage_stock'] );
-
-		$product->delete( true );
 	}
 }

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -14,9 +14,11 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Product_Variations_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -55,8 +57,8 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_variations_without_permission() {
 		wp_set_current_user( 0 );
-		$product    = WC_Helper_Product::create_variation_product();
-		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' ) );
+		$product  = WC_Helper_Product::create_variation_product();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' ) );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
 	}
@@ -72,8 +74,8 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$children     = $product->get_children();
 		$variation_id = $children[0];
 
-		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id ) );
-		$variation  = $response->get_data();
+		$response  = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id ) );
+		$variation = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $variation_id, $variation['id'] );
@@ -91,7 +93,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$product      = WC_Helper_Product::create_variation_product();
 		$children     = $product->get_children();
 		$variation_id = $children[0];
-		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id ) );
+		$response     = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id ) );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
 	}
@@ -171,13 +173,24 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'small', $variation['attributes'][0]['option'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
-		$request->set_body_params( array(
-			'sku'         => 'FIXED-SKU',
-			'sale_price'  => '8',
-			'description' => 'O_O',
-			'image'       => array( 'position' => 0, 'src' => 'https://cldup.com/Dr1Bczxq4q.png', 'alt' => 'test upload image' ),
-			'attributes'  => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
-		) );
+		$request->set_body_params(
+			array(
+				'sku'         => 'FIXED-SKU',
+				'sale_price'  => '8',
+				'description' => 'O_O',
+				'image'       => array(
+					'position' => 0,
+					'src'      => 'https://cldup.com/Dr1Bczxq4q.png',
+					'alt'      => 'test upload image',
+				),
+				'attributes'  => array(
+					array(
+						'name'   => 'pa_size',
+						'option' => 'medium',
+					),
+				),
+			)
+		);
 		$response  = $this->server->dispatch( $request );
 		$variation = $response->get_data();
 
@@ -204,9 +217,11 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$variation_id = $children[0];
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
-		$request->set_body_params( array(
-			'sku'         => 'FIXED-SKU-NO-PERMISSION',
-		) );
+		$request->set_body_params(
+			array(
+				'sku' => 'FIXED-SKU-NO-PERMISSION',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
@@ -221,9 +236,11 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_variation_product();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/0' );
-		$request->set_body_params( array(
-			'sku'         => 'FIXED-SKU-NO-PERMISSION',
-		) );
+		$request->set_body_params(
+			array(
+				'sku' => 'FIXED-SKU-NO-PERMISSION',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 		$product->delete( true );
@@ -243,12 +260,19 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 2, count( $variations ) );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/variations' );
-		$request->set_body_params( array(
-			'sku'            => 'DUMMY SKU VARIABLE MEDIUM',
-			'regular_price'  => '12',
-			'description'    => 'A medium size.',
-			'attributes'     => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
-		) );
+		$request->set_body_params(
+			array(
+				'sku'           => 'DUMMY SKU VARIABLE MEDIUM',
+				'regular_price' => '12',
+				'description'   => 'A medium size.',
+				'attributes'    => array(
+					array(
+						'name'   => 'pa_size',
+						'option' => 'medium',
+					),
+				),
+			)
+		);
 		$response  = $this->server->dispatch( $request );
 		$variation = $response->get_data();
 
@@ -272,15 +296,22 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_create_variation_without_permission() {
 		wp_set_current_user( 0 );
-		$product      = WC_Helper_Product::create_variation_product();
+		$product = WC_Helper_Product::create_variation_product();
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/variations' );
-		$request->set_body_params( array(
-			'sku'            => 'DUMMY SKU VARIABLE MEDIUM',
-			'regular_price'  => '12',
-			'description'    => 'A medium size.',
-			'attributes'     => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
-		) );
+		$request->set_body_params(
+			array(
+				'sku'           => 'DUMMY SKU VARIABLE MEDIUM',
+				'regular_price' => '12',
+				'description'   => 'A medium size.',
+				'attributes'    => array(
+					array(
+						'name'   => 'pa_size',
+						'option' => 'medium',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
@@ -294,26 +325,37 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$product  = WC_Helper_Product::create_variation_product();
 		$children = $product->get_children();
 		$request  = new WP_REST_Request( 'POST', '/wc/v2/products/' . $product->get_id() . '/variations/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'          => $children[0],
-					'description' => 'Updated description.',
-					'image'       => array( 'position' => 0, 'src' => 'https://cldup.com/Dr1Bczxq4q.png', 'alt' => 'test upload image' ),
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'          => $children[0],
+						'description' => 'Updated description.',
+						'image'       => array(
+							'position' => 0,
+							'src'      => 'https://cldup.com/Dr1Bczxq4q.png',
+							'alt'      => 'test upload image',
+						),
+					),
 				),
-			),
-			'delete' => array(
-				$children[1],
-			),
-			'create' => array(
-				array(
-					'sku'            => 'DUMMY SKU VARIABLE MEDIUM',
-					'regular_price'  => '12',
-					'description'    => 'A medium size.',
-					'attributes'     => array( array( 'name' => 'pa_size', 'option' => 'medium' ) ),
+				'delete' => array(
+					$children[1],
 				),
-			),
-		) );
+				'create' => array(
+					array(
+						'sku'           => 'DUMMY SKU VARIABLE MEDIUM',
+						'regular_price' => '12',
+						'description'   => 'A medium size.',
+						'attributes'    => array(
+							array(
+								'name'   => 'pa_size',
+								'option' => 'medium',
+							),
+						),
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -322,9 +364,9 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'medium', $data['create'][0]['attributes'][0]['option'] );
 		$this->assertEquals( $children[1], $data['delete'][0]['id'] );
 
-		$request = new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' );
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
 		$product->delete( true );
@@ -337,10 +379,10 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_variation_schema() {
 		wp_set_current_user( $this->user );
-		$product = WC_Helper_Product::create_simple_product();
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/products/' . $product->get_id() . '/variations' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$product    = WC_Helper_Product::create_simple_product();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/products/' . $product->get_id() . '/variations' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 37, count( $properties ) );
@@ -390,7 +432,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	public function test_update_variation_manage_stock() {
 		wp_set_current_user( $this->user );
 
-		$product      = WC_Helper_Product::create_variation_product();
+		$product = WC_Helper_Product::create_variation_product();
 		$product->set_manage_stock( false );
 		$product->save();
 
@@ -399,9 +441,11 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 
 		// Set stock to true.
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
-		$request->set_body_params( array(
-			'manage_stock' => true,
-		) );
+		$request->set_body_params(
+			array(
+				'manage_stock' => true,
+			)
+		);
 
 		$response  = $this->server->dispatch( $request );
 		$variation = $response->get_data();
@@ -411,9 +455,11 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 
 		// Set stock to false.
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
-		$request->set_body_params( array(
-			'manage_stock' => false,
-		) );
+		$request->set_body_params(
+			array(
+				'manage_stock' => false,
+			)
+		);
 
 		$response  = $this->server->dispatch( $request );
 		$variation = $response->get_data();
@@ -425,9 +471,11 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$product->set_manage_stock( true );
 		$product->save();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
-		$request->set_body_params( array(
-			'manage_stock' => false,
-		) );
+		$request->set_body_params(
+			array(
+				'manage_stock' => false,
+			)
+		);
 
 		$response  = $this->server->dispatch( $request );
 		$variation = $response->get_data();

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -14,9 +14,11 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Products_Controller();
-		$this->user     = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -73,7 +75,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
 		$products = $response->get_data();
-		$product = wc_get_product( $products[0]['id'] );
+		$product  = wc_get_product( $products[0]['id'] );
 		$product->delete( true );
 	}
 
@@ -89,14 +91,16 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$product  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains( array(
-			'id'            => $simple->get_id(),
-			'name'          => 'Dummy External Product',
-			'type'          => 'simple',
-			'status'        => 'publish',
-			'sku'           => 'DUMMY EXTERNAL SKU',
-			'regular_price' => 10,
-		), $product );
+		$this->assertContains(
+			array(
+				'id'            => $simple->get_id(),
+				'name'          => 'Dummy External Product',
+				'type'          => 'simple',
+				'status'        => 'publish',
+				'sku'           => 'DUMMY EXTERNAL SKU',
+				'regular_price' => 10,
+			), $product
+		);
 		$simple->delete( true );
 	}
 
@@ -179,12 +183,20 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEmpty( $data['sale_price'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
-		$request->set_body_params( array(
-			'sku'         => 'FIXED-SKU',
-			'sale_price'  => '8',
-			'description' => 'Testing',
-			'images'      => array( array( 'position' => 0, 'src' => 'https://cldup.com/Dr1Bczxq4q.png', 'alt' => 'test upload image' ) ),
-		) );
+		$request->set_body_params(
+			array(
+				'sku'         => 'FIXED-SKU',
+				'sale_price'  => '8',
+				'description' => 'Testing',
+				'images'      => array(
+					array(
+						'position' => 0,
+						'src'      => 'https://cldup.com/Dr1Bczxq4q.png',
+						'alt'      => 'test upload image',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -205,12 +217,25 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( array( 'small' ), $data['attributes'][0]['options'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
-		$request->set_body_params( array(
-			'attributes'  => array(
-				array( 'id' => 0, 'name' => 'pa_color', 'options' => array( 'red', 'yellow' ), 'visible' => false, 'variation' => 1 ),
-				array( 'name' => 'pa_size', 'options' => array( 'small' ), 'visible' => false, 'variation' => 1 ),
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'attributes' => array(
+					array(
+						'id'        => 0,
+						'name'      => 'pa_color',
+						'options'   => array( 'red', 'yellow' ),
+						'visible'   => false,
+						'variation' => 1,
+					),
+					array(
+						'name'      => 'pa_size',
+						'options'   => array( 'small' ),
+						'visible'   => false,
+						'variation' => 1,
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -227,10 +252,12 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'http://woocommerce.com', $data['external_url'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
-		$request->set_body_params( array(
-			'button_text'  => 'Test API Update',
-			'external_url' => 'http://automattic.com',
-		) );
+		$request->set_body_params(
+			array(
+				'button_text'  => 'Test API Update',
+				'external_url' => 'http://automattic.com',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -248,9 +275,11 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 		$product = WC_Helper_Product::create_simple_product();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
-		$request->set_body_params( array(
-			'sku' => 'FIXED-SKU-NO-PERMISSION',
-		) );
+		$request->set_body_params(
+			array(
+				'sku' => 'FIXED-SKU-NO-PERMISSION',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 		$product->delete( true );
@@ -265,9 +294,11 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/0' );
-		$request->set_body_params( array(
-			'sku' => 'FIXED-SKU-INVALID-ID',
-		) );
+		$request->set_body_params(
+			array(
+				'sku' => 'FIXED-SKU-INVALID-ID',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 		$product->delete( true );
@@ -282,22 +313,26 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products/shipping_classes' );
-		$request->set_body_params( array(
-			'name' => 'Test',
-		) );
+		$request->set_body_params(
+			array(
+				'name' => 'Test',
+			)
+		);
 		$response          = $this->server->dispatch( $request );
 		$data              = $response->get_data();
 		$shipping_class_id = $data['id'];
 
 		// Create simple
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
-		$request->set_body_params( array(
-			'type'           => 'simple',
-			'name'           => 'Test Simple Product',
-			'sku'            => 'DUMMY SKU SIMPLE API',
-			'regular_price'  => '10',
-			'shipping_class' => 'test',
-		) );
+		$request->set_body_params(
+			array(
+				'type'           => 'simple',
+				'name'           => 'Test Simple Product',
+				'sku'            => 'DUMMY SKU SIMPLE API',
+				'regular_price'  => '10',
+				'shipping_class' => 'test',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -311,14 +346,16 @@ class Products_API extends WC_REST_Unit_Test_Case {
 
 		// Create external
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
-		$request->set_body_params( array(
-			'type'           => 'external',
-			'name'           => 'Test External Product',
-			'sku'            => 'DUMMY SKU EXTERNAL API',
-			'regular_price'  => '10',
-			'button_text'    => 'Test Button',
-			'external_url'   => 'https://wordpress.org',
-		) );
+		$request->set_body_params(
+			array(
+				'type'          => 'external',
+				'name'          => 'Test External Product',
+				'sku'           => 'DUMMY SKU EXTERNAL API',
+				'regular_price' => '10',
+				'button_text'   => 'Test Button',
+				'external_url'  => 'https://wordpress.org',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -333,23 +370,25 @@ class Products_API extends WC_REST_Unit_Test_Case {
 
 		// Create variable
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
-		$request->set_body_params( array(
-			'type'           => 'variable',
-			'name'           => 'Test Variable Product',
-			'sku'            => 'DUMMY SKU VARIABLE API',
-			'attributes'     => array(
-				array(
-					'id'        => 0,
-					'name'      => 'pa_size',
-					'options'   => array(
-						'small',
-						'medium',
+		$request->set_body_params(
+			array(
+				'type'       => 'variable',
+				'name'       => 'Test Variable Product',
+				'sku'        => 'DUMMY SKU VARIABLE API',
+				'attributes' => array(
+					array(
+						'id'        => 0,
+						'name'      => 'pa_size',
+						'options'   => array(
+							'small',
+							'medium',
+						),
+						'visible'   => false,
+						'variation' => 1,
 					),
-					'visible'   => false,
-					'variation' => 1,
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -372,10 +411,12 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
-		$request->set_body_params( array(
-			'name'           => 'Test Product',
-			'regular_price'  => '12',
-		) );
+		$request->set_body_params(
+			array(
+				'name'          => 'Test Product',
+				'regular_price' => '12',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -388,32 +429,34 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$product   = WC_Helper_Product::create_simple_product();
 		$product_2 = WC_Helper_Product::create_simple_product();
 		$request   = new WP_REST_Request( 'POST', '/wc/v2/products/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'          => $product->get_id(),
-					'description' => 'Updated description.',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'          => $product->get_id(),
+						'description' => 'Updated description.',
+					),
 				),
-			),
-			'delete' => array(
-				$product_2->get_id(),
-			),
-			'create' => array(
-				array(
-					'sku'            => 'DUMMY SKU BATCH TEST 1',
-					'regular_price'  => '10',
-					'name'           => 'Test Batch Create 1',
-					'type'           => 'external',
-					'button_text'    => 'Test Button',
+				'delete' => array(
+					$product_2->get_id(),
 				),
-				array(
-					'sku'            => 'DUMMY SKU BATCH TEST 2',
-					'regular_price'  => '20',
-					'name'           => 'Test Batch Create 2',
-					'type'           => 'simple',
+				'create' => array(
+					array(
+						'sku'           => 'DUMMY SKU BATCH TEST 1',
+						'regular_price' => '10',
+						'name'          => 'Test Batch Create 1',
+						'type'          => 'external',
+						'button_text'   => 'Test Button',
+					),
+					array(
+						'sku'           => 'DUMMY SKU BATCH TEST 2',
+						'regular_price' => '20',
+						'name'          => 'Test Batch Create 2',
+						'type'          => 'simple',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -445,10 +488,12 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		for ( $i = 0; $i < 8; $i++ ) {
 			$product = WC_Helper_Product::create_simple_product();
 			if ( 0 === $i % 2 ) {
-				wp_update_post( array(
-					'ID'		  => $product->get_id(),
-					'post_status' => 'draft',
-				) );
+				wp_update_post(
+					array(
+						'ID'          => $product->get_id(),
+						'post_status' => 'draft',
+					)
+				);
 			}
 		}
 

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -53,11 +53,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'DUMMY SKU', $products[0]['sku'] );
 		$this->assertEquals( 'Dummy External Product', $products[1]['name'] );
 		$this->assertEquals( 'DUMMY EXTERNAL SKU', $products[1]['sku'] );
-
-		foreach ( $products as $key => $value ) {
-			$product = wc_get_product( $value['id'] );
-			$product->delete( true );
-		}
 	}
 
 	/**
@@ -70,13 +65,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		WC_Helper_Product::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
 		$this->assertEquals( 401, $response->get_status() );
-
-		// Remove product.
-		wp_set_current_user( $this->user );
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
-		$products = $response->get_data();
-		$product  = wc_get_product( $products[0]['id'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -101,7 +89,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 				'regular_price' => 10,
 			), $product
 		);
-		$simple->delete( true );
 	}
 
 	/**
@@ -114,7 +101,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$product  = WC_Helper_Product::create_simple_product();
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -134,7 +120,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
 		$variations = $response->get_data();
 		$this->assertEquals( 0, count( $variations ) );
-		$product->delete( true );
 	}
 
 	/**
@@ -149,7 +134,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -263,7 +247,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 'Test API Update', $data['button_text'] );
 		$this->assertEquals( 'http://automattic.com', $data['external_url'] );
-		$product->delete( true );
 	}
 
 	/**
@@ -282,7 +265,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -301,7 +283,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
-		$product->delete( true );
 	}
 
 	/**
@@ -473,8 +454,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$product->delete( true );
-		$product_2->delete( true );
 	}
 
 	/*
@@ -525,11 +504,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$products = $response->get_data();
 
 		$this->assertEquals( 8, count( $products ) );
-
-		foreach ( $products as $key => $value ) {
-			$product = wc_get_product( $value['id'] );
-			$product->delete( true );
-		}
 	}
 
 	/**
@@ -545,7 +519,5 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 65, count( $properties ) );
-		$product->delete( true );
 	}
-
 }

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -21,10 +21,12 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Shipping_Zones_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
-		$this->zones = array();
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		$this->zones    = array();
 	}
 
 	/**
@@ -78,63 +80,67 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		// "Rest of the World" zone exists by default
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/shipping/zones' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 1 );
-		$this->assertContains( array(
-			'id'     => 0,
-			'name'   => 'Locations not covered by your other zones',
-			'order'  => 0,
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/0' ),
+		$this->assertContains(
+			array(
+				'id'     => 0,
+				'name'   => 'Locations not covered by your other zones',
+				'order'  => 0,
+				'_links' => array(
+					'self'        => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/0' ),
+						),
+					),
+					'collection'  => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						),
+					),
+					'describedby' => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/0/locations' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones' ),
-					),
-				),
-				'describedby' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/0/locations' ),
-					),
-				),
-			),
-		), $data );
+			), $data
+		);
 
 		// Create a zone and make sure it's in the response
 		$this->create_shipping_zone( 'Zone 1' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/shipping/zones' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 2 );
-		$this->assertContains( array(
-			'id'     => 1,
-			'name'   => 'Zone 1',
-			'order'  => 0,
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/1' ),
+		$this->assertContains(
+			array(
+				'id'     => 1,
+				'name'   => 'Zone 1',
+				'order'  => 0,
+				'_links' => array(
+					'self'        => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/1' ),
+						),
+					),
+					'collection'  => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						),
+					),
+					'describedby' => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/1/locations' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones' ),
-					),
-				),
-				'describedby' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/1/locations' ),
-					),
-				),
-			),
-		), $data );
+			), $data
+		);
 	}
 
 	/**
@@ -168,9 +174,9 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_shipping_zone_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/shipping/zones' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/shipping/zones' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 3, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
@@ -187,36 +193,40 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones' );
-		$request->set_body_params( array(
-			'name'  => 'Test Zone',
-			'order' => 1,
-		) );
+		$request->set_body_params(
+			array(
+				'name'  => 'Test Zone',
+				'order' => 1,
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( array(
-			'id'     => $data['id'],
-			'name'   => 'Test Zone',
-			'order'  => 1,
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] ),
+		$this->assertEquals(
+			array(
+				'id'     => $data['id'],
+				'name'   => 'Test Zone',
+				'order'  => 1,
+				'_links' => array(
+					'self'        => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] ),
+						),
+					),
+					'collection'  => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						),
+					),
+					'describedby' => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] . '/locations' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones' ),
-					),
-				),
-				'describedby' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/' . $data['id'] . '/locations' ),
-					),
-				),
-			),
-		), $data );
+			), $data
+		);
 	}
 
 	/**
@@ -227,10 +237,12 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones' );
-		$request->set_body_params( array(
-			'name'  => 'Test Zone',
-			'order' => 1,
-		) );
+		$request->set_body_params(
+			array(
+				'name'  => 'Test Zone',
+				'order' => 1,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -245,36 +257,40 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$zone = $this->create_shipping_zone( 'Test Zone' );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/shipping/zones/' . $zone->get_id() );
-		$request->set_body_params( array(
-			'name'  => 'Zone Test',
-			'order' => 2,
-		) );
+		$request->set_body_params(
+			array(
+				'name'  => 'Zone Test',
+				'order' => 2,
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'     => $zone->get_id(),
-			'name'   => 'Zone Test',
-			'order'  => 2,
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+		$this->assertEquals(
+			array(
+				'id'     => $zone->get_id(),
+				'name'   => 'Zone Test',
+				'order'  => 2,
+				'_links' => array(
+					'self'        => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+						),
+					),
+					'collection'  => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						),
+					),
+					'describedby' => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones' ),
-					),
-				),
-				'describedby' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
-					),
-				),
-			),
-		), $data );
+			), $data
+		);
 	}
 
 	/**
@@ -285,10 +301,12 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/shipping/zones/555555' );
-		$request->set_body_params( array(
-			'name'  => 'Zone Test',
-			'order' => 2,
-		) );
+		$request->set_body_params(
+			array(
+				'name'  => 'Zone Test',
+				'order' => 2,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 404, $response->get_status() );
@@ -302,7 +320,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$zone = $this->create_shipping_zone( 'Zone 1' );
 
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v2/shipping/zones/' . $zone->get_id() );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v2/shipping/zones/' . $zone->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
@@ -347,28 +365,30 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'     => $zone->get_id(),
-			'name'   => 'Test Zone',
-			'order'  => 0,
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+		$this->assertEquals(
+			array(
+				'id'     => $zone->get_id(),
+				'name'   => 'Test Zone',
+				'order'  => 0,
+				'_links' => array(
+					'self'        => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+						),
+					),
+					'collection'  => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones' ),
+						),
+					),
+					'describedby' => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones' ),
-					),
-				),
-				'describedby' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
-					),
-				),
-			),
-		), $data );
+			), $data
+		);
 	}
 
 	/**
@@ -391,36 +411,40 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		// Create a zone
-		$zone = $this->create_shipping_zone( 'Zone 1', 0, array(
-			array(
-				'code' => 'US',
-				'type' => 'country',
-			),
-		) );
+		$zone = $this->create_shipping_zone(
+			'Zone 1', 0, array(
+				array(
+					'code' => 'US',
+					'type' => 'country',
+				),
+			)
+		);
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( count( $data ), 1 );
-		$this->assertEquals( array(
+		$this->assertEquals(
 			array(
-				'code'   => 'US',
-				'type'   => 'country',
-				'_links' => array(
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+				array(
+					'code'   => 'US',
+					'type'   => 'country',
+					'_links' => array(
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
-					),
-					'describes' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+						'describes'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+							),
 						),
 					),
 				),
-			),
-		), $data );
+			), $data
+		);
 	}
 
 	/**
@@ -446,76 +470,82 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' );
 		$request->add_header( 'Content-Type', 'application/json' );
-		$request->set_body( json_encode( array(
-			array(
-				'code' => 'UK',
-				'type' => 'country',
-			),
-			array(
-				'code' => 'US', // test that locations missing "type" treated as country.
-			),
-			array(
-				'code' => 'SW1A0AA',
-				'type' => 'postcode',
-			),
-			array(
-				'type' => 'continent', // test that locations missing "code" aren't saved
-			),
-		) ) );
+		$request->set_body(
+			json_encode(
+				array(
+					array(
+						'code' => 'UK',
+						'type' => 'country',
+					),
+					array(
+						'code' => 'US', // test that locations missing "type" treated as country.
+					),
+					array(
+						'code' => 'SW1A0AA',
+						'type' => 'postcode',
+					),
+					array(
+						'type' => 'continent', // test that locations missing "code" aren't saved
+					),
+				)
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( array(
+		$this->assertEquals(
 			array(
-				'code'   => 'UK',
-				'type'   => 'country',
-				'_links' => array(
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+				array(
+					'code'   => 'UK',
+					'type'   => 'country',
+					'_links' => array(
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
-					),
-					'describes' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+						'describes'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+							),
 						),
 					),
 				),
-			),
-			array(
-				'code' => 'US',
-				'type'   => 'country',
-				'_links' => array(
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+				array(
+					'code'   => 'US',
+					'type'   => 'country',
+					'_links' => array(
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
 						),
-					),
-					'describes' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
-						),
-					),
-				),
-			),
-			array(
-				'code'   => 'SW1A0AA',
-				'type'   => 'postcode',
-				'_links' => array(
-					'collection' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
-						),
-					),
-					'describes' => array(
-						array(
-							'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+						'describes'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+							),
 						),
 					),
 				),
-			),
-		), $data );
+				array(
+					'code'   => 'SW1A0AA',
+					'type'   => 'postcode',
+					'_links' => array(
+						'collection' => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/locations' ),
+							),
+						),
+						'describes'  => array(
+							array(
+								'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
+							),
+						),
+					),
+				),
+			), $data
+		);
 	}
 
 	/**
@@ -585,7 +615,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods' ),
 					),
 				),
-				'describes' => array(
+				'describes'  => array(
 					array(
 						'href' => rest_url( '/wc/v2/shipping/zones/' . $zone->get_id() ),
 					),
@@ -646,9 +676,9 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$method      = $methods[ $instance_id ];
 
 		// Test defaults
-		$request = new WP_REST_Request( 'GET', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
+		$request  = new WP_REST_Request( 'GET', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( 'title', $data['settings'] );
 		$this->assertEquals( 'Flat rate', $data['settings']['title']['value'] );
@@ -659,13 +689,15 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		// Update a single value
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
-		$request->set_body_params( array(
-			'settings' => array(
-				'cost' => 5,
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'cost' => 5,
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( 'title', $data['settings'] );
 		$this->assertEquals( 'Flat rate', $data['settings']['title']['value'] );
@@ -676,14 +708,16 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		// Test multiple settings
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
-		$request->set_body_params( array(
-			'settings' => array(
-				'cost'       => 10,
-				'tax_status' => 'none',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'cost'       => 10,
+					'tax_status' => 'none',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( 'title', $data['settings'] );
 		$this->assertEquals( 'Flat rate', $data['settings']['title']['value'] );
@@ -694,12 +728,14 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		// Test bogus
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
-		$request->set_body_params( array(
-			'settings' => array(
-				'cost'       => 10,
-				'tax_status' => 'this_is_not_a_valid_option',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'cost'       => 10,
+					'tax_status' => 'this_is_not_a_valid_option',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
@@ -708,12 +744,14 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 1, $data['order'] );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
-		$request->set_body_params( array(
-			'enabled' => false,
-			'order'   => 2,
-		) );
+		$request->set_body_params(
+			array(
+				'enabled' => false,
+				'order'   => 2,
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertFalse( $data['enabled'] );
 		$this->assertEquals( 2, $data['order'] );
@@ -729,11 +767,13 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$zone    = $this->create_shipping_zone( 'Zone 1' );
 		$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods' );
-		$request->set_body_params( array(
-			'method_id' => 'flat_rate',
-			'enabled' => false,
-			'order' => 2,
-		) );
+		$request->set_body_params(
+			array(
+				'method_id' => 'flat_rate',
+				'enabled'   => false,
+				'order'     => 2,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -755,7 +795,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$method      = $methods[ $instance_id ];
 		$request     = new WP_REST_Request( 'DELETE', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
 		$request->set_param( 'force', true );
-		$response    = $this->server->dispatch( $request );
+		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 }

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -30,16 +30,6 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Delete zones.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-		foreach ( $this->zones as $zone ) {
-			$zone->delete();
-		}
-	}
-
-	/**
 	 * Helper method to create a Shipping Zone.
 	 *
 	 * @param string $name Zone name.


### PR DESCRIPTION
WC unit tests don't need to remove data from the database before finishing. `WP_UnitTestCase` creates a transaction before each test starts and roll it back after it ends, so data is never actually written to the database. This simplifies the tests and makes them faster.

This PR removes all the code from WC API unit tests that removed data after performing all the assertions and it also includes a commit to fix PHPCS violations in the modified files.