### PR TITLE
Fix incorrectly closed system status table row

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -866,7 +866,7 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 						<?php esc_html_e( 'Learn how to update', 'woocommerce' ); ?>
 					</a>
 				</td>
-			/tr>
+			</tr>
 		<?php endif; ?>
 	</tbody>
 </table>


### PR DESCRIPTION
Introduced with https://github.com/woocommerce/woocommerce/commit/23b69eba531562692833ba2958fb827bf3eb838a#diff-1b33d607bfa554752b46fad3269637deR806

Before: https://cl.ly/2U0L091n351R
After: https://cl.ly/2J433Z3G2l1I

I had look around open PRs for anything already fixing this but couldn't see anything - apologies if dupe.
