### PR TITLE
i18n: Fix translation for "Related products" string

### DIFF
--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -24,7 +24,7 @@ if ( $related_products ) : ?>
 
 	<section class="related products">
 
-		<h2><?php esc_html_e( 'Related products', 'woocommerce' ); ?></h2>
+		<h2><?php printf( esc_html__( 'Related products', 'woocommerce' ) ); ?></h2>
 
 		<?php woocommerce_product_loop_start(); ?>
 


### PR DESCRIPTION
This complements @ramiy commit d2457fe922570dd307139b773bffd96f51d9abf2 and fixes translation for "Related products" string on Product page.

To test it, simply try to open any product page with Related products on a non-english language.
Before the fix, you will see the Related products is not being translated. After, everything looks good. :-)