### PR TITLE
Add default empty step class to html-csv-import-steps.php

### DIFF
--- a/includes/admin/importers/views/html-csv-import-steps.php
+++ b/includes/admin/importers/views/html-csv-import-steps.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <ol class="wc-progress-steps">
 	<?php foreach ( $this->steps as $step_key => $step ) : ?>
 		<?php
+		$step_class = '';
 		if ( $step_key === $this->step ) {
 			$step_class = 'active';
 		} elseif ( array_search( $this->step, array_keys( $this->steps ), true ) > array_search( $step_key, array_keys( $this->steps ), true ) ) {


### PR DESCRIPTION
Fixes this issue:
<img width="771" alt="screen shot 2018-05-10 at 11 39 05 am" src="https://user-images.githubusercontent.com/7317227/39888481-c12efc7c-5449-11e8-801a-c7905c90330d.png">

To test: Verify the `active` class only gets applied to the current screen in the importer and future steps are rendered in gray not purple.

This bug came from [a very large PR applying phpcbf to over a hundred files](https://github.com/woocommerce/woocommerce/pull/19253). We should look through the modified files and do some more testing around the changed files to make sure there were no other bugs introduced.
