### PR TITLE
Prevent infinite loops when grouped products group each other

### DIFF
--- a/includes/class-wc-product-grouped.php
+++ b/includes/class-wc-product-grouped.php
@@ -64,7 +64,7 @@ class WC_Product_Grouped extends WC_Product {
 		$on_sale  = false;
 
 		foreach ( $children as $child ) {
-			if ( $child->is_on_sale() ) {
+			if ( $child->is_purchasable() && ! $child->has_child() && $child->is_on_sale() ) {
 				$on_sale = true;
 				break;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`is_on_sale` for grouped products loops over children and checks if any of them are on sale. With 2 linked grouped products, this would cause them to both keep calling each other's `is_on_sale` method until timeout.

Fixes by excluding products with children or not on sale when checking if children are on sale.

Closes #20014

### How to test the changes in this Pull Request:

1. Create 2 grouped products
2. Link each other
3. View page. No errors? PR is working.

### Changelog entry

> Preventing an infinite loop if 2 grouped products are linked.
