### PR TITLE
Add phpunit-speedtrap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "wimg/php-compatibility": "^8.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
     "apigen/apigen": "^4",
-    "nette/utils": "~2.3.0"
+    "nette/utils": "~2.3.0",
+    "johnkary/phpunit-speedtrap": "v2.0.0"
   },
   "scripts": {
     "pre-update-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc2c57d2be29888a0e4c3a09ec26cbe3",
+    "content-hash": "90e327f21ad7c717c91787def1f0cfec",
     "packages": [
         {
             "name": "composer/installers",
@@ -643,6 +643,54 @@
             ],
             "abandoned": true,
             "time": "2014-05-27T05:29:25+00:00"
+        },
+        {
+            "name": "johnkary/phpunit-speedtrap",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnkary/phpunit-speedtrap.git",
+                "reference": "a1e39e0e3d07e0faee4ef3f342229d68fab07b5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnkary/phpunit-speedtrap/zipball/a1e39e0e3d07e0faee4ef3f342229d68fab07b5f",
+                "reference": "a1e39e0e3d07e0faee4ef3f342229d68fab07b5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JohnKary\\PHPUnit\\Listener\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Kary",
+                    "email": "john@johnkary.net"
+                }
+            ],
+            "description": "Find slow tests in your PHPUnit test suite",
+            "homepage": "https://github.com/johnkary/phpunit-speedtrap",
+            "keywords": [
+                "phpunit",
+                "profile",
+                "slow"
+            ],
+            "time": "2017-12-06T15:14:00+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -44,4 +44,7 @@
 			</exclude>
 		</whitelist>
 	</filter>
+	<listeners>
+		<listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
+	</listeners>
 </phpunit>


### PR DESCRIPTION
This PR is a proposal to use phpunit-speedtrap (https://github.com/johnkary/phpunit-speedtrap) together with PHPUnit. This tool, which is used by WP core (https://github.com/WordPress/wordpress-develop/blob/master/phpunit.xml.dist#L38), includes a report of slow-running unit tests to the PHPUnit output and it will help identify WC core tests that need to be changed to run faster.

Example output:

![screenshot from 2018-05-10 10-42-09](https://user-images.githubusercontent.com/77215/39872626-f5277b72-543e-11e8-843c-00d75ac47381.png)