### PR TITLE
 Remove unnecessary cleanup code from orders unit tests

### DIFF
--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -877,9 +877,13 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		add_action( 'woocommerce_payment_complete', array( $this, 'throwAnException' ) );
 
 		$this->assertFalse( $object->payment_complete( '12345' ) );
-		$note = current( wc_get_order_notes( array(
-			'order_id' => $object->get_id(),
-		) ) );
+		$note = current(
+			wc_get_order_notes(
+				array(
+					'order_id' => $object->get_id(),
+				)
+			)
+		);
 		$this->assertContains( 'Payment complete event failed', $note->content );
 
 		remove_action( 'woocommerce_payment_complete', array( $this, 'throwAnException' ) );
@@ -928,9 +932,13 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_payment_complete_order_status', array( $this, 'throwAnException' ) );
 
 		$this->assertFalse( $object->update_status( 'on-hold' ) );
-		$note = current( wc_get_order_notes( array(
-			'order_id' => $object->get_id(),
-		) ) );
+		$note = current(
+			wc_get_order_notes(
+				array(
+					'order_id' => $object->get_id(),
+				)
+			)
+		);
 		$this->assertContains( 'Update status event failed', $note->content );
 
 		remove_filter( 'woocommerce_payment_complete_order_status', array( $this, 'throwAnException' ) );
@@ -1853,9 +1861,13 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		add_action( 'woocommerce_before_order_object_save', array( $this, 'throwAnException' ) );
 
 		$object->save();
