### PR TITLE
Use default price if min/max price cannot be calculate

### DIFF
--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -122,7 +122,7 @@ class WC_Product_Grouped extends WC_Product {
 				$price = apply_filters( 'woocommerce_grouped_price_html', $price . $this->get_price_suffix(), $this, $child_prices );
 			}
 		} else {
-			$price = apply_filters( 'woocommerce_grouped_empty_price_html', '', $this );
+			$price = apply_filters( 'woocommerce_grouped_empty_price_html', $price, $this );
 		}
 
 		return apply_filters( 'woocommerce_get_price_html', $price, $this );


### PR DESCRIPTION
The default price passed to the function `get_price_html` is not used, but when isn't possible to produce a valid price instead of use the one passed an empty string is assigned. 

Devs will think they can pass a `$price` but it's not, the only way to set a default price is to use the filter `woocommerce_grouped_empty_price_html` or `woocommerce_get_price_html` but in both case the price can be an empty string.

Using the parameter make the function coherent with other functions and also allow devs to set a default price without using additional filters.
