### PR TITLE
Fix rounding of line items for orders

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1358,7 +1358,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		foreach ( $this->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
 			$taxes = $item->get_taxes();
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
-				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + (float) $tax : (float) $tax;
+				$tax_amount = (float) $tax;
+
+				if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+					$tax_amount = wc_round_tax_total( $tax_amount );
+				}
+
+				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + $tax_amount : $tax_amount;
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Cart item tax rounding differed slightly from order recalculation. This fixes that.

Closes #20081.

### How to test the changes in this Pull Request:

1. Create a line item costing 23.74
2. Create a line item costing 0.83
3. Set prices excl tax, 20% worldwide
4. Calc order taxes. You should end up with 4.92 taxes. This matches the frontend if you repeat there.