### PR TITLE
[3.4] Add JS listeners for reloading/reinitializing order items in edit-order page

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -274,7 +274,11 @@ jQuery( function ( $ ) {
 
 				// Meta
 				.on( 'click', 'button.add_order_item_meta', this.item_meta.add )
-				.on( 'click', 'button.remove_order_item_meta', this.item_meta.remove );
+				.on( 'click', 'button.remove_order_item_meta', this.item_meta.remove )
+
+				// Reload items
+				.on( 'wc_order_items_reload', this.reload_items )
+				.on( 'wc_order_items_reloaded', this.reloaded_items );
 
 			$( document.body )
 				.on( 'wc_backbone_modal_loaded', this.backbone.init )
@@ -316,6 +320,11 @@ jQuery( function ( $ ) {
 					wc_meta_boxes_order_items.stupidtable.init();
 				}
 			});
+		},
+
+		reloaded_items: function() {
+			wc_meta_boxes_order.init_tiptip();
+			wc_meta_boxes_order_items.stupidtable.init();
 		},
 
 		// When the qty is changed, increase or decrease costs

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -315,9 +315,8 @@ jQuery( function ( $ ) {
 				success: function( response ) {
 					$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 					$( '#woocommerce-order-items' ).find( '.inside' ).append( response );
-					wc_meta_boxes_order.init_tiptip();
+					wc_meta_boxes_order_items.reloaded_items();
 					wc_meta_boxes_order_items.unblock();
-					wc_meta_boxes_order_items.stupidtable.init();
 				}
 			});
 		},
@@ -402,9 +401,8 @@ jQuery( function ( $ ) {
 					if ( response.success ) {
 						$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-							wc_meta_boxes_order.init_tiptip();
+							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
-							wc_meta_boxes_order_items.stupidtable.init();
 					} else {
 						window.alert( response.data.error );
 					}
@@ -430,9 +428,8 @@ jQuery( function ( $ ) {
 				if ( response.success ) {
 					$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 						$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-						wc_meta_boxes_order.init_tiptip();
+						wc_meta_boxes_order_items.reloaded_items();
 						wc_meta_boxes_order_items.unblock();
-						wc_meta_boxes_order_items.stupidtable.init();
 				} else {
 					window.alert( response.data.error );
 				}
@@ -490,9 +487,8 @@ jQuery( function ( $ ) {
 					if ( response.success ) {
 						$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-							wc_meta_boxes_order.init_tiptip();
+							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
-							wc_meta_boxes_order_items.stupidtable.init();
 					} else {
 						window.alert( response.data.error );
 					}
@@ -569,9 +565,8 @@ jQuery( function ( $ ) {
 						if ( response.success ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-							wc_meta_boxes_order.init_tiptip();
+							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
-							wc_meta_boxes_order_items.stupidtable.init();
 						} else {
 							window.alert( response.data.error );
 						}
@@ -601,9 +596,8 @@ jQuery( function ( $ ) {
 						if ( response.success ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 								$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-								wc_meta_boxes_order.init_tiptip();
+								wc_meta_boxes_order_items.reloaded_items();
 								wc_meta_boxes_order_items.unblock();
-								wc_meta_boxes_order_items.stupidtable.init();
 						} else {
 							window.alert( response.data.error );
 						}
@@ -660,9 +654,8 @@ jQuery( function ( $ ) {
 					success: function( response ) {
 						$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 						$( '#woocommerce-order-items' ).find( '.inside' ).append( response );
-						wc_meta_boxes_order.init_tiptip();
+						wc_meta_boxes_order_items.reloaded_items();
 						wc_meta_boxes_order_items.unblock();
-						wc_meta_boxes_order_items.stupidtable.init();
 					}
 				});
 			}
@@ -687,9 +680,8 @@ jQuery( function ( $ ) {
 				success: function( response ) {
 					$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 					$( '#woocommerce-order-items' ).find( '.inside' ).append( response );
-					wc_meta_boxes_order.init_tiptip();
+					wc_meta_boxes_order_items.reloaded_items();
 					wc_meta_boxes_order_items.unblock();
-					wc_meta_boxes_order_items.stupidtable.init();
 				}
 			});
 
@@ -1137,8 +1129,7 @@ jQuery( function ( $ ) {
 						if ( response.success ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-							wc_meta_boxes_order.init_tiptip();
-							wc_meta_boxes_order_items.stupidtable.init();
+							wc_meta_boxes_order_items.reloaded_items();
 						} else {
 							window.alert( response.data.error );
 						}
@@ -1180,8 +1171,7 @@ jQuery( function ( $ ) {
 							if ( response.success ) {
 								$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 								$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
-								wc_meta_boxes_order.init_tiptip();
-								wc_meta_boxes_order_items.stupidtable.init();
+								wc_meta_boxes_order_items.reloaded_items();
 							} else {
 								window.alert( response.data.error );
 							}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds two new event listeners:

* `wc_order_items_reload` -- allows extension code to trigger an order items table refresh.
* `wc_order_items_reloaded` --  allows extension code to re-initialize the order-items table without duplicating initialization code (now contained in `reloaded_items`.

An extra commit was code to DRY up the code using the introduced `reloaded_items` function, which was added to handle the `wc_order_items_reloaded` event.

Adding this in the 3.4 cycle will allow us to implement WC extension features that would otherwise require core code duplication.

### How to test the changes in this Pull Request:

Does not change core functionality/behavior. **Code review needed**.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Introduced `wc_order_items_reload` and `wc_order_items_reloaded` edit-order page JS events.