### PR TITLE
Check Terms Conditions page exits

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -717,7 +717,8 @@ function wc_privacy_policy_page_id() {
  * @return bool
  */
 function wc_terms_and_conditions_checkbox_enabled() {
-	return wc_terms_and_conditions_page_id() && wc_get_terms_and_conditions_checkbox_text();
+	$page = get_post( wc_terms_and_conditions_page_id() );
+	return $page && wc_get_terms_and_conditions_checkbox_text();
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR does an actual check to ensure the page is present inside wc_terms_and_conditions_checkbox_enabled and not just rely on an ID that was saved. It caused issues where you would save a T&C page, set it in WooCommerce settings and then delete the page leaving the ID still saved.

Closes #19975 

### How to test the changes in this Pull Request:

1. Create Terms & Conditions page
2. Set the newly created page under WooCommerce -> Settings -> Advanced
3. Go to checkout page and see the link to accept terms and conditions
4. Trash the page you created then permanently remove the page as well
5. Go to checkout page, the link should be gone now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Ensure terms and conditions page actually exists before displaying the link on checkout.
