### PR TITLE
Allows manipulate cart shipping calculator data

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -24,20 +24,24 @@ class WC_Shortcode_Cart {
 		try {
 			WC()->shipping->reset_shipping();
 
-			$country  = isset( $_POST['calc_shipping_country'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_country'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
-			$state    = isset( $_POST['calc_shipping_state'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_state'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
-			$postcode = isset( $_POST['calc_shipping_postcode'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_postcode'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
-			$city     = isset( $_POST['calc_shipping_city'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_city'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$address = array();
 
-			if ( $postcode && ! WC_Validation::is_postcode( $postcode, $country ) ) {
+			$address['country']  = isset( $_POST['calc_shipping_country'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_country'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$address['state']    = isset( $_POST['calc_shipping_state'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_state'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$address['postcode'] = isset( $_POST['calc_shipping_postcode'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_postcode'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+			$address['city']     = isset( $_POST['calc_shipping_city'] ) ? wc_clean( wp_unslash( $_POST['calc_shipping_city'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+
+			$address = apply_filters( 'woocommerce_cart_calculate_shipping_address', $address );
+
+			if ( $address['postcode'] && ! WC_Validation::is_postcode( $address['postcode'], $address['country'] ) ) {
 				throw new Exception( __( 'Please enter a valid postcode / ZIP.', 'woocommerce' ) );
-			} elseif ( $postcode ) {
-				$postcode = wc_format_postcode( $postcode, $country );
+			} elseif ( $address['postcode'] ) {
+				$address['postcode'] = wc_format_postcode( $address['postcode'], $address['country'] );
 			}
 
-			if ( $country ) {
-				WC()->customer->set_location( $country, $state, $postcode, $city );
-				WC()->customer->set_shipping_location( $country, $state, $postcode, $city );
+			if ( $address['country'] ) {
+				WC()->customer->set_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
+				WC()->customer->set_shipping_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 			} else {
 				WC()->customer->set_billing_address_to_base();
 				WC()->customer->set_shipping_address_to_base();

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -31,16 +31,20 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 
 	<section class="shipping-calculator-form" style="display:none;">
 
-		<p class="form-row form-row-wide" id="calc_shipping_country_field">
-			<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state">
-				<option value=""><?php esc_html_e( 'Select a country&hellip;', 'woocommerce' ); ?></option>
-				<?php
-				foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
-					echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
-				}
-				?>
-			</select>
-		</p>
+		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_country', true ) ) : ?>
+
+			<p class="form-row form-row-wide" id="calc_shipping_country_field">
+				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state">
+					<option value=""><?php esc_html_e( 'Select a country&hellip;', 'woocommerce' ); ?></option>
+					<?php
+					foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
+						echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';
+					}
+					?>
+				</select>
+			</p>
+
+		<?php endif; ?>
 
 		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) ) : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Introduces `woocommerce_cart_calculate_shipping_address` and `woocommerce_shipping_calculator_enable_country` to allow full control in the cart shipping calculator fields.

In most of places it's not required so many fields in order to get shipping costs, for example in Brazil it's just required the customer's postcode, so having so many fields will be a problem for the customers, to many steps to just get shipping costs while in any other store they don't need.

### How to test the changes in this Pull Request:

1. Create two shipping zones, one for `São Paulo`, and another for `Rio de Janeiro`
2. Include Flat Rate shipping with different values into each shipping zone.
3. Apply the follow code:

```php
add_filter( 'woocommerce_shipping_calculator_enable_country', '__return_false' );
add_filter( 'woocommerce_shipping_calculator_enable_state', '__return_false' );
add_filter( 'woocommerce_shipping_calculator_enable_city', '__return_false' );

add_filter( 'woocommerce_cart_calculate_shipping_address', function( $address ) {
    if ( $address['postcode'] && WC_Validation::is_postcode( $address['postcode'], 'BR' ) ) {
        $postcode = wc_normalize_postcode( $address['postcode'] );
        $state    = get_brazilian_state_from_postcode( $postcode );

        if ( $state ) {
            $address['country'] = 'BR';
            $address['state']   = $state;
        }
    }

    return $address;
} );

function get_brazilian_state_from_postcode( $postcode ) {
    $postcode = (int) substr( $postcode, 0, 5 );

    switch ( $postcode ) {
        case $postcode >= 69900 && $postcode <= 69999:
            return 'AC';
        case $postcode >= 57000 && $postcode <= 57999:
            return 'AL';
        case $postcode >= 68900 && $postcode <= 68999:
            return 'AP';
        case $postcode >= 69400 && $postcode <= 69899:
            return 'AM';
        case $postcode >= 40000 && $postcode <= 48999:
            return 'BA';
        case $postcode >= 60000 && $postcode <= 63999:
            return 'CE';
        case $postcode >= 70000 && $postcode <= 73699:
            return 'DF';
        case $postcode >= 29000 && $postcode <= 29999:
            return 'ES';
        case $postcode >= 72800 && $postcode <= 76799:
            return 'GO';
        case $postcode >= 65000 && $postcode <= 65999:
            return 'MA';
        case $postcode >= 78000 && $postcode <= 78899:
            return 'MT';
        case $postcode >= 79000 && $postcode <= 79999:
            return 'MS';
        case $postcode >= 30000 && $postcode <= 39999:
            return 'MG';
        case $postcode >= 66000 && $postcode <= 68899:
            return 'PA';
        case $postcode >= 58000 && $postcode <= 58999:
            return 'PB';
        case $postcode >= 80000 && $postcode <= 87999:
            return 'PR';
        case $postcode >= 50000 && $postcode <= 56999:
            return 'PE';
        case $postcode >= 64000 && $postcode <= 64999:
            return 'PI';
        case $postcode >= 20000 && $postcode <= 28999:
            return 'RJ';
        case $postcode >= 59000 && $postcode <= 59999:
            return 'RN';
        case $postcode >= 90000 && $postcode <= 99999:
            return 'RS';
        case $postcode >= 78900 && $postcode <= 78999:
            return 'RO';
        case $postcode >= 69300 && $postcode <= 69389:
            return 'RR';
        case $postcode >= 88000 && $postcode <= 89999:
            return 'SC';
        case $postcode >= 01000 && $postcode <= 19999:
            return 'SP';
        case $postcode >= 49000 && $postcode <= 49999:
            return 'SE';
        case $postcode >= 77000 && $postcode <= 77995:
            return 'TO';
        default:
            return '';
    }
}
```

4. Test with `01311-300` for São Paulo and `23587-440` for Rio de Janeiro.
All shipping costs updated using shipping zones and without any warning about missing Country or State.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Introduced `woocommerce_cart_calculate_shipping_address` field to allow manipulate cart shipping calculator data.
