### PR TITLE
Add coupon usage count hooks

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -291,6 +291,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			add_post_meta( $coupon->get_id(), '_used_by', strtolower( $used_by ) );
 			$coupon->set_used_by( (array) get_post_meta( $coupon->get_id(), '_used_by' ) );
 		}
+
+		do_action( 'woocommerce_increase_coupon_usage_count', $coupon, $new_count, $used_by );
+
 		return $new_count;
 	}
 
@@ -316,6 +319,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 				$coupon->set_used_by( (array) get_post_meta( $coupon->get_id(), '_used_by' ) );
 			}
 		}
+
+		do_action( 'woocommerce_decrease_coupon_usage_count', $coupon, $new_count, $used_by );
+
 		return $new_count;
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Adds two action hooks related to updating coupon usage counts:
* `woocommerce_increase_coupon_usage_count`
* `woocommerce_decrease_coupon_usage_count`

These new hooks will allow developers to further extend WooCommerce Coupons. I am in the process of writing a coupon-related plugin that needs to track usage counts in a slightly different manner. At present it is not possible for my plugin to "know" when coupon usage counts are being updated. Adding hooks to the coupon usage count update methods will solve this problem.

### Other information:
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

- Added `woocommerce_increase_coupon_usage_count` and `woocommerce_decrease_coupon_usage_count` action hooks to increase extensibility of Coupons.
