### PR TITLE
When cleaning up CSV import, only remove product taxonomies

### DIFF
--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -258,11 +258,15 @@ class WC_Admin_Importers {
 				LEFT JOIN {$wpdb->posts} wp ON wp.ID = {$wpdb->postmeta}.post_id
 				WHERE wp.ID IS NULL
 			" );
+			// @codingStandardsIgnoreStart.
 			$wpdb->query( "
-				DELETE {$wpdb->term_relationships}.* FROM {$wpdb->term_relationships}
-				LEFT JOIN {$wpdb->posts} wp ON wp.ID = {$wpdb->term_relationships}.object_id
+				DELETE tr.* FROM {$wpdb->term_relationships} tr
+				LEFT JOIN {$wpdb->posts} wp ON wp.ID = tr.object_id
+				LEFT JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				WHERE wp.ID IS NULL
+				AND tt.taxonomy IN ( '" . implode( "','", array_map( 'esc_sql', get_object_taxonomies( 'product' ) ) ) . "' )
 			" );
+			// @codingStandardsIgnoreEnd.
 
 			// Send success.
 			wp_send_json_success(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Cleans up only relationships for product taxonomies, not all.

Closes #20051.

You can use the test instructions in https://github.com/woocommerce/woocommerce/issues/19863 since that was when this code was introduced.