### PR TITLE
Switch stock status when manage stock gets changed and qty is sufficient.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1314,7 +1314,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$this->set_stock_status( 'onbackorder' );
 
 			// If the stock level is changing and we do now have enough, force in stock status.
-		} elseif ( $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount', 0 ) && array_key_exists( 'stock_quantity', $this->get_changes() ) ) {
+		} elseif ( $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount', 0 ) && ( array_key_exists( 'stock_quantity', $this->get_changes() ) || array_key_exists( 'manage_stock', $this->get_changes() ) ) ) {
 			$this->set_stock_status( 'instock' );
 		}
 	}


### PR DESCRIPTION
As the stock quantity might be saved in the database from previous settings, stock_status needs to be in sync if qty is > 0.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #19967  .

### How to test the changes in this Pull Request:

1. Create variable product
2. Enable manage stock on variation level AND product level.
3. Set remaining qty to e.g. 5, save.
4. Un-check manage stock and set to Out of stock, save.
5. Check Manage stock, stock qty is immediately pre-filled with number entered in step 3.
6. Hit save changes.
7. Head to the shop--the variation that has just been activated shows is_in_stock = false and max_qty = <qty set in step 3>
8. Apply this fix.
9. Un-check manage stock and set to Out of stock, save.
10. Check Manage stock, stock qty is immediately pre-filled with number entered in step 3.
11. Hit save changes.
12. Go back to the shop--the variation that has just been activated correctly shows is_in_stock = true and max_qty = <qty set in step 3>


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Switch stock_status when manage stock gets changed to prevent being out of stock if stock quantity is > 0.
