### PR TITLE
Context for getting shipping methods for shipping zone.

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -279,7 +279,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		wp_localize_script(
 			'wc-shipping-zones', 'shippingZonesLocalizeScript', array(
-				'zones'                   => WC_Shipping_Zones::get_zones(),
+				'zones'                   => WC_Shipping_Zones::get_zones( 'json' ),
 				'default_zone'            => array(
 					'zone_id'    => 0,
 					'zone_name'  => '',

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2504,7 +2504,7 @@ class WC_AJAX {
 
 		wp_send_json_success(
 			array(
-				'zones' => WC_Shipping_Zones::get_zones(),
+				'zones' => WC_Shipping_Zones::get_zones( 'json' ),
 			)
 		);
 	}

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -20,9 +20,10 @@ class WC_Shipping_Zones {
 	 * Get shipping zones from the database.
 	 *
 	 * @since 2.6.0
+	 * @param string $context Getting shipping methods for what context. Valid values, admin, json.
 	 * @return array Array of arrays.
 	 */
-	public static function get_zones() {
+	public static function get_zones( $context = 'admin' ) {
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		$raw_zones  = $data_store->get_zones();
 		$zones      = array();
@@ -32,7 +33,7 @@ class WC_Shipping_Zones {
 			$zones[ $zone->get_id() ]            = $zone->get_data();
 			$zones[ $zone->get_id() ]['zone_id'] = $zone->get_id();
 			$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
-			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, 'json' );
+			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, $context );
 		}
 
 		return $zones;

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -29,9 +29,9 @@ class WC_Shipping_Zones {
 		$zones      = array();
 
 		foreach ( $raw_zones as $raw_zone ) {
-			$zone                                = new WC_Shipping_Zone( $raw_zone );
-			$zones[ $zone->get_id() ]            = $zone->get_data();
-			$zones[ $zone->get_id() ]['zone_id'] = $zone->get_id();
+			$zone                                                = new WC_Shipping_Zone( $raw_zone );
+			$zones[ $zone->get_id() ]                            = $zone->get_data();
+			$zones[ $zone->get_id() ]['zone_id']                 = $zone->get_id();
 			$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
 			$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, $context );
 		}


### PR DESCRIPTION
See #20022

This PR passes correct context when dealing with JSON and scripts.

To test:

1. Go to zones screen. Add zones
2. Try sorting zones via drag and drop. If it saves and loads correctly, this patch is working. #20022 alone will cause endless loading.