### PR TITLE
OBW: stylized checkboxes in "Recommended" step

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1242,7 +1242,7 @@ p.jetpack-terms {
 	}
 }
 
-.recommended-step {
+.wc-setup-content .recommended-step {
 	border: 1px solid #ebebeb;
 	border-radius: 4px;
 	padding: 2.5em;
@@ -1250,15 +1250,22 @@ p.jetpack-terms {
 	li {
 		list-style: none;
 
-		&:last-child .recommended-item {
+		&:last-child label {
 			margin-bottom: 0; // Avoid extra space at the end of the list.
 		}
 	}
 
-	.recommended-item {
+	label {
 		display: flex;
 		align-items: center;
 		margin-bottom: 1.5em;
+
+		&:before, &:after {
+			top: auto;
+		}
+		&:after {
+			margin-top: -1.5px;
+		}
 	}
 
 	.recommended-item-icon {
@@ -1266,7 +1273,7 @@ p.jetpack-terms {
 		border-radius: 7px;
 		height: 3.5em;
 		margin-right: 1em;
-		margin-left: 1em;
+		margin-left: 4px;
 
 		&.recommended-item-icon-storefront_theme {
 			background-color: #f4a224;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -389,7 +389,6 @@ body {
 		input[type="checkbox"]:checked + label::before {
 			background: #935687;
 			border-color: #935687;
-			outline: none;
 		}
 	}
 }

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -339,56 +339,57 @@ body {
 			font-size: 1em;
 			margin-top: 0;
 			margin-bottom: 20px;
-
-			input[type="checkbox"] {
-				opacity: 0;
+		}
+	}
+	.checkbox {
+		input[type="checkbox"] {
+			opacity: 0;
+			position: absolute;
+			left: -9999px;
+		}
+		label {
+			position: relative;
+			display: inline-block;
+			padding-left: 28px;
+			&:before,
+			&:after {
 				position: absolute;
-				left: -9999px;
-			}
-			label {
-				position: relative;
-				display: inline-block;
-				padding-left: 28px;
-				&:before,
-				&:after {
-					position: absolute;
-					content: "";
-					display: inline-block;
-				}
-				&:before {
-					height: 16px;
-					width: 16px;
-					left: 0px;
-					top: 3px;
-					border: 1px solid #aaa;
-					background-color: #fff;
-					border-radius: 3px;
-				}
-				&:after {
-					height: 5px;
-					width: 9px;
-					border-left: 2px solid;
-					border-bottom: 2px solid;
-					transform: rotate(-45deg);
-					left: 4px;
-					top: 7px;
-					color: #fff;
-				}
-			}
-			input[type="checkbox"] + label::after {
-				content: none;
-			}
-			input[type="checkbox"]:checked + label::after {
 				content: "";
+				display: inline-block;
 			}
-			input[type="checkbox"]:focus + label::before {
-				outline: rgb(59, 153, 252) auto 5px;
+			&:before {
+				height: 16px;
+				width: 16px;
+				left: 0px;
+				top: 3px;
+				border: 1px solid #aaa;
+				background-color: #fff;
+				border-radius: 3px;
 			}
-			input[type="checkbox"]:checked + label::before {
-				background: #935687;
-				border-color: #935687;
-				outline: none;
+			&:after {
+				height: 5px;
+				width: 9px;
+				border-left: 2px solid;
+				border-bottom: 2px solid;
+				transform: rotate(-45deg);
+				left: 4px;
+				top: 7px;
+				color: #fff;
 			}
+		}
+		input[type="checkbox"] + label::after {
+			content: none;
+		}
+		input[type="checkbox"]:checked + label::after {
+			content: "";
+		}
+		input[type="checkbox"]:focus + label::before {
+			outline: rgb(59, 153, 252) auto 5px;
+		}
+		input[type="checkbox"]:checked + label::before {
+			background: #935687;
+			border-color: #935687;
+			outline: none;
 		}
 	}
 }

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -207,7 +207,7 @@ jQuery( function( $ ) {
 			} );
 		} );
 
-		$( '.recommended-item-checkbox:checked' ).each( function() {
+		$( '.recommended-item input:checked' ).each( function() {
 			addPlugins( pluginLinkBySlug, $( this ), '.recommended-item' );
 		} );
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1682,16 +1682,16 @@ class WC_Admin_Setup_Wizard {
 		$img_url     = $item_info['img_url'];
 		$img_alt     = $item_info['img_alt'];
 		?>
-		<li>
-			<label class="recommended-item">
-				<input
-					class="recommended-item-checkbox"
-					type="checkbox"
-					name="<?php echo esc_attr( 'setup_' . $type ); ?>"
-					value="yes"
-					checked
-					data-plugins="<?php echo esc_attr( json_encode( isset( $item_info['plugins'] ) ? $item_info['plugins'] : null ) ); ?>"
-				/>
+		<li class="recommended-item checkbox">
+			<input
+				id="<?php echo esc_attr( 'wc_recommended_' . $type ); ?>"
+				type="checkbox"
+				name="<?php echo esc_attr( 'setup_' . $type ); ?>"
+				value="yes"
+				checked
+				data-plugins="<?php echo esc_attr( json_encode( isset( $item_info['plugins'] ) ? $item_info['plugins'] : null ) ); ?>"
+			/>
+			<label for="<?php echo esc_attr( 'wc_recommended_' . $type ); ?>">
 				<img
 					src="<?php echo esc_url( $img_url ); ?>"
 					class="<?php echo esc_attr( 'recommended-item-icon-' . $type ); ?> recommended-item-icon"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces native checkboxes with stylized ones (as established in https://github.com/woocommerce/woocommerce/pull/19723#issuecomment-381559250 and originally specified in p7bje6-S6-p2):

<img width="659" alt="screen shot 2018-05-07 at 9 45 17 am" src="https://user-images.githubusercontent.com/1867547/39705180-a17872ca-51db-11e8-9810-ffb305f4b44e.png">

Also a minor adjustment to show an outline (on focus) when checked, instead of only when not checked — let me know if the overridden `outline` rule was there for a reason.

<img width="463" alt="screen shot 2018-05-07 at 9 44 45 am" src="https://user-images.githubusercontent.com/1867547/39705188-a4a1f5ac-51db-11e8-8f0c-811b581e7b0d.png">

### How to test the changes in this Pull Request:

1. Make sure recommended step matches static design.
2. Make sure store setup step appears as before, with the exception of the outline on focus.