### PR TITLE
Set date created if null during update

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -132,6 +132,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$order->save_meta_data();
 		$order->set_version( WC_VERSION );
 
+		if ( null === $order->get_date_created( 'edit' ) ) {
+			$order->set_date_created( current_time( 'timestamp', true ) );
+		}
+
 		$changes = $order->get_changes();
 
 		// Only update the post when the post data changes.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If an order being updated does not yet have a date, set one.

Closes #20057.

### How to test the changes in this Pull Request:

See #20057.