### PR TITLE
Basic range download handling for Force download.

### DIFF
--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -299,7 +299,7 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 			throw new Exception( __( 'Invalid permission ID.', 'woocommerce' ) );
 		}
 
-		// TODO: how to log range downloads?
+		// TODO: how to log range downloads?, +test
 		if ( $range_download ) {
 			return;
 		}

--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -290,19 +290,13 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 	 * @throws Exception When permission ID is invalid.
 	 * @param int    $user_id         Id of the user performing the download.
 	 * @param string $user_ip_address IP Address of the user performing the download.
-	 * @param bool   $range_download  Whether the download is a partial/range download.
 	 */
-	public function track_download( $user_id = null, $user_ip_address = null, $range_download = false ) {
+	public function track_download( $user_id = null, $user_ip_address = null ) {
 		global $wpdb;
 
 		// Must have a permission_id to track download log.
 		if ( ! ( $this->get_id() > 0 ) ) {
 			throw new Exception( __( 'Invalid permission ID.', 'woocommerce' ) );
-		}
-
-		// Range downloads are not logged.
-		if ( $range_download ) {
-			return;
 		}
 
 		// Increment download count, and decrement downloads remaining.

--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -291,12 +291,17 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 	 * @param int    $user_id         Id of the user performing the download.
 	 * @param string $user_ip_address IP Address of the user performing the download.
 	 */
-	public function track_download( $user_id = null, $user_ip_address = null ) {
+	public function track_download( $user_id = null, $user_ip_address = null, $range_download = false ) {
 		global $wpdb;
 
 		// Must have a permission_id to track download log.
 		if ( ! ( $this->get_id() > 0 ) ) {
 			throw new Exception( __( 'Invalid permission ID.', 'woocommerce' ) );
+		}
+
+		// TODO: how to log range downloads?
+		if ( $range_download ) {
+			return;
 		}
 
 		// Increment download count, and decrement downloads remaining.

--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -290,6 +290,7 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 	 * @throws Exception When permission ID is invalid.
 	 * @param int    $user_id         Id of the user performing the download.
 	 * @param string $user_ip_address IP Address of the user performing the download.
+	 * @param bool   $range_download  Whether the download is a partial/range download.
 	 */
 	public function track_download( $user_id = null, $user_ip_address = null, $range_download = false ) {
 		global $wpdb;
@@ -299,7 +300,7 @@ class WC_Customer_Download extends WC_Data implements ArrayAccess {
 			throw new Exception( __( 'Invalid permission ID.', 'woocommerce' ) );
 		}
 
-		// TODO: how to log range downloads?, +test
+		// Range downloads are not logged.
 		if ( $range_download ) {
 			return;
 		}

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -101,7 +101,9 @@ class WC_Download_Handler {
 		$file_path        = $product->get_file_download_path( $download->get_download_id() );
 		$parsed_file_path = self::parse_file_path( $file_path );
 		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) );  // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged.
-		$download->track_download( $current_user_id > 0 ? $current_user_id : null, ! empty( $ip_address ) ? $ip_address : null, $download_range['is_range_request'] );
+		if ( ! $download_range['is_range_request'] ) {
+			$download->track_download( $current_user_id > 0 ? $current_user_id : null, ! empty( $ip_address ) ? $ip_address : null );
+		}
 
 		self::download( $file_path, $download->get_product_id() );
 	}

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -290,9 +290,16 @@ class WC_Download_Handler {
 	 * Parse the HTTP_RANGE request from iOS devices.
 	 * Does not support multi-range requests.
 	 *
-	 * @param int $file_size               Size of file in bytes.
-	 * @return array(int, int, bool, bool) Array containing info about range download request: beginning and length of
-	 * file chunk, whether the range is valid/supported and whether the request is a range request.
+	 * @param int $file_size Size of file in bytes.
+	 * @return array {
+	 *     Information about range download request: beginning and length of
+	 *     file chunk, whether the range is valid/supported and whether the request is a range request.
+	 *
+	 *     @type int  $start            Byte offset of the beginning of the range. Default 0.
+	 *     @type int  $length           Length of the requested file chunk in bytes. Optional.
+	 *     @type bool $is_range_valid   Whether the requested range is a valid and supported range.
+	 *     @type bool $is_range_request Whether the request is a range request.
+	 * }
 	 */
 	protected static function get_download_range( $file_size ) {
 		$start  = 0;
@@ -321,9 +328,12 @@ class WC_Download_Handler {
 			if ( strpos( $range, ',' ) !== false ) {
 				return $download_range;
 			}
-			// If the range starts with an '-' we start from the beginning
-			// If not, we forward the file pointer
-			// And make sure to get the end byte if specified.
+
+			/*
+			 * If the range starts with an '-' we start from the beginning.
+			 * If not, we forward the file pointer
+			 * and make sure to get the end byte if specified.
+			 */
 			if ( '-' === $range[0] ) {
 				// The n-number of the last bytes is requested.
 				$c_start = $file_size - substr( $range, 1 );
@@ -333,8 +343,10 @@ class WC_Download_Handler {
 				$c_end   = ( isset( $range[1] ) && is_numeric( $range[1] ) ) ? (int) $range[1] : $file_size;
 			}
 
-			// Check the range and make sure it's treated according to the specs: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html.
-			// End bytes can not be larger than $end.
+			/*
+			 * Check the range and make sure it's treated according to the specs: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html.
+			 * End bytes can not be larger than $end.
+			 */
 			$c_end = ( $c_end > $end ) ? $end : $c_end;
 			// Validate the requested range and return an error if it's not correct.
 			if ( $c_start > $c_end || $c_start > $file_size - 1 || $c_end >= $file_size ) {
@@ -354,8 +366,8 @@ class WC_Download_Handler {
 	/**
 	 * Force download - this is the default method.
 	 *
-	 * @param string $file_path      File path.
-	 * @param string $filename       File name.
+	 * @param string $file_path File path.
+	 * @param string $filename  File name.
 	 */
 	public static function download_file_force( $file_path, $filename ) {
 		$parsed_file_path = self::parse_file_path( $file_path );
@@ -402,7 +414,7 @@ class WC_Download_Handler {
 	 *
 	 * @param string $file_path      File path.
 	 * @param string $filename       File name.
-	 * @param array  $download_range Array containing info about range download request.
+	 * @param array  $download_range Array containing info about range download request (see {@see get_download_range} for structure).
 	 */
 	private static function download_headers( $file_path, $filename, $download_range = array() ) {
 		self::check_server_config();

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -310,12 +310,13 @@ class WC_Download_Handler {
 		$download_range['length'] = $file_size;
 
 		if ( isset( $_SERVER['HTTP_RANGE'] ) ) {
+			$http_range = sanitize_text_field( wp_unslash( $_SERVER['HTTP_RANGE'] ) );
 			$download_range['is_range_request'] = true;
 
 			$c_start = $start;
 			$c_end   = $end;
 			// Extract the range string.
-			list( , $range ) = explode( '=', $_SERVER['HTTP_RANGE'], 2 );
+			list( , $range ) = explode( '=', $http_range, 2 );
 			// Make sure the client hasn't sent us a multibyte range.
 			if ( strpos( $range, ',' ) !== false ) {
 				return $download_range;

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -427,10 +427,15 @@ class WC_Download_Handler {
 		header( 'Content-Disposition: attachment; filename="' . $filename . '";' );
 		header( 'Content-Transfer-Encoding: binary' );
 
+		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		if ( ! $file_size ) {
+			return;
+		}
+
 		if ( isset( $download_range['is_range_request'] ) && true === $download_range['is_range_request'] ) {
 			if ( false === $download_range['is_range_valid'] ) {
 				header( 'HTTP/1.1 416 Requested Range Not Satisfiable' );
-				header( 'Content-Range: bytes ' . $download_range['start'] . '-' . ( $download_range['length'] - 1 ) . '/' . $download_range['length'] );
+				header( 'Content-Range: bytes 0-' . ( $file_size - 1 ) . '/' . $file_size );
 				exit;
 			}
 
@@ -439,14 +444,11 @@ class WC_Download_Handler {
 			$length = $download_range['length'];
 
 			header( 'HTTP/1.1 206 Partial Content' );
-			header( 'Accept-Ranges: bytes' );
-			header( "Content-Range: bytes $start-$end/$length" );
+			header( "Accept-Ranges: 0-$file_size" );
+			header( "Content-Range: bytes $start-$end/$file_size" );
 			header( "Content-Length: $length" );
 		} else {
-			$size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-			if ( $size ) {
-				header( 'Content-Length: ' . $size );
-			}
+			header( 'Content-Length: ' . $file_size );
 		}
 	}
 

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -79,8 +79,15 @@ class WC_Download_Handler {
 
 		$download = new WC_Customer_Download( current( $download_ids ) );
 
+		$file_path        = $product->get_file_download_path( $download->get_download_id() );
+		$parsed_file_path = self::parse_file_path( $file_path );
+		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) );  // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged.
+
 		self::check_order_is_valid( $download );
-		self::check_downloads_remaining( $download );
+		if ( ! $download_range['is_range_request'] ) {
+			// If the remaining download count goes to 0, allow range requests to be able to finish streaming from iOS devices.
+			self::check_downloads_remaining( $download );
+		}
 		self::check_download_expiry( $download );
 		self::check_download_login_required( $download );
 
@@ -98,9 +105,6 @@ class WC_Download_Handler {
 		// Track the download in logs and change remaining/counts.
 		$current_user_id  = get_current_user_id();
 		$ip_address       = WC_Geolocation::get_ip_address();
-		$file_path        = $product->get_file_download_path( $download->get_download_id() );
-		$parsed_file_path = self::parse_file_path( $file_path );
-		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) );  // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged.
 		if ( ! $download_range['is_range_request'] ) {
 			$download->track_download( $current_user_id > 0 ? $current_user_id : null, ! empty( $ip_address ) ? $ip_address : null );
 		}

--- a/tests/unit-tests/customer/customer-download-log.php
+++ b/tests/unit-tests/customer/customer-download-log.php
@@ -128,11 +128,6 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, $download_1->get_download_count(), 'New permission download count should be zero.' );
 		$this->assertEquals( 10, $download_1->get_downloads_remaining(), 'New permission downloads remaining should be 10.' );
 
-		// Range download is not legged & does not reduce remaining download count.
-		$download_1->track_download( $customer_id_2, $ip_address, true );
-		$this->assertEquals( 0, $download_1->get_download_count(), 'After range download, permission download count should be 0.' );
-		$this->assertEquals( 10, $download_1->get_downloads_remaining(), 'After range download, permission downloads remaining should be 10.' );
-
 		// Track the download in logs and change remaining/counts.
 		$download_1->track_download( $customer_id_2, $ip_address );
 

--- a/tests/unit-tests/customer/customer-download-log.php
+++ b/tests/unit-tests/customer/customer-download-log.php
@@ -10,7 +10,7 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 	/**
 	 * Test: get_id
 	 */
-	function test_get_id() {
+	public function test_get_id() {
 		$customer_id = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
 		$download    = new WC_Customer_Download();
 		$download->set_user_id( $customer_id );
@@ -28,12 +28,12 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 	/**
 	 * Test: get_timestamp
 	 */
-	function test_get_timestamp() {
+	public function test_get_timestamp() {
 		$object = new WC_Customer_Download_Log();
 		$set_to = current_time( 'timestamp', true );
 
 		// Convert timestamp to WC_DateTime using ISO 8601 for PHP 5.2 compat.
-		$dt_str = date( 'c', $set_to );
+		$dt_str       = date( 'c', $set_to );
 		$wc_timestamp = new WC_DateTime( $dt_str );
 
 		$object->set_timestamp( $set_to );
@@ -43,7 +43,7 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 	/**
 	 * Test: get_permission_id
 	 */
-	function test_get_permission_id() {
+	public function test_get_permission_id() {
 		$object = new WC_Customer_Download_Log();
 		$set_to = 10;
 		$object->set_permission_id( $set_to );
@@ -53,7 +53,7 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 	/**
 	 * Test: get_user_id
 	 */
-	function test_get_user_id() {
+	public function test_get_user_id() {
 		$object = new WC_Customer_Download_Log();
 		$set_to = 10;
 		$object->set_user_id( $set_to );
@@ -63,7 +63,7 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 	/**
 	 * Test: get_user_ip_address
 	 */
-	function test_get_user_ip_address() {
+	public function test_get_user_ip_address() {
 		$object = new WC_Customer_Download_Log();
 		$set_to = '1.2.3.4';
 		$object->set_user_ip_address( $set_to );
@@ -78,7 +78,7 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
 		$customer_id_2 = wc_create_new_customer( 'test2@example.com', 'testuser2', 'testpassword2' );
 
-		$download_1 = new WC_Customer_Download;
+		$download_1 = new WC_Customer_Download();
 		$download_1->set_user_id( $customer_id_1 );
 		$download_1->set_order_id( 1 );
 		$download_1->save();
@@ -87,10 +87,10 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 		$timestamp = current_time( 'timestamp', true );
 
 		// Convert timestamp to WC_DateTime using ISO 8601 for PHP 5.2 compat.
-		$dt_str = date( 'c', $timestamp );
+		$dt_str       = date( 'c', $timestamp );
 		$wc_timestamp = new WC_DateTime( $dt_str );
 
-		$download_log = new WC_Customer_Download_Log;
+		$download_log = new WC_Customer_Download_Log();
 		$download_log->set_timestamp( $timestamp );
 		$download_log->set_permission_id( $download_1->get_id() );
 		$download_log->set_user_id( $customer_id_2 );
@@ -116,7 +116,7 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
 		$customer_id_2 = wc_create_new_customer( 'test2@example.com', 'testuser2', 'testpassword2' );
 
-		$download_1 = new WC_Customer_Download;
+		$download_1 = new WC_Customer_Download();
 		$download_1->set_user_id( $customer_id_1 );
 		$download_1->set_order_id( 1 );
 		$download_1->set_downloads_remaining( 10 );
@@ -141,9 +141,9 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 		$this->assertEquals( 9, $download_1->get_downloads_remaining(), 'After download, permission downloads remaining should be 9.' );
 
 		// Make sure download log was recorded properly.
-		$data_store = WC_Data_Store::load( 'customer-download-log' );
+		$data_store    = WC_Data_Store::load( 'customer-download-log' );
 		$download_logs = $data_store->get_download_logs( array(
-			'permission_id' => $download_1->get_id()
+			'permission_id' => $download_1->get_id(),
 		) );
 
 		$this->assertEquals( 1, count( $download_logs ), 'After single download, permission should have one download log in database.' );

--- a/tests/unit-tests/customer/customer-download-log.php
+++ b/tests/unit-tests/customer/customer-download-log.php
@@ -128,6 +128,11 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, $download_1->get_download_count(), 'New permission download count should be zero.' );
 		$this->assertEquals( 10, $download_1->get_downloads_remaining(), 'New permission downloads remaining should be 10.' );
 
+		// Range download is not legged & does not reduce remaining download count.
+		$download_1->track_download( $customer_id_2, $ip_address, true );
+		$this->assertEquals( 0, $download_1->get_download_count(), 'After range download, permission download count should be 0.' );
+		$this->assertEquals( 10, $download_1->get_downloads_remaining(), 'After range download, permission downloads remaining should be 10.' );
+
 		// Track the download in logs and change remaining/counts.
 		$download_1->track_download( $customer_id_2, $ip_address );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This change adds support for HTTP_RANGE requests (used by iOS devices) to `Force download` method.
One thing to note is that range request downloads are not logged (so that they are not counted as multiple downloads). The most reasonable option in my view would be to add extra column(s) to table `wp_wc_download_log`, e.g. columns `start` and `length` and then exclude range request log entries when counting number of downloads. 
Not sure how feasible db changes are mid-release-cycle, so I went for easier option for now--ignoring ranged downloads from the log. 
As the initial request from an iOS device is a normal (non-range) request, the download should be logged once anyway.
 
Closes #19640 .

### How to test the changes in this Pull Request:

1. Create a downloadable virtual product which contains larger audio or video file, e.g. an mp3 file.
2. Buy the product, go to My account > Downloads.
3. Try to download the mp3 file on iPhone/iPad.
4. Audio only plays first ~2 minutes, then starts from the beginning again, it does not indicate the length and does not allow seeking.
5. Apply this branch.
6. See the audio now shows correct length and allows seeking.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No, it's a bit tricky as headers interfere with phpunit's output and e2e tests don't run on iOS device.
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added support for HTTP_RANGE requests (used by iOS devices) to `Force download` method.
