### PR TITLE
Rename variable to prevent name collision

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -33,34 +33,34 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				'price',
 			), $product );
 
-			foreach ( $grouped_products as $grouped_product ) {
-				$post_object        = get_post( $grouped_product->get_id() );
-				$quantites_required = $quantites_required || ( $grouped_product->is_purchasable() && ! $grouped_product->has_options() );
+			foreach ( $grouped_products as $grouped_product_child ) {
+				$post_object        = get_post( $grouped_product_child->get_id() );
+				$quantites_required = $quantites_required || ( $grouped_product_child->is_purchasable() && ! $grouped_product_child->has_options() );
 				$post               = $post_object; // WPCS: override ok.
 				setup_postdata( $post );
 
-				echo '<tr id="product-' . esc_attr( $grouped_product->get_id() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', wc_get_product_class( '', $grouped_product->get_id() ) ) ) . '">';
+				echo '<tr id="product-' . esc_attr( $grouped_product_child->get_id() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', wc_get_product_class( '', $grouped_product_child->get_id() ) ) ) . '">';
 
 				// Output columns for each product.
 				foreach ( $grouped_product_columns as $column_id ) {
-					do_action( 'woocommerce_grouped_product_list_before_' . $column_id, $grouped_product );
+					do_action( 'woocommerce_grouped_product_list_before_' . $column_id, $grouped_product_child );
 
 					switch ( $column_id ) {
 						case 'quantity':
 							ob_start();
 
-							if ( ! $grouped_product->is_purchasable() || $grouped_product->has_options() || ! $grouped_product->is_in_stock() ) {
+							if ( ! $grouped_product_child->is_purchasable() || $grouped_product_child->has_options() || ! $grouped_product_child->is_in_stock() ) {
 								woocommerce_template_loop_add_to_cart();
-							} elseif ( $grouped_product->is_sold_individually() ) {
-								echo '<input type="checkbox" name="' . esc_attr( 'quantity[' . $grouped_product->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" />';
+							} elseif ( $grouped_product_child->is_sold_individually() ) {
+								echo '<input type="checkbox" name="' . esc_attr( 'quantity[' . $grouped_product_child->get_id() . ']' ) . '" value="1" class="wc-grouped-product-add-to-cart-checkbox" />';
 							} else {
 								do_action( 'woocommerce_before_add_to_cart_quantity' );
 
 								woocommerce_quantity_input( array(
-									'input_name'  => 'quantity[' . $grouped_product->get_id() . ']',
-									'input_value' => isset( $_POST['quantity'][ $grouped_product->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $grouped_product->get_id() ] ) ) ) : 0, // WPCS: CSRF ok, input var okay, sanitization ok.
-									'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $grouped_product ),
-									'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $grouped_product->get_max_purchase_quantity(), $grouped_product ),
+									'input_name'  => 'quantity[' . $grouped_product_child->get_id() . ']',
+									'input_value' => isset( $_POST['quantity'][ $grouped_product_child->get_id() ] ) ? wc_stock_amount( wc_clean( wp_unslash( $_POST['quantity'][ $grouped_product_child->get_id() ] ) ) ) : 0, // WPCS: CSRF ok, input var okay, sanitization ok.
+									'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $grouped_product_child ),
+									'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $grouped_product_child->get_max_purchase_quantity(), $grouped_product_child ),
 								) );
 
 								do_action( 'woocommerce_after_add_to_cart_quantity' );
@@ -69,21 +69,21 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 							$value = ob_get_clean();
 							break;
 						case 'label':
-							$value  = '<label for="product-' . esc_attr( $grouped_product->get_id() ) . '">';
-							$value .= $grouped_product->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', $grouped_product->get_permalink(), $grouped_product->get_id() ) ) . '">' . $grouped_product->get_name() . '</a>' : $grouped_product->get_name();
+							$value  = '<label for="product-' . esc_attr( $grouped_product_child->get_id() ) . '">';
+							$value .= $grouped_product_child->is_visible() ? '<a href="' . esc_url( apply_filters( 'woocommerce_grouped_product_list_link', $grouped_product_child->get_permalink(), $grouped_product_child->get_id() ) ) . '">' . $grouped_product_child->get_name() . '</a>' : $grouped_product_child->get_name();
 							$value .= '</label>';
 							break;
 						case 'price':
-							$value = $grouped_product->get_price_html() . wc_get_stock_html( $grouped_product );
+							$value = $grouped_product_child->get_price_html() . wc_get_stock_html( $grouped_product_child );
 							break;
 						default:
 							$value = '';
 							break;
 					}
 
-					echo '<td class="woocommerce-grouped-product-list-item__' . esc_attr( $column_id ) . '">' . apply_filters( 'woocommerce_grouped_product_list_column_' . $column_id, $value, $grouped_product ) . '</td>'; // WPCS: XSS ok.
+					echo '<td class="woocommerce-grouped-product-list-item__' . esc_attr( $column_id ) . '">' . apply_filters( 'woocommerce_grouped_product_list_column_' . $column_id, $value, $grouped_product_child ) . '</td>'; // WPCS: XSS ok.
 
-					do_action( 'woocommerce_grouped_product_list_after_' . $column_id, $grouped_product );
+					do_action( 'woocommerce_grouped_product_list_after_' . $column_id, $grouped_product_child );
 				}
 
 				echo '</tr>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20008 .

### How to test the changes in this Pull Request:

1. Add `var_dump( $grouped_product->get_id() );` within the `foreach` loop of `add-to-cart/grouped.php` and verify it does not get overriden.
2. Verify grouped product add to cart sections works correctly.

### Changelog entry

> * Fix - Rename variable to prevent name collision in single-product/add-to-cart/grouped.php