### PR TITLE
Plugin installer: fix extracting filename from path

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1079,7 +1079,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	 */
 	private static function associate_plugin_file( $plugins, $key ) {
 		$path                 = explode( '/', $key );
-		$filename             = array_slice( $path, -1 )[0];
+		$filename             = end( $path );
 		$plugins[ $filename ] = $key;
 		return $plugins;
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1078,8 +1078,9 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	 * @param string $key Plugin relative path. Example: woocommerce/woocommerce.php.
 	 */
 	private static function associate_plugin_file( $plugins, $key ) {
-		$path                = explode( '/', $key );
-		$plugins[ $path[1] ] = $key;
+		$path                 = explode( '/', $key );
+		$filename             = array_slice( $path, -1 )[0];
+		$plugins[ $filename ] = $key;
 		return $plugins;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/woocommerce/woocommerce/pull/19728 introduced an error when plugin files were present in the root plugins directory:

> PHP Notice:  Undefined offset: 1 in /srv/www/wordpress-default/public_html/wp-content/plugins/woocommerce/includes/class-wc-install.php on line 1082

This is a small change to extract the filename in a more suitable way.