### PR TITLE
Remove full stop after action name

### DIFF
--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -35,7 +35,7 @@ class WC_Auth {
 		add_action( 'init', array( __CLASS__, 'add_endpoint' ), 0 );
 
 		// Handle auth requests.
-		add_action( 'parse_request.', array( $this, 'handle_auth_requests' ), 0 );
+		add_action( 'parse_request', array( $this, 'handle_auth_requests' ), 0 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes full stop appended to an action name.

Closes #20072.
