### PR TITLE
Update quick edit logic to handle external products

### DIFF
--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -59,19 +59,30 @@ jQuery(function( $ ) {
 			$( 'input[name="_featured"]', '.inline-edit-row' ).removeAttr( 'checked' );
 		}
 
-		if ( 'yes' === manage_stock ) {
-			$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).show().removeAttr( 'style' );
-			$( '.stock_status_field' ).hide();
-			$( 'input[name="_manage_stock"]', '.inline-edit-row' ).attr( 'checked', 'checked' );
-		} else {
-			$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).hide();
-			$( '.stock_status_field' ).show().removeAttr( 'style' );
-			$( 'input[name="_manage_stock"]', '.inline-edit-row' ).removeAttr( 'checked' );
-		}
-
 		// Conditional display
 		var product_type       = $wc_inline_data.find( '.product_type' ).text(),
 			product_is_virtual = $wc_inline_data.find( '.product_is_virtual' ).text();
+
+		var product_supports_stock_status = 'external' !== product_type;
+		var product_supports_stock_fields = 'external' !== product_type && 'grouped' !== product_type;
+
+		$( '.stock_fields, .manage_stock_field, .stock_status_field, .backorder_field' ).show();
+
+		if ( product_supports_stock_fields ) {
+			if ( 'yes' === manage_stock ) {
+				$( '.stock_fields' ).show().removeAttr( 'style' );
+				$( '.stock_status_field' ).hide();
+				$( '.manage_stock_field input' ).prop( 'checked', true );
+			} else {
+				$( '.stock_qty_field', '.inline-edit-row' ).hide();
+				$( '.stock_status_field' ).show().removeAttr( 'style' );
+				$( '.manage_stock_field input' ).prop( 'checked', false );
+			}
+		} else if ( product_supports_stock_status ) {
+			$( '.stock_fields, .manage_stock_field, .backorder_field' ).hide();
+		} else {
+			$( '.stock_fields, .manage_stock_field, .stock_status_field, .backorder_field' ).hide();
+		}
 
 		if ( 'simple' === product_type || 'external' === product_type ) {
 			$( '.price_fields', '.inline-edit-row' ).show().removeAttr( 'style' );
@@ -85,12 +96,6 @@ jQuery(function( $ ) {
 			$( '.dimension_fields', '.inline-edit-row' ).show().removeAttr( 'style' );
 		}
 
-		if ( 'grouped' === product_type ) {
-			$( '.stock_fields', '.inline-edit-row' ).hide();
-		} else {
-			$( '.stock_fields', '.inline-edit-row' ).show().removeAttr( 'style' );
-		}
-
 		// Rename core strings
 		$( 'input[name="comment_status"]' ).parent().find( '.checkbox-title' ).text( woocommerce_quick_edit.strings.allow_reviews );
 	});
@@ -98,10 +103,10 @@ jQuery(function( $ ) {
 	$( '#the-list' ).on( 'change', '.inline-edit-row input[name="_manage_stock"]', function() {
 
 		if ( $( this ).is( ':checked' ) ) {
-			$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).show().removeAttr( 'style' );
+			$( '.stock_qty_field', '.inline-edit-row' ).show().removeAttr( 'style' );
 			$( '.stock_status_field' ).hide();
 		} else {
-			$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).hide();
+			$( '.stock_qty_field', '.inline-edit-row' ).hide();
 			$( '.stock_status_field' ).show().removeAttr( 'style' );
 		}
 

--- a/includes/admin/views/html-quick-edit-product.php
+++ b/includes/admin/views/html-quick-edit-product.php
@@ -1,12 +1,11 @@
 <?php
 /**
  * Admin View: Quick Edit Product
+ *
+ * @package admin.
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
+defined( 'ABSPATH' ) || exit;
 ?>
 
 <fieldset class="inline-edit-col-left">
@@ -82,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						}
 
 						foreach ( $options as $key => $value ) {
-							echo '<option value="' . esc_attr( $key ) . '">' . $value . '</option>';
+							echo '<option value="' . esc_attr( $key ) . '">' . esc_html( $value ) . '</option>';
 						}
 						?>
 					</select>
@@ -98,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<label>
 					<span class="title"><?php esc_html_e( 'Weight', 'woocommerce' ); ?></span>
 					<span class="input-text-wrap">
-						<input type="text" name="_weight" class="text weight" placeholder="<?php echo wc_format_localized_decimal( 0 ); ?>" value="">
+						<input type="text" name="_weight" class="text weight" placeholder="<?php echo esc_attr( wc_format_localized_decimal( 0 ) ); ?>" value="">
 					</span>
 				</label>
 				<br class="clear" />
@@ -161,8 +160,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</label>
 		</div>
 
-		<?php if ( get_option( 'woocommerce_manage_stock' ) == 'yes' ) : ?>
-			<div class="inline-edit-group">
+		<?php if ( get_option( 'woocommerce_manage_stock' ) === 'yes' ) : ?>
+			<div class="inline-edit-group manage_stock_field">
 				<label class="manage_stock">
 					<input type="checkbox" name="_manage_stock" value="1">
 					<span class="checkbox-title"><?php esc_html_e( 'Manage stock?', 'woocommerce' ); ?></span>
@@ -184,7 +183,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 
 		<div class="stock_fields">
-			<?php if ( get_option( 'woocommerce_manage_stock' ) == 'yes' ) : ?>
+			<?php if ( get_option( 'woocommerce_manage_stock' ) === 'yes' ) : ?>
 				<label class="stock_qty_field">
 					<span class="title"><?php esc_html_e( 'Stock qty', 'woocommerce' ); ?></span>
 					<span class="input-text-wrap">
@@ -210,6 +209,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php do_action( 'woocommerce_product_quick_edit_end' ); ?>
 
 		<input type="hidden" name="woocommerce_quick_edit" value="1" />
-		<input type="hidden" name="woocommerce_quick_edit_nonce" value="<?php echo wp_create_nonce( 'woocommerce_quick_edit_nonce' ); ?>" />
+		<input type="hidden" name="woocommerce_quick_edit_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woocommerce_quick_edit_nonce' ) ); ?>" />
 	</div>
 </fieldset>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

External products cannot be stock managed so these fields should be hidden.

Closes #19997.

Sidenote, quick/bulk edit in core is abysmal and I look forward to dropping it in favour of something else.

### How to test the changes in this Pull Request:

1. Quick edit an external product. No stock fields should be shown.
2. Quick edit grouped product. Only stock status is displayed.
3. Quick edit any other product. Stock fields should be shown.