-		$note = current( wc_get_order_notes( array(
-			'order_id' => $object->get_id(),
-		) ) );
+		$note = current(
+			wc_get_order_notes(
+				array(
+					'order_id' => $object->get_id(),
+				)
+			)
+		);
 		$this->assertContains( 'Error saving order', $note->content );
 
 		remove_action( 'woocommerce_before_order_object_save', array( $this, 'throwAnException' ) );

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -335,8 +335,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	 * Test: get_taxes
 	 */
 	public function test_get_taxes() {
-		global $wpdb;
-
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$tax_rate = array(
 			'tax_rate_country'  => '',
@@ -371,11 +369,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object->save();
 
 		$this->assertCount( 2, $object->get_taxes() );
-
-		// Cleanup.
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-		update_option( 'woocommerce_calc_taxes', 'no' );
 	}
 
 	/**
@@ -603,7 +596,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	 * Test: calculate_taxes
 	 */
 	public function test_calculate_taxes() {
-		global $wpdb;
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$tax_rate = array(
 			'tax_rate_country'  => '',
@@ -638,19 +630,12 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
 		$object->calculate_taxes();
 		$this->assertEquals( 5, $object->get_total_tax() );
-
-		// Cleanup.
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-		update_option( 'woocommerce_calc_taxes', 'no' );
-		$object->delete();
 	}
 
 	/**
 	 * Test: calculate_taxes_is_vat_excempt
 	 */
 	public function test_calculate_taxes_is_vat_excempt() {
-		global $wpdb;
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$tax_rate = array(
 			'tax_rate_country'  => '',
@@ -690,22 +675,13 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object->save();
 		$object->calculate_taxes();
 		$this->assertEquals( 0, $object->get_total_tax() );
-
-		// Cleanup.
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-		update_option( 'woocommerce_calc_taxes', 'no' );
-		$object->delete();
 	}
 
 	/**
 	 * Test: calculate_taxes_issue_with_addresses
 	 */
 	public function test_calculate_taxes_issue_with_addresses() {
-		global $wpdb;
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
 
 		$taxes = array();
 
@@ -754,7 +730,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	 * Test: calculate_totals
 	 */
 	public function test_calculate_totals() {
-		global $wpdb;
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$tax_rate = array(
 			'tax_rate_country'  => '',
@@ -789,11 +764,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
 		$object->calculate_totals();
 		$this->assertEquals( 55, $object->get_total() );
-
-		// Cleanup.
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-		update_option( 'woocommerce_calc_taxes', 'no' );
 	}
 
 	/**
@@ -1798,9 +1768,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
 		$order->remove_coupon( 'test' );
 		$this->assertEquals( 50, $order->get_total() );
-
-		$coupon->delete( true );
-		$order->delete( true );
 	}
 
 	/**
@@ -1822,9 +1789,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 
 		$order->remove_coupon( 'test' );
 		$this->assertEquals( 50, $order->get_total() );
-
-		$coupon->delete( true );
-		$order->delete( true );
 	}
 
 	/**

--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -176,7 +176,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'customer' => 0,
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order_1, $order_2 );
@@ -187,7 +187,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'customer' => 1,
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order_3, $order_4 );
@@ -198,7 +198,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'customer' => '',
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order_1, $order_2, $order_3, $order_4 );
@@ -217,11 +217,11 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order1->set_date_created( '2015-01-01 05:20:30' );
 		$order1->save();
 		$order_1 = $order1->get_id();
-		$order2   = WC_Helper_Order::create_order();
+		$order2  = WC_Helper_Order::create_order();
 		$order2->set_date_created( '2017-01-01' );
 		$order2->save();
 		$order_2 = $order2->get_id();
-		$order3   = WC_Helper_Order::create_order();
+		$order3  = WC_Helper_Order::create_order();
 		$order3->set_date_created( '2017-01-01' );
 		$order3->save();
 		$order_3 = $order3->get_id();
@@ -229,7 +229,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'date_before' => '2017-01-15',
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order_1, $order_2, $order_3 );
@@ -240,7 +240,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'date_before' => '2017-01-01',
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order_1 );
@@ -251,7 +251,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'date_before' => '2016-12-31',
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order_1 );
@@ -262,7 +262,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'date_after' => '2015-01-01 00:00:00',
-				'return' => 'ids',
+				'return'     => 'ids',
 			)
 		);
 		$expected = array( $order_1, $order_2, $order_3 );
@@ -273,7 +273,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'date_after' => '2016-01-01',
-				'return' => 'ids',
+				'return'     => 'ids',
 			)
 		);
 		$expected = array( $order_2, $order_3 );
@@ -284,8 +284,8 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders   = wc_get_orders(
 			array(
 				'date_before' => '2017-01-15',
-				'date_after' => '2015-01-01 00:00:00',
-				'return' => 'ids',
+				'date_after'  => '2015-01-01 00:00:00',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order_1, $order_2, $order_3 );
@@ -337,18 +337,18 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$refund = new WC_Order_Refund();
 		$refund->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
-				'type' => 'shop_order_refund',
+				'type'   => 'shop_order_refund',
 				'return' => 'ids',
 			)
 		);
 		$expected = array( $refund->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
-				'type' => 'shop_order',
+				'type'   => 'shop_order',
 				'return' => 'ids',
 			)
 		);
@@ -365,19 +365,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'version' => WC_VERSION,
-				'return' => 'ids',
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'version' => '2.1.0',
-				'return' => 'ids',
+				'return'  => 'ids',
 			)
 		);
 		$expected = array();
@@ -397,19 +397,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_created_via( 'checkout' );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'created_via' => 'rest-api',
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'created_via' => 'checkout',
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -431,7 +431,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'parent' => $parent->get_id(),
 				'return' => 'ids',
@@ -459,7 +459,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders = wc_get_orders(
 			array(
 				'parent_exclude' => array( $parent->get_id() ),
-				'return' => 'ids',
+				'return'         => 'ids',
 			)
 		);
 		sort( $orders );
@@ -478,10 +478,10 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'exclude' => array( $order1->get_id() ),
-				'return' => 'ids',
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -514,25 +514,25 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
-				'paged' => 1,
+				'paged'   => 1,
 				'orderby' => 'ID',
-				'order' => 'ASC',
-				'limit' => 1,
-				'return' => 'ids',
+				'order'   => 'ASC',
+				'limit'   => 1,
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
-				'paged' => 2,
+				'paged'   => 2,
 				'orderby' => 'ID',
-				'order' => 'ASC',
-				'limit' => 1,
-				'return' => 'ids',
+				'order'   => 'ASC',
+				'limit'   => 1,
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -550,12 +550,12 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
-				'offset' => 1,
+				'offset'  => 1,
 				'orderby' => 'ID',
-				'order' => 'ASC',
-				'return' => 'ids',
+				'order'   => 'ASC',
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -592,7 +592,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$orders = wc_get_orders(
 			array(
 				'paginate' => true,
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$this->assertEquals( 1, $orders->total );
@@ -611,21 +611,21 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order();
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'orderby' => 'ID',
-				'order' => 'DESC',
-				'return' => 'ids',
+				'order'   => 'DESC',
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id(), $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'orderby' => 'ID',
-				'order' => 'ASC',
-				'return' => 'ids',
+				'order'   => 'ASC',
+				'return'  => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id(), $order2->get_id() );
@@ -645,19 +645,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_currency( 'USD' );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'currency' => 'BRL',
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'currency' => 'USD',
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -677,19 +677,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_prices_include_tax( false );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'prices_include_tax' => 'yes',
-				'return' => 'ids',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'prices_include_tax' => 'no',
-				'return' => 'ids',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -709,19 +709,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_payment_method( 'cod' );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'payment_method' => 'cheque',
-				'return' => 'ids',
+				'return'         => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'payment_method' => 'cod',
-				'return' => 'ids',
+				'return'         => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -741,19 +741,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_payment_method_title( 'PayPal' );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'payment_method_title' => 'Check payments',
-				'return' => 'ids',
+				'return'               => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'payment_method_title' => 'PayPal',
-				'return' => 'ids',
+				'return'               => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -783,54 +783,54 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_total( 5.89 );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'discount_total' => 5.50,
-				'return' => 'ids',
+				'return'         => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'discount_tax' => 0.20,
-				'return' => 'ids',
+				'return'       => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_total' => 3.99,
-				'return' => 'ids',
+				'return'         => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_tax' => 0.15,
-				'return' => 'ids',
+				'return'       => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'cart_tax' => 0.10,
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
-				'total' => 5.89,
+				'total'  => 5.89,
 				'return' => 'ids',
 			)
 		);
@@ -861,19 +861,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_billing_email( $customer2->get_billing_email() );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'customer' => $customer1->get_billing_email(),
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'customer' => $customer2->get_id(),
-				'return' => 'ids',
+				'return'   => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -913,19 +913,19 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2->set_customer_id( $customer2->get_id() );
 		$order2->save();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'customer_id' => $customer1->get_id(),
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order1->get_id() );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'customer_id' => $customer2->get_id(),
-				'return' => 'ids',
+				'return'      => 'ids',
 			)
 		);
 		$expected = array( $order2->get_id() );
@@ -941,26 +941,26 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order1 = WC_Helper_Order::create_order();
 		$order1->set_props(
 			array(
-				'billing_email' => 'test1@test.com',
-				'billing_first_name' => 'Bill',
-				'billing_last_name' => 'Powers',
-				'billing_company' => 'TestCo.',
-				'billing_address_1' => '1234 Cool St.',
-				'billing_address_2' => 'Apt 2',
-				'billing_city' => 'Portland',
-				'billing_state' => 'OR',
-				'billing_postcode' => '97266',
-				'billing_country' => 'USA',
-				'billing_phone' => '503-123-4567',
+				'billing_email'       => 'test1@test.com',
+				'billing_first_name'  => 'Bill',
+				'billing_last_name'   => 'Powers',
+				'billing_company'     => 'TestCo.',
+				'billing_address_1'   => '1234 Cool St.',
+				'billing_address_2'   => 'Apt 2',
+				'billing_city'        => 'Portland',
+				'billing_state'       => 'OR',
+				'billing_postcode'    => '97266',
+				'billing_country'     => 'USA',
+				'billing_phone'       => '503-123-4567',
 				'shipping_first_name' => 'Jane',
-				'shipping_last_name' => 'Powers',
-				'shipping_company' => '',
-				'shipping_address_1' => '4321 Cool St.',
-				'shipping_address_2' => 'Apt 1',
-				'shipping_city' => 'Milwaukie',
-				'shipping_state' => 'OR',
-				'shipping_postcode' => '97222',
-				'shipping_country' => 'USA',
+				'shipping_last_name'  => 'Powers',
+				'shipping_company'    => '',
+				'shipping_address_1'  => '4321 Cool St.',
+				'shipping_address_2'  => 'Apt 1',
+				'shipping_city'       => 'Milwaukie',
+				'shipping_state'      => 'OR',
+				'shipping_postcode'   => '97222',
+				'shipping_country'    => 'USA',
 			)
 		);
 		$order1->save();
@@ -969,220 +969,220 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$order2 = WC_Helper_Order::create_order();
 		$order2->set_props(
 			array(
-				'billing_email' => 'test2@test.com',
-				'billing_first_name' => 'Joe',
-				'billing_last_name' => 'Thunder',
-				'billing_company' => 'ThunderCo.',
-				'billing_address_1' => '1234 Thunder St.',
-				'billing_address_2' => '',
-				'billing_city' => 'Vancouver',
-				'billing_state' => 'WA',
-				'billing_postcode' => '97267',
-				'billing_country' => 'USA',
-				'billing_phone' => '503-333-3333',
+				'billing_email'       => 'test2@test.com',
+				'billing_first_name'  => 'Joe',
+				'billing_last_name'   => 'Thunder',
+				'billing_company'     => 'ThunderCo.',
+				'billing_address_1'   => '1234 Thunder St.',
+				'billing_address_2'   => '',
+				'billing_city'        => 'Vancouver',
+				'billing_state'       => 'WA',
+				'billing_postcode'    => '97267',
+				'billing_country'     => 'USA',
+				'billing_phone'       => '503-333-3333',
 				'shipping_first_name' => 'Joseph',
-				'shipping_last_name' => 'Thunder',
-				'shipping_company' => 'Thunder Inc',
-				'shipping_address_1' => '1 Thunder Blvd',
-				'shipping_address_2' => '',
-				'shipping_city' => 'Vancouver',
-				'shipping_state' => 'WA',
-				'shipping_postcode' => '97233',
-				'shipping_country' => 'USA',
+				'shipping_last_name'  => 'Thunder',
+				'shipping_company'    => 'Thunder Inc',
+				'shipping_address_1'  => '1 Thunder Blvd',
+				'shipping_address_2'  => '',
+				'shipping_city'       => 'Vancouver',
+				'shipping_state'      => 'WA',
+				'shipping_postcode'   => '97233',
+				'shipping_country'    => 'USA',
 			)
 		);
 		$order2->save();
 		$order2_id = $order2->get_id();
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_email' => 'test1@test.com',
-				'return' => 'ids',
+				'return'        => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_first_name' => 'Joe',
-				'return' => 'ids',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_last_name' => 'Powers',
-				'return' => 'ids',
+				'return'            => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_company' => 'ThunderCo.',
-				'return' => 'ids',
+				'return'          => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_address_1' => '1234 Cool St.',
-				'return' => 'ids',
+				'return'            => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_address_2' => 'Apt 2',
-				'return' => 'ids',
+				'return'            => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_city' => 'Vancouver',
-				'return' => 'ids',
+				'return'       => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_state' => 'OR',
-				'return' => 'ids',
+				'return'        => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_postcode' => '97267',
-				'return' => 'ids',
+				'return'           => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_country' => 'USA',
-				'orderby' => 'ID',
-				'order' => 'ASC',
-				'return' => 'ids',
+				'orderby'         => 'ID',
+				'order'           => 'ASC',
+				'return'          => 'ids',
 			)
 		);
 		$expected = array( $order1_id, $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_phone' => '503-333-3333',
-				'return' => 'ids',
+				'return'        => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_first_name' => 'Jane',
-				'return' => 'ids',
+				'return'              => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_last_name' => 'Thunder',
-				'return' => 'ids',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_company' => 'Thunder Inc',
-				'return' => 'ids',
+				'return'           => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_address_1' => '1 Thunder Blvd',
-				'return' => 'ids',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_address_2' => 'Apt 1',
-				'return' => 'ids',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_city' => 'Vancouver',
-				'return' => 'ids',
+				'return'        => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_state' => 'OR',
-				'return' => 'ids',
+				'return'         => 'ids',
 			)
 		);
 		$expected = array( $order1_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_postcode' => '97233',
-				'return' => 'ids',
+				'return'            => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'shipping_country' => 'USA',
-				'orderby' => 'ID',
-				'order' => 'ASC',
-				'return' => 'ids',
+				'orderby'          => 'ID',
+				'order'            => 'ASC',
+				'return'           => 'ids',
 			)
 		);
 		$expected = array( $order1_id, $order2_id );
 		$this->assertEquals( $expected, $orders );
 
-		$orders = wc_get_orders(
+		$orders   = wc_get_orders(
 			array(
 				'billing_first_name' => 'Joe',
-				'billing_last_name' => 'Thunder',
-				'return' => 'ids',
+				'billing_last_name'  => 'Thunder',
+				'return'             => 'ids',
 			)
 		);
 		$expected = array( $order2_id );
@@ -1196,9 +1196,9 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_get_order_mixed_date_shipping_country() {
 		// Set up dates.
-		$start = time() - 1; // Start from one second ago.
-		$yesterday = strtotime( '-1 day', $start );
-		$end = strtotime( '+1 day', $start );
+		$start      = time() - 1; // Start from one second ago.
+		$yesterday  = strtotime( '-1 day', $start );
+		$end        = strtotime( '+1 day', $start );
 		$date_range = $start . '...' . $end;
 
 		// Populate orders.
@@ -1213,7 +1213,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$us_old = WC_Helper_Order::create_order();
 		$us_old->set_props(
 			array(
-				'date_created' => $yesterday,
+				'date_created'     => $yesterday,
 				'shipping_country' => 'US',
 			)
 		);
@@ -1237,36 +1237,36 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$mx_old->save();
 
 		// Test just date range.
-		$args = array(
+		$args     = array(
 			'return'       => 'ids',
 			'date_created' => $date_range,
 			'orderby'      => 'ID',
 			'order'        => 'ASC',
 		);
-		$orders = wc_get_orders( $args );
+		$orders   = wc_get_orders( $args );
 		$expected = array( $us_now->get_id(), $mx_now->get_id() );
 		$this->assertEquals( $expected, $orders );
 
 		// Test just US orders.
-		$args = array(
+		$args     = array(
 			'return'           => 'ids',
 			'shipping_country' => 'US',
 			'orderby'          => 'ID',
 			'order'            => 'ASC',
 		);
-		$orders = wc_get_orders( $args );
+		$orders   = wc_get_orders( $args );
 		$expected = array( $us_now->get_id(), $us_old->get_id() );
 		$this->assertEquals( $expected, $orders );
 
 		// Test US orders with date range.
-		$args = array(
+		$args     = array(
 			'return'           => 'ids',
 			'date_created'     => $date_range,
 			'shipping_country' => 'US',
 			'orderby'          => 'ID',
 			'order'            => 'ASC',
 		);
-		$orders = wc_get_orders( $args );
+		$orders   = wc_get_orders( $args );
 		$expected = array( $us_now->get_id() );
 		$this->assertEquals( $expected, $orders );
 	}
@@ -1286,7 +1286,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 			'customer_note' => false,
 			'added_by'      => 'system',
 		);
-		$note = (array) wc_get_order_note( $note_id );
+		$note         = (array) wc_get_order_note( $note_id );
 		unset( $note['date_created'] );
 
 		$this->assertEquals( $expected, $note );
@@ -1309,7 +1309,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$notes = wc_get_order_notes(
 			array(
 				'order_id' => $order->get_id(),
-				'type' => 'customer',
+				'type'     => 'customer',
 			)
 		);
 		$this->assertEquals( 1, count( $notes ) );
@@ -1317,7 +1317,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$notes = wc_get_order_notes(
 			array(
 				'order_id' => $order->get_id(),
-				'type' => 'internal',
+				'type'     => 'internal',
 			)
 		);
 		$this->assertEquals( 2, count( $notes ) );

--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -205,11 +205,6 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		sort( $expected );
 		sort( $orders );
 		$this->assertEquals( $expected, $orders );
-
-		$order1->delete();
-		$order2->delete();
-		$order3->delete();
-		$order4->delete();
 	}
 
 	/**
@@ -297,10 +292,6 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		sort( $expected );
 		sort( $orders );
 		$this->assertEquals( $expected, $orders );
-
-		$order1->delete();
-		$order2->delete();
-		$order3->delete();
 	}
 
 	/**


### PR DESCRIPTION
It is not necessary to manually remove data added to the database after each test. WP unit tests framework does this automatically.

This PR also includes PHPCS fixes for the modified files.