### PR TITLE
Remove hardcoded border in email template

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -10,57 +10,79 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     3.2.0
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.4.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $text_align = is_rtl() ? 'right' : 'left';
 
 foreach ( $items as $item_id => $item ) :
-	$product = $item->get_product();
-	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+	$product       = $item->get_product();
+	$sku           = '';
+	$purchase_note = '';
+	$image         = '';
+
+	if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+		continue;
+	}
+
+	if ( is_object( $product ) ) {
+		$sku           = $product->get_sku();
+		$purchase_note = $product->get_purchase_note();
+		$image         = $product->get_image( $image_size );
+	}
+
+	?>
+	<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
+		<td class="td" style="text-align:<?php echo esc_attr( $text_align ); ?>; vertical-align: middle; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; word-wrap:break-word;">
+		<?php
+
+		// Show title/image etc.
+		if ( $show_image ) {
+			echo wp_kses_post( apply_filters( 'woocommerce_order_item_thumbnail', $image, $item ) );
+		}
+
+		// Product name.
+		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+
+		// SKU.
+		if ( $show_sku && $sku ) {
+			echo wp_kses_post( ' (#' . $sku . ')' );
+		}
+
+		// allow other plugins to add additional product information here.
+		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
+
+		wc_display_item_meta( $item );
+
+		// allow other plugins to add additional product information here.
+		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
+
 		?>
-		<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
-			<td class="td" style="text-align:<?php echo $text_align; ?>; vertical-align:middle; border: 1px solid #eee; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; word-wrap:break-word;"><?php
+		</td>
+		<td class="td" style="text-align:<?php echo esc_attr( $text_align ); ?>; vertical-align:middle; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
+			<?php echo wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item ) ); ?>
+		</td>
+		<td class="td" style="text-align:<?php echo esc_attr( $text_align ); ?>; vertical-align:middle; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
+			<?php echo wp_kses_post( $order->get_formatted_line_subtotal( $item ) ); ?>
+		</td>
+	</tr>
+	<?php
 
-				// Show title/image etc
-				if ( $show_image ) {
-					echo apply_filters( 'woocommerce_order_item_thumbnail', '<div style="margin-bottom: 5px"><img src="' . ( $product->get_image_id() ? current( wp_get_attachment_image_src( $product->get_image_id(), 'thumbnail' ) ) : wc_placeholder_img_src() ) . '" alt="' . esc_attr__( 'Product image', 'woocommerce' ) . '" height="' . esc_attr( $image_size[1] ) . '" width="' . esc_attr( $image_size[0] ) . '" style="vertical-align:middle; margin-' . ( is_rtl() ? 'left' : 'right' ) . ': 10px;" /></div>', $item );
-				}
-
-				// Product name
-				echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
-
-				// SKU
-				if ( $show_sku && is_object( $product ) && $product->get_sku() ) {
-					echo ' (#' . $product->get_sku() . ')';
-				}
-
-				// allow other plugins to add additional product information here
-				do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
-
-				wc_display_item_meta( $item );
-
-				// allow other plugins to add additional product information here
-				do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
-
-			?></td>
-			<td class="td" style="text-align:<?php echo $text_align; ?>; vertical-align:middle; border: 1px solid #eee; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;"><?php echo apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item ); ?></td>
-			<td class="td" style="text-align:<?php echo $text_align; ?>; vertical-align:middle; border: 1px solid #eee; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;"><?php echo $order->get_formatted_line_subtotal( $item ); ?></td>
+	if ( $show_purchase_note && $purchase_note ) {
+		?>
+		<tr>
+			<td colspan="3" style="text-align:<?php echo esc_attr( $text_align ); ?>; vertical-align:middle; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
+				<?php
+				echo wp_kses_post( wpautop( do_shortcode( $purchase_note ) ) );
+				?>
+			</td>
 		</tr>
 		<?php
 	}
-
-	if ( $show_purchase_note && is_object( $product ) && ( $purchase_note = $product->get_purchase_note() ) ) : ?>
-		<tr>
-			<td colspan="3" style="text-align:<?php echo $text_align; ?>; vertical-align:middle; border: 1px solid #eee; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;"><?php echo wpautop( do_shortcode( wp_kses_post( $purchase_note ) ) ); ?></td>
-		</tr>
-	<?php endif; ?>
+	?>
 
 <?php endforeach; ?>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -11,7 +11,6 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates/Emails
  * @version 3.3.0
  */
@@ -134,6 +133,7 @@ $text_lighter_20 = wc_hex_lighter( $text, 20 );
 .td {
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;
 	border: 1px solid <?php echo esc_attr( $body_darker_10 ); ?>;
+	vertical-align: middle;
 }
 
 .address {
@@ -197,13 +197,14 @@ a {
 
 img {
 	border: none;
-	display: inline;
+	display: inline-block;
 	font-size: 14px;
 	font-weight: bold;
 	height: auto;
-	line-height: 100%;
 	outline: none;
 	text-decoration: none;
 	text-transform: capitalize;
+	vertical-align: middle;
+	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
 }
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes hardcoded borders from the template files.

Also takes care of PHPCS violations and improves image display when enabled.

Closes #20070.

### How to test the changes in this Pull Request:

1. Set BG and body colors to non-white.
2. Set text color to white. 
3. Send email from order screen.
4. Verify borders are not grey in the items table.