### PR TITLE
Wrap cell in ' rather than prepend

### DIFF
--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -354,7 +354,7 @@ abstract class WC_CSV_Exporter {
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
 		if ( in_array( mb_substr( $data, 0, 1 ), $active_content_triggers, true ) ) {
-			$data = "'" . $data;
+			$data = "'" . $data . "'";
 		}
 
 		return $data;

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -771,12 +771,11 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 */
 	protected function unescape_negative_number( $value ) {
 		if ( 0 === strpos( $value, "'-" ) ) {
-			$unescaped = substr_replace( $value, '', 0, 1 );
+			$unescaped = trim( $value, "'" );
 			if ( is_numeric( $unescaped ) ) {
 				return $unescaped;
 			}
 		}
-
 		return $value;
 	}
 }

--- a/tests/unit-tests/exporter/product.php
+++ b/tests/unit-tests/exporter/product.php
@@ -24,16 +24,16 @@ class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 		$exporter = new WC_Product_CSV_Exporter();
 
 		$data = "=cmd|' /C calc'!A0";
-		$this->assertEquals( "'=cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'=cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
 
 		$data = "+cmd|' /C calc'!A0";
-		$this->assertEquals( "'+cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'+cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
 
 		$data = "-cmd|' /C calc'!A0";
-		$this->assertEquals( "'-cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'-cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
 
 		$data = "@cmd|' /C calc'!A0";
-		$this->assertEquals( "'@cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'@cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The escaping in the export prepends -, +, and = characters with a `'` to prevent arbitrary code being ran in Excel.

This change wraps instead so it doesn't look like a broken/stray character is being exported.

Closes #20039.

### How to test the changes in this Pull Request:

1. Set stock to -1
2. Export. Check CSV has '-1' in the CSV.
3. Set stock to -2 in admin interface.
4. Import. Check -1 is set.