### PR TITLE
Context for getting shipping methods for shipping zone.

### DIFF
--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -20,9 +20,10 @@ class WC_Shipping_Zones {
 	 * Get shipping zones from the database.
 	 *
 	 * @since 2.6.0
+	 * @param string $context Getting shipping methods for what context. Valid values, admin, json.
 	 * @return array Array of arrays.
 	 */
-	public static function get_zones() {
+	public static function get_zones( $context = 'admin' ) {
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		$raw_zones  = $data_store->get_zones();
 		$zones      = array();
@@ -32,7 +33,7 @@ class WC_Shipping_Zones {
 			$zones[ $zone->get_id() ]            = $zone->get_data();
 			$zones[ $zone->get_id() ]['zone_id'] = $zone->get_id();
 			$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
-			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, 'json' );
+			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, $context );
 		}
 
 		return $zones;


### PR DESCRIPTION
Method `get_zones()` uses `$zone->get_shipping_methods` always with context 'json'. It should be parametrized and default with context 'admin'. 