### PR TITLE
OBW: Set only applicable fields as required when enabling shipping zone

### DIFF
--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -110,9 +110,11 @@ jQuery( function( $ ) {
 
 	$( '.wc-wizard-services' ).on( 'change', '.wc-wizard-shipping-method-enable', function() {
 		var checked = $( this ).is( ':checked' );
+		var selectedMethod = $( '.wc-wizard-shipping-method-select .method' ).val();
 
 		$( this )
 			.closest( '.wc-wizard-service-item' )
+			.find( '.' + selectedMethod )
 			.find( '.shipping-method-required-field' )
 			.prop( 'required', checked );
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Bug fix. In the setup wizard "Shipping" step, after disabling a zone and then enabling again with a method other than flat rate, the "Continue" button does nothing except show a console error:

> An invalid form control with name='shipping_zones[domestic][flat_rate][cost]' is not focusable.

This change ensures that, upon enabling the zone, the flat rate cost field only gets set as `required` when the shipping method is `flat_rate`.

(Tested in Chrome.)

### How to test the changes in this Pull Request:

When enabling the shipping zone on a method other than flat rate (and with flat rate cost not having been filled in), clicking the "Continue" button should proceed to the next step.

If shipping zones are already set up, can force displaying this UI with a code change:

```diff
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -881,7 +881,7 @@ class WC_Admin_Setup_Wizard {
                <h1><?php esc_html_e( 'Shipping', 'woocommerce' ); ?></h1>
                <p><?php echo wp_kses_post( $intro_text ); ?></p>
                <form method="post">
-                       <?php if ( empty( $existing_zones ) ) : ?>
+                       <?php if ( true ) : ?>
                                <ul class="wc-wizard-services shipping">
                                        <li class="wc-wizard-service-item">
                                                <div class="wc-wizard-service-name">
```
